### PR TITLE
Try to run e2e tests with the post editor in full screen mode.

### DIFF
--- a/packages/e2e-test-utils-playwright/src/admin/create-new-post.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/create-new-post.ts
@@ -42,6 +42,6 @@ export async function createNewPost(
 
 	await this.editor.setPreferences( 'core/edit-post', {
 		welcomeGuide: options.showWelcomeGuide ?? false,
-		fullscreenMode: options.fullscreenMode ?? false,
+		fullscreenMode: options.fullscreenMode ?? true,
 	} );
 }

--- a/packages/e2e-test-utils-playwright/src/admin/edit-post.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/edit-post.ts
@@ -19,6 +19,6 @@ export async function editPost( this: Admin, postId: string | number ) {
 
 	await this.editor.setPreferences( 'core/edit-post', {
 		welcomeGuide: false,
-		fullscreenMode: false,
+		fullscreenMode: true,
 	} );
 }

--- a/test/e2e/specs/editor/various/a11y.spec.js
+++ b/test/e2e/specs/editor/various/a11y.spec.js
@@ -21,7 +21,6 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 		page,
 		pageUtils,
 		editor,
-		browserName,
 	} ) => {
 		// To do: run with iframe.
 		await editor.switchToLegacyCanvas();
@@ -49,14 +48,12 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 		// When full screen mode is enabled, check the first tabbable element
 		// within the 'Editor top bar' region is the 'View Posts' link otherwise
 		// check it's the 'Block Inserter' button.
-		// In webkit (Safari) links aren't tabbable by default so we always test
-		// for the 'Block Inserter' button.
-		let elementToTest = isFullScreenMode
+		// When running this test locally, make sure that in macOS webkit (Safari)
+		// links are focusable and tabbable by setting the related preferences at
+		// system and browser level.
+		const elementToTest = isFullScreenMode
 			? 'role=link[name=/View Posts/i]'
 			: 'role=button[name=/Block Inserter/i]';
-		if ( browserName === 'webkit' ) {
-			elementToTest = 'role=button[name=/Block Inserter/i]';
-		}
 
 		await expect( page.locator( elementToTest ) ).toBeFocused();
 	} );

--- a/test/e2e/specs/editor/various/fullscreen-mode.spec.js
+++ b/test/e2e/specs/editor/various/fullscreen-mode.spec.js
@@ -18,7 +18,7 @@ test.describe( 'Fullscreen Mode', () => {
 		} );
 	} );
 
-	test( 'should open the fullscreen mode from the more menu', async ( {
+	test( 'should open and close the fullscreen mode from the more menu', async ( {
 		page,
 	} ) => {
 		// Open Options Menu
@@ -26,20 +26,61 @@ test.describe( 'Fullscreen Mode', () => {
 			'role=region[name="Editor top bar"i] >> role=button[name="Options"i]'
 		);
 
-		// Select Full Screen Mode
-		await page
-			.locator( 'role=menuitemcheckbox', { hasText: 'Fullscreen mode' } )
-			.click();
+		const body = page.locator( 'body' );
 
-		// Check the body class.
-		await expect( page.locator( 'body' ) ).toHaveClass(
-			/is-fullscreen-mode/
-		);
+		const fullScreenCheckbox = page
+			.getByRole( 'menuitemcheckbox' )
+			.filter( { hasText: 'Fullscreen mode' } );
 
-		await expect(
-			page.locator(
-				'role=region[name="Editor top bar"i] >> role=link[name="View Posts"i]'
-			)
-		).toBeVisible();
+		const viewPostsLink = page.getByRole( 'link', {
+			name: 'View Posts',
+		} );
+
+		// Select Full Screen Mode.
+		await fullScreenCheckbox.click();
+
+		// Check the body does have the CSS class.
+		await expect( body ).toHaveClass( /is-fullscreen-mode/ );
+
+		// Check the View Posts link is visible.
+		await expect( viewPostsLink ).toBeVisible();
+
+		// Unselect Full Screen Mode.
+		await fullScreenCheckbox.click();
+
+		// Check the body does not have the CSS class.
+		await expect( body ).not.toHaveClass( /is-fullscreen-mode/ );
+
+		// Check the View Posts link is not visible.
+		await expect( viewPostsLink ).toBeHidden();
+	} );
+
+	test( 'should open and close the fullscreen mode via the keyboard shortcut', async ( {
+		page,
+		pageUtils,
+	} ) => {
+		const body = page.locator( 'body' );
+
+		const viewPostsLink = page.getByRole( 'link', {
+			name: 'View Posts',
+		} );
+
+		// Emulates CTRL+Shift+Alt + F
+		await pageUtils.pressKeys( 'secondary+F' );
+
+		// Check the body does have the CSS class.
+		await expect( body ).toHaveClass( /is-fullscreen-mode/ );
+
+		// Check the View Posts link is visible.
+		await expect( viewPostsLink ).toBeVisible();
+
+		// Emulates CTRL+Shift+Alt + F
+		await pageUtils.pressKeys( 'secondary+F' );
+
+		// Check the body does not have the CSS class.
+		await expect( body ).not.toHaveClass( /is-fullscreen-mode/ );
+
+		// Check the View Posts link is not visible.
+		await expect( viewPostsLink ).toBeHidden();
 	} );
 } );

--- a/test/e2e/specs/editor/various/fullscreen-mode.spec.js
+++ b/test/e2e/specs/editor/various/fullscreen-mode.spec.js
@@ -74,6 +74,12 @@ test.describe( 'Fullscreen Mode', () => {
 		// Check the View Posts link is visible.
 		await expect( viewPostsLink ).toBeVisible();
 
+		await expect(
+			page
+				.getByRole( 'button', { name: 'Dismiss this notice' } )
+				.filter( { hasText: 'Fullscreen mode activated' } )
+		).toBeVisible();
+
 		// Emulates CTRL+Shift+Alt + F
 		await pageUtils.pressKeys( 'secondary+F' );
 
@@ -82,5 +88,11 @@ test.describe( 'Fullscreen Mode', () => {
 
 		// Check the View Posts link is not visible.
 		await expect( viewPostsLink ).toBeHidden();
+
+		await expect(
+			page
+				.getByRole( 'button', { name: 'Dismiss this notice' } )
+				.filter( { hasText: 'Fullscreen mode deactivated' } )
+		).toBeVisible();
 	} );
 } );

--- a/test/e2e/specs/editor/various/fullscreen-mode.spec.js
+++ b/test/e2e/specs/editor/various/fullscreen-mode.spec.js
@@ -4,12 +4,18 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Fullscreen Mode', () => {
-	test.beforeEach( async ( { admin } ) => {
+	test.beforeEach( async ( { admin, editor } ) => {
 		await admin.createNewPost();
+		await editor.setPreferences( 'core/edit-post', {
+			fullscreenMode: false,
+		} );
 	} );
 
-	test.afterEach( async ( { requestUtils } ) => {
+	test.afterEach( async ( { requestUtils, editor } ) => {
 		await requestUtils.deleteAllPosts();
+		await editor.setPreferences( 'core/edit-post', {
+			fullscreenMode: true,
+		} );
 	} );
 
 	test( 'should open the fullscreen mode from the more menu', async ( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/69276

The Post Editor full screen mode was enabled by default on March 2020 in https://github.com/WordPress/gutenberg/pull/20611. However, the e2e tests still run with full screen mode disabled by default.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The e2e tests should run with the editor UI in the same state provided to users by default. This is particularly important when testing for accessibility feaetures like focus management, tab sequence and the like.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Switches the `fullscreenMode` preference to true by default in the e2e tests utils configuration.
- Adjusts two tests.

Note: as mentioned by @t-hamano on the associated issue, this change might affect developers who are already using `@worpdress/e2e-test-utils-playwright` for their e2e tests. I'd think a dev note would be OK to inform developers as making the e2e test environment run the UI in a state that faithfully represents the actual UI provided to users outweighs potential backward compatibility issues.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
N/A.Observe the tests pass.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
