### PR TITLE
Gallery: Allow gallery to have more columns than total images

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -561,7 +561,7 @@ export default function GalleryEdit( props ) {
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
-					{ images.length > 1 && (
+					{ images.length > 0 && (
 						<RangeControl
 							__nextHasNoMarginBottom
 							label={ __( 'Columns' ) }
@@ -572,7 +572,7 @@ export default function GalleryEdit( props ) {
 							}
 							onChange={ setColumnsNumber }
 							min={ 1 }
-							max={ Math.min( MAX_COLUMNS, images.length ) }
+							max={ Math.min( MAX_COLUMNS ) }
 							{ ...MOBILE_CONTROL_PROPS_RANGE_CONTROL }
 							required
 							__next40pxDefaultSize

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -43,6 +43,9 @@ export default function Gallery( props ) {
 					'is-cropped': imageCrop,
 				}
 			) }
+			style={ {
+				'--gallery-columns': columns || 3,
+			} }
 		>
 			{ blockProps.children }
 			{ isSelected && ! blockProps.children && (

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -11,13 +11,13 @@ figure.wp-block-gallery.has-nested-images {
 	// Need bogus :not(#individual-image) to override long :not()
 	// specificity chain on default image block on front end.
 	figure.wp-block-image:not(#individual-image) {
-		width: calc(50% - (var(--wp--style--unstable-gallery-gap, #{$grid-unit-20}) / 2));
+		width: calc((100% - (var(--wp--style--unstable-gallery-gap, #{$grid-unit-20}) * (var(--gallery-columns, 2) - 1))) / var(--gallery-columns, 2));
 		margin: 0;
 	}
 
 	figure.wp-block-image {
 		display: flex;
-		flex-grow: 1;
+		flex-grow: 0;
 		justify-content: center;
 		position: relative;
 		flex-direction: column;
@@ -31,7 +31,7 @@ figure.wp-block-gallery.has-nested-images {
 		> a {
 			margin: 0;
 			flex-direction: column;
-			flex-grow: 1;
+			flex-grow: 0;
 		}
 
 		img {
@@ -154,22 +154,21 @@ figure.wp-block-gallery.has-nested-images {
 	@include break-small {
 		@for $i from 3 through 8 {
 			&.columns-#{ $i } figure.wp-block-image:not(#individual-image) {
-				width: calc(#{math.div(100%, $i)} - (var(--wp--style--unstable-gallery-gap, #{$grid-unit-20}) * #{math.div($i - 1, $i)}));
-
+				width: calc((100% - (var(--wp--style--unstable-gallery-gap, #{$grid-unit-20}) * (#{$i} - 1))) / #{$i});
 			}
 		}
 		// If number of columns not explicitly set default to 3 columns if 3 or more images.
 		&.columns-default {
 			figure.wp-block-image:not(#individual-image) {
-
-				width: calc(33.33% - (var(--wp--style--unstable-gallery-gap, 16px) * #{math.div(2, 3)}));
+				width: calc((100% - (var(--wp--style--unstable-gallery-gap, #{$grid-unit-20}) * (var(--gallery-columns, 3) - 1))) / var(--gallery-columns, 3));
 			}
-			// If only 2 child images use 2 columns.
+
+			// Keep existing special cases for 1-2 images
 			figure.wp-block-image:not(#individual-image):first-child:nth-last-child(2),
 			figure.wp-block-image:not(#individual-image):first-child:nth-last-child(2) ~ figure.wp-block-image:not(#individual-image) {
-				width: calc(50% - (var(--wp--style--unstable-gallery-gap, 16px) * 0.5));
+				width: calc(50% - (var(--wp--style--unstable-gallery-gap, #{$grid-unit-20}) * 0.5));
 			}
-			// For a single image set to 100%.
+
 			figure.wp-block-image:not(#individual-image):first-child:nth-last-child(1) {
 				width: 100%;
 			}


### PR DESCRIPTION
Fixes [#55231](https://github.com/WordPress/gutenberg/issues/55231)

## What?
This PR modifies the Gallery block to allow setting the number of columns independently from the number of images, removing the current restriction where column count cannot exceed image count.

## Why?
Currently, the Gallery block does not allow setting more columns than there are images. This creates inconsistencies in layouts where multiple galleries need to maintain the same column width, particularly when displaying content like candidate photos where equal sizing is important for fairness.

## How?
- Modified the column width calculation in gallery styles to properly account for gaps
- Removed the UI restriction that prevented setting columns > number of images
- Fixed flex-grow behavior to prevent images from expanding to fill empty columns
- Updated width calculations to maintain consistent image sizes across different gallery configurations

## Testing Instructions
1. Create a new post
2. Insert a Gallery block
3. Add 2 images to the gallery
4. Try setting the number of columns to 4
5. Verify that the 2 images maintain consistent sizes and don't expand to fill empty spaces
6. Add another gallery below with 4 images and set to 4 columns
7. Verify that images in both galleries are the same size despite different image counts

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2025-01-28 at 6 21 52 PM](https://github.com/user-attachments/assets/fb4f7ae8-cac6-4466-a349-d907f04a8c35)

![Screenshot 2025-01-28 at 6 22 01 PM](https://github.com/user-attachments/assets/20a34509-bd21-441b-b8bc-b3feb5dcb0eb)
