### PR TITLE
Autocompleters: Change user slug color

### DIFF
--- a/packages/editor/src/components/autocompleters/style.scss
+++ b/packages/editor/src/components/autocompleters/style.scss
@@ -24,7 +24,6 @@
 	}
 	.editor-autocompleters__user-slug {
 		margin-left: 8px;
-		color: $gray-200;
 		white-space: nowrap;
 		text-overflow: ellipsis;
 		overflow: none;

--- a/packages/editor/src/components/autocompleters/style.scss
+++ b/packages/editor/src/components/autocompleters/style.scss
@@ -24,15 +24,12 @@
 	}
 	.editor-autocompleters__user-slug {
 		margin-left: 8px;
-		color: $gray-700;
+		color: $gray-200;
 		white-space: nowrap;
 		text-overflow: ellipsis;
 		overflow: none;
 		max-width: 100px;
 		flex-grow: 0;
 		flex-shrink: 0;
-	}
-	&:hover .editor-autocompleters__user-slug {
-		color: var(--wp-admin-theme-color);
 	}
 }

--- a/packages/editor/src/components/autocompleters/style.scss
+++ b/packages/editor/src/components/autocompleters/style.scss
@@ -31,4 +31,7 @@
 		flex-grow: 0;
 		flex-shrink: 0;
 	}
+	&:not(.is-primary) .editor-autocompleters__user-slug {
+		color: $gray-700;
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?  
Closes #69001  

This PR improves the accessibility and readability of user slugs in the autocompleter dropdown when selecting a user.  

## Why?  
The current color contrast of the user slug text in the autocompleter list is insufficient, making it hard to read.  
- Selected state: Contrast ratio of `1:1` (`#757575` on `#007cba`)  
- Hover state: Contrast ratio of `1.26:1` (`#007cba` on `#006ba1`)  

These values do not meet accessibility guidelines and hinder usability.  

## How?  
- Removed the hardcoded `$gray-700` color for the slug text.  
- Removed the hover color override (`var(--wp-admin-theme-color)`) to avoid low contrast issues.
- Allowed the slug to inherit color from the parent list item for better consistency and accessibility.  

## Testing Instructions  
1. Open a post or page in the editor.  
2. Type `@` in the editor to trigger the user autocompleter dropdown.  
3. Select a user and observe the color contrast of the slug text in both selected and hover states.  

## Screencast  
https://github.com/user-attachments/assets/e65ee637-92b5-4261-8235-0efad74490fa