### PR TITLE
ColorPicker: Add tests for `ColorPicker` Alpha slider

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Unreleased
 
+### Internal
+
+-   `ColorPicker`: Add tests for Alpha slider functionality ([#69203](https://github.com/WordPress/gutenberg/pull/69203)).
+
 ## 29.8.0 (2025-04-11)
 
-### Documentation 
+### Documentation
 
 -   `Popover`: Expose Popover TypeScript types for subcomponents. ([#69619](https://github.com/WordPress/gutenberg/pull/69619))
 

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -407,18 +407,13 @@ describe( 'ColorPicker', () => {
 			// Initially type 7 in the alpha input, we expect it to be called with #ffffff12
 			await user.type( alphaInput, '7' );
 
-			expect( onChange ).toHaveBeenCalledTimes( 2 );
-			await waitFor( () => {
-				expect( onChange ).toHaveBeenCalledWith( '#ffffff12' );
-			} );
-
 			// Now with 75% opacity we expect it to be called with #ffffffbf
 			await user.type( alphaInput, '5' );
 
+			// Called twice, once per key stroke (`7` and `5`)
 			expect( onChange ).toHaveBeenCalledTimes( 3 );
-			await waitFor( () => {
-				expect( onChange ).toHaveBeenCalledWith( '#ffffffbf' );
-			} );
+			expect( onChange ).toHaveBeenNthCalledWith( 2, '#ffffff12' );
+			expect( onChange ).toHaveBeenNthCalledWith( 3, '#ffffffbf' );
 
 			expect( alphaSlider ).toHaveValue( '75' );
 			expect( alphaInput ).toHaveValue( 75 );

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -394,7 +394,7 @@ describe( 'ColorPicker', () => {
 				expect( onChange ).toHaveBeenCalledTimes( 1 );
 			} );
 
-			expect( onChange ).toHaveBeenCalledWith( '#ffffffbf' );
+			expect( onChange ).toHaveBeenLastCalledWith( '#ffffffbf' );
 			expect( alphaInput ).toHaveValue( 75 );
 			expect( alphaSlider ).toHaveValue( '75' );
 

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -342,4 +342,41 @@ describe( 'ColorPicker', () => {
 			} );
 		} );
 	} );
+
+	describe.each( [
+		[ 'hsl', 'HSL', '75', '#ffffffbf' ],
+		[ 'rgb', 'RGB', '75', '#ffffffbf' ],
+	] )(
+		'Alpha-enabled %s format',
+		( format, formatLabel, alphaValue, expected ) => {
+			it( `should update alpha correctly when ${ formatLabel } format is selected`, async () => {
+				const user = userEvent.setup();
+				const onChange = jest.fn();
+				const color = '#ffffff80';
+
+				render(
+					<ColorPicker
+						onChange={ onChange }
+						color={ color }
+						enableAlpha
+					/>
+				);
+
+				const formatSelector = screen.getByRole( 'combobox' );
+				expect( formatSelector ).toBeVisible();
+				await user.selectOptions( formatSelector, format );
+
+				const alphaInput = screen.getByRole( 'spinbutton', {
+					name: 'Alpha',
+				} );
+				expect( alphaInput ).toBeVisible();
+
+				await user.clear( alphaInput );
+				await user.type( alphaInput, alphaValue );
+
+				expect( onChange ).toHaveBeenCalledTimes( 3 );
+				expect( onChange ).toHaveBeenLastCalledWith( expected );
+			} );
+		}
+	);
 } );

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -41,6 +41,34 @@ const legacyColorMatcher = {
 	source: 'hex',
 };
 
+// Without the controlled component, slider values don't update after changes.
+// Controlled component with state helps synchronize input box and slider during testing.
+const ControlledColorPicker = ( {
+	onChange: onChangeProp,
+	initialColor = '#000000',
+	...restProps
+}: React.ComponentProps< typeof ColorPicker > & { initialColor?: string } ) => {
+	const [ colorState, setColorState ] = useState( initialColor );
+
+	const internalOnChange: typeof onChangeProp = ( newColor ) => {
+		onChangeProp?.( newColor );
+		setColorState( newColor );
+	};
+
+	return (
+		<>
+			<ColorPicker
+				{ ...restProps }
+				onChange={ internalOnChange }
+				color={ colorState }
+			/>
+			<button onClick={ () => setColorState( '#4d87ba' ) }>
+				Set color to #4d87ba
+			</button>
+		</>
+	);
+};
+
 describe( 'ColorPicker', () => {
 	describe( 'legacy props', () => {
 		it( 'should fire onChangeComplete with the legacy color format', async () => {
@@ -143,31 +171,6 @@ describe( 'ColorPicker', () => {
 		it( 'sliders should use accurate H and S values based on user interaction when possible', async () => {
 			const user = userEvent.setup();
 			const onChange = jest.fn();
-
-			const ControlledColorPicker = ( {
-				onChange: onChangeProp,
-				...restProps
-			}: React.ComponentProps< typeof ColorPicker > ) => {
-				const [ colorState, setColorState ] = useState( '#000000' );
-
-				const internalOnChange: typeof onChangeProp = ( newColor ) => {
-					onChangeProp?.( newColor );
-					setColorState( newColor );
-				};
-
-				return (
-					<>
-						<ColorPicker
-							{ ...restProps }
-							onChange={ internalOnChange }
-							color={ colorState }
-						/>
-						<button onClick={ () => setColorState( '#4d87ba' ) }>
-							Set color to #4d87ba
-						</button>
-					</>
-				);
-			};
 
 			render(
 				<ControlledColorPicker
@@ -351,30 +354,12 @@ describe( 'ColorPicker', () => {
 			const user = userEvent.setup();
 			const onChange = jest.fn();
 
-			const ControlledColorPicker = ( {
-				onChange: onChangeProp,
-				...restProps
-			}: React.ComponentProps< typeof ColorPicker > ) => {
-				const [ colorState, setColorState ] = useState( '#ffffff80' );
-
-				const internalOnChange: typeof onChangeProp = ( newColor ) => {
-					onChangeProp?.( newColor );
-					setColorState( newColor );
-				};
-
-				return (
-					<>
-						<ColorPicker
-							{ ...restProps }
-							onChange={ internalOnChange }
-							color={ colorState }
-						/>
-					</>
-				);
-			};
-
 			render(
-				<ControlledColorPicker onChange={ onChange } enableAlpha />
+				<ControlledColorPicker
+					onChange={ onChange }
+					enableAlpha
+					initialColor="#ffffff80"
+				/>
 			);
 
 			const formatSelector = screen.getByRole( 'combobox' );

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -344,83 +344,105 @@ describe( 'ColorPicker', () => {
 	} );
 
 	describe.each( [
-		[ 'hsl', 'HSL', '75', '#ffffff12' ],
-		[ 'rgb', 'RGB', '75', '#ffffff12' ],
-	] )(
-		'Alpha-enabled %s format',
-		( format, formatLabel, alphaValue, expected ) => {
-			it( `should update alpha correctly when ${ formatLabel } format is selected`, async () => {
-				const user = userEvent.setup();
-				const onChange = jest.fn();
+		[ 'hsl', 'HSL' ],
+		[ 'rgb', 'RGB' ],
+	] )( 'Alpha-enabled %s format', ( format, formatLabel ) => {
+		it( `should update alpha correctly when ${ formatLabel } format is selected`, async () => {
+			const user = userEvent.setup();
+			const onChange = jest.fn();
 
-				const ControlledColorPicker = ( {
-					onChange: onChangeProp,
-					...restProps
-				}: React.ComponentProps< typeof ColorPicker > ) => {
-					const [ colorState, setColorState ] =
-						useState( '#ffffff80' );
+			const ControlledColorPicker = ( {
+				onChange: onChangeProp,
+				...restProps
+			}: React.ComponentProps< typeof ColorPicker > ) => {
+				const [ colorState, setColorState ] = useState( '#ffffff80' );
 
-					const internalOnChange: typeof onChangeProp = (
-						newColor
-					) => {
-						onChangeProp?.( newColor );
-						setColorState( newColor );
-					};
-
-					return (
-						<>
-							<ColorPicker
-								{ ...restProps }
-								onChange={ internalOnChange }
-								color={ colorState }
-							/>
-						</>
-					);
+				const internalOnChange: typeof onChangeProp = ( newColor ) => {
+					onChangeProp?.( newColor );
+					setColorState( newColor );
 				};
 
-				render(
-					<ControlledColorPicker onChange={ onChange } enableAlpha />
+				return (
+					<>
+						<ColorPicker
+							{ ...restProps }
+							onChange={ internalOnChange }
+							color={ colorState }
+						/>
+					</>
 				);
+			};
 
-				const formatSelector = screen.getByRole( 'combobox' );
-				expect( formatSelector ).toBeVisible();
-				await user.selectOptions( formatSelector, format );
+			render(
+				<ControlledColorPicker onChange={ onChange } enableAlpha />
+			);
 
-				const alphaInput = screen.getByRole( 'spinbutton', {
-					name: 'Alpha',
-				} );
-				expect( alphaInput ).toBeVisible();
+			const formatSelector = screen.getByRole( 'combobox' );
+			expect( formatSelector ).toBeVisible();
+			await user.selectOptions( formatSelector, format );
 
-				const alphaSliders = screen.getAllByRole( 'slider', {
-					name: 'Alpha',
-				} );
-
-				const alphaSlider = alphaSliders.at( -1 )!;
-
-				expect( alphaSlider ).toHaveValue( '50' );
-				expect( alphaInput ).toHaveValue( Number( '50' ) );
-
-				fireEvent.change( alphaSlider, {
-					target: { value: alphaValue },
-				} );
-				expect( onChange ).not.toHaveBeenCalled();
-
-				await waitFor( () => {
-					expect( alphaInput ).toHaveValue( Number( alphaValue ) );
-				} );
-
-				await waitFor( () => {
-					expect( alphaSlider ).toHaveValue( alphaValue );
-				} );
-
-				await user.clear( alphaInput );
-				await user.type( alphaInput, alphaValue );
-
-				expect( alphaInput ).toHaveValue( Number( alphaValue ) );
-
-				expect( onChange ).toHaveBeenCalledTimes( 3 );
-				expect( onChange ).toHaveBeenLastCalledWith( expected );
+			const alphaInput = screen.getByRole( 'spinbutton', {
+				name: 'Alpha',
 			} );
-		}
-	);
+			expect( alphaInput ).toBeVisible();
+
+			const alphaSliders = screen.getAllByRole( 'slider', {
+				name: 'Alpha',
+			} );
+
+			expect( alphaSliders ).toHaveLength( 2 );
+
+			// Choose the second slider which is the actual slider of type: input[type="range"]
+			const alphaSlider = alphaSliders.at( -1 )!;
+
+			expect( alphaSlider ).toHaveValue( '50' );
+			expect( alphaInput ).toHaveValue( 50 );
+
+			expect( onChange ).not.toHaveBeenCalledWith();
+
+			// Test pattern 1: Update the slider
+			fireEvent.change( alphaSlider, {
+				target: { value: 75 },
+			} );
+
+			await waitFor( () => {
+				expect( onChange ).toHaveBeenCalledTimes( 1 );
+			} );
+			await waitFor( () => {
+				expect( onChange ).toHaveBeenCalledWith( '#ffffffbf' );
+			} );
+
+			await waitFor( () => {
+				expect( alphaInput ).toHaveValue( 75 );
+			} );
+			await waitFor( () => {
+				expect( alphaSlider ).toHaveValue( '75' );
+			} );
+
+			onChange.mockClear();
+
+			// Test pattern 2: Update the alphaInput
+			await user.clear( alphaInput );
+			expect( onChange ).toHaveBeenCalledTimes( 1 );
+
+			// Initially type 7 in the alpha input, we expect it to be called with #ffffff12
+			await user.type( alphaInput, '7' );
+
+			expect( onChange ).toHaveBeenCalledTimes( 2 );
+			await waitFor( () => {
+				expect( onChange ).toHaveBeenCalledWith( '#ffffff12' );
+			} );
+
+			// Now with 75% opacity we expect it to be called with #ffffffbf
+			await user.type( alphaInput, '5' );
+
+			expect( onChange ).toHaveBeenCalledTimes( 3 );
+			await waitFor( () => {
+				expect( onChange ).toHaveBeenCalledWith( '#ffffffbf' );
+			} );
+
+			expect( alphaSlider ).toHaveValue( '75' );
+			expect( alphaInput ).toHaveValue( 75 );
+		} );
+	} );
 } );

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -344,22 +344,42 @@ describe( 'ColorPicker', () => {
 	} );
 
 	describe.each( [
-		[ 'hsl', 'HSL', '75', '#ffffffbf' ],
-		[ 'rgb', 'RGB', '75', '#ffffffbf' ],
+		[ 'hsl', 'HSL', '75', '#ffffff12' ],
+		[ 'rgb', 'RGB', '75', '#ffffff12' ],
 	] )(
 		'Alpha-enabled %s format',
 		( format, formatLabel, alphaValue, expected ) => {
 			it( `should update alpha correctly when ${ formatLabel } format is selected`, async () => {
 				const user = userEvent.setup();
 				const onChange = jest.fn();
-				const color = '#ffffff80';
+
+				const ControlledColorPicker = ( {
+					onChange: onChangeProp,
+					...restProps
+				}: React.ComponentProps< typeof ColorPicker > ) => {
+					const [ colorState, setColorState ] =
+						useState( '#ffffff80' );
+
+					const internalOnChange: typeof onChangeProp = (
+						newColor
+					) => {
+						onChangeProp?.( newColor );
+						setColorState( newColor );
+					};
+
+					return (
+						<>
+							<ColorPicker
+								{ ...restProps }
+								onChange={ internalOnChange }
+								color={ colorState }
+							/>
+						</>
+					);
+				};
 
 				render(
-					<ColorPicker
-						onChange={ onChange }
-						color={ color }
-						enableAlpha
-					/>
+					<ControlledColorPicker onChange={ onChange } enableAlpha />
 				);
 
 				const formatSelector = screen.getByRole( 'combobox' );
@@ -371,24 +391,32 @@ describe( 'ColorPicker', () => {
 				} );
 				expect( alphaInput ).toBeVisible();
 
+				const alphaSliders = screen.getAllByRole( 'slider', {
+					name: 'Alpha',
+				} );
+
+				const alphaSlider = alphaSliders.at( -1 )!;
+
+				expect( alphaSlider ).toHaveValue( '50' );
+				expect( alphaInput ).toHaveValue( Number( '50' ) );
+
+				fireEvent.change( alphaSlider, {
+					target: { value: alphaValue },
+				} );
+				expect( onChange ).not.toHaveBeenCalled();
+
+				await waitFor( () => {
+					expect( alphaInput ).toHaveValue( Number( alphaValue ) );
+				} );
+
+				await waitFor( () => {
+					expect( alphaSlider ).toHaveValue( alphaValue );
+				} );
+
 				await user.clear( alphaInput );
 				await user.type( alphaInput, alphaValue );
 
-				const alphaSliders = await screen.findAllByText( 'Alpha' );
-				expect( alphaSliders ).toHaveLength( 2 );
-
-				const alphaSlider = [ alphaSliders[ 0 ] ];
-				expect( alphaSlider ).toHaveLength( 1 );
-
-				fireEvent.pointerDown( alphaSlider[ 0 ], {
-					clientX: 0,
-					clientY: 0,
-				} );
-				fireEvent.pointerMove( alphaSlider[ 0 ], {
-					clientX: 75,
-					clientY: 0,
-				} );
-				fireEvent.pointerUp( alphaSlider[ 0 ] );
+				expect( alphaInput ).toHaveValue( Number( alphaValue ) );
 
 				expect( onChange ).toHaveBeenCalledTimes( 3 );
 				expect( onChange ).toHaveBeenLastCalledWith( expected );

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -3,6 +3,7 @@
  */
 import { fireEvent, screen, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { click } from '@ariakit/test';
 
 /**
  * WordPress dependencies
@@ -13,7 +14,6 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { ColorPicker } from '..';
-import { click } from '@ariakit/test';
 
 const hslaMatcher = expect.objectContaining( {
 	h: expect.any( Number ),
@@ -405,10 +405,10 @@ describe( 'ColorPicker', () => {
 			expect( onChange ).toHaveBeenCalledTimes( 1 );
 
 			// Initially type 7 in the alpha input, we expect it to be called with #ffffff12
-			await user.type( alphaInput, '7' );
+			await user.keyboard( '7' );
 
 			// Now with 75% opacity we expect it to be called with #ffffffbf
-			await user.type( alphaInput, '5' );
+			await user.keyboard( '5' );
 
 			// Called twice, once per key stroke (`7` and `5`)
 			expect( onChange ).toHaveBeenCalledTimes( 3 );

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -374,6 +374,22 @@ describe( 'ColorPicker', () => {
 				await user.clear( alphaInput );
 				await user.type( alphaInput, alphaValue );
 
+				const alphaSliders = await screen.findAllByText( 'Alpha' );
+				expect( alphaSliders ).toHaveLength( 2 );
+
+				const alphaSlider = [ alphaSliders[ 0 ] ];
+				expect( alphaSlider ).toHaveLength( 1 );
+
+				fireEvent.pointerDown( alphaSlider[ 0 ], {
+					clientX: 0,
+					clientY: 0,
+				} );
+				fireEvent.pointerMove( alphaSlider[ 0 ], {
+					clientX: 75,
+					clientY: 0,
+				} );
+				fireEvent.pointerUp( alphaSlider[ 0 ] );
+
 				expect( onChange ).toHaveBeenCalledTimes( 3 );
 				expect( onChange ).toHaveBeenLastCalledWith( expected );
 			} );

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -383,7 +383,7 @@ describe( 'ColorPicker', () => {
 			expect( alphaSlider ).toHaveValue( '50' );
 			expect( alphaInput ).toHaveValue( 50 );
 
-			expect( onChange ).not.toHaveBeenCalledWith();
+			expect( onChange ).not.toHaveBeenCalled();
 
 			// Test pattern 1: Update the slider
 			fireEvent.change( alphaSlider, {
@@ -393,16 +393,10 @@ describe( 'ColorPicker', () => {
 			await waitFor( () => {
 				expect( onChange ).toHaveBeenCalledTimes( 1 );
 			} );
-			await waitFor( () => {
-				expect( onChange ).toHaveBeenCalledWith( '#ffffffbf' );
-			} );
 
-			await waitFor( () => {
-				expect( alphaInput ).toHaveValue( 75 );
-			} );
-			await waitFor( () => {
-				expect( alphaSlider ).toHaveValue( '75' );
-			} );
+			expect( onChange ).toHaveBeenCalledWith( '#ffffffbf' );
+			expect( alphaInput ).toHaveValue( 75 );
+			expect( alphaSlider ).toHaveValue( '75' );
 
 			onChange.mockClear();
 


### PR DESCRIPTION

## What?
Closes https://github.com/WordPress/gutenberg/issues/49344
Related comment: https://github.com/WordPress/gutenberg/pull/49214#discussion_r1146267260

Related PRs: https://github.com/WordPress/gutenberg/pull/49214, https://github.com/WordPress/gutenberg/pull/49698

This PR improves the unit tests for the `ColorPicker` component by adding test coverage for the Alpha slider and its corresponding input field when `enableAlpha`. Previously, tests covered most input fields (hex, HSL, RGB, and hue slider), but the Alpha slider had no dedicated tests.


## Why?

The maintainers have emphasized that these tests are important for the editor. While previous tests validated various input interactions, they did not:

- Ensure that the Alpha slider updates correctly when the input field is changed.
- Cover `enableAlpha={true}`, leaving a gap in test coverage.

## How?

- Added tests to check that the Alpha slider updates when the user types in the Alpha input field and when adjusting the slider.
- Verified that the correct RGBA/HSLA values are passed to onChange when changing transparency via both the input field and the slider.
- Used user-event for more accurate simulation of real user interactions.

## Testing Instructions
1. Run the test by the following command:

```shell
npm run test:unit packages/components/src/color-picker/test/index.tsx
```
2. Check that the new test cases for the Alpha slider and input field pass.
3. Confirm that the test verifies the expected value in onChange when modifying alpha.
4. Review the test implementation to ensure coverage of both slider and input interactions.


## Screenshot

<img width="919" alt="image" src="https://github.com/user-attachments/assets/fd8b17c5-aecb-4889-9284-3a96b68ae232" />

