### PR TITLE
Transform page list to list

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -27,8 +27,8 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo, useState, useEffect, useCallback } from '@wordpress/element';
-import { useEntityRecords } from '@wordpress/core-data';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
+import { useSelect, useDispatch, select } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -258,6 +258,7 @@ export default function PageListEdit( {
 		hasDraggedChild,
 		isChildOfNavigation,
 	} = useSelect(
+		// eslint-disable-next-line no-shadow
 		( select ) => {
 			const {
 				getBlockParentsByBlockName,
@@ -406,3 +407,57 @@ export default function PageListEdit( {
 		</>
 	);
 }
+export const transforms = {
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/list' ],
+			transform: () => {
+				const pages = select( coreStore ).getEntityRecords(
+					'postType',
+					'page',
+					{
+						per_page: -1,
+						status: 'publish',
+					}
+				);
+
+				if ( ! pages || pages.length === 0 ) {
+					return createBlock( 'core/list', {
+						ordered: false,
+					} );
+				}
+
+				const createListItems = ( parentId = 0 ) => {
+					return pages
+						.filter( ( page ) => page.parent === parentId )
+						.map( ( page ) => {
+							const childItems = createListItems( page.id );
+							const listItem = createBlock( 'core/list-item', {
+								content: `<a href="${ page.link }">${ page.title.rendered }</a>`,
+							} );
+							if ( childItems.length > 0 ) {
+								const subList = createBlock(
+									'core/list',
+									{},
+									childItems
+								);
+								listItem.innerBlocks = [ subList ];
+							}
+							return listItem;
+						} );
+				};
+
+				const innerBlocks = createListItems();
+
+				return createBlock(
+					'core/list',
+					{
+						ordered: false,
+					},
+					innerBlocks
+				);
+			},
+		},
+	],
+};

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -27,8 +27,8 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo, useState, useEffect, useCallback } from '@wordpress/element';
-import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
-import { useSelect, useDispatch, select } from '@wordpress/data';
+import { useEntityRecords } from '@wordpress/core-data';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -258,7 +258,6 @@ export default function PageListEdit( {
 		hasDraggedChild,
 		isChildOfNavigation,
 	} = useSelect(
-		// eslint-disable-next-line no-shadow
 		( select ) => {
 			const {
 				getBlockParentsByBlockName,
@@ -407,57 +406,3 @@ export default function PageListEdit( {
 		</>
 	);
 }
-export const transforms = {
-	to: [
-		{
-			type: 'block',
-			blocks: [ 'core/list' ],
-			transform: () => {
-				const pages = select( coreStore ).getEntityRecords(
-					'postType',
-					'page',
-					{
-						per_page: -1,
-						status: 'publish',
-					}
-				);
-
-				if ( ! pages || pages.length === 0 ) {
-					return createBlock( 'core/list', {
-						ordered: false,
-					} );
-				}
-
-				const createListItems = ( parentId = 0 ) => {
-					return pages
-						.filter( ( page ) => page.parent === parentId )
-						.map( ( page ) => {
-							const childItems = createListItems( page.id );
-							const listItem = createBlock( 'core/list-item', {
-								content: `<a href="${ page.link }">${ page.title.rendered }</a>`,
-							} );
-							if ( childItems.length > 0 ) {
-								const subList = createBlock(
-									'core/list',
-									{},
-									childItems
-								);
-								listItem.innerBlocks = [ subList ];
-							}
-							return listItem;
-						} );
-				};
-
-				const innerBlocks = createListItems();
-
-				return createBlock(
-					'core/list',
-					{
-						ordered: false,
-					},
-					innerBlocks
-				);
-			},
-		},
-	],
-};

--- a/packages/block-library/src/page-list/index.js
+++ b/packages/block-library/src/page-list/index.js
@@ -8,7 +8,7 @@ import { pages } from '@wordpress/icons';
  */
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
-import edit from './edit.js';
+import edit, { transforms } from './edit.js';
 
 const { name } = metadata;
 
@@ -18,6 +18,7 @@ export const settings = {
 	icon: pages,
 	example: {},
 	edit,
+	transforms,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/page-list/index.js
+++ b/packages/block-library/src/page-list/index.js
@@ -8,7 +8,8 @@ import { pages } from '@wordpress/icons';
  */
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
-import edit, { transforms } from './edit.js';
+import transforms from './transforms.js';
+import edit from './edit.js';
 
 const { name } = metadata;
 

--- a/packages/block-library/src/page-list/transforms.js
+++ b/packages/block-library/src/page-list/transforms.js
@@ -1,0 +1,71 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+import { store as coreStore } from '@wordpress/core-data';
+import { select } from '@wordpress/data';
+const transforms = {
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/list' ],
+			transform: ( attributes ) => {
+				const { style, fontFamily } = attributes;
+				const pages = select( coreStore ).getEntityRecords(
+					'postType',
+					'page',
+					{
+						per_page: 100,
+						status: 'publish',
+						orderBy: 'menu_order',
+						order: 'asc',
+						_fields: [
+							'id',
+							'link',
+							'parent',
+							'title',
+							'menu_order',
+						],
+					}
+				);
+
+				if ( ! pages || pages.length === 0 ) {
+					return createBlock( 'core/list', {} );
+				}
+
+				const createListItems = ( parentId = 0 ) => {
+					return pages
+						.filter( ( page ) => page.parent === parentId )
+						.map( ( page ) => {
+							const childItems = createListItems( page.id );
+							const listItem = createBlock( 'core/list-item', {
+								content: `<a href="${ page.link }">${ page.title.rendered }</a>`,
+							} );
+							if ( childItems.length > 0 ) {
+								const subList = createBlock(
+									'core/list',
+									{},
+									childItems
+								);
+								listItem.innerBlocks = [ subList ];
+							}
+							return listItem;
+						} );
+				};
+
+				const innerBlocks = createListItems();
+
+				return createBlock(
+					'core/list',
+					{
+						style,
+						fontFamily,
+					},
+					innerBlocks
+				);
+			},
+		},
+	],
+};
+
+export default transforms;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/44458

## Why?
Currently Page list block has no transform option for list block.


## How?
Added list block transformation to Page list block.


## Testing Instructions

- Go to WP admin dashboard.
- Edit/create any post/page.
- Create a Page List Block
- Try to transform it to a list block.


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->



https://github.com/user-attachments/assets/ba6d7bc5-9271-424d-8acd-0ece0d78f81b


