### PR TITLE
Flex Layout: Fix incorrect default alignment values for `Vertical Alignment Control` component

### DIFF
--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -56,6 +56,11 @@ const verticalAlignmentMap = {
 	'space-between': 'space-between',
 };
 
+const DEFAULT_ALIGNMENT = {
+	horizontal: 'center',
+	vertical: 'top',
+};
+
 const flexWrapOptions = [ 'wrap', 'nowrap' ];
 
 export default {
@@ -201,8 +206,8 @@ function FlexLayoutVerticalAlignmentControl( { layout, onChange } ) {
 
 	const defaultVerticalAlignment =
 		orientation === 'horizontal'
-			? verticalAlignmentMap.center
-			: verticalAlignmentMap.top;
+			? DEFAULT_ALIGNMENT.horizontal
+			: DEFAULT_ALIGNMENT.vertical;
 
 	const { verticalAlignment = defaultVerticalAlignment } = layout;
 

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -56,7 +56,7 @@ const verticalAlignmentMap = {
 	'space-between': 'space-between',
 };
 
-const DEFAULT_ALIGNMENT = {
+const defaultAlignments = {
 	horizontal: 'center',
 	vertical: 'top',
 };
@@ -206,8 +206,8 @@ function FlexLayoutVerticalAlignmentControl( { layout, onChange } ) {
 
 	const defaultVerticalAlignment =
 		orientation === 'horizontal'
-			? DEFAULT_ALIGNMENT.horizontal
-			: DEFAULT_ALIGNMENT.vertical;
+			? defaultAlignments.horizontal
+			: defaultAlignments.vertical;
 
 	const { verticalAlignment = defaultVerticalAlignment } = layout;
 


### PR DESCRIPTION
## What, Why and How?

Fixes: #68864 

This PR addresses a bug in which the default `vertical alignment` value does not render as selected in the Vertical Alignment Toolbar when the orientation is set to vertical. The issue arises because the `layout.verticalAlignment` property is expected to store the alignment key (e.g., `top`, `center`, `bottom`, `stretch`, etc.) but instead holds the resolved CSS value (e.g., `flex-start`).

## Testing Instructions
1. Create a `Row Block`.
2. Verify from the `Block Toolbar` that the default alignment value is `Align middle`.
3. Convert the same `Block` to a `Column` block.
4. Confirm that the default alignment value for is now appropriately set to `Top`.


## Screencast

https://github.com/user-attachments/assets/db451918-0c26-4317-8adc-a811d056d2ea

## Screenshots

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/a8ce3b22-70a5-4e37-a908-1af5dcf2ae68)|![after](https://github.com/user-attachments/assets/dac1f769-bc12-4458-aa1b-28d2f894062d)|
