### PR TITLE
Post formats: Make title and description human readable

### DIFF
--- a/lib/compat/wordpress-6.8/block-template-utils.php
+++ b/lib/compat/wordpress-6.8/block-template-utils.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Make the title and description of the post format templates human readable.
+ *
+ * @param array $default_template_types Default template types.
+ * @return array Filtered template type data.
+ */
+function gutenberg_post_format_template_title_description( $default_template_types ) {
+	$post_formats = get_post_format_strings();
+
+	foreach ( $post_formats as $post_format_slug => $post_format_name ) {
+		$default_template_types[ 'taxonomy-post_format-post-format-' . $post_format_slug ] = array(
+			'title'       => sprintf(
+				/* translators: %s: Post format name. */
+				_x( 'Post Format: %s', 'Template name' ),
+				$post_format_name
+			),
+			'description' => sprintf(
+				/* translators: %s: Post format name. */
+				__( 'Displays the %s Post Format archive.' ),
+				$post_format_name
+			),
+		);
+	}
+	return $default_template_types;
+}
+
+add_filter( 'default_template_types', 'gutenberg_post_format_template_title_description', 10, 1 );

--- a/lib/compat/wordpress-6.8/block-template-utils.php
+++ b/lib/compat/wordpress-6.8/block-template-utils.php
@@ -18,7 +18,7 @@ function gutenberg_post_format_template_title_description( $default_template_typ
 			),
 			'description' => sprintf(
 				/* translators: %s: Post format name. */
-				__( 'Displays the %s Post Format archive.' ),
+				__( 'Displays the %s post format archive.' ),
 				$post_format_name
 			),
 		);

--- a/lib/load.php
+++ b/lib/load.php
@@ -104,6 +104,7 @@ require __DIR__ . '/compat/wordpress-6.8/functions.php';
 require __DIR__ . '/compat/wordpress-6.8/post.php';
 require __DIR__ . '/compat/wordpress-6.8/site-editor.php';
 require __DIR__ . '/compat/wordpress-6.8/class-gutenberg-rest-user-controller.php';
+require __DIR__ . '/compat/wordpress-6.8/block-template-utils.php';
 
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->https://github.com/WordPress/gutenberg/issues/65319

This PR adds a new 6.8 compatibility file with a filter that makes the title and description of the post format templates human readable.
This change is already merged into WordPress 6.8 in https://core.trac.wordpress.org/ticket/62326
No additional PHP backport from Gutenberg to core is needed.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
In the template data views, the post format templates showed the slug instead of a title, and there was no description.

## How?
Filters `default_template_types` to add a description and title to the different post format templates.

## Testing Instructions
First, you need a block theme, and you need to enable post format support on the active theme.

Example:
```
function twentytwentyfour_setup(){
	add_theme_support( 'post-formats', array( 'standard', 'aside', 'gallery', 'audio', 'video', 'link', 'image', 'chat', 'status', 'quote' ) );
}

add_action( 'after_setup_theme', 'twentytwentyfour_setup' );
```

Next, add a post format archive template inside the templates folder.
The content of the file does not matter for this test. I have used the link post format as example:
`templates/taxonomy-post_format-post-format-link.html`

Go to Appearance > Editor > Templates.
Note that the link archive is available, and that there is a name and description.

## Screenshots or screencast <!-- if applicable -->
After: The link post format template on the Site Editor Template screen has a readable name and description.
![Screenshot 2025-02-21 120542](https://github.com/user-attachments/assets/4812b83e-e77f-4cf0-836a-8c03a62375d5)

