### PR TITLE
Block Editor: Add documentation for `BlockRemovalWarningModal` component

### DIFF
--- a/packages/block-editor/src/components/block-removal-warning-modal/README.md
+++ b/packages/block-editor/src/components/block-removal-warning-modal/README.md
@@ -1,0 +1,34 @@
+# Block Removal Warning Modal
+
+The BlockRemovalWarningModal component displays a confirmation dialog when users attempt to remove blocks that have been flagged as requiring confirmation before deletion. It provides a safeguard against accidentally removing important blocks in WordPress.
+
+## Usage
+
+```jsx
+import { BlockRemovalWarningModal } from '@wordpress/block-editor';
+
+function Example() {
+    const rules = [
+        {
+            postTypes: ['wp_template'],
+            callback(removedBlocks) {
+                if (removedBlocks.some(block => block.name === 'core/post-content')) {
+                    return 'Warning message about template block removal';
+                }
+            },
+        },
+    ];
+
+    return <BlockRemovalWarningModal rules={rules} />;
+}
+```
+
+## Props
+
+### `rules`
+
+-   Type: `Array`
+-   Required: Yes
+-   Description: Array of rules that determine when to show warnings and what messages to display. Each rule    object should contain:
+    -   `postTypes`: Array of post types the rule applies to
+    -   `callback`: Function that receives removed blocks and returns a warning message if needed

--- a/packages/block-editor/src/components/block-removal-warning-modal/index.js
+++ b/packages/block-editor/src/components/block-removal-warning-modal/index.js
@@ -16,6 +16,35 @@ import { __ } from '@wordpress/i18n';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
+/**
+ * A modal component that displays warning messages when attempting to remove critical blocks
+ * from WordPress templates and patterns. Provides confirmation dialog and handling for safe
+ * block removal with customizable rules.
+ *
+ * @see https://github.com/WordPress/gutenberg/tree/HEAD/packages/block-editor/src/components/block-removal-warning
+ *
+ * @example
+ * ```jsx
+ * import { BlockRemovalWarningModal } from '@wordpress/block-editor';
+ *
+ * function Example() {
+ *     const rules = [{
+ *         postTypes: ['wp_template'],
+ *         callback(removedBlocks) {
+ *             if (removedBlocks.some(block => block.name === 'core/post-content')) {
+ *                 return 'Warning: Removing this block will affect template display.';
+ *             }
+ *         },
+ *     }];
+ *
+ *     return <BlockRemovalWarningModal rules={rules} />;
+ * }
+ * ```
+ *
+ * @param {Object}   props       Component props.
+ * @param {Object[]} props.rules Array of removal warning rules. Each rule should contain
+ *                               postTypes array and a callback function.
+ */
 export function BlockRemovalWarningModal( { rules } ) {
 	const { clientIds, selectPrevious, message } = useSelect( ( select ) =>
 		unlock( select( blockEditorStore ) ).getRemovalPromptData()


### PR DESCRIPTION
Related to: #22891

## What?
Adds documentation for the `BlockRemovalWarningModal` component by:

- Adding a comprehensive README.md file
- Adding JSDoc comments with proper syntax, examples, and prop descriptions

## Why?
The `BlockRemovalWarningModal` component currently lacks documentation, making it difficult for developers to understand and implement the component correctly:

- Clear documentation of all available props and their usage
- Examples showing how to implement the component properly
- Documentation of component views and internal structure
