### PR TITLE
Test: Add e2e test for 404 page

### DIFF
--- a/test/e2e/specs/site-editor/navigation.spec.js
+++ b/test/e2e/specs/site-editor/navigation.spec.js
@@ -111,8 +111,6 @@ test.describe( 'Site editor navigation', () => {
 		admin,
 		page,
 	} ) => {
-		await admin.visitSiteEditor();
-
 		// Navigate to a non-existent template.
 		await admin.visitAdminPage( 'site-editor.php', 'p=/template-foo-bar' );
 

--- a/test/e2e/specs/site-editor/navigation.spec.js
+++ b/test/e2e/specs/site-editor/navigation.spec.js
@@ -114,16 +114,16 @@ test.describe( 'Site editor navigation', () => {
 		await admin.visitSiteEditor();
 
 		// Navigate to a non-existent template.
-		await page.goto( '/wp-admin/site-editor.php?p=%2Ftemplate-foo-bar' );
+		await admin.visitAdminPage( 'site-editor.php', 'p=/template-foo-bar' );
 
 		// Verify the 404 error notice is displayed with the correct message.
 		await expect(
-			page
-				.locator( '.components-notice__content' )
-				.getByText(
-					'The requested page could not be found. Please check the URL.'
-				)
-		).toBeVisible();
+			page.locator(
+				'.edit-site-layout__area .components-notice__content'
+			)
+		).toHaveText(
+			'The requested page could not be found. Please check the URL.'
+		);
 	} );
 } );
 

--- a/test/e2e/specs/site-editor/navigation.spec.js
+++ b/test/e2e/specs/site-editor/navigation.spec.js
@@ -106,6 +106,25 @@ test.describe( 'Site editor navigation', () => {
 		// We should have our editor canvas button back
 		await expect( editorCanvasButton ).toBeVisible();
 	} );
+
+	test( 'Should show 404 page when navigating to non-existent template', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitSiteEditor();
+
+		// Navigate to a non-existent template.
+		await page.goto( '/wp-admin/site-editor.php?p=%2Ftemplate-foo-bar' );
+
+		// Verify the 404 error notice is displayed with the correct message.
+		await expect(
+			page
+				.locator( '.components-notice__content' )
+				.getByText(
+					'The requested page could not be found. Please check the URL.'
+				)
+		).toBeVisible();
+	} );
 } );
 
 class EditorNavigationUtils {


### PR DESCRIPTION
Related to: https://github.com/WordPress/gutenberg/pull/69234#issuecomment-2671616050
PR: #69234

## What?
Add E2E test for 404 page in the Site Editor

## Why?
This PR adds coverage for 404 page in the Site Editor.

## Testing Instructions
1. Run E2E tests for the site-editor:
```
npm run test:e2e:debug -- test/e2e/specs/site-editor/navigation.spec.js
```
2. Verify the new 404 test passes

## Screenshots:

![image](https://github.com/user-attachments/assets/93f54081-c1ac-4daf-b8ae-ec4598e86998)
