### PR TITLE
Updated Inline Document order

### DIFF
--- a/packages/interface/src/components/complementary-area-toggle/index.js
+++ b/packages/interface/src/components/complementary-area-toggle/index.js
@@ -13,9 +13,9 @@ import { store as interfaceStore } from '../../store';
 /**
  * Whether the role supports checked state.
  *
+ * @see https://www.w3.org/TR/wai-aria-1.1/#aria-checked
  * @param {import('react').AriaRole} role Role.
  * @return {boolean} Whether the role supports checked state.
- * @see https://www.w3.org/TR/wai-aria-1.1/#aria-checked
  */
 function roleSupportsCheckedState( role ) {
 	return [

--- a/packages/react-native-bridge/common/gutenberg-web-single-block/editor-behavior-overrides.js
+++ b/packages/react-native-bridge/common/gutenberg-web-single-block/editor-behavior-overrides.js
@@ -13,8 +13,8 @@ function isAndroid() {
  * tapped. This is done via the 'hideTextSelectionContextMenu' method, which
  * is sent back to the Android app, where the dismissal is then handle.
  *
- * @return {void}
  * @see https://github.com/WordPress/gutenberg/pull/34668
+ * @return {void}
  */
 function manageTextSelectionContextMenu() {
 	// Listeners for native context menu visibility changes.


### PR DESCRIPTION
Updated Inline Document Order in Below Mentioned Files according to [Php Coding Standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php)

- packages/interface/src/components/complementary-area-toggle/index.js
- packages/react-native-bridge/common/gutenberg-web-single-block/editor-behavior-overrides.js