### PR TITLE
Font size picker: Fix i10n and a11y for `HeaderLabel`

### DIFF
--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -6,7 +6,7 @@ import type { ForwardedRef } from 'react';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { settings } from '@wordpress/icons';
 import {
 	useState,
@@ -140,13 +140,7 @@ const UnforwardedFontSizePicker = (
 			<VisuallyHidden as="legend">{ __( 'Font size' ) }</VisuallyHidden>
 			<Spacer>
 				<Header className="components-font-size-picker__header">
-					<HeaderLabel
-						aria-label={ sprintf(
-							/* translators: %s: Additional header hint. */
-							__( 'Size %s' ),
-							headerHint || ''
-						) }
-					>
+					<HeaderLabel>
 						{ createInterpolateElement(
 							__( 'Size <HeaderHint />' ),
 							{

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -6,9 +6,14 @@ import type { ForwardedRef } from 'react';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { settings } from '@wordpress/icons';
-import { useState, useMemo, forwardRef } from '@wordpress/element';
+import {
+	useState,
+	useMemo,
+	forwardRef,
+	createInterpolateElement,
+} from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -136,13 +141,23 @@ const UnforwardedFontSizePicker = (
 			<Spacer>
 				<Header className="components-font-size-picker__header">
 					<HeaderLabel
-						aria-label={ `${ __( 'Size' ) } ${ headerHint || '' }` }
+						aria-label={ sprintf(
+							/* translators: %s: Additional header hint. */
+							__( 'Size %s' ),
+							headerHint || ''
+						) }
 					>
-						{ __( 'Size' ) }
-						{ headerHint && (
-							<HeaderHint className="components-font-size-picker__header__hint">
-								{ headerHint }
-							</HeaderHint>
+						{ createInterpolateElement(
+							__( 'Size <HeaderHint />' ),
+							{
+								HeaderHint: headerHint ? (
+									<HeaderHint className="components-font-size-picker__header__hint">
+										{ headerHint }
+									</HeaderHint>
+								) : (
+									<></>
+								),
+							}
 						) }
 					</HeaderLabel>
 					{ ! disableCustomFontSizes && (


### PR DESCRIPTION
Closes: https://github.com/WordPress/gutenberg/issues/63810

## What?
- This PR refactors the `font-size-picker` component to improve the translation in the HeaderLabel. It ensures that text concatenation issues are resolved for gendered languages (e.g., Italian).
- There is an aria-label in the HeaderLabel component, which renders a `<span>`. Since this element is non-interactive and purely for display purposes, having an aria-label here does not make sense, as it would be ignored by screen readers.

## Why?

Currently, the `font-size-picker` renders text by concatenating strings (e.g., "Size " + headerHint), which makes translation inaccurate for languages with gendered nouns. For example, in Italian, the noun 'Size' is translated to the feminine form "Dimensione," but concatenating it with size adjectives (which are masculine) results in incorrect translations like "Dimensione piccolo" (incorrect).

## How?

- Refactored the `HeaderLabel` component to use `createInterpolateElement` for proper translation of Size and headerHint.
- Removed the aria-label in the `HeaderLabel`.


