### PR TITLE
Image Block: Fix image resizing issues with manual width input

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -59,6 +59,9 @@ figure.wp-block-image:not(.wp-block) {
 		width: inherit;
 		height: inherit;
 	}
+
+	min-width: inherit !important;
+	min-height: inherit !important;
 }
 
 .block-editor-block-list__block[data-type="core/image"] .block-editor-block-toolbar .block-editor-url-input__button-modal {


### PR DESCRIPTION
Fixes: #68814

## What?
Fix manual image size input being disregarded after clicking an image by removing minimum size constraints from the resizable container.

## Why?
Currently, when users manually set the width of an image, the size is unexpectedly reset to a minimum size after clicking the image in the editor. This happens because the resizable container has default minimum dimensions that override the manually input values. This creates a frustrating user experience when trying to resize images to small dimensions.


## Testing Instructions
1. Add a row or stack block to a page or post
2. Insert an image block within the row or stack.
3. Select the image block.
4. Try to set the width to a small value (e.g., 80px) using the Width input field
5. Verify that the image maintains its manually set width instead of resetting to a larger size
6. Try different width values to ensure the behavior is consistent
7. Test with different image sizes and alignments to ensure the fix doesn't affect other image block functionality


## Screenshots or screencast

### Before:
https://github.com/user-attachments/assets/3b8fefc0-64e7-46ae-a6da-74dbe1b887b9

### After:
https://github.com/user-attachments/assets/791ba483-ac6b-4699-b404-1cdb9b023232


