### PR TITLE
Admin bar: Update the Edit Site link

### DIFF
--- a/backport-changelog/6.8/8372.md
+++ b/backport-changelog/6.8/8372.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/8372
+
+* https://github.com/WordPress/gutenberg/pull/69271

--- a/lib/compat/wordpress-6.8/admin-bar.php
+++ b/lib/compat/wordpress-6.8/admin-bar.php
@@ -23,7 +23,7 @@ function gutenberg_wp_admin_bar_edit_site_menu( $wp_admin_bar ) {
 	$wp_admin_bar->add_node(
 		array(
 			'id'    => 'site-editor',
-			'title' => _x( 'Edit Site', 'site editor link from admin bar' ),
+			'title' => __( 'Edit Site' ),
 			'href'  => admin_url( 'site-editor.php' ),
 		)
 	);

--- a/lib/compat/wordpress-6.8/admin-bar.php
+++ b/lib/compat/wordpress-6.8/admin-bar.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Updates the Edit Site link in the admin bar to point to the top level of the Site Editor.
+ * Removes the use of the $_wp_current_template_id global and the query args.
+ * Displays the link while in the admin area.
+ * Changes the capitalization of the link text to match WP 6.8: https://core.trac.wordpress.org/ticket/62971
+ *
+ * Note: Backports into wp-includes\admin-bar.php wp_admin_bar_edit_site_menu()
+ *
+ * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
+ */
+function gutenberg_wp_admin_bar_edit_site_menu( $wp_admin_bar ) {
+	// Don't show if a block theme is not activated.
+	if ( ! wp_is_block_theme() ) {
+		return;
+	}
+
+	// Don't show for users who can't edit theme options.
+	if ( ! current_user_can( 'edit_theme_options' ) ) {
+		return;
+	}
+
+	$wp_admin_bar->add_node(
+		array(
+			'id'    => 'site-editor',
+			'title' => _x( 'Edit Site', 'site editor link from admin bar' ),
+			'href'  => admin_url( 'site-editor.php' ),
+		)
+	);
+}
+
+add_action( 'admin_bar_menu', 'gutenberg_wp_admin_bar_edit_site_menu', 41 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -98,6 +98,7 @@ require __DIR__ . '/compat/wordpress-6.7/compat.php';
 require __DIR__ . '/compat/wordpress-6.7/post-formats.php';
 
 // WordPress 6.8 compat.
+require __DIR__ . '/compat/wordpress-6.8/admin-bar.php';
 require __DIR__ . '/compat/wordpress-6.8/preload.php';
 require __DIR__ . '/compat/wordpress-6.8/blocks.php';
 require __DIR__ . '/compat/wordpress-6.8/functions.php';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Partial for <!-- #ISSUE-NUMBER or URL -->https://github.com/WordPress/gutenberg/issues/63785
Closes https://github.com/WordPress/gutenberg/issues/63784 (based on https://github.com/WordPress/gutenberg/issues/63785#issuecomment-2241767513)

This PR changes the Edit Site link in the admin bar to point to the top level (the "home") of the Site Editor, instead of opening the current template.

Based on feedback in https://core.trac.wordpress.org/ticket/62368, the Edit Site link also shows in the admin area.
Showing the link while in the admin area makes the admin bar more consistent and makes it easier to use, since you can use your muscle memory.

This PR replaces two stale PR's: https://github.com/WordPress/gutenberg/pull/66894 and https://github.com/WordPress/gutenberg/pull/63835

## How?
By using the filter, the current menu item is replaced, since they share the same id: "site-editor" (There is no need to remove the current menu item first, it is replaced).
The template global and the query args are removed, since they are no longer needed.
The capitalization is changed to Edit Site, to match a change that is already merged in to 6.8: https://core.trac.wordpress.org/ticket/62971

I used 41 as the priority, because it is what was used when the menu item was first added to Gutenberg, in a compat file that has since been deleted. I am not entirely sure what this is based on, but it is probably because themes have priority 40.

## Testing Instructions
Activate a block theme.
Confirm that the Edit Site link shows in the admin bar, and that it leads to the Site Editor, without opening a specific template.
Activate a classic theme and confirm that the link does not show.

## Screenshots or screencast <!-- if applicable -->

This screenshot shows the new link in the admin bar while in the admin area:
![image](https://github.com/user-attachments/assets/9ce6908d-d752-4413-ada6-1a9707010236)

