### PR TITLE
Add an Actionlint workflow.

### DIFF
--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -1,0 +1,34 @@
+name: Lint GitHub Actions workflows
+on:
+    workflow_call:
+
+permissions: {}
+
+jobs:
+    # Runs the actionlint GitHub Action workflow file linter.
+    #
+    # This helps guard against common mistakes including strong type checking for expressions (${{ }}), security checks,
+    # `run:` script checking, glob syntax validation, and more.
+    #
+    # Performs the following steps:
+    # - Checks out the repository.
+    # - Runs actionlint.
+    actionlint:
+        name: Run actionlint
+        runs-on: ubuntu-24.04
+        permissions:
+            contents: read
+        timeout-minutes: 5
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+              with:
+                  persist-credentials: false
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+
+            # actionlint is static checker for GitHub Actions workflow files.
+            # See https://github.com/rhysd/actionlint.
+            - name: Run actionlint
+              uses: docker://rhysd/actionlint:1.7.7
+              with:
+                  args: "-color -verbose"

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,36 @@
+name: Lint GitHub Actions workflow files
+
+on:
+    push:
+        branches:
+            - trunk
+        paths:
+            # Only run when changes are made to workflow files.
+            - '.github/workflows/**'
+    pull_request:
+        branches:
+            - trunk
+        paths:
+            # Only run when changes are made to workflow files.
+            - '.github/workflows/**'
+    workflow_dispatch:
+
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+    # The concurrency group contains the workflow name and the branch name for pull requests
+    # or the commit hash for any other events.
+    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
+jobs:
+    lint:
+        name: Lint GitHub Action files
+        permissions:
+            security-events: write
+            actions: read
+            contents: read
+        uses: ./.github/workflows/reusable-workflow-lint.yml


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This introduces a new workflow which lints all the GitHub Actions workflow files using [actionlint](https://github.com/rhysd/actionlint).

## Why?

This helps guard against common mistakes including strong type checking for expressions (`${{...}}`), security checks, `run:` script checking, glob syntax validation, and more.

## Testing Instructions

This change only affects the workflows on GitHub Actions, there is no user-facing change to test.

You can run actionlint locally on macOS if you wish:

1. Install it with `brew install actionlint`
2. Run `actionlint` from the root of the project

## Reusable workflow

For now, this branch uses its own reusable workflow. It might be preferable to use the existing one from the wordpress-develop repo, but it looks like that will be the first instance of this outside of the Props Bot usage. Thoughts?