### PR TITLE
Swap fullscreen mode snackbar notice message.

### DIFF
--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -530,8 +530,8 @@ export const toggleFullscreenMode =
 			.dispatch( noticesStore )
 			.createInfoNotice(
 				isFullscreen
-					? __( 'Fullscreen mode activated.' )
-					: __( 'Fullscreen mode deactivated.' ),
+					? __( 'Fullscreen mode deactivated.' )
+					: __( 'Fullscreen mode activated.' ),
 				{
 					id: 'core/edit-post/toggle-fullscreen-mode/notice',
 					type: 'snackbar',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/69303

<!-- In a few words, what is the PR actually doing? -->
The snackbar notice messages when switching fullscreen mode via the keyboard shortcut are swapped.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The snaclbar notice messages should be the correct ones.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Swaps the messages.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Edit a post
- Use the fullscreen mode keyboard shortcut. On macOS it's Shift+Option+Command+F.
- Observe the snackbar notice says 'activated' when activating and 'deactivated' when deactivating.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
