### PR TITLE
Storybook: Add Story for Block Manager

### DIFF
--- a/packages/block-editor/src/components/block-manager/stories/index.story.js
+++ b/packages/block-editor/src/components/block-manager/stories/index.story.js
@@ -1,0 +1,97 @@
+/**
+ * Internal dependencies
+ */
+import BlockManager from '..';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+const meta = {
+	title: 'BlockEditor/BlockManager',
+	component: BlockManager,
+	tags: [ 'status-private' ],
+	parameters: {
+		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
+			description: {
+				component:
+					'The BlockSwitcher component is used to switch between different block types.',
+			},
+		},
+	},
+	argTypes: {
+		blockTypes: {
+			control: {
+				type: null,
+			},
+			description: 'An array of blocks.',
+			table: {
+				type: { summary: 'Array' },
+			},
+		},
+		selectedBlockTypes: {
+			control: {
+				type: null,
+			},
+			description: 'An array of selected blocks.',
+			table: {
+				type: { summary: 'Array' },
+			},
+		},
+		onChange: {
+			action: 'onChange',
+			control: {
+				type: null,
+			},
+			description:
+				'Function to be called when the selected blocks change.',
+			table: {
+				type: {
+					summary: 'Function',
+				},
+			},
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	args: {
+		blockTypes: [
+			{
+				name: 'core/paragraph',
+				title: 'Paragraph',
+			},
+			{
+				name: 'core/heading',
+				title: 'Heading',
+			},
+		],
+		selectedBlockTypes: [
+			{
+				name: 'core/heading',
+				title: 'Heading',
+			},
+		],
+	},
+	render: function Template( { onChange, ...args } ) {
+		const [ selectedBlockTypes, setSelectedBlockTypes ] = useState(
+			args.selectedBlockTypes
+		);
+		return (
+			<BlockManager
+				{ ...args }
+				onChange={ ( newSelectedBlockTypes ) => {
+					setSelectedBlockTypes( newSelectedBlockTypes );
+					onChange( newSelectedBlockTypes );
+				} }
+				selectedBlockTypes={ selectedBlockTypes }
+			/>
+		);
+	},
+};

--- a/packages/block-editor/src/components/block-manager/stories/index.story.js
+++ b/packages/block-editor/src/components/block-manager/stories/index.story.js
@@ -19,7 +19,7 @@ const meta = {
 			},
 			description: {
 				component:
-					'The BlockSwitcher component is used to switch between different block types.',
+					'The `BlockManager` component displays a list of blocks with quick navigation.',
 			},
 		},
 	},


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?

This PR adds the story for Block Manager Component

## Testing Instructions
- Run npm run storybook:dev
- Open Storybook at http://localhost:50240/
- Check the BlockSwitcher Story

## Screenshots or screencast 


https://github.com/user-attachments/assets/9fb914e4-646c-489d-9e4b-20ccbe533e15


