### PR TITLE
Editor: Update post-type support key for new default rendering mode

### DIFF
--- a/backport-changelog/6.8/8123.md
+++ b/backport-changelog/6.8/8123.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/8123
 
 * https://github.com/WordPress/gutenberg/pull/68549
+* https://github.com/WordPress/gutenberg/pull/68745

--- a/lib/compat/wordpress-6.8/post.php
+++ b/lib/compat/wordpress-6.8/post.php
@@ -17,7 +17,7 @@ function gutenberg_update_page_editor_support( $args ) {
 	if ( false !== $editor_support_key ) {
 		unset( $args['supports'][ $editor_support_key ] );
 		$args['supports']['editor'] = array(
-			'default_mode' => 'template-locked',
+			'default-mode' => 'template-locked',
 		);
 	}
 

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -198,8 +198,8 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 
 				const _defaultMode = Array.isArray( postTypeSupports?.editor )
 					? postTypeSupports.editor.find(
-							( features ) => 'default_mode' in features
-					  )?.default_mode
+							( features ) => 'default-mode' in features
+					  )?.[ 'default-mode' ]
 					: undefined;
 				const hasDefaultMode = RENDERING_MODES.includes( _defaultMode );
 


### PR DESCRIPTION
## What?
This is a follow-up to #68549.

PR changes the `default_mode` feature key to `default-mode`. Use a dash separator for consistency. See https://github.com/WordPress/gutenberg/pull/68549#discussion_r1918516384.

## Testing Instructions
None. All CI checks should pass.
