### PR TITLE
Position: preserve Individual Styles While Updating `Position` for Multi-Selected Blocks

### DIFF
--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -10,7 +10,7 @@ import { __, _x, sprintf } from '@wordpress/i18n';
 import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
 import { BaseControl, CustomSelectControl } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useMemo, Platform } from '@wordpress/element';
 
 /**
@@ -192,15 +192,22 @@ export function useIsPositionDisabled( { name: blockName } = {} ) {
  *
  * @return {Element} Position panel.
  */
-export function PositionPanelPure( {
-	style = {},
-	clientId,
-	name: blockName,
-	setAttributes,
-} ) {
+export function PositionPanelPure( { style = {}, clientId, name: blockName } ) {
 	const allowFixed = hasFixedPositionSupport( blockName );
 	const allowSticky = hasStickyPositionSupport( blockName );
 	const value = style?.position?.type;
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	const { selectedClientIds, selectedBlocks } = useSelect( ( select ) => {
+		const { getBlocksByClientId, getSelectedBlockClientIds } =
+			select( blockEditorStore );
+		const selectedBlockClientIds = getSelectedBlockClientIds();
+
+		return {
+			selectedClientIds: selectedBlockClientIds,
+			selectedBlocks: getBlocksByClientId( selectedBlockClientIds ),
+		};
+	}, [] );
 
 	const { firstParentClientId } = useSelect(
 		( select ) => {
@@ -242,21 +249,32 @@ export function PositionPanelPure( {
 		// In the future, it could be useful to allow for an offset value.
 		const placementValue = '0px';
 
-		const newStyle = {
-			...style,
-			position: {
-				...style?.position,
-				type: next,
-				top:
-					next === 'sticky' || next === 'fixed'
-						? placementValue
-						: undefined,
-			},
-		};
+		if ( ! selectedClientIds?.length || ! selectedBlocks?.length ) {
+			return;
+		}
 
-		setAttributes( {
-			style: cleanEmptyObject( newStyle ),
-		} );
+		const attributesByClientId = Object.fromEntries(
+			selectedBlocks?.map(
+				( { clientId: blockClientId, attributes } ) => [
+					blockClientId,
+					{
+						style: cleanEmptyObject( {
+							...attributes?.style,
+							position: {
+								...attributes?.style?.position,
+								type: next,
+								top:
+									next === 'sticky' || next === 'fixed'
+										? placementValue
+										: undefined,
+							},
+						} ),
+					},
+				]
+			)
+		);
+
+		updateBlockAttributes( selectedClientIds, attributesByClientId, true );
 	};
 
 	const selectedOption = value


### PR DESCRIPTION
## What, Why and How?
Fixes: #68843 

Previously, modifying the `Position` attribute of multiple group blocks caused a bug where the custom styles of the first block were incorrectly applied to all other selected blocks, overriding their **individual** styles.

This PR resolves the issue by utilizing the `Selected Client Ids` to identify the currently selected blocks. It retrieves the individual attributes of each block and dispatches a single `updateBlockAttributes` action to update all selected blocks simultaneously while preserving their existing custom styles.


## Testing Instructions
1. Create multiple `Group Blocks` or blocks that support `Position Property`.
2. Apply different custom backgrounds and text colors to these `Blocks`.
3. Select all the `Group Blocks` and try applying the `Position Property` to all of them simultaneously.
4. Notice, that changing the `Position` from `Default` to `Stick` or from `Sticky` to `Default` preserves the previous block styles.

## Screencast


https://github.com/user-attachments/assets/37267c95-5f23-4ca5-bdc9-414a1db3e0b0
