### PR TITLE
Editor: Persist user's 'Show Template' preference

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -391,7 +391,7 @@ function Layout( {
 	} = useSelect(
 		( select ) => {
 			const { get } = select( preferencesStore );
-			const { isFeatureActive } = select( editPostStore );
+			const { isFeatureActive, hasMetaBoxes } = select( editPostStore );
 			const { canUser, getPostType, getTemplateId } = unlock(
 				select( coreStore )
 			);
@@ -403,9 +403,11 @@ function Layout( {
 				kind: 'postType',
 				name: 'wp_template',
 			} );
-			const { isZoomOut } = unlock( select( blockEditorStore ) );
-			const { getEditorMode, getRenderingMode } = select( editorStore );
-			const { getDefaultRenderingMode } = unlock( select( editorStore ) );
+			const { getBlockSelectionStart, isZoomOut } = unlock(
+				select( blockEditorStore )
+			);
+			const { getEditorMode, getRenderingMode, getDefaultRenderingMode } =
+				unlock( select( editorStore ) );
 			const isRenderingPostOnly = getRenderingMode() === 'post-only';
 			const isNotDesignPostType =
 				! DESIGN_POST_TYPES.includes( currentPostType );
@@ -417,15 +419,13 @@ function Layout( {
 
 			return {
 				mode: getEditorMode(),
-				isFullscreenActive:
-					select( editPostStore ).isFeatureActive( 'fullscreenMode' ),
-				hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
+				isFullscreenActive: isFeatureActive( 'fullscreenMode' ),
+				hasActiveMetaboxes: hasMetaBoxes(),
 				hasResolvedMode:
 					defaultMode === 'template-locked'
 						? !! _templateId
 						: defaultMode !== undefined,
-				hasBlockSelected:
-					!! select( blockEditorStore ).getBlockSelectionStart(),
+				hasBlockSelected: !! getBlockSelectionStart(),
 				showIconLabels: get( 'core', 'showIconLabels' ),
 				isDistractionFree: get( 'core', 'distractionFree' ),
 				showMetaBoxes:

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -379,6 +379,7 @@ function Layout( {
 	const {
 		mode,
 		isFullscreenActive,
+		hasResolvedMode,
 		hasActiveMetaboxes,
 		hasBlockSelected,
 		showIconLabels,
@@ -404,18 +405,25 @@ function Layout( {
 			} );
 			const { isZoomOut } = unlock( select( blockEditorStore ) );
 			const { getEditorMode, getRenderingMode } = select( editorStore );
+			const { getDefaultRenderingMode } = unlock( select( editorStore ) );
 			const isRenderingPostOnly = getRenderingMode() === 'post-only';
 			const isNotDesignPostType =
 				! DESIGN_POST_TYPES.includes( currentPostType );
 			const isDirectlyEditingPattern =
 				currentPostType === 'wp_block' &&
 				! onNavigateToPreviousEntityRecord;
+			const _templateId = getTemplateId( currentPostType, currentPostId );
+			const defaultMode = getDefaultRenderingMode( currentPostType );
 
 			return {
 				mode: getEditorMode(),
 				isFullscreenActive:
 					select( editPostStore ).isFeatureActive( 'fullscreenMode' ),
 				hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
+				hasResolvedMode:
+					defaultMode === 'template-locked'
+						? !! _templateId
+						: defaultMode !== undefined,
 				hasBlockSelected:
 					!! select( blockEditorStore ).getBlockSelectionStart(),
 				showIconLabels: get( 'core', 'showIconLabels' ),
@@ -429,7 +437,7 @@ function Layout( {
 					isViewable &&
 					canViewTemplate &&
 					! isEditingTemplate
-						? getTemplateId( currentPostType, currentPostId )
+						? _templateId
 						: null,
 				enablePaddingAppender:
 					! isZoomOut() && isRenderingPostOnly && isNotDesignPostType,
@@ -443,7 +451,8 @@ function Layout( {
 			onNavigateToPreviousEntityRecord,
 		]
 	);
-	useMetaBoxInitialization( hasActiveMetaboxes );
+
+	useMetaBoxInitialization( hasActiveMetaboxes && hasResolvedMode );
 
 	const [ paddingAppenderRef, paddingStyle ] = usePaddingAppender(
 		enablePaddingAppender

--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -46,7 +46,6 @@ export default function BlockThemeControl( { id } ) {
 	}, [] );
 
 	const { get: getPreference } = useSelect( preferencesStore );
-	const { set: setPreference } = useDispatch( preferencesStore );
 
 	const { editedRecord: template, hasResolved } = useEntityRecord(
 		'postType',
@@ -54,7 +53,9 @@ export default function BlockThemeControl( { id } ) {
 		id
 	);
 	const { createSuccessNotice } = useDispatch( noticesStore );
-	const { setRenderingMode } = useDispatch( editorStore );
+	const { setRenderingMode, setDefaultRenderingMode } = unlock(
+		useDispatch( editorStore )
+	);
 
 	const canCreateTemplate = useSelect(
 		( select ) =>
@@ -154,11 +155,7 @@ export default function BlockThemeControl( { id } ) {
 										? 'template-locked'
 										: 'post-only';
 									setRenderingMode( newRenderingMode );
-									setPreference(
-										'core',
-										'renderingMode',
-										newRenderingMode
-									);
+									setDefaultRenderingMode( newRenderingMode );
 								} }
 							>
 								{ __( 'Show template' ) }

--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -46,6 +46,7 @@ export default function BlockThemeControl( { id } ) {
 	}, [] );
 
 	const { get: getPreference } = useSelect( preferencesStore );
+	const { set: setPreference } = useDispatch( preferencesStore );
 
 	const { editedRecord: template, hasResolved } = useEntityRecord(
 		'postType',
@@ -149,10 +150,14 @@ export default function BlockThemeControl( { id } ) {
 								isSelected={ ! isTemplateHidden }
 								role="menuitemcheckbox"
 								onClick={ () => {
-									setRenderingMode(
-										isTemplateHidden
-											? 'template-locked'
-											: 'post-only'
+									const newRenderingMode = isTemplateHidden
+										? 'template-locked'
+										: 'post-only';
+									setRenderingMode( newRenderingMode );
+									setPreference(
+										'core',
+										'renderingMode',
+										newRenderingMode
 									);
 								} }
 							>

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -56,8 +56,9 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			templateId: getCurrentTemplateId(),
 		};
 	}, [] );
-	const { setDeviceType, setRenderingMode } = useDispatch( editorStore );
-	const { set: setPreference } = useDispatch( preferencesStore );
+	const { setDeviceType, setRenderingMode, setDefaultRenderingMode } = unlock(
+		useDispatch( editorStore )
+	);
 	const { resetZoomLevel } = unlock( useDispatch( blockEditorStore ) );
 
 	const handleDevicePreviewChange = ( newDeviceType ) => {
@@ -165,11 +166,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 										? 'template-locked'
 										: 'post-only';
 									setRenderingMode( newRenderingMode );
-									setPreference(
-										'core',
-										'renderingMode',
-										newRenderingMode
-									);
+									setDefaultRenderingMode( newRenderingMode );
 								} }
 							>
 								{ __( 'Show template' ) }

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -57,6 +57,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 		};
 	}, [] );
 	const { setDeviceType, setRenderingMode } = useDispatch( editorStore );
+	const { set: setPreference } = useDispatch( preferencesStore );
 	const { resetZoomLevel } = unlock( useDispatch( blockEditorStore ) );
 
 	const handleDevicePreviewChange = ( newDeviceType ) => {
@@ -160,10 +161,14 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 								isSelected={ ! isTemplateHidden }
 								role="menuitemcheckbox"
 								onClick={ () => {
-									setRenderingMode(
-										isTemplateHidden
-											? 'template-locked'
-											: 'post-only'
+									const newRenderingMode = isTemplateHidden
+										? 'template-locked'
+										: 'post-only';
+									setRenderingMode( newRenderingMode );
+									setPreference(
+										'core',
+										'renderingMode',
+										newRenderingMode
 									);
 								} }
 							>

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -15,6 +15,7 @@ import {
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { store as noticesStore } from '@wordpress/notices';
+import { store as preferencesStore } from '@wordpress/preferences';
 import { privateApis as editPatternsPrivateApis } from '@wordpress/patterns';
 import { createBlock } from '@wordpress/blocks';
 
@@ -195,12 +196,18 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					'getPostType',
 					[ post.type ]
 				);
-
-				const _defaultMode = Array.isArray( postTypeSupports?.editor )
+				const postTypeDefaultMode = Array.isArray(
+					postTypeSupports?.editor
+				)
 					? postTypeSupports.editor.find(
 							( features ) => 'default-mode' in features
 					  )?.[ 'default-mode' ]
 					: undefined;
+				const userDefaultMode = select( preferencesStore ).get(
+					'core',
+					'renderingMode'
+				);
+				const _defaultMode = userDefaultMode || postTypeDefaultMode;
 				const hasDefaultMode = RENDERING_MODES.includes( _defaultMode );
 
 				// Wait for template resolution when rendering in a `template-locked` mode.

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -210,7 +210,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			[ post.type, hasTemplate ]
 		);
 
-		const shouldRenderTemplate = !! template && mode !== 'post-only';
+		const shouldRenderTemplate = hasTemplate && mode !== 'post-only';
 		const rootLevelPost = shouldRenderTemplate ? template : post;
 		const defaultBlockContext = useMemo( () => {
 			const postContext = {};
@@ -327,7 +327,9 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 
 		// Sets the right rendering mode when loading the editor.
 		useEffect( () => {
-			setRenderingMode( defaultMode );
+			if ( defaultMode ) {
+				setRenderingMode( defaultMode );
+			}
 		}, [ defaultMode, setRenderingMode ] );
 
 		useHideBlocksFromInserter( post.type, mode );

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -15,7 +15,6 @@ import {
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { store as noticesStore } from '@wordpress/notices';
-import { store as preferencesStore } from '@wordpress/preferences';
 import { privateApis as editPatternsPrivateApis } from '@wordpress/patterns';
 import { createBlock } from '@wordpress/blocks';
 
@@ -56,11 +55,6 @@ const NON_CONTEXTUAL_POST_TYPES = [
 	'wp_navigation',
 	'wp_template_part',
 ];
-
-/**
- * These are rendering modes that the editor supports.
- */
-const RENDERING_MODES = [ 'post-only', 'template-locked' ];
 
 /**
  * Depending on the post, template and template mode,
@@ -184,43 +178,28 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					getEditorSelection,
 					getRenderingMode,
 					__unstableIsEditorReady,
-				} = select( editorStore );
-				const {
-					getEntitiesConfig,
-					getPostType,
-					hasFinishedResolution,
-				} = select( coreStore );
+					getDefaultRenderingMode,
+				} = unlock( select( editorStore ) );
+				const { getEntitiesConfig } = select( coreStore );
 
-				const postTypeSupports = getPostType( post.type )?.supports;
-				const hasLoadedPostObject = hasFinishedResolution(
-					'getPostType',
-					[ post.type ]
-				);
-				const postTypeDefaultMode = Array.isArray(
-					postTypeSupports?.editor
-				)
-					? postTypeSupports.editor.find(
-							( features ) => 'default-mode' in features
-					  )?.[ 'default-mode' ]
-					: undefined;
-				const userDefaultMode = select( preferencesStore ).get(
-					'core',
-					'renderingMode'
-				);
-				const _defaultMode = userDefaultMode || postTypeDefaultMode;
-				const hasDefaultMode = RENDERING_MODES.includes( _defaultMode );
-
-				// Wait for template resolution when rendering in a `template-locked` mode.
+				const _defaultMode = getDefaultRenderingMode( post.type );
+				/**
+				 * To avoid content "flash", wait until rendering mode has been resolved.
+				 * This is important for the initial render of the editor.
+				 *
+				 * - Wait for template to be resolved if the default mode is 'template-locked'.
+				 * - Wait for default mode to be resolved otherwise.
+				 */
 				const hasResolvedMode =
-					hasLoadedPostObject && _defaultMode === 'template-locked'
+					_defaultMode === 'template-locked'
 						? hasTemplate
-						: true;
+						: _defaultMode !== undefined;
 
 				return {
 					editorSettings: getEditorSettings(),
 					isReady: __unstableIsEditorReady() && hasResolvedMode,
 					mode: getRenderingMode(),
-					defaultMode: hasDefaultMode ? _defaultMode : 'post-only',
+					defaultMode: _defaultMode,
 					selection: getEditorSelection(),
 					postTypeEntities:
 						post.type === 'wp_template'

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -492,3 +492,36 @@ export const removeTemplates =
 				.createErrorNotice( errorMessage, { type: 'snackbar' } );
 		}
 	};
+
+/**
+ * Set the default rendering mode preference for the current post type.
+ *
+ * @param {string} mode The rendering mode to set as default.
+ */
+export const setDefaultRenderingMode =
+	( mode ) =>
+	( { select, registry } ) => {
+		const postType = select.getCurrentPostType();
+		const theme = registry
+			.select( coreStore )
+			.getCurrentTheme()?.stylesheet;
+		const renderingModes =
+			registry
+				.select( preferencesStore )
+				.get( 'core', 'renderingModes' )?.[ theme ] ?? {};
+
+		if ( renderingModes[ postType ] === mode ) {
+			return;
+		}
+
+		const newModes = {
+			[ theme ]: {
+				...renderingModes,
+				[ postType ]: mode,
+			},
+		};
+
+		registry
+			.dispatch( preferencesStore )
+			.set( 'core', 'renderingModes', newModes );
+	};

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -232,15 +232,24 @@ export const getPostBlocksByName = createRegistrySelector( ( select ) =>
  */
 export const getDefaultRenderingMode = createRegistrySelector(
 	( select ) => ( state, postType ) => {
-		const postTypeEntity = select( coreStore ).getPostType( postType );
-		const currentTheme = select( coreStore ).getCurrentTheme();
+		const { getPostType, getCurrentTheme, hasFinishedResolution } =
+			select( coreStore );
 
-		// Wait for the post type and theme resolutions.
-		if ( ! postTypeEntity || ! currentTheme ) {
+		// This needs to be called before `hasFinishedResolution`.
+		// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+		const currentTheme = getCurrentTheme();
+		// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+		const postTypeEntity = getPostType( postType );
+
+		// Wait for the post type and theme resolution.
+		if (
+			! hasFinishedResolution( 'getPostType', [ postType ] ) ||
+			! hasFinishedResolution( 'getCurrentTheme' )
+		) {
 			return undefined;
 		}
 
-		const theme = currentTheme.stylesheet;
+		const theme = currentTheme?.stylesheet;
 		const defaultModePreference = select( preferencesStore ).get(
 			'core',
 			'renderingModes'

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -256,7 +256,7 @@ export const getDefaultRenderingMode = createRegistrySelector(
 		const defaultMode = defaultModePreference || postTypeDefaultMode;
 
 		// Fallback gracefully to 'post-only' when rendering mode is not supported.
-		if ( ! defaultMode || ! RENDERING_MODES.includes( defaultMode ) ) {
+		if ( ! RENDERING_MODES.includes( defaultMode ) ) {
 			return 'post-only';
 		}
 

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -16,6 +16,7 @@ import {
 	verse,
 } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -33,6 +34,11 @@ const EMPTY_INSERTION_POINT = {
 	insertionIndex: undefined,
 	filterValue: undefined,
 };
+
+/**
+ * These are rendering modes that the editor supports.
+ */
+const RENDERING_MODES = [ 'post-only', 'template-locked' ];
 
 /**
  * Get the inserter.
@@ -214,4 +220,46 @@ export const getPostBlocksByName = createRegistrySelector( ( select ) =>
 		},
 		() => [ select( blockEditorStore ).getBlocks() ]
 	)
+);
+
+/**
+ * Returns the default rendering mode for a post type by user preference or post type configuration.
+ *
+ * @param {Object} state    Global application state.
+ * @param {string} postType The post type.
+ *
+ * @return {string} The default rendering mode. Returns `undefined` while resolving value.
+ */
+export const getDefaultRenderingMode = createRegistrySelector(
+	( select ) => ( state, postType ) => {
+		const postTypeEntity = select( coreStore ).getPostType( postType );
+		const currentTheme = select( coreStore ).getCurrentTheme();
+
+		// Wait for the post type and theme resolutions.
+		if ( ! postTypeEntity || ! currentTheme ) {
+			return undefined;
+		}
+
+		const theme = currentTheme.stylesheet;
+		const defaultModePreference = select( preferencesStore ).get(
+			'core',
+			'renderingModes'
+		)?.[ theme ]?.[ postType ];
+		const postTypeDefaultMode = Array.isArray(
+			postTypeEntity?.supports?.editor
+		)
+			? postTypeEntity.supports.editor.find(
+					( features ) => 'default-mode' in features
+			  )?.[ 'default-mode' ]
+			: undefined;
+
+		const defaultMode = defaultModePreference || postTypeDefaultMode;
+
+		// Fallback gracefully to 'post-only' when rendering mode is not supported.
+		if ( ! defaultMode || ! RENDERING_MODES.includes( defaultMode ) ) {
+			return 'post-only';
+		}
+
+		return defaultMode;
+	}
 );

--- a/test/e2e/specs/site-editor/preload.spec.js
+++ b/test/e2e/specs/site-editor/preload.spec.js
@@ -46,6 +46,9 @@ test.describe( 'Preload', () => {
 		expect( requests ).toEqual( [
 			// Seems to be coming from `enableComplementaryArea`.
 			'/wp/v2/users/me',
+			// There are two separate settings OPTIONS requests. We should fix
+			// so the one for canUser and getEntityRecord are reused.
+			'/wp/v2/settings',
 		] );
 	} );
 } );

--- a/test/native/integration-test-helpers/initialize-editor.js
+++ b/test/native/integration-test-helpers/initialize-editor.js
@@ -38,7 +38,7 @@ export async function initializeEditor( props, { component } = {} ) {
 	resolutionSpy.mockImplementation( ( selectorName, args ) => {
 		// The mobile editor only supports the `post-only` rendering mode, so we
 		// presume a resolved `getPostType` selector to unblock editor rendering.
-		if ( 'getPostType' === selectorName ) {
+		if ( [ 'getPostType', 'getCurrentTheme' ].includes( selectorName ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
## What?
Closes #68250.
Alternative to #68257.

PR introduces user preference persistence for the new default rendering mode (Show Template), while keeping the editor's rendering mode state separate.

## Why an alternative

I'm hesitant about handling user preferences logic inside the `getRenderingMode` and `setRenderingMode`. Why?

* Currently, the editor expects the correct editing mode to be set when loading. It is how post-type default mode is handled, and it leaves room for programmatically toggling the mode (Redux state) without touching the settings. See the `useNavigateToEntityRecord` for [example use cases](https://github.com/WordPress/gutenberg/blob/b06588e805acbe6ba92124e495055781eb21a7ce/packages/edit-post/src/hooks/use-navigate-to-entity-record.js#L54-L72).
* Deriving default mode in the `EditorProvider` makes it easier to control how fast the component can mark the editor as "ready". When user preference isn't `template-locked` the component doesn't have to wait for the template to be resolved.
* Avoid repeating possible pitfalls of `setBockEditingMode`. While it's early to judge here, I can see some similarities. You can read more about the subject here - https://make.wordpress.org/core/2024/09/12/gutenberg-development-practices-and-common-pitfalls/#:~:text=Be%20declarative%20as%20much%20as%20possible.
* The new private `getDefaultRenderingMode` selector helps derive the state. It was getting too complex to keep inside the `mapSelect` callback.

## How?
* Introduces a new private `getDefaultRenderingMode` selector and `setDefaultRenderingMode` action. They help keep logic simple inside the components.
* The preference is stored for the current theme and post type. See https://github.com/WordPress/gutenberg/issues/68250#issuecomment-2677519810 and details below.

The user preferences are retained when switching themes. If the user selects `template-locked` mode for a post type in a block theme and switches to classic, the editor will try to render that post type with `template-locked` and fail. Block editor can only render block templates; it cannot render PHP.

To prevent users from accidentally breaking editor rendering when switching between themes, rendering mode preferences are stored using the theme stylesheet as a top-level key.

```json
{
    "twentytwentyfive": {
        "post": "post-only",
        "page": "template-locked"
    }
}
```

## Testing Instructions
1. Using a block theme.
2. Open a page.
3. Confirm it renders in a `template-locked` state.
4. Disable the "Show Template" in the sidebar.
5. Reload the page and confirm it now uses `post-only` as the default rendering mode.
6. Re-enable "Show Template" from the sidebar bar.
7. Open a post.
8. Confirm that it still renders in `post-only`.
9. Switch to a classic theme.
10. Confirm that posts and pages load correctly without showing the template.

### Testing Instructions for Keyboard
Same.
