### PR TITLE
Add padding, margin and experimental border support to `Pagination` block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -735,7 +735,7 @@ Displays a paginated navigation to next/previous set of posts, when applicable. 
 -	**Category:** theme
 -	**Ancestor:** core/query
 -	**Allowed Blocks:** core/query-pagination-previous, core/query-pagination-numbers, core/query-pagination-next
--	**Supports:** align, color (background, gradients, link, text), interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** align, color (background, gradients, link, text), interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** paginationArrow, showLabel
 
 ## Next Page

--- a/packages/block-library/src/query-pagination/block.json
+++ b/packages/block-library/src/query-pagination/block.json
@@ -62,6 +62,16 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true
 		}
 	},
 	"editorStyle": "wp-block-query-pagination-editor",


### PR DESCRIPTION
## What, Why and How?
Closes #69109 

The Query Pagination block now includes support for:
1. Margin and padding spacing controls.
2. Border width, color, style, and radius controls.

These changes give users more flexibility in styling pagination elements to match their theme design.

## Testing Instructions
1. Add a Query block to a page.
2. Insert Query Pagination block.
3. Open the block settings sidebar.
4. Verify new controls are available:
4.1. Margin controls
4.2. Padding controls
4.3. Border controls (width, color, style, radius)
5. Test applying different values.
6. Check the styling renders correctly on the front end.

## Screencast

https://github.com/user-attachments/assets/213af59d-6d9d-4f3e-ad02-652edad95445

