### PR TITLE
Gallery: Remove unused inline menu styles

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -25,7 +25,6 @@ $z-layers: (
 	".components-popover__close": 5,
 	".block-editor-block-list__insertion-point": 6,
 	".block-editor-warning": 5,
-	".block-library-gallery-item__inline-menu": 20,
 	".block-editor-url-input__suggestions": 30,
 	".edit-post-layout__footer": 30,
 	".interface-interface-skeleton__header": 30,

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -141,10 +141,6 @@
 	background: $white;
 	border: $border-width solid $gray-900;
 
-	@media not (prefers-reduced-motion) {
-		transition: box-shadow 0.2s ease-out;
-	}
-
 	&:hover {
 		box-shadow: $elevation-x-small;
 	}

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -117,10 +117,6 @@
 		opacity: 0.3;
 	}
 
-	.is-selected .block-library-gallery-item__inline-menu {
-		display: inline-flex;
-	}
-
 	.block-editor-media-placeholder {
 		margin: 0;
 		height: 100%;
@@ -128,54 +124,6 @@
 		.components-placeholder__label {
 			display: flex;
 		}
-	}
-}
-
-.block-library-gallery-item__inline-menu {
-	display: none;
-	position: absolute;
-	top: -2px;
-	margin: $grid-unit-10;
-	z-index: z-index(".block-library-gallery-item__inline-menu");
-	border-radius: $radius-small;
-	background: $white;
-	border: $border-width solid $gray-900;
-
-	&:hover {
-		box-shadow: $elevation-x-small;
-	}
-
-	@include break-small() {
-		// Use smaller buttons to fit when there are many columns.
-		.columns-7 &,
-		.columns-8 & {
-			padding: $grid-unit-05 * 0.5;
-		}
-	}
-
-	.components-button.has-icon {
-		&:not(:focus) {
-			border: none;
-			box-shadow: none;
-		}
-
-		@include break-small() {
-			// Use smaller buttons to fit when there are many columns.
-			.columns-7 &,
-			.columns-8 & {
-				padding: 0;
-				width: inherit;
-				height: inherit;
-			}
-		}
-	}
-
-	&.is-left {
-		left: -2px;
-	}
-
-	&.is-right {
-		right: -2px;
 	}
 }
 


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/68282
Follow-up: https://github.com/WordPress/gutenberg/pull/68315#discussion_r1900538228

## What?
Remove unused CSS transition used for the gallery block's inline menu that is no longer being used.


## Why?
The `.block-library-gallery-item__inline-menu` element was previously used for gallery controls but has since been removed/replaced. This transition is now unused, making them technical debt that should be cleaned up.

This PR follows up on the discussion from [#68315](https://github.com/WordPress/gutenberg/pull/68315#discussion_r1900538228) where it was identified that these styles could be safely removed.

## Testing Instructions

- Open the Block Editor
- Insert a Gallery block
- Add multiple images to the gallery
- Select individual images in the gallery
- Verify that gallery controls work correctly
- Verify that image selection and manipulation still work as expected
- Ensure no visual regressions in gallery block functionality

