### PR TITLE
Audio: Show notice when inserting a non-audio URL in the `Audio` block

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -62,11 +62,13 @@ function AudioEdit( {
 		};
 	}
 
-	function checkAudioType( url ) {
+	function isValidAudioFile( url ) {
 		return new Promise( ( resolve ) => {
-			const audio = new window.Audio( url );
+			const audio = new window.Audio();
+			audio.preload = 'metadata';
+			audio.src = url;
 
-			audio.oncanplaythrough = () => resolve( true );
+			audio.oncanplay = () => resolve( true );
 			audio.onerror = () => resolve( false );
 		} );
 	}
@@ -75,7 +77,7 @@ function AudioEdit( {
 		// Set the block's src from the edit component's state, and switch off
 		// the editing UI.
 
-		const isAudio = await checkAudioType( newSrc );
+		const isAudio = await isValidAudioFile( newSrc );
 
 		if ( ! isAudio ) {
 			createErrorNotice( 'The selected URL is not a valid audio file.', {


### PR DESCRIPTION
Closes: https://github.com/WordPress/gutenberg/issues/32456

## What?
This PR adds a validation check when a URL is inserted into the Audio block. If the URL is not a valid audio file, a warning notice is displayed, informing the user that the file is not supported.

## Why?

- Currently, when a non-audio URL is inserted into the Audio block, the block is added but does not play, leaving users without any feedback. 
- This improvement ensures better user experience by providing an immediate error message when an invalid file is selected.

## How?

- Introduced a `isValidAudioFile()` function that verifies whether a given URL points to a playable audio file.
- Modified `onSelectURL()` to check the validity of the URL before setting it in the block.
- If the URL is not an audio file, a `createErrorNotice()` snackbar is displayed with an appropriate message.

**Efficient Audio Validation**

  - Used `Audio()` with `preload="metadata"` instead of the default auto to prevent unnecessary download.
  - `oncanplay` fires as soon as metadata is available, ensuring a quick check, unlike `oncanplaythrough`, which buffers more data.
  - Observed valid URLs load metadata instantly, with Chrome limiting downloads to prevent full file retrieval unless necessary.
  - Observed Invalid URLs take slightly longer, as the browser must fully resolve the request before triggering `onerror`.

## Testing Instructions

1. Open a post or page in the block editor.
2. Add an Audio block.
3. Insert a valid audio URL (e.g., .mp3 or .wav).
    - The audio should load and be playable.
4. Insert a non-audio URL (e.g., a link to an image or a random webpage).
     - A warning notice should appear: "The selected URL is not a valid audio file."
     - The block should not attempt to load or play the invalid file.

## Screencast

https://github.com/user-attachments/assets/48781abc-0316-4078-9502-2e6cc222b174


