### PR TITLE
PR Template: Suggest linking the issue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,8 @@
 https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
 
 ## What?
-Closes: <!-- Replace with Gutenberg issue link -->
+<!-- Link this PR with the issue it addresses -->
+Closes <!-- #ISSUE-NUMBER or URL -->
 
 <!-- In a few words, what is the PR actually doing? -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
 
 ## What?
-<!-- Link this PR with the issue it addresses -->
+<!-- Link this PR with the issue it addresses, if applicable. -->
 Closes <!-- #ISSUE-NUMBER or URL -->
 
 <!-- In a few words, what is the PR actually doing? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,8 @@
 https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
 
 ## What?
+Closes: <!-- Replace with Gutenberg issue link -->
+
 <!-- In a few words, what is the PR actually doing? -->
 
 ## Why?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
 
 ## What?
-<!-- Link this PR with the issue it addresses, if applicable. -->
+<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
 Closes <!-- #ISSUE-NUMBER or URL -->
 
 <!-- In a few words, what is the PR actually doing? -->


### PR DESCRIPTION
## What?
Update the PR template and recommend linking the issue using a [reserved keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests).

## Why?
Often, PRs aren't linked to their corresponding issue or incorrectly reference them.

## Testing Instructions
None.