### PR TITLE
Fix Dependabot ignore statements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,13 +13,9 @@ updates:
           - '[Type] Build Tooling'
       ignore:
           - dependency-name: 'actions/setup-java'
-            versions: ['*']
           - dependency-name: 'gradle/*'
-            versions: ['*']
           - dependency-name: 'reactivecircus/*'
-            versions: ['*']
           - dependency-name: 'ruby/setup-ruby'
-            versions: ['*']
       groups:
           github-actions:
               patterns:


### PR DESCRIPTION
## What?
The `dependabot.yml` file does not support `*` for a version in `ignore` statements. Omitting the `version` all together properly ignores all versions.

Follow up to #69118 and #69122.

## Testing Instructions
I've confirmed this works as expected on my fork.