### PR TITLE
FontFamilyControl: Add label and help prop.

### DIFF
--- a/packages/block-editor/src/components/font-family/README.md
+++ b/packages/block-editor/src/components/font-family/README.md
@@ -76,6 +76,22 @@ The current font family value.
 
 The rest of the props are passed down to the underlying `<SelectControl />` instance.
 
+### label
+
+The label displayed above the control.
+
+- Type: `String`
+- Required: No
+- Default: 'Font'
+
+### help
+
+Help text displayed below the control, providing guidance or context.
+Accepts either a string or a function. If a function is provided, it receives the current value as an argument.
+
+- Type: `String|Element|Function`
+- Required: No
+
 #### `__next40pxDefaultSize`
 
 - Type: `boolean`

--- a/packages/block-editor/src/components/font-family/index.js
+++ b/packages/block-editor/src/components/font-family/index.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { CustomSelectControl } from '@wordpress/components';
+import { BaseControl, CustomSelectControl } from '@wordpress/components';
 import deprecated from '@wordpress/deprecated';
 import { __ } from '@wordpress/i18n';
 
@@ -24,6 +24,8 @@ export default function FontFamilyControl( {
 	onChange,
 	fontFamilies,
 	className,
+	label = __( 'Font' ),
+	help,
 	...props
 } ) {
 	const [ blockLevelFontFamilies ] = useSettings( 'typography.fontFamilies' );
@@ -74,18 +76,38 @@ export default function FontFamilyControl( {
 
 	const selectedValue =
 		options.find( ( option ) => option.key === value ) ?? '';
+
+	let helpLabel;
+	if ( help ) {
+		if ( typeof help === 'function' ) {
+			if ( value !== undefined ) {
+				helpLabel = help( value );
+			}
+		} else {
+			helpLabel = help;
+		}
+	}
+
 	return (
-		<CustomSelectControl
-			__next40pxDefaultSize={ __next40pxDefaultSize }
-			__shouldNotWarnDeprecated36pxSize
-			label={ __( 'Font' ) }
-			value={ selectedValue }
-			onChange={ ( { selectedItem } ) => onChange( selectedItem.key ) }
-			options={ options }
-			className={ clsx( 'block-editor-font-family-control', className, {
-				'is-next-has-no-margin-bottom': __nextHasNoMarginBottom,
-			} ) }
-			{ ...props }
-		/>
+		<BaseControl __nextHasNoMarginBottom help={ helpLabel }>
+			<CustomSelectControl
+				__next40pxDefaultSize={ __next40pxDefaultSize }
+				__shouldNotWarnDeprecated36pxSize
+				value={ selectedValue }
+				onChange={ ( { selectedItem } ) =>
+					onChange( selectedItem.key )
+				}
+				label={ label }
+				options={ options }
+				className={ clsx(
+					'block-editor-font-family-control',
+					className,
+					{
+						'is-next-has-no-margin-bottom': __nextHasNoMarginBottom,
+					}
+				) }
+				{ ...props }
+			/>
+		</BaseControl>
 	);
 }

--- a/packages/block-editor/src/components/font-family/stories/index.story.js
+++ b/packages/block-editor/src/components/font-family/stories/index.story.js
@@ -16,12 +16,13 @@ export default {
 			control: 'text',
 			table: {
 				type: { summary: 'string' },
+				defaultValue: { summary: 'Font' },
 			},
 		},
 		help: {
 			control: 'text',
 			table: {
-				type: { summary: 'string | function' },
+				type: { summary: 'string | function | element' },
 			},
 		},
 	},

--- a/packages/block-editor/src/components/font-family/stories/index.story.js
+++ b/packages/block-editor/src/components/font-family/stories/index.story.js
@@ -11,6 +11,20 @@ import FontFamilyControl from '..';
 export default {
 	component: FontFamilyControl,
 	title: 'BlockEditor/FontFamilyControl',
+	argTypes: {
+		label: {
+			control: 'text',
+			table: {
+				type: { summary: 'string' },
+			},
+		},
+		help: {
+			control: 'text',
+			table: {
+				type: { summary: 'string | function' },
+			},
+		},
+	},
 };
 
 export const Default = {


### PR DESCRIPTION
Part of #68551  
Follow up https://github.com/WordPress/gutenberg/issues/68551#issuecomment-2578076019  

## What?  
This PR introduces `label` and `help` props to the `FontFamilyControl` component. These changes allow developers to specify a custom label for the control and provide contextual help text below the control. Additionally, documentation and stories for these new props have been added or updated.  

## Why?  
The `FontFamilyControl` component lacked flexibility in customizing its label and providing contextual guidance, which limited its usability. Adding these props improves developer control and enhances the user interface by allowing context-specific customization.  

## How?  
1. Added `label` and `help` props to the `FontFamilyControl` component.  
   - `label` defaults to "Font" if not provided.  
   - `help` can be a string, function, or element. Functions receive the current value as an argument.  
2. Updated the component to use `BaseControl` for consistent handling of labels and help text.  
3. Modified the Storybook configuration to include these props, adding controls and default values.  
4. Updated the documentation (`README.md`) to detail the usage of the `label` and `help` props.  

## Testing Instructions  
1. Open Storybook for the `FontFamilyControl` component.  
2. Locate the `label` and `help` controls in the Storybook panel.  
3. Modify the `label` prop and ensure that the label changes accordingly in the rendered component.  
4. Modify the `help` prop:
   - Add static text and verify it is displayed below the control.
5. Verify the default values for `label` (should be "Font") and `help` (should be empty unless specified).  

## Screencast  

https://github.com/user-attachments/assets/0046c0a6-cb5c-44d8-9576-b169ecbdb54f

