### PR TITLE
Editor: Hide block editor warnings for pattern previews

### DIFF
--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -19,6 +19,10 @@ const MemoizedBlockList = memo( BlockList );
 
 const MAX_HEIGHT = 2000;
 const EMPTY_ADDITIONAL_STYLES = [];
+const PREVIEW_STYLES = {
+	css: 'body{height:auto;overflow:hidden;border:none;padding:0;} .block-editor-warning{display:none;} .is-root-container .block-editor-block-list__block.has-warning:after{background:none;}',
+	__unstableType: 'presets',
+};
 
 function ScaledBlockPreview( {
 	viewportWidth,
@@ -42,14 +46,7 @@ function ScaledBlockPreview( {
 	// Avoid scrollbars and hide block editor warnings for pattern previews.
 	const editorStyles = useMemo( () => {
 		if ( styles ) {
-			return [
-				...styles,
-				{
-					css: 'body{height:auto;overflow:hidden;border:none;padding:0;} .block-editor-warning{display:none;} .is-root-container .block-editor-block-list__block.has-warning:after{background:none;}',
-					__unstableType: 'presets',
-				},
-				...additionalStyles,
-			];
+			return [ ...styles, PREVIEW_STYLES, ...additionalStyles ];
 		}
 
 		return styles;

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -21,7 +21,7 @@ const MAX_HEIGHT = 2000;
 const EMPTY_ADDITIONAL_STYLES = [];
 const PREVIEW_STYLES = {
 	css: `body{height:auto;overflow:hidden;border:none;padding:0;}
-		.block-editor-warning,.components-placeholder:not(.block-editor-media-placeholder){display:none;}
+		.block-editor-warning,.components-placeholder:not(:has(.components-placeholder__illustration)){display:none;}
 		.is-root-container .block-editor-block-list__block.has-warning:after{background:none;}`,
 	__unstableType: 'presets',
 };

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -20,7 +20,9 @@ const MemoizedBlockList = memo( BlockList );
 const MAX_HEIGHT = 2000;
 const EMPTY_ADDITIONAL_STYLES = [];
 const PREVIEW_STYLES = {
-	css: 'body{height:auto;overflow:hidden;border:none;padding:0;} .block-editor-warning{display:none;} .is-root-container .block-editor-block-list__block.has-warning:after{background:none;}',
+	css: `body{height:auto;overflow:hidden;border:none;padding:0;}
+		.block-editor-warning{display:none;}
+		.is-root-container .block-editor-block-list__block.has-warning:after{background:none;}`,
 	__unstableType: 'presets',
 };
 

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -39,13 +39,13 @@ function ScaledBlockPreview( {
 		};
 	}, [] );
 
-	// Avoid scrollbars for pattern previews.
+	// Avoid scrollbars and hide block editor warnings for pattern previews.
 	const editorStyles = useMemo( () => {
 		if ( styles ) {
 			return [
 				...styles,
 				{
-					css: 'body{height:auto;overflow:hidden;border:none;padding:0;}',
+					css: 'body{height:auto;overflow:hidden;border:none;padding:0;} .block-editor-warning{display:none;} .is-root-container .block-editor-block-list__block.has-warning:after{background:none;}',
 					__unstableType: 'presets',
 				},
 				...additionalStyles,

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -21,7 +21,7 @@ const MAX_HEIGHT = 2000;
 const EMPTY_ADDITIONAL_STYLES = [];
 const PREVIEW_STYLES = {
 	css: `body{height:auto;overflow:hidden;border:none;padding:0;}
-		.block-editor-warning{display:none;}
+		.block-editor-warning,.wp-block-query > .components-placeholder{display:none;}
 		.is-root-container .block-editor-block-list__block.has-warning:after{background:none;}`,
 	__unstableType: 'presets',
 };

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -21,7 +21,7 @@ const MAX_HEIGHT = 2000;
 const EMPTY_ADDITIONAL_STYLES = [];
 const PREVIEW_STYLES = {
 	css: `body{height:auto;overflow:hidden;border:none;padding:0;}
-		.block-editor-warning,.wp-block-query > .components-placeholder{display:none;}
+		.block-editor-warning,.components-placeholder:not(.block-editor-media-placeholder){display:none;}
 		.is-root-container .block-editor-block-list__block.has-warning:after{background:none;}`,
 	__unstableType: 'presets',
 };


### PR DESCRIPTION
## What, Why and How?
This PR addresses the issue of warning interactive elements being displayed within IFrame Previews in the Preview Components. It was concluded that these warnings are not required to be rendered in Previews. This change hides the warnings to improve the IFrame Previews' visual consistency and user experience.

## Testing Instructions

1. Go to the Site editor > Patterns > and edit one of your custom patterns under 'My patterns'.
2. Switch the editor to the 'code' view and alter the markup to intentionally make one of the pattern's block invalid.
3. Switch the editor back to the 'visual' view.
4. Observe the editor renders the Block contains unexpected or invalid content. warning.
5. Click 'Open navigation' at the top left of the screen and go to 'My patterns'.
6. Observe the pattern card preview **_do not render_** the Warning in the preview.

## Screenshots

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/1b127352-3654-478a-a3b7-78ba4ed99bc3)|![after](https://github.com/user-attachments/assets/65ebd857-df06-4c60-905c-790e198b3b2c)|

|Before|After|
|-|-|
|<img width="613" alt="Screenshot 2025-01-16 at 12 50 03 PM" src="https://github.com/user-attachments/assets/6ea54417-8981-47ba-b8fe-eff97392a9cd" />|<img width="613" alt="Screenshot 2025-01-16 at 12 49 38 PM" src="https://github.com/user-attachments/assets/edefff27-25bf-4b73-a7e8-4336a0108006" />|

Closes: #68131 