### PR TITLE
Site Title: Fix logic for 'aria-current' attribute

### DIFF
--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -31,7 +31,7 @@ function render_block_core_site_title( $attributes ) {
 	}
 
 	if ( $attributes['isLink'] ) {
-		$aria_current = is_front_page() && ( is_home() || 'page' === get_option( 'show_on_front' ) ) ? ' aria-current="page"' : '';
+		$aria_current = ! is_paged() && ( is_front_page() || is_home() && ( (int) get_option( 'page_for_posts' ) !== get_queried_object_id() ) ) ? ' aria-current="page"' : '';
 		$link_target  = ! empty( $attributes['linkTarget'] ) ? $attributes['linkTarget'] : '_self';
 
 		$site_title = sprintf(

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -31,7 +31,7 @@ function render_block_core_site_title( $attributes ) {
 	}
 
 	if ( $attributes['isLink'] ) {
-		$aria_current = is_home() || ( is_front_page() && 'page' === get_option( 'show_on_front' ) ) ? ' aria-current="page"' : '';
+		$aria_current = is_front_page() && ( is_home() || 'page' === get_option( 'show_on_front' ) ) ? ' aria-current="page"' : '';
 		$link_target  = ! empty( $attributes['linkTarget'] ) ? $attributes['linkTarget'] : '_self';
 
 		$site_title = sprintf(


### PR DESCRIPTION
## What?
This updates the core/site-title block and the aria-current attribute. This should only be applied to the front page and prevents the aria-current being applied if a user has a separate front page from the posts page. (the posts page should not have an aria-current attribute applied to site title in these instances)

## Why?
Resolves bug where a separate posts page has the site-title attribute applied to the site-title (should only be applied to the front page)

## How?


## Testing Instructions
1. Under settings->reading select a posts page and a homepage.
2. Visit the posts page on the front end and inspect the site title, you'll see an aria-current attribute applied. 

Trac ticket: https://core.trac.wordpress.org/ticket/62874