### PR TITLE
Writing Flow: restore early return for no block selection in tab nav hook

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -125,6 +125,10 @@ export default function useTabNav() {
 				return;
 			}
 
+			if ( ! hasMultiSelection() && ! getSelectedBlockClientId() ) {
+				return;
+			}
+
 			const isShift = event.shiftKey;
 			const direction = isShift ? 'findPrevious' : 'findNext';
 			const nextTabbable = focus.tabbable[ direction ]( event.target );

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -111,10 +111,7 @@ export default function useTabNav() {
 
 	const ref = useRefEffect( ( node ) => {
 		function onKeyDown( event ) {
-			if (
-				event.defaultPrevented ||
-				( ! hasMultiSelection() && ! getSelectedBlockClientId() )
-			) {
+			if ( event.defaultPrevented ) {
 				return;
 			}
 

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -111,7 +111,10 @@ export default function useTabNav() {
 
 	const ref = useRefEffect( ( node ) => {
 		function onKeyDown( event ) {
-			if ( event.defaultPrevented ) {
+			if (
+				event.defaultPrevented ||
+				( ! hasMultiSelection() && ! getSelectedBlockClientId() )
+			) {
 				return;
 			}
 


### PR DESCRIPTION
## What?
Closes #69037
Fixes tab navigation error in Site Editor preview frame
## Why?
Tab navigation from preview frame causes console errors after #65204 removed an early return condition. Issue doesn't exist in WP 6.7.1 without Gutenberg.
## How?
Restores early return in useTabNav hook:
```JS
if (event.defaultPrevented || (!hasMultiSelection() && !getSelectedBlockClientId())) {
    return;
}
```


This prevents unnecessary processing when no selection exists, fixing the error while maintaining functionality.

## Testing Instructions

- Open Site Editor
- Tab through UI until preview frame is focused
- Tab forward/backward from preview frame
- Verify no console errors appear

## Testing Instructions for Keyboard

- Open Site Editor
- Use Tab key to navigate through interface elements
- When preview frame is focused (visible focus outline), press Tab and Shift+Tab
- Verify seamless navigation without console errors
- Confirm focus moves correctly to next/previous UI elements

## ScreenCast

https://github.com/user-attachments/assets/2b5e9b67-82f3-4233-8a39-b946adc43f91

