### PR TITLE
Fix: Click-through blur effect when gallery images have a caption.

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -58,6 +58,8 @@ figure.wp-block-gallery.has-nested-images {
 			content: "";
 			height: 100%;
 			max-height: 40%;
+			pointer-events: none;
+			cursor: pointer;
 
 			// Blur the background under the gradient scrim.
 			backdrop-filter: blur(3px);

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -59,7 +59,6 @@ figure.wp-block-gallery.has-nested-images {
 			height: 100%;
 			max-height: 40%;
 			pointer-events: none;
-			cursor: pointer;
 
 			// Blur the background under the gradient scrim.
 			backdrop-filter: blur(3px);


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/69061

## Why?
This PR is intended to resolve the issue which makes the blur effect block the image click 

## How?
This PR makes the following changes to the SCSS file: 
```css 
pointer-events: none;
cursor: pointer;
```
This will help the cursor to appear on the blur part of the image and it will be clickable as well 


## Testing Instructions
- Create a new post 
- Add a new gallery block 
- Add some images to the gallery block 
- Add caption to the images 
- Notice the images in the frontend 
- Notice that large part of the area above the caption is now clickable, previously it was not


## Screenshots or screencast 

Before | After 
----- | ----- 
https://github.com/user-attachments/assets/3b9bca6f-63ec-4f9e-9d9c-e3538f2e413a | https://github.com/user-attachments/assets/a42643fa-bb90-497d-8c74-5e3d3cda3c1c

PS: Sorry for the bad screen recording, my laptop's screen recorder wasn't able to show the `cursor: pointer` behaviour so had to rely on phone for recording 😓 
