### PR TITLE
Update step values for size control

### DIFF
--- a/packages/edit-site/src/components/global-styles/size-control/index.js
+++ b/packages/edit-site/src/components/global-styles/size-control/index.js
@@ -60,6 +60,7 @@ function SizeControl( {
 						onChange={ handleUnitControlChange }
 						units={ units }
 						min={ 0 }
+						step={ isValueUnitRelative ? 0.001 : 1 }
 						disabled={ disabled }
 					/>
 				</FlexItem>
@@ -76,7 +77,7 @@ function SizeControl( {
 							onChange={ handleRangeControlChange }
 							min={ 0 }
 							max={ isValueUnitRelative ? 10 : 100 }
-							step={ isValueUnitRelative ? 0.1 : 1 }
+							step={ isValueUnitRelative ? 0.001 : 1 }
 							disabled={ disabled }
 						/>
 					</Spacer>


### PR DESCRIPTION

## What?
Fixes https://github.com/WordPress/gutenberg/issues/68599

## Why?
This PR adds the requested precession for font sizes with relative units

## How?
The step value for the `UnitControl` and `RangeControl` have been updated to 0.001 to handle 3 digits of decimal precession 

## Testing Instructions
- Open the page/post 
- Starting typing 
- Visit the `Typography` section on the right panel 
- Change the unit to rem and slide the unit slider 
- Notice the font size value is showing upto 3 decimal place 

## Screenshots or screencast 

https://github.com/user-attachments/assets/37b5459c-b09c-4274-971d-7b790472e32e
