### PR TITLE
Inserter: Hide drag-and-drop help text on mobile devices when previewing patterns

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -644,5 +644,10 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-tabbed-sidebar__tabpanel .block-editor-inserter__help-text {
+	display: none;
 	padding: 0 $grid-unit-30 $grid-unit-20;
+
+	@include break-mobile {
+		display: block;
+	}
 }


### PR DESCRIPTION
## What, Why and How?
Closes #69158 

This PR hides the Drag and Drop helper text on the Patterns Preview page in the Global Inserter for mobile devices, as the text is not actionable or relevant on smaller screens.

The `display: none` property is used to hide the helper text on mobile breakpoints.

## Testing Instructions

1. Navigate to the post/page edit page.
2. Toggle the Global Inserter.
3. Navigate to the patterns tab.
4. Confirm the helper text on mobile devices is not visible.

## Screenshots

|Before|After|
|-|-|
|![bug](https://github.com/user-attachments/assets/542f87bb-6da1-4147-9369-9c971203b2b6)|![pr](https://github.com/user-attachments/assets/46b17e02-d56d-442a-9524-3b83211948ec)|

