### PR TITLE
Try using `dialog` element for image lightbox

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -287,7 +287,6 @@ function block_core_image_print_lightbox_overlay() {
 			data-wp-on-async-window--resize="callbacks.setOverlayStyles"
 			data-wp-on-async-window--scroll="actions.handleScroll"
 			data-wp-bind--style="state.overlayStyles"
-			tabindex="-1"
 			>
 				<button type="button" aria-label="$close_button_label" style="fill: $close_button_color" class="close-button">
 					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path d="m13.06 12 6.47-6.47-1.06-1.06L12 10.94 5.53 4.47 4.47 5.53 10.94 12l-6.47 6.47 1.06 1.06L12 13.06l6.47 6.47 1.06-1.06L13.06 12Z"></path></svg>

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -269,14 +269,14 @@ function block_core_image_print_lightbox_overlay() {
 	}
 
 	echo <<<HTML
-		<div
+		<dialog
 			class="wp-lightbox-overlay zoom"
 			data-wp-interactive="core/image"
 			data-wp-context='{}'
 			data-wp-bind--role="state.roleAttribute"
 			data-wp-bind--aria-label="state.currentImage.ariaLabel"
 			data-wp-bind--aria-modal="state.ariaModal"
-			data-wp-class--active="state.overlayEnabled"
+			data-wp-bind--open="state.overlayEnabled"
 			data-wp-class--show-closing-animation="state.showClosingAnimation"
 			data-wp-watch="callbacks.setOverlayFocus"
 			data-wp-on--keydown="actions.handleKeydown"
@@ -303,7 +303,7 @@ function block_core_image_print_lightbox_overlay() {
 					</figure>
 				</div>
 				<div class="scrim" style="background-color: $background_color" aria-hidden="true"></div>
-		</div>
+		</dialog>
 HTML;
 }
 

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -278,6 +278,12 @@
 		opacity: 0.9;
 	}
 
+	&:is(dialog) {
+		margin: 0;
+		padding: 0;
+		border: 0;
+	}
+
 	// When fading, make the image come in slightly slower
 	// or faster than the scrim to give a sense of depth.
 	&[open] {

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -280,7 +280,7 @@
 
 	// When fading, make the image come in slightly slower
 	// or faster than the scrim to give a sense of depth.
-	&.active {
+	&[open] {
 		visibility: visible;
 		@media not (prefers-reduced-motion) {
 			animation: both turn-on-visibility 0.25s;
@@ -292,7 +292,8 @@
 		}
 	}
 	&.show-closing-animation {
-		&:not(.active) {
+		&:not([open]) {
+			display: block;
 			@media not (prefers-reduced-motion) {
 				animation: both turn-off-visibility 0.35s;
 			}
@@ -306,7 +307,7 @@
 
 	@media not (prefers-reduced-motion) {
 		&.zoom {
-			&.active {
+			&[open] {
 				opacity: 1;
 				visibility: visible;
 				animation: none;
@@ -322,7 +323,8 @@
 				}
 			}
 			&.show-closing-animation {
-				&:not(.active) {
+				&:not([open]) {
+					display: block;
 					animation: none;
 					.lightbox-image-container {
 						animation: lightbox-zoom-out 0.4s;

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -102,6 +102,13 @@ const { state, actions, callbacks } = store(
 
 				// Computes the styles of the overlay for the animation.
 				callbacks.setOverlayStyles();
+
+				const lightboxOverlay = document.querySelector(
+					'dialog#wp-core-image-lightbox-overlay'
+				);
+				if ( lightboxOverlay ) {
+					lightboxOverlay.showModal();
+				}
 			},
 			hideLightbox() {
 				if ( state.overlayEnabled ) {
@@ -126,6 +133,13 @@ const { state, actions, callbacks } = store(
 						// Resets the current image id to mark the overlay as closed.
 						state.currentImageId = null;
 					}, 450 );
+
+					const lightboxOverlay = document.querySelector(
+						'dialog#wp-core-image-lightbox-overlay'
+					);
+					if ( lightboxOverlay ) {
+						lightboxOverlay.close();
+					}
 				}
 			},
 			handleKeydown( event ) {


### PR DESCRIPTION
This PR explores using the `dialog` element for the image lightbox instead of a regular less semantic `div`.

A better version of this is #68726, which uses the Popover API.