### PR TITLE
Exclude Iterator helpers from polyfills

### DIFF
--- a/packages/babel-preset-default/polyfill-exclusions.js
+++ b/packages/babel-preset-default/polyfill-exclusions.js
@@ -28,4 +28,9 @@ module.exports = [
 	//
 	// @see https://github.com/WordPress/gutenberg/pull/67230
 	/^es(next)?\.set\./,
+	// Remove Iterator feature polyfills.
+	// For the same reasoning as for Set exlusion above, we're excluding all iterator helper polyfills.
+	//
+	// @see https://github.com/WordPress/wordpress-develop/pull/8224#issuecomment-2636390007.
+	/^es(next)?\.iterator\./,
 ];

--- a/phpunit/script-dependencies-test.php
+++ b/phpunit/script-dependencies-test.php
@@ -4,6 +4,8 @@
  * @group script-dependencies
  */
 class Test_Script_Dependencies extends WP_UnitTestCase {
+	public $bundled_scripts = array( 'wp-upload-media' );
+
 	/**
 	 * Tests for accidental `wp-polyfill` script dependents.
 	 */
@@ -15,6 +17,11 @@ class Test_Script_Dependencies extends WP_UnitTestCase {
 		// Iterate over all registered scripts, finding dependents of the `wp-polyfill` script.
 		// Based on private `WP_Scripts::get_dependents` method.
 		foreach ( $registered_scripts as $registered_handle => $args ) {
+			// Ignore bundled packages, they don't load separate polyfills.
+			if ( in_array( $registered_handle, $this->bundled_scripts, true ) ) {
+				continue;
+			}
+
 			if ( in_array( 'wp-polyfill', $args->deps, true ) ) {
 				$dependents[] = $registered_handle;
 			}
@@ -34,7 +41,6 @@ class Test_Script_Dependencies extends WP_UnitTestCase {
 			'wp-router',
 			'wp-url',
 			'wp-widgets',
-			'wp-upload-media',
 		);
 
 		$this->assertEqualSets( $expected, $dependents );

--- a/phpunit/script-dependencies-test.php
+++ b/phpunit/script-dependencies-test.php
@@ -37,9 +37,6 @@ class Test_Script_Dependencies extends WP_UnitTestCase {
 			'wp-upload-media',
 		);
 
-		sort( $expected, SORT_STRING );
-		sort( $dependents, SORT_STRING );
-
-		$this->assertSame( $expected, $dependents );
+		$this->assertEqualSets( $expected, $dependents );
 	}
 }

--- a/phpunit/script-dependencies-test.php
+++ b/phpunit/script-dependencies-test.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @group script-dependencies
+ */
+class Test_Script_Dependencies extends WP_UnitTestCase {
+	/**
+	 * Tests for accidental `wp-polyfill` script dependents.
+	 */
+	public function test_polyfill_dependents() {
+		$scripts            = wp_scripts();
+		$registered_scripts = $scripts->registered;
+		$dependents         = array();
+
+		// Iterate over all registered scripts, finding dependents of the `wp-polyfill` script.
+		// Based on private `WP_Scripts::get_dependents` method.
+		foreach ( $registered_scripts as $registered_handle => $args ) {
+			if ( in_array( 'wp-polyfill', $args->deps, true ) ) {
+				$dependents[] = $registered_handle;
+			}
+		}
+
+		// This list should get smaller over time as we remove `wp-polyfill` dependencies.
+		// If the list update is intentional, please add a comment explaining why.
+		$expected = array(
+			'react',
+			'wp-blob',
+			'wp-block-editor',
+			'wp-block-library',
+			'wp-blocks',
+			'wp-edit-site',
+			'wp-core-data',
+			'wp-editor',
+			'wp-router',
+			'wp-url',
+			'wp-widgets',
+			'wp-upload-media',
+		);
+
+		sort( $expected, SORT_STRING );
+		sort( $dependents, SORT_STRING );
+
+		$this->assertSame( $expected, $dependents );
+	}
+}


### PR DESCRIPTION
## What?
Similar to #67230.
Related https://github.com/WordPress/wordpress-develop/pull/8224.

PR updates the polyfill exclusion list and adds a rule for new `Iterator` helpers.

## Why?
When `core-js` was updated in #67708, it accidentally re-introduced `wp-polyfill` as a dependency for multiple packages.

## Testing Instructions
CI tests are passing.
