### PR TITLE
Site Editor: fix back link from “Navigation” sub-menus in mobile web

### DIFF
--- a/packages/edit-site/src/components/site-editor-routes/navigation-item.js
+++ b/packages/edit-site/src/components/site-editor-routes/navigation-item.js
@@ -6,7 +6,6 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 /**
  * Internal dependencies
  */
-import { NAVIGATION_POST_TYPE } from '../../utils/constants';
 import Editor from '../editor';
 import SidebarNavigationScreenNavigationMenu from '../sidebar-navigation-screen-navigation-menu';
 import { unlock } from '../../lock-unlock';
@@ -20,9 +19,7 @@ function MobileNavigationItemView() {
 	return canvas === 'edit' ? (
 		<Editor />
 	) : (
-		<SidebarNavigationScreenNavigationMenu
-			backPath={ { postType: NAVIGATION_POST_TYPE } }
-		/>
+		<SidebarNavigationScreenNavigationMenu backPath="/navigation" />
 	);
 }
 


### PR DESCRIPTION
## What, why & how
A trivial fix to make using the back button from a navigation item’s view go to the navigation list view. In trunk it unintentionally goes to the root level. It’s done by replacing an object with a string. I think it was supposed to be this way since #67199 but got overlooked.

## Testing Instructions
1. Open the site editor in a narrow viewport (< 783px)
2. Click the “Navigation” menu item
3. Click a navigation item
4. Click the “Back” button
5. Verify the parent menu is visible (not the root menu)

## Screenshots or screencast 
|Before|After|
|-|-|
| <video src="https://github.com/user-attachments/assets/c84b5a89-0154-4288-aeb7-6ae51f68e519"/> | <video src="https://github.com/user-attachments/assets/994d010d-1fde-4a6f-bb5f-e1dd6fd9eb50"/> |
