### PR TITLE
Block Hooks: Enable first/last child insertion next to Classic block

### DIFF
--- a/backport-changelog/6.8/8212.md
+++ b/backport-changelog/6.8/8212.md
@@ -2,3 +2,4 @@ https://github.com/WordPress/wordpress-develop/pull/8212
 
 * https://github.com/WordPress/gutenberg/pull/68926
 * https://github.com/WordPress/gutenberg/pull/69142
+* https://github.com/WordPress/gutenberg/pull/69241


### PR DESCRIPTION
## What?
Closes #68988. 

Allow insertion of a hooked block as the first or last child of the Post Content block (and, less importantly, of the Synced Pattern and Navigation blocks).

## Why?

As of https://github.com/WordPress/gutenberg/pull/67272, Block Hooks are applied to post content. This includes injecting hooked blocks as the first or last child of the Post Content block. However, this didn't work if the post content itself didn't contain any block markup (which is possible if it was originally created in the classic editor, or if it only contains one Classic block).

This limitation is due to the way hooked block insertion works (explained [here](https://github.com/WordPress/gutenberg/issues/68988#issuecomment-2663272032)).

## How?
By wrapping content that doesn't contain any blocks in a temporary Classic block wrapper, and removing the latter after Block Hooks have been applied.

## Testing Instructions
- Create a new post that only includes one Classic block.
- Install and activate the [test plugin](https://github.com/WordPress/gutenberg/blob/90ee09a5d28b68f1e2cd5291709de0da06f7418e/packages/e2e-tests/plugins/block-hooks.php). (You might have to zip it before doing so.)
- Reload the post on the frontend.
- Verify that it now includes a paragraph block in the last child position (see screenshot below).
- Open the post in the editor, and switch to the Code Editor.
- Verify that the markup looks as expected.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
| <img width="540" alt="image" src="https://github.com/user-attachments/assets/55242306-5552-416b-8a8f-299bae3ab9a0" /> | <img width="580" alt="image" src="https://github.com/user-attachments/assets/1fb49d35-6c64-4b97-b176-5ffc76e756df" /> |
