### PR TITLE
Fix: Navigation Block - Can't delete default custom links.

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -439,6 +439,11 @@ export default function NavigationLinkEdit( {
 			event.stopPropagation();
 			setIsLinkOpen( true );
 			setOpenedBy( ref.current );
+		} else if ( event.key === 'Delete' ) {
+			if ( ! url && ( ! label || label.length === 0 ) ) {
+				event.preventDefault();
+				onReplace( [] );
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes [#56387](https://github.com/WordPress/gutenberg/issues/56387)

## What?
Add keyboard Delete handling to remove empty Navigation Link blocks.

## Why?
Currently, when users add a new Navigation Link block, they get an empty custom link with "Add link" placeholder text. Users naturally expect to be able to delete this empty link using the Delete key, but this functionality is missing. This PR implements this expected behavior, improving the user experience and making the Navigation block behavior more intuitive.

## How?
- Extended the existing onKeyDown handler in NavigationLinkEdit component
- Added logic to detect Delete key events
- Implemented deletion only for empty links (no URL and no label) to prevent accidental deletions
Utilized existing onReplace([]) mechanism for block removal

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
- Create or edit a Navigation block
- Add a new Navigation Link block
- Without entering any text or URL, press the Delete key
- Verify that the empty link block is removed

## Screenshots or screencast <!-- if applicable -->
[screen-capture.webm](https://github.com/user-attachments/assets/a0fad86d-1fc4-4f57-8de2-a323806f042a)

