### PR TITLE
Inline Commenting: Avoid querying comments when the experiment is disabled

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -29,8 +29,6 @@ import AddCommentToolbarButton from './comment-button-toolbar';
 import { useGlobalStylesContext } from '../global-styles-provider';
 import { getCommentIdsFromBlocks } from './utils';
 
-const isBlockCommentExperimentEnabled =
-	window?.__experimentalEnableBlockComment;
 const modifyBlockCommentAttributes = ( settings ) => {
 	if ( ! settings.attributes.blockCommentId ) {
 		settings.attributes = {
@@ -329,8 +327,7 @@ export default function CollabSidebar() {
 		} );
 	}
 
-	// Check if the experimental flag is enabled.
-	if ( ! isBlockCommentExperimentEnabled || postStatus === 'publish' ) {
+	if ( postStatus === 'publish' ) {
 		return null; // or maybe return some message indicating no threads are available.
 	}
 

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -32,6 +32,9 @@ import {
 } from '../../store/constants';
 import { unlock } from '../../lock-unlock';
 
+const isBlockCommentExperimentEnabled =
+	window?.__experimentalEnableBlockComment;
+
 const toolbarVariations = {
 	distractionFreeDisabled: { y: '-50px' },
 	distractionFreeHover: { y: 0 },
@@ -195,7 +198,10 @@ function Header( {
 						}
 					/>
 				) }
-				<CollabSidebar />
+
+				{ isBlockCommentExperimentEnabled ? (
+					<CollabSidebar />
+				) : undefined }
 
 				{ customSaveButton }
 				<MoreMenu />


### PR DESCRIPTION
## What?
PR moves the experimental block comments check and avoids rendering the `CollabSidebar` component when the experiment is disabled.

## Why?
* Avoids making unnecessary REST API requests and computations when the experiment is disabled. See: https://github.com/WordPress/gutenberg/pull/67347#discussion_r1869091369.
* Prevents potentially leaking experimental features into major WP releases.

## Testing Instructions
1. Ensure "Enables multi-user block level commenting." is disabled.
2. Open a post.
3. Confirm that no request is made for the `comments` endpoint.
4. Confirm that the experiment works as before when enabled.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2025-01-13 at 13 57 27](https://github.com/user-attachments/assets/76ecab83-a0f0-4d90-af39-bc396de69e0f)

