### PR TITLE
Spacer block: Fix dimension control when no spacing presets are available

### DIFF
--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -44,10 +44,6 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 		defaultValues: { px: 100, em: 10, rem: 10, vw: 10, vh: 25 },
 	} );
 
-	const handleOnChange = ( unprocessedValue ) => {
-		onChange( unprocessedValue.all );
-	};
-
 	// Force the unit to update to `px` when the Spacer is being resized.
 	const [ parsedQuantity, parsedUnit ] =
 		parseQuantityAndUnitFromRawValue( value );
@@ -57,23 +53,24 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 
 	return (
 		<>
-			{ ( ! spacingSizes || spacingSizes?.length === 0 ) && (
+			{ spacingSizes?.length < 2 ? (
 				<UnitControl
 					id={ inputId }
 					isResetValueOnUnitChange
 					min={ MIN_SPACER_SIZE }
-					onChange={ handleOnChange }
+					onChange={ onChange }
 					value={ computedValue }
 					units={ units }
 					label={ label }
 					__next40pxDefaultSize
 				/>
-			) }
-			{ spacingSizes?.length > 0 && (
+			) : (
 				<View className="tools-panel-item-spacing">
 					<SpacingSizesControl
 						values={ { all: computedValue } }
-						onChange={ handleOnChange }
+						onChange={ ( { all } ) => {
+							onChange( all );
+						} }
 						label={ label }
 						sides={ [ 'all' ] }
 						units={ units }


### PR DESCRIPTION
## What?
If no spacing presets are available then the dimension control is not supposed provide a way to pick from them.

It looks like the problem came about with #61842. In that PR, the [method of accessing the presets in the Spacer block’s controls was changed](https://github.com/WordPress/gutenberg/commit/75d0173916bee81173e99a9294f6d5bdc384f181#diff-dc82d64e09778668b1ce1591d521fcd10c745dd88bdf279455d55b32b180eba5L28-R32) and resulted in there always being at least one preset whereas before it may have been zero. That made the conditional display of a control for no presets unreachable and the control never shown.

## Why?
To match the apparent intention of the implementation and improve the UI.

## How?
- Changes the conditional to show the basic control when there are less than two presets.
- Uses a `onChange` adapter function only for the control with presets.

## Testing Instructions
1. Add a Spacer block in the editor (but not inside a flex layout like Row/Stack/Navigation)
2. Open the Block settings sidebar
3. Note that the Height control allows using presets
4. Paste and run the following snippet in the dev console to remove spacing presets:
   ```js
	wp.data.dispatch( 'core/block-editor' ).updateSettings( {
		__experimentalFeatures: {
			...wp.data.select( 'core/block-editor' ).getSettings().__experimentalFeatures,
			spacing: {},
		},
	} );
   ```
5. Note that the Height control has changed to the basic one without an option to use presets.

## Screenshots or screencast <!-- if applicable -->
In these the active theme specifies zero spacing presets:
|Before | After |
|-|-|
| <video src="https://github.com/user-attachments/assets/d42e9176-5b8e-4e85-acbd-89303ccf3476"/> | <video src="https://github.com/user-attachments/assets/e6b0e404-54e7-4c3b-9f16-f6b964012b92"/> |
