### PR TITLE
Block support: Add server-side processing for ariaLabel

### DIFF
--- a/backport-changelog/6.8/8274.md
+++ b/backport-changelog/6.8/8274.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/8274
+
+* https://github.com/WordPress/gutenberg/pull/69096

--- a/lib/block-supports/aria-label.php
+++ b/lib/block-supports/aria-label.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Aria label block support flag.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Registers the aria-label block attribute for block types that support it.
+ *
+ * @param WP_Block_Type $block_type Block Type.
+ */
+function gutenberg_register_aria_label_support( $block_type ) {
+	$has_aria_label_support = block_has_support( $block_type, array( 'ariaLabel' ), false );
+
+	if ( ! $has_aria_label_support ) {
+		return;
+	}
+
+	if ( ! $block_type->attributes ) {
+		$block_type->attributes = array();
+	}
+
+	if ( ! array_key_exists( 'ariaLabel', $block_type->attributes ) ) {
+		$block_type->attributes['ariaLabel'] = array(
+			'type' => 'string',
+		);
+	}
+}
+
+/**
+ * Add the aria-label to the output.
+ *
+ * @param WP_Block_Type $block_type Block Type.
+ * @param array         $block_attributes Block attributes.
+ *
+ * @return array Block aria-label.
+ */
+function gutenberg_apply_aria_label_support( $block_type, $block_attributes ) {
+	if ( ! $block_attributes ) {
+		return array();
+	}
+
+	$has_aria_label_support = block_has_support( $block_type, array( 'ariaLabel' ), false );
+	if ( ! $has_aria_label_support ) {
+		return array();
+	}
+
+	$has_aria_label = array_key_exists( 'ariaLabel', $block_attributes );
+	if ( ! $has_aria_label ) {
+		return array();
+	}
+	return array( 'aria-label' => $block_attributes['ariaLabel'] );
+}
+
+// Register the block support.
+WP_Block_Supports::get_instance()->register(
+	'aria-label',
+	array(
+		'register_attribute' => 'gutenberg_register_aria_label_support',
+		'apply'              => 'gutenberg_apply_aria_label_support',
+	)
+);

--- a/lib/load.php
+++ b/lib/load.php
@@ -177,6 +177,7 @@ require __DIR__ . '/block-supports/duotone.php';
 require __DIR__ . '/block-supports/shadow.php';
 require __DIR__ . '/block-supports/background.php';
 require __DIR__ . '/block-supports/block-style-variations.php';
+require __DIR__ . '/block-supports/aria-label.php';
 
 // Data views.
 require_once __DIR__ . '/experimental/data-views.php';

--- a/phpunit/block-supports/aria-label-test.php
+++ b/phpunit/block-supports/aria-label-test.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Test the aria-label block support.
+ *
+ * @package Gutenberg
+ */
+class WP_Block_Supports_Aria_Label_Test extends WP_UnitTestCase {
+	/**
+	 * @var string|null
+	 */
+	private $test_block_name;
+
+	public function set_up() {
+		parent::set_up();
+		$this->test_block_name = null;
+	}
+
+	public function tear_down() {
+		unregister_block_type( $this->test_block_name );
+		$this->test_block_name = null;
+		parent::tear_down();
+	}
+
+	/**
+	 * Registers a new block for testing aria-label support.
+	 *
+	 * @param string $block_name Name for the test block.
+	 * @param array  $supports   Array defining block support configuration.
+	 *
+	 * @return WP_Block_Type The block type for the newly registered test block.
+	 */
+	private function register_aria_label_block_with_support( $block_name, $supports = array() ) {
+		$this->test_block_name = $block_name;
+		register_block_type(
+			$this->test_block_name,
+			array(
+				'api_version' => 3,
+				'supports'    => $supports,
+			)
+		);
+		$registry = WP_Block_Type_Registry::get_instance();
+
+		return $registry->get_registered( $this->test_block_name );
+	}
+
+	/**
+	 * Tests that position block support works as expected.
+	 *
+	 * @dataProvider data_aria_label_block_support
+	 *
+	 * @param boolean|array $support Aria label block support configuration.
+	 * @param string        $value   Aria label value for attribute object.
+	 * @param array         $expected       Expected aria label block support styles.
+	 */
+	public function test_gutenberg_apply_aria_label_support( $support, $value, $expected ) {
+		$block_type  = self::register_aria_label_block_with_support(
+			'test/aria-label-block',
+			array( 'ariaLabel' => $support )
+		);
+		$block_attrs = array( 'ariaLabel' => $value );
+		$actual      = gutenberg_apply_aria_label_support( $block_type, $block_attrs );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_aria_label_block_support() {
+		return array(
+			'aria-label attribute is applied' => array(
+				'support'  => true,
+				'value'    => 'Label',
+				'expected' => array( 'aria-label' => 'Label' ),
+			),
+			'aria-label attribute is not applied if block does not support it' => array(
+				'support'  => false,
+				'value'    => 'Label',
+				'expected' => array(),
+			),
+		);
+	}
+}


### PR DESCRIPTION
## What?

- Closes #68764
- Follow-up https://github.com/WordPress/gutenberg/pull/69002
- Core backport PR: https://github.com/WordPress/wordpress-develop/pull/8274

## Why?

In #69002, we updated the schema and added a migration to change the attribute value to a comment delimiter so that the `ariaLabel` block support would work in dynamic blocks.

However, because server-side processing was missing, this support did not work properly in blocks that used the `ServerSideRender` component, for example.

## How?

Like many other block supports, add block support via the register method.

## Testing Instructions

Here we will test adding ariaLabel support to the archive block.

First, make the following changes:

<details><summary>Diff</summary>

Note that the `get_block_wrapper_attributes` function is in lines 46 and 92. Update line 92.

```diff
diff --git a/packages/block-library/src/archives/block.json b/packages/block-library/src/archives/block.json
index 0351a4b694..80e037e390 100644
--- a/packages/block-library/src/archives/block.json
+++ b/packages/block-library/src/archives/block.json
@@ -25,6 +25,7 @@
                }
        },
        "supports": {
+               "ariaLabel": true,
                "align": true,
                "__experimentalBorder": {
                        "radius": true,
diff --git a/packages/block-library/src/archives/index.php b/packages/block-library/src/archives/index.php
index 2846b6ca1a..6ef5190a66 100644
--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -89,7 +89,7 @@ function render_block_core_archives( $attributes ) {
 
        $archives = wp_get_archives( $archives_args );
 
-       $wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $class ) );
+       $wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $class, 'aria-label' => $attributes['ariaLabel'] ) );
 
        if ( empty( $archives ) ) {
                return sprintf(
```

</details> 

In the post content, insert the following HTML:

```html
<!-- wp:archives {"ariaLabel":"Archive Block Aria Label"} /-->
```

Confirm that the aria-label attribute is added to the block in both the frontend and the editor.

In the trunk branch, you’ll get an error like this:

![image](https://github.com/user-attachments/assets/8f694db1-22c8-4fe9-a433-38c3fac2b6a0)