### PR TITLE
Classic themes: update the die handler to remove access to the Site Editor

### DIFF
--- a/lib/compat/wordpress-6.8/site-editor.php
+++ b/lib/compat/wordpress-6.8/site-editor.php
@@ -106,8 +106,7 @@ function gutenberg_redirect_site_editor_deprecated_urls() {
 add_action( 'admin_init', 'gutenberg_redirect_site_editor_deprecated_urls' );
 
 /**
- * Filter the `wp_die_handler` to allow access to the Site Editor's new pages page
- * for Classic themes.
+ * Filter the `wp_die_handler` to allow access to some Site Editor pages for Classic themes.
  *
  * site-editor.php's access is forbidden for hybrid/classic themes and only allowed with some very special query args (some very special pages like template parts...).
  * The only way to disable this protection since we're changing the urls in Gutenberg is to override the wp_die_handler.
@@ -116,9 +115,22 @@ add_action( 'admin_init', 'gutenberg_redirect_site_editor_deprecated_urls' );
  * @return callable The default handler or a custom handler.
  */
 function gutenberg_styles_wp_die_handler( $default_handler ) {
-	if ( ! wp_is_block_theme() && str_contains( $_SERVER['REQUEST_URI'], 'site-editor.php' ) && current_user_can( 'edit_theme_options' ) ) {
-		return '__return_false';
+	if ( ! wp_is_block_theme() ) {
+		// Trim the / that may be added when navigating through the Site Editor.
+		$p = isset( $_REQUEST['p'] ) ? ltrim( urldecode( $_REQUEST['p'] ), '/' ) : '';
+
+		if ( 'pattern' === $p ) {
+			return '__return_false';
+		}
+
+		if ( current_theme_supports( 'editor-styles' ) || wp_theme_has_theme_json() ) {
+			// Allow access to the first page of the Site Editor and the stylebook.
+			if ( '' === $p || 'stylebook' === $p ) {
+				return '__return_false';
+			}
+		}
 	}
+
 	return $default_handler;
 }
 add_filter( 'wp_die_handler', 'gutenberg_styles_wp_die_handler' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/68950

Updates `function gutenberg_styles_wp_die_handler` in the 6.8 Site Editor compatibility file to only allow access to patterns,
and conditional access to the first page and the stylebook.

In this PR, I am using the existing condition for accessing the style book: the editor-styles theme support, or theme.json.
It does not include the changes proposed to the theme support. https://github.com/WordPress/gutenberg/pull/68940

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Users of classic themes had access to parts of the Site Editor that do not work with classic themes.

## Help wanted
Should the **pattern** page available to all users? Or should I re-add `current_user_can( 'edit_theme_options' )`
https://github.com/WordPress/gutenberg/issues/61637


## Testing Instructions
Activate a classic theme.
Go to wp-admin/site-editor.php?p=%2Ftemplate
Go to wp-admin/site-editor.php?p=%2Fpage
The screens should not be available and show a message saying that the theme is not compatible.

If the classic theme has added theme support for editor-styles:
Go to wp-admin/site-editor.php
Go to wp-admin/site-editor.php?p=stylebook
The screens should be available.
