### PR TITLE
Inserter: Remove block default icon from no results message

### DIFF
--- a/packages/block-directory/src/components/downloadable-blocks-panel/no-results.js
+++ b/packages/block-directory/src/components/downloadable-blocks-panel/no-results.js
@@ -2,17 +2,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Icon, blockDefault } from '@wordpress/icons';
 import { Tip, ExternalLink } from '@wordpress/components';
 
 function DownloadableBlocksNoResults() {
 	return (
 		<>
 			<div className="block-editor-inserter__no-results">
-				<Icon
-					className="block-editor-inserter__no-results-icon"
-					icon={ blockDefault }
-				/>
 				<p>{ __( 'No results found.' ) }</p>
 			</div>
 			<div className="block-editor-inserter__tips">

--- a/packages/block-editor/src/components/inserter/no-results.js
+++ b/packages/block-editor/src/components/inserter/no-results.js
@@ -2,15 +2,10 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Icon, blockDefault } from '@wordpress/icons';
 
 function InserterNoResults() {
 	return (
 		<div className="block-editor-inserter__no-results">
-			<Icon
-				className="block-editor-inserter__no-results-icon"
-				icon={ blockDefault }
-			/>
 			<p>{ __( 'No results found.' ) }</p>
 		</div>
 	);


### PR DESCRIPTION
Closes:  #68688
## What?
This PR removes the block default icon from the “No results found” message in the Inserter.

## Why?
The icon appears to be a leftover and does not add significant value to the UI. Additionally, it is shown in cases where it feels inappropriate, such as when there are no results for patterns or media. Removing the icon ensures a cleaner and more consistent experience.

## How?
The PR removes the <Icon> component displaying the blockDefault icon from no-results.js in both the block-editor and block-directory packages.

## Testing Instructions
1. Open the main Inserter.
2. Search for a non-existing block and verify that only the “No results found” message is displayed, without an icon.
3. Repeat the search for patterns and media, ensuring the same behavior.
## Screenshots or screencast

https://github.com/user-attachments/assets/15d75c2f-f502-43d3-8f6c-1c08984c98d9
