### PR TITLE
Storybook: Add Story for Block Tools

### DIFF
--- a/packages/block-editor/src/components/block-tools/stories/index.story.js
+++ b/packages/block-editor/src/components/block-tools/stories/index.story.js
@@ -1,0 +1,66 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import BlockTools from '../';
+
+export default {
+	title: 'BlockEditor/BlockTools',
+	component: BlockTools,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'Block tools (the block toolbar, select/navigation mode toolbar, the insertion point and a slot for the inline rich text toolbar). Must be wrapped around the block content and editor styles wrapper or iframe.',
+			},
+		},
+	},
+	argTypes: {
+		children: {
+			control: {
+				type: null,
+			},
+			description: 'The block content and style container.',
+			table: {
+				type: {
+					summary: 'object',
+				},
+			},
+		},
+		__unstableContentRef: {
+			control: {
+				type: 'object',
+			},
+			description: 'Ref holding the content scroll container.',
+			table: {
+				type: {
+					summary: 'object',
+				},
+			},
+		},
+		props: {
+			control: {
+				type: 'object',
+			},
+			description: 'Props',
+			table: {
+				type: {
+					summary: 'object',
+				},
+			},
+		},
+	},
+};
+
+export const Default = {
+	args: {
+		children: <h2>{ __( 'Block content' ) }</h2>,
+	},
+	render: function Template( { children, ...args } ) {
+		return <BlockTools { ...args }>{ children }</BlockTools>;
+	},
+};


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR adds Story for Block Tools component 

## Testing Instructions
- Run npm run storybook:dev
- Open Storybook at http://localhost:50240/
- Visit `BlockTools` Storybook 

## Screenshots or screencast 

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/1ffe719d-e4c3-47c2-bc8d-4df8db408b71" />
