### PR TITLE
feat: Enable / Disable Per View Pagination filter in DataViews.

### DIFF
--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -20,6 +20,7 @@ type DataViewsContextType< Item > = {
 	paginationInfo: {
 		totalItems: number;
 		totalPages: number;
+		enablePerView: boolean;
 	};
 	selection: string[];
 	onChangeSelection: SetSelection;
@@ -40,6 +41,7 @@ const DataViewsContext = createContext< DataViewsContextType< any > >( {
 	paginationInfo: {
 		totalItems: 0,
 		totalPages: 0,
+		enablePerView: true,
 	},
 	selection: [],
 	onChangeSelection: () => {},

--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -20,7 +20,7 @@ type DataViewsContextType< Item > = {
 	paginationInfo: {
 		totalItems: number;
 		totalPages: number;
-		enablePerView: boolean;
+		enablePerPageFilter: boolean;
 	};
 	selection: string[];
 	onChangeSelection: SetSelection;
@@ -41,7 +41,7 @@ const DataViewsContext = createContext< DataViewsContextType< any > >( {
 	paginationInfo: {
 		totalItems: 0,
 		totalPages: 0,
-		enablePerView: true,
+		enablePerPageFilter: true,
 	},
 	selection: [],
 	onChangeSelection: () => {},

--- a/packages/dataviews/src/components/dataviews-pagination/index.tsx
+++ b/packages/dataviews/src/components/dataviews-pagination/index.tsx
@@ -19,7 +19,11 @@ function DataViewsPagination() {
 	const {
 		view,
 		onChangeView,
-		paginationInfo: { totalItems = 0, totalPages, enablePerView = true },
+		paginationInfo: {
+			totalItems = 0,
+			totalPages,
+			enablePerPageFilter = true,
+		},
 	} = useContext( DataViewsContext );
 
 	if ( ! totalItems || ! totalPages ) {
@@ -55,7 +59,7 @@ function DataViewsPagination() {
 				justify="end"
 				spacing={ 6 }
 			>
-				{ enablePerView && (
+				{ enablePerPageFilter && (
 					<HStack
 						justify="flex-start"
 						expanded={ false }

--- a/packages/dataviews/src/components/dataviews-pagination/index.tsx
+++ b/packages/dataviews/src/components/dataviews-pagination/index.tsx
@@ -19,7 +19,7 @@ function DataViewsPagination() {
 	const {
 		view,
 		onChangeView,
-		paginationInfo: { totalItems = 0, totalPages },
+		paginationInfo: { totalItems = 0, totalPages, enablePerView = true },
 	} = useContext( DataViewsContext );
 
 	if ( ! totalItems || ! totalPages ) {
@@ -55,43 +55,45 @@ function DataViewsPagination() {
 				justify="end"
 				spacing={ 6 }
 			>
-				<HStack
-					justify="flex-start"
-					expanded={ false }
-					spacing={ 1 }
-					className="dataviews-pagination__page-select"
-				>
-					{ createInterpolateElement(
-						sprintf(
-							// translators: 1: Current page number, 2: Total number of pages.
-							_x(
-								'<div>Page</div>%1$s<div>of %2$s</div>',
-								'paging'
+				{ enablePerView && (
+					<HStack
+						justify="flex-start"
+						expanded={ false }
+						spacing={ 1 }
+						className="dataviews-pagination__page-select"
+					>
+						{ createInterpolateElement(
+							sprintf(
+								// translators: 1: Current page number, 2: Total number of pages.
+								_x(
+									'<div>Page</div>%1$s<div>of %2$s</div>',
+									'paging'
+								),
+								'<CurrentPage />',
+								totalPages
 							),
-							'<CurrentPage />',
-							totalPages
-						),
-						{
-							div: <div aria-hidden />,
-							CurrentPage: (
-								<SelectControl
-									aria-label={ __( 'Current page' ) }
-									value={ currentPage.toString() }
-									options={ pageSelectOptions }
-									onChange={ ( newValue ) => {
-										onChangeView( {
-											...view,
-											page: +newValue,
-										} );
-									} }
-									size="small"
-									__nextHasNoMarginBottom
-									variant="minimal"
-								/>
-							),
-						}
-					) }
-				</HStack>
+							{
+								div: <div aria-hidden />,
+								CurrentPage: (
+									<SelectControl
+										aria-label={ __( 'Current page' ) }
+										value={ currentPage.toString() }
+										options={ pageSelectOptions }
+										onChange={ ( newValue ) => {
+											onChangeView( {
+												...view,
+												page: +newValue,
+											} );
+										} }
+										size="small"
+										__nextHasNoMarginBottom
+										variant="minimal"
+									/>
+								),
+							}
+						) }
+					</HStack>
+				) }
 				<HStack expanded={ false } spacing={ 1 }>
 					<Button
 						onClick={ () =>

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -41,7 +41,7 @@ type DataViewsProps< Item > = {
 	paginationInfo: {
 		totalItems: number;
 		totalPages: number;
-		enablePerView: boolean;
+		enablePerPageFilter: boolean;
 	};
 	defaultLayouts: SupportedLayouts;
 	selection?: string[];

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -41,6 +41,7 @@ type DataViewsProps< Item > = {
 	paginationInfo: {
 		totalItems: number;
 		totalPages: number;
+		enablePerView: boolean;
 	};
 	defaultLayouts: SupportedLayouts;
 	selection?: string[];

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -65,7 +65,11 @@ export const Empty = () => {
 	return (
 		<DataViews
 			getItemId={ ( item ) => item.id.toString() }
-			paginationInfo={ { totalItems: 0, totalPages: 0 } }
+			paginationInfo={ {
+				totalItems: 0,
+				totalPages: 0,
+				enablePerView: true,
+			} }
 			data={ [] }
 			view={ view }
 			fields={ fields }

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -68,7 +68,7 @@ export const Empty = () => {
 			paginationInfo={ {
 				totalItems: 0,
 				totalPages: 0,
-				enablePerView: true,
+				enablePerPageFilter: true,
 			} }
 			data={ [] }
 			view={ view }

--- a/packages/dataviews/src/filter-and-sort-data-view.ts
+++ b/packages/dataviews/src/filter-and-sort-data-view.ts
@@ -41,7 +41,7 @@ export function filterSortAndPaginate< Item >(
 	paginationInfo: {
 		totalItems: number;
 		totalPages: number;
-		enablePerView: boolean;
+		enablePerPageFilter: boolean;
 	};
 } {
 	if ( ! data ) {
@@ -50,7 +50,7 @@ export function filterSortAndPaginate< Item >(
 			paginationInfo: {
 				totalItems: 0,
 				totalPages: 0,
-				enablePerView: false,
+				enablePerPageFilter: false,
 			},
 		};
 	}
@@ -168,7 +168,7 @@ export function filterSortAndPaginate< Item >(
 		paginationInfo: {
 			totalItems,
 			totalPages,
-			enablePerView: true,
+			enablePerPageFilter: true,
 		},
 	};
 }

--- a/packages/dataviews/src/filter-and-sort-data-view.ts
+++ b/packages/dataviews/src/filter-and-sort-data-view.ts
@@ -38,12 +38,20 @@ export function filterSortAndPaginate< Item >(
 	fields: Field< Item >[]
 ): {
 	data: Item[];
-	paginationInfo: { totalItems: number; totalPages: number };
+	paginationInfo: {
+		totalItems: number;
+		totalPages: number;
+		enablePerView: boolean;
+	};
 } {
 	if ( ! data ) {
 		return {
 			data: EMPTY_ARRAY,
-			paginationInfo: { totalItems: 0, totalPages: 0 },
+			paginationInfo: {
+				totalItems: 0,
+				totalPages: 0,
+				enablePerView: false,
+			},
 		};
 	}
 	const _fields = normalizeFields( fields );
@@ -160,6 +168,7 @@ export function filterSortAndPaginate< Item >(
 		paginationInfo: {
 			totalItems,
 			totalPages,
+			enablePerView: true,
 		},
 	};
 }


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #69193

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Some data sources DataViews interacts with don't support per-page pagination. The issue is that there's no way for the DataViews component to display only previous/next links

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Adds `enablePerView` flag in the `paginationInfo`. `paginationInfo` is passed as an prop to DataViews component.
- By default it will be true and will show the Per Page filter.
- If passed false, it will not render the filter.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
- You can create a custom component using DataViews.
- Pass true to `enablePerPageFilter` to `paginationinfo` along with `totalItems` and `totalPages`.
- The Per Page pagination filter will not be visible.

or,
- You can open the Template List from the site editor.
- In the code add the true to `enablePerPageFilter` to `paginationinfo` and pass it as prop to the DataViews component.
- The Per Page pagination filter will not be visible.

## Screenshots or screencast <!-- if applicable -->

With Per Page filter enabled (default)
![code1](https://github.com/user-attachments/assets/f3ed565a-85e6-4d84-872a-1c7598cdb7d7)


With Per Page filter disable:
![code](https://github.com/user-attachments/assets/3b746f9c-22af-4546-a416-032765d7e272)
