### PR TITLE
ESLint: Improve lint regex for preventing "toggle" word usage in translation ready functions 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -116,7 +116,7 @@ const restrictedSyntax = [
 	},
 	{
 		selector:
-			'CallExpression[callee.name=/^(__|_x|_n|_nx)$/] > Literal[value=/^toggle\\b/i]',
+			'CallExpression[callee.name=/^(__|_x|_n|_nx)$/] > Literal[value=/toggle\\b/i]',
 		message: "Avoid using the verb 'Toggle' in translatable strings",
 	},
 ];

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -95,7 +95,7 @@ function ToolSelector( props, ref ) {
 					</NavigableMenu>
 					<div className="block-editor-tool-selector__help">
 						{ __(
-							'Tools provide different sets of interactions for blocks. Toggle between simplified content tools (Write) and advanced visual editing tools (Design).'
+							'Tools provide different sets of interactions for blocks. Choose between simplified content tools (Write) and advanced visual editing tools (Design).'
 						) }
 					</div>
 				</>

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -257,7 +257,7 @@ function LayoutPanelPure( {
 												'Nested blocks use content width with options for full and wide widths.'
 										  )
 										: __(
-												'Nested blocks will fill the width of this container. Toggle to constrain.'
+												'Nested blocks will fill the width of this container.'
 										  )
 								}
 							/>

--- a/packages/components/src/mobile/bottom-sheet/switch-cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/switch-cell.native.js
@@ -57,7 +57,7 @@ export default function BottomSheetSwitchCell( props ) {
 			accessibilityRole="none"
 			accessibilityHint={
 				/* translators: accessibility text (hint for switches) */
-				__( 'Double tap to toggle setting' )
+				__( 'Double tap to change setting' )
 			}
 			onPress={ onPress }
 			editable={ false }


### PR DESCRIPTION
Related Comment: https://github.com/WordPress/gutenberg/pull/67741#issuecomment-2622475649

Related issue: https://github.com/WordPress/gutenberg/issues/66372

## What?
As described in the above comment, after the new rule had been added to prevent the usage of the word "toggle" in the repositiory. The solution merged previoulsy could be optimised better by improving the regex. 



## Why?
Previously the word toggle was only detected/flaagged incase if it were the first word in the string ie __("toggle is the first word") but if "toggle" was used in the middle or at the end it would not be flagged. 

## How?
Updated the regex of the eslint rule to further improve the warning. and prevent usage of the word toggle. 

The new regex: `Literal[value=/toggle\\b/i]`

## Screencast

#### Before

https://github.com/user-attachments/assets/31b66721-567d-4bdd-ac31-4a1bb9d322af

#### After

https://github.com/user-attachments/assets/9d0d7127-6217-4f0d-bdc2-19913d292079


