### PR TITLE
Query: Sync "Max pages to show" setting between Query and Pagination blocks

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -736,7 +736,7 @@ Displays a paginated navigation to next/previous set of posts, when applicable. 
 -	**Ancestor:** core/query
 -	**Allowed Blocks:** core/query-pagination-previous, core/query-pagination-numbers, core/query-pagination-next
 -	**Supports:** align, color (background, gradients, link, text), interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** paginationArrow, showLabel
+-	**Attributes:** pages, paginationArrow, showLabel
 
 ## Next Page
 

--- a/packages/block-library/src/query-pagination/block.json
+++ b/packages/block-library/src/query-pagination/block.json
@@ -20,6 +20,9 @@
 		"showLabel": {
 			"type": "boolean",
 			"default": true
+		},
+		"pages": {
+			"type": "number"
 		}
 	},
 	"usesContext": [ "queryId", "query" ],


### PR DESCRIPTION
# Work in Progress

To do:

- I am planning to refactor the code to make it more perfomant and organise it better. 
- I will explore options to improve the code quality

Related issues: https://github.com/WordPress/gutenberg/issues/63027 , https://github.com/WordPress/gutenberg/issues/63028

## What?

- Display "Max pages to show" only when a Pagination block is an inner block of the Query Loop.
- Add the "Max pages to show" setting to the Pagination block, syncing it with the Query block for consistency.

## Why?
Improves clarity by ensuring the setting only appears when relevant and enhances usability by allowing adjustments from both the Query and Pagination blocks.



## How?

- Checks if Pagination is an inner block before showing the setting.
- Syncs the setting between Query and Pagination blocks.

## Testing Instructions

1. Add a Query Loop block > Start blank > Title & Date.
2. Click 'Display settings' in the block toolbar.
3. Verify "Max pages to show" appears only if a Pagination block is inside the Query Loop.
4. Confirm that the setting is synced between the Query and Pagination blocks.
5. Change the value and ensure updates reflect correctly in both places.



## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
