### PR TITLE
Fix: Remove Renaming in Pages List Block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -512,7 +512,7 @@ Display a list of all pages. ([Source](https://github.com/WordPress/gutenberg/tr
 -	**Name:** core/page-list
 -	**Category:** widgets
 -	**Allowed Blocks:** core/page-list-item
--	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~, ~~reusable~~
 -	**Attributes:** isNested, parentPageID
 
 ## Page List Item

--- a/packages/block-library/src/page-list/block.json
+++ b/packages/block-library/src/page-list/block.json
@@ -76,7 +76,8 @@
 				"padding": false,
 				"margin": false
 			}
-		}
+		},
+		"renaming": false
 	},
 	"editorStyle": "wp-block-page-list-editor",
 	"style": "wp-block-page-list"


### PR DESCRIPTION
## What?
Remove the renaming from `Page List` Block.

## Why?
The Page List block offers a "Rename" option. It's not clear why you would want to rename this block, and if you do, you'll probably be very confused about what the block is doing.
Closes [#56268](https://github.com/WordPress/gutenberg/issues/56268)

## How?
This change will prevent the rename option from appearing in the block's options menu.
```json
{
   "supports": {
      "renaming": "false"
   }
}
```

## Testing Instructions
1. Open a post
2. Create a Page List Block
3. Click on the three dots.
4. Now you can see you can't rename the block. (Image below)

## Screenshots or screencast
<img width="426" alt="Screenshot 2025-01-20 at 02 49 14" src="https://github.com/user-attachments/assets/dbb6c166-d46b-477d-9f31-d1913c80a152" />
<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
