### PR TITLE
StoryBook: Add story for BlockSettingsMenu

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/stories/index.story.js
+++ b/packages/block-editor/src/components/block-settings-menu/stories/index.story.js
@@ -1,0 +1,59 @@
+/**
+ * Internal dependencies
+ */
+import BlockSettingsMenu from '../';
+
+/**
+ * Storybook metadata
+ */
+const meta = {
+	title: 'BlockEditor/BlockSettingsMenu',
+	component: BlockSettingsMenu,
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The `BlockSettingsMenu` component displays the block settings menu, with options like duplicate, remove, etc. It wraps the `BlockSettingsDropdown` and provides toolbar functionality.',
+			},
+			canvas: { sourceState: 'shown' },
+		},
+	},
+	argTypes: {
+		clientIds: {
+			control: 'array',
+			description:
+				'Array of clientIds for the blocks that will be acted upon. Can be used to control block actions like duplicate or delete.',
+			table: {
+				type: { summary: 'Array' },
+			},
+		},
+		__experimentalSelectBlock: {
+			control: 'function',
+			description:
+				'A callback for selecting a block. When provided, interacting with the dropdown options (like duplicate) will not update the editor selection.',
+			table: {
+				type: { summary: 'function' },
+			},
+		},
+	},
+};
+
+export default meta;
+
+/**
+ * Default Story
+ */
+export const Default = {
+	args: {
+		clientIds: [ 'block-1', 'block-2' ],
+		__experimentalSelectBlock: () => {},
+	},
+	render: function Template( { clientIds, __experimentalSelectBlock } ) {
+		return (
+			<BlockSettingsMenu
+				clientIds={ clientIds }
+				__experimentalSelectBlock={ __experimentalSelectBlock }
+			/>
+		);
+	},
+};


### PR DESCRIPTION

Part of: https://github.com/WordPress/gutenberg/issues/67165


## What?
This PR will add story for `BlockSettingsMenu` in the Storybook.


## Testing Instructions

1. Run npm run storybook:dev
2. Open the storybook on [localhost](http://localhost:50240/)
3. Check the `BlockSettingsMenu` story.

## Screenshots or screencast
<img width="1170" alt="image" src="https://github.com/user-attachments/assets/c1a32daa-b3f0-4b60-97c0-34e90337a728" />

