### PR TITLE
Add Support for Searching by Multiple Option Properties to `ComboboxControl`

### DIFF
--- a/packages/components/src/combobox-control/README.md
+++ b/packages/components/src/combobox-control/README.md
@@ -40,7 +40,7 @@ function MyComboboxControl() {
 			value={ fontSize }
 			onChange={ setFontSize }
 			options={ filteredOptions }
-			filterProperties={ ['value', 'label'] }
+			filterFields={ ['value', 'label'] }
 			onFilterValueChange={ ( inputValue ) =>
 				setFilteredOptions(
 					options.filter( ( option ) =>
@@ -92,7 +92,7 @@ Function called when the control's search input value changes. The argument cont
 -   Type: `( value: string ) => void`
 -   Required: No
 
-#### filterProperties
+#### filterFields
 
 The list of option properties that should be used for filtering the options.
 

--- a/packages/components/src/combobox-control/README.md
+++ b/packages/components/src/combobox-control/README.md
@@ -40,10 +40,13 @@ function MyComboboxControl() {
 			value={ fontSize }
 			onChange={ setFontSize }
 			options={ filteredOptions }
+			filterProperties={ ['value', 'label'] }
 			onFilterValueChange={ ( inputValue ) =>
 				setFilteredOptions(
 					options.filter( ( option ) =>
-						option.value === inputValue
+						['value', 'label'].some((key) =>
+							option[key]?.toLowerCase().includes(inputValue.toLowerCase())
+						)
 					)
 				)
 			}
@@ -89,9 +92,17 @@ Function called when the control's search input value changes. The argument cont
 -   Type: `( value: string ) => void`
 -   Required: No
 
+#### filterProperties
+
+The list of option properties that should be used for filtering the options.
+
+-   Type: `Array<string>`
+-   Required: No
+-   Default: `['value']`
+
 #### onChange
 
-Function called with the selected value changes.
+Function called when the selected value changes.
 
 -   Type: `( value: string | null | undefined ) => void`
 -   Required: No

--- a/packages/components/src/combobox-control/index.tsx
+++ b/packages/components/src/combobox-control/index.tsx
@@ -132,6 +132,7 @@ function ComboboxControl( props: ComboboxControlProps ) {
 		__experimentalRenderItem,
 		expandOnFocus = true,
 		placeholder,
+		filterFields = 'label',
 	} = useDeprecated36pxDefaultSizeProp( props );
 
 	const [ value, setValue ] = useControlledValue( {
@@ -157,17 +158,33 @@ function ComboboxControl( props: ComboboxControlProps ) {
 		const startsWithMatch: ComboboxControlOption[] = [];
 		const containsMatch: ComboboxControlOption[] = [];
 		const match = normalizeTextString( inputValue );
+		const searchFields = Array.isArray( filterFields )
+			? filterFields
+			: [ filterFields ];
+
 		options.forEach( ( option ) => {
-			const index = normalizeTextString( option.label ).indexOf( match );
-			if ( index === 0 ) {
-				startsWithMatch.push( option );
-			} else if ( index > 0 ) {
-				containsMatch.push( option );
+			for ( const field of searchFields ) {
+				if ( ! option[ field ] ) {
+					continue;
+				}
+
+				const fieldValue = normalizeTextString(
+					String( option[ field ] )
+				);
+				const index = fieldValue.indexOf( match );
+
+				if ( index === 0 ) {
+					startsWithMatch.push( option );
+					break;
+				} else if ( index > 0 ) {
+					containsMatch.push( option );
+					break;
+				}
 			}
 		} );
 
 		return startsWithMatch.concat( containsMatch );
-	}, [ inputValue, options ] );
+	}, [ inputValue, options, filterFields ] );
 
 	const onSuggestionSelected = (
 		newSelectedSuggestion: ComboboxControlOption

--- a/packages/components/src/combobox-control/types.ts
+++ b/packages/components/src/combobox-control/types.ts
@@ -86,4 +86,11 @@ export type ComboboxControlProps = Pick<
 	 * If passed, the combobox input will show a placeholder string if no values are present.
 	 */
 	placeholder?: string;
+
+	/**
+	 * Specify which option field(s) to use for filtering suggestions.
+	 * Can be a single field name or an array of field names.
+	 * @default 'label'
+	 */
+	filterFields?: string | string[];
 };


### PR DESCRIPTION
## Why?
This PR is intended to solve issue mentioned here: https://github.com/WordPress/gutenberg/issues/68760

## How?
- Introduced a new filterKeys prop that allows specifying which properties should be considered when filtering options.
- Updated the filtering logic to iterate through the defined properties and match against the input value.
- Added support for partial matching across specified properties.
- Updated the component's README documentation to reflect the new feature and usage guidelines.

## Testing Instructions
1. Open the WordPress block editor.
2. Insert a block that uses the `ComboboxControl` component.
3. Pass an array of options containing multiple properties (e.g., value, label, description).
4. Set the filterKeys prop to ['label', 'description'].
5. Type a query in the search input and verify that matching occurs across the specified fields.
6. Ensure selections work correctly and the correct value is passed to the onChange handler.

## Screenshots or screencast

https://github.com/user-attachments/assets/ec650686-07f8-4f9c-bd13-0041e401f6fd


