### PR TITLE
Block support: Preserve aria-label value in comment delimiter

### DIFF
--- a/packages/block-editor/src/hooks/aria-label.js
+++ b/packages/block-editor/src/hooks/aria-label.js
@@ -4,13 +4,6 @@
 import { addFilter } from '@wordpress/hooks';
 import { hasBlockSupport } from '@wordpress/blocks';
 
-const ARIA_LABEL_SCHEMA = {
-	type: 'string',
-	source: 'attribute',
-	attribute: 'aria-label',
-	selector: '*',
-};
-
 /**
  * Filters registered block settings, extending attributes with ariaLabel using aria-label
  * of the first node.
@@ -28,7 +21,9 @@ export function addAttribute( settings ) {
 		// Gracefully handle if settings.attributes is undefined.
 		settings.attributes = {
 			...settings.attributes,
-			ariaLabel: ARIA_LABEL_SCHEMA,
+			ariaLabel: {
+				type: 'string',
+			},
 		};
 	}
 

--- a/packages/blocks/src/api/parser/apply-built-in-validation-fixes.js
+++ b/packages/blocks/src/api/parser/apply-built-in-validation-fixes.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { fixCustomClassname } from './fix-custom-classname';
+import { fixAriaLabel } from './fix-aria-label';
 
 /**
  * Attempts to fix block invalidation by applying build-in validation fixes
@@ -15,11 +16,22 @@ import { fixCustomClassname } from './fix-custom-classname';
  * @return {WPBlock} Fixed block object
  */
 export function applyBuiltInValidationFixes( block, blockType ) {
-	const updatedBlockAttributes = fixCustomClassname(
-		block.attributes,
+	const { attributes, originalContent } = block;
+	let updatedBlockAttributes = attributes;
+
+	// Fix block invalidation for className attribute.
+	updatedBlockAttributes = fixCustomClassname(
+		attributes,
 		blockType,
-		block.originalContent
+		originalContent
 	);
+	// Fix block invalidation for ariaLabel attribute.
+	updatedBlockAttributes = fixAriaLabel(
+		updatedBlockAttributes,
+		blockType,
+		originalContent
+	);
+
 	return {
 		...block,
 		attributes: updatedBlockAttributes,

--- a/packages/blocks/src/api/parser/fix-aria-label.js
+++ b/packages/blocks/src/api/parser/fix-aria-label.js
@@ -1,0 +1,51 @@
+/**
+ * Internal dependencies
+ */
+import { hasBlockSupport } from '../registration';
+import { parseWithAttributeSchema } from './get-block-attributes';
+
+const ARIA_LABEL_ATTR_SCHEMA = {
+	type: 'string',
+	source: 'attribute',
+	selector: '[data-aria-label] > *',
+	attribute: 'aria-label',
+};
+
+/**
+ * Given an HTML string, returns the aria-label attribute assigned to
+ * the root element in the markup.
+ *
+ * @param {string} innerHTML Markup string from which to extract the aria-label.
+ *
+ * @return {string} The aria-label assigned to the root element.
+ */
+export function getHTMLRootElementAriaLabel( innerHTML ) {
+	const parsed = parseWithAttributeSchema(
+		`<div data-aria-label>${ innerHTML }</div>`,
+		ARIA_LABEL_ATTR_SCHEMA
+	);
+	return parsed;
+}
+
+/**
+ * Given a parsed set of block attributes, if the block supports ariaLabel
+ * and an aria-label attribute is found, the aria-label attribute is assigned
+ * to the block attributes.
+ *
+ * @param {Object} blockAttributes Original block attributes.
+ * @param {Object} blockType       Block type settings.
+ * @param {string} innerHTML       Original block markup.
+ *
+ * @return {Object} Filtered block attributes.
+ */
+export function fixAriaLabel( blockAttributes, blockType, innerHTML ) {
+	if ( ! hasBlockSupport( blockType, 'ariaLabel', false ) ) {
+		return blockAttributes;
+	}
+	const modifiedBlockAttributes = { ...blockAttributes };
+	const ariaLabel = getHTMLRootElementAriaLabel( innerHTML );
+	if ( ariaLabel ) {
+		modifiedBlockAttributes.ariaLabel = ariaLabel;
+	}
+	return modifiedBlockAttributes;
+}

--- a/packages/blocks/src/api/parser/test/index.js
+++ b/packages/blocks/src/api/parser/test/index.js
@@ -82,6 +82,39 @@ describe( 'block parser', () => {
 			} );
 		} );
 
+		it( 'should apply aria-label block validation fixes', () => {
+			registerBlockType( 'core/test-block', {
+				...defaultBlockSettings,
+				attributes: {
+					fruit: {
+						type: 'string',
+						source: 'text',
+						selector: 'div',
+					},
+				},
+				supports: {
+					ariaLabel: true,
+				},
+				save: ( { attributes } ) => (
+					<div aria-label={ attributes.ariaLabel }>
+						{ attributes.fruit }
+					</div>
+				),
+			} );
+
+			const block = parseRawBlock( {
+				blockName: 'core/test-block',
+				innerHTML: '<div aria-label="custom-label">Bananas</div>',
+				attrs: { fruit: 'Bananas' },
+			} );
+
+			expect( block.name ).toEqual( 'core/test-block' );
+			expect( block.attributes ).toEqual( {
+				fruit: 'Bananas',
+				ariaLabel: 'custom-label',
+			} );
+		} );
+
 		it( 'should create the requested block if it exists', () => {
 			registerBlockType( 'core/test-block', defaultBlockSettings );
 


### PR DESCRIPTION
Fixes #68764
Alternatives to #68735

## What?

This PR changes the schema for the `ariaLabel` block support to save its value in the comment delimiter.

That is, the block HTML will be updated to look like this:

```html
<!-- From... -->
<!-- wp:group {"layout":{"type":"constrained"}} -->
<div aria-label="my-label" class="wp-block-group"></div>
<!-- /wp:group -->

<!-- To... -->
<!-- wp:group {"layout":{"type":"constrained"},"ariaLabel":"my-label"} -->
<div aria-label="my-label" class="wp-block-group"></div>
<!-- /wp:group -->
```

## Why?

The current schema references the `aria-label` attribute if it exists in the HTML markup. This works fine for the Group block, whose HTML markup is preserved, but the value cannot be referenced in the Navigation block, whose HTML markup is not preserved.

As a result, as reported in #68719, when you update a template that contains a Navigation block with the `aria-label` attribute, `the aria-label` value disappears.

In Twenty Twenty-Five and Twenty Twenty-Four, `aria-label` is applied to some Navigation blocks. I believe that the disappearance of this value is a issue from an accessibility perspective.

## How?

Remove the `source`, `attribute`, and `selector` fields from the schema definition. This will break Group blocks that already support `ariaLabel`, so something needs to be done about it.

I noticed that there is already a fix for block validation regarding custom class names ([`fixCustomClassname()` function](https://github.com/WordPress/gutenberg/blob/trunk/packages/blocks/src/api/parser/fix-custom-classname.js)). I used this process to automatically migrate the attributes via the `fixAriaLabel()` function so that block validation does not fail.

To solve this problem, I considered three approaches (See #68764). I believe this approach is the best.

## Testing Instructions

### Group Block

- Open the code editor and enter HTML like below:
  ```html
  <!-- wp:group {"layout":{"type":"constrained"}} -->
  <div aria-label="my-label" class="wp-block-group"></div>
  <!-- /wp:group -->
  ```
- Save the post and refresh your browser. The block should not break.
- Make a change to the post content.
- Open the code editor. The HTML should be updated as below:
  ```html
  <!-- wp:group {"layout":{"type":"constrained"},"ariaLabel":"my-label"} -->
  <div aria-label="my-label" class="wp-block-group"></div>
  <!-- /wp:group -->
  ```
- Save the post and refresh your browser. The block should not break.

### Navigation Block

- Activate the Twenty Twenty-Five theme.
- After resetting the Footer template part, open the editor canvas. This template part contains Navigation blocks with aria-labels `About`, `Privacy`, and `Social`.
- Make changes to this template part and save it.
- Open the code editor. The three `aria-labe`l values ​​should not have disappeared.
- Open the site. The three `aria-label` values ​​should not have disappeared.