### PR TITLE
Release Workflow: Install Subversion

### DIFF
--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -167,6 +167,9 @@ jobs:
             VERSION: ${{ github.event.release.name }}
 
         steps:
+            - name: Install Subversion
+              run: |
+                  apt-get update -y && apt-get install -y subversion
             - name: Check out Gutenberg trunk from WP.org plugin repo
               run: |
                   svn checkout "$PLUGIN_REPO_URL/trunk" --username "$SVN_USERNAME" --password "$SVN_PASSWORD"

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -170,6 +170,7 @@ jobs:
             - name: Install Subversion
               run: |
                   apt-get update -y && apt-get install -y subversion
+
             - name: Check out Gutenberg trunk from WP.org plugin repo
               run: |
                   svn checkout "$PLUGIN_REPO_URL/trunk" --username "$SVN_USERNAME" --password "$SVN_PASSWORD"

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -226,6 +226,10 @@ jobs:
             VERSION: ${{ github.event.release.name }}
 
         steps:
+            - name: Install Subversion
+              run: |
+                  apt-get update -y && apt-get install -y subversion
+
             - name: Download and unzip Gutenberg plugin asset into tags folder
               env:
                   PLUGIN_URL: ${{ github.event.release.assets[0].browser_download_url }}


### PR DESCRIPTION
## What?
Adds step to install manually `svn` for plugin release workflow.

## Why?
The latest GitHub action runners remove `svn`. See https://github.com/actions/runner-images/issues/9848.

## Testing Instructions
