### PR TITLE
Improve visibility of Social Icons block appender in dark themes

### DIFF
--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -102,9 +102,14 @@
 	position: static; // display inline.
 
 	.block-editor-button-block-appender {
+		background: $gray-900;
 		height: 1.5em;
 		width: 1.5em;
 		font-size: inherit;
 		padding: 0;
+
+		svg {
+			color: $white;
+		}
 	}
 }


### PR DESCRIPTION
## What?
Closes: #51799 

This PR improves the visibility of the Social Icons block appender (`[+]` button) when used inside a Navigation block, especially on dark themes. The appender's icon is now styled to ensure it contrasts well with dark backgrounds.

## Why?
The appender in the Social Icons block is currently hard to see on dark themes, as its color does not contrast well with the background. This PR addresses this issue by explicitly setting the appender's icon color to white and ensuring it has a consistent background color.

## How?
- Added CSS to target the `svg` element inside the `.block-editor-button-block-appender`.
- Set the `color` of the `svg` to white for better visibility on dark themes.
- Ensured the changes do not affect the appender's appearance in light themes or other contexts.

## Testing Instructions
1. Open the Gutenberg editor.
2. Add a Navigation block.
3. Insert a Social Icons block inside the Navigation block.
4. Switch to a dark theme.
5. Verify that the appender (`[+]` button) is clearly visible.
6. Switch to a light theme and ensure the appender looks consistent.

## Screenshots or screencast
### Before Changes
https://github.com/user-attachments/assets/7781bfb4-2d69-4454-afe8-88d52f0e6926

### After changes
https://github.com/user-attachments/assets/10c70b1f-b473-4933-a8de-f3f9a1cec0d0