### PR TITLE
Rename `aspect` property to `ratio` to carry the `defaultAspect` in `AspectRatioDropdown`

### DIFF
--- a/packages/block-editor/src/components/image-editor/aspect-ratio-dropdown.js
+++ b/packages/block-editor/src/components/image-editor/aspect-ratio-dropdown.js
@@ -93,7 +93,7 @@ export default function AspectRatioDropdown( { toggleProps } ) {
 							{
 								slug: 'original',
 								name: __( 'Original' ),
-								aspect: defaultAspect,
+								ratio: defaultAspect,
 							},
 							...( showDefaultRatios
 								? defaultRatios


### PR DESCRIPTION
## What, Why and How?
Closes #69084

This PR fixes an issue where selecting `Original Ratio` while cropping an image applies an incorrect ratio to the Image block. Additionally, since `Original Ratio` represents the default state, it should be pre-selected by default.

## Testing Instructions
1. Create an `Image Block` and pick an Image.
2. From the `Toolbar Controls` toggle `Crop` then `Aspect Ratio`.
3. Choose `Original` from `Aspect Ratio`.
4. Confirm that the `Image` now properly reflects to the `Original` ratio.

## Screencast


https://github.com/user-attachments/assets/5eae0b51-e1bc-4f83-9e9e-6a58347ee3cf




