### PR TITLE
PostTitle: Add fallback for empty title

### DIFF
--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -83,7 +83,9 @@ export default function PostTitleEdit( {
 		) : (
 			<TagName
 				{ ...blockProps }
-				dangerouslySetInnerHTML={ { __html: fullTitle?.rendered } }
+				dangerouslySetInnerHTML={ {
+					__html: fullTitle?.rendered || __( '(no title)' ),
+				} }
 			/>
 		);
 	}
@@ -111,7 +113,7 @@ export default function PostTitleEdit( {
 					rel={ rel }
 					onClick={ ( event ) => event.preventDefault() }
 					dangerouslySetInnerHTML={ {
-						__html: fullTitle?.rendered,
+						__html: fullTitle?.rendered || __( '(no title)' ),
 					} }
 				/>
 			</TagName>

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Server-side rendering of the `core/post-title` block.
  *
@@ -27,8 +28,8 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 	 */
 	$title = get_the_title();
 
-	if ( ! $title ) {
-		return '';
+	if (! $title) {
+		$title = __('(no title)');
 	}
 
 	$tag_name = 'h2';

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -28,8 +28,8 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 	 */
 	$title = get_the_title();
 
-	if (! $title) {
-		$title = __('(no title)');
+	if ( ! $title ) {
+		$title = __( '(no title)' );
 	}
 
 	$tag_name = 'h2';


### PR DESCRIPTION
Closes: #69039

## What?
This PR fixes the Query Loop Block's Post Title component to display "(no title)" for posts without titles, maintaining consistency with WordPress core behavior in both editor and frontend.

## Why?
Currently, the Post Title Block renders an empty `<h2>` tag for posts without titles, creating inconsistency with other WordPress interfaces like Latest Posts block and post listing pages which show "(no title)". This affects both usability and accessibility.

## How?
- Modified `post-title/edit.js` to display "(no title)" when `fullTitle.rendered` is empty
- Updated `post-title/index.php` to show "(no title)" instead of returning an empty string when no title exists
- Applied these changes for both linked and unlinked title variants

## Testing Instructions
- Create a post without a title
- Add a Query Loop Block to new post
- Select Post Title in the pattern or add it separately
- Verify "(no title)" appears instead of an empty heading
- Enable "Make title a link" in block settings
- Verify "(no title)" appears as a linked text
- Check both editor and frontend views

## Screencast

https://github.com/user-attachments/assets/61cef60c-9c23-4336-bf68-f860bcf3e573
