### PR TITLE
Query Block: Fix 'parents' argument validation

### DIFF
--- a/backport-changelog/6.8/8245.md
+++ b/backport-changelog/6.8/8245.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/8245
+
+* https://github.com/WordPress/gutenberg/pull/68983

--- a/lib/compat/wordpress-6.8/blocks.php
+++ b/lib/compat/wordpress-6.8/blocks.php
@@ -217,3 +217,20 @@ function gutenberg_update_ignored_hooked_blocks_postmeta( $post ) {
 add_filter( 'rest_pre_insert_page', 'gutenberg_update_ignored_hooked_blocks_postmeta' );
 add_filter( 'rest_pre_insert_post', 'gutenberg_update_ignored_hooked_blocks_postmeta' );
 add_filter( 'rest_pre_insert_wp_block', 'gutenberg_update_ignored_hooked_blocks_postmeta' );
+
+/**
+ * Update Query `parents` argument validation for hierarchical post types.
+ * A zero is a valid parent ID for hierarchical post types. Used to display top-level items.
+ *
+ * @param array    $query The query vars.
+ * @param WP_Block $block Block instance.
+ * @return array   The filtered query vars.
+ */
+function gutenberg_parents_query_vars_from_query_block( $query, $block ) {
+	if ( ! empty( $block->context['query']['parents'] ) && is_post_type_hierarchical( $query['post_type'] ) ) {
+		$query['post_parent__in'] = array_unique( array_map( 'intval', $block->context['query']['parents'] ) );
+	}
+
+	return $query;
+}
+add_filter( 'query_loop_block_query_vars', 'gutenberg_parents_query_vars_from_query_block', 10, 2 );


### PR DESCRIPTION
## What?
Part of #68620

PR updates Query `parents` argument validation for hierarchical post types to allow querying only top-level entries, using `"parents":[0]`.

## Why?
* A zero is a valid parent ID for hierarchical post types. Used to display top-level items.
* Helps developers provide custom query patterns that only display top-level pages.

## Testing Instructions
1. Ensure you have a couple of pages with and without parents.
2. Create a page.
3. Add a Test Query using the code editor.
4. Confirm that the Query block displays only the top-level items.

### Testing Instructions for Keyboard
Same.

### Test Query

<details><summary>Markup</summary>
<p>

```html
<!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"page","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[0],"format":[]}} -->
<div class="wp-block-query"><!-- wp:post-template -->
<!-- wp:post-title /-->

<!-- wp:post-date /-->
<!-- /wp:post-template -->

<!-- wp:query-pagination -->
<!-- wp:query-pagination-previous /-->

<!-- wp:query-pagination-numbers /-->

<!-- wp:query-pagination-next /-->
<!-- /wp:query-pagination -->

<!-- wp:query-no-results -->
<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
<p></p>
<!-- /wp:paragraph -->
<!-- /wp:query-no-results --></div>
<!-- /wp:query -->
``` 

</p>
</details> 