### PR TITLE
Quality: Remove unused props and styles from SidebarNavigationScreen

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -36,7 +36,6 @@ export default function SidebarNavigationScreen( {
 	isRoot,
 	title,
 	actions,
-	meta,
 	content,
 	footer,
 	description,
@@ -121,14 +120,6 @@ export default function SidebarNavigationScreen( {
 						</div>
 					) }
 				</HStack>
-				{ meta && (
-					<>
-						<div className="edit-site-sidebar-navigation-screen__meta">
-							{ meta }
-						</div>
-					</>
-				) }
-
 				<div className="edit-site-sidebar-navigation-screen__content">
 					{ description && (
 						<p className="edit-site-sidebar-navigation-screen__description">

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -27,29 +27,6 @@
 	}
 }
 
-.edit-site-sidebar-navigation-screen__meta {
-	margin: 0 0 $grid-unit-20 $grid-unit-20;
-	color: $gray-400;
-	.components-text {
-		color: $gray-400;
-	}
-}
-
-.edit-site-sidebar-navigation-screen__page-link {
-	color: $gray-600;
-	display: inline-block;
-	word-break: break-word;
-
-	&:hover,
-	&:focus {
-		color: $white;
-	}
-
-	.components-external-link__icon {
-		margin-left: $grid-unit-05;
-	}
-}
-
 .edit-site-sidebar-navigation-screen__title-icon {
 	position: sticky;
 	top: 0;


### PR DESCRIPTION
I noticed this while reviewing ~#48650~ #68165

## What?

### Remove unused `meta` prop

This prop was required for the page detail screen, but there is no longer a page detail screen (See https://github.com/WordPress/gutenberg/pull/50767/files#diff-8ce0ed2dae75d0d1d0c447ac6f8ef78bf47ffbb61e1e3d069c743369637032f9R192-R199).

### Remove unused CSS selectors

The two selectors `.edit-site-sidebar-navigation-screen__meta` and `.edit-site-sidebar-navigation-screen__page-link` were needed for the page details screen, but are no longer needed.

Below is a screenshot of WordPress 6.5:

![meta](https://github.com/user-attachments/assets/2e4522b8-8269-4ddf-a876-a3a1040eb218)

## Testing Instructions

Verify that your site editor sidebar still works as expected.