### PR TITLE
ESLint: Add rule to prevent usage of the word 'sidebar' in translatable strings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -121,7 +121,7 @@ const restrictedSyntax = [
 	},
 	{
 		selector:
-			'CallExpression[callee.name=/^(__|_x|_n|_nx)$/] > Literal[value=/^sidebar\\b/i]',
+			'CallExpression[callee.name=/^(__|_x|_n|_nx)$/] > Literal[value=/sidebar/i]',
 		message: "Avoid using the word 'sidebar' in translatable strings",
 	},
 ];

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -119,6 +119,11 @@ const restrictedSyntax = [
 			'CallExpression[callee.name=/^(__|_x|_n|_nx)$/] > Literal[value=/^toggle\\b/i]',
 		message: "Avoid using the verb 'Toggle' in translatable strings",
 	},
+	{
+		selector:
+			'CallExpression[callee.name=/^(__|_x|_n|_nx)$/] > Literal[value=/^sidebar\\b/i]',
+		message: "Avoid using the word 'sidebar' in translatable strings",
+	},
 ];
 
 /** `no-restricted-syntax` rules for components. */

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -121,7 +121,7 @@ const restrictedSyntax = [
 	},
 	{
 		selector:
-			'CallExpression[callee.name=/^(__|_x|_n|_nx)$/] > Literal[value=/sidebar/i]',
+			'CallExpression[callee.name=/^(__|_x|_n|_nx)$/] > Literal[value=/sidebar\\b/i]',
 		message: "Avoid using the word 'sidebar' in translatable strings",
 	},
 ];

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -121,7 +121,7 @@ const restrictedSyntax = [
 	},
 	{
 		selector:
-			'CallExpression[callee.name=/^(__|_x|_n|_nx)$/] > Literal[value=/sidebar\\b/i]',
+			'CallExpression[callee.name=/^(__|_x|_n|_nx)$/] > Literal[value=/(?<![-\\w])sidebar(?![-\\w])/i]',
 		message:
 			"Avoid using the word 'sidebar' in translatable strings. Consider using 'panel' instead.",
 	},

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -122,7 +122,8 @@ const restrictedSyntax = [
 	{
 		selector:
 			'CallExpression[callee.name=/^(__|_x|_n|_nx)$/] > Literal[value=/sidebar\\b/i]',
-		message: "Avoid using the word 'sidebar' in translatable strings",
+		message:
+			"Avoid using the word 'sidebar' in translatable strings. Consider using 'panel' instead.",
 	},
 ];
 

--- a/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal-content.js
@@ -51,7 +51,7 @@ function AddCustomGenericTemplateModalContent( { onClose, createTemplate } ) {
 					placeholder={ defaultTitle }
 					disabled={ isBusy }
 					help={ __(
-						'Describe the template, e.g. "Post with sidebar". A custom template can be manually applied to any post or page.'
+						'Describe the template, e.g. "Post with panel". A custom template can be manually applied to any post or page.'
 					) }
 				/>
 				<HStack

--- a/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal-content.js
@@ -51,7 +51,8 @@ function AddCustomGenericTemplateModalContent( { onClose, createTemplate } ) {
 					placeholder={ defaultTitle }
 					disabled={ isBusy }
 					help={ __(
-						'Describe the template, e.g. "Post with panel". A custom template can be manually applied to any post or page.'
+						// eslint-disable-next-line no-restricted-syntax -- 'sidebar' is a common web design term for layouts
+						'Describe the template, e.g. "Post with sidebar". A custom template can be manually applied to any post or page.'
 					) }
 				/>
 				<HStack

--- a/packages/edit-site/src/components/welcome-guide/page.js
+++ b/packages/edit-site/src/components/welcome-guide/page.js
@@ -57,7 +57,7 @@ export default function WelcomeGuidePage() {
 							</h1>
 							<p className="edit-site-welcome-guide__text">
 								{ __(
-									'It’s now possible to edit page content in the site editor. To customise other parts of the page like the header and footer switch to editing the template using the settings sidebar.'
+									'It’s now possible to edit page content in the site editor. To customise other parts of the page like the header and footer switch to editing the template using the settings panel.'
 								) }
 							</p>
 						</>

--- a/packages/edit-site/src/components/welcome-guide/page.js
+++ b/packages/edit-site/src/components/welcome-guide/page.js
@@ -57,7 +57,8 @@ export default function WelcomeGuidePage() {
 							</h1>
 							<p className="edit-site-welcome-guide__text">
 								{ __(
-									'It’s now possible to edit page content in the site editor. To customise other parts of the page like the header and footer switch to editing the template using the settings panel.'
+									// eslint-disable-next-line no-restricted-syntax -- 'sidebar' is a common web design term for layouts
+									'It’s now possible to edit page content in the site editor. To customise other parts of the page like the header and footer switch to editing the template using the settings sidebar.'
 								) }
 							</p>
 						</>

--- a/packages/edit-widgets/src/components/sidebar/widget-areas.js
+++ b/packages/edit-widgets/src/components/sidebar/widget-areas.js
@@ -33,7 +33,8 @@ export default function WidgetAreas( { selectedWidgetAreaId } ) {
 	let description;
 	if ( ! selectedWidgetArea ) {
 		description = __(
-			'Widget Areas are global parts in your site’s layout that can accept blocks. These vary by theme, but are typically parts like your Side bar or Footer.'
+			// eslint-disable-next-line no-restricted-syntax -- 'sidebar' is a common web design term for layouts
+			'Widget Areas are global parts in your site’s layout that can accept blocks. These vary by theme, but are typically parts like your Sidebar or Footer.'
 		);
 	} else if ( selectedWidgetAreaId === 'wp_inactive_widgets' ) {
 		description = __(

--- a/packages/edit-widgets/src/components/sidebar/widget-areas.js
+++ b/packages/edit-widgets/src/components/sidebar/widget-areas.js
@@ -33,7 +33,7 @@ export default function WidgetAreas( { selectedWidgetAreaId } ) {
 	let description;
 	if ( ! selectedWidgetArea ) {
 		description = __(
-			'Widget Areas are global parts in your site’s layout that can accept blocks. These vary by theme, but are typically parts like your Sidebar or Footer.'
+			'Widget Areas are global parts in your site’s layout that can accept blocks. These vary by theme, but are typically parts like your Side bar or Footer.'
 		);
 	} else if ( selectedWidgetAreaId === 'wp_inactive_widgets' ) {
 		description = __(

--- a/packages/editor/src/components/post-template/create-new-template-modal.js
+++ b/packages/editor/src/components/post-template/create-new-template-modal.js
@@ -126,7 +126,8 @@ export default function CreateNewTemplateModal( { onClose } ) {
 						placeholder={ DEFAULT_TITLE }
 						disabled={ isBusy }
 						help={ __(
-							'Describe the template, e.g. "Post with panel". A custom template can be manually applied to any post or page.'
+							// eslint-disable-next-line no-restricted-syntax -- 'sidebar' is a common web design term for layouts
+							'Describe the template, e.g. "Post with sidebar". A custom template can be manually applied to any post or page.'
 						) }
 					/>
 					<HStack justify="right">

--- a/packages/editor/src/components/post-template/create-new-template-modal.js
+++ b/packages/editor/src/components/post-template/create-new-template-modal.js
@@ -126,7 +126,7 @@ export default function CreateNewTemplateModal( { onClose } ) {
 						placeholder={ DEFAULT_TITLE }
 						disabled={ isBusy }
 						help={ __(
-							'Describe the template, e.g. "Post with sidebar". A custom template can be manually applied to any post or page.'
+							'Describe the template, e.g. "Post with panel". A custom template can be manually applied to any post or page.'
 						) }
 					/>
 					<HStack justify="right">

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -88,7 +88,7 @@ function PreferencesModalContents( { extraSections = {} } ) {
 									scope="core"
 									featureName="showListViewByDefault"
 									help={ __(
-										'Opens the List View sidebar by default.'
+										'Opens the List View panel by default.'
 									) }
 									label={ __( 'Always open List View' ) }
 								/>

--- a/packages/editor/src/components/sidebar/header.js
+++ b/packages/editor/src/components/sidebar/header.js
@@ -22,7 +22,7 @@ const SidebarHeader = ( _, ref ) => {
 		return {
 			documentLabel:
 				// translators: Default label for the Document sidebar tab, not selected.
-				getPostTypeLabel() || _x( 'Document', 'noun, sidebar' ),
+				getPostTypeLabel() || _x( 'Document', 'noun, panel' ),
 		};
 	}, [] );
 

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -103,7 +103,7 @@ const SidebarContent = ( {
 			headerClassName="editor-sidebar__panel-tabs"
 			title={
 				/* translators: button label text should, if possible, be under 16 characters. */
-				_x( 'Settings', 'sidebar button label' )
+				_x( 'Settings', 'panel button label' )
 			}
 			toggleShortcut={ keyboardShortcut }
 			icon={ isRTL() ? drawerLeft : drawerRight }


### PR DESCRIPTION
Related comment: https://github.com/WordPress/gutenberg/issues/61499#issuecomment-2607544219

## What?
This PR introduces a new ESLint rule to prevent the use of the term "sidebar" in user-facing strings throughout the codebase. The rule aims to ensure that more generic and accessible terms like "panel" are used in place of "sidebar."


## Why?
The term "sidebar" is problematic for blind and low-vision users, as it relies on spatial concepts that are irrelevant to them. Additionally, the term can be misleading on smaller screens where "sidebars" are often full-width overlays. This change is necessary to align with the accessibility guidelines. It ensures consistency in user-facing language across WordPress projects.


## How?
The PR implements an ESLint rule that flags occurrences of the word "sidebar" in translatable strings, helping developers avoid its usage in user-facing content. The rule is added to the .eslintrc.js configuration to prevent new instances of this term from being introduced.


## Testing Instructions

1. Change any word inside any translation ready functions to "sidebar" in any file.
2. Check if your IDE raises an ESLint error with the message: "Avoid using the word 'sidebar' in translatable strings."


## Screencast 


https://github.com/user-attachments/assets/42dcf1b3-315d-43cb-b798-954a8030c4c4



