### PR TITLE
Paste: Enable space before heading text ~ handle Hex/# value

### DIFF
--- a/packages/blocks/src/api/raw-handling/markdown-converter.js
+++ b/packages/blocks/src/api/raw-handling/markdown-converter.js
@@ -11,6 +11,7 @@ const converter = new showdown.Converter( {
 	omitExtraWLInCodeBlocks: true,
 	simpleLineBreaks: true,
 	strikethrough: true,
+	requireSpaceBeforeHeadingText: true,
 } );
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/69221

This PR updates the Markdown converter by enabling the requireSpaceBeforeHeadingText option in the showdown configuration. This change ensures that headings are only recognized when there is a space between the hash (#) and the heading text.

## Why?
Previously, when hex values/hashtags (e.g. #Heading) were pasted, the # were stripped out, leading to issues as described in #69221. By requiring a space after the heading marker, the converter now adheres to standard Markdown practices, reducing rendering inconsistencies.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The solution was implemented by modifying the showdown converter options. Specifically, we set requireSpaceBeforeHeadingText to true. This forces the converter to only treat strings as headings when space between "#" and the title(# Heading) is used. Subsequently, strings representing hex values/hastags remains intact.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Open a post or page in Gutenberg.
2. Test Heading Conversion:
    - Enter a hex value without a space (e.g. #ffffff). It should remain intact ~ #ffffff
    - Enter a heading with a space (e.g. # Heading). It should render as normally.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before:- 

https://github.com/user-attachments/assets/b415fe57-3ed5-4a9a-98c5-c11df0e57505

### On enabling this:-
If a hex value is pasted(with no space), it retains the #.

https://github.com/user-attachments/assets/5d3978e1-181f-4fe8-8218-c90af825388a

If a value with a space is pasted, it behaves as expected.

https://github.com/user-attachments/assets/b798d95b-686a-417d-8d70-5707ff9531db





