### PR TITLE
Global Styles: Prevent Unwanted ItemGroup List Rendering in Border Panel 

### DIFF
--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -298,7 +298,7 @@ export default function BorderPanel( {
 						</BaseControl.VisualLabel>
 					) : null }
 
-					<ItemGroup isBordered isSeparated>
+					<ItemGroup isBordered isSeparated role="none">
 						<ShadowPopover
 							shadow={ shadow }
 							onShadowChange={ setShadow }

--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -7,7 +7,6 @@ import {
 	__experimentalIsDefinedBorder as isDefinedBorder,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
-	__experimentalItemGroup as ItemGroup,
 	BaseControl,
 } from '@wordpress/components';
 import { useCallback, useMemo } from '@wordpress/element';
@@ -298,13 +297,11 @@ export default function BorderPanel( {
 						</BaseControl.VisualLabel>
 					) : null }
 
-					<ItemGroup isBordered isSeparated role="none">
-						<ShadowPopover
-							shadow={ shadow }
-							onShadowChange={ setShadow }
-							settings={ settings }
-						/>
-					</ItemGroup>
+					<ShadowPopover
+						shadow={ shadow }
+						onShadowChange={ setShadow }
+						settings={ settings }
+					/>
 				</ToolsPanelItem>
 			) }
 		</Wrapper>

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -61,11 +61,6 @@
 	}
 }
 
-.block-editor-global-styles-filters-panel__dropdown {
-	border: 1px solid $gray-300;
-	border-radius: $radius-small;
-}
-
 // These styles are similar to the color palette.
 .block-editor-global-styles__shadow-indicator {
 	appearance: none;

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -25,9 +25,6 @@
 	display: block;
 	padding: 0;
 	position: relative;
-}
-
-.block-editor-global-styles__shadow-dropdown {
 	border: 1px solid $gray-300;
 	border-radius: $radius-small;
 }

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -27,6 +27,11 @@
 	position: relative;
 }
 
+.block-editor-global-styles__shadow-dropdown {
+	border: 1px solid $gray-300;
+	border-radius: $radius-small;
+}
+
 .block-editor-global-styles-filters-panel__dropdown-toggle,
 .block-editor-global-styles__shadow-dropdown-toggle {
 	width: 100%;


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/67425

## What?
Revised `<ItemGroup>` to use `role="none"` and prevent it from rendering an unnecessary `role="list"` when it is not semantically required.

## Why?

Avoids adding unwanted list roles where a semantic list is not necessary, ensuring accessibility standards are maintained without enforcing unnecessary constraints.

## How?

Updated `<ItemGroup>` to include `role="none"` and an optional as prop for flexibility. Removed instances of `role="list" `where a list structure wasn't required.


## Testing Instructions

1. Add a new post.
2. Add a block, such as a button, that includes shadow support.
3. Inspect the "Drop Shadow" section of the button and observe the rendered ItemsGroup element.
4. Validate that the UI behavior and appearance remain unchanged.

## Screenshots or screencast 


### Before
<img width="1470" alt="Screenshot 2025-01-13 at 3 38 24 PM" src="https://github.com/user-attachments/assets/d13b376d-352d-4769-b464-37aaea2c0c56" />


### After
<img width="1470" alt="Screenshot 2025-01-13 at 3 36 39 PM" src="https://github.com/user-attachments/assets/2fd777f5-62ed-4d04-aa6a-28f85b0c24b2" />
