### PR TITLE
Code Quality: Delete unused function from PHP Sync Issue generation script

### DIFF
--- a/bin/generate-php-sync-issue.mjs
+++ b/bin/generate-php-sync-issue.mjs
@@ -156,17 +156,6 @@ async function main() {
 	fs.writeFileSync( nodePath.join( __dirname, 'issueContent.md' ), content );
 }
 
-/**
- * Checks if the first date is after the second date.
- *
- * @param {string} date1 - The first date.
- * @param {string} date2 - The second date.
- * @return {boolean} - Returns true if the first date is after the second date, false otherwise.
- */
-function isAfter( date1, date2 ) {
-	return new Date( date1 ) > new Date( date2 );
-}
-
 function validateDate( sinceArg ) {
 	const sinceDate = new Date( sinceArg );
 	const maxPreviousDate = new Date();


### PR DESCRIPTION
## What?

Remove unused `isAfter()` function to avoid ESLint warning:

![is-after](https://github.com/user-attachments/assets/821f51e6-f006-46ba-b70f-6a83c4c8422b)

## Why?

As a result of #59549, this function is no longer referenced. Also, since this function is not exported, it can be safely removed.

## Testing Instructions

It should be enough to confirm it passes CIs.