### PR TITLE
Components: Fix typo for notice color in readme.md

### DIFF
--- a/packages/components/src/notice/README.md
+++ b/packages/components/src/notice/README.md
@@ -19,7 +19,7 @@ Notices are color-coded to indicate the type of message being communicated:
 - **Informational** notices are **blue** by default.
 - If there is a parent `Theme` component with an `accent` color prop, informational notices will take on that color instead.
 - **Success** notices are **green.**
-- **Warning** notices are **yellow\*\***.\*\*
+- **Warning** notices are **yellow.**
 - **Error** notices are **red.**
 
 If an icon is included in the Notice, it should be color-coded to match the Notice state.


### PR DESCRIPTION
Removed extra characters from applying bold in markdown.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Fixes typo on https://developer.wordpress.org/block-editor/reference-guides/components/notice/ 

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

 ![Screenshot 2025-02-14 at 11 49 00 AM](https://github.com/user-attachments/assets/4c575f34-594c-473e-bef4-171fa08d9a31)

