### PR TITLE
Cover Block: Add `E2E` Test for `FocalPointPicker`

### DIFF
--- a/test/e2e/specs/editor/blocks/cover.spec.js
+++ b/test/e2e/specs/editor/blocks/cover.spec.js
@@ -297,6 +297,41 @@ test.describe( 'Cover', () => {
 
 		expect( isClickable ).toBe( false );
 	} );
+
+	test( 'can use focal point picker to set the focal point of the cover image', async ( {
+		editor,
+		coverBlockUtils,
+		page,
+	} ) => {
+		await editor.insertBlock( { name: 'core/cover' } );
+		const coverBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Cover',
+		} );
+
+		await coverBlockUtils.upload(
+			coverBlock.getByTestId( 'form-file-upload-input' )
+		);
+
+		await editor.page.keyboard.press( 'ArrowUp' );
+
+		const focalPointLeft = page.getByLabel( 'Focal point left position' );
+
+		const focalPointTop = page.getByLabel( 'Focal point top position' );
+
+		await focalPointLeft.fill( '20' );
+		await focalPointTop.fill( '20' );
+
+		await expect( focalPointLeft ).toHaveValue( '20' );
+		await expect( focalPointTop ).toHaveValue( '20' );
+
+		await focalPointLeft.fill( '120' );
+		await focalPointTop.fill( '120' );
+
+		await page.keyboard.press( 'Tab' );
+
+		await expect( focalPointLeft ).toHaveValue( '100' );
+		await expect( focalPointTop ).toHaveValue( '100' );
+	} );
 } );
 
 class CoverBlockUtils {

--- a/test/e2e/specs/editor/blocks/cover.spec.js
+++ b/test/e2e/specs/editor/blocks/cover.spec.js
@@ -328,17 +328,14 @@ test.describe( 'Cover', () => {
 		await expect( focalPointLeft ).toHaveValue( '20' );
 		await expect( focalPointTop ).toHaveValue( '30' );
 
-		const blockAttributes = await page.evaluate( () => {
-			const selectedBlock = window.wp.data
-				.select( 'core/block-editor' )
-				.getSelectedBlock();
-			return selectedBlock?.attributes;
-		} );
-
-		expect( blockAttributes.focalPoint ).toMatchObject( {
-			x: 0.2,
-			y: 0.2,
-		} );
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/cover',
+				attributes: {
+					focalPoint: { x: 0.2, y: 0.3 },
+				},
+			},
+		] );
 
 		const coverImage = coverBlock.locator(
 			'img.wp-block-cover__image-background'

--- a/test/e2e/specs/editor/blocks/cover.spec.js
+++ b/test/e2e/specs/editor/blocks/cover.spec.js
@@ -327,6 +327,18 @@ test.describe( 'Cover', () => {
 
 		await expect( focalPointLeft ).toHaveValue( '20' );
 		await expect( focalPointTop ).toHaveValue( '20' );
+
+		const blockAttributes = await page.evaluate( () => {
+			const selectedBlock = window.wp.data
+				.select( 'core/block-editor' )
+				.getSelectedBlock();
+			return selectedBlock?.attributes;
+		} );
+
+		expect( blockAttributes.focalPoint ).toMatchObject( {
+			x: 0.2,
+			y: 0.2,
+		} );
 	} );
 } );
 

--- a/test/e2e/specs/editor/blocks/cover.spec.js
+++ b/test/e2e/specs/editor/blocks/cover.spec.js
@@ -323,10 +323,10 @@ test.describe( 'Cover', () => {
 		} );
 
 		await focalPointLeft.fill( '20' );
-		await focalPointTop.fill( '20' );
+		await focalPointTop.fill( '30' );
 
 		await expect( focalPointLeft ).toHaveValue( '20' );
-		await expect( focalPointTop ).toHaveValue( '20' );
+		await expect( focalPointTop ).toHaveValue( '30' );
 
 		const blockAttributes = await page.evaluate( () => {
 			const selectedBlock = window.wp.data

--- a/test/e2e/specs/editor/blocks/cover.spec.js
+++ b/test/e2e/specs/editor/blocks/cover.spec.js
@@ -341,7 +341,7 @@ test.describe( 'Cover', () => {
 			'img.wp-block-cover__image-background'
 		);
 
-		await expect( coverImage ).toHaveCSS( 'object-position', '20% 20%' );
+		await expect( coverImage ).toHaveCSS( 'object-position', '20% 30%' );
 	} );
 } );
 

--- a/test/e2e/specs/editor/blocks/cover.spec.js
+++ b/test/e2e/specs/editor/blocks/cover.spec.js
@@ -339,6 +339,12 @@ test.describe( 'Cover', () => {
 			x: 0.2,
 			y: 0.2,
 		} );
+
+		const coverImage = coverBlock.locator(
+			'img.wp-block-cover__image-background'
+		);
+
+		await expect( coverImage ).toHaveCSS( 'object-position', '20% 20%' );
 	} );
 } );
 

--- a/test/e2e/specs/editor/blocks/cover.spec.js
+++ b/test/e2e/specs/editor/blocks/cover.spec.js
@@ -314,9 +314,13 @@ test.describe( 'Cover', () => {
 
 		await editor.selectBlocks( coverBlock );
 
-		const focalPointLeft = page.getByLabel( 'Focal point left position' );
+		const focalPointLeft = page.getByRole( 'spinbutton', {
+			name: 'Focal point left position',
+		} );
 
-		const focalPointTop = page.getByLabel( 'Focal point top position' );
+		const focalPointTop = page.getByRole( 'spinbutton', {
+			name: 'Focal point top position',
+		} );
 
 		await focalPointLeft.fill( '20' );
 		await focalPointTop.fill( '20' );

--- a/test/e2e/specs/editor/blocks/cover.spec.js
+++ b/test/e2e/specs/editor/blocks/cover.spec.js
@@ -312,7 +312,7 @@ test.describe( 'Cover', () => {
 			coverBlock.getByTestId( 'form-file-upload-input' )
 		);
 
-		await editor.page.keyboard.press( 'ArrowUp' );
+		await editor.selectBlocks( coverBlock );
 
 		const focalPointLeft = page.getByLabel( 'Focal point left position' );
 
@@ -323,14 +323,6 @@ test.describe( 'Cover', () => {
 
 		await expect( focalPointLeft ).toHaveValue( '20' );
 		await expect( focalPointTop ).toHaveValue( '20' );
-
-		await focalPointLeft.fill( '120' );
-		await focalPointTop.fill( '120' );
-
-		await page.keyboard.press( 'Tab' );
-
-		await expect( focalPointLeft ).toHaveValue( '100' );
-		await expect( focalPointTop ).toHaveValue( '100' );
 	} );
 } );
 


### PR DESCRIPTION


## What?
Closes: https://github.com/WordPress/gutenberg/issues/29002

This PR adds an end-to-end (E2E) test to ensure the Focal Point Picker in the Cover block works correctly.

## Why?

We've encountered regressions in the past related to the Cover block's Focal Point Picker (e.g., #28487). Currently, there is no E2E test coverage for this feature, so adding a test will help prevent future regressions.



## How?

1. Inserts a Cover block in the editor.
2. Uploads an image to the Cover block.
3. Uses the Focal Point Picker to set specific values for the left and top focal points.
4. Verifies that the values are correctly applied and constrained within the valid range.

## Testing Instructions

Run the test using the following command:

```sh
npm run test:e2e /Users/im3dabasia/Desktop/gutenberg/test/e2e/specs/editor/blocks/cover.spec.js
```

To run only this test, temporarily modify the test to use `.only()` like this:

```sh
test.only( 'can use focal point picker...', async () => { ... } );
```

For debugging, change headless to false in the playwright.config.js file to view the UI while the test runs.



## Screencast 

https://github.com/user-attachments/assets/3651da98-5927-4987-a72b-f9d6ada9aaaf

 **Screenshot of the test cases for the Cover block. Observe the 8th test case, which has been added in this PR.**


<img width="991" alt="image" src="https://github.com/user-attachments/assets/1ecfb8bc-c7c9-4c2f-a3a6-9294fa16b009" />
