### PR TITLE
Fix installing svn during deploys

### DIFF
--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -169,7 +169,7 @@ jobs:
         steps:
             - name: Install Subversion
               run: |
-                  apt-get update -y && apt-get install -y subversion
+                  sudo apt-get update -y && sudo apt-get install -y subversion
 
             - name: Check out Gutenberg trunk from WP.org plugin repo
               run: |
@@ -228,7 +228,7 @@ jobs:
         steps:
             - name: Install Subversion
               run: |
-                  apt-get update -y && apt-get install -y subversion
+                  sudo apt-get update -y && sudo apt-get install -y subversion
 
             - name: Download and unzip Gutenberg plugin asset into tags folder
               env:


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

This fixes a permissions error by installing svn into the worker as sudo. Follow up to #68837.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As seen in [this run](https://github.com/WordPress/gutenberg/actions/runs/13158042809/job/36719637807) attempting to install SVN into the worker failed due to insufficient permissions.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Uses `sudo` when installing SVN.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

