### PR TITLE
Adds JSDoc for all form elements

### DIFF
--- a/packages/block-library/src/form-input/edit.js
+++ b/packages/block-library/src/form-input/edit.js
@@ -18,6 +18,22 @@ import { PanelBody, TextControl, CheckboxControl } from '@wordpress/components';
 
 import { useRef } from '@wordpress/element';
 
+/*
+ * InputFieldBlock - A WordPress block for rendering and managing input fields with customizable attributes.
+ *
+ * @param {Object} props 									Component properties.
+ * @param {Object} props.attributes 						The block's attributes.
+ * @param {string} props.attributes.type 					The type of the input field (e.g., 'text', 'checkbox', 'textarea', 'hidden').
+ * @param {string} props.attributes.name 					The name attribute for the input field.
+ * @param {string} props.attributes.label 					The label text for the input field.
+ * @param {boolean} props.attributes.inlineLabel 			Determines if the label is inline with the input field.
+ * @param {boolean} props.attributes.required 				Indicates whether the input field is required.
+ * @param {string} props.attributes.placeholder 			The placeholder text for the input field.
+ * @param {string} props.attributes.value 					The value of the input field.
+ * @param {Function} props.setAttributes 					Function to update block attributes.
+ * @param {string} props.className 							The class name for the block.
+ * @returns {JSX.Element} 									The rendered InputFieldBlock component.
+ */
 function InputFieldBlock( { attributes, setAttributes, className } ) {
 	const { type, name, label, inlineLabel, required, placeholder, value } =
 		attributes;

--- a/packages/block-library/src/form-submission-notification/edit.js
+++ b/packages/block-library/src/form-submission-notification/edit.js
@@ -26,6 +26,15 @@ const TEMPLATE = [
 	],
 ];
 
+/*
+ * Edit - The edit function for the custom block, allowing configuration and rendering within the block editor.
+ *
+ * @param {Object} props 							Component properties.
+ * @param {Object} props.attributes 				The attributes of the block.
+ * @param {string} props.attributes.type 			The notification type (e.g., 'success', 'error').
+ * @param {string} props.clientId 					The unique identifier for the block instance.
+ * @returns {JSX.Element} 							The rendered edit component.
+ */
 const Edit = ( { attributes, clientId } ) => {
 	const { type } = attributes;
 	const blockProps = useBlockProps( {

--- a/packages/block-library/src/form-submit-button/edit.js
+++ b/packages/block-library/src/form-submit-button/edit.js
@@ -20,6 +20,12 @@ const TEMPLATE = [
 		],
 	],
 ];
+
+/*
+ * Edit - The edit function for the custom block, defining its structure and behavior in the block editor.
+ *
+ * @returns {JSX.Element} The rendered edit component.
+ */
 const Edit = () => {
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {

--- a/packages/block-library/src/form/edit.js
+++ b/packages/block-library/src/form/edit.js
@@ -50,6 +50,23 @@ const TEMPLATE = [
 	[ 'core/form-submit-button', {} ],
 ];
 
+/*
+ * Edit component for the custom form block.
+ *
+ * This function renders the block's edit interface in the WordPress block editor, allowing users to configure
+ * form submission settings and define inner block content. The form block supports email and custom submission methods.
+ *
+ * @param {Object} props 									Component properties.
+ * @param {Object} props.attributes 						The block's attributes.
+ * @param {string} props.attributes.action 					The action URL for the form submission.
+ * @param {string} props.attributes.method 					The HTTP method for the form submission (e.g., 'get', 'post').
+ * @param {string} props.attributes.email 					The email address for form submissions (used in "email" mode).
+ * @param {string} props.attributes.submissionMethod 		The method for handling form submissions ('email' or 'custom').
+ * @param {Function} props.setAttributes 					Function to update block attributes.
+ * @param {string} props.clientId 							The unique client ID for the block instance.
+ *
+ * @returns {JSX.Element} The edit interface for the custom form block.
+ */
 const Edit = ( { attributes, setAttributes, clientId } ) => {
 	const { action, method, email, submissionMethod } = attributes;
 	const blockProps = useBlockProps();


### PR DESCRIPTION
## What?

This PR adds the JSDoc comment for all Form block.

## Why?

Part of https://github.com/WordPress/gutenberg/issues/64057