### PR TITLE
Embed: Remove aspect ratio classes when transforming into Paragraph

### DIFF
--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -123,7 +123,8 @@ export function addTransforms( result, source, index, results ) {
 	// if source N does not exists we do nothing.
 	if ( source[ index ] ) {
 		const originClassName = source[ index ]?.attributes.className;
-		if ( originClassName ) {
+		// Avoid overriding classes if the transformed block already includes them.
+		if ( originClassName && result.attributes.className === undefined ) {
 			return {
 				...result,
 				attributes: {

--- a/packages/block-library/src/embed/transforms.js
+++ b/packages/block-library/src/embed/transforms.js
@@ -7,6 +7,7 @@ import { createBlock } from '@wordpress/blocks';
  * Internal dependencies
  */
 import metadata from './block.json';
+import { removeAspectRatioClasses } from './util';
 
 const { name: EMBED_BLOCK } = metadata;
 
@@ -33,13 +34,14 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'core/paragraph' ],
 			isMatch: ( { url } ) => !! url,
-			transform: ( { url, caption } ) => {
+			transform: ( { url, caption, className } ) => {
 				let value = `<a href="${ url }">${ url }</a>`;
 				if ( caption?.trim() ) {
 					value += `<br />${ caption }`;
 				}
 				return createBlock( 'core/paragraph', {
 					content: value,
+					className: removeAspectRatioClasses( className ),
 				} );
 			},
 		},


### PR DESCRIPTION
## What?
Fixes #39616
Alternative to #44947 and #60895.

Updates embed block transformation to remove aspect ratio classes while retaining any additional classes added by the user. The aspect ratio classes are specific to embed blocks and shouldn't be kept during transformations.

Adjust the custom classes transformation hook to add classes only from the source when the transformation doesn't provide them. Avoids attribute overrides when the transformed block already provides class names.

## Testing Instructions
1. Open a post or page.
2. Embed a YouTube link.
3. Transform into Paragraph.
4. Confirm no additional classes are displayed in the Advanced panel.
5. Embed a YouTube link.
6. Add a custom test class.
7. Transform into Paragraph.
8. Confirm that only the custom test class was retained.

### Testing Instructions for Keyboard
Same.