### PR TITLE
Spacer: Fix flex layout unit reset

### DIFF
--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -260,7 +260,7 @@ const SpacerEdit = ( {
 			isFlexLayout &&
 			selfStretch !== 'fill' &&
 			selfStretch !== 'fit' &&
-			! flexSize
+			flexSize === undefined
 		) {
 			if ( inheritedOrientation === 'horizontal' ) {
 				// If spacer is moving from a vertical container to a horizontal container,


### PR DESCRIPTION
fixes #51616 

alternate to https://github.com/WordPress/gutenberg/pull/68212

## What?
This PR fixes the issue where the unit in the spacer block resets to px when the input value is cleared.

## Why?
When removing the value from input fields like spacer block, the unit automatically resets to px. This behavior causes unexpected results and reduces user control over custom styles. Fixing this improves usability and ensures a consistent editing experience.

## How?
The fix was applied in `/packages/block-library/src/spacer/edit.js`, where the unit was being dropped due to useEffect hook not working as expected. The implementation reverses the change made to `flexSize === undefined`

## Testing Instructions

1. Open the WordPress editor (post or page).
2. Add a Spacer block inside a stack.
3. Change its unit to vh.
4. Clear the height value to input a new value.
5. Ensure the unit stays as vh and does not revert to px.

## Screencast

https://github.com/user-attachments/assets/6ce01b9f-534c-467d-96c6-833e99bb8fc1


