### PR TITLE
Storybook: Add Image Editor Component

### DIFF
--- a/packages/block-editor/src/components/image-editor/index.js
+++ b/packages/block-editor/src/components/image-editor/index.js
@@ -14,6 +14,45 @@ import ZoomDropdown from './zoom-dropdown';
 import RotationButton from './rotation-button';
 import FormControls from './form-controls';
 
+/**
+ * ImageEditor component displays the image editor UI.
+ *
+ * @param {Object}   props                 Component props.
+ * @param {string}   props.id              The id of the image being edited.
+ * @param {string}   props.url             The url of the image being edited.
+ * @param {number}   props.width           The width of the image being edited.
+ * @param {number}   props.height          The height of the image being edited.
+ * @param {number}   props.naturalHeight   The natural height of the image being edited.
+ * @param {number}   props.naturalWidth    The natural width of the image being edited.
+ * @param {Function} props.onSaveImage     Callback to save the image.
+ * @param {Function} props.onFinishEditing Callback to finish editing the image.
+ * @param {Object}   props.borderProps     Border properties.
+ *
+ * @return {Element} The ImageEditor component
+ *
+ * @example
+ * ```jsx
+ * function MyImageEditor() {
+ * 	return (
+ * 		<ImageEditor
+ * 			id="image-id"
+ * 			url="https://example.com/image.jpg"
+ * 			width={ 300 }
+ * 			height={ 200 }
+ * 			naturalWidth={ 600 }
+ * 			naturalHeight={ 400 }
+ * 			onSaveImage={() => {}}
+ * 			onFinishEditing={() => {}}
+ * 			borderProps={{
+ * 				style: {
+ * 					backgroundColor: '#e0e0e0',
+ *               },
+ *              className: 'my-image-editor',
+ * 			}}
+ * 		/>
+ * 	);
+ * }
+ */
 export default function ImageEditor( {
 	id,
 	url,

--- a/packages/block-editor/src/components/image-editor/stories/index.story.js
+++ b/packages/block-editor/src/components/image-editor/stories/index.story.js
@@ -84,7 +84,7 @@ const meta = {
 		},
 		onSaveImage: {
 			control: {
-				type: 'function',
+				type: null,
 			},
 			description: 'Function to call when the image is saved',
 			table: {
@@ -95,7 +95,7 @@ const meta = {
 		},
 		onFinishEditing: {
 			control: {
-				type: 'function',
+				type: null,
 			},
 			description: 'Function to call when editing is finished',
 			table: {
@@ -108,7 +108,7 @@ const meta = {
 			control: {
 				type: 'object',
 			},
-			description: 'Border properties of the image being edited',
+			description: 'The area around the image',
 			table: {
 				type: {
 					summary: 'object',
@@ -125,15 +125,14 @@ export const Default = {
 		id: 'image-id',
 		url: 'https://cdn-icons-png.flaticon.com/512/174/174881.png',
 		width: 300,
-		height: 200,
+		height: 300,
 		naturalHeight: 600,
 		naturalWidth: 800,
-		onSaveImage: () => {},
-		onFinishEditing: () => {},
 		borderProps: {
-			borderRadius: 5,
-			borderWidth: 1,
-			borderColor: 'green',
+			style: {
+				backgroundColor: '#e0e0e0',
+				border: '1px solid #000',
+			},
 		},
 	},
 	render: function Template( args ) {

--- a/packages/block-editor/src/components/image-editor/stories/index.story.js
+++ b/packages/block-editor/src/components/image-editor/stories/index.story.js
@@ -1,0 +1,142 @@
+/**
+ * Internal dependencies
+ */
+import ImageEditor from '..';
+
+const meta = {
+	title: 'BlockEditor/ImageEditor',
+	component: ImageEditor,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'The `ImageEditor` component is used to edit images in the block editor',
+			},
+		},
+	},
+	argTypes: {
+		id: {
+			control: {
+				type: 'text',
+			},
+			description: 'The id of the image being edited',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		url: {
+			control: {
+				type: 'text',
+			},
+			description: 'The url of the image being edited',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		width: {
+			control: {
+				type: 'number',
+			},
+			description: 'The width of the image being edited',
+			table: {
+				type: {
+					summary: 'number',
+				},
+			},
+		},
+		height: {
+			control: {
+				type: 'number',
+			},
+			description: 'The height of the image being edited',
+			table: {
+				type: {
+					summary: 'number',
+				},
+			},
+		},
+		naturalHeight: {
+			control: {
+				type: 'number',
+			},
+			description: 'The natural height of the image being edited',
+			table: {
+				type: {
+					summary: 'number',
+				},
+			},
+		},
+		naturalWidth: {
+			control: {
+				type: 'number',
+			},
+			description: 'The natural width of the image being edited',
+			table: {
+				type: {
+					summary: 'number',
+				},
+			},
+		},
+		onSaveImage: {
+			control: {
+				type: 'function',
+			},
+			description: 'Function to call when the image is saved',
+			table: {
+				type: {
+					summary: 'function',
+				},
+			},
+		},
+		onFinishEditing: {
+			control: {
+				type: 'function',
+			},
+			description: 'Function to call when editing is finished',
+			table: {
+				type: {
+					summary: 'function',
+				},
+			},
+		},
+		borderProps: {
+			control: {
+				type: 'object',
+			},
+			description: 'Border properties of the image being edited',
+			table: {
+				type: {
+					summary: 'object',
+				},
+			},
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	args: {
+		id: 'image-id',
+		url: 'https://cdn-icons-png.flaticon.com/512/174/174881.png',
+		width: 300,
+		height: 200,
+		naturalHeight: 600,
+		naturalWidth: 800,
+		onSaveImage: () => {},
+		onFinishEditing: () => {},
+		borderProps: {
+			borderRadius: 5,
+			borderWidth: 1,
+			borderColor: 'green',
+		},
+	},
+	render: function Template( args ) {
+		return <ImageEditor { ...args } />;
+	},
+};


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR adds storybook for Image Editor Component 

## Testing Instructions
- Start Storybook by running npm run storybook:dev
- Open Storybook at http://localhost:50240/
- Navigate to "BlockEditor/ImageEditor" in the Storybook sidebar

## Screenshots or screencast 

https://github.com/user-attachments/assets/fdc5bf2c-d854-4a4b-b75f-a48c798d75c4
