### PR TITLE
Add missing list role to the list of blocks in the global Styles.

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-block-list.js
+++ b/packages/edit-site/src/components/global-styles/screen-block-list.js
@@ -137,6 +137,8 @@ function BlockList( { filterValue } ) {
 		<div
 			ref={ blockTypesListRef }
 			className="edit-site-block-types-item-list"
+			// By default, BlockMenuItem has a role=listitem so this div must have a list role.
+			role="list"
 		>
 			{ filteredBlockTypes.map( ( block ) => (
 				<BlockMenuItem


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/69025

Quick PR to add a missing ARIA role.

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Semantically, the list of blocks in Styles > Blocks is a series of list items but it misses a wrapping `list`.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is equivalent to a series of `<li>` elements with no wrapping `<ul>` element and impacts the way screen readers are expected to announce the list itself, the amount of items and position.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds `role="list"` to the wrapping element.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Repeat the steps from the issue https://github.com/WordPress/gutenberg/issues/69025
- Observe the items are now wrapepd within an element with `role="list"`.

Note: if you like and if you use Chrome, you can switch the DOM inspector to the accessibility tree view to better check the correct semantic structure:

![Screenshot 2025-02-04 at 14 21 50](https://github.com/user-attachments/assets/67b62694-ad34-4c54-8e7e-20c7ecf440ac)



### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
