### PR TITLE
Stroybook: Add Story for RichTextToolbarButton

### DIFF
--- a/packages/block-editor/src/components/rich-text/stories/rich-text-toolbar-button.story.js
+++ b/packages/block-editor/src/components/rich-text/stories/rich-text-toolbar-button.story.js
@@ -1,0 +1,113 @@
+/**
+ * Internal dependencies
+ */
+import { RichTextToolbarButton } from '../toolbar-button';
+
+/**
+ * WordPress dependencies
+ */
+import { SlotFillProvider, Slot } from '@wordpress/components';
+import { formatBold } from '@wordpress/icons';
+
+const meta = {
+	title: 'BlockEditor/RichTextToolbarButton',
+	component: RichTextToolbarButton,
+	parameters: {
+		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
+			description: {
+				component:
+					'The `RichTextToolbarButton` component is used to render a button in the rich text toolbar.',
+			},
+		},
+	},
+	decorators: [
+		( Story ) => (
+			<SlotFillProvider>
+				<div className="components-toolbar">
+					<Story />
+					<Slot name="RichText.ToolbarControls.bold" />
+				</div>
+			</SlotFillProvider>
+		),
+	],
+	argTypes: {
+		name: {
+			control: {
+				type: 'text',
+			},
+			description: 'Name of the button.',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		icon: {
+			control: {
+				type: null,
+			},
+			description: 'Icon of the button.',
+			table: {
+				type: {
+					summary: 'object',
+				},
+			},
+		},
+		shortcutType: {
+			control: {
+				type: 'text',
+			},
+			description: 'Type of the shortcut.',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		shortcutCharacter: {
+			control: {
+				type: 'text',
+			},
+			description: 'Character of the shortcut.',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		props: {
+			control: {
+				type: null,
+			},
+			description: 'Props of the button.',
+			table: {
+				type: {
+					summary: 'object',
+					detail: `Here are examples of the props you can pass:
+                
+                    - title: The title of the button (e.g., 'Bold').
+                    - onClick: Function triggered when the button is clicked.
+                    - isActive: A boolean to indicate whether the format is active.
+                    `,
+				},
+			},
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	args: {
+		name: 'bold',
+		icon: formatBold,
+		shortcutType: 'primary',
+		shortcutCharacter: 'b',
+	},
+	render: function Template( args ) {
+		return <RichTextToolbarButton { ...args } />;
+	},
+};

--- a/packages/block-editor/src/components/rich-text/toolbar-button.js
+++ b/packages/block-editor/src/components/rich-text/toolbar-button.js
@@ -4,6 +4,35 @@
 import { Fill, ToolbarButton } from '@wordpress/components';
 import { displayShortcut } from '@wordpress/keycodes';
 
+/**
+ * RichTextToolbarButton component displays a button in the rich text toolbar.
+ *
+ * @param {Object} props                   The component props.
+ * @param {string} props.name              Name of the button.
+ * @param {string} props.shortcutType      Type of the shortcut.
+ * @param {string} props.shortcutCharacter Character of the shortcut.
+ * @param {Object} props.props             Props to pass to the `ToolbarButton` component.
+ *
+ * @return {Element} The toolbar button element.
+ *
+ * @example
+ * ```jsx
+ * function MyRichTextToolbarButton() {
+ * 	return (
+ * 		<RichTextToolbarButton
+ * 			name="my-button"
+ * 			icon={ icon }
+ * 			title="My button"
+ * 			onClick={ () => {
+ * 				console.log( 'Button clicked!' );
+ * 			}
+ *         shortCutType="primary"
+ *         shortCutCharacter="b"
+ * 		/>
+ * );
+ * }
+ * ```
+ */
 export function RichTextToolbarButton( {
 	name,
 	shortcutType,


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR adds Story for RichTextToolbarButton

## Testing Instructions
- Run npm run storybook:dev
- Open Storybook at http://localhost:50240/
- Check the RichTextToolbarButton Story

## Screenshots or screencast 

![image](https://github.com/user-attachments/assets/e46d359c-01fe-4703-b1ba-a9c355926e20)

