### PR TITLE
Fix Amazon Kindle Embed Title

### DIFF
--- a/packages/block-library/src/embed/variations.js
+++ b/packages/block-library/src/embed/variations.js
@@ -331,7 +331,7 @@ const variations = [
 		attributes: { providerNameSlug: 'wordpress-tv', responsive: true },
 	},
 	{
-		name: 'amazon-kindle',
+		name: 'amazon',
 		title: getTitle( 'Amazon Kindle' ),
 		icon: embedAmazonIcon,
 		keywords: [ __( 'ebook' ) ],
@@ -340,7 +340,7 @@ const variations = [
 			/^https?:\/\/([a-z0-9-]+\.)?(amazon|amzn)(\.[a-z]{2,4})+\/.+/i,
 			/^https?:\/\/(www\.)?(a\.co|z\.cn)\/.+/i,
 		],
-		attributes: { providerNameSlug: 'amazon-kindle' },
+		attributes: { providerNameSlug: 'amazon' },
 	},
 	{
 		name: 'pinterest',


### PR DESCRIPTION
## What?
Resolves: https://github.com/WordPress/gutenberg/issues/68714

This PR addresses an issue in the **Amazon Kindle Embed block** where, after embedding a valid URL, the block incorrectly reverts to the default placeholder text instead of showing the correct text.

## Why?
This PR is necessary to fix the user experience when embedding Kindle content. Currently, users expect the block to render the embedded preview after entering a valid URL, but the block erroneously displays the default placeholder text, creating confusion and reducing usability.

## Testing Instructions
1. Open a post or page in the WordPress Gutenberg editor.
2. Add a new block by clicking the "+" button.
3. Search for and insert the **Amazon Kindle Embed** block.
4. Observe the default text in the block:
   - Expected: The block displays `Amazon Kindle Embed` - "Embed Amazon Kindle content."
5. Enter a valid Amazon Kindle URL in the URL field and press Enter.
6. Expected: The block displays `Amazon Kindle Embed` - "Embed Amazon Kindle content." [SAME]

## Screenshots or screencast

|Before|After|
|-|-|
|![Screenshot 2025-01-16 at 16 38 11](https://github.com/user-attachments/assets/22627029-b28c-4a78-92cb-e634d175cd49)|![Screenshot 2025-01-16 at 16 39 12](https://github.com/user-attachments/assets/ef44e5a5-ce45-4709-a2a5-0f4025bfc16a)|
|![Screenshot 2025-01-16 at 16 38 11](https://github.com/user-attachments/assets/22627029-b28c-4a78-92cb-e634d175cd49)|![Screenshot 2025-01-16 at 16 38 11](https://github.com/user-attachments/assets/22627029-b28c-4a78-92cb-e634d175cd49)|

<!-- Replace `link-to-before-screenshot` and `link-to-after-screenshot` with appropriate links to images -->
