### PR TITLE
List: Add Layout Support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -415,7 +415,7 @@ An organized collection of items displayed in a specific order. ([Source](https:
 -	**Name:** core/list
 -	**Category:** text
 -	**Allowed Blocks:** core/list-item
--	**Supports:** __unstablePasteTextInline, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** __unstablePasteTextInline, anchor, layout, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** ordered, placeholder, reversed, start, type, values
 
 ## List Item

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -39,6 +39,7 @@
 	"supports": {
 		"anchor": true,
 		"html": false,
+		"layout": true,
 		"__experimentalBorder": {
 			"color": true,
 			"radius": true,


### PR DESCRIPTION
## What ? 
Part of https://github.com/WordPress/gutenberg/issues/43248

## Why?
The block was missing the layout support 

## How?
The PR adds the following to the `block.json` of the block to support the 'Layout' 

```jsx
 "supports": {
    "layout": true
 }
```

## Testing Instructions
- Open the editor 
- Insert the List block 
- Select the list block and notice the right panel 
- Observe that the 'Layout' section is present in the settings tab 

## Screenshots or screencast 

https://github.com/user-attachments/assets/9f58bef6-a6a5-4e71-b9ca-9031575b4ba3


