### PR TITLE
Performance Tests: Update method for creating sample content

### DIFF
--- a/packages/e2e-test-utils-playwright/src/request-utils/pages.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/pages.ts
@@ -74,7 +74,7 @@ export async function createPage(
 	const page = await this.rest< Page >( {
 		method: 'POST',
 		path: `/wp/v2/pages`,
-		params: payload,
+		data: { ...payload },
 	} );
 
 	return page;

--- a/test/performance/fixtures/perf-utils.ts
+++ b/test/performance/fixtures/perf-utils.ts
@@ -140,6 +140,15 @@ export class PerfUtils {
 	}
 
 	/**
+	 * Loads the content of the large post fixture.
+	 */
+	async loadContentForLargePost() {
+		return readFile(
+			path.join( process.env.ASSETS_PATH!, 'large-post.html' )
+		);
+	}
+
+	/**
 	 * Loads blocks from an HTML fixture with given path into the editor canvas.
 	 *
 	 * @param filepath Path to the HTML fixture.

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -62,12 +62,14 @@ test.describe( 'Site Editor Performance', () => {
 	test.describe( 'Loading', () => {
 		let draftId = null;
 
-		test( 'Setup the test page', async ( { admin, perfUtils } ) => {
-			await admin.createNewPost( { postType: 'page' } );
-			await perfUtils.setRenderingMode( 'post-only' );
-			await perfUtils.loadBlocksForLargePost();
+		test( 'Setup the test page', async ( { requestUtils, perfUtils } ) => {
+			const content = await perfUtils.loadContentForLargePost();
+			const page = await requestUtils.createPage( {
+				content,
+				status: 'draft',
+			} );
 
-			draftId = await perfUtils.saveDraft();
+			draftId = page.id;
 		} );
 
 		const samples = 10;
@@ -121,13 +123,15 @@ test.describe( 'Site Editor Performance', () => {
 	test.describe( 'Typing', () => {
 		let draftId = null;
 
-		test( 'Setup the test post', async ( { admin, editor, perfUtils } ) => {
-			await admin.createNewPost( { postType: 'page' } );
-			await perfUtils.setRenderingMode( 'post-only' );
-			await perfUtils.loadBlocksForLargePost();
-			await editor.insertBlock( { name: 'core/paragraph' } );
+		test( 'Setup the test post', async ( { requestUtils, perfUtils } ) => {
+			const content = await perfUtils.loadContentForLargePost();
+			const page = await requestUtils.createPage( {
+				content:
+					content + `<!-- wp:paragraph --><!-- /wp:paragraph -->`,
+				status: 'draft',
+			} );
 
-			draftId = await perfUtils.saveDraft();
+			draftId = page.id;
 		} );
 
 		test( 'Run the test', async ( { admin, perfUtils, metrics, page } ) => {


### PR DESCRIPTION
## What?
Required for #69173.

PR updates the method for creating page fixtures for the Site Editor's performance tests. Instead of creating large pages "manually," the new method uses a REST API, eliminating the need to switch the editor's rendering mode.

Bonus: Using REST API requests should be a bit faster.

## Testing Instructions
All related CI checks should be green.