### PR TITLE
Warn if a template does not have one main element

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -478,6 +478,10 @@ Monitors local autosaves of a post in the editor. It uses several hooks and func
 
 The module also checks for sessionStorage support and conditionally exports the `LocalAutosaveMonitor` component based on that.
 
+### MainElementWarnings
+
+Undocumented declaration.
+
 ### MediaPlaceholder
 
 > **Deprecated** since 5.3, use `wp.blockEditor.MediaPlaceholder` instead.

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -26,6 +26,7 @@ import SavePublishPanels from '../save-publish-panels';
 import TextEditor from '../text-editor';
 import VisualEditor from '../visual-editor';
 import EditorContentSlotFill from './content-slot-fill';
+import MainElementWarnings from '../main-element-warnings';
 
 const interfaceLabels = {
 	/* translators: accessibility text for the editor top bar landmark region. */
@@ -139,7 +140,10 @@ export default function EditorInterface( {
 			content={
 				<>
 					{ ! isDistractionFree && ! isPreviewMode && (
-						<EditorNotices />
+						<>
+							<EditorNotices />
+							<MainElementWarnings />
+						</>
 					) }
 
 					<EditorContentSlotFill.Slot>

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -21,6 +21,7 @@ export { default as EntitiesSavedStates } from './entities-saved-states';
 export { useIsDirty as useEntitiesSavedStatesIsDirty } from './entities-saved-states/hooks/use-is-dirty';
 export { default as ErrorBoundary } from './error-boundary';
 export { default as LocalAutosaveMonitor } from './local-autosave-monitor';
+export { default as MainElementWarnings } from './main-element-warnings';
 export { default as PageAttributesCheck } from './page-attributes/check';
 export { default as PageAttributesOrder } from './page-attributes/order';
 export { default as PageAttributesPanel } from './page-attributes/panel';

--- a/packages/editor/src/components/main-element-warnings/index.js
+++ b/packages/editor/src/components/main-element-warnings/index.js
@@ -1,0 +1,57 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
+const checkMainTag = ( blocks, mainTagCount ) => {
+	blocks.forEach( ( block ) => {
+		if ( block.attributes.tagName === 'main' ) {
+			mainTagCount++;
+		}
+		// If the block has innerBlocks, call the function again.
+		if ( block.innerBlocks.length > 0 ) {
+			mainTagCount = checkMainTag( block.innerBlocks, mainTagCount );
+		}
+	} );
+
+	return mainTagCount;
+};
+
+export default function MainElementWarnings() {
+	const { type, blocks } = useSelect( ( select ) => {
+		const postType = select( editorStore ).getCurrentPostType();
+		const { getBlocks } = select( blockEditorStore );
+		return {
+			type: postType,
+			blocks: getBlocks(),
+		};
+	}, [] );
+
+	const { createWarningNotice, removeNotice } = useDispatch( noticesStore );
+
+	useEffect( () => {
+		if ( 'wp_template' === type ) {
+			const mainTagCount = checkMainTag( blocks, 0 );
+
+			removeNotice( 'edit-site-main-notice' );
+
+			if ( 0 === mainTagCount || 1 < mainTagCount ) {
+				createWarningNotice(
+					__( 'Your template should have exactly one main element.' ),
+					{ id: 'edit-site-main-notice' }
+				);
+			}
+		}
+	}, [ type, blocks, createWarningNotice, removeNotice ] );
+
+	return null;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds a new component that checks if a template has exactly one main HTML element, and creates a dismissible warning notice if the main HTML element is used incorrectly.

Closes https://github.com/WordPress/gutenberg/issues/35354

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Having a single `<main>` element in a template is important for accessibility, but also for the Zoom Out feature.
The skip link feature is only enabled on templates that has a `<main> `element.
See the issue for more details.

## Testing Instructions
Activate a block theme
Go to Appearance > Editor and open any template.
If there is no warning message at the top of the editor, then the template has a `<main>` element.
Locate the block with the `<main>` element: This is usually a group, but any block with the `tagName` attribute could be using it.

Duplicate the block with the `<main>` element and confirm if there is a warning at the top of the editor.
Confirm that the warning can be dismissed.
Delete all blocks with a `<main>` element and confirm if there is a warning at the top of the editor.

## Screenshots or screencast <!-- if applicable -->

<img width="1499" alt="The Site Editor with the Home template open, a warning notice shows at the top of the editor." src="https://github.com/user-attachments/assets/74620f57-ebea-4fb8-b929-23a7a6b8d5c6" />

