### PR TITLE
Core Data: add type for term entity

### DIFF
--- a/packages/core-data/src/dynamic-entities.ts
+++ b/packages/core-data/src/dynamic-entities.ts
@@ -18,6 +18,7 @@ export type WPEntityTypes< C extends ET.Context = 'edit' > = {
 	Site: ET.Settings< C >;
 	Status: ET.PostStatusObject< C >;
 	Taxonomy: ET.Taxonomy< C >;
+	Term: ET.Term< C >;
 	Theme: ET.Theme< C >;
 	UnstableBase: ET.UnstableBase< C >;
 	User: ET.User< C >;

--- a/packages/core-data/src/entity-types/index.ts
+++ b/packages/core-data/src/entity-types/index.ts
@@ -17,6 +17,7 @@ import type { PostRevision } from './post-revision';
 import type { Settings } from './settings';
 import type { Sidebar } from './sidebar';
 import type { Taxonomy } from './taxonomy';
+import type { Term } from './term';
 import type { Theme } from './theme';
 import type { User } from './user';
 import type { Type } from './type';
@@ -46,6 +47,7 @@ export type {
 	Taxonomy,
 	TemplatePartArea,
 	TemplateType,
+	Term,
 	Theme,
 	Type,
 	Updatable,
@@ -105,6 +107,7 @@ export interface PerPackageEntityRecords< C extends Context > {
 		| Settings< C >
 		| Sidebar< C >
 		| Taxonomy< C >
+		| Term< C >
 		| Theme< C >
 		| User< C >
 		| Type< C >

--- a/packages/core-data/src/entity-types/term.ts
+++ b/packages/core-data/src/entity-types/term.ts
@@ -1,0 +1,57 @@
+/**
+ * Internal dependencies
+ */
+import type { Context, ContextualField, OmitNevers } from './helpers';
+
+import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';
+
+declare module './base-entity-records' {
+	export namespace BaseEntityRecords {
+		export interface Term< C extends Context > {
+			/**
+			 * Unique identifier for the term.
+			 */
+			id: number;
+			/**
+			 * Number of published posts for the term.
+			 */
+			count: ContextualField< number, 'view' | 'edit', C >;
+			/**
+			 * HTML description of the term.
+			 */
+			description: ContextualField< string, 'view' | 'edit', C >;
+			/**
+			 * URL of the term.
+			 */
+			link: string;
+			/**
+			 * HTML title for the term.
+			 */
+			name: string;
+			/**
+			 * An alphanumeric identifier for the term unique to its type.
+			 */
+			slug: string;
+			/**
+			 * Type attribution for the term.
+			 */
+			taxonomy: string;
+			/**
+			 * The parent term ID. Only present for hierarchical taxonomies.
+			 */
+			parent?: number;
+			/**
+			 * Meta fields.
+			 */
+			meta: ContextualField<
+				Record< string, string >,
+				'view' | 'edit',
+				C
+			>;
+		}
+	}
+}
+
+export type Term< C extends Context = 'edit' > = OmitNevers<
+	_BaseEntityRecords.Term< C >
+>;


### PR DESCRIPTION
## What?

Follow-up to #67668, makes it easy to use proper types when doing something like `wp.data.select('core').getEntityRecords('taxonomy', 'category')`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See above

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding types

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

n/a

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

n/a

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

n/a