### PR TITLE
Style Book: Disable the device preview button in the header

### DIFF
--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -95,11 +95,12 @@ function Header( {
 		[ 'post', 'page', 'wp_template' ].includes( postType ) &&
 		hasSectionRootClientId;
 
-	const disablePreviewOption = [
-		NAVIGATION_POST_TYPE,
-		TEMPLATE_PART_POST_TYPE,
-		PATTERN_POST_TYPE,
-	].includes( postType );
+	const disablePreviewOption =
+		[
+			NAVIGATION_POST_TYPE,
+			TEMPLATE_PART_POST_TYPE,
+			PATTERN_POST_TYPE,
+		].includes( postType ) || forceDisableBlockTools;
 
 	const [ isBlockToolsCollapsed, setIsBlockToolsCollapsed ] =
 		useState( true );


### PR DESCRIPTION
## What?
Resolves #67737.

PR updates the `disablePreviewOption` condition and disabled the Device Preview dropdown when rendering the non-default editor canvas.

## Why?
Similar to #65970.

> Resizable Editor and Device Preview currently cannot work together, so we should always disable the device preview button in a resizable Editor.

## Testing Instructions
1. Go to Site Editor
2. Open the Style Book
3. Confirm that the "View" button in the header is disabled.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2025-01-22 at 22 32 01](https://github.com/user-attachments/assets/78ffa136-c03d-4c33-8de0-31d4ce3a8fb4)
