### PR TITLE
Added Missing Global Documentation

### DIFF
--- a/lib/experimental/navigation-theme-opt-in.php
+++ b/lib/experimental/navigation-theme-opt-in.php
@@ -29,6 +29,8 @@
  *
  * @see https://core.trac.wordpress.org/ticket/50544
  *
+ * @global WP_Customize_Manager $wp_customize 
+ *
  * @param int   $menu_id         ID of the updated menu.
  * @param int   $menu_item_db_id ID of the new menu item.
  * @param array $args            An array of arguments used to update/add the menu item.

--- a/lib/experimental/navigation-theme-opt-in.php
+++ b/lib/experimental/navigation-theme-opt-in.php
@@ -29,7 +29,7 @@
  *
  * @see https://core.trac.wordpress.org/ticket/50544
  *
- * @global WP_Customize_Manager $wp_customize 
+ * @global WP_Customize_Manager $wp_customize
  *
  * @param int   $menu_id         ID of the updated menu.
  * @param int   $menu_item_db_id ID of the new menu item.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Added  `@global` documentation in `lib/experimental/navigation-theme-opt-in.php` file

<!-- In a few words, what is the PR actually doing? -->

## Why?
`@global` documentation is missing in `lib/experimental/navigation-theme-opt-in.php` file

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open  `lib/experimental/navigation-theme-opt-in.php` file
2. See `@global` documentation is missing