### PR TITLE
SpacerControls: default the height to `100px` if left unset

### DIFF
--- a/packages/block-library/src/spacer/constants.js
+++ b/packages/block-library/src/spacer/constants.js
@@ -1,1 +1,2 @@
 export const MIN_SPACER_SIZE = 0;
+export const DEFAULT_HEIGHT = '100px';

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -23,7 +23,7 @@ import { View } from '@wordpress/primitives';
  * Internal dependencies
  */
 import { unlock } from '../lock-unlock';
-import { MIN_SPACER_SIZE } from './constants';
+import { DEFAULT_HEIGHT, MIN_SPACER_SIZE } from './constants';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const { useSpacingSizes } = unlock( blockEditorPrivateApis );
@@ -100,7 +100,7 @@ export default function SpacerControls( {
 				resetAll={ () => {
 					setAttributes( {
 						width: undefined,
-						height: '100px',
+						height: DEFAULT_HEIGHT,
 					} );
 				} }
 				dropdownMenuProps={ dropdownMenuProps }
@@ -128,9 +128,9 @@ export default function SpacerControls( {
 					<ToolsPanelItem
 						label={ __( 'Height' ) }
 						isShownByDefault
-						hasValue={ () => height !== '100px' }
+						hasValue={ () => height !== DEFAULT_HEIGHT }
 						onDeselect={ () =>
-							setAttributes( { height: '100px' } )
+							setAttributes( { height: DEFAULT_HEIGHT } )
 						}
 					>
 						<DimensionInput

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -137,7 +137,7 @@ export default function SpacerControls( {
 							label={ __( 'Height' ) }
 							value={ height }
 							onChange={ ( nextHeight ) =>
-								setAttributes( { height: nextHeight } )
+								setAttributes( { height: nextHeight ?? '0px' } )
 							}
 							isResizing={ isResizing }
 						/>

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -137,7 +137,7 @@ export default function SpacerControls( {
 							label={ __( 'Height' ) }
 							value={ height }
 							onChange={ ( nextHeight ) =>
-								setAttributes( { height: nextHeight ?? '0px' } )
+								setAttributes( { height: nextHeight ?? '' } )
 							}
 							isResizing={ isResizing }
 						/>

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -137,7 +137,7 @@ export default function SpacerControls( {
 							label={ __( 'Height' ) }
 							value={ height }
 							onChange={ ( nextHeight ) =>
-								setAttributes( { height: nextHeight } )
+								setAttributes( { height: nextHeight ?? '' } )
 							}
 							isResizing={ isResizing }
 						/>

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -137,7 +137,7 @@ export default function SpacerControls( {
 							label={ __( 'Height' ) }
 							value={ height }
 							onChange={ ( nextHeight ) =>
-								setAttributes( { height: nextHeight ?? '' } )
+								setAttributes( { height: nextHeight } )
 							}
 							isResizing={ isResizing }
 						/>

--- a/packages/block-library/src/spacer/deprecated.js
+++ b/packages/block-library/src/spacer/deprecated.js
@@ -3,39 +3,59 @@
  */
 import { useBlockProps } from '@wordpress/block-editor';
 
-const deprecated = [
-	{
-		attributes: {
-			height: {
-				type: 'number',
-				default: 100,
-			},
-			width: {
-				type: 'number',
-			},
-		},
-		migrate( attributes ) {
-			const { height, width } = attributes;
-			return {
-				...attributes,
-				width: width !== undefined ? `${ width }px` : undefined,
-				height: height !== undefined ? `${ height }px` : undefined,
-			};
-		},
-		save( { attributes } ) {
-			return (
-				<div
-					{ ...useBlockProps.save( {
-						style: {
-							height: attributes.height,
-							width: attributes.width,
-						},
-						'aria-hidden': true,
-					} ) }
-				/>
-			);
+const deprecatedSave = ( { attributes } ) => {
+	return (
+		<div
+			{ ...useBlockProps.save( {
+				style: {
+					height: attributes.height,
+					width: attributes.width,
+				},
+				'aria-hidden': true,
+			} ) }
+		/>
+	);
+};
+
+const v2 = {
+	attributes: {
+		height: {
+			type: 'string',
 		},
 	},
-];
+	isEligible( { height, width } ) {
+		return height === undefined && width === undefined;
+	},
+	migrate( attributes ) {
+		return {
+			...attributes,
+			height: '',
+		};
+	},
+	save: deprecatedSave,
+};
+
+const v1 = {
+	attributes: {
+		height: {
+			type: 'number',
+			default: 100,
+		},
+		width: {
+			type: 'number',
+		},
+	},
+	migrate( attributes ) {
+		const { height, width } = attributes;
+		return {
+			...attributes,
+			width: width !== undefined ? `${ width }px` : undefined,
+			height: `${ height }px`,
+		};
+	},
+	save: deprecatedSave,
+};
+
+const deprecated = [ v2, v1 ];
 
 export default deprecated;

--- a/packages/block-library/src/spacer/deprecated.js
+++ b/packages/block-library/src/spacer/deprecated.js
@@ -3,60 +3,39 @@
  */
 import { useBlockProps } from '@wordpress/block-editor';
 
-const deprecatedSave = ( { attributes } ) => {
-	return (
-		<div
-			{ ...useBlockProps.save( {
-				style: {
-					height: attributes.height,
-					width: attributes.width,
-				},
-				'aria-hidden': true,
-			} ) }
-		/>
-	);
-};
+const deprecated = [
+	{
+		attributes: {
+			height: {
+				type: 'number',
+				default: 100,
+			},
+			width: {
+				type: 'number',
+			},
+		},
+		migrate( attributes ) {
+			const { height, width } = attributes;
+			return {
+				...attributes,
+				width: width !== undefined ? `${ width }px` : undefined,
+				height: height !== undefined ? `${ height }px` : undefined,
+			};
+		},
+		save( { attributes } ) {
+			return (
+				<div
+					{ ...useBlockProps.save( {
+						style: {
+							height: attributes.height,
+							width: attributes.width,
+						},
+						'aria-hidden': true,
+					} ) }
+				/>
+			);
+		},
+	},
+];
 
-const v2 = {
-	attributes: {
-		height: {
-			type: 'string',
-		},
-		width: {
-			type: 'string',
-		},
-	},
-	isEligible( { height, width } ) {
-		return height === undefined && width === undefined;
-	},
-	migrate( attributes ) {
-		return {
-			...attributes,
-			height: '',
-		};
-	},
-	save: deprecatedSave,
-};
-
-const v1 = {
-	attributes: {
-		height: {
-			type: 'number',
-			default: 100,
-		},
-		width: {
-			type: 'number',
-		},
-	},
-	migrate( attributes ) {
-		const { height, width } = attributes;
-		return {
-			...attributes,
-			width: width !== undefined ? `${ width }px` : undefined,
-			height: `${ height }px`,
-		};
-	},
-	save: deprecatedSave,
-};
-
-export default [ v2, v1 ];
+export default deprecated;

--- a/packages/block-library/src/spacer/deprecated.js
+++ b/packages/block-library/src/spacer/deprecated.js
@@ -22,6 +22,9 @@ const v2 = {
 		height: {
 			type: 'string',
 		},
+		width: {
+			type: 'string',
+		},
 	},
 	isEligible( { height, width } ) {
 		return height === undefined && width === undefined;

--- a/packages/block-library/src/spacer/deprecated.js
+++ b/packages/block-library/src/spacer/deprecated.js
@@ -56,6 +56,4 @@ const v1 = {
 	save: deprecatedSave,
 };
 
-const deprecated = [ v2, v1 ];
-
-export default deprecated;
+export default [ v2, v1 ];

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -169,7 +169,7 @@ const SpacerEdit = ( {
 
 	const getHeightForVerticalBlocks = () => {
 		if ( isFlexLayout ) {
-			return undefined;
+			return DEFAULT_HEIGHT;
 		}
 		return (
 			temporaryHeight ||
@@ -283,7 +283,7 @@ const SpacerEdit = ( {
 				const newSize =
 					getCustomValueFromPreset( width, spacingSizes ) ||
 					getCustomValueFromPreset( height, spacingSizes ) ||
-					'100px';
+					DEFAULT_HEIGHT;
 				setAttributesCovertly( {
 					width: '0px',
 					style: {
@@ -299,7 +299,7 @@ const SpacerEdit = ( {
 				const newSize =
 					getCustomValueFromPreset( height, spacingSizes ) ||
 					getCustomValueFromPreset( width, spacingSizes ) ||
-					'100px';
+					DEFAULT_HEIGHT;
 				setAttributesCovertly( {
 					height: '0px',
 					style: {

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -23,7 +23,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
  */
 import { unlock } from '../lock-unlock';
 import SpacerControls from './controls';
-import { MIN_SPACER_SIZE } from './constants';
+import { DEFAULT_HEIGHT, MIN_SPACER_SIZE } from './constants';
 
 const { useSpacingSizes } = unlock( blockEditorPrivateApis );
 
@@ -171,7 +171,11 @@ const SpacerEdit = ( {
 		if ( isFlexLayout ) {
 			return undefined;
 		}
-		return temporaryHeight || getSpacingPresetCssVar( height ) || '100px';
+		return (
+			temporaryHeight ||
+			getSpacingPresetCssVar( height ) ||
+			DEFAULT_HEIGHT
+		);
 	};
 
 	const getWidthForHorizontalBlocks = () => {

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -171,7 +171,7 @@ const SpacerEdit = ( {
 		if ( isFlexLayout ) {
 			return undefined;
 		}
-		return temporaryHeight || getSpacingPresetCssVar( height ) || undefined;
+		return temporaryHeight || getSpacingPresetCssVar( height ) || '100px';
 	};
 
 	const getWidthForHorizontalBlocks = () => {

--- a/packages/block-library/src/spacer/save.js
+++ b/packages/block-library/src/spacer/save.js
@@ -3,6 +3,8 @@
  */
 import { useBlockProps, getSpacingPresetCssVar } from '@wordpress/block-editor';
 
+const DEFAULT_HEIGHT = '100px';
+
 export default function save( { attributes } ) {
 	const { height, width, style } = attributes;
 	const { layout: { selfStretch } = {} } = style || {};
@@ -13,7 +15,8 @@ export default function save( { attributes } ) {
 		<div
 			{ ...useBlockProps.save( {
 				style: {
-					height: getSpacingPresetCssVar( finalHeight ),
+					height:
+						getSpacingPresetCssVar( finalHeight ) || DEFAULT_HEIGHT,
 					width: getSpacingPresetCssVar( width ),
 				},
 				'aria-hidden': true,

--- a/packages/block-library/src/spacer/save.js
+++ b/packages/block-library/src/spacer/save.js
@@ -3,7 +3,10 @@
  */
 import { useBlockProps, getSpacingPresetCssVar } from '@wordpress/block-editor';
 
-const DEFAULT_HEIGHT = '100px';
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_HEIGHT } from './constants';
 
 export default function save( { attributes } ) {
 	const { height, width, style } = attributes;


### PR DESCRIPTION
## What, Why and How?

Fixes: #68817 

When the height of the `spacer block` is set to `undefined`, on reloading the editor, a `Recovery Error` is shown for the `Spacer Block`.

The root cause of the problem lies in the fact that the default value of `height` attribute defined in `block.json` is `100px`, therefore, whenever the `height` attribute is made `undefined`, on reload, the default value kicks in and causes a mismatch in the content generated by the `save` function as well as the `post body` leading to this warning:
```
Content generated by the `save` function:
<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>

Content retrieved from post body:
<div aria-hidden="true" class="wp-block-spacer"></div>
```

There are two potential solutions for this problem:
1. Remove the default value of height attribute (`100px`) from `block.json`.
https://github.com/WordPress/gutenberg/blob/a60dd78e467a1e2de68b40eca3aaa9d51b085020/packages/block-library/src/spacer/block.json#L12

2. Save `0px` if height is `undefined`.

The later approach i.e. (2) makes more sense as:
i. This is how the height slider implements it.
ii. Width follows a similar approach.
iii. It doesn't quite make sense to save the height of the `spacer` as `undefined`.

## Testing Instructions
1. Create a spacer block.
2. Set its height to `undefined` by trying to save an empty input.
3. Save and reload the page and confirm no `Block Recovery` error occurs.

## Screencast

https://github.com/user-attachments/assets/dce43133-4d09-4737-8a6b-9ce7869d188e
