### PR TITLE
Feat: Block Options Add alongside / Add next to option #56379

### DIFF
--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -6,6 +6,7 @@ import {
 	hasBlockSupport,
 	switchToBlockType,
 	store as blocksStore,
+	createBlock,
 } from '@wordpress/blocks';
 
 /**
@@ -93,6 +94,44 @@ export default function BlockActions( {
 		},
 		onInsertAfter() {
 			insertAfterBlock( clientIds[ clientIds.length - 1 ] );
+		},
+		onAddAlongside() {
+			if ( ! clientIds.length ) {
+				return;
+			}
+
+			const originalBlock = getBlocksByClientId( clientIds )[ 0 ];
+
+			if ( ! originalBlock ) {
+				return;
+			}
+
+			const groupingBlockName = getGroupingBlockName();
+
+			// Create the new block to go alongside
+			const newBlock = createBlock( getDefaultBlockName() );
+
+			// Create the row/group block with flex layout
+			const rowBlock = createBlock(
+				groupingBlockName,
+				{
+					layout: {
+						type: 'flex',
+						orientation: 'horizontal',
+						justifyContent: 'left',
+					},
+				},
+				[
+					createBlock(
+						originalBlock.name,
+						originalBlock.attributes,
+						originalBlock.innerBlocks
+					),
+					newBlock,
+				]
+			);
+
+			replaceBlocks( clientIds, rowBlock, 0, 0 );
 		},
 		onGroup() {
 			if ( ! clientIds.length ) {

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -214,6 +214,7 @@ export function BlockSettingsDropdown( {
 				canRemove,
 				onDuplicate,
 				onInsertAfter,
+				onAddAlongside,
 				onInsertBefore,
 				onRemove,
 				onCopy,
@@ -305,6 +306,14 @@ export function BlockSettingsDropdown( {
 												}
 											>
 												{ __( 'Add after' ) }
+											</MenuItem>
+											<MenuItem
+												onClick={ pipe(
+													onClose,
+													onAddAlongside
+												) }
+											>
+												{ __( 'Add alongside' ) }
 											</MenuItem>
 										</>
 									) }


### PR DESCRIPTION
Fixes [#56379](https://github.com/WordPress/gutenberg/issues/56379)

## What?
This PR adds a new "Add alongside" option in the block toolbar that allows users to quickly create side-by-side (horizontal) layouts by wrapping the selected block in a flex group.

## Why?
Currently, creating side-by-side layouts requires multiple steps and understanding of block structure. Users who don't understand web layout concepts find it confusing that we only have "Add before" and "Add after" options, since visually adjacent blocks appear to be "alongside" each other. This PR makes it more intuitive to create horizontal layouts.

## How?
- Added a new onAddAlongside action in BlockActions component
- Added corresponding menu item in BlockSettingsDropdown component
- The action wraps the selected block in a Group block with flex layout and adds a new default block next to it

## Testing Instructions
1. Open the block editor
2. Insert any block (e.g., paragraph or heading)
3. Click the block toolbar's menu (three dots)
4. Click "Add alongside"
5. Verify that:
   a. The original block is now inside a Group block with flex layout
   b. A new empty block appears next to the original block
   c. Both blocks are horizontally aligned

## Screenshots or screencast <!-- if applicable -->
[screen-capture (4).webm](https://github.com/user-attachments/assets/b86e05cc-6bd4-483f-8608-80e4a3e88a7a)

![Screenshot 2025-01-22 at 2 51 49 PM](https://github.com/user-attachments/assets/62f24bb2-d8ee-4b7d-a63d-d9959744a104)

