### PR TITLE
Navigation Block: Let `flex-grow`/`flex-basis` be applied to the List Items

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -149,22 +149,10 @@ class WP_Navigation_Block_Renderer {
 	 */
 	private static function get_markup_for_inner_block( $inner_block ) {
 		$inner_block_content = $inner_block->render();
-
-		if ( empty( $inner_block_content ) ) {
-			return $inner_block_content;
-		}
-
-		if ( static::does_block_need_a_list_item_wrapper( $inner_block ) ) {
-			$style        = '';
-			$self_stretch = $inner_block->parsed_block['attrs']['style']['layout']['selfStretch'] ?? null;
-
-			// If the block is set to fill then set the flex-grow to 1.
-			if ( 'fill' === $self_stretch ) {
-				$style = 'flex-grow: 1;';
+		if ( ! empty( $inner_block_content ) ) {
+			if ( static::does_block_need_a_list_item_wrapper( $inner_block ) ) {
+				return '<li class="wp-block-navigation-item wp-block-navigation-item__wrapper">' . $inner_block_content . '</li>';
 			}
-
-			$style_attribute = $style ? sprintf( ' style="%s"', $style ) : '';
-			return sprintf( '<li class="wp-block-navigation-item"%1$s>%2$s</li>', $style_attribute, $inner_block_content );
 		}
 
 		return $inner_block_content;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -164,7 +164,7 @@ class WP_Navigation_Block_Renderer {
 			}
 
 			$style_attribute = $style ? sprintf( ' style="%s"', $style ) : '';
-			return sprintf( '<li class="wp-block-navigation-item" %1$s>%2$s</li>', $style_attribute, $inner_block_content );
+			return sprintf( '<li class="wp-block-navigation-item"%1$s>%2$s</li>', $style_attribute, $inner_block_content );
 		}
 
 		return $inner_block_content;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -149,10 +149,22 @@ class WP_Navigation_Block_Renderer {
 	 */
 	private static function get_markup_for_inner_block( $inner_block ) {
 		$inner_block_content = $inner_block->render();
-		if ( ! empty( $inner_block_content ) ) {
-			if ( static::does_block_need_a_list_item_wrapper( $inner_block ) ) {
-				return '<li class="wp-block-navigation-item">' . $inner_block_content . '</li>';
+
+		if ( empty( $inner_block_content ) ) {
+			return $inner_block_content;
+		}
+
+		if ( static::does_block_need_a_list_item_wrapper( $inner_block ) ) {
+			$style        = '';
+			$self_stretch = $inner_block->parsed_block['attrs']['style']['layout']['selfStretch'] ?? null;
+
+			// If the block is set to fill then set the flex-grow to 1.
+			if ( 'fill' === $self_stretch ) {
+				$style = 'flex-grow: 1;';
 			}
+
+			$style_attribute = $style ? sprintf( ' style="%s"', $style ) : '';
+			return sprintf( '<li class="wp-block-navigation-item" %1$s>%2$s</li>', $style_attribute, $inner_block_content );
 		}
 
 		return $inner_block_content;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -39,6 +39,10 @@ $navigation-icon-size: 24px;
 		.wp-block-navigation__submenu-container:empty {
 			display: none;
 		}
+
+		&.wp-block-navigation-item__wrapper {
+			display: contents;
+		}
 	}
 
 	// Menu item link.

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -59,7 +59,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		// Invoke the private method.
 		$result = $method->invoke( $reflection, $site_title_block );
 
-		$expected = '<li class="wp-block-navigation-item"><h1 class="wp-block-site-title"><a href="http://' . WP_TESTS_DOMAIN . '" target="_self" rel="home">Test Blog</a></h1></li>';
+		$expected = '<li class="wp-block-navigation-item wp-block-navigation-item__wrapper"><h1 class="wp-block-site-title"><a href="http://' . WP_TESTS_DOMAIN . '" target="_self" rel="home">Test Blog</a></h1></li>';
 		$this->assertEquals( $expected, $result );
 	}
 
@@ -151,7 +151,7 @@ class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {
 		// Invoke the private method.
 		$result = $method->invoke( $reflection, $heading_block );
 
-		$expected = '<li class="wp-block-navigation-item"><div class="wp-block-testsuite-sample-block">Hello World</div></li>';
+		$expected = '<li class="wp-block-navigation-item wp-block-navigation-item__wrapper"><div class="wp-block-testsuite-sample-block">Hello World</div></li>';
 		$this->assertEquals( $expected, $result );
 
 		remove_filter( 'block_core_navigation_listable_blocks', $filter_needs_list_item_wrapper_function, 10, 1 );


### PR DESCRIPTION
## What, Why and How?

Fixes: #68753 

This PR addresses a bug where the `flex-grow` property does not work as expected for blocks, such as `social links`, nested within the `core/navigation` block. The issue arises because these blocks are wrapped in a list item (`<li>`) element, which prevents the `flex-grow` style from being applied effectively.

## Testing Instructions

1. Add a `social links block` inside a `core/navigation` block.
2. Enable the `width grow` feature for the `social links` block.
3. Verify that the block now correctly stretches to fill available space using `flex-grow`.
4. Repeat the above steps with custom blocks that also rely on list item wrappers.

## Screencast


https://github.com/user-attachments/assets/0f09e287-aee8-4469-b059-a31b159794ab

