### PR TITLE
Fix: Template Part 403 request error occurs in edit mode

### DIFF
--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -130,12 +130,17 @@ export default function PostPreviewButton( {
 				editor.getCurrentPostType( 'type' )
 			);
 
+			const canView = postType?.viewable ?? false;
+			const previewUrl = canView
+				? editor.getEditedPostPreviewLink()
+				: null;
+
 			return {
 				postId: editor.getCurrentPostId(),
 				currentPostLink: editor.getCurrentPostAttribute( 'link' ),
-				previewLink: editor.getEditedPostPreviewLink(),
+				previewLink: previewUrl,
 				isSaveable: editor.isEditedPostSaveable(),
-				isViewable: postType?.viewable ?? false,
+				isViewable: canView,
 			};
 		}, [] );
 


### PR DESCRIPTION
Fixes [#68670](https://github.com/WordPress/gutenberg/issues/68670)

## What?
Prevents unnecessary API requests for post preview links when editing template parts in the site editor, which currently causes 403 errors to appear in the browser console.

## How?
Modified the PostPreviewButton component to only fetch preview links when the post type is actually viewable. This is done by:
1. Checking the viewable status early in the useSelect hook
2. Only calling getEditedPostPreviewLink() if the content is viewable
