### PR TITLE
PostSticky: Update Help Text for Clarity and Consistency

### DIFF
--- a/packages/editor/src/components/post-sticky/index.js
+++ b/packages/editor/src/components/post-sticky/index.js
@@ -29,7 +29,7 @@ export default function PostSticky() {
 			<CheckboxControl
 				className="editor-post-sticky__checkbox-control"
 				label={ __( 'Sticky' ) }
-				help={ __( 'Pin this post to the top of the blog.' ) }
+				help={ __( 'Make this post sticky' ) }
 				checked={ postSticky }
 				onChange={ () => editPost( { sticky: ! postSticky } ) }
 				__nextHasNoMarginBottom


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?  
Closes: #69300  

Updates the help text in Gutenberg’s `PostSticky` component to improve consistency with Quick Edit and WordPress core terminology.  

## Why?  
The current help text:  
> "Pin this post to the top of the blog."  

is inconsistent with Quick Edit, which uses **"Make this post sticky."** Additionally, "pinning" and "top of the blog" can be misleading, as sticky posts are not necessarily restricted to the top of the blog they may also appear in archives, custom queries, and other views.  

This update improves clarity and ensures consistency across the WordPress UI.  

## How?  
- Updated the `help` text in `PostSticky` component to "Make this post sticky"

## Screenshots

### Before:

<img width="651" alt="Screenshot 2025-02-25 at 2 09 40 PM" src="https://github.com/user-attachments/assets/9e51d44a-5cc8-4aa3-9905-25be65ab591d" />

### After:
<img width="651" alt="Screenshot 2025-02-25 at 2 09 40 PM" src="https://github.com/user-attachments/assets/5a025322-732c-426a-9492-40f3aeb258cc" />
