### PR TITLE
Improve Site Editor usability by adding descriptions under Design menu items

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-item/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-item/index.js
@@ -32,6 +32,7 @@ export default function SidebarNavigationItem( {
 	uid,
 	to,
 	onClick,
+	description,
 	children,
 	...props
 } ) {
@@ -80,6 +81,11 @@ export default function SidebarNavigationItem( {
 				) }
 				{ ! withChevron && suffix }
 			</HStack>
+			{ description && (
+				<p className="edit-site-sidebar-navigation-item__description">
+					{ description }
+				</p>
+			) }
 		</Item>
 	);
 }

--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -35,6 +35,10 @@
 	}
 }
 
+.edit-site-sidebar-navigation-item__description {
+	margin: 10px 0;
+}
+
 .edit-site-sidebar-navigation-screen__content .block-editor-list-view-block-select-button {
 	cursor: grab;
 	padding: $grid-unit-10 $grid-unit-10 $grid-unit-10 0;

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -27,6 +27,9 @@ export function MainSidebarNavigationContent( { isBlockBasedTheme = true } ) {
 						to="/navigation"
 						withChevron
 						icon={ navigation }
+						description={ __(
+							'Manage your Navigation menus. (Navigation, Footer navigation\u2026)'
+						) }
 					>
 						{ __( 'Navigation' ) }
 					</SidebarNavigationItem>
@@ -34,6 +37,9 @@ export function MainSidebarNavigationContent( { isBlockBasedTheme = true } ) {
 						to="/styles"
 						uid="global-styles-navigation-item"
 						icon={ styles }
+						description={ __(
+							'Choose a different style combination for the theme styles. (Blue, Green, Orange\u2026)'
+						) }
 					>
 						{ __( 'Styles' ) }
 					</SidebarNavigationItemGlobalStyles>
@@ -42,6 +48,9 @@ export function MainSidebarNavigationContent( { isBlockBasedTheme = true } ) {
 						to="/page"
 						withChevron
 						icon={ page }
+						description={ __(
+							'Browse and edit pages on your site. (Home page, index, Sample page\u2026)'
+						) }
 					>
 						{ __( 'Pages' ) }
 					</SidebarNavigationItem>
@@ -50,6 +59,9 @@ export function MainSidebarNavigationContent( { isBlockBasedTheme = true } ) {
 						to="/template"
 						withChevron
 						icon={ layout }
+						description={ __(
+							'Express the layout of your site with templates. (Page, single posts, 404\u2026)'
+						) }
 					>
 						{ __( 'Templates' ) }
 					</SidebarNavigationItem>
@@ -70,6 +82,9 @@ export function MainSidebarNavigationContent( { isBlockBasedTheme = true } ) {
 				to="/pattern"
 				withChevron
 				icon={ symbol }
+				description={ __(
+					'Manage what patterns are available when editing the site. (Call to action, headers, footers\u2026)'
+				) }
 			>
 				{ __( 'Patterns' ) }
 			</SidebarNavigationItem>


### PR DESCRIPTION
## What?
This PR is intended to solve issue mentioned here: #55741

## Why?
Many users, especially beginners, find it difficult to distinguish between templates and pages or understand where content originates. Adding descriptions provides contextual guidance, helping users navigate the Site Editor more efficiently and reducing confusion.

## How?
- Updated the SidebarNavigationItem component to accept an optional description prop.
- Provided descriptive text for each menu item to clarify its purpose.
- Updated styles to remove default margins for the description to align with design guidelines.

## Testing Instructions
1. Open the Site Editor in a block-based theme.
2. Navigate to the Design menu from the sidebar.
3. Verify that each item (Templates, Pages, Styles, Patterns, etc.) now includes a description.
4. Ensure descriptions provide meaningful guidance.
5. Test navigation by clicking on each menu item.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<img width="1463" alt="Screenshot 2025-01-23 at 3 08 05 PM" src="https://github.com/user-attachments/assets/330164ef-7892-4473-b3be-9c069f569803" />|<img width="1463" alt="Screenshot 2025-01-23 at 4 03 53 PM" src="https://github.com/user-attachments/assets/fa28270b-eb07-470a-b8d6-28a275d10dc4" />|


