### PR TITLE
Use the term menu instead of navigation in nav elements labels.

### DIFF
--- a/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
+++ b/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
@@ -47,7 +47,7 @@ function useConvertClassicToBlockMenu(
 			} catch ( err ) {
 				throw new Error(
 					sprintf(
-						// translators: %s: the name of a menu (e.g. Header navigation).
+						// translators: %s: The name of a menu (e.g. Header menu).
 						__( `Unable to fetch classic menu "%s" from API.` ),
 						menuName
 					),
@@ -61,7 +61,7 @@ function useConvertClassicToBlockMenu(
 			if ( classicMenuItems === null ) {
 				throw new Error(
 					sprintf(
-						// translators: %s: the name of a menu (e.g. Header navigation).
+						// translators: %s: The name of a menu (e.g. Header menu).
 						__( `Unable to fetch classic menu "%s" from API.` ),
 						menuName
 					)
@@ -98,7 +98,7 @@ function useConvertClassicToBlockMenu(
 			} catch ( err ) {
 				throw new Error(
 					sprintf(
-						// translators: %s: the name of a menu (e.g. Header navigation).
+						// translators: %s: The name of a menu (e.g. Header menu).
 						__( `Unable to create Navigation Menu "%s".` ),
 						menuName
 					),
@@ -155,7 +155,7 @@ function useConvertClassicToBlockMenu(
 					if ( throwOnError ) {
 						throw new Error(
 							sprintf(
-								// translators: %s: the name of a menu (e.g. Header navigation).
+								// translators: %s: The name of a menu (e.g. Header menu).
 								__( `Unable to create Navigation Menu "%s".` ),
 								menuName
 							),

--- a/packages/block-library/src/navigation/edit/use-generate-default-navigation-title.js
+++ b/packages/block-library/src/navigation/edit/use-generate-default-navigation-title.js
@@ -50,12 +50,12 @@ export default function useGenerateDefaultNavigationTitle( clientId ) {
 
 		const title = area
 			? sprintf(
-					// translators: %s: the name of a menu (e.g. Header navigation).
-					__( '%s navigation' ),
+					// translators: %s: the name of a menu (e.g. Header menu).
+					__( '%s menu' ),
 					area
 			  )
-			: // translators: 'navigation' as in website navigation.
-			  __( 'Navigation' );
+			: // translators: 'menu' as in website navigation menu.
+			  __( 'Menu' );
 
 		// Determine how many menus start with the automatic title.
 		const matchingMenuTitleCount = [

--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -174,7 +174,7 @@ function ScreenRevisions() {
 						changePage={ setCurrentPage }
 						totalItems={ revisionsCount }
 						disabled={ isLoading }
-						label={ __( 'Global Styles pagination navigation' ) }
+						label={ __( 'Global Styles pagination' ) }
 					/>
 				</div>
 			) }

--- a/packages/edit-site/src/components/pagination/index.js
+++ b/packages/edit-site/src/components/pagination/index.js
@@ -22,7 +22,7 @@ export default function Pagination( {
 	className,
 	disabled = false,
 	buttonVariant = 'tertiary',
-	label = __( 'Pagination Navigation' ),
+	label = __( 'Pagination' ),
 } ) {
 	return (
 		<HStack

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -269,9 +269,7 @@ test.describe( 'Style Revisions', () => {
 		}
 		await userGlobalStylesRevisions.openStylesPanel();
 		await page.getByRole( 'button', { name: 'Revisions' } ).click();
-		const pagination = page.getByLabel(
-			'Global Styles pagination navigation'
-		);
+		const pagination = page.getByLabel( 'Global Styles pagination' );
 		await expect( pagination ).toContainText( '1 of 2' );
 		await pagination.getByRole( 'button', { name: 'Next page' } ).click();
 		await expect( pagination ).toContainText( '2 of 2' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/68682

## What?
<!-- In a few words, what is the PR actually doing? -->
Any `<nav>` element `aria-label` should not contain the term 'navigation'.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Screen readers already announce `<nav>` elements as 'navigation' because that's the implicit role of a `<nav>` element.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Changes the default title used for  the Navigation block so that it uses the term 'Menu' instead of 'Navigation'.
- Removes the term 'pagination' from the global styes revisions pagination.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Repeat the steps from the issue https://github.com/WordPress/gutenberg/issues/68682
- Observe the term 'navigation' is no longer used in the `<nav>` elements.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
