### PR TITLE
Editor: Combine selectors in the 'Header' component

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -54,15 +54,17 @@ function InserterMenu(
 	},
 	ref
 ) {
-	const isZoomOutMode = useSelect(
-		( select ) => unlock( select( blockEditorStore ) ).isZoomOut(),
-		[]
-	);
-	const hasSectionRootClientId = useSelect(
-		( select ) =>
-			!! unlock( select( blockEditorStore ) ).getSectionRootClientId(),
-		[]
-	);
+	const { isZoomOutMode, hasSectionRootClientId } = useSelect( ( select ) => {
+		const { isZoomOut, getSectionRootClientId } = unlock(
+			select( blockEditorStore )
+		);
+
+		return {
+			isZoomOutMode: isZoomOut(),
+			hasSectionRootClientId: !! getSectionRootClientId(),
+		};
+	}, [] );
+
 	const [ filterValue, setFilterValue, delayedFilterValue ] =
 		useDebouncedInput( __experimentalFilterValue );
 	const [ hoveredItem, setHoveredItem ] = useState( null );

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -68,6 +68,7 @@ function Header( {
 		showIconLabels,
 		hasFixedToolbar,
 		hasBlockSelection,
+		hasSectionRootClientId,
 	} = useSelect( ( select ) => {
 		const { get: getPreference } = select( preferencesStore );
 		const {
@@ -75,6 +76,9 @@ function Header( {
 			getCurrentPostType,
 			isPublishSidebarOpened: _isPublishSidebarOpened,
 		} = select( editorStore );
+		const { getBlockSelectionStart, getSectionRootClientId } = unlock(
+			select( blockEditorStore )
+		);
 
 		return {
 			postType: getCurrentPostType(),
@@ -82,14 +86,14 @@ function Header( {
 			isPublishSidebarOpened: _isPublishSidebarOpened(),
 			showIconLabels: getPreference( 'core', 'showIconLabels' ),
 			hasFixedToolbar: getPreference( 'core', 'fixedToolbar' ),
-			hasBlockSelection:
-				!! select( blockEditorStore ).getBlockSelectionStart(),
+			hasBlockSelection: !! getBlockSelectionStart(),
+			hasSectionRootClientId: !! getSectionRootClientId(),
 		};
 	}, [] );
 
-	const canBeZoomedOut = [ 'post', 'page', 'wp_template' ].includes(
-		postType
-	);
+	const canBeZoomedOut =
+		[ 'post', 'page', 'wp_template' ].includes( postType ) &&
+		hasSectionRootClientId;
 
 	const disablePreviewOption = [
 		NAVIGATION_POST_TYPE,
@@ -106,12 +110,6 @@ function Header( {
 			( hasFixedToolbar &&
 				( ! hasBlockSelection || isBlockToolsCollapsed ) ) );
 	const hasBackButton = useHasBackButton();
-
-	const hasSectionRootClientId = useSelect(
-		( select ) =>
-			!! unlock( select( blockEditorStore ) ).getSectionRootClientId(),
-		[]
-	);
 
 	/*
 	 * The edit-post-header classname is only kept for backward compatibility
@@ -180,11 +178,9 @@ function Header( {
 					forceIsAutosaveable={ forceIsDirty }
 				/>
 
-				{ canBeZoomedOut &&
-					isWideViewport &&
-					hasSectionRootClientId && (
-						<ZoomOutToggle disabled={ forceDisableBlockTools } />
-					) }
+				{ isWideViewport && canBeZoomedOut && (
+					<ZoomOutToggle disabled={ forceDisableBlockTools } />
+				) }
 
 				{ ( isWideViewport || ! showIconLabels ) && (
 					<PinnedItems.Slot scope="core" />


### PR DESCRIPTION
## What?
This is a follow-up to #67232.

PR updates the `Header` and `InserterMenu` components to combine datastore subscriptions.

## Why?
Reduces the number of store subscriptions for the `block-editor` store, which is the most active store. As far as I can tell, there's no real reason to keep separate subscriptions.

## Testing Instructions
Borrowed from #67232.

1. Test in Site Editor
2. Remove <main> from template
3. See Zoom Out is no longer possible to activate
4. Test that you can still access Zoom Out from a Page (using Post Editor and Site Editor).

### Testing Instructions for Keyboard
Same.
