### PR TITLE
Enhance: Added show outline command 

### DIFF
--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -87,6 +87,10 @@ const getEditorCommandLoader = () =>
 			toggleSpotlightMode,
 			toggleTopToolbar,
 		} = useDispatch( editorStore );
+
+		// We need to use unlock here because the `useDispatch` hook is used before the `useSelect` hook.
+		// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+		const { setListViewTab } = unlock( useDispatch( editorStore ) ); // disabled eslint due to error "Variables should not be assigned until just prior its first reference".
 		const { openModal, enableComplementaryArea, disableComplementaryArea } =
 			useDispatch( interfaceStore );
 		const { getCurrentPostId } = useSelect( editorStore );
@@ -158,6 +162,28 @@ const getEditorCommandLoader = () =>
 						type: 'snackbar',
 					}
 				);
+			},
+		} );
+
+		commands.push( {
+			name: 'core/show-outline',
+			label: __( 'Show document outline' ),
+			icon: listView,
+			keywords: [
+				'structure',
+				'hierarchy',
+				'organization',
+				'sections',
+				'outline',
+			],
+			callback: ( { close } ) => {
+				setIsListViewOpened( true );
+				setListViewTab( 'outline' );
+				close();
+				createInfoNotice( __( 'Document outline opened.' ), {
+					id: 'core/editor/show-outline/notice',
+					type: 'snackbar',
+				} );
 			},
 		} );
 

--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -167,7 +167,7 @@ const getEditorCommandLoader = () =>
 
 		commands.push( {
 			name: 'core/show-outline',
-			label: __( 'Show document outline' ),
+			label: __( 'Show or hide document outline' ),
 			icon: listView,
 			keywords: [
 				'structure',
@@ -177,13 +177,23 @@ const getEditorCommandLoader = () =>
 				'outline',
 			],
 			callback: ( { close } ) => {
-				setIsListViewOpened( true );
-				setListViewTab( 'outline' );
+				// If list view is closed, open it with outline tab
+				if ( ! isListViewOpen ) {
+					setIsListViewOpened( true );
+					setListViewTab( 'outline' );
+					createInfoNotice( __( 'Document outline opened.' ), {
+						id: 'core/editor/show-outline/notice',
+						type: 'snackbar',
+					} );
+				} else {
+					// If list view is open, close it
+					setIsListViewOpened( false );
+					createInfoNotice( __( 'Document outline closed.' ), {
+						id: 'core/editor/show-outline/notice',
+						type: 'snackbar',
+					} );
+				}
 				close();
-				createInfoNotice( __( 'Document outline opened.' ), {
-					id: 'core/editor/show-outline/notice',
-					type: 'snackbar',
-				} );
 			},
 		} );
 

--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -3,6 +3,7 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, isRTL, sprintf } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
 import {
 	blockDefault,
 	code,
@@ -183,31 +184,34 @@ const getEditorCommandLoader = () =>
 
 		commands.push( {
 			name: 'core/show-outline',
-			label:
-				currentListViewTab === 'outline' && isListViewOpen
-					? __( 'Hide document outline' )
-					: __( 'Show document outline' ),
+			label: __( 'Show or hide document outline' ),
 			icon: listView,
 			callback: ( { close } ) => {
 				// If list view is closed, open it with outline tab
 				if ( ! isListViewOpen ) {
 					setIsListViewOpened( true );
 					setListViewTab( 'outline' );
-					createInfoNotice( __( 'Document outline opened.' ), {
+					const message = __( 'Document outline opened.' );
+					speak( message, 'assertive' );
+					createInfoNotice( message, {
 						id: 'core/editor/show-outline/notice',
 						type: 'snackbar',
 					} );
 				} else if ( currentListViewTab !== 'outline' ) {
 					// Currently on list-view tab, so switch to outline tab
 					setListViewTab( 'outline' );
-					createInfoNotice( __( 'Document outline opened.' ), {
+					const message = __( 'Document outline opened.' );
+					speak( message, 'assertive' );
+					createInfoNotice( message, {
 						id: 'core/editor/show-outline/notice',
 						type: 'snackbar',
 					} );
 				} else {
 					// Currently on outline tab, so close the list view
 					setIsListViewOpened( false );
-					createInfoNotice( __( 'Document outline closed.' ), {
+					const message = __( 'Document outline closed.' );
+					speak( message, 'assertive' );
+					createInfoNotice( message, {
 						id: 'core/editor/show-outline/notice',
 						type: 'snackbar',
 					} );

--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -54,10 +54,12 @@ const getEditorCommandLoader = () =>
 			isCodeEditingEnabled,
 			isRichEditingEnabled,
 			isPublishSidebarEnabled,
+			currentListViewTab,
 		} = useSelect( ( select ) => {
 			const { get } = select( preferencesStore );
 			const { isListViewOpened, getCurrentPostType, getEditorSettings } =
 				select( editorStore );
+			const { getListViewTab } = unlock( select( editorStore ) );
 			const { getSettings } = select( blockEditorStore );
 			const { getPostType } = select( coreStore );
 
@@ -74,6 +76,7 @@ const getEditorCommandLoader = () =>
 				isRichEditingEnabled: getEditorSettings().richEditingEnabled,
 				isPublishSidebarEnabled:
 					select( editorStore ).isPublishSidebarEnabled(),
+				currentListViewTab: getListViewTab(),
 			};
 		}, [] );
 		const { getActiveComplementaryArea } = useSelect( interfaceStore );
@@ -146,28 +149,44 @@ const getEditorCommandLoader = () =>
 
 		commands.push( {
 			name: 'core/toggle-list-view',
-			label: isListViewOpen
-				? __( 'Close List View' )
-				: __( 'Open List View' ),
+			label:
+				isListViewOpen && currentListViewTab === 'list-view'
+					? __( 'Close List View' )
+					: __( 'Open List View' ),
 			icon: listView,
 			callback: ( { close } ) => {
-				setIsListViewOpened( ! isListViewOpen );
-				close();
-				createInfoNotice(
-					isListViewOpen
-						? __( 'List View off.' )
-						: __( 'List View on.' ),
-					{
+				if ( ! isListViewOpen ) {
+					// When opening the list view, always reset to the list-view tab
+					setIsListViewOpened( true );
+					setListViewTab( 'list-view' );
+					createInfoNotice( __( 'List View opened.' ), {
 						id: 'core/editor/toggle-list-view/notice',
 						type: 'snackbar',
-					}
-				);
+					} );
+				} else if ( 'list-view' !== currentListViewTab ) {
+					// When closing
+					setListViewTab( 'list-view' );
+					createInfoNotice( __( 'List View opened.' ), {
+						id: 'core/editor/toggle-list-view/notice',
+						type: 'snackbar',
+					} );
+				} else {
+					setIsListViewOpened( false );
+					createInfoNotice( __( 'List View closed.' ), {
+						id: 'core/editor/toggle-list-view/notice',
+						type: 'snackbar',
+					} );
+				}
+				close();
 			},
 		} );
 
 		commands.push( {
 			name: 'core/show-outline',
-			label: __( 'Show or hide document outline' ),
+			label:
+				currentListViewTab === 'outline' && isListViewOpen
+					? __( 'Hide document outline' )
+					: __( 'Show document outline' ),
 			icon: listView,
 			keywords: [
 				'structure',
@@ -185,8 +204,15 @@ const getEditorCommandLoader = () =>
 						id: 'core/editor/show-outline/notice',
 						type: 'snackbar',
 					} );
+				} else if ( 'outline' !== currentListViewTab ) {
+					// Currently on list-view tab, so switch to outline tab
+					setListViewTab( 'outline' );
+					createInfoNotice( __( 'Document outline opened.' ), {
+						id: 'core/editor/show-outline/notice',
+						type: 'snackbar',
+					} );
 				} else {
-					// If list view is open, close it
+					// Currently on outline tab, so close the list view
 					setIsListViewOpened( false );
 					createInfoNotice( __( 'Document outline closed.' ), {
 						id: 'core/editor/show-outline/notice',

--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -163,7 +163,7 @@ const getEditorCommandLoader = () =>
 						id: 'core/editor/toggle-list-view/notice',
 						type: 'snackbar',
 					} );
-				} else if ( 'list-view' !== currentListViewTab ) {
+				} else if ( currentListViewTab !== 'list-view' ) {
 					// When closing
 					setListViewTab( 'list-view' );
 					createInfoNotice( __( 'List View opened.' ), {
@@ -188,13 +188,6 @@ const getEditorCommandLoader = () =>
 					? __( 'Hide document outline' )
 					: __( 'Show document outline' ),
 			icon: listView,
-			keywords: [
-				'structure',
-				'hierarchy',
-				'organization',
-				'sections',
-				'outline',
-			],
 			callback: ( { close } ) => {
 				// If list view is closed, open it with outline tab
 				if ( ! isListViewOpen ) {
@@ -204,7 +197,7 @@ const getEditorCommandLoader = () =>
 						id: 'core/editor/show-outline/notice',
 						type: 'snackbar',
 					} );
-				} else if ( 'outline' !== currentListViewTab ) {
+				} else if ( currentListViewTab !== 'outline' ) {
 					// Currently on list-view tab, so switch to outline tab
 					setListViewTab( 'outline' );
 					createInfoNotice( __( 'Document outline opened.' ), {

--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -27,6 +27,7 @@ import EditorHistoryUndo from '../editor-history/undo';
 function DocumentTools( { className, disableBlockTools = false } ) {
 	const { setIsInserterOpened, setIsListViewOpened } =
 		useDispatch( editorStore );
+	const { setListViewTab } = unlock( useDispatch( editorStore ) );
 	const {
 		isDistractionFree,
 		isInserterOpened,
@@ -77,10 +78,15 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 	/* translators: accessibility text for the editor toolbar */
 	const toolbarAriaLabel = __( 'Document tools' );
 
-	const toggleListView = useCallback(
-		() => setIsListViewOpened( ! isListViewOpen ),
-		[ setIsListViewOpened, isListViewOpen ]
-	);
+	const toggleListView = useCallback( () => {
+		if ( ! isListViewOpen ) {
+			// When opening the list view, always reset to the list-view tab
+			setIsListViewOpened( true );
+			setListViewTab( 'list-view' );
+		} else {
+			setIsListViewOpened( false );
+		}
+	}, [ setIsListViewOpened, setListViewTab, isListViewOpen ] );
 
 	const toggleInserter = useCallback(
 		() => setIsInserterOpened( ! isInserterOpened ),

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -26,6 +26,12 @@ export default function ListViewSidebar() {
 	const { setIsListViewOpened } = useDispatch( editorStore );
 	const { getListViewToggleRef } = unlock( useSelect( editorStore ) );
 
+	// Tracks our current tab.
+	const { listViewTab: tab } = useSelect( ( select ) => ( {
+		listViewTab: unlock( select( editorStore ) ).getListViewTab(),
+	} ) );
+	const { setListViewTab: setTab } = unlock( useDispatch( editorStore ) );
+
 	// This hook handles focus when the sidebar first renders.
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );
 
@@ -48,8 +54,6 @@ export default function ListViewSidebar() {
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the dropZoneElement updates.
 	const [ dropZoneElement, setDropZoneElement ] = useState( null );
-	// Tracks our current tab.
-	const [ tab, setTab ] = useState( 'list-view' );
 
 	// This ref refers to the sidebar as a whole.
 	const sidebarRef = useRef();
@@ -146,7 +150,7 @@ export default function ListViewSidebar() {
 				] }
 				onClose={ closeListView }
 				onSelect={ ( tabName ) => setTab( tabName ) }
-				defaultTabId="list-view"
+				defaultTabId={ tab }
 				ref={ tabsRef }
 				closeButtonLabel={ __( 'Close' ) }
 			/>

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -150,7 +150,7 @@ export default function ListViewSidebar() {
 				] }
 				onClose={ closeListView }
 				onSelect={ ( tabName ) => setTab( tabName ) }
-				defaultTabId={ tab }
+				selectedTab={ tab }
 				ref={ tabsRef }
 				closeButtonLabel={ __( 'Close' ) }
 			/>

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -8,7 +8,7 @@ import {
 import { useFocusOnMount, useMergeRefs } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { focus } from '@wordpress/dom';
-import { useCallback, useRef, useState } from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { ESCAPE } from '@wordpress/keycodes';
@@ -61,6 +61,8 @@ export default function ListViewSidebar() {
 	const tabsRef = useRef();
 	// This ref refers to the list view application area.
 	const listViewRef = useRef();
+	// This ref refers to the outline application area.
+	const outlineRef = useRef();
 
 	// Must merge the refs together so focus can be handled properly in the next function.
 	const listViewContainerRef = useMergeRefs( [
@@ -93,7 +95,16 @@ export default function ListViewSidebar() {
 			listViewFocusArea.focus();
 			// Outline tab is selected.
 		} else {
-			tabPanelFocus.focus();
+			// Try to focus the first tabbable element in the outline, otherwise focus the tab panel.
+			const outlineApplicationFocus = focus.tabbable.find(
+				outlineRef.current
+			)[ 0 ];
+			const outlineFocusArea = sidebarRef.current.contains(
+				outlineApplicationFocus
+			)
+				? outlineApplicationFocus
+				: tabPanelFocus;
+			outlineFocusArea.focus();
 		}
 	}
 
@@ -114,6 +125,18 @@ export default function ListViewSidebar() {
 	// This only fires when the sidebar is open because of the conditional rendering.
 	// It is the same shortcut to open but that is defined as a global shortcut and only fires when the sidebar is closed.
 	useShortcut( 'core/editor/toggle-list-view', handleToggleListViewShortcut );
+
+	// Handle focus when tab changes (e.g., from command execution).
+	useEffect( () => {
+		// Only manage focus if the sidebar is already open and we're switching tabs.
+		if ( sidebarRef.current && tabsRef.current ) {
+			// Small delay to ensure the tab panel has rendered.
+			const timeoutId = setTimeout( () => {
+				handleSidebarFocus( tab );
+			}, 0 );
+			return () => clearTimeout( timeoutId );
+		}
+	}, [ tab ] );
 
 	return (
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
@@ -146,6 +169,7 @@ export default function ListViewSidebar() {
 								<ListViewOutline />
 							</div>
 						),
+						panelRef: outlineRef,
 					},
 				] }
 				onClose={ closeListView }

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -528,6 +528,15 @@ export const setDefaultRenderingMode =
 	};
 
 /**
+ * Action that sets the list view tab.
+ * @param {string} tab The tab to set.
+ */
+export const setListViewTab = ( tab ) => ( {
+	type: 'SET_LIST_VIEW_TAB',
+	tab,
+} );
+
+/**
  * Set the current global styles navigation path.
  *
  * @param {string} path The navigation path.

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -272,6 +272,15 @@ export const getDefaultRenderingMode = createRegistrySelector(
 );
 
 /**
+ * Returns the current list view tab.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {string} The current list view tab.
+ */
+export const getListViewTab = ( state ) => state.listViewTab ?? 'list-view';
+
+/**
  * Get the current global styles navigation path.
  *
  * @param {Object} state Global application state.

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -385,6 +385,21 @@ export function publishSidebarActive( state = false, action ) {
 }
 
 /**
+ * Reducer to set the tab in the list view.
+ * @param {string} state  Current state.
+ * @param {Object} action Dispatched action.
+ * @return {string} Updated state.
+ */
+export function listViewTab( state = 'list-view', action ) {
+	switch ( action.type ) {
+		case 'SET_LIST_VIEW_TAB':
+			return action.tab;
+		default:
+			return state;
+	}
+}
+
+/**
  * Reducer for the current global styles navigation path.
  *
  * @param {string} state  Current state.
@@ -456,4 +471,5 @@ export default combineReducers( {
 	showStylebook,
 	canvasMinHeight,
 	dataviews: dataviewsReducer,
+	listViewTab,
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Attempt to resolve #53191

## What?
Added "Show document outline" command to open List View in outline tab.

## Why?

- Improves accessibility by providing keyboard command for outline view
- Implements feature request from #53191
- Makes outline functionality more discoverable

## How?

- Added private API to manage List View tabs
- Created new command to open List View with outline tab active
- Reused existing List View functionality

## Testing Instructions

- Open editor
- Press Cmd+k (Mac) or Ctrl+k (Windows)
- Type "outline"
- Select "Show document outline"
- Verify List View opens in outline tab
- Verify that command palette is closed
- Verify outline remains visible

## Testing Instructions for Keyboard

- Press Cmd+k (Mac) or Ctrl+k (Windows)
- Type "outline" using keyboard
- Use arrow keys to navigate to "Show document outline"
- Press Enter to activate
- Verify focus moves to outline
- Tab to navigate outline items


## ScreenCast
https://github.com/user-attachments/assets/edd05b47-fb6d-460d-9a0c-79e85c47147d

 
