### PR TITLE
Color Gradients: Adjust `max-width` for color gradient swatch to accommodate `reset` button size

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -111,7 +111,7 @@ $swatch-gap: 12px;
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
-		max-width: calc(100% - $button-size-next-default-40px);
+		max-width: calc(100% - ($button-size-next-default-40px + $grid-unit-05));
 	}
 }
 

--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -111,6 +111,7 @@ $swatch-gap: 12px;
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
+		max-width: calc(100% - $button-size-next-default-40px);
 	}
 }
 


### PR DESCRIPTION
## What, Why & How?
This PR addresses an issue in the Navigation block's Submenu & Overlay Background color setting, where the text label becomes excessively large (in width). As a result, the Reset button overlaps with the text, disrupting the layout and negatively impacting usability. This overlap makes it difficult for users to interact with the controls effectively.

## Testing Instructions
1. Navigate to the `Navigation block`.
2. Provide a Submenu & Overlay Background color.
3. Notice the Submenu & Overlay Background setting's text under Color settings **_does not overlap_** with the reset button.

## Screenshots
|Before|After|
|-|-|
|![Screenshot 2025-01-13 at 2 19 00 PM](https://github.com/user-attachments/assets/37c986e5-f37b-4db0-8132-c2266d0f8459)|![Screenshot 2025-01-13 at 2 14 43 PM](https://github.com/user-attachments/assets/f0dab97c-e3c4-4a5c-b4ad-50f7d48424c5)|

Closes: #68625 