### PR TITLE
Cover: Fix placeholder color options keyboard accessibility

### DIFF
--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -203,7 +203,7 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
                 class="components-circular-option-picker"
               >
                 <div
-                  aria-label="Custom color picker."
+                  aria-label="Custom color picker"
                   id="components-circular-option-picker-0"
                   role="listbox"
                 >

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -515,6 +515,7 @@ function CoverEdit( {
 								onChange={ onSetOverlayColor }
 								clearable={ false }
 								asButtons
+								aria-label={ __( 'Background color' ) }
 							/>
 						</div>
 					</CoverPlaceholder>

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -515,7 +515,7 @@ function CoverEdit( {
 								onChange={ onSetOverlayColor }
 								clearable={ false }
 								asButtons
-								aria-label={ __( 'Background color' ) }
+								aria-label={ __( 'Overlay color' ) }
 							/>
 						</div>
 					</CoverPlaceholder>

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -514,6 +514,7 @@ function CoverEdit( {
 								value={ overlayColor.color }
 								onChange={ onSetOverlayColor }
 								clearable={ false }
+								asButtons
 							/>
 						</div>
 					</CoverPlaceholder>

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -47,7 +47,7 @@ async function setup( attributes, useCoreBlocks, customSettings ) {
 
 async function createAndSelectBlock() {
 	await userEvent.click(
-		screen.getByRole( 'option', {
+		screen.getByRole( 'button', {
 			name: 'Black',
 		} )
 	);
@@ -72,7 +72,7 @@ describe( 'Cover block', () => {
 
 		test( 'can set overlay color using color picker on block placeholder', async () => {
 			const { container } = await setup();
-			const colorPicker = screen.getByRole( 'option', {
+			const colorPicker = screen.getByRole( 'button', {
 				name: 'Black',
 			} );
 			await userEvent.click( colorPicker );
@@ -96,7 +96,7 @@ describe( 'Cover block', () => {
 			await setup();
 
 			await userEvent.click(
-				screen.getByRole( 'option', {
+				screen.getByRole( 'button', {
 					name: 'Black',
 				} )
 			);
@@ -389,7 +389,7 @@ describe( 'Cover block', () => {
 	describe( 'isDark settings', () => {
 		test( 'should toggle is-light class if background changed from light to dark', async () => {
 			await setup();
-			const colorPicker = screen.getByRole( 'option', {
+			const colorPicker = screen.getByRole( 'button', {
 				name: 'White',
 			} );
 			await userEvent.click( colorPicker );
@@ -413,7 +413,7 @@ describe( 'Cover block', () => {
 		} );
 		test( 'should remove is-light class if overlay color is removed', async () => {
 			await setup();
-			const colorPicker = screen.getByRole( 'option', {
+			const colorPicker = screen.getByRole( 'button', {
 				name: 'White',
 			} );
 			await userEvent.click( colorPicker );
@@ -426,7 +426,7 @@ describe( 'Cover block', () => {
 				} )
 			);
 			await userEvent.click( screen.getByText( 'Overlay' ) );
-			// The default color is black, so clicking the black color option will remove the background color,
+			// The default color is black, so clicking the black color button will remove the background color,
 			// which should remove the isDark setting and assign the is-light class.
 			const popupColorPicker = screen.getByRole( 'option', {
 				name: 'White',

--- a/packages/components/src/border-box-control/test/index.tsx
+++ b/packages/components/src/border-box-control/test/index.tsx
@@ -202,7 +202,7 @@ describe( 'BorderBoxControl', () => {
 			await waitFor( () =>
 				expect(
 					screen.getByRole( 'button', {
-						name: 'Custom color picker.',
+						name: 'Custom color picker',
 					} )
 				).toBeVisible()
 			);

--- a/packages/components/src/border-control/test/index.js
+++ b/packages/components/src/border-control/test/index.js
@@ -138,7 +138,7 @@ describe( 'BorderControl', () => {
 
 			const customColorPicker = getButton( /Custom color picker/ );
 			const circularOptionPicker = screen.getByRole( 'listbox', {
-				name: 'Custom color picker.',
+				name: 'Custom color picker',
 			} );
 			const colorSwatchButtons =
 				within( circularOptionPicker ).getAllByRole( 'option' );

--- a/packages/components/src/circular-option-picker/README.md
+++ b/packages/components/src/circular-option-picker/README.md
@@ -93,6 +93,19 @@ Prevents keyboard interaction from wrapping around. Only used when `asButtons` i
 - Required: No
 - Default: `true`
 
+### `aria-labelledby`: `string`
+
+The ID reference list of one or more elements that label the wrapper element.
+
+- Required: No
+
+### `aria-label`: `string`
+
+The label for the wrapper element. Not used if an 'aria-labelledby' is provided.
+
+- Required: No
+- Default: `Custom color picker`
+
 ## Subcomponents
 
 ### `CircularOptionPicker.ButtonAction`

--- a/packages/components/src/circular-option-picker/circular-option-picker-option-group.tsx
+++ b/packages/components/src/circular-option-picker/circular-option-picker-option-group.tsx
@@ -15,7 +15,7 @@ export function OptionGroup( {
 }: OptionGroupProps ) {
 	const role =
 		'aria-label' in additionalProps || 'aria-labelledby' in additionalProps
-			? 'group'
+			? 'listbox'
 			: undefined;
 
 	return (

--- a/packages/components/src/circular-option-picker/circular-option-picker-option-group.tsx
+++ b/packages/components/src/circular-option-picker/circular-option-picker-option-group.tsx
@@ -15,7 +15,7 @@ export function OptionGroup( {
 }: OptionGroupProps ) {
 	const role =
 		'aria-label' in additionalProps || 'aria-labelledby' in additionalProps
-			? 'listbox'
+			? 'group'
 			: undefined;
 
 	return (

--- a/packages/components/src/circular-option-picker/circular-option-picker.tsx
+++ b/packages/components/src/circular-option-picker/circular-option-picker.tsx
@@ -132,7 +132,7 @@ function ButtonsCircularOptionPicker(
 	);
 
 	return (
-		<div { ...additionalProps } id={ baseId }>
+		<div { ...additionalProps } role="group" id={ baseId }>
 			<CircularOptionPickerContext.Provider value={ contextValue }>
 				{ options }
 				{ children }

--- a/packages/components/src/circular-option-picker/index.tsx
+++ b/packages/components/src/circular-option-picker/index.tsx
@@ -9,6 +9,6 @@ export {
 	ButtonAction,
 	DropdownLinkAction,
 } from './circular-option-picker-actions';
-export { useComputeCircularOptionPickerCommonProps } from './utils';
+export { getComputeCircularOptionPickerCommonProps } from './utils';
 
 export default CircularOptionPicker;

--- a/packages/components/src/circular-option-picker/index.tsx
+++ b/packages/components/src/circular-option-picker/index.tsx
@@ -9,5 +9,6 @@ export {
 	ButtonAction,
 	DropdownLinkAction,
 } from './circular-option-picker-actions';
+export { useComputeCircularOptionPickerCommonProps } from './utils';
 
 export default CircularOptionPicker;

--- a/packages/components/src/circular-option-picker/stories/index.story.tsx
+++ b/packages/components/src/circular-option-picker/stories/index.story.tsx
@@ -131,7 +131,7 @@ WithLoopingDisabled.parameters = {
 	docs: {
 		source: {
 			code: `<CircularOptionPicker
-  aria-label="${ WithLoopingDisabled.args[ 'aria-label' ] }"
+  'aria-label': 'Circular Option Picker',
   loop={false}
   options={<DefaultOptions />}
 />`,

--- a/packages/components/src/circular-option-picker/test/index.tsx
+++ b/packages/components/src/circular-option-picker/test/index.tsx
@@ -57,6 +57,7 @@ describe( 'CircularOptionPicker', () => {
 
 			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
 			expect( screen.queryByRole( 'option' ) ).not.toBeInTheDocument();
+			expect( screen.getByRole( 'group' ) ).toBeInTheDocument();
 			expect( screen.getByRole( 'button' ) ).toBeInTheDocument();
 		} );
 	} );

--- a/packages/components/src/circular-option-picker/types.ts
+++ b/packages/components/src/circular-option-picker/types.ts
@@ -40,16 +40,17 @@ type CommonCircularOptionPickerProps = {
 	 * The child elements.
 	 */
 	children?: ReactNode;
-} & (
-	| {
-			'aria-label': string;
-			'aria-labelledby'?: never;
-	  }
-	| {
-			'aria-label'?: never;
-			'aria-labelledby': string;
-	  }
-);
+	/**
+	 * The ID reference list of one or more elements that label the wrapper
+	 * element.
+	 */
+	'aria-labelledby'?: string;
+	/**
+	 * The label for the wrapper element. Defaults to 'Custom color picker'. Not
+	 * used if an 'aria-labelledby' is provided.
+	 */
+	'aria-label'?: string;
+};
 
 type WithBaseId = {
 	baseId: string;

--- a/packages/components/src/circular-option-picker/types.ts
+++ b/packages/components/src/circular-option-picker/types.ts
@@ -40,7 +40,16 @@ type CommonCircularOptionPickerProps = {
 	 * The child elements.
 	 */
 	children?: ReactNode;
-};
+} & (
+	| {
+			'aria-label': string;
+			'aria-labelledby'?: never;
+	  }
+	| {
+			'aria-label'?: never;
+			'aria-labelledby': string;
+	  }
+);
 
 type WithBaseId = {
 	baseId: string;
@@ -59,16 +68,7 @@ type FullListboxCircularOptionPickerProps = CommonCircularOptionPickerProps & {
 	 * @default true
 	 */
 	loop?: boolean;
-} & (
-		| {
-				'aria-label': string;
-				'aria-labelledby'?: never;
-		  }
-		| {
-				'aria-label'?: never;
-				'aria-labelledby': string;
-		  }
-	);
+};
 
 export type ListboxCircularOptionPickerProps = WithBaseId &
 	Omit< FullListboxCircularOptionPickerProps, 'asButtons' >;

--- a/packages/components/src/circular-option-picker/utils.tsx
+++ b/packages/components/src/circular-option-picker/utils.tsx
@@ -1,0 +1,27 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Computes the common props for the CircularOptionPicker.
+ */
+export function useComputeCircularOptionPickerCommonProps(
+	asButtons?: boolean,
+	loop?: boolean,
+	ariaLabel?: string,
+	ariaLabelledby?: string
+) {
+	const metaProps = asButtons
+		? { asButtons: true }
+		: { asButtons: false, loop };
+
+	const labelProps = {
+		'aria-labelledby': ariaLabelledby,
+		'aria-label': ariaLabelledby
+			? undefined
+			: ariaLabel || __( 'Custom color picker' ),
+	};
+
+	return { metaProps, labelProps };
+}

--- a/packages/components/src/circular-option-picker/utils.tsx
+++ b/packages/components/src/circular-option-picker/utils.tsx
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Computes the common props for the CircularOptionPicker.
  */
-export function useComputeCircularOptionPickerCommonProps(
+export function getComputeCircularOptionPickerCommonProps(
 	asButtons?: boolean,
 	loop?: boolean,
 	ariaLabel?: string,

--- a/packages/components/src/color-palette/index.tsx
+++ b/packages/components/src/color-palette/index.tsx
@@ -235,7 +235,7 @@ function UnforwardedColorPalette(
 				buttonLabelName,
 				displayValue
 		  )
-		: __( 'Custom color picker.' );
+		: __( 'Custom color picker' );
 
 	const paletteCommonProps = {
 		clearColor,

--- a/packages/components/src/color-palette/index.tsx
+++ b/packages/components/src/color-palette/index.tsx
@@ -19,7 +19,9 @@ import { useCallback, useMemo, useState, forwardRef } from '@wordpress/element';
  */
 import Dropdown from '../dropdown';
 import { ColorPicker } from '../color-picker';
-import CircularOptionPicker from '../circular-option-picker';
+import CircularOptionPicker, {
+	useComputeCircularOptionPickerCommonProps,
+} from '../circular-option-picker';
 import { VStack } from '../v-stack';
 import { Truncate } from '../truncate';
 import { ColorHeading } from './styles';
@@ -251,50 +253,12 @@ function UnforwardedColorPalette(
 		</CircularOptionPicker.ButtonAction>
 	);
 
-	let metaProps:
-		| { asButtons: false; loop?: boolean; 'aria-label': string }
-		| { asButtons: false; loop?: boolean; 'aria-labelledby': string }
-		| { asButtons: true; 'aria-label': string }
-		| { asButtons: true; 'aria-labelledby': string };
-
-	if ( asButtons ) {
-		const _metaProps: { asButtons: true } = {
-			asButtons: true,
-		};
-
-		if ( ariaLabel ) {
-			metaProps = { ..._metaProps, 'aria-label': ariaLabel };
-		} else if ( ariaLabelledby ) {
-			metaProps = {
-				..._metaProps,
-				'aria-labelledby': ariaLabelledby,
-			};
-		} else {
-			metaProps = {
-				..._metaProps,
-				'aria-label': __( 'Custom color picker.' ),
-			};
-		}
-	} else {
-		const _metaProps: { asButtons: false; loop?: boolean } = {
-			asButtons: false,
-			loop,
-		};
-
-		if ( ariaLabel ) {
-			metaProps = { ..._metaProps, 'aria-label': ariaLabel };
-		} else if ( ariaLabelledby ) {
-			metaProps = {
-				..._metaProps,
-				'aria-labelledby': ariaLabelledby,
-			};
-		} else {
-			metaProps = {
-				..._metaProps,
-				'aria-label': __( 'Custom color picker.' ),
-			};
-		}
-	}
+	const { metaProps, labelProps } = useComputeCircularOptionPickerCommonProps(
+		asButtons,
+		loop,
+		ariaLabel,
+		ariaLabelledby
+	);
 
 	return (
 		<VStack spacing={ 3 } ref={ forwardedRef } { ...additionalProps }>
@@ -352,6 +316,7 @@ function UnforwardedColorPalette(
 			{ ( colors.length > 0 || actions ) && (
 				<CircularOptionPicker
 					{ ...metaProps }
+					{ ...labelProps }
 					actions={ actions }
 					options={
 						hasMultipleColorOrigins ? (

--- a/packages/components/src/color-palette/index.tsx
+++ b/packages/components/src/color-palette/index.tsx
@@ -254,10 +254,27 @@ function UnforwardedColorPalette(
 	let metaProps:
 		| { asButtons: false; loop?: boolean; 'aria-label': string }
 		| { asButtons: false; loop?: boolean; 'aria-labelledby': string }
-		| { asButtons: true };
+		| { asButtons: true; 'aria-label': string }
+		| { asButtons: true; 'aria-labelledby': string };
 
 	if ( asButtons ) {
-		metaProps = { asButtons: true };
+		const _metaProps: { asButtons: true } = {
+			asButtons: true,
+		};
+
+		if ( ariaLabel ) {
+			metaProps = { ..._metaProps, 'aria-label': ariaLabel };
+		} else if ( ariaLabelledby ) {
+			metaProps = {
+				..._metaProps,
+				'aria-labelledby': ariaLabelledby,
+			};
+		} else {
+			metaProps = {
+				..._metaProps,
+				'aria-label': __( 'Custom color picker.' ),
+			};
+		}
 	} else {
 		const _metaProps: { asButtons: false; loop?: boolean } = {
 			asButtons: false,

--- a/packages/components/src/color-palette/index.tsx
+++ b/packages/components/src/color-palette/index.tsx
@@ -20,7 +20,7 @@ import { useCallback, useMemo, useState, forwardRef } from '@wordpress/element';
 import Dropdown from '../dropdown';
 import { ColorPicker } from '../color-picker';
 import CircularOptionPicker, {
-	useComputeCircularOptionPickerCommonProps,
+	getComputeCircularOptionPickerCommonProps,
 } from '../circular-option-picker';
 import { VStack } from '../v-stack';
 import { Truncate } from '../truncate';
@@ -253,7 +253,7 @@ function UnforwardedColorPalette(
 		</CircularOptionPicker.ButtonAction>
 	);
 
-	const { metaProps, labelProps } = useComputeCircularOptionPickerCommonProps(
+	const { metaProps, labelProps } = getComputeCircularOptionPickerCommonProps(
 		asButtons,
 		loop,
 		ariaLabel,

--- a/packages/components/src/color-palette/test/index.tsx
+++ b/packages/components/src/color-palette/test/index.tsx
@@ -258,7 +258,7 @@ describe( 'ColorPalette', () => {
 		expect( screen.queryByText( colorCode ) ).not.toBeInTheDocument();
 		expect(
 			screen.getByRole( 'button', {
-				name: /^Custom color picker.$/,
+				name: /^Custom color picker$/,
 			} )
 		).toBeInTheDocument();
 	} );

--- a/packages/components/src/duotone-picker/duotone-picker.tsx
+++ b/packages/components/src/duotone-picker/duotone-picker.tsx
@@ -14,7 +14,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import ColorListPicker from './color-list-picker';
 import CircularOptionPicker, {
-	useComputeCircularOptionPickerCommonProps,
+	getComputeCircularOptionPickerCommonProps,
 } from '../circular-option-picker';
 import { VStack } from '../v-stack';
 
@@ -129,7 +129,7 @@ function DuotonePicker( {
 		);
 	} );
 
-	const { metaProps, labelProps } = useComputeCircularOptionPickerCommonProps(
+	const { metaProps, labelProps } = getComputeCircularOptionPickerCommonProps(
 		asButtons,
 		loop,
 		ariaLabel,

--- a/packages/components/src/duotone-picker/duotone-picker.tsx
+++ b/packages/components/src/duotone-picker/duotone-picker.tsx
@@ -13,7 +13,9 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import ColorListPicker from './color-list-picker';
-import CircularOptionPicker from '../circular-option-picker';
+import CircularOptionPicker, {
+	useComputeCircularOptionPickerCommonProps,
+} from '../circular-option-picker';
 import { VStack } from '../v-stack';
 
 import CustomDuotoneBar from './custom-duotone-bar';
@@ -127,50 +129,12 @@ function DuotonePicker( {
 		);
 	} );
 
-	let metaProps:
-		| { asButtons: false; loop?: boolean; 'aria-label': string }
-		| { asButtons: false; loop?: boolean; 'aria-labelledby': string }
-		| { asButtons: true; 'aria-label': string }
-		| { asButtons: true; 'aria-labelledby': string };
-
-	if ( asButtons ) {
-		const _metaProps: { asButtons: true } = {
-			asButtons: true,
-		};
-
-		if ( ariaLabel ) {
-			metaProps = { ..._metaProps, 'aria-label': ariaLabel };
-		} else if ( ariaLabelledby ) {
-			metaProps = {
-				..._metaProps,
-				'aria-labelledby': ariaLabelledby,
-			};
-		} else {
-			metaProps = {
-				..._metaProps,
-				'aria-label': __( 'Custom color picker.' ),
-			};
-		}
-	} else {
-		const _metaProps: { asButtons: false; loop?: boolean } = {
-			asButtons: false,
-			loop,
-		};
-
-		if ( ariaLabel ) {
-			metaProps = { ..._metaProps, 'aria-label': ariaLabel };
-		} else if ( ariaLabelledby ) {
-			metaProps = {
-				..._metaProps,
-				'aria-labelledby': ariaLabelledby,
-			};
-		} else {
-			metaProps = {
-				..._metaProps,
-				'aria-label': __( 'Custom color picker.' ),
-			};
-		}
-	}
+	const { metaProps, labelProps } = useComputeCircularOptionPickerCommonProps(
+		asButtons,
+		loop,
+		ariaLabel,
+		ariaLabelledby
+	);
 
 	const options = unsetable
 		? [ unsetOption, ...duotoneOptions ]
@@ -180,6 +144,7 @@ function DuotonePicker( {
 		<CircularOptionPicker
 			{ ...otherProps }
 			{ ...metaProps }
+			{ ...labelProps }
 			options={ options }
 			actions={
 				!! clearable && (

--- a/packages/components/src/duotone-picker/duotone-picker.tsx
+++ b/packages/components/src/duotone-picker/duotone-picker.tsx
@@ -130,10 +130,27 @@ function DuotonePicker( {
 	let metaProps:
 		| { asButtons: false; loop?: boolean; 'aria-label': string }
 		| { asButtons: false; loop?: boolean; 'aria-labelledby': string }
-		| { asButtons: true };
+		| { asButtons: true; 'aria-label': string }
+		| { asButtons: true; 'aria-labelledby': string };
 
 	if ( asButtons ) {
-		metaProps = { asButtons: true };
+		const _metaProps: { asButtons: true } = {
+			asButtons: true,
+		};
+
+		if ( ariaLabel ) {
+			metaProps = { ..._metaProps, 'aria-label': ariaLabel };
+		} else if ( ariaLabelledby ) {
+			metaProps = {
+				..._metaProps,
+				'aria-labelledby': ariaLabelledby,
+			};
+		} else {
+			metaProps = {
+				..._metaProps,
+				'aria-label': __( 'Custom color picker.' ),
+			};
+		}
 	} else {
 		const _metaProps: { asButtons: false; loop?: boolean } = {
 			asButtons: false,

--- a/packages/components/src/gradient-picker/index.tsx
+++ b/packages/components/src/gradient-picker/index.tsx
@@ -8,7 +8,9 @@ import { useCallback, useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import CircularOptionPicker from '../circular-option-picker';
+import CircularOptionPicker, {
+	useComputeCircularOptionPickerCommonProps,
+} from '../circular-option-picker';
 import CustomGradientPicker from '../custom-gradient-picker';
 import { VStack } from '../v-stack';
 import { ColorHeading } from '../color-palette/styles';
@@ -128,54 +130,17 @@ function Component( props: PickerProps< any > ) {
 		<SingleOrigin { ...additionalProps } />
 	);
 
-	let metaProps:
-		| { asButtons: false; loop?: boolean; 'aria-label': string }
-		| { asButtons: false; loop?: boolean; 'aria-labelledby': string }
-		| { asButtons: true; 'aria-label': string }
-		| { asButtons: true; 'aria-labelledby': string };
-
-	if ( asButtons ) {
-		const _metaProps: { asButtons: true } = {
-			asButtons: true,
-		};
-
-		if ( ariaLabel ) {
-			metaProps = { ..._metaProps, 'aria-label': ariaLabel };
-		} else if ( ariaLabelledby ) {
-			metaProps = {
-				..._metaProps,
-				'aria-labelledby': ariaLabelledby,
-			};
-		} else {
-			metaProps = {
-				..._metaProps,
-				'aria-label': __( 'Custom color picker.' ),
-			};
-		}
-	} else {
-		const _metaProps: { asButtons: false; loop?: boolean } = {
-			asButtons: false,
-			loop,
-		};
-
-		if ( ariaLabel ) {
-			metaProps = { ..._metaProps, 'aria-label': ariaLabel };
-		} else if ( ariaLabelledby ) {
-			metaProps = {
-				..._metaProps,
-				'aria-labelledby': ariaLabelledby,
-			};
-		} else {
-			metaProps = {
-				..._metaProps,
-				'aria-label': __( 'Custom color picker.' ),
-			};
-		}
-	}
+	const { metaProps, labelProps } = useComputeCircularOptionPickerCommonProps(
+		asButtons,
+		loop,
+		ariaLabel,
+		ariaLabelledby
+	);
 
 	return (
 		<CircularOptionPicker
 			{ ...metaProps }
+			{ ...labelProps }
 			actions={ actions }
 			options={ options }
 		/>

--- a/packages/components/src/gradient-picker/index.tsx
+++ b/packages/components/src/gradient-picker/index.tsx
@@ -131,10 +131,27 @@ function Component( props: PickerProps< any > ) {
 	let metaProps:
 		| { asButtons: false; loop?: boolean; 'aria-label': string }
 		| { asButtons: false; loop?: boolean; 'aria-labelledby': string }
-		| { asButtons: true };
+		| { asButtons: true; 'aria-label': string }
+		| { asButtons: true; 'aria-labelledby': string };
 
 	if ( asButtons ) {
-		metaProps = { asButtons: true };
+		const _metaProps: { asButtons: true } = {
+			asButtons: true,
+		};
+
+		if ( ariaLabel ) {
+			metaProps = { ..._metaProps, 'aria-label': ariaLabel };
+		} else if ( ariaLabelledby ) {
+			metaProps = {
+				..._metaProps,
+				'aria-labelledby': ariaLabelledby,
+			};
+		} else {
+			metaProps = {
+				..._metaProps,
+				'aria-label': __( 'Custom color picker.' ),
+			};
+		}
 	} else {
 		const _metaProps: { asButtons: false; loop?: boolean } = {
 			asButtons: false,

--- a/packages/components/src/gradient-picker/index.tsx
+++ b/packages/components/src/gradient-picker/index.tsx
@@ -9,7 +9,7 @@ import { useCallback, useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import CircularOptionPicker, {
-	useComputeCircularOptionPickerCommonProps,
+	getComputeCircularOptionPickerCommonProps,
 } from '../circular-option-picker';
 import CustomGradientPicker from '../custom-gradient-picker';
 import { VStack } from '../v-stack';
@@ -130,7 +130,7 @@ function Component( props: PickerProps< any > ) {
 		<SingleOrigin { ...additionalProps } />
 	);
 
-	const { metaProps, labelProps } = useComputeCircularOptionPickerCommonProps(
+	const { metaProps, labelProps } = getComputeCircularOptionPickerCommonProps(
 		asButtons,
 		loop,
 		ariaLabel,

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -324,13 +324,13 @@ test.describe( 'Buttons', () => {
 		await page.click(
 			'role=region[name="Editor settings"i] >> role=button[name="Text"i]'
 		);
-		await page.click( 'role=button[name="Custom color picker."i]' );
+		await page.click( 'role=button[name="Custom color picker"i]' );
 		await page.fill( 'role=textbox[name="Hex color"i]', 'ff0000' );
 
 		await page.click(
 			'role=region[name="Editor settings"i] >> role=button[name="Background"i]'
 		);
-		await page.click( 'role=button[name="Custom color picker."i]' );
+		await page.click( 'role=button[name="Custom color picker"i]' );
 		await page.fill( 'role=textbox[name="Hex color"i]', '00ff00' );
 
 		// Check the content.

--- a/test/e2e/specs/editor/blocks/cover.spec.js
+++ b/test/e2e/specs/editor/blocks/cover.spec.js
@@ -33,7 +33,7 @@ test.describe( 'Cover', () => {
 		} );
 
 		// Locate the Black color swatch.
-		const blackColorSwatch = coverBlock.getByRole( 'option', {
+		const blackColorSwatch = coverBlock.getByRole( 'button', {
 			name: 'Black',
 		} );
 		await expect( blackColorSwatch ).toBeVisible();
@@ -105,7 +105,7 @@ test.describe( 'Cover', () => {
 		// Choose a color swatch to transform the placeholder block into
 		// a functioning block.
 		await coverBlock
-			.getByRole( 'option', {
+			.getByRole( 'button', {
 				name: 'Black',
 			} )
 			.click();
@@ -128,7 +128,7 @@ test.describe( 'Cover', () => {
 			name: 'Block: Cover',
 		} );
 		await coverBlock
-			.getByRole( 'option', {
+			.getByRole( 'button', {
 				name: 'Black',
 			} )
 			.click();
@@ -240,7 +240,7 @@ test.describe( 'Cover', () => {
 		// Choose a color swatch to transform the placeholder block into
 		// a functioning block.
 		await coverBlock
-			.getByRole( 'option', {
+			.getByRole( 'button', {
 				name: 'Black',
 			} )
 			.click();
@@ -266,7 +266,7 @@ test.describe( 'Cover', () => {
 		// Choose a color swatch to transform the placeholder block into
 		// a functioning block.
 		await secondCoverBlock
-			.getByRole( 'option', {
+			.getByRole( 'button', {
 				name: 'Black',
 			} )
 			.click();

--- a/test/e2e/specs/editor/blocks/heading.spec.js
+++ b/test/e2e/specs/editor/blocks/heading.spec.js
@@ -184,7 +184,7 @@ test.describe( 'Heading', () => {
 
 		await textColor.click();
 		await page
-			.getByRole( 'button', { name: /Custom color picker./i } )
+			.getByRole( 'button', { name: /Custom color picker/i } )
 			.click();
 
 		await page

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -162,10 +162,10 @@ test.describe( 'List View', () => {
 		// make the inner blocks appear.
 		await editor.canvas
 			.getByRole( 'document', { name: 'Block: Cover' } )
-			.getByRole( 'listbox', {
-				name: 'Custom color picker.',
+			.getByRole( 'group', {
+				name: 'Background color',
 			} )
-			.getByRole( 'option' )
+			.getByRole( 'button' )
 			.first()
 			.click();
 

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -163,7 +163,7 @@ test.describe( 'List View', () => {
 		await editor.canvas
 			.getByRole( 'document', { name: 'Block: Cover' } )
 			.getByRole( 'group', {
-				name: 'Background color',
+				name: 'Overlay color',
 			} )
 			.getByRole( 'button' )
 			.first()


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/68639

## What?
<!-- In a few words, what is the PR actually doing? -->
- The color options in the Cover block placeholder can't be fully operated with the keyboard.
- When the circular options picker is rendered with `asButtons` set to true, it would be best for it to have a `role=group` and appropriate labeling.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Any UI must fully work with the keyboard.
- Labeling is essential to communicate assistive technology users what an UI is about.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## In the fist commit
Setting `asButtons` to true makes the circular options picker render the buttons as a a list of buttons that are all focusable and tabbables. This basically removes the arrow keys navigation that is in use when the options are rendered as a listbox, which conflicts with WritingFlow.

## In the second commit.
I just wanted to set a `role="group"` and a meaningful `aria-label` when `asButtons` is true. This is important because otherwise the options are just a series of buttons. Adding a `role="group"` to the wrapper makes them logically grouped and the `aria-label` communicates users what this group of buttons is about.

However, I discovered that adding `aria-label` didn't render an aria-label attribute when `asButtons` is true. Turned out the aria-label and aria-labelledby props were only allowed for the `ListboxCircularOptionPicker` and not for `ButtonsCircularOptionPicker`.

I'm not that familiar with TypeScript and I had to make a series of changes to make this work that honestly I don't fully understand. I would greatly appreciate some eyes from contributors more familiar than me with TypeScript.
Note that I had to make changes to the allowed types also for the components that consume `CircularOptionPicker` which are: `ColorPalette`, `DuotonePicker` and `GradientPicker`.

To recap;
on trunk, by default the circular option picker renders:
- a `role="listbox"`
- a default `aria-label="Custom color picker."` that cab be passed a custom aria-label 

Instead, when rendered as normal buttons via `asButton`, it renders:
- no role
- passing an `aria-label` doesn't work

I just want the `asButtons` version have a `role=group` and an `aria-label`.


Note: to my understanding, this old issue https://github.com/WordPress/gutenberg/issues/54055 was aiming to provide a better labeling mechanism for these components but it seems it still needs to be addressed. It would be nice to consider further improvements in the context of that issue.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Repeat the steps from the issue https://github.com/WordPress/gutenberg/issues/68639#issuecomment-2587258773
- Observe that all the color options in the Cover block placeholder can be navigated with Tab and Shit+Tab.
- Inspect the DOM.
- Observe the color options wrapper has a `role="group"` and an `aria-label="Background color"`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
