### PR TITLE
FormTokenField: Validate input before tokenizing on space

### DIFF
--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -235,7 +235,12 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 				break;
 			case 'Space':
 				if ( tokenizeOnSpace ) {
-					preventDefault = addCurrentToken();
+					if (
+						inputHasValidValue() &&
+						__experimentalValidateInput( incompleteTokenValue )
+					) {
+						preventDefault = addCurrentToken();
+					}
 				}
 				break;
 			case 'Escape':

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -235,12 +235,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 				break;
 			case 'Space':
 				if ( tokenizeOnSpace ) {
-					if (
-						inputHasValidValue() &&
-						__experimentalValidateInput( incompleteTokenValue )
-					) {
-						preventDefault = addCurrentToken();
-					}
+					preventDefault = addCurrentToken();
 				}
 				break;
 			case 'Escape':
@@ -389,7 +384,11 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 	}
 
 	function handleCommaKey() {
-		if ( inputHasValidValue() ) {
+		if (
+			inputHasValidValue() &&
+			( ! __experimentalValidateInput ||
+				__experimentalValidateInput( incompleteTokenValue ) )
+		) {
 			addNewToken( incompleteTokenValue );
 		}
 
@@ -437,7 +436,11 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		if ( selectedSuggestion ) {
 			addNewToken( selectedSuggestion );
 			preventDefault = true;
-		} else if ( inputHasValidValue() ) {
+		} else if (
+			inputHasValidValue() &&
+			( ! __experimentalValidateInput ||
+				__experimentalValidateInput( incompleteTokenValue ) )
+		) {
 			addNewToken( incompleteTokenValue );
 			preventDefault = true;
 		}


### PR DESCRIPTION
Closes #69252

## What?
This PR fixes the `FormTokenField` component to properly validate input before creating tokens when pressing the space key.

## Why?
Currently, when the `tokenizeOnSpace` prop is enabled, the FormTokenField component creates tokens immediately on space press without checking the `experimentalValidateInput` function. This can lead to invalid tokens being created, which is inconsistent with the validation behavior when using other methods of token creation (like pressing Enter or comma).

## How?
Modified the space key handler in the `onKeyDown` function to:
1. Check if there's valid input using `inputHasValidValue()`
2. Call `experimentalValidateInput` with the current value
3. Only create a token if both checks pass
