### PR TITLE
Toolbar: Adjust colors for dark mode support

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancement
 
 -   `ComboboxControl`: Handle Unicode characters when matching values ([#70180](https://github.com/WordPress/gutenberg/pull/70180)).
+-   `Toolbar`: Adjust colors for dark mode support ([#69278](https://github.com/WordPress/gutenberg/pull/69278)).
 
 ## 29.10.0 (2025-05-22)
 
@@ -12,7 +13,6 @@
 
 -   `Snackbar`: Add support to open links in a new tab ([#69905](https://github.com/WordPress/gutenberg/pull/69905)).
 -   `ColorPicker`: Add a visual cue when the value is copied ([#70083](https://github.com/WordPress/gutenberg/pull/70083)).
--   `Toolbar`: Adjust colors for dark mode support ([#69278](https://github.com/WordPress/gutenberg/pull/69278)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 -   `Snackbar`: Add support to open links in a new tab ([#69905](https://github.com/WordPress/gutenberg/pull/69905)).
 -   `ColorPicker`: Add a visual cue when the value is copied ([#70083](https://github.com/WordPress/gutenberg/pull/70083)).
+-   `Toolbar`: Adjust colors for dark mode support ([#69278](https://github.com/WordPress/gutenberg/pull/69278)).
 
 ### Internal
 

--- a/packages/components/src/toolbar/toolbar-group/style.scss
+++ b/packages/components/src/toolbar/toolbar-group/style.scss
@@ -1,7 +1,7 @@
 .components-toolbar-group {
 	min-height: $block-toolbar-height;
-	border-right: $border-width solid $gray-900;
-	background-color: $white;
+	border-right: $border-width solid $components-color-foreground;
+	background-color: $components-color-foreground-inverted;
 	display: inline-flex;
 	flex-shrink: 0;
 	flex-wrap: wrap;
@@ -41,8 +41,8 @@
 .components-toolbar {
 	min-height: $block-toolbar-height;
 	margin: 0;
-	border: $border-width solid $gray-900;
-	background-color: $white;
+	border: $border-width solid $components-color-foreground;
+	background-color: $components-color-foreground-inverted;
 	display: inline-flex;
 	flex-shrink: 0;
 	flex-wrap: wrap;

--- a/packages/components/src/toolbar/toolbar-group/style.scss
+++ b/packages/components/src/toolbar/toolbar-group/style.scss
@@ -1,7 +1,7 @@
 .components-toolbar-group {
 	min-height: $block-toolbar-height;
 	border-right: $border-width solid $components-color-foreground;
-	background-color: $components-color-foreground-inverted;
+	background-color: $components-color-background;
 	display: inline-flex;
 	flex-shrink: 0;
 	flex-wrap: wrap;
@@ -42,7 +42,7 @@
 	min-height: $block-toolbar-height;
 	margin: 0;
 	border: $border-width solid $components-color-foreground;
-	background-color: $components-color-foreground-inverted;
+	background-color: $components-color-background;
 	display: inline-flex;
 	flex-shrink: 0;
 	flex-wrap: wrap;

--- a/packages/components/src/toolbar/toolbar/style.scss
+++ b/packages/components/src/toolbar/toolbar/style.scss
@@ -1,6 +1,6 @@
 .components-accessible-toolbar {
 	display: inline-flex;
-	border: $border-width solid $gray-900;
+	border: $border-width solid $components-color-foreground;
 	border-radius: $radius-small;
 	flex-shrink: 0;
 
@@ -14,13 +14,11 @@
 		& > .components-toolbar-group {
 			border-right: none;
 		}
-
 	}
 }
 
 .components-accessible-toolbar,
 .components-toolbar {
-
 	&[aria-orientation="vertical"] {
 		display: flex;
 		flex-direction: column;
@@ -56,7 +54,7 @@
 			z-index: -1;
 
 			// Animate in.
-			@media not (prefers-reduced-motion) {
+			@media not ( prefers-reduced-motion ) {
 				animation: components-button__appear-animation 0.1s ease;
 				animation-fill-mode: forwards;
 			}
@@ -79,7 +77,7 @@
 			}
 
 			&::before {
-				background: $gray-900;
+				background: $components-color-foreground;
 			}
 		}
 
@@ -98,7 +96,6 @@
 		}
 	}
 }
-
 
 @keyframes components-button__appear-animation {
 	from {


### PR DESCRIPTION
related to #66454

## What?
This PR updates the toolbar components ( ToolbarGroup and Toolbar ) to use theme-adaptive color variables instead of hardcoded values, ensuring correct styling in both light and dark modes.

## Why?
Previously, the toolbar components used hardcoded colors like $white and $gray-900, leading to inconsistent styling, especially in dark mode. Issues included:
	•	Toolbars had a white background in dark mode, making elements hard to see.
	•	Borders didn’t adjust properly to theme colors.
	•	The ::before pseudo-element used $gray-900, which didn’t adapt well to dark mode.
	
## How?

- Replaced $white with $components-color-foreground-inverted for better adaptability.
- Replaced $gray-900 with $components-color-foreground for consistency.
- Applied changes to:
  - .components-toolbar-group
  - .components-toolbar
  - .components-accessible-toolbar
  - The ::before background overlay.


## Testing Instructions

1. Open Storybook and navigate to the Toolbar component.
2. Toggle dark mode using the Storybook theme switcher.
3. Verify that the toolbar, buttons, and icons remain visible and have proper contrast.
4. Check that borders and background colors adapt correctly in both light and dark modes.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/271a11de-a334-4511-b1f7-4f7547171aca
