### PR TITLE
Add format attribute to the palette's color property

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -194,6 +194,7 @@
 									},
 									"color": {
 										"description": "CSS hex or rgb(a) string.",
+										"format": "color",
 										"type": "string"
 									}
 								},


### PR DESCRIPTION
## What?

Enhances the JSON schema for WordPress theme.json to enable color swatches and the color picker functionality for hex values within JSON in VS Code.

This PR adds the `format` attribute to the palette's color property and sets `color` as the value.

## Why?

This change improves the developer experience by visually displaying color values through swatches and enabling a color picker in VS Code. It simplifies working with color-related properties in theme.json and style variations, reducing errors and enhancing productivity.

## How?

Updates the JSON schema to include the `"format": "color"` attribute to the palette's color property.

## Testing Instructions

1. Open a WordPress project in VS Code.
2. Add or update a theme.json file with color-related settings (e.g., settings.color.palette).
3. Verify that color swatches are displayed next to color values in VS Code.
4. Ensure the color picker activates when editing color values.
5. Confirm compatibility with various color formats, including:
   - Hex (`#3858e9`)
   - Hex with alpha (`#3858e950`)

Test `theme.json`

```json
{
	"settings": {
		"color": {
			"palette": [
				{
					"color": "#3858e9",
					"name": "Hex",
					"slug": "hex"
				},
				{
					"color": "#3858e950",
					"name": "Hex with Alpha",
					"slug": "hex-alpha"
				}
			]
		},
	}
}
```

## Screenshots or screencast

<img width="386" alt="Screenshot 2025-01-25 at 3 33 06 PM" src="https://github.com/user-attachments/assets/ec354135-7c63-46d1-9002-92dc71f2c27a" />
