### PR TITLE
Skip flaky 'navigation-frontend-interactivity' e2e tests on Firefox

### DIFF
--- a/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
@@ -375,7 +375,16 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			} );
 		} );
 
-		test( 'submenu click on the arrow interactions', async ( { page } ) => {
+		test( 'submenu click on the arrow interactions', async ( {
+			page,
+			browserName,
+		} ) => {
+			// eslint-disable-next-line playwright/no-skipped-test
+			test.skip(
+				browserName === 'firefox',
+				'The test is flaky when running on Firefox'
+			);
+
 			await page.goto( '/' );
 			const arrowButton = page.getByRole( 'button', {
 				name: 'Submenu submenu',
@@ -470,7 +479,13 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 		test( 'page-list submenu user interactions', async ( {
 			page,
 			pageUtils,
+			browserName,
 		} ) => {
+			// eslint-disable-next-line playwright/no-skipped-test
+			test.skip(
+				browserName === 'firefox',
+				'The test is flaky when running on Firefox'
+			);
 			await page.goto( '/' );
 			const submenuButton = page.getByRole( 'button', {
 				name: 'Parent',


### PR DESCRIPTION
## What?
These tests are consistently failing ([example](https://github.com/WordPress/gutenberg/actions/runs/12749872443/attempts/1?pr=67766)). Skipping them for Firefox until anyone has time to debug the root cause.

## Testing Instructions
Testart E2E test CI jobs a couple of times. Confirm that skipped tests aren't failing for other browsers.
