### PR TITLE
List Item: Add layout support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -426,7 +426,7 @@ An individual item within a list. ([Source](https://github.com/WordPress/gutenbe
 -	**Category:** text
 -	**Parent:** core/list
 -	**Allowed Blocks:** core/list
--	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fontSize, lineHeight), ~~className~~
+-	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout, spacing (margin, padding), splitting, typography (fontSize, lineHeight), ~~className~~
 -	**Attributes:** content, placeholder
 
 ## Login/out

--- a/packages/block-library/src/list-item/block.json
+++ b/packages/block-library/src/list-item/block.json
@@ -22,6 +22,7 @@
 	"supports": {
 		"anchor": true,
 		"className": false,
+		"layout": true,
 		"splitting": true,
 		"__experimentalBorder": {
 			"color": true,

--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -89,7 +89,7 @@ export default function ListItemEdit( {
 				<RichText
 					ref={ useMergeRefs( [ useEnterRef, useSpaceRef ] ) }
 					identifier="content"
-					tagName="div"
+					tagName="span"
 					onChange={ ( nextContent ) =>
 						setAttributes( { content: nextContent } )
 					}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Part of: https://github.com/WordPress/gutenberg/issues/43248

## What?
Added Layout support to the List Item Block.

## Why?
The block was missing Layout Support Features.

## Testing Instructions

1. Test the List Item block in both the block editor and site editor.
2. Confirm that the layout setting work correctly, and display correctly on the front.

## Screencast 

https://github.com/user-attachments/assets/8166d2e5-1a94-4c6b-b738-67c951c15f7b

