### PR TITLE
Video Block: Disable autoplay when video is not muted

### DIFF
--- a/packages/block-library/src/video/edit-common-settings.js
+++ b/packages/block-library/src/video/edit-common-settings.js
@@ -73,7 +73,9 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 					checked={ !! autoplay }
 					help={
 						! muted
-							? __( 'Autoplay is disbaled when unmuted' )
+							? __(
+									'Autoplay can be enabled when Mute is enabled.'
+							  )
 							: getAutoplayHelp
 					}
 					disabled={ ! muted }

--- a/packages/block-library/src/video/edit-common-settings.js
+++ b/packages/block-library/src/video/edit-common-settings.js
@@ -65,6 +65,7 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 					onChange={ toggleFactory.autoplay }
 					checked={ !! autoplay }
 					help={ getAutoplayHelp }
+					disabled={ ! muted }
 				/>
 			</ToolsPanelItem>
 			<ToolsPanelItem

--- a/packages/block-library/src/video/edit-common-settings.js
+++ b/packages/block-library/src/video/edit-common-settings.js
@@ -7,7 +7,7 @@ import {
 	SelectControl,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
-import { useMemo, useCallback, Platform } from '@wordpress/element';
+import { useMemo, useCallback, Platform, useEffect } from '@wordpress/element';
 
 const options = [
 	{ value: 'auto', label: __( 'Auto' ) },
@@ -22,6 +22,13 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 	const autoPlayHelpText = __(
 		'Autoplay may cause usability issues for some users.'
 	);
+
+	useEffect( () => {
+		if ( ! muted && autoplay ) {
+			setAttributes( { autoplay: false } );
+		}
+	}, [ muted, autoplay, setAttributes ] );
+
 	const getAutoplayHelp = Platform.select( {
 		web: useCallback( ( checked ) => {
 			return checked ? autoPlayHelpText : null;
@@ -64,7 +71,11 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 					label={ __( 'Autoplay' ) }
 					onChange={ toggleFactory.autoplay }
 					checked={ !! autoplay }
-					help={ getAutoplayHelp }
+					help={
+						! muted
+							? __( 'Autoplay is disbaled when unmuted' )
+							: getAutoplayHelp
+					}
 					disabled={ ! muted }
 				/>
 			</ToolsPanelItem>

--- a/packages/block-library/src/video/edit-common-settings.js
+++ b/packages/block-library/src/video/edit-common-settings.js
@@ -24,10 +24,12 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 	);
 
 	useEffect( () => {
-		if ( ! muted && autoplay ) {
-			setAttributes( { autoplay: false } );
+		if ( autoplay ) {
+			setAttributes( { muted: true } );
+		} else {
+			setAttributes( { muted: false } );
 		}
-	}, [ muted, autoplay, setAttributes ] );
+	}, [ autoplay, setAttributes ] );
 
 	const getAutoplayHelp = Platform.select( {
 		web: useCallback( ( checked ) => {
@@ -71,14 +73,7 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 					label={ __( 'Autoplay' ) }
 					onChange={ toggleFactory.autoplay }
 					checked={ !! autoplay }
-					help={
-						! muted
-							? __(
-									'Autoplay can be enabled when Mute is enabled.'
-							  )
-							: getAutoplayHelp
-					}
-					disabled={ ! muted }
+					help={ getAutoplayHelp }
 				/>
 			</ToolsPanelItem>
 			<ToolsPanelItem
@@ -109,6 +104,10 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 					label={ __( 'Muted' ) }
 					onChange={ toggleFactory.muted }
 					checked={ !! muted }
+					disabled={ autoplay }
+					help={
+						autoplay ? __( 'Muted because of Autoplay.' ) : null
+					}
 				/>
 			</ToolsPanelItem>
 			<ToolsPanelItem

--- a/packages/block-library/src/video/edit-common-settings.js
+++ b/packages/block-library/src/video/edit-common-settings.js
@@ -7,7 +7,7 @@ import {
 	SelectControl,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
-import { useMemo, useCallback, Platform, useEffect } from '@wordpress/element';
+import { useMemo, useCallback, Platform } from '@wordpress/element';
 
 const options = [
 	{ value: 'auto', label: __( 'Auto' ) },
@@ -23,14 +23,6 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 		'Autoplay may cause usability issues for some users.'
 	);
 
-	useEffect( () => {
-		if ( autoplay ) {
-			setAttributes( { muted: true } );
-		} else {
-			setAttributes( { muted: false } );
-		}
-	}, [ autoplay, setAttributes ] );
-
 	const getAutoplayHelp = Platform.select( {
 		web: useCallback( ( checked ) => {
 			return checked ? autoPlayHelpText : null;
@@ -41,7 +33,11 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 	const toggleFactory = useMemo( () => {
 		const toggleAttribute = ( attribute ) => {
 			return ( newValue ) => {
-				setAttributes( { [ attribute ]: newValue } );
+				setAttributes( {
+					[ attribute ]: newValue,
+					// Set muted when autoplay changes
+					...( attribute === 'autoplay' && { muted: newValue } ),
+				} );
 			};
 		};
 
@@ -65,7 +61,7 @@ const VideoSettings = ( { setAttributes, attributes } ) => {
 				isShownByDefault
 				hasValue={ () => !! autoplay }
 				onDeselect={ () => {
-					setAttributes( { autoplay: false } );
+					setAttributes( { autoplay: false, muted: false } );
 				} }
 			>
 				<ToggleControl


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/69218

## Why?
The users are unaware that the video is not playing when autoplay is enabled but the mute option is not selected.

## How?
This PR disables the autoplay toggle when the video is not muted and displays a user-friendly message prompting the user to enable the mute option for autoplay to work.

Implementation is based on this comment https://github.com/WordPress/gutenberg/issues/69218#issuecomment-2664874853

## Testing Instructions

- Open a post 
- Add a 'Video' Block 
- Add the video to the video block 
- Notice on the right panel that the 'Autoplay' is disabled unless the user doesn't toggle the 'Muted' switch 

## Screenshots or screencast 

https://github.com/user-attachments/assets/36b77917-61e3-492f-8759-9f32690d4817



