### PR TITLE
iAPI Router: add missing changelog entry for #68923

### DIFF
--- a/packages/interactivity-router/CHANGELOG.md
+++ b/packages/interactivity-router/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Fix CSS rule order in some constructed style sheets. ([#68923](https://github.com/WordPress/gutenberg/pull/68923))
+
 ## 2.17.0 (2025-01-29)
 
 ## 2.16.0 (2025-01-15)


### PR DESCRIPTION
The following PR was merged without a proper changelog entry:

- #68923

This PR adds it.
