### PR TITLE
Component: Extract `getNodeText` to its own file and add unit tests

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   `useAutocomplete`: Fix autocomple UI flicker when deleting trigger prefix ([#69562](https://github.com/WordPress/gutenberg/pull/69562)).
 -   `FormTokenField`: Use `color-mix` for disabled option selection background ([#69621](https://github.com/WordPress/gutenberg/pull/69621)).
 -   `CustomSelectControl`: Fix check icon color to adapt with dark theme ([#69626](https://github.com/WordPress/gutenberg/pull/69626)).
+-   `AutoComplete`: Extracts `getNodeText` function into a separate file and adds unit tests ([#69135](https://github.com/WordPress/gutenberg/pull/69135)).
 
 ## 29.6.0 (2025-03-13)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,7 +7,7 @@
 -   `useAutocomplete`: Fix autocomple UI flicker when deleting trigger prefix ([#69562](https://github.com/WordPress/gutenberg/pull/69562)).
 -   `FormTokenField`: Use `color-mix` for disabled option selection background ([#69621](https://github.com/WordPress/gutenberg/pull/69621)).
 -   `CustomSelectControl`: Fix check icon color to adapt with dark theme ([#69626](https://github.com/WordPress/gutenberg/pull/69626)).
--   `AutoComplete`: Extracts `getNodeText` function into a separate file and adds unit tests ([#69135](https://github.com/WordPress/gutenberg/pull/69135)).
+-   `Autocomplete`: Extracts `getNodeText` function into a separate file and adds unit tests ([#69135](https://github.com/WordPress/gutenberg/pull/69135)).
 
 ## 29.6.0 (2025-03-13)
 

--- a/packages/components/src/autocomplete/index.tsx
+++ b/packages/components/src/autocomplete/index.tsx
@@ -40,35 +40,7 @@ import type {
 	UseAutocompleteProps,
 	WPCompleter,
 } from './types';
-
-const getNodeText = ( node: React.ReactNode ): string => {
-	if ( node === null ) {
-		return '';
-	}
-
-	switch ( typeof node ) {
-		case 'string':
-		case 'number':
-			return node.toString();
-			break;
-		case 'boolean':
-			return '';
-			break;
-		case 'object': {
-			if ( node instanceof Array ) {
-				return node.map( getNodeText ).join( '' );
-			}
-			if ( 'props' in node ) {
-				return getNodeText( node.props.children );
-			}
-			break;
-		}
-		default:
-			return '';
-	}
-
-	return '';
-};
+import getNodeText from '../utils/get-node-text';
 
 const EMPTY_FILTERED_OPTIONS: KeyedOption[] = [];
 

--- a/packages/components/src/utils/get-node-text.ts
+++ b/packages/components/src/utils/get-node-text.ts
@@ -7,10 +7,6 @@ const getNodeText = ( node: React.ReactNode ): string => {
 		case 'string':
 		case 'number':
 			return node.toString();
-			break;
-		case 'boolean':
-			return '';
-			break;
 		case 'object': {
 			if ( node instanceof Array ) {
 				return node.map( getNodeText ).join( '' );
@@ -18,13 +14,11 @@ const getNodeText = ( node: React.ReactNode ): string => {
 			if ( 'props' in node ) {
 				return getNodeText( node.props.children );
 			}
-			break;
+			return '';
 		}
 		default:
 			return '';
 	}
-
-	return '';
 };
 
 export default getNodeText;

--- a/packages/components/src/utils/get-node-text.ts
+++ b/packages/components/src/utils/get-node-text.ts
@@ -1,0 +1,30 @@
+const getNodeText = ( node: React.ReactNode ): string => {
+	if ( node === null ) {
+		return '';
+	}
+
+	switch ( typeof node ) {
+		case 'string':
+		case 'number':
+			return node.toString();
+			break;
+		case 'boolean':
+			return '';
+			break;
+		case 'object': {
+			if ( node instanceof Array ) {
+				return node.map( getNodeText ).join( '' );
+			}
+			if ( 'props' in node ) {
+				return getNodeText( node.props.children );
+			}
+			break;
+		}
+		default:
+			return '';
+	}
+
+	return '';
+};
+
+export default getNodeText;

--- a/packages/components/src/utils/test/get-node-text.js
+++ b/packages/components/src/utils/test/get-node-text.js
@@ -1,0 +1,37 @@
+/**
+ * Internal dependencies
+ */
+import getNodeText from '../get-node-text';
+
+describe( 'getNodeText', () => {
+	it( 'should return an empty string for null', () => {
+		expect( getNodeText( null ) ).toBe( '' );
+	} );
+
+	it( 'should return the string representation of a string node', () => {
+		expect( getNodeText( 'Hello' ) ).toBe( 'Hello' );
+	} );
+
+	it( 'should return the string representation of a number node', () => {
+		expect( getNodeText( 123 ) ).toBe( '123' );
+	} );
+
+	it( 'should return an empty string for a boolean node', () => {
+		expect( getNodeText( true ) ).toBe( '' );
+	} );
+
+	it( 'should concatenate text from an array of nodes', () => {
+		expect( getNodeText( [ 'Hello', ' ', 'World' ] ) ).toBe(
+			'Hello World'
+		);
+	} );
+
+	it( 'should return text from a React element with children', () => {
+		const element = (
+			<div>
+				Hello <span>World</span>
+			</div>
+		);
+		expect( getNodeText( element ) ).toBe( 'Hello World' );
+	} );
+} );


### PR DESCRIPTION


Related PR: https://github.com/WordPress/gutenberg/pull/54902
Related Issue: https://github.com/WordPress/gutenberg/issues/55495

## What?
Closes: #55495
Extracts `getNodeText` into its own file, adds unit tests, and refactors unused code.

## Why?
The original implementation was merged quickly to address an accessibility issue (#47767). This PR improves maintainability by isolating the function, adding tests, and removing unnecessary code.

## How?

- Moved `getNodeText` to a separate file.
- Added unit tests to verify expected behavior.
- Removed redundant or unused code from the function.

## Testing Instructions
Run the following command to execute unit tests for `getNodeText`:

```shell
npm run test:unit packages/components/src/utils/test/get-node-text.js
```


## Screenshots or screencast 

<img width="867" alt="image" src="https://github.com/user-attachments/assets/8273be99-51e9-4b59-b907-392669fd546f" />


