### PR TITLE
Storybook: Add Story for Default Block Appender 

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/index.js
+++ b/packages/block-editor/src/components/default-block-appender/index.js
@@ -23,6 +23,21 @@ import { store as blockEditorStore } from '../../store';
  */
 export const ZWNBSP = '\ufeff';
 
+/**
+ * DefaultBlockAppender component used to add a new block to the editor when the editor is empty.
+ *
+ * @param {Object} props              Component props.
+ * @param {string} props.rootClientId The client ID of the root block of the editor.
+ *
+ * @return {WPElement} The DefaultBlockAppender component.
+ *
+ * @example
+ * ```jsx
+ * function MyComponent() {
+ * 	return <DefaultBlockAppender rootClientId="root-block-id" />;
+ * }
+ * ```
+ */
 export default function DefaultBlockAppender( { rootClientId } ) {
 	const { showPrompt, isLocked, placeholder, isManualGrid } = useSelect(
 		( select ) => {

--- a/packages/block-editor/src/components/default-block-appender/stories/index.story.js
+++ b/packages/block-editor/src/components/default-block-appender/stories/index.story.js
@@ -1,0 +1,46 @@
+/**
+ * Internal dependencies
+ */
+import { DefaultBlockAppender } from '../..';
+
+/**
+ * WordPress dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+import { createBlock } from '@wordpress/blocks';
+
+registerCoreBlocks();
+
+const blockEditorState = [ createBlock( 'core/paragraph' ) ];
+
+const meta = {
+	title: 'BlockEditor/DefaultBlockAppender',
+	component: DefaultBlockAppender,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'The DefaultBlockAppender component is used to add a new block to the editor when the editor is empty.',
+			},
+		},
+	},
+	argTypes: {
+		rootClientId: {
+			description: 'The client ID of the root block of the editor.',
+			type: { name: 'string' },
+			required: true,
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	args: {
+		rootClientId: blockEditorState.map( ( block ) => block.clientId )[ 0 ],
+	},
+	render: function Template( args ) {
+		return <DefaultBlockAppender { ...args } />;
+	},
+};


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR adds story for Default Block Appender 

## Testing Instructions
- Run npm run storybook:dev
- Open Storybook at http://localhost:50240/
- Check the DefaultBlockAppender Story

## Screenshots or screencast 


https://github.com/user-attachments/assets/871c0374-2869-4169-be6f-72cf4922add6


