### PR TITLE
Tests: Fix preloading e2e test

### DIFF
--- a/test/e2e/specs/site-editor/preload.spec.js
+++ b/test/e2e/specs/site-editor/preload.spec.js
@@ -46,9 +46,6 @@ test.describe( 'Preload', () => {
 		expect( requests ).toEqual( [
 			// Seems to be coming from `enableComplementaryArea`.
 			'/wp/v2/users/me',
-			// There are two separate settings OPTIONS requests. We should fix
-			// so the one for canUser and getEntityRecord are reused.
-			'/wp/v2/settings',
 		] );
 	} );
 } );


### PR DESCRIPTION
## What?
Related #69173.

PR fixes failing preloading e2e test.

## Why?
It started failing after #69173 was merge, but passing on PR itself.

## Testing Instructions
CI checks should be green.
