### PR TITLE
Lint: Fix broken URL reference for `stylelint` user guide configuration 

### DIFF
--- a/packages/scripts/scripts/lint-style.js
+++ b/packages/scripts/scripts/lint-style.js
@@ -20,7 +20,7 @@ const args = getArgsFromCLI();
 
 const defaultFilesArgs = hasFileArgInCLI() ? [] : [ '**/*.{css,pcss,scss}' ];
 
-// See: https://stylelint.io/user-guide/configuration
+// See: https://stylelint.io/user-guide/configure/
 const hasLintConfig =
 	hasArgInCLI( '--config' ) ||
 	hasProjectFile( '.stylelintrc.js' ) ||


### PR DESCRIPTION
Closes: https://github.com/WordPress/gutenberg/issues/68705

## What?

Fixes the broken URL for the Stylelint reference, which was previously pointing to a "Page Not Found" error.

## How?
Updated the URL from: `https://stylelint.io/user-guide/configuration ` to: `https://stylelint.io/user-guide/configure/`



## Screenshots or screencast 

|Before|After|
|-|-|
|<img width="1470" alt="image" src="https://github.com/user-attachments/assets/11d6c833-b353-43e5-9cdc-5b6a117b92f8" />|<img width="1470" alt="image" src="https://github.com/user-attachments/assets/63371969-3896-45fb-8fcf-fec33d8063cf" />|
