### PR TITLE
Global Styles: Defer revisions for font activation until explicit save

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -93,7 +93,7 @@ function FontLibraryProvider( { children } ) {
 	 *
 	 * @param {Array} fonts - The font families that will be saved to the database.
 	 */
-	const saveFontFamilies = async ( fonts ) => {
+	const saveFontFamilies = async ( fonts, shouldAutoSave = false ) => {
 		// Gets the global styles database post content.
 		const updatedGlobalStyles = globalStyles.record;
 
@@ -104,8 +104,14 @@ function FontLibraryProvider( { children } ) {
 			fonts
 		);
 
-		// Saves a new version of the global styles in the database.
-		await saveEntityRecord( 'root', 'globalStyles', updatedGlobalStyles );
+		if ( shouldAutoSave ) {
+			// Saves a new version of the global styles in the database.
+			await saveEntityRecord(
+				'root',
+				'globalStyles',
+				updatedGlobalStyles
+			);
+		}
 	};
 
 	// Library Fonts
@@ -309,8 +315,7 @@ function FontLibraryProvider( { children } ) {
 					fontFamiliesToActivate
 				);
 				// Save the global styles to the database.
-				await saveFontFamilies( activeFonts );
-
+				await saveFontFamilies( activeFonts, true );
 				refreshLibrary();
 			}
 
@@ -343,7 +348,7 @@ function FontLibraryProvider( { children } ) {
 					fontFamilyToUninstall
 				);
 				// Save the global styles to the database.
-				await saveFontFamilies( activeFonts );
+				await saveFontFamilies( activeFonts, true );
 			}
 
 			// Refresh the library (the library font families from database).

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -92,6 +92,7 @@ function FontLibraryProvider( { children } ) {
 	 * It uses the font families from the param to avoid using the font families from an outdated state.
 	 *
 	 * @param {Array} fonts - The font families that will be saved to the database.
+	 * @param {boolean} persist - Whether to immediately persist changes to the database.
 	 */
 	const saveFontFamilies = async ( fonts, persist = false ) => {
 		// Gets the global styles database post content.

--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -93,7 +93,7 @@ function FontLibraryProvider( { children } ) {
 	 *
 	 * @param {Array} fonts - The font families that will be saved to the database.
 	 */
-	const saveFontFamilies = async ( fonts, shouldAutoSave = false ) => {
+	const saveFontFamilies = async ( fonts, persist = false ) => {
 		// Gets the global styles database post content.
 		const updatedGlobalStyles = globalStyles.record;
 
@@ -104,7 +104,7 @@ function FontLibraryProvider( { children } ) {
 			fonts
 		);
 
-		if ( shouldAutoSave ) {
+		if ( persist ) {
 			// Saves a new version of the global styles in the database.
 			await saveEntityRecord(
 				'root',


### PR DESCRIPTION


## What?

Closes #67270

Modifies font management to control when typography settings changes create revisions.


## Why?

Currently, every font activation/deactivation operation triggers an immediate save and creates a new revision, even while users are still making changes. This results in multiple unexpected revisions being created during a single editing session, making it harder for users to restore their changes coherently. Users expect revisions to be created only when they explicitly click the Save button.

## How?

Modified the saveFontFamilies function to accept a shouldAutoSave parameter that controls when changes are immediately saved to the database. Font installation and uninstallation operations (which require filesystem changes) continue to save immediately, while font activation and deactivation changes are deferred until the user explicitly saves.

## Testing Instructions

- Go to the Site editor > Styles
- Install a new font family (verify a revision is created immediately)
- Activate/deactivate different font variants of the installed font
- Verify no new revisions are created during activation/deactivation
- Click the Save button at the top right of the editor
- Go to Styles > Revisions and verify that only two revisions exist:
   - One from the initial font installation
   - One containing all your font activation/deactivation changes


## Screencast 


https://github.com/user-attachments/assets/3a0e0dc3-eae0-474b-af46-0380ac1e3505

