### PR TITLE
Site Hub: Navigate correctly in mobile view

### DIFF
--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -28,8 +28,8 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { store as editSiteStore } from '../../store';
 import SiteIcon from '../site-icon';
 import { unlock } from '../../lock-unlock';
-const { useHistory } = unlock( routerPrivateApis );
 import { SidebarNavigationContext } from '../sidebar';
+const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 const SiteHub = memo(
 	forwardRef( ( { isTransparent }, ref ) => {
@@ -117,29 +117,25 @@ export default SiteHub;
 
 export const SiteHubMobile = memo(
 	forwardRef( ( { isTransparent }, ref ) => {
+		const { path } = useLocation();
 		const history = useHistory();
 		const { navigate } = useContext( SidebarNavigationContext );
 
-		const { dashboardLink, isBlockTheme, homeUrl, siteTitle } = useSelect(
-			( select ) => {
-				const { getSettings } = unlock( select( editSiteStore ) );
-
-				const { getEntityRecord, getCurrentTheme } =
-					select( coreStore );
-				const _site = getEntityRecord( 'root', 'site' );
-				return {
-					dashboardLink: getSettings().__experimentalDashboardLink,
-					isBlockTheme: getCurrentTheme()?.is_block_theme,
-					homeUrl: getEntityRecord( 'root', '__unstableBase' )?.home,
-					siteTitle:
-						! _site?.title && !! _site?.url
-							? filterURLForDisplay( _site?.url )
-							: _site?.title,
-				};
-			},
-			[]
-		);
+		const { dashboardLink, homeUrl, siteTitle } = useSelect( ( select ) => {
+			const { getSettings } = unlock( select( editSiteStore ) );
+			const { getEntityRecord } = select( coreStore );
+			const _site = getEntityRecord( 'root', 'site' );
+			return {
+				dashboardLink: getSettings().__experimentalDashboardLink,
+				homeUrl: getEntityRecord( 'root', '__unstableBase' )?.home,
+				siteTitle:
+					! _site?.title && !! _site?.url
+						? filterURLForDisplay( _site?.url )
+						: _site?.title,
+			};
+		}, [] );
 		const { open: openCommandCenter } = useDispatch( commandsStore );
+		const isRoot = path === '/';
 
 		return (
 			<div className="edit-site-site-hub">
@@ -160,7 +156,7 @@ export const SiteHubMobile = memo(
 								transform: 'scale(0.5)',
 								borderRadius: 4,
 							} }
-							{ ...( ! isBlockTheme
+							{ ...( isRoot
 								? {
 										href: dashboardLink,
 										label: __( 'Go to the Dashboard' ),


### PR DESCRIPTION
## What?
Closes #69155

This PR fixes the site hub so that it points to the correct navigation destination in mobile view.

## Why?

As mentioned in #69155, the following two problems have occurred:

- Block Theme: On the Design menu, the site hub does nothing when clicked, and is mislabeled
- Classic Theme: Can't return to the root Design menu from the Style/Patterns menu

## How?

Regardless of theme type, check if the current path is a root.

- If the path is a root, the site hub icon will act as a link back to the dashboard.
- If the path is not a root, the site hub icon will act as a button to go back to the Design menu.

## Testing Instructions

In the mobile view, test the following navigation:

### Block Theme

- Appearance > Editor >Design menu >  Styles menu
- Click the site hub button
- Make sure you return to the Design menu
- Click the site hub button again 
- Make sure you return to the dashboard

### Classic Theme

- Appearance > Design >Patterns menu
- Click the site hub button
- Make sure you return to the Design menu
- Click the site hub button again 
- Make sure you return to the dashboard
