### PR TITLE
Shadow Panel: Add reset button

### DIFF
--- a/packages/block-editor/src/components/global-styles/shadow-panel-components.js
+++ b/packages/block-editor/src/components/global-styles/shadow-panel-components.js
@@ -5,10 +5,8 @@ import { __ } from '@wordpress/i18n';
 import {
 	__experimentalVStack as VStack,
 	__experimentalHeading as Heading,
-	__experimentalHStack as HStack,
 	__experimentalDropdownContentWrapper as DropdownContentWrapper,
 	Button,
-	FlexItem,
 	Dropdown,
 	Composite,
 	Tooltip,
@@ -143,6 +141,9 @@ function renderShadowToggle( shadow, onShadowChange ) {
 
 		const removeButtonProps = {
 			onClick: () => {
+				if ( isOpen ) {
+					onToggle();
+				}
 				onShadowChange( undefined );
 			},
 			className: clsx(
@@ -154,15 +155,12 @@ function renderShadowToggle( shadow, onShadowChange ) {
 
 		return (
 			<>
-				<Button __next40pxDefaultSize { ...toggleProps }>
-					<HStack justify="flex-start">
-						<Icon
-							className="block-editor-global-styles__toggle-icon"
-							icon={ shadowIcon }
-							size={ 24 }
-						/>
-						<FlexItem>{ __( 'Drop shadow' ) }</FlexItem>
-					</HStack>
+				<Button
+					__next40pxDefaultSize
+					icon={ shadowIcon }
+					{ ...toggleProps }
+				>
+					{ __( 'Drop shadow' ) }
 				</Button>
 				{ !! shadow && (
 					<Button

--- a/packages/block-editor/src/components/global-styles/shadow-panel-components.js
+++ b/packages/block-editor/src/components/global-styles/shadow-panel-components.js
@@ -5,8 +5,10 @@ import { __ } from '@wordpress/i18n';
 import {
 	__experimentalVStack as VStack,
 	__experimentalHeading as Heading,
+	__experimentalHStack as HStack,
 	__experimentalDropdownContentWrapper as DropdownContentWrapper,
 	Button,
+	FlexItem,
 	Dropdown,
 	Composite,
 	Tooltip,
@@ -150,17 +152,20 @@ function renderShadowToggle( shadow, onShadowChange ) {
 				'block-editor-global-styles__shadow-editor__remove-button',
 				{ 'is-open': isOpen }
 			),
-			label: __( 'Remove shadow' ),
+			label: __( 'Remove' ),
 		};
 
 		return (
 			<>
-				<Button
-					__next40pxDefaultSize
-					icon={ shadowIcon }
-					{ ...toggleProps }
-				>
-					{ __( 'Drop shadow' ) }
+				<Button __next40pxDefaultSize { ...toggleProps }>
+					<HStack justify="flex-start">
+						<Icon
+							className="block-editor-global-styles__toggle-icon"
+							icon={ shadowIcon }
+							size={ 24 }
+						/>
+						<FlexItem>{ __( 'Drop shadow' ) }</FlexItem>
+					</HStack>
 				</Button>
 				{ !! shadow && (
 					<Button

--- a/packages/block-editor/src/components/global-styles/shadow-panel-components.js
+++ b/packages/block-editor/src/components/global-styles/shadow-panel-components.js
@@ -13,7 +13,7 @@ import {
 	Composite,
 	Tooltip,
 } from '@wordpress/components';
-import { useMemo } from '@wordpress/element';
+import { useMemo, useRef } from '@wordpress/element';
 import { shadow as shadowIcon, Icon, check, reset } from '@wordpress/icons';
 
 /**
@@ -135,10 +135,13 @@ export function ShadowPopover( { shadow, onShadowChange, settings } ) {
 
 function renderShadowToggle( shadow, onShadowChange ) {
 	return ( { onToggle, isOpen } ) => {
+		const shadowButtonRef = useRef( undefined );
+
 		const toggleProps = {
 			onClick: onToggle,
 			className: clsx( { 'is-open': isOpen } ),
 			'aria-expanded': isOpen,
+			ref: shadowButtonRef,
 		};
 
 		const removeButtonProps = {
@@ -147,6 +150,8 @@ function renderShadowToggle( shadow, onShadowChange ) {
 					onToggle();
 				}
 				onShadowChange( undefined );
+				// Return focus to parent button.
+				shadowButtonRef.current?.focus();
 			},
 			className: clsx(
 				'block-editor-global-styles__shadow-editor__remove-button',

--- a/packages/block-editor/src/components/global-styles/shadow-panel-components.js
+++ b/packages/block-editor/src/components/global-styles/shadow-panel-components.js
@@ -14,7 +14,7 @@ import {
 	Tooltip,
 } from '@wordpress/components';
 import { useMemo } from '@wordpress/element';
-import { shadow as shadowIcon, Icon, check } from '@wordpress/icons';
+import { shadow as shadowIcon, Icon, check, reset } from '@wordpress/icons';
 
 /**
  * External dependencies
@@ -119,7 +119,7 @@ export function ShadowPopover( { shadow, onShadowChange, settings } ) {
 		<Dropdown
 			popoverProps={ popoverProps }
 			className="block-editor-global-styles__shadow-dropdown"
-			renderToggle={ renderShadowToggle() }
+			renderToggle={ renderShadowToggle( shadow, onShadowChange ) }
 			renderContent={ () => (
 				<DropdownContentWrapper paddingSize="medium">
 					<ShadowPopoverContainer
@@ -133,7 +133,7 @@ export function ShadowPopover( { shadow, onShadowChange, settings } ) {
 	);
 }
 
-function renderShadowToggle() {
+function renderShadowToggle( shadow, onShadowChange ) {
 	return ( { onToggle, isOpen } ) => {
 		const toggleProps = {
 			onClick: onToggle,
@@ -141,17 +141,38 @@ function renderShadowToggle() {
 			'aria-expanded': isOpen,
 		};
 
+		const removeButtonProps = {
+			onClick: () => {
+				onShadowChange( undefined );
+			},
+			className: clsx(
+				'block-editor-global-styles__shadow-editor__remove-button',
+				{ 'is-open': isOpen }
+			),
+			label: __( 'Remove shadow' ),
+		};
+
 		return (
-			<Button __next40pxDefaultSize { ...toggleProps }>
-				<HStack justify="flex-start">
-					<Icon
-						className="block-editor-global-styles__toggle-icon"
-						icon={ shadowIcon }
-						size={ 24 }
+			<>
+				<Button __next40pxDefaultSize { ...toggleProps }>
+					<HStack justify="flex-start">
+						<Icon
+							className="block-editor-global-styles__toggle-icon"
+							icon={ shadowIcon }
+							size={ 24 }
+						/>
+						<FlexItem>{ __( 'Drop shadow' ) }</FlexItem>
+					</HStack>
+				</Button>
+				{ !! shadow && (
+					<Button
+						__next40pxDefaultSize
+						size="small"
+						icon={ reset }
+						{ ...removeButtonProps }
 					/>
-					<FlexItem>{ __( 'Drop shadow' ) }</FlexItem>
-				</HStack>
-			</Button>
+				) }
+			</>
 		);
 	};
 }

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -1,7 +1,3 @@
-.block-editor-global-styles__toggle-icon {
-	fill: currentColor;
-}
-
 // @todo Ideally, popover, swatch size, and gap values should be CSS variables
 // to apply precise grid layouts.
 // https://github.com/WordPress/gutenberg/blob/954ecae571abbddc113d3a4bd8e1a72230180554/packages/block-editor/src/components/duotone-control/style.scss#L3-L9
@@ -33,6 +29,33 @@
 		&.is-open {
 			background-color: $gray-100;
 		}
+	}
+}
+
+.block-editor-global-styles__shadow-dropdown {
+	> .components-button.has-icon.has-text:first-child {
+		gap: $grid-unit-10;
+	}
+}
+
+.block-editor-global-styles__shadow-editor__remove-button {
+	position: absolute;
+	right: 0;
+	top: $grid-unit;
+	margin: auto $grid-unit auto;
+	opacity: 0;
+	transition: opacity 0.1s ease-in-out;
+	@include reduce-motion("transition");
+
+	.block-editor-global-styles__shadow-dropdown:hover &,
+	&:focus,
+	&:hover {
+		opacity: 1;
+	}
+
+	@media (hover: none) {
+		// Show reset button on devices that do not support hover.
+		opacity: 1;
 	}
 }
 
@@ -77,25 +100,4 @@
 	// CSS input is always LTR regardless of language.
 	/*rtl:ignore*/
 	direction: ltr;
-}
-
-.block-editor-global-styles__shadow-editor__remove-button {
-	position: absolute;
-	right: 0;
-	top: $grid-unit;
-	margin: auto $grid-unit auto;
-	opacity: 0;
-	transition: opacity 0.1s ease-in-out;
-	@include reduce-motion("transition");
-
-	.block-editor-global-styles__shadow-dropdown:hover &,
-	&:focus,
-	&:hover {
-		opacity: 1;
-	}
-
-	@media (hover: none) {
-		// Show reset button on devices that do not support hover.
-		opacity: 1;
-	}
 }

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -1,3 +1,7 @@
+.block-editor-global-styles__toggle-icon {
+	fill: currentColor;
+}
+
 // @todo Ideally, popover, swatch size, and gap values should be CSS variables
 // to apply precise grid layouts.
 // https://github.com/WordPress/gutenberg/blob/954ecae571abbddc113d3a4bd8e1a72230180554/packages/block-editor/src/components/duotone-control/style.scss#L3-L9
@@ -32,20 +36,15 @@
 	}
 }
 
-.block-editor-global-styles__shadow-dropdown {
-	> .components-button.has-icon.has-text:first-child {
-		gap: $grid-unit-10;
-	}
-}
-
 .block-editor-global-styles__shadow-editor__remove-button {
 	position: absolute;
 	right: 0;
 	top: $grid-unit;
 	margin: auto $grid-unit auto;
 	opacity: 0;
-	transition: opacity 0.1s ease-in-out;
-	@include reduce-motion("transition");
+	@media not (prefers-reduced-motion) {
+		transition: opacity 0.1s ease-in-out;
+	}
 
 	.block-editor-global-styles__shadow-dropdown:hover &,
 	&:focus,

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -24,6 +24,7 @@
 .block-editor-global-styles__shadow-dropdown {
 	display: block;
 	padding: 0;
+	position: relative;
 
 	button {
 		width: 100%;
@@ -76,4 +77,25 @@
 	// CSS input is always LTR regardless of language.
 	/*rtl:ignore*/
 	direction: ltr;
+}
+
+.block-editor-global-styles__shadow-editor__remove-button {
+	position: absolute;
+	right: 0;
+	top: $grid-unit;
+	margin: auto $grid-unit auto;
+	opacity: 0;
+	transition: opacity 0.1s ease-in-out;
+	@include reduce-motion("transition");
+
+	.block-editor-global-styles__shadow-dropdown:hover &,
+	&:focus,
+	&:hover {
+		opacity: 1;
+	}
+
+	@media (hover: none) {
+		// Show reset button on devices that do not support hover.
+		opacity: 1;
+	}
 }


### PR DESCRIPTION
## What, Why and How?
Closes #68973

This PR adds a reset button to the `Shadow Panel`, which becomes visible on hover or focus.

## Testing Instructions
1. Navigate to the `post edit` page.
2. Create a `Group block` and try changing the default `shadow`.
3. Observe the presence of the new `reset` button, which appears on hover.
4. Try pressing the `reset` button and confirm the shadow gets reset.

## Screencast


https://github.com/user-attachments/assets/8c0dcaaa-3013-4437-aa83-d50e84c7bdbf


