### PR TITLE
Home Link: Enable all non-interactive formats

### DIFF
--- a/packages/block-library/src/home-link/edit.js
+++ b/packages/block-library/src/home-link/edit.js
@@ -51,12 +51,6 @@ export default function HomeEdit( { attributes, setAttributes, context } ) {
 					aria-label={ __( 'Home link text' ) }
 					placeholder={ __( 'Add home link' ) }
 					withoutInteractiveFormatting
-					allowedFormats={ [
-						'core/bold',
-						'core/italic',
-						'core/image',
-						'core/strikethrough',
-					] }
 				/>
 			</a>
 		</div>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Similar #67585 #67559

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Allow customization from plugins, allowing for a variety of design expressions !

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Allows consumers to register custom formats that can be used with navigation blocks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open a post or page.
2. Insert a navigation block.
3. Confirm that all non-interactive formats are visible for the Home link.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->
![before](https://github.com/user-attachments/assets/901cf4c0-38df-441e-bf84-f544703bb03b) | ![after](https://github.com/user-attachments/assets/ece3e1e5-81bb-4b97-8017-aad27cd580ea)|
