### PR TITLE
Editor: Add an extra check before enabling the new default rendering mode for Pages

### DIFF
--- a/backport-changelog/6.8/8123.md
+++ b/backport-changelog/6.8/8123.md
@@ -3,3 +3,4 @@ https://github.com/WordPress/wordpress-develop/pull/8123
 * https://github.com/WordPress/gutenberg/pull/68549
 * https://github.com/WordPress/gutenberg/pull/68745
 * https://github.com/WordPress/gutenberg/pull/69160
+* https://github.com/WordPress/gutenberg/pull/69209

--- a/lib/compat/wordpress-6.8/post.php
+++ b/lib/compat/wordpress-6.8/post.php
@@ -12,7 +12,7 @@ function gutenberg_update_page_editor_support() {
 		return;
 	}
 
-	if ( wp_is_block_theme() ) {
+	if ( wp_is_block_theme() && current_theme_supports( 'block-templates' ) ) {
 		add_post_type_support( 'page', 'editor', array( 'default-mode' => 'template-locked' ) );
 	}
 }


### PR DESCRIPTION
## What?
This is a small follow-up to #69160.

PR hardens condition before enabling `template-locked` as default rendering mode for Pages.

## Why?
While it should be an edge case for a block theme not to support `block-templates`, it's still technically doable. See: https://github.com/WordPress/gutenberg/issues/67875#issuecomment-2655718449.

## Testing Instructions
1. Open a page.
2. Confirm that it loads with a template-locked view.
3. Doesn't change the current behavior.
4. Remove `block-templates` theme support.
5. Reload the page.
6. Confirm that it loads in `post-only` mode.

### Testing Instructions for Keyboard
Same.
