### PR TITLE
Components: Fix placeholder color inconsistency across `SearchControl`, `TextControl`, `Inputcontrol`

### DIFF
--- a/packages/components/src/input-control/styles/input-control-styles.tsx
+++ b/packages/components/src/input-control/styles/input-control-styles.tsx
@@ -12,7 +12,13 @@ import type { CSSProperties, ReactNode } from 'react';
 import type { WordPressComponentProps } from '../../context';
 import { Flex, FlexItem } from '../../flex';
 import { Text } from '../../text';
-import { baseLabelTypography, COLORS, CONFIG, rtl } from '../../utils';
+import {
+	baseLabelTypography,
+	COLORS,
+	CONFIG,
+	rtl,
+	placeholderStyles,
+} from '../../utils';
 import type { LabelPosition, Size, PrefixSuffixWrapperProps } from '../types';
 
 type ContainerProps = {
@@ -283,20 +289,7 @@ export const Input = styled.input< InputProps >`
 		${ fontSizeStyles }
 		${ sizeStyles }
 		${ customPaddings }
-
-		&::-webkit-input-placeholder {
-			line-height: normal;
-			color: ${ COLORS.ui.darkGrayPlaceholder };
-		}
-
-		&::-moz-placeholder {
-			opacity: 1; // Necessary because Firefox reduces this from 1.
-			color: ${ COLORS.ui.darkGrayPlaceholder };
-		}
-
-		&:-ms-input-placeholder {
-			color: ${ COLORS.ui.darkGrayPlaceholder };
-		}
+		${ placeholderStyles }
 
 		&[type='email'],
 		&[type='url'] {

--- a/packages/components/src/input-control/styles/input-control-styles.tsx
+++ b/packages/components/src/input-control/styles/input-control-styles.tsx
@@ -285,10 +285,12 @@ export const Input = styled.input< InputProps >`
 		${ customPaddings }
 
 		&::-webkit-input-placeholder {
+			line-height: normal;
 			color: ${ COLORS.ui.darkGrayPlaceholder };
 		}
 
 		&::-moz-placeholder {
+			opacity: 1; // Necessary because Firefox reduces this from 1.
 			color: ${ COLORS.ui.darkGrayPlaceholder };
 		}
 

--- a/packages/components/src/text-control/style.scss
+++ b/packages/components/src/text-control/style.scss
@@ -36,7 +36,6 @@
 	}
 
 	&::-moz-placeholder {
-		opacity: 1; // Necessary because Firefox reduces this from 1.
 		color: $dark-gray-placeholder;
 	}
 

--- a/packages/components/src/text-control/style.scss
+++ b/packages/components/src/text-control/style.scss
@@ -29,6 +29,20 @@
 		padding-left: $grid-unit-15;
 		padding-right: $grid-unit-15;
 	}
+
+	// Use opacity to work in various editor styles.
+	&::-webkit-input-placeholder {
+		color: $dark-gray-placeholder;
+	}
+
+	&::-moz-placeholder {
+		opacity: 1; // Necessary because Firefox reduces this from 1.
+		color: $dark-gray-placeholder;
+	}
+
+	&:-ms-input-placeholder {
+		color: $dark-gray-placeholder;
+	}
 }
 
 .components-text-control__input[type="email"],

--- a/packages/components/src/utils/placeholder.js
+++ b/packages/components/src/utils/placeholder.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { css } from '@emotion/react';
+
+/**
+ * Internal dependencies
+ */
+import { COLORS } from './colors-values';
+
+export const placeholderStyles = css`
+	&::placeholder {
+		color: ${ COLORS.ui.darkGrayPlaceholder };
+	}
+
+	&::-webkit-input-placeholder {
+		color: ${ COLORS.ui.darkGrayPlaceholder };
+		line-height: normal;
+	}
+
+	&::-moz-placeholder {
+		color: ${ COLORS.ui.darkGrayPlaceholder };
+		opacity: 1;
+	}
+
+	&:-ms-input-placeholder {
+		color: ${ COLORS.ui.darkGrayPlaceholder };
+	}
+`;

--- a/packages/components/src/utils/placeholder.js
+++ b/packages/components/src/utils/placeholder.js
@@ -15,7 +15,6 @@ export const placeholderStyles = css`
 
 	&::-webkit-input-placeholder {
 		color: ${ COLORS.ui.darkGrayPlaceholder };
-		line-height: normal;
 	}
 
 	&::-moz-placeholder {

--- a/packages/components/src/utils/placeholder.js
+++ b/packages/components/src/utils/placeholder.js
@@ -20,7 +20,6 @@ export const placeholderStyles = css`
 
 	&::-moz-placeholder {
 		color: ${ COLORS.ui.darkGrayPlaceholder };
-		opacity: 1;
 	}
 
 	&:-ms-input-placeholder {

--- a/packages/components/src/utils/style-mixins.js
+++ b/packages/components/src/utils/style-mixins.js
@@ -6,3 +6,4 @@ export { breakpoint } from './breakpoint';
 export { default as CONFIG } from './config-values';
 export { COLORS } from './colors-values';
 export { baseLabelTypography } from './base-label';
+export { placeholderStyles } from './placeholder';


### PR DESCRIPTION
Closes: https://github.com/WordPress/gutenberg/issues/64666

## What?
  This PR ensures a consistent placeholder color across the `InputControl`, `SearchControl`, and `TextControl` components by defining the color explicitly.

## Why?
To address the issue where placeholder color varied depending on the applied styles.


## How?
The placeholder color has been defined at the component level to avoid inconsistencies and improve accessibility.

## Testing Instructions

1. Test the `InputControl`, `SearchControl`, and `TextControl` components in the storybook
2. Ensure the placeholder color is consistent and meets the contrast ratio requirements.


| **Component**   | **Foreground Color**       | **Background Color**        |
|-----------------|----------------------------|-----------------------------|
| **InputControl** | `#1e1e1e9e` (dark gray 62% opacity)      | `#ffffff` (white)                 |
| **SearchControl**| `#1e1e1e9e` (dark gray 62% opacity)           | `#f0f0f0` (light gray)      |
| **TextControl**  | `#1e1e1e9e` (dark gray 62% opacity)      | `#ffffff` (white)               |



## Screenshots

### SearchControl 
- Their are talks around removing the background color to make the input box consistent with other input boxes https://github.com/WordPress/gutenberg/issues/56388#issuecomment-2300138008



|Before|After|
|-|-|
|<img width="1015" alt="image" src="https://github.com/user-attachments/assets/9a2a903a-c6d3-4cdb-b6c4-ea750d4692a0" />|<img width="1034" alt="image" src="https://github.com/user-attachments/assets/b64e7406-1023-4697-8250-c0f7c307e66d" />|


### TextControl

|Before|After|
|-|-|
|<img width="1011" alt="image" src="https://github.com/user-attachments/assets/bf2023e4-a0f5-4cae-81f2-65e533911b20" />|<img width="1030" alt="image" src="https://github.com/user-attachments/assets/abc61557-74ab-4313-aeff-09a956fbb164" />|

### InputControl

|Before|After|
|-|-|
|<img width="1010" alt="image" src="https://github.com/user-attachments/assets/7bff10bd-68cf-472d-8f56-06c93e0f0ff7" />|<img width="1014" alt="image" src="https://github.com/user-attachments/assets/4186ff69-7d44-49e5-8350-9197ea0437ec" />|