### PR TITLE
Adding heading to TOC

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -914,7 +914,7 @@ Summarize your post with a list of headings. Add HTML anchors to Heading blocks 
 -	**Experimental:** true
 -	**Category:** design
 -	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** headings, onlyIncludeCurrentPage
+-	**Attributes:** headings, onlyIncludeCurrentPage, title
 
 ## Tag Cloud
 

--- a/packages/block-library/src/table-of-contents/block.json
+++ b/packages/block-library/src/table-of-contents/block.json
@@ -19,6 +19,10 @@
 		"onlyIncludeCurrentPage": {
 			"type": "boolean",
 			"default": false
+		},
+		"title": {
+			"type": "string",
+			"default": "Table of Contents"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/table-of-contents/edit.js
+++ b/packages/block-library/src/table-of-contents/edit.js
@@ -123,14 +123,14 @@ export default function TableOfContentsEdit( {
 			>
 				<ToolsPanelItem
 					hasValue={ () => !! title }
-					label={ __( 'Title' ) }
+					label={ __( 'HEADING TEXT' ) }
 					onDeselect={ () => setAttributes( { title: '' } ) }
 					isShownByDefault
 				>
 					<TextControl
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
-						label={ __( 'Title' ) }
+						label={ __( 'HEADING TEXT' ) }
 						value={ title }
 						help={ __(
 							'Set the heading text of the block. Default value: Table of Contents'
@@ -193,7 +193,11 @@ export default function TableOfContentsEdit( {
 	return (
 		<>
 			<nav { ...blockProps }>
-				{ title && <h2>{ title }</h2> }
+				{ title && (
+					<h2 className="wp-block-table-of-contents__title">
+						{ title }
+					</h2>
+				) }
 				<ol>
 					<TableOfContentsList
 						nestedHeadingList={ headingTree }

--- a/packages/block-library/src/table-of-contents/edit.js
+++ b/packages/block-library/src/table-of-contents/edit.js
@@ -16,6 +16,7 @@ import {
 	ToolbarGroup,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	TextControl,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { renderToString } from '@wordpress/element';
@@ -44,10 +45,11 @@ import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
  * @param {string}                       props.clientId
  * @param {(attributes: Object) => void} props.setAttributes
  *
+ * @param {string}                       props.attributes.title
  * @return {Component} The component.
  */
 export default function TableOfContentsEdit( {
-	attributes: { headings = [], onlyIncludeCurrentPage },
+	attributes: { headings = [], onlyIncludeCurrentPage, title },
 	clientId,
 	setAttributes,
 } ) {
@@ -120,6 +122,25 @@ export default function TableOfContentsEdit( {
 				dropdownMenuProps={ dropdownMenuProps }
 			>
 				<ToolsPanelItem
+					hasValue={ () => !! title }
+					label={ __( 'Title' ) }
+					onDeselect={ () => setAttributes( { title: '' } ) }
+					isShownByDefault
+				>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Title' ) }
+						value={ title }
+						help={ __(
+							'Set the heading text of the block. Default value: Table of Contents'
+						) }
+						onChange={ ( value ) =>
+							setAttributes( { title: value } )
+						}
+					/>
+				</ToolsPanelItem>
+				<ToolsPanelItem
 					hasValue={ () => !! onlyIncludeCurrentPage }
 					label={ __( 'Only include current page' ) }
 					onDeselect={ () =>
@@ -172,6 +193,7 @@ export default function TableOfContentsEdit( {
 	return (
 		<>
 			<nav { ...blockProps }>
+				{ title && <h2>{ title }</h2> }
 				<ol>
 					<TableOfContentsList
 						nestedHeadingList={ headingTree }

--- a/packages/block-library/src/table-of-contents/save.js
+++ b/packages/block-library/src/table-of-contents/save.js
@@ -9,12 +9,13 @@ import { useBlockProps } from '@wordpress/block-editor';
 import TableOfContentsList from './list';
 import { linearToNestedHeadingList } from './utils';
 
-export default function save( { attributes: { headings = [] } } ) {
+export default function save( { attributes: { headings = [], title } } ) {
 	if ( headings.length === 0 ) {
 		return null;
 	}
 	return (
 		<nav { ...useBlockProps.save() }>
+			{ title && <h2>{ title }</h2> }
 			<ol>
 				<TableOfContentsList
 					nestedHeadingList={ linearToNestedHeadingList( headings ) }

--- a/packages/block-library/src/table-of-contents/save.js
+++ b/packages/block-library/src/table-of-contents/save.js
@@ -15,7 +15,9 @@ export default function save( { attributes: { headings = [], title } } ) {
 	}
 	return (
 		<nav { ...useBlockProps.save() }>
-			{ title && <h2>{ title }</h2> }
+			{ title && (
+				<h2 className="wp-block-table-of-contents__title">{ title }</h2>
+			) }
 			<ol>
 				<TableOfContentsList
 					nestedHeadingList={ linearToNestedHeadingList( headings ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes : https://github.com/WordPress/gutenberg/issues/52378

## Why?
There is no good way of setting a title for the Table of Contents block



## How?
Added settings to include title for the Table of Content block.

## Testing Instructions

- Open a post or page. 
-  Insert a heading block. 
-  Check the settings added to include title for the block.
-  Verify the title is displaying properly in editor and frontend.



## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![Screenshot (4)](https://github.com/user-attachments/assets/e64c2a0e-fce0-4b55-abf8-ed50247f677a)|![Screenshot (5)](https://github.com/user-attachments/assets/cdc3ec2f-c58a-4351-93ab-c1c1e19065a2)|
