### PR TITLE
Fix flaky navigation-frontend-interactivity e2e tests

### DIFF
--- a/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
@@ -61,15 +61,22 @@ export async function visitSiteEditor(
 			'.edit-site-canvas-loader, .edit-site-canvas-spinner'
 		);
 
-		// Wait for the canvas loader to appear first, so that the locator that
-		// waits for the hidden state doesn't resolve prematurely.
-		await canvasLoader.waitFor( { state: 'visible', timeout: 60_000 } );
-		await canvasLoader.waitFor( {
-			state: 'hidden',
-			// Bigger timeout is needed for larger entities, like the Large Post
-			// HTML fixture that we load for performance tests, which often
-			// doesn't make it under the default timeout value.
-			timeout: 60_000,
-		} );
+		try {
+			// Wait for the canvas loader to appear first, so that the locator that
+			// waits for the hidden state doesn't resolve prematurely.
+			await canvasLoader.waitFor( { state: 'visible', timeout: 60_000 } );
+			await canvasLoader.waitFor( {
+				state: 'hidden',
+				// Bigger timeout is needed for larger entities, like the Large Post
+				// HTML fixture that we load for performance tests, which often
+				// doesn't make it under the default timeout value.
+				timeout: 60_000,
+			} );
+		} catch ( error ) {
+			// If the canvas loader is already disappeared, skip the waiting.
+			await this.page
+				.getByRole( 'region', { name: 'Editor content' } )
+				.waitFor();
+		}
 	}
 }


### PR DESCRIPTION
Alternatives to #68643

## What?

Trying to solve the flaky tests in `navigation-frontend-interactivity.spec.js`:

- https://github.com/WordPress/gutenberg/issues/61884
- https://github.com/WordPress/gutenberg/issues/55816
- https://github.com/WordPress/gutenberg/issues/51348

## How?

As mentioned in [this comment](https://github.com/WordPress/gutenberg/pull/68643#issuecomment-2589720990), this may be because the canvas loader disappears very early. As a fallback, wait for the editor canvas instead of the canvas loader.

## Testing Instructions

Let's see if the E2E tests are stable and successful.