### PR TITLE
Image block: unwrap img element in editor

### DIFF
--- a/packages/block-library/src/image/constants.js
+++ b/packages/block-library/src/image/constants.js
@@ -6,3 +6,4 @@ export const LINK_DESTINATION_CUSTOM = 'custom';
 export const NEW_TAB_REL = [ 'noreferrer', 'noopener' ];
 export const ALLOWED_MEDIA_TYPES = [ 'image' ];
 export const MEDIA_ID_NO_FEATURED_IMAGE_SET = 0;
+export const SIZED_LAYOUTS = [ 'flex', 'grid' ];

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -48,19 +48,6 @@ figure.wp-block-image:not(.wp-block) {
 	}
 }
 
-// This is necessary for the editor resize handles to accurately work on a non-floated, non-resized, small image.
-.wp-block-image .components-resizable-box__container {
-	// Using "display: table" because:
-	// - it visually hides empty white space in between elements
-	// - it allows the element to be as wide as its contents (instead of 100% width, as it would be with `display: block`)
-	display: table;
-	img {
-		display: block;
-		width: inherit;
-		height: inherit;
-	}
-}
-
 .block-editor-block-list__block[data-type="core/image"] .block-editor-block-toolbar .block-editor-url-input__button-modal {
 	position: absolute;
 	left: 0;

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -19,7 +19,11 @@ import {
 	DropdownMenu,
 	Popover,
 } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
+import {
+	useMergeRefs,
+	useResizeObserver,
+	useViewportMatch,
+} from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	BlockControls,
@@ -34,7 +38,7 @@ import {
 	privateApis as blockEditorPrivateApis,
 	BlockSettingsMenuControls,
 } from '@wordpress/block-editor';
-import { useEffect, useMemo, useState, useRef } from '@wordpress/element';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 import { __, _x, sprintf, isRTL } from '@wordpress/i18n';
 import { getFilename } from '@wordpress/url';
 import { getBlockBindingsSource, switchToBlockType } from '@wordpress/blocks';
@@ -54,7 +58,7 @@ import { Caption } from '../utils/caption';
  * Module constants
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
-import { MIN_SIZE, ALLOWED_MEDIA_TYPES } from './constants';
+import { MIN_SIZE, ALLOWED_MEDIA_TYPES, SIZED_LAYOUTS } from './constants';
 import { evalAspectRatio } from './utils';
 
 const { DimensionsTool, ResolutionTool } = unlock( blockEditorPrivateApis );
@@ -280,12 +284,13 @@ export default function Image( {
 		lightbox,
 		metadata,
 	} = attributes;
-
-	// The only supported unit is px, so we can parseInt to strip the px here.
-	const numericWidth = width ? parseInt( width, 10 ) : undefined;
-	const numericHeight = height ? parseInt( height, 10 ) : undefined;
-
-	const imageRef = useRef();
+	const [ imageElement, setImageElement ] = useState();
+	const [ pixelSize, setPixelSize ] = useState( {} );
+	const setResizeObserved = useResizeObserver( ( [ entry ] ) => {
+		const [ rect ] = entry.borderBoxSize;
+		setPixelSize( { width: rect.inlineSize, height: rect.blockSize } );
+	} );
+	const setRefs = useMergeRefs( [ setImageElement, setResizeObserved ] );
 	const { allowResize = true } = context;
 	const { getBlock, getSettings } = useSelect( blockEditorStore );
 
@@ -369,34 +374,18 @@ export default function Image( {
 			.catch( () => {} );
 	}, [ id, url, isSingleSelected, externalBlob ] );
 
-	// Get naturalWidth and naturalHeight from image ref, and fall back to loaded natural
+	// Get naturalWidth and naturalHeight from image, and fall back to loaded natural
 	// width and height. This resolves an issue in Safari where the loaded natural
 	// width and height is otherwise lost when switching between alignments.
 	// See: https://github.com/WordPress/gutenberg/pull/37210.
 	const { naturalWidth, naturalHeight } = useMemo( () => {
 		return {
 			naturalWidth:
-				imageRef.current?.naturalWidth ||
-				loadedNaturalWidth ||
-				undefined,
+				imageElement?.naturalWidth || loadedNaturalWidth || undefined,
 			naturalHeight:
-				imageRef.current?.naturalHeight ||
-				loadedNaturalHeight ||
-				undefined,
+				imageElement?.naturalHeight || loadedNaturalHeight || undefined,
 		};
-	}, [
-		loadedNaturalWidth,
-		loadedNaturalHeight,
-		imageRef.current?.complete,
-	] );
-
-	function onResizeStart() {
-		toggleSelection( false );
-	}
-
-	function onResizeStop() {
-		toggleSelection( true );
-	}
+	}, [ loadedNaturalWidth, loadedNaturalHeight, imageElement?.complete ] );
 
 	function onImageError() {
 		setHasImageErrored( true );
@@ -604,7 +593,7 @@ export default function Image( {
 				dropdownMenuProps={ dropdownMenuProps }
 			>
 				{ isResizable &&
-					( parentLayoutType === 'grid'
+					( SIZED_LAYOUTS.includes( parentLayoutType )
 						? aspectRatioControl
 						: dimensionsControl ) }
 			</ToolsPanel>
@@ -836,7 +825,7 @@ export default function Image( {
 						</ToolsPanelItem>
 					) }
 					{ isResizable &&
-						( parentLayoutType === 'grid'
+						( SIZED_LAYOUTS.includes( parentLayoutType )
 							? aspectRatioControl
 							: dimensionsControl ) }
 					{ !! imageSizeOptions.length && (
@@ -926,17 +915,14 @@ export default function Image( {
 					alt={ defaultedAlt }
 					onError={ onImageError }
 					onLoad={ onImageLoad }
-					ref={ imageRef }
+					ref={ setRefs }
 					className={ borderProps.className }
+					width={ naturalWidth }
+					height={ naturalHeight }
 					style={ {
-						width:
-							( width && height ) || aspectRatio
-								? '100%'
-								: undefined,
-						height:
-							( width && height ) || aspectRatio
-								? '100%'
-								: undefined,
+						aspectRatio,
+						width,
+						height,
 						objectFit: scale,
 						...borderProps.style,
 						...shadowProps.style,
@@ -953,8 +939,7 @@ export default function Image( {
 				<ImageEditor
 					id={ id }
 					url={ url }
-					width={ numericWidth }
-					height={ numericHeight }
+					{ ...pixelSize }
 					naturalHeight={ naturalHeight }
 					naturalWidth={ naturalWidth }
 					onSaveImage={ ( imageAttributes ) =>
@@ -967,26 +952,21 @@ export default function Image( {
 				/>
 			</ImageWrapper>
 		);
-	} else if ( ! isResizable || parentLayoutType === 'grid' ) {
-		img = (
-			<div style={ { width, height, aspectRatio } }>
-				<ImageWrapper href={ href }>{ img }</ImageWrapper>
-			</div>
-		);
 	} else {
+		img = <ImageWrapper href={ href }>{ img }</ImageWrapper>;
+	}
+
+	let resizableBox;
+	if (
+		isResizable &&
+		isSingleSelected &&
+		! isEditingImage &&
+		! SIZED_LAYOUTS.includes( parentLayoutType )
+	) {
 		const numericRatio = aspectRatio && evalAspectRatio( aspectRatio );
-		const customRatio = numericWidth / numericHeight;
+		const customRatio = pixelSize.width / pixelSize.height;
 		const naturalRatio = naturalWidth / naturalHeight;
 		const ratio = numericRatio || customRatio || naturalRatio || 1;
-		const currentWidth =
-			! numericWidth && numericHeight
-				? numericHeight * ratio
-				: numericWidth;
-		const currentHeight =
-			! numericHeight && numericWidth
-				? numericWidth / ratio
-				: numericHeight;
-
 		const minWidth =
 			naturalWidth < naturalHeight ? MIN_SIZE : MIN_SIZE * ratio;
 		const minHeight =
@@ -1032,21 +1012,16 @@ export default function Image( {
 			}
 		}
 		/* eslint-enable no-lonely-if */
-		img = (
+		resizableBox = (
 			<ResizableBox
 				style={ {
-					display: 'block',
-					objectFit: scale,
-					aspectRatio:
-						! width && ! height && aspectRatio
-							? aspectRatio
-							: undefined,
+					position: 'absolute',
+					// To match the vertical-align: bottom of the img (from style.scss)
+					// top is auto and bottom 0. This matters when the img height is less
+					// than the line-height.
+					inset: 'auto 0 0 0',
 				} }
-				size={ {
-					width: currentWidth ?? 'auto',
-					height: currentHeight ?? 'auto',
-				} }
-				showHandle={ isSingleSelected }
+				size={ pixelSize }
 				minWidth={ minWidth }
 				maxWidth={ maxResizeWidth }
 				minHeight={ minHeight }
@@ -1058,9 +1033,27 @@ export default function Image( {
 					bottom: true,
 					left: showLeftHandle,
 				} }
-				onResizeStart={ onResizeStart }
-				onResizeStop={ ( event, direction, elt ) => {
-					onResizeStop();
+				onResizeStart={ () => {
+					toggleSelection( false );
+					setResizeObserved( null );
+				} }
+				onResize={ ( event, direction, elt, delta ) => {
+					Object.assign( imageElement.style, {
+						width: `${ pixelSize.width + delta.width }px`,
+						height: `${ pixelSize.height + delta.height }px`,
+					} );
+				} }
+				onResizeStop={ ( event, direction, elt, delta ) => {
+					toggleSelection( true );
+					setResizeObserved( imageElement );
+					Object.assign( imageElement.style, {
+						width: '',
+						height: '',
+					} );
+					setPixelSize( ( current ) => ( {
+						width: current.width + delta.width,
+						height: current.height + delta.height,
+					} ) );
 
 					// Clear hardcoded width if the resized width is close to the max-content width.
 					if (
@@ -1091,9 +1084,7 @@ export default function Image( {
 					} );
 				} }
 				resizeRatio={ align === 'center' ? 2 : 1 }
-			>
-				<ImageWrapper href={ href }>{ img }</ImageWrapper>
-			</ResizableBox>
+			/>
 		);
 	}
 
@@ -1139,6 +1130,7 @@ export default function Image( {
 			{ controls }
 			{ featuredImageControl }
 			{ img }
+			{ resizableBox }
 
 			<Caption
 				attributes={ attributes }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -530,49 +530,49 @@ export default function Image( {
 
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
-	const dimensionsControl = (
-		<DimensionsTool
-			value={ { width, height, scale, aspectRatio } }
-			onChange={ ( {
-				width: newWidth,
-				height: newHeight,
-				scale: newScale,
-				aspectRatio: newAspectRatio,
-			} ) => {
-				// Rebuilding the object forces setting `undefined`
-				// for values that are removed since setAttributes
-				// doesn't do anything with keys that aren't set.
-				setAttributes( {
-					// CSS includes `height: auto`, but we need
-					// `width: auto` to fix the aspect ratio when
-					// only height is set due to the width and
-					// height attributes set via the server.
-					width: ! newWidth && newHeight ? 'auto' : newWidth,
+	const dimensionsControl =
+		isResizable &&
+		( SIZED_LAYOUTS.includes( parentLayoutType ) ? (
+			<DimensionsTool
+				value={ { aspectRatio } }
+				onChange={ ( { aspectRatio: newAspectRatio } ) => {
+					setAttributes( {
+						aspectRatio: newAspectRatio,
+						scale: 'cover',
+					} );
+				} }
+				defaultAspectRatio="auto"
+				tools={ [ 'aspectRatio' ] }
+			/>
+		) : (
+			<DimensionsTool
+				value={ { width, height, scale, aspectRatio } }
+				onChange={ ( {
+					width: newWidth,
 					height: newHeight,
 					scale: newScale,
 					aspectRatio: newAspectRatio,
-				} );
-			} }
-			defaultScale="cover"
-			defaultAspectRatio="auto"
-			scaleOptions={ scaleOptions }
-			unitsOptions={ dimensionsUnitsOptions }
-		/>
-	);
-
-	const aspectRatioControl = (
-		<DimensionsTool
-			value={ { aspectRatio } }
-			onChange={ ( { aspectRatio: newAspectRatio } ) => {
-				setAttributes( {
-					aspectRatio: newAspectRatio,
-					scale: 'cover',
-				} );
-			} }
-			defaultAspectRatio="auto"
-			tools={ [ 'aspectRatio' ] }
-		/>
-	);
+				} ) => {
+					// Rebuilding the object forces setting `undefined`
+					// for values that are removed since setAttributes
+					// doesn't do anything with keys that aren't set.
+					setAttributes( {
+						// CSS includes `height: auto`, but we need
+						// `width: auto` to fix the aspect ratio when
+						// only height is set due to the width and
+						// height attributes set via the server.
+						width: ! newWidth && newHeight ? 'auto' : newWidth,
+						height: newHeight,
+						scale: newScale,
+						aspectRatio: newAspectRatio,
+					} );
+				} }
+				defaultScale="cover"
+				defaultAspectRatio="auto"
+				scaleOptions={ scaleOptions }
+				unitsOptions={ dimensionsUnitsOptions }
+			/>
+		) );
 
 	const resetAll = () => {
 		setAttributes( {
@@ -592,10 +592,7 @@ export default function Image( {
 				resetAll={ resetAll }
 				dropdownMenuProps={ dropdownMenuProps }
 			>
-				{ isResizable &&
-					( SIZED_LAYOUTS.includes( parentLayoutType )
-						? aspectRatioControl
-						: dimensionsControl ) }
+				{ dimensionsControl }
 			</ToolsPanel>
 		</InspectorControls>
 	);
@@ -824,10 +821,7 @@ export default function Image( {
 							/>
 						</ToolsPanelItem>
 					) }
-					{ isResizable &&
-						( SIZED_LAYOUTS.includes( parentLayoutType )
-							? aspectRatioControl
-							: dimensionsControl ) }
+					{ dimensionsControl }
 					{ !! imageSizeOptions.length && (
 						<ResolutionTool
 							value={ sizeSlug }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -38,7 +38,7 @@ import {
 	privateApis as blockEditorPrivateApis,
 	BlockSettingsMenuControls,
 } from '@wordpress/block-editor';
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __, _x, sprintf, isRTL } from '@wordpress/i18n';
 import { getFilename } from '@wordpress/url';
 import { getBlockBindingsSource, switchToBlockType } from '@wordpress/blocks';
@@ -285,11 +285,20 @@ export default function Image( {
 		metadata,
 	} = attributes;
 	const [ imageElement, setImageElement ] = useState();
+	const [ resizeDelta, setResizeDelta ] = useState( null );
 	const [ pixelSize, setPixelSize ] = useState( {} );
+	const [ offsetTop, setOffsetTop ] = useState( 0 );
 	const setResizeObserved = useResizeObserver( ( [ entry ] ) => {
-		const [ rect ] = entry.borderBoxSize;
-		setPixelSize( { width: rect.inlineSize, height: rect.blockSize } );
+		if ( ! resizeDelta ) {
+			const [ box ] = entry.borderBoxSize;
+			setPixelSize( { width: box.inlineSize, height: box.blockSize } );
+		}
+		// This is usually 0 unless the image height is less than the line-height.
+		setOffsetTop( entry.target.offsetTop );
 	} );
+	const effectResizeableBoxPlacement = useCallback( () => {
+		setOffsetTop( imageElement?.offsetTop ?? 0 );
+	}, [ imageElement ] );
 	const setRefs = useMergeRefs( [ setImageElement, setResizeObserved ] );
 	const { allowResize = true } = context;
 	const { getBlock, getSettings } = useSelect( blockEditorStore );
@@ -915,8 +924,13 @@ export default function Image( {
 					height={ naturalHeight }
 					style={ {
 						aspectRatio,
-						width,
-						height,
+						...( resizeDelta
+							? {
+									width: pixelSize.width + resizeDelta.width,
+									height:
+										pixelSize.height + resizeDelta.height,
+							  }
+							: { width, height } ),
 						objectFit: scale,
 						...borderProps.style,
 						...shadowProps.style,
@@ -1008,12 +1022,13 @@ export default function Image( {
 		/* eslint-enable no-lonely-if */
 		resizableBox = (
 			<ResizableBox
+				ref={ effectResizeableBoxPlacement }
 				style={ {
 					position: 'absolute',
 					// To match the vertical-align: bottom of the img (from style.scss)
-					// top is auto and bottom 0. This matters when the img height is less
-					// than the line-height.
-					inset: 'auto 0 0 0',
+					// syncs the top with the img. This matters when the img height is
+					// less than the line-height.
+					inset: `${ offsetTop }px 0 0 0`,
 				} }
 				size={ pixelSize }
 				minWidth={ minWidth }
@@ -1029,21 +1044,13 @@ export default function Image( {
 				} }
 				onResizeStart={ () => {
 					toggleSelection( false );
-					setResizeObserved( null );
 				} }
 				onResize={ ( event, direction, elt, delta ) => {
-					Object.assign( imageElement.style, {
-						width: `${ pixelSize.width + delta.width }px`,
-						height: `${ pixelSize.height + delta.height }px`,
-					} );
+					setResizeDelta( delta );
 				} }
 				onResizeStop={ ( event, direction, elt, delta ) => {
 					toggleSelection( true );
-					setResizeObserved( imageElement );
-					Object.assign( imageElement.style, {
-						width: '',
-						height: '',
-					} );
+					setResizeDelta( null );
 					setPixelSize( ( current ) => ( {
 						width: current.width + delta.width,
 						height: current.height + delta.height,


### PR DESCRIPTION
## What?
An attempt to fix several issues with the Image block in the editor by:
- Making the editor markup more similar to the front end (removes `div` wrapper around `img`).
- Omitting size controls of Image block when inside flex layouts.
I don’t think there’s as strong a reason to do this but I tried it because the size controls seem likely to be confusing in flex layouts.

There is also a few minor changes related to code quality.

## Why?
Most generally this seems like a good idea because the markup becomes more similar to that of the front end.
- Fixes #38381
- Fixes #52219
- Fixes #68057
- Fixes #68668
- Fixes #67506

## How?
1. Removes wrapping divs from the `img` in the editor markup.
   - The `ResizableBox` component is made a sibling (instead of a parent).
   - Removes the wrapping div that was there when not resizable.
2. Adds logic/state to ensure overlaid placement of the `ResizableBox` on the `img`.
   -  a mount effect on `ResizableBox`
   -  resize observation on the `img`
3. In flex layouts, omits the `ResizableBox` and width/height inspector controls.

## Testing Instructions

- Follow the reproduction steps for the linked issues and verify that you cannot reproduce them
- Test everything you can think of having to do with the Image block

<details><summary>Markup I used in testing these issues. You’ll have to replace the images with your own though.</summary>

```html
<!-- wp:paragraph -->
<p>The following are editor specific bugs or incongruities as compared to the front end.</p>
<!-- /wp:paragraph -->

<!-- wp:heading {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20"}}},"fontSize":"large"} -->
<h2 class="wp-block-heading has-large-font-size" style="padding-top:var(--wp--preset--spacing--20)">⛔️ Resize handle placement is incorrect for an non-resized image whose natural width is less than the theme’s content width</h2>
<!-- /wp:heading -->

<!-- wp:image {"id":19,"sizeSlug":"full","linkDestination":"none"} -->
<figure class="wp-block-image size-full"><img src="http://localhost:8888/wp-content/uploads/2024/05/pine-flower.webp" alt="" class="wp-image-19"/></figure>
<!-- /wp:image -->

<!-- wp:heading {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20"},"margin":{"top":"40vh"}}},"fontSize":"large"} -->
<h2 class="wp-block-heading has-large-font-size" style="margin-top:40vh;padding-top:var(--wp--preset--spacing--20)">⛔️ Width stretched to content width for an non-resized image whose natural width is less than the theme’s content width when aspect ratio is specified</h2>
<!-- /wp:heading -->

<!-- wp:image {"id":19,"aspectRatio":"16/9","scale":"cover","sizeSlug":"full","linkDestination":"none"} -->
<figure class="wp-block-image size-full"><img src="http://localhost:8888/wp-content/uploads/2024/05/pine-flower.webp" alt="" class="wp-image-19" style="aspect-ratio:16/9;object-fit:cover"/></figure>
<!-- /wp:image -->

<!-- wp:heading {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20"},"margin":{"top":"40vh"}}},"fontSize":"large"} -->
<h2 class="wp-block-heading has-large-font-size" style="margin-top:40vh;padding-top:var(--wp--preset--spacing--20)">⛔️ Wrong size in flex and grid layouts</h2>
<!-- /wp:heading -->

<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
<div class="wp-block-group"><!-- wp:image {"id":135,"width":"130px","height":"auto","scale":"cover","sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
<figure class="wp-block-image size-full is-resized"><img src="http://localhost:8888/wp-content/uploads/2024/07/image.jpeg" alt="" class="wp-image-135" style="object-fit:cover;width:130px;height:auto"/></figure>
<!-- /wp:image -->

<!-- wp:paragraph {"style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
<p>In a row block, if an image is resized to a specific width and placed next to a potentially wide block like a multi-lined paragraph, it maintains its specified size yet the appears small on the front end. This breaks WYSIWYG expectations.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"layout":{"type":"grid","columnCount":3,"rowCount":2,"isManualPlacement":true,"minimumColumnWidth":null}} -->
<div class="wp-block-group"><!-- wp:image {"id":19,"width":"504px","height":"auto","sizeSlug":"full","linkDestination":"none","style":{"layout":{"columnStart":1,"rowStart":1,"rowSpan":2}}} -->
<figure class="wp-block-image size-full is-resized"><img src="http://localhost:8888/wp-content/uploads/2024/05/pine-flower.webp" alt="" class="wp-image-19" style="width:504px;height:auto"/></figure>
<!-- /wp:image -->

<!-- wp:paragraph {"style":{"color":{"background":"#ffffffa8"},"layout":{"columnStart":2,"rowStart":1}},"fontSize":"medium"} -->
<p class="has-background has-medium-font-size" style="background-color:#ffffffa8">In a grid block, it’s a similar situation.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"color":{"background":"#ffffffa8"},"layout":{"columnStart":3,"rowStart":1}},"fontSize":"medium"} -->
<p class="has-background has-medium-font-size" style="background-color:#ffffffa8">Another sibling.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:heading {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20"},"margin":{"top":"40vh"}}},"fontSize":"large"} -->
<h2 class="wp-block-heading has-large-font-size" style="margin-top:40vh;padding-top:var(--wp--preset--spacing--20)">⛔️ If the image is shorter than the line-height so too is the figure and vertical alignment is incongruent with the front end</h2>
<!-- /wp:heading -->

<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}},"color":{"background":"#f3d5f1"}},"fontSize":"xx-large","layout":{"type":"constrained"}} -->
<div class="wp-block-group has-background has-xx-large-font-size" style="background-color:#f3d5f1;padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)"><!-- wp:image {"id":63,"width":"32px","sizeSlug":"full","linkDestination":"none","style":{"spacing":{"margin":{"left":"var:preset|spacing|20","right":"0"}}}} -->
<figure class="wp-block-image size-full is-resized" style="margin-right:0;margin-left:var(--wp--preset--spacing--20)"><img src="http://localhost:8888/wp-content/uploads/2024/06/transparent-site-icon.png" alt="" class="wp-image-63" style="width:32px"/></figure>
<!-- /wp:image --></div>
<!-- /wp:group -->

<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|40","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}},"typography":{"letterSpacing":"21px"},"color":{"background":"#f3d5f1"}},"fontSize":"xx-large","layout":{"type":"constrained","justifyContent":"center"}} -->
<div class="wp-block-group has-background has-xx-large-font-size" style="background-color:#f3d5f1;padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--20);letter-spacing:21px"><!-- wp:image {"id":63,"width":"32px","height":"auto","sizeSlug":"full","linkDestination":"none","align":"left","style":{"spacing":{"margin":{"left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}}} -->
<figure class="wp-block-image alignleft size-full is-resized" style="margin-right:var(--wp--preset--spacing--20);margin-left:var(--wp--preset--spacing--20)"><img src="http://localhost:8888/wp-content/uploads/2024/06/transparent-site-icon.png" alt="" class="wp-image-63" style="width:32px;height:auto" title="fub"/></figure>
<!-- /wp:image -->

<!-- wp:paragraph -->
<p>SOMETHING</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:heading {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20"},"margin":{"top":"50vh"}}},"fontSize":"large"} -->
<h2 class="wp-block-heading has-large-font-size" style="margin-top:50vh;padding-top:var(--wp--preset--spacing--20)">⛔️ Image may disappear when cropping/rotating in flex layouts</h2>
<!-- /wp:heading -->

<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
<div class="wp-block-group"><!-- wp:image {"id":74,"scale":"cover","sizeSlug":"full","linkDestination":"none","style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
<figure class="wp-block-image size-full"><img src="http://localhost:8888/wp-content/uploads/2024/06/Example-Background-Image.jpg" alt="" class="wp-image-74" style="object-fit:cover"/></figure>
<!-- /wp:image -->

<!-- wp:paragraph -->
<p>It happens if the image lacks a specified size and even without other siblings in the row.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:spacer -->
<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->
```

</details>

## Screenshots or screencast <!-- if applicable -->

### Editor/Front-end incongruities

#### Wrong size in flex and grid layouts (#68057 is open for this but is Row specific) 
|Before|Front end|After|
|-|-|-|
| <img width="960" alt="image-block-size-in-grid-flex-before" src="https://github.com/user-attachments/assets/e77d635e-abde-4faf-9ecb-d487731d9df9" /> | <img width="960" alt="image-block-size-in-grid-flex-front" src="https://github.com/user-attachments/assets/ff1f5fba-104f-4f1c-9059-94bbf7998761" /> | <img width="960" alt="image-block-size-in-grid-flex-after" src="https://github.com/user-attachments/assets/ac81c92b-db73-46f8-9aa1-bbaf5764b7ad" /> |

#### Image incorrectly filling the content-width #52219
An image block with an image that is smaller than the width of the post container with a specified aspect ratio and no specified size is incorrectly filling the width of the container.
|Before|Front end|After|
|-|-|-|
| <img width="960" alt="image-block-stretch-w-aspect-ratio-before" src="https://github.com/user-attachments/assets/8507c0ef-fc2c-48c5-bf16-8f2ec2985bd0" /> | <img width="960" alt="image-block-stretch-w-aspect-ratio-front" src="https://github.com/user-attachments/assets/2d4fbfb4-e0a3-47ac-b794-8b5df9040c3b" /> | <img width="960" alt="image-block-stretch-w-aspect-ratio-after" src="https://github.com/user-attachments/assets/05650a9c-9eeb-4b3f-90fa-89b96c22c0df" /> |

#### Layout incorrect for images that are shorter than line-height (no open issue, I think)
If the image is shorter than the line-height so too is the figure and vertical alignment is incongruent with the front end
|Before|Front end|After|
|-|-|-|
| <img width="960" alt="image-block-short-before" src="https://github.com/user-attachments/assets/3d1c7dee-1092-447f-948e-3314f68862d2" /> | <img width="960" alt="image-block-short-front" src="https://github.com/user-attachments/assets/8aea5a3d-b749-46ca-954f-69db850d615e" /> | <img width="960" alt="image-block-short-after" src="https://github.com/user-attachments/assets/2557da4e-e114-418f-8430-16784871c010" /> |

### Editor-only issues

#### Resize handles out of place (I think there’s no open issue)
It affects images that are narrower than the content width with no size specified.
|Before|After|
|-|-|
| <img width="960" alt="image-block-resize-handle-before" src="https://github.com/user-attachments/assets/2fd746cb-b8e8-44a1-b59e-0fccba974ad2" /> | <img width="960" alt="image-block-resize-handle-after" src="https://github.com/user-attachments/assets/c4f07fd3-6ee5-491e-b762-0b95437657c8" /> |

#### Disappearing image when editing (crop/rotate) auto-sized images inside flex layouts #68668

https://github.com/user-attachments/assets/da67ff6c-9091-419e-b571-2d792148bf03

#### Layout shifts when editing (crop/rotate) auto-sized images
In trunk, an image without any specified size doesn’t maintain its displayed size when cropping/rotating. In this branch the image size will be maintained. This is an incidental change but might be hard to separate from the fix for the preceding issue. Besides it seems like a nice thing for consistency with how it works in most other scenarios (no layout shift).

|Before|After|
|-|-|
| <img width="960" alt="image-block-crop-unsized-before" src="https://github.com/user-attachments/assets/8e2b1925-6d67-4cee-9bad-654f7ccd60c4" /> | <img width="960" alt="image-block-crop-unsized-after" src="https://github.com/user-attachments/assets/a0c5b49a-0408-4641-9954-35439959b6f6" /> |