### PR TITLE
Site editor: fix nav error due to lack of context provider in narrow viewports

### DIFF
--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -31,30 +31,6 @@ function focusSidebarElement( el, direction, focusSelector ) {
 	elementToFocus?.focus();
 }
 
-// Navigation state that is updated when navigating back or forward. Helps us
-// manage the animations and also focus.
-function createNavState() {
-	let state = {
-		direction: null,
-		focusSelector: null,
-	};
-
-	return {
-		get() {
-			return state;
-		},
-		navigate( direction, focusSelector = null ) {
-			state = {
-				direction,
-				focusSelector:
-					direction === 'forward' && focusSelector
-						? focusSelector
-						: state.focusSelector,
-			};
-		},
-	};
-}
-
 function SidebarContentWrapper( { children, shouldAnimate } ) {
 	const navState = useContext( SidebarNavigationContext );
 	const wrapperRef = useRef();
@@ -92,18 +68,14 @@ export default function SidebarContent( {
 	shouldAnimate,
 	children,
 } ) {
-	const [ navState ] = useState( createNavState );
-
 	return (
-		<SidebarNavigationContext.Provider value={ navState }>
-			<div className="edit-site-sidebar__content">
-				<SidebarContentWrapper
-					shouldAnimate={ shouldAnimate }
-					key={ routeKey }
-				>
-					{ children }
-				</SidebarContentWrapper>
-			</div>
-		</SidebarNavigationContext.Provider>
+		<div className="edit-site-sidebar__content">
+			<SidebarContentWrapper
+				shouldAnimate={ shouldAnimate }
+				key={ routeKey }
+			>
+				{ children }
+			</SidebarContentWrapper>
+		</div>
 	);
 }


### PR DESCRIPTION
## What?
Avoids a non-fatal error being logged in the console when navigating the site editor in narrow viewports.

The changes here were a quick take on this and there certainly may be a better solution.

## Why?
To keep the console logs clean. Resolves #68929 

## How?
Moves the context provider that’s missing in the narrow viewport out/up in the tree so it’s a available for the mobile route area.

## Testing Instructions
1. Open the site editor in a narrow viewport (< 783px).
2. Select a menu items that has a sub menu.
3. Verify no console errors are logged.
