### PR TITLE
Site Editor: show pattern category step in navigation for mobile

### DIFF
--- a/packages/edit-site/src/components/site-editor-routes/patterns.js
+++ b/packages/edit-site/src/components/site-editor-routes/patterns.js
@@ -1,8 +1,27 @@
 /**
+ * WordPress dependencies
+ */
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+
+/**
  * Internal dependencies
  */
 import SidebarNavigationScreenPatterns from '../sidebar-navigation-screen-patterns';
 import PagePatterns from '../page-patterns';
+import { unlock } from '../../lock-unlock';
+
+const { useLocation } = unlock( routerPrivateApis );
+
+function MobilePatternsView() {
+	const { query = {} } = useLocation();
+	const { categoryId } = query;
+
+	return !! categoryId ? (
+		<PagePatterns />
+	) : (
+		<SidebarNavigationScreenPatterns backPath="/" />
+	);
+}
 
 export const patternsRoute = {
 	name: 'patterns',
@@ -10,6 +29,6 @@ export const patternsRoute = {
 	areas: {
 		sidebar: <SidebarNavigationScreenPatterns backPath="/" />,
 		content: <PagePatterns />,
-		mobile: <PagePatterns />,
+		mobile: <MobilePatternsView />,
 	},
 };


### PR DESCRIPTION
## What?

Alternative to #67505

Navigate to the Pattern category list in mobile view. This allows access to template parts in mobile view.

## Why?

In mobile view, tapping the Patterns menu in the site editor takes you to the "All Patterns" page, meaning that users cannot access the All template parts page unless they manually enter a URL.

## How?

In between the two screens, add the  Pattern Category List page.

- Before: Design > All patterns
- After: Design > Patterns > All patterns or All template Parts

In terms of implementation, it is similar to implementing the navigation route.

## Testing Instructions

For each of the following pages, verify that screen navigation works as expected.

### Design Menu

- Site Hub Button > Go To Dashboard
- Back Button > Go To Dashboard

### Patterns Menu

- Site Hub Button > Design Menu
- Back Button > Design Menu

### Patterns/Template Parts List

- Site Hub Button > Design Menu
- User pattern or template parts > Editor Canvas

### Pattern/Template Part Editor Canvas

- Site Hub Button > 

## Screenshots or screencast <!-- if applicable -->

The screenshot below shows the link relationships between each screen. Click on the image to see a high resolution version.

<img width="2130" alt="Untitled" src="https://github.com/user-attachments/assets/653aa34f-7b26-406f-bde9-bc724ac4f479" />
