### PR TITLE
Post Terms: Removing wp_kses_post causing issue

### DIFF
--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -49,9 +49,9 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 	$post_terms = get_the_term_list(
 		$block->context['postId'],
 		$attributes['term'],
-		wp_kses_post( $prefix ),
+		$prefix,
 		'<span class="wp-block-post-terms__separator">' . esc_html( $separator ) . '</span>',
-		wp_kses_post( $suffix )
+		$suffix 
 	);
 
 	if ( is_wp_error( $post_terms ) || empty( $post_terms ) ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/68742

## Why?
 The bg color of the prefix and suffix format is different from the normal display.

## How?
Removing wp_kses_post  which causing the issue. 

As mentioned in this [ticket](https://github.com/WordPress/gutenberg/pull/40803) 

`This probably isn't really necessary, but for consistency with the other blocks that have RichText fields and server-render those fields, I thought we could add it in. (Happy to close this out if folks think it doesn't need it).`

This removal mightn't affect anything.


## Testing Instructions

- Open a post or page.
- Insert a Post Terms block.
- Set the Prefix to a Color from the toolbar.
- When you look at the front you can see that the Background is not being rendered.


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->



Uploading Screenshare - 2025-01-21 8_38_06 PM.mp4…



