### PR TITLE
Global Styles: Remove unused prop for 'BackgroundImageControls'

### DIFF
--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -378,7 +378,6 @@ function BackgroundImageControls( {
 						label={ imgLabel }
 					/>
 				}
-				variant="secondary"
 				renderToggle={ ( props ) => (
 					<Button { ...props } __next40pxDefaultSize />
 				) }


### PR DESCRIPTION
## What?
PR removes unused variant prop passed to `MediaReplaceFlow` by the `BackgroundImageControls` component.

## Why?
The `MediaReplaceFlow` doesn't accept or use the `variant` property.

## Testing Instructions
None. Just confirm CI checks are passing.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2025-01-12 at 16 04 12](https://github.com/user-attachments/assets/35644498-cca0-492b-acae-9b2e8601ee4c)
