### PR TITLE
Try using popover API for image lightbox

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -295,7 +295,14 @@ function block_core_image_print_lightbox_overlay() {
 			data-wp-on-async-window--scroll="actions.handleScroll"
 			data-wp-bind--style="state.overlayStyles"
 			>
-				<button type="button" aria-label="$close_button_label" style="fill: $close_button_color" class="close-button">
+				<button
+					type="button"
+					popovertarget="wp-core-image-lightbox-overlay"
+					popovertargetaction="hide"
+					aria-label="$close_button_label"
+					style="fill: $close_button_color"
+					class="close-button"
+				>
 					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path d="m13.06 12 6.47-6.47-1.06-1.06L12 10.94 5.53 4.47 4.47 5.53 10.94 12l-6.47 6.47 1.06 1.06L12 13.06l6.47 6.47 1.06-1.06L13.06 12Z"></path></svg>
 				</button>
 				<div class="lightbox-image-container">

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -230,7 +230,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 			data-wp-on--click="actions.setCurrentImage"
 		>
 			' . $img[0] . '
-			<div
+			<span
 				class="wp-lightbox-indicator"
 				data-wp-style--right="state.imageButtonRight"
 				data-wp-style--top="state.imageButtonTop"
@@ -238,7 +238,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 				<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12" aria-hidden="true">
 					<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
 				</svg>
-			</div>
+			</span>
 		</button>';
 
 	$body_content = preg_replace( '/<img[^>]+>/', $button, $body_content );

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -284,7 +284,6 @@ function block_core_image_print_lightbox_overlay() {
 			data-wp-bind--role="state.roleAttribute"
 			data-wp-bind--aria-label="state.currentImage.ariaLabel"
 			data-wp-bind--aria-modal="state.ariaModal"
-			data-wp-class--show-closing-animation="state.showClosingAnimation"
 			data-wp-watch="callbacks.setOverlayFocus"
 			data-wp-on--toggle="actions.handleToggle"
 			data-wp-on--keydown="actions.handleKeydown"

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -270,6 +270,11 @@ function block_core_image_print_lightbox_overlay() {
 	}
 
 	echo <<<HTML
+		<style>
+			.wp-lightbox-overlay[popover]::backdrop {
+				background-color: $background_color;
+			}
+		</style>
 		<div
 			id="wp-core-image-lightbox-overlay"
 			popover="auto"

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -210,10 +210,6 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$p->set_attribute( 'data-wp-init', 'callbacks.setButtonStyles' );
 	$p->set_attribute( 'data-wp-on-async--load', 'callbacks.setButtonStyles' );
 	$p->set_attribute( 'data-wp-on-async-window--resize', 'callbacks.setButtonStyles' );
-	// Sets an event callback on the `img` because the `figure` element can also
-	// contain a caption, and we don't want to trigger the lightbox when the
-	// caption is clicked.
-	$p->set_attribute( 'data-wp-on--click', 'actions.showLightbox' );
 	$p->set_attribute( 'data-wp-class--hide', 'state.isContentHidden' );
 	$p->set_attribute( 'data-wp-class--show', 'state.isContentVisible' );
 
@@ -223,22 +219,26 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$img = null;
 	preg_match( '/<img[^>]+>/', $body_content, $img );
 
-	$button =
-		$img[0]
-		. '<button
+	$button = '
+		<button
 			popovertarget="wp-core-image-lightbox-overlay"
-			class="lightbox-trigger"
+			class="wp-lightbox-image-button"
 			type="button"
 			aria-haspopup="dialog"
 			aria-label="' . esc_attr( $aria_label ) . '"
 			data-wp-init="callbacks.initTriggerButton"
 			data-wp-on--click="actions.setCurrentImage"
-			data-wp-style--right="state.imageButtonRight"
-			data-wp-style--top="state.imageButtonTop"
 		>
-			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
-				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
-			</svg>
+			' . $img[0] . '
+			<div
+				class="wp-lightbox-indicator"
+				data-wp-style--right="state.imageButtonRight"
+				data-wp-style--top="state.imageButtonTop"
+			>
+				<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12" aria-hidden="true">
+					<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+				</svg>
+			</div>
 		</button>';
 
 	$body_content = preg_replace( '/<img[^>]+>/', $button, $body_content );

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -213,7 +213,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	// Sets an event callback on the `img` because the `figure` element can also
 	// contain a caption, and we don't want to trigger the lightbox when the
 	// caption is clicked.
-	$p->set_attribute( 'data-wp-on-async--click', 'actions.showLightbox' );
+	$p->set_attribute( 'data-wp-on--click', 'actions.showLightbox' );
 	$p->set_attribute( 'data-wp-class--hide', 'state.isContentHidden' );
 	$p->set_attribute( 'data-wp-class--show', 'state.isContentVisible' );
 
@@ -226,12 +226,13 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 	$button =
 		$img[0]
 		. '<button
+			popovertarget="wp-core-image-lightbox-overlay"
 			class="lightbox-trigger"
 			type="button"
 			aria-haspopup="dialog"
 			aria-label="' . esc_attr( $aria_label ) . '"
 			data-wp-init="callbacks.initTriggerButton"
-			data-wp-on-async--click="actions.showLightbox"
+			data-wp-on--click="actions.setCurrentImage"
 			data-wp-style--right="state.imageButtonRight"
 			data-wp-style--top="state.imageButtonTop"
 		>
@@ -270,15 +271,17 @@ function block_core_image_print_lightbox_overlay() {
 
 	echo <<<HTML
 		<div
+			id="wp-core-image-lightbox-overlay"
+			popover="auto"
 			class="wp-lightbox-overlay zoom"
 			data-wp-interactive="core/image"
 			data-wp-context='{}'
 			data-wp-bind--role="state.roleAttribute"
 			data-wp-bind--aria-label="state.currentImage.ariaLabel"
 			data-wp-bind--aria-modal="state.ariaModal"
-			data-wp-class--active="state.overlayEnabled"
 			data-wp-class--show-closing-animation="state.showClosingAnimation"
 			data-wp-watch="callbacks.setOverlayFocus"
+			data-wp-on--toggle="actions.handleToggle"
 			data-wp-on--keydown="actions.handleKeydown"
 			data-wp-on-async--touchstart="actions.handleTouchStart"
 			data-wp-on--touchmove="actions.handleTouchMove"
@@ -287,7 +290,6 @@ function block_core_image_print_lightbox_overlay() {
 			data-wp-on-async-window--resize="callbacks.setOverlayStyles"
 			data-wp-on-async-window--scroll="actions.handleScroll"
 			data-wp-bind--style="state.overlayStyles"
-			tabindex="-1"
 			>
 				<button type="button" aria-label="$close_button_label" style="fill: $close_button_color" class="close-button">
 					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path d="m13.06 12 6.47-6.47-1.06-1.06L12 10.94 5.53 4.47 4.47 5.53 10.94 12l-6.47 6.47 1.06 1.06L12 13.06l6.47 6.47 1.06-1.06L13.06 12Z"></path></svg>
@@ -302,7 +304,6 @@ function block_core_image_print_lightbox_overlay() {
 						<img data-wp-bind--alt="state.currentImage.alt" data-wp-bind--class="state.currentImage.imgClassNames" data-wp-bind--style="state.imgStyles" data-wp-bind--src="state.enlargedSrc">
 					</figure>
 				</div>
-				<div class="scrim" style="background-color: $background_color" aria-hidden="true"></div>
 		</div>
 HTML;
 }

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -199,7 +199,6 @@
 	position: fixed;
 	top: 0;
 	left: 0;
-	z-index: 100000;
 	overflow: hidden;
 	width: 100%;
 	height: 100vh;
@@ -213,7 +212,6 @@
 		right: calc(env(safe-area-inset-right) + 16px); // equivalent to $grid-unit-20
 		padding: 0;
 		cursor: pointer;
-		z-index: 5000000;
 		min-width: 40px; // equivalent to $button-size-next-default-40px
 		min-height: 40px; // equivalent to $button-size-next-default-40px
 		display: flex;
@@ -237,7 +235,6 @@
 		transform: translate(-50%, -50%);
 		width: var(--wp--lightbox-container-width);
 		height: var(--wp--lightbox-container-height);
-		z-index: 9999999999;
 	}
 
 	.wp-block-image {
@@ -249,7 +246,6 @@
 		justify-content: center;
 		align-items: center;
 		box-sizing: border-box;
-		z-index: 3000000;
 		margin: 0;
 
 		img {

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -269,18 +269,20 @@
 		background: none;
 	}
 
-	.scrim {
-		width: 100%;
-		height: 100%;
-		position: absolute;
-		z-index: 2000000;
+	&::backdrop {
 		background-color: rgb(255, 255, 255);
 		opacity: 0.9;
 	}
 
+	&[popover] {
+		margin: 0;
+		padding: 0;
+		border: 0;
+	}
+
 	// When fading, make the image come in slightly slower
-	// or faster than the scrim to give a sense of depth.
-	&.active {
+	// or faster than the backdrop to give a sense of depth.
+	&:popover-open {
 		visibility: visible;
 		@media not (prefers-reduced-motion) {
 			animation: both turn-on-visibility 0.25s;
@@ -292,7 +294,8 @@
 		}
 	}
 	&.show-closing-animation {
-		&:not(.active) {
+		&:not(:popover-open) {
+			display: block;
 			@media not (prefers-reduced-motion) {
 				animation: both turn-off-visibility 0.35s;
 			}
@@ -306,7 +309,7 @@
 
 	@media not (prefers-reduced-motion) {
 		&.zoom {
-			&.active {
+			&:popover-open {
 				opacity: 1;
 				visibility: visible;
 				animation: none;
@@ -317,12 +320,13 @@
 						animation: none;
 					}
 				}
-				.scrim {
+				&::backdrop {
 					animation: turn-on-visibility 0.4s forwards;
 				}
 			}
 			&.show-closing-animation {
-				&:not(.active) {
+				&:not(:popover-open) {
+					display: block;
 					animation: none;
 					.lightbox-image-container {
 						animation: lightbox-zoom-out 0.4s;
@@ -331,7 +335,7 @@
 							animation: none;
 						}
 					}
-					.scrim {
+					&::backdrop {
 						animation: turn-off-visibility 0.4s forwards;
 					}
 				}

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -141,20 +141,37 @@
 	display: flex;
 	flex-direction: column;
 
-	img {
+	.wp-lightbox-image-button {
+		background-color: transparent;
+		border: none;
+		display: block;
+		margin: 0;
+		padding: 0;
 		cursor: zoom-in;
+
+		&:focus-visible {
+			outline: 3px auto rgb(90 90 90 / 25%);
+			outline: 3px auto -webkit-focus-ring-color;
+			outline-offset: 3px;
+
+			&:has(.hide) {
+				outline: 0;
+				outline-offset: 0;
+			}
+		}
+
+		&:hover .wp-lightbox-indicator,
+		&:focus .wp-lightbox-indicator {
+			cursor: pointer;
+			opacity: 1;
+		}
 	}
 
-	img:hover + button {
-		opacity: 1;
-	}
-
-	button {
+	.wp-lightbox-indicator {
 		opacity: 0;
 		border: none;
 		background-color: rgb(90 90 90 / 25%);
 		backdrop-filter: blur($grid-unit-20) saturate(180%);
-		cursor: zoom-in;
 		display: flex;
 		justify-content: center;
 		align-items: center;
@@ -170,28 +187,6 @@
 		@media not (prefers-reduced-motion) {
 			transition: opacity 0.2s ease;
 		}
-
-		&:focus-visible {
-			outline: 3px auto rgb(90 90 90 / 25%);
-			outline: 3px auto -webkit-focus-ring-color;
-			outline-offset: 3px;
-		}
-
-		&:hover {
-			cursor: pointer;
-			opacity: 1;
-		}
-
-		&:focus {
-			opacity: 1;
-		}
-
-		&:hover,
-		&:focus,
-		&:not(:hover):not(:active):not(.has-background) {
-			background-color: rgb(90 90 90 / 25%);
-			border: none;
-		}
 	}
 }
 
@@ -203,8 +198,75 @@
 	width: 100%;
 	height: 100vh;
 	box-sizing: border-box;
-	visibility: hidden;
+	opacity: 0;
+	background-color: transparent;
 	cursor: zoom-out;
+
+	&[popover] {
+		margin: 0;
+		padding: 0;
+		border: 0;
+	}
+
+	&::backdrop {
+		background-color: rgb(255, 255, 255);
+		opacity: 0;
+	}
+
+	&:popover-open {
+		opacity: 1;
+		&::backdrop {
+			opacity: 0.9;
+		}
+	}
+
+	@media not (prefers-reduced-motion) {
+		&,
+		&::backdrop {
+			transition: opacity 0.35s, display 0.35s allow-discrete, overlay 0.35s allow-discrete;
+		}
+
+		// When fading, make the image come in slightly slower
+		// or faster than the backdrop to give a sense of depth.
+		img {
+			animation: both turn-off-visibility 0.25s;
+		}
+		&:popover-open {
+			img {
+				animation: both turn-on-visibility 0.45s;
+			}
+		}
+
+		&.zoom {
+			// Opacity is not animated in "zoom" mode, so set it to the same as the open state even when closed.
+			opacity: 1;
+			&::backdrop {
+				opacity: 0.9;
+			}
+
+			&,
+			&::backdrop {
+				transition: display 0.4s allow-discrete, overlay 0.4s allow-discrete;
+			}
+
+			.lightbox-image-container {
+				animation: lightbox-zoom-out 0.4s;
+				// Override fade animation for image
+				img {
+					animation: none;
+				}
+			}
+			&:popover-open {
+				.lightbox-image-container {
+					animation: lightbox-zoom-in 0.4s;
+					// Override fade animation for image
+					img {
+						animation: none;
+					}
+				}
+			}
+		}
+	}
 
 	.close-button {
 		position: absolute;
@@ -263,80 +325,6 @@
 	button {
 		border: none;
 		background: none;
-	}
-
-	&::backdrop {
-		background-color: rgb(255, 255, 255);
-		opacity: 0.9;
-	}
-
-	&[popover] {
-		margin: 0;
-		padding: 0;
-		border: 0;
-	}
-
-	// When fading, make the image come in slightly slower
-	// or faster than the backdrop to give a sense of depth.
-	&:popover-open {
-		visibility: visible;
-		@media not (prefers-reduced-motion) {
-			animation: both turn-on-visibility 0.25s;
-		}
-		img {
-			@media not (prefers-reduced-motion) {
-				animation: both turn-on-visibility 0.35s;
-			}
-		}
-	}
-	&.show-closing-animation {
-		&:not(:popover-open) {
-			display: block;
-			@media not (prefers-reduced-motion) {
-				animation: both turn-off-visibility 0.35s;
-			}
-			img {
-				@media not (prefers-reduced-motion) {
-					animation: both turn-off-visibility 0.25s;
-				}
-			}
-		}
-	}
-
-	@media not (prefers-reduced-motion) {
-		&.zoom {
-			&:popover-open {
-				opacity: 1;
-				visibility: visible;
-				animation: none;
-				.lightbox-image-container {
-					animation: lightbox-zoom-in 0.4s;
-					// Override fade animation for image
-					img {
-						animation: none;
-					}
-				}
-				&::backdrop {
-					animation: turn-on-visibility 0.4s forwards;
-				}
-			}
-			&.show-closing-animation {
-				&:not(:popover-open) {
-					display: block;
-					animation: none;
-					.lightbox-image-container {
-						animation: lightbox-zoom-out 0.4s;
-						// Override fade animation for image
-						img {
-							animation: none;
-						}
-					}
-					&::backdrop {
-						animation: turn-off-visibility 0.4s forwards;
-					}
-				}
-			}
-		}
 	}
 }
 

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -84,10 +84,6 @@ const { state, actions, callbacks } = store(
 		},
 		actions: {
 			showLightbox() {
-				if ( ! actions.setCurrentImage() ) {
-					return;
-				}
-
 				const lightboxOverlay = document.querySelector(
 					'#wp-core-image-lightbox-overlay[popover]'
 				);
@@ -108,11 +104,10 @@ const { state, actions, callbacks } = store(
 
 				// Bails out if the image has not loaded yet.
 				if ( ! state.metadata[ imageId ].imageRef?.complete ) {
-					return false;
+					return;
 				}
 
 				state.currentImageId = imageId;
-				return true;
 			},
 			resetCurrentImage() {
 				state.currentImageId = null;

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -83,15 +83,15 @@ const { state, actions, callbacks } = store(
 			},
 		},
 		actions: {
-			showLightbox() {
-				const lightboxOverlay = document.querySelector(
-					'#wp-core-image-lightbox-overlay[popover]'
-				);
-				if ( lightboxOverlay ) {
-					lightboxOverlay.showPopover();
+			hideLightbox( event ) {
+				/*
+				 * This handler is purely for the custom action of hiding the lightbox when clicking anywhere inside.
+				 * If this handler is triggered due to a click on the close button, it should be ignored as that
+				 * button automatically hides the lightbox via `popovertarget` and `popovertargetaction`.
+				 */
+				if ( event?.target?.tagName === 'BUTTON' ) {
+					return;
 				}
-			},
-			hideLightbox() {
 				const lightboxOverlay = document.querySelector(
 					'#wp-core-image-lightbox-overlay[popover]'
 				);

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -126,14 +126,11 @@ const { state, actions, callbacks } = store(
 			},
 			handleHideLightbox() {
 				if ( state.overlayEnabled ) {
-					// Starts the overlay closing animation. The showClosingAnimation
-					// class is used to avoid showing it on page load.
-					state.showClosingAnimation = true;
 					state.overlayEnabled = false;
 
 					// Waits until the close animation has completed before allowing a
 					// user to scroll again. The duration of this animation is defined in
-					// the `styles.scss` file, but in any case we should wait a few
+					// the `style.scss` file, but in any case we should wait a few
 					// milliseconds longer than the duration, otherwise a user may scroll
 					// too soon and cause the animation to look sloppy.
 					setTimeout( function () {
@@ -143,9 +140,6 @@ const { state, actions, callbacks } = store(
 						state.currentImage.buttonRef.focus( {
 							preventScroll: true,
 						} );
-
-						// Resets the closing animation class.
-						state.showClosingAnimation = false;
 
 						// Resets the current image id to mark the overlay as closed.
 						actions.resetCurrentImage();


### PR DESCRIPTION
This PR explores using the `popover` API for the image lightbox as well as related animation capabilities, in order to improve accessibility and simplify the implementation.

Benefits:
* Accessibility out of the box, e.g. based on `popovertarget` attribute used on both the button to open the lightbox and the button to close it (see https://www.w3.org/TR/html-aam-1.0/#att-popovertarget).
* Open/closed state out of the box, via `popover` and `popovertarget` attributes, which allows removing some now unnecessary event listeners.
    * The `tabindex="-1"` is now no longer necessary on the lightbox container element as it cannot be focused unless open anyways.
* Better semantics by wrapping the `img` element itself with a `button`, as the image itself can be clicked to open the lightbox.
    * What was previously the `button` is now simply a visual indicator that the image can be clicked to open a lightbox, _within_ the actual button.
    * That visual indicator now uses `aria-hidden="true"` because for screen readers it's not helpful, since the button itself already provides the information about the possible interaction.
* Appears in top-level, which allows to remove all the `z-index` hacks (top-level is higher than any `z-index` can be).
* Automatically includes a `::backdrop` pseudo element that can be styled, which allows removing the semantically pointless `div.scrim` element.
* Pressing `Escape` automatically closes the lightbox.
* Uses the `transition` CSS property on the `[popover]` element and its `::backdrop` in combination with special `overlay` property and the `allow-discrete` value to keep the elements in the DOM after closure until the animation is completed, avoiding the need for the previous workaround with the `show-closing-animation` extra class.

I have tested and compared this in depth with the original behavior, both with and without the (hard-coded) `zoom` class on the lightbox container (which based on its presence will lead to different animation behavior). From what I can tell, everything is working as expected. Of course further testing is much appreciated.

Learn more:
* https://developer.chrome.com/blog/introducing-popover-api
* https://developer.chrome.com/blog/entry-exit-animations#animating_elements_to_and_from_the_top-layer

Previous related experiment is #68725, which however is not as suitable for an approach.