### PR TITLE
Inserter: Remove unused no-results-icon styles

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -168,10 +168,6 @@ $block-inserter-tabs-height: 44px;
 	text-align: center;
 }
 
-.block-editor-inserter__no-results-icon {
-	fill: $gray-600;
-}
-
 .block-editor-inserter__child-blocks {
 	padding: 0 $grid-unit-20;
 }


### PR DESCRIPTION
related to: #68688
follow up: https://github.com/WordPress/gutenberg/pull/68693#pullrequestreview-2588993052

## What?
Removed unused styles for .block-editor-inserter__no-results-icon.

## Why?
The no results icon was removed earlier, so the styles are no longer needed.
