### PR TITLE
Add optional chain to sizes indexing of media details in edit-site

### DIFF
--- a/packages/edit-site/src/components/media/index.js
+++ b/packages/edit-site/src/components/media/index.js
@@ -6,11 +6,11 @@ import { useEntityRecord } from '@wordpress/core-data';
 function Media( { id, size = [ 'large', 'medium', 'thumbnail' ], ...props } ) {
 	const { record: media } = useEntityRecord( 'root', 'media', id );
 	const currentSize = size.find(
-		( s ) => !! media?.media_details?.sizes[ s ]
+		( s ) => !! media?.media_details?.sizes?.[ s ]
 	);
 
 	const mediaUrl =
-		media?.media_details?.sizes[ currentSize ]?.source_url ||
+		media?.media_details?.sizes?.[ currentSize ]?.source_url ||
 		media?.source_url;
 
 	if ( ! mediaUrl ) {


### PR DESCRIPTION
## What?
This optional chaining is already present in 21 other lines in Gutenberg where `sizes` (in `media_details`) is indexed, but is missing on these two lines.

## Why?
For some reason, `media_details` is an empty object for some of my attachments on my site, so this throws a TypeError. This change resolves this issue.

## How?
`?.` is optional chaining to short circuit before the TypeError.

## Testing Instructions
I don't actually know how some attachments don't have media_details on my site in the first place. I tried to reproduce on a playground with some hooks from the real site, e.g.

```php
add_filter( 'intermediate_image_sizes', '__return_empty_array' );
```

1. Make attachment(s) which don't cause media_details to be set (see above).
2. Create a page and set one of these attachments as the featured image of the page.
3. Open `/wp-admin/site-editor.php?postType=page` to trigger the page thumbnails to be shown in the list, which triggers this code path and throws the TypeError without this change.

<details>
<summary>n/a from PR template</summary>

### Testing Instructions for Keyboard
n/a

## Screenshots or screencast
n/a
</details>