### PR TITLE
Remove block icon from InstalledBlocksPrePublishPanel.

### DIFF
--- a/packages/block-directory/src/plugins/index.js
+++ b/packages/block-directory/src/plugins/index.js
@@ -13,6 +13,8 @@ import InstalledBlocksPrePublishPanel from './installed-blocks-pre-publish-panel
 import getInstallMissing from './get-install-missing';
 
 registerPlugin( 'block-directory', {
+	// The icon is explicitly set to undefined to prevent PluginPrePublishPanel
+	// from rendering the fallback icon pluginIcon.
 	icon: undefined,
 	render() {
 		return (

--- a/packages/block-directory/src/plugins/index.js
+++ b/packages/block-directory/src/plugins/index.js
@@ -13,6 +13,7 @@ import InstalledBlocksPrePublishPanel from './installed-blocks-pre-publish-panel
 import getInstallMissing from './get-install-missing';
 
 registerPlugin( 'block-directory', {
+	icon: undefined,
 	render() {
 		return (
 			<>

--- a/packages/block-directory/src/plugins/installed-blocks-pre-publish-panel/index.js
+++ b/packages/block-directory/src/plugins/installed-blocks-pre-publish-panel/index.js
@@ -3,7 +3,6 @@
  */
 import { _n, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { blockDefault } from '@wordpress/icons';
 import { PluginPrePublishPanel } from '@wordpress/editor';
 
 /**
@@ -24,7 +23,6 @@ export default function InstalledBlocksPrePublishPanel() {
 
 	return (
 		<PluginPrePublishPanel
-			icon={ blockDefault }
 			title={ sprintf(
 				// translators: %d: number of blocks (number).
 				_n(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
See https://github.com/WordPress/gutenberg/issues/68688
See https://github.com/WordPress/gutenberg/issues/69045

<!-- In a few words, what is the PR actually doing? -->

When a block is installed from the block directory, `InstalledBlocksPrePublishPanel` renders a panel in the pre-publish sidebar with information about the newly installed block.

This panel also shows a `block` icon that doesn't add value and is inconsistent with its intended usage.
Under the hood, it uses `PluginPrePublishPanel`. In fact, the block-directory is registered as a plugin. However, `PluginPrePublishPanel` is intended to show an icon _for external plugins_. https://github.com/WordPress/gutenberg/pull/53302 introduced simple logic to 1) render an  icon if passed 2) otherwise show the icon registered with the plugin.  The intent is to show an icon to make users understand the panel is added by a plugin.
In this case the panel is added by the editor core though. It's an editor feature and it should not show a meaningless, unnecessary, `block` icon.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The editor should not show unnecessary, confusing, icons.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Sets the icon to `undefined` in the `block-directory` plugin registration.
- Removes the `icon` prop specifically passed to the block directory `InstalledBlocksPrePublishPanel`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Edit a post.
- Install a block from the block directory (search new blocks to install in the Inserter).
- Once the block is installed and added to the post, click Publish to display the pre-publish sidebar.
- Observe the panel that says 'Added: 1 block` doesn't show an icon any longer.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/7a0bb992-656e-4fb9-8841-6a61be00193a)|![after](https://github.com/user-attachments/assets/c3060a3e-8e6a-41ce-81b5-26664c501bc9)|




