### PR TITLE
Omit edit-only behaviors from `Iframe` in previews

### DIFF
--- a/packages/block-editor/src/components/block-canvas/index.js
+++ b/packages/block-editor/src/components/block-canvas/index.js
@@ -32,7 +32,7 @@ export function ExperimentalBlockCanvas( {
 	children = <BlockList />,
 	styles,
 	contentRef: contentRefProp,
-	iframeProps,
+	iframeProps = {},
 } ) {
 	useBlockCommands();
 	const isTabletViewport = useViewportMatch( 'medium', '<' );
@@ -40,6 +40,8 @@ export function ExperimentalBlockCanvas( {
 	const clearerRef = useBlockSelectionClearer();
 	const localRef = useRef();
 	const contentRef = useMergeRefs( [ contentRefProp, clearerRef, localRef ] );
+	const { ref: iframeRefProp, ...restIframeProps } = iframeProps;
+	const iframeRef = useMergeRefs( [ iframeRefProp, resetTypingRef ] );
 	const zoomLevel = useSelect(
 		( select ) => unlock( select( blockEditorStore ) ).getZoomLevel(),
 		[]
@@ -82,9 +84,9 @@ export function ExperimentalBlockCanvas( {
 			style={ { height, display: 'flex' } }
 		>
 			<Iframe
-				{ ...iframeProps }
+				{ ...restIframeProps }
 				{ ...zoomOutIframeProps }
-				ref={ resetTypingRef }
+				ref={ iframeRef }
 				contentRef={ contentRef }
 				style={ {
 					...iframeProps?.style,

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -274,15 +274,12 @@ function Iframe( {
 		isEditable ? clearerRef : null,
 		isEditable ? writingFlowRef : null,
 	] );
-	// The before and after focusable div elements should be output only if the
-	// writing flow behaviors are enabled (isEditable). The tabIndex condition
-	// may be useless now in core but kept as it’s been around since:
-	// https://github.com/WordPress/gutenberg/pull/28165
-	const shouldRenderFocusCaptureElements = tabIndex >= 0 || isEditable;
+	// The before and after elements are only needed if editable.
+	const [ usedBefore, usedAfter ] = isEditable ? [ before, after ] : [];
 
 	const iframe = (
 		<>
-			{ shouldRenderFocusCaptureElements && before }
+			{ usedBefore }
 			{ /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */ }
 			<iframe
 				{ ...props }
@@ -350,7 +347,7 @@ function Iframe( {
 						iframeDocument.documentElement
 					) }
 			</iframe>
-			{ shouldRenderFocusCaptureElements && after }
+			{ usedAfter }
 		</>
 	);
 

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -114,8 +114,6 @@ function Iframe( {
 	/** @type {[Document, import('react').Dispatch<Document>]} */
 	const [ iframeDocument, setIframeDocument ] = useState();
 	const [ bodyClasses, setBodyClasses ] = useState( [] );
-	const clearerRef = useBlockSelectionClearer();
-	const [ before, writingFlowRef, after ] = useWritingFlow();
 
 	const setRef = useRefEffect( ( node ) => {
 		node._load = () => {
@@ -259,14 +257,15 @@ function Iframe( {
 
 	useEffect( () => cleanup, [ cleanup ] );
 
-	const disabledRef = useDisabled( { isDisabled: ! readonly } );
+	const clearerRef = useBlockSelectionClearer();
+	const [ before, writingFlowRef, after ] = useWritingFlow();
 	const bubbleEventsRef = useBubbleEvents( iframeDocument );
 	// Avoids attaching some refs and rendering the focus capture div elements
 	// that are are only needed in edit mode.
 	const isEditable = tabIndex >= 0 && ! readonly;
 	const bodyRef = useMergeRefs( [
 		contentRef,
-		disabledRef,
+		useDisabled( { isDisabled: ! readonly } ),
 		isEditable ? bubbleEventsRef : null,
 		isEditable ? clearerRef : null,
 		isEditable ? writingFlowRef : null,

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -67,6 +67,13 @@ export function useWritingFlow() {
 				},
 				[ hasMultiSelection ]
 			),
+			useRefEffect(
+				( node ) => () => {
+					node.removeAttribute( 'tabindex' );
+					node.removeAttribute( 'contenteditable' );
+				},
+				[]
+			),
 		] ),
 		after,
 	];


### PR DESCRIPTION
## What?

This updates the `Iframe` component so that some behaviors are omitted when not needed such as in block/pattern previews and the "view" canvas in the Site editor. This includes a change in the edit-site package that was needed as a consequence.

## Why?
- It fixes #69154
- It should lessen some resource usage in block previews.

## How?
This omits writing flow, block selection clearing and event bubbling behaviors when the content is not editable.

In lieu of describing the details here I’ll put them in review comments.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
