### PR TITLE
Fix: Menu: reconsider the modal behavior 

### DIFF
--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -238,7 +238,7 @@ function CompactItemActions< Item >( {
 						/>
 					}
 				/>
-				<Menu.Popover>
+				<Menu.Popover modal={ false }>
 					<ActionsMenuGroup
 						actions={ actions }
 						item={ item }

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -241,7 +241,7 @@ function ListItem< Item >( {
 								/>
 							}
 						/>
-						<Menu.Popover>
+						<Menu.Popover modal={ false }>
 							<ActionsMenuGroup
 								actions={ eligibleActions }
 								item={ item }


### PR DESCRIPTION
## What?
Fixes #68830 

## Why?
As discussed in the accessibility bug scrub, The modal behavior is unnecessary, it would be better if the menus did not behave as modals.

## How?
This PR adds `modal = {false}` to `Menu.Popover` to prevent the modal like behaviour in the Page Section

## Testing Instructions
- Go the editor 
- Go to Pages
- Open the actions dropdown  
- Observe that the modal behaviour is absent and one can easily select other items present on the page despite the dropdown being open

## Screenshots or screencast


https://github.com/user-attachments/assets/13bd6036-8733-4123-8575-ef93d38bd20a


