### PR TITLE
Spacing-Visualizer: Handle undefined blockElement

### DIFF
--- a/packages/block-editor/src/hooks/spacing-visualizer.js
+++ b/packages/block-editor/src/hooks/spacing-visualizer.js
@@ -18,9 +18,12 @@ import { useBlockElement } from '../components/block-list/use-block-props/use-bl
 
 function SpacingVisualizer( { clientId, value, computeStyle, forceShow } ) {
 	const blockElement = useBlockElement( clientId );
-	const [ style, updateStyle ] = useReducer( () =>
-		computeStyle( blockElement )
-	);
+	const [ style, updateStyle ] = useReducer( ( state ) => {
+		if ( ! blockElement ) {
+			return state;
+		}
+		return computeStyle( blockElement );
+	} );
 
 	useLayoutEffect( () => {
 		if ( ! blockElement ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->https://github.com/Automattic/jetpack/issues/39417

<!-- In a few words, what is the PR actually doing? -->
When creating the `core/video` block transformed from another block, e.g. `videopress/video`, the `blockElement` could not be created yet, so it is `undefined`. This code prevents an error, handing the `undefined` scenario.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
There is an error when transforming from the VideoPress block to the video block and the error block is displayed with the message:
```
This block has encountered an error and cannot be previewed.
```
And the corresponding Javascript error in the console:
```
spacing-visualizer.js:84 Uncaught TypeError: Cannot read properties of undefined (reading 'ownerDocument')
    at getComputedCSS (spacing-visualizer.js:84:17)
    at computeStyle (spacing-visualizer.js:95:17)
    at spacing-visualizer.js:31:10
    at updateReducer (react-dom.js?ver=18:15855:24)
    at Object.useReducer (react-dom.js?ver=18:17089:18)
    at useReducer (react.js?ver=18:1616:23)
    at SpacingVisualizer (spacing-visualizer.js:21:43)
    at renderWithHooks (react-dom.js?ver=18:15496:20)
    at updateFunctionComponent (react-dom.js?ver=18:19627:22)
    at beginWork (react-dom.js?ver=18:21650:18)
```


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The code returns the passed `state` in the `useReducer` when the `blockElement` is undefined, keeping the previous state.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. In a Jetpack connected site
2. Install VideoPress plugin
3. Add a post and add a video using the VideoPress block
4. Transform the VideoPress block to a core video block
5. An error message block is displayed

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before video
https://github.com/user-attachments/assets/20528a51-c40d-4cc7-92aa-ede1583cc6c3

### After video

https://github.com/user-attachments/assets/92246737-d253-4d8e-b3cf-dbd9c888f791


