### PR TITLE
Post Template Panel: Display popover on the left side of the sidebar

### DIFF
--- a/packages/editor/src/components/post-template/classic-theme.js
+++ b/packages/editor/src/components/post-template/classic-theme.js
@@ -16,11 +16,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { store as editorStore } from '../../store';
 import CreateNewTemplateModal from './create-new-template-modal';
 import { useAllowSwitchingTemplates } from './hooks';
-
-const POPOVER_PROPS = {
-	className: 'editor-post-template__dropdown',
-	placement: 'bottom-start',
-};
+import PostPanelRow from '../post-panel-row';
 
 function PostTemplateToggle( { isOpen, onClick } ) {
 	const templateTitle = useSelect( ( select ) => {
@@ -216,17 +212,37 @@ function PostTemplateDropdownContent( { onClose } ) {
 }
 
 function ClassicThemeControl() {
+	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
+	// Memoize popoverProps to avoid returning a new object every time.
+	const popoverProps = useMemo(
+		() => ( {
+			// Anchor the popover to the middle of the entire row so that it doesn't
+			// move around when the label changes.
+			anchor: popoverAnchor,
+			className: 'editor-post-template__dropdown',
+			placement: 'left-start',
+			offset: 36,
+			shift: true,
+		} ),
+		[ popoverAnchor ]
+	);
+
 	return (
-		<Dropdown
-			popoverProps={ POPOVER_PROPS }
-			focusOnMount
-			renderToggle={ ( { isOpen, onToggle } ) => (
-				<PostTemplateToggle isOpen={ isOpen } onClick={ onToggle } />
-			) }
-			renderContent={ ( { onClose } ) => (
-				<PostTemplateDropdownContent onClose={ onClose } />
-			) }
-		/>
+		<PostPanelRow label={ __( 'Template' ) } ref={ setPopoverAnchor }>
+			<Dropdown
+				popoverProps={ popoverProps }
+				focusOnMount
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<PostTemplateToggle
+						isOpen={ isOpen }
+						onClick={ onToggle }
+					/>
+				) }
+				renderContent={ ( { onClose } ) => (
+					<PostTemplateDropdownContent onClose={ onClose } />
+				) }
+			/>
+		</PostPanelRow>
 	);
 }
 

--- a/packages/editor/src/components/post-template/panel.js
+++ b/packages/editor/src/components/post-template/panel.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -11,7 +10,6 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '../../store';
 import ClassicThemeControl from './classic-theme';
 import BlockThemeControl from './block-theme';
-import PostPanelRow from '../post-panel-row';
 
 /**
  * Displays the template controls based on the current editor settings and user permissions.
@@ -65,19 +63,11 @@ export default function PostTemplatePanel() {
 	}, [] );
 
 	if ( ( ! isBlockTheme || ! canViewTemplates ) && isVisible ) {
-		return (
-			<PostPanelRow label={ __( 'Template' ) }>
-				<ClassicThemeControl />
-			</PostPanelRow>
-		);
+		return <ClassicThemeControl />;
 	}
 
 	if ( isBlockTheme && !! templateId ) {
-		return (
-			<PostPanelRow label={ __( 'Template' ) }>
-				<BlockThemeControl id={ templateId } />
-			</PostPanelRow>
-		);
+		return <BlockThemeControl id={ templateId } />;
 	}
 	return null;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

I noticed that in the post sidebar, only the post template popovers are positioned differently:

![image](https://github.com/user-attachments/assets/09a7d251-0ea5-41b2-86a2-54f6a8e41031)

## Why?

For consistency in popover positioning

## How?

Like many other Panel implementations, uses a `PanelRow` as an anchor ([Example](https://github.com/WordPress/gutenberg/blob/9b387c839e289c93dd6e91708202e3ab5e6f072f/packages/editor/src/components/post-status/index.js#L111-L125)).

## Testing Instructions

Check the position of the popover in both the block and classic themes.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/7f58aca2-7a3d-42af-89e1-a679ddd81fbb

