### PR TITLE
Fix: Add isNavigationBlock utility to identify navigation blocks

### DIFF
--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -6,6 +6,7 @@ import {
 	store as blocksStore,
 	isReusableBlock,
 	isTemplatePart,
+	isNavigationBlock,
 	__experimentalGetBlockLabel as getBlockLabel,
 } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
@@ -83,7 +84,9 @@ export default function useBlockDisplayInformation( clientId ) {
 			const attributes = getBlockAttributes( clientId );
 			const match = getActiveBlockVariation( blockName, attributes );
 			const isSynced =
-				isReusableBlock( blockType ) || isTemplatePart( blockType );
+				isReusableBlock( blockType ) ||
+				isTemplatePart( blockType ) ||
+				isNavigationBlock( blockType );
 			const syncedTitle = isSynced
 				? getBlockLabel( blockType, attributes )
 				: undefined;

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -365,6 +365,18 @@ _Returns_
 
 -   `boolean`: True if a block contains at least one child blocks with inserter support and false otherwise.
 
+### isNavigationBlock
+
+Determines whether or not the given block is a navigation block. This is a special block type that is used to represent a navigation menu.
+
+_Parameters_
+
+-   _blockOrType_ `Object`: Block or Block Type to test.
+
+_Returns_
+
+-   `boolean`: Whether the given block is a navigation block.
+
 ### isReusableBlock
 
 Determines whether or not the given block is a reusable block. This is a special block type that is used to point to a global block stored via the API.

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -133,6 +133,7 @@ export {
 	getBlockVariations,
 	isReusableBlock,
 	isTemplatePart,
+	isNavigationBlock,
 	getChildBlockNames,
 	hasChildBlocks,
 	hasChildBlocksWithInserterSupport,

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -580,6 +580,18 @@ export function isTemplatePart( blockOrType ) {
 }
 
 /**
+ * Determines whether or not the given block is a navigation block. This is a
+ * special block type that is used to represent a navigation menu.
+ *
+ * @param {Object} blockOrType Block or Block Type to test.
+ *
+ * @return {boolean} Whether the given block is a navigation block.
+ */
+export function isNavigationBlock( blockOrType ) {
+	return blockOrType?.name === 'core/navigation';
+}
+
+/**
  * Returns an array with the child blocks of a given block.
  *
  * @param {string} blockName Name of block (example: “latest-posts”).


### PR DESCRIPTION
## What, Why and How?
While determining the `Block Information`, the `Navigation` block is incorrectly excluded as a `synced block`. This PR addresses and resolves that issue.

## Testing Instructions
1. Navigate to the `site editor`.
2. Create a `Navigation` block.
3. Notice, the block's name is displayed in the `Block Card`.

## Screenshots

|Before|
|-|
|![before](https://github.com/user-attachments/assets/52610bd0-ea2e-416d-8b2b-ad1e94b13f93)|

|After|
|-|
|![after](https://github.com/user-attachments/assets/baedaf65-6142-4a69-ad66-755cd6b7ad73)|

Closes: #68646 