### PR TITLE
Fix: Update error message in private actions.

### DIFF
--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -205,7 +205,11 @@ export const saveDirtyEntities =
 				) {
 					registry
 						.dispatch( noticesStore )
-						.createErrorNotice( __( 'Saving failed.' ) );
+						.createErrorNotice(
+							__(
+								'Saving failed. Some records could not be saved. Please check your internet connection or try again.'
+							)
+						);
 				} else {
 					registry
 						.dispatch( noticesStore )
@@ -221,13 +225,17 @@ export const saveDirtyEntities =
 						} );
 				}
 			} )
-			.catch( ( error ) =>
+			.catch( ( error ) => {
+				let errorMessage = __(
+					'Saving failed. An unexpected error occurred.'
+				);
+				if ( error?.message ) {
+					errorMessage += ` ${ error.message }`;
+				}
 				registry
 					.dispatch( noticesStore )
-					.createErrorNotice(
-						`${ __( 'Saving failed.' ) } ${ error }`
-					)
-			);
+					.createErrorNotice( errorMessage, { type: 'snackbar' } );
+			} );
 	};
 
 /**


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
This PR improves error handling in the Gutenberg editor by providing more specific and user-friendly error messages when saving operations fail. It replaces the generic "Saving failed" message with detailed context, making it easier to identify the issue and troubleshoot.
Closes #57245

## How?
The current "Saving failed" message is too generic and does not provide sufficient information for users or developers to understand the root cause of the error.

## Testing Instructions
1. Open the browser's Developer Tools and block some API requests in the Network tab.
2. Save changes and verify that the message "Some records could not be saved" is displayed.
