### PR TITLE
Remove react-native dependabot group - Take 2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,16 @@ updates:
       labels:
           - 'GitHub Actions'
           - '[Type] Build Tooling'
+      ignore:
+          - dependency-name: 'actions/setup-java'
+            versions: ['*']
+          - dependency-name: 'gradle/*'
+            versions: ['*']
+          - dependency-name: 'reactivecircus/*'
+            versions: ['*']
+          - dependency-name: 'ruby/setup-ruby'
+            versions: ['*']
       groups:
           github-actions:
               patterns:
                   - '*'
-              exclude-patterns:
-                  - 'actions/setup-java'
-                  - 'gradle/*'
-                  - 'reactivecircus/*'
-                  - 'ruby/setup-ruby'


### PR DESCRIPTION
## What?
Makes more adjustments to the Dependabot file to prevent updating 3rd party actions related to React Native testing.

## Why?
This is a follow up to #69118, which resulted in those actions being split into individual PRs instead of being grouped and did not exclude them entirely.