### PR TITLE
Block Editor: Fix 'isBlockVisibleInTheInserter' selector helper performance

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -624,6 +624,33 @@ export const getBlockParents = createSelector(
 
 /**
  * Given a block client ID and a block name, returns the list of all its parents
+ * from top to bottom, filtered by the given name(s).
+ *
+ * The function is not exported and not memoized because
+ * it's not efficient to call memoized selectors inside other selectors.
+ *
+ * @param {Object}          state     Editor state.
+ * @param {string}          clientId  Block from which to find root client ID.
+ * @param {string|string[]} blockName Block name(s) to filter.
+ * @param {boolean}         ascending Order results from bottom to top (true) or top to bottom (false).
+ *
+ * @return {Array} ClientIDs of the parent blocks.
+ */
+function getBlockParentsByBlockNameUnmemoized(
+	state,
+	clientId,
+	blockName,
+	ascending = false
+) {
+	const parents = getBlockParents( state, clientId, ascending );
+	const hasName = Array.isArray( blockName )
+		? ( name ) => blockName.includes( name )
+		: ( name ) => blockName === name;
+	return parents.filter( ( id ) => hasName( getBlockName( state, id ) ) );
+}
+
+/**
+ * Given a block client ID and a block name, returns the list of all its parents
  * from top to bottom, filtered by the given name(s). For example, if passed
  * 'core/group' as the blockName, it will only return parents which are group
  * blocks. If passed `[ 'core/group', 'core/cover']`, as the blockName, it will
@@ -637,13 +664,7 @@ export const getBlockParents = createSelector(
  * @return {Array} ClientIDs of the parent blocks.
  */
 export const getBlockParentsByBlockName = createSelector(
-	( state, clientId, blockName, ascending = false ) => {
-		const parents = getBlockParents( state, clientId, ascending );
-		const hasName = Array.isArray( blockName )
-			? ( name ) => blockName.includes( name )
-			: ( name ) => blockName === name;
-		return parents.filter( ( id ) => hasName( getBlockName( state, id ) ) );
-	},
+	getBlockParentsByBlockNameUnmemoized,
 	( state ) => [ state.blocks.parents ]
 );
 /**
@@ -1629,11 +1650,16 @@ const isBlockVisibleInTheInserter = (
 		const rootBlockName = getBlockName( state, rootClientId );
 		// This is an exception to the rule that says that all blocks are visible in the inserter.
 		// Blocks that require a given parent or ancestor are only visible if we're within that parent.
-		return (
+		if (
 			parents.includes( 'core/post-content' ) ||
-			parents.includes( rootBlockName ) ||
-			getBlockParentsByBlockName( state, rootClientId, parents ).length >
-				0
+			parents.includes( rootBlockName )
+		) {
+			return true;
+		}
+
+		return (
+			getBlockParentsByBlockNameUnmemoized( state, rootClientId, parents )
+				.length > 0
 		);
 	}
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -624,33 +624,6 @@ export const getBlockParents = createSelector(
 
 /**
  * Given a block client ID and a block name, returns the list of all its parents
- * from top to bottom, filtered by the given name(s).
- *
- * The function is not exported and not memoized because
- * it's not efficient to call memoized selectors inside other selectors.
- *
- * @param {Object}          state     Editor state.
- * @param {string}          clientId  Block from which to find root client ID.
- * @param {string|string[]} blockName Block name(s) to filter.
- * @param {boolean}         ascending Order results from bottom to top (true) or top to bottom (false).
- *
- * @return {Array} ClientIDs of the parent blocks.
- */
-function getBlockParentsByBlockNameUnmemoized(
-	state,
-	clientId,
-	blockName,
-	ascending = false
-) {
-	const parents = getBlockParents( state, clientId, ascending );
-	const hasName = Array.isArray( blockName )
-		? ( name ) => blockName.includes( name )
-		: ( name ) => blockName === name;
-	return parents.filter( ( id ) => hasName( getBlockName( state, id ) ) );
-}
-
-/**
- * Given a block client ID and a block name, returns the list of all its parents
  * from top to bottom, filtered by the given name(s). For example, if passed
  * 'core/group' as the blockName, it will only return parents which are group
  * blocks. If passed `[ 'core/group', 'core/cover']`, as the blockName, it will
@@ -664,7 +637,13 @@ function getBlockParentsByBlockNameUnmemoized(
  * @return {Array} ClientIDs of the parent blocks.
  */
 export const getBlockParentsByBlockName = createSelector(
-	getBlockParentsByBlockNameUnmemoized,
+	( state, clientId, blockName, ascending = false ) => {
+		const parents = getBlockParents( state, clientId, ascending );
+		const hasName = Array.isArray( blockName )
+			? ( name ) => blockName.includes( name )
+			: ( name ) => blockName === name;
+		return parents.filter( ( id ) => hasName( getBlockName( state, id ) ) );
+	},
 	( state ) => [ state.blocks.parents ]
 );
 /**
@@ -1647,20 +1626,23 @@ const isBlockVisibleInTheInserter = (
 		Array.isArray( blockType.parent ) ? blockType.parent : []
 	).concat( Array.isArray( blockType.ancestor ) ? blockType.ancestor : [] );
 	if ( parents.length > 0 ) {
-		const rootBlockName = getBlockName( state, rootClientId );
 		// This is an exception to the rule that says that all blocks are visible in the inserter.
 		// Blocks that require a given parent or ancestor are only visible if we're within that parent.
-		if (
-			parents.includes( 'core/post-content' ) ||
-			parents.includes( rootBlockName )
-		) {
+		if ( parents.includes( 'core/post-content' ) ) {
 			return true;
 		}
 
-		return (
-			getBlockParentsByBlockNameUnmemoized( state, rootClientId, parents )
-				.length > 0
-		);
+		let current = rootClientId;
+		let hasParent = false;
+		do {
+			if ( parents.includes( getBlockName( state, current ) ) ) {
+				hasParent = true;
+				break;
+			}
+			current = state.blocks.parents.get( current );
+		} while ( current );
+
+		return hasParent;
 	}
 
 	return true;


### PR DESCRIPTION
## What?
Resolves #68875.

Fixes recent performance regression in the Block Editor package.

## Why?
The `isBlockVisibleInTheInserter` function is often called even when the inserter isn't visible. The internal function `getBlockParentsByBlockName` is a memoized selector but receives a new `parents` array reference on every call.

Calling a memoized selector with an unstable argument reference can degrade performance.

## Testing Instructions
1. Open the Site Editor.
2. Edit Navigation menu
3. Add multiple submenu items.
4. Open List View.
5. Test block hover and selection multiple times.
6. Actions should be snappy.

Notes:
* The issue can be reproduced in the post editor, but it's more noticeable in the site editor.
* React DevTools also affect performance for the best results test via incognito mode

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2025-01-27 at 16 35 21](https://github.com/user-attachments/assets/691e2ef7-05de-4901-9415-ce593e92fba9)
