### PR TITLE
Search Results Title Block: Add dropdown menu props to Tools Panel component

### DIFF
--- a/packages/block-library/src/query-title/edit.js
+++ b/packages/block-library/src/query-title/edit.js
@@ -141,6 +141,7 @@ export default function QueryTitleEdit( {
 								showSearchTerm: true,
 							} )
 						}
+						dropdownMenuProps={ dropdownMenuProps }
 					>
 						<ToolsPanelItem
 							hasValue={ () => ! showSearchTerm }


### PR DESCRIPTION
Follow up on #67915

## What?

The Query Title block consists of the following two variations:

- Archive Title
- Search Results Title

In #67915, we forgot to add `dropdownProps` to the ToolsPanel component of the Search Results Title block variation.

## Screenshots or screencast <!-- if applicable -->

![image](https://github.com/user-attachments/assets/72290529-6149-4b2f-b9f1-8cb67b12be74)
