### PR TITLE
DataViews: Align Table Header

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -36,11 +36,6 @@
 		td:first-child,
 		th:first-child {
 			padding-left: $grid-unit-60;
-
-			.dataviews-view-table-header-button,
-			.dataviews-view-table-header {
-				margin-left: - #{$grid-unit-10};
-			}
 		}
 
 		td:last-child,


### PR DESCRIPTION
## What, Why and How?
Closes #69274

This PR corrects the misalignment of the `Title` button (the first button in the data-views header) by removing the unintended negative margin.

## Testing Instructions

1. Run storybook locally. (`npm run storybook:dev`)
2. Navigate to `DataViews` and verify the `Title` button is now aligned with the rest of the content.

## Screenshots

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/330da70b-aea8-45f0-8513-4a3122d90aa9)|![after](https://github.com/user-attachments/assets/a8a9bff6-ac27-4dfa-9e27-27c4fa1d2a65)|

