### PR TITLE
Site Editor: Make current theme and editor settings available to route area resolvers

### DIFF
--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -4,6 +4,7 @@
 import { useSelect } from '@wordpress/data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useCallback } from '@wordpress/element';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -30,9 +31,15 @@ function AppLayout() {
 
 export default function App() {
 	useRegisterSiteEditorRoutes();
-	const routes = useSelect( ( select ) => {
-		return unlock( select( editSiteStore ) ).getRoutes();
+	const { routes, currentTheme, themeSupports } = useSelect( ( select ) => {
+		const { getCurrentTheme, getThemeSupports } = select( coreStore );
+		return {
+			routes: unlock( select( editSiteStore ) ).getRoutes(),
+			currentTheme: getCurrentTheme(),
+			themeSupports: getThemeSupports(),
+		};
 	}, [] );
+
 	const beforeNavigate = useCallback( ( { path, query } ) => {
 		if ( ! isPreviewingTheme() ) {
 			return { path, query };
@@ -55,6 +62,7 @@ export default function App() {
 			routes={ routes }
 			pathArg="p"
 			beforeNavigate={ beforeNavigate }
+			context={ { currentTheme, themeSupports } }
 		>
 			<AppLayout />
 		</RouterProvider>

--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -31,12 +31,10 @@ function AppLayout() {
 
 export default function App() {
 	useRegisterSiteEditorRoutes();
-	const { routes, currentTheme, themeSupports } = useSelect( ( select ) => {
-		const { getCurrentTheme, getThemeSupports } = select( coreStore );
+	const { routes, currentTheme } = useSelect( ( select ) => {
 		return {
 			routes: unlock( select( editSiteStore ) ).getRoutes(),
-			currentTheme: getCurrentTheme(),
-			themeSupports: getThemeSupports(),
+			currentTheme: select( coreStore ).getCurrentTheme(),
 		};
 	}, [] );
 
@@ -63,10 +61,7 @@ export default function App() {
 			pathArg="p"
 			beforeNavigate={ beforeNavigate }
 			matchResolverArgs={ {
-				siteData: {
-					currentTheme,
-					themeSupports,
-				},
+				siteData: { currentTheme },
 			} }
 		>
 			<AppLayout />

--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -31,10 +31,11 @@ function AppLayout() {
 
 export default function App() {
 	useRegisterSiteEditorRoutes();
-	const { routes, currentTheme } = useSelect( ( select ) => {
+	const { routes, currentTheme, editorSettings } = useSelect( ( select ) => {
 		return {
 			routes: unlock( select( editSiteStore ) ).getRoutes(),
 			currentTheme: select( coreStore ).getCurrentTheme(),
+			editorSettings: select( editSiteStore ).getSettings(),
 		};
 	}, [] );
 
@@ -57,9 +58,9 @@ export default function App() {
 
 	const matchResolverArgsValue = useMemo(
 		() => ( {
-			siteData: { currentTheme },
+			siteData: { currentTheme, editorSettings },
 		} ),
-		[ currentTheme ]
+		[ currentTheme, editorSettings ]
 	);
 
 	return (

--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -35,6 +35,7 @@ export default function App() {
 		return {
 			routes: unlock( select( editSiteStore ) ).getRoutes(),
 			currentTheme: select( coreStore ).getCurrentTheme(),
+			// This is a temp solution until the has_theme_json value is available for the current theme.
 			editorSettings: select( editSiteStore ).getSettings(),
 		};
 	}, [] );

--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -3,7 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -55,14 +55,19 @@ export default function App() {
 		};
 	}, [] );
 
+	const matchResolverArgsValue = useMemo(
+		() => ( {
+			siteData: { currentTheme },
+		} ),
+		[ currentTheme ]
+	);
+
 	return (
 		<RouterProvider
 			routes={ routes }
 			pathArg="p"
 			beforeNavigate={ beforeNavigate }
-			matchResolverArgs={ {
-				siteData: { currentTheme },
-			} }
+			matchResolverArgs={ matchResolverArgsValue }
 		>
 			<AppLayout />
 		</RouterProvider>

--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -62,7 +62,12 @@ export default function App() {
 			routes={ routes }
 			pathArg="p"
 			beforeNavigate={ beforeNavigate }
-			context={ { currentTheme, themeSupports } }
+			matchResolverArgs={ {
+				siteData: {
+					currentTheme,
+					themeSupports,
+				},
+			} }
 		>
 			<AppLayout />
 		</RouterProvider>

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -45,6 +45,7 @@ interface Match {
 	widths: Record< string, number >;
 	query?: Record< string, any >;
 	params?: Record< string, any >;
+	context?: Record< string, any >;
 }
 
 export type BeforeNavigate = ( arg: {
@@ -153,7 +154,8 @@ export function useHistory() {
 export default function useMatch(
 	location: LocationWithQuery,
 	matcher: RouteRecognizer,
-	pathArg: string
+	pathArg: string,
+	context: Record< string, any >
 ): Match {
 	const { query: rawQuery = {} } = location;
 
@@ -178,7 +180,11 @@ export default function useMatch(
 					if ( typeof value === 'function' ) {
 						return [
 							key,
-							value( { query, params: result.params } ),
+							value( {
+								query,
+								params: result.params,
+								context,
+							} ),
 						];
 					}
 					return [ key, value ];
@@ -193,7 +199,7 @@ export default function useMatch(
 			query,
 			path: addQueryArgs( path, query ),
 		};
-	}, [ matcher, rawQuery, pathArg ] );
+	}, [ matcher, rawQuery, pathArg, context ] );
 }
 
 export function RouterProvider( {
@@ -201,11 +207,13 @@ export function RouterProvider( {
 	pathArg,
 	beforeNavigate,
 	children,
+	context,
 }: {
 	routes: Route[];
 	pathArg: string;
 	beforeNavigate?: BeforeNavigate;
 	children: React.ReactNode;
+	context: Record< string, any >;
 } ) {
 	const location = useSyncExternalStore(
 		history.listen,
@@ -221,7 +229,7 @@ export function RouterProvider( {
 		} );
 		return ret;
 	}, [ routes ] );
-	const match = useMatch( location, matcher, pathArg );
+	const match = useMatch( location, matcher, pathArg, context );
 	const config = useMemo(
 		() => ( { beforeNavigate, pathArg } ),
 		[ beforeNavigate, pathArg ]

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -45,7 +45,6 @@ interface Match {
 	widths: Record< string, number >;
 	query?: Record< string, any >;
 	params?: Record< string, any >;
-	context?: Record< string, any >;
 }
 
 export type BeforeNavigate = ( arg: {
@@ -155,7 +154,7 @@ export default function useMatch(
 	location: LocationWithQuery,
 	matcher: RouteRecognizer,
 	pathArg: string,
-	context: Record< string, any >
+	matchResolverArgs: Record< string, any >
 ): Match {
 	const { query: rawQuery = {} } = location;
 
@@ -183,7 +182,7 @@ export default function useMatch(
 							value( {
 								query,
 								params: result.params,
-								context,
+								...matchResolverArgs,
 							} ),
 						];
 					}
@@ -199,7 +198,7 @@ export default function useMatch(
 			query,
 			path: addQueryArgs( path, query ),
 		};
-	}, [ matcher, rawQuery, pathArg, context ] );
+	}, [ matcher, rawQuery, pathArg, matchResolverArgs ] );
 }
 
 export function RouterProvider( {
@@ -207,13 +206,13 @@ export function RouterProvider( {
 	pathArg,
 	beforeNavigate,
 	children,
-	context,
+	matchResolverArgs,
 }: {
 	routes: Route[];
 	pathArg: string;
 	beforeNavigate?: BeforeNavigate;
 	children: React.ReactNode;
-	context: Record< string, any >;
+	matchResolverArgs: Record< string, any >;
 } ) {
 	const location = useSyncExternalStore(
 		history.listen,
@@ -229,7 +228,7 @@ export function RouterProvider( {
 		} );
 		return ret;
 	}, [ routes ] );
-	const match = useMatch( location, matcher, pathArg, context );
+	const match = useMatch( location, matcher, pathArg, matchResolverArgs );
 	const config = useMemo(
 		() => ( { beforeNavigate, pathArg } ),
 		[ beforeNavigate, pathArg ]


### PR DESCRIPTION
Preparation to move #69005 and #69043 forward

## What?

This PR adds a new ~`context`~ `matchResolverArgs` parameter to the `useMatch` hook.

This will allow us to control whether or not to render a particular area based on the theme, for example.

## Why?

Currently, the site editor determines what to render in which area based on the path, and if the area is not `undefined`, it renders the component in some wrapper element ([example](https://github.com/WordPress/gutenberg/blob/e532b746c40101e2468383ecbfa92cc5ee244069/packages/edit-site/src/components/layout/index.js#L181)).

As attempted in https://github.com/WordPress/gutenberg/pull/69005#pullrequestreview-2629244026, there are cases where we don't want to render a specific area itself based on a condition. For example, whether it's a block theme.

However, even if a component returns null based on a certain condition, like this, the result is not equal to `undefined`, so the area wrapper itself will be rendered:

```jsx
// In non-block-based themes, the empty preview area is rendered
function Component() {
	const isBlockBasedTheme = useSelect( ( select ) => {
		return select( coreStore ).getCurrentTheme()?.is_block_theme;
	}, [] );
	if ( isBlockBasedTheme ) {
		return null;
	}
	return <SomeScreen />
}

export const someRoute = {
	areas: {
		preview: <Component />,
	},
};
```

## How?

- Add a ~`context`~ `matchResolverArgs` parameter to the `useMatch` hook. This context can be used to pass any information through the `RouterProvider`.
- In the site editor's RouterProvider, add the current theme and theme support as context.

## Testing Instructions

For example, make the following changes: You should now have access to the information provided by your router provider:

```diff
diff --git a/packages/edit-site/src/components/site-editor-routes/pages.js b/packages/edit-site/src/components/site-editor-routes/pages.js
index 5f2a4e341e..bf11b7d314 100644
--- a/packages/edit-site/src/components/site-editor-routes/pages.js
+++ b/packages/edit-site/src/components/site-editor-routes/pages.js
@@ -35,7 +35,8 @@ export const pagesRoute = {
                        />
                ),
                content: <PostList postType="page" />,
-               preview( { query } ) {
+               preview( { query, siteData } ) {
+                       console.log( siteData );
                        const isListView =
                                ( query.layout === 'list' || ! query.layout ) &&
                                query.isCustom !== 'true';
```

In #69005, we are trying to control which screens are exposed to the classic theme. For example, to not expose the navigation screen to the classic theme, we should be able to disable the specific area itself as follows:

```jsx
export const navigationRoute = {
	name: 'navigation',
	path: '/navigation',
	areas: {
		preview( { siteData } ) {
			const isBlockTheme = siteData.currentTheme?.is_block_theme;
			return isBlockTheme ? <Editor /> : undefined;
		},
	},
};
```

In #69043, we are trying to control access to the StyleBook based on theme support. For example, we should be able to disable the specific area itself as follows:

```jsx
export const stylebookRoute = {
	name: 'stylebook',
	path: '/stylebook',
	areas: {
		preview( { siteData } ) {
			const hasStyleBookSupport = siteData.currentTheme?.theme_supports?.stylebook;
			return hasStyleBookSupport ? <StyleBookPreview /> : undefined;
		},
	},
};
```