### PR TITLE
Site editor: obviate sidebar context

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-item/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-item/index.js
@@ -14,13 +14,12 @@ import {
 import { isRTL } from '@wordpress/i18n';
 import { chevronRightSmall, chevronLeftSmall, Icon } from '@wordpress/icons';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
-import { useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
-import { SidebarNavigationContext } from '../sidebar';
+import { useNavStep } from '../sidebar';
 
 const { useHistory, useLink } = unlock( routerPrivateApis );
 
@@ -36,16 +35,14 @@ export default function SidebarNavigationItem( {
 	...props
 } ) {
 	const history = useHistory();
-	const { navigate } = useContext( SidebarNavigationContext );
+	const navStep = useNavStep( 'forward', !! uid && `[id="${ uid }"]` );
 	// If there is no custom click handler, create one that navigates to `params`.
 	function handleClick( e ) {
 		if ( onClick ) {
 			onClick( e );
-			navigate( 'forward' );
 		} else if ( to ) {
 			e.preventDefault();
-			history.navigate( to );
-			navigate( 'forward', `[id="${ uid }"]` );
+			history.navigate( to, { state: navStep } );
 		}
 	}
 	const linkProps = useLink( to );

--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -16,7 +16,6 @@ import { chevronRight, chevronLeft } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
-import { useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -28,7 +27,7 @@ import {
 	isPreviewingTheme,
 	currentlyPreviewingTheme,
 } from '../../utils/is-previewing-theme';
-import { SidebarNavigationContext } from '../sidebar';
+import { useNavStep } from '../sidebar';
 
 const { useHistory, useLocation } = unlock( routerPrivateApis );
 
@@ -61,8 +60,8 @@ export default function SidebarNavigationScreen( {
 	);
 	const location = useLocation();
 	const history = useHistory();
-	const { navigate } = useContext( SidebarNavigationContext );
 	const backPath = backPathProp ?? location.state?.backPath;
+	const navStep = useNavStep( 'back' );
 	const icon = isRTL() ? chevronRight : chevronLeft;
 
 	return (
@@ -82,8 +81,9 @@ export default function SidebarNavigationScreen( {
 					{ ! isRoot && (
 						<SidebarButton
 							onClick={ () => {
-								history.navigate( backPath );
-								navigate( 'back' );
+								history.navigate( backPath, {
+									state: navStep,
+								} );
 							} }
 							icon={ icon }
 							label={ __( 'Back' ) }

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -17,13 +17,13 @@ import { unlock } from '../../lock-unlock';
 
 const { useLocation } = unlock( routerPrivateApis );
 
-// Focus a sidebar element after a navigation. The element to focus is either
+// Focus an element after a navigation. The element to focus is either
 // specified by `focusSelector` (when navigating back) or it is the first
-// tabbable element (usually the "Back" button).
+// tabbable element in the sidebar (usually the "Back" button).
 function focusSidebarElement( el, direction, focusSelector ) {
 	let elementToFocus;
 	if ( direction === 'back' && focusSelector ) {
-		elementToFocus = el.querySelector( focusSelector );
+		elementToFocus = el.ownerDocument.querySelector( focusSelector );
 	}
 	if ( direction !== null && ! elementToFocus ) {
 		const [ firstTabbable ] = focus.tabbable.find( el );

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -15,7 +15,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
-import { memo, forwardRef, useContext } from '@wordpress/element';
+import { memo, forwardRef } from '@wordpress/element';
 import { search } from '@wordpress/icons';
 import { store as commandsStore } from '@wordpress/commands';
 import { displayShortcut } from '@wordpress/keycodes';
@@ -28,8 +28,9 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { store as editSiteStore } from '../../store';
 import SiteIcon from '../site-icon';
 import { unlock } from '../../lock-unlock';
+import { useNavStep } from '../sidebar';
+
 const { useHistory } = unlock( routerPrivateApis );
-import { SidebarNavigationContext } from '../sidebar';
 
 const SiteHub = memo(
 	forwardRef( ( { isTransparent }, ref ) => {
@@ -118,7 +119,7 @@ export default SiteHub;
 export const SiteHubMobile = memo(
 	forwardRef( ( { isTransparent }, ref ) => {
 		const history = useHistory();
-		const { navigate } = useContext( SidebarNavigationContext );
+		const navStep = useNavStep( 'back' );
 
 		const { dashboardLink, isBlockTheme, homeUrl, siteTitle } = useSelect(
 			( select ) => {
@@ -167,8 +168,9 @@ export const SiteHubMobile = memo(
 								  }
 								: {
 										onClick: () => {
-											history.navigate( '/' );
-											navigate( 'back' );
+											history.navigate( '/', {
+												state: navStep,
+											} );
 										},
 										label: __( 'Go to Site Editor' ),
 								  } ) }


### PR DESCRIPTION
## What?

The moves some state into the router so that it can be accessed without a context provider.

## Why?

This should facilitate fixing some style issues and improving the markup in the site editor by getting rid of the need for components that rely on this state having to be nested within the sidebar.

Closes #68929 

## How?
Moves the state from the sidebar and its context provider to the router. A new helper hook is introduced and used in place of the `navigate` function that was provided by the sidebar context.

Right now this is based on #69103 because it does a similar thing and includes a change needed here too (exposing the router’s location.state through the `useLocation` hook.).


## Testing Instructions

### Maintained functionality of trunk (non-mobile-sized viewports)
These are keyboard instructions because otherwise focus rings aren’t visible.
1. Open the Site editor in viewport (>= 783px)
2. Tab to a sidebar item with a sub menu (Navigation, Pages, Templates, Patterns).
3. Press space or enter to navigate
4. Note the back button is focused
5. Press space or enter to navigate back
6. Note the menu item you had previously navigated to is focused
7. Repeat step 3 through 6 for all items with sub menus

### As a fix for #68929

1. Open the site editor in a narrow viewport (< 783px).
2. Navigate to the sub menu of one of the sidebar items.
3. Verify no console errors are logged.

### Bonus fix for mobile size viewports

Right now, the sidebar focus management fails in mobile sized viewports. I’ll get back to this later…

1. Open the site editor in a narrow viewport (< 783px).
2. …