### PR TITLE
Comment Template: Add `blockGap` support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -178,7 +178,7 @@ Contains the block elements used to display a comment, like the title, date, aut
 -	**Name:** core/comment-template
 -	**Category:** design
 -	**Parent:** core/comments
--	**Supports:** align, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** align, interactivity (clientNavigation), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 
 ## Comments
 

--- a/packages/block-library/src/comment-template/block.json
+++ b/packages/block-library/src/comment-template/block.json
@@ -12,9 +12,13 @@
 		"align": true,
 		"html": false,
 		"reusable": false,
+		"layout": true,
 		"spacing": {
 			"margin": true,
-			"padding": true
+			"padding": true,
+			"blockGap": {
+				"__experimentalDefault": "1.25em"
+			}
 		},
 		"typography": {
 			"fontSize": true,

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -116,7 +116,7 @@ function CommentTemplateInnerBlocks( {
 } ) {
 	const { children, ...innerBlocksProps } = useInnerBlocksProps(
 		{},
-		{ template: TEMPLATE }
+		{ template: TEMPLATE, __unstableDisableLayoutClassNames: true }
 	);
 
 	return (
@@ -241,8 +241,9 @@ const CommentsList = ( {
 export default function CommentTemplateEdit( {
 	clientId,
 	context: { postId },
+	__unstableLayoutClassNames: layoutClassNames,
 } ) {
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( { className: layoutClassNames } );
 
 	const [ activeCommentId, setActiveCommentId ] = useState();
 	const {

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -43,11 +43,18 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 		 */
 		add_filter( 'render_block_context', $filter_block_context, 1 );
 
+		// Get an instance of the current Comment Template block.
+		$block_instance = $block->parsed_block;
+
+		// Set the block name to one that does not correspond to an existing registered block.
+		// This ensures that for the inner instances of the Comment Template block, we do not render any block supports.
+		$block_instance['blockName'] = 'core/null';
+
 		/*
 		 * We construct a new WP_Block instance from the parsed block so that
 		 * it'll receive any changes made by the `render_block_data` filter.
 		 */
-		$block_content = ( new WP_Block( $block->parsed_block ) )->render( array( 'dynamic' => false ) );
+		$block_content = ( new WP_Block( $block_instance ) )->render( array( 'dynamic' => false ) );
 
 		remove_filter( 'render_block_context', $filter_block_context, 1 );
 

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -51,7 +51,7 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 		$block_instance['blockName'] = 'core/null';
 
 		/*
-		 * We construct a new WP_Block instance from the parsed block so that
+		 * We construct a new WP_Block instance from the block instance so that
 		 * it'll receive any changes made by the `render_block_data` filter.
 		 */
 		$block_content = ( new WP_Block( $block_instance ) )->render( array( 'dynamic' => false ) );

--- a/phpunit/blocks/render-comment-template-test.php
+++ b/phpunit/blocks/render-comment-template-test.php
@@ -159,7 +159,6 @@ END;
 
 		$args = $render_block_callback->get_args();
 		$this->assertSame( 'core/comment-content', $args[0][2]->name );
-		$this->assertSame( 'core/comment-template', $args[1][2]->name );
 		$this->assertCount( 2, $args[1][2]->inner_blocks, "Inner block inserted by render_block_data filter wasn't retained." );
 		$this->assertInstanceOf(
 			'WP_Block',


### PR DESCRIPTION
## What?
Closes #69284
Part of #43243 

This PR adds `Block Gap` support to the `Comment Template` Block.

## Why?

1. To bring consistency between `Post Template` and `Comment Template`.
2. Currently, users need to provide a `bottom margin` to add spacing between multiple comments, `Block Gap` would streamline and simplify the process.

## How?

1. The corresponding `block.json` was updated to incorporate the support for `layout` and `blockGap`.
2. The `tests` were effectively handled as per the code comments mentioned below.

## Testing Instructions
1. Create a new `Comments` Block.
2. Confirm that the `Comment Template` was automatically inserted as an inner block.
3. Navigate to the `styles` tab of the `Comment Template` block.
4. Confirm that the `Block Spacing` settings are effectively applied on both the `editor` and `front-end` screens. 

## Screencast
![block-gap-demo](https://github.com/user-attachments/assets/0eadda1e-8697-4746-94c2-9f169ce15235)
