### PR TITLE
DataViews: Apply width styles to titleField in table layout

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- DataViews: Apply width styles to titleField in table layout. [#69191](https://github.com/WordPress/gutenberg/pull/69191)
+
 ### Enhancements
 
 - DataForm: support `isDisabled` field property. [#77090](https://github.com/WordPress/gutenberg/pull/77090)

--- a/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
@@ -220,7 +220,19 @@ function TableRow< Item >( {
 				</td>
 			) }
 			{ hasPrimaryColumn && (
-				<td>
+				<td
+					style={ {
+						width: titleField?.id
+							? view.layout?.styles?.[ titleField.id ]?.width
+							: undefined,
+						maxWidth: titleField?.id
+							? view.layout?.styles?.[ titleField.id ]?.maxWidth
+							: undefined,
+						minWidth: titleField?.id
+							? view.layout?.styles?.[ titleField.id ]?.minWidth
+							: undefined,
+					} }
+				>
 					<ColumnPrimary
 						item={ item }
 						level={ level }
@@ -488,7 +500,23 @@ function ViewTable< Item >( {
 							</th>
 						) }
 						{ hasPrimaryColumn && (
-							<th scope="col">
+							<th
+								scope="col"
+								style={ {
+									width: titleField?.id
+										? view.layout?.styles?.[ titleField.id ]
+												?.width
+										: undefined,
+									maxWidth: titleField?.id
+										? view.layout?.styles?.[ titleField.id ]
+												?.maxWidth
+										: undefined,
+									minWidth: titleField?.id
+										? view.layout?.styles?.[ titleField.id ]
+												?.minWidth
+										: undefined,
+								} }
+							>
 								{ titleField && (
 									<ColumnHeaderMenu
 										ref={ headerMenuRef(

--- a/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
@@ -222,15 +222,15 @@ function TableRow< Item >( {
 			{ hasPrimaryColumn && (
 				<td
 					style={ {
-						width: titleField?.id
-							? view.layout?.styles?.[ titleField.id ]?.width
-							: undefined,
-						maxWidth: titleField?.id
-							? view.layout?.styles?.[ titleField.id ]?.maxWidth
-							: undefined,
-						minWidth: titleField?.id
-							? view.layout?.styles?.[ titleField.id ]?.minWidth
-							: undefined,
+						width:
+							titleField?.id &&
+							view.layout?.styles?.[ titleField.id ]?.width,
+						maxWidth:
+							titleField?.id &&
+							view.layout?.styles?.[ titleField.id ]?.maxWidth,
+						minWidth:
+							titleField?.id &&
+							view.layout?.styles?.[ titleField.id ]?.minWidth,
 					} }
 				>
 					<ColumnPrimary
@@ -503,18 +503,18 @@ function ViewTable< Item >( {
 							<th
 								scope="col"
 								style={ {
-									width: titleField?.id
-										? view.layout?.styles?.[ titleField.id ]
-												?.width
-										: undefined,
-									maxWidth: titleField?.id
-										? view.layout?.styles?.[ titleField.id ]
-												?.maxWidth
-										: undefined,
-									minWidth: titleField?.id
-										? view.layout?.styles?.[ titleField.id ]
-												?.minWidth
-										: undefined,
+									width:
+										titleField?.id &&
+										view.layout?.styles?.[ titleField.id ]
+											?.width,
+									maxWidth:
+										titleField?.id &&
+										view.layout?.styles?.[ titleField.id ]
+											?.maxWidth,
+									minWidth:
+										titleField?.id &&
+										view.layout?.styles?.[ titleField.id ]
+											?.minWidth,
 								} }
 							>
 								{ titleField && (

--- a/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layouts/table/index.tsx
@@ -151,6 +151,11 @@ function TableRow< Item >( {
 		( titleField && showTitle ) ||
 		( mediaField && showMedia ) ||
 		( descriptionField && showDescription );
+	const {
+		width: titleWidth,
+		maxWidth: titleMaxWidth,
+		minWidth: titleMinWidth,
+	} = ( titleField?.id && view.layout?.styles?.[ titleField.id ] ) || {};
 
 	return (
 		<tr
@@ -222,15 +227,9 @@ function TableRow< Item >( {
 			{ hasPrimaryColumn && (
 				<td
 					style={ {
-						width:
-							titleField?.id &&
-							view.layout?.styles?.[ titleField.id ]?.width,
-						maxWidth:
-							titleField?.id &&
-							view.layout?.styles?.[ titleField.id ]?.maxWidth,
-						minWidth:
-							titleField?.id &&
-							view.layout?.styles?.[ titleField.id ]?.minWidth,
+						width: titleWidth,
+						maxWidth: titleMaxWidth,
+						minWidth: titleMinWidth,
 					} }
 				>
 					<ColumnPrimary
@@ -399,6 +398,11 @@ function ViewTable< Item >( {
 		( mediaField && showMedia ) ||
 		( descriptionField && showDescription );
 	const columns = view.fields ?? [];
+	const {
+		width: titleWidth,
+		maxWidth: titleMaxWidth,
+		minWidth: titleMinWidth,
+	} = ( titleField?.id && view.layout?.styles?.[ titleField.id ] ) || {};
 	const headerMenuRef =
 		( column: string, index: number ) => ( node: HTMLButtonElement ) => {
 			if ( node ) {
@@ -503,18 +507,9 @@ function ViewTable< Item >( {
 							<th
 								scope="col"
 								style={ {
-									width:
-										titleField?.id &&
-										view.layout?.styles?.[ titleField.id ]
-											?.width,
-									maxWidth:
-										titleField?.id &&
-										view.layout?.styles?.[ titleField.id ]
-											?.maxWidth,
-									minWidth:
-										titleField?.id &&
-										view.layout?.styles?.[ titleField.id ]
-											?.minWidth,
+									width: titleWidth,
+									maxWidth: titleMaxWidth,
+									minWidth: titleMinWidth,
 								} }
 							>
 								{ titleField && (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Closes: #69185

## What?
Apply layout styles (width, maxWidth, minWidth) to the primary column (titleField) in DataViews table layout, consistent with how they are applied to other fields.

## Why?
Currently, width-related styles from view.layout.styles are only applied to regular fields but not to the primary column (titleField). This inconsistency prevents consumers from controlling table layout shifts through min/max widths for all columns, including the primary column.

## How?
Added style properties to both the table header (<th>) and table cell (<td>) elements for the primary column, applying the same width-related styles that are already supported for other fields:

- width
- maxWidth
- minWidth

The styles are conditionally applied based on the existence of the titleField and its corresponding styles in the view.layout configuration.

## Testing Instructions

1. Start the Storybook development server: npm run storybook:dev
2. Navigate to "DataViews > DataViews > Default" story
3. Modify the default view configuration to include width styles for both title and categories:

```js
const [view, setView] = useState<View>({
  ...DEFAULT_VIEW,
  fields: ['categories'],
  titleField: 'title',
  descriptionField: 'description',
  mediaField: 'image',
  layout: {
    styles: {
      title: {
        maxWidth: '200px',
      },
      categories: {
        maxWidth: '200px',
      },
    },
  },
});
```

4. Inspect the DataViews table in the browser
5. Verify that both the title and categories columns have the maxWidth style applied to their respective cells

## Screenshots

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/3ec72a0d-8248-48ce-92f4-4d23954207eb)|![image](https://github.com/user-attachments/assets/eb1ce576-0cd0-4a38-b62a-febf85623826)|
