### PR TITLE
Remove non translatable additional info from font size picker visual label and improve labeling

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bug Fixes
 
+-   `FontSizePicker`: Remove non translatable additional info from font size picker visual label and improve labeling. ([#69011](https://github.com/WordPress/gutenberg/pull/69011)).
 -   `Notice`: Fix text contrast for dark mode ([#69226](https://github.com/WordPress/gutenberg/pull/69226)).
 
 ## 29.4.0 (2025-02-12)

--- a/packages/components/src/font-size-picker/font-size-picker-select.tsx
+++ b/packages/components/src/font-size-picker/font-size-picker-select.tsx
@@ -7,12 +7,11 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import CustomSelectControl from '../custom-select-control';
-import { parseQuantityAndUnitFromRawValue } from '../unit-control';
 import type {
 	FontSizePickerSelectProps,
 	FontSizePickerSelectOption,
 } from './types';
-import { getCommonSizeUnit, isSimpleCssValue } from './utils';
+import { isSimpleCssValue } from './utils';
 
 const DEFAULT_OPTION: FontSizePickerSelectOption = {
 	key: 'default',
@@ -23,20 +22,11 @@ const DEFAULT_OPTION: FontSizePickerSelectOption = {
 const FontSizePickerSelect = ( props: FontSizePickerSelectProps ) => {
 	const { __next40pxDefaultSize, fontSizes, value, size, onChange } = props;
 
-	const areAllSizesSameUnit = !! getCommonSizeUnit( fontSizes );
-
 	const options: FontSizePickerSelectOption[] = [
 		DEFAULT_OPTION,
 		...fontSizes.map( ( fontSize ) => {
 			let hint;
-			if ( areAllSizesSameUnit ) {
-				const [ quantity ] = parseQuantityAndUnitFromRawValue(
-					fontSize.size
-				);
-				if ( quantity !== undefined ) {
-					hint = String( quantity );
-				}
-			} else if ( isSimpleCssValue( fontSize.size ) ) {
+			if ( isSimpleCssValue( fontSize.size ) ) {
 				hint = String( fontSize.size );
 			}
 			return {

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -216,7 +216,7 @@ const UnforwardedFontSizePicker = (
 										}
 										__shouldNotWarnDeprecated36pxSize
 										className="components-font-size-picker__custom-input"
-										label={ __( 'Font size' ) }
+										label={ __( 'Custom font size' ) }
 										hideLabelFromVision
 										value={ valueQuantity }
 										initialPosition={ fallbackFontSize }

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -9,6 +9,7 @@ import type { ForwardedRef } from 'react';
 import { __ } from '@wordpress/i18n';
 import { settings } from '@wordpress/icons';
 import { useState, forwardRef } from '@wordpress/element';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -21,7 +22,6 @@ import {
 	parseQuantityAndUnitFromRawValue,
 	useCustomUnits,
 } from '../unit-control';
-import { VisuallyHidden } from '../visually-hidden';
 import type { FontSizePickerProps } from './types';
 import { Container, Header, HeaderLabel, HeaderToggle } from './styles';
 import { Spacer } from '../spacer';
@@ -49,6 +49,11 @@ const UnforwardedFontSizePicker = (
 		withSlider = false,
 		withReset = true,
 	} = props;
+
+	const labelId = useInstanceId(
+		UnforwardedFontSizePicker,
+		'font-size-picker-label'
+	);
 
 	const units = useCustomUnits( {
 		availableUnits: unitsProp,
@@ -100,11 +105,17 @@ const UnforwardedFontSizePicker = (
 	} );
 
 	return (
-		<Container ref={ ref } className="components-font-size-picker">
-			<VisuallyHidden as="legend">{ __( 'Font size' ) }</VisuallyHidden>
+		<Container
+			ref={ ref }
+			className="components-font-size-picker"
+			// This Container component renders a fieldset element that needs to be labeled.
+			aria-labelledby={ labelId }
+		>
 			<Spacer>
 				<Header className="components-font-size-picker__header">
-					<HeaderLabel>{ __( 'Font size' ) }</HeaderLabel>
+					<HeaderLabel id={ labelId }>
+						{ __( 'Font size' ) }
+					</HeaderLabel>
 					{ ! disableCustomFontSizes && (
 						<HeaderToggle
 							label={

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -184,7 +184,7 @@ const UnforwardedFontSizePicker = (
 							<UnitControl
 								__next40pxDefaultSize={ __next40pxDefaultSize }
 								__shouldNotWarnDeprecated36pxSize
-								label={ __( 'Custom font size' ) }
+								label={ __( 'Font size' ) }
 								labelPosition="top"
 								hideLabelFromVision
 								value={ value }
@@ -216,7 +216,7 @@ const UnforwardedFontSizePicker = (
 										}
 										__shouldNotWarnDeprecated36pxSize
 										className="components-font-size-picker__custom-input"
-										label={ __( 'Custom font size' ) }
+										label={ __( 'Font size' ) }
 										hideLabelFromVision
 										value={ valueQuantity }
 										initialPosition={ fallbackFontSize }

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -8,7 +8,7 @@ import type { ForwardedRef } from 'react';
  */
 import { __ } from '@wordpress/i18n';
 import { settings } from '@wordpress/icons';
-import { useState, useMemo, forwardRef } from '@wordpress/element';
+import { useState, forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -22,19 +22,11 @@ import {
 	useCustomUnits,
 } from '../unit-control';
 import { VisuallyHidden } from '../visually-hidden';
-import { getCommonSizeUnit } from './utils';
 import type { FontSizePickerProps } from './types';
-import {
-	Container,
-	Header,
-	HeaderHint,
-	HeaderLabel,
-	HeaderToggle,
-} from './styles';
+import { Container, Header, HeaderLabel, HeaderToggle } from './styles';
 import { Spacer } from '../spacer';
 import FontSizePickerSelect from './font-size-picker-select';
 import FontSizePickerToggleGroup from './font-size-picker-toggle-group';
-import { T_SHIRT_NAMES } from './constants';
 import { maybeWarnDeprecated36pxSize } from '../utils/deprecated-36px-size';
 
 const DEFAULT_UNITS = [ 'px', 'em', 'rem', 'vw', 'vh' ];
@@ -83,29 +75,6 @@ const UnforwardedFontSizePicker = (
 				: ( 'togglegroup' as const );
 	}
 
-	const headerHint = useMemo( () => {
-		switch ( currentPickerType ) {
-			case 'custom':
-				return __( 'Custom' );
-			case 'togglegroup':
-				if ( selectedFontSize ) {
-					return (
-						selectedFontSize.name ||
-						T_SHIRT_NAMES[ fontSizes.indexOf( selectedFontSize ) ]
-					);
-				}
-				break;
-			case 'select':
-				const commonUnit = getCommonSizeUnit( fontSizes );
-				if ( commonUnit ) {
-					return `(${ commonUnit })`;
-				}
-				break;
-		}
-
-		return '';
-	}, [ currentPickerType, selectedFontSize, fontSizes ] );
-
 	if ( fontSizes.length === 0 && disableCustomFontSizes ) {
 		return null;
 	}
@@ -135,16 +104,7 @@ const UnforwardedFontSizePicker = (
 			<VisuallyHidden as="legend">{ __( 'Font size' ) }</VisuallyHidden>
 			<Spacer>
 				<Header className="components-font-size-picker__header">
-					<HeaderLabel
-						aria-label={ `${ __( 'Size' ) } ${ headerHint || '' }` }
-					>
-						{ __( 'Size' ) }
-						{ headerHint && (
-							<HeaderHint className="components-font-size-picker__header__hint">
-								{ headerHint }
-							</HeaderHint>
-						) }
-					</HeaderLabel>
+					<HeaderLabel>{ __( 'Font size' ) }</HeaderLabel>
 					{ ! disableCustomFontSizes && (
 						<HeaderToggle
 							label={
@@ -213,7 +173,7 @@ const UnforwardedFontSizePicker = (
 							<UnitControl
 								__next40pxDefaultSize={ __next40pxDefaultSize }
 								__shouldNotWarnDeprecated36pxSize
-								label={ __( 'Custom' ) }
+								label={ __( 'Font size' ) }
 								labelPosition="top"
 								hideLabelFromVision
 								value={ value }
@@ -245,7 +205,7 @@ const UnforwardedFontSizePicker = (
 										}
 										__shouldNotWarnDeprecated36pxSize
 										className="components-font-size-picker__custom-input"
-										label={ __( 'Custom Size' ) }
+										label={ __( 'Font size' ) }
 										hideLabelFromVision
 										value={ valueQuantity }
 										initialPosition={ fallbackFontSize }

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -173,7 +173,7 @@ const UnforwardedFontSizePicker = (
 							<UnitControl
 								__next40pxDefaultSize={ __next40pxDefaultSize }
 								__shouldNotWarnDeprecated36pxSize
-								label={ __( 'Font size' ) }
+								label={ __( 'Custom font size' ) }
 								labelPosition="top"
 								hideLabelFromVision
 								value={ value }

--- a/packages/components/src/font-size-picker/styles.ts
+++ b/packages/components/src/font-size-picker/styles.ts
@@ -10,7 +10,6 @@ import BaseControl from '../base-control';
 import Button from '../button';
 import { HStack } from '../h-stack';
 import { space } from '../utils/space';
-import { COLORS } from '../utils';
 
 export const Container = styled.fieldset`
 	border: 0;
@@ -32,8 +31,4 @@ export const HeaderLabel = styled( BaseControl.VisualLabel )`
 	gap: ${ space( 1 ) };
 	justify-content: flex-start;
 	margin-bottom: 0;
-`;
-
-export const HeaderHint = styled.span`
-	color: ${ COLORS.gray[ 700 ] };
 `;

--- a/packages/components/src/font-size-picker/test/index.tsx
+++ b/packages/components/src/font-size-picker/test/index.tsx
@@ -52,7 +52,9 @@ describe( 'FontSizePicker', () => {
 			await render(
 				<FontSizePicker value={ value } onChange={ onChange } />
 			);
-			const input = screen.getByLabelText( 'Custom' );
+			const input = screen.getByRole( 'spinbutton', {
+				name: 'Font size',
+			} );
 			await user.clear( input );
 			await user.type( input, '80' );
 			expect( onChange ).toHaveBeenCalledTimes( 3 ); // Once for the clear, then once per keystroke.
@@ -79,7 +81,9 @@ describe( 'FontSizePicker', () => {
 			await user.click(
 				screen.getByRole( 'button', { name: 'Set custom size' } )
 			);
-			const input = screen.getByLabelText( 'Custom' );
+			const input = screen.getByRole( 'spinbutton', {
+				name: 'Font size',
+			} );
 			await user.type( input, '80' );
 			expect( onChange ).toHaveBeenCalledTimes( 2 ); // Once per keystroke.
 			expect( onChange ).toHaveBeenCalledWith( expectedValue );
@@ -129,27 +133,13 @@ describe( 'FontSizePicker', () => {
 			const options = screen.getAllByRole( 'option' );
 			expect( options ).toHaveLength( 7 );
 			expect( options[ 0 ] ).toHaveAccessibleName( 'Default' );
-			expect( options[ 1 ] ).toHaveAccessibleName( 'Tiny 8' );
-			expect( options[ 2 ] ).toHaveAccessibleName( 'Small 12' );
-			expect( options[ 3 ] ).toHaveAccessibleName( 'Medium 16' );
-			expect( options[ 4 ] ).toHaveAccessibleName( 'Large 20' );
-			expect( options[ 5 ] ).toHaveAccessibleName( 'Extra Large 30' );
-			expect( options[ 6 ] ).toHaveAccessibleName( 'xx-large 40' );
+			expect( options[ 1 ] ).toHaveAccessibleName( 'Tiny 8px' );
+			expect( options[ 2 ] ).toHaveAccessibleName( 'Small 12px' );
+			expect( options[ 3 ] ).toHaveAccessibleName( 'Medium 16px' );
+			expect( options[ 4 ] ).toHaveAccessibleName( 'Large 20px' );
+			expect( options[ 5 ] ).toHaveAccessibleName( 'Extra Large 30px' );
+			expect( options[ 6 ] ).toHaveAccessibleName( 'xx-large 40px' );
 		} );
-
-		test.each( [
-			{ value: undefined, expectedLabel: 'Size (px)' },
-			{ value: '8px', expectedLabel: 'Size (px)' },
-			{ value: '3px', expectedLabel: 'Size Custom' },
-		] )(
-			'displays $expectedLabel as label when value is $value',
-			async ( { value, expectedLabel } ) => {
-				await render(
-					<FontSizePicker fontSizes={ fontSizes } value={ value } />
-				);
-				expect( screen.getByLabelText( expectedLabel ) ).toBeVisible();
-			}
-		);
 
 		test.each( [
 			{
@@ -158,7 +148,7 @@ describe( 'FontSizePicker', () => {
 				expectedArguments: [ undefined ],
 			},
 			{
-				option: 'Tiny 8',
+				option: 'Tiny 8px',
 				value: undefined,
 				expectedArguments: [ '8px', fontSizes[ 0 ] ],
 			},
@@ -252,23 +242,6 @@ describe( 'FontSizePicker', () => {
 				expect(
 					screen.getByRole( 'combobox', { name: 'Font size' } )
 				).toHaveTextContent( option );
-			}
-		);
-
-		test.each( [
-			{ value: undefined, expectedLabel: 'Size' },
-			{ value: '8px', expectedLabel: 'Size' },
-			{ value: '1em', expectedLabel: 'Size' },
-			{ value: '2rem', expectedLabel: 'Size' },
-			{ value: 'clamp(1.75rem, 3vw, 2.25rem)', expectedLabel: 'Size' },
-			{ value: '3px', expectedLabel: 'Size Custom' },
-		] )(
-			'displays $expectedLabel as label when value is $value',
-			async ( { value, expectedLabel } ) => {
-				await render(
-					<FontSizePicker fontSizes={ fontSizes } value={ value } />
-				);
-				expect( screen.getByLabelText( expectedLabel ) ).toBeVisible();
 			}
 		);
 
@@ -372,20 +345,6 @@ describe( 'FontSizePicker', () => {
 			expect( options[ 4 ] ).toHaveAccessibleName( 'Gigantosaurus' );
 		} );
 
-		test.each( [
-			{ value: undefined, expectedLabel: 'Size' },
-			{ value: '12px', expectedLabel: 'Size Small' },
-			{ value: '40px', expectedLabel: 'Size Gigantosaurus' },
-		] )(
-			'displays $expectedLabel as label when value is $value',
-			async ( { value, expectedLabel } ) => {
-				await render(
-					<FontSizePicker fontSizes={ fontSizes } value={ value } />
-				);
-				expect( screen.getByLabelText( expectedLabel ) ).toBeVisible();
-			}
-		);
-
 		it( 'calls onChange when a font size is selected', async () => {
 			const user = userEvent.setup();
 			const onChange = jest.fn();
@@ -438,25 +397,6 @@ describe( 'FontSizePicker', () => {
 			expect( options[ 3 ] ).toHaveTextContent( 'XL' );
 			expect( options[ 3 ] ).toHaveAccessibleName( 'Extra Large' );
 		} );
-
-		test.each( [
-			{ value: undefined, expectedLabel: 'Size' },
-			{ value: '12px', expectedLabel: 'Size Small' },
-			{ value: '1em', expectedLabel: 'Size Medium' },
-			{ value: '2rem', expectedLabel: 'Size Large' },
-			{
-				value: 'clamp(1.75rem, 3vw, 2.25rem)',
-				expectedLabel: 'Size Extra Large',
-			},
-		] )(
-			'displays $expectedLabel as label when value is $value',
-			async ( { value, expectedLabel } ) => {
-				await render(
-					<FontSizePicker fontSizes={ fontSizes } value={ value } />
-				);
-				expect( screen.getByLabelText( expectedLabel ) ).toBeVisible();
-			}
-		);
 
 		test.each( [
 			{ radio: 'Small', expectedArguments: [ '12px', fontSizes[ 0 ] ] },
@@ -524,14 +464,18 @@ describe( 'FontSizePicker', () => {
 			await render(
 				<FontSizePicker fontSizes={ fontSizes } value="3px" />
 			);
-			expect( screen.getByLabelText( 'Custom' ) ).toBeVisible();
+			expect(
+				screen.getByRole( 'spinbutton', { name: 'Font size' } )
+			).toBeVisible();
 		} );
 
 		it( 'hides custom input when disableCustomFontSizes is set to `true` with a custom font size', async () => {
 			const { rerender } = await render(
 				<FontSizePicker fontSizes={ fontSizes } value="3px" />
 			);
-			expect( screen.getByLabelText( 'Custom' ) ).toBeVisible();
+			expect(
+				screen.getByRole( 'spinbutton', { name: 'Font size' } )
+			).toBeVisible();
 
 			rerender(
 				<FontSizePicker
@@ -549,7 +493,9 @@ describe( 'FontSizePicker', () => {
 			const { rerender } = await render(
 				<FontSizePicker fontSizes={ fontSizes } value="3px" />
 			);
-			expect( screen.getByLabelText( 'Custom' ) ).toBeVisible();
+			expect(
+				screen.getByRole( 'spinbutton', { name: 'Font size' } )
+			).toBeVisible();
 
 			rerender(
 				<FontSizePicker
@@ -557,7 +503,9 @@ describe( 'FontSizePicker', () => {
 					value={ fontSizes[ 0 ].size }
 				/>
 			);
-			expect( screen.getByLabelText( 'Custom' ) ).toBeVisible();
+			expect(
+				screen.getByRole( 'spinbutton', { name: 'Font size' } )
+			).toBeVisible();
 		} );
 
 		it( 'allows custom values by default', async () => {
@@ -569,7 +517,10 @@ describe( 'FontSizePicker', () => {
 			await user.click(
 				screen.getByRole( 'button', { name: 'Set custom size' } )
 			);
-			await user.type( screen.getByLabelText( 'Custom' ), '80' );
+			await user.type(
+				screen.getByRole( 'spinbutton', { name: 'Font size' } ),
+				'80'
+			);
 			expect( onChange ).toHaveBeenCalledTimes( 2 ); // Once per keystroke.
 			expect( onChange ).toHaveBeenCalledWith( '80px' );
 		} );
@@ -585,7 +536,10 @@ describe( 'FontSizePicker', () => {
 				screen.getByRole( 'button', { name: 'Set custom size' } )
 			);
 
-			await user.type( screen.getByLabelText( 'Custom' ), '80' );
+			await user.type(
+				screen.getByRole( 'spinbutton', { name: 'Font size' } ),
+				'80'
+			);
 
 			await user.click(
 				screen.getByRole( 'button', { name: 'Use size preset' } )
@@ -632,7 +586,9 @@ describe( 'FontSizePicker', () => {
 			await user.click(
 				screen.getByRole( 'button', { name: 'Set custom size' } )
 			);
-			const sliderInput = screen.getByLabelText( 'Custom Size' );
+			const sliderInput = screen.getByRole( 'slider', {
+				name: 'Font size',
+			} );
 			fireEvent.change( sliderInput, {
 				target: { value: 80 },
 			} );

--- a/packages/components/src/font-size-picker/test/utils.ts
+++ b/packages/components/src/font-size-picker/test/utils.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { isSimpleCssValue, getCommonSizeUnit } from '../utils';
+import { isSimpleCssValue } from '../utils';
 
 describe( 'isSimpleCssValue', () => {
 	test.each( [
@@ -29,41 +29,5 @@ describe( 'isSimpleCssValue', () => {
 		[ 'var(--wp--font-size)', false ],
 	] )( 'given %p as argument, returns %p', ( cssValue, result ) => {
 		expect( isSimpleCssValue( cssValue ) ).toBe( result );
-	} );
-} );
-
-describe( 'getCommonSizeUnit', () => {
-	it( 'returns null when fontSizes is empty', () => {
-		expect( getCommonSizeUnit( [] ) ).toBe( null );
-	} );
-
-	it( 'returns px when all sizes are px', () => {
-		expect(
-			getCommonSizeUnit( [
-				{ slug: 'small', size: '10px' },
-				{ slug: 'medium', size: '20px' },
-				{ slug: 'large', size: '30px' },
-			] )
-		).toBe( 'px' );
-	} );
-
-	it( 'returns em when all sizes are em', () => {
-		expect(
-			getCommonSizeUnit( [
-				{ slug: 'small', size: '1em' },
-				{ slug: 'medium', size: '2em' },
-				{ slug: 'large', size: '3em' },
-			] )
-		).toBe( 'em' );
-	} );
-
-	it( 'returns null when sizes are heterogeneous', () => {
-		expect(
-			getCommonSizeUnit( [
-				{ slug: 'small', size: '10px' },
-				{ slug: 'medium', size: '2em' },
-				{ slug: 'large', size: '3rem' },
-			] )
-		).toBe( null );
 	} );
 } );

--- a/packages/components/src/font-size-picker/utils.ts
+++ b/packages/components/src/font-size-picker/utils.ts
@@ -1,8 +1,7 @@
 /**
  * Internal dependencies
  */
-import type { FontSizePickerProps, FontSize } from './types';
-import { parseQuantityAndUnitFromRawValue } from '../unit-control';
+import type { FontSizePickerProps } from './types';
 
 /**
  * Some themes use css vars for their font sizes, so until we
@@ -17,26 +16,4 @@ export function isSimpleCssValue(
 	const sizeRegex =
 		/^[\d\.]+(px|em|rem|vw|vh|%|svw|lvw|dvw|svh|lvh|dvh|vi|svi|lvi|dvi|vb|svb|lvb|dvb|vmin|svmin|lvmin|dvmin|vmax|svmax|lvmax|dvmax)?$/i;
 	return sizeRegex.test( String( value ) );
-}
-
-/**
- * If all of the given font sizes have the same unit (e.g. 'px'), return that
- * unit. Otherwise return null.
- *
- * @param fontSizes List of font sizes.
- * @return The common unit, or null.
- */
-export function getCommonSizeUnit( fontSizes: FontSize[] ) {
-	const [ firstFontSize, ...otherFontSizes ] = fontSizes;
-	if ( ! firstFontSize ) {
-		return null;
-	}
-	const [ , firstUnit ] = parseQuantityAndUnitFromRawValue(
-		firstFontSize.size
-	);
-	const areAllSizesSameUnit = otherFontSizes.every( ( fontSize ) => {
-		const [ , unit ] = parseQuantityAndUnitFromRawValue( fontSize.size );
-		return unit === firstUnit;
-	} );
-	return areAllSizesSameUnit ? firstUnit : null;
 }

--- a/test/e2e/specs/editor/various/font-size-picker.spec.js
+++ b/test/e2e/specs/editor/various/font-size-picker.spec.js
@@ -31,7 +31,7 @@ test.describe( 'Font Size Picker', () => {
 			await page.click(
 				'role=region[name="Editor settings"i] >> role=button[name="Set custom size"i]'
 			);
-			await page.click( 'role=spinbutton[name="Custom"i]' );
+			await page.click( 'role=spinbutton[name="Font size"i]' );
 
 			await page.keyboard.type( '23' );
 
@@ -54,7 +54,7 @@ test.describe( 'Font Size Picker', () => {
 			await page.click(
 				'role=region[name="Editor settings"i] >> role=button[name="Set custom size"i]'
 			);
-			await page.click( 'role=spinbutton[name="Custom"i]' );
+			await page.click( 'role=spinbutton[name="Font size"i]' );
 			await page.keyboard.type( '23' );
 
 			await expect.poll( editor.getEditedPostContent )
@@ -214,7 +214,7 @@ test.describe( 'Font Size Picker', () => {
 			await page.click(
 				'role=region[name="Editor settings"i] >> role=button[name="Set custom size"i]'
 			);
-			await page.click( 'role=spinbutton[name="Custom"i]' );
+			await page.click( 'role=spinbutton[name="Font size"i]' );
 			await pageUtils.pressKeys( 'primary+A' );
 			await page.keyboard.press( 'Backspace' );
 
@@ -299,7 +299,7 @@ test.describe( 'Font Size Picker', () => {
 			await page.click(
 				'role=region[name="Editor settings"i] >> role=button[name="Set custom size"i]'
 			);
-			await page.click( 'role=spinbutton[name="Custom"i]' );
+			await page.click( 'role=spinbutton[name="Font size"i]' );
 			await pageUtils.pressKeys( 'primary+A' );
 			await page.keyboard.press( 'Backspace' );
 

--- a/test/e2e/specs/site-editor/style-variations.spec.js
+++ b/test/e2e/specs/site-editor/style-variations.spec.js
@@ -133,7 +133,7 @@ test.describe( 'Global styles variations', () => {
 		await page.click( 'role=button[name="Text"i]' );
 
 		await expect(
-			page.locator( 'role=spinbutton[name="Custom font size"i]' )
+			page.locator( 'role=spinbutton[name="Font size"i]' )
 		).toHaveValue( '15' );
 	} );
 

--- a/test/e2e/specs/site-editor/style-variations.spec.js
+++ b/test/e2e/specs/site-editor/style-variations.spec.js
@@ -97,8 +97,8 @@ test.describe( 'Global styles variations', () => {
 		await page.click( 'role=button[name="Text"i]' );
 
 		await expect(
-			page.locator( 'css=.components-font-size-picker__header__hint' )
-		).toHaveText( 'Medium' );
+			page.locator( 'role=radio[name="Medium"i]' )
+		).toHaveAttribute( 'aria-checked', 'true' );
 	} );
 
 	test( 'should apply custom colors and font sizes in a variation', async ( {
@@ -132,14 +132,8 @@ test.describe( 'Global styles variations', () => {
 		await page.click( 'role=button[name="Typography"i]' );
 		await page.click( 'role=button[name="Text"i]' );
 
-		// TODO: to avoid use classnames to locate these elements,
-		//  we could provide accessible attributes to the source code in packages/components/src/font-size-picker/index.js.
 		await expect(
-			page.locator( 'css=.components-font-size-picker__header__hint' )
-		).toHaveText( 'Custom' );
-
-		await expect(
-			page.locator( 'role=spinbutton[name="Custom"i]' )
+			page.locator( 'role=spinbutton[name="Custom font size"i]' )
 		).toHaveValue( '15' );
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/63810
Alternative to https://github.com/WordPress/gutenberg/pull/68826

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->
For all the font size picker 3 variants (ToggleGroup, CustomSelectControl and Custom size UnitControl + RangeControl), the component visual labeling is made of visibel text 'Size' and some additional textual info e.g. the selected size, or the font size unit or a hardcoded string 'Custom'. Noting the component also uses a `fieldset` element with a visually hidden `legend` that make the labeling of the entire group and controls a little noisy.

This string is not fully translatable because it's just concatenated with the string 'Size'. Also, I'd argue the additional info doesn't add great value because:
- The selected size is already evident in the UI.
- The unit in use should be in the option of the CustomSelectControl, there is no need to repeat it in the header.
- The string `Custom` is unnecessary because users do know they switched the UI to st a custom size.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Strings should be fully translatable and follow the WordPress localization best practices.
- Visual labeling should match the actual labeling of the controls (the accessible name).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- This PR entirely removes the `headerHint` additional info from the visual label.
- When the font size picker renders a CustomSelectControl, the units are now always in the options even when they all use the same unit. There is no value in differentiating when the options use mixed units or the same unit, it just makes the code unnecessarily complicated and the UI changes unexpectedly for users.
- Simplifies the labeling to 'Font size' and avoids mismatches between visual labeling and actual labeling.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Activate Twenty Twenty-Four.
- Edit a post and select a Paragraph block.
- Observe the font size picker in the inspector renders the ToggleGroup.
- Select one of the 5 font sizes and observe the text above the font size picker doesn't change.
- Alter the theme.json file to add one more font size or switch to a theme that provides more than 5 font sizes. Make sure all the font sizes use the same unit type.
- Edit a post and select a Paragraph block.
- Observe the font size picker now renders the custom select.
- Observe the text above the font size picker doesn't show the size unit.
- Click the icon button 'Set custom size'.
- Observe the font size picker now renders the UnitControl and the RangeControl for the custom font size.
- Observe the text above the font size picker doesn't show the text 'Custom'.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before:

![before](https://github.com/user-attachments/assets/e7ee8fd9-7f1d-47f5-901e-b23eaba07df7)


After:

![after](https://github.com/user-attachments/assets/dcc36407-0f23-4a37-a01b-a4a1329746b6)

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
