### PR TITLE
Post Date Block: Fix reset button display state

### DIFF
--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -179,9 +179,7 @@ export default function PostDateEdit( {
 					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
-						hasValue={ () =>
-							format !== undefined && format !== siteFormat
-						}
+						hasValue={ () => !! format }
 						label={ __( 'Date Format' ) }
 						onDeselect={ () =>
 							setAttributes( { format: undefined } )


### PR DESCRIPTION
Follow up on #67906

## What?

Fix incorrect display of reset button in the Archive block.

## Why?

The `hasValue` prop in the "Date format" format doesn't seem to be correct. I think the `hasValue` prop is determined solely by whether the current value is the default value for the block attribute or not.

## Testing Instructions

- Insert a Date block.
- Disable "Default format" button.
  - ❌ trunk: The reset button is not displayed.
  - ✅ This PR: The reset button is displayed.
- Enable "Default format" button.
  - ❌ trunk: The reset button is displayed. When the reset button is pressed, nothing happens.
  - ✅ This PR: The reset button is not displayed.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/74c7b334-ba97-40bb-bb0e-b7275ba0669a