### PR TITLE
Use contextual snackbar text when activating a theme from preview

### DIFF
--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -209,7 +209,7 @@ export const saveDirtyEntities =
 				} else {
 					registry
 						.dispatch( noticesStore )
-						.createSuccessNotice( __( 'Theme updated.' ), {
+						.createSuccessNotice( __( 'Theme activated.' ), {
 							type: 'snackbar',
 							id: saveNoticeId,
 							actions: [

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -209,7 +209,7 @@ export const saveDirtyEntities =
 				} else {
 					registry
 						.dispatch( noticesStore )
-						.createSuccessNotice( __( 'Site updated.' ), {
+						.createSuccessNotice( __( 'Theme updated.' ), {
 							type: 'snackbar',
 							id: saveNoticeId,
 							actions: [

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -207,18 +207,27 @@ export const saveDirtyEntities =
 						.dispatch( noticesStore )
 						.createErrorNotice( __( 'Saving failed.' ) );
 				} else {
+					const isActivatingTheme = onSave
+						?.toString()
+						.includes( 'activateTheme' );
+
 					registry
 						.dispatch( noticesStore )
-						.createSuccessNotice( __( 'Theme activated.' ), {
-							type: 'snackbar',
-							id: saveNoticeId,
-							actions: [
-								{
-									label: __( 'View site' ),
-									url: homeUrl,
-								},
-							],
-						} );
+						.createSuccessNotice(
+							isActivatingTheme
+								? __( 'Theme activated.' )
+								: __( 'Site updated.' ),
+							{
+								type: 'snackbar',
+								id: saveNoticeId,
+								actions: [
+									{
+										label: __( 'View site' ),
+										url: homeUrl,
+									},
+								],
+							}
+						);
 				}
 			} )
 			.catch( ( error ) =>

--- a/test/e2e/specs/site-editor/activate-theme.spec.js
+++ b/test/e2e/specs/site-editor/activate-theme.spec.js
@@ -23,7 +23,7 @@ test.describe( 'Activate theme', () => {
 			.click();
 		await expect(
 			page.getByRole( 'button', { name: 'Dismiss this notice' } )
-		).toContainText( 'Site updated' );
+		).toContainText( 'Emptytheme activated' );
 		await admin.visitAdminPage( 'themes.php' );
 		await expect( page.getByLabel( 'Customize Emptytheme' ) ).toBeVisible();
 	} );
@@ -46,7 +46,7 @@ test.describe( 'Activate theme', () => {
 			.click();
 		await expect(
 			page.getByRole( 'button', { name: 'Dismiss this notice' } )
-		).toContainText( 'Site updated' );
+		).toContainText( 'Emptytheme activated' );
 		await admin.visitAdminPage( 'themes.php' );
 		await expect( page.getByLabel( 'Customize Emptytheme' ) ).toBeVisible();
 	} );


### PR DESCRIPTION
Fixes [#56876](https://github.com/WordPress/gutenberg/issues/56876)

## What?
This PR updates the success notification message displayed when activating a theme via the Site Editor. Previously, the message showed "Site updated.", which has now been corrected to "Theme activated." for better clarity.

## Why?
The current message, "Site updated.", can be misleading as it does not accurately convey the action taken when activating a theme. This change improves the user experience by providing a clearer and more appropriate notification.

## Testing Instructions
1. Go to Appearance --> Themes
2. Click on Live Preview of any theme
3. In left bottom corner of Site Editor click on Activate {Theme_Name} button
4. Check the snackbar with updated message "Theme activated"

|Before|After|
|-|-|
|![Screenshot 2025-01-20 at 2 37 24 PM](https://github.com/user-attachments/assets/5e8bef2a-998e-4664-a6c2-b504ea19bbc0)|![Screenshot 2025-01-20 at 2 29 22 PM](https://github.com/user-attachments/assets/5834f563-90ff-4a75-b27c-b48c7551a40e)|


