### PR TITLE
Site Logo: Prevent uploading multiple images via drag and drop

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -506,6 +506,11 @@ export default function LogoEdit( {
 	};
 
 	const onFilesDrop = ( filesList ) => {
+		if ( filesList?.length > 1 ) {
+			onUploadError( __( 'Only one image can be used as a site logo.' ) );
+			return;
+		}
+
 		getSettings().mediaUpload( {
 			allowedTypes: ALLOWED_MEDIA_TYPES,
 			filesList,


### PR DESCRIPTION
## What?
PR adds a check to the `onFilesDrop` callback and prevents multiple image uploads via drag and drop.

## Why?
The block can only use a single image as the site logo.

## Testing Instructions
1. Open a post or page.
2. Add the Site Logo block.
3. Reset the site logo.
4. Try dragging and dropping multiple images on Media control in the sidebar.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2025-01-12 at 17 15 03](https://github.com/user-attachments/assets/89a0ac81-6b3e-4abc-b6d4-9032e14aece7)
