### PR TITLE
Enabled Full height in Additional CSS

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -55,6 +55,7 @@ function ScreenRoot() {
 	return (
 		<Card
 			size="small"
+			isBorderless
 			className="edit-site-global-styles-screen-root"
 			isRounded={ false }
 		>

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -235,7 +235,7 @@
 .edit-site-global-styles-sidebar__navigator-screen {
 	display: flex;
 	flex-direction: column;
-	height: 100%
+	height: 100%;
 }
 
 .edit-site-global-styles-sidebar__navigator-screen .single-column {

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -228,9 +228,14 @@
 	}
 }
 
+.edit-site-global-styles-sidebar__navigator-provider {
+	height: 100%;
+}
+
 .edit-site-global-styles-sidebar__navigator-screen {
 	display: flex;
 	flex-direction: column;
+	height: 100%
 }
 
 .edit-site-global-styles-sidebar__navigator-screen .single-column {

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -248,10 +248,6 @@
 	color: inherit;
 }
 
-.edit-site-global-styles-screen-root.edit-site-global-styles-screen-root {
-	box-shadow: none;
-}
-
 .edit-site-global-styles-sidebar__panel .block-editor-block-icon svg {
 	fill: currentColor;
 }

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -248,6 +248,10 @@
 	color: inherit;
 }
 
+.edit-site-global-styles-screen-root.edit-site-global-styles-screen-root {
+	box-shadow: none;
+}
+
 .edit-site-global-styles-sidebar__panel .block-editor-block-icon svg {
 	fill: currentColor;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/68928  <!-- #ISSUE-NUMBER or URL -->
Enabled Full height in Additional CSS Field in Sidebar

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- The Additional CSS field is not displaying at full height in the Site Editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Added Full Height (100%) for Additional CSS Field.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Go to Additional CSS Field in Editor(Sidebar)
2. See Error
<!-- 3. etc. -->



## Screenshots or Screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

#### Before Patch:
![before-patch](https://github.com/user-attachments/assets/c4421e79-828d-4d49-b357-c8de9befa2cc)

#### After Patch:
![after-patch](https://github.com/user-attachments/assets/9ec9f602-8d11-46ec-aee4-cf037480a947)