### PR TITLE
Editor: Avoid a 'flash' when rendering in 'template-locked' mode

### DIFF
--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -204,15 +204,14 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 				const hasDefaultMode = RENDERING_MODES.includes( _defaultMode );
 
 				// Wait for template resolution when rendering in a `template-locked` mode.
-				const canRenderDefaultMode =
-					_defaultMode === 'template-locked' ? hasTemplate : true;
+				const hasResolvedMode =
+					hasLoadedPostObject && _defaultMode === 'template-locked'
+						? hasTemplate
+						: true;
 
 				return {
 					editorSettings: getEditorSettings(),
-					isReady:
-						__unstableIsEditorReady() &&
-						hasLoadedPostObject &&
-						canRenderDefaultMode,
+					isReady: __unstableIsEditorReady() && hasResolvedMode,
 					mode: getRenderingMode(),
 					defaultMode: hasDefaultMode ? _defaultMode : 'post-only',
 					selection: getEditorSelection(),

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -203,14 +203,18 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					: undefined;
 				const hasDefaultMode = RENDERING_MODES.includes( _defaultMode );
 
+				// Wait for template resolution when rendering in a `template-locked` mode.
+				const canRenderDefaultMode =
+					_defaultMode === 'template-locked' ? hasTemplate : true;
+
 				return {
 					editorSettings: getEditorSettings(),
-					isReady: __unstableIsEditorReady() && hasLoadedPostObject,
+					isReady:
+						__unstableIsEditorReady() &&
+						hasLoadedPostObject &&
+						canRenderDefaultMode,
 					mode: getRenderingMode(),
-					defaultMode:
-						hasTemplate && hasDefaultMode
-							? _defaultMode
-							: 'post-only',
+					defaultMode: hasDefaultMode ? _defaultMode : 'post-only',
 					selection: getEditorSelection(),
 					postTypeEntities:
 						post.type === 'wp_template'


### PR DESCRIPTION
## What?
Closes #69088.
Requires #69106.

PR tries to fix the editor rendering mode "flash" by delaying rendering until the page template resolves when the default rendering mode is `template-locked`.

## Why?
See: #69088.

## Todos

- [ ] Test cases when a block theme can't resolve a template. Example: block theme uses a PHP template for a specific page.
- [x] Check if we need to account for cases when the block theme doesn't support block templates. I think it's a really odd cases, but we've had reports. See #67875.

## Testing Instructions
1. Using a block theme, open a page in the editor.
2. Confirm that the editor starts rendering in template-locked mode.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
