### PR TITLE
Custom Gradient Picker: Add border to improve visibility of light gradients

### DIFF
--- a/packages/components/src/custom-gradient-picker/gradient-bar/index.tsx
+++ b/packages/components/src/custom-gradient-picker/gradient-bar/index.tsx
@@ -22,6 +22,25 @@ import type {
 } from '../types';
 import type { MouseEventHandler } from 'react';
 
+const isLightGradient = (
+	background: React.CSSProperties[ 'background' ]
+): boolean => {
+	if ( typeof background !== 'string' ) {
+		return false;
+	}
+
+	return (
+		background.includes( 'rgb(255, 255, 255)' ) ||
+		background.includes( '#fff' ) ||
+		background.includes( '#ffffff' ) ||
+		background.includes( 'white' ) ||
+		// Check for rgba with high values.
+		/rgba?\(\s*(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d),\s*(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d),\s*(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)(?:,\s*(?:0?\.\d+|1))?\s*\)/.test(
+			background
+		)
+	);
+};
+
 const customGradientBarReducer = (
 	state: CustomGradientBarReducerState,
 	action: CustomGradientBarReducerAction
@@ -135,7 +154,11 @@ export default function CustomGradientBar( {
 		<div
 			className={ clsx(
 				'components-custom-gradient-picker__gradient-bar',
-				{ 'has-gradient': hasGradient }
+				{
+					'has-gradient': hasGradient,
+					'has-light-gradient':
+						hasGradient && isLightGradient( background ),
+				}
 			) }
 			onMouseEnter={ onMouseEnterAndMove }
 			onMouseMove={ onMouseEnterAndMove }

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -7,6 +7,16 @@ $components-custom-gradient-picker__padding: $grid-unit-20; // 48px container, 1
 	position: relative;
 	z-index: 1;
 
+	border: 1px solid $components-color-accent;
+	box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+
+	&.has-light-gradient {
+		border: 1px solid $gray-900;
+		box-shadow:
+			inset 0 0 0 1px rgba(0, 0, 0, 0.1),
+			0 0 0 1px rgba(0, 0, 0, 0.1);
+	}
+
 	&.has-gradient {
 		// The background image creates a checkerboard pattern. Ignore rtlcss to
 		// make it work both in LTR and RTL.


### PR DESCRIPTION
Closes #50507

## What?
Adds a visible border and subtle box shadow to the gradient picker bar to improve visibility when using white or light-colored gradients.


## Why?
Currently, when the gradient is white or very light in color, the field in the color palette panel is hard to see, making it difficult for users to interact with the gradient controls. This creates a poor user experience when working with light colors.

## How?
- Added a default border using WordPress admin theme color
- Implemented a dynamic border that becomes more prominent for light gradients
- Added subtle box shadow for better definition
- Maintained existing checkerboard pattern for transparency
- Added utility function to detect light gradients
- Added appropriate className conditionals

## Testing Instructions
1. Open the block editor
2. Add any block that supports gradients (like a Cover block)
3. Open the gradient picker
4. Create a gradient using white or very light colors
5. Verify that the gradient bar is clearly visible with a border
6. Create another gradient with dark colors
7. Verify that the border is appropriately subtle for dark gradients
8. Test different gradient combinations to ensure the border visibility is appropriate


## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/f9b4f44d-4eb4-4c86-a707-117e275efd21

### After

https://github.com/user-attachments/assets/586280b3-5bcf-4103-bff5-b5cb8b771971

