### PR TITLE
Show duplicative heading level text when showIconLabels is enabled

### DIFF
--- a/packages/block-editor/src/components/block-heading-level-dropdown/index.js
+++ b/packages/block-editor/src/components/block-heading-level-dropdown/index.js
@@ -39,6 +39,7 @@ export default function HeadingLevelDropdown( {
 	options = HEADING_LEVELS,
 	value,
 	onChange,
+	showIconLabels = false,
 } ) {
 	const validOptions = options
 		.filter(
@@ -53,16 +54,18 @@ export default function HeadingLevelDropdown( {
 			label={ __( 'Change level' ) }
 			controls={ validOptions.map( ( targetLevel ) => {
 				const isActive = targetLevel === value;
+				const title =
+					targetLevel === 0
+						? __( 'Paragraph' )
+						: sprintf(
+								// translators: %d: heading level e.g: "1", "2", "3"
+								__( 'Heading %d' ),
+								targetLevel
+						  );
+
 				return {
 					icon: <HeadingLevelIcon level={ targetLevel } />,
-					title:
-						targetLevel === 0
-							? __( 'Paragraph' )
-							: sprintf(
-									// translators: %d: heading level e.g: "1", "2", "3"
-									__( 'Heading %d' ),
-									targetLevel
-							  ),
+					title: showIconLabels ? title : undefined,
 					isActive,
 					onClick() {
 						onChange( targetLevel );

--- a/packages/block-editor/src/components/block-heading-level-dropdown/index.js
+++ b/packages/block-editor/src/components/block-heading-level-dropdown/index.js
@@ -3,6 +3,8 @@
  */
 import { ToolbarDropdownMenu } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { store as preferencesStore } from '@wordpress/preferences';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -39,13 +41,18 @@ export default function HeadingLevelDropdown( {
 	options = HEADING_LEVELS,
 	value,
 	onChange,
-	showIconLabels = false,
 } ) {
 	const validOptions = options
 		.filter(
 			( option ) => option === 0 || HEADING_LEVELS.includes( option )
 		)
 		.sort( ( a, b ) => a - b ); // Sorts numerically in ascending order;
+
+	const showIconLabels = useSelect(
+		( select ) =>
+			select( preferencesStore ).get( 'core', 'showIconLabels' ),
+		[]
+	);
 
 	return (
 		<ToolbarDropdownMenu


### PR DESCRIPTION
Fixes [#56621](https://github.com/WordPress/gutenberg/issues/56621)

## What?
Update the HeadingLevelDropdown component to show text labels alongside icons when `showIconLabels` is enabled.

## How?
- Added `useSelect` hook to get `showIconLabels` preference from the preferences store
- Show icon label based on showIconLabels value

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2025-01-21 at 5 12 57 PM](https://github.com/user-attachments/assets/a9162c48-df2a-448f-8213-c8f7118fb978)

