### PR TITLE
Details Block: Fix empty summary fallback and add translation support

### DIFF
--- a/packages/block-library/src/details/save.js
+++ b/packages/block-library/src/details/save.js
@@ -2,10 +2,13 @@
  * WordPress dependencies
  */
 import { RichText, useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
 
 export default function save( { attributes } ) {
 	const { showContent } = attributes;
-	const summary = attributes.summary ? attributes.summary : 'Details';
+	const summary = attributes.summary?.toString().trim()
+		? attributes.summary
+		: __( 'Details' );
 	const blockProps = useBlockProps.save();
 
 	return (

--- a/packages/block-library/src/details/save.js
+++ b/packages/block-library/src/details/save.js
@@ -2,19 +2,15 @@
  * WordPress dependencies
  */
 import { RichText, useBlockProps, InnerBlocks } from '@wordpress/block-editor';
-import { __ } from '@wordpress/i18n';
 
 export default function save( { attributes } ) {
 	const { showContent } = attributes;
-	const summary = attributes.summary?.toString().trim()
-		? attributes.summary
-		: __( 'Details' );
 	const blockProps = useBlockProps.save();
 
 	return (
 		<details { ...blockProps } open={ showContent }>
 			<summary>
-				<RichText.Content value={ summary } />
+				<RichText.Content value={ attributes.summary } />
 			</summary>
 			<InnerBlocks.Content />
 		</details>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes: https://github.com/WordPress/gutenberg/issues/68657

## What?
Fix the fallback text behaviour for empty summaries in the Details block.

## How?
- Added proper empty content check using `toString().trim()`
- Made the fallback text translatable using `__()` from `@wordpress/i18n`

## Screenshots or screencast <!-- if applicable -->
![image](https://github.com/user-attachments/assets/5dd3de84-38a1-49ba-bc43-1ab902de71cc)

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
