### PR TITLE
Block Editor: Prevent negative width values in Spacer block when used inside a row block

### DIFF
--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -48,6 +48,7 @@ function helpText( selfStretch, parentLayout ) {
  *
  * @param {boolean}  props.isShownByDefault
  * @param {string}   props.panelId
+ * @param {number}   [props.minUnitValue=0] Minimum allowed value for the unit control
  * @return {Element} child layout edit element.
  */
 export default function ChildLayoutControl( {
@@ -56,6 +57,7 @@ export default function ChildLayoutControl( {
 	parentLayout,
 	isShownByDefault,
 	panelId,
+	minUnitValue = 0,
 } ) {
 	const {
 		type: parentType,
@@ -71,6 +73,7 @@ export default function ChildLayoutControl( {
 				parentLayout={ parentLayout }
 				isShownByDefault={ isShownByDefault }
 				panelId={ panelId }
+				minUnitValue={ minUnitValue }
 			/>
 		);
 	} else if ( parentLayoutType === 'grid' ) {
@@ -94,6 +97,7 @@ function FlexControls( {
 	parentLayout,
 	isShownByDefault,
 	panelId,
+	minUnitValue,
 } ) {
 	const { selfStretch, flexSize } = childLayout;
 	const { orientation = 'horizontal' } = parentLayout ?? {};
@@ -188,6 +192,7 @@ function FlexControls( {
 						} );
 					} }
 					value={ flexSize }
+					min={ minUnitValue }
 					label={ flexResetLabel }
 					hideLabelFromVision
 				/>

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -97,7 +97,6 @@ function FlexControls( {
 	parentLayout,
 	isShownByDefault,
 	panelId,
-	minUnitValue,
 } ) {
 	const { selfStretch, flexSize } = childLayout;
 	const { orientation = 'horizontal' } = parentLayout ?? {};
@@ -192,7 +191,7 @@ function FlexControls( {
 						} );
 					} }
 					value={ flexSize }
-					min={ minUnitValue }
+					min={ 0 }
 					label={ flexResetLabel }
 					hideLabelFromVision
 				/>

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -48,7 +48,6 @@ function helpText( selfStretch, parentLayout ) {
  *
  * @param {boolean}  props.isShownByDefault
  * @param {string}   props.panelId
- * @param {number}   [props.minUnitValue=0] Minimum allowed value for the unit control
  * @return {Element} child layout edit element.
  */
 export default function ChildLayoutControl( {
@@ -57,7 +56,6 @@ export default function ChildLayoutControl( {
 	parentLayout,
 	isShownByDefault,
 	panelId,
-	minUnitValue = 0,
 } ) {
 	const {
 		type: parentType,
@@ -73,7 +71,6 @@ export default function ChildLayoutControl( {
 				parentLayout={ parentLayout }
 				isShownByDefault={ isShownByDefault }
 				panelId={ panelId }
-				minUnitValue={ minUnitValue }
 			/>
 		);
 	} else if ( parentLayoutType === 'grid' ) {


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/68847 (Point 1)

## What?
Prevent negative width values in the Spacer block when used inside Row blocks.


## Why?
Currently, when a Spacer block is placed in a Row block, it can accept negative width values, which is not ideal. 


## Testing Instructions
- Create or open a post/page
- Add a Row block
- Insert a Spacer block inside the Row
- Try to set a negative width value using the resize handle
- Verify that the minimum width remains at 0

## Screencast 


### Before 


https://github.com/user-attachments/assets/eeb075ad-b22e-43a7-8a23-8ee8bb99c506







### After 


https://github.com/user-attachments/assets/9b98d737-8d0d-442c-9928-f3e5b47cfc25


