### PR TITLE
Fix post summary panel controls accessibility

### DIFF
--- a/packages/editor/src/components/blog-title/index.js
+++ b/packages/editor/src/components/blog-title/index.js
@@ -1,13 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { debounce } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import {
-	Button,
 	Dropdown,
 	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
@@ -20,6 +19,7 @@ import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '
 import { TEMPLATE_POST_TYPE } from '../../store/constants';
 import PostPanelRow from '../post-panel-row';
 import { store as editorStore } from '../../store';
+import PostPanelRowButton from '../post-panel-row-button';
 
 const EMPTY_OBJECT = {};
 
@@ -84,25 +84,20 @@ export default function BlogTitle() {
 	};
 	const decodedTitle = decodeEntities( postsPageTitle );
 	return (
-		<PostPanelRow label={ __( 'Blog title' ) } ref={ setPopoverAnchor }>
+		<PostPanelRow ref={ setPopoverAnchor }>
 			<Dropdown
 				popoverProps={ popoverProps }
+				className="editor-blog-title-dropdown"
 				contentClassName="editor-blog-title-dropdown__content"
 				focusOnMount
 				renderToggle={ ( { isOpen, onToggle } ) => (
-					<Button
-						size="compact"
-						variant="tertiary"
-						aria-expanded={ isOpen }
-						aria-label={ sprintf(
-							// translators: %s: Current post link.
-							__( 'Change blog title: %s' ),
-							decodedTitle
-						) }
+					<PostPanelRowButton
+						label={ __( 'Blog title' ) }
+						displayedValue={ decodedTitle }
+						isExpanded={ isOpen }
 						onClick={ onToggle }
-					>
-						{ decodedTitle }
-					</Button>
+						aria-haspopup="true"
+					/>
 				) }
 				renderContent={ ( { onClose } ) => (
 					<>

--- a/packages/editor/src/components/blog-title/style.scss
+++ b/packages/editor/src/components/blog-title/style.scss
@@ -1,3 +1,7 @@
+.editor-blog-title-dropdown {
+	width: 100%;
+}
+
 .editor-blog-title-dropdown__content .components-popover__content {
 	min-width: 320px;
 	padding: $grid-unit-20;

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -7,12 +7,7 @@ import removeAccents from 'remove-accents';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import {
-	Button,
-	Dropdown,
-	ComboboxControl,
-	ExternalLink,
-} from '@wordpress/components';
+import { Dropdown, ComboboxControl, ExternalLink } from '@wordpress/components';
 import { debounce } from '@wordpress/compose';
 import {
 	createInterpolateElement,
@@ -31,6 +26,7 @@ import { filterURLForDisplay } from '@wordpress/url';
 import PostPanelRow from '../post-panel-row';
 import { buildTermsTree } from '../../utils/terms';
 import { store as editorStore } from '../../store';
+import PostPanelRowButton from '../post-panel-row-button';
 
 function getTitle( post ) {
 	return post?.title?.rendered
@@ -224,19 +220,13 @@ function PostParentToggle( { isOpen, onClick } ) {
 		[ parentPost ]
 	);
 	return (
-		<Button
-			size="compact"
+		<PostPanelRowButton
+			label={ __( 'Parent' ) }
+			displayedValue={ parentTitle }
 			className="editor-post-parent__panel-toggle"
-			variant="tertiary"
-			aria-expanded={ isOpen }
-			aria-label={
-				// translators: %s: Current post parent.
-				sprintf( __( 'Change parent: %s' ), parentTitle )
-			}
+			isExpanded={ isOpen }
 			onClick={ onClick }
-		>
-			{ parentTitle }
-		</Button>
+		/>
 	);
 }
 
@@ -262,7 +252,7 @@ export function ParentRow() {
 		[ popoverAnchor ]
 	);
 	return (
-		<PostPanelRow label={ __( 'Parent' ) } ref={ setPopoverAnchor }>
+		<PostPanelRow ref={ setPopoverAnchor }>
 			<Dropdown
 				popoverProps={ popoverProps }
 				className="editor-post-parent__panel-dropdown"

--- a/packages/editor/src/components/page-attributes/style.scss
+++ b/packages/editor/src/components/page-attributes/style.scss
@@ -1,15 +1,9 @@
-.editor-post-parent__panel,
-.editor-post-order__panel {
-	padding-top: $grid-unit-10;
-	.editor-post-panel__row-control > div {
-		width: 100%;
-	}
+.editor-post-parent__panel-dropdown {
+	width: 100%;
 }
 
-.editor-post-parent__panel-dialog,
-.editor-post-order__panel-dialog {
-	.editor-post-parent,
-	.editor-post-order {
+.editor-post-parent__panel-dialog {
+	.editor-post-parent {
 		margin: $grid-unit-10;
 	}
 

--- a/packages/editor/src/components/post-author/panel.js
+++ b/packages/editor/src/components/post-author/panel.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
-import { Button, Dropdown } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Dropdown } from '@wordpress/components';
 import { useState, useMemo } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '@wordpress/block-editor';
@@ -14,25 +14,20 @@ import PostAuthorCheck from './check';
 import PostAuthorForm from './index';
 import PostPanelRow from '../post-panel-row';
 import { useAuthorsQuery } from './hook';
+import PostPanelRowButton from '../post-panel-row-button';
 
 function PostAuthorToggle( { isOpen, onClick } ) {
 	const { postAuthor } = useAuthorsQuery();
 	const authorName =
 		decodeEntities( postAuthor?.name ) || __( '(No author)' );
 	return (
-		<Button
-			size="compact"
+		<PostPanelRowButton
+			label={ __( 'Author' ) }
+			displayedValue={ authorName }
 			className="editor-post-author__panel-toggle"
-			variant="tertiary"
-			aria-expanded={ isOpen }
-			aria-label={
-				// translators: %s: Author name.
-				sprintf( __( 'Change author: %s' ), authorName )
-			}
+			isExpanded={ isOpen }
 			onClick={ onClick }
-		>
-			{ authorName }
-		</Button>
+		/>
 	);
 }
 
@@ -59,9 +54,10 @@ export function PostAuthor() {
 	);
 	return (
 		<PostAuthorCheck>
-			<PostPanelRow label={ __( 'Author' ) } ref={ setPopoverAnchor }>
+			<PostPanelRow ref={ setPopoverAnchor }>
 				<Dropdown
 					popoverProps={ popoverProps }
+					className="editor-post-author__panel-dropdown"
 					contentClassName="editor-post-author__panel-dialog"
 					focusOnMount
 					renderToggle={ ( { isOpen, onToggle } ) => (

--- a/packages/editor/src/components/post-author/style.scss
+++ b/packages/editor/src/components/post-author/style.scss
@@ -1,8 +1,4 @@
-.editor-post-author__panel {
-	padding-top: $grid-unit-10;
-}
-
-.editor-post-author__panel .editor-post-panel__row-control > div {
+.editor-post-author__panel-dropdown {
 	width: 100%;
 }
 

--- a/packages/editor/src/components/post-discussion/panel.js
+++ b/packages/editor/src/components/post-discussion/panel.js
@@ -4,7 +4,6 @@
 import { __, _x } from '@wordpress/i18n';
 import {
 	Dropdown,
-	Button,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -20,6 +19,7 @@ import PostTypeSupportCheck from '../post-type-support-check';
 import PostComments from '../post-comments';
 import PostPingbacks from '../post-pingbacks';
 import PostPanelRow from '../post-panel-row';
+import PostPanelRowButton from '../post-panel-row-button';
 
 const PANEL_NAME = 'discussion-panel';
 
@@ -59,31 +59,34 @@ function PostDiscussionToggle( { isOpen, onClick } ) {
 			trackbacksSupported: !! postType.supports.trackbacks,
 		};
 	}, [] );
-	let label;
+	let discussionStatus;
 	if ( commentStatus === 'open' ) {
 		if ( pingStatus === 'open' ) {
-			label = _x( 'Open', 'Adjective: e.g. "Comments are open"' );
+			discussionStatus = _x(
+				'Open',
+				'Adjective: e.g. "Comments are open"'
+			);
 		} else {
-			label = trackbacksSupported
+			discussionStatus = trackbacksSupported
 				? __( 'Comments only' )
 				: _x( 'Open', 'Adjective: e.g. "Comments are open"' );
 		}
 	} else if ( pingStatus === 'open' ) {
-		label = commentsSupported ? __( 'Pings only' ) : __( 'Pings enabled' );
+		discussionStatus = commentsSupported
+			? __( 'Pings only' )
+			: __( 'Pings enabled' );
 	} else {
-		label = __( 'Closed' );
+		discussionStatus = __( 'Closed' );
 	}
 	return (
-		<Button
-			size="compact"
+		<PostPanelRowButton
+			label={ __( 'Discussion' ) }
+			displayedValue={ discussionStatus }
 			className="editor-post-discussion__panel-toggle"
-			variant="tertiary"
-			aria-label={ __( 'Change discussion options' ) }
 			aria-expanded={ isOpen }
 			onClick={ onClick }
-		>
-			{ label }
-		</Button>
+			aria-haspopup="true"
+		/>
 	);
 }
 
@@ -125,7 +128,7 @@ export default function PostDiscussionPanel() {
 
 	return (
 		<PostTypeSupportCheck supportKeys={ [ 'comments', 'trackbacks' ] }>
-			<PostPanelRow label={ __( 'Discussion' ) } ref={ setPopoverAnchor }>
+			<PostPanelRow ref={ setPopoverAnchor }>
 				<Dropdown
 					popoverProps={ popoverProps }
 					className="editor-post-discussion__panel-dropdown"

--- a/packages/editor/src/components/post-discussion/style.scss
+++ b/packages/editor/src/components/post-discussion/style.scss
@@ -1,3 +1,7 @@
+.editor-post-discussion__panel-dropdown {
+	width: 100%;
+}
+
 .editor-post-discussion__panel-dialog .editor-post-discussion {
 	// sidebar width - popover padding - form margin
 	min-width: $sidebar-width - $grid-unit-20 - $grid-unit-20;

--- a/packages/editor/src/components/post-format/panel.js
+++ b/packages/editor/src/components/post-format/panel.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { Button, Dropdown } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { Dropdown } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { useState, useMemo } from '@wordpress/element';
 import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '@wordpress/block-editor';
@@ -14,6 +14,7 @@ import { default as PostFormatForm, POST_FORMATS } from './';
 import PostFormatCheck from './check';
 import PostPanelRow from '../post-panel-row';
 import { store as editorStore } from '../../store';
+import PostPanelRowButton from '../post-panel-row-button';
 
 /**
  * Renders the Post Author Panel component.
@@ -49,25 +50,20 @@ function PostFormat() {
 	);
 	return (
 		<PostFormatCheck>
-			<PostPanelRow label={ __( 'Format' ) } ref={ setPopoverAnchor }>
+			<PostPanelRow ref={ setPopoverAnchor }>
 				<Dropdown
 					popoverProps={ popoverProps }
+					className="editor-post-format__dropdown"
 					contentClassName="editor-post-format__dialog"
 					focusOnMount
 					renderToggle={ ( { isOpen, onToggle } ) => (
-						<Button
-							size="compact"
-							variant="tertiary"
-							aria-expanded={ isOpen }
-							aria-label={ sprintf(
-								// translators: %s: Current post format.
-								__( 'Change format: %s' ),
-								activeFormat?.caption
-							) }
+						<PostPanelRowButton
+							label={ __( 'Format' ) }
+							displayedValue={ activeFormat?.caption }
+							isExpanded={ isOpen }
 							onClick={ onToggle }
-						>
-							{ activeFormat?.caption }
-						</Button>
+							aria-haspopup="true"
+						/>
 					) }
 					renderContent={ ( { onClose } ) => (
 						<div className="editor-post-format__dialog-content">

--- a/packages/editor/src/components/post-format/style.scss
+++ b/packages/editor/src/components/post-format/style.scss
@@ -1,3 +1,7 @@
+.editor-post-format__dropdown {
+	width: 100%;
+}
+
 [class].editor-post-format__suggestion {
 	margin: $grid-unit-05 0 0 0;
 }

--- a/packages/editor/src/components/post-last-revision/index.js
+++ b/packages/editor/src/components/post-last-revision/index.js
@@ -13,6 +13,7 @@ import { addQueryArgs } from '@wordpress/url';
 import PostLastRevisionCheck from './check';
 import PostPanelRow from '../post-panel-row';
 import { store as editorStore } from '../../store';
+import PostPanelRowButton from '../post-panel-row-button';
 
 function usePostLastRevisionInfo() {
 	return useSelect( ( select ) => {
@@ -57,15 +58,14 @@ export function PrivatePostLastRevision() {
 	const { lastRevisionId, revisionsCount } = usePostLastRevisionInfo();
 	return (
 		<PostLastRevisionCheck>
-			<PostPanelRow label={ __( 'Revisions' ) }>
-				<Button
+			<PostPanelRow>
+				<PostPanelRowButton
+					label={ __( 'Revisions' ) }
+					displayedValue={ revisionsCount }
 					href={ addQueryArgs( 'revision.php', {
 						revision: lastRevisionId,
 					} ) }
 					className="editor-private-post-last-revision__button"
-					text={ revisionsCount }
-					variant="tertiary"
-					size="compact"
 				/>
 			</PostPanelRow>
 		</PostLastRevisionCheck>

--- a/packages/editor/src/components/post-panel-row-button/index.js
+++ b/packages/editor/src/components/post-panel-row-button/index.js
@@ -13,12 +13,27 @@ import {
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 
+/**
+ * Renders a button to display a setting name and its value in an accessible way.
+ * The label prop should be used to provide a meaningful accessible name of the button.
+ * The displayedValue visually shows the value within the button and avoids to
+ * alter the accessible name. Instead, its content is exposed to assistive technology
+ * in the accessible description of the button.
+ *
+ * @param {Object}   props                  Component props.
+ * @param {string}   [props.className]      Additional classes to apply to the button.
+ * @param {Function} [props.onClick]        The callback function to be executed when the user clicks the button.
+ * @param {string}   [props.label]          Visible label and accessible name of the button.
+ * @param {string}   [props.displayedValue] Visible value of the setting and accessible description of the button.
+ * @param {string}   [props.icon]           Optional icon to be shown before the value.
+ * @param {booleab}  [props.isExpanded]     Used for the aria-expanded ARIA state of the button.
+ * @return {React.ReactNode} The rendered PostPanelRowButton component.
+ */
 export default function PostPanelRowButton( {
 	className,
 	onClick,
 	label,
 	displayedValue,
-	description,
 	icon,
 	isExpanded,
 	...props
@@ -53,7 +68,7 @@ export default function PostPanelRowButton( {
 				</HStack>
 			</Button>
 			<div hidden id={ descriptionId }>
-				{ description || displayedValue }
+				{ displayedValue }
 			</div>
 		</>
 	);

--- a/packages/editor/src/components/post-panel-row-button/index.js
+++ b/packages/editor/src/components/post-panel-row-button/index.js
@@ -18,6 +18,7 @@ export default function PostPanelRowButton( {
 	onClick,
 	label,
 	displayedValue,
+	description,
 	icon,
 	isExpanded,
 	...props
@@ -52,7 +53,7 @@ export default function PostPanelRowButton( {
 				</HStack>
 			</Button>
 			<div hidden id={ descriptionId }>
-				{ displayedValue }
+				{ description || displayedValue }
 			</div>
 		</>
 	);

--- a/packages/editor/src/components/post-panel-row-button/index.js
+++ b/packages/editor/src/components/post-panel-row-button/index.js
@@ -59,7 +59,10 @@ export default function PostPanelRowButton( {
 						{ label }
 					</span>
 					<span
-						className="editor-post-panel__row-button-value"
+						className={ clsx(
+							'editor-post-panel__row-button-value',
+							{ 'has-icon': !! icon }
+						) }
 						aria-hidden="true"
 					>
 						{ icon && <Icon icon={ icon } /> }

--- a/packages/editor/src/components/post-panel-row-button/index.js
+++ b/packages/editor/src/components/post-panel-row-button/index.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	Icon,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
+
+export default function PostPanelRowButton( {
+	className,
+	onClick,
+	label,
+	displayedValue,
+	icon,
+	isExpanded,
+} ) {
+	const descriptionId = useInstanceId(
+		PostPanelRowButton,
+		'editor-post-panel__row-button-description'
+	);
+
+	return (
+		<>
+			<Button
+				className={ clsx( 'editor-post-panel__row-button', className ) }
+				variant="tertiary"
+				size="compact"
+				aria-expanded={ isExpanded }
+				onClick={ onClick }
+				aria-describedby={ descriptionId }
+			>
+				<HStack as="span">
+					<span className="editor-post-panel__row-button-label">
+						{ label }
+					</span>
+					<span
+						className="editor-post-panel__row-button-value"
+						aria-hidden="true"
+					>
+						{ icon && <Icon icon={ icon } /> }
+						{ displayedValue }
+					</span>
+				</HStack>
+			</Button>
+			<div hidden id={ descriptionId }>
+				{ displayedValue }
+			</div>
+		</>
+	);
+}

--- a/packages/editor/src/components/post-panel-row-button/index.js
+++ b/packages/editor/src/components/post-panel-row-button/index.js
@@ -20,6 +20,7 @@ export default function PostPanelRowButton( {
 	displayedValue,
 	icon,
 	isExpanded,
+	...props
 } ) {
 	const descriptionId = useInstanceId(
 		PostPanelRowButton,
@@ -35,6 +36,7 @@ export default function PostPanelRowButton( {
 				aria-expanded={ isExpanded }
 				onClick={ onClick }
 				aria-describedby={ descriptionId }
+				{ ...props }
 			>
 				<HStack as="span">
 					<span className="editor-post-panel__row-button-label">

--- a/packages/editor/src/components/post-panel-row-button/style.scss
+++ b/packages/editor/src/components/post-panel-row-button/style.scss
@@ -24,4 +24,9 @@
 	padding-left: $grid-unit-15;
 	padding-right: $grid-unit-15;
 	color: $gray-900;
+
+	&.has-icon {
+		padding-left: $grid-unit-10;
+		gap: $grid-unit-05;
+	}
 }

--- a/packages/editor/src/components/post-panel-row-button/style.scss
+++ b/packages/editor/src/components/post-panel-row-button/style.scss
@@ -1,0 +1,27 @@
+.editor-post-panel__row-button.editor-post-panel__row-button {
+	width: calc(100% + $grid-unit-20);
+	max-width: none;
+	margin: 0 -1 * $grid-unit-10;
+	padding-left: $grid-unit-10;
+	padding-right: $grid-unit-10;
+}
+
+.editor-post-panel__row-button-label {
+	width: 38%;
+	flex-shrink: 0;
+	min-height: $grid-unit-40;
+	display: flex;
+	align-items: center;
+	line-height: $grid-unit-05 * 5;
+	hyphens: auto;
+	color: $gray-900;
+}
+
+.editor-post-panel__row-button-value {
+	flex-grow: 1;
+	min-height: $grid-unit-40;
+	display: flex;
+	align-items: center;
+	padding-left: $grid-unit-15;
+	padding-right: $grid-unit-15;
+}

--- a/packages/editor/src/components/post-panel-row-button/style.scss
+++ b/packages/editor/src/components/post-panel-row-button/style.scss
@@ -14,7 +14,6 @@
 	align-items: center;
 	line-height: $grid-unit-05 * 5;
 	hyphens: auto;
-	color: $gray-900;
 }
 
 .editor-post-panel__row-button-value {
@@ -24,4 +23,5 @@
 	align-items: center;
 	padding-left: $grid-unit-15;
 	padding-right: $grid-unit-15;
+	color: $gray-900;
 }

--- a/packages/editor/src/components/post-panel-row/style.scss
+++ b/packages/editor/src/components/post-panel-row/style.scss
@@ -28,7 +28,6 @@
 		white-space: normal;
 		text-wrap: balance; // Fallback for Safari.
 		text-wrap: pretty;
-		height: auto;
 		min-height: $button-size-compact;
 	}
 

--- a/packages/editor/src/components/post-schedule/panel.js
+++ b/packages/editor/src/components/post-schedule/panel.js
@@ -69,7 +69,7 @@ export default function PostSchedulePanel() {
 					contentClassName="editor-post-schedule__dialog"
 					renderToggle={ ( { onToggle, isOpen } ) => (
 						<PostPanelRowButton
-							label={ __( 'Publish date' ) }
+							label={ __( 'Publish' ) }
 							displayedValue={ label }
 							className="editor-post-schedule__dialog-toggle"
 							onClick={ onToggle }

--- a/packages/editor/src/components/post-schedule/panel.js
+++ b/packages/editor/src/components/post-schedule/panel.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { Button, Dropdown } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { Dropdown } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { useState, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
@@ -20,6 +20,7 @@ import {
 	PATTERN_POST_TYPE,
 	NAVIGATION_POST_TYPE,
 } from '../../store/constants';
+import PostPanelRowButton from '../post-panel-row-button';
 
 const DESIGN_POST_TYPES = [
 	TEMPLATE_POST_TYPE,
@@ -54,37 +55,26 @@ export default function PostSchedulePanel() {
 	);
 
 	const label = usePostScheduleLabel();
-	const fullLabel = usePostScheduleLabel( { full: true } );
 	if ( DESIGN_POST_TYPES.includes( postType ) ) {
 		return null;
 	}
 
 	return (
 		<PostScheduleCheck>
-			<PostPanelRow label={ __( 'Publish' ) } ref={ setPopoverAnchor }>
+			<PostPanelRow ref={ setPopoverAnchor }>
 				<Dropdown
 					popoverProps={ popoverProps }
 					focusOnMount
 					className="editor-post-schedule__panel-dropdown"
 					contentClassName="editor-post-schedule__dialog"
 					renderToggle={ ( { onToggle, isOpen } ) => (
-						<Button
-							size="compact"
+						<PostPanelRowButton
+							label={ __( 'Publish date' ) }
+							displayedValue={ label }
 							className="editor-post-schedule__dialog-toggle"
-							variant="tertiary"
-							tooltipPosition="middle left"
 							onClick={ onToggle }
-							aria-label={ sprintf(
-								// translators: %s: Current post date.
-								__( 'Change date: %s' ),
-								label
-							) }
-							label={ fullLabel }
-							showTooltip={ label !== fullLabel }
-							aria-expanded={ isOpen }
-						>
-							{ label }
-						</Button>
+							isExpanded={ isOpen }
+						/>
 					) }
 					renderContent={ ( { onClose } ) => (
 						<PostScheduleForm onClose={ onClose } />

--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -2,14 +2,13 @@
  * WordPress dependencies
  */
 import {
-	Button,
 	CheckboxControl,
 	Dropdown,
 	__experimentalVStack as VStack,
 	TextControl,
 	RadioControl,
 } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, useMemo } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
@@ -36,6 +35,7 @@ import PostPanelRow from '../post-panel-row';
 import PostSticky from '../post-sticky';
 import { PrivatePostSchedule } from '../post-schedule';
 import { store as editorStore } from '../../store';
+import PostPanelRowButton from '../post-panel-row-button';
 
 const postStatusesInfo = {
 	'auto-draft': { label: __( 'Draft' ), icon: drafts },
@@ -164,7 +164,7 @@ export default function PostStatus() {
 	};
 
 	return (
-		<PostPanelRow label={ __( 'Status' ) } ref={ setPopoverAnchor }>
+		<PostPanelRow ref={ setPopoverAnchor }>
 			{ canEdit ? (
 				<Dropdown
 					className="editor-post-status"
@@ -172,21 +172,14 @@ export default function PostStatus() {
 					popoverProps={ popoverProps }
 					focusOnMount
 					renderToggle={ ( { onToggle, isOpen } ) => (
-						<Button
-							className="editor-post-status__toggle"
-							variant="tertiary"
-							size="compact"
-							onClick={ onToggle }
+						<PostPanelRowButton
+							label={ __( 'Status' ) }
 							icon={ postStatusesInfo[ status ]?.icon }
-							aria-label={ sprintf(
-								// translators: %s: Current post status.
-								__( 'Change status: %s' ),
-								postStatusesInfo[ status ]?.label
-							) }
-							aria-expanded={ isOpen }
-						>
-							{ postStatusesInfo[ status ]?.label }
-						</Button>
+							displayedValue={ postStatusesInfo[ status ]?.label }
+							className="editor-post-status__toggle"
+							onClick={ onToggle }
+							isExpanded={ isOpen }
+						/>
 					) }
 					renderContent={ ( { onClose } ) => (
 						<>

--- a/packages/editor/src/components/post-status/style.scss
+++ b/packages/editor/src/components/post-status/style.scss
@@ -1,5 +1,5 @@
 .editor-post-status {
-	max-width: 100%;
+	width: 100%;
 
 	&.is-read-only {
 		padding: 6px 12px;

--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -24,6 +24,7 @@ import SwapTemplateButton from './swap-template-button';
 import ResetDefaultTemplate from './reset-default-template';
 import { unlock } from '../../lock-unlock';
 import CreateNewTemplate from './create-new-template';
+import PostPanelRowButton from '../post-panel-row-button';
 
 export default function BlockThemeControl( { id } ) {
 	const {
@@ -106,18 +107,17 @@ export default function BlockThemeControl( { id } ) {
 		}
 	};
 	return (
-		<PostPanelRow label={ __( 'Template' ) } ref={ setPopoverAnchor }>
+		<PostPanelRow ref={ setPopoverAnchor }>
 			<DropdownMenu
 				popoverProps={ popoverProps }
 				focusOnMount
 				toggleProps={ {
-					size: 'compact',
-					variant: 'tertiary',
-					tooltipPosition: 'middle left',
+					as: PostPanelRowButton,
+					displayedValue: decodeEntities( template.title ),
 				} }
-				label={ __( 'Template options' ) }
-				text={ decodeEntities( template.title ) }
+				label={ __( 'Template' ) }
 				icon={ null }
+				className="editor-post-template__panel-dropdown"
 			>
 				{ ( { onClose } ) => (
 					<>

--- a/packages/editor/src/components/post-template/classic-theme.js
+++ b/packages/editor/src/components/post-template/classic-theme.js
@@ -17,6 +17,7 @@ import { store as editorStore } from '../../store';
 import CreateNewTemplateModal from './create-new-template-modal';
 import { useAllowSwitchingTemplates } from './hooks';
 import PostPanelRow from '../post-panel-row';
+import PostPanelRowButton from '../post-panel-row-button';
 
 function PostTemplateToggle( { isOpen, onClick } ) {
 	const templateTitle = useSelect( ( select ) => {
@@ -41,15 +42,13 @@ function PostTemplateToggle( { isOpen, onClick } ) {
 	}, [] );
 
 	return (
-		<Button
-			__next40pxDefaultSize
-			variant="tertiary"
-			aria-expanded={ isOpen }
-			aria-label={ __( 'Template options' ) }
+		<PostPanelRowButton
+			label={ __( 'Template' ) }
+			displayedValue={ templateTitle ?? __( 'Default template' ) }
+			isExpanded={ isOpen }
 			onClick={ onClick }
-		>
-			{ templateTitle ?? __( 'Default template' ) }
-		</Button>
+			aria-haspopup="true"
+		/>
 	);
 }
 
@@ -228,7 +227,7 @@ function ClassicThemeControl() {
 	);
 
 	return (
-		<PostPanelRow label={ __( 'Template' ) } ref={ setPopoverAnchor }>
+		<PostPanelRow ref={ setPopoverAnchor }>
 			<Dropdown
 				popoverProps={ popoverProps }
 				focusOnMount
@@ -241,6 +240,7 @@ function ClassicThemeControl() {
 				renderContent={ ( { onClose } ) => (
 					<PostTemplateDropdownContent onClose={ onClose } />
 				) }
+				className="editor-post-template__panel-dropdown"
 			/>
 		</PostPanelRow>
 	);

--- a/packages/editor/src/components/post-template/style.scss
+++ b/packages/editor/src/components/post-template/style.scss
@@ -1,3 +1,7 @@
+.editor-post-template__panel-dropdown {
+	width: 100%;
+}
+
 .editor-post-template__swap-template-modal {
 	z-index: z-index(".editor-post-template__swap-template-modal");
 }

--- a/packages/editor/src/components/post-url/panel.js
+++ b/packages/editor/src/components/post-url/panel.js
@@ -3,7 +3,7 @@
  */
 import { useMemo, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { Dropdown, ExternalLink } from '@wordpress/components';
+import { Dropdown } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { safeDecodeURIComponent } from '@wordpress/url';
 import { store as coreStore } from '@wordpress/core-data';
@@ -53,8 +53,6 @@ export default function PostURLPanel() {
 		[ popoverAnchor ]
 	);
 
-	const label = isFrontPage ? __( 'Link' ) : __( 'Slug' );
-
 	return (
 		<PostURLCheck>
 			<PostPanelRow ref={ setPopoverAnchor }>
@@ -68,7 +66,7 @@ export default function PostURLPanel() {
 							<PostURLToggle
 								isOpen={ isOpen }
 								onClick={ onToggle }
-								label={ label }
+								label={ __( 'Slug' ) }
 							/>
 						) }
 						renderContent={ ( { onClose } ) => (
@@ -109,12 +107,25 @@ function FrontPageLink() {
 	}, [] );
 
 	return (
-		<ExternalLink
-			className="editor-post-url__front-page-link"
+		<PostPanelRowButton
+			label={ __( 'Link' ) }
+			displayedValue={
+				<span>
+					<span>{ postLink } &#8599;</span>
+				</span>
+			}
+			description={
+				<>
+					{
+						/* translators: accessibility text */
+						__( '(opens in a new tab)' )
+					}
+					{ postLink }
+				</>
+			}
 			href={ postLink }
 			target="_blank"
-		>
-			{ postLink }
-		</ExternalLink>
+			className="editor-post-url__front-page-link"
+		/>
 	);
 }

--- a/packages/editor/src/components/post-url/panel.js
+++ b/packages/editor/src/components/post-url/panel.js
@@ -3,8 +3,8 @@
  */
 import { useMemo, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { Dropdown, Button, ExternalLink } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { Dropdown, ExternalLink } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { safeDecodeURIComponent } from '@wordpress/url';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -15,6 +15,7 @@ import PostURLCheck from './check';
 import PostURL from './index';
 import PostPanelRow from '../post-panel-row';
 import { store as editorStore } from '../../store';
+import PostPanelRowButton from '../post-panel-row-button';
 
 /**
  * Renders the `PostURLPanel` component.
@@ -56,7 +57,7 @@ export default function PostURLPanel() {
 
 	return (
 		<PostURLCheck>
-			<PostPanelRow label={ label } ref={ setPopoverAnchor }>
+			<PostPanelRow ref={ setPopoverAnchor }>
 				{ ! isFrontPage && (
 					<Dropdown
 						popoverProps={ popoverProps }
@@ -67,6 +68,7 @@ export default function PostURLPanel() {
 							<PostURLToggle
 								isOpen={ isOpen }
 								onClick={ onToggle }
+								label={ label }
 							/>
 						) }
 						renderContent={ ( { onClose } ) => (
@@ -80,7 +82,7 @@ export default function PostURLPanel() {
 	);
 }
 
-function PostURLToggle( { isOpen, onClick } ) {
+function PostURLToggle( { isOpen, onClick, label } ) {
 	const { slug } = useSelect( ( select ) => {
 		return {
 			slug: select( editorStore ).getEditedPostSlug(),
@@ -88,19 +90,13 @@ function PostURLToggle( { isOpen, onClick } ) {
 	}, [] );
 	const decodedSlug = safeDecodeURIComponent( slug );
 	return (
-		<Button
-			size="compact"
+		<PostPanelRowButton
+			label={ label }
+			displayedValue={ <>{ decodedSlug }</> }
 			className="editor-post-url__panel-toggle"
-			variant="tertiary"
-			aria-expanded={ isOpen }
-			aria-label={
-				// translators: %s: Current post link.
-				sprintf( __( 'Change link: %s' ), decodedSlug )
-			}
 			onClick={ onClick }
-		>
-			<>{ decodedSlug }</>
-		</Button>
+			isExpanded={ isOpen }
+		/>
 	);
 }
 

--- a/packages/editor/src/components/post-url/style.scss
+++ b/packages/editor/src/components/post-url/style.scss
@@ -17,10 +17,10 @@
 /* rtl:end:ignore */
 
 .editor-post-url__front-page-link {
-	// Match padding on tertiary buttons for alignment.
-	padding: $grid-unit-15 * 0.5 0 $grid-unit-15 * 0.5 $grid-unit-15;
+	.editor-post-panel__row-button-value {
+		color: inherit;
+	}
 }
-
 
 .editor-post-url__link-slug {
 	font-weight: 600;

--- a/packages/editor/src/components/posts-per-page/index.js
+++ b/packages/editor/src/components/posts-per-page/index.js
@@ -5,7 +5,6 @@ import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import {
-	Button,
 	Dropdown,
 	__experimentalNumberControl as NumberControl,
 } from '@wordpress/components';
@@ -18,6 +17,7 @@ import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '
 import { TEMPLATE_POST_TYPE } from '../../store/constants';
 import { store as editorStore } from '../../store';
 import PostPanelRow from '../post-panel-row';
+import PostPanelRowButton from '../post-panel-row-button';
 
 export default function PostsPerPage() {
 	const { editEntityRecord } = useDispatch( coreStore );
@@ -62,21 +62,20 @@ export default function PostsPerPage() {
 		} );
 	};
 	return (
-		<PostPanelRow label={ __( 'Posts per page' ) } ref={ setPopoverAnchor }>
+		<PostPanelRow ref={ setPopoverAnchor }>
 			<Dropdown
 				popoverProps={ popoverProps }
+				className="editor-posts-per-page-dropdown"
 				contentClassName="editor-posts-per-page-dropdown__content"
 				focusOnMount
 				renderToggle={ ( { isOpen, onToggle } ) => (
-					<Button
-						size="compact"
-						variant="tertiary"
-						aria-expanded={ isOpen }
-						aria-label={ __( 'Change posts per page' ) }
+					<PostPanelRowButton
+						label={ __( 'Posts per page' ) }
+						displayedValue={ postsPerPage }
+						isExpanded={ isOpen }
 						onClick={ onToggle }
-					>
-						{ postsPerPage }
-					</Button>
+						aria-haspopup="true"
+					/>
 				) }
 				renderContent={ ( { onClose } ) => (
 					<>

--- a/packages/editor/src/components/posts-per-page/style.scss
+++ b/packages/editor/src/components/posts-per-page/style.scss
@@ -1,3 +1,7 @@
+.editor-posts-per-page-dropdown {
+	width: 100%;
+}
+
 .editor-posts-per-page-dropdown__content .components-popover__content {
 	min-width: 320px;
 	padding: $grid-unit-20;

--- a/packages/editor/src/components/site-discussion/index.js
+++ b/packages/editor/src/components/site-discussion/index.js
@@ -5,7 +5,6 @@ import { __, _x } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import {
-	Button,
 	Dropdown,
 	RadioControl,
 	__experimentalVStack as VStack,
@@ -20,6 +19,7 @@ import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '
 import { TEMPLATE_POST_TYPE } from '../../store/constants';
 import PostPanelRow from '../post-panel-row';
 import { store as editorStore } from '../../store';
+import PostPanelRowButton from '../post-panel-row-button';
 
 const COMMENT_OPTIONS = [
 	{
@@ -84,23 +84,24 @@ export default function SiteDiscussion() {
 		} );
 	};
 	return (
-		<PostPanelRow label={ __( 'Discussion' ) } ref={ setPopoverAnchor }>
+		<PostPanelRow ref={ setPopoverAnchor }>
 			<Dropdown
 				popoverProps={ popoverProps }
+				className="editor-site-discussion-dropdown"
 				contentClassName="editor-site-discussion-dropdown__content"
 				focusOnMount
 				renderToggle={ ( { isOpen, onToggle } ) => (
-					<Button
-						size="compact"
-						variant="tertiary"
-						aria-expanded={ isOpen }
-						aria-label={ __( 'Change discussion settings' ) }
+					<PostPanelRowButton
+						label={ __( 'Discussion' ) }
+						displayedValue={
+							allowCommentsOnNewPosts
+								? __( 'Comments open' )
+								: __( 'Comments closed' )
+						}
+						isExpanded={ isOpen }
 						onClick={ onToggle }
-					>
-						{ allowCommentsOnNewPosts
-							? __( 'Comments open' )
-							: __( 'Comments closed' ) }
-					</Button>
+						aria-haspopup="true"
+					/>
 				) }
 				renderContent={ ( { onClose } ) => (
 					<>

--- a/packages/editor/src/components/site-discussion/style.scss
+++ b/packages/editor/src/components/site-discussion/style.scss
@@ -1,3 +1,7 @@
+.editor-site-discussion-dropdown {
+	width: 100%;
+}
+
 .editor-site-discussion-dropdown__content .components-popover__content {
 	min-width: 320px;
 	padding: $grid-unit-20;

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -29,6 +29,7 @@
 @import "./components/post-last-revision/style.scss";
 @import "./components/post-locked-modal/style.scss";
 @import "./components/post-panel-row/style.scss";
+@import "./components/post-panel-row-button/style.scss";
 @import "./components/post-panel-section/style.scss";
 @import "./components/post-publish-panel/style.scss";
 @import "./components/post-saved-state/style.scss";

--- a/test/e2e/specs/editor/various/change-detection.spec.js
+++ b/test/e2e/specs/editor/various/change-detection.spec.js
@@ -80,7 +80,7 @@ test.describe( 'Change detection', () => {
 
 		// Toggle post as needing review (not persisted for autosave).
 		await editor.openDocumentSettingsSidebar();
-		await page.getByRole( 'button', { name: 'Change status:' } ).click();
+		await page.getByRole( 'button', { name: 'Status' } ).click();
 		await page.getByRole( 'radio', { name: 'Pending' } ).click();
 		// Force autosave to occur immediately.
 		await Promise.all( [

--- a/test/e2e/specs/editor/various/datepicker.spec.js
+++ b/test/e2e/specs/editor/various/datepicker.spec.js
@@ -35,16 +35,22 @@ TIMEZONES.forEach( ( timezone ) => {
 		test( 'should show the publishing date as "Immediately" if the date is not altered', async ( {
 			page,
 		} ) => {
+			const settingsRegion = page.getByRole( 'region', {
+				name: 'Editor settings',
+			} );
 			await expect(
-				page.getByRole( 'button', { name: 'Publish date' } )
+				settingsRegion.getByRole( 'button', { name: 'Publish' } )
 			).toContainText( 'Immediately' );
 		} );
 
 		test( 'should show the publishing date if the date is in the past', async ( {
 			page,
 		} ) => {
-			const datepicker = page.getByRole( 'button', {
-				name: 'Publish date',
+			const settingsRegion = page.getByRole( 'region', {
+				name: 'Editor settings',
+			} );
+			const datepicker = settingsRegion.getByRole( 'button', {
+				name: 'Publish',
 			} );
 			await datepicker.click();
 
@@ -58,15 +64,18 @@ TIMEZONES.forEach( ( timezone ) => {
 
 			// The expected date format will be "Sep 26, 2018 11:52 pm".
 			await expect(
-				page.getByRole( 'button', { name: 'Publish date' } )
+				settingsRegion.getByRole( 'button', { name: 'Publish' } )
 			).toContainText( /[A-Za-z]+\s\d{1,2},\s\d{1,4}/ );
 		} );
 
 		test( 'should show the publishing date if the date is in the future', async ( {
 			page,
 		} ) => {
-			const datepicker = page.getByRole( 'button', {
-				name: 'Publish date',
+			const settingsRegion = page.getByRole( 'region', {
+				name: 'Editor settings',
+			} );
+			const datepicker = settingsRegion.getByRole( 'button', {
+				name: 'Publish',
 			} );
 			await datepicker.click();
 
@@ -80,15 +89,18 @@ TIMEZONES.forEach( ( timezone ) => {
 
 			// The expected date format will be "Sep 26, 2018 11:52 pm".
 			await expect(
-				page.getByRole( 'button', { name: 'Publish date' } )
+				settingsRegion.getByRole( 'button', { name: 'Publish' } )
 			).toContainText( /[A-Za-z]+\s\d{1,2},\s\d{1,4}/ );
 		} );
 
 		test( 'should show the publishing date as "Immediately" if the date is cleared', async ( {
 			page,
 		} ) => {
-			const datepicker = page.getByRole( 'button', {
-				name: 'Publish date',
+			const settingsRegion = page.getByRole( 'region', {
+				name: 'Editor settings',
+			} );
+			const datepicker = settingsRegion.getByRole( 'button', {
+				name: 'Publish',
 			} );
 			await datepicker.click();
 
@@ -108,7 +120,7 @@ TIMEZONES.forEach( ( timezone ) => {
 				.click();
 
 			await expect(
-				page.getByRole( 'button', { name: 'Publish date' } )
+				settingsRegion.getByRole( 'button', { name: 'Publish' } )
 			).toContainText( 'Immediately' );
 		} );
 	} );

--- a/test/e2e/specs/editor/various/datepicker.spec.js
+++ b/test/e2e/specs/editor/various/datepicker.spec.js
@@ -36,15 +36,15 @@ TIMEZONES.forEach( ( timezone ) => {
 			page,
 		} ) => {
 			await expect(
-				page.getByRole( 'button', { name: 'Change date' } )
-			).toHaveText( 'Immediately' );
+				page.getByRole( 'button', { name: 'Publish date' } )
+			).toContainText( 'Immediately' );
 		} );
 
 		test( 'should show the publishing date if the date is in the past', async ( {
 			page,
 		} ) => {
 			const datepicker = page.getByRole( 'button', {
-				name: 'Change date',
+				name: 'Publish date',
 			} );
 			await datepicker.click();
 
@@ -58,15 +58,15 @@ TIMEZONES.forEach( ( timezone ) => {
 
 			// The expected date format will be "Sep 26, 2018 11:52 pm".
 			await expect(
-				page.getByRole( 'button', { name: 'Change date' } )
-			).toContainText( /^[A-Za-z]+\s\d{1,2},\s\d{1,4}/ );
+				page.getByRole( 'button', { name: 'Publish date' } )
+			).toContainText( /[A-Za-z]+\s\d{1,2},\s\d{1,4}/ );
 		} );
 
 		test( 'should show the publishing date if the date is in the future', async ( {
 			page,
 		} ) => {
 			const datepicker = page.getByRole( 'button', {
-				name: 'Change date',
+				name: 'Publish date',
 			} );
 			await datepicker.click();
 
@@ -80,15 +80,15 @@ TIMEZONES.forEach( ( timezone ) => {
 
 			// The expected date format will be "Sep 26, 2018 11:52 pm".
 			await expect(
-				page.getByRole( 'button', { name: 'Change date' } )
-			).toContainText( /^[A-Za-z]+\s\d{1,2},\s\d{1,4}/ );
+				page.getByRole( 'button', { name: 'Publish date' } )
+			).toContainText( /[A-Za-z]+\s\d{1,2},\s\d{1,4}/ );
 		} );
 
 		test( 'should show the publishing date as "Immediately" if the date is cleared', async ( {
 			page,
 		} ) => {
 			const datepicker = page.getByRole( 'button', {
-				name: 'Change date',
+				name: 'Publish date',
 			} );
 			await datepicker.click();
 
@@ -108,8 +108,8 @@ TIMEZONES.forEach( ( timezone ) => {
 				.click();
 
 			await expect(
-				page.getByRole( 'button', { name: 'Change date' } )
-			).toHaveText( 'Immediately' );
+				page.getByRole( 'button', { name: 'Publish date' } )
+			).toContainText( 'Immediately' );
 		} );
 	} );
 } );

--- a/test/e2e/specs/editor/various/new-post.spec.js
+++ b/test/e2e/specs/editor/various/new-post.spec.js
@@ -40,7 +40,7 @@ test.describe( 'new editor state', () => {
 		// Should display the Post Formats UI.
 		await editor.openDocumentSettingsSidebar();
 		await expect(
-			page.locator( 'role=button[name="Change Format: Standard"i]' )
+			page.locator( 'role=button[name="Format"i]' )
 		).toBeVisible();
 	} );
 

--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -109,7 +109,7 @@ test.describe( 'Post Editor Template mode', () => {
 			} )
 			.click();
 		await expect(
-			page.getByRole( 'button', { name: 'Template options' } )
+			page.getByRole( 'button', { name: 'Template' } )
 		).toHaveText( 'Single Entries' );
 	} );
 
@@ -175,7 +175,7 @@ class PostEditorTemplateMode {
 		// Only match the beginning of Select template: because it contains the template name or slug afterwards.
 		await this.editorSettingsSidebar
 			.getByRole( 'button', {
-				name: 'Template options',
+				name: 'Template',
 			} )
 			.click();
 	}

--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -110,7 +110,7 @@ test.describe( 'Post Editor Template mode', () => {
 			.click();
 		await expect(
 			page.getByRole( 'button', { name: 'Template' } )
-		).toHaveText( 'Single Entries' );
+		).toContainText( 'Single Entries' );
 	} );
 
 	test( 'Allow creating custom block templates in classic themes', async ( {

--- a/test/e2e/specs/editor/various/post-visibility.spec.js
+++ b/test/e2e/specs/editor/various/post-visibility.spec.js
@@ -45,7 +45,12 @@ test.describe( 'Post visibility', () => {
 		await editor.openDocumentSettingsSidebar();
 
 		// Set a publish date for the next month.
-		await page.click( 'role=button[name="Publish date"i]' );
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', {
+				name: 'Publish',
+			} )
+			.click();
 
 		await page.click( 'role=button[name="View next month"i]' );
 		await page.click( 'role=application[name="Calendar"] >> text=15' );

--- a/test/e2e/specs/editor/various/post-visibility.spec.js
+++ b/test/e2e/specs/editor/various/post-visibility.spec.js
@@ -17,9 +17,7 @@ test.describe( 'Post visibility', () => {
 
 			await editor.openDocumentSettingsSidebar();
 
-			await page
-				.getByRole( 'button', { name: 'Change status:' } )
-				.click();
+			await page.getByRole( 'button', { name: 'Status' } ).click();
 			await page.getByRole( 'radio', { name: 'Private' } ).click();
 
 			const currentStatus = await page.evaluate( () => {
@@ -47,7 +45,7 @@ test.describe( 'Post visibility', () => {
 		await editor.openDocumentSettingsSidebar();
 
 		// Set a publish date for the next month.
-		await page.click( 'role=button[name="Change date: Immediately"i]' );
+		await page.click( 'role=button[name="Publish date"i]' );
 
 		await page.click( 'role=button[name="View next month"i]' );
 		await page.click( 'role=application[name="Calendar"] >> text=15' );
@@ -57,7 +55,7 @@ test.describe( 'Post visibility', () => {
 				name: 'Close',
 			} )
 			.click();
-		await page.getByRole( 'button', { name: 'Change status:' } ).click();
+		await page.getByRole( 'button', { name: 'Status' } ).click();
 		await page.getByRole( 'radio', { name: 'Private' } ).click();
 		await page
 			.getByRole( 'region', { name: 'Editor top bar' } )

--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -183,7 +183,7 @@ test.describe( 'Preview', () => {
 
 		// Return to editor and switch to Draft.
 		await editorPage.bringToFront();
-		await page.getByRole( 'button', { name: 'Change status:' } ).click();
+		await page.getByRole( 'button', { name: 'Status' } ).click();
 		await page.getByRole( 'radio', { name: 'Draft' } ).click();
 		await page
 			.getByRole( 'region', { name: 'Editor top bar' } )

--- a/test/e2e/specs/editor/various/publish-panel.spec.js
+++ b/test/e2e/specs/editor/various/publish-panel.spec.js
@@ -66,7 +66,7 @@ test.describe( 'Post publish panel', () => {
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'Test Post' );
 		await page
-			.getByRole( 'region', 'Editor top bar' )
+			.getByRole( 'region', { name: 'Editor top bar' } )
 			.getByRole( 'button', { name: 'Publish', exact: true } )
 			.click();
 
@@ -102,7 +102,7 @@ test.describe( 'Post publish panel', () => {
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'Test Post' );
 		await page
-			.getByRole( 'region', 'Editor top bar' )
+			.getByRole( 'region', { name: 'Editor top bar' } )
 			.getByRole( 'button', { name: 'Publish', exact: true } )
 			.click();
 		await pageUtils.pressKeys( 'shift+Tab' );

--- a/test/e2e/specs/editor/various/scheduling.spec.js
+++ b/test/e2e/specs/editor/various/scheduling.spec.js
@@ -40,9 +40,13 @@ test.describe( 'Scheduling', () => {
 					topBar.getByRole( 'button', { name: 'Publish' } )
 				).toBeVisible();
 
+				const settingsRegion = page.getByRole( 'region', {
+					name: 'Editor settings',
+				} );
+
 				// Open the datepicker.
-				await page
-					.getByRole( 'button', { name: 'Publish date' } )
+				await settingsRegion
+					.getByRole( 'button', { name: 'Publish' } )
 					.click();
 
 				// Change the publishing date to a year in the future.
@@ -69,7 +73,11 @@ test.describe( 'Scheduling', () => {
 	} ) => {
 		await admin.createNewPost();
 		await editor.openDocumentSettingsSidebar();
-		await page.getByRole( 'button', { name: 'Publish date' } ).click();
+
+		const settingsRegion = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+		await settingsRegion.getByRole( 'button', { name: 'Publish' } ).click();
 
 		const calendar = page.getByRole( 'application', { name: 'Calendar' } );
 		const prevMonth = calendar.getByRole( 'button', {

--- a/test/e2e/specs/editor/various/scheduling.spec.js
+++ b/test/e2e/specs/editor/various/scheduling.spec.js
@@ -42,7 +42,7 @@ test.describe( 'Scheduling', () => {
 
 				// Open the datepicker.
 				await page
-					.getByRole( 'button', { name: 'Change date' } )
+					.getByRole( 'button', { name: 'Publish date' } )
 					.click();
 
 				// Change the publishing date to a year in the future.
@@ -69,7 +69,7 @@ test.describe( 'Scheduling', () => {
 	} ) => {
 		await admin.createNewPost();
 		await editor.openDocumentSettingsSidebar();
-		await page.getByRole( 'button', { name: 'Change date' } ).click();
+		await page.getByRole( 'button', { name: 'Publish date' } ).click();
 
 		const calendar = page.getByRole( 'application', { name: 'Calendar' } );
 		const prevMonth = calendar.getByRole( 'button', {

--- a/test/e2e/specs/editor/various/sidebar-permalink.spec.js
+++ b/test/e2e/specs/editor/various/sidebar-permalink.spec.js
@@ -34,7 +34,7 @@ test.describe( 'Sidebar Permalink', () => {
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'aaaa (Updated)' );
 		await expect(
-			page.getByRole( 'button', { name: 'Change link' } )
+			page.getByRole( 'button', { name: 'Slug' } )
 		).toBeHidden();
 	} );
 
@@ -54,7 +54,7 @@ test.describe( 'Sidebar Permalink', () => {
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'aaaa (Updated)' );
 		await expect(
-			page.getByRole( 'button', { name: 'Change link' } )
+			page.getByRole( 'button', { name: 'Slug' } )
 		).toBeHidden();
 	} );
 
@@ -75,7 +75,7 @@ test.describe( 'Sidebar Permalink', () => {
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'aaaa (Updated)' );
 		await expect(
-			page.getByRole( 'button', { name: 'Change link' } )
+			page.getByRole( 'button', { name: 'Slug' } )
 		).toBeVisible();
 	} );
 } );

--- a/test/e2e/specs/editor/various/sidebar.spec.js
+++ b/test/e2e/specs/editor/various/sidebar.spec.js
@@ -126,7 +126,7 @@ test.describe( 'Sidebar', () => {
 			name: 'Discussion',
 		} );
 		const postAuthorPanel = page.getByRole( 'button', {
-			name: 'admin',
+			name: 'Author',
 		} );
 
 		await expect( postExcerptPanel ).toBeVisible();

--- a/test/e2e/specs/editor/various/sidebar.spec.js
+++ b/test/e2e/specs/editor/various/sidebar.spec.js
@@ -123,7 +123,7 @@ test.describe( 'Sidebar', () => {
 			name: 'Set featured image',
 		} );
 		const postDiscussionPanel = page.getByRole( 'button', {
-			name: 'Change discussion options',
+			name: 'Discussion',
 		} );
 		const postAuthorPanel = page.getByRole( 'button', {
 			name: 'admin',

--- a/test/e2e/specs/editor/various/switch-to-draft.spec.js
+++ b/test/e2e/specs/editor/various/switch-to-draft.spec.js
@@ -47,7 +47,7 @@ test.describe( 'Clicking "Switch to draft" on a published/scheduled post/page', 
 
 					await editor.openDocumentSettingsSidebar();
 					await page
-						.getByRole( 'button', { name: 'Change status:' } )
+						.getByRole( 'button', { name: 'Status' } )
 						.click();
 					await page.getByRole( 'radio', { name: 'Draft' } ).click();
 

--- a/test/e2e/specs/editor/various/template-resolution.spec.js
+++ b/test/e2e/specs/editor/various/template-resolution.spec.js
@@ -57,12 +57,12 @@ test.describe( 'Template resolution', () => {
 			await admin.editPost( newPage.id );
 			await editor.openDocumentSettingsSidebar();
 			await expect(
-				page.getByRole( 'button', { name: 'Template options' } )
+				page.getByRole( 'button', { name: 'Template' } )
 			).toHaveText( 'Single Entries' );
 			await updateSiteSettings( { requestUtils, pageId: newPage.id } );
 			await page.reload();
 			await expect(
-				page.getByRole( 'button', { name: 'Template options' } )
+				page.getByRole( 'button', { name: 'Template' } )
 			).toHaveText( 'Index' );
 		} );
 		test( 'Site editor proper template resolution', async ( {
@@ -83,7 +83,7 @@ test.describe( 'Template resolution', () => {
 			} );
 			await editor.openDocumentSettingsSidebar();
 			await expect(
-				page.getByRole( 'button', { name: 'Template options' } )
+				page.getByRole( 'button', { name: 'Template' } )
 			).toHaveText( 'Index' );
 		} );
 	} );

--- a/test/e2e/specs/editor/various/template-resolution.spec.js
+++ b/test/e2e/specs/editor/various/template-resolution.spec.js
@@ -58,12 +58,12 @@ test.describe( 'Template resolution', () => {
 			await editor.openDocumentSettingsSidebar();
 			await expect(
 				page.getByRole( 'button', { name: 'Template' } )
-			).toHaveText( 'Single Entries' );
+			).toContainText( 'Single Entries' );
 			await updateSiteSettings( { requestUtils, pageId: newPage.id } );
 			await page.reload();
 			await expect(
 				page.getByRole( 'button', { name: 'Template' } )
-			).toHaveText( 'Index' );
+			).toContainText( 'Index' );
 		} );
 		test( 'Site editor proper template resolution', async ( {
 			page,
@@ -84,7 +84,7 @@ test.describe( 'Template resolution', () => {
 			await editor.openDocumentSettingsSidebar();
 			await expect(
 				page.getByRole( 'button', { name: 'Template' } )
-			).toHaveText( 'Index' );
+			).toContainText( 'Index' );
 		} );
 	} );
 } );

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -288,7 +288,7 @@ test.describe( 'Pages', () => {
 		// Empty theme's custom template with `postTypes: ['post']`, should not be suggested.
 		await expect( templateItem ).toHaveCount( 1 );
 		await templateItem.click();
-		await expect( templateOptionsButton ).toHaveText( 'demo' );
+		await expect( templateOptionsButton ).toContainText( 'demo' );
 		await editor.saveSiteEditorEntities( {
 			isOnlyCurrentEntityDirty: true,
 		} );

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -276,7 +276,7 @@ test.describe( 'Pages', () => {
 		const templateOptionsButton = page
 			.getByRole( 'region', { name: 'Editor settings' } )
 			.getByRole( 'button', { name: 'Template' } );
-		await expect( templateOptionsButton ).toHaveText( 'Single Entries' );
+		await expect( templateOptionsButton ).toContainText( 'Single Entries' );
 		await templateOptionsButton.click();
 		await page
 			.getByRole( 'menu', { name: 'Template' } )
@@ -300,7 +300,7 @@ test.describe( 'Pages', () => {
 			.getByText( 'Use default template' );
 		await expect( resetButton ).toBeVisible();
 		await resetButton.click();
-		await expect( templateOptionsButton ).toHaveText( 'Single Entries' );
+		await expect( templateOptionsButton ).toContainText( 'Single Entries' );
 	} );
 
 	test( 'change template options should respect the declared `postTypes`', async ( {

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -107,7 +107,7 @@ test.describe( 'Pages', () => {
 		} );
 		await editorSettings.getByRole( 'tab', { name: 'Page' } ).click();
 		await editorSettings
-			.getByRole( 'button', { name: 'Template options' } )
+			.getByRole( 'button', { name: 'Template' } )
 			.click();
 		await page.getByRole( 'menuitem', { name: 'Edit template' } ).click();
 		await expect(
@@ -185,10 +185,10 @@ test.describe( 'Pages', () => {
 		// Toggle template preview to "off".
 		const templateOptionsButton = page
 			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'button', { name: 'Template options' } );
+			.getByRole( 'button', { name: 'Template' } );
 		await templateOptionsButton.click();
 		const templatePreviewButton = page
-			.getByRole( 'menu', { name: 'Template options' } )
+			.getByRole( 'menu', { name: 'Template' } )
 			.getByRole( 'menuitemcheckbox', { name: 'Show template' } );
 
 		await expect( templatePreviewButton ).toHaveAttribute(
@@ -275,11 +275,11 @@ test.describe( 'Pages', () => {
 		await editor.openDocumentSettingsSidebar();
 		const templateOptionsButton = page
 			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'button', { name: 'Template options' } );
+			.getByRole( 'button', { name: 'Template' } );
 		await expect( templateOptionsButton ).toHaveText( 'Single Entries' );
 		await templateOptionsButton.click();
 		await page
-			.getByRole( 'menu', { name: 'Template options' } )
+			.getByRole( 'menu', { name: 'Template' } )
 			.getByText( 'Change template' )
 			.click();
 		const templateItem = page.locator(
@@ -296,7 +296,7 @@ test.describe( 'Pages', () => {
 		// Now reset, and apply the default template back.
 		await templateOptionsButton.click();
 		const resetButton = page
-			.getByRole( 'menu', { name: 'Template options' } )
+			.getByRole( 'menu', { name: 'Template' } )
 			.getByText( 'Use default template' );
 		await expect( resetButton ).toBeVisible();
 		await resetButton.click();
@@ -311,13 +311,13 @@ test.describe( 'Pages', () => {
 		await editor.openDocumentSettingsSidebar();
 		const templateOptionsButton = page
 			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'button', { name: 'Template options' } );
+			.getByRole( 'button', { name: 'Template' } );
 		await templateOptionsButton.click();
 		// Empty theme has only one custom template with `postTypes: ['post']`,
 		// so it should not be suggested.
 		await expect(
 			page
-				.getByRole( 'menu', { name: 'Template options' } )
+				.getByRole( 'menu', { name: 'Template' } )
 				.getByText( 'Change template' )
 		).toHaveCount( 0 );
 	} );

--- a/test/e2e/specs/site-editor/template-registration.spec.js
+++ b/test/e2e/specs/site-editor/template-registration.spec.js
@@ -108,7 +108,7 @@ test.describe( 'Block template registration', () => {
 
 		// Change template.
 		await page.getByRole( 'button', { name: 'Post', exact: true } ).click();
-		await page.getByRole( 'button', { name: 'Template options' } ).click();
+		await page.getByRole( 'button', { name: 'Template' } ).click();
 		await page.getByRole( 'menuitem', { name: 'Change template' } ).click();
 		await page.getByText( 'Plugin Template' ).click();
 
@@ -135,7 +135,7 @@ test.describe( 'Block template registration', () => {
 
 		// Change template.
 		await page.getByRole( 'button', { name: 'Post', exact: true } ).click();
-		await page.getByRole( 'button', { name: 'Template options' } ).click();
+		await page.getByRole( 'button', { name: 'Template' } ).click();
 		await page.getByRole( 'menuitem', { name: 'Change template' } ).click();
 		await page.getByText( 'Custom', { exact: true } ).click();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

FIxes https://github.com/WordPress/gutenberg/issues/63992

This PR aims to address a long standing issue where some editor controls (visible labels + buttons) are designed to provide 1) a setting name 2) the current value or state.
See 
https://github.com/WordPress/gutenberg/issues/470
https://github.com/WordPress/gutenberg/issues/63308

## What?
<!-- In a few words, what is the PR actually doing? -->
The fundamental, long standing, problem with such a pattern is that currently the value / state is used for the visible label of the button. This is less than ideal because buttons should be labeled to communicate _what_ they are about, not the value or state.

In some cases, these buttons are complemented with an `aria-label` attribute e.g. `Change status: {value}` that does clarify the _what_ for blind screen reader users but it introduces a mismatch between the visible text and the actual accessible name that impacts other users, e.g. sighted screen reader users or voice control users.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Buttons should be labeled to communicate _what_ they are about. They are not the right place for values or states.
A complete mismatch between visible text and accesible name must be avoided.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR aims to establish a new pattern to have controls (buttons) communicate both the _what_ (the setting name) and the value or state in an accessible way.

The key point is that the accessible name must be visually exposed and must not be altered by the value or state. To do so, name and value/state must be semantically separated while, visually, they can be presented together.

- Introduces a new editor component `PostPanelRowButton` that is a wrapper around the Button base component.
- Replaces all the visual labels and buttons in the Post summary panel with `PostPanelRowButton`.
- `PostPanelRowButton` does two important things:
  - Exposes the `label` prop as part of the visible text _and_ accessible name of the button e.g. `Status`.
  - Uses the `displayedValue` prop to:
    - Visually show the value/state within the button but keeping it hidden from assistive technology.
    - Use the value/state as accessible description of the button.
- This way, the setting name and the value/state are separated, while still visually presented together.
- Screen readers would announce both the accessible name and description e.g. `Status, Draft, button`.
- Voice control users can issue a voice command e.g. `Click Status` to activate the button.
- Visually, the button takes the whole width of the panel and the setting name is now blue instead of the value/state. The value/state is always dark grey except the `PostURLPanel` when it shows the front page link. This seems a reasonable exception to me because the value is, well, a link.

Example screenshot:

![Screenshot 2025-01-22 at 14 08 27](https://github.com/user-attachments/assets/841aaaf2-d186-4281-937e-28c655b9d0c4)

Note 1:
I removed the tooltip used to show the full publish date/time for a few reasons:
- Tooltips should eclusively be used to visually expose the accessible name of a control. They are not the right place for additional info or descriptions.
- The current tooltiip implementation based on Ariakit pollutes the accessible description of a control. which is here used to communicate the setting value.
- Users can always see the full date and time by opening the datepicker popover.


Note 2:
- Please double check the [list of the components that populate the panel](https://github.com/WordPress/gutenberg/blob/06ee5e14d06beecdf26e07afaae6b4a5d47eaef8/packages/editor/src/components/sidebar/post-summary.js#L75-L91).
- Plugins that add their own stuff to the `PluginPostStatusInfo` slot should not be affected by this change. The fills renders normally at the end of the panel. However, if plugins add controls that used to replicate the previous design, they may want to adapt to the new one. Screenshot of a demo fill:

![Screenshot 2025-01-22 at 14 40 21](https://github.com/user-attachments/assets/9525ddfe-f059-433d-9d3a-806e3327c836)



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Test at least in 3 places:

Post editor, editing a post:
- Observe and test all the controls in the Post summary panel.

Post editor, editing a page:
- Observe and test all the controls in the Post summary panel.
- Edit the front page and observe and test all the controls in the Post summary panel.

Site editor, editing a template:
- Observe and test all the controls in the Post summary panel.

Worth reminding the 'Publish' date/time setting should be tested for several cases:setting the site timezone to different values:
- First, test setting your local timezone.
- Create a new post, observe it says `Immediately`.
- Change to same date but at a later time. Observe it says `Today at {time}`.
- Change the date to tomorrow. Observe it says `Tomorrow at {time}`.
- Change to a future date or past date and observe it works as expected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before and after screenshots for: post, page, front page, template.

|Before|After|
|-|-|
|![post before](https://github.com/user-attachments/assets/17fbf71c-1dd9-4491-9159-9dab952be153)|![post after](https://github.com/user-attachments/assets/55ed491d-5c93-443f-9ec8-67afa74b8a6d)|
|![page before](https://github.com/user-attachments/assets/550836c1-1f77-4c04-afeb-1bd54ee89f7e)|![page after](https://github.com/user-attachments/assets/de6fd7b5-794b-4c96-8279-f7de8e3185fc)|
|![front page before](https://github.com/user-attachments/assets/1c3d0335-fd79-4993-ad4e-a7c6f55ca6e9)|![front page after](https://github.com/user-attachments/assets/1613ba25-0f1f-4a03-b140-7daae865cb9b)|
|![template before](https://github.com/user-attachments/assets/3cf7ecfd-927b-447d-ae36-a2e586c29562)|<![template after](https://github.com/user-attachments/assets/83fa2a92-2519-4607-8f26-1c0059de3e6a)|




