### PR TITLE
File Block: Add Option to Show File Size

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -273,7 +273,7 @@ Add a link to a downloadable file. ([Source](https://github.com/WordPress/gutenb
 -	**Name:** core/file
 -	**Category:** media
 -	**Supports:** align, anchor, color (background, gradients, link, ~~text~~), interactivity, spacing (margin, padding)
--	**Attributes:** blob, displayPreview, downloadButtonText, fileId, fileName, href, id, previewHeight, showDownloadButton, textLinkHref, textLinkTarget
+-	**Attributes:** blob, displayPreview, downloadButtonText, fileId, fileName, fileSize, href, id, previewHeight, showDownloadButton, showFileSize, textLinkHref, textLinkTarget
 
 ## Footnotes
 

--- a/packages/block-library/src/file/block.json
+++ b/packages/block-library/src/file/block.json
@@ -67,7 +67,7 @@
 		},
 		"showFileSize": {
 			"type": "boolean",
-			"default": true
+			"default": false
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/file/block.json
+++ b/packages/block-library/src/file/block.json
@@ -60,6 +60,14 @@
 		"previewHeight": {
 			"type": "number",
 			"default": 600
+		},
+		"fileSize": {
+			"type": "string",
+			"default": ""
+		},
+		"showFileSize": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/file/block.json
+++ b/packages/block-library/src/file/block.json
@@ -67,7 +67,7 @@
 		},
 		"showFileSize": {
 			"type": "boolean",
-			"default": false
+			"default": true
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -310,11 +310,17 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 						}
 						placeholder={ __( 'Write file name…' ) }
 						withoutInteractiveFormatting
-						onChange={ ( text ) =>
+						onChange={ ( text ) => {
+							// Remove the already added file size from the file name.
+							const cleanFileName = text.replace(
+								/\s*\(\d+(\.\d{1,2})?\s*MB\)$/,
+								''
+							);
+
 							setAttributes( {
-								fileName: removeAnchorTag( text ),
-							} )
-						}
+								fileName: removeAnchorTag( cleanFileName ),
+							} );
+						} }
 						href={ textLinkHref }
 					/>
 					{ showDownloadButton && (

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -121,7 +121,6 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 				fileId: undefined,
 				displayPreview: undefined,
 				previewHeight: undefined,
-				fileSize: undefined,
 			} );
 			setTemporaryURL();
 			return;
@@ -317,11 +316,11 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 						value={ fileName }
 						placeholder={ __( 'Write file name…' ) }
 						withoutInteractiveFormatting
-						onChange={ ( text ) => {
+						onChange={ ( text ) =>
 							setAttributes( {
 								fileName: removeAnchorTag( text ),
-							} );
-						} }
+							} )
+						}
 						href={ textLinkHref }
 					/>
 					{ showDownloadButton && (

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -74,7 +74,9 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 		displayPreview,
 		previewHeight,
 		showFileSize,
+		fileSize,
 	} = attributes;
+
 	const [ temporaryURL, setTemporaryURL ] = useState( attributes.blob );
 	const { media } = useSelect(
 		( select ) => ( {
@@ -85,10 +87,6 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 		} ),
 		[ id ]
 	);
-
-	const fileSize = media?.media_details?.filesize
-		? formatFileSize( media.media_details.filesize )
-		: null;
 
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { toggleSelection, __unstableMarkNextChangeAsNotPersistent } =
@@ -123,6 +121,7 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 				fileId: undefined,
 				displayPreview: undefined,
 				previewHeight: undefined,
+				fileSize: undefined,
 			} );
 			setTemporaryURL();
 			return;
@@ -141,6 +140,10 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 			previewHeight: isPdf ? attributes.previewHeight ?? 600 : undefined,
 		};
 
+		const newFileSize = newMedia?.filesizeInBytes
+			? formatFileSize( newMedia.filesizeInBytes )
+			: null;
+
 		setAttributes( {
 			href: newMedia.url,
 			fileName: newMedia.title,
@@ -148,6 +151,7 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 			id: newMedia.id,
 			fileId: `wp-block-file--media-${ clientId }`,
 			blob: undefined,
+			fileSize: newFileSize,
 			...pdfAttributes,
 		} );
 		setTemporaryURL();

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -36,6 +36,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import FileBlockInspector from './inspector';
 import { browserSupportsPdfs, formatFileSize } from './utils';
 import removeAnchorTag from '../utils/remove-anchor-tag';
+import removeFileSize from '../utils/remove-file-size';
 import { useUploadMediaFromBlobURL } from '../utils/hooks';
 
 export const MIN_PREVIEW_HEIGHT = 200;
@@ -311,11 +312,7 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 						placeholder={ __( 'Write file name…' ) }
 						withoutInteractiveFormatting
 						onChange={ ( text ) => {
-							// Remove the already added file size from the file name.
-							const cleanFileName = text.replace(
-								/\s*\(\d+(\.\d{1,2})?\s*MB\)$/,
-								''
-							);
+							const cleanFileName = removeFileSize( text );
 
 							setAttributes( {
 								fileName: removeAnchorTag( cleanFileName ),

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -34,7 +34,7 @@ import { store as noticesStore } from '@wordpress/notices';
  * Internal dependencies
  */
 import FileBlockInspector from './inspector';
-import { browserSupportsPdfs } from './utils';
+import { browserSupportsPdfs, formatFileSize } from './utils';
 import removeAnchorTag from '../utils/remove-anchor-tag';
 import { useUploadMediaFromBlobURL } from '../utils/hooks';
 
@@ -72,6 +72,7 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 		downloadButtonText,
 		displayPreview,
 		previewHeight,
+		showFileSize,
 	} = attributes;
 	const [ temporaryURL, setTemporaryURL ] = useState( attributes.blob );
 	const { media } = useSelect(
@@ -83,6 +84,10 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 		} ),
 		[ id ]
 	);
+
+	const fileSize = media?.media_details?.filesize
+		? formatFileSize( media.media_details.filesize )
+		: null;
 
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { toggleSelection, __unstableMarkNextChangeAsNotPersistent } =
@@ -167,6 +172,10 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 		setAttributes( { showDownloadButton: newValue } );
 	}
 
+	function changeShowFileSize( newValue ) {
+		setAttributes( { showFileSize: newValue } );
+	}
+
 	function changeDisplayPreview( newValue ) {
 		setAttributes( { displayPreview: newValue } );
 	}
@@ -236,6 +245,8 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 					changeDisplayPreview,
 					previewHeight,
 					changePreviewHeight,
+					showFileSize,
+					changeShowFileSize,
 				} }
 			/>
 			<BlockControls group="other">
@@ -292,7 +303,11 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 					<RichText
 						identifier="fileName"
 						tagName="a"
-						value={ fileName }
+						value={
+							showFileSize && fileSize
+								? `${ fileName } (${ fileSize })`
+								: fileName
+						}
 						placeholder={ __( 'Write file name…' ) }
 						withoutInteractiveFormatting
 						onChange={ ( text ) =>

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -178,7 +178,13 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 	}
 
 	function changeShowFileSize( newValue ) {
-		setAttributes( { showFileSize: newValue } );
+		const cleanFileName = removeFileSize( fileName );
+
+		const updatedFileName = newValue
+			? `${ cleanFileName } (${ fileSize })`
+			: cleanFileName;
+
+		setAttributes( { showFileSize: newValue, fileName: updatedFileName } );
 	}
 
 	function changeDisplayPreview( newValue ) {
@@ -308,18 +314,12 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 					<RichText
 						identifier="fileName"
 						tagName="a"
-						value={
-							showFileSize && fileSize
-								? `${ fileName } (${ fileSize })`
-								: fileName
-						}
+						value={ fileName }
 						placeholder={ __( 'Write file name…' ) }
 						withoutInteractiveFormatting
 						onChange={ ( text ) => {
-							const cleanFileName = removeFileSize( text );
-
 							setAttributes( {
-								fileName: removeAnchorTag( cleanFileName ),
+								fileName: removeAnchorTag( text ),
 							} );
 						} }
 						href={ textLinkHref }

--- a/packages/block-library/src/file/inspector.js
+++ b/packages/block-library/src/file/inspector.js
@@ -26,6 +26,8 @@ export default function FileBlockInspector( {
 	changeDisplayPreview,
 	previewHeight,
 	changePreviewHeight,
+	showFileSize,
+	changeShowFileSize,
 } ) {
 	const { href, textLinkHref, attachmentPage } = hrefs;
 
@@ -91,6 +93,12 @@ export default function FileBlockInspector( {
 						label={ __( 'Show download button' ) }
 						checked={ showDownloadButton }
 						onChange={ changeShowDownloadButton }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show file size' ) }
+						checked={ showFileSize }
+						onChange={ changeShowFileSize }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/file/save.js
+++ b/packages/block-library/src/file/save.js
@@ -23,6 +23,8 @@ export default function save( { attributes } ) {
 		downloadButtonText,
 		displayPreview,
 		previewHeight,
+		showFileSize,
+		fileSize,
 	} = attributes;
 
 	const pdfEmbedLabel = RichText.isEmpty( fileName )
@@ -32,6 +34,9 @@ export default function save( { attributes } ) {
 		  fileName.toString();
 
 	const hasFilename = ! RichText.isEmpty( fileName );
+
+	const formattedFileName =
+		showFileSize && fileSize ? `${ fileName } (${ fileSize })` : fileName;
 
 	// Only output an `aria-describedby` when the element it's referring to is
 	// actually rendered.
@@ -63,7 +68,7 @@ export default function save( { attributes } ) {
 							textLinkTarget ? 'noreferrer noopener' : undefined
 						}
 					>
-						<RichText.Content value={ fileName } />
+						<RichText.Content value={ formattedFileName } />
 					</a>
 				) }
 				{ showDownloadButton && (

--- a/packages/block-library/src/file/save.js
+++ b/packages/block-library/src/file/save.js
@@ -23,8 +23,6 @@ export default function save( { attributes } ) {
 		downloadButtonText,
 		displayPreview,
 		previewHeight,
-		showFileSize,
-		fileSize,
 	} = attributes;
 
 	const pdfEmbedLabel = RichText.isEmpty( fileName )
@@ -34,9 +32,6 @@ export default function save( { attributes } ) {
 		  fileName.toString();
 
 	const hasFilename = ! RichText.isEmpty( fileName );
-
-	const formattedFileName =
-		showFileSize && fileSize ? `${ fileName } (${ fileSize })` : fileName;
 
 	// Only output an `aria-describedby` when the element it's referring to is
 	// actually rendered.
@@ -68,7 +63,7 @@ export default function save( { attributes } ) {
 							textLinkTarget ? 'noreferrer noopener' : undefined
 						}
 					>
-						<RichText.Content value={ formattedFileName } />
+						<RichText.Content value={ fileName } />
 					</a>
 				) }
 				{ showDownloadButton && (

--- a/packages/block-library/src/file/utils/index.js
+++ b/packages/block-library/src/file/utils/index.js
@@ -54,3 +54,10 @@ const createActiveXObject = ( type ) => {
 	}
 	return ax;
 };
+
+export const formatFileSize = ( size ) => {
+	if ( ! size ) {
+		return null;
+	}
+	return ( size / ( 1024 * 1024 ) ).toFixed( 2 ) + ' MB';
+};

--- a/packages/block-library/src/file/utils/index.js
+++ b/packages/block-library/src/file/utils/index.js
@@ -55,6 +55,12 @@ const createActiveXObject = ( type ) => {
 	return ax;
 };
 
+/**
+ * Helper function for returning file size in MB
+ *
+ * @param {string} size The size of the file in bytes
+ * @return {string} The size of the file in MB
+ */
 export const formatFileSize = ( size ) => {
 	if ( ! size ) {
 		return null;

--- a/packages/block-library/src/utils/remove-file-size.js
+++ b/packages/block-library/src/utils/remove-file-size.js
@@ -1,0 +1,11 @@
+/**
+ * Removes file size from a string.
+ *
+ * @param {string} value The value to remove file size from.
+ *
+ * @return {string} The value with file size removed.
+ */
+export default function removeFileSize( value ) {
+	// Remove the already added file size from the file name.
+	return value.replace( /\s*\(\d+(\.\d{1,2})?\s*MB\)$/, '' );
+}


### PR DESCRIPTION

## What?
Closes https://github.com/WordPress/gutenberg/issues/59093

## Why?
Currently, users cannot see the file size of linked files in the File block. This PR adds an option in the inspector panel to display the file size next to the file name, helping users make informed decisions before downloading large files.



## How?

- Introduces a showFileSize attribute to conditionally append the file size to the file name.
- Ensures file size is added and removed when toggled on/off.
- Updates the RichText component to handle dynamic file name updates.

## Testing Instructions

1. Open a new post or page.
2. Insert a File block.
3. Upload or select a media file.
4. In the block settings (Inspector panel), toggle Show File Size:
        - The file size should appear in brackets next to the file name.
        - When disabled, the file size should be removed.
5. Verify that changes reflect both in the editor and on the frontend.

## Screencast 

https://github.com/user-attachments/assets/07135827-9b1f-4ba8-86d2-ebeb5c7d67c1



