### PR TITLE
fix: Icons not showing in sidebar editor for some template parts

### DIFF
--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -26,6 +26,10 @@ import { unlock } from '../../lock-unlock';
 import PostActions from '../post-actions';
 import usePageTypeBadge from '../../utils/pageTypeBadge';
 import { getTemplateInfo } from '../../utils/get-template-info';
+import {
+	getTemplatePartIcon,
+	templateParts,
+} from '../../utils/get-template-part-icon';
 const { Badge } = unlock( componentsPrivateApis );
 
 /**
@@ -104,7 +108,14 @@ export default function PostCardPanel( {
 				className="editor-post-card-panel__header"
 				align="flex-start"
 			>
-				<Icon className="editor-post-card-panel__icon" icon={ icon } />
+				<Icon
+					className="editor-post-card-panel__icon"
+					icon={
+						templateParts.includes( icon )
+							? getTemplatePartIcon( icon )
+							: icon
+					}
+				/>
 				<Text
 					numberOfLines={ 2 }
 					truncate

--- a/packages/editor/src/dataviews/fields/content-preview/content-preview-view.tsx
+++ b/packages/editor/src/dataviews/fields/content-preview/content-preview-view.tsx
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
+	// @ts-ignore
 	BlockPreview,
 	privateApis as blockEditorPrivateApis,
 	// @ts-ignore

--- a/packages/editor/src/utils/get-template-part-icon.js
+++ b/packages/editor/src/utils/get-template-part-icon.js
@@ -24,3 +24,5 @@ export function getTemplatePartIcon( iconName ) {
 	}
 	return symbolFilledIcon;
 }
+
+export const templateParts = [ 'header', 'footer', 'sidebar' ];


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->
Address https://github.com/WordPress/gutenberg/issues/68649

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Icons not showing for the header and footer template part in the site editor.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
- Open the Site Editor.
- Edit a Header template part.
- Confirm that icon is displayed in document settings.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/c5d64b38-3775-40d0-b024-417967044d6d


