### PR TITLE
Site Editor: Add user capability check for the Export feature

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -517,7 +517,12 @@ export const canUser =
 			resourcePath =
 				entityConfig.baseURL + ( resource.id ? '/' + resource.id : '' );
 		} else {
-			resourcePath = `/wp/v2/${ resource }` + ( id ? '/' + id : '' );
+			// Allows checking permissions for non-default (`/wp/v2`) namespaces
+			// such as `/wp-block-editor/v1`.
+			const isCustomNamespace = !! resource?.startsWith( '/' );
+			resourcePath =
+				( isCustomNamespace ? resource : `/wp/v2/${ resource }` ) +
+				( id ? '/' + id : '' );
 		}
 
 		let response;

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -707,6 +707,28 @@ describe( 'canUser', () => {
 			true
 		);
 	} );
+
+	it( 'allows checking permissions for non-default namespaces', async () => {
+		triggerFetch.mockImplementation( () => ( {
+			headers: new Map( [ [ 'allow', 'GET' ] ] ),
+		} ) );
+
+		await canUser(
+			'read',
+			'/wp-block-editor/v1/export'
+		)( { dispatch, registry, resolveSelect } );
+
+		expect( triggerFetch ).toHaveBeenCalledWith( {
+			path: '/wp-block-editor/v1/export',
+			method: 'OPTIONS',
+			parse: false,
+		} );
+
+		expect( dispatch.receiveUserPermission ).toHaveBeenCalledWith(
+			'read//wp-block-editor/v1/export',
+			true
+		);
+	} );
 } );
 
 describe( 'getAutosaves', () => {

--- a/packages/edit-site/src/components/more-menu/index.js
+++ b/packages/edit-site/src/components/more-menu/index.js
@@ -1,8 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 
 /**
@@ -15,14 +13,10 @@ import { unlock } from '../../lock-unlock';
 const { ToolsMoreMenuGroup, PreferencesModal } = unlock( editorPrivateApis );
 
 export default function MoreMenu() {
-	const isBlockBasedTheme = useSelect( ( select ) => {
-		return select( coreStore ).getCurrentTheme().is_block_theme;
-	}, [] );
-
 	return (
 		<>
 			<ToolsMoreMenuGroup>
-				{ isBlockBasedTheme && <SiteExport /> }
+				<SiteExport />
 				<WelcomeGuideMenuItem />
 			</ToolsMoreMenuGroup>
 			<PreferencesModal />

--- a/packages/edit-site/src/components/more-menu/site-export.js
+++ b/packages/edit-site/src/components/more-menu/site-export.js
@@ -5,12 +5,24 @@ import { __, _x } from '@wordpress/i18n';
 import { MenuItem } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { download } from '@wordpress/icons';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 import { downloadBlob } from '@wordpress/blob';
 import { store as noticesStore } from '@wordpress/notices';
 
 export default function SiteExport() {
+	const { isBlockBasedTheme, canExport } = useSelect( ( select ) => {
+		const { canUser, getCurrentTheme } = select( coreStore );
+		return {
+			isBlockBasedTheme: getCurrentTheme().is_block_theme,
+			canExport: canUser( 'read', '/wp-block-editor/v1/export' ) ?? false,
+		};
+	}, [] );
 	const { createErrorNotice } = useDispatch( noticesStore );
+
+	if ( ! isBlockBasedTheme || ! canExport ) {
+		return null;
+	}
 
 	async function handleExport() {
 		try {


### PR DESCRIPTION
## What?
Closes #46661.
Related https://core.trac.wordpress.org/ticket/57379.

PR adds a user capability check for the Export feature in the Site Editor. Users without export capabilities will not be able to use this feature.

## How

* Updates `canUser` resolve to support custom REST namespaces, such as `/wp-block-editor/v1`. The logic is very basic and should be used only internally.
* Move required checks into the `SiteExport` component.

## Testing Instructions
1. Use the [WordPress Beta Tester](https://wordpress.org/plugins/wordpress-beta-tester/) plugin or `wp-env` to run the latest WP alpha.
2. Temporarily remove the `export` cap for Administrators - `wp cap remove administrator export`.
3. Navigate to Site Editor and open the "Options" drop-down.
4. Confirm that the "Export" menu items aren't rendered.
5. Restore default caps for Administrators - `wp role reset administrator`

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast
![CleanShot 2025-02-08 at 20 26 10](https://github.com/user-attachments/assets/74d87b8a-b793-4e9e-94a9-76827001b549)