### PR TITLE
Feature: Add classname to the div inside `components-modal__content` after the `components-modal__header` div

### DIFF
--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -358,6 +358,7 @@ function UnforwardedModal(
 						) }
 
 						<div
+							className="components-modal__body"
 							ref={ useMergeRefs( [
 								childrenContainerRef,
 								focusOnMount === 'firstContentElement'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR adds a new classname, `components-modal__body`, to the div immediately following `components-modal__header` inside the `components-modal__content` of the `Modal` component.

## Why?

Currently, the Modal component lacks a specific classname for the div directly after the components-modal__header. This absence forces developers to make extra efforts to target the div, often requiring unnecessarily high CSS specificity. This not only complicates styling but also increases the likelihood of conflicts. By adding the components-modal__body classname, this change:

- Maintains consistency with other modal elements by following a structured naming convention.

- Separates the header from the body, improving the modularity of the modal structure.

- Reduces unnecessary specificity, making it easier for developers to target and style the modal body cleanly and efficiently.

## How?

The implementation introduces a components-modal__body classname to the div after the components-modal__header within the Modal component. This classname adheres to Gutenberg’s naming standards, ensuring backward compatibility and providing a clean separation between the header and body sections of the modal.

## Testing Instructions

- Open the Block Editor in WordPress.

- Click on the Block Inserter (the "+" button in the editor toolbar).

- Navigate to the Patterns tab.

- Click on Explore all patterns to open the modal.

- Inspect the modal structure using browser developer tools.

- Verify that the div following components-modal__header now includes the components-modal__body classname.

<!-- ### Testing Instructions for Keyboard -->
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

<img width="1062" alt="Screenshot 2025-01-28 at 3 31 15 PM" src="https://github.com/user-attachments/assets/d3b29dd0-2f29-42eb-94b4-1310ada645c7" />

### After

<img width="1272" alt="Screenshot 2025-01-28 at 3 40 18 PM" src="https://github.com/user-attachments/assets/2b6a44db-0140-4650-8c8e-f7e4af7d527f" />

## Issue

Closes #68918 
