### PR TITLE
Update paragraph block placeholder text format for consistency

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -169,7 +169,9 @@ function ParagraphBlock( {
 						: __( 'Block: Paragraph' )
 				}
 				data-empty={ RichText.isEmpty( content ) }
-				placeholder={ placeholder || __( 'Type / to choose a block' ) }
+				placeholder={
+					placeholder || __( `Type ' / ' to choose a block` )
+				}
 				data-custom-placeholder={ placeholder ? true : undefined }
 				__unstableEmbedURLOnPaste
 				__unstableAllowPrefixTransformations


### PR DESCRIPTION
Fixes [#56371](https://github.com/WordPress/gutenberg/issues/56371)

## What?
Updates placeholder text in paragraph blocks to use ' / ' for the forward slash key.

## Why?
Fixes confusion for new users who misinterpreted "Type / to choose a block" as "Type OR choose a block"

## How?
Updated the placeholder text to `'Type ' / ' to choose a block'`

## Testing Instructions
1. Open block editor
2. Create new paragraph block
2. Verify placeholder shows `' / '` in placeholder

## Screenshots

#### Before
![Screenshot 2025-01-24 at 1 47 41 PM](https://github.com/user-attachments/assets/5db4f455-af92-46b3-a3c3-400b787ddd75)

#### After
![Screenshot 2025-01-24 at 1 45 32 PM](https://github.com/user-attachments/assets/6c7ea085-962e-4e19-9a7b-01d83f9a165c)
