### PR TITLE
Social Block: Respect custom font size from default for Normal styles

### DIFF
--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -39,12 +39,6 @@
 		font-size: 16px; // 16 makes for a quarter-padding that keeps the icon centered.
 	}
 
-	// Normal/default.
-	&,
-	&.has-normal-icon-size {
-		font-size: 24px;
-	}
-
 	// Large.
 	&.has-large-icon-size {
 		font-size: 36px;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Closes  #69182
## What?

This PR ensures that the font size set in theme.json for the Social Icons block is applied correctly, even when the "Normal" size is selected.

## Why?

Currently, when selecting the "Normal" icon size for the Social Icons block, the has-normal-icon-size class is added, which enforces a default font size of 24px. This prevents any font size defined in theme.json from taking effect. By removing the has-normal-icon-size class from the styles, we allow theme.json settings to properly dictate the font size.

## How?

- Removed the `&.has-normal-icon-size` selector from the default styles, which previously enforced a fixed 24px font size.

- Ensured that theme.json font size settings take precedence.



## Testing Instructions
1. Open theme.json in a block theme (e.g., Twenty Twenty-Five).

2. Add the following snippet:
```CSS
"core/social-links": {
    "typography": {
        "fontSize": "96px"
    }
},
```
3. Add a Social Icons block to a post.

4. Click "Size" and select "Normal".

5. Check the front-end rendering and confirm that the font size reflects the theme.json setting instead of being overridden by default styles.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/289c1ebd-c50f-46ab-93f5-2a4a4bba64f4


 