### PR TITLE
Fast follow: Redirections of deprecated site editor URLs.

### DIFF
--- a/backport-changelog/6.8/7903.md
+++ b/backport-changelog/6.8/7903.md
@@ -1,3 +1,5 @@
 https://github.com/WordPress/wordpress-develop/pull/7903
 
 * https://github.com/WordPress/gutenberg/pull/67199
+* https://github.com/WordPress/gutenberg/pull/68971
+

--- a/lib/compat/wordpress-6.8/site-editor.php
+++ b/lib/compat/wordpress-6.8/site-editor.php
@@ -106,10 +106,13 @@ function gutenberg_get_site_editor_redirection() {
 	return add_query_arg( array( 'p' => '/' ) );
 }
 
+/**
+ * Redirect old site editor urls to the new updated ones.
+ */
 function gutenberg_redirect_site_editor_deprecated_urls() {
 	$redirection = gutenberg_get_site_editor_redirection();
 	if ( false !== $redirection ) {
-		wp_redirect( $redirection, 301 );
+		wp_safe_redirect( $redirection );
 		exit;
 	}
 }

--- a/lib/compat/wordpress-6.8/site-editor.php
+++ b/lib/compat/wordpress-6.8/site-editor.php
@@ -15,6 +15,16 @@ add_filter(
 	}
 );
 
+/**
+ * Maps old site editor urls to the new updated ones.
+ *
+ * @since 6.8.0
+ * @access private
+ *
+ * @global string $pagenow The filename of the current screen.
+ *
+ * @return string|false The new URL to redirect to, or false if no redirection is needed.
+ */
 function gutenberg_get_site_editor_redirection() {
 	global $pagenow;
 	if ( 'site-editor.php' !== $pagenow || isset( $_REQUEST['p'] ) || ! $_SERVER['QUERY_STRING'] ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Follow up to #67199
Incorporating changes in https://github.com/WordPress/wordpress-develop/pull/7903
See https://core.trac.wordpress.org/ticket/62585
See https://github.com/WordPress/gutenberg/pull/67199

* Adds docblock to `gutenberg_get_site_editor_redirection()`
* Uses `wp_safe_redirect()`
* Uses temporary redirect instead of a 301


## Why?

Bringing suggested changes from https://github.com/WordPress/wordpress-develop/pull/7903 to the plugin

* Docblocks are good
* For redirects within WP it's best to use safe redirects to validate the destination
* Logged in and logged out users will be redirected to different locations, so 302 redirects are needed to ensure the browser doesn't cache an incorrect destination

## How?

As above.

## Testing Instructions

1. Log in to WP
2. Visit a deprecated site editor URL
3. Ensure it redirects to the expected location
4. [Repeat for multiple deprecated URLs]
5. Log out of WP
6. Visit a deprecated site editor URL
7. Ensure it redirects to the login screen rather than the new URL

If you've tested the redirection of site editor URLs in the past, your browser may have the permanent redirects cached. If that is the case, you will need to test in a browser you don't usually use.



### Testing Instructions for Keyboard

N/A

## Screenshots or screencast <!-- if applicable -->

N/A