### PR TITLE
Editor: Use a stable array ref as fallback value in 'BlockVisibility'

### DIFF
--- a/packages/editor/src/components/preferences-modal/block-visibility.js
+++ b/packages/editor/src/components/preferences-modal/block-visibility.js
@@ -14,6 +14,7 @@ import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
 const { BlockManager } = unlock( blockEditorPrivateApis );
+const EMPTY_ARRAY = [];
 
 export default function BlockVisibility() {
 	const { showBlockTypes, hideBlockTypes } = unlock(
@@ -31,7 +32,7 @@ export default function BlockVisibility() {
 				select( editorStore ).getEditorSettings().allowedBlockTypes,
 			hiddenBlockTypes:
 				select( preferencesStore ).get( 'core', 'hiddenBlockTypes' ) ??
-				[],
+				EMPTY_ARRAY,
 		};
 	}, [] );
 


### PR DESCRIPTION
## What?
This is a follow-up to #67052.

PR updates the selector value fallback in the `BlockVisibility` component to use a stable array reference instead of returning a new array on each call.

Note: The issue doesn't affect current editors because they preset preference default values.

https://github.com/WordPress/gutenberg/blob/b06588e805acbe6ba92124e495055781eb21a7ce/packages/edit-post/src/index.js#L67

## Why?
Prevents potential `useSelect` hook warnings when the `hiddenBlockTypes` user preference is `undefined`.

## Testing Instructions
1. Open a post or page.
2. Confirm that the block visibility manager works as before.

### Testing Instructions for Keyboard
Same.