### PR TITLE
Page List Block: fix empty settings panel

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -322,58 +322,60 @@ export default function PageListEdit( {
 
 	return (
 		<>
-			<InspectorControls>
-				<ToolsPanel
-					label={ __( 'Settings' ) }
-					resetAll={ () => {
-						setAttributes( { parentPageID: 0 } );
-					} }
-					dropdownMenuProps={ dropdownMenuProps }
-				>
-					{ pagesTree.length > 0 && (
-						<ToolsPanelItem
-							label={ __( 'Parent Page' ) }
-							hasValue={ () => parentPageID !== 0 }
-							onDeselect={ () =>
-								setAttributes( { parentPageID: 0 } )
-							}
-							isShownByDefault
-						>
-							<ComboboxControl
-								__nextHasNoMarginBottom
-								__next40pxDefaultSize
-								className="editor-page-attributes__parent"
-								label={ __( 'Parent' ) }
-								value={ parentPageID }
-								options={ pagesTree }
-								onChange={ ( value ) =>
-									setAttributes( {
-										parentPageID: value ?? 0,
-									} )
+			{ ( pagesTree.length > 0 || allowConvertToLinks ) && (
+				<InspectorControls>
+					<ToolsPanel
+						label={ __( 'Settings' ) }
+						resetAll={ () => {
+							setAttributes( { parentPageID: 0 } );
+						} }
+						dropdownMenuProps={ dropdownMenuProps }
+					>
+						{ pagesTree.length > 0 && (
+							<ToolsPanelItem
+								label={ __( 'Parent Page' ) }
+								hasValue={ () => parentPageID !== 0 }
+								onDeselect={ () =>
+									setAttributes( { parentPageID: 0 } )
 								}
-								help={ __(
-									'Choose a page to show only its subpages.'
-								) }
-							/>
-						</ToolsPanelItem>
-					) }
-
-					{ allowConvertToLinks && (
-						<div style={ { gridColumn: '1 / -1' } }>
-							<p>{ convertDescription }</p>
-							<Button
-								__next40pxDefaultSize
-								variant="primary"
-								accessibleWhenDisabled
-								disabled={ ! hasResolvedPages }
-								onClick={ convertToNavigationLinks }
+								isShownByDefault
 							>
-								{ __( 'Edit' ) }
-							</Button>
-						</div>
-					) }
-				</ToolsPanel>
-			</InspectorControls>
+								<ComboboxControl
+									__nextHasNoMarginBottom
+									__next40pxDefaultSize
+									className="editor-page-attributes__parent"
+									label={ __( 'Parent' ) }
+									value={ parentPageID }
+									options={ pagesTree }
+									onChange={ ( value ) =>
+										setAttributes( {
+											parentPageID: value ?? 0,
+										} )
+									}
+									help={ __(
+										'Choose a page to show only its subpages.'
+									) }
+								/>
+							</ToolsPanelItem>
+						) }
+
+						{ allowConvertToLinks && (
+							<div style={ { gridColumn: '1 / -1' } }>
+								<p>{ convertDescription }</p>
+								<Button
+									__next40pxDefaultSize
+									variant="primary"
+									accessibleWhenDisabled
+									disabled={ ! hasResolvedPages }
+									onClick={ convertToNavigationLinks }
+								>
+									{ __( 'Edit' ) }
+								</Button>
+							</div>
+						) }
+					</ToolsPanel>
+				</InspectorControls>
+			) }
 			{ allowConvertToLinks && (
 				<>
 					<BlockControls group="other">


### PR DESCRIPTION
Follow up on https://github.com/WordPress/gutenberg/pull/67903

## What?

The Page List item has two `ToolsPanelItem` components that are conditionally rendered.

This PR prevents an empty `ToolPanel` component from being rendered when neither control is available.

## How?

See https://github.com/WordPress/gutenberg/pull/68756/files?diff=split&w=1

## Testing Instructions

- Delete all pages.
- Insert a Page List block.

## Screenshots or screencast <!-- if applicable -->

### Before

![image](https://github.com/user-attachments/assets/36880964-876f-48a1-99d4-8f80f26c6182)

### After

![image](https://github.com/user-attachments/assets/34ec608b-e303-431f-bfd6-e504db851eec)



