### PR TITLE
Regenerate block fixtures

### DIFF
--- a/test/integration/fixtures/blocks/core__separator-color.json
+++ b/test/integration/fixtures/blocks/core__separator-color.json
@@ -4,8 +4,8 @@
 		"isValid": true,
 		"attributes": {
 			"opacity": "alpha-channel",
-			"backgroundColor": "accent",
-			"tagName": "hr"
+			"tagName": "hr",
+			"backgroundColor": "accent"
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__separator-custom-color.json
+++ b/test/integration/fixtures/blocks/core__separator-custom-color.json
@@ -4,12 +4,12 @@
 		"isValid": true,
 		"attributes": {
 			"opacity": "alpha-channel",
+			"tagName": "hr",
 			"style": {
 				"color": {
 					"background": "#5da54c"
 				}
-			},
-			"tagName": "hr"
+			}
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
## What?

This comment raised the issue: https://github.com/WordPress/gutenberg/pull/68848#discussion_r1936812581

I noticed that when I ran `fixtures:regenerate` on the trunk branch, it somehow updated the fixture file of the Spacer block, so I'm submitting that update.

## Why?

This fixture file was added by #67530.

My guess is that this fixture file was manually updated. As a result, although the fixture is correct, the order of the code generated by the `fixtures:regenerate` command is different, so I think a difference has occurred.

## How?

Run `fixtures:regenerate`.

## Testing Instructions

Nothing.