### PR TITLE
Query block: Add option to ignore sticky posts behavior

### DIFF
--- a/backport-changelog/6.8/8265.md
+++ b/backport-changelog/6.8/8265.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/8265
+
+* https://github.com/WordPress/gutenberg/pull/69057

--- a/lib/compat/wordpress-6.8/blocks.php
+++ b/lib/compat/wordpress-6.8/blocks.php
@@ -222,15 +222,30 @@ add_filter( 'rest_pre_insert_wp_block', 'gutenberg_update_ignored_hooked_blocks_
  * Update Query `parents` argument validation for hierarchical post types.
  * A zero is a valid parent ID for hierarchical post types. Used to display top-level items.
  *
+ * Add new handler for `sticky` query argument.
+ *
  * @param array    $query The query vars.
  * @param WP_Block $block Block instance.
  * @return array   The filtered query vars.
  */
-function gutenberg_parents_query_vars_from_query_block( $query, $block ) {
+function gutenberg_update_query_vars_from_query_block_6_8( $query, $block ) {
 	if ( ! empty( $block->context['query']['parents'] ) && is_post_type_hierarchical( $query['post_type'] ) ) {
 		$query['post_parent__in'] = array_unique( array_map( 'intval', $block->context['query']['parents'] ) );
 	}
 
+	if ( isset( $block->context['query']['sticky'] ) && ! empty( $block->context['query']['sticky'] ) ) {
+		if ( 'ignore' === $block->context['query']['sticky'] ) {
+			$sticky = get_option( 'sticky_posts' );
+
+			/**
+			 * The core will set `post__not_in` because it asserts that any sticky value other than `only` is `exclude`.
+			 * Let's override that while supporting any `post__not_in` values outside sticky post logic.
+			 */
+			$query['post__not_in']        = array_diff( $query['post__not_in'], ! empty( $sticky ) ? $sticky : array() );
+			$query['ignore_sticky_posts'] = 1;
+		}
+	}
+
 	return $query;
 }
-add_filter( 'query_loop_block_query_vars', 'gutenberg_parents_query_vars_from_query_block', 10, 2 );
+add_filter( 'query_loop_block_query_vars', 'gutenberg_update_query_vars_from_query_block_6_8', 10, 2 );

--- a/packages/block-library/src/query/edit/inspector-controls/sticky-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/sticky-control.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 
 const stickyOptions = [
 	{ label: __( 'Include' ), value: '' },
+	{ label: __( 'Ignore' ), value: 'ignore' },
 	{ label: __( 'Exclude' ), value: 'exclude' },
 	{ label: __( 'Only' ), value: 'only' },
 ];


### PR DESCRIPTION
## What?
Closes #66221.
Alternative to #66222.

PR adds a new option for the Query block's sticky post setting: "Ignore," which doesn't prepend sticky posts at the top but displays them in the natural order of the query.

It's the same as setting `ignore_sticky_posts` to `true` for `WP_Query`.

## Why?
Makes the Query block more consistent with the front end.

## Testing Instructions
1. Have at least a sticky post on the blog.
2. Create a page and add a simple Query block.
3. Confirm that the sticky post is displayed at the top by default.
4. Change the sticky post setting to "Ignore".
5. Confirm that now it's displayed in natural order.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/45724a26-d7be-4c57-a2ba-4bd8b2be1a62