### PR TITLE
Fix: block manager scrollable UI a11y fix

### DIFF
--- a/packages/block-editor/src/components/block-manager/category.js
+++ b/packages/block-editor/src/components/block-manager/category.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, forwardRef } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
 import { CheckboxControl } from '@wordpress/components';
 
@@ -9,97 +9,94 @@ import { CheckboxControl } from '@wordpress/components';
  * Internal dependencies
  */
 import BlockTypesChecklist from './checklist';
-const a = forwardRef( () => {
-	return a;
-} );
 
-const BlockManagerCategory = forwardRef(
-	( { title, blockTypes, selectedBlockTypes, onChange }, ref ) => {
-		const instanceId = useInstanceId( BlockManagerCategory );
+const BlockManagerCategory = ( {
+	title,
+	blockTypes,
+	selectedBlockTypes,
+	onChange,
+} ) => {
+	const instanceId = useInstanceId( BlockManagerCategory );
 
-		const toggleVisible = useCallback(
-			( blockType, nextIsChecked ) => {
-				if ( nextIsChecked ) {
-					onChange( [ ...selectedBlockTypes, blockType ] );
-				} else {
-					onChange(
-						selectedBlockTypes.filter(
-							( { name } ) => name !== blockType.name
-						)
-					);
-				}
-			},
-			[ selectedBlockTypes, onChange ]
-		);
+	const toggleVisible = useCallback(
+		( blockType, nextIsChecked ) => {
+			if ( nextIsChecked ) {
+				onChange( [ ...selectedBlockTypes, blockType ] );
+			} else {
+				onChange(
+					selectedBlockTypes.filter(
+						( { name } ) => name !== blockType.name
+					)
+				);
+			}
+		},
+		[ selectedBlockTypes, onChange ]
+	);
 
-		const toggleAllVisible = useCallback(
-			( nextIsChecked ) => {
-				if ( nextIsChecked ) {
-					onChange( [
-						...selectedBlockTypes,
-						...blockTypes.filter(
-							( blockType ) =>
-								! selectedBlockTypes.find(
-									( { name } ) => name === blockType.name
-								)
-						),
-					] );
-				} else {
-					onChange(
-						selectedBlockTypes.filter(
-							( selectedBlockType ) =>
-								! blockTypes.find(
-									( { name } ) =>
-										name === selectedBlockType.name
-								)
-						)
-					);
-				}
-			},
-			[ blockTypes, selectedBlockTypes, onChange ]
-		);
+	const toggleAllVisible = useCallback(
+		( nextIsChecked ) => {
+			if ( nextIsChecked ) {
+				onChange( [
+					...selectedBlockTypes,
+					...blockTypes.filter(
+						( blockType ) =>
+							! selectedBlockTypes.find(
+								( { name } ) => name === blockType.name
+							)
+					),
+				] );
+			} else {
+				onChange(
+					selectedBlockTypes.filter(
+						( selectedBlockType ) =>
+							! blockTypes.find(
+								( { name } ) => name === selectedBlockType.name
+							)
+					)
+				);
+			}
+		},
+		[ blockTypes, selectedBlockTypes, onChange ]
+	);
 
-		if ( ! blockTypes.length ) {
-			return null;
-		}
-
-		const checkedBlockNames = blockTypes
-			.map( ( { name } ) => name )
-			.filter( ( type ) =>
-				( selectedBlockTypes ?? [] ).some(
-					( selectedBlockType ) => selectedBlockType.name === type
-				)
-			);
-
-		const titleId =
-			'block-editor-block-manager__category-title-' + instanceId;
-
-		const isAllChecked = checkedBlockNames.length === blockTypes.length;
-		const isIndeterminate = ! isAllChecked && checkedBlockNames.length > 0;
-
-		return (
-			<div
-				role="group"
-				aria-labelledby={ titleId }
-				className="block-editor-block-manager__category"
-				ref={ ref }
-			>
-				<CheckboxControl
-					__nextHasNoMarginBottom
-					checked={ isAllChecked }
-					onChange={ toggleAllVisible }
-					className="block-editor-block-manager__category-title"
-					indeterminate={ isIndeterminate }
-					label={ <span id={ titleId }>{ title }</span> }
-				/>
-				<BlockTypesChecklist
-					blockTypes={ blockTypes }
-					value={ checkedBlockNames }
-					onItemChange={ toggleVisible }
-				/>
-			</div>
-		);
+	if ( ! blockTypes.length ) {
+		return null;
 	}
-);
+
+	const checkedBlockNames = blockTypes
+		.map( ( { name } ) => name )
+		.filter( ( type ) =>
+			( selectedBlockTypes ?? [] ).some(
+				( selectedBlockType ) => selectedBlockType.name === type
+			)
+		);
+
+	const titleId = 'block-editor-block-manager__category-title-' + instanceId;
+
+	const isAllChecked = checkedBlockNames.length === blockTypes.length;
+	const isIndeterminate = ! isAllChecked && checkedBlockNames.length > 0;
+
+	return (
+		<div
+			role="group"
+			aria-labelledby={ titleId }
+			className="block-editor-block-manager__category"
+		>
+			<CheckboxControl
+				__nextHasNoMarginBottom
+				checked={ isAllChecked }
+				onChange={ toggleAllVisible }
+				className="block-editor-block-manager__category-title"
+				indeterminate={ isIndeterminate }
+				label={ <span id={ titleId }>{ title }</span> }
+			/>
+			<BlockTypesChecklist
+				blockTypes={ blockTypes }
+				value={ checkedBlockNames }
+				onItemChange={ toggleVisible }
+			/>
+		</div>
+	);
+};
 
 export default BlockManagerCategory;

--- a/packages/block-editor/src/components/block-manager/category.js
+++ b/packages/block-editor/src/components/block-manager/category.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback } from '@wordpress/element';
+import { useCallback, forwardRef } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
 import { CheckboxControl } from '@wordpress/components';
 
@@ -9,94 +9,97 @@ import { CheckboxControl } from '@wordpress/components';
  * Internal dependencies
  */
 import BlockTypesChecklist from './checklist';
+const a = forwardRef( () => {
+	return a;
+} );
 
-function BlockManagerCategory( {
-	title,
-	blockTypes,
-	selectedBlockTypes,
-	onChange,
-} ) {
-	const instanceId = useInstanceId( BlockManagerCategory );
+const BlockManagerCategory = forwardRef(
+	( { title, blockTypes, selectedBlockTypes, onChange }, ref ) => {
+		const instanceId = useInstanceId( BlockManagerCategory );
 
-	const toggleVisible = useCallback(
-		( blockType, nextIsChecked ) => {
-			if ( nextIsChecked ) {
-				onChange( [ ...selectedBlockTypes, blockType ] );
-			} else {
-				onChange(
-					selectedBlockTypes.filter(
-						( { name } ) => name !== blockType.name
-					)
-				);
-			}
-		},
-		[ selectedBlockTypes, onChange ]
-	);
-
-	const toggleAllVisible = useCallback(
-		( nextIsChecked ) => {
-			if ( nextIsChecked ) {
-				onChange( [
-					...selectedBlockTypes,
-					...blockTypes.filter(
-						( blockType ) =>
-							! selectedBlockTypes.find(
-								( { name } ) => name === blockType.name
-							)
-					),
-				] );
-			} else {
-				onChange(
-					selectedBlockTypes.filter(
-						( selectedBlockType ) =>
-							! blockTypes.find(
-								( { name } ) => name === selectedBlockType.name
-							)
-					)
-				);
-			}
-		},
-		[ blockTypes, selectedBlockTypes, onChange ]
-	);
-
-	if ( ! blockTypes.length ) {
-		return null;
-	}
-
-	const checkedBlockNames = blockTypes
-		.map( ( { name } ) => name )
-		.filter( ( type ) =>
-			( selectedBlockTypes ?? [] ).some(
-				( selectedBlockType ) => selectedBlockType.name === type
-			)
+		const toggleVisible = useCallback(
+			( blockType, nextIsChecked ) => {
+				if ( nextIsChecked ) {
+					onChange( [ ...selectedBlockTypes, blockType ] );
+				} else {
+					onChange(
+						selectedBlockTypes.filter(
+							( { name } ) => name !== blockType.name
+						)
+					);
+				}
+			},
+			[ selectedBlockTypes, onChange ]
 		);
 
-	const titleId = 'block-editor-block-manager__category-title-' + instanceId;
+		const toggleAllVisible = useCallback(
+			( nextIsChecked ) => {
+				if ( nextIsChecked ) {
+					onChange( [
+						...selectedBlockTypes,
+						...blockTypes.filter(
+							( blockType ) =>
+								! selectedBlockTypes.find(
+									( { name } ) => name === blockType.name
+								)
+						),
+					] );
+				} else {
+					onChange(
+						selectedBlockTypes.filter(
+							( selectedBlockType ) =>
+								! blockTypes.find(
+									( { name } ) =>
+										name === selectedBlockType.name
+								)
+						)
+					);
+				}
+			},
+			[ blockTypes, selectedBlockTypes, onChange ]
+		);
 
-	const isAllChecked = checkedBlockNames.length === blockTypes.length;
-	const isIndeterminate = ! isAllChecked && checkedBlockNames.length > 0;
+		if ( ! blockTypes.length ) {
+			return null;
+		}
 
-	return (
-		<div
-			role="group"
-			aria-labelledby={ titleId }
-			className="block-editor-block-manager__category"
-		>
-			<CheckboxControl
-				__nextHasNoMarginBottom
-				checked={ isAllChecked }
-				onChange={ toggleAllVisible }
-				className="block-editor-block-manager__category-title"
-				indeterminate={ isIndeterminate }
-				label={ <span id={ titleId }>{ title }</span> }
-			/>
-			<BlockTypesChecklist
-				blockTypes={ blockTypes }
-				value={ checkedBlockNames }
-				onItemChange={ toggleVisible }
-			/>
-		</div>
-	);
-}
+		const checkedBlockNames = blockTypes
+			.map( ( { name } ) => name )
+			.filter( ( type ) =>
+				( selectedBlockTypes ?? [] ).some(
+					( selectedBlockType ) => selectedBlockType.name === type
+				)
+			);
+
+		const titleId =
+			'block-editor-block-manager__category-title-' + instanceId;
+
+		const isAllChecked = checkedBlockNames.length === blockTypes.length;
+		const isIndeterminate = ! isAllChecked && checkedBlockNames.length > 0;
+
+		return (
+			<div
+				role="group"
+				aria-labelledby={ titleId }
+				className="block-editor-block-manager__category"
+				ref={ ref }
+			>
+				<CheckboxControl
+					__nextHasNoMarginBottom
+					checked={ isAllChecked }
+					onChange={ toggleAllVisible }
+					className="block-editor-block-manager__category-title"
+					indeterminate={ isIndeterminate }
+					label={ <span id={ titleId }>{ title }</span> }
+				/>
+				<BlockTypesChecklist
+					blockTypes={ blockTypes }
+					value={ checkedBlockNames }
+					onItemChange={ toggleVisible }
+				/>
+			</div>
+		);
+	}
+);
 
 export default BlockManagerCategory;

--- a/packages/block-editor/src/components/block-manager/category.js
+++ b/packages/block-editor/src/components/block-manager/category.js
@@ -10,12 +10,12 @@ import { CheckboxControl } from '@wordpress/components';
  */
 import BlockTypesChecklist from './checklist';
 
-const BlockManagerCategory = ( {
+function BlockManagerCategory( {
 	title,
 	blockTypes,
 	selectedBlockTypes,
 	onChange,
-} ) => {
+} ) {
 	const instanceId = useInstanceId( BlockManagerCategory );
 
 	const toggleVisible = useCallback(
@@ -97,6 +97,6 @@ const BlockManagerCategory = ( {
 			/>
 		</div>
 	);
-};
+}
 
 export default BlockManagerCategory;


### PR DESCRIPTION
Closes #67959

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes an issue where focused elements in scrollable lists with sticky headers or footers can remain hidden behind those elements when navigating using a keyboard or keyboard-like devices.

## Why?

Sticky headers and footers are commonly used in the  UI to keep certain elements fixed while scrolling. 

## How?

### **Block Manager Issue**
The issue is resolved by dynamically adjusting the scroll position of the container based on the position of sticky elements and the currently focused element. Here's how it was implemented:

1. **Identify Key Elements:**  
   - A scrollable container is selected using `document.querySelector` to target the relevant modal or scrollable content.  
   - Sticky elements within the scrollable container are identified using `querySelectorAll`.

2. **Focus Handling:**  
   - An event listener is added to the container to monitor `focusin` events, which are triggered whenever an element inside the container gains focus.  
   - A utility function, `getActiveStickyElement`, determines the currently active sticky element based on its position relative to the scrollable container.

3. **Scroll Adjustment Logic:**  
   - When an element inside the container gains focus, its position is compared to the bottom of the sticky element.  
   - If the focused element is hidden behind the sticky header/footer, the scroll position of the container is adjusted using `scrollTo` with the `smooth` behavior for a better user experience.  

4. **Event Listener Cleanup:**  
   - The event listener is removed during the cleanup phase of the `useEffect` hook to avoid memory leaks or unintended behavior when the component unmounts.  

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard

**Preferences Modal Dialog:**

Open the Preferences Modal Dialog > Blocks.
Ensure the list of blocks is long enough to make the panel scrollable.
Use the Tab key to navigate and then Shift+Tab to navigate backwards.
Confirm that focused elements remain visible during navigation.
Test across different browsers (e.g., Chrome, Safari, Firefox) to ensure consistent behavior.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/d4fb7903-854d-489c-bc78-cf649cf14f96