### PR TITLE
Editor: Conditionally enable the new default rendering mode for Pages

### DIFF
--- a/backport-changelog/6.8/8123.md
+++ b/backport-changelog/6.8/8123.md
@@ -2,3 +2,4 @@ https://github.com/WordPress/wordpress-develop/pull/8123
 
 * https://github.com/WordPress/gutenberg/pull/68549
 * https://github.com/WordPress/gutenberg/pull/68745
+* https://github.com/WordPress/gutenberg/pull/69160

--- a/lib/compat/wordpress-6.8/post.php
+++ b/lib/compat/wordpress-6.8/post.php
@@ -4,23 +4,16 @@
  * Set the default editor mode for the page post type to `template-locked`.
  *
  * Note: This backports into `create_initial_post_types` in WordPress Core.
- *
- * @param array $args Array of post type arguments.
- * @return array Updated array of post type arguments.
  */
-function gutenberg_update_page_editor_support( $args ) {
-	if ( empty( $args['supports'] ) ) {
-		return $args;
+function gutenberg_update_page_editor_support() {
+	// Avoid enabling the editor for pages when it's not supported.
+	// This is plugin specific safeguard.
+	if ( ! post_type_supports( 'page', 'editor' ) ) {
+		return;
 	}
 
-	$editor_support_key = array_search( 'editor', $args['supports'], true );
-	if ( false !== $editor_support_key ) {
-		unset( $args['supports'][ $editor_support_key ] );
-		$args['supports']['editor'] = array(
-			'default-mode' => 'template-locked',
-		);
+	if ( wp_is_block_theme() ) {
+		add_post_type_support( 'page', 'editor', array( 'default-mode' => 'template-locked' ) );
 	}
-
-	return $args;
 }
-add_action( 'register_page_post_type_args', 'gutenberg_update_page_editor_support' );
+add_action( 'init', 'gutenberg_update_page_editor_support' );


### PR DESCRIPTION
## What?
Part of #68684.

PR updates logic to enable a new default mode for pages and only enables it for block-based themes.

## Why?
* The users get the most out of this rendering mode when using block themes.
* It will eventually work for hybrid themes, but there are some known issues that I'm not sure we can resolve for WP 6.8 (but I'll try my best). See https://github.com/WordPress/gutenberg/issues/64341.
* This is also the original direction, which got lost during refactorings. See https://github.com/WordPress/gutenberg/pull/62304.

See: https://github.com/WordPress/wordpress-develop/pull/8123#issuecomment-2650756927

## Testing Instructions
Using a block theme.

1. Open a page.
2. Confirm that it loads with a template-locked view.
3. Doesn't change the current behavior.

Using a hybrid theme.

1. Open a page.
2. Create a block-based template for it and save it.
3. Confirm that it doesn't load with a template-locked view

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="1449" alt="Screenshot 2025-02-12 at 18 02 37" src="https://github.com/user-attachments/assets/049c7252-c33e-489b-98ce-5315f289326e" />

