### PR TITLE
ColorPicker: Add component test for Copy button with clipboard mocking

### DIFF
--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -383,41 +383,86 @@ describe( 'ColorPicker', () => {
 	// } );
 
 	describe( 'ColorPicker copy button', () => {
+		let capturedValue: string | undefined;
+		let originalCreateElement: typeof document.createElement;
+		let originalExecCommand: typeof document.execCommand;
+
+		beforeEach( () => {
+			// Store original methods
+			originalCreateElement = document.createElement.bind( document );
+			originalExecCommand = document.execCommand;
+			capturedValue = undefined;
+
+			// Setup mocks
+			document.createElement = jest
+				.fn()
+				.mockImplementation( ( tagName: string ) => {
+					if ( tagName === 'textarea' ) {
+						const textarea = originalCreateElement( tagName );
+						Object.defineProperty( textarea, 'value', {
+							set( value ) {
+								capturedValue = value;
+								return value;
+							},
+							get() {
+								return capturedValue;
+							},
+						} );
+						return textarea;
+					}
+					return originalCreateElement( tagName );
+				} );
+
+			document.execCommand = jest.fn();
+		} );
+
+		afterEach( () => {
+			// Restore original methods
+			document.createElement = originalCreateElement;
+			document.execCommand = originalExecCommand;
+			capturedValue = undefined;
+			jest.restoreAllMocks();
+		} );
+
 		describe.each( [
 			[ 'hsl', 'HSL', 'hsl(0, 0%, 0%)' ],
 			[ 'rgb', 'RGB', 'rgb(0, 0, 0)' ],
 			[ 'hex', 'HEX', '#000000' ],
-		] )( 'copy button test for %s format', ( format, formatLabel ) => {
-			it( `should copy the color value to the clipboard for ${ formatLabel }`, async () => {
-				const color = '#000000';
-				const mockExecCommand = jest.fn();
-				document.execCommand = mockExecCommand;
+		] )(
+			'copy button test for %s format',
+			( format, formatLabel, expectedValue ) => {
+				it( `should copy the color value to the clipboard for ${ formatLabel }`, async () => {
+					const color = '#000000';
+					const user = userEvent.setup();
 
-				render( <ColorPicker color={ color } enableAlpha={ false } /> );
+					render(
+						<ColorPicker color={ color } enableAlpha={ false } />
+					);
 
-				const formatSelector = screen.getByRole( 'combobox' );
-				fireEvent.change( formatSelector, {
-					target: { value: format },
+					const formatSelector = screen.getByRole( 'combobox' );
+					await user.selectOptions( formatSelector, format );
+
+					const copyButton = screen.getByRole( 'button', {
+						name: 'Copy',
+					} );
+
+					await user.click( copyButton );
+
+					await waitFor( () => {
+						expect( document.execCommand ).toHaveBeenCalledWith(
+							'copy'
+						);
+					} );
+
+					await waitFor( () => {
+						expect( capturedValue ).toBe( expectedValue );
+					} );
+
+					expect( screen.getByRole( 'button' ) ).toHaveAccessibleName(
+						'Copied!'
+					);
 				} );
-
-				const copyButton = screen.getByRole( 'button', {
-					name: 'Copy',
-				} );
-
-				fireEvent.click( copyButton );
-
-				await waitFor( () => {
-					expect( mockExecCommand ).toHaveBeenCalledWith( 'copy' );
-				} );
-
-				expect( screen.getByRole( 'button' ) ).toHaveAccessibleName(
-					'Copied!'
-				);
-			} );
-
-			afterEach( () => {
-				jest.restoreAllMocks();
-			} );
-		} );
+			}
+		);
 	} );
 } );

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -342,4 +342,31 @@ describe( 'ColorPicker', () => {
 			} );
 		} );
 	} );
+
+	test( 'should copy the color value to the clipboard', async () => {
+		const color = '#000';
+		const user = userEvent.setup();
+
+		const readTextMock = jest
+			.spyOn( navigator.clipboard, 'readText' )
+			.mockResolvedValue( color );
+
+		render( <ColorPicker color={ color } enableAlpha={ false } /> );
+
+		const formatSelector = screen.getByRole( 'combobox' );
+		expect( formatSelector ).toBeVisible();
+		await user.selectOptions( formatSelector, 'hex' );
+
+		const copyButton = screen.getByRole( 'button', { name: 'Copy' } );
+		expect( copyButton ).toBeVisible();
+
+		await user.click( copyButton );
+
+		await waitFor( async () => {
+			const copiedText = await navigator.clipboard.readText();
+			expect( copiedText ).toBe( color );
+		} );
+
+		readTextMock.mockRestore();
+	} );
 } );

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -343,45 +343,6 @@ describe( 'ColorPicker', () => {
 		} );
 	} );
 
-	// describe.each( [
-	// 	[ 'hsl', 'HSL' ],
-	// 	[ 'rgb', 'RGB' ],
-	// 	[ 'hex', 'HEX' ],
-	// ] )( 'copy button test for %s format', ( format, formatLabel ) => {
-	// 	it( `should copy the color value to the clipboard for ${ formatLabel }`, async () => {
-	// 		const color = '#000';
-	// 		const user = userEvent.setup();
-
-	// 		// Mocks navigator.clipboard.readText to return the provided color value, simulating clipboard behavior in tests.
-	// 		// This ensures that when the clipboard is read, the color value is returned.
-	// 		// Reference: https://jestjs.io/docs/jest-object#jestspyonobject-methodname
-	// 		const readTextMock = jest
-	// 			.spyOn( navigator.clipboard, 'readText' )
-	// 			.mockResolvedValue( color );
-
-	// 		render( <ColorPicker color={ color } enableAlpha={ false } /> );
-
-	// 		const formatSelector = screen.getByRole( 'combobox' );
-	// 		expect( formatSelector ).toBeVisible();
-	// 		await user.selectOptions( formatSelector, format );
-
-	// 		const copyButton = screen.getByRole( 'button', {
-	// 			name: 'Copy',
-	// 		} );
-	// 		expect( copyButton ).toBeVisible();
-
-	// 		await user.click( copyButton );
-
-	// 		await waitFor( async () => {
-	// 			const copiedText = await navigator.clipboard.readText();
-	// 			expect( copiedText ).toBe( color );
-	// 		} );
-
-	// 		// Restores the original readText implementation.
-	// 		readTextMock.mockRestore();
-	// 	} );
-	// } );
-
 	describe( 'ColorPicker copy button', () => {
 		let capturedValue: string | undefined;
 		let originalCreateElement: typeof document.createElement;

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -343,42 +343,81 @@ describe( 'ColorPicker', () => {
 		} );
 	} );
 
-	describe.each( [
-		[ 'hsl', 'HSL' ],
-		[ 'rgb', 'RGB' ],
-		[ 'hex', 'HEX' ],
-	] )( 'copy button test for %s format', ( format, formatLabel ) => {
-		it( `should copy the color value to the clipboard for ${ formatLabel }`, async () => {
-			const color = '#000';
-			const user = userEvent.setup();
+	// describe.each( [
+	// 	[ 'hsl', 'HSL' ],
+	// 	[ 'rgb', 'RGB' ],
+	// 	[ 'hex', 'HEX' ],
+	// ] )( 'copy button test for %s format', ( format, formatLabel ) => {
+	// 	it( `should copy the color value to the clipboard for ${ formatLabel }`, async () => {
+	// 		const color = '#000';
+	// 		const user = userEvent.setup();
 
-			// Mocks navigator.clipboard.readText to return the provided color value, simulating clipboard behavior in tests.
-			// This ensures that when the clipboard is read, the color value is returned.
-			// Reference: https://jestjs.io/docs/jest-object#jestspyonobject-methodname
-			const readTextMock = jest
-				.spyOn( navigator.clipboard, 'readText' )
-				.mockResolvedValue( color );
+	// 		// Mocks navigator.clipboard.readText to return the provided color value, simulating clipboard behavior in tests.
+	// 		// This ensures that when the clipboard is read, the color value is returned.
+	// 		// Reference: https://jestjs.io/docs/jest-object#jestspyonobject-methodname
+	// 		const readTextMock = jest
+	// 			.spyOn( navigator.clipboard, 'readText' )
+	// 			.mockResolvedValue( color );
 
-			render( <ColorPicker color={ color } enableAlpha={ false } /> );
+	// 		render( <ColorPicker color={ color } enableAlpha={ false } /> );
 
-			const formatSelector = screen.getByRole( 'combobox' );
-			expect( formatSelector ).toBeVisible();
-			await user.selectOptions( formatSelector, format );
+	// 		const formatSelector = screen.getByRole( 'combobox' );
+	// 		expect( formatSelector ).toBeVisible();
+	// 		await user.selectOptions( formatSelector, format );
 
-			const copyButton = screen.getByRole( 'button', {
-				name: 'Copy',
+	// 		const copyButton = screen.getByRole( 'button', {
+	// 			name: 'Copy',
+	// 		} );
+	// 		expect( copyButton ).toBeVisible();
+
+	// 		await user.click( copyButton );
+
+	// 		await waitFor( async () => {
+	// 			const copiedText = await navigator.clipboard.readText();
+	// 			expect( copiedText ).toBe( color );
+	// 		} );
+
+	// 		// Restores the original readText implementation.
+	// 		readTextMock.mockRestore();
+	// 	} );
+	// } );
+
+	describe( 'ColorPicker copy button', () => {
+		describe.each( [
+			[ 'hsl', 'HSL', 'hsl(0, 0%, 0%)' ],
+			[ 'rgb', 'RGB', 'rgb(0, 0, 0)' ],
+			[ 'hex', 'HEX', '#000000' ],
+		] )( 'copy button test for %s format', ( format, formatLabel ) => {
+			it( `should copy the color value to the clipboard for ${ formatLabel }`, async () => {
+				const color = '#000000';
+				const mockExecCommand = jest.fn();
+				document.execCommand = mockExecCommand;
+
+				render( <ColorPicker color={ color } enableAlpha={ false } /> );
+
+				const formatSelector = screen.getByRole( 'combobox' );
+				fireEvent.change( formatSelector, {
+					target: { value: format },
+				} );
+
+				const copyButton = screen.getByRole( 'button', {
+					name: 'Copy',
+				} );
+
+				fireEvent.click( copyButton );
+
+				await waitFor( () => {
+					expect( mockExecCommand ).toHaveBeenCalledWith( 'copy' );
+				} );
+
+				expect( screen.getByRole( 'button' ) ).toHaveAccessibleName(
+					'Copied!'
+				);
 			} );
-			expect( copyButton ).toBeVisible();
 
-			await user.click( copyButton );
-
-			await waitFor( async () => {
-				const copiedText = await navigator.clipboard.readText();
-				expect( copiedText ).toBe( color );
+			afterEach( () => {
+				jest.restoreAllMocks();
 			} );
-
-			// Restores the original readText implementation.
-			readTextMock.mockRestore();
 		} );
 	} );
 } );

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -352,6 +352,9 @@ describe( 'ColorPicker', () => {
 			const color = '#000';
 			const user = userEvent.setup();
 
+			// Mocks navigator.clipboard.readText to return the provided color value, simulating clipboard behavior in tests.
+			// This ensures that when the clipboard is read, the color value is returned.
+			// Reference: https://jestjs.io/docs/jest-object#jestspyonobject-methodname
 			const readTextMock = jest
 				.spyOn( navigator.clipboard, 'readText' )
 				.mockResolvedValue( color );
@@ -374,6 +377,7 @@ describe( 'ColorPicker', () => {
 				expect( copiedText ).toBe( color );
 			} );
 
+			// Restores the original readText implementation.
 			readTextMock.mockRestore();
 		} );
 	} );

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -343,30 +343,38 @@ describe( 'ColorPicker', () => {
 		} );
 	} );
 
-	test( 'should copy the color value to the clipboard', async () => {
-		const color = '#000';
-		const user = userEvent.setup();
+	describe.each( [
+		[ 'hsl', 'HSL' ],
+		[ 'rgb', 'RGB' ],
+		[ 'hex', 'HEX' ],
+	] )( 'copy button test for %s format', ( format, formatLabel ) => {
+		it( `should copy the color value to the clipboard for ${ formatLabel }`, async () => {
+			const color = '#000';
+			const user = userEvent.setup();
 
-		const readTextMock = jest
-			.spyOn( navigator.clipboard, 'readText' )
-			.mockResolvedValue( color );
+			const readTextMock = jest
+				.spyOn( navigator.clipboard, 'readText' )
+				.mockResolvedValue( color );
 
-		render( <ColorPicker color={ color } enableAlpha={ false } /> );
+			render( <ColorPicker color={ color } enableAlpha={ false } /> );
 
-		const formatSelector = screen.getByRole( 'combobox' );
-		expect( formatSelector ).toBeVisible();
-		await user.selectOptions( formatSelector, 'hex' );
+			const formatSelector = screen.getByRole( 'combobox' );
+			expect( formatSelector ).toBeVisible();
+			await user.selectOptions( formatSelector, format );
 
-		const copyButton = screen.getByRole( 'button', { name: 'Copy' } );
-		expect( copyButton ).toBeVisible();
+			const copyButton = screen.getByRole( 'button', {
+				name: 'Copy',
+			} );
+			expect( copyButton ).toBeVisible();
 
-		await user.click( copyButton );
+			await user.click( copyButton );
 
-		await waitFor( async () => {
-			const copiedText = await navigator.clipboard.readText();
-			expect( copiedText ).toBe( color );
+			await waitFor( async () => {
+				const copiedText = await navigator.clipboard.readText();
+				expect( copiedText ).toBe( color );
+			} );
+
+			readTextMock.mockRestore();
 		} );
-
-		readTextMock.mockRestore();
 	} );
 } );


### PR DESCRIPTION
## Work in Progress

- Work on adding/updating the test to include all three format selectors: HSL, HEX, and RGB.

Follow-up PR for: https://github.com/WordPress/gutenberg/pull/49698#issue-1661313006
> I'd like to add another test for the `Copy` button, but I wasn't quite sure how to properly mock it. Rather than delay this PR, I'll put this on a list to come back to later.

## What?
Adds a component test for the Copy button in the ColorPicker component, ensuring clipboard functionality is properly mocked and tested.

## Why?
The Copy button functionality wasn't previously tested. This PR introduces a test to verify that the correct color value is copied to the clipboard when the button is clicked.



## How?

1. Mocked `navigator.clipboard.readText` using `jest.spyOn`.
2. Simulates user interactions with userEvent to select a format and trigger the copy action.
3. Verifies that the copied text matches the expected color value.

## Testing Instructions
1. Run the test by the following command:

```shell
npm run test:unit packages/components/src/color-picker/test/index.tsx
```
2. Ensure all the tests pass 


## Screenshot
<img width="930" alt="Screenshot 2025-02-18 at 2 10 29 PM" src="https://github.com/user-attachments/assets/69fc654a-9ad2-4ab2-bb4b-599a8846e06b" />




