### PR TITLE
Fix editor loading state shows flash of incorrect rendering mode

### DIFF
--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -207,10 +207,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					editorSettings: getEditorSettings(),
 					isReady: __unstableIsEditorReady() && hasLoadedPostObject,
 					mode: getRenderingMode(),
-					defaultMode:
-						hasTemplate && hasDefaultMode
-							? _defaultMode
-							: 'post-only',
+					defaultMode: hasDefaultMode ? _defaultMode : 'post-only',
 					selection: getEditorSelection(),
 					postTypeEntities:
 						post.type === 'wp_template'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
attempt fix #69088
related https://github.com/WordPress/gutenberg/pull/68110
## What?
Address editor rendering mode initialization issue identified in #69088.

## Why?
Current implementation delays setting default rendering mode until template loads, causing "post-only" state to be set temporarily.

## How?
Modify default mode initialization to:
```js
	defaultMode: hasDefaultMode ? _defaultMode : 'post-only';
```
This maintains mode validation while removing template dependency.
 
 ## Testing Instructions

- Open editor with a template-supported post type
- Verify rendering does not flash the "post-only" page view.
- Confirm mode switches correctly between post-only and template-locked states
- Test with various post types to ensure proper mode initialization

## ScreenCast


https://github.com/user-attachments/assets/1de440b6-dfcf-43b3-a852-edd259019795


