### PR TITLE
Adds JSdoc for comments component.

### DIFF
--- a/packages/block-library/src/comments-pagination-next/edit.js
+++ b/packages/block-library/src/comments-pagination-next/edit.js
@@ -10,6 +10,17 @@ const arrowMap = {
 	chevron: '»',
 };
 
+/*
+ * Renders the Comments Pagination Next block in the block editor.
+ *
+ * @param {Object} props                                   Component properties.
+ * @param {Object} props.attributes                        Block attributes.
+ * @param {string} props.attributes.label                  The label for the "Next Comments" pagination link.
+ * @param {Function} props.setAttributes                   Function to update block attributes.
+ * @param {Object} props.context                           Block context.
+ * @param {string} props.context['comments/paginationArrow'] The type of arrow to display for pagination (e.g., "next", "previous").
+ * @returns {JSX.Element}                                  The Comments Pagination Next Edit component.
+ */
 export default function CommentsPaginationNextEdit( {
 	attributes: { label },
 	setAttributes,

--- a/packages/block-library/src/comments-pagination-previous/edit.js
+++ b/packages/block-library/src/comments-pagination-previous/edit.js
@@ -10,6 +10,17 @@ const arrowMap = {
 	chevron: '«',
 };
 
+/*
+ * Renders the Comments Pagination Previous block in the block editor.
+ *
+ * @param {Object} props                                   Component properties.
+ * @param {Object} props.attributes                        Block attributes.
+ * @param {string} props.attributes.label                  The label for the "Previous Comments" pagination link.
+ * @param {Function} props.setAttributes                   Function to update block attributes.
+ * @param {Object} props.context                           Block context.
+ * @param {string} props.context['comments/paginationArrow'] The type of arrow to display for pagination (e.g., "next", "previous").
+ * @returns {JSX.Element}                                  The Comments Pagination Previous Edit component.
+ */
 export default function CommentsPaginationPreviousEdit( {
 	attributes: { label },
 	setAttributes,

--- a/packages/block-library/src/comments-pagination/edit.js
+++ b/packages/block-library/src/comments-pagination/edit.js
@@ -23,6 +23,16 @@ const TEMPLATE = [
 	[ 'core/comments-pagination-next' ],
 ];
 
+/*
+ * Renders the Query Pagination block in the block editor.
+ *
+ * @param {Object} props                                  Component properties.
+ * @param {Object} props.attributes                       Block attributes.
+ * @param {string} props.attributes.paginationArrow       The selected pagination arrow type.
+ * @param {Function} props.setAttributes                  Function to update block attributes.
+ * @param {string} props.clientId                         The unique client ID for the block.
+ * @returns {JSX.Element}                                 The Query Pagination Edit component.
+ */
 export default function QueryPaginationEdit( {
 	attributes: { paginationArrow },
 	setAttributes,

--- a/packages/block-library/src/comments-title/edit.js
+++ b/packages/block-library/src/comments-title/edit.js
@@ -22,6 +22,22 @@ import { useSelect } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 
+/*
+ * Edit component for the block, rendering the block's interface in the editor.
+ *
+ * @param {Object} props                                  Component properties.
+ * @param {Object} props.attributes                       Block attributes.
+ * @param {string} props.attributes.textAlign             Text alignment for the block (e.g., "left", "center", "right").
+ * @param {boolean} props.attributes.showPostTitle        Whether to display the post title in the block.
+ * @param {boolean} props.attributes.showCommentsCount    Whether to display the comments count in the block.
+ * @param {number} props.attributes.level                 Heading level (e.g., 1 for `<h1>`, 2 for `<h2>`, etc.).
+ * @param {Array} props.attributes.levelOptions           Options for heading levels available in the dropdown.
+ * @param {Function} props.setAttributes                  Function to update block attributes.
+ * @param {Object} props.context                          Block context.
+ * @param {string} props.context.postType                 The post type of the current post.
+ * @param {number|undefined} props.context.postId         The ID of the current post. Undefined if editing in the Site Editor.
+ * @returns {JSX.Element}                                 The rendered Edit component.
+ */
 export default function Edit( {
 	attributes: {
 		textAlign,

--- a/packages/block-library/src/comments/edit/comments-inspector-controls.js
+++ b/packages/block-library/src/comments/edit/comments-inspector-controls.js
@@ -10,6 +10,18 @@ import { InspectorControls } from '@wordpress/block-editor';
  */
 import { htmlElementMessages } from '../../utils/messages';
 
+/*
+ * Renders the Comments Inspector Controls component.
+ *
+ * This component allows users to select an HTML element (`tagName`) for rendering
+ * the comments placeholder in the WordPress editor.
+ *
+ * @param {Object} props                             Component properties.
+ * @param {Object} props.attributes                  The attributes of the component.
+ * @param {string} props.attributes.tagName          The HTML element tag name (e.g., 'div', 'section', 'aside').
+ * @param {Function} props.setAttributes             Function to update component attributes.
+ * @returns {JSX.Element}                            The Comments Inspector Controls component.
+ */
 export default function CommentsInspectorControls( {
 	attributes: { tagName },
 	setAttributes,

--- a/packages/block-library/src/comments/edit/comments-legacy.js
+++ b/packages/block-library/src/comments/edit/comments-legacy.js
@@ -20,6 +20,21 @@ import { Button } from '@wordpress/components';
  */
 import Placeholder from './placeholder';
 
+/*
+ * Renders the legacy version of the Comments block.
+ *
+ * This component serves as a placeholder for the Comments block, informing the user
+ * that they are using the legacy version and providing an option to switch to an editable mode.
+ *
+ * @param {Object} props                              Component properties.
+ * @param {Object} props.attributes                   Block attributes.
+ * @param {string} [props.attributes.textAlign]       Text alignment for the block (e.g., 'left', 'center', 'right').
+ * @param {Function} props.setAttributes              Function to update block attributes.
+ * @param {Object} props.context                      Contextual properties.
+ * @param {string} props.context.postType             The type of the post (e.g., 'post', 'page').
+ * @param {string} props.context.postId               The ID of the current post.
+ * @returns {JSX.Element}                             The legacy Comments block placeholder component.
+ */
 export default function CommentsLegacy( {
 	attributes,
 	setAttributes,

--- a/packages/block-library/src/comments/edit/index.js
+++ b/packages/block-library/src/comments/edit/index.js
@@ -10,6 +10,20 @@ import CommentsInspectorControls from './comments-inspector-controls';
 import CommentsLegacy from './comments-legacy';
 import TEMPLATE from './template';
 
+/*
+ * Renders the editable version of the Comments block.
+ *
+ * This component determines whether to render the legacy version of the Comments block
+ * or the editable version based on the block's attributes. It also includes inspector controls
+ * for additional settings.
+ *
+ * @param {Object} props                              Component properties.
+ * @param {Object} props.attributes                   Block attributes.
+ * @param {string} props.attributes.tagName           The HTML tag name used for rendering the block (e.g., 'div', 'section').
+ * @param {boolean} props.attributes.legacy           Indicates whether the block is in legacy mode.
+ * @param {Function} props.setAttributes              Function to update block attributes.
+ * @returns {JSX.Element}                             The Comments block component.
+ */
 export default function CommentsEdit( props ) {
 	const { attributes, setAttributes } = props;
 	const { tagName: TagName, legacy } = attributes;

--- a/packages/block-library/src/comments/edit/placeholder.js
+++ b/packages/block-library/src/comments/edit/placeholder.js
@@ -12,6 +12,15 @@ import { createInterpolateElement } from '@wordpress/element';
  */
 import CommentsForm from '../../post-comments-form/form';
 
+/*
+ * Renders a placeholder for post comments, including navigation, a sample comment,
+ * and a form for adding new comments.
+ *
+ * @param {Object} props                       Component properties.
+ * @param {string} props.postType              The type of the post (e.g., 'post', 'page').
+ * @param {string} props.postId                The ID of the post.
+ * @returns {JSX.Element}                      The Post Comments Placeholder component.
+ */
 export default function PostCommentsPlaceholder( { postType, postId } ) {
 	let [ postTitle ] = useEntityProp( 'postType', postType, 'title', postId );
 	postTitle = postTitle || __( 'Post Title' );


### PR DESCRIPTION
## What?

This PR adds the JSDoc comment for comments block.

## Why?

Part of https://github.com/WordPress/gutenberg/issues/64057