### PR TITLE
Fixed: Empty Pattern Overlap in Pattern Title in Dataviews Table Layout

### DIFF
--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -19,6 +19,8 @@
 	.dataviews-view-table & {
 		width: 96px;
 		flex-grow: 0;
+		text-wrap: balance; // Fallback for Safari.
+		text-wrap: pretty;
 	}
 }
 

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -48,7 +48,7 @@
 		.components-heading {
 			flex-grow: 1;
 			flex-basis: 0;
-			white-space: normal;
+			white-space: nowrap;
 		}
 	}
 

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -48,7 +48,7 @@
 		.components-heading {
 			flex-grow: 1;
 			flex-basis: 0;
-			white-space: nowrap;
+			white-space: normal;
 		}
 	}
 

--- a/packages/edit-site/src/components/page-templates/style.scss
+++ b/packages/edit-site/src/components/page-templates/style.scss
@@ -23,6 +23,8 @@
 		position: relative;
 		width: 120px;
 		max-height: 160px;
+		text-wrap: balance; // Fallback for Safari.
+		text-wrap: pretty;
 
 		&::after {
 			content: "";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
When viewing all patterns on Appearance > Editor > Patterns using the table layout, the text that explains that a pattern is empty overlaps the pattern name. This makes the text difficult to read.

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes  https://github.com/WordPress/gutenberg/issues/68937

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Empty Pattern Overlap in Pattern Title in Dataviews Table Layout So its Hard to Read.

## Testing Instructions
- Create a new empty pattern.
- Go to Appearance > Editor > Patterns
- Select the table layout.
- Locate the pattern in the table.

## Screenshots or Screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

#### Before Patch
![before-patch](https://github.com/user-attachments/assets/b0332313-c42d-43c0-b4f7-bbcd29a75f0b)

#### After Patch
![after-patch](https://github.com/user-attachments/assets/db10085f-a7e4-4af1-b28b-3c180453e8d1)

