### PR TITLE
Updated Typo in Constants.js

### DIFF
--- a/packages/edit-site/src/components/style-book/constants.ts
+++ b/packages/edit-site/src/components/style-book/constants.ts
@@ -168,7 +168,7 @@ export const STYLE_BOOK_ALL_BLOCKS_SUBCATEGORIES: StyleBookCategory[] = [
 	},
 ];
 
-// Style book preview categories are organised slightly differently to the editor ones.
+// Style book preview categories are organized slightly differently to the editor ones.
 export const STYLE_BOOK_PREVIEW_CATEGORIES: StyleBookCategory[] = [
 	{
 		slug: 'overview',


### PR DESCRIPTION
Updated Typo in Constants.js. Used `organized` Instead of `organised`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

- Open packages/edit-site/src/components/style-book/constants.ts file 
- Go to Line no 171

