### PR TITLE
Archives Block: Fix reset button display state

### DIFF
--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -61,7 +61,7 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 						<ToolsPanelItem
 							label={ __( 'Show label' ) }
 							isShownByDefault
-							hasValue={ () => showLabel }
+							hasValue={ () => ! showLabel }
 							onDeselect={ () =>
 								setAttributes( { showLabel: false } )
 							}
@@ -102,7 +102,7 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 					<ToolsPanelItem
 						label={ __( 'Group by' ) }
 						isShownByDefault
-						hasValue={ () => !! type }
+						hasValue={ () => type !== 'monthly' }
 						onDeselect={ () =>
 							setAttributes( { type: 'monthly' } )
 						}


### PR DESCRIPTION
Follow up on #67841

## What?

Fix incorrect display of reset button in the Archive block.

## Why?

I found that the `hasValue` prop was incorrect for two `ToolsPanelItem` components.

## Testing Instructions

Inset an Archive block. Make sure that the Reset button is not visible:

| Before | After |
|--------|--------|
|  ![image](https://github.com/user-attachments/assets/e1d8d45d-f4a9-4e33-b663-48313b10c9d0) | ![image](https://github.com/user-attachments/assets/226316a8-6920-496c-8975-c0fc8a39adf9) |


Enable "Display as dropdown" toggle. Make sure the reset button on the "Show label" control is not displayed:

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/97f0b1fb-6e1a-4eb2-9315-b9eb6755b640) | ![image](https://github.com/user-attachments/assets/bac71fbe-55ff-45d2-9765-7be414c8d373) |
