### PR TITLE
Template Part: Add layout support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -931,7 +931,7 @@ Edit the different global regions of your site, like the header, footer, sidebar
 
 -	**Name:** core/template-part
 -	**Category:** theme
--	**Supports:** align, interactivity (clientNavigation), ~~html~~, ~~renaming~~, ~~reusable~~
+-	**Supports:** align, interactivity (clientNavigation), layout, ~~html~~, ~~renaming~~, ~~reusable~~
 -	**Attributes:** area, slug, tagName, theme
 
 ## Term Description

--- a/packages/block-library/src/template-part/block.json
+++ b/packages/block-library/src/template-part/block.json
@@ -23,6 +23,7 @@
 	"supports": {
 		"align": true,
 		"html": false,
+		"layout": true,
 		"reusable": false,
 		"renaming": false,
 		"interactivity": {


### PR DESCRIPTION

## What?
Part of: #43248 

Add layout support to the Template Part block.


## Why?

Currently, the Template Part block lacks layout controls. 

## How?

Added layout support by enabling it in the block's configuration ( `block.json` ). Since the Template Part block already uses `useInnerBlocksProps`, enabling the layout support property is sufficient to implement this feature.

```json
"supports": {
    "layout": true
}
```

## Testing Instructions
- Create or edit a template in the Site Editor
- Add a Template Part block
- Add blocks inside the Template Part (e.g., paragraphs, headings)
- Select the Template Part block
- Verify in the sidebar that:
   - Layout controls are now available
   - The justification is working as expected
   - The width modifications are working as expected


## Screencast

https://github.com/user-attachments/assets/62baf2a0-f75a-4030-9b0a-f25bc98b9eac


