### PR TITLE
BlockSwitcher: Add README and JS doc for BlockSwitcher component

### DIFF
--- a/packages/block-editor/src/components/block-switcher/README.md
+++ b/packages/block-editor/src/components/block-switcher/README.md
@@ -1,0 +1,26 @@
+# Block Switcher
+
+The `BlockSwitcher` component provides a toolbar dropdown menu for converting between block types, applying block styles, and accessing pattern transformations. It appears in the block toolbar when these transformation options are available.
+
+## Usage
+
+Render component to enable block transformations.
+
+```jsx
+import { BlockSwitcher } from '@wordpress/block-editor';
+
+function MyBlockSwitcher() {
+	return (
+		<BlockSwitcher clientIds={['ch1d82m9-d33a-4c12-b5d9-a8927e12b654']} />
+	);
+}
+```
+
+## Props
+
+### clientIds
+
+The client IDs of the blocks that will be displayed in the block list.
+
+-   Type: `Array<String>`
+-   Required: Yes

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -186,6 +186,28 @@ function BlockSwitcherDropdownMenuContents( {
 	);
 }
 
+/**
+ * The `BlockSwitcher` component provides a toolbar dropdown menu for converting
+ * between block types, applying block styles, and accessing pattern
+ * transformations. It appears in the block toolbar when these transformation
+ * options are available.
+ *
+ * @example
+ * ```jsx
+ * import { BlockSwitcher } from '@wordpress/block-editor';
+ *
+ * function MyBlockSwitcher() {
+ *     return (
+ *         <BlockSwitcher clientIds={['ch1d82m9-d33a-4c12-b5d9-a8927e12b654']} />
+ *     );
+ * }
+ * ```
+ *
+ * @param {Object}   props           Component props.
+ * @param {string[]} props.clientIds The client IDs of the blocks that will be displayed in the block list.
+ *
+ * @return {Element} The BlockSwitcher component.
+ */
 export const BlockSwitcher = ( { clientIds } ) => {
 	const {
 		hasContentOnlyLocking,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
related to: #22891

## What?

This PR adds documentation for the BlockSwitcher component, including JSDoc comments and an updated README with usage examples and prop details. 

## Why?
The goal of this PR is to improve the documentation for the BlockSwitcher component, making it easier for developers to understand how to use it. The updates help clarify the component’s purpose and usage.

## How?
The JSDoc comments within the code have been updated, and the README now includes examples and explanations for the BlockSwitcher component and its clientIds prop.