### PR TITLE
Wrong initial pattern category selected by default -- Fix

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -68,12 +68,10 @@ function InserterMenu(
 	const [ filterValue, setFilterValue, delayedFilterValue ] =
 		useDebouncedInput( __experimentalFilterValue );
 	const [ hoveredItem, setHoveredItem ] = useState( null );
-	const [ selectedPatternCategory, setSelectedPatternCategory ] = useState(
-		{
-			"name": "core/starter-content",
-			"label": "Starter content"
-		}
-	);
+	const [ selectedPatternCategory, setSelectedPatternCategory ] = useState( {
+		name: 'core/starter-content',
+		label: 'Starter content',
+	} );
 	const [ patternFilter, setPatternFilter ] = useState( 'all' );
 	const [ selectedMediaCategory, setSelectedMediaCategory ] =
 		useState( null );

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -69,7 +69,10 @@ function InserterMenu(
 		useDebouncedInput( __experimentalFilterValue );
 	const [ hoveredItem, setHoveredItem ] = useState( null );
 	const [ selectedPatternCategory, setSelectedPatternCategory ] = useState(
-		__experimentalInitialCategory
+		{
+			"name": "core/starter-content",
+			"label": "Starter content"
+		}
 	);
 	const [ patternFilter, setPatternFilter ] = useState( 'all' );
 	const [ selectedMediaCategory, setSelectedMediaCategory ] =


### PR DESCRIPTION
Part of #68736 

## What?
The default category selection was modified to add a new page.

## Why?
The wrong initial pattern category was selected by default while "Add new page"

## Testing Instructions

1. Go to WordPress admin -> pages-> Add new page
2. Check default category selected is "Starter Content" instead of "All"


## Screenshots or screencast <!-- if applicable -->
<img width="1434" alt="starter-content-default-category" src="https://github.com/user-attachments/assets/f6d0b204-60c3-446f-9b4e-b984e5cd9bd7" />
