### PR TITLE
Quick Inserter: Restore pattern search and insertion

### DIFF
--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -21,6 +21,7 @@ import { store as blockEditorStore } from '../../store';
 
 const SEARCH_THRESHOLD = 6;
 const SHOWN_BLOCK_TYPES = 6;
+const SHOWN_BLOCK_PATTERNS = 2;
 
 export default function QuickInserter( {
 	onSelect,
@@ -106,7 +107,9 @@ export default function QuickInserter( {
 					rootClientId={ rootClientId }
 					clientId={ clientId }
 					isAppender={ isAppender }
-					maxBlockPatterns={ 0 }
+					maxBlockPatterns={
+						!! filterValue ? SHOWN_BLOCK_PATTERNS : 0
+					}
 					maxBlockTypes={ SHOWN_BLOCK_TYPES }
 					isDraggable={ false }
 					selectBlockOnInsert={ selectBlockOnInsert }

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -84,7 +84,9 @@ function InserterSearchResults( {
 	] = useBlockTypesState( destinationRootClientId, onInsertBlocks, isQuick );
 	const [ patterns, , onClickPattern ] = usePatternsState(
 		onInsertBlocks,
-		destinationRootClientId
+		destinationRootClientId,
+		undefined,
+		isQuick
 	);
 
 	const filteredBlockPatterns = useMemo( () => {


### PR DESCRIPTION
## What?
Closes #68752.
Partially reverts #67738.

PR restores the ability to search and insert (synced) patterns via Quick Inserter. The patterns only appear in search results when parent blocks allow insertion.

The bug reported in #67693 was caused by a misconfiguration of the `usePatternsState` hook; it was missing the `isQuick` flag value.

## Why?
This makes Quick Inserter consistent with block autocompleter.

## Testing Instructions

**When `allowBlocks` is defined**
1. Open a post or page.
2. Insert a Social Icons block.
3. Open the Quick Inserter by clicking the <kbd>+</kbd> button.
4. Search the blocks and confirm that patterns aren't available in search results.

**When any block can be inserted**
1. Add a Stack block.
2. Open the Quick Inserter.
3. Search the blocks and confirm that patterns are available in search results.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2025-02-04 at 17 12 03](https://github.com/user-attachments/assets/0fb6c08a-9da3-4f2c-bc7a-9d46f5edf724)
![CleanShot 2025-02-04 at 17 12 13](https://github.com/user-attachments/assets/dd17e635-040b-499f-8fcf-9bbcab46e050)
