### PR TITLE
Fix: Prevent `FontSizePicker` crash when no font size exists

### DIFF
--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -53,9 +53,11 @@ function styleToAttributes( style ) {
 	const updatedStyle = { ...omit( style, [ 'fontFamily' ] ) };
 	const fontSizeValue = style?.typography?.fontSize;
 	const fontFamilyValue = style?.typography?.fontFamily;
-	const fontSizeSlug = fontSizeValue?.startsWith( 'var:preset|font-size|' )
-		? fontSizeValue.substring( 'var:preset|font-size|'.length )
-		: undefined;
+	const fontSizeSlug =
+		typeof fontSizeValue === 'string' &&
+		fontSizeValue?.startsWith( 'var:preset|font-size|' )
+			? fontSizeValue.substring( 'var:preset|font-size|'.length )
+			: undefined;
 	const fontFamilySlug = fontFamilyValue?.startsWith(
 		'var:preset|font-family|'
 	)

--- a/test/emptytheme/theme.json
+++ b/test/emptytheme/theme.json
@@ -2,18 +2,15 @@
 	"$schema": "../../schemas/json/theme.json",
 	"version": 3,
 	"settings": {
-		"appearanceTools": true,
 		"layout": {
 			"contentSize": "840px",
 			"wideSize": "1100px"
+		},
+		"color": {
+			"defaultPalette": false
+		},
+		"typography": {
+			"defaultFontSizes": false
 		}
-	},
-	"customTemplates": [
-		{
-			"name": "custom-template",
-			"title": "Custom",
-			"postTypes": [ "post" ]
-		}
-	],
-	"patterns": [ "short-text-surrounded-by-round-images", "partner-logos" ]
+	}
 }

--- a/test/emptytheme/theme.json
+++ b/test/emptytheme/theme.json
@@ -2,15 +2,18 @@
 	"$schema": "../../schemas/json/theme.json",
 	"version": 3,
 	"settings": {
+		"appearanceTools": true,
 		"layout": {
 			"contentSize": "840px",
 			"wideSize": "1100px"
-		},
-		"color": {
-			"defaultPalette": false
-		},
-		"typography": {
-			"defaultFontSizes": false
 		}
-	}
+	},
+	"customTemplates": [
+		{
+			"name": "custom-template",
+			"title": "Custom",
+			"postTypes": [ "post" ]
+		}
+	],
+	"patterns": [ "short-text-surrounded-by-round-images", "partner-logos" ]
 }


### PR DESCRIPTION
Closes: https://github.com/WordPress/gutenberg/issues/62072

## What?
This PR fixes a crash in the Typography panel's font size picker when no font size presets exist in theme.json. It ensures that the font size picker is disabled when no presets are available and prevents errors when setting a custom font size.


## Why?
Currently, if a theme has defaultFontSizes set to false and no font size presets are defined, changing the font size causes the block to crash due to `fontSizeValue?.startsWith` being called on an invalid type. This PR resolves the issue by ensuring fontSizeValue is always a valid string before performing operations on it.


## How?
Added a check to ensure fontSizeValue is a string before calling `.startsWith()`.

## Testing Instructions
1. Enable the Emptytheme.
2. Update theme.json with the following configuration(Snippet shared down below)
3. Open the typography panel for a paragraph block.
- ✅ The font size picker should be disabled instead of rendering an empty dropdown.
4. Click the "Set custom size" button and enter a font size.
- ✅ The block should no longer crash.


Code snippet for theme.json

```json
{
   "$schema": "../../schemas/json/theme.json",
   "version": 3,
   "settings": {
      "layout": {
         "contentSize": "840px",
         "wideSize": "1100px"
      },
      "color": {
         "defaultPalette": false
      },
      "typography": {
         "defaultFontSizes": false
      }
   }
}

```

## Screenshots or screencast 

### Before

https://github.com/user-attachments/assets/ceb83de2-0c63-4287-be4b-ba4cb1800f63


### After

https://github.com/user-attachments/assets/635e77cb-1d99-4ec4-8d13-e5aa7b9ac529




