### PR TITLE
Added Missing Double Quote in Number Control

### DIFF
--- a/packages/components/src/number-control/README.md
+++ b/packages/components/src/number-control/README.md
@@ -4,7 +4,7 @@
 This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
 </div>
 
-NumberControl is an enhanced HTML [`input[type="number]`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number) element.
+NumberControl is an enhanced HTML [`input[type="number"]`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number) element.
 
 ## Usage
 


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Added Missing double quote in input type number

<!-- In a few words, what is the PR actually doing? -->

## Why?
`input[type="number]` double quote is missing here. 

**Ref:** https://developer.wordpress.org/block-editor/reference-guides/components/number-control/

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Added Missing double quote `input[type="number"]`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open packages/components/src/number-control/README.md file
2. See Error
