### PR TITLE
Add padding to tab list in tab component

### DIFF
--- a/packages/components/src/tabs/styles.ts
+++ b/packages/components/src/tabs/styles.ts
@@ -15,6 +15,7 @@ export const StyledTabList = styled( Ariakit.TabList )`
 	display: flex;
 	align-items: stretch;
 	overflow-x: auto;
+	padding-bottom: 3px;
 
 	&[aria-orientation='vertical'] {
 		flex-direction: column;


### PR DESCRIPTION


## What?
Fixes https://github.com/WordPress/gutenberg/issues/67155

## Why?
There was scrolling problem where scrollbar was overlapping the text and there was UI issue on windows for scrollbar as well 

## How?
This PR adds necessary padding to the Tab to avoid overlapping and fix the UI 

## Testing Instructions
- Open Editor 
- Check the right panel 
- Try to add some long words in the Tab or change the language
- Confirm that overlapping doesn't happen now 

## Screenshots or screencast

https://github.com/user-attachments/assets/ee3bcd5c-0727-4182-a0f7-c69651ceeae3



