### PR TITLE
Details: Enable all non-interactive formats

### DIFF
--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -102,7 +102,6 @@ function DetailsEdit( { attributes, setAttributes } ) {
 						identifier="summary"
 						aria-label={ __( 'Write summary' ) }
 						placeholder={ placeholder || __( 'Write summary…' ) }
-						allowedFormats={ [] }
 						withoutInteractiveFormatting
 						value={ summary }
 						onChange={ ( newSummary ) =>

--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -91,13 +91,12 @@ function DetailsEdit( { attributes, setAttributes } ) {
 					) }
 				/>
 			</InspectorControls>
-			<details { ...innerBlocksProps } open={ isOpen }>
-				<summary
-					onClick={ ( event ) => {
-						event.preventDefault();
-						setIsOpen( ! isOpen );
-					} }
-				>
+			<details
+				{ ...innerBlocksProps }
+				open={ isOpen }
+				onToggle={ ( event ) => setIsOpen( event.target.open ) }
+			>
+				<summary>
 					<RichText
 						identifier="summary"
 						aria-label={ __( 'Write summary' ) }


### PR DESCRIPTION
Closes: https://github.com/WordPress/gutenberg/issues/68738

## What?
PR removes hardcoded allowlist for RichText formats in the Details blocks. Now, all non-interactive formats are allowed within these blocks.

This changes matches the behaviour of the button, navigation block

## Why?
Allows consumers to register custom formats that can be used with details blocks.

## Testing instructions
1. Open a post or page.
2. Insert a details block.
3. Confirm that all non-interactive formats are visible for the details block.

## Screenshots or screencast 


<img width="1466" alt="image" src="https://github.com/user-attachments/assets/41476c98-53c2-4ca9-96de-74d745bae565" />
