### PR TITLE
Site Logo: Remove unused argument for 'mediaUpload' function

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -517,7 +517,6 @@ export default function LogoEdit( {
 				onInitialSelectLogo( image );
 			},
 			onError: onUploadError,
-			onRemoveLogo,
 		} );
 	};
 


### PR DESCRIPTION
## What?
PR removes the `onRemoveLogo` callback passed to the `mediaUpload` method, which is never called.

## Testing Instructions
None. PR removes the argument that did nothing.
