### PR TITLE
Split the dataviews primary and non primary actions for display purposes

### DIFF
--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -153,22 +153,28 @@ export default function ItemActions< Item >( {
 	isCompact,
 }: ItemActionsProps< Item > ) {
 	const registry = useRegistry();
-	const { primaryActions, eligibleActions } = useMemo( () => {
-		// If an action is eligible for all items, doesn't need
-		// to provide the `isEligible` function.
-		const _eligibleActions = actions.filter(
-			( action ) => ! action.isEligible || action.isEligible( item )
-		);
-		const _primaryActions = _eligibleActions.filter(
-			( action ) => action.isPrimary && !! action.icon
-		);
-		return {
-			primaryActions: _primaryActions,
-			eligibleActions: _eligibleActions,
-		};
-	}, [ actions, item ] );
+	const { primaryActions, eligibleActions, nonPrimaryActions } =
+		useMemo( () => {
+			// If an action is eligible for all items, doesn't need
+			// to provide the `isEligible` function.
+			const _eligibleActions = actions.filter(
+				( action ) => ! action.isEligible || action.isEligible( item )
+			);
+			const _primaryActions = _eligibleActions.filter(
+				( action ) => action.isPrimary && !! action.icon
+			);
+			const _nonPrimaryActions = _eligibleActions.filter(
+				( action ) => ! _primaryActions.includes( action )
+			);
 
-	if ( isCompact ) {
+			return {
+				primaryActions: _primaryActions,
+				eligibleActions: _eligibleActions,
+				nonPrimaryActions: _nonPrimaryActions,
+			};
+		}, [ actions, item ] );
+
+	if ( isCompact && eligibleActions.length > 1 ) {
 		return (
 			<CompactItemActions
 				item={ item }
@@ -179,12 +185,16 @@ export default function ItemActions< Item >( {
 		);
 	}
 
-	// If all actions are primary, there is no need to render the dropdown.
-	if ( primaryActions.length === eligibleActions.length ) {
+	// If there is only one action or all actions are primary,
+	// there is no need to render the dropdown.
+	if (
+		eligibleActions.length === 1 ||
+		primaryActions.length === eligibleActions.length
+	) {
 		return (
 			<PrimaryActions
 				item={ item }
-				actions={ primaryActions }
+				actions={ eligibleActions || primaryActions }
 				registry={ registry }
 			/>
 		);
@@ -207,7 +217,7 @@ export default function ItemActions< Item >( {
 			/>
 			<CompactItemActions
 				item={ item }
-				actions={ eligibleActions }
+				actions={ nonPrimaryActions }
 				registry={ registry }
 			/>
 		</HStack>

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -179,20 +179,29 @@ function ListItem< Item >( {
 		}
 	}, [ isSelected ] );
 
-	const { primaryAction, eligibleActions } = useMemo( () => {
-		// If an action is eligible for all items, doesn't need
-		// to provide the `isEligible` function.
-		const _eligibleActions = actions.filter(
-			( action ) => ! action.isEligible || action.isEligible( item )
-		);
-		const _primaryActions = _eligibleActions.filter(
-			( action ) => action.isPrimary && !! action.icon
-		);
-		return {
-			primaryAction: _primaryActions[ 0 ],
-			eligibleActions: _eligibleActions,
-		};
-	}, [ actions, item ] );
+	const { primaryAction, eligibleActions, nonPrimaryActions } =
+		useMemo( () => {
+			// If an action is eligible for all items, doesn't need
+			// to provide the `isEligible` function.
+			const _eligibleActions = actions.filter(
+				( action ) => ! action.isEligible || action.isEligible( item )
+			);
+			const _primaryAction = _eligibleActions.filter(
+				( action ) => action.isPrimary && !! action.icon
+			)[ 0 ];
+			const _nonPrimaryActions = _eligibleActions.filter(
+				( action ) => action !== _primaryAction
+			);
+			return {
+				// Actually, primaryAction is the first primary action. There may
+				// be more. This variable should be renamed. Also nonPrimaryActions
+				// should be renamed because it's all the actions except the first
+				// primary one.
+				primaryAction: _primaryAction,
+				eligibleActions: _eligibleActions,
+				nonPrimaryActions: _nonPrimaryActions,
+			};
+		}, [ actions, item ] );
 
 	const hasOnlyOnePrimaryAction = primaryAction && actions.length === 1;
 
@@ -243,7 +252,7 @@ function ListItem< Item >( {
 						/>
 						<Menu.Popover>
 							<ActionsMenuGroup
-								actions={ eligibleActions }
+								actions={ nonPrimaryActions }
 								item={ item }
 								registry={ registry }
 								setActiveModalAction={ setActiveModalAction }

--- a/packages/fields/src/actions/duplicate-pattern.tsx
+++ b/packages/fields/src/actions/duplicate-pattern.tsx
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { copy } from '@wordpress/icons';
 import { _x } from '@wordpress/i18n';
 // @ts-ignore
 import { privateApis as patternsPrivateApis } from '@wordpress/patterns';
@@ -19,6 +20,7 @@ const { CreatePatternModalContents, useDuplicatePatternProps } =
 const duplicatePattern: Action< Pattern > = {
 	id: 'duplicate-pattern',
 	label: _x( 'Duplicate', 'action label' ),
+	icon: copy,
 	isEligible: ( item ) => item.type !== 'wp_template_part',
 	modalHeader: _x( 'Duplicate pattern', 'action label' ),
 	RenderModal: ( { items, closeModal } ) => {

--- a/packages/fields/src/actions/duplicate-post.tsx
+++ b/packages/fields/src/actions/duplicate-post.tsx
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { copy } from '@wordpress/icons';
 import { useDispatch } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { store as coreStore } from '@wordpress/core-data';
@@ -30,6 +31,7 @@ const formDuplicateAction = {
 const duplicatePost: Action< BasePost > = {
 	id: 'duplicate-post',
 	label: _x( 'Duplicate', 'action label' ),
+	icon: copy,
 	isEligible( { status } ) {
 		return status !== 'trash';
 	},

--- a/packages/fields/src/actions/duplicate-template-part.tsx
+++ b/packages/fields/src/actions/duplicate-template-part.tsx
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { copy } from '@wordpress/icons';
 import { useDispatch } from '@wordpress/data';
 import { _x, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
@@ -22,6 +23,7 @@ import { getItemTitle } from './utils';
 const duplicateTemplatePart: Action< TemplatePart > = {
 	id: 'duplicate-template-part',
 	label: _x( 'Duplicate', 'action label' ),
+	icon: copy,
 	isEligible: ( item ) => item.type === 'wp_template_part',
 	modalHeader: _x( 'Duplicate template part', 'action label' ),
 	RenderModal: ( { items, closeModal } ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
See https://github.com/WordPress/gutenberg/issues/68789

This is a demo PR so far, to illustrate what I would like to propose for https://github.com/WordPress/gutenberg/issues/68789

- Filters out the primary actions from the dataviews dropdown menus. The primary actions are already displayed outside of the menu as single buttons and displaying them in two places isn't ideal.
- When there's only one action available, it should display a single button and not a dropdown menu with only one action.

The second point implies that _all_ actions should now have an icon. That's because _any_ action may now be displayed as a single button if it's the only action available. So far, I've added a few icons for some actions but not for all of them yet.

This is a demo, I would greatly appreciate that someone else more familiar then me with dataviews could have a look at it as there's likely many things I'm missing.

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Go to Pages and observe the 'Edit' action is not duplicate in the menu any longer:

![pages](https://github.com/user-attachments/assets/33edb7e9-9d4b-409e-b995-e7043e879146)

Go to Templates and observe the only available action (Edit) is now displayed with a single icon button a no longer with an ellipsis dropdown menu that contains only one action:

![templates only one action](https://github.com/user-attachments/assets/acf4dce9-08a2-4fca-9015-19c8d95fd41b)

Go to All Patterns and observe the only available action (Duplicate) is now displayed with a single icon button a no longer with an ellipsis dropdown menu that contains only one action:

![patterns only one action](https://github.com/user-attachments/assets/20d07661-c0bf-4356-927b-671d19b6cbd7)

Make sure you have at least one custom pattern (Duplicate one of the 'All patterns)'. Go to My patterns and observe all actions are inside the dropdown menu. This is unchanged from trunk and respects the `isCompact` prop.

![custom pattern isCompact](https://github.com/user-attachments/assets/6b771754-1740-4588-ad20-7d193dddd54b)


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
