### PR TITLE
Social Icons Block - Add focus to social links 

### DIFF
--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -103,6 +103,11 @@
 			color: currentColor;
 			fill: currentColor;
 		}
+		&:focus {
+			outline: 2px solid #000;
+			outline-offset: 2px;
+			border-radius: 9999px;
+		}
 	}
 }
 


### PR DESCRIPTION
## What?
Currently the social icon links lack a visual indicator when the element is in focus.

## Why?
This will provide a visual indicator to the social links when a user tabs through the page.

## How?
Adds focus styles for the elements

## Testing Instructions
1 - Open a post or page
2 - Add the social icons block and include links.
3 - Test on the front end by tabbing through the page, you should now see a 2px border on the social icons.

### Testing Instructions for Keyboard
See above testing instructions, this is specific to keyboard users.

Side by Side of before and after:
<img width="109" alt="Screenshot 2025-02-10 at 5 59 37 PM" src="https://github.com/user-attachments/assets/4e54f63d-642b-4bd7-8c4b-169fd5e407bb" />
