### PR TITLE
Fix: DataViews edit page and template: remove multiple edit actions 

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -161,7 +161,7 @@ function GridItem< Item >( {
 					{ renderedTitleField }
 				</div>
 				{ !! actions?.length && (
-					<ItemActions item={ item } actions={ actions } isCompact />
+					<ItemActions item={ item } actions={ actions } />
 				) }
 			</HStack>
 			<VStack spacing={ 1 }>

--- a/packages/edit-site/src/components/dataviews-actions/index.js
+++ b/packages/edit-site/src/components/dataviews-actions/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { edit } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -19,6 +20,7 @@ export const useEditPostAction = () => {
 		() => ( {
 			id: 'edit-post',
 			label: __( 'Edit' ),
+			icon: edit,
 			isPrimary: true,
 			isEligible( post ) {
 				if ( post.status === 'trash' ) {

--- a/packages/edit-site/src/components/dataviews-actions/index.js
+++ b/packages/edit-site/src/components/dataviews-actions/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { edit } from '@wordpress/icons';
 import { useMemo } from '@wordpress/element';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 
@@ -21,7 +20,6 @@ export const useEditPostAction = () => {
 			id: 'edit-post',
 			label: __( 'Edit' ),
 			isPrimary: true,
-			icon: edit,
 			isEligible( post ) {
 				if ( post.status === 'trash' ) {
 					return false;

--- a/packages/edit-site/src/components/dataviews-actions/index.js
+++ b/packages/edit-site/src/components/dataviews-actions/index.js
@@ -2,9 +2,9 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { edit } from '@wordpress/icons';
 import { useMemo } from '@wordpress/element';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
-import { edit } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -20,8 +20,8 @@ export const useEditPostAction = () => {
 		() => ( {
 			id: 'edit-post',
 			label: __( 'Edit' ),
-			icon: edit,
 			isPrimary: true,
+			icon: edit,
 			isEligible( post ) {
 				if ( post.status === 'trash' ) {
 					return false;


### PR DESCRIPTION
## Why?
This PR is intended to solve issue mentioned here https://github.com/WordPress/gutenberg/issues/68789

## How?
It removes the vertical 3 dots present ( only if one option is present in dropdown ) and replace it with the edit icon in the Template section of Editor ( Grid and Table ) 

## Testing Instructions
- Open Editor 
- Go to template and click on the 3 vertical dots present on the left panel 
- Notice, now the 3 vertical dots are gone and there is a single edit icon 

## Screenshots or screencast 

![image](https://github.com/user-attachments/assets/d915e30f-fecd-4079-9d10-c2a13ebb120e)
![image](https://github.com/user-attachments/assets/574da2de-c2d6-4640-8858-835856ae1bdc)



