### PR TITLE
Spacer: Adjust to inherit `display` and `flex` properties

### DIFF
--- a/packages/block-library/src/spacer/editor.scss
+++ b/packages/block-library/src/spacer/editor.scss
@@ -1,4 +1,7 @@
 .block-editor-block-list__block[data-type="core/spacer"] {
+	display: inherit;
+	flex-direction: inherit;
+
 	// This generates an invisible field above the spacer, which makes its minimum clickable-to-select height larger.
 	&::before {
 		content: "";
@@ -44,5 +47,10 @@
 		margin-bottom: 0;
 		// Important is used to have higher specificity than the inline style set by re-resizable library.
 		height: 100% !important;
+	}
+
+	// Allows the resizable container to occupy all remaining vertical space.
+	&:not(.resize-horizontal) {
+		flex-grow: inherit;
 	}
 }

--- a/packages/block-library/src/spacer/editor.scss
+++ b/packages/block-library/src/spacer/editor.scss
@@ -49,7 +49,7 @@
 		height: 100% !important;
 	}
 
-	// Allows the resizable container to occupy all remaining vertical space.
+	// Ensures the resizable container fills the remaining vertical space.
 	&:not(.resize-horizontal) {
 		flex-grow: inherit;
 	}


### PR DESCRIPTION
## What, Why and How?

Fixes: #68889

This PR addresses a bug where the `Spacer` block fails to fill the available space when the `height` is set to "Grow" within a `stack` block with a defined `minimum height`. Instead of expanding, the Spacer block's height incorrectly becomes `0`.

## Testing Instructions

1. Create a stack block.
2. Set the minimum height of the block to 500px.
3. Add a spacer block within it.
4. Set the height of the spacer block to Grow.
5. Observe the height properly reflects the available space.

## Screenshots or screencast

https://github.com/user-attachments/assets/b62934dc-5f64-4c57-98b3-16b118f0d550

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/fc6c7ab8-be3c-45c3-b0b3-d06d54f80907)|![after](https://github.com/user-attachments/assets/b19ac74e-09db-428d-a9cb-762713bfe81b)|
