### PR TITLE
FocalPointPicker: Fix Sidebar Overflow Issue

### DIFF
--- a/packages/components/src/focal-point-picker/styles/focal-point-picker-style.ts
+++ b/packages/components/src/focal-point-picker/styles/focal-point-picker-style.ts
@@ -18,6 +18,7 @@ export const MediaWrapper = styled.div`
 	display: flex;
 	text-align: center;
 	width: 100%;
+	overflow: hidden;
 `;
 
 export const MediaContainer = styled.div`


### PR DESCRIPTION
Closes:  #68914

## What?
This PR adds overflow: hidden to the MediaWrapper styled element in the FocalPointPicker to fix the sidebar overflow issue and prevent the horizontal scrollbar from appearing.

## Why?
Moving the focal point to the far right side in FocalPointPicker caused the Editor sidebar to overflow, resulting in a visible horizontal scrollbar. This PR addresses that issue by modifying the styling of MediaWrapper.

## How?
The overflow: hidden CSS rule was added to the MediaWrapper styled element in the focal-point-picker-style.ts file, which ensures that any overflow is contained, preventing the sidebar from exceeding its boundaries when the focal point is adjusted.

## Testing Instructions
1.	Open a post or page in the WordPress editor.
2.	Add a Cover or Media & Text block.
3.	Select an image and open the block settings in the sidebar.
4.	Use the FocalPointPicker to move the focal point to the far right.
5.	Check that the sidebar no longer overflows and that no horizontal scrollbar appears.


## Screencast 

https://github.com/user-attachments/assets/43cbfc69-6474-4b9a-9fbf-fe9250a31686



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media focal-point picker layout behavior to keep contained content positioned consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->