### PR TITLE
Input Control: Remove mobile-specific font size override in input controls

### DIFF
--- a/packages/components/src/input-control/styles/input-control-styles.tsx
+++ b/packages/components/src/input-control/styles/input-control-styles.tsx
@@ -162,18 +162,13 @@ export const fontSizeStyles = ( { inputSize: size }: InputProps ) => {
 	};
 
 	const fontSize = sizes[ size as Size ] || sizes.default;
-	const fontSizeMobile = '16px';
 
 	if ( ! fontSize ) {
 		return '';
 	}
 
 	return css`
-		font-size: ${ fontSizeMobile };
-
-		@media ( min-width: 600px ) {
-			font-size: ${ fontSize };
-		}
+		font-size: ${ fontSize };
 	`;
 };
 


### PR DESCRIPTION
## What?

Closes: #69113 

Removes mobile-specific font size override in input controls to maintain consistent typography across screen sizes.


## Why?
Currently, there's an inconsistency in font sizes on mobile screens where the selected text in custom select controls appears at `16px` while other elements remain at `13px`. This creates:
- Visual disruption in typography hierarchy
- Inconsistency between selected text (`16px`) and dropdown options (`13px`)
- Unnecessary variation from other form controls and text elements

## Testing Instructions
- Open any page/post with a custom select control (e.g., the Typography panel in the block editor)
- View the page at mobile width (below `600px`)
- Verify that:
   - The selected text in dropdowns is now 13px (consistent with other elements)
   - The dropdown options remain at 13px
   - The text appears visually consistent with other form controls


## Screencast 

Before

https://github.com/user-attachments/assets/db829910-87ee-4dfd-adf2-bd777f052092


After




https://github.com/user-attachments/assets/76e5037d-92c8-4c2b-824e-bfbe71edb6a0

