### PR TITLE
REST API: Adds the site reading options to the index

### DIFF
--- a/backport-changelog/6.8/8345.md
+++ b/backport-changelog/6.8/8345.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/8345
+
+* https://github.com/WordPress/gutenberg/pull/69106

--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -51,6 +51,9 @@ function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 				'default_template_part_areas',
 				'default_template_types',
 				'url',
+				'page_for_posts',
+				'page_on_front',
+				'show_on_front',
 			)
 		);
 		$paths[] = '/wp/v2/templates/lookup?slug=front-page';

--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -36,26 +36,6 @@ function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 
 		$paths[] = '/wp/v2/settings';
 		$paths[] = array( '/wp/v2/settings', 'OPTIONS' );
-		$paths[] = '/?_fields=' . implode(
-			',',
-			// @see packages/core-data/src/entities.js
-			array(
-				'description',
-				'gmt_offset',
-				'home',
-				'name',
-				'site_icon',
-				'site_icon_url',
-				'site_logo',
-				'timezone_string',
-				'default_template_part_areas',
-				'default_template_types',
-				'url',
-				'page_for_posts',
-				'page_on_front',
-				'show_on_front',
-			)
-		);
 		$paths[] = '/wp/v2/templates/lookup?slug=front-page';
 		$paths[] = '/wp/v2/templates/lookup?slug=home';
 	}
@@ -93,6 +73,26 @@ function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 
 		// Used by getBlockPatternCategories in useBlockEditorSettings.
 		$paths[] = '/wp/v2/block-patterns/categories';
+		$paths[] = '/?_fields=' . implode(
+			',',
+			// @see packages/core-data/src/entities.js
+			array(
+				'description',
+				'gmt_offset',
+				'home',
+				'name',
+				'site_icon',
+				'site_icon_url',
+				'site_logo',
+				'timezone_string',
+				'default_template_part_areas',
+				'default_template_types',
+				'url',
+				'page_for_posts',
+				'page_on_front',
+				'show_on_front',
+			)
+		);
 	}
 	return $paths;
 }

--- a/lib/compat/wordpress-6.8/rest-api.php
+++ b/lib/compat/wordpress-6.8/rest-api.php
@@ -72,6 +72,21 @@ function gutenberg_add_default_template_types_to_index( WP_REST_Response $respon
 add_filter( 'rest_index', 'gutenberg_add_default_template_types_to_index' );
 
 /**
+ * Adds the site reading options to the REST API index.
+ *
+ * @param WP_REST_Response $response REST API response.
+ * @return WP_REST_Response Modified REST API response.
+ */
+function gutenberg_add_rest_index_reading_options( WP_REST_Response $response ) {
+	$response->data['page_for_posts'] = (int) get_option( 'page_for_posts' );
+	$response->data['page_on_front']  = (int) get_option( 'page_on_front' );
+	$response->data['show_on_front']  = get_option( 'show_on_front' );
+
+	return $response;
+}
+add_filter( 'rest_index', 'gutenberg_add_rest_index_reading_options' );
+
+/**
  * Adds `ignore_sticky` parameter to the post collection endpoint.
  *
  * Note: Backports into the wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php file.

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -34,6 +34,9 @@ export const rootEntitiesConfig = [
 				'default_template_part_areas',
 				'default_template_types',
 				'url',
+				'page_for_posts',
+				'page_on_front',
+				'show_on_front',
 			].join( ',' ),
 		},
 		// The entity doesn't support selecting multiple records.

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -6,12 +6,7 @@ import { createSelector, createRegistrySelector } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import {
-	canUser,
-	getDefaultTemplateId,
-	getEntityRecord,
-	type State,
-} from './selectors';
+import { getDefaultTemplateId, getEntityRecord, type State } from './selectors';
 import { STORE_NAME } from './name';
 import { unlock } from './lock-unlock';
 
@@ -139,16 +134,9 @@ interface SiteData {
 export const getHomePage = createRegistrySelector( ( select ) =>
 	createSelector(
 		() => {
-			const canReadSiteData = select( STORE_NAME ).canUser( 'read', {
-				kind: 'root',
-				name: 'site',
-			} );
-			if ( ! canReadSiteData ) {
-				return null;
-			}
 			const siteData = select( STORE_NAME ).getEntityRecord(
 				'root',
-				'site'
+				'__unstableBase'
 			) as SiteData | undefined;
 			if ( ! siteData ) {
 				return null;
@@ -168,10 +156,7 @@ export const getHomePage = createRegistrySelector( ( select ) =>
 			return { postType: 'wp_template', postId: frontPageTemplateId };
 		},
 		( state ) => [
-			canUser( state, 'read', {
-				kind: 'root',
-				name: 'site',
-			} ) && getEntityRecord( state, 'root', 'site' ),
+			getEntityRecord( state, 'root', '__unstableBase' ),
 			getDefaultTemplateId( state, {
 				slug: 'front-page',
 			} ),
@@ -180,16 +165,10 @@ export const getHomePage = createRegistrySelector( ( select ) =>
 );
 
 export const getPostsPageId = createRegistrySelector( ( select ) => () => {
-	const canReadSiteData = select( STORE_NAME ).canUser( 'read', {
-		kind: 'root',
-		name: 'site',
-	} );
-	if ( ! canReadSiteData ) {
-		return null;
-	}
-	const siteData = select( STORE_NAME ).getEntityRecord( 'root', 'site' ) as
-		| SiteData
-		| undefined;
+	const siteData = select( STORE_NAME ).getEntityRecord(
+		'root',
+		'__unstableBase'
+	) as SiteData | undefined;
 	return siteData?.show_on_front === 'page'
 		? normalizePageId( siteData.page_for_posts )
 		: null;

--- a/test/e2e/specs/site-editor/preload.spec.js
+++ b/test/e2e/specs/site-editor/preload.spec.js
@@ -44,11 +44,11 @@ test.describe( 'Preload', () => {
 
 		// To do: these should all be removed or preloaded.
 		expect( requests ).toEqual( [
+			// Seems to be coming from `enableComplementaryArea`.
+			'/wp/v2/users/me',
 			// There are two separate settings OPTIONS requests. We should fix
 			// so the one for canUser and getEntityRecord are reused.
 			'/wp/v2/settings',
-			// Seems to be coming from `enableComplementaryArea`.
-			'/wp/v2/users/me',
 		] );
 	} );
 } );


### PR DESCRIPTION
## What?
Closes #68870.

PR exposes the site reading settings via the REST index, which allows low-capability users to preview and change templates.

## Why?
The `/settings` endpoint requires the [`manage_options` capability](https://github.com/WordPress/wordpress-develop/blob/6fea443d8f5f80090d01eab828ec8bbe6acbf2e5/src/wp-includes/rest-api/endpoints/class-wp-rest-settings-controller.php#L59-L69) to access the site settings and does not have a mechanism for `readonly` the settings.

Until [#48885](https://core.trac.wordpress.org/ticket/48885) is resolved, the only option for exposing `readonly` settings is the REST API index.

## How
Use `getEntityRecord( state, 'root', '__unstableBase' )` to access new `readonly` settings.

> [!NOTE]
>  I've not touched other places where these settings are used because it's not a matter of simple search and replace.
>
> While not an issue for non-administrator users, some components also need to account for edited settings. Currently, that's impossible with `getEntityRecord( state, 'root', '__unstableBase' )`.

## Testing Instructions

1. Create a test "editor" user and log in with that account.
2. Open a page.
3. Confirm that you can view and change templates.

P.S. You might see 403 requests for the Navigation block. That needs to be handled separately.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
<img width="384" alt="Screenshot 2025-02-11 at 21 16 21" src="https://github.com/user-attachments/assets/4803b6e1-8ab7-45f7-b08a-a4e67fed949f" />