### PR TITLE
Fix : Block Inserter Search Infinity Spinner

### DIFF
--- a/packages/block-directory/src/store/resolvers.js
+++ b/packages/block-directory/src/store/resolvers.js
@@ -35,7 +35,7 @@ export const getDownloadableBlocks =
 			);
 
 			dispatch( receiveDownloadableBlocks( blocks, filterValue ) );
-		} catch ( error ) {
+		} catch {
 			dispatch( receiveDownloadableBlocks( [], filterValue ) );
 		}
 	};

--- a/packages/block-directory/src/store/resolvers.js
+++ b/packages/block-directory/src/store/resolvers.js
@@ -35,5 +35,7 @@ export const getDownloadableBlocks =
 			);
 
 			dispatch( receiveDownloadableBlocks( blocks, filterValue ) );
-		} catch {}
+		} catch ( error ) {
+			dispatch( receiveDownloadableBlocks( [], filterValue ) );
+		}
 	};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- https://core.trac.wordpress.org/ticket/62796

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- When the user is `offline`, the search prodiuces a `500 error code`, the `Infinity Spinner` is not hidden
- The `Spinner` should be hidden once the request fails, and should render the relevant placeholder

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Return `empty array` in the place of `blocks` in the `error` part of the `trycatch` block

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="465" alt="Screenshot 2025-01-10 at 5 30 28 PM" src="https://github.com/user-attachments/assets/0651c768-f605-4e4e-a797-c7b66da35696" /> | <img width="468" alt="Screenshot 2025-01-10 at 5 27 54 PM" src="https://github.com/user-attachments/assets/e3abb6f5-8c97-4dc3-81f1-45a85c626a12" /> |
