### PR TITLE
Block Editor: Fix block color contrast checker

### DIFF
--- a/packages/block-editor/src/hooks/contrast-checker.js
+++ b/packages/block-editor/src/hooks/contrast-checker.js
@@ -76,6 +76,8 @@ export default function BlockColorContrastChecker( { clientId } ) {
 			setColors( getBlockElementColors( blockEl ) );
 		}
 
+		// Combine `useLayoutEffect` and two rAF calls to ensure that values are read
+		// after the current paint but before the next paint.
 		window.requestAnimationFrame( () =>
 			window.requestAnimationFrame( updateColors )
 		);

--- a/packages/block-editor/src/hooks/contrast-checker.js
+++ b/packages/block-editor/src/hooks/contrast-checker.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useLayoutEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -9,8 +9,47 @@ import { useState, useEffect } from '@wordpress/element';
 import ContrastChecker from '../components/contrast-checker';
 import { useBlockElement } from '../components/block-list/use-block-props/use-block-refs';
 
-function getComputedStyle( node ) {
-	return node.ownerDocument.defaultView.getComputedStyle( node );
+function getComputedValue( node, property ) {
+	return node.ownerDocument.defaultView
+		.getComputedStyle( node )
+		.getPropertyValue( property );
+}
+
+function getBlockElementColors( blockEl ) {
+	if ( ! blockEl ) {
+		return {};
+	}
+
+	const firstLinkElement = blockEl.querySelector( 'a' );
+	const linkColor = !! firstLinkElement?.innerText
+		? getComputedValue( firstLinkElement, 'color' )
+		: null;
+
+	const textColor = getComputedValue( blockEl, 'color' );
+
+	let backgroundColorNode = blockEl;
+	let backgroundColor = getComputedValue(
+		backgroundColorNode,
+		'background-color'
+	);
+	while (
+		backgroundColor === 'rgba(0, 0, 0, 0)' &&
+		backgroundColorNode.parentNode &&
+		backgroundColorNode.parentNode.nodeType ===
+			backgroundColorNode.parentNode.ELEMENT_NODE
+	) {
+		backgroundColorNode = backgroundColorNode.parentNode;
+		backgroundColor = getComputedValue(
+			backgroundColorNode,
+			'background-color'
+		);
+	}
+
+	return {
+		textColor,
+		backgroundColor,
+		linkColor,
+	};
 }
 
 export default function BlockColorContrastChecker( { clientId } ) {
@@ -21,40 +60,31 @@ export default function BlockColorContrastChecker( { clientId } ) {
 
 	// There are so many things that can change the color of a block
 	// So we perform this check on every render.
-	useEffect( () => {
+	useLayoutEffect( () => {
 		if ( ! blockEl ) {
 			return;
 		}
-		setDetectedColor( getComputedStyle( blockEl ).color );
 
-		const firstLinkElement = blockEl.querySelector( 'a' );
-		if ( firstLinkElement && !! firstLinkElement.innerText ) {
-			setDetectedLinkColor( getComputedStyle( firstLinkElement ).color );
+		function updateColors() {
+			const colors = getBlockElementColors( blockEl );
+			setDetectedColor( colors.textColor );
+			setDetectedBackgroundColor( colors.backgroundColor );
+			if ( colors.linkColor ) {
+				setDetectedLinkColor( colors.linkColor );
+			}
 		}
 
-		let backgroundColorNode = blockEl;
-		let backgroundColor =
-			getComputedStyle( backgroundColorNode ).backgroundColor;
-		while (
-			backgroundColor === 'rgba(0, 0, 0, 0)' &&
-			backgroundColorNode.parentNode &&
-			backgroundColorNode.parentNode.nodeType ===
-				backgroundColorNode.parentNode.ELEMENT_NODE
-		) {
-			backgroundColorNode = backgroundColorNode.parentNode;
-			backgroundColor =
-				getComputedStyle( backgroundColorNode ).backgroundColor;
-		}
-
-		setDetectedBackgroundColor( backgroundColor );
-	}, [ blockEl ] );
+		window.requestAnimationFrame( () =>
+			window.requestAnimationFrame( updateColors )
+		);
+	} );
 
 	return (
 		<ContrastChecker
 			backgroundColor={ detectedBackgroundColor }
 			textColor={ detectedColor }
-			enableAlphaChecker
 			linkColor={ detectedLinkColor }
+			enableAlphaChecker
 		/>
 	);
 }

--- a/packages/block-editor/src/hooks/contrast-checker.js
+++ b/packages/block-editor/src/hooks/contrast-checker.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useLayoutEffect } from '@wordpress/element';
+import { useLayoutEffect, useReducer } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -23,7 +23,7 @@ function getBlockElementColors( blockEl ) {
 	const firstLinkElement = blockEl.querySelector( 'a' );
 	const linkColor = !! firstLinkElement?.innerText
 		? getComputedValue( firstLinkElement, 'color' )
-		: null;
+		: undefined;
 
 	const textColor = getComputedValue( blockEl, 'color' );
 
@@ -52,11 +52,18 @@ function getBlockElementColors( blockEl ) {
 	};
 }
 
+function reducer( prevColors, newColors ) {
+	const hasChanged = Object.keys( newColors ).some(
+		( key ) => prevColors[ key ] !== newColors[ key ]
+	);
+
+	// Do not re-render if the colors have not changed.
+	return hasChanged ? newColors : prevColors;
+}
+
 export default function BlockColorContrastChecker( { clientId } ) {
-	const [ detectedBackgroundColor, setDetectedBackgroundColor ] = useState();
-	const [ detectedColor, setDetectedColor ] = useState();
-	const [ detectedLinkColor, setDetectedLinkColor ] = useState();
 	const blockEl = useBlockElement( clientId );
+	const [ colors, setColors ] = useReducer( reducer, {} );
 
 	// There are so many things that can change the color of a block
 	// So we perform this check on every render.
@@ -66,12 +73,7 @@ export default function BlockColorContrastChecker( { clientId } ) {
 		}
 
 		function updateColors() {
-			const colors = getBlockElementColors( blockEl );
-			setDetectedColor( colors.textColor );
-			setDetectedBackgroundColor( colors.backgroundColor );
-			if ( colors.linkColor ) {
-				setDetectedLinkColor( colors.linkColor );
-			}
+			setColors( getBlockElementColors( blockEl ) );
 		}
 
 		window.requestAnimationFrame( () =>
@@ -81,9 +83,9 @@ export default function BlockColorContrastChecker( { clientId } ) {
 
 	return (
 		<ContrastChecker
-			backgroundColor={ detectedBackgroundColor }
-			textColor={ detectedColor }
-			linkColor={ detectedLinkColor }
+			backgroundColor={ colors.backgroundColor }
+			textColor={ colors.textColor }
+			linkColor={ colors.linkColor }
 			enableAlphaChecker
 		/>
 	);


### PR DESCRIPTION
## What?
Fixes #67035.
Alternative to #67036.

Combine `useLayoutEffect` and two rAF calls to ensure that values are read after the current paint but before the next paint.

## Why?
The solution is similar to #59227, which also needs to read computed styles from the block element.

Quoting from: #59227.
> React does not guarantee that useEffect will be called after the browser paints and, in fact, useEffect can be called before a paint when React is handling a user event (e.g. a click) or if a useLayoutEffect in the component tree updates state (e.g. calls setState). See https://github.com/facebook/react/issues/20863#issuecomment-976582680.

This is probably a better summary for React 18 - https://github.com/facebook/react/issues/24409#issuecomment-1103917606.

## Testing Instructions
1. Open a post.
2. Add paragraph block.
3. Change block colors.
4. Confirm that the contrast checker is displayed when selecting problematic color combinations.

### Testing Instructions for Keyboard
Same.
