### PR TITLE
Global Styles: Fix incorrect usage of ItemGroup in the Background image panel

### DIFF
--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -125,7 +125,12 @@ function InspectorImagePreviewItem( {
 		}
 	}, [ toggleProps?.isOpen, onToggleCallback ] );
 	return (
-		<ItemGroup as={ as } className={ className } { ...toggleProps }>
+		<ItemGroup
+			role="none"
+			as={ as }
+			className={ className }
+			{ ...toggleProps }
+		>
 			<HStack
 				justify="flex-start"
 				as="span"

--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -126,7 +126,9 @@ function InspectorImagePreviewItem( {
 	}, [ toggleProps?.isOpen, onToggleCallback ] );
 	return (
 		<ItemGroup
-			role="none"
+			// TODO: Remove role when button is used. This is a temporary fix to not have role="list" on a button.
+			// See https://github.com/WordPress/gutenberg/pull/68631
+			role={ as === 'span' ? 'none' : 'button' }
 			as={ as }
 			className={ className }
 			{ ...toggleProps }

--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -118,13 +118,13 @@ function InspectorImagePreviewItem( {
 	className,
 	onToggleCallback = noop,
 } ) {
-	useEffect( () => {
-		if ( typeof toggleProps?.isOpen !== 'undefined' ) {
-			onToggleCallback( toggleProps?.isOpen );
-		}
-	}, [ toggleProps?.isOpen, onToggleCallback ] );
-
 	const { isOpen, ...restToggleProps } = toggleProps;
+
+	useEffect( () => {
+		if ( typeof isOpen !== 'undefined' ) {
+			onToggleCallback( isOpen );
+		}
+	}, [ isOpen, onToggleCallback ] );
 
 	const renderPreviewContent = () => {
 		return (

--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -17,7 +17,6 @@ import {
 	FocalPointPicker,
 	MenuItem,
 	VisuallyHidden,
-	__experimentalItemGroup as ItemGroup,
 	__experimentalHStack as HStack,
 	__experimentalTruncate as Truncate,
 	Dropdown,
@@ -111,7 +110,6 @@ export const backgroundPositionToCoords = ( value ) => {
 };
 
 function InspectorImagePreviewItem( {
-	as = 'span',
 	imgUrl,
 	toggleProps = {},
 	filename,
@@ -124,12 +122,9 @@ function InspectorImagePreviewItem( {
 			onToggleCallback( toggleProps?.isOpen );
 		}
 	}, [ toggleProps?.isOpen, onToggleCallback ] );
-	return (
-		<ItemGroup
-			// TODO: Remove role when button is used. This is a temporary fix to not have role="list" on a button.
-			// See https://github.com/WordPress/gutenberg/pull/68631
-			role={ as === 'span' ? 'none' : 'button' }
-			as={ as }
+	return imgUrl ? (
+		<Button
+			__next40pxDefaultSize
 			className={ className }
 			{ ...toggleProps }
 		>
@@ -169,7 +164,29 @@ function InspectorImagePreviewItem( {
 					</VisuallyHidden>
 				</FlexItem>
 			</HStack>
-		</ItemGroup>
+		</Button>
+	) : (
+		<FlexItem
+			className={ className }
+			as="span"
+			style={ imgUrl ? {} : { flexGrow: 1 } }
+		>
+			<Truncate
+				numberOfLines={ 1 }
+				className="block-editor-global-styles-background-panel__inspector-media-replace-title"
+			>
+				{ label }
+			</Truncate>
+			<VisuallyHidden as="span">
+				{ imgUrl
+					? sprintf(
+							/* translators: %s: file name */
+							__( 'Background image: %s' ),
+							filename || label
+					  )
+					: __( 'No background image selected' ) }
+			</VisuallyHidden>
+		</FlexItem>
 	);
 }
 
@@ -208,7 +225,6 @@ function BackgroundControlsPanel( {
 						filename={ filename }
 						label={ imgLabel }
 						toggleProps={ toggleProps }
-						as="button"
 						onToggleCallback={ onToggleCallback }
 					/>
 				);

--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -124,6 +124,8 @@ function InspectorImagePreviewItem( {
 		}
 	}, [ toggleProps?.isOpen, onToggleCallback ] );
 
+	const { isOpen, ...restToggleProps } = toggleProps;
+
 	const renderPreviewContent = () => {
 		return (
 			<HStack
@@ -169,7 +171,8 @@ function InspectorImagePreviewItem( {
 		<Button
 			__next40pxDefaultSize
 			className={ className }
-			{ ...toggleProps }
+			{ ...restToggleProps }
+			aria-expanded={ isOpen }
 		>
 			{ renderPreviewContent() }
 		</Button>

--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -124,7 +124,7 @@ function InspectorImagePreviewItem( {
 		}
 	}, [ toggleProps?.isOpen, onToggleCallback ] );
 
-	const renderLabelContent = () => {
+	const renderPreviewContent = () => {
 		return (
 			<HStack
 				justify="flex-start"
@@ -171,10 +171,10 @@ function InspectorImagePreviewItem( {
 			className={ className }
 			{ ...toggleProps }
 		>
-			{ renderLabelContent() }
+			{ renderPreviewContent() }
 		</Button>
 	) : (
-		renderLabelContent()
+		renderPreviewContent()
 	);
 }
 

--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -110,6 +110,7 @@ export const backgroundPositionToCoords = ( value ) => {
 };
 
 function InspectorImagePreviewItem( {
+	as = 'span',
 	imgUrl,
 	toggleProps = {},
 	filename,
@@ -122,12 +123,9 @@ function InspectorImagePreviewItem( {
 			onToggleCallback( toggleProps?.isOpen );
 		}
 	}, [ toggleProps?.isOpen, onToggleCallback ] );
-	return imgUrl ? (
-		<Button
-			__next40pxDefaultSize
-			className={ className }
-			{ ...toggleProps }
-		>
+
+	const renderLabelContent = () => {
+		return (
 			<HStack
 				justify="flex-start"
 				as="span"
@@ -164,29 +162,19 @@ function InspectorImagePreviewItem( {
 					</VisuallyHidden>
 				</FlexItem>
 			</HStack>
+		);
+	};
+
+	return as === 'button' ? (
+		<Button
+			__next40pxDefaultSize
+			className={ className }
+			{ ...toggleProps }
+		>
+			{ renderLabelContent() }
 		</Button>
 	) : (
-		<FlexItem
-			className={ className }
-			as="span"
-			style={ imgUrl ? {} : { flexGrow: 1 } }
-		>
-			<Truncate
-				numberOfLines={ 1 }
-				className="block-editor-global-styles-background-panel__inspector-media-replace-title"
-			>
-				{ label }
-			</Truncate>
-			<VisuallyHidden as="span">
-				{ imgUrl
-					? sprintf(
-							/* translators: %s: file name */
-							__( 'Background image: %s' ),
-							filename || label
-					  )
-					: __( 'No background image selected' ) }
-			</VisuallyHidden>
-		</FlexItem>
+		renderLabelContent()
 	);
 }
 
@@ -225,6 +213,7 @@ function BackgroundControlsPanel( {
 						filename={ filename }
 						label={ imgLabel }
 						toggleProps={ toggleProps }
+						as="button"
 						onToggleCallback={ onToggleCallback }
 					/>
 				);

--- a/packages/components/src/number-control/stories/index.story.tsx
+++ b/packages/components/src/number-control/stories/index.story.tsx
@@ -45,7 +45,6 @@ const Template: StoryFn< typeof NumberControl > = ( {
 			<NumberControl
 				{ ...props }
 				value={ value }
-				className="hello"
 				onChange={ ( v, extra ) => {
 					setValue( v );
 					setIsValidValue(

--- a/packages/components/src/number-control/stories/index.story.tsx
+++ b/packages/components/src/number-control/stories/index.story.tsx
@@ -45,6 +45,7 @@ const Template: StoryFn< typeof NumberControl > = ( {
 			<NumberControl
 				{ ...props }
 				value={ value }
+				className="hello"
 				onChange={ ( v, extra ) => {
 					setValue( v );
 					setIsValidValue(


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/67425

## What?
Improved the `ItemGroup` component to handle role attributes correctly based on its rendered HTML element. When rendered as a span, it now applies `role="none"` to prevent incorrect semantic meaning, and when rendered as a button, it correctly applies `role="button"`.


## Why?

The previous implementation incorrectly applied `role="list"` in scenarios where a semantic list wasn't appropriate, causing accessibility issues. This change ensures we maintain proper accessibility standards by applying the correct ARIA roles based on the actual HTML element being rendered.


## How?
Updated the component to conditionally set the role attribute based on the as prop:

1. When as="span", it sets `role="none"` to remove any implied semantic meaning
2. Otherwise, it applies `role="button`" for proper accessibility

## Testing Instructions

1. Navigate to Appearance > Editor
2. Navigate to Global Styles > Background.
3. Inspect rendered Button labeled 'Add background image'  and confirm they no longer include `role="list"` when unnecessary.
4. Validate that UI behavior and appearance remain unaffected.



|Before|After|
|-|-|
|<img width="1470" alt="Screenshot 2025-01-13 at 3 04 57 PM" src="https://github.com/user-attachments/assets/9d7be483-5629-4357-a360-9ba89d6c96fe" />|<img width="1470" alt="Screenshot 2025-01-13 at 3 14 12 PM" src="https://github.com/user-attachments/assets/9f7bb698-acfc-4a48-b4b5-e7941fb6a204" />
|
