### PR TITLE
Notice: Fix text contrast for dark mode

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 -   `NumberControl`: Fix invalid HTML attributes for infinite bounds ([#69033](https://github.com/WordPress/gutenberg/pull/69033)).
 
+### Bug Fixes
+
+-   `Notice`: Fix text contrast for dark mode ([#69226](https://github.com/WordPress/gutenberg/pull/69226)).
+
 ## 29.4.0 (2025-02-12)
 
 -   `FontSizePicker`: Remove Custom option from dropdown to prevent unexpected context changes during keyboard navigation ([#69038](https://github.com/WordPress/gutenberg/pull/69038)).

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -6,6 +6,7 @@
 	border-left: 4px solid $components-color-accent;
 	padding: 8px 12px;
 	align-items: center;
+	color: $gray-900;
 
 	&.is-dismissible {
 		position: relative;


### PR DESCRIPTION
## What?

See https://github.com/WordPress/gutenberg/issues/66454#issuecomment-2664565868

<!-- In a few words, what is the PR actually doing? -->

## Why?

The text in the `Notice` component has no explicit text color applied to it, so it will appear white in dark mode. As a result, the text will be invisible in most statuses.

## How?

Apply an explicit black text color. This value also matches [the text color of the Placeholder component](https://github.com/WordPress/gutenberg/blob/c0f3cd9f9484b650d1d0410b55750081a232e05a/packages/components/src/placeholder/style.scss#L10). 


## Testing Instructions

Launch Storybook and switch to dark mode.

## Screenshots or screencast <!-- if applicable -->

| Status | Before | After |
|--------|--------|--------|
| info | ![image](https://github.com/user-attachments/assets/3c1c938b-f1db-419c-ab53-112dcc08aec4) | ![image](https://github.com/user-attachments/assets/027ff3f2-29ca-4035-95a4-f6a9602e1f9a) |
| warning | ![image](https://github.com/user-attachments/assets/00770a0a-fbda-4469-8f43-afbb78c00cd3) |![image](https://github.com/user-attachments/assets/8468b3ef-860e-421c-aac0-5acb181f3a3e) |
| success | ![image](https://github.com/user-attachments/assets/09636f51-2846-44c9-824c-fffeed7520ec) | ![image](https://github.com/user-attachments/assets/1755ae97-f466-4f6b-ba51-c94fdb8565be) |
| error | ![image](https://github.com/user-attachments/assets/546fceee-3621-4d62-9771-04446bccd5d5) | ![image](https://github.com/user-attachments/assets/68f2be89-0ef2-484d-9e08-0cb058796667) |