### PR TITLE
Fix: Audio block: Media picker allows non-audio items

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -160,6 +160,39 @@ export function MediaPlaceholder( {
 		setSrc( value?.src ?? '' );
 	}, [ value?.src ] );
 
+	const handleMediaSelection = ( selectedMedia ) => {
+		if ( Array.isArray( selectedMedia ) ) {
+			const validMedia = selectedMedia.filter( ( media ) => {
+				const mediaType = media.type?.split( '/' )[ 0 ];
+				return (
+					allowedTypes?.includes( mediaType ) ||
+					allowedTypes?.includes( media.type )
+				);
+			} );
+
+			if ( validMedia.length !== selectedMedia.length ) {
+				onError( __( 'Some files are not allowed.' ) );
+
+				if ( validMedia.length === 0 ) {
+					return;
+				}
+			}
+
+			onSelect( validMedia );
+		} else {
+			const mediaType = selectedMedia.type?.split( '/' )[ 0 ];
+			if (
+				! allowedTypes?.includes( mediaType ) ||
+				! allowedTypes?.includes( selectedMedia.type )
+			) {
+				onError( __( 'File type not allowed.' ) );
+				return;
+			}
+
+			onSelect( selectedMedia );
+		}
+	};
+
 	const onlyAllowsImages = () => {
 		if ( ! allowedTypes || allowedTypes.length === 0 ) {
 			return false;
@@ -451,7 +484,7 @@ export function MediaPlaceholder( {
 				addToGallery={ addToGallery }
 				gallery={ multiple && onlyAllowsImages() }
 				multiple={ multiple }
-				onSelect={ onSelect }
+				onSelect={ handleMediaSelection }
 				allowedTypes={ allowedTypes }
 				mode="browse"
 				value={


### PR DESCRIPTION
Fixes [#56607](https://github.com/WordPress/gutenberg/issues/56607)

## What?
Fixes the Media Placeholder component in the Audio block to properly validate media types, preventing non-audio files from being selected in the Audio block.

## Why?
Currently, when using the Media Library option in the Audio block, users can select non-audio media items and that were able to add in Audio block.

## How?
- Adding a new `handleMediaSelection` function that validates media types before processing

## Screenshots or screencast <!-- if applicable -->
### Before
[screen-capture (6).webm](https://github.com/user-attachments/assets/ded0d3ca-5c25-4e33-85a7-a9fbd049753d)

### After
[screen-capture (7).webm](https://github.com/user-attachments/assets/6e4bf664-bed6-4c7f-95fd-8c4262d0e427)


