### PR TITLE
Zoom Out: Prevent showing `Quick Inserter` in zoom out mode

### DIFF
--- a/packages/block-editor/src/components/block-tools/use-show-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/use-show-block-tools.js
@@ -24,6 +24,7 @@ export function useShowBlockTools() {
 			getBlockMode,
 			getSettings,
 			__unstableGetEditorMode,
+			isZoomOut,
 			isTyping,
 		} = unlock( select( blockEditorStore ) );
 
@@ -37,12 +38,14 @@ export function useShowBlockTools() {
 			hasSelectedBlock &&
 			isUnmodifiedDefaultBlock( block ) &&
 			getBlockMode( clientId ) !== 'html';
+		const isZoomOutMode = isZoomOut();
 		const _showEmptyBlockSideInserter =
 			clientId &&
 			! isTyping() &&
 			// Hide the block inserter on the navigation mode.
 			// See https://github.com/WordPress/gutenberg/pull/66636#discussion_r1824728483.
 			editorMode !== 'navigation' &&
+			! isZoomOutMode &&
 			isEmptyDefaultBlock;
 		const _showBlockToolbarPopover =
 			! getSettings().hasFixedToolbar &&


### PR DESCRIPTION
## What, Why and How?
The `Quick Inserter` remained visible during `zoom out` mode due to a missing check in the rendering logic. The issue was resolved by adding a condition to verify if `zoom out` mode is active before displaying the `Quick Inserter`.

## Testing Instructions
1. Navigate to `Site Editor`.
2. Create a `paragraph` block.
3. Notice, that the `Quick Inserter` becomes visible when the `paragraph` block is selected.
4. Try zooming out and confirm the `Quick Inserter` is not visible when zoomed out.

## Screencast
https://github.com/user-attachments/assets/7ac62ce7-4138-4eac-b931-586d7ab95bcf

Closes: #68287 