### PR TITLE
Added php.net/date links

### DIFF
--- a/packages/date/README.md
+++ b/packages/date/README.md
@@ -27,7 +27,7 @@ _Related_
 
 _Parameters_
 
--   _dateFormat_ `string`: PHP-style formatting string. See [php.net/date](https://php.net/date).
+-   _dateFormat_ `string`: PHP-style formatting string. See [php.net/date](https://www.php.net/manual/en/function.date.php).
 -   _dateValue_ `Moment | Date | string | undefined`: Date object or string, parsable by moment.js.
 -   _timezone_ `string | number | undefined`: Timezone to output result in or a UTC offset. Defaults to timezone from site.
 
@@ -48,7 +48,7 @@ _Related_
 
 _Parameters_
 
--   _dateFormat_ `string`: PHP-style formatting string. See [php.net/date](https://php.net/date).
+-   _dateFormat_ `string`: PHP-style formatting string. See [php.net/date](https://www.php.net/manual/en/function.date.php).
 -   _dateValue_ `Moment | Date | string | undefined`: Date object or string, parsable by moment.js.
 -   _timezone_ `string | number | boolean | undefined=`: Timezone to output result in or a UTC offset. Defaults to timezone from site. Notice: `boolean` is effectively deprecated, but still supported for backward compatibility reasons.
 
@@ -62,7 +62,7 @@ Formats a date. Does not alter the date's timezone.
 
 _Parameters_
 
--   _dateFormat_ `string`: PHP-style formatting string. See [php.net/date](https://php.net/date).
+-   _dateFormat_ `string`: PHP-style formatting string. See [php.net/date](https://www.php.net/manual/en/function.date.php).
 -   _dateValue_ `Moment | Date | string | undefined`: Date object or string, parsable by moment.js.
 
 _Returns_
@@ -95,7 +95,7 @@ Formats a date (like `date()` in PHP), in the UTC timezone.
 
 _Parameters_
 
--   _dateFormat_ `string`: PHP-style formatting string. See [php.net/date](https://php.net/date).
+-   _dateFormat_ `string`: PHP-style formatting string. See [php.net/date](https://www.php.net/manual/en/function.date.php).
 -   _dateValue_ `Moment | Date | string | undefined`: Date object or string, parsable by moment.js.
 
 _Returns_
@@ -108,7 +108,7 @@ Formats a date (like `wp_date()` in PHP), translating it into site's locale and 
 
 _Parameters_
 
--   _dateFormat_ `string`: PHP-style formatting string. See [php.net/date](https://php.net/date).
+-   _dateFormat_ `string`: PHP-style formatting string. See [php.net/date](https://www.php.net/manual/en/function.date.php).
 -   _dateValue_ `Moment | Date | string | undefined`: Date object or string, parsable by moment.js.
 
 _Returns_

--- a/packages/date/README.md
+++ b/packages/date/README.md
@@ -27,7 +27,7 @@ _Related_
 
 _Parameters_
 
--   _dateFormat_ `string`: PHP-style formatting string. See php.net/date.
+-   _dateFormat_ `string`: PHP-style formatting string. See [php.net/date](https://php.net/date).
 -   _dateValue_ `Moment | Date | string | undefined`: Date object or string, parsable by moment.js.
 -   _timezone_ `string | number | undefined`: Timezone to output result in or a UTC offset. Defaults to timezone from site.
 
@@ -48,7 +48,7 @@ _Related_
 
 _Parameters_
 
--   _dateFormat_ `string`: PHP-style formatting string. See php.net/date.
+-   _dateFormat_ `string`: PHP-style formatting string. See [php.net/date](https://php.net/date).
 -   _dateValue_ `Moment | Date | string | undefined`: Date object or string, parsable by moment.js.
 -   _timezone_ `string | number | boolean | undefined=`: Timezone to output result in or a UTC offset. Defaults to timezone from site. Notice: `boolean` is effectively deprecated, but still supported for backward compatibility reasons.
 
@@ -62,7 +62,7 @@ Formats a date. Does not alter the date's timezone.
 
 _Parameters_
 
--   _dateFormat_ `string`: PHP-style formatting string. See php.net/date.
+-   _dateFormat_ `string`: PHP-style formatting string. See [php.net/date](https://php.net/date).
 -   _dateValue_ `Moment | Date | string | undefined`: Date object or string, parsable by moment.js.
 
 _Returns_
@@ -95,7 +95,7 @@ Formats a date (like `date()` in PHP), in the UTC timezone.
 
 _Parameters_
 
--   _dateFormat_ `string`: PHP-style formatting string. See php.net/date.
+-   _dateFormat_ `string`: PHP-style formatting string. See [php.net/date](https://php.net/date).
 -   _dateValue_ `Moment | Date | string | undefined`: Date object or string, parsable by moment.js.
 
 _Returns_
@@ -108,7 +108,7 @@ Formats a date (like `wp_date()` in PHP), translating it into site's locale and 
 
 _Parameters_
 
--   _dateFormat_ `string`: PHP-style formatting string. See php.net/date.
+-   _dateFormat_ `string`: PHP-style formatting string. See [php.net/date](https://php.net/date).
 -   _dateValue_ `Moment | Date | string | undefined`: Date object or string, parsable by moment.js.
 
 _Returns_

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -445,7 +445,7 @@ const formatMap = {
  * Formats a date. Does not alter the date's timezone.
  *
  * @param {string}                             dateFormat PHP-style formatting string.
- *                                                        See php.net/date.
+ *                                                        See [php.net/date](https://php.net/date).
  * @param {Moment | Date | string | undefined} dateValue  Date object or string,
  *                                                        parsable by moment.js.
  *
@@ -487,7 +487,7 @@ export function format( dateFormat, dateValue = new Date() ) {
  * Formats a date (like `date()` in PHP).
  *
  * @param {string}                             dateFormat PHP-style formatting string.
- *                                                        See php.net/date.
+ *                                                        See [php.net/date](https://php.net/date).
  * @param {Moment | Date | string | undefined} dateValue  Date object or string, parsable
  *                                                        by moment.js.
  * @param {string | number | undefined}        timezone   Timezone to output result in or a
@@ -508,7 +508,7 @@ export function date( dateFormat, dateValue = new Date(), timezone ) {
  * Formats a date (like `date()` in PHP), in the UTC timezone.
  *
  * @param {string}                             dateFormat PHP-style formatting string.
- *                                                        See php.net/date.
+ *                                                        See [php.net/date](https://php.net/date).
  * @param {Moment | Date | string | undefined} dateValue  Date object or string,
  *                                                        parsable by moment.js.
  *
@@ -526,7 +526,7 @@ export function gmdate( dateFormat, dateValue = new Date() ) {
  * behaves like `gmdateI18n`.
  *
  * @param {string}                                 dateFormat PHP-style formatting string.
- *                                                            See php.net/date.
+ *                                                            See [php.net/date](https://php.net/date).
  * @param {Moment | Date | string | undefined}     dateValue  Date object or string, parsable by
  *                                                            moment.js.
  * @param {string | number | boolean | undefined=} timezone   Timezone to output result in or a
@@ -559,7 +559,7 @@ export function dateI18n( dateFormat, dateValue = new Date(), timezone ) {
  * and using the UTC timezone.
  *
  * @param {string}                             dateFormat PHP-style formatting string.
- *                                                        See php.net/date.
+ *                                                        See [php.net/date](https://php.net/date).
  * @param {Moment | Date | string | undefined} dateValue  Date object or string,
  *                                                        parsable by moment.js.
  *

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -445,7 +445,7 @@ const formatMap = {
  * Formats a date. Does not alter the date's timezone.
  *
  * @param {string}                             dateFormat PHP-style formatting string.
- *                                                        See [php.net/date](https://php.net/date).
+ *                                                        See [php.net/date](https://www.php.net/manual/en/function.date.php).
  * @param {Moment | Date | string | undefined} dateValue  Date object or string,
  *                                                        parsable by moment.js.
  *
@@ -487,7 +487,7 @@ export function format( dateFormat, dateValue = new Date() ) {
  * Formats a date (like `date()` in PHP).
  *
  * @param {string}                             dateFormat PHP-style formatting string.
- *                                                        See [php.net/date](https://php.net/date).
+ *                                                        See [php.net/date](https://www.php.net/manual/en/function.date.php).
  * @param {Moment | Date | string | undefined} dateValue  Date object or string, parsable
  *                                                        by moment.js.
  * @param {string | number | undefined}        timezone   Timezone to output result in or a
@@ -508,7 +508,7 @@ export function date( dateFormat, dateValue = new Date(), timezone ) {
  * Formats a date (like `date()` in PHP), in the UTC timezone.
  *
  * @param {string}                             dateFormat PHP-style formatting string.
- *                                                        See [php.net/date](https://php.net/date).
+ *                                                        See [php.net/date](https://www.php.net/manual/en/function.date.php).
  * @param {Moment | Date | string | undefined} dateValue  Date object or string,
  *                                                        parsable by moment.js.
  *
@@ -526,7 +526,7 @@ export function gmdate( dateFormat, dateValue = new Date() ) {
  * behaves like `gmdateI18n`.
  *
  * @param {string}                                 dateFormat PHP-style formatting string.
- *                                                            See [php.net/date](https://php.net/date).
+ *                                                            See [php.net/date](https://www.php.net/manual/en/function.date.php).
  * @param {Moment | Date | string | undefined}     dateValue  Date object or string, parsable by
  *                                                            moment.js.
  * @param {string | number | boolean | undefined=} timezone   Timezone to output result in or a
@@ -559,7 +559,7 @@ export function dateI18n( dateFormat, dateValue = new Date(), timezone ) {
  * and using the UTC timezone.
  *
  * @param {string}                             dateFormat PHP-style formatting string.
- *                                                        See [php.net/date](https://php.net/date).
+ *                                                        See [php.net/date](https://www.php.net/manual/en/function.date.php).
  * @param {Moment | Date | string | undefined} dateValue  Date object or string,
  *                                                        parsable by moment.js.
  *


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
- Added php.net/date Links.

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Refreshed PR: [ #54205 ](https://github.com/WordPress/gutenberg/pull/54205)

## Why?
- Link is Missing in `See php.net/date`