### PR TITLE
[Type] Enhancement Shortens the warning message.

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -570,7 +570,7 @@ function Navigation( {
 	const submenuAccessibilityNotice =
 		! showSubmenuIcon && ! openSubmenusOnClick
 			? __(
-					'The current menu options offer reduced accessibility for users and are not recommended. Enabling either "Open on Click" or "Show arrow" offers enhanced accessibility by allowing keyboard users to browse submenus selectively.'
+					'The current menu options limit accessibility. Enabling "Open on Click" or "Show Arrow" improves usability for keyboard users navigating submenus.'
 			  )
 			: '';
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes [#68181](https://github.com/WordPress/gutenberg/issues/68181)

<!-- In a few words, what is the PR actually doing? -->
Shortens the verbose warning message found in the Navigation block settings, the Submenu section has two toggles. If they are both switched to "off" the warning message in question appears.
## Why?
Reduces verbosity and improves readability through conciseness.

## How?
Updates the warning message text description.

## Testing Instructions
1. Add a navigation block.
2. In the submenu section disable both toggles.
3. The warning message appears.