### PR TITLE
Editor: children prop to accept `ReactNode`

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1476,12 +1476,12 @@ A component which renders its own children only if the current editor post type 
 _Parameters_
 
 -   _props_ `Object`: Props.
--   _props.children_ `React.ReactElement`: Children to be rendered if post type supports.
+-   _props.children_ `React.ReactNode`: Children to be rendered if post type supports.
 -   _props.supportKeys_ `(string|string[])`: String or string array of keys to test.
 
 _Returns_
 
--   `React.ReactElement`: The component to be rendered.
+-   `React.ReactNode`: The component to be rendered.
 
 ### PostURL
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -293,11 +293,11 @@ Component check if there are any headings (core/heading blocks) present in the d
 _Parameters_
 
 -   _props_ `Object`: Props.
--   _props.children_ `React.ReactElement`: Children to be rendered.
+-   _props.children_ `React.ReactNode`: Children to be rendered.
 
 _Returns_
 
--   `React.ReactElement`: The component to be rendered or null if there are headings.
+-   `React.ReactNode`: The component to be rendered or null if there are headings.
 
 ### EditorHistoryRedo
 
@@ -524,11 +524,11 @@ Wrapper component that renders its children only if the post type supports page 
 _Parameters_
 
 -   _props_ `Object`: - The component props.
--   _props.children_ `React.ReactElement`: - The child components to render.
+-   _props.children_ `React.ReactNode`: - The child components to render.
 
 _Returns_
 
--   `React.ReactElement`: The rendered child components or null if page attributes are not supported.
+-   `React.ReactNode`: The rendered child components or null if page attributes are not supported.
 
 ### PageAttributesOrder
 
@@ -1211,11 +1211,11 @@ This component checks the publishing status of the current post. If the post is 
 _Parameters_
 
 -   _props_ `Object`: Component properties.
--   _props.children_ `React.ReactElement`: Children to be rendered.
+-   _props.children_ `React.ReactNode`: Children to be rendered.
 
 _Returns_
 
--   `React.ReactElement`: The rendered child elements or null if the post is already published or the user doesn't have the capability to publish.
+-   `React.ReactNode`: The rendered child elements or null if the post is already published or the user doesn't have the capability to publish.
 
 ### PostPingbacks
 
@@ -1287,11 +1287,11 @@ Wrapper component that renders its children only if post has a publish action.
 _Parameters_
 
 -   _props_ `Object`: Props.
--   _props.children_ `React.ReactElement`: Children to be rendered.
+-   _props.children_ `React.ReactNode`: Children to be rendered.
 
 _Returns_
 
--   `React.ReactElement`: - The component to be rendered or null if there is no publish action.
+-   `React.ReactNode`: - The component to be rendered or null if there is no publish action.
 
 ### PostScheduleLabel
 
@@ -1328,11 +1328,11 @@ Wrapper component that renders its children only if post has a sticky action.
 _Parameters_
 
 -   _props_ `Object`: Props.
--   _props.children_ `React.ReactElement`: Children to be rendered.
+-   _props.children_ `React.ReactNode`: Children to be rendered.
 
 _Returns_
 
--   `React.ReactElement`: The component to be rendered or null if post type is not 'post' or hasStickyAction is false.
+-   `React.ReactNode`: The component to be rendered or null if post type is not 'post' or hasStickyAction is false.
 
 ### PostSwitchToDraftButton
 
@@ -1374,7 +1374,7 @@ _Parameters_
 
 _Returns_
 
--   `React.ReactElement`: The rendered children components or null if the current post type has no taxonomies.
+-   `React.ReactNode`: The rendered children components or null if the current post type has no taxonomies.
 
 ### PostTaxonomiesFlatTermSelector
 
@@ -1463,11 +1463,11 @@ Wrapper component that renders its children only if the post can be trashed.
 _Parameters_
 
 -   _props_ `Object`: The component props.
--   _props.children_ `React.ReactElement`: The child components.
+-   _props.children_ `React.ReactNode`: The child components.
 
 _Returns_
 
--   `React.ReactElement | null`: The rendered child components or null if the post can't be trashed.
+-   `React.ReactNode`: The rendered child components or null if the post can't be trashed.
 
 ### PostTypeSupportCheck
 
@@ -1509,11 +1509,11 @@ Check if the post URL is valid and visible.
 _Parameters_
 
 -   _props_ `Object`: The component props.
--   _props.children_ `React.ReactElement`: The child components.
+-   _props.children_ `React.ReactNode`: The child components.
 
 _Returns_
 
--   `React.ReactElement`: The child components if the post URL is valid and visible, otherwise null.
+-   `React.ReactNode`: The child components if the post URL is valid and visible, otherwise null.
 
 ### PostURLLabel
 
@@ -1657,12 +1657,12 @@ Checks if the current theme supports specific features and renders the children 
 _Parameters_
 
 -   _props_ `Object`: The component props.
--   _props.children_ `React.ReactElement`: The children to render if the theme supports the specified features.
+-   _props.children_ `React.ReactNode`: The children to render if the theme supports the specified features.
 -   _props.supportKeys_ `string|string[]`: The key(s) of the theme support(s) to check.
 
 _Returns_
 
--   `React.ReactElement`: The rendered children if the theme supports the specified features, otherwise null.
+-   `React.ReactNode`: The rendered children if the theme supports the specified features, otherwise null.
 
 ### TimeToRead
 

--- a/packages/editor/src/components/document-outline/check.js
+++ b/packages/editor/src/components/document-outline/check.js
@@ -7,10 +7,10 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 /**
  * Component check if there are any headings (core/heading blocks) present in the document.
  *
- * @param {Object}             props          Props.
- * @param {React.ReactElement} props.children Children to be rendered.
+ * @param {Object}          props          Props.
+ * @param {React.ReactNode} props.children Children to be rendered.
  *
- * @return {React.ReactElement} The component to be rendered or null if there are headings.
+ * @return {React.ReactNode} The component to be rendered or null if there are headings.
  */
 export default function DocumentOutlineCheck( { children } ) {
 	const hasHeadings = useSelect( ( select ) => {

--- a/packages/editor/src/components/page-attributes/check.js
+++ b/packages/editor/src/components/page-attributes/check.js
@@ -12,10 +12,10 @@ import { store as editorStore } from '../../store';
 /**
  * Wrapper component that renders its children only if the post type supports page attributes.
  *
- * @param {Object}             props          - The component props.
- * @param {React.ReactElement} props.children - The child components to render.
+ * @param {Object}          props          - The component props.
+ * @param {React.ReactNode} props.children - The child components to render.
  *
- * @return {React.ReactElement} The rendered child components or null if page attributes are not supported.
+ * @return {React.ReactNode} The rendered child components or null if page attributes are not supported.
  */
 export function PageAttributesCheck( { children } ) {
 	const supportsPageAttributes = useSelect( ( select ) => {

--- a/packages/editor/src/components/post-pending-status/check.js
+++ b/packages/editor/src/components/post-pending-status/check.js
@@ -13,10 +13,10 @@ import { store as editorStore } from '../../store';
  * If the post is already published or the user doesn't have the
  * capability to publish, it returns null.
  *
- * @param {Object}             props          Component properties.
- * @param {React.ReactElement} props.children Children to be rendered.
+ * @param {Object}          props          Component properties.
+ * @param {React.ReactNode} props.children Children to be rendered.
  *
- * @return {React.ReactElement} The rendered child elements or null if the post is already published or the user doesn't have the capability to publish.
+ * @return {React.ReactNode} The rendered child elements or null if the post is already published or the user doesn't have the capability to publish.
  */
 export function PostPendingStatusCheck( { children } ) {
 	const { hasPublishAction, isPublished } = useSelect( ( select ) => {

--- a/packages/editor/src/components/post-schedule/check.js
+++ b/packages/editor/src/components/post-schedule/check.js
@@ -11,10 +11,10 @@ import { store as editorStore } from '../../store';
 /**
  * Wrapper component that renders its children only if post has a publish action.
  *
- * @param {Object}             props          Props.
- * @param {React.ReactElement} props.children Children to be rendered.
+ * @param {Object}          props          Props.
+ * @param {React.ReactNode} props.children Children to be rendered.
  *
- * @return {React.ReactElement} - The component to be rendered or null if there is no publish action.
+ * @return {React.ReactNode} - The component to be rendered or null if there is no publish action.
  */
 export default function PostScheduleCheck( { children } ) {
 	const hasPublishAction = useSelect( ( select ) => {

--- a/packages/editor/src/components/post-sticky/check.js
+++ b/packages/editor/src/components/post-sticky/check.js
@@ -11,10 +11,10 @@ import { store as editorStore } from '../../store';
 /**
  * Wrapper component that renders its children only if post has a sticky action.
  *
- * @param {Object}             props          Props.
- * @param {React.ReactElement} props.children Children to be rendered.
+ * @param {Object}          props          Props.
+ * @param {React.ReactNode} props.children Children to be rendered.
  *
- * @return {React.ReactElement} The component to be rendered or null if post type is not 'post' or hasStickyAction is false.
+ * @return {React.ReactNode} The component to be rendered or null if post type is not 'post' or hasStickyAction is false.
  */
 export default function PostStickyCheck( { children } ) {
 	const { hasStickyAction, postType } = useSelect( ( select ) => {

--- a/packages/editor/src/components/post-taxonomies/check.js
+++ b/packages/editor/src/components/post-taxonomies/check.js
@@ -15,7 +15,7 @@ import { store as editorStore } from '../../store';
  * @param {Object}          props          The component props.
  * @param {React.ReactNode} props.children The children components to render.
  *
- * @return {React.ReactElement} The rendered children components or null if the current post type has no taxonomies.
+ * @return {React.ReactNode} The rendered children components or null if the current post type has no taxonomies.
  */
 export default function PostTaxonomiesCheck( { children } ) {
 	const hasTaxonomies = useSelect( ( select ) => {

--- a/packages/editor/src/components/post-trash/check.js
+++ b/packages/editor/src/components/post-trash/check.js
@@ -13,10 +13,10 @@ import { GLOBAL_POST_TYPES } from '../../store/constants';
 /**
  * Wrapper component that renders its children only if the post can be trashed.
  *
- * @param {Object}             props          The component props.
- * @param {React.ReactElement} props.children The child components.
+ * @param {Object}          props          The component props.
+ * @param {React.ReactNode} props.children The child components.
  *
- * @return {React.ReactElement | null} The rendered child components or null if the post can't be trashed.
+ * @return {React.ReactNode} The rendered child components or null if the post can't be trashed.
  */
 export default function PostTrashCheck( { children } ) {
 	const { canTrashPost } = useSelect( ( select ) => {

--- a/packages/editor/src/components/post-type-support-check/index.js
+++ b/packages/editor/src/components/post-type-support-check/index.js
@@ -13,13 +13,13 @@ import { store as editorStore } from '../../store';
  * A component which renders its own children only if the current editor post
  * type supports one of the given `supportKeys` prop.
  *
- * @param {Object}             props             Props.
- * @param {React.ReactElement} props.children    Children to be rendered if post
- *                                               type supports.
- * @param {(string|string[])}  props.supportKeys String or string array of keys
- *                                               to test.
+ * @param {Object}            props             Props.
+ * @param {React.ReactNode}   props.children    Children to be rendered if post
+ *                                              type supports.
+ * @param {(string|string[])} props.supportKeys String or string array of keys
+ *                                              to test.
  *
- * @return {React.ReactElement} The component to be rendered.
+ * @return {React.ReactNode} The component to be rendered.
  */
 function PostTypeSupportCheck( { children, supportKeys } ) {
 	const postType = useSelect( ( select ) => {

--- a/packages/editor/src/components/post-url/check.js
+++ b/packages/editor/src/components/post-url/check.js
@@ -12,10 +12,10 @@ import { store as editorStore } from '../../store';
 /**
  * Check if the post URL is valid and visible.
  *
- * @param {Object}             props          The component props.
- * @param {React.ReactElement} props.children The child components.
+ * @param {Object}          props          The component props.
+ * @param {React.ReactNode} props.children The child components.
  *
- * @return {React.ReactElement} The child components if the post URL is valid and visible, otherwise null.
+ * @return {React.ReactNode} The child components if the post URL is valid and visible, otherwise null.
  */
 export default function PostURLCheck( { children } ) {
 	const isVisible = useSelect( ( select ) => {

--- a/packages/editor/src/components/theme-support-check/index.js
+++ b/packages/editor/src/components/theme-support-check/index.js
@@ -12,11 +12,11 @@ import { store as editorStore } from '../../store';
 /**
  * Checks if the current theme supports specific features and renders the children if supported.
  *
- * @param {Object}             props             The component props.
- * @param {React.ReactElement} props.children    The children to render if the theme supports the specified features.
- * @param {string|string[]}    props.supportKeys The key(s) of the theme support(s) to check.
+ * @param {Object}          props             The component props.
+ * @param {React.ReactNode} props.children    The children to render if the theme supports the specified features.
+ * @param {string|string[]} props.supportKeys The key(s) of the theme support(s) to check.
  *
- * @return {React.ReactElement} The rendered children if the theme supports the specified features, otherwise null.
+ * @return {React.ReactNode} The rendered children if the theme supports the specified features, otherwise null.
  */
 export default function ThemeSupportCheck( { children, supportKeys } ) {
 	const { postType, themeSupports } = useSelect( ( select ) => {


### PR DESCRIPTION
Closes: https://github.com/WordPress/gutenberg/issues/68835

## What?
Updated the children prop type in `PostTypeSupportCheck` to accept `ReactNode` instead of `ReactElement`, making it more flexible and preventing unnecessary typecasting.










