### PR TITLE
npm scripts: use `node -p` instead of `echo`

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
 		"build": "npm run build:packages && wp-scripts build",
 		"build:analyze-bundles": "npm run build -- --webpack-bundle-analyzer",
 		"build:package-types": "node ./bin/packages/validate-typescript-version.js && ( tsc --build || ( echo 'tsc failed. Try cleaning up first: `npm run clean:package-types`'; exit 1 ) ) && node ./bin/packages/check-build-type-declaration-files.js",
-		"build:profile-types": "rimraf ./ts-traces && npm run clean:package-types && node ./bin/packages/validate-typescript-version.js && ( tsc --build --extendedDiagnostics --generateTrace ./ts-traces || ( echo 'tsc failed.'; exit 1 ) ) && node ./bin/packages/check-build-type-declaration-files.js && npx --yes @typescript/analyze-trace ts-traces > ts-traces/analysis.txt && echo $'\n\nDone! Build traces saved to ts-traces/ directory.\nTrace analysis saved to ts-traces/analysis.txt.'",
+		"build:profile-types": "rimraf ./ts-traces && npm run clean:package-types && node ./bin/packages/validate-typescript-version.js && ( tsc --build --extendedDiagnostics --generateTrace ./ts-traces || ( echo 'tsc failed.'; exit 1 ) ) && node ./bin/packages/check-build-type-declaration-files.js && npx --yes @typescript/analyze-trace ts-traces > ts-traces/analysis.txt && node -p \"'\\n\\nDone! Build traces saved to ts-traces/ directory.\\nTrace analysis saved to ts-traces/analysis.txt.'\"",
 		"prebuild:packages": "npm run clean:packages && npm run --if-present --workspaces build",
 		"build:packages": "npm run --silent build:package-types && node ./bin/packages/build.js",
 		"postbuild:packages": " npm run --if-present --workspaces build:wp",


### PR DESCRIPTION
- Follow-up #68533
- See https://github.com/WordPress/gutenberg/pull/68533#discussion_r1922693121

## What?

#68533 added the `build:profile-types`command to measure typescript performance. This command uses the `$''` format to output text with newlines, which doesn't seem to display correctly on some CLIs.

Below are some examples of the output:

<details><summary>Windows Host OS</summary>

```
npm run build:profile-types

> gutenberg@20.2.0-rc.1 build:profile-types
> rimraf ./ts-traces && npm run clean:package-types && node ./bin/packages/validate-typescript-version.js && ( tsc --build --extendedDiagnostics --generateTrace ./ts-traces || ( echo 'tsc failed.'; exit 1 ) ) && node ./bin/packages/check-build-type-declaration-files.js && npx --yes @typescript/analyze-trace ts-traces > ts-traces/analysis.txt && echo $'
> 
> Done! Build traces saved to ts-traces/ directory.
> Trace analysis saved to ts-traces/analysis.txt.'


> gutenberg@20.2.0-rc.1 clean:package-types
> tsc --build --clean && rimraf --glob "./packages/*/build-types"

...

Build time:                           169.97s
$'
```

</details> 

<details><summary>Windows WSL2 (Ubuntu 22.04.4 LTS)</summary>

```
npm run build:profile-types

> gutenberg@20.2.0-rc.1 build:profile-types
> rimraf ./ts-traces && npm run clean:package-types && node ./bin/packages/validate-typescript-version.js && ( tsc --build --extendedDiagnostics --generateTrace ./ts-traces || ( echo 'tsc failed.'; exit 1 ) ) && node ./bin/packages/check-build-type-declaration-files.js && npx --yes @typescript/analyze-trace ts-traces > ts-traces/analysis.txt && echo $'
> 
> Done! Build traces saved to ts-traces/ directory.
> Trace analysis saved to ts-traces/analysis.txt.'


> gutenberg@20.2.0-rc.1 clean:package-types
> tsc --build --clean && rimraf --glob "./packages/*/build-types"

...

Build time:                           156.32s
$

Done! Build traces saved to ts-traces/ directory.
Trace analysis saved to ts-traces/analysis.txt.
```

</details> 

As you can see, the character `$` may be output as is, or the message indicating completion may not be displayed.

## How?

Use [`node -p`](https://nodejs.org/api/cli.html#-p---print-script) instead of `echo`. This is a native Node command, so it should work on all OS.

## Testing Instructions

- Run `npm run build:profile-types`
- The text should now be displayed correctly, like so:

```
npm run build:profile-types

> gutenberg@20.2.0-rc.1 build:profile-types
> rimraf ./ts-traces && npm run clean:package-types && node ./bin/packages/validate-typescript-version.js && ( tsc --build --extendedDiagnostics --generateTrace ./ts-traces || ( echo 'tsc failed.'; exit 1 ) ) && node ./bin/packages/check-build-type-declaration-files.js && npx --yes @typescript/analyze-trace ts-traces > ts-traces/analysis.txt && node -p "'\n\nDone! Build traces saved to ts-traces/ directory.\nTrace analysis saved to ts-traces/analysis.txt.'"


> gutenberg@20.2.0-rc.1 clean:package-types
> tsc --build --clean && rimraf --glob "./packages/*/build-types"

...


Build time:                           151.58s


Done! Build traces saved to ts-traces/ directory.
Trace analysis saved to ts-traces/analysis.txt.
```