### PR TITLE
Add WP_ENV_MULTISITE environment variable.

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Add a `WP_ENV_MULTISITE` environment variable to override the `multisite` option ([#68792](https://github.com/WordPress/gutenberg/pull/68792)).
+
 ## 10.16.0 (2025-01-15)
 
 ## 10.15.0 (2025-01-02)

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -701,6 +701,17 @@ You can tell `wp-env` to use a specific PHP version for compatibility and testin
 }
 ```
 
+### Specific if multisite is enabled
+
+You can tell `wp-env`  if the site should be multisite enabled. This can also be set via the environment variable `WP_ENV_MULTISITE`.
+
+```json
+{
+	"multsite": true,
+	"plugins": [ "." ]
+}
+```
+
 ### Node Lifecycle Script
 
 This is useful for performing some actions after setting up the environment, such as bootstrapping an E2E test environment.

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -701,7 +701,7 @@ You can tell `wp-env` to use a specific PHP version for compatibility and testin
 }
 ```
 
-### Specific if multisite is enabled
+### Multisite support
 
 You can tell `wp-env`  if the site should be multisite enabled. This can also be set via the environment variable `WP_ENV_MULTISITE`.
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -707,7 +707,7 @@ You can tell `wp-env`  if the site should be multisite enabled. This can also be
 
 ```json
 {
-	"multsite": true,
+	"multisite": true,
 	"plugins": [ "." ]
 }
 ```

--- a/packages/env/lib/config/get-config-from-environment-vars.js
+++ b/packages/env/lib/config/get-config-from-environment-vars.js
@@ -23,7 +23,7 @@ const { checkPort, checkVersion, checkString } = require( './validate-config' );
  * @property {?number}                  phpmyadminPort   An override for the development environment's phpMyAdmin port.
  * @property {?WPSource}                coreSource       An override for all environment's coreSource.
  * @property {?string}                  phpVersion       An override for all environment's PHP version.
- * @property {?bool}                    multisite       An override for if environmen should be multisite.
+ * @property {?boolean}                 multisite        An override for if environmen should be multisite.
  * @property {?Object.<string, string>} lifecycleScripts An override for various lifecycle scripts.
  */
 
@@ -70,7 +70,7 @@ module.exports = function getConfigFromEnvironmentVars( cacheDirectoryPath ) {
 	}
 
 	if ( process.env.WP_ENV_MULTISITE ) {
-		environmentConfig.multisite = !!process.env.WP_ENV_MULTISITE;
+		environmentConfig.multisite = !! process.env.WP_ENV_MULTISITE;
 	}
 
 	return environmentConfig;

--- a/packages/env/lib/config/get-config-from-environment-vars.js
+++ b/packages/env/lib/config/get-config-from-environment-vars.js
@@ -23,6 +23,7 @@ const { checkPort, checkVersion, checkString } = require( './validate-config' );
  * @property {?number}                  phpmyadminPort   An override for the development environment's phpMyAdmin port.
  * @property {?WPSource}                coreSource       An override for all environment's coreSource.
  * @property {?string}                  phpVersion       An override for all environment's PHP version.
+ * @property {?bool}                  multisite       An override for if environmen should be multisite.
  * @property {?Object.<string, string>} lifecycleScripts An override for various lifecycle scripts.
  */
 
@@ -66,6 +67,10 @@ module.exports = function getConfigFromEnvironmentVars( cacheDirectoryPath ) {
 			process.env.WP_ENV_PHP_VERSION
 		);
 		environmentConfig.phpVersion = process.env.WP_ENV_PHP_VERSION;
+	}
+
+	if ( process.env.WP_ENV_MULTISITE ) {
+		environmentConfig.multisite = !!process.env.WP_ENV_MULTISITE;
 	}
 
 	return environmentConfig;

--- a/packages/env/lib/config/get-config-from-environment-vars.js
+++ b/packages/env/lib/config/get-config-from-environment-vars.js
@@ -23,7 +23,7 @@ const { checkPort, checkVersion, checkString } = require( './validate-config' );
  * @property {?number}                  phpmyadminPort   An override for the development environment's phpMyAdmin port.
  * @property {?WPSource}                coreSource       An override for all environment's coreSource.
  * @property {?string}                  phpVersion       An override for all environment's PHP version.
- * @property {?bool}                  multisite       An override for if environmen should be multisite.
+ * @property {?bool}                    multisite       An override for if environmen should be multisite.
  * @property {?Object.<string, string>} lifecycleScripts An override for various lifecycle scripts.
  */
 


### PR DESCRIPTION
In https://github.com/WordPress/gutenberg/pull/67845 support for `multisite` was added in option in `wp-env` setups.

Related: https://github.com/WordPress/gutenberg/pull/68125

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR, it adds the functionality to can be specified via the `WP_ENV_MULTISITE` environment variable or in the configuration file. 

## Why?
It makes it easier to define it the site is multisite in a CI context. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
