### PR TITLE
Navigation: Fix typo in `history.navigation's` function call

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menu-handlers.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/use-navigation-menu-handlers.js
@@ -42,7 +42,7 @@ function useDeleteNavigationMenu() {
 					type: 'snackbar',
 				}
 			);
-			history.navivate( '/navigation' );
+			history.navigate( '/navigation' );
 		} catch ( error ) {
 			createErrorNotice(
 				sprintf(


### PR DESCRIPTION
## What, Why and How?
Fixes a typo in the `use-navigation-menu-handlers` hook that prevents navigation to `/navigation` and triggers a warning.

## Testing Instructions

1. Navigate to the site editor.
2. Make sure you have created a Navigation Menu.
3. Navigate to the Navigation page.
4. Choose any Navigation Menu and delete it.
5. Observe, the deletion happens as expected.

## Screencast

![PR Demo](https://github.com/user-attachments/assets/9d53a8bc-be09-452d-a0a8-9f89633bb6a8)


closes: #68622 