### PR TITLE
Fix typo incorrect article before "user interface"

### DIFF
--- a/docs/how-to-guides/themes/global-settings-and-styles.md
+++ b/docs/how-to-guides/themes/global-settings-and-styles.md
@@ -111,7 +111,7 @@ body {
 
 ## Specification
 
-This specification is the same for the three different origins that use this format: core, themes, and users. Themes can override core's defaults by creating a file called `theme.json`. Users, via the site editor, will also be able to override theme's or core's preferences via an user interface that is being worked on.
+This specification is the same for the three different origins that use this format: core, themes, and users. Themes can override core's defaults by creating a file called `theme.json`. Users, via the site editor, will also be able to override theme's or core's preferences via a user interface that is being worked on.
 
 ```json
 {


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/69167

## Why?
The phrase "an user interface" is grammatically incorrect because "user" starts with a consonant sound, which requires the article "a" instead of "an". This small fix improves the clarity of the documentation.

## How?
Updated the documentation by replacing "an user interface" with "a user interface".

## Testing Instructions
Review the updated documentation text.
Confirm that the grammar is now correct.
