### PR TITLE
Monitor workflow files in non-default locations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,9 @@ version: 2
 updates:
     # Check for updates to GitHub Actions.
     - package-ecosystem: 'github-actions'
-      directory: '/'
+      directories:
+          - '.github/workflows'
+          - '.github/setup-node'
       schedule:
           interval: 'daily'
       open-pull-requests-limit: 10


### PR DESCRIPTION
## What?
In addition to the default `.github/workflows` directory for GitHub Actions workflows, the repo also has a `setup-node` folder containing a composite action. This is not currently monitored by Dependabot for updates.

There are several updates to 3rd party actions in this composite action that are needed to avoid problems as a result of upstream changes. This updates the Dependabot configuration to also monitor this directory.