### PR TITLE
Title Blocks: Add transformations between Post Title and Query Title

### DIFF
--- a/packages/block-library/src/post-title/index.js
+++ b/packages/block-library/src/post-title/index.js
@@ -10,6 +10,7 @@ import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
 import deprecated from './deprecated';
+import transforms from './transforms';
 
 const { name } = metadata;
 export { metadata, name };
@@ -17,6 +18,7 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
+	transforms,
 	deprecated,
 };
 

--- a/packages/block-library/src/post-title/transforms.js
+++ b/packages/block-library/src/post-title/transforms.js
@@ -1,0 +1,54 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+const transforms = {
+	from: [
+		{
+			type: 'block',
+			blocks: [ 'core/query-title' ],
+			transform: ( attributes ) => {
+				return createBlock( 'core/post-title', {
+					textAlign: attributes.textAlign,
+					level: attributes.level || 2,
+					style: attributes.style || {},
+				} );
+			},
+		},
+	],
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/query-title' ],
+			name: 'archive-title',
+			title: __( 'Archive Title' ),
+			transform: ( attributes ) => {
+				return createBlock( 'core/query-title', {
+					textAlign: attributes.textAlign,
+					level: attributes.level || 1,
+					type: 'archive',
+					showPrefix: true,
+				} );
+			},
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/query-title' ],
+			name: 'search-title',
+			title: __( 'Search Results Title' ),
+			transform: ( attributes ) => {
+				return createBlock( 'core/query-title', {
+					textAlign: attributes.textAlign,
+					level: attributes.level || 1,
+					type: 'search',
+					showPrefix: true,
+					showSearchTerm: true,
+				} );
+			},
+		},
+	],
+};
+
+export default transforms;

--- a/packages/block-library/src/query-title/variations.js
+++ b/packages/block-library/src/query-title/variations.js
@@ -15,7 +15,7 @@ const variations = [
 		attributes: {
 			type: 'archive',
 		},
-		scope: [ 'inserter' ],
+		scope: [ 'inserter', 'transform' ],
 	},
 	{
 		isDefault: false,
@@ -28,7 +28,7 @@ const variations = [
 		attributes: {
 			type: 'search',
 		},
-		scope: [ 'inserter' ],
+		scope: [ 'inserter', 'transform' ],
 	},
 ];
 


### PR DESCRIPTION
Closes: #69270 

## What?
Add block transformations between the Post Title block and Query Title block variations (Archive Title and Search Results Title).

## Why?
Currently, users cannot transform between the Post Title block and different variations of the Query Title block (Archive Title and Search Results Title). This enhancement improves the block editor's usability by allowing seamless transformation between these related title blocks.

## How?
- Updated the Post Title block's transforms.js to support transformations to both Query Title variations
- Added appropriate title attributes to show distinct transformation options in the block toolbar
- Ensured all relevant attributes are preserved during transformation
- Added transform scope to Query Title variations to enable the transformations

## Testing Instructions
1. Create a new post or page
2. Insert a Post Title block
3. Click the block toolbar's transform icon (two overlapping squares)
4. Verify you see "Query Title" block
5. Transform the Post Title block to Archive Title or Search Results Title
6. Transform it back to Post Title

## Screenshots or screencast
### Before
https://github.com/user-attachments/assets/cacef423-01b8-46b2-940a-05e6a1e6d690

### After

https://github.com/user-attachments/assets/c498e99d-5ca4-4a1a-9add-fb3d79aeb347


