### PR TITLE
Navigation Link: Improve accessibility by removing non-interactive tooltips

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -527,9 +527,9 @@ export default function NavigationLinkEdit( {
 				<a className={ classes }>
 					{ /* eslint-enable */ }
 					{ ! url ? (
-						<span className="wp-block-navigation-link__placeholder-text">
-							{ missingText }
-						</span>
+						<div className="wp-block-navigation-link__placeholder-text">
+							<span>{ missingText }</span>
+						</div>
 					) : (
 						<>
 							{ ! isInvalid &&

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -17,7 +17,7 @@ import {
 	ToolbarGroup,
 } from '@wordpress/components';
 import { displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
 	BlockControls,
 	InspectorControls,
@@ -527,10 +527,7 @@ export default function NavigationLinkEdit( {
 				<a className={ classes }>
 					{ /* eslint-enable */ }
 					{ ! url ? (
-						<span
-							className="wp-block-navigation-link__placeholder-text"
-							aria-label={ __( 'This item is missing a link' ) }
-						>
+						<span className="wp-block-navigation-link__placeholder-text">
 							{ missingText }
 						</span>
 					) : (
@@ -584,15 +581,7 @@ export default function NavigationLinkEdit( {
 										}
 									) }
 								>
-									<span
-										aria-label={ sprintf(
-											/* translators: %s: link status (Invalid or Draft) */
-											__( 'Navigation link text - %s' ),
-											isInvalid
-												? __( 'Invalid' )
-												: __( 'Draft' )
-										) }
-									>
+									<span>
 										{
 											// Some attributes are stored in an escaped form. It's a legacy issue.
 											// Ideally they would be stored in a raw, unescaped form.

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -532,11 +532,12 @@ export default function NavigationLinkEdit( {
 				<a className={ classes }>
 					{ /* eslint-enable */ }
 					{ ! url ? (
-						<div className="wp-block-navigation-link__placeholder-text">
-							<Tooltip text={ tooltipText }>
-								<span>{ missingText }</span>
-							</Tooltip>
-						</div>
+						<span
+							className="wp-block-navigation-link__placeholder-text"
+							aria-label={ __( 'This item is missing a link' ) }
+						>
+							{ missingText }
+						</span>
 					) : (
 						<>
 							{ ! isInvalid &&

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -14,11 +14,10 @@ import {
 	TextControl,
 	TextareaControl,
 	ToolbarButton,
-	Tooltip,
 	ToolbarGroup,
 } from '@wordpress/components';
 import { displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	BlockControls,
 	InspectorControls,
@@ -490,10 +489,6 @@ export default function NavigationLinkEdit( {
 	const placeholderText = `(${
 		isInvalid ? __( 'Invalid' ) : __( 'Draft' )
 	})`;
-	const tooltipText =
-		isInvalid || isDraft
-			? __( 'This item has been deleted, or is a draft' )
-			: __( 'This item is missing a link' );
 
 	return (
 		<>
@@ -579,27 +574,38 @@ export default function NavigationLinkEdit( {
 							{ ( isInvalid ||
 								isDraft ||
 								isLabelFieldFocused ) && (
-								<div className="wp-block-navigation-link__placeholder-text wp-block-navigation-link__label">
-									<Tooltip text={ tooltipText }>
-										<span
-											aria-label={ __(
-												'Navigation link text'
-											) }
-										>
-											{
-												// Some attributes are stored in an escaped form. It's a legacy issue.
-												// Ideally they would be stored in a raw, unescaped form.
-												// Unescape is used here to "recover" the escaped characters
-												// so they display without encoding.
-												// See `updateAttributes` for more details.
-												`${ decodeEntities( label ) } ${
-													isInvalid || isDraft
-														? placeholderText
-														: ''
-												}`.trim()
-											}
-										</span>
-									</Tooltip>
+								<div
+									className={ clsx(
+										'wp-block-navigation-link__placeholder-text',
+										'wp-block-navigation-link__label',
+										{
+											'is-invalid': isInvalid,
+											'is-draft': isDraft,
+										}
+									) }
+								>
+									<span
+										aria-label={ sprintf(
+											/* translators: %s: link status (Invalid or Draft) */
+											__( 'Navigation link text - %s' ),
+											isInvalid
+												? __( 'Invalid' )
+												: __( 'Draft' )
+										) }
+									>
+										{
+											// Some attributes are stored in an escaped form. It's a legacy issue.
+											// Ideally they would be stored in a raw, unescaped form.
+											// Unescape is used here to "recover" the escaped characters
+											// so they display without encoding.
+											// See `updateAttributes` for more details.
+											`${ decodeEntities( label ) } ${
+												isInvalid || isDraft
+													? placeholderText
+													: ''
+											}`.trim()
+										}
+									</span>
 								</div>
 							) }
 						</>

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -101,7 +101,6 @@
 			padding-bottom: 0.1em;
 		}
 
-
 		&.is-invalid,
 		&.is-draft {
 			span {

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -80,7 +80,7 @@
 	background-image: none !important;
 
 	// Draw a wavy underline.
-	.wp-block-navigation-link__placeholder-text span {
+	.wp-block-navigation-link__placeholder-text {
 		$blur: 10%;
 		$width: 6%;
 		$stop1: 30%;

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -63,12 +63,9 @@
 	}
 
 	.wp-block-navigation-link__placeholder-text {
-		&.is-invalid {
-			--wp-underline-color: var(--wp--preset--color--vivid-red);
-		}
-
+		&.is-invalid,
 		&.is-draft {
-			--wp-underline-color: var(--wp--preset--color--luminous-vivid-amber);
+			--wp-underline-color: var(--wp--preset--color--vivid-red);
 		}
 	}
 }

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -61,6 +61,16 @@
 		margin-bottom: $grid-unit-20;
 		margin-left: $grid-unit-20;
 	}
+
+	.wp-block-navigation-link__placeholder-text {
+		&.is-invalid {
+			--wp-underline-color: var(--wp--preset--color--vivid-red);
+		}
+
+		&.is-draft {
+			--wp-underline-color: var(--wp--preset--color--luminous-vivid-amber);
+		}
+	}
 }
 
 .wp-block-navigation-link__invalid-item {

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -61,13 +61,6 @@
 		margin-bottom: $grid-unit-20;
 		margin-left: $grid-unit-20;
 	}
-
-	.wp-block-navigation-link__placeholder-text {
-		&.is-invalid,
-		&.is-draft {
-			--wp-underline-color: var(--wp--preset--color--vivid-red);
-		}
-	}
 }
 
 .wp-block-navigation-link__invalid-item {
@@ -88,23 +81,33 @@
 
 	// Draw a wavy underline.
 	.wp-block-navigation-link__placeholder-text {
-		$blur: 10%;
-		$width: 6%;
-		$stop1: 30%;
-		$stop2: 64%;
+		span {
+			$blur: 10%;
+			$width: 6%;
+			$stop1: 30%;
+			$stop2: 64%;
 
-		--wp-underline-color: var(--wp-admin-theme-color);
+			--wp-underline-color: var(--wp-admin-theme-color);
 
-		background-image:
-			linear-gradient(45deg, transparent ($stop1 - $blur), var(--wp-underline-color) $stop1, var(--wp-underline-color) ($stop1 + $width), transparent ($stop1 + $width + $blur)),
-			linear-gradient(135deg, transparent ($stop2 - $blur), var(--wp-underline-color) $stop2, var(--wp-underline-color) ($stop2 + $width), transparent ($stop2 + $width + $blur));
-		background-position: 0 100%;
-		background-size: 6px 3px;
-		background-repeat: repeat-x;
+			background-image:
+				linear-gradient(45deg, transparent ($stop1 - $blur), var(--wp-underline-color) $stop1, var(--wp-underline-color) ($stop1 + $width), transparent ($stop1 + $width + $blur)),
+				linear-gradient(135deg, transparent ($stop2 - $blur), var(--wp-underline-color) $stop2, var(--wp-underline-color) ($stop2 + $width), transparent ($stop2 + $width + $blur));
+			background-position: 0 100%;
+			background-size: 6px 3px;
+			background-repeat: repeat-x;
 
-		// Since applied to a span, it doesn't change the footprint of the item,
-		// but it does vertically shift the underline to better align.
-		padding-bottom: 0.1em;
+			// Since applied to a span, it doesn't change the footprint of the item,
+			// but it does vertically shift the underline to better align.
+			padding-bottom: 0.1em;
+		}
+
+
+		&.is-invalid,
+		&.is-draft {
+			span {
+				--wp-underline-color: var(--wp--preset--color--vivid-red);
+			}
+		}
 	}
 
 	// This needs extra specificity.


### PR DESCRIPTION
Fixes: #68597 

## What?
Improves accessibility in the Navigation Link block by replacing tooltips with visual states for invalid and draft links.

## Why?
The current implementation misuses tooltips to show additional information about link states. This creates accessibility issues.

## Testing Instructions

- Test Missing Link State:
  - Add a Navigation block
  - Notice the "Add link" placeholder with a wavy underline
  - Verify no tooltip appears on the hover



- Test Invalid Link State:
  - Add a Navigation Link block
  - Link it to any post
  - Move that post to the trash in another tab
  - Return to editor and refresh

- Verify:

  - Link shows "(Invalid)" suffix
  - Has red wavy underline
  - No tooltip on hover



- Test Draft Link State:
  - Add a Navigation Link block
  - Create and link to a draft post

- Verify:
  - Link shows "(Draft)" suffix
  - Has yellow/warning wavy underline
  - No tooltip on hover

## Screencast 

Before

https://github.com/user-attachments/assets/bcf6d6f3-07f7-4c37-af2f-8f0ae7b0c6de



After


https://github.com/user-attachments/assets/9bfd8978-02ad-49ce-9c0e-bc214971b763




