### PR TITLE
Core Data: Check post-type support before requesting autosaves

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -580,8 +580,15 @@ export const canUserEditEntityRecord =
 export const getAutosaves =
 	( postType, postId ) =>
 	async ( { dispatch, resolveSelect } ) => {
-		const { rest_base: restBase, rest_namespace: restNamespace = 'wp/v2' } =
-			await resolveSelect.getPostType( postType );
+		const {
+			rest_base: restBase,
+			rest_namespace: restNamespace = 'wp/v2',
+			supports,
+		} = await resolveSelect.getPostType( postType );
+		if ( ! supports?.autosave ) {
+			return;
+		}
+
 		const autosaves = await apiFetch( {
 			path: `/${ restNamespace }/${ restBase }/${ postId }/autosaves?context=edit`,
 		} );

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -726,7 +726,10 @@ describe( 'getAutosaves', () => {
 		const postType = 'post';
 		const postId = 1;
 		const restBase = 'posts';
-		const postEntityConfig = { rest_base: restBase };
+		const postEntityConfig = {
+			rest_base: restBase,
+			supports: { autosave: true },
+		};
 
 		triggerFetch.mockImplementation( () => SUCCESSFUL_RESPONSE );
 		const dispatch = Object.assign( jest.fn(), {
@@ -750,7 +753,10 @@ describe( 'getAutosaves', () => {
 		const postType = 'post';
 		const postId = 1;
 		const restBase = 'posts';
-		const postEntityConfig = { rest_base: restBase };
+		const postEntityConfig = {
+			rest_base: restBase,
+			supports: { autosave: true },
+		};
 
 		triggerFetch.mockImplementation( () => [] );
 		const dispatch = Object.assign( jest.fn(), {


### PR DESCRIPTION
## What?
PR updates the `getAutosaves` core data resolver to check if the post type supports autosaves before requesting data.

## Why?
Starting from WordPress 6.6, individual post-types can [disable autosaves](https://make.wordpress.org/core/2024/06/25/miscellaneous-developer-changes-in-wordpress-6-6/#allowed-disabling-autosave-support-for-individual-post-types). The extra checks prevent unnecessary requests and 404 errors.

## Testing Instructions
1. Disable autosaves for pages.
2. Open a post.
3. Using DevTools, request autosaves for a page - `wp.data.select( 'core' ).getAutosave( 'page', pageId );`
4. Confirm that the request doesn't trigger a 404 error.

```php
// Disable autosave for pages.
add_action( 'init', function() {
	remove_post_type_support( 'page', 'autosave' );
} );
```

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2025-01-15 at 13 14 12](https://github.com/user-attachments/assets/3ced028a-a2ed-40ea-8b31-01831eadbe0c)
