### PR TITLE
Global Styles: Make Additional CSS button always work

### DIFF
--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -56,6 +56,7 @@ const { Slot: GlobalStylesMenuSlot, Fill: GlobalStylesMenuFill } =
 function GlobalStylesActionMenu() {
 	const [ canReset, onReset ] = useGlobalStylesReset();
 	const { toggle } = useDispatch( preferencesStore );
+	const { goTo } = useNavigator();
 	const { canEditCSS } = useSelect( ( select ) => {
 		const { getEntityRecord, __experimentalGetCurrentGlobalStylesId } =
 			select( coreStore );
@@ -73,6 +74,7 @@ function GlobalStylesActionMenu() {
 		useDispatch( editSiteStore )
 	);
 	const loadCustomCSS = () => {
+		goTo( '/css' );
 		setEditorCanvasContainerView( 'global-styles-css' );
 	};
 
@@ -271,9 +273,6 @@ function GlobalStylesEditorCanvasContainerLink() {
 				if ( ! isRevisionsOpen ) {
 					goTo( '/revisions' );
 				}
-				break;
-			case 'global-styles-css':
-				goTo( '/css' );
 				break;
 			// The stand-alone style book is open
 			// and the revisions panel is open,


### PR DESCRIPTION
## What?

This PR makes the Additional CSS button in the global styles work in all states.

- Closes #68949
- Alternatives to #68954

## Why?

The global styles sidebar screen switches automatically depending on the state of the canvas view, mainly through the `useEffect` hook [here](https://github.com/WordPress/gutenberg/blob/047fdacb742fada81d21121eb3fdb3f87ce0168a/packages/edit-site/src/components/global-styles/ui.js#L264-L297). Furthermore, the initial value of the canvas view is `undefined`.

The first time you click the Additional CSS button, the canvas view changes from `undefined` to `global-styles-css`. The `useEffect()` hook detects this change and navigates the global styles sidebar screens to CSS.

After that, you press the back button and then click the Additional CSS button again. This time, the canvas view remains `global-styles-css`, so `useEffect()` hook has no effect and the screen does not switch.

## How?

In the button's click event, I restored the deleted `goTo()` function. This ensures that the Additional CSS button always works, regardless of the state of the canvas view.

Furthermore, I removed the similar code in the `useEffect()` hook to prevent `goTo()` from being executed twice.

## Testing Instructions

- Site Editor > Global Styles > Click the Additional CSS button
- The CSS screen opens
- Click the back button
- Click the Additional CSS button again
- The CSS screen opens

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/10f8ce7c-7866-4ee3-8a6c-58e8d41ba330
