### PR TITLE
Video: fix react component warning error

### DIFF
--- a/packages/block-library/src/video/edit-common-settings.js
+++ b/packages/block-library/src/video/edit-common-settings.js
@@ -125,7 +125,7 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 					/* translators: Setting to play videos within the webpage on mobile browsers rather than opening in a fullscreen player. */
 					label={ __( 'Play inline' ) }
 					onChange={ toggleFactory.playsInline }
-					checked={ playsInline }
+					checked={ !! playsInline }
 					help={ __(
 						'When enabled, videos will play directly within the webpage on mobile browsers, instead of opening in a fullscreen player.'
 					) }


### PR DESCRIPTION
Follow up on ##67044

## What?

Fixes a browser console error that occurs when enabling the "Play inline" toggle in the video block:

https://github.com/user-attachments/assets/c5ed9a15-74de-4930-9248-ab7034306b19

## Why?

When refactoring to ToolsPanel, it appears that the boolean conversion was unintentionally removed.

See: https://github.com/WordPress/gutenberg/pull/67044/files?diff=unified&w=1#diff-d84ec848de75eae2ff5b4424cc28de1f97db17a6354f3b0f793fae8f2b4bbfd5R127-R128

## Testing Instructions

- Insert Video block and add a video.
- Enable the Play inline toggle.
- Verify that no errors are logged to the browser console.