### PR TITLE
Performance: Improve StyleBook resize responsiveness for Classic Theme

### DIFF
--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -24,7 +24,6 @@ import {
 } from '@wordpress/block-editor';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { useSelect, dispatch } from '@wordpress/data';
-import { useResizeObserver } from '@wordpress/compose';
 import {
 	useMemo,
 	useState,
@@ -227,7 +226,6 @@ function StyleBook( {
 	userConfig = {},
 	path = '',
 } ) {
-	const [ resizeObserver, sizes ] = useResizeObserver();
 	const [ textColor ] = useGlobalStyle( 'color.text' );
 	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
 	const colors = useMultiOriginPalettes();
@@ -282,7 +280,6 @@ function StyleBook( {
 		>
 			<div
 				className={ clsx( 'edit-site-style-book', {
-					'is-wide': sizes.width > 600,
 					'is-button': !! onClick,
 				} ) }
 				style={ {
@@ -290,7 +287,6 @@ function StyleBook( {
 					background: backgroundColor,
 				} }
 			>
-				{ resizeObserver }
 				{ showTabs ? (
 					<Tabs>
 						<div className="edit-site-style-book__tablist-container">
@@ -331,7 +327,6 @@ function StyleBook( {
 										isSelected={ isSelected }
 										onSelect={ onSelect }
 										settings={ settings }
-										sizes={ sizes }
 										title={ tab.title }
 										goTo={ goTo }
 									/>
@@ -346,7 +341,6 @@ function StyleBook( {
 						onClick={ onClick }
 						onSelect={ onSelect }
 						settings={ settings }
-						sizes={ sizes }
 						goTo={ goTo }
 					/>
 				) }
@@ -420,7 +414,6 @@ export const StyleBookPreview = ( { userConfig = {}, isStatic = false } ) => {
 		onChangeSection( `/blocks/${ encodeURIComponent( blockName ) }` );
 	};
 
-	const [ resizeObserver, sizes ] = useResizeObserver();
 	const colors = useMultiOriginPalettes();
 	const examples = getExamples( colors );
 	const examplesForSinglePageUse = getExamplesForSinglePageUse( examples );
@@ -489,14 +482,12 @@ export const StyleBookPreview = ( { userConfig = {}, isStatic = false } ) => {
 
 	return (
 		<div className="edit-site-style-book">
-			{ resizeObserver }
 			<BlockEditorProvider settings={ settings }>
 				<GlobalStylesRenderer disableRootPadding />
 				<StyleBookBody
 					examples={ displayedExamples }
 					settings={ settings }
 					goTo={ goTo }
-					sizes={ sizes }
 					isSelected={ ! isStatic ? isSelected : null }
 					onSelect={ ! isStatic ? onSelect : null }
 				/>
@@ -511,7 +502,6 @@ export const StyleBookBody = ( {
 	onClick,
 	onSelect,
 	settings,
-	sizes,
 	title,
 	goTo,
 } ) => {
@@ -574,9 +564,7 @@ export const StyleBookBody = ( {
 					'body { cursor: pointer; } body * { pointer-events: none; }' }
 			</style>
 			<Examples
-				className={ clsx( 'edit-site-style-book__examples', {
-					'is-wide': sizes.width > 600,
-				} ) }
+				className="edit-site-style-book__examples"
 				filteredExamples={ examples }
 				label={
 					title


### PR DESCRIPTION
## What?

This PR improves resize responsiveness by removing unnecessary resize observers from the StyleBook for the Classic theme.

Closes https://github.com/WordPress/gutenberg/issues/68978

## Why?

When I measured with the browser developer tools, I confirmed that a large number of requests like the one below were generated every time the canvas was resized:

```
http://localhost:8888/index.php?rest_route=%2Fwp%2Fv2%2Fblock-renderer%2Fcore%2Farchives&context=edit&attributes%5BdisplayAsDropdown%5D=false&attributes%5BshowLabel%5D=true&attributes%5BshowPostCounts%5D=false&attributes%5Btype%5D=monthly&_locale=user
```

These seem to be related to dynamic blocks that are rendered on the server side.

I suspected that this was due to the `StyleBook` component and `StyleBookPreview` component using the `useResizeObserver` hook, which causes re-rendering every time the canvas is resized.

## How?

This hook seems to be used to monitor the width of the container and add the CSS selector `is-wide` when the width is 600px or more. However, this CSS selector is not used anywhere (See [this stylesheet](https://github.com/WordPress/gutenberg/blob/4f5270a4b4641d91d3f73577bb004f181f626865/packages/edit-site/src/components/style-book/style.scss)).

When I remove these resize observers, the resizing responsiveness of the canvas seems to improve dramatically.

## Testing Instructions

- Enable Twenty Twenty-One theme
- Appearance > Design > Styles
- Resize the Stylebook canvas

## Screenshots or screencast <!-- if applicable -->

Compare this to the video uploaded in #68978.

https://github.com/user-attachments/assets/465b7408-70e9-4de1-83fc-267599eacdca
