### PR TITLE
Testing: Add e2e test for basic ContrastChecker functionality

### DIFF
--- a/test/e2e/specs/editor/various/contrast-checker.spec.js
+++ b/test/e2e/specs/editor/various/contrast-checker.spec.js
@@ -19,10 +19,10 @@ test.describe( 'ContrastChecker', () => {
 		} );
 
 		await page.getByRole( 'button', { name: 'Text', exact: true } ).click();
-		await page.getByLabel( 'Black' ).click();
+		await page.getByRole( 'option', { name: 'Black' } ).click();
 
 		await page.getByRole( 'button', { name: 'Background' } ).click();
-		await page.getByLabel( 'Black' ).click();
+		await page.getByRole( 'option', { name: 'Black' } ).click();
 
 		const lowContrastWarning = page.locator(
 			'.block-editor-contrast-checker'

--- a/test/e2e/specs/editor/various/contrast-checker.spec.js
+++ b/test/e2e/specs/editor/various/contrast-checker.spec.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-const { test } = require( '@wordpress/e2e-test-utils-playwright' );
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'ContrastChecker', () => {
 	test.beforeEach( async ( { admin } ) => {
@@ -34,6 +34,12 @@ test.describe( 'ContrastChecker', () => {
 		);
 		await page.click(
 			'button.components-circular-option-picker__option[aria-label="Black"]'
+		);
+
+		const warningElement = page.locator( '.block-editor-contrast-checker' );
+		await expect( warningElement ).toBeVisible();
+		await expect( warningElement ).toContainText(
+			'This color combination may be hard for people to read'
 		);
 	} );
 } );

--- a/test/e2e/specs/editor/various/contrast-checker.spec.js
+++ b/test/e2e/specs/editor/various/contrast-checker.spec.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'ContrastChecker', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'shows warning when text and background colors have low contrast', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Contrast Checker Test' },
+		} );
+
+		await editor.openDocumentSettingsSidebar();
+
+		await page.click( 'role=button[name="Color settings"]' );
+
+		await page.click( 'role=button[name="Text color"]' );
+		await page.click( 'button[aria-label="Color: Black"]' );
+
+		await page.click( 'role=button[name="Background color"]' );
+		await page.click( 'button[aria-label="Color: Black"]' );
+
+		const contrastWarning = page.locator(
+			'.block-editor-contrast-checker'
+		);
+		await expect( contrastWarning ).toBeVisible();
+
+		const warningText = await contrastWarning.textContent();
+		expect( warningText ).toContain(
+			'This color combination may be hard for people to read'
+		);
+	} );
+} );

--- a/test/e2e/specs/editor/various/contrast-checker.spec.js
+++ b/test/e2e/specs/editor/various/contrast-checker.spec.js
@@ -12,27 +12,23 @@ test.describe( 'ContrastChecker', () => {
 		editor,
 		page,
 	} ) => {
+		await editor.openDocumentSettingsSidebar();
 		await editor.insertBlock( {
 			name: 'core/paragraph',
 			attributes: { content: 'Contrast Checker Test' },
 		} );
 
-		const paragraph = editor.canvas.getByRole( 'document', {
-			name: 'Block: Paragraph',
-		} );
-		await paragraph.click();
+		await page.getByRole( 'button', { name: 'Text', exact: true } ).click();
+		await page.getByLabel( 'Black' ).click();
 
-		await page.click( '[data-wp-component="FlexItem"]:has-text("Text")' );
-		await page.click( 'button[aria-label="Black"]' );
+		await page.getByRole( 'button', { name: 'Background' } ).click();
+		await page.getByLabel( 'Black' ).click();
 
-		await page.click(
-			'[data-wp-component="FlexItem"]:has-text("Background")'
+		const lowContrastWarning = page.locator(
+			'.block-editor-contrast-checker'
 		);
-		await page.click( 'button[aria-label="Black"]' );
-
-		const warningElement = page.locator( '.block-editor-contrast-checker' );
-		await expect( warningElement ).toBeVisible();
-		await expect( warningElement ).toContainText(
+		await expect( lowContrastWarning ).toBeVisible();
+		await expect( lowContrastWarning ).toContainText(
 			'This color combination may be hard for people to read'
 		);
 	} );

--- a/test/e2e/specs/editor/various/contrast-checker.spec.js
+++ b/test/e2e/specs/editor/various/contrast-checker.spec.js
@@ -3,33 +3,55 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
+const WARNING_TEXT = 'This color combination may be hard for people to read';
+
 test.describe( 'ContrastChecker', () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
 	} );
 
-	test( 'should show warning when text and background colors have low contrast', async ( {
+	test( 'should show warning for insufficient contrast', async ( {
 		editor,
 		page,
 	} ) => {
 		await editor.openDocumentSettingsSidebar();
-		await editor.insertBlock( {
-			name: 'core/paragraph',
-			attributes: { content: 'Contrast Checker Test' },
+
+		await test.step( 'Check black text on black background', async () => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Black text on Black background' },
+			} );
+
+			await page
+				.getByRole( 'button', { name: 'Text', exact: true } )
+				.click();
+			await page.getByRole( 'option', { name: 'Black' } ).click();
+			await page.getByRole( 'button', { name: 'Background' } ).click();
+			await page.getByRole( 'option', { name: 'Black' } ).click();
+
+			const lowContrastWarning = page.locator(
+				'.block-editor-contrast-checker'
+			);
+			await expect( lowContrastWarning ).toBeVisible();
+			await expect( lowContrastWarning ).toContainText( WARNING_TEXT );
 		} );
 
-		await page.getByRole( 'button', { name: 'Text', exact: true } ).click();
-		await page.getByRole( 'option', { name: 'Black' } ).click();
+		await test.step( 'Check white text on default background', async () => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'White text on Default background' },
+			} );
 
-		await page.getByRole( 'button', { name: 'Background' } ).click();
-		await page.getByRole( 'option', { name: 'Black' } ).click();
+			await page
+				.getByRole( 'button', { name: 'Text', exact: true } )
+				.click();
+			await page.getByRole( 'option', { name: 'White' } ).click();
 
-		const lowContrastWarning = page.locator(
-			'.block-editor-contrast-checker'
-		);
-		await expect( lowContrastWarning ).toBeVisible();
-		await expect( lowContrastWarning ).toContainText(
-			'This color combination may be hard for people to read'
-		);
+			const lowContrastWarning = page.locator(
+				'.block-editor-contrast-checker'
+			);
+			await expect( lowContrastWarning ).toBeVisible();
+			await expect( lowContrastWarning ).toContainText( WARNING_TEXT );
+		} );
 	} );
 } );

--- a/test/e2e/specs/editor/various/contrast-checker.spec.js
+++ b/test/e2e/specs/editor/various/contrast-checker.spec.js
@@ -16,6 +16,10 @@ test.describe( 'ContrastChecker', () => {
 	} ) => {
 		await editor.openDocumentSettingsSidebar();
 
+		const lowContrastWarning = page.locator(
+			'.block-editor-contrast-checker'
+		);
+
 		await test.step( 'Check black text on black background', async () => {
 			await editor.insertBlock( {
 				name: 'core/paragraph',
@@ -29,9 +33,6 @@ test.describe( 'ContrastChecker', () => {
 			await page.getByRole( 'button', { name: 'Background' } ).click();
 			await page.getByRole( 'option', { name: 'Black' } ).click();
 
-			const lowContrastWarning = page.locator(
-				'.block-editor-contrast-checker'
-			);
 			await expect( lowContrastWarning ).toBeVisible();
 			await expect( lowContrastWarning ).toContainText( WARNING_TEXT );
 		} );
@@ -47,11 +48,31 @@ test.describe( 'ContrastChecker', () => {
 				.click();
 			await page.getByRole( 'option', { name: 'White' } ).click();
 
-			const lowContrastWarning = page.locator(
-				'.block-editor-contrast-checker'
-			);
 			await expect( lowContrastWarning ).toBeVisible();
 			await expect( lowContrastWarning ).toContainText( WARNING_TEXT );
 		} );
+	} );
+
+	test( 'should not show warning for sufficient contrast', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.openDocumentSettingsSidebar();
+
+		const lowContrastWarning = page.locator(
+			'.block-editor-contrast-checker'
+		);
+
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Black text on White background' },
+		} );
+
+		await page.getByRole( 'button', { name: 'Text', exact: true } ).click();
+		await page.getByRole( 'option', { name: 'Black' } ).click();
+		await page.getByRole( 'button', { name: 'Background' } ).click();
+		await page.getByRole( 'option', { name: 'White' } ).click();
+
+		await expect( lowContrastWarning ).not.toBeVisible();
 	} );
 } );

--- a/test/e2e/specs/editor/various/contrast-checker.spec.js
+++ b/test/e2e/specs/editor/various/contrast-checker.spec.js
@@ -1,14 +1,14 @@
 /**
  * WordPress dependencies
  */
-const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+const { test } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'ContrastChecker', () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
 	} );
 
-	test( 'shows warning when text and background colors have low contrast', async ( {
+	test( 'should show warning when text and background colors have low contrast', async ( {
 		editor,
 		page,
 	} ) => {
@@ -17,24 +17,23 @@ test.describe( 'ContrastChecker', () => {
 			attributes: { content: 'Contrast Checker Test' },
 		} );
 
-		await editor.openDocumentSettingsSidebar();
+		const paragraph = editor.canvas.getByRole( 'document', {
+			name: 'Block: Paragraph',
+		} );
+		await paragraph.click();
 
-		await page.click( 'role=button[name="Color settings"]' );
-
-		await page.click( 'role=button[name="Text color"]' );
-		await page.click( 'button[aria-label="Color: Black"]' );
-
-		await page.click( 'role=button[name="Background color"]' );
-		await page.click( 'button[aria-label="Color: Black"]' );
-
-		const contrastWarning = page.locator(
-			'.block-editor-contrast-checker'
+		await page.click(
+			'button.block-editor-panel-color-gradient-settings__dropdown:has-text("Text")'
 		);
-		await expect( contrastWarning ).toBeVisible();
+		await page.click(
+			'button.components-circular-option-picker__option[aria-label="Black"]'
+		);
 
-		const warningText = await contrastWarning.textContent();
-		expect( warningText ).toContain(
-			'This color combination may be hard for people to read'
+		await page.click(
+			'button.block-editor-panel-color-gradient-settings__dropdown:has-text("Background")'
+		);
+		await page.click(
+			'button.components-circular-option-picker__option[aria-label="Black"]'
 		);
 	} );
 } );

--- a/test/e2e/specs/editor/various/contrast-checker.spec.js
+++ b/test/e2e/specs/editor/various/contrast-checker.spec.js
@@ -22,19 +22,13 @@ test.describe( 'ContrastChecker', () => {
 		} );
 		await paragraph.click();
 
-		await page.click(
-			'button.block-editor-panel-color-gradient-settings__dropdown:has-text("Text")'
-		);
-		await page.click(
-			'button.components-circular-option-picker__option[aria-label="Black"]'
-		);
+		await page.click( '[data-wp-component="FlexItem"]:has-text("Text")' );
+		await page.click( 'button[aria-label="Black"]' );
 
 		await page.click(
-			'button.block-editor-panel-color-gradient-settings__dropdown:has-text("Background")'
+			'[data-wp-component="FlexItem"]:has-text("Background")'
 		);
-		await page.click(
-			'button.components-circular-option-picker__option[aria-label="Black"]'
-		);
+		await page.click( 'button[aria-label="Black"]' );
 
 		const warningElement = page.locator( '.block-editor-contrast-checker' );
 		await expect( warningElement ).toBeVisible();


### PR DESCRIPTION
Closes: #68853 

## What?

Add a basic end-to-end test for the ContrastChecker component that verifies the low-contrast warning appears immediately when the text and background colors have insufficient contrast.

## Why?

After enhancing the ContrastChecker component in #68799, it's important to ensure its core functionality of detecting and warning about low-contrast color combinations works reliably. 

## Testing Instructions
- Run `npm run test:e2e -- editor/various/contrast-checker.spec.js` to execute the test
- Verify that it is passing and debug (if necessary) to check the working

## Screencast



https://github.com/user-attachments/assets/27abc341-9289-4895-9bb2-5eefbf85fc24


