### PR TITLE
Fix: Better error handling when creating a new page from the inline link popover

### DIFF
--- a/packages/block-editor/src/components/link-control/use-create-page.js
+++ b/packages/block-editor/src/components/link-control/use-create-page.js
@@ -1,3 +1,5 @@
+/* global navigator */
+
 /**
  * WordPress dependencies
  */
@@ -14,6 +16,11 @@ export default function useCreatePage( handleCreatePage ) {
 		setErrorMessage( null );
 
 		try {
+			// Check for offline status
+			if ( ! navigator.onLine ) {
+				throw new Error( __( 'You are probably offline.' ) );
+			}
+
 			// Make cancellable in order that we can avoid setting State
 			// if the component unmounts during the call to `createSuggestion`
 			cancelableCreateSuggestion.current = makeCancelable(


### PR DESCRIPTION
Fixes [#57266](https://github.com/WordPress/gutenberg/issues/57266)

## What?
Improves error handling when creating a new page from the inline link popover by providing user-friendly error messages and consistent error behavior with the Site Editor.

## Why?
Previously, when errors occurred during page creation (e.g., network issues), technical error messages like "Cannot read properties of undefined" were shown to users. This provided poor user feedback and wasn't consistent with how errors are handled in the Site Editor.

## How?
- Added offline status check in the `useCreatePage` hook

## Testing Instructions
1. Open the Post Editor
2. Select some text and click the link button in the toolbar
3. Type something that doesn't match any existing post
4. Click "Create page: [your text]" at the bottom of the suggestions
5. Before clicking, turn off your internet connection (you can use browser dev tools Network tab's offline mode)
6. Click the create page button
7. Verify you see a snackbar notice saying "You are probably offline."
8. Turn your internet back on and try again - the page should be created successfully

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2025-01-17 at 5 28 36 PM](https://github.com/user-attachments/assets/e8f76dff-e89a-48bc-94f0-beade82cb39b) 
