### PR TITLE
Enhance Terminology for Filter Operators in DataViews

### DIFF
--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -1065,14 +1065,14 @@ Configuration of the filters.
 
 Operators:
 
-| Operator   | Selection      | Description                                                             | Example                                            |
-| ---------- | -------------- | ----------------------------------------------------------------------- | -------------------------------------------------- |
-| `is`       | Single item    | `EQUAL TO`. The item's field is equal to a single value.                | Author is Admin                                    |
-| `isNot`    | Single item    | `NOT EQUAL TO`. The item's field is not equal to a single value.        | Author is not Admin                                |
-| `isAny`    | Multiple items | `OR`. The item's field is present in a list of values.                  | Author is any: Admin, Editor                       |
-| `isNone`   | Multiple items | `NOT OR`. The item's field is not present in a list of values.          | Author is none: Admin, Editor                      |
-| `isAll`    | Multiple items | `AND`. The item's field has all of the values in the list.              | Category is all: Book, Review, Science Fiction     |
-| `isNotAll` | Multiple items | `NOT AND`. The item's field doesn't have all of the values in the list. | Category is not all: Book, Review, Science Fiction |
+| Operator   | Selection      | Description                                                                 | Example                                            |
+|------------|----------------|-----------------------------------------------------------------------------|----------------------------------------------------|
+| `is`       | Single item    | `EQUAL TO`. The item's field is equal to a single value.                    | Author is Admin                                    |
+| `isNot`    | Single item    | `NOT EQUAL TO`. The item's field is not equal to a single value.            | Author is not Admin                                |
+| `isAny`    | Multiple items | `OR`. The item's field is included in a list of values.                     | Author includes: Admin, Editor                       |
+| `isNone`   | Multiple items | `NOT OR`. The item's field is not included in a list of values.             | Author excludes: Admin, Editor                      |
+| `isAll`    | Multiple items | `AND`. The item's field includes all the values in the list.                | Category is all: Book, Review, Science Fiction     |
+| `isNotAll` | Multiple items | `NOT AND`. The item's field does not include all of the values in the list. | Category is not all: Book, Review, Science Fiction |
 
 `is` and `isNot` are single-selection operators, while `isAny`, `isNone`, `isAll`, and `isNotALl` are multi-selection. A filter with no operators declared will support the `isAny` and `isNone` multi-selection operators by default. A filter cannot mix single-selection & multi-selection operators; if a single-selection operator is present in the list of valid operators, the multi-selection ones will be discarded, and the filter won't allow selecting more than one item.
 

--- a/packages/dataviews/src/components/dataviews-filters/filter-summary.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter-summary.tsx
@@ -80,8 +80,8 @@ const FilterText = ( {
 	if ( filterInView?.operator === OPERATOR_IS_ANY ) {
 		return createInterpolateElement(
 			sprintf(
-				/* translators: 1: Filter name. 3: Filter value. e.g.: "Author is any: Admin, Editor". */
-				__( '<Name>%1$s is any: </Name><Value>%2$s</Value>' ),
+				/* translators: 1: Filter name. 3: Filter value. e.g.: "Author includes: Admin, Editor". */
+				__( '<Name>%1$s includes: </Name><Value>%2$s</Value>' ),
 				filter.name,
 				activeElements.map( ( element ) => element.label ).join( ', ' )
 			),
@@ -92,8 +92,8 @@ const FilterText = ( {
 	if ( filterInView?.operator === OPERATOR_IS_NONE ) {
 		return createInterpolateElement(
 			sprintf(
-				/* translators: 1: Filter name. 3: Filter value. e.g.: "Author is none: Admin, Editor". */
-				__( '<Name>%1$s is none: </Name><Value>%2$s</Value>' ),
+				/* translators: 1: Filter name. 3: Filter value. e.g.: "Author excludes: Admin, Editor". */
+				__( '<Name>%1$s excludes: </Name><Value>%2$s</Value>' ),
 				filter.name,
 				activeElements.map( ( element ) => element.label ).join( ', ' )
 			),

--- a/packages/dataviews/src/constants.ts
+++ b/packages/dataviews/src/constants.ts
@@ -36,11 +36,11 @@ export const OPERATORS: Record< Operator, { key: string; label: string } > = {
 	},
 	[ OPERATOR_IS_ANY ]: {
 		key: 'is-any-filter',
-		label: __( 'Is any' ),
+		label: __( 'Includes' ),
 	},
 	[ OPERATOR_IS_NONE ]: {
 		key: 'is-none-filter',
-		label: __( 'Is none' ),
+		label: __( 'Excludes' ),
 	},
 	[ OPERATOR_IS_ALL ]: {
 		key: 'is-all-filter',


### PR DESCRIPTION
## What, Why and How?

Fixes: #67124

This PR updates the terminology for `filter operators` in the template editor to improve clarity and consistency. The following changes have been implemented:

1. The label of isAny operator has been replaced with includes.
2. The label of isNone operator has been replaced with excludes.
3. The readme is updated as per [this](https://github.com/WordPress/gutenberg/issues/67124#issuecomment-2500966295) suggestion to better reflect on the purpose of the operators through descriptions and examples.

## Testing Instructions

1. Go to `Editor -> Templates`.
2. Locate the `Filter Options` and confirm that `includes` is available.
3. Ensure that when `includes` is selected, the label (e.g., `Author includes`) updates accordingly.
4. Perform the same check for `excludes`.
5. Verify that `isAny` has been replaced with `includes` and `isNone` with `excludes`.

## Screenshots

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/cf14df14-75f0-4a63-afe0-d0b891bc10c8)|![after](https://github.com/user-attachments/assets/0fb966db-9cb7-40ae-9dd2-c583c930457d)|
|![before-2](https://github.com/user-attachments/assets/a212cfe9-a935-47b6-b2f3-fac0c5c4ed52)|![after-2](https://github.com/user-attachments/assets/0fdbc2a8-bc96-4c7b-9f00-0a36b4b75c7f)|
