### PR TITLE
fix ensure post meta panel stays visible in all rendering modes

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -453,7 +453,6 @@ function Layout( {
 				isDistractionFree: get( 'core', 'distractionFree' ),
 				showMetaBoxes:
 					! DESIGN_POST_TYPES.includes( currentPostType ) &&
-					getRenderingMode() === 'post-only' &&
 					! isZoomOut,
 				isWelcomeGuideVisible: isFeatureActive( 'welcomeGuide' ),
 				templateId:

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -426,8 +426,7 @@ function Layout( {
 				select( editPostStore )
 			);
 			const { canUser, getPostType } = select( coreStore );
-			const { getDeviceType, getEditorMode, getRenderingMode } =
-				select( editorStore );
+			const { getDeviceType, getEditorMode } = select( editorStore );
 			const { __unstableGetEditorMode } = unlock(
 				select( blockEditorStore )
 			);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

this ensures the changes in https://github.com/WordPress/gutenberg/pull/66508 what were undone in https://github.com/WordPress/gutenberg/pull/68902 are actually applied

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

to ensure the fix in #66508 actually works in 6.7.2

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

removing the rendering mode check

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Install a plugin that has a metabox such as yoast SEO
2. Open a post/page
3. Enable the "Show Template" option
4. Ensure the metabox stays visible at the bottom
he change.


https://github.com/user-attachments/assets/2bc21fa2-5564-4210-8da0-70e8df6e3390


