### PR TITLE
[List Block] - Add support for block gap

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -415,7 +415,7 @@ An organized collection of items displayed in a specific order. ([Source](https:
 -	**Name:** core/list
 -	**Category:** text
 -	**Allowed Blocks:** core/list-item
--	**Supports:** __unstablePasteTextInline, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** __unstablePasteTextInline, anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout (~~allowEditing~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** ordered, placeholder, reversed, start, type, values
 
 ## List Item

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -37,6 +37,9 @@
 		}
 	},
 	"supports": {
+		"layout": {
+			"allowEditing": false
+		},
 		"anchor": true,
 		"html": false,
 		"__experimentalBorder": {
@@ -71,8 +74,10 @@
 			"padding": true,
 			"__experimentalDefaultControls": {
 				"margin": false,
-				"padding": false
-			}
+				"padding": false,
+				"blockGap": true
+			},
+			"blockGap": true
 		},
 		"__unstablePasteTextInline": true,
 		"__experimentalOnMerge": true,
@@ -81,6 +86,7 @@
 			"clientNavigation": true
 		}
 	},
+
 	"selectors": {
 		"border": ".wp-block-list:not(.wp-block-list .wp-block-list)"
 	},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Resolves #69308

## What?   
This PR implements the `blockGap` support for the `core/list` block, allowing control over spacing between list items.  

## Why?  
<!-- Why is this PR necessary? What problem is it solving? -->  
The `core/list` block currently lacks `blockGap` and layout support, making it difficult to control the spacing between `core/list-item` blocks. Since `core/list-item` is a separate block, the gap should be adjustable through `blockGap`, ensuring better design flexibility and consistency with other blocks that support spacing control.  

## How?  
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->  
- Added `supports: { spacing: { blockGap: true } }` to the `core/list` block.  
- Added `Layout` support and disabled editing.
- Ensured that the `blockGap` value is applied correctly in the block's styling.  

## Testing Instructions  
1. Open the Block Editor (Gutenberg).  
2. Insert a `List` block (`core/list`).  
3. Add multiple `List Item` (`core/list-item`) blocks inside it.  
4. Adjust the `blockGap` value using the spacing controls in the sidebar.  
5. Verify that the spacing between list items updates correctly both in the editor and frontend.  
6. Save and refresh to ensure the setting persists.  

## Screencast

https://github.com/user-attachments/assets/97977717-b2aa-4e74-957d-4ca6428fbd9f



