### PR TITLE
E2E: Add test coverage for Navigation block fallback behavior

### DIFF
--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -199,6 +199,57 @@ test.describe( 'Navigation block', () => {
 		} );
 	} );
 
+	test.describe( 'Navigation block fallback behavior', () => {
+		test( 'falls back to Page List when no menus exist', async ( {
+			admin,
+			editor,
+		} ) => {
+			await admin.createNewPost();
+			await editor.insertBlock( { name: 'core/navigation' } );
+
+			const pageListBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Page List',
+			} );
+
+			await expect( pageListBlock ).toBeVisible();
+
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/navigation',
+				},
+			] );
+		} );
+
+		test( 'uses first non-empty menu as fallback', async ( {
+			admin,
+			editor,
+			requestUtils,
+		} ) => {
+			await admin.createNewPost();
+
+			const menu = await requestUtils.createNavigationMenu( {
+				title: 'First Menu',
+				content:
+					'<!-- wp:navigation-link {"label":"First Link","type":"custom","url":"http://wordpress.org","kind":"custom"} /-->',
+			} );
+
+			await editor.insertBlock( { name: 'core/navigation' } );
+
+			await expect(
+				editor.canvas.locator(
+					`role=textbox[name="Navigation link text"i] >> text="First Link"`
+				)
+			).toBeVisible();
+
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/navigation',
+					attributes: { ref: menu.id },
+				},
+			] );
+		} );
+	} );
+
 	test.describe( 'As a user I want to create submenus using the navigation block', () => {
 		test( 'create a submenu', async ( {
 			admin,

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -200,7 +200,7 @@ test.describe( 'Navigation block', () => {
 	} );
 
 	test.describe( 'Fronted fallback behavior', () => {
-		test( 'should fall back to Page List when no menus exist', async ( {
+		test( 'should render a Page List on the frontend when no menus exist', async ( {
 			admin,
 			editor,
 			page,
@@ -208,15 +208,10 @@ test.describe( 'Navigation block', () => {
 			await admin.createNewPost();
 			await editor.insertBlock( { name: 'core/navigation' } );
 
-			await expect(
-				editor.canvas.getByRole( 'document', {
-					name: 'Block: Page List',
-				} )
-			).toBeVisible();
-
 			const postId = await editor.publishPost();
 			await page.goto( `/?p=${ postId }` );
 
+			await expect( page.locator( '.wp-block-page-list' ) ).toBeVisible();
 			await expect(
 				page.getByRole( 'link', { name: 'Cat', exact: true } )
 			).toBeVisible();
@@ -225,68 +220,6 @@ test.describe( 'Navigation block', () => {
 			).toBeVisible();
 			await expect(
 				page.getByRole( 'link', { name: 'Walrus', exact: true } )
-			).toBeVisible();
-		} );
-
-		test( 'should use first non-empty menu as fallback', async ( {
-			admin,
-			editor,
-			page,
-			requestUtils,
-		} ) => {
-			await admin.createNewPost();
-
-			await requestUtils.createNavigationMenu( {
-				title: 'Empty Menu',
-				content: '',
-			} );
-			const validMenu = await requestUtils.createNavigationMenu( {
-				title: 'Primary Menu',
-				content:
-					'<!-- wp:navigation-link {"label":"Home","url":"/"} /-->',
-			} );
-
-			await editor.insertBlock( { name: 'core/navigation' } );
-
-			await expect( editor.canvas.getByText( 'Home' ) ).toBeVisible();
-			await expect.poll( editor.getBlocks ).toMatchObject( [
-				{
-					name: 'core/navigation',
-					attributes: { ref: validMenu.id },
-				},
-			] );
-
-			const postId = await editor.publishPost();
-			await page.goto( `/?p=${ postId }` );
-			await expect(
-				page.getByRole( 'link', { name: 'Home', exact: true } )
-			).toBeVisible();
-		} );
-
-		test( 'should fall back to Page List when all menus are empty', async ( {
-			admin,
-			editor,
-		} ) => {
-			await admin.createNewPost();
-
-			await editor.insertBlock( {
-				name: 'core/navigation',
-				attributes: {},
-			} );
-
-			await expect.poll( editor.getBlocks ).toMatchObject( [
-				{
-					name: 'core/navigation',
-					attributes: expect.not.objectContaining( {
-						ref: expect.any( Number ),
-					} ),
-				},
-			] );
-
-			await expect(
-				editor.canvas.getByRole( 'document', {
-					name: 'Block: Page List',
-				} )
 			).toBeVisible();
 		} );
 	} );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -199,7 +199,7 @@ test.describe( 'Navigation block', () => {
 		} );
 	} );
 
-	test.describe( 'Navigation block fallback behavior', () => {
+	test.describe( 'Navigation block fronted fallback behavior', () => {
 		test( 'should fall back to Page List when no menus exist', async ( {
 			admin,
 			editor,
@@ -228,33 +228,39 @@ test.describe( 'Navigation block', () => {
 			).toBeVisible();
 		} );
 
-		test( 'uses first non-empty menu as fallback', async ( {
+		test( 'should use first non-empty menu as fallback', async ( {
 			admin,
 			editor,
+			page,
 			requestUtils,
 		} ) => {
 			await admin.createNewPost();
 
-			const menu = await requestUtils.createNavigationMenu( {
-				title: 'First Menu',
+			await requestUtils.createNavigationMenu( {
+				title: 'Empty Menu',
+				content: '<!-- wp:paragraph --><!-- /wp:paragraph -->',
+			} );
+			const validMenu = await requestUtils.createNavigationMenu( {
+				title: 'Primary Menu',
 				content:
-					'<!-- wp:navigation-link {"label":"First Link","type":"custom","url":"http://wordpress.org","kind":"custom"} /-->',
+					'<!-- wp:navigation-link {"label":"Home","url":"/"} /-->',
 			} );
 
 			await editor.insertBlock( { name: 'core/navigation' } );
 
-			await expect(
-				editor.canvas.locator(
-					`role=textbox[name="Navigation link text"i] >> text="First Link"`
-				)
-			).toBeVisible();
-
+			await expect( editor.canvas.getByText( 'Home' ) ).toBeVisible();
 			await expect.poll( editor.getBlocks ).toMatchObject( [
 				{
 					name: 'core/navigation',
-					attributes: { ref: menu.id },
+					attributes: { ref: validMenu.id },
 				},
 			] );
+
+			const postId = await editor.publishPost();
+			await page.goto( `/?p=${ postId }` );
+			await expect(
+				page.getByRole( 'link', { name: 'Home', exact: true } )
+			).toBeVisible();
 		} );
 	} );
 

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -200,24 +200,32 @@ test.describe( 'Navigation block', () => {
 	} );
 
 	test.describe( 'Navigation block fallback behavior', () => {
-		test( 'falls back to Page List when no menus exist', async ( {
+		test( 'should fall back to Page List when no menus exist', async ( {
 			admin,
 			editor,
+			page,
 		} ) => {
 			await admin.createNewPost();
 			await editor.insertBlock( { name: 'core/navigation' } );
 
-			const pageListBlock = editor.canvas.getByRole( 'document', {
-				name: 'Block: Page List',
-			} );
+			await expect(
+				editor.canvas.getByRole( 'document', {
+					name: 'Block: Page List',
+				} )
+			).toBeVisible();
 
-			await expect( pageListBlock ).toBeVisible();
+			const postId = await editor.publishPost();
+			await page.goto( `/?p=${ postId }` );
 
-			await expect.poll( editor.getBlocks ).toMatchObject( [
-				{
-					name: 'core/navigation',
-				},
-			] );
+			await expect(
+				page.getByRole( 'link', { name: 'Cat', exact: true } )
+			).toBeVisible();
+			await expect(
+				page.getByRole( 'link', { name: 'Dog', exact: true } )
+			).toBeVisible();
+			await expect(
+				page.getByRole( 'link', { name: 'Walrus', exact: true } )
+			).toBeVisible();
 		} );
 
 		test( 'uses first non-empty menu as fallback', async ( {

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -263,7 +263,7 @@ test.describe( 'Navigation block', () => {
 			).toBeVisible();
 		} );
 
-		test( 'should fall back to Page List when all navigation posts are empty', async ( {
+		test( 'should fall back to Page List when all menus are empty', async ( {
 			admin,
 			editor,
 		} ) => {

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -222,6 +222,44 @@ test.describe( 'Navigation block', () => {
 				page.getByRole( 'link', { name: 'Walrus', exact: true } )
 			).toBeVisible();
 		} );
+
+		test( 'should render the first non-empty menu on the frontend', async ( {
+			admin,
+			editor,
+			page,
+			requestUtils,
+		} ) => {
+			// The fallback should pick "Menu A" because it comes first alphabetically.
+			await requestUtils.createNavigationMenu( {
+				title: 'Menu B',
+				content:
+					'<!-- wp:navigation-link {"label":"Dog","url":"#dog"} /-->',
+			} );
+			await requestUtils.createNavigationMenu( {
+				title: 'Menu A',
+				content:
+					'<!-- wp:navigation-link {"label":"Cat","url":"#cat"} /-->',
+			} );
+
+			await admin.createNewPost();
+			await editor.insertBlock( { name: 'core/navigation' } );
+
+			const postId = await editor.publishPost();
+			await page.goto( `/?p=${ postId }` );
+
+			await expect(
+				page.getByRole( 'link', {
+					name: 'Cat',
+					exact: true,
+				} )
+			).toBeVisible();
+			await expect(
+				page.getByRole( 'link', {
+					name: 'Dog',
+					exact: true,
+				} )
+			).toBeHidden();
+		} );
 	} );
 
 	test.describe( 'As a user I want to create submenus using the navigation block', () => {

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -260,6 +260,37 @@ test.describe( 'Navigation block', () => {
 				} )
 			).toBeHidden();
 		} );
+
+		test( 'should skip empty menus and render the next available menu', async ( {
+			admin,
+			editor,
+			page,
+			requestUtils,
+		} ) => {
+			// The fallback should skip empty 'Menu A' and render non-empty 'Menu B'.
+			await requestUtils.createNavigationMenu( {
+				title: 'Menu A',
+				content: '',
+			} );
+			await requestUtils.createNavigationMenu( {
+				title: 'Menu B',
+				content:
+					'<!-- wp:navigation-link {"label":"Dog","url":"#dog"} /-->',
+			} );
+
+			await admin.createNewPost();
+			await editor.insertBlock( { name: 'core/navigation' } );
+
+			const postId = await editor.publishPost();
+			await page.goto( `/?p=${ postId }` );
+
+			await expect(
+				page.getByRole( 'link', {
+					name: 'Dog',
+					exact: true,
+				} )
+			).toBeVisible();
+		} );
 	} );
 
 	test.describe( 'As a user I want to create submenus using the navigation block', () => {

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -199,7 +199,7 @@ test.describe( 'Navigation block', () => {
 		} );
 	} );
 
-	test.describe( 'Navigation block fronted fallback behavior', () => {
+	test.describe( 'Fronted fallback behavior', () => {
 		test( 'should fall back to Page List when no menus exist', async ( {
 			admin,
 			editor,

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -238,7 +238,7 @@ test.describe( 'Navigation block', () => {
 
 			await requestUtils.createNavigationMenu( {
 				title: 'Empty Menu',
-				content: '<!-- wp:paragraph --><!-- /wp:paragraph -->',
+				content: '',
 			} );
 			const validMenu = await requestUtils.createNavigationMenu( {
 				title: 'Primary Menu',
@@ -260,6 +260,33 @@ test.describe( 'Navigation block', () => {
 			await page.goto( `/?p=${ postId }` );
 			await expect(
 				page.getByRole( 'link', { name: 'Home', exact: true } )
+			).toBeVisible();
+		} );
+
+		test( 'should fall back to Page List when all navigation posts are empty', async ( {
+			admin,
+			editor,
+		} ) => {
+			await admin.createNewPost();
+
+			await editor.insertBlock( {
+				name: 'core/navigation',
+				attributes: {},
+			} );
+
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/navigation',
+					attributes: expect.not.objectContaining( {
+						ref: expect.any( Number ),
+					} ),
+				},
+			] );
+
+			await expect(
+				editor.canvas.getByRole( 'document', {
+					name: 'Block: Page List',
+				} )
 			).toBeVisible();
 		} );
 	} );


### PR DESCRIPTION

## What?

Closes https://github.com/WordPress/gutenberg/issues/36825

Adds E2E test coverage for Navigation block fallback behavior, ensuring the navigation block falls back appropriately when no menus exist and uses the first non-empty menu as a fallback.

## Why?

In #36740, functionality was added to provide fallback behavior for the Navigation block, determining what users see when there are no menus or when menus become unavailable. This PR adds dedicated test coverage to ensure this new fallback behavior remains stable and works as expected.

## How?
Added two new E2E tests in the `navigation.spec.js` file:

- Tests that the block falls back to a Page List when no menus exist
- Tests that the block uses the first non-empty menu as a fallback

## Testing Instructions
- Run 
```bash
npm run test:e2e -- editor/blocks/navigation.spec.js
```
- Verify that all tests pass



To manually verify the behavior:

- Create a new post
- Insert a Navigation block with no menus present - should show Page List
- Create a menu with content and insert a Navigation block - should show menu-content

