### PR TITLE
Editor: Don't use selector shortcuts for the taxonomy queries

### DIFF
--- a/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
@@ -16,8 +16,12 @@ import { store as editorStore } from '../../store';
 function MaybeCategoryPanel() {
 	const hasNoCategory = useSelect( ( select ) => {
 		const postType = select( editorStore ).getCurrentPostType();
-		const { canUser, getEntityRecord, getTaxonomy } = select( coreStore );
-		const categoriesTaxonomy = getTaxonomy( 'category' );
+		const { canUser, getEntityRecord } = select( coreStore );
+		const categoriesTaxonomy = getEntityRecord(
+			'root',
+			'taxonomy',
+			'category'
+		);
 		const defaultCategoryId = canUser( 'read', {
 			kind: 'root',
 			name: 'site',

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -36,7 +36,11 @@ const TagsPanel = () => {
 const MaybeTagsPanel = () => {
 	const { hasTags, isPostTypeSupported } = useSelect( ( select ) => {
 		const postType = select( editorStore ).getCurrentPostType();
-		const tagsTaxonomy = select( coreStore ).getTaxonomy( 'post_tag' );
+		const tagsTaxonomy = select( coreStore ).getEntityRecord(
+			'root',
+			'taxonomy',
+			'post_tag'
+		);
 		const _isPostTypeSupported = tagsTaxonomy?.types?.includes( postType );
 		const areTagsFetched = tagsTaxonomy !== undefined;
 		const tags =

--- a/packages/editor/src/components/post-taxonomies/check.js
+++ b/packages/editor/src/components/post-taxonomies/check.js
@@ -20,9 +20,11 @@ import { store as editorStore } from '../../store';
 export default function PostTaxonomiesCheck( { children } ) {
 	const hasTaxonomies = useSelect( ( select ) => {
 		const postType = select( editorStore ).getCurrentPostType();
-		const taxonomies = select( coreStore ).getTaxonomies( {
-			per_page: -1,
-		} );
+		const taxonomies = select( coreStore ).getEntityRecords(
+			'root',
+			'taxonomy',
+			{ per_page: -1 }
+		);
 		return taxonomies?.some( ( taxonomy ) =>
 			taxonomy.types.includes( postType )
 		);

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -100,10 +100,10 @@ export function FlatTermSelector( { slug, __nextHasNoMarginBottom } ) {
 		( select ) => {
 			const { getCurrentPost, getEditedPostAttribute } =
 				select( editorStore );
-			const { getEntityRecords, getTaxonomy, hasFinishedResolution } =
+			const { getEntityRecords, getEntityRecord, hasFinishedResolution } =
 				select( coreStore );
 			const post = getCurrentPost();
-			const _taxonomy = getTaxonomy( slug );
+			const _taxonomy = getEntityRecord( 'root', 'taxonomy', slug );
 			const _termIds = _taxonomy
 				? getEditedPostAttribute( _taxonomy.rest_base )
 				: EMPTY_ARRAY;

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -175,9 +175,9 @@ export function HierarchicalTermSelector( { slug } ) {
 		( select ) => {
 			const { getCurrentPost, getEditedPostAttribute } =
 				select( editorStore );
-			const { getTaxonomy, getEntityRecords, isResolving } =
+			const { getEntityRecord, getEntityRecords, isResolving } =
 				select( coreStore );
-			const _taxonomy = getTaxonomy( slug );
+			const _taxonomy = getEntityRecord( 'root', 'taxonomy', slug );
 			const post = getCurrentPost();
 
 			return {

--- a/packages/editor/src/components/post-taxonomies/index.js
+++ b/packages/editor/src/components/post-taxonomies/index.js
@@ -18,7 +18,11 @@ export function PostTaxonomies( { taxonomyWrapper = identity } ) {
 	const { postType, taxonomies } = useSelect( ( select ) => {
 		return {
 			postType: select( editorStore ).getCurrentPostType(),
-			taxonomies: select( coreStore ).getTaxonomies( { per_page: -1 } ),
+			taxonomies: select( coreStore ).getEntityRecords(
+				'root',
+				'taxonomy',
+				{ per_page: -1 }
+			),
 		};
 	}, [] );
 	const visibleTaxonomies = ( taxonomies ?? [] ).filter(

--- a/packages/editor/src/components/post-taxonomies/test/index.js
+++ b/packages/editor/src/components/post-taxonomies/test/index.js
@@ -44,6 +44,19 @@ describe( 'PostTaxonomies', () => {
 		},
 	};
 
+	const allTaxonomies = [ genresTaxonomy, categoriesTaxonomy ];
+
+	const hidesUI = [
+		genresTaxonomy,
+		{
+			...categoriesTaxonomy,
+			types: [ 'post', 'page', 'book' ],
+			visibility: {
+				show_ui: false,
+			},
+		},
+	];
+
 	beforeEach( () => {
 		jest.spyOn( select( editorStore ), 'getCurrentPost' ).mockReturnValue( {
 			_links: {
@@ -70,8 +83,8 @@ describe( 'PostTaxonomies', () => {
 			},
 		} );
 
-		jest.spyOn( select( coreStore ), 'getTaxonomy' ).mockImplementation(
-			( slug ) => {
+		jest.spyOn( select( coreStore ), 'getEntityRecord' ).mockImplementation(
+			( kind, name, slug ) => {
 				switch ( slug ) {
 					case 'category': {
 						return categoriesTaxonomy;
@@ -91,8 +104,11 @@ describe( 'PostTaxonomies', () => {
 			select( editorStore ),
 			'getCurrentPostType'
 		).mockReturnValue( 'page' );
-		jest.spyOn( select( coreStore ), 'getTaxonomies' ).mockReturnValue(
-			taxonomies
+		jest.spyOn(
+			select( coreStore ),
+			'getEntityRecords'
+		).mockImplementation( ( kind, name ) =>
+			kind === 'root' && name === 'taxonomy' ? taxonomies : null
 		);
 
 		const { container } = render( <PostTaxonomies /> );
@@ -105,10 +121,12 @@ describe( 'PostTaxonomies', () => {
 			select( editorStore ),
 			'getCurrentPostType'
 		).mockReturnValue( 'book' );
-		jest.spyOn( select( coreStore ), 'getTaxonomies' ).mockReturnValue( [
-			genresTaxonomy,
-			categoriesTaxonomy,
-		] );
+		jest.spyOn(
+			select( coreStore ),
+			'getEntityRecords'
+		).mockImplementation( ( kind, name ) =>
+			kind === 'root' && name === 'taxonomy' ? allTaxonomies : null
+		);
 
 		render( <PostTaxonomies /> );
 
@@ -129,16 +147,12 @@ describe( 'PostTaxonomies', () => {
 			select( editorStore ),
 			'getCurrentPostType'
 		).mockReturnValue( 'book' );
-		jest.spyOn( select( coreStore ), 'getTaxonomies' ).mockReturnValue( [
-			genresTaxonomy,
-			{
-				...categoriesTaxonomy,
-				types: [ 'post', 'page', 'book' ],
-				visibility: {
-					show_ui: false,
-				},
-			},
-		] );
+		jest.spyOn(
+			select( coreStore ),
+			'getEntityRecords'
+		).mockImplementation( ( kind, name ) =>
+			kind === 'root' && name === 'taxonomy' ? hidesUI : null
+		);
 
 		render( <PostTaxonomies /> );
 


### PR DESCRIPTION
## What?
Similar to #64884.
Related to #61013.

This is a minor performance optimization. PR replaces shortcut taxonomy selectors with `getEntityRecord(s)`, which avoids making a separate call for each taxonomy when the editor loads.

## Why?

> I just realized that the aliases also de-opt per-entity resolutions when fetching collections (https://github.com/WordPress/gutenberg/pull/26575). This means that calling getMediaItems doesn't resolve the individual getMedia calls, and the editor has to make additional requests.

Ideally, this should be resolved at the data package level, but that might require a more significant rewrite. Small hotfixes that improve editor performance should be acceptable for the moment.

See #61013 for additional details.

## Testing Instructions
1. Open a post.
2. Inspect the Networks tab and filter by the `taxonomies` slug.
3. Confirm there's only a single request.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|![CleanShot 2025-02-02 at 10 43 45](https://github.com/user-attachments/assets/b450a952-801b-4db2-88d1-78908b3bfbf7)|![CleanShot 2025-02-02 at 10 41 45](https://github.com/user-attachments/assets/2c759d12-a600-451c-b7d7-3cf1029f3254)|




