### PR TITLE
Upload Media: Fix package dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52663,6 +52663,7 @@
 			"version": "0.1.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@babel/runtime": "7.25.7",
 				"@shopify/web-worker": "^6.4.0",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/blob": "file:../blob",
@@ -52678,6 +52679,10 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
 			}
 		},
 		"packages/url": {

--- a/packages/upload-media/package.json
+++ b/packages/upload-media/package.json
@@ -27,6 +27,7 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
+		"@babel/runtime": "7.25.7",
 		"@shopify/web-worker": "^6.4.0",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/blob": "file:../blob",
@@ -38,6 +39,10 @@
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/url": "file:../url",
 		"uuid": "^9.0.1"
+	},
+	"peerDependencies": {
+		"react": "^18.0.0",
+		"react-dom": "^18.0.0"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
## What?
Resolves #68694.

PR adds missing dependencies for the `@wordpress/upload-media` package.

## Testing Instructions
Verify that the change makes sense.
