### PR TITLE
Block directory: Some error messages show the Try reloading the page. string twice

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-notice/index.js
+++ b/packages/block-directory/src/components/downloadable-block-notice/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -24,9 +23,6 @@ export const DownloadableBlockNotice = ( { block } ) => {
 		<div className="block-directory-downloadable-block-notice">
 			<div className="block-directory-downloadable-block-notice__content">
 				{ errorNotice.message }
-				{ errorNotice.isFatal
-					? ' ' + __( 'Try reloading the page.' )
-					: null }
 			</div>
 		</div>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: #69048 

<!-- In a few words, what is the PR actually doing? -->
- This PR resolves the issue of duplicate error messages by preventing the redundant appending of the `Try reloading the page` string when displaying the notice for fatal errors when installing a new block via the block directory. It ensures that the message is clear and concise, without unnecessary repetition.

## Why?
- #69048 
- Following the recommended solution which is listed [here](https://github.com/WordPress/gutenberg/issues/69048#issuecomment-2637237909).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- It removes the duplicated message by eliminating the code responsible for appending the same string when displaying the message for a fatal error

## Testing Instructions
- TBH, Not sure how to provide instructions other than altering the code to trigger some errors.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![Before](https://github.com/user-attachments/assets/e69c2829-a5a6-4dd3-b480-b1f4f9d4ecaf)|![After](https://github.com/user-attachments/assets/a856354d-b482-481a-9994-611ff3347ac5)|
