### PR TITLE
Font Library: Use slugs instead of weight or style names to generate checkboxId.

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/collection-font-variant.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/collection-font-variant.js
@@ -10,7 +10,7 @@ import {
 /**
  * Internal dependencies
  */
-import { getFontFaceVariantName } from './utils';
+import { getFontFaceVariantName, getFontFaceVariantSlug } from './utils';
 import FontDemo from './font-demo';
 import { unlock } from '../../../lock-unlock';
 
@@ -32,7 +32,7 @@ function CollectionFontVariant( {
 
 	const displayName = font.name + ' ' + getFontFaceVariantName( face );
 	const checkboxId = kebabCase(
-		`${ font.slug }-${ getFontFaceVariantName( face ) }`
+		`${ font.slug }-${ getFontFaceVariantSlug( face ) }`
 	);
 
 	return (

--- a/packages/edit-site/src/components/global-styles/font-library-modal/library-font-variant.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/library-font-variant.js
@@ -11,7 +11,7 @@ import {
 /**
  * Internal dependencies
  */
-import { getFontFaceVariantName } from './utils';
+import { getFontFaceVariantName, getFontFaceVariantSlug } from './utils';
 import { FontLibraryContext } from './context';
 import FontDemo from './font-demo';
 import { unlock } from '../../../lock-unlock';
@@ -42,7 +42,7 @@ function LibraryFontVariant( { face, font } ) {
 
 	const displayName = font.name + ' ' + getFontFaceVariantName( face );
 	const checkboxId = kebabCase(
-		`${ font.slug }-${ getFontFaceVariantName( face ) }`
+		`${ font.slug }-${ getFontFaceVariantSlug( face ) }`
 	);
 
 	return (

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/constants.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/constants.js
@@ -5,19 +5,63 @@ import { _x } from '@wordpress/i18n';
 
 export const ALLOWED_FILE_EXTENSIONS = [ 'otf', 'ttf', 'woff', 'woff2' ];
 
-export const FONT_WEIGHTS = {
-	100: _x( 'Thin', 'font weight' ),
-	200: _x( 'Extra-light', 'font weight' ),
-	300: _x( 'Light', 'font weight' ),
-	400: _x( 'Normal', 'font weight' ),
-	500: _x( 'Medium', 'font weight' ),
-	600: _x( 'Semi-bold', 'font weight' ),
-	700: _x( 'Bold', 'font weight' ),
-	800: _x( 'Extra-bold', 'font weight' ),
-	900: _x( 'Black', 'font weight' ),
-};
+export const FONT_WEIGHTS = [
+	{
+		value: 100,
+		label: _x( 'Thin', 'font weight' ),
+		slug: 'thin',
+	},
+	{
+		value: 200,
+		label: _x( 'Extra-light', 'font weight' ),
+		slug: 'extra-light',
+	},
+	{
+		value: 300,
+		label: _x( 'Light', 'font weight' ),
+		slug: 'light',
+	},
+	{
+		value: 400,
+		label: _x( 'Normal', 'font weight' ),
+		slug: 'normal',
+	},
+	{
+		value: 500,
+		label: _x( 'Medium', 'font weight' ),
+		slug: 'medium',
+	},
+	{
+		value: 600,
+		label: _x( 'Semi-bold', 'font weight' ),
+		slug: 'semi-bold',
+	},
+	{
+		value: 700,
+		label: _x( 'Bold', 'font weight' ),
+		slug: 'bold',
+	},
+	{
+		value: 800,
+		label: _x( 'Extra-bold', 'font weight' ),
+		slug: 'extra-bold',
+	},
+	{
+		value: 900,
+		label: _x( 'Black', 'font weight' ),
+		slug: 'black',
+	},
+];
 
-export const FONT_STYLES = {
-	normal: _x( 'Normal', 'font style' ),
-	italic: _x( 'Italic', 'font style' ),
-};
+export const FONT_STYLES = [
+	{
+		value: 'normal',
+		label: _x( 'Normal', 'font style' ),
+		slug: 'normal',
+	},
+	{
+		value: 'italic',
+		label: _x( 'Italic', 'font style' ),
+		slug: 'italic',
+	},
+];

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/constants.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/constants.js
@@ -7,47 +7,47 @@ export const ALLOWED_FILE_EXTENSIONS = [ 'otf', 'ttf', 'woff', 'woff2' ];
 
 export const FONT_WEIGHTS = [
 	{
-		value: 100,
+		value: '100',
 		label: _x( 'Thin', 'font weight' ),
 		slug: 'thin',
 	},
 	{
-		value: 200,
+		value: '200',
 		label: _x( 'Extra-light', 'font weight' ),
 		slug: 'extra-light',
 	},
 	{
-		value: 300,
+		value: '300',
 		label: _x( 'Light', 'font weight' ),
 		slug: 'light',
 	},
 	{
-		value: 400,
+		value: '400',
 		label: _x( 'Normal', 'font weight' ),
 		slug: 'normal',
 	},
 	{
-		value: 500,
+		value: '500',
 		label: _x( 'Medium', 'font weight' ),
 		slug: 'medium',
 	},
 	{
-		value: 600,
+		value: '600',
 		label: _x( 'Semi-bold', 'font weight' ),
 		slug: 'semi-bold',
 	},
 	{
-		value: 700,
+		value: '700',
 		label: _x( 'Bold', 'font weight' ),
 		slug: 'bold',
 	},
 	{
-		value: 800,
+		value: '800',
 		label: _x( 'Extra-bold', 'font weight' ),
 		slug: 'extra-bold',
 	},
 	{
-		value: 900,
+		value: '900',
 		label: _x( 'Black', 'font weight' ),
 		slug: 'black',
 	},

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
@@ -34,36 +34,30 @@ export function isUrlEncoded( url ) {
 	return url !== decodeURIComponent( url );
 }
 
-export function getFontFaceVariantName( face ) {
+function getFontFaceVariant( face ) {
 	const matchedWeight = FONT_WEIGHTS.find(
 		( weight ) => weight.value === face.fontWeight
 	);
-	const weightName = matchedWeight?.label || face.fontWeight;
-
 	const matchedStyle = FONT_STYLES.find(
 		( style ) => style.value === face.fontStyle
 	);
+	return [ matchedWeight, matchedStyle ];
+}
 
+export function getFontFaceVariantName( face ) {
+	const [ weight, style ] = getFontFaceVariant( face );
+	const weightName = weight?.label || face.fontWeight;
 	const styleName =
-		face.fontStyle === 'normal'
-			? ''
-			: matchedStyle?.label || face.fontStyle;
+		face.fontStyle === 'normal' ? '' : style?.label || face.fontStyle;
 	return `${ weightName } ${ styleName }`;
 }
 
 export function getFontFaceVariantSlug( face ) {
-	const matchedWeight = FONT_WEIGHTS.find(
-		( weight ) => weight.value === face.fontWeight
-	);
-	const weightName = matchedWeight?.slug || face.fontWeight;
-
-	const matchedStyle = FONT_STYLES.find(
-		( style ) => style.value === face.fontStyle
-	);
-
-	const styleName =
-		face.fontStyle === 'normal' ? '' : matchedStyle?.slug || face.fontStyle;
-	return `${ weightName } ${ styleName }`;
+	const [ weight, style ] = getFontFaceVariant( face );
+	const weightSlug = weight?.slug || face.fontWeight;
+	const styleSlug =
+		face.fontStyle === 'normal' ? '' : style?.slug || face.fontStyle;
+	return `${ weightSlug } ${ styleSlug }`;
 }
 
 export function mergeFontFaces( existing = [], incoming = [] ) {

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
@@ -35,11 +35,34 @@ export function isUrlEncoded( url ) {
 }
 
 export function getFontFaceVariantName( face ) {
-	const weightName = FONT_WEIGHTS[ face.fontWeight ] || face.fontWeight;
+	const matchedWeight = FONT_WEIGHTS.find(
+		( weight ) => weight.value === face.fontWeight
+	);
+	const weightName = matchedWeight?.label || face.fontWeight;
+
+	const matchedStyle = FONT_STYLES.find(
+		( style ) => style.value === face.fontStyle
+	);
+
 	const styleName =
 		face.fontStyle === 'normal'
 			? ''
-			: FONT_STYLES[ face.fontStyle ] || face.fontStyle;
+			: matchedStyle?.label || face.fontStyle;
+	return `${ weightName } ${ styleName }`;
+}
+
+export function getFontFaceVariantSlug( face ) {
+	const matchedWeight = FONT_WEIGHTS.find(
+		( weight ) => weight.value === face.fontWeight
+	);
+	const weightName = matchedWeight?.slug || face.fontWeight;
+
+	const matchedStyle = FONT_STYLES.find(
+		( style ) => style.value === face.fontStyle
+	);
+
+	const styleName =
+		face.fontStyle === 'normal' ? '' : matchedStyle?.slug || face.fontStyle;
 	return `${ weightName } ${ styleName }`;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

fix:   #68934

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
