### PR TITLE
Block Editor: Fix regression for root appender logic

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -201,6 +201,11 @@ function Items( {
 						getDefaultBlockName(),
 						rootClientId
 					) );
+			const hasSelectedRoot = !! (
+				rootClientId &&
+				selectedBlockClientId &&
+				rootClientId === selectedBlockClientId
+			);
 
 			return {
 				order: _order,
@@ -214,8 +219,8 @@ function Items( {
 					hasAppender &&
 					! _isZoomOut() &&
 					( hasCustomAppender ||
-						showRootAppender ||
-						rootClientId === selectedBlockClientId ),
+						hasSelectedRoot ||
+						showRootAppender ),
 			};
 		},
 		[ rootClientId, hasAppender, hasCustomAppender ]


### PR DESCRIPTION
## What?
A follow-up to #68951.

PR fixes a regression when the root appender is incorrectly displayed.

After switching a method for retrieving `selectedBlockClientId`, a `rootClientId === selectedBlockClientId` condition became true when no blocks were selected. Why?

The `getSelectedBlockClientId` select returns `null` with no block selection, and `rootClientId` is `undefined`, failing equality checks. Now `selectedBlockClientId` also returns `undefined`, which introduces a regression.

I've hardened the check to ensure equality is checked only for `clientId` strings.

## Testing Instructions
1. Confirm that the fix introduced in #68951 still works.
2. When all blocks are enabled, open a post.
3. Add some blocks and clear block selection.
4. Confirm that the root appender isn't displayed.
5. Add a group with some child blocks.
6. Confirm that the root appender is displayed when selecting the group.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2025-02-01 at 19 34 12](https://github.com/user-attachments/assets/1c18fd30-d9c1-4201-a838-3cccc7fc13c8)

