### PR TITLE
Storybook: Add Story for RichTextShortcut

### DIFF
--- a/packages/block-editor/src/components/rich-text/stories/rich-text-shortcut.story.js
+++ b/packages/block-editor/src/components/rich-text/stories/rich-text-shortcut.story.js
@@ -1,0 +1,69 @@
+/**
+ * Internal dependencies
+ */
+import { RichTextShortcut } from '../shortcut.js';
+
+/**
+ * WordPress dependencies
+ */
+const meta = {
+	title: 'BlockEditor/RichTextShortcut',
+	component: RichTextShortcut,
+	parameters: {
+		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
+			description: {
+				component:
+					'The `RichTextShortcut` component is used to define a keyboard shortcut for a specific action.',
+			},
+		},
+	},
+	argTypes: {
+		character: {
+			control: {
+				type: 'text',
+			},
+			description: 'The character that triggers the shortcut.',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		type: {
+			control: {
+				type: 'select',
+				options: [ 'primary', 'access' ],
+			},
+			description: 'The type of shortcut.',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		onUse: {
+			description: 'Function to be called when the shortcut is used.',
+			table: {
+				type: {
+					summary: 'function',
+				},
+			},
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	args: {
+		character: 'b',
+		type: 'primary',
+		onUse: () => {},
+	},
+	render: function Template( args ) {
+		return <RichTextShortcut { ...args } />;
+	},
+};

--- a/packages/block-editor/src/components/rich-text/stories/rich-text-shortcut.story.js
+++ b/packages/block-editor/src/components/rich-text/stories/rich-text-shortcut.story.js
@@ -1,11 +1,9 @@
 /**
  * Internal dependencies
  */
+import { keyboardShortcutContext } from '../index.js';
 import { RichTextShortcut } from '../shortcut.js';
 
-/**
- * WordPress dependencies
- */
 const meta = {
 	title: 'BlockEditor/RichTextShortcut',
 	component: RichTextShortcut,
@@ -53,6 +51,19 @@ const meta = {
 			},
 		},
 	},
+	decorators: [
+		( Story ) => {
+			const keyboardShortcuts = {
+				current: new Set(),
+			};
+
+			return (
+				<keyboardShortcutContext.Provider value={ keyboardShortcuts }>
+					{ Story() }
+				</keyboardShortcutContext.Provider>
+			);
+		},
+	],
 };
 
 export default meta;


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?

This PR adds story for RichTextShortcut component


## Testing Instructions
- Run npm run storybook:dev
- Open Storybook at http://localhost:50240/
- Check the RichTextShortcut Story

## Screenshots or screencast 

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/5451ec17-cddf-4160-b4e5-2392e0bd4d2a" />
