### PR TITLE
StoryBook: Add story for `ObserveTyping`

### DIFF
--- a/packages/block-editor/src/components/observe-typing/stories/index.story.js
+++ b/packages/block-editor/src/components/observe-typing/stories/index.story.js
@@ -22,7 +22,7 @@ const meta = {
 	},
 	argTypes: {
 		children: {
-			control: 'text',
+			control: 'element',
 			description: 'Content wrapped by the ObserveTyping component.',
 			table: {
 				type: { summary: 'ReactNode' },
@@ -33,27 +33,29 @@ const meta = {
 
 export default meta;
 
+function MyInput() {
+	const [ isTyping, setIsTyping ] = useState( false );
+
+	const onTypingStart = () => setIsTyping( true );
+	const onTypingStop = () => setIsTyping( false );
+
+	return (
+		<div>
+			<p>{ isTyping ? 'Typing...' : 'Not typing' }</p>
+			<input
+				type="text"
+				onFocus={ onTypingStart }
+				onBlur={ onTypingStop }
+			/>
+		</div>
+	);
+}
+
 export const Default = {
 	render: function Template( { children, ...args } ) {
-		const [ isTyping, setIsTyping ] = useState( false );
-
-		const onTypingStart = () => setIsTyping( true );
-		const onTypingStop = () => setIsTyping( false );
-
-		return (
-			<ObserveTyping { ...args }>
-				<div>
-					<p>{ isTyping ? 'Typing...' : 'Not typing' }</p>
-					<input
-						type="text"
-						onFocus={ onTypingStart }
-						onBlur={ onTypingStop }
-					/>
-				</div>
-			</ObserveTyping>
-		);
+		return <ObserveTyping { ...args }>{ children }</ObserveTyping>;
 	},
 	args: {
-		children: 'This is the area where typing will be observed.',
+		children: <MyInput />,
 	},
 };

--- a/packages/block-editor/src/components/observe-typing/stories/index.story.js
+++ b/packages/block-editor/src/components/observe-typing/stories/index.story.js
@@ -1,0 +1,59 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import ObserveTyping from '../index.js';
+
+const meta = {
+	title: 'BlockEditor/ObserveTyping',
+	component: ObserveTyping,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'A component that observes typing events and manages the typing flag in the editor.',
+			},
+		},
+	},
+	argTypes: {
+		children: {
+			control: 'text',
+			description: 'Content wrapped by the ObserveTyping component.',
+			table: {
+				type: { summary: 'ReactNode' },
+			},
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	render: function Template( { children, ...args } ) {
+		const [ isTyping, setIsTyping ] = useState( false );
+
+		const onTypingStart = () => setIsTyping( true );
+		const onTypingStop = () => setIsTyping( false );
+
+		return (
+			<ObserveTyping { ...args }>
+				<div>
+					<p>{ isTyping ? 'Typing...' : 'Not typing' }</p>
+					<input
+						type="text"
+						onFocus={ onTypingStart }
+						onBlur={ onTypingStop }
+					/>
+				</div>
+			</ObserveTyping>
+		);
+	},
+	args: {
+		children: 'This is the area where typing will be observed.',
+	},
+};


### PR DESCRIPTION
# Work in progress

Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR will add stories for `ObserveTyping` component in the Storybook.


## Testing Instructions

1. Run npm run storybook:dev
2. Open the storybook on http://localhost:50240/
3. Check the `ObserveTyping` story.

## Screenshots or screencast 



