### PR TITLE
Social Links: Don't prepend URL fragments

### DIFF
--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -42,9 +42,9 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 
 	/**
 	 * Prepend URL with https:// if it doesn't appear to contain a scheme
-	 * and it's not a relative link starting with //.
+	 * and it's not a relative link or a fragment.
 	 */
-	if ( ! parse_url( $url, PHP_URL_SCHEME ) && ! str_starts_with( $url, '//' ) ) {
+	if ( ! parse_url( $url, PHP_URL_SCHEME ) && ! str_starts_with( $url, '//' ) && ! str_starts_with( $url, '#' ) ) {
 		$url = 'https://' . $url;
 	}
 


### PR DESCRIPTION
## What?
This is a follow-up to #42167.
PR of https://github.com/WordPress/gutenberg/issues/55543#issuecomment-2327932561.

PR updates logic in Social Links rendered and avoids prepending URL fragments with `https://`.

## Why?
The fragments are valid URLs often used as placeholders for Social Icons. They can also refer to social sections on a website.

## Testing Instructions
1. Open a Post or Page
2. Insert the example block (snippet below).
3. Save and view the post.
4. On the front end, inspect block elements and confirm that the Instagram fragment has no `https://` prefix.
5. Confirm that other links are rendered correctly.

<details><summary>Social Links example</summary>
<p>

```html
<!-- wp:social-links -->
<ul class="wp-block-social-links"><!-- wp:social-link {"url":"//twitter.com/WordPress","service":"twitter"} /-->
<!-- wp:social-link {"url":"profiles.wordpress.org/wordpress/","service":"wordpress"} /-->
<!-- wp:social-link {"url":"http://github.com/WordPress","service":"github"} /-->
<!-- wp:social-link {"url":"#instagram","service":"instagram"} /--></ul>
<!-- /wp:social-links -->
``` 

</p>
</details> 

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
