### PR TITLE
Improve grid visualizer resize observation

### DIFF
--- a/packages/block-editor/src/components/grid/grid-visualizer.js
+++ b/packages/block-editor/src/components/grid/grid-visualizer.js
@@ -54,29 +54,21 @@ const GridVisualizerGrid = forwardRef(
 		const [ isDroppingAllowed, setIsDroppingAllowed ] = useState( false );
 
 		useEffect( () => {
-			const observers = [];
-			for ( const element of [ gridElement, ...gridElement.children ] ) {
-				const observer = new window.ResizeObserver( () => {
-					setGridInfo( getGridInfo( gridElement ) );
-				} );
-				observer.observe( element );
-				observers.push( observer );
-			}
-
-			const mutationObserver = new window.MutationObserver( () => {
+			const resizeCallback = () =>
 				setGridInfo( getGridInfo( gridElement ) );
-			} );
-			mutationObserver.observe( gridElement, {
-				attributeFilter: [ 'style', 'class' ],
-				childList: true,
-				subtree: true,
-			} );
-			observers.push( mutationObserver );
-
+			// Both the container’s border-box and content-box are observed as they may
+			// change independently. This requires two observers because a single one
+			// can’t be made to monitor both on the same element.
+			const borderBoxSpy = new window.ResizeObserver( resizeCallback );
+			borderBoxSpy.observe( gridElement, { box: 'border-box' } );
+			const contentBoxSpy = new window.ResizeObserver( resizeCallback );
+			contentBoxSpy.observe( gridElement );
+			for ( const element of gridElement.children ) {
+				contentBoxSpy.observe( element );
+			}
 			return () => {
-				for ( const observer of observers ) {
-					observer.disconnect();
-				}
+				borderBoxSpy.disconnect();
+				contentBoxSpy.disconnect();
 			};
 		}, [ gridElement ] );
 

--- a/packages/block-editor/src/components/grid/grid-visualizer.js
+++ b/packages/block-editor/src/components/grid/grid-visualizer.js
@@ -56,16 +56,13 @@ const GridVisualizerGrid = forwardRef(
 		useEffect( () => {
 			const resizeCallback = () =>
 				setGridInfo( getGridInfo( gridElement ) );
-			// Both the container’s border-box and content-box are observed as they may
-			// change independently. This requires two observers because a single one
+			// Both border-box and content-box are observed as they may change
+			// independently. This requires two observers because a single one
 			// can’t be made to monitor both on the same element.
 			const borderBoxSpy = new window.ResizeObserver( resizeCallback );
 			borderBoxSpy.observe( gridElement, { box: 'border-box' } );
 			const contentBoxSpy = new window.ResizeObserver( resizeCallback );
 			contentBoxSpy.observe( gridElement );
-			for ( const element of gridElement.children ) {
-				contentBoxSpy.observe( element );
-			}
 			return () => {
 				borderBoxSpy.disconnect();
 				contentBoxSpy.disconnect();

--- a/packages/block-editor/src/components/grid/style.scss
+++ b/packages/block-editor/src/components/grid/style.scss
@@ -20,6 +20,7 @@
 
 .block-editor-grid-visualizer__grid {
 	display: grid;
+	position: absolute;
 }
 
 .block-editor-grid-visualizer__cell {

--- a/packages/block-editor/src/components/grid/utils.js
+++ b/packages/block-editor/src/components/grid/utils.js
@@ -187,10 +187,12 @@ export function getGridInfo( gridElement ) {
 			gridTemplateColumns,
 			gridTemplateRows,
 			gap: getComputedCSS( gridElement, 'gap' ),
-			paddingTop: `calc(${ paddingTop } + ${ borderTopWidth })`,
-			paddingRight: `calc(${ paddingRight } + ${ borderRightWidth })`,
-			paddingBottom: `calc(${ paddingBottom } + ${ borderBottomWidth })`,
-			paddingLeft: `calc(${ paddingLeft } + ${ borderLeftWidth })`,
+			inset: `
+				calc(${ paddingTop } + ${ borderTopWidth })
+				calc(${ paddingRight } + ${ borderRightWidth })
+				calc(${ paddingBottom } + ${ borderBottomWidth })
+				calc(${ paddingLeft } + ${ borderLeftWidth })
+			`,
 		},
 	};
 }


### PR DESCRIPTION
## What?
A follow up to #68230 where it was noted that:
> It should work correctly when applied via global styles, not just on the block instance.
> * **Note:** However, only the vertical padding does not sync immediately in the global styles, probably because neither the `ResizeObserver` nor the `MutationObserber` can detect the change.

A resize observer can detect that change, but it has to be specified to observe the border-box. That’s because vertical padding in most cases will affect not the content-box but the border-box.

## Why?
Primarily, to have the keep the grid visualizer in sync with changes to global styles like margin/border/padding. I’ve also tried some additional changes that aim to reduce resource usage by instantiating less objects and observing fewer elements.

## How?
The core changes are these:
- Adds another resize observer and uses it to observe the border-box of the block (code comment hopefully elucidates why another observer is needed).
- Removes the mutation observer.

There are a few more things that didn’t have to be changed and I will add review comments for explanation/discussion.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast 

### Before

https://github.com/user-attachments/assets/4c50c6f9-3a74-47c7-893a-a936452bdc3c

### After

https://github.com/user-attachments/assets/e16a77c4-b356-42a1-878e-926b6ed222e8

