### PR TITLE
Disable hover animation on preview frame for classic themes

### DIFF
--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -236,6 +236,7 @@ function Layout() {
 													gradientValue ??
 													backgroundColor,
 											} }
+											disableZoom
 										>
 											{ areas.preview }
 										</ResizableFrame>

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -236,7 +236,6 @@ function Layout() {
 													gradientValue ??
 													backgroundColor,
 											} }
-											disableZoom
 										>
 											{ areas.preview }
 										</ResizableFrame>

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -89,6 +89,7 @@ function ResizableFrame( {
 	/** The default (unresized) width/height of the frame, based on the space available in the viewport. */
 	defaultSize,
 	innerContentStyle,
+	disableZoom,
 } ) {
 	const history = useHistory();
 	const { path, query } = useLocation();
@@ -254,7 +255,7 @@ function ResizableFrame( {
 				}
 			} }
 			whileHover={
-				canvas === 'view'
+				canvas === 'view' && ! disableZoom
 					? {
 							scale: 1.005,
 							transition: {

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -89,7 +89,6 @@ function ResizableFrame( {
 	/** The default (unresized) width/height of the frame, based on the space available in the viewport. */
 	defaultSize,
 	innerContentStyle,
-	disableZoom,
 } ) {
 	const history = useHistory();
 	const { path, query } = useLocation();
@@ -255,7 +254,7 @@ function ResizableFrame( {
 				}
 			} }
 			whileHover={
-				canvas === 'view' && ! disableZoom
+				canvas === 'view' && isBlockTheme
 					? {
 							scale: 1.005,
 							transition: {


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
closes #68948

## Why?
- There is a zoom effect or hover on classic theme preview, which is unwanted.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Added an extra parameter to `ResizableFrame` component to disable the zoom and can be passed from where the component is rendered.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Activate a classic theme with the theme support for editor-styles
2. Navigate to Design
3. Hover on the theme preview, the zoom effect is disabled.

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/user-attachments/assets/4837eeb7-8f40-4a1f-8e3f-1e127fab1bba

After:


https://github.com/user-attachments/assets/d1162990-cdbe-4d56-bd4a-bb8e030d635b


