### PR TITLE
fix: Adds ariaLabel attribute to navigation block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -473,7 +473,7 @@ A collection of blocks that allow visitors to get around your site. ([Source](ht
 -	**Category:** theme
 -	**Allowed Blocks:** core/navigation-link, core/search, core/social-links, core/page-list, core/spacer, core/home-link, core/site-title, core/site-logo, core/navigation-submenu, core/loginout, core/buttons
 -	**Supports:** align (full, wide), ariaLabel, inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~
--	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, templateLock, textColor
+-	**Attributes:** __unstableLocation, ariaLabel, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, templateLock, textColor
 
 ## Custom Link
 

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -84,6 +84,10 @@
 		"templateLock": {
 			"type": [ "string", "boolean" ],
 			"enum": [ "all", "insert", "contentOnly", false ]
+		},
+		"ariaLabel": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"providesContext": {

--- a/test/integration/fixtures/blocks/core__navigation.json
+++ b/test/integration/fixtures/blocks/core__navigation.json
@@ -8,7 +8,8 @@
 			"overlayMenu": "mobile",
 			"icon": "handle",
 			"hasIcon": true,
-			"maxNestingLevel": 5
+			"maxNestingLevel": 5,
+			"ariaLabel": ""
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->

fixes https://github.com/WordPress/gutenberg/issues/68719

## Why?
- The navigation block doesn't preserve the default aria-label attributes passed from a theme pattern when making any change to the template part the pattern is used into.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- In footer.php we are adding `ariaLabel ` as an attribute, but we haven't added this attribute to block.json of the Navigation block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
- Activate Twenty Twenty-Four.
- Make sure the Footer hasn't been customized. Reset any change if necessary.
- Go to any page on the front end.
- Inspect the 3 <nav> elements in the footer.
- Observe they all have an appropriate aria-label: About, Privacy, Social Media.
- Note: these are the values that come from [the theme pattern footer.php](https://github.com/WordPress/wordpress-develop/blob/5b01d24d8c5f2cfa4b96349967a9759e52888d03/src/wp-content/themes/twentytwentyfour/patterns/footer.php).
- Edit the footer and make any unrelated change, e.g.: change the Site title to open in a new tab and save.
- Go to any page on the front end.
- Inspect the 3 <nav> elements in the footer.
- Observe the aria-label, it is preserved.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/18430773-d84e-4ba0-96c2-989e53d8ea81


