### PR TITLE
Core Data: Allow 'null' as raw attribute value

### DIFF
--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -465,7 +465,10 @@ export const getRawEntityRecord = createSelector(
 					// Because edits are the "raw" attribute values,
 					// we return those from record selectors to make rendering,
 					// comparisons, and joins with edits easier.
-					accumulator[ _key ] = record[ _key ]?.raw ?? record[ _key ];
+					accumulator[ _key ] =
+						record[ _key ]?.raw !== undefined
+							? record[ _key ]?.raw
+							: record[ _key ];
 				} else {
 					accumulator[ _key ] = record[ _key ];
 				}

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -332,6 +332,48 @@ describe( 'getRawEntityRecord', () => {
 			},
 		} );
 	} );
+	it( 'should allow `null` as raw value', () => {
+		const state = deepFreeze( {
+			entities: {
+				config: [
+					{
+						kind: 'someKind',
+						name: 'someName',
+						rawAttributes: [ 'title' ],
+					},
+				],
+				records: {
+					someKind: {
+						someName: {
+							queriedData: {
+								items: {
+									default: {
+										post: {
+											title: {
+												raw: null,
+												rendered: 'Placeholder',
+											},
+										},
+									},
+								},
+								itemIsComplete: {
+									default: {
+										post: true,
+									},
+								},
+								queries: {},
+							},
+						},
+					},
+				},
+			},
+		} );
+		expect(
+			getRawEntityRecord( state, 'someKind', 'someName', 'post' )
+		).toEqual( {
+			title: null,
+		} );
+	} );
 } );
 
 describe( 'getEntityRecords', () => {


### PR DESCRIPTION
## What?
Fixes #69236.

PR fixes a regression `getRawEntityRecord` to allow raw attribute values to be `null`.

## Testing Instructions
CI checks should pass.
