### PR TITLE
Remove `react-native` dependabot group.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,8 +19,4 @@ updates:
                   - 'actions/setup-java'
                   - 'gradle/*'
                   - 'reactivecircus/*'
-          react-native:
-              patterns:
-                  - 'actions/setup-java'
-                  - 'gradle/*'
-                  - 'reactivecircus/*'
+                  - 'ruby/setup-ruby'


### PR DESCRIPTION
## What?
Mobile development is effectively on hold. The two related GitHub Action workflows have been disabled (#67799) because the MacOS 12 runner is now unsupported by GitHub and work is required to make the workflows compatible with newer runner images (see #67595).

## How?
This removes the `react-native` dependabot group to avoid pull requests from being opened for 3rd party actions that are only used in these workflows since the updates cannot be properly tested.
