### PR TITLE
Zoom out: Add an Editor setting to disable Zoom out mode

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -824,6 +824,7 @@ _Properties_
 -   _\_\_experimentalBlockDirectory_ `boolean`: Whether the user has enabled the Block Directory
 -   _\_\_experimentalBlockPatterns_ `Array`: Array of objects representing the block patterns
 -   _\_\_experimentalBlockPatternCategories_ `Array`: Array of objects representing the block pattern categories
+-   _zoomOutEnabled_ `boolean`: Whether the zoom out feature is enabled or not.
 
 ### SkipToSelectedBlock
 

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -54,14 +54,18 @@ function InserterMenu(
 	},
 	ref
 ) {
-	const { isZoomOutMode, hasSectionRootClientId } = useSelect( ( select ) => {
-		const { isZoomOut, getSectionRootClientId } = unlock(
+	const {
+		isZoomOutMode,
+		zoomOutEditorSettingEnabled,
+		hasSectionRootClientId,
+	} = useSelect( ( select ) => {
+		const { isZoomOut, getSectionRootClientId, getSettings } = unlock(
 			select( blockEditorStore )
 		);
-
 		return {
 			isZoomOutMode: isZoomOut(),
 			hasSectionRootClientId: !! getSectionRootClientId(),
+			zoomOutEditorSettingEnabled: getSettings().zoomOutEnabled,
 		};
 	}, [] );
 
@@ -90,6 +94,7 @@ function InserterMenu(
 	const [ selectedTab, setSelectedTab ] = useState( getInitialTab() );
 
 	const shouldUseZoomOut =
+		zoomOutEditorSettingEnabled &&
 		hasSectionRootClientId &&
 		( selectedTab === 'patterns' || selectedTab === 'media' );
 

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -33,6 +33,7 @@ export const PREFERENCES_DEFAULTS = {
  * @property {boolean}       __experimentalBlockDirectory           Whether the user has enabled the Block Directory
  * @property {Array}         __experimentalBlockPatterns            Array of objects representing the block patterns
  * @property {Array}         __experimentalBlockPatternCategories   Array of objects representing the block pattern categories
+ * @property {boolean}       zoomOutEnabled                         Whether the zoom out feature is enabled or not.
  */
 export const SETTINGS_DEFAULTS = {
 	alignWide: false,

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -91,7 +91,13 @@ function Header( {
 		};
 	}, [] );
 
+	const zoomOutEditorSettingEnabled = useSelect(
+		( select ) => select( editorStore ).getEditorSettings().zoomOutEnabled,
+		[]
+	);
+
 	const canBeZoomedOut =
+		zoomOutEditorSettingEnabled &&
 		[ 'post', 'page', 'wp_template' ].includes( postType ) &&
 		hasSectionRootClientId;
 

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -86,6 +86,7 @@ const BLOCK_EDITOR_SETTINGS = [
 	'__unstableHasCustomAppender',
 	'__unstableResolvedAssets',
 	'__unstableIsBlockBasedTheme',
+	'zoomOutEnabled',
 ];
 
 const {

--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -21,6 +21,7 @@ import { SETTINGS_DEFAULTS } from '@wordpress/block-editor';
  * @property {Array?}        allowedMimeTypes      List of allowed mime types and file extensions
  * @property {number}        maxUploadFileSize     Maximum upload file size
  * @property {boolean}       supportsLayout        Whether the editor supports layouts.
+ * @property {boolean}       zoomOutEnabled        Whether the zoom out feature is enabled or not.
  */
 export const EDITOR_SETTINGS_DEFAULTS = {
 	...SETTINGS_DEFAULTS,
@@ -30,4 +31,5 @@ export const EDITOR_SETTINGS_DEFAULTS = {
 	fontLibraryEnabled: true,
 	enableCustomFields: undefined,
 	defaultRenderingMode: 'post-only',
+	zoomOutEnabled: true,
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add a setting called "zoomOutEnabled" to the `editor` and `block-editor` packages. The setting defaults to `true` and can be filtered with` block_editor_settings_all`. When `false`, the zoom out mode is disabled.

Closes https://github.com/WordPress/gutenberg/issues/63584
## Why?
The reasons why the filter was requested are listed in the issue :)

## Testing Instructions
This will require careful testing of both the Site Editor and block editor.

Apply the PR and activate a block theme.
The zoom out mode should be available by default: With available, I mean that all flows should work as they do without this PR.
The zoom out toggle button should work.
The zoom out should activate when the patterns tab is opened through the inserter, etc.
There should be no regressions to the zoom out mode in the block editor, when editing templates in the block editor,
or the Site Editor.

After testing for regressions it is time to disable it.
Add this basic example code to your theme , for example in fuctions.php:
```
function wp_docs_block_editor_settings( $editor_settings, $editor_context ) {
    $editor_settings['zoomOutEnabled'] = false;
    return $editor_settings;
}

add_filter( 'block_editor_settings_all', 'wp_docs_block_editor_settings', 10, 2 );
```
Now re-test the block editor, including the "edit template" and "show template" options and the pattern inserter.
The zoom out mode should not be activated.
The toggle to enable and deactivate zoom out should not be visible.

Test the Site Editor, including the pattern inserter. The zoom out mode should not be available.

But wait we aren't finished yet!
Activate a classic theme and add the filter in the code above, for example in functions.php.
Create a new post.
Insert a group block. Set the HTML element on the group block to main in the Advanced panel of the block.
Save. The zoom out option should not be available.


## Screenshots or screencast <!-- if applicable -->
Example of editing a post, with the zoom out option missing:
![The top toolbar of the block editor](https://github.com/user-attachments/assets/95818dea-a934-466a-ab3e-803e0f71b7a4)

## Todo:
Documentation and test.