### PR TITLE
Navigation Link Block: Use stable variable for underline color styling

### DIFF
--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -104,7 +104,7 @@
 		&.is-invalid,
 		&.is-draft {
 			span {
-				--wp-underline-color: var(--wp--preset--color--vivid-red);
+				--wp-underline-color: #{$alert-red};
 			}
 		}
 	}


### PR DESCRIPTION
Follow-up of: https://github.com/WordPress/gutenberg/pull/68628
Related: https://github.com/WordPress/gutenberg/pull/68628#issuecomment-2621402464

## What?
Updates the navigation link block's invalid/draft state underline color to use an SCSS variable.

## Why?
To maintain consistency with Gutenberg's color system and improve maintainability.


## Testing Instructions
1. Create a new post
2. Add a Navigation block
3. Add a Navigation Link block within it
4. Set the link to a draft post
5. Verify that the underline color appears red (#cc1818)
6. Create an invalid link state (linking to a trashed post)
7. Verify that the underline color appears red (#cc1818)

## Screenshots

|Before|After|
|:---:|:---:|
|<img width="565" alt="Before navigation link invalid state 1" src="https://github.com/user-attachments/assets/bfb6cb83-3475-4b86-83fb-f1a63463e4e9" />|<img width="565" alt="After navigation link invalid state 1" src="https://github.com/user-attachments/assets/a1c0105f-784f-40b5-8222-2cfbd16b1502" />|
|<img width="565" alt="Before navigation link invalid state 2" src="https://github.com/user-attachments/assets/83797a67-1459-4222-9848-3855c56b5392" />|<img width="565" alt="After navigation link invalid state 2" src="https://github.com/user-attachments/assets/83deee7e-e426-422d-90ba-51520d45c369" />|


