### PR TITLE
Base Styles: Update `z-index` for snackbars to ensure proper layering with modals

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -110,11 +110,11 @@ $z-layers: (
 	// Below the block toolbar.
 	".block-editor-grid-visualizer": 30,
 
-	// Show snackbars above everything (similar to popovers)
-	".components-snackbar-list": 100000,
-
 	// Show modal under the wp-admin menus and the popover
 	".components-modal__screen-overlay": 100000,
+
+	// Show snackbars above everything (similar to popovers)
+	".components-snackbar-list": 100001,
 
 	// Show popovers above wp-admin menus and submenus and sidebar:
 	// #adminmenuwrap { z-index: 9990 }


### PR DESCRIPTION
## What, Why & How?

closes: #68728 

This PR addresses the bug where the `Snackbar` gets displayed below the `Dialog` by incrementing the `z-index`.

## Testing Instructions

1. Navigate to the `post edit` screen.
2. Open the `Block Inserter`.
3. Navigate to the Patterns tab and open the `Explore all patterns` dialog.
4. Try selecting a Pattern from the Dialog.
5. Confirm that the `snackbar` now gets rendered above the `dialog`.

## Screencast

https://github.com/user-attachments/assets/b24d9308-8753-44ee-a0bd-0d8cfdb5ec83