### PR TITLE
Fixed: Dimensions Custom Unit behaviour is not working as expected

### DIFF
--- a/packages/components/src/box-control/test/index.tsx
+++ b/packages/components/src/box-control/test/index.tsx
@@ -446,7 +446,7 @@ describe( 'BoxControl', () => {
 			} );
 		} );
 
-		it( 'should not pass invalid CSS unit only values to onChange', async () => {
+		it( 'should preserve CSS unit when passing to onChange', async () => {
 			const user = userEvent.setup();
 			const setState = jest.fn();
 
@@ -460,10 +460,10 @@ describe( 'BoxControl', () => {
 			);
 
 			expect( setState ).toHaveBeenCalledWith( {
-				top: undefined,
-				right: undefined,
-				bottom: undefined,
-				left: undefined,
+				top: '0rem',
+				right: '0rem',
+				bottom: '0rem',
+				left: '0rem',
 			} );
 		} );
 	} );

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -160,10 +160,20 @@ function UnforwardedUnitControl(
 	) => {
 		const { data } = changeProps;
 
-		let nextValue = `${ parsedQuantity ?? '' }${ nextUnitValue }`;
+		let nextValue = getValidParsedQuantityAndUnit(
+			'',
+			units,
+			parsedQuantity ?? 0,
+			nextUnitValue
+		).join( '' );
 
 		if ( isResetValueOnUnitChange && data?.default !== undefined ) {
-			nextValue = `${ data.default }${ nextUnitValue }`;
+			nextValue = getValidParsedQuantityAndUnit(
+				data.default,
+				units,
+				parsedQuantity ?? 0,
+				nextUnitValue
+			).join( '' );
 		}
 
 		onChangeProp?.( nextValue, changeProps );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
fixes #68734 
## What?
The issue occurs when changing the typography dimensions (e.g., padding/margin) from "Use size preset" to "Set Custom Size" and switching the unit type from px to another unit. The selected unit resets back to px, requiring users to select their desired unit twice.

## Why?

- Reset Behavior: The code resets the value due to improper handling of the selected unit and the fallback logic in the getValidParsedQuantityAndUnit function.
- Unit Validation: The nextValue computation doesn't persist the new unit properly, resulting in an override to the default (px).
- User Experience Issue: This creates unnecessary friction, as users need to repeat actions to achieve the intended result.

## How?
The fix ensures the selected unit is preserved during the transition by improving the logic inside the getValidParsedQuantityAndUnit function:

- Introduced validation to check the current and next units.
- Applied fallback logic only when needed (e.g., reset defaults only if explicitly required).

## Testing Instructions

1. Select any block paragraph, pullquote, quote, etc.
2. Add dummy text
3. Go to block settings and change "Typography Dimensions" from "Use size preset" to "Set Custom Size"
4. Now, change its type from "px" to any other based on requirement
5. Now, change size using range control.

## Screencast

https://github.com/user-attachments/assets/e93bb286-a329-440c-ab98-158f920fb5cb


