### PR TITLE
Navigation Submenu: Add Layout Support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -493,7 +493,7 @@ Add a submenu to your navigation. ([Source](https://github.com/WordPress/gutenbe
 -	**Name:** core/navigation-submenu
 -	**Category:** design
 -	**Parent:** core/navigation
--	**Supports:** interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** interactivity (clientNavigation), layout, typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** description, id, isTopLevelItem, kind, label, opensInNewTab, rel, title, type, url
 
 ## Page Break

--- a/packages/block-library/src/navigation-submenu/block.json
+++ b/packages/block-library/src/navigation-submenu/block.json
@@ -59,6 +59,7 @@
 	"supports": {
 		"reusable": false,
 		"html": false,
+		"layout": true,
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,


### PR DESCRIPTION


## What?
Part of https://github.com/WordPress/gutenberg/issues/43248


## Why?
The block was missing the layout support 

## How?
The PR adds the following to the `block.json` of the block to support the 'Layout' 

```jsx
 "supports": {
    "layout": true
 }
```

## Testing Instructions
- Open the editor 
- Insert the Menu block 
- Add a menu and then create a submenu for it
- Select the submenu block and see the right panel 
- Observe that the 'Layout' section is present in the settings tab in the right panel 

## Screenshots or screencast 


https://github.com/user-attachments/assets/139cb9bb-f4b0-4c78-8909-fb2376876052


