### PR TITLE
Archives: Add Color Support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -14,7 +14,7 @@ Display a date archive of your posts. ([Source](https://github.com/WordPress/gut
 
 -	**Name:** core/archives
 -	**Category:** widgets
--	**Supports:** align, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** displayAsDropdown, showLabel, showPostCounts, type
 
 ## Audio

--- a/packages/block-library/src/archives/block.json
+++ b/packages/block-library/src/archives/block.json
@@ -54,6 +54,15 @@
 				"fontSize": true
 			}
 		},
+		"color": {
+			"gradients": true,
+			"link": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true,
+				"link": true
+			}
+		},
 		"interactivity": {
 			"clientNavigation": true
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR Adds Text, Background, Gradient, and link Color Support in the Archives block.

Part Of:  https://github.com/WordPress/gutenberg/issues/43245

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This Block is missing Color Support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The PR Adds the Color Supports in block.json and the Documentation file `docs/reference-guides/core-blocks.md`.

## Testing Instructions
- Create a New Post / Page.
- Add an Archives Block. 
- Adjust the Color Settings.
- Compare Result in the Editor and Front-end Side.

## Screenshots or Screencast <!-- if applicable -->

https://github.com/user-attachments/assets/d9802abb-29db-4df0-bb36-f28b53722846

