### PR TITLE
List View: Fix focus outline style

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -641,6 +641,7 @@ function ListViewBlock( {
 								tabIndex,
 								onClick: clearSettingsAnchorRect,
 								onFocus,
+								size: 'small',
 							} }
 							disableOpenOnArrowDown
 							expand={ expand }

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -78,10 +78,7 @@
 		}
 
 		&:focus::after {
-			box-shadow:
-				inset 0 0 0 1px $white,
-				0 0 0 var(--wp-admin-border-width-focus)
-				var(--wp-block-synced-color);
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-block-synced-color);
 		}
 	}
 	&.is-selected .block-editor-list-view-block-contents,
@@ -308,7 +305,7 @@
 	.block-editor-list-view-block__menu-cell,
 	.block-editor-list-view-block__mover-cell {
 		line-height: 0;
-		width: $button-size;
+		width: $button-size-small + $grid-unit-05;
 		vertical-align: middle;
 
 		> * {
@@ -322,21 +319,6 @@
 			> * {
 				opacity: 1;
 			}
-		}
-
-		&,
-		.components-button.has-icon {
-			width: $button-size-small;
-			min-width: $button-size-small;
-			padding: 0;
-		}
-	}
-
-	.block-editor-list-view-block__menu-cell {
-		padding-right: $grid-unit-05;
-
-		.components-button.has-icon {
-			height: 24px;
 		}
 	}
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -8,10 +8,6 @@
 }
 
 .edit-site-sidebar-navigation-screen-navigation-menus__content {
-	.block-editor-list-view-leaf .block-editor-list-view-block__contents-cell {
-		width: 100%;
-	}
-
 	.block-editor-list-view-leaf .block-editor-list-view-block-contents {
 		white-space: normal;
 	}


### PR DESCRIPTION
## What?

Closes #69189

This PR will ensure that the correct focus style is applied regardless of where the ListView component is used.

## Why?

A list view item consists of two cells, the second cell is expected to be 28px wide. This 28px is the combined value of the dropdown toggle button width (`24px`) + right padding (`4px`):

![image](https://github.com/user-attachments/assets/314bcb70-918f-4184-8096-bf3a2cbfc633)

However, for blocks that don't allow dropdown toggles, only an empty cell will be rendered. The cell itself [has a width of `24px`](https://github.com/WordPress/gutenberg/blob/3df54ec6a39b342c20d8598524fd418155c55172/packages/block-editor/src/components/list-view/style.scss#L327).

In the post editor, the `box-sizing` value of this cell is the browser's default `content-box`, so the cell width is `24px + 4px right padding = 28px`, which means no outline shift.

On the other hand, in the site editor, the `box-sizing` value of this cell is `border-box`, which means the cell has a width of `24px`.

The fact that the cell is `24px` wide instead of the expected `28px` will cause the absolutely positioned focus to shift right.

## How?

- First of all, it seems incorrect to apply a 24px width to a cell that is always expected to be 28px wide. [Here](https://github.com/WordPress/gutenberg/pull/69201/files#diff-735e8db581e5a7cfc61e7ca12a2bb79e0b931f98a0e1bf209d957fd23de9eb67R311) we apply 28px to the cell's width.
- It is overridden by CSS to make the dropdown toggle button `24px` in size. To get around this, add [`size:small` to the `toggleProps`](https://github.com/WordPress/gutenberg/pull/69201/files#diff-8eb8020d3cc753bf34c8fff765a5e1813542918882ae2fcc2833eab2ea446b6cR630). As a result, remove the CSS override, which is no longer needed.
- Fixes outline of synced blocks that have a different box-shadow property than the focus style of regular blocks.

## Testing Instructions

Go to the following places where list views are used:

- Post Editor
- Site Editor > Pages Menu > Page
- Site Editor > Navigation Menu
- Site Editor > Navigation Block > Block Sitebar > Settings Tab 

Make sure all styles are applied correctly:

- Background color when the item is selected
- Outline when the item is focused
- Outline when the item is selected and focused
- Outline when the dropdown button is focused

## Screenshots or screencast <!-- if applicable -->

In the screenshot below, I've applied some pseudo styles.

### Site Editor > Pages Menu > Page

- The focus outline cut-off is resolved.
- The size of the focus outline for the sync block matches that of the other blocks.

|Before|After|
|-|-|
| ![image](https://github.com/user-attachments/assets/5f61d3ec-c993-41af-b843-179e92c64c72) | ![image](https://github.com/user-attachments/assets/0d27dc59-82e8-4ee8-88c6-23fd3bdd8681) |

### Site Editor > Navigation Menu

The selected and focused item is resolved.

|Before|After|
|-|-|
| ![image](https://github.com/user-attachments/assets/0a50ab08-f65f-4ecf-8d25-844a930304fa) | ![image](https://github.com/user-attachments/assets/d7b6809f-6bb1-4e3f-975f-107207f046f4) |

### Site Editor > Navigation Block > Block Sitebar > Settings Tab 

No visual changes.

|Before|After|
|-|-|
| ![image](https://github.com/user-attachments/assets/583b3783-6c1a-4299-a716-dfddc46b9228) | ![image](https://github.com/user-attachments/assets/98bb1212-6d01-4a90-9018-9bd4fee67d78) |
