### PR TITLE
Block Editor: Display root appender when default block is disabled

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -19,6 +19,7 @@ import {
 	useCallback,
 	useEffect,
 } from '@wordpress/element';
+import { getDefaultBlockName } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -178,6 +179,7 @@ function Items( {
 				getBlockEditingMode,
 				isSectionBlock,
 				isZoomOut: _isZoomOut,
+				canInsertBlockType,
 			} = unlock( select( blockEditorStore ) );
 
 			const _order = getBlockOrder( rootClientId );
@@ -191,6 +193,15 @@ function Items( {
 			}
 
 			const selectedBlockClientId = getSelectedBlockClientId();
+			const canInsertDefaultBlock = canInsertBlockType(
+				getDefaultBlockName(),
+				rootClientId
+			);
+			const showRootAppender =
+				! rootClientId &&
+				! selectedBlockClientId &&
+				( ! _order.length || ! canInsertDefaultBlock );
+
 			return {
 				order: _order,
 				selectedBlocks: getSelectedBlockClientIds(),
@@ -203,10 +214,8 @@ function Items( {
 					hasAppender &&
 					! _isZoomOut() &&
 					( hasCustomAppender ||
-						rootClientId === selectedBlockClientId ||
-						( ! rootClientId &&
-							! selectedBlockClientId &&
-							! _order.length ) ),
+						showRootAppender ||
+						rootClientId === selectedBlockClientId ),
 			};
 		},
 		[ rootClientId, hasAppender, hasCustomAppender ]

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -172,7 +172,6 @@ function Items( {
 			const {
 				getSettings,
 				getBlockOrder,
-				getSelectedBlockClientId,
 				getSelectedBlockClientIds,
 				__unstableGetVisibleBlocks,
 				getTemplateLock,
@@ -192,19 +191,20 @@ function Items( {
 				};
 			}
 
-			const selectedBlockClientId = getSelectedBlockClientId();
-			const canInsertDefaultBlock = canInsertBlockType(
-				getDefaultBlockName(),
-				rootClientId
-			);
+			const selectedBlockClientIds = getSelectedBlockClientIds();
+			const selectedBlockClientId = selectedBlockClientIds[ 0 ];
 			const showRootAppender =
 				! rootClientId &&
 				! selectedBlockClientId &&
-				( ! _order.length || ! canInsertDefaultBlock );
+				( ! _order.length ||
+					! canInsertBlockType(
+						getDefaultBlockName(),
+						rootClientId
+					) );
 
 			return {
 				order: _order,
-				selectedBlocks: getSelectedBlockClientIds(),
+				selectedBlocks: selectedBlockClientIds,
 				visibleBlocks: __unstableGetVisibleBlocks(),
 				isZoomOut: _isZoomOut(),
 				shouldRenderAppender:


### PR DESCRIPTION
## What?
Fixes #66679.
Follow-up to #60697.

PR updates a condition for displaying the root appender to account for the disabled default block (Paragraph).

## Why?
When consumers disable the default block without setting up a replacement, adding blocks directly from Canvas is not easy. The "root padding appender" only works for the default block.

## Testing Instructions
1. Open a post.
3. Disable the Paragraph block using Preferences.
4. Add an Image or any remaining blocks to the post.
5. Confirm that the button appender is displayed when a block isn't selected.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2025-01-30 at 09 05 48](https://github.com/user-attachments/assets/09665dee-c2d1-4a36-bbf6-bd74d86ccb35)

