### PR TITLE
Link UI: Placeholder text

### DIFF
--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -114,7 +114,8 @@ const LinkControlSearchInput = forwardRef(
 			}
 		};
 
-		const inputLabel = placeholder ?? __( 'Search or type URL' );
+		const inputLabel =
+			placeholder ?? __( 'Search for a Page/Post or type URL' );
 
 		return (
 			<div className="block-editor-link-control__search-input-container">


### PR DESCRIPTION
Fixes [#56378](https://github.com/WordPress/gutenberg/issues/56378)

## What?
Update the placeholder text to "Search for a Page/Post or type URL".

## Why?
When users first open the Link UI it's not clear what they are meant to do. I have seen users who thought they were only able to enter URLs, and that it wouldn't work for draft pages/pages.

## Testing Instructions
1. Click on 'Add Link' option in Toolbar
2. Check the placeholder text of search input is more clear

## Screenshots or screencast <!-- if applicable -->
#### Before
![Screenshot 2025-01-23 at 2 48 53 PM](https://github.com/user-attachments/assets/86ed8cc5-3cfd-4005-9192-f7c3ca35a674)

#### After
![Screenshot 2025-01-23 at 10 51 32 AM](https://github.com/user-attachments/assets/cef1665c-5275-4cf5-a655-cb6d137734c4)


