### PR TITLE
Fix: Additional CSS button not working after back navigation

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-css.js
+++ b/packages/edit-site/src/components/global-styles/screen-css.js
@@ -4,11 +4,13 @@
 import { __ } from '@wordpress/i18n';
 import { ExternalLink } from '@wordpress/components';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
+import { store as editSiteStore } from '../../store';
 import ScreenHeader from './header';
 
 const { useGlobalStyle, AdvancedPanel: StylesAdvancedPanel } = unlock(
@@ -25,6 +27,10 @@ function ScreenCSS() {
 	const [ inheritedStyle, setStyle ] = useGlobalStyle( '', undefined, 'all', {
 		shouldDecodeEncode: false,
 	} );
+
+	const { setEditorCanvasContainerView } = unlock(
+		useDispatch( editSiteStore )
+	);
 
 	return (
 		<>
@@ -44,6 +50,9 @@ function ScreenCSS() {
 						</ExternalLink>
 					</>
 				}
+				onBack={ () => {
+					setEditorCanvasContainerView( undefined );
+				} }
 			/>
 			<div className="edit-site-global-styles-screen-css">
 				<StylesAdvancedPanel

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -258,19 +258,8 @@ function GlobalStylesEditorCanvasContainerLink() {
 			unlock( select( editSiteStore ) ).getEditorCanvasContainerView(),
 		[]
 	);
-	const { path } = location;
+	const path = location?.path;
 	const isRevisionsOpen = path === '/revisions';
-	const { setEditorCanvasContainerView } = unlock(
-		useDispatch( editSiteStore )
-	);
-	const previousPath = usePrevious( path );
-
-	// Reset editorCanvasContainerView when navigating away from '/css'
-	useEffect( () => {
-		if ( previousPath === '/css' && path !== '/css' ) {
-			setEditorCanvasContainerView( undefined );
-		}
-	}, [ path, previousPath, setEditorCanvasContainerView ] );
 
 	// If the user switches the editor canvas container view, redirect
 	// to the appropriate screen. This effectively allows deep linking to the

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -258,8 +258,19 @@ function GlobalStylesEditorCanvasContainerLink() {
 			unlock( select( editSiteStore ) ).getEditorCanvasContainerView(),
 		[]
 	);
-	const path = location?.path;
+	const { path } = location;
 	const isRevisionsOpen = path === '/revisions';
+	const { setEditorCanvasContainerView } = unlock(
+		useDispatch( editSiteStore )
+	);
+	const previousPath = usePrevious( path );
+
+	// Reset editorCanvasContainerView when navigating away from '/css'
+	useEffect( () => {
+		if ( previousPath === '/css' && path !== '/css' ) {
+			setEditorCanvasContainerView( undefined );
+		}
+	}, [ path, previousPath, setEditorCanvasContainerView ] );
 
 	// If the user switches the editor canvas container view, redirect
 	// to the appropriate screen. This effectively allows deep linking to the


### PR DESCRIPTION
Closes: #68949

## What?
Fixed the Additional CSS button not working after navigating back from the CSS screen.

<!-- In a few words, what is the PR actually doing? -->

## Why?
- The Additional CSS button stopped responding after using it once and navigating back
- This happened because the editor canvas view state wasn't being reset on navigation
- The issue made the Additional CSS feature inaccessible after initial use

## How?
- Added onBack handler to ScreenCSS component to manage view state cleanup
- Added setEditorCanvasContainerView dispatch in ScreenCSS for proper state management
- Reset editor canvas view state when navigating back from CSS screen

## Testing Instructions
1. Open Site Editor
2. Navigate to Global Styles
3. Click the Additional CSS button
    - ✅ CSS screen should open
4. Click the back button to return to Global Styles
5. Click the Additional CSS button again
    - ✅ CSS screen should open again
6. Repeat steps 4-5 multiple times to ensure consistent behavior
    - ✅ Additional CSS button should work every time

## Screencast:

https://github.com/user-attachments/assets/53b5b8ad-d00a-408e-aaf3-dbc06c102d8d
