### PR TITLE
Cover Block: Show settings inspector controls in the Site Editor

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -24,6 +24,7 @@ import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { isBlobURL } from '@wordpress/blob';
 import { store as noticesStore } from '@wordpress/notices';
+import { getPath } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -132,6 +133,10 @@ function CoverEdit( {
 			};
 		},
 		[ featuredImage, useFeaturedImage ]
+	);
+
+	const isSiteEditor = getPath( window.location.href )?.includes(
+		'site-editor.php'
 	);
 	const mediaUrl =
 		media?.media_details?.sizes?.[ sizeSlug ]?.source_url ??
@@ -396,6 +401,7 @@ function CoverEdit( {
 	const currentSettings = {
 		isVideoBackground,
 		isImageBackground,
+		isSiteEditor,
 		mediaElement,
 		hasInnerBlocks,
 		url,

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -24,7 +24,6 @@ import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { isBlobURL } from '@wordpress/blob';
 import { store as noticesStore } from '@wordpress/notices';
-import { getPath } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -133,10 +132,6 @@ function CoverEdit( {
 			};
 		},
 		[ featuredImage, useFeaturedImage ]
-	);
-
-	const isSiteEditor = getPath( window.location.href )?.includes(
-		'site-editor.php'
 	);
 	const mediaUrl =
 		media?.media_details?.sizes?.[ sizeSlug ]?.source_url ??
@@ -401,7 +396,6 @@ function CoverEdit( {
 	const currentSettings = {
 		isVideoBackground,
 		isImageBackground,
-		isSiteEditor,
 		mediaElement,
 		hasInnerBlocks,
 		url,

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -116,7 +116,6 @@ export default function CoverInspectorControls( {
 	const {
 		isVideoBackground,
 		isImageBackground,
-		isSiteEditor,
 		mediaElement,
 		url,
 		overlayColor,
@@ -197,7 +196,7 @@ export default function CoverInspectorControls( {
 	return (
 		<>
 			<InspectorControls>
-				{ ( !! url || ( useFeaturedImage && isSiteEditor ) ) && (
+				{ ( !! url || useFeaturedImage ) && (
 					<ToolsPanel
 						label={ __( 'Settings' ) }
 						resetAll={ () => {

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -116,6 +116,7 @@ export default function CoverInspectorControls( {
 	const {
 		isVideoBackground,
 		isImageBackground,
+		isSiteEditor,
 		mediaElement,
 		url,
 		overlayColor,
@@ -196,7 +197,7 @@ export default function CoverInspectorControls( {
 	return (
 		<>
 			<InspectorControls>
-				{ !! url && (
+				{ ( !! url || isSiteEditor ) && (
 					<ToolsPanel
 						label={ __( 'Settings' ) }
 						resetAll={ () => {

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -197,7 +197,7 @@ export default function CoverInspectorControls( {
 	return (
 		<>
 			<InspectorControls>
-				{ ( !! url || isSiteEditor ) && (
+				{ ( !! url || ( useFeaturedImage && isSiteEditor ) ) && (
 					<ToolsPanel
 						label={ __( 'Settings' ) }
 						resetAll={ () => {


### PR DESCRIPTION
## What?
1. The `Cover` block was not showing the `Settings` inspector controls in the Site Editor.

<!-- In a few words, what is the PR actually doing? -->

## Why?
1. Because the `url` attribute was undefined for `featured image` (fetched contextually in the post) when editing a template.

## How?
1. Extend the condition to show the `Settings` inspector controls if the user is editing a template.

## Testing Instructions
1. Edit a template (e.g., a Single Post template) in the Site Editor.
2. Add a Cover block.
3. Switch the image source to "Use Featured Image" → The Fixed Background option is now available.

Resolves: https://github.com/WordPress/gutenberg/issues/69179

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/6aab2be4-4bf1-4938-a0b0-3d8287851e6c


