### PR TITLE
Template Part block: Guard against `get_block_file_template` returning `null`

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -70,7 +70,9 @@ function render_block_core_template_part( $attributes ) {
 			if ( 0 === validate_file( $attributes['slug'] ) ) {
 				$block_template = get_block_file_template( $template_part_id, 'wp_template_part' );
 
-				$content = $block_template->content;
+				if ( isset( $block_template->content ) ) {
+					$content = $block_template->content;
+				}
 				if ( isset( $block_template->area ) ) {
 					$area = $block_template->area;
 				}


### PR DESCRIPTION
## What?
Add a guard to ensure `$block_template->content` exists before assigning its value to a variable.

## Why?
The Template Part PHP code uses [`get_block_file_template()`](https://developer.wordpress.org/reference/functions/get_block_file_template/) to fetch information about the given template part from the corresponding theme's block template file. However, that function can return `null`, and the code currently guard against that when attempting to get the returned `$block_template` object's `->content` field.

## How?
See above.

By keeping `$content` set to its initial `null`, a later check in the Template Part block code will issue a more user-friendly warning.

## Testing Instructions
- On a site that uses a block theme (e.g. TT5), open the Site Editor, and switch to the code editor.
- Insert the block markup for a Post Template block that references a template part that doesn't exist (see below for an example).
- Save the template and view the frontend. The error message should match the "After" screenshot further below.

```html
<!-- wp:template-part {"slug":"post-meta"} /-->
```

## Screenshots or screencast

|Before|After|
|-|-|
| <img width="533" alt="image" src="https://github.com/user-attachments/assets/a719fa68-109c-405f-a00f-3165dac781ff" /> | <img width="533" alt="image" src="https://github.com/user-attachments/assets/8d20b354-abfa-4cb4-a65d-ca39892729c4" /> |
