### PR TITLE
Editor: Improve conditions for displaying new page assembler

### DIFF
--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -12,13 +12,8 @@ import { store as interfaceStore } from '@wordpress/interface';
 import { store as editorStore } from '../../store';
 
 export default function StartPageOptions() {
-	const { postId, shouldEnable } = useSelect( ( select ) => {
-		const {
-			isEditedPostDirty,
-			isEditedPostEmpty,
-			getCurrentPostId,
-			getCurrentPostType,
-		} = select( editorStore );
+	const { postId, enabled } = useSelect( ( select ) => {
+		const { getCurrentPostId, getCurrentPostType } = select( editorStore );
 		const preferencesModalActive =
 			select( interfaceStore ).isModalActive( 'editor/preferences' );
 		const choosePatternModalEnabled = select( preferencesStore ).get(
@@ -27,24 +22,34 @@ export default function StartPageOptions() {
 		);
 		return {
 			postId: getCurrentPostId(),
-			shouldEnable:
+			enabled:
 				choosePatternModalEnabled &&
 				! preferencesModalActive &&
-				! isEditedPostDirty() &&
-				isEditedPostEmpty() &&
 				'page' === getCurrentPostType(),
 		};
 	}, [] );
+	const { isEditedPostDirty, isEditedPostEmpty } = useSelect( editorStore );
 	const { setIsInserterOpened } = useDispatch( editorStore );
 
 	useEffect( () => {
-		if ( shouldEnable ) {
+		if ( ! enabled ) {
+			return;
+		}
+
+		const isFreshPage = ! isEditedPostDirty() && isEditedPostEmpty();
+		if ( isFreshPage ) {
 			setIsInserterOpened( {
 				tab: 'patterns',
 				category: 'core/starter-content',
 			} );
 		}
-	}, [ postId, shouldEnable, setIsInserterOpened ] );
+	}, [
+		postId,
+		enabled,
+		setIsInserterOpened,
+		isEditedPostDirty,
+		isEditedPostEmpty,
+	] );
 
 	return null;
 }

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -43,6 +43,9 @@ export default function StartPageOptions() {
 				category: 'core/starter-content',
 			} );
 		}
+
+		// Note: The `postId` ensures the effect re-runs when pages are switched without remounting the component.
+		// Examples: changing pages in the List View, creating a new page via Command Palette.
 	}, [
 		postId,
 		enabled,


### PR DESCRIPTION
## What?
Part of #68736.

Solves the following cases when the new page "assembler" shouldn't be displayed (again):

- removing all content and clearing the title on a page that's already been saved.
- while save of a page with a title but no content is in progress.

Originally fixed via #54245, but accidentally regressed in #60745. Page creation doesn't use the `auto-draft` status in the Site Editor, so the `isCleanNewPost` selector was no longer applicable.

## Testing Instructions

### Instruction one
1. Create a new page.
2. Close the new page "assembler".
3. Add the page title and save.
4. The inserter shouldn't re-open after saving.

### Instruction two
1. Create a new page.
2. Add a content.
3. Close the new page "assembler".
4. Remove all content.
5. The inserter shouldn't re-open.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2025-01-27 at 10 42 26](https://github.com/user-attachments/assets/f3e371c8-1fbf-4f12-b9ef-74d0d6918047)
