### PR TITLE
Site Editor: Have `useNavigateToPreviousEntityRecord` rely on location state

### DIFF
--- a/packages/edit-site/src/components/block-editor/use-navigate-to-entity-record.js
+++ b/packages/edit-site/src/components/block-editor/use-navigate-to-entity-record.js
@@ -9,18 +9,20 @@ import { useCallback } from '@wordpress/element';
  */
 import { unlock } from '../../lock-unlock';
 
-const { useHistory } = unlock( routerPrivateApis );
+const { useHistory, useLocation } = unlock( routerPrivateApis );
 
 export default function useNavigateToEntityRecord() {
 	const history = useHistory();
+	const { query } = useLocation();
 
 	const onNavigateToEntityRecord = useCallback(
 		( params ) => {
 			history.navigate(
-				`/${ params.postType }/${ params.postId }?canvas=edit&focusMode=true`
+				`/${ params.postType }/${ params.postId }?canvas=edit&focusMode=true`,
+				{ state: { priorCanvas: query.canvas } }
 			);
 		},
-		[ history ]
+		[ history, query.canvas ]
 	);
 
 	return onNavigateToEntityRecord;

--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -4,7 +4,6 @@
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
-import { usePrevious } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -18,22 +17,16 @@ const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 function useNavigateToPreviousEntityRecord() {
 	const location = useLocation();
-	const previousLocation = usePrevious( location );
 	const history = useHistory();
-	const goBack = useMemo( () => {
+	return useMemo( () => {
 		const isFocusMode =
 			location.query.focusMode ||
 			( location?.params?.postId &&
 				FOCUSABLE_ENTITIES.includes( location?.params?.postType ) );
-		const didComeFromEditorCanvas =
-			previousLocation?.query.canvas === 'edit';
-		const showBackButton = isFocusMode && didComeFromEditorCanvas;
+		const { priorCanvas } = location.state || {};
+		const showBackButton = isFocusMode && priorCanvas === 'edit';
 		return showBackButton ? () => history.back() : undefined;
-		// `previousLocation` changes when the component updates for any reason, not
-		// just when location changes. Until this is fixed we can't add it to deps. See
-		// https://github.com/WordPress/gutenberg/pull/58710#discussion_r1479219465.
 	}, [ location, history ] );
-	return goBack;
 }
 
 export function useSpecificEditorSettings() {

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -3,6 +3,8 @@
  */
 import RouteRecognizer from 'route-recognizer';
 import { createBrowserHistory } from 'history';
+import type { ReactNode } from 'react';
+import type { Location } from 'history';
 
 /**
  * WordPress dependencies
@@ -20,11 +22,6 @@ import {
 	buildQueryString,
 } from '@wordpress/url';
 import { useEvent } from '@wordpress/compose';
-
-/**
- * Internal dependencies
- */
-import type { ReactNode } from 'react';
 
 const history = createBrowserHistory();
 interface Route {
@@ -68,7 +65,7 @@ export interface NavigationOptions {
 const RoutesContext = createContext< Match | null >( null );
 export const ConfigContext = createContext< Config >( { pathArg: 'p' } );
 
-const locationMemo = new WeakMap();
+const locationMemo = new WeakMap< Location, LocationWithQuery >();
 function getLocationWithQuery() {
 	const location = history.location;
 	let locationWithQuery = locationMemo.get( location );
@@ -155,7 +152,7 @@ export default function useMatch(
 	matcher: RouteRecognizer,
 	pathArg: string
 ): Match {
-	const { query: rawQuery = {} } = location;
+	const { query: rawQuery = {}, state } = location;
 
 	return useMemo( () => {
 		const { [ pathArg ]: path = '/', ...query } = rawQuery;
@@ -168,6 +165,7 @@ export default function useMatch(
 				widths: {},
 				query,
 				params: {},
+				state,
 			};
 		}
 
@@ -192,8 +190,9 @@ export default function useMatch(
 			params: result.params,
 			query,
 			path: addQueryArgs( path, query ),
+			state,
 		};
-	}, [ matcher, rawQuery, pathArg ] );
+	}, [ matcher, rawQuery, pathArg, state ] );
 }
 
 export function RouterProvider( {

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -42,6 +42,7 @@ interface Match {
 	widths: Record< string, number >;
 	query?: Record< string, any >;
 	params?: Record< string, any >;
+	state: Location[ 'state' ];
 }
 
 export type BeforeNavigate = ( arg: {


### PR DESCRIPTION
## What?
Makes the code concerned with whether to show a back button more robust.

Originally made to fix #69016.

## Why?

Code quality. Currently the `useNavigateToPreviousEntityRecord` hook relies on the `usePrevious` hook to keep some state locally. This, as seen in #69016, can fail if the consuming component remounts. While remounts are best avoided and unlikely to return in this case, the changes here make it impervious to remounts. Besides that, there are more reasons to avoid using the `usePrevious` hook:
- In this case it requires omitting its state from dependencies—against the exhaustive deps lint rule
- Its implementation reads a ref during render and that’s also [against advise](https://react.dev/reference/react/useRef#caveats)

## How?
- Updates `useNavigateToEntityRecord` to store the state that was kept by `usePrevious` in the the router’s `location.state`
- Exposes the `location.state` through the `useLocation` hook
- Updates `navigateToPreviousEntityRecord` to use the new state from the router

## Testing Instructions
1. Edit a **page** in the **Site editor**
2. Either:
   - Select a template part and click "Edit" in its toolbar
   - Click "Edit template" from the "Template options" menu in the Document summary panel
3. Verify that the "Back" button is present in the Document bar

