### PR TITLE
Fix the List View focus management

### DIFF
--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -44,6 +44,7 @@ function ListViewBlockSelectButton(
 		draggable,
 		isExpanded,
 		ariaDescribedBy,
+		isSelected,
 	},
 	ref
 ) {
@@ -102,6 +103,7 @@ function ListViewBlockSelectButton(
 			href={ `#block-${ clientId }` }
 			aria-describedby={ ariaDescribedBy }
 			aria-expanded={ isExpanded }
+			data-is-selected={ isSelected ? true : undefined }
 		>
 			<ListViewExpander onClick={ onToggleExpanded } />
 			<BlockIcon

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -179,12 +179,27 @@ function ListViewComponent(
 		ref,
 	] );
 
+	const timerIdRef = useRef();
+
 	useEffect( () => {
-		// If a blocks are already selected when the list view is initially
+		// If any blocks are already selected when the list view is initially
 		// mounted, shift focus to the first selected block.
-		if ( selectedClientIds?.length ) {
-			focusListItem( selectedClientIds[ 0 ], elementRef?.current );
-		}
+		// The ListView may render within other components that already manage
+		// initial focus via `useFocusOnMount` e.g. the `ListViewSidebar`. As
+		// `useFocusOnMount` uses a timeout internally, it runs last and may steal
+		// focus from the selected item. We use another timeout to make ListView
+		// set its own initial focus last.
+		timerIdRef.current = setTimeout( () => {
+			if ( selectedClientIds?.length ) {
+				focusListItem( selectedClientIds[ 0 ], elementRef?.current );
+			}
+		}, 0 );
+
+		return () => {
+			if ( timerIdRef.current ) {
+				clearTimeout( timerIdRef.current );
+			}
+		};
 		// Only focus on the selected item when the list view is mounted.
 	}, [] );
 

--- a/packages/components/src/tree-grid/README.md
+++ b/packages/components/src/tree-grid/README.md
@@ -12,6 +12,8 @@ A tree grid is a hierarchical 2 dimensional UI component, for example it could b
 
 A tree grid allows the user to navigate using arrow keys. Up/down to navigate vertically across rows, and left/right to navigate horizontally between focusables in a row.
 
+To make the keyboard navigation and roving tabindex behaviors work as expected it is important to avoid programmatically setting focus on any of the focusable items in the tree grid. In fact, `RovingTabIndexItem` handles the logic to make only one item navigable with the Tab key at a time. The other items can be navigated with the arrow keys. Triggering a focus event may conflict with the `RovingTabIndexItem` internal logic.
+
 For more information on a tree grid, see the following links:
 
 -   https://www.w3.org/TR/wai-aria-practices/examples/treegrid/treegrid-1.html

--- a/packages/editor/src/components/global-keyboard-shortcuts/index.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/index.js
@@ -91,9 +91,15 @@ export default function EditorKeyboardShortcuts() {
 		savePost();
 	} );
 
-	// Only opens the list view. Other functionality for this shortcut happens in the rendered sidebar.
+	// Only opens the list view. Other functionality for this shortcut happens
+	// in the rendered sidebar. When the `showListViewByDefault` preference is
+	// enabled, the sidebar is rendered by default. As such, we need to prevent
+	// the callback from running twice by using an additional check for
+	// `event.defaultPrevented` otherwise the shortcut:
+	// 1. It will first be invoked in the sidebar, thus closing it.
+	// 2. It will then run again here, reopening the sidebar unexpectedly.
 	useShortcut( 'core/editor/toggle-list-view', ( event ) => {
-		if ( ! isListViewOpened() ) {
+		if ( ! isListViewOpened() && ! event.defaultPrevented ) {
 			event.preventDefault();
 			setIsListViewOpened( true );
 		}

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -81,6 +81,13 @@ export default function ListViewSidebar() {
 			// Either focus the list view selected item or the active tab in the
 			// tablist. Must have a fallback because the list view does not
 			// render when there are no blocks.
+			// Important: The `core/editor/toggle-list-view` keyboard shortcut
+			// callback runs when the `keydown` event fires. At that point the
+			// ListView hasn't received focus yet and its internal mechanism to
+			// handle the tabindex attribute hasn't run yet. As such, there may
+			// be an additional item that is 'tabbable' but it's not the
+			// selected item. Filtering based on the `data-is-selected` attribute
+			// attribute makes sure to target the selected item.
 			const listViewSelectedItem = focus.tabbable
 				.find( listViewRef.current )
 				.filter( ( item ) =>

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -53,7 +53,7 @@ export default function ListViewSidebar() {
 
 	// This ref refers to the sidebar as a whole.
 	const sidebarRef = useRef();
-	// This ref refers to the tab panel.
+	// This ref refers to the tablist.
 	const tabsRef = useRef();
 	// This ref refers to the list view application area.
 	const listViewRef = useRef();

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -132,7 +132,7 @@ export default function ListViewSidebar() {
 			// handle the tabindex attribute hasn't run yet. As such, there may
 			// be an additional item that is 'tabbable' but it's not the
 			// selected item. Filtering based on the `data-is-selected` attribute
-			// attribute makes sure to target the selected item.
+			// makes sure to target the selected item.
 			const listViewSelectedItem = focus.tabbable
 				.find( listViewRef.current )
 				.filter( ( item ) =>

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -74,27 +74,28 @@ export default function ListViewSidebar() {
 	 * @return void
 	 */
 	function handleSidebarFocus( currentTab ) {
-		// Tab panel focus.
-		const tabPanelFocus = focus.tabbable.find( tabsRef.current )[ 0 ];
+		// Active tab in the tablist.
+		const activeTab = focus.tabbable.find( tabsRef.current )[ 0 ];
 		// List view tab is selected.
 		if ( currentTab === 'list-view' ) {
-			// Either focus the list view or the tab panel. Must have a fallback
-			// because the list view does not render when there are no blocks.
+			// Either focus the list view selected item or the active tab in the
+			// tablist. Must have a fallback because the list view does not
+			// render when there are no blocks.
 			const listViewSelectedItem = focus.tabbable
 				.find( listViewRef.current )
 				.filter( ( item ) =>
 					item.hasAttribute( 'data-is-selected' )
 				)[ 0 ];
-			const listViewFocusArea = sidebarRef.current.contains(
+			const listViewFocusTarget = sidebarRef.current.contains(
 				listViewSelectedItem
 			)
 				? listViewSelectedItem
-				: tabPanelFocus;
+				: activeTab;
 
-			listViewFocusArea.focus();
+			listViewFocusTarget.focus();
 			// Outline tab is selected.
 		} else {
-			tabPanelFocus.focus();
+			activeTab.focus();
 		}
 	}
 

--- a/packages/editor/src/components/list-view-sidebar/index.js
+++ b/packages/editor/src/components/list-view-sidebar/index.js
@@ -60,10 +60,11 @@ export default function ListViewSidebar() {
 
 	// Must merge the refs together so focus can be handled properly in the next function.
 	const listViewContainerRef = useMergeRefs( [
-		focusOnMountRef,
 		listViewRef,
 		setDropZoneElement,
 	] );
+
+	const tabsPanelRef = useMergeRefs( [ focusOnMountRef, tabsRef ] );
 
 	/*
 	 * Callback function to handle list view or outline focus.
@@ -77,15 +78,19 @@ export default function ListViewSidebar() {
 		const tabPanelFocus = focus.tabbable.find( tabsRef.current )[ 0 ];
 		// List view tab is selected.
 		if ( currentTab === 'list-view' ) {
-			// Either focus the list view or the tab panel. Must have a fallback because the list view does not render when there are no blocks.
-			const listViewApplicationFocus = focus.tabbable.find(
-				listViewRef.current
-			)[ 0 ];
+			// Either focus the list view or the tab panel. Must have a fallback
+			// because the list view does not render when there are no blocks.
+			const listViewSelectedItem = focus.tabbable
+				.find( listViewRef.current )
+				.filter( ( item ) =>
+					item.hasAttribute( 'data-is-selected' )
+				)[ 0 ];
 			const listViewFocusArea = sidebarRef.current.contains(
-				listViewApplicationFocus
+				listViewSelectedItem
 			)
-				? listViewApplicationFocus
+				? listViewSelectedItem
 				: tabPanelFocus;
+
 			listViewFocusArea.focus();
 			// Outline tab is selected.
 		} else {
@@ -147,7 +152,7 @@ export default function ListViewSidebar() {
 				onClose={ closeListView }
 				onSelect={ ( tabName ) => setTab( tabName ) }
 				defaultTabId="list-view"
-				ref={ tabsRef }
+				ref={ tabsPanelRef }
 				closeButtonLabel={ __( 'Close' ) }
 			/>
 		</div>

--- a/test/e2e/specs/editor/various/block-hierarchy-navigation.spec.js
+++ b/test/e2e/specs/editor/various/block-hierarchy-navigation.spec.js
@@ -240,6 +240,9 @@ test.describe( 'Navigating the block hierarchy', () => {
 				name: 'Block navigation structure',
 			} )
 		).toBeVisible();
+		// Move focus to the first item in the List view,
+		// which happens to be the Group block.
+		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Enter' );
 
 		await expect(

--- a/test/e2e/specs/site-editor/list-view.spec.js
+++ b/test/e2e/specs/site-editor/list-view.spec.js
@@ -69,6 +69,9 @@ test.describe( 'Site Editor List View', () => {
 		} );
 		await expect( listView ).toBeVisible();
 
+		// Move focus to the first item in the List view,
+		// which happens to be the site title block.
+		await page.keyboard.press( 'Tab' );
 		// The site title block should have focus.
 		await expect(
 			listView.getByRole( 'link', {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/69147

It is important to understand the List View focus management and the intended behavior of the keyboard shortcut as implemented in https://github.com/WordPress/gutenberg/pull/45135
- When the List View is closed, the keyboard shortcut should open it.
- When the List View is open, the keyboard shortcut does two different things:
  - If the List View panel does not contain focus already, it moves focus to it _and_ depending on selection:
    - With no block selected: it used to move focus to the first item, if any. In this PR this changes and focus goes to the first tab of the panel.
	- With one block selected, focus goes to the selected item.
	- With multiple block selected, focus goes to the first of the selected items.
  - If the List View panel does contain focus already, the keyboard shortcut closes the panel

This mechanism is buggy for several user flows, some of them are detailed on the associated issue https://github.com/WordPress/gutenberg/issues/69147.
This PR aims to make the focus management and the keyboard shortcut behavior more reliable and adds e2e tests to cover some failing scenarios.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The List View keyboard shortcut should always work as intended.
The currently selected item (if any) should always receive focus when opening the List View or when using the  keyboard shortcut.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Initial focus

One notable change is about initial focus:

When there are no blocks selected:
Initial focus is now set on the first tab of the Document Overview panel because of two reasons:
- The tree grid item `RovingTabIndexItem` handles logic to make only one item "tabbable" at a time. Attempting to set initial focus on mount on the first item conflicts with the `RovingTabIndexItem` internal logic and may end up in two items being "tabbable", which should never happen.
- Other panels, for example, the main inserter, do set focus on the first tab. As such, the Document Overview panel should be consistent and behave in the same way.

When there are blocks selected:
Initial focus should be set to the corresponding item in the List View. On trunk, this fails in at lest two cases:
- When a nested block is selected opening the List View with the keyboard shortcut always sets focus on the first item. Expected: to set focus on the selected item.
- When the List View is open first and then any block is selected, opening the List View with the keyboard shortcut sets focus on the first item. Expected: to set focus on the selected item.

## The 'Always open List View' preference 
With this preference enabled, things are a little more complicated because:

The `core/editor/toggle-list-view` [is used globally](https://github.com/WordPress/gutenberg/blob/afd4d376fe08fdd1825bc9ee6017952c1e744e37/packages/editor/src/components/global-keyboard-shortcuts/index.js#L95-L100) and it is also used [in the ListViewSidebar component](https://github.com/WordPress/gutenberg/blob/afd4d376fe08fdd1825bc9ee6017952c1e744e37/packages/editor/src/components/list-view-sidebar/index.js#L112).

This isn't a big deal when the panel is closed by default. However, when the panel is open by default because of the 'Always open List View' preference, using the keyboard shortcut will actually run both of them, the 'local' one and the 'global' one. As a result, the panel closes and then reopens immediately. It does it so fast that it's invisible to the eyes and it seems like nothing happened, the panel stays open. Apparently, this unintended behavior missed some proper testing when the preference was implemented.
Note: This happens only on first page load. This PR tries to introduce some logic to determine whether the `ListViewSidebar` renders for the first time or not.

## Technical points for discussion
- The `ListViewSidebar` now uses a `renderCounter` variable to determine if it renders for the first time or not. I'm not sure this is the best 'React' way to do it but I couldn't find other ways. I also tried to use `useInstanceId` but it doesn't guarantee the count is correct because it must be used inside the component and at that point it appears the component already rendered twice. Any suggestions for a better approach are welcome.
- `ListViewComponent` now uses a timeout when calling `focusListItem`, which is the function responsible for setting focus on the selected item. The timeout is important to prevent `useFocusOnMount` (which internally does use a timeout) to set focus last. Actually, `focusListItem` should be called last instead.
- I added a `data-is-selected` attribute to make moving focus to the actual selected item more reliable. Suggestions for any better approach are welcome. 



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Regardless of whether the List View is opened and closed by clicking the toggle button in the top bar or via the keyboard shortcut the most important behaviors to test are:
- When opening the List View, focus should go to the selected item.
- If there is no block selected, focus should go to the first tab of the panel.
- When using the keyboard shortcut and the List View panel is already open, the panel should stay open and focus should be moved to it based on the above logic.
- When using the keyboard shortcut and the List View panel is already open and does contain focus, the panel should close.
- Test with the all the potential user flows you can think of, for example: empty post, no block selected, one block selected, inner block selected, multiple blocks selected etc.
- Test all scenarios with the 'Always open List View' preference disabled and enabled.
- Observe the added tests pass. 



### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
