### PR TITLE
Media Utils: Restrict file uploads with `multiple` prop in `uploadMedia` and `mediaUpload`

### DIFF
--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -313,12 +313,6 @@ function BackgroundImageControls( {
 
 	// Drag and drop callback, restricting image to one.
 	const onFilesDrop = ( filesList ) => {
-		if ( filesList?.length > 1 ) {
-			onUploadError(
-				__( 'Only one image can be used as a background image.' )
-			);
-			return;
-		}
 		getSettings().mediaUpload( {
 			allowedTypes: [ IMAGE_BACKGROUND_TYPE ],
 			filesList,
@@ -326,6 +320,7 @@ function BackgroundImageControls( {
 				onSelectMedia( image );
 			},
 			onError: onUploadError,
+			multiple: false,
 		} );
 	};
 

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -227,6 +227,7 @@ export function MediaPlaceholder( {
 			filesList: files,
 			onFileChange: setMedia,
 			onError,
+			multiple,
 		} );
 	};
 

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -499,11 +499,6 @@ export default function LogoEdit( {
 	};
 
 	const onFilesDrop = ( filesList ) => {
-		if ( filesList?.length > 1 ) {
-			onUploadError( __( 'Only one image can be used as a site logo.' ) );
-			return;
-		}
-
 		getSettings().mediaUpload( {
 			allowedTypes: ALLOWED_MEDIA_TYPES,
 			filesList,
@@ -515,6 +510,7 @@ export default function LogoEdit( {
 				onInitialSelectLogo( image );
 			},
 			onError: onUploadError,
+			multiple: false,
 		} );
 	};
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -500,6 +500,7 @@ _Parameters_
 -   _$0.onError_ `Function`: Function called when an error happens.
 -   _$0.onFileChange_ `Function`: Function called each time a file or a temporary representation of the file is available.
 -   _$0.onSuccess_ `Function`: Function called after the final representation of the file is available.
+-   _$0.multiple_ `boolean`: Whether to allow multiple files to be uploaded.
 
 ### MediaUploadCheck
 

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -125,6 +125,7 @@ function PostFeaturedImage( {
 				noticeOperations.removeAllNotices();
 				noticeOperations.createErrorNotice( message );
 			},
+			multiple: false,
 		} );
 	}
 
@@ -345,6 +346,7 @@ const applyWithDispatch = withDispatch(
 							noticeOperations.removeAllNotices();
 							noticeOperations.createErrorNotice( message );
 						},
+						multiple: false,
 					} );
 			},
 			onRemoveImage() {

--- a/packages/editor/src/utils/media-upload/index.js
+++ b/packages/editor/src/utils/media-upload/index.js
@@ -38,7 +38,7 @@ export default function mediaUpload( {
 	onError = noop,
 	onFileChange,
 	onSuccess,
-	multiple,
+	multiple = true,
 } ) {
 	const { getCurrentPost, getEditorSettings } = select( editorStore );
 	const {

--- a/packages/editor/src/utils/media-upload/index.js
+++ b/packages/editor/src/utils/media-upload/index.js
@@ -28,6 +28,7 @@ const noop = () => {};
  * @param {Function} $0.onError           Function called when an error happens.
  * @param {Function} $0.onFileChange      Function called each time a file or a temporary representation of the file is available.
  * @param {Function} $0.onSuccess         Function called after the final representation of the file is available.
+ * @param {boolean}  $0.multiple          Whether to allow multiple files to be uploaded.
  */
 export default function mediaUpload( {
 	additionalData = {},
@@ -37,6 +38,7 @@ export default function mediaUpload( {
 	onError = noop,
 	onFileChange,
 	onSuccess,
+	multiple,
 } ) {
 	const { getCurrentPost, getEditorSettings } = select( editorStore );
 	const {
@@ -92,5 +94,6 @@ export default function mediaUpload( {
 			onError( message );
 		},
 		wpAllowedMimeTypes,
+		multiple,
 	} );
 }

--- a/packages/media-utils/README.md
+++ b/packages/media-utils/README.md
@@ -56,6 +56,7 @@ _Parameters_
 -   _$0.onFileChange_ `UploadMediaArgs[ 'onFileChange' ]`: Function called each time a file or a temporary representation of the file is available.
 -   _$0.wpAllowedMimeTypes_ `UploadMediaArgs[ 'wpAllowedMimeTypes' ]`: List of allowed mime types and file extensions.
 -   _$0.signal_ `UploadMediaArgs[ 'signal' ]`: Abort signal.
+-   _$0.multiple_ `UploadMediaArgs[ 'multiple' ]`: Whether to allow multiple files to be uploaded.
 
 ### validateFileSize
 

--- a/packages/media-utils/src/utils/test/upload-media.ts
+++ b/packages/media-utils/src/utils/test/upload-media.ts
@@ -196,4 +196,18 @@ describe( 'uploadMedia', () => {
 		);
 		expect( uploadToServer ).not.toHaveBeenCalled();
 	} );
+
+	it( 'should throw error when multiple files are selected in single file upload mode', async () => {
+		const onError = jest.fn();
+		await uploadMedia( {
+			filesList: [ imageFile, xmlFile ],
+			onError,
+			multiple: false,
+		} );
+
+		expect( onError ).toHaveBeenCalledWith(
+			new Error( 'Only one file can be used here.' )
+		);
+		expect( uploadToServer ).not.toHaveBeenCalled();
+	} );
 } );

--- a/packages/media-utils/src/utils/upload-error.ts
+++ b/packages/media-utils/src/utils/upload-error.ts
@@ -1,7 +1,7 @@
 interface UploadErrorArgs {
 	code: string;
 	message: string;
-	file?: File;
+	file: File;
 	cause?: Error;
 }
 
@@ -13,7 +13,7 @@ interface UploadErrorArgs {
  */
 export class UploadError extends Error {
 	code: string;
-	file?: File;
+	file: File;
 
 	constructor( { code, message, file, cause }: UploadErrorArgs ) {
 		super( message, { cause } );

--- a/packages/media-utils/src/utils/upload-error.ts
+++ b/packages/media-utils/src/utils/upload-error.ts
@@ -1,7 +1,7 @@
 interface UploadErrorArgs {
 	code: string;
 	message: string;
-	file: File;
+	file?: File;
 	cause?: Error;
 }
 
@@ -13,7 +13,7 @@ interface UploadErrorArgs {
  */
 export class UploadError extends Error {
 	code: string;
-	file: File;
+	file?: File;
 
 	constructor( { code, message, file, cause }: UploadErrorArgs ) {
 		super( message, { cause } );

--- a/packages/media-utils/src/utils/upload-media.ts
+++ b/packages/media-utils/src/utils/upload-media.ts
@@ -42,6 +42,8 @@ interface UploadMediaArgs {
 	wpAllowedMimeTypes?: Record< string, string > | null;
 	// Abort signal.
 	signal?: AbortSignal;
+	// Whether to allow multiple files to be uploaded.
+	multiple?: boolean;
 }
 
 /**
@@ -57,6 +59,7 @@ interface UploadMediaArgs {
  * @param $0.onFileChange       Function called each time a file or a temporary representation of the file is available.
  * @param $0.wpAllowedMimeTypes List of allowed mime types and file extensions.
  * @param $0.signal             Abort signal.
+ * @param $0.multiple           Whether to allow multiple files to be uploaded.
  */
 export function uploadMedia( {
 	wpAllowedMimeTypes,
@@ -67,7 +70,18 @@ export function uploadMedia( {
 	onError,
 	onFileChange,
 	signal,
+	multiple = true,
 }: UploadMediaArgs ) {
+	if ( ! multiple && filesList.length > 1 ) {
+		onError?.(
+			new UploadError( {
+				code: 'GENERAL',
+				message: __( 'Only one image can be used here.' ),
+			} )
+		);
+		return;
+	}
+
 	const validFiles = [];
 
 	const filesSet: Array< Partial< Attachment > | null > = [];

--- a/packages/media-utils/src/utils/upload-media.ts
+++ b/packages/media-utils/src/utils/upload-media.ts
@@ -73,12 +73,7 @@ export function uploadMedia( {
 	multiple = true,
 }: UploadMediaArgs ) {
 	if ( ! multiple && filesList.length > 1 ) {
-		onError?.(
-			new UploadError( {
-				code: 'GENERAL',
-				message: __( 'Only one file can be used here.' ),
-			} )
-		);
+		onError?.( new Error( __( 'Only one file can be used here.' ) ) );
 		return;
 	}
 

--- a/packages/media-utils/src/utils/upload-media.ts
+++ b/packages/media-utils/src/utils/upload-media.ts
@@ -76,7 +76,7 @@ export function uploadMedia( {
 		onError?.(
 			new UploadError( {
 				code: 'GENERAL',
-				message: __( 'Only one image can be used here.' ),
+				message: __( 'Only one file can be used here.' ),
 			} )
 		);
 		return;


### PR DESCRIPTION
## What?
Closes #68629

This PR adds a `multiple` prop to the `uploadMedia` and `mediaUpload` functions. The prop defaults to `True`. When set to `False`, any attempts to drop or select multiple images result in an error message returned to the user, and the process aborts completely due to an early return.

## Why?

This PR uses a generalized approach to implement prop-based restrictions on file uploads instead of implementing separate logic in the consumers. Some consumer implementations include:

https://github.com/WordPress/gutenberg/blob/0c42f22a87f5c8891e282cce0329a34d525811e0/packages/block-editor/src/components/background-image-control/index.js#L316

https://github.com/WordPress/gutenberg/blob/0c42f22a87f5c8891e282cce0329a34d525811e0/packages/block-library/src/site-logo/edit.js#L509

## How?

The `multiple` prop, which accepts a boolean value, has been introduced in the `uploadMedia` and `mediaUpload` functions. When `multiple` is set to `false` and multiple images are selected, the process is aborted early, triggering the `onError` callback.

## Testing Instructions

1. Try uploading multiple files in the following places:
1.1. Site logo block
1.2. Featured image block
1.3. Featured image panel in the document sidebar
1.4. Media & text block
1.5. Cover block
2. Ensure multiple files abort the process.

## Screencast

![final-testing](https://github.com/user-attachments/assets/9ebd4f6d-e76f-42a5-8a32-b360d2e10c19)

