### PR TITLE
Fix: Linked featured image block cannot be selected correctly

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -49,11 +49,6 @@ function getMediaSourceUrlBySizeSlug( media, slug ) {
 	);
 }
 
-const disabledClickProps = {
-	onClick: ( event ) => event.preventDefault(),
-	'aria-disabled': true,
-};
-
 export default function PostFeaturedImageEdit( {
 	clientId,
 	attributes,
@@ -318,11 +313,7 @@ export default function PostFeaturedImageEdit( {
 				{ controls }
 				<div { ...blockProps }>
 					{ !! isLink ? (
-						<a
-							href={ postPermalink }
-							target={ linkTarget }
-							{ ...disabledClickProps }
-						>
+						<a href={ postPermalink } target={ linkTarget }>
 							{ placeholder() }
 						</a>
 					) : (
@@ -430,11 +421,7 @@ export default function PostFeaturedImageEdit( {
 			<figure { ...blockProps }>
 				{ /* If the featured image is linked, wrap in an <a /> tag to trigger any inherited link element styles */ }
 				{ !! isLink ? (
-					<a
-						href={ postPermalink }
-						target={ linkTarget }
-						{ ...disabledClickProps }
-					>
+					<a href={ postPermalink } target={ linkTarget }>
 						{ image }
 					</a>
 				) : (

--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -100,9 +100,9 @@
 
 	// When the Post Featured Image block is linked,
 	// it's wrapped with a disabled <a /> tag.
-	// Restore cursor style so it doesn't appear 'clickable'.
+	// Ensure that the link is not clickable.
 	> a {
-		cursor: default;
+		pointer-events: none;
 	}
 
 	// When the Post Featured Image block is linked,


### PR DESCRIPTION
Fixes #68774

## What?

This PR will allow the linked Featured Image block to be selected correctly.

## Why?

The `a` element appears unclickable at first glance because [`disabledClickProps`](https://github.com/WordPress/gutenberg/pull/68775/files#diff-6c9425038047ddb10343bedf2e9af51b36d7cf841b3f46f5a0657702c1a732b2L52-L56) has been applied to it. However:

- Even if the `onClick` event is prevented via `preventDefault`, the click event itself will still occur.
- Because `aria-disabled` is an ARIA attribute, it doesn't actually disable the element.

Therefore, when you select a block, the a element inside it will be selected instead of the block, so the outline will not be displayed and the delete key will not work.

## How?

I used `pointer-events:none` as a simpler approach.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard

- Insert a Post Featured Image block.
- Enable "Link to Post".
- Hover the mouse over the block. The mouse cursor remains in its default state.
- Select the block.
- The block has a blue outline.
- Press the delete key (Del). The block is deleted.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/e9e9b4ee-b801-47ee-941c-5be903ba994c