### PR TITLE
Added Missing Global Documentation in Query Total Block

### DIFF
--- a/packages/block-library/src/query-total/index.php
+++ b/packages/block-library/src/query-total/index.php
@@ -10,7 +10,7 @@
  *
  * @since 6.8.0
  *
- * @global WP_Query $wp_query WordPress Query object. 
+ * @global WP_Query $wp_query WordPress Query object.
  *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.

--- a/packages/block-library/src/query-total/index.php
+++ b/packages/block-library/src/query-total/index.php
@@ -10,6 +10,8 @@
  *
  * @since 6.8.0
  *
+ * @global WP_Query $wp_query WordPress Query object. 
+ *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
  * @param WP_Block $block      Block instance.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
- Added Global Documentation in Query Total Block

<!-- In a few words, what is the PR actually doing? -->

## Why?
- Global Documentation is Missing in `packages/block-library/src/query-total/index.php` file

## How?
- Added Global Documentation in  `packages/block-library/src/query-total/index.php` file

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open `packages/block-library/src/query-total/index.php` file
2. See Global Documentation is Missing 

