### PR TITLE
BlockStylesPanel: should only be displayed in default editing mode

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -26,7 +26,6 @@ import useInspectorControlsTabs from '../inspector-controls-tabs/use-inspector-c
 import AdvancedControls from '../inspector-controls-tabs/advanced-controls-panel';
 import PositionControls from '../inspector-controls-tabs/position-controls-panel';
 import useBlockInspectorAnimationSettings from './useBlockInspectorAnimationSettings';
-import { useBlockEditingMode } from '../block-editing-mode';
 import BlockQuickNavigation from '../block-quick-navigation';
 import { useBorderPanelLabel } from '../../hooks/border';
 
@@ -222,7 +221,10 @@ const BlockInspectorSingleBlock = ( {
 	);
 	const blockInformation = useBlockDisplayInformation( clientId );
 	const borderPanelLabel = useBorderPanelLabel( { blockName } );
-	const blockEditingMode = useBlockEditingMode();
+	const blockEditingMode = useSelect( ( select ) => {
+		const { getBlockEditingMode } = select( blockEditorStore );
+		return getBlockEditingMode( clientId );
+	} );
 	const contentClientIds = useSelect(
 		( select ) => {
 			// Avoid unnecessary subscription.
@@ -244,19 +246,6 @@ const BlockInspectorSingleBlock = ( {
 		[ isSectionBlock, clientId ]
 	);
 
-	const isWithinContentBlock = useSelect(
-		( select ) => {
-			const { getBlockParents, getBlockName } =
-				select( blockEditorStore );
-			const parents = getBlockParents( clientId );
-
-			return parents.some(
-				( parent ) => getBlockName( parent ) === 'core/post-content'
-			);
-		},
-		[ clientId ]
-	);
-
 	return (
 		<div className="block-editor-block-inspector">
 			<BlockCard
@@ -274,11 +263,9 @@ const BlockInspectorSingleBlock = ( {
 			) }
 			{ ! showTabs && (
 				<>
-					{ ( isWithinContentBlock ||
-						blockEditingMode === 'default' ) &&
-						hasBlockStyles && (
-							<BlockStylesPanel clientId={ clientId } />
-						) }
+					{ blockEditingMode === 'default' && hasBlockStyles && (
+						<BlockStylesPanel clientId={ clientId } />
+					) }
 
 					{ contentClientIds && contentClientIds?.length > 0 && (
 						<PanelBody title={ __( 'Content' ) }>

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -244,6 +244,19 @@ const BlockInspectorSingleBlock = ( {
 		[ isSectionBlock, clientId ]
 	);
 
+	const isWithinContentBlock = useSelect(
+		( select ) => {
+			const { getBlockParents, getBlockName } =
+				select( blockEditorStore );
+			const parents = getBlockParents( clientId );
+
+			return parents.some(
+				( parent ) => getBlockName( parent ) === 'core/post-content'
+			);
+		},
+		[ clientId ]
+	);
+
 	return (
 		<div className="block-editor-block-inspector">
 			<BlockCard
@@ -261,9 +274,11 @@ const BlockInspectorSingleBlock = ( {
 			) }
 			{ ! showTabs && (
 				<>
-					{ blockEditingMode === 'default' && hasBlockStyles && (
-						<BlockStylesPanel clientId={ clientId } />
-					) }
+					{ ( isWithinContentBlock ||
+						blockEditingMode === 'default' ) &&
+						hasBlockStyles && (
+							<BlockStylesPanel clientId={ clientId } />
+						) }
 
 					{ contentClientIds && contentClientIds?.length > 0 && (
 						<PanelBody title={ __( 'Content' ) }>

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -26,6 +26,7 @@ import useInspectorControlsTabs from '../inspector-controls-tabs/use-inspector-c
 import AdvancedControls from '../inspector-controls-tabs/advanced-controls-panel';
 import PositionControls from '../inspector-controls-tabs/position-controls-panel';
 import useBlockInspectorAnimationSettings from './useBlockInspectorAnimationSettings';
+import { useBlockEditingMode } from '../block-editing-mode';
 import BlockQuickNavigation from '../block-quick-navigation';
 import { useBorderPanelLabel } from '../../hooks/border';
 
@@ -221,6 +222,7 @@ const BlockInspectorSingleBlock = ( {
 	);
 	const blockInformation = useBlockDisplayInformation( clientId );
 	const borderPanelLabel = useBorderPanelLabel( { blockName } );
+	const blockEditingMode = useBlockEditingMode();
 	const contentClientIds = useSelect(
 		( select ) => {
 			// Avoid unnecessary subscription.
@@ -259,7 +261,7 @@ const BlockInspectorSingleBlock = ( {
 			) }
 			{ ! showTabs && (
 				<>
-					{ hasBlockStyles && (
+					{ blockEditingMode === 'default' && hasBlockStyles && (
 						<BlockStylesPanel clientId={ clientId } />
 					) }
 


### PR DESCRIPTION
## What?
Closes #69238

This PR adds logic to prevent rendering `BlockStylesPanel` when the editing mode is not set to `default`. This fixes the core problem that causes the `Block Style Variations` to be displayed for the `Heading Block` when viewed from `Document Outline`, as described in the parent issue.

## Why?

Since other settings within the Block Settings are not displayed in this scenario, showing the Block Style Variations is unnecessary, especially if they cannot be saved.

## How?

Similar to how the other Panels such as `Color`, `Typography`, `Dimensions`, `Border`, and `BackgroundImage` are only rendered when the `Editing Mode` is set to `default`, this PR implements the same condition for rendering the `BlockStylesPanel` to keep the code logic consistent and achieve the desired outcome.

Ref.
https://github.com/WordPress/gutenberg/blob/4680ff3504d291e0c08a550b04f5add76f95e23b/packages/block-editor/src/hooks/style.js#L345-L347

## Testing Instructions

1. Open the page template in the Site Editor.
2. Add a heading block anywhere on the template, and save.
3. Create a new page.
4. With "Show template" enabled, open the Document Outline.
5. Confirm that the heading you added to the template is listed: Click on it.
6. Confirm you cannot see the `Block Style Variations` for the `Heading Block`.
7. Confirm the above Panel shows as expected when editing the `Template`.

## Screenshots

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/3c562638-d4e6-4af4-b77a-eff1d99a8c32)|![after-1](https://github.com/user-attachments/assets/d73a7bb8-9549-4a62-821b-aa38a905f3a9)|
