### PR TITLE
Details block: Add placeholder attribute

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -255,7 +255,7 @@ Hide and show additional content. ([Source](https://github.com/WordPress/gutenbe
 -	**Name:** core/details
 -	**Category:** text
 -	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout (~~allowEditing~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** allowedBlocks, name, showContent, summary
+-	**Attributes:** allowedBlocks, name, placeholder, showContent, summary
 
 ## Embed
 

--- a/packages/block-library/src/details/block.json
+++ b/packages/block-library/src/details/block.json
@@ -25,6 +25,9 @@
 		},
 		"allowedBlocks": {
 			"type": "array"
+		},
+		"placeholder": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -31,7 +31,8 @@ const TEMPLATE = [
 ];
 
 function DetailsEdit( { attributes, setAttributes } ) {
-	const { name, showContent, summary, allowedBlocks } = attributes;
+	const { name, showContent, summary, allowedBlocks, placeholder } =
+		attributes;
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
@@ -100,7 +101,7 @@ function DetailsEdit( { attributes, setAttributes } ) {
 					<RichText
 						identifier="summary"
 						aria-label={ __( 'Write summary' ) }
-						placeholder={ __( 'Write summary…' ) }
+						placeholder={ placeholder || __( 'Write summary…' ) }
 						allowedFormats={ [] }
 						withoutInteractiveFormatting
 						value={ summary }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
It would be useful to be able to set a placeholder in the summary of Details.
Add a placeholder as shown below.

Similar
#30958
#1891

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page. -->
2. Insert a Details block. -->
3. Switch to the code editor and add a placeholer.

example
```HTML
<!-- wp:details {"placeholder":"summary is here!"} -->
<details class="wp-block-details"><summary></summary><!-- wp:paragraph {"placeholder":"Type / to add a hidden block"} -->
<p></p>
<!-- /wp:paragraph --></details>
<!-- /wp:details -->
```


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| ![before](https://github.com/user-attachments/assets/1a634718-ca6f-4996-9666-6f5adf3c1c10) | ![placeholder](https://github.com/user-attachments/assets/b9778694-9dae-4c9a-b730-3f8c875a56b9) |

