### PR TITLE
Editor: Display error message when loading current post fails

### DIFF
--- a/packages/editor/src/components/editor/index.js
+++ b/packages/editor/src/components/editor/index.js
@@ -31,12 +31,17 @@ function Editor( {
 	extraSidebarPanels,
 	...props
 } ) {
-	const { post, template, hasLoadedPost } = useSelect(
+	const { post, template, hasLoadedPost, error } = useSelect(
 		( select ) => {
-			const { getEntityRecord, hasFinishedResolution } =
-				select( coreStore );
+			const {
+				getEntityRecord,
+				getResolutionError,
+				hasFinishedResolution,
+			} = select( coreStore );
+
+			const postArgs = [ 'postType', postType, postId ];
 			return {
-				post: getEntityRecord( 'postType', postType, postId ),
+				post: getEntityRecord( ...postArgs ),
 				template: templateId
 					? getEntityRecord(
 							'postType',
@@ -44,11 +49,12 @@ function Editor( {
 							templateId
 					  )
 					: undefined,
-				hasLoadedPost: hasFinishedResolution( 'getEntityRecord', [
-					'postType',
-					postType,
-					postId,
-				] ),
+				hasLoadedPost: hasFinishedResolution(
+					'getEntityRecord',
+					postArgs
+				),
+				error: getResolutionError( 'getEntityRecord', postArgs )
+					?.message,
 			};
 		},
 		[ postType, postId, templateId ]
@@ -57,10 +63,15 @@ function Editor( {
 	return (
 		<>
 			{ hasLoadedPost && ! post && (
-				<Notice status="warning" isDismissible={ false }>
-					{ __(
-						"You attempted to edit an item that doesn't exist. Perhaps it was deleted?"
-					) }
+				<Notice
+					status={ !! error ? 'error' : 'warning' }
+					isDismissible={ false }
+				>
+					{ ! error
+						? __(
+								"You attempted to edit an item that doesn't exist. Perhaps it was deleted?"
+						  )
+						: error }
 				</Notice>
 			) }
 			{ !! post && (


### PR DESCRIPTION
## What?
Related to #67358.

PR replaces a generic notice message with an actual error message when `Editor` fails to load a post due to an error.

## Why?
This should help debug cases like #67358.

## Testing Instructions
1. Apply test patch.
2. Open a post.
3. Confirm that the error message is displayed.

<details><summary>Test error</summary>
<p>

```
diff --git packages/core-data/src/resolvers.js packages/core-data/src/resolvers.js
index 173cfbd8833..43c18791491 100644
--- packages/core-data/src/resolvers.js
+++ packages/core-data/src/resolvers.js
@@ -178,6 +178,8 @@ export const getEntityRecord =
 					response.headers?.get( 'allow' )
 				);
 
+				throw new Error( 'This is a test error' );
+
 				const canUserResolutionsArgs = [];
 				const receiveUserPermissionArgs = {};
 				for ( const action of ALLOWED_RESOURCE_ACTIONS ) {
``` 

</p>
</details> 

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|![CleanShot 2025-02-02 at 17 26 14](https://github.com/user-attachments/assets/8d2d3c17-5436-48a1-a535-eca7577717c3)|![CleanShot 2025-02-02 at 17 25 17](https://github.com/user-attachments/assets/9dc64200-88d7-4276-955b-7feb1fa7dd69)|
