### PR TITLE
ServerSideRender: refactor fetchData to use `useCallback` and `refs`

### DIFF
--- a/packages/server-side-render/CHANGELOG.md
+++ b/packages/server-side-render/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Fix `ServerSideRender` not updating when attributes change by properly implementing debounced fetch with refs ([#69237](https://github.com/WordPress/gutenberg/pull/69237)).
+
 ## 5.22.0 (2025-04-11)
 
 ## 5.21.0 (2025-03-27)

--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -117,14 +117,13 @@ export default function ServerSideRender( props ) {
 			return;
 		}
 
-		const currentProps = latestPropsRef.current;
 		const {
 			attributes,
 			block,
 			skipBlockSupportAttributes = false,
 			httpMethod = 'GET',
 			urlQueryArgs,
-		} = currentProps;
+		} = latestPropsRef.current;
 
 		setIsLoading( true );
 

--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -106,11 +106,7 @@ export default function ServerSideRender( props ) {
 	const prevProps = usePrevious( props );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const latestPropsRef = useRef( props );
-
-	// Store props in ref to prevent stale closures in the fetchData callback.
-	useEffect( () => {
-		latestPropsRef.current = props;
-	}, [ props ] );
+	latestPropsRef.current = props;
 
 	const fetchData = useCallback( () => {
 		if ( ! isMountedRef.current ) {

--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -7,7 +7,13 @@ import fastDeepEqual from 'fast-deep-equal/es6';
  * WordPress dependencies
  */
 import { useDebounce, usePrevious } from '@wordpress/compose';
-import { RawHTML, useEffect, useRef, useState } from '@wordpress/element';
+import {
+	RawHTML,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
@@ -87,12 +93,7 @@ function DefaultLoadingResponsePlaceholder( { children, showLoader } ) {
 
 export default function ServerSideRender( props ) {
 	const {
-		attributes,
-		block,
 		className,
-		httpMethod = 'GET',
-		urlQueryArgs,
-		skipBlockSupportAttributes = false,
 		EmptyResponsePlaceholder = DefaultEmptyResponsePlaceholder,
 		ErrorResponsePlaceholder = DefaultErrorResponsePlaceholder,
 		LoadingResponsePlaceholder = DefaultLoadingResponsePlaceholder,
@@ -104,11 +105,26 @@ export default function ServerSideRender( props ) {
 	const [ response, setResponse ] = useState( null );
 	const prevProps = usePrevious( props );
 	const [ isLoading, setIsLoading ] = useState( false );
+	const latestPropsRef = useRef( props );
 
-	function fetchData() {
+	// Store props in ref to prevent stale closures in the fetchData callback.
+	useEffect( () => {
+		latestPropsRef.current = props;
+	}, [ props ] );
+
+	const fetchData = useCallback( () => {
 		if ( ! isMountedRef.current ) {
 			return;
 		}
+
+		const currentProps = latestPropsRef.current;
+		const {
+			attributes,
+			block,
+			skipBlockSupportAttributes = false,
+			httpMethod = 'GET',
+			urlQueryArgs,
+		} = currentProps;
 
 		setIsLoading( true );
 
@@ -177,7 +193,7 @@ export default function ServerSideRender( props ) {
 			} ) );
 
 		return fetchRequest;
-	}
+	}, [] );
 
 	const debouncedFetchData = useDebounce( fetchData, 500 );
 


### PR DESCRIPTION
## What?
Closes #69220

The `ServerSideRender` does not re-render when the attributes change. This issue can be best reproduced with the `Calendar` block where the `Background` property does not reflect on the editor upon making changes.

## Why and How?

According to the `useDebounce` implementation, if any of the arguments change, including the function to debounce, the scheduled call gets canceled.

Ref:
https://github.com/WordPress/gutenberg/blob/c85696411b28c879c1a7547b941db141c0fba8a6/packages/compose/src/hooks/use-debounce/index.js#L36

In our case, the `fetchData` function changes. The debounce function should ideally be wrapped within a `useCallback` as recommended here:
https://github.com/WordPress/gutenberg/blob/c85696411b28c879c1a7547b941db141c0fba8a6/packages/compose/src/hooks/use-debounce/index.js#L17-L20

This alone won't suffice as the change in `props` causes the `fetchData` to re-create/change again. It's best to mimic the props with refs which should be used within `fetchData` with an empty dependency array. The ref will act as a "pointer" to current props without causing function recreation and this approach won't cancel the debounce calls as reflected in the screencast below.

## Testing Instructions

1. Add Calendar Block.
2. Change the text color & background color.
3. Confirm the changes happen both on the editor and front-end.

_Note: A similar issue involving the `Latest Comments` block is also fixed._

## Screencast

https://github.com/user-attachments/assets/2b22e011-e0af-40d7-8e0d-9181db8ab98d
