### PR TITLE
List item inline style fix

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -86,7 +86,6 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 		// We're using a pseudo element to overflow placeholder borders
 		// and any border inside the block itself.
 		&::after {
-			@include selected-block-focus();
 			z-index: 1;
 		}
 	}
@@ -199,13 +198,6 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 		}
 	}
 
-	&.is-hovered:not(.is-selected),
-	&:not(.rich-text):not([contenteditable="true"]).is-selected {
-
-		&::after {
-			@include selected-block-focus();
-		}
-	}
 }
 
 // Colorize outlines for template parts and synced patterns (.is-reusable).


### PR DESCRIPTION
Fixes #68727

## What?
This PR resolves conflict with the default style added for content

## Why?
When we register style via `register_block_style` for list-item it gets conflicted with the default style mentioned in content.scss
We can either remove the default style or reduce the priority or else we can provide `!important` to our inline style. So it will have more preference.

## How?
I have removed the default style causing conflicts.

## Testing Instructions

1. Add an inline or inline-block pseudo ::after element via CSS to a core/list-item.
```
\register_block_style( 
    'core/list-item' , 
    array(
        'default'      => false,
        'name'         => 'acme-list',
        'lable'         => 'ACME List',
        'inline_style' => '.is-style-acme-list { position: relative; } .is-style-acme-list::after { content: "This is a fancy orange box."; background-color: #ffba10; } '
    )
);
```