### PR TITLE
Editor: Optimize 'PostAuthorCheck' component data selection

### DIFF
--- a/packages/editor/src/components/post-author/check.js
+++ b/packages/editor/src/components/post-author/check.js
@@ -23,11 +23,14 @@ import { AUTHORS_QUERY } from './constants';
 export default function PostAuthorCheck( { children } ) {
 	const { hasAssignAuthorAction, hasAuthors } = useSelect( ( select ) => {
 		const post = select( editorStore ).getCurrentPost();
-		const authors = select( coreStore ).getUsers( AUTHORS_QUERY );
+		const canAssignAuthor = post?._links?.[ 'wp:action-assign-author' ]
+			? true
+			: false;
 		return {
-			hasAssignAuthorAction:
-				post._links?.[ 'wp:action-assign-author' ] ?? false,
-			hasAuthors: authors?.length >= 1,
+			hasAssignAuthorAction: canAssignAuthor,
+			hasAuthors: canAssignAuthor
+				? select( coreStore ).getUsers( AUTHORS_QUERY )?.length >= 1
+				: false,
 		};
 	}, [] );
 


### PR DESCRIPTION
## What?

PR updates the data selection logic in the `PostAuthorCheck` component and avoids querying users when the author can't be changed for a post type.

An author can't be assigned to a post type when it doesn't support authors, or the current user doesn't have the right capabilities.

## Why?
Reduces the number of network requests made when opening templates or template parts in the site editor.

## Testing Instructions
1. Open any template in Site Editor.
2. Confirm that there's no request for fetching authors.
3. Open a post.
4. Confirm that you can change the post author as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|![CleanShot 2025-02-08 at 11 59 53](https://github.com/user-attachments/assets/813ef6de-ce76-4b4f-9e96-f875598fb807)|![CleanShot 2025-02-08 at 12 00 55](https://github.com/user-attachments/assets/d9eb53c5-5389-44e9-a359-fbbccfe90be7)|
