### PR TITLE
Fix: Extra top and bottom margin issue in Social Link block for classic theme below twenty twenty

### DIFF
--- a/packages/block-library/src/social-link/editor.scss
+++ b/packages/block-library/src/social-link/editor.scss
@@ -16,6 +16,7 @@
 	height: auto;
 	font-weight: inherit;
 	font-family: inherit;
+	margin: 0;
 
 	// This rule ensures social link buttons display correctly in template parts.
 	opacity: 1;


### PR DESCRIPTION


## What?
fixes #69098

<!-- In a few words, what is the PR actually doing? -->

## Why?
- Extra margin top and bottom is getting added coming from classic.css file.

## How?
- Added `margin: 0` to editor styles for Social Link Block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
- Activate any theme below twenty twenty, this seem problem for the theme Twenty Ten to Twenty Twenty
- Type / to choose a block
- Select Social Icons block
- Add number of social icons and its link
- Now, we can see the extra top & bottom margin into the icons on the editor side.

## Screenshots or screencast <!-- if applicable -->

Before:
![Screenshot 2025-02-07 at 10 53 55 PM](https://github.com/user-attachments/assets/d54487c9-6e62-4754-a7a8-f9f385166df0)

After:
![Screenshot 2025-02-07 at 10 54 15 PM](https://github.com/user-attachments/assets/9dfe5b7f-7b9d-45fd-adbd-b0edd2fee438)


