### PR TITLE
Storybook: Add Story for Block Quick Navigation Component 

### DIFF
--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -19,6 +19,30 @@ import BlockIcon from '../block-icon';
 import useBlockDisplayInformation from '../use-block-display-information';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
 
+/**
+ * BlockQuickNavigation component displays a list of blocks with quick navigation
+ *
+ * @example
+ * ```jsx
+ * function MyBlockQuickNavigation() {
+ * return (
+ * <BlockQuickNavigation
+ *    clientIds={ [ 'block-1', 'block-2' ] }
+ *   onSelect={ ( clientId ) => {
+ *    console.log( `Block ${ clientId } selected` );
+ *  } }
+ * />
+ * );
+ * }
+ * />
+ * ```
+ *
+ * @param {Object}   props           Component props
+ * @param {Array}    props.clientIds Array of block clientIds
+ * @param {Function} props.onSelect  Callback function to call when a block is selected
+ *
+ * @return {Element} The BlockQuickNavigation component
+ */
 export default function BlockQuickNavigation( { clientIds, onSelect } ) {
 	if ( ! clientIds.length ) {
 		return null;

--- a/packages/block-editor/src/components/block-quick-navigation/stories/index.story.js
+++ b/packages/block-editor/src/components/block-quick-navigation/stories/index.story.js
@@ -1,0 +1,77 @@
+/**
+ * Internal dependencies
+ */
+import BlockQuickNavigation from '..';
+
+/**
+ * WordPress dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+import { createBlock } from '@wordpress/blocks';
+import { dispatch } from '@wordpress/data';
+
+registerCoreBlocks();
+
+const blockEditorState = [
+	createBlock( 'core/paragraph' ),
+	createBlock( 'core/heading' ),
+];
+
+dispatch( 'core/block-editor' ).resetBlocks( blockEditorState );
+
+const meta = {
+	title: 'BlockEditor/BlockQuickNavigation',
+	component: BlockQuickNavigation,
+	tags: [ 'status-private' ],
+	parameters: {
+		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
+			description: {
+				component:
+					'The `BlockQuickNavigation` component displays a list of blocks with quick navigation.',
+			},
+		},
+	},
+	argTypes: {
+		clientIds: {
+			control: { type: null },
+			description: 'Array of block clientIds',
+			table: {
+				type: {
+					summary: 'Array',
+				},
+			},
+		},
+		onSelect: {
+			control: {
+				type: 'function',
+			},
+			description: 'Callback function to call when a block is selected',
+			table: {
+				type: {
+					summary: 'Function',
+				},
+			},
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	args: {
+		clientIds: blockEditorState.map( ( block ) => block.clientId ),
+	},
+	render: function Template( { onSelect, ...args } ) {
+		return (
+			<BlockQuickNavigation
+				{ ...args }
+				onSelect={ ( ...changeArgs ) => {
+					onSelect( ...changeArgs );
+				} }
+			/>
+		);
+	},
+};


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR adds story for Block Quick Navigation Component 

## Testing Instructions
- Run npm run storybook:dev
- Open Storybook at http://localhost:50240/
- Check the BlockQuickNavigation Story

## Screenshots or screencast 

![image](https://github.com/user-attachments/assets/6467e20b-5735-46ea-a31e-dc239744fdbc)

