### PR TITLE
DataViews Pagination: improve pagination logic to handle empty pages

### DIFF
--- a/packages/dataviews/src/components/dataviews-footer/index.tsx
+++ b/packages/dataviews/src/components/dataviews-footer/index.tsx
@@ -27,11 +27,12 @@ export default function DataViewsFooter() {
 	const hasBulkActions =
 		useSomeItemHasAPossibleBulkAction( actions, data ) &&
 		[ LAYOUT_TABLE, LAYOUT_GRID ].includes( view.type );
+	const currentPage = view.page ?? 1;
 
 	if (
 		! totalItems ||
 		! totalPages ||
-		( totalPages <= 1 && ! hasBulkActions )
+		( totalPages <= 1 && currentPage <= totalPages && ! hasBulkActions )
 	) {
 		return null;
 	}

--- a/packages/dataviews/src/components/dataviews-pagination/index.tsx
+++ b/packages/dataviews/src/components/dataviews-pagination/index.tsx
@@ -6,7 +6,12 @@ import {
 	__experimentalHStack as HStack,
 	SelectControl,
 } from '@wordpress/components';
-import { createInterpolateElement, memo, useContext } from '@wordpress/element';
+import {
+	createInterpolateElement,
+	memo,
+	useContext,
+	useEffect,
+} from '@wordpress/element';
 import { sprintf, __, _x, isRTL } from '@wordpress/i18n';
 import { next, previous } from '@wordpress/icons';
 
@@ -20,13 +25,25 @@ function DataViewsPagination() {
 		view,
 		onChangeView,
 		paginationInfo: { totalItems = 0, totalPages },
+		data,
 	} = useContext( DataViewsContext );
+
+	const currentPage = view.page ?? 1;
+
+	// If the current page is not the first page, and there are no items on the current page, go to the previous page.
+	useEffect( () => {
+		if ( currentPage !== 1 && ! data.length ) {
+			onChangeView( {
+				...view,
+				page: currentPage - 1,
+			} );
+		}
+	}, [ data.length, currentPage, view, onChangeView ] );
 
 	if ( ! totalItems || ! totalPages ) {
 		return null;
 	}
 
-	const currentPage = view.page ?? 1;
 	const pageSelectOptions = Array.from( Array( totalPages ) ).map(
 		( _, i ) => {
 			const page = i + 1;


### PR DESCRIPTION
## What, Why and How?
This PR addresses an issue in the `DataViewsPagination` component where deleting the last item on a page results in a 'No results found' message instead of navigating to the previous page.

**Changes Made:**
- Added logic to navigate to the previous page when the last item on the current page is deleted and there exists a previous page to navigate.

## Testing Instructions

1. Navigate to the `site editor`.
2. Navigate to `Patterns`.
3. Confirm all the patterns are displayed in a pagination.
4. Make sure, on a particular page, that there's just one data item being displayed.
5. Delete that particular data item.
6. Confirm, that the page navigates back properly.

## Screencasts
https://github.com/user-attachments/assets/0b711d3d-7923-4c63-b978-68cabc047a13

https://github.com/user-attachments/assets/5e6a3d32-bc90-4ea3-b8e1-def52e2859ed

Closes: #68707 