### PR TITLE
Updated Small Typo in Feature-flags.md file

### DIFF
--- a/docs/how-to-guides/feature-flags.md
+++ b/docs/how-to-guides/feature-flags.md
@@ -54,7 +54,7 @@ if ( globalThis.IS_GUTENBERG_PLUGIN ) {
 
 ```js
 if ( true ) {
-	// Wepack has replaced `globalThis.IS_GUTENBERG_PLUGIN` with `true`
+	// Webpack has replaced `globalThis.IS_GUTENBERG_PLUGIN` with `true`
 	pluginOnlyFeature();
 }
 ```


### PR DESCRIPTION
In docs/how-to-guides/feature-flags.md File Line no 57 `Wepack` Should be `Webpack`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open docs/how-to-guides/feature-flags.md file
2. Go to Line no 57