### PR TITLE
Fixed Media & Text Block - Image not rendered properly on frontend when inside stack

### DIFF
--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -123,6 +123,11 @@
 	object-fit: cover;
 }
 
+// We need to set the width explicitly to 100% to make sure the image is responsive and works with stack/crop.
+.wp-block-media-text.is-image-fill-element {
+	width: 100%;
+}
+
 /*
 * Here we here not able to use a mobile first CSS approach.
 * Custom widths are set using inline styles, and on mobile,

--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -106,7 +106,6 @@
 
 /* Image fill for versions 8 and onwards */
 .wp-block-media-text.is-image-fill-element > .wp-block-media-text__media {
-	position: absolute;
 	height: 100%;
 	min-height: 250px;
 }
@@ -117,7 +116,6 @@
 }
 
 .wp-block-media-text.is-image-fill-element > .wp-block-media-text__media img {
-	position: absolute;
 	width: 100%;
 	height: 100%;
 	object-fit: cover;

--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -123,11 +123,6 @@
 	object-fit: cover;
 }
 
-// We need to set the width explicitly to 100% to make sure the image is responsive and works with stack/crop.
-.wp-block-media-text.is-image-fill-element {
-	width: 100%;
-}
-
 /*
 * Here we here not able to use a mobile first CSS approach.
 * Custom widths are set using inline styles, and on mobile,

--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -106,7 +106,7 @@
 
 /* Image fill for versions 8 and onwards */
 .wp-block-media-text.is-image-fill-element > .wp-block-media-text__media {
-	position: relative;
+	position: absolute;
 	height: 100%;
 	min-height: 250px;
 }


### PR DESCRIPTION
fixes #68609

## What?
Fix image width issue for Media & Text block when used with image fill inside flex containers (Stack/Row).

## Why?
When a Media & Text block with `is-image-fill-element` is placed inside a flex container (.is-layout-flex), the image width becomes zero on render despite working correctly in the editor. This causes the image to disappear on the frontend while remaining visible in the editor.

## How?
Added an explicit width declaration for Media & Text blocks when they appear inside flex containers. The minimal CSS fix ensures the block takes full width of its container:

```css
.wp-block-media-text.is-image-fill-element {
    width: 100%;
}
```


## Testing Instructions

1. Create a new post or page
2. Add a Stack block (Group block with vertical flex layout)
3. Inside the Stack, insert a Media & Text block
4. Upload or select an image
5. In the sidebar settings, enable "Crop image to fill" option
6. Save and view the post/page
7. Verify that the image appears correctly and maintains its width on the frontend

## Screenshot

![image](https://github.com/user-attachments/assets/27130bd6-e38e-4fc5-ac1a-1a93b51776c2)

![image](https://github.com/user-attachments/assets/899f1fe4-4876-45ed-97cc-3c551b40824c)

