### PR TITLE
Fix: Empty state of custom field can cause SEO problem

### DIFF
--- a/packages/block-library/src/heading/index.php
+++ b/packages/block-library/src/heading/index.php
@@ -22,7 +22,7 @@
  * @return string The content of the block being rendered.
  */
 function block_core_heading_render( $attributes, $content ) {
-	if ( ! $content ) {
+	if ( ! $content || '' === trim( strip_tags( $content ) ) ) {
 		return $content;
 	}
 

--- a/packages/block-library/src/heading/save.js
+++ b/packages/block-library/src/heading/save.js
@@ -10,6 +10,11 @@ import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const { textAlign, content, level } = attributes;
+
+	if ( ! content || content.trim() === '' ) {
+		return null;
+	}
+
 	const TagName = 'h' + level;
 
 	const className = clsx( {


### PR DESCRIPTION
Fixes [#66887](https://github.com/WordPress/gutenberg/issues/66887)

## What?
Prevents empty heading tags from being rendered in the frontend when using block bindings or when heading content is empty.

## Why?
Empty heading tags `(<h1>, <h2>, etc.)` can cause SEO issues as they create unnecessary markup in the page structure. This is particularly problematic when using block bindings where the heading content might be dynamically empty. The fix ensures better SEO practices by preventing empty heading tags from being output.

## How?
Added empty content checks in both:
1. The block's save.js to prevent empty headings from being saved
2. The PHP render callback to prevent empty headings from being rendered

## Testing Instructions
1. Create a new post
2. Add a heading block
3. Leave it empty or delete its content
4. Save and view the post
5. Verify no empty heading tag is rendered in the frontend HTML
