### PR TITLE
Editor: Update data selector in 'PostPreviewButton'

### DIFF
--- a/packages/editor/src/components/post-preview-button/index.js
+++ b/packages/editor/src/components/post-preview-button/index.js
@@ -129,13 +129,17 @@ export default function PostPreviewButton( {
 			const postType = core.getPostType(
 				editor.getCurrentPostType( 'type' )
 			);
+			const canView = postType?.viewable ?? false;
+			if ( ! canView ) {
+				return { isViewable: canView };
+			}
 
 			return {
 				postId: editor.getCurrentPostId(),
 				currentPostLink: editor.getCurrentPostAttribute( 'link' ),
 				previewLink: editor.getEditedPostPreviewLink(),
 				isSaveable: editor.isEditedPostSaveable(),
-				isViewable: postType?.viewable ?? false,
+				isViewable: canView,
 			};
 		}, [] );
 


### PR DESCRIPTION
## What?
Closes #68670.
Alternative to #68674.

PR updates the data selector in the `PostPreviewButton` and returns early when a post type isn't viewable.

## Why?
Calling selectors like `getEditedPostPreviewLink` is unnecessary when the post type isn't viewable, and the component renders nothing.

## Testing Instructions
1. Open a template part in the Site Editor.
2. Reset the template part to ensure content is coming from the file.
3. Reload the editor.
4. Confirm there are no 403 requests.

### Testing Instructions for Keyboard
Same.

