### PR TITLE
resolve latest comment block font size issue in editorside  issue

### DIFF
--- a/packages/block-library/src/latest-comments/block.json
+++ b/packages/block-library/src/latest-comments/block.json
@@ -56,6 +56,7 @@
 				"fontSize": true
 			}
 		},
+		"style": true,
 		"interactivity": {
 			"clientNavigation": true
 		}

--- a/packages/block-library/src/latest-comments/edit.js
+++ b/packages/block-library/src/latest-comments/edit.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { useEffect } from '@wordpress/element';
 import {
 	Disabled,
 	RangeControl,
@@ -31,8 +32,48 @@ const MIN_COMMENTS = 1;
 const MAX_COMMENTS = 100;
 
 export default function LatestComments( { attributes, setAttributes } ) {
-	const { commentsToShow, displayAvatar, displayDate, displayExcerpt } =
-		attributes;
+	const {
+		commentsToShow,
+		displayAvatar,
+		displayDate,
+		displayExcerpt,
+		style,
+	} = attributes;
+
+	const typographyStyles = {
+		fontSize: style?.typography?.fontSize || undefined,
+		lineHeight: style?.typography?.lineHeight || undefined,
+		fontFamily: style?.typography?.__experimentalFontFamily || undefined,
+		fontWeight: style?.typography?.__experimentalFontWeight || undefined,
+		fontStyle: style?.typography?.__experimentalFontStyle || undefined,
+		textTransform:
+			style?.typography?.__experimentalTextTransform || undefined,
+		textDecoration:
+			style?.typography?.__experimentalTextDecoration || undefined,
+		letterSpacing:
+			style?.typography?.__experimentalLetterSpacing || undefined,
+	};
+
+	const blockProps = useBlockProps( {
+		style: typographyStyles, // Apply styles to the parent block
+	} );
+
+	useEffect( () => {
+		// Apply typography styles to the <ol> element after the content is rendered
+		const applyTypographyStyles = () => {
+			const olElement = document.querySelector(
+				'.wp-block-latest-comments ol'
+			);
+			if ( olElement ) {
+				Object.assign( olElement.style, typographyStyles );
+			}
+		};
+
+		// Apply styles initially
+		applyTypographyStyles();
+
+		// The server-side render will trigger the re-apply after content is rendered
+	}, [ typographyStyles ] );
 
 	const serverSideAttributes = {
 		...attributes,
@@ -45,7 +86,7 @@ export default function LatestComments( { attributes, setAttributes } ) {
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	return (
-		<div { ...useBlockProps() }>
+		<div { ...blockProps }>
 			<InspectorControls>
 				<ToolsPanel
 					label={ __( 'Settings' ) }
@@ -148,6 +189,15 @@ export default function LatestComments( { attributes, setAttributes } ) {
 					// the block appears on the frontend. Setting the locale
 					// explicitly prevents any middleware from setting it to 'user'.
 					urlQueryArgs={ { _locale: 'site' } }
+					onRender={ () => {
+						// This function is called whenever the ServerSideRender completes rendering
+						const olElement = document.querySelector(
+							'.wp-block-latest-comments ol'
+						);
+						if ( olElement ) {
+							Object.assign( olElement.style, typographyStyles );
+						}
+					} }
 				/>
 			</Disabled>
 		</div>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Resolve the issue :- #68876 
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Latest Comment block having issue with typography in editor side.
When we change the font size then it should be applied to the Latest comment block font size.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This Pr will resolve the mentioned issue and whenever we change font size from the inspector it will immediately implemented to the Latest Comment Block.