### PR TITLE
[WP6.7] e2e:fix WP Editor Meta Boxes test

### DIFF
--- a/test/e2e/specs/editor/plugins/wp-editor-meta-box.spec.js
+++ b/test/e2e/specs/editor/plugins/wp-editor-meta-box.spec.js
@@ -27,7 +27,7 @@ test.describe( 'WP Editor Meta Boxes', () => {
 		// Switch tinymce to Text mode, first waiting for it to initialize
 		// because otherwise it will flip back to Visual mode once initialized.
 		await page.locator( '#test_tinymce_id_ifr' ).waitFor();
-		await page.locator( 'role=button[name="Text"i]' ).click();
+		await page.locator( 'role=button[name="Code"i]' ).click();
 
 		// Type something in the tinymce Text mode textarea.
 		const metaBoxField = page.locator( '#test_tinymce_id' );


### PR DESCRIPTION
## What?

Backport #68872 to the `wp/6.7` branch

## Why?

There are three open PRs for the WP 6.7.2 release. To make them mergable, we need to first resolve the E2E test failures in the `wp/6.7` branch.

> In the following changeset, the `Text` tab in the classic editor has been changed to `Code`. As a result, the selectors in e2e tests need to be updated.
> 
> https://core.trac.wordpress.org/changeset/59696

## Testing Instructions

It should pass all e2e tests.