### PR TITLE
Remove HTML entities from post slug during cleaning

### DIFF
--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -15,6 +15,7 @@ import { Platform } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -999,7 +1000,9 @@ export function getPermalink( state ) {
 export function getEditedPostSlug( state ) {
 	return (
 		getEditedPostAttribute( state, 'slug' ) ||
-		cleanForSlug( getEditedPostAttribute( state, 'title' ) ) ||
+		cleanForSlug(
+			decodeEntities( getEditedPostAttribute( state, 'title' ) )
+		) ||
 		getCurrentPostId( state )
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR ensures that HTML entities, such as `&`, are properly decoded when generating post slugs. It modifies the `getEditedPostSlug` selector to decode entities in post titles before cleaning them for slug creation.


## Why?
The current implementation adds unnecessary HTML entities like amp to slugs when saving drafts. This behavior can cause confusion and lead to unnecessarily long or SEO-unfriendly URLs. For example, a draft title containing `&` becomes `/ampersand-amp-and/`, but upon publishing, it correctly becomes `/ampersand-and/`. This PR fixes the inconsistency by decoding HTML entities before cleaning the slug.

Fixes #62543

## How?

- Added decodeEntities from @wordpress/html-entities to the getEditedPostSlug selector.
- Updated the slug-cleaning process to decode HTML entities in the post title before passing it to cleanForSlug.

Code changes are minimal and located in `packages/editor/src/store/selectors.js`.

## Testing Instructions

1. Go to Settings > Permalinks and set the permalink structure to "Post name".
2. Create a new post with a title containing special characters, e.g., Ampersand & And.
3. Save the post as a draft.
4. Check the generated URL in the editor sidebar.
   - Before: /ampersand-amp-and/
   - After: /ampersand-and/
5. Publish the post and confirm the URL remains /ampersand-and/.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
