### PR TITLE
File Block: Add Option to Show File Type

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -273,7 +273,7 @@ Add a link to a downloadable file. ([Source](https://github.com/WordPress/gutenb
 -	**Name:** core/file
 -	**Category:** media
 -	**Supports:** align, anchor, color (background, gradients, link, ~~text~~), interactivity, spacing (margin, padding)
--	**Attributes:** blob, displayPreview, downloadButtonText, fileId, fileName, href, id, previewHeight, showDownloadButton, textLinkHref, textLinkTarget
+-	**Attributes:** blob, displayPreview, downloadButtonText, fileId, fileName, fileType, href, id, previewHeight, showDownloadButton, showFileType, textLinkHref, textLinkTarget
 
 ## Footnotes
 

--- a/packages/block-library/src/file/block.json
+++ b/packages/block-library/src/file/block.json
@@ -60,6 +60,14 @@
 		"previewHeight": {
 			"type": "number",
 			"default": 600
+		},
+		"showFileType": {
+			"type": "boolean",
+			"default": false
+		},
+		"fileType": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -34,7 +34,11 @@ import { store as noticesStore } from '@wordpress/notices';
  * Internal dependencies
  */
 import FileBlockInspector from './inspector';
-import { browserSupportsPdfs } from './utils';
+import {
+	browserSupportsPdfs,
+	getFileExtension,
+	removeExtensionFromFile,
+} from './utils';
 import removeAnchorTag from '../utils/remove-anchor-tag';
 import { useUploadMediaFromBlobURL } from '../utils/hooks';
 
@@ -73,6 +77,7 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 		displayPreview,
 		previewHeight,
 		showFileType,
+		fileType,
 	} = attributes;
 	const [ temporaryURL, setTemporaryURL ] = useState( attributes.blob );
 	const { media } = useSelect(
@@ -84,8 +89,6 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 		} ),
 		[ id ]
 	);
-
-	const fileType = media?.mime_type?.split( '/' )[ 1 ];
 
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { toggleSelection, __unstableMarkNextChangeAsNotPersistent } =
@@ -138,6 +141,8 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 			previewHeight: isPdf ? attributes.previewHeight ?? 600 : undefined,
 		};
 
+		const newFileType = getFileExtension( newMedia?.filename );
+
 		setAttributes( {
 			href: newMedia.url,
 			fileName: newMedia.title,
@@ -145,6 +150,7 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 			id: newMedia.id,
 			fileId: `wp-block-file--media-${ clientId }`,
 			blob: undefined,
+			fileType: newFileType,
 			...pdfAttributes,
 		} );
 		setTemporaryURL();
@@ -171,7 +177,15 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 	}
 
 	function changeShowFileType( newValue ) {
-		setAttributes( { showFileType: newValue } );
+		let updatedFileName = fileName;
+
+		if ( ! newValue ) {
+			updatedFileName = removeExtensionFromFile( fileName );
+		} else if ( ! fileName.endsWith( `.${ fileType }` ) ) {
+			updatedFileName = `${ fileName }.${ fileType }`;
+		}
+
+		setAttributes( { showFileType: newValue, fileName: updatedFileName } );
 	}
 
 	function changeDisplayPreview( newValue ) {
@@ -301,11 +315,7 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 					<RichText
 						identifier="fileName"
 						tagName="a"
-						value={
-							showFileType
-								? `${ fileName }.${ fileType }`
-								: fileName
-						}
+						value={ fileName }
 						placeholder={ __( 'Write file name…' ) }
 						withoutInteractiveFormatting
 						onChange={ ( text ) =>

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -72,6 +72,7 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 		downloadButtonText,
 		displayPreview,
 		previewHeight,
+		showFileType,
 	} = attributes;
 	const [ temporaryURL, setTemporaryURL ] = useState( attributes.blob );
 	const { media } = useSelect(
@@ -83,6 +84,8 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 		} ),
 		[ id ]
 	);
+
+	const fileType = media?.mime_type?.split( '/' )[ 1 ];
 
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { toggleSelection, __unstableMarkNextChangeAsNotPersistent } =
@@ -167,6 +170,10 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 		setAttributes( { showDownloadButton: newValue } );
 	}
 
+	function changeShowFileType( newValue ) {
+		setAttributes( { showFileType: newValue } );
+	}
+
 	function changeDisplayPreview( newValue ) {
 		setAttributes( { displayPreview: newValue } );
 	}
@@ -236,6 +243,8 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 					changeDisplayPreview,
 					previewHeight,
 					changePreviewHeight,
+					showFileType,
+					changeShowFileType,
 				} }
 			/>
 			<BlockControls group="other">
@@ -292,7 +301,11 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 					<RichText
 						identifier="fileName"
 						tagName="a"
-						value={ fileName }
+						value={
+							showFileType
+								? `${ fileName }.${ fileType }`
+								: fileName
+						}
 						placeholder={ __( 'Write file name…' ) }
 						withoutInteractiveFormatting
 						onChange={ ( text ) =>

--- a/packages/block-library/src/file/inspector.js
+++ b/packages/block-library/src/file/inspector.js
@@ -26,6 +26,8 @@ export default function FileBlockInspector( {
 	changeDisplayPreview,
 	previewHeight,
 	changePreviewHeight,
+	showFileType,
+	changeShowFileType,
 } ) {
 	const { href, textLinkHref, attachmentPage } = hrefs;
 
@@ -91,6 +93,12 @@ export default function FileBlockInspector( {
 						label={ __( 'Show download button' ) }
 						checked={ showDownloadButton }
 						onChange={ changeShowDownloadButton }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show file type' ) }
+						checked={ showFileType }
+						onChange={ changeShowFileType }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/file/utils/index.js
+++ b/packages/block-library/src/file/utils/index.js
@@ -54,3 +54,25 @@ const createActiveXObject = ( type ) => {
 	}
 	return ax;
 };
+
+/**
+ * Returns the file extension from a given file name
+ *
+ * @param {string} file The name of the file.
+ * @return {string|null} File extension or null if it does not have one.
+ */
+export function getFileExtension( file ) {
+	return file.includes( '.' ) ? file.split( '.' ).pop() || null : null;
+}
+
+/**
+ * Returns the file name from a given file name
+ *
+ * @param {string} file The name of the file.
+ * @return {string|null} File name without the extension
+ */
+export function removeExtensionFromFile( file ) {
+	return file.includes( '.' )
+		? file.substring( 0, file.lastIndexOf( '.' ) )
+		: file;
+}


### PR DESCRIPTION

## What?
Closes https://github.com/WordPress/gutenberg/issues/59091


## Why?
Currently, the File block only displays the file name. Adding an option to show the file type (extension) can improve clarity, making it easier for users to recognize the file format at a glance.


## How?

- Introduced a new toggle option in the inspector controls to enable/disable file type display.
- When enabled, the file type (extension) is appended to the file name.
- The file type is derived from the filename

## Testing Instructions

1. Open a post or page in the editor.
2. Insert a File block.
3. Upload or select a file from the media library.
4. In the block settings sidebar, toggle on Show File Type.
5. Verify that the file type (e.g., .pdf, .jpg) appears alongside the file name.
6. Toggle the option off and confirm that the file type is removed.


## Screenshots or screencast 


https://github.com/user-attachments/assets/c1fd2368-0802-421d-8e0c-f0bacc957033



