### PR TITLE
FontSizePicker: Fix FontSizePicker Storybook control type and improve documentation

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Documentation
+
 -   `FontSizePicker`: Fix Storybook units control type to use `inline-check` and improve documentation clarifying unitless mode in `README.md` ([#68936](https://github.com/WordPress/gutenberg/pull/68936)).
 
 ### Bug Fixes

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   `FontSizePicker`: Fix Storybook units control type to use `inline-check` and improve documentation clarifying unitless mode in `README.md` ([#68936](https://github.com/WordPress/gutenberg/pull/68936)).
+
 ### Bug Fixes
 
 -   `TextControl`: Ensures email and url inputs have consistent LTR alignment in RTL languages ([#68561](https://github.com/WordPress/gutenberg/pull/68561)).

--- a/packages/components/src/font-size-picker/README.md
+++ b/packages/components/src/font-size-picker/README.md
@@ -92,14 +92,14 @@ Size of the control.
 
 Available units for custom font size selection.
 
-**Note**: For the `units` property to work, the current font size value must be specified as strings with units (e.g., `'12px'` instead of `12`). When the font size is provided as a number, the component operates in "unitless mode" where the `units` property has no effect.
-
 -   Required: No
 -   Default: `[ 'px', 'em', 'rem', 'vw', 'vh' ]`
 
 ### `value`: `number | string`
 
 The current font size value.
+
+**Note**: For the `units` property to work, the current font size value must be specified as strings with units (e.g., `'12px'` instead of `12`). When the font size is provided as a number, the component operates in "unitless mode" where the `units` property has no effect.
 
 -   Required: No
 

--- a/packages/components/src/font-size-picker/README.md
+++ b/packages/components/src/font-size-picker/README.md
@@ -92,7 +92,7 @@ Size of the control.
 
 Available units for custom font size selection.
 
-**Important Note**: For the units property to work, font sizes must be specified as strings with units (e.g., `'12px'` instead of `12`). When font sizes are provided as numbers, the component operates in "unitless mode" where the units property has no effect.
+**Note**: For the `units` property to work, the current font size value must be specified as strings with units (e.g., `'12px'` instead of `12`). When the font size is provided as a number, the component operates in "unitless mode" where the `units` property has no effect.
 
 -   Required: No
 -   Default: `[ 'px', 'em', 'rem', 'vw', 'vh' ]`

--- a/packages/components/src/font-size-picker/README.md
+++ b/packages/components/src/font-size-picker/README.md
@@ -92,6 +92,8 @@ Size of the control.
 
 Available units for custom font size selection.
 
+**Important Note**: For the units property to work, font sizes must be specified as strings with units (e.g., `'12px'` instead of `12`). When font sizes are provided as numbers, the component operates in "unitless mode" where the units property has no effect.
+
 -   Required: No
 -   Default: `[ 'px', 'em', 'rem', 'vw', 'vh' ]`
 

--- a/packages/components/src/font-size-picker/stories/index.story.tsx
+++ b/packages/components/src/font-size-picker/stories/index.story.tsx
@@ -18,6 +18,10 @@ const meta: Meta< typeof FontSizePicker > = {
 	component: FontSizePicker,
 	argTypes: {
 		value: { control: false },
+		units: {
+			control: 'inline-check',
+			options: [ 'px', 'em', 'rem', 'vw', 'vh' ],
+		},
 	},
 	parameters: {
 		actions: { argTypesRegex: '^on.*' },

--- a/packages/components/src/font-size-picker/types.ts
+++ b/packages/components/src/font-size-picker/types.ts
@@ -34,6 +34,10 @@ export type FontSizePickerProps = {
 	units?: string[];
 	/**
 	 * The current font size value.
+	 *
+	 * Note: For the `units` property to work, the current font size value must be specified
+	 * as strings with units (e.g., '12px' instead of 12). When the font size is provided
+	 * as a number, the component operates in "unitless mode" where the `units` property has no effect.
 	 */
 	value?: number | string;
 	/**

--- a/packages/components/src/unit-control/utils.ts
+++ b/packages/components/src/unit-control/utils.ts
@@ -394,7 +394,7 @@ export function filterUnitsWithSettings(
 	// Although the `isArray` check shouldn't be necessary (given the signature of
 	// this typed function), it's better to stay on the side of caution, since
 	// this function may be called from un-typed environments.
-	return Array.isArray( availableUnits ) && Array.isArray( allowedUnitValues )
+	return Array.isArray( availableUnits )
 		? availableUnits.filter( ( unit ) =>
 				allowedUnitValues.includes( unit.value )
 		  )

--- a/packages/components/src/unit-control/utils.ts
+++ b/packages/components/src/unit-control/utils.ts
@@ -394,11 +394,11 @@ export function filterUnitsWithSettings(
 	// Although the `isArray` check shouldn't be necessary (given the signature of
 	// this typed function), it's better to stay on the side of caution, since
 	// this function may be called from un-typed environments.
-	return Array.isArray( availableUnits )
+	return Array.isArray( availableUnits ) && Array.isArray( allowedUnitValues )
 		? availableUnits.filter( ( unit ) =>
 				allowedUnitValues.includes( unit.value )
 		  )
-		: [];
+		: availableUnits;
 }
 
 /**

--- a/packages/components/src/unit-control/utils.ts
+++ b/packages/components/src/unit-control/utils.ts
@@ -398,7 +398,7 @@ export function filterUnitsWithSettings(
 		? availableUnits.filter( ( unit ) =>
 				allowedUnitValues.includes( unit.value )
 		  )
-		: availableUnits;
+		: [];
 }
 
 /**


### PR DESCRIPTION

## What?

Closes: #68553 

This PR fixes an issue with the FontSizePicker component in Storybook where changing the `units` prop was causing an error. It also clarifies the documentation around the component's `unitless mode`.

## Why?

When trying to change the units prop in Storybook, an error was occurring: `allowedUnitValues.includes is not a function`. This happened because clicking the `Set object` button in Storybook initialized the value as an empty object instead of an array. Additionally, the documentation didn't clearly explain when the `units` prop would actually have an effect.

## How?

- Changes the Storybook control type for the `units` prop from the default to `inline-check` with predefined options
- Improves the `README` documentation to clearly explain the relationship between `string/number` font-size values and the `unitless mode`

## Testing Instructions



- Run Storybook with `npm run storybook:dev`
- Navigate to the `FontSizePicker` component
- Verify you can select different unit options using the checkboxes without any errors
- Verify that the component's documentation explains that the `units` property only works when font sizes are specified as strings with units


## Screencast 

https://github.com/user-attachments/assets/b7840050-6630-43d3-9d96-7b7f173915da


