### PR TITLE
Post Terms Block: Add option to disable term links

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -670,7 +670,7 @@ Post terms. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages
 -	**Name:** core/post-terms
 -	**Category:** theme
 -	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** prefix, separator, suffix, term, textAlign
+-	**Attributes:** isLinkDisabled, prefix, separator, suffix, term, textAlign
 
 ## Time to Read
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -670,7 +670,7 @@ Post terms. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages
 -	**Name:** core/post-terms
 -	**Category:** theme
 -	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** isLinkDisabled, prefix, separator, suffix, term, textAlign
+-	**Attributes:** enableLinks, prefix, separator, suffix, term, textAlign
 
 ## Time to Read
 

--- a/packages/block-library/src/post-terms/block.json
+++ b/packages/block-library/src/post-terms/block.json
@@ -24,6 +24,10 @@
 		"suffix": {
 			"type": "string",
 			"default": ""
+		},
+		"isLinkDisabled": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"usesContext": [ "postId", "postType" ],

--- a/packages/block-library/src/post-terms/block.json
+++ b/packages/block-library/src/post-terms/block.json
@@ -25,9 +25,9 @@
 			"type": "string",
 			"default": ""
 		},
-		"isLinkDisabled": {
+		"enableLinks": {
 			"type": "boolean",
-			"default": false
+			"default": true
 		}
 	},
 	"usesContext": [ "postId", "postType" ],

--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -69,6 +69,7 @@ export default function PostTermsEdit( {
 		className: clsx( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 			[ `taxonomy-${ term }` ]: term,
+			'has-disabled-links': isLinkDisabled,
 		} ),
 	} );
 
@@ -127,27 +128,16 @@ export default function PostTermsEdit( {
 					! isLoading &&
 					hasPostTerms &&
 					postTerms
-						.map( ( postTerm ) =>
-							isLinkDisabled ? (
-								<span
-									key={ postTerm.id }
-									className="wp-block-post-terms__term"
-								>
-									{ decodeEntities( postTerm.name ) }
-								</span>
-							) : (
-								<a
-									key={ postTerm.id }
-									href={ postTerm.link }
-									onClick={ ( event ) =>
-										event.preventDefault()
-									}
-									rel="tag"
-								>
-									{ decodeEntities( postTerm.name ) }
-								</a>
-							)
-						)
+						.map( ( postTerm ) => (
+							<a
+								key={ postTerm.id }
+								href={ postTerm.link }
+								onClick={ ( event ) => event.preventDefault() }
+								rel="tag"
+							>
+								{ decodeEntities( postTerm.name ) }
+							</a>
+						) )
 						.reduce( ( prev, curr ) => (
 							<>
 								{ prev }

--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -15,7 +15,7 @@ import {
 	RichText,
 } from '@wordpress/block-editor';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
-import { Spinner, TextControl } from '@wordpress/components';
+import { Spinner, TextControl, ToggleControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
@@ -44,7 +44,8 @@ export default function PostTermsEdit( {
 	setAttributes,
 	insertBlocksAfter,
 } ) {
-	const { term, textAlign, separator, prefix, suffix } = attributes;
+	const { term, textAlign, separator, prefix, suffix, isLinkDisabled } =
+		attributes;
 	const { postId, postType } = context;
 
 	const selectedTerm = useSelect(
@@ -93,6 +94,15 @@ export default function PostTermsEdit( {
 					} }
 					help={ __( 'Enter character(s) used to separate terms.' ) }
 				/>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Disable links' ) }
+					checked={ !! isLinkDisabled }
+					onChange={ () =>
+						setAttributes( { isLinkDisabled: ! isLinkDisabled } )
+					}
+					help={ __( 'Display terms as plain text without links.' ) }
+				/>
 			</InspectorControls>
 			<div { ...blockProps }>
 				{ isLoading && hasPost && <Spinner /> }
@@ -117,16 +127,27 @@ export default function PostTermsEdit( {
 					! isLoading &&
 					hasPostTerms &&
 					postTerms
-						.map( ( postTerm ) => (
-							<a
-								key={ postTerm.id }
-								href={ postTerm.link }
-								onClick={ ( event ) => event.preventDefault() }
-								rel="tag"
-							>
-								{ decodeEntities( postTerm.name ) }
-							</a>
-						) )
+						.map( ( postTerm ) =>
+							isLinkDisabled ? (
+								<span
+									key={ postTerm.id }
+									className="wp-block-post-terms__term"
+								>
+									{ decodeEntities( postTerm.name ) }
+								</span>
+							) : (
+								<a
+									key={ postTerm.id }
+									href={ postTerm.link }
+									onClick={ ( event ) =>
+										event.preventDefault()
+									}
+									rel="tag"
+								>
+									{ decodeEntities( postTerm.name ) }
+								</a>
+							)
+						)
 						.reduce( ( prev, curr ) => (
 							<>
 								{ prev }

--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -74,7 +74,6 @@ export default function PostTermsEdit( {
 		className: clsx( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 			[ `taxonomy-${ term }` ]: term,
-			'has-disabled-links': ! enableLinks,
 		} ),
 	} );
 
@@ -138,16 +137,27 @@ export default function PostTermsEdit( {
 					! isLoading &&
 					hasPostTerms &&
 					postTerms
-						.map( ( postTerm ) => (
-							<a
-								key={ postTerm.id }
-								href={ postTerm.link }
-								onClick={ ( event ) => event.preventDefault() }
-								rel="tag"
-							>
-								{ decodeEntities( postTerm.name ) }
-							</a>
-						) )
+						.map( ( postTerm ) => {
+							const Tag = enableLinks ? 'a' : 'span';
+							return (
+								<Tag
+									key={ postTerm.id }
+									{ ...( enableLinks
+										? {
+												href: postTerm.link,
+												rel: 'tag',
+												onClick: ( event ) =>
+													event.preventDefault(),
+										  }
+										: {
+												className:
+													'wp-block-post-terms__term',
+										  } ) }
+								>
+									{ decodeEntities( postTerm.name ) }
+								</Tag>
+							);
+						} )
 						.reduce( ( prev, curr ) => (
 							<>
 								{ prev }

--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -15,7 +15,12 @@ import {
 	RichText,
 } from '@wordpress/block-editor';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
-import { Spinner, TextControl, ToggleControl } from '@wordpress/components';
+import {
+	Spinner,
+	TextControl,
+	ToggleControl,
+	PanelBody,
+} from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
@@ -44,7 +49,7 @@ export default function PostTermsEdit( {
 	setAttributes,
 	insertBlocksAfter,
 } ) {
-	const { term, textAlign, separator, prefix, suffix, isLinkDisabled } =
+	const { term, textAlign, separator, prefix, suffix, enableLinks } =
 		attributes;
 	const { postId, postType } = context;
 
@@ -69,7 +74,7 @@ export default function PostTermsEdit( {
 		className: clsx( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 			[ `taxonomy-${ term }` ]: term,
-			'has-disabled-links': isLinkDisabled,
+			'has-disabled-links': ! enableLinks,
 		} ),
 	} );
 
@@ -83,6 +88,20 @@ export default function PostTermsEdit( {
 					} }
 				/>
 			</BlockControls>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings' ) }>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Enable links' ) }
+						onChange={ ( value ) =>
+							setAttributes( {
+								enableLinks: value,
+							} )
+						}
+						checked={ enableLinks }
+					/>
+				</PanelBody>
+			</InspectorControls>
 			<InspectorControls group="advanced">
 				<TextControl
 					__next40pxDefaultSize
@@ -94,15 +113,6 @@ export default function PostTermsEdit( {
 						setAttributes( { separator: nextValue } );
 					} }
 					help={ __( 'Enter character(s) used to separate terms.' ) }
-				/>
-				<ToggleControl
-					__nextHasNoMarginBottom
-					label={ __( 'Disable links' ) }
-					checked={ !! isLinkDisabled }
-					onChange={ () =>
-						setAttributes( { isLinkDisabled: ! isLinkDisabled } )
-					}
-					help={ __( 'Display terms as plain text without links.' ) }
 				/>
 			</InspectorControls>
 			<div { ...blockProps }>

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -24,19 +24,28 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$classes = array( 'taxonomy-' . $attributes['term'] );
+	$classes = array(
+		'wp-block-post-terms',
+		'taxonomy-' . $attributes['term']
+	);
+
 	if ( isset( $attributes['textAlign'] ) ) {
 		$classes[] = 'has-text-align-' . $attributes['textAlign'];
 	}
+
+	if ( isset( $attributes['isLinkDisabled'] ) && $attributes['isLinkDisabled'] ) {
+		$classes[] = 'has-disabled-links';
+	}
+
 	if ( isset( $attributes['style']['elements']['link']['color']['text'] ) ) {
 		$classes[] = 'has-link-color';
 	}
 
-	$separator = empty( $attributes['separator'] ) ? ' ' : $attributes['separator'];
-
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
 
-	$prefix = "<div $wrapper_attributes>";
+	$separator = empty( $attributes['separator'] ) ? ' ' : $attributes['separator'];
+	$prefix = '<div ' . $wrapper_attributes . '>';
+
 	if ( isset( $attributes['prefix'] ) && $attributes['prefix'] ) {
 		$prefix .= '<span class="wp-block-post-terms__prefix">' . $attributes['prefix'] . '</span>';
 	}
@@ -44,21 +53,6 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 	$suffix = '</div>';
 	if ( isset( $attributes['suffix'] ) && $attributes['suffix'] ) {
 		$suffix = '<span class="wp-block-post-terms__suffix">' . $attributes['suffix'] . '</span>' . $suffix;
-	}
-
-	// If links are disabled, get terms and render them without links.
-	if ( isset( $attributes['isLinkDisabled'] ) && $attributes['isLinkDisabled'] ) {
-		$terms = get_the_terms( $block->context['postId'], $attributes['term'] );
-		if ( is_wp_error( $terms ) || empty( $terms ) ) {
-			return '';
-		}
-
-		$term_links = array();
-		foreach ( $terms as $term ) {
-			$term_links[] = '<span class="wp-block-post-terms__term">' . esc_html( $term->name ) . '</span>';
-		}
-
-		return $prefix . join( '<span class="wp-block-post-terms__separator">' . esc_html( $separator ) . '</span>', $term_links ) . $suffix;
 	}
 
 	$post_terms = get_the_term_list(

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -46,7 +46,7 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 		$suffix = '<span class="wp-block-post-terms__suffix">' . $attributes['suffix'] . '</span>' . $suffix;
 	}
 
-	// If links are disabled, get terms and render them without links
+	// If links are disabled, get terms and render them without links.
 	if ( isset( $attributes['isLinkDisabled'] ) && $attributes['isLinkDisabled'] ) {
 		$terms = get_the_terms( $block->context['postId'], $attributes['term'] );
 		if ( is_wp_error( $terms ) || empty( $terms ) ) {
@@ -58,9 +58,7 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 			$term_links[] = '<span class="wp-block-post-terms__term">' . esc_html( $term->name ) . '</span>';
 		}
 
-		return $prefix . 
-			   join( '<span class="wp-block-post-terms__separator">' . esc_html( $separator ) . '</span>', $term_links ) . 
-			   $suffix;
+		return $prefix . join( '<span class="wp-block-post-terms__separator">' . esc_html( $separator ) . '</span>', $term_links ) . $suffix;
 	}
 
 	$post_terms = get_the_term_list(

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -26,7 +26,7 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 
 	$classes = array(
 		'wp-block-post-terms',
-		'taxonomy-' . $attributes['term']
+		'taxonomy-' . $attributes['term'],
 	);
 
 	if ( isset( $attributes['textAlign'] ) ) {
@@ -44,7 +44,7 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
 
 	$separator = empty( $attributes['separator'] ) ? ' ' : $attributes['separator'];
-	$prefix = '<div ' . $wrapper_attributes . '>';
+	$prefix    = '<div ' . $wrapper_attributes . '>';
 
 	if ( isset( $attributes['prefix'] ) && $attributes['prefix'] ) {
 		$prefix .= '<span class="wp-block-post-terms__prefix">' . $attributes['prefix'] . '</span>';

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -46,6 +46,23 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 		$suffix = '<span class="wp-block-post-terms__suffix">' . $attributes['suffix'] . '</span>' . $suffix;
 	}
 
+	// If links are disabled, get terms and render them without links
+	if ( isset( $attributes['isLinkDisabled'] ) && $attributes['isLinkDisabled'] ) {
+		$terms = get_the_terms( $block->context['postId'], $attributes['term'] );
+		if ( is_wp_error( $terms ) || empty( $terms ) ) {
+			return '';
+		}
+
+		$term_links = array();
+		foreach ( $terms as $term ) {
+			$term_links[] = '<span class="wp-block-post-terms__term">' . esc_html( $term->name ) . '</span>';
+		}
+
+		return $prefix . 
+			   join( '<span class="wp-block-post-terms__separator">' . esc_html( $separator ) . '</span>', $term_links ) . 
+			   $suffix;
+	}
+
 	$post_terms = get_the_term_list(
 		$block->context['postId'],
 		$attributes['term'],

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -24,10 +24,7 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$classes = array(
-		'wp-block-post-terms',
-		'taxonomy-' . $attributes['term'],
-	);
+	$classes = array( 'taxonomy-' . $attributes['term'] );
 
 	if ( isset( $attributes['textAlign'] ) ) {
 		$classes[] = 'has-text-align-' . $attributes['textAlign'];
@@ -41,10 +38,11 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 		$classes[] = 'has-link-color';
 	}
 
+	$separator = empty( $attributes['separator'] ) ? ' ' : $attributes['separator'];
+
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
 
-	$separator = empty( $attributes['separator'] ) ? ' ' : $attributes['separator'];
-	$prefix    = '<div ' . $wrapper_attributes . '>';
+	$prefix = "<div $wrapper_attributes>";
 
 	if ( isset( $attributes['prefix'] ) && $attributes['prefix'] ) {
 		$prefix .= '<span class="wp-block-post-terms__prefix">' . $attributes['prefix'] . '</span>';

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -30,10 +30,6 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 		$classes[] = 'has-text-align-' . $attributes['textAlign'];
 	}
 
-	if ( isset( $attributes['enableLinks'] ) && ! $attributes['enableLinks'] ) {
-		$classes[] = 'has-disabled-links';
-	}
-
 	if ( isset( $attributes['style']['elements']['link']['color']['text'] ) ) {
 		$classes[] = 'has-link-color';
 	}
@@ -53,16 +49,35 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 		$suffix = '<span class="wp-block-post-terms__suffix">' . $attributes['suffix'] . '</span>' . $suffix;
 	}
 
-	$post_terms = get_the_term_list(
-		$block->context['postId'],
-		$attributes['term'],
-		wp_kses_post( $prefix ),
-		'<span class="wp-block-post-terms__separator">' . esc_html( $separator ) . '</span>',
-		wp_kses_post( $suffix )
-	);
+	if ( ! isset( $attributes['enableLinks'] ) || ! $attributes['enableLinks'] ) {
+		$terms = get_the_terms( $block->context['postId'], $attributes['term'] );
+		if ( is_wp_error( $terms ) || empty( $terms ) ) {
+			return '';
+		}
 
-	if ( is_wp_error( $post_terms ) || empty( $post_terms ) ) {
-		return '';
+		$terms_html = array();
+		foreach ( $terms as $term ) {
+			$terms_html[] = '<span class="wp-block-post-terms__term">' . esc_html( $term->name ) . '</span>';
+		}
+
+		$post_terms = $prefix;
+		$post_terms .= implode(
+			'<span class="wp-block-post-terms__separator">' . esc_html( $separator ) . '</span>',
+			$terms_html
+		);
+		$post_terms .= $suffix;
+	} else {
+		$post_terms = get_the_term_list(
+			$block->context['postId'],
+			$attributes['term'],
+			wp_kses_post( $prefix ),
+			'<span class="wp-block-post-terms__separator">' . esc_html( $separator ) . '</span>',
+			wp_kses_post( $suffix )
+		);
+
+		if ( is_wp_error( $post_terms ) || empty( $post_terms ) ) {
+			return '';
+		}
 	}
 
 	return $post_terms;

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -30,7 +30,7 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 		$classes[] = 'has-text-align-' . $attributes['textAlign'];
 	}
 
-	if ( isset( $attributes['isLinkDisabled'] ) && $attributes['isLinkDisabled'] ) {
+	if ( isset( $attributes['enableLinks'] ) && ! $attributes['enableLinks'] ) {
 		$classes[] = 'has-disabled-links';
 	}
 

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -25,11 +25,9 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 	}
 
 	$classes = array( 'taxonomy-' . $attributes['term'] );
-
 	if ( isset( $attributes['textAlign'] ) ) {
 		$classes[] = 'has-text-align-' . $attributes['textAlign'];
 	}
-
 	if ( isset( $attributes['style']['elements']['link']['color']['text'] ) ) {
 		$classes[] = 'has-link-color';
 	}
@@ -39,7 +37,6 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
 
 	$prefix = "<div $wrapper_attributes>";
-
 	if ( isset( $attributes['prefix'] ) && $attributes['prefix'] ) {
 		$prefix .= '<span class="wp-block-post-terms__prefix">' . $attributes['prefix'] . '</span>';
 	}
@@ -60,7 +57,7 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 			$terms_html[] = '<span class="wp-block-post-terms__term">' . esc_html( $term->name ) . '</span>';
 		}
 
-		$post_terms = $prefix;
+		$post_terms  = $prefix;
 		$post_terms .= implode(
 			'<span class="wp-block-post-terms__separator">' . esc_html( $separator ) . '</span>',
 			$terms_html

--- a/packages/block-library/src/post-terms/style.scss
+++ b/packages/block-library/src/post-terms/style.scss
@@ -5,4 +5,12 @@
 	.wp-block-post-terms__separator {
 		white-space: pre-wrap;
 	}
+
+	&.has-disabled-links {
+		a {
+			pointer-events: none;
+			cursor: default;
+			text-decoration: none;
+		}
+	}
 }

--- a/packages/block-library/src/post-terms/style.scss
+++ b/packages/block-library/src/post-terms/style.scss
@@ -5,12 +5,4 @@
 	.wp-block-post-terms__separator {
 		white-space: pre-wrap;
 	}
-
-	&.has-disabled-links {
-		a {
-			pointer-events: none;
-			cursor: default;
-			text-decoration: none;
-		}
-	}
 }

--- a/test/integration/fixtures/blocks/core__post-terms.json
+++ b/test/integration/fixtures/blocks/core__post-terms.json
@@ -5,7 +5,8 @@
 		"attributes": {
 			"separator": ", ",
 			"prefix": "",
-			"suffix": ""
+			"suffix": "",
+			"isLinkDisabled": false
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__post-terms.json
+++ b/test/integration/fixtures/blocks/core__post-terms.json
@@ -6,7 +6,7 @@
 			"separator": ", ",
 			"prefix": "",
 			"suffix": "",
-			"isLinkDisabled": false
+			"enableLinks": true
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/69250
Adds a new option to the Post Terms block that allows users to disable link interactivity while preserving the visual styling of terms.

<!-- In a few words, what is the PR actually doing? -->

## How?
- Added a new `isLinkDisabled` attribute to the block with a default value of `false`
- Added a toggle control in the block's Inspector Controls panel
- When enabled, adds a `has-disabled-links` class to the wrapper div
- Used CSS to make links non-interactive while preserving their visual style:
  - `pointer-events: none`
  - `cursor: default`
  - `text-decoration: none`

## Testing Instructions
1. Add a Post Terms block to a post/page
2. Open the block settings sidebar
3. Look for the "Disable links" toggle under the separator option

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->



https://github.com/user-attachments/assets/04903e5d-b195-4e8b-8b90-1ea9ac161f29

