### PR TITLE
Storybook: Add Story for Block Patterns List

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/stories/index.story.js
+++ b/packages/block-editor/src/components/block-patterns-list/stories/index.story.js
@@ -1,64 +1,137 @@
 /**
- * External dependencies
- */
-import blockLibraryStyles from '!!raw-loader!../../../../../block-library/build-style/style.css';
-
-/**
  * Internal dependencies
  */
-import BlockPatternsList from '../';
-import { ExperimentalBlockEditorProvider } from '../../provider';
+import BlockPatternsList from '..';
 import patterns from './fixtures';
 
-const blockEditorSettings = {
-	styles: [ { css: blockLibraryStyles } ],
+/**
+ * WordPress dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+registerCoreBlocks();
+
+/**
+ * Storybook metadata
+ */
+const meta = {
+	title: 'BlockEditor/BlockPatternsList',
+	component: BlockPatternsList,
+	parameters: {
+		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
+			description: {
+				component:
+					'The `BlockPatternsList` component renders a list of block patterns.',
+			},
+		},
+	},
+	argTypes: {
+		blockPatterns: {
+			control: {
+				type: 'object',
+			},
+			description: 'The patterns to render.',
+			table: {
+				type: {
+					summary: 'object',
+				},
+			},
+		},
+		shownPatterns: {
+			contorl: { type: null },
+			description:
+				'Usually this component is used with `useAsyncList` for performance reasons and you should provide the returned list from that hook. Alternatively it should have the same value with `blockPatterns.`',
+			table: {
+				type: {
+					summary: 'object',
+				},
+			},
+		},
+		onClickPattern: {
+			control: { type: null },
+			description:
+				'Callback function to handle the click event on a pattern.',
+			table: {
+				type: {
+					summary: 'function',
+				},
+			},
+		},
+		onHover: {
+			control: {
+				type: null,
+			},
+			description:
+				'Callback function to handle the hover event on a pattern.',
+			table: {
+				type: {
+					summary: 'function',
+				},
+			},
+		},
+		showTitlesAsTooltip: {
+			control: {
+				type: 'boolean',
+			},
+			description:
+				'Whether to render the title of each pattern as a tooltip. If enabled',
+			table: {
+				type: {
+					summary: 'boolean',
+				},
+			},
+		},
+		orientation: {
+			control: {
+				type: 'string',
+			},
+			description: 'Orientation for the underlying composite widget.',
+			table: {
+				defaultValue: {
+					summary: 'both',
+				},
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		category: {
+			control: {
+				type: 'string',
+			},
+			description: 'The currently selected pattern category.',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		isDraggable: {
+			control: {
+				type: 'boolean',
+			},
+			description: 'Whether the pattern list item should be draggable.',
+			table: {
+				type: {
+					summary: 'boolean',
+				},
+			},
+		},
+	},
 };
 
-export default {
-	component: BlockPatternsList,
-	title: 'BlockEditor/BlockPatternsList',
-};
+export default meta;
 
 export const Default = {
-	render: function Template( props ) {
-		return (
-			<ExperimentalBlockEditorProvider settings={ blockEditorSettings }>
-				<BlockPatternsList { ...props } />
-			</ExperimentalBlockEditorProvider>
-		);
-	},
 	args: {
 		blockPatterns: patterns,
 		isDraggable: false,
 		label: 'Block patterns story',
 		showTitlesAsTooltip: false,
 	},
-	argTypes: {
-		blockPatterns: { description: 'The patterns to render.' },
-		shownPatterns: {
-			description:
-				'Usually this component is used with `useAsyncList` for performance reasons and you should provide the returned list from that hook. Alternatively it should have the same value with `blockPatterns`.',
-		},
-		onClickPattern: { type: 'function' },
-		onHover: { type: 'function' },
-		showTitlesAsTooltip: {
-			description:
-				'Whether to render the title of each pattern as a tooltip. If enabled',
-		},
-		orientation: {
-			description: 'Orientation for the underlying composite widget.',
-			table: {
-				defaultValue: { summary: 'both' },
-				type: { summary: 'string' },
-			},
-		},
-		category: { description: 'The currently selected pattern category.' },
-		isDraggable: {
-			description: 'Whether the pattern list item should be draggable.',
-		},
-	},
-	parameters: {
-		actions: { argTypesRegex: '^on.*' },
-		controls: { expanded: true },
+	render: function Template( args ) {
+		return <BlockPatternsList { ...args } />;
 	},
 };

--- a/packages/block-editor/src/components/block-patterns-list/stories/index.story.js
+++ b/packages/block-editor/src/components/block-patterns-list/stories/index.story.js
@@ -1,14 +1,25 @@
 /**
+ * External dependencies
+ */
+import blockLibraryStyles from '!!raw-loader!../../../../../block-library/build-style/style.css';
+
+/**
  * Internal dependencies
  */
 import BlockPatternsList from '..';
 import patterns from './fixtures';
+import { ExperimentalBlockEditorProvider } from '../../provider';
 
 /**
  * WordPress dependencies
  */
 import { registerCoreBlocks } from '@wordpress/block-library';
+import { __ } from '@wordpress/i18n';
 registerCoreBlocks();
+
+const blockEditorSettings = {
+	styles: [ { css: blockLibraryStyles } ],
+};
 
 /**
  * Storybook metadata
@@ -128,10 +139,14 @@ export const Default = {
 	args: {
 		blockPatterns: patterns,
 		isDraggable: false,
-		label: 'Block patterns story',
+		label: __( 'Block patterns story' ),
 		showTitlesAsTooltip: false,
 	},
 	render: function Template( args ) {
-		return <BlockPatternsList { ...args } />;
+		return (
+			<ExperimentalBlockEditorProvider settings={ blockEditorSettings }>
+				<BlockPatternsList { ...args } />
+			</ExperimentalBlockEditorProvider>
+		);
 	},
 };


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR adds the story for Block Patterns List

## Testing Instructions
- Run npm run storybook:dev
- Open Storybook at http://localhost:50240/
- Check the BlockPatternsList Story

## Screenshots or screencast 

https://github.com/user-attachments/assets/9dce8e42-7850-4c8a-a114-3376fd99db53

