### PR TITLE
E2E: Split list view keyboard shortcuts into multiple tests

### DIFF
--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -499,7 +499,174 @@ test.describe( 'List View', () => {
 		).toBeFocused();
 	} );
 
-	test( 'should cut, copy, paste, select, duplicate, insert, delete, and deselect blocks using keyboard', async ( {
+	test( 'should duplicate block using keyboard', async ( {
+		editor,
+		pageUtils,
+		listViewUtils,
+	} ) => {
+		// Insert blocks of different types.
+		await editor.insertBlock( { name: 'core/group' } );
+		await editor.insertBlock( { name: 'core/file' } );
+		await editor.insertBlock( { name: 'core/image' } );
+
+		// Open List View.
+		const listView = await listViewUtils.openListView();
+
+		// Move focus and selection to the file block to set up for testing duplication.
+		await listView
+			.getByRole( 'gridcell', { name: 'File', exact: true } )
+			.dblclick();
+
+		// Test duplication behaviour.
+		await pageUtils.pressKeys( 'primaryShift+d' );
+
+		await expect
+			.poll(
+				listViewUtils.getBlocksWithA11yAttributes,
+				'Duplicating a block should retain selection on existing block, move focus to duplicated block.'
+			)
+			.toMatchObject( [
+				{ name: 'core/group' },
+				{ name: 'core/file', selected: true },
+				{ name: 'core/file', focused: true },
+				{ name: 'core/image' },
+			] );
+	} );
+
+	test( 'should copy and paste blocks using keyboard', async ( {
+		editor,
+		page,
+		pageUtils,
+		listViewUtils,
+	} ) => {
+		// Insert blocks of different types.
+		await editor.insertBlock( { name: 'core/heading' } );
+		await editor.insertBlock( { name: 'core/file' } );
+		await editor.insertBlock( {
+			name: 'core/group',
+			innerBlocks: [
+				{ name: 'core/paragraph' },
+				{ name: 'core/pullquote' },
+			],
+		} );
+
+		// Open List View.
+		const listView = await listViewUtils.openListView();
+
+		// Click the newly inserted Group block List View item to ensure it is focused.
+		await listView
+			.getByRole( 'link', {
+				name: 'Group',
+				expanded: false,
+			} )
+			.click();
+
+		// Move down to group block, expand, and then move to the paragraph block.
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'ArrowDown' );
+		await pageUtils.pressKeys( 'primary+c' );
+		await page.keyboard.press( 'ArrowUp' );
+		await pageUtils.pressKeys( 'primary+v' );
+
+		await expect
+			.poll(
+				listViewUtils.getBlocksWithA11yAttributes,
+				'Should be able to copy focused block and paste in the list view via keyboard shortcuts'
+			)
+			.toMatchObject( [
+				{ name: 'core/heading', selected: false, focused: false },
+				{ name: 'core/file', selected: false, focused: false },
+				{
+					name: 'core/group',
+					selected: true,
+					innerBlocks: [
+						{
+							name: 'core/pullquote',
+							selected: false,
+							focused: true,
+						},
+						{
+							name: 'core/pullquote',
+							selected: false,
+							focused: false,
+						},
+					],
+				},
+			] );
+	} );
+
+	test( 'should cut and paste blocks using keyboard', async ( {
+		editor,
+		pageUtils,
+		listViewUtils,
+	} ) => {
+		// Insert blocks of different types.
+		await editor.insertBlock( { name: 'core/heading' } );
+		await editor.insertBlock( { name: 'core/file' } );
+		await editor.insertBlock( {
+			name: 'core/group',
+			innerBlocks: [
+				{ name: 'core/pullquote' },
+				{ name: 'core/pullquote' },
+			],
+		} );
+
+		// Open List View.
+		const listView = await listViewUtils.openListView();
+
+		// Click the newly inserted Group block List View item to ensure it is focused.
+		await listView
+			.getByRole( 'link', {
+				name: 'Group',
+				expanded: false,
+			} )
+			.click();
+
+		// Cut the block.
+		await pageUtils.pressKeys( 'primary+x' );
+
+		await expect
+			.poll(
+				listViewUtils.getBlocksWithA11yAttributes,
+				'Should be able to cut a block in the list view, with the preceding block being selected'
+			)
+			.toMatchObject( [
+				{ name: 'core/heading', selected: false, focused: false },
+				{ name: 'core/file', selected: true, focused: true },
+			] );
+
+		await pageUtils.pressKeys( 'primary+v' );
+
+		await expect
+			.poll(
+				listViewUtils.getBlocksWithA11yAttributes,
+				'Should be able to paste previously cut block in the list view via keyboard shortcuts'
+			)
+			.toMatchObject( [
+				{ name: 'core/heading', selected: false, focused: false },
+				{
+					name: 'core/group',
+					selected: true,
+					focused: true,
+					innerBlocks: [
+						{
+							name: 'core/pullquote',
+							selected: false,
+							focused: false,
+						},
+						{
+							name: 'core/pullquote',
+							selected: false,
+							focused: false,
+						},
+					],
+				},
+			] );
+	} );
+
+	test( 'should select and deselect blocks using keyboard', async ( {
 		editor,
 		page,
 		pageUtils,
@@ -626,7 +793,7 @@ test.describe( 'List View', () => {
 				{ name: 'core/file', selected: true, focused: false },
 			] );
 
-		// Deselect blocks via Escape key.
+		// Deselect all blocks via Escape key.
 		await page.keyboard.press( 'Escape' );
 		// Collapse the columns block.
 		await page.keyboard.press( 'ArrowLeft' );
@@ -646,25 +813,63 @@ test.describe( 'List View', () => {
 				{ name: 'core/file', selected: false, focused: false },
 			] );
 
-		// Move focus and selection to the file block to set up for testing duplication.
+		// Select the columns block and focus the file block
 		await listView
-			.getByRole( 'gridcell', { name: 'File', exact: true } )
-			.dblclick();
+			.getByRole( 'gridcell', { name: 'Columns', exact: true } )
+			.click();
+		await listView
+			.getByRole( 'gridcell', { name: 'File' } )
+			.getByRole( 'link' )
+			.focus();
 
-		// Test duplication behaviour.
-		await pageUtils.pressKeys( 'primaryShift+d' );
+		// Deselect single block via Escape key.
+		await page.keyboard.press( 'Escape' );
 
 		await expect
 			.poll(
 				listViewUtils.getBlocksWithA11yAttributes,
-				'Duplicating a block should retain selection on existing block, move focus to duplicated block.'
+				'Pressing Escape should deselect the Columns block'
 			)
 			.toMatchObject( [
-				{ name: 'core/group' },
-				{ name: 'core/columns' },
-				{ name: 'core/file', selected: true },
-				{ name: 'core/file', focused: true },
+				{ name: 'core/group', selected: false, focused: false },
+				{
+					name: 'core/columns',
+					selected: false,
+					focused: false,
+				},
+				{ name: 'core/file', selected: false, focused: true },
 			] );
+	} );
+
+	test( 'should insert and delete blocks using keyboard', async ( {
+		editor,
+		page,
+		pageUtils,
+		listViewUtils,
+	} ) => {
+		// Insert some blocks of different types.
+		await editor.insertBlock( { name: 'core/group' } );
+		await editor.insertBlock( {
+			name: 'core/columns',
+			innerBlocks: [
+				{
+					name: 'core/column',
+					innerBlocks: [
+						{ name: 'core/heading' },
+						{ name: 'core/paragraph' },
+					],
+				},
+				{
+					name: 'core/column',
+					innerBlocks: [ { name: 'core/verse' } ],
+				},
+			],
+		} );
+		await editor.insertBlock( { name: 'core/file' } );
+		await editor.insertBlock( { name: 'core/file' } );
+
+		// Open List View.
+		const listView = await listViewUtils.openListView();
 
 		// Test insert before.
 		await pageUtils.pressKeys( 'primaryAlt+t' );
@@ -688,7 +893,7 @@ test.describe( 'List View', () => {
 		await expect
 			.poll(
 				listViewUtils.getBlocksWithA11yAttributes,
-				'Inserting a block before should move selection and focus to the inserted block.'
+				'Inserting a block after should move selection and focus to the inserted block.'
 			)
 			.toMatchObject( [
 				{ name: 'core/group' },
@@ -884,113 +1089,6 @@ test.describe( 'List View', () => {
 					{ name: 'core/file', selected: false, focused: true },
 				] );
 		}
-
-		// Deselect blocks via Escape key.
-		await page.keyboard.press( 'Escape' );
-
-		await expect
-			.poll(
-				listViewUtils.getBlocksWithA11yAttributes,
-				'Pressing Escape should deselect blocks'
-			)
-			.toMatchObject( [
-				{ name: 'core/heading', selected: false, focused: false },
-				{ name: 'core/file', selected: false, focused: true },
-			] );
-
-		// Copy and paste blocks. To begin, add another Group block.
-		await editor.insertBlock( {
-			name: 'core/group',
-			innerBlocks: [
-				{ name: 'core/paragraph' },
-				{ name: 'core/pullquote' },
-			],
-		} );
-
-		// Click the newly inserted Group block List View item to ensure it is focused.
-		await listView
-			.getByRole( 'link', {
-				name: 'Group',
-				expanded: false,
-			} )
-			.click();
-
-		// Move down to group block, expand, and then move to the paragraph block.
-		await page.keyboard.press( 'ArrowDown' );
-		await page.keyboard.press( 'ArrowRight' );
-		await page.keyboard.press( 'ArrowDown' );
-		await page.keyboard.press( 'ArrowDown' );
-		await pageUtils.pressKeys( 'primary+c' );
-		await page.keyboard.press( 'ArrowUp' );
-		await pageUtils.pressKeys( 'primary+v' );
-
-		await expect
-			.poll(
-				listViewUtils.getBlocksWithA11yAttributes,
-				'Should be able to copy focused block and paste in the list view via keyboard shortcuts'
-			)
-			.toMatchObject( [
-				{ name: 'core/heading', selected: false, focused: false },
-				{ name: 'core/file', selected: false, focused: false },
-				{
-					name: 'core/group',
-					selected: true,
-					innerBlocks: [
-						{
-							name: 'core/pullquote',
-							selected: false,
-							focused: true,
-						},
-						{
-							name: 'core/pullquote',
-							selected: false,
-							focused: false,
-						},
-					],
-				},
-			] );
-
-		// Cut and paste blocks.
-		await page.keyboard.press( 'ArrowUp' );
-		await pageUtils.pressKeys( 'primary+x' );
-
-		await expect
-			.poll(
-				listViewUtils.getBlocksWithA11yAttributes,
-				'Should be able to cut a block in the list view, with the preceding block being selected'
-			)
-			.toMatchObject( [
-				{ name: 'core/heading', selected: false, focused: false },
-				{ name: 'core/file', selected: true, focused: true },
-			] );
-
-		await pageUtils.pressKeys( 'primary+v' );
-
-		await expect
-			.poll(
-				listViewUtils.getBlocksWithA11yAttributes,
-				'Should be able to paste previously cut block in the list view via keyboard shortcuts'
-			)
-			.toMatchObject( [
-				{ name: 'core/heading', selected: false, focused: false },
-				{
-					name: 'core/group',
-					selected: true,
-					focused: true,
-					innerBlocks: [
-						{
-							name: 'core/pullquote',
-							selected: false,
-							focused: false,
-						},
-						{
-							name: 'core/pullquote',
-							selected: false,
-							focused: false,
-						},
-					],
-				},
-			] );
 	} );
 
 	test( 'should create a group block from the selected multiple blocks', async ( {

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -966,7 +966,7 @@ test.describe( 'List View', () => {
 				{ name: 'core/file' },
 			] );
 
-		// Move the focus to the second colummn block.
+		// Expand the current column.
 		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.press( 'ArrowDown' );

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -666,7 +666,7 @@ test.describe( 'List View', () => {
 			] );
 	} );
 
-	test( 'should select and deselect blocks using keyboard', async ( {
+	test( 'should select blocks using keyboard', async ( {
 		editor,
 		page,
 		pageUtils,
@@ -696,7 +696,7 @@ test.describe( 'List View', () => {
 		await editor.insertBlock( { name: 'core/file' } );
 
 		// Open List View.
-		const listView = await listViewUtils.openListView();
+		await listViewUtils.openListView();
 
 		await expect
 			.poll(
@@ -792,25 +792,59 @@ test.describe( 'List View', () => {
 				},
 				{ name: 'core/file', selected: true, focused: false },
 			] );
+	} );
+
+	test( 'should deselect blocks using keyboard', async ( {
+		editor,
+		page,
+		pageUtils,
+		listViewUtils,
+	} ) => {
+		// Insert some blocks of different types.
+		await editor.insertBlock( {
+			name: 'core/group',
+			innerBlocks: [ { name: 'core/pullquote' } ],
+		} );
+		await editor.insertBlock( {
+			name: 'core/columns',
+			innerBlocks: [
+				{
+					name: 'core/column',
+					innerBlocks: [
+						{ name: 'core/heading' },
+						{ name: 'core/paragraph' },
+					],
+				},
+				{
+					name: 'core/column',
+					innerBlocks: [ { name: 'core/verse' } ],
+				},
+			],
+		} );
+		await editor.insertBlock( { name: 'core/file' } );
+
+		// Open List View.
+		const listView = await listViewUtils.openListView();
+
+		// Select all the blocks.
+		await pageUtils.pressKeys( 'primary+a' );
 
 		// Deselect all blocks via Escape key.
 		await page.keyboard.press( 'Escape' );
-		// Collapse the columns block.
-		await page.keyboard.press( 'ArrowLeft' );
 
 		await expect
 			.poll(
 				listViewUtils.getBlocksWithA11yAttributes,
-				'All blocks should be deselected, with focus on the Columns block.'
+				'All blocks should be deselected, with focus on the last inserted block.'
 			)
 			.toMatchObject( [
 				{ name: 'core/group', selected: false, focused: false },
 				{
 					name: 'core/columns',
 					selected: false,
-					focused: true,
+					focused: false,
 				},
-				{ name: 'core/file', selected: false, focused: false },
+				{ name: 'core/file', selected: false, focused: true },
 			] );
 
 		// Select the columns block and focus the file block

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -875,7 +875,49 @@ test.describe( 'List View', () => {
 			] );
 	} );
 
-	test( 'should insert and delete blocks using keyboard', async ( {
+	test( 'should insert blocks using keyboard', async ( {
+		editor,
+		pageUtils,
+		listViewUtils,
+	} ) => {
+		// Insert multiple blocks of different types.
+		await editor.insertBlock( { name: 'core/group' } );
+		await editor.insertBlock( { name: 'core/file' } );
+
+		// Open List View.
+		await listViewUtils.openListView();
+
+		// Test insert before.
+		await pageUtils.pressKeys( 'primaryAlt+t' );
+
+		await expect
+			.poll(
+				listViewUtils.getBlocksWithA11yAttributes,
+				'Inserting a block before should move selection and focus to the inserted block.'
+			)
+			.toMatchObject( [
+				{ name: 'core/group', focused: false, selected: false },
+				{ name: 'core/paragraph', focused: true, selected: true },
+				{ name: 'core/file', selected: false },
+			] );
+
+		// Test insert after.
+		await pageUtils.pressKeys( 'primaryAlt+y' );
+
+		await expect
+			.poll(
+				listViewUtils.getBlocksWithA11yAttributes,
+				'Inserting a block after should move selection and focus to the inserted block.'
+			)
+			.toMatchObject( [
+				{ name: 'core/group', focused: false, selected: false },
+				{ name: 'core/paragraph', focused: false, selected: false },
+				{ name: 'core/paragraph', focused: true, selected: true },
+				{ name: 'core/file', selected: false },
+			] );
+	} );
+
+	test( 'should delete blocks using keyboard', async ( {
 		editor,
 		page,
 		pageUtils,
@@ -905,42 +947,11 @@ test.describe( 'List View', () => {
 		// Open List View.
 		const listView = await listViewUtils.openListView();
 
-		// Test insert before.
-		await pageUtils.pressKeys( 'primaryAlt+t' );
-
-		await expect
-			.poll(
-				listViewUtils.getBlocksWithA11yAttributes,
-				'Inserting a block before should move selection and focus to the inserted block.'
-			)
-			.toMatchObject( [
-				{ name: 'core/group' },
-				{ name: 'core/columns' },
-				{ name: 'core/file', selected: false },
-				{ name: 'core/paragraph', focused: true, selected: true },
-				{ name: 'core/file', selected: false },
-			] );
-
-		// Test insert after.
-		await pageUtils.pressKeys( 'primaryAlt+y' );
-
-		await expect
-			.poll(
-				listViewUtils.getBlocksWithA11yAttributes,
-				'Inserting a block after should move selection and focus to the inserted block.'
-			)
-			.toMatchObject( [
-				{ name: 'core/group' },
-				{ name: 'core/columns' },
-				{ name: 'core/file', selected: false },
-				{ name: 'core/paragraph', focused: false, selected: false },
-				{ name: 'core/paragraph', focused: true, selected: true },
-				{ name: 'core/file', selected: false },
-			] );
-
-		// Remove the inserted blocks.
-		await page.keyboard.press( 'Delete' );
-		await page.keyboard.press( 'Delete' );
+		// Select the first file block.
+		await listView
+			.getByRole( 'gridcell', { name: 'File', exact: true } )
+			.first()
+			.dblclick();
 
 		// Delete the first File block.
 		await page.keyboard.press( 'Delete' );
@@ -955,7 +966,7 @@ test.describe( 'List View', () => {
 				{ name: 'core/file' },
 			] );
 
-		// Expand the current column.
+		// Move the focus to the second colummn block.
 		await page.keyboard.press( 'ArrowRight' );
 		await page.keyboard.press( 'ArrowDown' );
 		await page.keyboard.press( 'ArrowDown' );


### PR DESCRIPTION
## What, Why and How?
Part of #64305 

This PR splits [List View > should cut, copy, paste, select, duplicate, insert, delete, and deselect blocks using keyboard](https://github.com/WordPress/gutenberg/blob/a52b95110ae225bbcb6a63af3b8700717ebc7060/test/e2e/specs/editor/various/list-view.spec.js#L499) into the following tests:

1. should duplicate block using keyboard
2. should copy and paste blocks using keyboard
3. should cut and paste blocks using keyboard
4. should select blocks using keyboard
5. should deselect blocks using keyboard
6. should insert blocks using keyboard
7. should delete blocks using keyboard

## Testing Instructions

1. In a local environment, run the following command:
```
npm run test:e2e -- /test/e2e/specs/editor/various/list-view.spec.js
```
2. Confirm all the tests corresponding to the `list-view.spec.js` pass.


## Screenshot
<img width="1470" alt="e2e" src="https://github.com/user-attachments/assets/6c1ab368-0124-42f1-a1bd-a030a577e8eb" />

