### PR TITLE
Fix: Avatar Block Exceeds Editor Width When 'Link to User Profile' Option is Enabled

### DIFF
--- a/packages/block-library/src/avatar/edit.js
+++ b/packages/block-library/src/avatar/edit.js
@@ -193,29 +193,13 @@ const UserEdit = ( { attributes, context, setAttributes, isSelected } ) => {
 				avatar={ avatar }
 				setAttributes={ setAttributes }
 			/>
-			{ attributes.isLink ? (
-				<a
-					href="#avatar-pseudo-link"
-					className="wp-block-avatar__link"
-					onClick={ ( event ) => event.preventDefault() }
-				>
-					<ResizableAvatar
-						attributes={ attributes }
-						avatar={ avatar }
-						blockProps={ blockProps }
-						isSelected={ isSelected }
-						setAttributes={ setAttributes }
-					/>
-				</a>
-			) : (
-				<ResizableAvatar
-					attributes={ attributes }
-					avatar={ avatar }
-					blockProps={ blockProps }
-					isSelected={ isSelected }
-					setAttributes={ setAttributes }
-				/>
-			) }
+			<ResizableAvatar
+				attributes={ attributes }
+				avatar={ avatar }
+				blockProps={ blockProps }
+				isSelected={ isSelected }
+				setAttributes={ setAttributes }
+			/>
 		</>
 	);
 };


### PR DESCRIPTION
Fixes [#69180](https://github.com/WordPress/gutenberg/issues/69180)

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes the Avatar block width issue in the editor when "Link to User Profile" option is enabled. Currently, the block extends beyond the editor's maximum width constraints while maintaining correct frontend display.

<!-- In a few words, what is the PR actually doing? -->

## Why?
The Avatar block's wrapper element is not properly constrained within the editor's width boundaries when the link option is enabled. This creates an inconsistent editing experience, though the frontend display remains unaffected. The fix ensures visual consistency between the editor and frontend rendering.

## How?
Removed unwanted a tag wrapper from the editor

## Testing Instructions
1. Open the WordPress block editor
2. Add a new Avatar block to your post/page
3. In the block settings sidebar, enable the "Link to User Profile" option
4. Verify the Avatar block stays within the editor's maximum width
5. Preview the page to confirm the frontend display remains correct

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2025-02-13 at 3 06 10 PM](https://github.com/user-attachments/assets/f8f51037-f1c1-446b-82d5-61897a0db590)
