### PR TITLE
Used https in main-dashboard-button.md file

### DIFF
--- a/docs/reference-guides/slotfills/main-dashboard-button.md
+++ b/docs/reference-guides/slotfills/main-dashboard-button.md
@@ -33,7 +33,7 @@ registerPlugin( 'main-dashboard-button-test', {
 
 ### Change the icon and link
 
-This example will change the icon in the header to indicate an external link that will take the user to http://wordpress.org when clicked.
+This example will change the icon in the header to indicate an external link that will take the user to https://wordpress.org when clicked.
 
 ```js
 import { registerPlugin } from '@wordpress/plugins';
@@ -45,7 +45,7 @@ import { external } from '@wordpress/icons';
 
 const MainDashboardButtonIconTest = () => (
 	<MainDashboardButton>
-		<FullscreenModeClose icon={ external } href="http://wordpress.org" />
+		<FullscreenModeClose icon={ external } href="https://wordpress.org" />
 	</MainDashboardButton>
 );
 
@@ -54,4 +54,4 @@ registerPlugin( 'main-dashboard-button-icon-test', {
 } );
 ```
 
-![The edit post screen in fullscreen mode displaying an external link icon instead of the default W](https://developer.wordpress.org/files/2024/08/main-dashboard-button-external-link-example.png 'Change the icon in the header to indicate an external link that will take the user to http://wordpress.org when clicked')
+![The edit post screen in fullscreen mode displaying an external link icon instead of the default W](https://developer.wordpress.org/files/2024/08/main-dashboard-button-external-link-example.png 'Change the icon in the header to indicate an external link that will take the user to https://wordpress.org when clicked')


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/68882

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Used https Instead of http in URL in below documentation file

- docs/reference-guides/slotfills/main-dashboard-button.md

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
http://wordpress.org is redirecting on https://wordpress.org

## Testing Instructions
- Open docs/reference-guides/slotfills/main-dashboard-button.md file
- See There are several instances using http://wordpress.org it should be https://wordpress.org
