### PR TITLE
DataView Actions Modal: Allow customizable `modal size` through props

### DIFF
--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -705,6 +705,23 @@ The header text to show in the modal.
 -   Type: `string`
 -   Optional
 
+### `modalSize`
+
+Specifies the size of the modal window when displaying action content using `RenderModal`.
+
+-	Type: `string`
+-	Optional
+-	Default: `'medium'`
+-	One of: `'small'`, `'medium'`, `'large'`, `'fill'`
+
+Example:
+
+```js
+{
+	modalSize: 'large';
+}
+```
+
 ## Fields API
 
 ### `id`

--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -111,7 +111,7 @@ export function ActionModal< Item >( {
 			__experimentalHideHeader={ !! action.hideModalHeader }
 			onRequestClose={ closeModal }
 			focusOnMount="firstContentElement"
-			size="medium"
+			size={ action.modalSize || 'medium' }
 			overlayClassName={ `dataviews-action-modal dataviews-action-modal__${ kebabCase(
 				action.id
 			) }` }

--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -110,7 +110,7 @@ export function ActionModal< Item >( {
 			title={ action.modalHeader || label }
 			__experimentalHideHeader={ !! action.hideModalHeader }
 			onRequestClose={ closeModal }
-			focusOnMount="firstContentElement"
+			focusOnMount={ action.modalFocusOnMount }
 			size={ action.modalSize || 'medium' }
 			overlayClassName={ `dataviews-action-modal dataviews-action-modal__${ kebabCase(
 				action.id

--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -110,7 +110,7 @@ export function ActionModal< Item >( {
 			title={ action.modalHeader || label }
 			__experimentalHideHeader={ !! action.hideModalHeader }
 			onRequestClose={ closeModal }
-			focusOnMount={ action.modalFocusOnMount }
+			focusOnMount="firstContentElement"
 			size={ action.modalSize || 'medium' }
 			overlayClassName={ `dataviews-action-modal dataviews-action-modal__${ kebabCase(
 				action.id

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -463,6 +463,11 @@ export interface ActionModal< Item > extends ActionBase< Item > {
 	 * The header of the modal.
 	 */
 	modalHeader?: string;
+
+	/**
+	 * The size of the modal.
+	 */
+	modalSize?: 'small' | 'medium' | 'large' | 'fill';
 }
 
 export interface ActionButton< Item > extends ActionBase< Item > {

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -4,6 +4,11 @@
 import type { ReactElement, ComponentType } from 'react';
 
 /**
+ * WordPress dependencies
+ */
+import type { useFocusOnMount } from '@wordpress/compose';
+
+/**
  * Internal dependencies
  */
 import type { SetSelection } from './private-types';
@@ -468,6 +473,13 @@ export interface ActionModal< Item > extends ActionBase< Item > {
 	 * The size of the modal.
 	 */
 	modalSize?: 'small' | 'medium' | 'large' | 'fill';
+
+	/**
+	 * The focus on mount of the modal.
+	 */
+	modalFocusOnMount?:
+		| Parameters< typeof useFocusOnMount >[ 0 ]
+		| 'firstContentElement';
 }
 
 export interface ActionButton< Item > extends ActionBase< Item > {

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -4,11 +4,6 @@
 import type { ReactElement, ComponentType } from 'react';
 
 /**
- * WordPress dependencies
- */
-import type { useFocusOnMount } from '@wordpress/compose';
-
-/**
  * Internal dependencies
  */
 import type { SetSelection } from './private-types';
@@ -473,13 +468,6 @@ export interface ActionModal< Item > extends ActionBase< Item > {
 	 * The size of the modal.
 	 */
 	modalSize?: 'small' | 'medium' | 'large' | 'fill';
-
-	/**
-	 * The focus on mount of the modal.
-	 */
-	modalFocusOnMount?:
-		| Parameters< typeof useFocusOnMount >[ 0 ]
-		| 'firstContentElement';
 }
 
 export interface ActionButton< Item > extends ActionBase< Item > {

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -466,6 +466,8 @@ export interface ActionModal< Item > extends ActionBase< Item > {
 
 	/**
 	 * The size of the modal.
+	 *
+	 * @default 'medium'
 	 */
 	modalSize?: 'small' | 'medium' | 'large' | 'fill';
 }


### PR DESCRIPTION
## What?
Closes #69294

This PR would allow the consumers to set up the `modal size` within `DataView actions`.

## Why?

The consumer implementation supports various modal behaviors but does not specify the `size` prop, which the internal `Modal` component supports. Currently, the size prop is hardcoded.

## How?

The type declarations for `ActionModal` have been updated, allowing `action.modalSize` to be used as the prop for customization.

## Testing Instructions

1. Start the storybook development server (`npm run storybook:dev`).
2. Add/modify the `modalSize` prop here in the action with id `delete`: https://github.com/WordPress/gutenberg/blob/889858999783880fd73c3cf50164af18758a952c/packages/dataviews/src/components/dataviews/stories/fixtures.tsx#L578
3. Confirm that the `modal size` changes.

## Screencast

https://github.com/user-attachments/assets/b96c4181-d251-4b78-b887-fbaac6ded229

