### PR TITLE
Fix: Add `rel="tag"` to individual anchor links in editor markup of the post terms block

### DIFF
--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -122,6 +122,7 @@ export default function PostTermsEdit( {
 								key={ postTerm.id }
 								href={ postTerm.link }
 								onClick={ ( event ) => event.preventDefault() }
+								rel="tag"
 							>
 								{ decodeEntities( postTerm.name ) }
 							</a>


### PR DESCRIPTION
_This was a really minor change I noticed whilst working on something else, so I quickly created this PR without adding an issue first. Happy to create one if this is more controversial_

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds the `rel="tag"` attribute to the `a` elements of the `post-terms` block in the editor 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because the frontend markup renders them that way. On the server we use the [`get_the_term_list`](https://developer.wordpress.org/reference/functions/get_the_term_list/) function to produce the markup which includes the `rel="tag"` attribute.

https://github.com/WordPress/gutenberg/blob/56883338749aa23acc75481c3bbc605bf1cb5a81/packages/block-library/src/post-terms/index.php#L49-L55

https://github.com/WordPress/wordpress-develop/blob/d2a7bee9a6201f0276492ff29afd8c509480d266/src/wp-includes/category-template.php#L1356

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adding the attribute in the edit.js file

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Insert the Post Categories block
2. Inspect the markup
3. See that any links have the `rel="tag"` attribute present
4. Open the page on the frontend and see that the markup matches the editor
