### PR TITLE
[Background Image Control] - Added placeholder for background images

### DIFF
--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -8,6 +8,7 @@ import clsx from 'clsx';
  */
 import {
 	ToggleControl,
+	ColorIndicator,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	__experimentalUnitControl as UnitControl,
@@ -131,23 +132,33 @@ function InspectorImagePreviewItem( {
 				as="span"
 				className="block-editor-global-styles-background-panel__inspector-preview-inner"
 			>
-				{ imgUrl && (
-					<span
-						className="block-editor-global-styles-background-panel__inspector-image-indicator-wrapper"
-						aria-hidden
-					>
+				<span
+					className="block-editor-global-styles-background-panel__inspector-image-indicator-wrapper"
+					aria-hidden
+				>
+					{ imgUrl ? (
 						<span
 							className="block-editor-global-styles-background-panel__inspector-image-indicator"
 							style={ {
 								backgroundImage: `url(${ imgUrl })`,
 							} }
 						/>
-					</span>
-				) }
+					) : (
+						<ColorIndicator
+							as="span"
+							className="block-editor-global-styles-background-panel__inspector-image-indicator"
+							colorValue={ undefined }
+						/>
+					) }
+				</span>
 				<FlexItem as="span" style={ imgUrl ? {} : { flexGrow: 1 } }>
 					<Truncate
 						numberOfLines={ 1 }
-						className="block-editor-global-styles-background-panel__inspector-media-replace-title"
+						className={
+							imgUrl
+								? 'block-editor-global-styles-background-panel__inspector-media-replace-title'
+								: 'block-editor-global-styles-background-panel__inspector-media-replace-title-placeholder'
+						}
 					>
 						{ label }
 					</Truncate>

--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -146,7 +146,7 @@ function InspectorImagePreviewItem( {
 					) : (
 						<ColorIndicator
 							as="span"
-							className="block-editor-global-styles-background-panel__inspector-image-indicator"
+							className="block-editor-global-styles-background-panel__inspector-image-indicator "
 							colorValue={ undefined }
 						/>
 					) }

--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -146,7 +146,7 @@ function InspectorImagePreviewItem( {
 					) : (
 						<ColorIndicator
 							as="span"
-							className="block-editor-global-styles-background-panel__inspector-image-indicator "
+							className="block-editor-global-styles-background-panel__inspector-image-indicator"
 							colorValue={ undefined }
 						/>
 					) }

--- a/packages/block-editor/src/components/background-image-control/style.scss
+++ b/packages/block-editor/src/components/background-image-control/style.scss
@@ -99,6 +99,13 @@
 	text-align-last: center;
 }
 
+.block-editor-global-styles-background-panel__inspector-media-replace-title-placeholder {
+	word-break: break-all;
+	// The Button component is white-space: nowrap, and that won't work with line-clamp.
+	white-space: normal;
+	text-align: start;
+}
+
 .block-editor-global-styles-background-panel__inspector-preview-inner {
 	.block-editor-global-styles-background-panel__inspector-image-indicator-wrapper {
 		width: 20px;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Attempt fix #69243

## What?
This PR ensures that when a Group has no background image, the placeholder (grey crossed-out circle) is displayed alongside the "Add background image" text.

## Why?
Currently, when a Group has no background image, only the text "Add background image" is shown, but the placeholder icon is missing. This inconsistency affects the visual clarity of the UI. The placeholder is present for color options, so it should also be added for background images for consistency.

## How?

- Added the missing placeholder (grey crossed-out circle) next to the "Add background image" text.
- Matched the placeholder style to the one used for colors.
- Ensured that when an image is added, it appears within the same circular container as expected.

```JS
<ColorIndicator
	 as="span"
	 className="block-editor-global-styles-background-panel__inspector-image-indicator"
	 colorValue={ undefined }
/>
```


## Testing Instructions

1. Open a post or page in the editor.
2. Insert a Group block.
3. Ensure that the "Add background image" text now includes the grey crossed-out circle as a placeholder.
4. Add a background image and verify that it displays correctly in the same circular placeholder area.
5. Remove the background image and confirm that the placeholder reappears.

## Screencast

https://github.com/user-attachments/assets/b8fae57d-769b-4009-8ffb-b4a1863997c2



