### PR TITLE
Refactor PlainText component

### DIFF
--- a/packages/block-editor/src/components/plain-text/index.native.js
+++ b/packages/block-editor/src/components/plain-text/index.native.js
@@ -1,164 +1,164 @@
 /**
  * External dependencies
  */
-import { TextInput, Platform, Dimensions } from 'react-native';
-
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import React, {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+} from '@wordpress/element';
+import { TextInput, Platform, Dimensions } from 'react-native';
 import { getPxFromCssUnit } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import RichText from '../rich-text';
-
-/**
- * Internal dependencies
- */
 import styles from './style.scss';
 
-export default class PlainText extends Component {
-	constructor() {
-		super( ...arguments );
-		this.isAndroid = Platform.OS === 'android';
+function PlainText( props ) {
+	const {
+		isSelected,
+		style,
+		__experimentalVersion,
+		onFocus,
+		onBlur,
+		onChange,
+		...otherProps
+	} = props;
 
-		this.onChangeTextInput = this.onChangeTextInput.bind( this );
-		this.onChangeRichText = this.onChangeRichText.bind( this );
-	}
+	const inputRef = useRef( null );
+	const timeoutRef = useRef( null );
+	const prevIsSelectedRef = useRef( isSelected );
+	const isAndroid = useMemo( () => Platform.OS === 'android', [] );
 
-	componentDidMount() {
-		// If isSelected is true, we should request the focus on this TextInput.
-		if (
-			this._input &&
-			this._input.isFocused() === false &&
-			this.props.isSelected
-		) {
-			if ( this.isAndroid ) {
-				/*
-				 * There seems to be an issue in React Native where the keyboard doesn't show if called shortly after rendering.
-				 * As a common work around this delay is used.
-				 * https://github.com/facebook/react-native/issues/19366#issuecomment-400603928
-				 */
-				this.timeoutID = setTimeout( () => {
-					this._input.focus();
-				}, 100 );
-			} else {
-				this._input.focus();
-			}
-		}
-	}
-
-	componentDidUpdate( prevProps ) {
-		if ( ! this.props.isSelected && prevProps.isSelected ) {
-			this._input?.blur();
-		}
-	}
-
-	componentWillUnmount() {
-		if ( this.isAndroid ) {
-			clearTimeout( this.timeoutID );
-		}
-	}
-
-	focus() {
-		this._input?.focus();
-	}
-
-	blur() {
-		this._input?.blur();
-	}
-
-	getFontSize() {
-		const { style } = this.props;
-
+	const getFontSize = useCallback( () => {
 		if ( ! style?.fontSize ) {
 			return;
 		}
-
 		const { width, height } = Dimensions.get( 'window' );
 		const cssUnitOptions = { height, width };
-
 		return {
 			fontSize: parseFloat(
 				getPxFromCssUnit( style.fontSize, cssUnitOptions )
 			),
 		};
-	}
+	}, [ style?.fontSize ] );
 
-	replaceLineBreakTags( value ) {
-		return value?.replace( RegExp( '<br>', 'gim' ), '\n' );
-	}
+	const replaceLineBreakTags = useCallback( ( value ) => {
+		return value?.replace( /<br>/gim, '\n' );
+	}, [] );
 
-	onChangeTextInput( event ) {
-		const { onChange } = this.props;
-		onChange( event.nativeEvent.text );
-	}
+	const onChangeTextInput = useCallback(
+		( event ) => {
+			onChange( event.nativeEvent.text );
+		},
+		[ onChange ]
+	);
 
-	onChangeRichText( value ) {
-		const { onChange } = this.props;
-		// The <br> tags have to be replaced with new line characters
-		// as the content of plain text shouldn't contain HTML tags.
-		onChange( this.replaceLineBreakTags( value ) );
-	}
+	const onChangeRichText = useCallback(
+		( value ) => {
+			// The <br> tags have to be replaced with new line characters
+			// as the content of plain text shouldn't contain HTML tags.
+			onChange( replaceLineBreakTags( value ) );
+		},
+		[ onChange, replaceLineBreakTags ]
+	);
 
-	render() {
-		const { style, __experimentalVersion, onFocus, ...otherProps } =
-			this.props;
-		const textStyles = [
-			style || styles[ 'block-editor-plain-text' ],
-			this.getFontSize(),
-		];
-
-		if ( __experimentalVersion === 2 ) {
-			const disableFormattingProps = {
-				withoutInteractiveFormatting: true,
-				disableEditingMenu: true,
-				__unstableDisableFormats: true,
-				disableSuggestions: true,
-			};
-
-			const forcePlainTextProps = {
-				preserveWhiteSpace: true,
-				__unstablePastePlainText: true,
-				multiline: false,
-			};
-
-			const fontProps = {
-				fontFamily: style?.fontFamily,
-				fontSize: style?.fontSize,
-				fontWeight: style?.fontWeight,
-			};
-
-			return (
-				<RichText
-					{ ...otherProps }
-					{ ...disableFormattingProps }
-					{ ...forcePlainTextProps }
-					{ ...fontProps }
-					identifier="content"
-					style={ style }
-					onChange={ this.onChangeRichText }
-					unstableOnFocus={ onFocus }
-				/>
-			);
+	useEffect( () => {
+		if (
+			inputRef.current &&
+			! inputRef.current.isFocused() &&
+			isSelected
+		) {
+			if ( isAndroid ) {
+				/*
+				 * There seems to be an issue in React Native where the keyboard doesn't show if called shortly after rendering.
+				 * As a common work around this delay is used.
+				 * https://github.com/facebook/react-native/issues/19366#issuecomment-400603928
+				 */
+				timeoutRef.current = setTimeout( () => {
+					inputRef.current?.focus();
+				}, 100 );
+			} else {
+				inputRef.current?.focus();
+			}
 		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	useEffect( () => {
+		if ( ! isSelected && prevIsSelectedRef.current ) {
+			inputRef.current?.blur();
+		}
+		prevIsSelectedRef.current = isSelected;
+	}, [ isSelected ] );
+
+	useEffect( () => {
+		return () => {
+			if ( isAndroid && timeoutRef.current ) {
+				clearTimeout( timeoutRef.current );
+			}
+		};
+	}, [ isAndroid ] );
+
+	const textStyles = useMemo(
+		() => [ style || styles[ 'block-editor-plain-text' ], getFontSize() ],
+		[ style, getFontSize ]
+	);
+
+	if ( __experimentalVersion === 2 ) {
+		const disableFormattingProps = {
+			withoutInteractiveFormatting: true,
+			disableEditingMenu: true,
+			__unstableDisableFormats: true,
+			disableSuggestions: true,
+		};
+
+		const forcePlainTextProps = {
+			preserveWhiteSpace: true,
+			__unstablePastePlainText: true,
+			multiline: false,
+		};
+
+		const fontProps = {
+			fontFamily: style?.fontFamily,
+			fontSize: style?.fontSize,
+			fontWeight: style?.fontWeight,
+		};
 
 		return (
-			<TextInput
-				{ ...this.props }
-				ref={ ( x ) => ( this._input = x ) }
-				onChange={ this.onChangeTextInput }
-				onFocus={ this.props.onFocus } // Always assign onFocus as a props.
-				onBlur={ this.props.onBlur } // Always assign onBlur as a props.
-				fontFamily={
-					( this.props.style && this.props.style.fontFamily ) ||
-					styles[ 'block-editor-plain-text' ].fontFamily
-				}
-				style={ textStyles }
-				scrollEnabled={ false }
+			<RichText
+				{ ...otherProps }
+				{ ...disableFormattingProps }
+				{ ...forcePlainTextProps }
+				{ ...fontProps }
+				identifier="content"
+				style={ style }
+				onChange={ onChangeRichText }
+				unstableOnFocus={ onFocus }
 			/>
 		);
 	}
+
+	return (
+		<TextInput
+			{ ...otherProps }
+			ref={ inputRef }
+			onChange={ onChangeTextInput }
+			onFocus={ onFocus } // Always assign onFocus as a props.
+			onBlur={ onBlur } // Always assign onBlur as a props.
+			fontFamily={
+				style?.fontFamily ||
+				styles[ 'block-editor-plain-text' ].fontFamily
+			}
+			style={ textStyles }
+			scrollEnabled={ false }
+		/>
+	);
 }
+
+export default React.memo( PlainText );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Refactor the `PlainText` React component from a React Class to a Functional Component.

## Why?
React introduced Hooks in version 16.8 and recommends defining components as functions instead of classes.

## How?
[Following this document](https://react.dev/reference/react/PureComponent#alternatives)

## Testing Instructions
1. Open a post or page in the editor.
2. Insert a Plain Text block.
3. Enter and edit text content.
4. Ensure the text is displayed and saved as expected.
