### PR TITLE
Query Loop: Remove unused styles

### DIFF
--- a/packages/block-library/src/query/editor.scss
+++ b/packages/block-library/src/query/editor.scss
@@ -1,24 +1,3 @@
-.block-library-query-toolbar__popover .components-popover__content {
-	min-width: 230px;
-
-	.block-library-query-toolbar__popover-number-control {
-		margin-bottom: $grid-unit-10;
-	}
-}
-
-.block-library-query__pattern-selection-content .block-editor-block-patterns-list {
-	display: grid;
-	grid-template-columns: 1fr 1fr 1fr;
-	grid-gap: $grid-unit-10;
-
-	.block-editor-block-patterns-list__list-item {
-		margin-bottom: 0;
-		.block-editor-block-preview__container {
-			max-height: 250px;
-		}
-	}
-}
-
 .block-library-query-pattern__selection-modal {
 
 	.block-editor-block-patterns-list {
@@ -45,20 +24,10 @@
 	}
 }
 
-.block-library-query-toolspanel__design {
-	.block-library-query-pattern__selection-content {
-		margin-top: $grid-unit-10;
-	}
-}
-
 .wp-block-query__enhanced-pagination-modal {
 	@include break-small() {
 		max-width: $break-mobile;
 	}
-}
-
-.wp-block-query__enhanced-pagination-notice {
-	margin: 0;
 }
 
 .block-editor-block-settings-menu__popover {


### PR DESCRIPTION
## What?

This PR removes unused styles in the Query Loop block.

## Why?

Code quality.

## How?

### .block-library-query-toolbar__popover

This CSS was needed when the query filter control was in the block toolbar: https://github.com/WordPress/gutenberg/pull/26992

Then the element with this CSS class was deleted: https://github.com/WordPress/gutenberg/pull/58207/files#diff-168766f853e5687fa469d2eee2d2d9e0c351aed334a937a42f8349a76ab5fe2cL32

### .block-library-query__pattern-selection-content

It appears that at the time the PR in which this CSS was added was submitted, no elements with this CSS class existed: https://github.com/WordPress/gutenberg/pull/38997/files#diff-f0ac68acacc980ececd13a033228c4fef1d62982d9c0c4b6efee0bad5c993b98R9

### .block-library-query-toolspanel__design

It appears that at the time the PR in which this CSS was added was submitted, no elements with this CSS class existed: https://github.com/WordPress/gutenberg/pull/66993/files#diff-f0ac68acacc980ececd13a033228c4fef1d62982d9c0c4b6efee0bad5c993b98R48

### .wp-block-query__enhanced-pagination-notice

This CSS was needed to reset the margins of the Notice component: https://github.com/WordPress/gutenberg/pull/54455/files?diff=unified&w=0#diff-d8002d815f5181ff6567ce80f0771f5c725ad0ea5333cd68bd3e7d7cd47650e4R42

Then this Notice component has been removed: https://github.com/WordPress/gutenberg/commit/b483df2fd37d2d4c925f4e78e62512e9f0146fb2#diff-d8002d815f5181ff6567ce80f0771f5c725ad0ea5333cd68bd3e7d7cd47650e4L39

## Testing Instructions

- Insert a Query Loop block.
- Click the Choose button
- Confirm that the Choose a Pattern modal is displayed correctly.
- Click the "Change design" button from the block toolbar.
- Confirm that the drop-down content is displayed correctly.
