### PR TITLE
Archives: Update padding for archives block to remain consistent with `list`

### DIFF
--- a/packages/block-library/src/archives/editor.scss
+++ b/packages/block-library/src/archives/editor.scss
@@ -1,7 +1,3 @@
-ul.wp-block-archives {
-	padding-left: 2.5em;
-}
-
 // The following styles are to prevent duplicate spacing and borders for the archives
 // block in the editor given it uses server side rendering.
 // See https://github.com/WordPress/gutenberg/pull/63400

--- a/packages/block-library/src/archives/style.scss
+++ b/packages/block-library/src/archives/style.scss
@@ -3,10 +3,6 @@
 	box-sizing: border-box;
 }
 
-ul.wp-block-archives {
-	padding-left: 2.5em;
-}
-
 .wp-block-archives-dropdown {
 	label {
 		display: block;

--- a/packages/block-library/src/archives/style.scss
+++ b/packages/block-library/src/archives/style.scss
@@ -4,7 +4,7 @@
 }
 
 ul.wp-block-archives {
-	padding-left: $grid-unit-20;
+	padding-left: 2.5em;
 }
 
 .wp-block-archives-dropdown {

--- a/packages/block-library/src/archives/style.scss
+++ b/packages/block-library/src/archives/style.scss
@@ -3,6 +3,10 @@
 	box-sizing: border-box;
 }
 
+ul.wp-block-archives {
+	padding-left: $grid-unit-20;
+}
+
 .wp-block-archives-dropdown {
 	label {
 		display: block;


### PR DESCRIPTION
## What, Why and How?
Closes #69007

This PR removes redundant styles applied for the `ul` element within `Archives` block.
Ref:
https://github.com/WordPress/gutenberg/blob/693e315bd00ac36828364bc0b0d8f1fe22b5963c/packages/block-library/src/archives/editor.scss#L1-L3

This style should be considered redundant because, by default, `ul` adds a `40px` padding using `padding-inline-start` which matches the `2.5em` padding in the above rule thereby making it redundant.

![Screenshot 2025-02-03 at 5 40 45 PM](https://github.com/user-attachments/assets/caaf027b-37cb-487f-9659-3c71700b505f)


## Testing Instructions

1. Set `Empty Theme` as the Active Theme.
2. Navigate to the `post-edit` page.
3. Add `Archive`, `List`, and `Categories List` blocks in order.
4. Confirm that they are identically aligned.


## Screenshots

![Screenshot 2025-02-03 at 5 37 58 PM](https://github.com/user-attachments/assets/b8443ae7-7a9f-4f08-9360-9e8be80fc5b2)

