### PR TITLE
Rename Block to Selected Block

### DIFF
--- a/packages/edit-widgets/src/components/sidebar/index.js
+++ b/packages/edit-widgets/src/components/sidebar/index.js
@@ -50,7 +50,7 @@ function SidebarHeader( { selectedWidgetAreaBlock } ) {
 					: __( 'Widget Areas' ) }
 			</Tabs.Tab>
 			<Tabs.Tab tabId={ BLOCK_INSPECTOR_IDENTIFIER }>
-				{ __( 'Block' ) }
+				{ __( 'Selected Block' ) }
 			</Tabs.Tab>
 		</Tabs.TabList>
 	);

--- a/packages/editor/src/components/sidebar/header.js
+++ b/packages/editor/src/components/sidebar/header.js
@@ -41,7 +41,7 @@ const SidebarHeader = ( _, ref ) => {
 				data-tab-id={ sidebars.block }
 			>
 				{ /* translators: Text label for the Block Settings Sidebar tab. */ }
-				{ __( 'Block' ) }
+				{ __( 'Selected Block' ) }
 			</Tabs.Tab>
 		</Tabs.TabList>
 	);


### PR DESCRIPTION
## What?
Update the label to "Selected Block" in Block Inspector.
![image](https://github.com/user-attachments/assets/b4cd7bff-d5c8-464e-8481-8efd35ec413b)


## Why?
Closes https://github.com/WordPress/gutenberg/issues/56375
It's not clear to new users how the Block Inspector relates to the blocks in the canvas, especially when no block is selected:
![image](https://github.com/user-attachments/assets/b7d37e60-9535-4538-a2a9-9d35451e3402)

## Testing Instructions
1. Go to any post.
2. Click on any block.


