### PR TITLE
Fix: Font loading/unloading fails in Code Editor

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-families.js
+++ b/packages/edit-site/src/components/global-styles/font-families.js
@@ -12,6 +12,8 @@ import {
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { settings } from '@wordpress/icons';
 import { useContext } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -49,6 +51,7 @@ function FontFamilies() {
 		undefined,
 		'base'
 	);
+	const { switchEditorMode } = useDispatch( editorStore );
 	const themeFonts = mapFontsWithSource( fontFamilies?.theme, 'theme' );
 	const customFonts = mapFontsWithSource( fontFamilies?.custom, 'custom' );
 	const activeFonts = [ ...themeFonts, ...customFonts ].sort( ( a, b ) =>
@@ -73,7 +76,10 @@ function FontFamilies() {
 				<HStack justify="space-between">
 					<Subtitle level={ 3 }>{ __( 'Fonts' ) }</Subtitle>
 					<Button
-						onClick={ () => setModalTabOpen( 'installed-fonts' ) }
+						onClick={ () => {
+							switchEditorMode( 'visual' );
+							setModalTabOpen( 'installed-fonts' );
+						} }
 						label={ __( 'Manage fonts' ) }
 						icon={ settings }
 						size="small"
@@ -103,6 +109,7 @@ function FontFamilies() {
 							variant="secondary"
 							__next40pxDefaultSize
 							onClick={ () => {
+								switchEditorMode( 'visual' );
 								setModalTabOpen(
 									hasInstalledFonts
 										? 'installed-fonts'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
- Resolves https://github.com/WordPress/gutenberg/issues/69139
- Font loading/unloading fails in the `Code Editor` mode.

## Why?
- The font library updates fonts via the fonts property of the root document and iframe document when loading and unloading fonts. However, if the editor mode is switched to the code editor, font updates fail because the iframe document does not exist. 

## How?
- Switches to the `Visual Mode` when the user clicks on the button to open the font library. Since showing the `Visual Mode` when managing fonts makes more sense from the users POV.

## Testing Instructions
1. Visit the site editor.
2. Open a template.
3. Switch to the code editor.
4. Open the font library.
5. Attempt to upload a font.


## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/221d6352-1e50-42b2-8d5c-06b7d2ce2f7c

