### PR TITLE
Block Hooks: Fix duplicated insertion in Post Content

### DIFF
--- a/backport-changelog/6.8/8212.md
+++ b/backport-changelog/6.8/8212.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/8212
 
 * https://github.com/WordPress/gutenberg/pull/68926
+* https://github.com/WordPress/gutenberg/pull/69142

--- a/lib/compat/wordpress-6.8/blocks.php
+++ b/lib/compat/wordpress-6.8/blocks.php
@@ -124,8 +124,13 @@ function gutenberg_insert_hooked_blocks_into_rest_response( $response, $post ) {
 
 	return $response;
 }
+remove_filter( 'rest_prepare_page', 'insert_hooked_blocks_into_rest_response' );
 add_filter( 'rest_prepare_page', 'gutenberg_insert_hooked_blocks_into_rest_response', 10, 2 );
+
+remove_filter( 'rest_prepare_post', 'insert_hooked_blocks_into_rest_response' );
 add_filter( 'rest_prepare_post', 'gutenberg_insert_hooked_blocks_into_rest_response', 10, 2 );
+
+remove_filter( 'rest_prepare_wp_block', 'insert_hooked_blocks_into_rest_response' );
 add_filter( 'rest_prepare_wp_block', 'gutenberg_insert_hooked_blocks_into_rest_response', 10, 2 );
 
 /**

--- a/lib/compat/wordpress-6.8/blocks.php
+++ b/lib/compat/wordpress-6.8/blocks.php
@@ -77,61 +77,61 @@ if ( ! function_exists( 'apply_block_hooks_to_content_from_post_object' ) ) {
 	add_filter( 'the_content', 'apply_block_hooks_to_content_from_post_object', 8 );
 	// Remove apply_block_hooks_to_content filter (previously added in Core).
 	remove_filter( 'the_content', 'apply_block_hooks_to_content', 8 );
-}
 
-/**
- * Hooks into the REST API response for the Posts endpoint and adds the first and last inner blocks.
- *
- * @since 6.6.0
- * @since 6.8.0 Support non-`wp_navigation` post types.
- *
- * @param WP_REST_Response $response The response object.
- * @param WP_Post          $post     Post object.
- * @return WP_REST_Response The response object.
- */
-function gutenberg_insert_hooked_blocks_into_rest_response( $response, $post ) {
-	if ( empty( $response->data['content']['raw'] ) ) {
+	/**
+	 * Hooks into the REST API response for the Posts endpoint and adds the first and last inner blocks.
+	 *
+	 * @since 6.6.0
+	 * @since 6.8.0 Support non-`wp_navigation` post types.
+	 *
+	 * @param WP_REST_Response $response The response object.
+	 * @param WP_Post          $post     Post object.
+	 * @return WP_REST_Response The response object.
+	 */
+	function gutenberg_insert_hooked_blocks_into_rest_response( $response, $post ) {
+		if ( empty( $response->data['content']['raw'] ) ) {
+			return $response;
+		}
+
+		$response->data['content']['raw'] = apply_block_hooks_to_content_from_post_object(
+			$response->data['content']['raw'],
+			$post,
+			'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata'
+		);
+
+		// If the rendered content was previously empty, we leave it like that.
+		if ( empty( $response->data['content']['rendered'] ) ) {
+			return $response;
+		}
+
+		// No need to inject hooked blocks twice.
+		$priority = has_filter( 'the_content', 'apply_block_hooks_to_content_from_post_object' );
+		if ( false !== $priority ) {
+			remove_filter( 'the_content', 'apply_block_hooks_to_content_from_post_object', $priority );
+		}
+
+		/** This filter is documented in wp-includes/post-template.php */
+		$response->data['content']['rendered'] = apply_filters(
+			'the_content',
+			$response->data['content']['raw']
+		);
+
+		// Add back the filter.
+		if ( false !== $priority ) {
+			add_filter( 'the_content', 'apply_block_hooks_to_content_from_post_object', $priority );
+		}
+
 		return $response;
 	}
+	remove_filter( 'rest_prepare_page', 'insert_hooked_blocks_into_rest_response' );
+	add_filter( 'rest_prepare_page', 'gutenberg_insert_hooked_blocks_into_rest_response', 10, 2 );
 
-	$response->data['content']['raw'] = apply_block_hooks_to_content_from_post_object(
-		$response->data['content']['raw'],
-		$post,
-		'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata'
-	);
+	remove_filter( 'rest_prepare_post', 'insert_hooked_blocks_into_rest_response' );
+	add_filter( 'rest_prepare_post', 'gutenberg_insert_hooked_blocks_into_rest_response', 10, 2 );
 
-	// If the rendered content was previously empty, we leave it like that.
-	if ( empty( $response->data['content']['rendered'] ) ) {
-		return $response;
-	}
-
-	// No need to inject hooked blocks twice.
-	$priority = has_filter( 'the_content', 'apply_block_hooks_to_content_from_post_object' );
-	if ( false !== $priority ) {
-		remove_filter( 'the_content', 'apply_block_hooks_to_content_from_post_object', $priority );
-	}
-
-	/** This filter is documented in wp-includes/post-template.php */
-	$response->data['content']['rendered'] = apply_filters(
-		'the_content',
-		$response->data['content']['raw']
-	);
-
-	// Add back the filter.
-	if ( false !== $priority ) {
-		add_filter( 'the_content', 'apply_block_hooks_to_content_from_post_object', $priority );
-	}
-
-	return $response;
+	remove_filter( 'rest_prepare_wp_block', 'insert_hooked_blocks_into_rest_response' );
+	add_filter( 'rest_prepare_wp_block', 'gutenberg_insert_hooked_blocks_into_rest_response', 10, 2 );
 }
-remove_filter( 'rest_prepare_page', 'insert_hooked_blocks_into_rest_response' );
-add_filter( 'rest_prepare_page', 'gutenberg_insert_hooked_blocks_into_rest_response', 10, 2 );
-
-remove_filter( 'rest_prepare_post', 'insert_hooked_blocks_into_rest_response' );
-add_filter( 'rest_prepare_post', 'gutenberg_insert_hooked_blocks_into_rest_response', 10, 2 );
-
-remove_filter( 'rest_prepare_wp_block', 'insert_hooked_blocks_into_rest_response' );
-add_filter( 'rest_prepare_wp_block', 'gutenberg_insert_hooked_blocks_into_rest_response', 10, 2 );
 
 /**
  * Updates the wp_postmeta with the list of ignored hooked blocks


### PR DESCRIPTION
## What?

In the editor, hooked blocks are currently inserted twice into post content (when using the GB plugin on a WP `trunk` install).
This was likely introduced by https://github.com/WordPress/gutenberg/pull/67272 and its Core counterpart, [`[59523]`](https://core.trac.wordpress.org/changeset/59523). It was probably not discovered earlier as it requires testing GB against Core `trunk`.

Likely also affects Synced Patterns (https://github.com/WordPress/gutenberg/pull/68058 and [`[59543]`](https://core.trac.wordpress.org/changeset/59543)), which are also fixed by this PR.

Discovered while working on https://github.com/WordPress/gutenberg/pull/69044, which is adding e2e test coverage for this exact scenario (and others).

## Why?
It's a bug 🤷‍♂️ 

## How?
By removing the `insert_hooked_blocks_into_rest_response` filter before adding GB's own version, `gutenberg_insert_hooked_blocks_into_rest_response`.

## Testing Instructions
This is covered by end-to-end tests introduced by https://github.com/WordPress/gutenberg/pull/69044. Follow that PR's instructions to run tests locally, and cherry-pick the commit from this PR on top to verify that it fixes the issue.

