### PR TITLE
Fix: Missing 'No blocks found.' message for block search in editor 

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-block-list.js
+++ b/packages/edit-site/src/components/global-styles/screen-block-list.js
@@ -7,6 +7,7 @@ import {
 	FlexItem,
 	SearchControl,
 	__experimentalHStack as HStack,
+	__experimentalText as Text,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import {
@@ -139,9 +140,9 @@ function BlockList( { filterValue } ) {
 			className="edit-site-block-types-item-list"
 		>
 			{ filteredBlockTypes.length === 0 ? (
-				<div className="block-editor-inserter__no-results">
-					<p>{ __( 'No blocks found.' ) }</p>
-				</div>
+				<Text align="center" as="p">
+					{ __( 'No blocks found.' ) }
+				</Text>
 			) : (
 				filteredBlockTypes.map( ( block ) => (
 					<BlockMenuItem

--- a/packages/edit-site/src/components/global-styles/screen-block-list.js
+++ b/packages/edit-site/src/components/global-styles/screen-block-list.js
@@ -138,12 +138,18 @@ function BlockList( { filterValue } ) {
 			ref={ blockTypesListRef }
 			className="edit-site-block-types-item-list"
 		>
-			{ filteredBlockTypes.map( ( block ) => (
-				<BlockMenuItem
-					block={ block }
-					key={ 'menu-itemblock-' + block.name }
-				/>
-			) ) }
+			{ filteredBlockTypes.length === 0 ? (
+				<div className="block-editor-inserter__no-results">
+					<p>{ __( 'No blocks found.' ) }</p>
+				</div>
+			) : (
+				filteredBlockTypes.map( ( block ) => (
+					<BlockMenuItem
+						block={ block }
+						key={ 'menu-itemblock-' + block.name }
+					/>
+				) )
+			) }
 		</div>
 	);
 }


### PR DESCRIPTION


## What?
Closes #69035 


## Why?
This PR is intended to resolve the issue of absence of 'No blocks found.' text when there is an unsuccessful search for the blocks  

## How?
Added a check to ensure that when no search results are found, the text “No blocks found.” is rendered.

## Testing Instructions
1. Open Editor 
2. Go to styles 
3. Open 'Blocks'
3. Search for a block that doesn't exist 
4. Notice the presence of text 'No blocks found.' on the blank white column 


## Screenshots 

|Before|After|
|------|------|
<img width="555" alt="Image" src="https://github.com/user-attachments/assets/f9fbdec6-ac08-40e3-a43a-fefce0b4df62" /> | <img width="555" alt="image" src="https://github.com/user-attachments/assets/4d4a0208-d625-4a64-b0ab-8872c9d5d9dc" />
