### PR TITLE
fix: Block focus removed even on clicking the inspector control to add Url

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -612,19 +612,28 @@ export default function NavigationLinkEdit( {
 								// If there is no link then remove the auto-inserted block.
 								// This avoids empty blocks which can provided a poor UX.
 								if ( ! url ) {
-									// Fixes https://github.com/WordPress/gutenberg/issues/61361
-									// There's a chance we're closing due to the user selecting the browse all button.
-									// Only move focus if the focus is still within the popover ui. If it's not within
-									// the popover, it's because something has taken the focus from the popover, and
-									// we don't want to steal it back.
+									const inspectorControls =
+										document.querySelector(
+											'.editor-sidebar'
+										);
+
+									// Only move focus if the focus is still within the popover UI or Inspector Controls.
+									// If the focus is not within these elements, it means something else has taken the focus
+									// (e.g., outside the editor), and we can safely proceed to remove the block.
 									if (
 										linkUIref.current.contains(
 											window.document.activeElement
+										) ||
+										inspectorControls.contains(
+											window.document.activeElement
 										)
 									) {
-										// Select the previous block to keep focus nearby
-										selectPreviousBlock( clientId, true );
+										// Focus is within the popover or inspector; don't remove the block.
+										return;
 									}
+
+									// Select the previous block to keep focus nearby.
+									selectPreviousBlock( clientId, true );
 
 									// Remove the link.
 									onReplace( [] );


### PR DESCRIPTION
## What?
fixes https://github.com/WordPress/gutenberg/issues/65962

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- After we insert Custom List block (core/navigation-link) if we clicking anything after that, block previous to it gets focused and the Custom List block is removed from the editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open site editor.
2. Click the navigation block in the header.
3. Try adding a Custom Link block.
4. Clicks anything other the side editor panel (Inspector Controls) the block will get removed.
5. Try again inserting the block and click on the input fields to add Text and Url, the above behaviour will not occur.


## Screenshots or screencast <!-- if applicable -->
Before:

https://github.com/user-attachments/assets/1c8dd97f-8aad-402d-b8a0-023aa54a1d1f

After:


https://github.com/user-attachments/assets/f79f704e-b6ab-4382-af36-994972136b61



