### PR TITLE
Inserter: Align Quick Inserter Patterns with Block Directory UI

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -26,9 +26,13 @@ import InserterDraggableBlocks from '../inserter-draggable-blocks';
 import BlockPatternsPaging from '../block-patterns-paging';
 import { INSERTER_PATTERN_TYPES } from '../inserter/block-patterns-tab/utils';
 
-const WithToolTip = ( { showTooltip, title, children } ) => {
+const WithToolTip = ( { showTooltip, placement, title, children } ) => {
 	if ( showTooltip ) {
-		return <Tooltip text={ title }>{ children }</Tooltip>;
+		return (
+			<Tooltip placement={ placement } text={ title }>
+				{ children }
+			</Tooltip>
+		);
 	}
 	return <>{ children }</>;
 };
@@ -42,6 +46,7 @@ function BlockPattern( {
 	showTitlesAsTooltip,
 	category,
 	isSelected,
+	placement,
 } ) {
 	const [ isDragging, setIsDragging ] = useState( false );
 	const { blocks, viewportWidth } = pattern;
@@ -97,6 +102,7 @@ function BlockPattern( {
 					<WithToolTip
 						showTooltip={ showTitlesAsTooltip && ! isUserPattern }
 						title={ pattern.title }
+						placement={ placement }
 					>
 						<Composite.Item
 							render={
@@ -190,6 +196,7 @@ function BlockPatternsList(
 		category,
 		showTitlesAsTooltip,
 		pagingProps,
+		placement,
 	},
 	ref
 ) {
@@ -232,6 +239,7 @@ function BlockPatternsList(
 					isSelected={
 						!! activePattern && activePattern === pattern.name
 					}
+					placement={ placement }
 				/>
 			) ) }
 			{ pagingProps && <BlockPatternsPaging { ...pagingProps } /> }

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -191,6 +191,8 @@ function InserterSearchResults( {
 					onClickPattern={ onClickPattern }
 					onHover={ onHoverPattern }
 					isDraggable={ isDraggable }
+					showTitlesAsTooltip
+					placement="top"
 				/>
 			</div>
 		</InserterPanel>


### PR DESCRIPTION


## What?
This PR adds a tooltip to the search results component used as part of the quick inserter patterns within the inserter menu.

Part of: https://github.com/WordPress/gutenberg/issues/24975

Related PR: https://github.com/WordPress/gutenberg/pull/46419


## Why?

- Currently, tooltips are not consistently displayed across different inserter components. For example, the Block Directory Downloadable Blocks Panel already uses tooltips with a top placement, but the same is not the case for the Quick Inserter Patterns component.

- This update ensures a uniform user experience by introducing tooltips in the Quick Inserter Patterns section (`block-editor-inserter__quick-inserter-patterns`).

## How?

- Implemented a tooltip for quick inserter patterns results in the inserter, controlled via the existing `showTitlesAsTooltip` prop to ensure flexibility.
- No hardcoded placement values—maintains consistency with other tooltip implementations.
- This change should not affect existing functionality in the codebase.

## Screenshots or screencast 

### Before 

https://github.com/user-attachments/assets/f0db4f42-188f-44cb-800d-3468add624f5





### After



https://github.com/user-attachments/assets/761d8b35-a2a6-4d48-b3db-2e6e5eb8e299



