### PR TITLE
`Spacer`: Fix changes being marked as persistent to `undo`

### DIFF
--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -259,13 +259,14 @@ const SpacerEdit = ( {
 	};
 
 	useEffect( () => {
+		__unstableMarkNextChangeAsNotPersistent();
+
 		if (
 			isFlexLayout &&
 			selfStretch !== 'fill' &&
 			selfStretch !== 'fit' &&
 			flexSize === undefined
 		) {
-			__unstableMarkNextChangeAsNotPersistent();
 			if ( inheritedOrientation === 'horizontal' ) {
 				// If spacer is moving from a vertical container to a horizontal container,
 				// it might not have width but have height instead.
@@ -305,7 +306,6 @@ const SpacerEdit = ( {
 			isFlexLayout &&
 			( selfStretch === 'fill' || selfStretch === 'fit' )
 		) {
-			__unstableMarkNextChangeAsNotPersistent();
 			if ( inheritedOrientation === 'horizontal' ) {
 				setAttributes( {
 					width: undefined,
@@ -317,16 +317,18 @@ const SpacerEdit = ( {
 			}
 		} else if ( ! isFlexLayout && ( selfStretch || flexSize ) ) {
 			if ( inheritedOrientation === 'horizontal' ) {
-				__unstableMarkNextChangeAsNotPersistent();
 				setAttributes( {
 					width: flexSize,
 				} );
 			} else {
-				__unstableMarkNextChangeAsNotPersistent();
 				setAttributes( {
 					height: flexSize,
 				} );
 			}
+
+			// This ensures that the next change is not marked as persistent
+			// when the user changes the container layout.
+			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( {
 				style: {
 					...blockStyle,

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -16,7 +16,7 @@ import {
 import { ResizableBox } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import { View } from '@wordpress/primitives';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -123,6 +123,9 @@ const SpacerEdit = ( {
 
 	const onResizeStart = () => toggleSelection( false );
 	const onResizeStop = () => toggleSelection( true );
+
+	const { __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( blockEditorStore );
 
 	const handleOnVerticalResizeStop = ( newHeight ) => {
 		onResizeStop();
@@ -262,6 +265,7 @@ const SpacerEdit = ( {
 			selfStretch !== 'fit' &&
 			flexSize === undefined
 		) {
+			__unstableMarkNextChangeAsNotPersistent();
 			if ( inheritedOrientation === 'horizontal' ) {
 				// If spacer is moving from a vertical container to a horizontal container,
 				// it might not have width but have height instead.
@@ -269,6 +273,7 @@ const SpacerEdit = ( {
 					getCustomValueFromPreset( width, spacingSizes ) ||
 					getCustomValueFromPreset( height, spacingSizes ) ||
 					'100px';
+
 				setAttributes( {
 					width: '0px',
 					style: {
@@ -285,6 +290,7 @@ const SpacerEdit = ( {
 					getCustomValueFromPreset( height, spacingSizes ) ||
 					getCustomValueFromPreset( width, spacingSizes ) ||
 					'100px';
+
 				setAttributes( {
 					height: '0px',
 					style: {
@@ -301,6 +307,7 @@ const SpacerEdit = ( {
 			isFlexLayout &&
 			( selfStretch === 'fill' || selfStretch === 'fit' )
 		) {
+			__unstableMarkNextChangeAsNotPersistent();
 			if ( inheritedOrientation === 'horizontal' ) {
 				setAttributes( {
 					width: undefined,
@@ -312,14 +319,17 @@ const SpacerEdit = ( {
 			}
 		} else if ( ! isFlexLayout && ( selfStretch || flexSize ) ) {
 			if ( inheritedOrientation === 'horizontal' ) {
+				__unstableMarkNextChangeAsNotPersistent();
 				setAttributes( {
 					width: flexSize,
 				} );
 			} else {
+				__unstableMarkNextChangeAsNotPersistent();
 				setAttributes( {
 					height: flexSize,
 				} );
 			}
+
 			setAttributes( {
 				style: {
 					...blockStyle,
@@ -342,6 +352,7 @@ const SpacerEdit = ( {
 		setAttributes,
 		spacingSizes,
 		width,
+		__unstableMarkNextChangeAsNotPersistent,
 	] );
 
 	return (

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -273,7 +273,6 @@ const SpacerEdit = ( {
 					getCustomValueFromPreset( width, spacingSizes ) ||
 					getCustomValueFromPreset( height, spacingSizes ) ||
 					'100px';
-
 				setAttributes( {
 					width: '0px',
 					style: {
@@ -290,7 +289,6 @@ const SpacerEdit = ( {
 					getCustomValueFromPreset( height, spacingSizes ) ||
 					getCustomValueFromPreset( width, spacingSizes ) ||
 					'100px';
-
 				setAttributes( {
 					height: '0px',
 					style: {
@@ -329,7 +327,6 @@ const SpacerEdit = ( {
 					height: flexSize,
 				} );
 			}
-
 			setAttributes( {
 				style: {
 					...blockStyle,

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -259,16 +259,13 @@ const SpacerEdit = ( {
 	};
 
 	useEffect( () => {
-		// This ensures the next change is not marked as persistent
-		// which lets the user undo the change.
-		__unstableMarkNextChangeAsNotPersistent();
-
 		if (
 			isFlexLayout &&
 			selfStretch !== 'fill' &&
 			selfStretch !== 'fit' &&
 			flexSize === undefined
 		) {
+			__unstableMarkNextChangeAsNotPersistent();
 			if ( inheritedOrientation === 'horizontal' ) {
 				// If spacer is moving from a vertical container to a horizontal container,
 				// it might not have width but have height instead.
@@ -308,6 +305,7 @@ const SpacerEdit = ( {
 			isFlexLayout &&
 			( selfStretch === 'fill' || selfStretch === 'fit' )
 		) {
+			__unstableMarkNextChangeAsNotPersistent();
 			if ( inheritedOrientation === 'horizontal' ) {
 				setAttributes( {
 					width: undefined,
@@ -318,6 +316,7 @@ const SpacerEdit = ( {
 				} );
 			}
 		} else if ( ! isFlexLayout && ( selfStretch || flexSize ) ) {
+			__unstableMarkNextChangeAsNotPersistent();
 			if ( inheritedOrientation === 'horizontal' ) {
 				setAttributes( {
 					width: flexSize,

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -259,13 +259,20 @@ const SpacerEdit = ( {
 	};
 
 	useEffect( () => {
+		// To avoid interfering with undo/redo operations any changes in this
+		// effect must not make history and should be preceded by
+		// `__unstableMarkNextChangeAsNotPersistent()`.
+		const setAttributesCovertly = ( nextAttributes ) => {
+			__unstableMarkNextChangeAsNotPersistent();
+			setAttributes( nextAttributes );
+		};
+
 		if (
 			isFlexLayout &&
 			selfStretch !== 'fill' &&
 			selfStretch !== 'fit' &&
 			flexSize === undefined
 		) {
-			__unstableMarkNextChangeAsNotPersistent();
 			if ( inheritedOrientation === 'horizontal' ) {
 				// If spacer is moving from a vertical container to a horizontal container,
 				// it might not have width but have height instead.
@@ -273,7 +280,7 @@ const SpacerEdit = ( {
 					getCustomValueFromPreset( width, spacingSizes ) ||
 					getCustomValueFromPreset( height, spacingSizes ) ||
 					'100px';
-				setAttributes( {
+				setAttributesCovertly( {
 					width: '0px',
 					style: {
 						...blockStyle,
@@ -289,7 +296,7 @@ const SpacerEdit = ( {
 					getCustomValueFromPreset( height, spacingSizes ) ||
 					getCustomValueFromPreset( width, spacingSizes ) ||
 					'100px';
-				setAttributes( {
+				setAttributesCovertly( {
 					height: '0px',
 					style: {
 						...blockStyle,
@@ -305,32 +312,16 @@ const SpacerEdit = ( {
 			isFlexLayout &&
 			( selfStretch === 'fill' || selfStretch === 'fit' )
 		) {
-			__unstableMarkNextChangeAsNotPersistent();
-			if ( inheritedOrientation === 'horizontal' ) {
-				setAttributes( {
-					width: undefined,
-				} );
-			} else {
-				setAttributes( {
-					height: undefined,
-				} );
-			}
+			setAttributesCovertly(
+				inheritedOrientation === 'horizontal'
+					? { width: undefined }
+					: { height: undefined }
+			);
 		} else if ( ! isFlexLayout && ( selfStretch || flexSize ) ) {
-			__unstableMarkNextChangeAsNotPersistent();
-			if ( inheritedOrientation === 'horizontal' ) {
-				setAttributes( {
-					width: flexSize,
-				} );
-			} else {
-				setAttributes( {
-					height: flexSize,
-				} );
-			}
-
-			// This ensures that the next change is not marked as persistent
-			// when the user changes the container layout.
-			__unstableMarkNextChangeAsNotPersistent();
-			setAttributes( {
+			setAttributesCovertly( {
+				...( inheritedOrientation === 'horizontal'
+					? { width: flexSize }
+					: { height: flexSize } ),
 				style: {
 					...blockStyle,
 					layout: {

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -259,6 +259,8 @@ const SpacerEdit = ( {
 	};
 
 	useEffect( () => {
+		// This ensures the next change is not marked as persistent
+		// which lets the user undo the change.
 		__unstableMarkNextChangeAsNotPersistent();
 
 		if (


### PR DESCRIPTION
## What, Why and How?

Fixes: #68863 

Currently, inserting or moving a `Spacer block` into a Row or Stack block disrupts the `undo` functionality. Similarly, moving a `Spacer block` out of a Row or Stack block also breaks the `undo` behavior. 

Also, Converting a `Row block` containing a `Spacer block` into a `Group block` caused undo to fail.

## Testing Instructions

Step 1: Navigate to the `post edit` page.
Step 2: Verify the undo functionality with `Spacer` works for the following cases:

- Case 1: Using `Flex Containers`. ( i.e. `Row` & `Stack` without setting `selfStretch` to `fit` or `fill` ).
- Case 2: Using `Flex Containers` with `selfStretch` to be either `fit` or `fill`.
- Case 3: `Non-Flex Container` with `selfStretch` to be either `fit` or `fill`.
- Case 4: Move `Spacer` into `Row/Stack`.
- Case 5: Move `Spacer` out of `Row/Stack`.
- Case 6: With `Spacer` inserted into a `Row/Stack`, convert it to `Group` and verify undo.

## Screencast

https://github.com/user-attachments/assets/3f53a999-b70b-4f07-871a-fc67df9ac4c3


