### PR TITLE
Changed Inline Documentation Order

### DIFF
--- a/packages/i18n/src/sprintf.js
+++ b/packages/i18n/src/sprintf.js
@@ -17,10 +17,10 @@ const logErrorOnce = memoize( console.error ); // eslint-disable-line no-console
  * Returns a formatted string. If an error occurs in applying the format, the
  * original format string is returned.
  *
+ * @see https://www.npmjs.com/package/sprintf-js
+ *
  * @param {string} format The format of the string to generate.
  * @param {...*}   args   Arguments to apply to the format.
- *
- * @see https://www.npmjs.com/package/sprintf-js
  *
  * @return {string} The formatted string.
  */

--- a/packages/token-list/src/index.ts
+++ b/packages/token-list/src/index.ts
@@ -200,8 +200,9 @@ export default class TokenList {
 	 *
 	 * Always returns `true` in this implementation.
 	 *
-	 * @param _token
 	 * @see https://dom.spec.whatwg.org/#dom-domtokenlist-supports
+	 *
+	 * @param _token
 	 *
 	 * @return Whether token is supported.
 	 */

--- a/packages/widgets/src/index.js
+++ b/packages/widgets/src/index.js
@@ -18,8 +18,9 @@ export * from './utils';
  * Note that for the block to be useful, any scripts required by a widget must
  * be loaded into the page.
  *
- * @param {Object} supports Block support settings.
  * @see https://developer.wordpress.org/block-editor/how-to-guides/widgets/legacy-widget-block/
+ *
+ * @param {Object} supports Block support settings.
  */
 export function registerLegacyWidgetBlock( supports = {} ) {
 	const { metadata, settings, name } = legacyWidget;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
- Changed Inline Documentation Order in below files.
  1. packages/i18n/src/sprintf.js
  2. packages/token-list/src/index.ts
  3. packages/widgets/src/index.js

## How?
- Changed Inline Documentation Order (Added `@see` tag before `@param` tag)

## Testing Instructions
1. Open Mentioned Files
2.  See Inline Documentation Order
