### PR TITLE
e2e: Fix "add new" selector

### DIFF
--- a/test/e2e/specs/editor/various/block-editor-keyboard-shortcuts.spec.js
+++ b/test/e2e/specs/editor/various/block-editor-keyboard-shortcuts.spec.js
@@ -192,7 +192,7 @@ test.describe( 'Block editor keyboard shortcuts', () => {
 				.getByRole( 'menuitem', { name: 'Create pattern' } )
 				.click();
 			await page
-				.getByRole( 'dialog', { name: 'add new pattern' } )
+				.getByRole( 'dialog', { name: 'add pattern' } )
 				.getByRole( 'textbox', { name: 'Name' } )
 				.fill( 'hi' );
 

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -269,7 +269,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			.click();
 		await page.getByRole( 'menuitem', { name: 'Create pattern' } ).click();
 		const createPatternDialog = page.getByRole( 'dialog', {
-			name: 'add new pattern',
+			name: 'add pattern',
 		} );
 		await createPatternDialog
 			.getByRole( 'textbox', { name: 'Name' } )

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -40,16 +40,16 @@ test.describe( 'Pattern Overrides', () => {
 
 			await page
 				.getByRole( 'region', { name: 'Patterns content' } )
-				.getByRole( 'button', { name: 'add new pattern' } )
+				.getByRole( 'button', { name: 'add pattern' } )
 				.click();
 
 			await page
-				.getByRole( 'menu', { name: 'add new pattern' } )
-				.getByRole( 'menuitem', { name: 'add new pattern' } )
+				.getByRole( 'menu', { name: 'add pattern' } )
+				.getByRole( 'menuitem', { name: 'add pattern' } )
 				.click();
 
 			const createPatternDialog = page.getByRole( 'dialog', {
-				name: 'add new pattern',
+				name: 'add pattern',
 			} );
 			await createPatternDialog
 				.getByRole( 'textbox', { name: 'Name' } )

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -37,7 +37,7 @@ test.describe( 'Unsynced pattern', () => {
 		await page.getByRole( 'menuitem', { name: 'Create pattern' } ).click();
 
 		const createPatternDialog = page.getByRole( 'dialog', {
-			name: 'add new pattern',
+			name: 'add pattern',
 		} );
 		await createPatternDialog
 			.getByRole( 'textbox', { name: 'Name' } )
@@ -136,7 +136,7 @@ test.describe( 'Synced pattern', () => {
 		await page.getByRole( 'menuitem', { name: 'Create pattern' } ).click();
 
 		const createPatternDialog = page.getByRole( 'dialog', {
-			name: 'add new pattern',
+			name: 'add pattern',
 		} );
 		await createPatternDialog
 			.getByRole( 'textbox', { name: 'Name' } )
@@ -376,7 +376,7 @@ test.describe( 'Synced pattern', () => {
 		await editor.clickBlockOptionsMenuItem( 'Create pattern' );
 
 		const createPatternDialog = page.getByRole( 'dialog', {
-			name: 'add new pattern',
+			name: 'add pattern',
 		} );
 		await createPatternDialog
 			.getByRole( 'textbox', { name: 'Name' } )
@@ -426,7 +426,7 @@ test.describe( 'Synced pattern', () => {
 		await editor.clickBlockOptionsMenuItem( 'Create pattern' );
 
 		const createPatternDialog = editor.page.getByRole( 'dialog', {
-			name: 'add new pattern',
+			name: 'add pattern',
 		} );
 		await createPatternDialog
 			.getByRole( 'textbox', { name: 'Name' } )
@@ -610,7 +610,7 @@ test.describe( 'Synced pattern', () => {
 		await editor.clickBlockOptionsMenuItem( 'Create pattern' );
 
 		const createPatternDialog = editor.page.getByRole( 'dialog', {
-			name: 'add new pattern',
+			name: 'add pattern',
 		} );
 		await createPatternDialog
 			.getByRole( 'textbox', { name: 'Name' } )

--- a/test/e2e/specs/editor/various/taxonomies.spec.js
+++ b/test/e2e/specs/editor/various/taxonomies.spec.js
@@ -79,9 +79,7 @@ test.describe( 'Taxonomies', () => {
 		const tagName = 'tag-' + generateRandomNumber();
 		const tags = page.locator( '.components-form-token-field__token-text' );
 
-		await page
-			.getByRole( 'combobox', { name: 'Add New Tag' } )
-			.fill( tagName );
+		await page.getByRole( 'combobox', { name: 'Add tag' } ).fill( tagName );
 		await page.keyboard.press( 'Enter' );
 
 		await expect( tags ).toHaveCount( 1 );
@@ -116,9 +114,7 @@ test.describe( 'Taxonomies', () => {
 		const tagName = "tag'-" + generateRandomNumber();
 		const tags = page.locator( '.components-form-token-field__token-text' );
 
-		await page
-			.getByRole( 'combobox', { name: 'Add New Tag' } )
-			.fill( tagName );
+		await page.getByRole( 'combobox', { name: 'Add tag' } ).fill( tagName );
 		await page.keyboard.press( 'Enter' );
 
 		await expect( tags ).toHaveCount( 1 );

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -1088,7 +1088,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 
 		await editor.clickBlockOptionsMenuItem( 'Create pattern' );
 		const createPatternDialog = editor.page.getByRole( 'dialog', {
-			name: 'add new pattern',
+			name: 'add pattern',
 		} );
 		await createPatternDialog
 			.getByRole( 'textbox', { name: 'Name' } )

--- a/test/e2e/specs/site-editor/block-style-variations.spec.js
+++ b/test/e2e/specs/site-editor/block-style-variations.spec.js
@@ -302,7 +302,7 @@ class SiteEditorBlockStyleVariations {
 
 async function draftNewPage( page ) {
 	await page.getByRole( 'button', { name: 'Pages' } ).click();
-	await page.getByRole( 'button', { name: 'Add new page' } ).click();
+	await page.getByRole( 'button', { name: 'Add page' } ).click();
 	await page
 		.locator( 'role=dialog[name="Draft new: page"i]' )
 		.locator( 'role=textbox[name="title"i]' )

--- a/test/e2e/specs/site-editor/command-center.spec.js
+++ b/test/e2e/specs/site-editor/command-center.spec.js
@@ -29,7 +29,7 @@ test.describe( 'Site editor command palette', () => {
 			.focus();
 		await page.keyboard.press( 'Meta+k' );
 		await page.keyboard.type( 'new page' );
-		await page.getByRole( 'option', { name: 'Add new page' } ).click();
+		await page.getByRole( 'option', { name: 'Add page' } ).click();
 		await expect( page ).toHaveURL(
 			/\/wp-admin\/site-editor.php\?p=%2Fpage%2F(\d+)&canvas=edit/
 		);

--- a/test/e2e/specs/site-editor/command-center.spec.js
+++ b/test/e2e/specs/site-editor/command-center.spec.js
@@ -29,7 +29,7 @@ test.describe( 'Site editor command palette', () => {
 			.focus();
 		await page.keyboard.press( 'Meta+k' );
 		await page.keyboard.type( 'new page' );
-		await page.getByRole( 'option', { name: 'Add page' } ).click();
+		await page.getByRole( 'option', { name: 'Add new page' } ).click();
 		await expect( page ).toHaveURL(
 			/\/wp-admin\/site-editor.php\?p=%2Fpage%2F(\d+)&canvas=edit/
 		);

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -5,7 +5,7 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 async function draftNewPage( page ) {
 	await page.getByRole( 'button', { name: 'Pages' } ).click();
-	await page.getByRole( 'button', { name: 'Add new page' } ).click();
+	await page.getByRole( 'button', { name: 'Add page' } ).click();
 	await page
 		.locator( 'role=dialog[name="Draft new: page"i]' )
 		.locator( 'role=textbox[name="title"i]' )

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -247,7 +247,7 @@ test.describe( 'Pages', () => {
 		// Create a custom template first.
 		const templateName = 'demo';
 		await page.getByRole( 'button', { name: 'Templates' } ).click();
-		await page.getByRole( 'button', { name: 'Add New Template' } ).click();
+		await page.getByRole( 'button', { name: 'Add template' } ).click();
 		await page
 			.getByRole( 'button', {
 				name: 'A custom template can be manually applied to any post or page.',

--- a/test/e2e/specs/site-editor/patterns.spec.js
+++ b/test/e2e/specs/site-editor/patterns.spec.js
@@ -43,21 +43,21 @@ test.describe( 'Patterns', () => {
 		await expect( patterns.content ).toContainText( 'No results' );
 
 		await patterns.content
-			.getByRole( 'button', { name: 'add new pattern' } )
+			.getByRole( 'button', { name: 'add pattern' } )
 			.click();
 
 		const addNewMenuItem = page
 			.getByRole( 'menu', {
-				name: 'add new pattern',
+				name: 'add pattern',
 			} )
 			.getByRole( 'menuitem', {
-				name: 'add new pattern',
+				name: 'add pattern',
 			} );
 		await expect( addNewMenuItem ).toBeFocused();
 		await addNewMenuItem.click();
 
 		const createPatternDialog = page.getByRole( 'dialog', {
-			name: 'add new pattern',
+			name: 'add pattern',
 		} );
 		await createPatternDialog
 			.getByRole( 'textbox', { name: 'Name' } )

--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -57,7 +57,7 @@ test.describe( 'Site editor url navigation', () => {
 		await page.click( 'role=button[name="add pattern"i]' );
 		await page
 			.getByRole( 'menu', { name: 'add pattern' } )
-			.getByRole( 'menuitem', { name: 'add new template part' } )
+			.getByRole( 'menuitem', { name: 'add template part' } )
 			.click();
 		// Fill in a name in the dialog that pops up.
 		await page.type( 'role=dialog >> role=textbox[name="Name"i]', 'Demo' );

--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -56,7 +56,7 @@ test.describe( 'Site editor url navigation', () => {
 		await page.click( 'role=button[name="Patterns"i]' );
 		await page.click( 'role=button[name="add new pattern"i]' );
 		await page
-			.getByRole( 'menu', { name: 'add new pattern' } )
+			.getByRole( 'menu', { name: 'add pattern' } )
 			.getByRole( 'menuitem', { name: 'add new template part' } )
 			.click();
 		// Fill in a name in the dialog that pops up.

--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -33,7 +33,7 @@ test.describe( 'Site editor url navigation', () => {
 
 		await admin.visitSiteEditor();
 		await page.click( 'role=button[name="Templates"]' );
-		await page.click( 'role=button[name="Add New Template"i]' );
+		await page.click( 'role=button[name="Add Template"i]' );
 		await page
 			.getByRole( 'button', {
 				name: 'Single item: Post',

--- a/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-url-navigation.spec.js
@@ -54,7 +54,7 @@ test.describe( 'Site editor url navigation', () => {
 	} ) => {
 		await admin.visitSiteEditor();
 		await page.click( 'role=button[name="Patterns"i]' );
-		await page.click( 'role=button[name="add new pattern"i]' );
+		await page.click( 'role=button[name="add pattern"i]' );
 		await page
 			.getByRole( 'menu', { name: 'add pattern' } )
 			.getByRole( 'menuitem', { name: 'add new template part' } )

--- a/test/e2e/specs/site-editor/template-registration.spec.js
+++ b/test/e2e/specs/site-editor/template-registration.spec.js
@@ -275,7 +275,7 @@ test.describe( 'Block template registration', () => {
 		await admin.visitSiteEditor( {
 			postType: 'wp_template',
 		} );
-		await page.getByLabel( 'Add New Template' ).click();
+		await page.getByLabel( 'Add template' ).click();
 		await page.getByRole( 'button', { name: 'Author Archives' } ).click();
 		await page
 			.getByRole( 'button', { name: 'Author For a specific item' } )

--- a/test/e2e/specs/site-editor/templates.spec.js
+++ b/test/e2e/specs/site-editor/templates.spec.js
@@ -14,7 +14,7 @@ test.describe( 'Templates', () => {
 		const templateName = 'demo';
 		await admin.visitSiteEditor();
 		await page.getByRole( 'button', { name: 'Templates' } ).click();
-		await page.getByRole( 'button', { name: 'Add New Template' } ).click();
+		await page.getByRole( 'button', { name: 'Add template' } ).click();
 		await page
 			.getByRole( 'button', {
 				name: 'A custom template can be manually applied to any post or page.',


### PR DESCRIPTION
## What? Why?

The following core patch removed "New" from the labels related to adding new items, which seems to have caused some e2e tests to fail.

~https://core.trac.wordpress.org/changeset/59791~
https://core.trac.wordpress.org/changeset/59784

| Before the patch | After the patch |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/a0b55341-d459-43ea-a20d-45018cb5749c) | ![image](https://github.com/user-attachments/assets/646272b6-75b8-4189-9d86-0e649f2b89fd)| 

## Testing Instructions

I'm checking the CI results to fix any failures.