### PR TITLE
Login/out Block: Enhance Customization Options for "Display as Form"

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -436,7 +436,7 @@ Show login & logout links. ([Source](https://github.com/WordPress/gutenberg/tree
 -	**Name:** core/loginout
 -	**Category:** theme
 -	**Supports:** className, color (background, gradients, link, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
--	**Attributes:** displayLoginAsForm, redirectToCurrent
+-	**Attributes:** displayLoginAsForm, formData, redirectToCurrent, showLostLink, showRememberMe
 
 ## Media & Text
 

--- a/packages/block-library/src/loginout/block.json
+++ b/packages/block-library/src/loginout/block.json
@@ -15,6 +15,18 @@
 		"redirectToCurrent": {
 			"type": "boolean",
 			"default": true
+		},
+		"formData": {
+			"type": "object",
+			"default": {}
+		},
+		"showRememberMe": {
+			"type": "boolean",
+			"default": true
+		},
+		"showLostLink": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"example": {

--- a/packages/block-library/src/loginout/edit.js
+++ b/packages/block-library/src/loginout/edit.js
@@ -8,6 +8,7 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
@@ -15,6 +16,7 @@ import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 export default function LoginOutEdit( { attributes, setAttributes } ) {
 	const { displayLoginAsForm, redirectToCurrent } = attributes;
+	const [ isEditingForm, setIsEditingForm ] = useState( false );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	return (
@@ -49,6 +51,23 @@ export default function LoginOutEdit( { attributes, setAttributes } ) {
 							}
 						/>
 					</ToolsPanelItem>
+					{ displayLoginAsForm && (
+						<ToolsPanelItem
+							label={ __( 'Show Login Form' ) }
+							isShownByDefault
+							hasValue={ () => ! isEditingForm }
+							onDeselect={ () => setIsEditingForm( true ) }
+						>
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={ __( 'Show Login Form' ) }
+								checked={ isEditingForm }
+								onChange={ () =>
+									setIsEditingForm( ! isEditingForm )
+								}
+							/>
+						</ToolsPanelItem>
+					) }
 					<ToolsPanelItem
 						label={ __( 'Redirect to current URL' ) }
 						isShownByDefault
@@ -75,7 +94,11 @@ export default function LoginOutEdit( { attributes, setAttributes } ) {
 					className: 'logged-in',
 				} ) }
 			>
-				<a href="#login-pseudo-link">{ __( 'Log out' ) }</a>
+				{ isEditingForm ? (
+					<>show Form</>
+				) : (
+					<a href="#login-pseudo-link">{ __( 'Log out' ) }</a>
+				) }
 			</div>
 		</>
 	);

--- a/packages/block-library/src/loginout/edit.js
+++ b/packages/block-library/src/loginout/edit.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	RichText,
+	useBlockProps,
+} from '@wordpress/block-editor';
 import {
 	ToggleControl,
 	__experimentalToolsPanel as ToolsPanel,
@@ -15,8 +19,9 @@ import { useState } from '@wordpress/element';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 export default function LoginOutEdit( { attributes, setAttributes } ) {
-	const { displayLoginAsForm, redirectToCurrent } = attributes;
-	const [ isEditingForm, setIsEditingForm ] = useState( false );
+	const { displayLoginAsForm, redirectToCurrent, formData, showRememberMe } =
+		attributes;
+	const [ isEditingForm, setIsEditingForm ] = useState( displayLoginAsForm );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	return (
@@ -52,21 +57,44 @@ export default function LoginOutEdit( { attributes, setAttributes } ) {
 						/>
 					</ToolsPanelItem>
 					{ displayLoginAsForm && (
-						<ToolsPanelItem
-							label={ __( 'Show Login Form' ) }
-							isShownByDefault
-							hasValue={ () => ! isEditingForm }
-							onDeselect={ () => setIsEditingForm( true ) }
-						>
-							<ToggleControl
-								__nextHasNoMarginBottom
-								label={ __( 'Show Login Form' ) }
-								checked={ isEditingForm }
-								onChange={ () =>
-									setIsEditingForm( ! isEditingForm )
-								}
-							/>
-						</ToolsPanelItem>
+						<>
+							<ToolsPanelItem
+								label={ __( 'View Login Form' ) }
+								isShownByDefault
+								hasValue={ () => ! isEditingForm }
+								onDeselect={ () => setIsEditingForm( true ) }
+							>
+								<ToggleControl
+									__nextHasNoMarginBottom
+									label={ __( 'View Login Form' ) }
+									checked={ isEditingForm }
+									onChange={ () =>
+										setIsEditingForm( ! isEditingForm )
+									}
+								/>
+							</ToolsPanelItem>
+							<ToolsPanelItem
+								label={ __( 'Show Remember Field' ) }
+								isShownByDefault
+								hasValue={ () => ! showRememberMe }
+								onDeselect={ () => {
+									setAttributes( {
+										showRememberMe: true,
+									} );
+								} }
+							>
+								<ToggleControl
+									__nextHasNoMarginBottom
+									label={ __( 'Show Remember Form' ) }
+									checked={ showRememberMe }
+									onChange={ () =>
+										setAttributes( {
+											showRememberMe: ! showRememberMe,
+										} )
+									}
+								/>
+							</ToolsPanelItem>
+						</>
 					) }
 					<ToolsPanelItem
 						label={ __( 'Redirect to current URL' ) }
@@ -95,7 +123,80 @@ export default function LoginOutEdit( { attributes, setAttributes } ) {
 				} ) }
 			>
 				{ isEditingForm ? (
-					<>show Form</>
+					<div className="wp-block-loginout-form">
+						<div className="wp-block-loginout-form__fields">
+							<RichText
+								tagName="label"
+								value={ formData.usernameLabel ?? 'Username' }
+								onChange={ ( usernameLabel ) =>
+									setAttributes( {
+										formData: {
+											...formData,
+											usernameLabel,
+										},
+									} )
+								}
+							/>
+
+							<input
+								type="text"
+								placeholder="Username"
+								disabled
+							/>
+						</div>
+						<div className="wp-block-loginout-form__fields">
+							<RichText
+								tagName="label"
+								value={ formData.passwordLabel ?? 'Password' }
+								onChange={ ( passwordLabel ) =>
+									setAttributes( {
+										formData: {
+											...formData,
+											passwordLabel,
+										},
+									} )
+								}
+							/>
+							<input
+								type="password"
+								placeholder="Password"
+								disabled
+							/>
+						</div>
+						{ /* Remember me checkbox */ }
+						{ !! showRememberMe && (
+							<div className="wp-block-loginout-form__fields">
+								<input type="checkbox" disabled />
+
+								<RichText
+									tagName="label"
+									value={
+										formData.rememberLabel ?? 'Remember me'
+									}
+									onChange={ ( rememberLabel ) =>
+										setAttributes( {
+											formData: {
+												...formData,
+												rememberLabel,
+											},
+										} )
+									}
+								/>
+							</div>
+						) }
+
+						<div className="wp-block-loginout-form__fields">
+							<RichText
+								tagName="button"
+								value={ formData.submitLabel ?? 'Log in' }
+								onChange={ ( submitLabel ) =>
+									setAttributes( {
+										formData: { ...formData, submitLabel },
+									} )
+								}
+							/>
+						</div>
+					</div>
 				) : (
 					<a href="#login-pseudo-link">{ __( 'Log out' ) }</a>
 				) }

--- a/packages/block-library/src/loginout/index.php
+++ b/packages/block-library/src/loginout/index.php
@@ -30,8 +30,28 @@ function render_block_core_loginout( $attributes ) {
 		// Add a class.
 		$classes .= ' has-login-form';
 
+		$args = array(
+			'echo'     => false,
+			'remember' => $attributes['showRememberMe'],
+		);
+
+		if ( ! empty( $attributes['formData'] ) ) {
+			if ( ! empty( $attributes['formData']['rememberMeLabel'] ) ) {
+				$args['label_remember'] = $attributes['formData']['rememberMeLabel'];
+			}
+			if ( ! empty( $attributes['formData']['passwordLabel'] ) ) {
+				$args['label_password'] = $attributes['formData']['passwordLabel'];
+			}
+			if ( ! empty( $attributes['formData']['usernameLabel'] ) ) {
+				$args['label_username'] = $attributes['formData']['usernameLabel'];
+			}
+			if ( ! empty( $attributes['formData']['submitLabel'] ) ) {
+				$args['label_log_in'] = $attributes['formData']['submitLabel'];
+			}
+		}
+
 		// Get the form.
-		$contents = wp_login_form( array( 'echo' => false ) );
+		$contents = wp_login_form( $args );
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );

--- a/packages/block-library/src/loginout/index.php
+++ b/packages/block-library/src/loginout/index.php
@@ -36,8 +36,8 @@ function render_block_core_loginout( $attributes ) {
 		);
 
 		if ( ! empty( $attributes['formData'] ) ) {
-			if ( ! empty( $attributes['formData']['rememberMeLabel'] ) ) {
-				$args['label_remember'] = $attributes['formData']['rememberMeLabel'];
+			if ( ! empty( $attributes['formData']['rememberLabel'] ) ) {
+				$args['label_remember'] = $attributes['formData']['rememberLabel'];
 			}
 			if ( ! empty( $attributes['formData']['passwordLabel'] ) ) {
 				$args['label_password'] = $attributes['formData']['passwordLabel'];

--- a/packages/block-library/src/loginout/style.scss
+++ b/packages/block-library/src/loginout/style.scss
@@ -2,3 +2,18 @@
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 }
+
+.wp-block-loginout .wp-block-loginout-form {
+	// This block has customizable padding, border-box makes that more predictable.
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	gap: 20px;
+}
+
+.wp-block-loginout-form__fields {
+	// This block has customizable padding, border-box makes that more predictable.
+	display: flex;
+	flex-direction: row;
+	gap: 5px;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
This PR explore possible enhancements for #68896 (do not merge), Just add feedbacks.

## What?
Adds the ability to edit the login form labels, hide/unhide remember me fields and preview the form in editor.

## Video to review

https://github.com/user-attachments/assets/28aca5dc-4963-4cc2-b60a-2e54da1794d6


