### PR TITLE
Schema: Add author properties to theme.json

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -2586,6 +2586,18 @@
 			"description": "Description of the global styles variation.",
 			"type": "string"
 		},
+		"author": {
+			"description": "Name of the theme author.",
+			"type": "string"
+		},
+		"authorURI": {
+			"description": "URI to the theme author's WordPress profile or website.",
+			"type": "string"
+		},
+		"styleURI": {
+			"description": "URI to the theme's documentation or repository.",
+			"type": "string"
+		},
 		"blockTypes": {
 			"description": "List of block types that can use the block style variation this theme.json file represents.",
 			"type": "array",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes: https://github.com/WordPress/gutenberg/issues/68786

## What?
Adds three new top-level properties to the theme.json schema to support author attribution and documentation links:
- author: Theme author's name
- authorURI: Link to author's WordPress profile/website
- styleURI: Link to theme documentation or repository