### PR TITLE
Prevent Grid Column Width Exceeding Container (Grid interactivity)

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -498,7 +498,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		}
 
 		if ( ! empty( $layout['columnCount'] ) && ! empty( $layout['minimumColumnWidth'] ) ) {
-			$max_value       = 'max(' . $layout['minimumColumnWidth'] . ', (100% - (' . $responsive_gap_value . ' * (' . $layout['columnCount'] . ' - 1))) /' . $layout['columnCount'] . ')';
+			$max_value       = 'max(min(' . $layout['minimumColumnWidth'] . ', 100%), (100% - (' . $responsive_gap_value . ' * (' . $layout['columnCount'] . ' - 1))) /' . $layout['columnCount'] . ')';
 			$layout_styles[] = array(
 				'selector'     => $selector,
 				'declarations' => array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/69060 <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->
Updates the `$max_value` calculation in the `gutenberg_get_layout_style` function to prevent columns from exceeding the container's width. Adds a `min` function to ensure `minimumColumnWidth` does not surpass 100% of the container's available space.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This PR is necessary to fix layout issues where columns could become wider than their container, especially on smaller viewports. This ensures a responsive and consistent layout.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The PR modifies the `$max_value` calculation in the `gutenberg_get_layout_style` function by adding a `min` function to limit the `minimumColumnWidth` to a maximum of 100% of the container's available space.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Create a Playground: https://playground.wordpress.net/?networking=yes&plugin=gutenberg
2. Enable "Blocks: add Grid interactivity" in the Experimental settings
3. Add this to a page:
```
<!-- wp:group {"align":"full","layout":{"type":"grid","columnCount":2,"minimumColumnWidth":"793px"}} -->
<div class="wp-block-group alignfull"><!-- wp:group {"style":{"color":{"background":"#ff0000"},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"20px","right":"20px"}}},"layout":{"type":"default"}} -->
<div class="wp-block-group has-background" style="background-color:#ff0000;padding-top:var(--wp--preset--spacing--30);padding-right:20px;padding-bottom:var(--wp--preset--spacing--30);padding-left:20px"><!-- wp:paragraph -->
<p>On mobile this column gets wider than its container</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"style":{"color":{"background":"#ff0000"},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"20px","right":"20px"}}},"layout":{"type":"default"}} -->
<div class="wp-block-group has-background" style="background-color:#ff0000;padding-top:var(--wp--preset--spacing--30);padding-right:20px;padding-bottom:var(--wp--preset--spacing--30);padding-left:20px"><!-- wp:paragraph -->
<p>On mobile this column gets wider than its container</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```
4. Check frontend at 400px viewport and confirm the columns are exceeding the viewport/grid container. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
--

## Screenshots or screencast <!-- if applicable -->
<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/a389ec32-9d4b-4fae-bc88-0660310399d9)|![image](https://github.com/user-attachments/assets/efad891a-02df-4da1-a17d-6f11dc749cab)|