### PR TITLE
Social Links: Remove redundant reduce-motion mixin

### DIFF
--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -89,7 +89,6 @@
 // Unconfigured placeholder links are semitransparent.
 .wp-social-link.wp-social-link__is-incomplete {
 	opacity: 0.5;
-	@include reduce-motion("transition");
 }
 
 .wp-block-social-links .is-selected .wp-social-link__is-incomplete,


### PR DESCRIPTION
Part of / Closes: #68282 
Follow up: https://github.com/WordPress/gutenberg/issues/68282#issuecomment-2626744895

## What?

Removes redundant reduce-motion mixin from social links incomplete state in editor styles.


## Why?


In the social links editor styles, we had a reduce-motion mixin applied to the incomplete social link state (`wp-social-link__is-incomplete`). However, this mixin was unnecessary because:

- There is no explicit opacity transition defined that needs to be disabled
- The only animation (transform on hover) is already properly handled with a media query in `style.scss`
- The opacity change is instant by default



### Testing Instructions

1. In the editor, add a Social Links block
2. Click the "+" button to start adding a new social link but don't complete it
3. Verify the incomplete social link appears semi-transparent (opacity: 0.5)
4. Test opacity changes - Hover over the incomplete link - it should become fully opaque



Test motion preferences:
1. Enable "Emulate CSS media feature prefers-reduced-motion: reduce"
2. Verify the opacity change remains instant


## Screencast


https://github.com/user-attachments/assets/de097021-fa54-465f-96df-9deea3014928


