### PR TITLE
Query Page Numbers Block: Fix reset button display state

### DIFF
--- a/packages/block-library/src/query-pagination-numbers/edit.js
+++ b/packages/block-library/src/query-pagination-numbers/edit.js
@@ -67,7 +67,7 @@ export default function QueryPaginationNumbersEdit( {
 				>
 					<ToolsPanelItem
 						label={ __( 'Number of links' ) }
-						hasValue={ () => midSize !== undefined }
+						hasValue={ () => midSize !== 2 }
 						onDeselect={ () => setAttributes( { midSize: 2 } ) }
 						isShownByDefault
 					>


### PR DESCRIPTION
Follow up on #67958

## What?

Fix incorrect display of the reset button in the Page Numbers block.

## Why?

Because the default value of the `midSize` attribute is `2`, its value will never be `undefined`. Therefore, `midSize !== undefined` will always be true and the value cannot be restored to `2`.

## Testing Instructions

- Insert a Pagination block.
- Select the Page Numbers Block.
- Change the value.
  - ❌ trunk: The reset button is not displayed.
  - ✅ This PR: The reset button is displayed.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/3cedceba-b23f-4713-9bab-093c95b1ba87
