### PR TITLE
Fix Syntax Issue in Documentation

### DIFF
--- a/packages/interactivity-router/README.md
+++ b/packages/interactivity-router/README.md
@@ -80,7 +80,7 @@ Example:
      <li><a href="/post-2">Post 2</a></li>
      <li><a href="/post-3">Post 3</a></li>
   </ul>
-  <a data-wp-on--click="actions.navigate" href="/page/2">
+  <a data-wp-on--click="actions.navigate" href="/page/2">Page 2</a>
 </div>
 ```
 


### PR DESCRIPTION
Refreshed https://github.com/WordPress/gutenberg/pull/66059 with Latest Trunk.

Added link text and closing `</a>` anchor in HTML example line: 83

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Added closing `</a>` tag


## How?

before:

```html
<div data-wp-interactive="myblock" data-wp-router-region="main-list">
  <ul>
     <li><a href="/post-1">Post 1</a></li>
     <li><a href="/post-2">Post 2</a></li>
     <li><a href="/post-3">Post 3</a></li>
  </ul>
  <a data-wp-on--click="actions.navigate" href="/page/2">
</div>
```
after:

```html
<div data-wp-interactive="myblock" data-wp-router-region="main-list">
  <ul>
     <li><a href="/post-1">Post 1</a></li>
     <li><a href="/post-2">Post 2</a></li>
     <li><a href="/post-3">Post 3</a></li>
  </ul>
  <a data-wp-on--click="actions.navigate" href="/page/2">Page 2</a>
</div>
```
