### PR TITLE
Style Book: Increase color examples per row to six

### DIFF
--- a/packages/edit-site/src/components/style-book/examples.tsx
+++ b/packages/edit-site/src/components/style-book/examples.tsx
@@ -101,7 +101,7 @@ function getOverviewBlockExamples(
 				<ColorExamples
 					colors={ themePalette.colors }
 					type="colors"
-					templateColumns="repeat(auto-fill, minmax( 200px, 1fr ))"
+					templateColumns="repeat(auto-fill, minmax( 120px, 1fr ))"
 					itemHeight="32px"
 				/>
 			),

--- a/packages/editor/src/components/style-book/examples.tsx
+++ b/packages/editor/src/components/style-book/examples.tsx
@@ -95,7 +95,7 @@ function getOverviewBlockExamples(
 				<ColorExamples
 					colors={ themePalette.colors }
 					type="colors"
-					templateColumns="repeat(auto-fill, minmax( 200px, 1fr ))"
+					templateColumns="repeat(auto-fill, minmax( 120px, 1fr ))"
 					itemHeight="32px"
 				/>
 			),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?  
Closes #69165

This PR updates the Style Book to display six colors per row instead of four, ensuring consistency with the color palette component in the block editor.  

## Why?  
The current Style Book layout displays only four colors per row, which is inconsistent with the editor's color palette component that displays six colors per row. This change enhances the design system experience by maintaining uniformity across the editor and ensuring a more logical color organization.  

## How?  
The `templateColumns` property in `ColorExamples` has been adjusted to use a smaller minimum column width (`120px` instead of `200px`), allowing six colors to fit in a row.  

## Testing Instructions  

1. Open the Site Editor.  
2. Navigate to the Style Book.  
3. Locate the color palette section.  
4. Verify that six colors are displayed per row instead of four.  

## Screenshots or Screencast  

Before:

https://github.com/user-attachments/assets/ac350635-58cf-4f10-937d-7a4b628d3339


After:

https://github.com/user-attachments/assets/df605db9-d1b3-45a2-93c5-4c8b8105d75b
