### PR TITLE
Fix: List item inline/inline-block pseudo css issue in editor

### DIFF
--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -97,6 +97,7 @@ export default function ListItemEdit( {
 					aria-label={ __( 'List text' ) }
 					placeholder={ placeholder || __( 'List' ) }
 					onMerge={ onMerge }
+					style={ { display: 'inline-block' } }
 				/>
 				{ innerBlocksProps.children }
 			</li>


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->
fixes https://github.com/WordPress/gutenberg/issues/68727

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- List item adds div for RichText input. So adding psuedo css to list item behaves unexpectedly due to an extra div added to list item in the editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Added `display: inline-block;` to RickText div.

## Testing Instructions
<!-- Please include step-by-step instructions on how to test this PR. -->

### Styles used to register block style for core/list-item:
```
\register_block_style( 
    'core/list-item' , 
    array(
        'default'      => false,
        'name'         => 'acme-list',
        'lable'         => 'ACME List',
        'inline_style' => '.is-style-acme-list { position: relative; } .is-style-acme-list::after { content: "This is a fancy orange box."; background-color: #ffba10; } '
    )
);
```


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Frontend:

![frontend](https://github.com/user-attachments/assets/af68b43b-6d0e-4624-9300-78c609722587)


Editor:

https://github.com/user-attachments/assets/6a92845a-fdc4-4e2e-bd58-52c4396ee3a3

Editor Inspect code:

![editor](https://github.com/user-attachments/assets/0df0c96e-d5d1-4afa-96f8-cab5414731c1)

