### PR TITLE
Update the opt-in for the stylebook in classic themes

### DIFF
--- a/docs/how-to-guides/themes/theme-support.md
+++ b/docs/how-to-guides/themes/theme-support.md
@@ -10,6 +10,7 @@ There are a few new concepts to consider when building themes:
 -   **Frontend & Editor Styles** - To get the most out of blocks, theme authors will want to make sure Core styles look good and opt-in, or write their own styles to best fit their theme.
 -   **Block Tools** - Themes can opt-in to several block tools like line height, custom units.
 -   **Core Block Patterns** - Themes can opt-out of the default block patterns.
+-   **Stylebook** -Themes can opt-in to displaying the stylebook, with a preview of various blocks.
 
 By default, blocks provide their styles to enable basic support for blocks in themes without any change. They also [provide opt-in opinionated styles](#default-block-styles). Themes can add/override these styles, or they can provide no styles at all, and rely fully on what the blocks provide.
 
@@ -511,3 +512,19 @@ This feature is only relevant for non block based themes, as block based themes 
 The standalone template part editor does not allow editors to create new, or delete existing template parts. This is because the theme manually needs to include the template part in the PHP template.
 
 You can find out more about block based template parts in the [themes handbook block template and template parts section](https://developer.wordpress.org/themes/block-themes/templates-and-template-parts/#block-c5fa39a2-a27d-4bd2-98d0-dc6249a0801a).
+
+## Stylebook
+
+The stylebook is a way to preview the design of various blocks, without needing to place them in the editor.
+It is accessed from the Apperance > Design menu.
+
+```php
+add_theme_support(
+	'editor',
+	array(
+		'stylebook'
+	)
+);
+```
+
+This feature is only relevant for non block based themes, as block based themes already support the Stylebook as part of the site editor.

--- a/lib/compat/wordpress-6.8/site-editor.php
+++ b/lib/compat/wordpress-6.8/site-editor.php
@@ -130,7 +130,7 @@ add_filter( 'wp_die_handler', 'gutenberg_styles_wp_die_handler' );
  * @global array $submenu
  */
 function gutenberg_add_styles_submenu_item() {
-	if ( ! wp_is_block_theme() && ( current_theme_supports( 'editor-styles' ) || wp_theme_has_theme_json() ) ) {
+	if ( ! wp_is_block_theme() && ( current_theme_supports( 'editor', 'stylebook' ) || wp_theme_has_theme_json() ) ) {
 		global $submenu;
 
 		$styles_menu_item = array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR changes how classic themes can opt-in to show the stylebook under the menu Appearance > Design.

Previously the stylebook was shown when the theme included `add_theme_support( 'editor-styles' );`
The PR replaces the check for `editor-style`s with `current_theme_supports( 'editor', 'stylebook' )`

What this does not do:
The PR does not offer a way to disable the style book for classic themes that add theme.json.
To do: Figure out what to do about the direct path to the stylebook
`wp-admin/site-editor.php?p=%2Fstylebook`

Partial for https://github.com/WordPress/gutenberg/issues/68036


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Theme developers may want to use `editor-styles` without the stylebook. A use case would be when the developer has created its own style guide.
- Theme developers may be unaware that using the existing theme support enables new features.
- By adding a new 'editor' theme support, theme developers can explicitly opt-in to the stylebook.
The new `editor` theme support can be extended later, as an alias for existing theme support related to the Site Editor, and for new features.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The PR replaces the check for `editor-styles` with `current_theme_supports( 'editor', 'stylebook' )`

## Testing Instructions
There should be no change for block themes and hybrid themes:
classic themes with theme.json
classic themes with templatest/index.html

Activating a classic theme should not enable the Design menu unless the theme support is added.

To add the theme support, copy paste the following into the theme setup function, usually in functions.php:
```
		add_theme_support(
			'editor',
			array(
				'stylebook'
			)
		);
```
After it is added, the design menu item with the nested Patterns and Styles pages should be available.
The Pattern menu item should not be showing directly under Appearance.
