### PR TITLE
Table Block: Preserve Column Alignment when Pasting Markdown Tables

### DIFF
--- a/packages/block-library/src/table/transforms.js
+++ b/packages/block-library/src/table/transforms.js
@@ -8,6 +8,25 @@ import { createBlock } from '@wordpress/blocks';
  */
 import { normalizeRowColSpan } from './utils';
 
+/**
+ * Extracts text alignment from a style attribute string.
+ *
+ * @param {string} styleAttr The style attribute string.
+ * @return {string|undefined} The alignment ('left', 'right', 'center', or undefined).
+ */
+const getAlignmentFromStyle = ( styleAttr ) => {
+	if ( ! styleAttr ) {
+		return undefined;
+	}
+
+	const alignMatch = styleAttr.match( /text-align:\s*(\w+)/i );
+	if ( alignMatch && alignMatch[ 1 ] ) {
+		return alignMatch[ 1 ].toLowerCase();
+	}
+
+	return undefined;
+};
+
 const tableContentPasteSchema = ( { phrasingContentSchema } ) => ( {
 	tr: {
 		allowEmpty: true,
@@ -15,12 +34,12 @@ const tableContentPasteSchema = ( { phrasingContentSchema } ) => ( {
 			th: {
 				allowEmpty: true,
 				children: phrasingContentSchema,
-				attributes: [ 'scope', 'colspan', 'rowspan' ],
+				attributes: [ 'scope', 'colspan', 'rowspan', 'style' ],
 			},
 			td: {
 				allowEmpty: true,
 				children: phrasingContentSchema,
-				attributes: [ 'colspan', 'rowspan' ],
+				attributes: [ 'colspan', 'rowspan', 'style' ],
 			},
 		},
 	},
@@ -79,11 +98,16 @@ const transforms = {
 									col.getAttribute( 'colspan' )
 								);
 
+								const styleAttr = col.getAttribute( 'style' );
+								const align =
+									getAlignmentFromStyle( styleAttr );
+
 								colAcc.push( {
 									tag: col.nodeName.toLowerCase(),
 									content: col.innerHTML,
 									rowspan,
 									colspan,
+									align,
 								} );
 
 								return colAcc;

--- a/packages/block-library/src/table/transforms.js
+++ b/packages/block-library/src/table/transforms.js
@@ -8,25 +8,6 @@ import { createBlock } from '@wordpress/blocks';
  */
 import { normalizeRowColSpan } from './utils';
 
-/**
- * Extracts text alignment from a style attribute string.
- *
- * @param {string} styleAttr The style attribute string.
- * @return {string|undefined} The alignment ('left', 'right', 'center', or undefined).
- */
-const getAlignmentFromStyle = ( styleAttr ) => {
-	if ( ! styleAttr ) {
-		return undefined;
-	}
-
-	const alignMatch = styleAttr.match( /text-align:\s*(\w+)/i );
-	if ( alignMatch && alignMatch[ 1 ] ) {
-		return alignMatch[ 1 ].toLowerCase();
-	}
-
-	return undefined;
-};
-
 const tableContentPasteSchema = ( { phrasingContentSchema } ) => ( {
 	tr: {
 		allowEmpty: true,
@@ -98,9 +79,16 @@ const transforms = {
 									col.getAttribute( 'colspan' )
 								);
 
-								const styleAttr = col.getAttribute( 'style' );
-								const align =
-									getAlignmentFromStyle( styleAttr );
+								const { textAlign } = col.style || {};
+
+								let align;
+								if (
+									textAlign === 'left' ||
+									textAlign === 'center' ||
+									textAlign === 'right'
+								) {
+									align = textAlign;
+								}
 
 								colAcc.push( {
 									tag: col.nodeName.toLowerCase(),

--- a/packages/blocks/src/api/raw-handling/test/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/test/paste-handler.js
@@ -61,7 +61,7 @@ const tableWithHeaderFooterAndBodyUsingRowspan = `
 	</tfoot>
 </table>`;
 
-const markdownTableHTML = `
+const tableWithCellAlignments = `
 <table>
 	<thead>
 		<tr>
@@ -176,34 +176,9 @@ describe( 'pasteHandler', () => {
 		expect( result.isValid ).toBeTruthy();
 	} );
 
-	it( 'can handle a video', () => {
-		const [ result ] = pasteHandler( {
-			HTML: '<video controls src="https://example.com/media.mp4" autoplay loop muted controls playsinline preload="auto" poster="https://example.com/media.jpg"></video>',
-			tagName: 'p',
-			preserveWhiteSpace: false,
-		} );
-
-		expect( console ).toHaveLogged();
-
-		delete result.attributes.caption;
-		expect( result.attributes ).toEqual( {
-			autoplay: true,
-			loop: true,
-			muted: true,
-			controls: true,
-			playsInline: true,
-			preload: 'auto',
-			poster: 'https://example.com/media.jpg',
-			src: 'https://example.com/media.mp4',
-			tracks: [],
-		} );
-		expect( result.name ).toEqual( 'core/video' );
-		expect( result.isValid ).toBeTruthy();
-	} );
-
 	it( 'can preserve column alignments when pasting Markdown tables', () => {
 		const [ result ] = pasteHandler( {
-			HTML: markdownTableHTML,
+			HTML: tableWithCellAlignments,
 			tagName: 'p',
 		} );
 
@@ -286,5 +261,30 @@ describe( 'pasteHandler', () => {
 			],
 			foot: [],
 		} );
+	} );
+
+	it( 'can handle a video', () => {
+		const [ result ] = pasteHandler( {
+			HTML: '<video controls src="https://example.com/media.mp4" autoplay loop muted controls playsinline preload="auto" poster="https://example.com/media.jpg"></video>',
+			tagName: 'p',
+			preserveWhiteSpace: false,
+		} );
+
+		expect( console ).toHaveLogged();
+
+		delete result.attributes.caption;
+		expect( result.attributes ).toEqual( {
+			autoplay: true,
+			loop: true,
+			muted: true,
+			controls: true,
+			playsInline: true,
+			preload: 'auto',
+			poster: 'https://example.com/media.jpg',
+			src: 'https://example.com/media.mp4',
+			tracks: [],
+		} );
+		expect( result.name ).toEqual( 'core/video' );
+		expect( result.isValid ).toBeTruthy();
 	} );
 } );

--- a/packages/blocks/src/api/raw-handling/test/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/test/paste-handler.js
@@ -176,7 +176,7 @@ describe( 'pasteHandler', () => {
 		expect( result.isValid ).toBeTruthy();
 	} );
 
-	it( 'can preserve column alignments when pasting Markdown tables', () => {
+	it( 'can handle a table with cell alignments', () => {
 		const [ result ] = pasteHandler( {
 			HTML: tableWithCellAlignments,
 			tagName: 'p',

--- a/packages/blocks/src/api/raw-handling/test/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/test/paste-handler.js
@@ -61,6 +61,26 @@ const tableWithHeaderFooterAndBodyUsingRowspan = `
 	</tfoot>
 </table>`;
 
+const markdownTableHTML = `
+<table>
+	<thead>
+		<tr>
+			<th style="text-align: left;">A - Left</th>
+			<th style="text-align: center;">B - Centered</th>
+			<th style="text-align: right;">C - Right</th>
+			<th>D - None</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td style="text-align: left;">100</td>
+			<td style="text-align: center;">150</td>
+			<td style="text-align: right;">200</td>
+			<td>250</td>
+		</tr>
+	</tbody>
+</table>`;
+
 describe( 'pasteHandler', () => {
 	beforeAll( () => {
 		initAndRegisterTableBlock();
@@ -179,5 +199,92 @@ describe( 'pasteHandler', () => {
 		} );
 		expect( result.name ).toEqual( 'core/video' );
 		expect( result.isValid ).toBeTruthy();
+	} );
+
+	it( 'can preserve column alignments when pasting Markdown tables', () => {
+		const [ result ] = pasteHandler( {
+			HTML: markdownTableHTML,
+			tagName: 'p',
+		} );
+
+		expect( console ).toHaveLogged();
+
+		delete result.attributes.caption;
+
+		expect( result.name ).toEqual( 'core/table' );
+		expect( result.isValid ).toBeTruthy();
+
+		expect( result.attributes ).toEqual( {
+			hasFixedLayout: true,
+			head: [
+				{
+					cells: [
+						{
+							content: 'A - Left',
+							tag: 'th',
+							align: 'left',
+							colspan: undefined,
+							rowspan: undefined,
+						},
+						{
+							content: 'B - Centered',
+							tag: 'th',
+							align: 'center',
+							colspan: undefined,
+							rowspan: undefined,
+						},
+						{
+							content: 'C - Right',
+							tag: 'th',
+							align: 'right',
+							colspan: undefined,
+							rowspan: undefined,
+						},
+						{
+							content: 'D - None',
+							tag: 'th',
+							align: undefined,
+							colspan: undefined,
+							rowspan: undefined,
+						},
+					],
+				},
+			],
+			body: [
+				{
+					cells: [
+						{
+							content: '100',
+							tag: 'td',
+							align: 'left',
+							colspan: undefined,
+							rowspan: undefined,
+						},
+						{
+							content: '150',
+							tag: 'td',
+							align: 'center',
+							colspan: undefined,
+							rowspan: undefined,
+						},
+						{
+							content: '200',
+							tag: 'td',
+							align: 'right',
+							colspan: undefined,
+							rowspan: undefined,
+						},
+						{
+							content: '250',
+							tag: 'td',
+							align: undefined,
+							colspan: undefined,
+							rowspan: undefined,
+						},
+					],
+				},
+			],
+			foot: [],
+		} );
 	} );
 } );

--- a/test/native/jest.config.js
+++ b/test/native/jest.config.js
@@ -27,6 +27,9 @@ const RAW_HANDLING_UNSUPPORTED_UNIT_TESTS = [
 	'figure-content-reducer',
 	'normalise-blocks',
 	'image-corrector',
+	// Disabled due to jsdom-jscore-rn limitations.
+	// See: https://github.com/WordPress/gutenberg/pull/69322#issuecomment-2789510963
+	'paste-handler',
 ];
 
 module.exports = {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/69319

This PR improves the Table block by making sure column alignments are preserved when pasting Markdown tables.


## Testing Instructions
1. Open the editor in a post or page.
2. Copy and paste this Markdown table into the editor:
```markdown
| A - Left | B - Centered | C - Right | D - None |
| :------- | :----------: | --------: | -------- |
| 100      |     150      |       200 | 250      |
| 200      |     250      |       300 | 350      |
| 300      |     350      |       400 | 450      |
| 400      |     450      |       500 | 550      |
| 500      |     550      |       600 | 650      |
```
3. The table should appear in the editor with the correct column alignments.


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
![Screenshot 2025-02-26 at 3 52 03 PM](https://github.com/user-attachments/assets/270aad9b-e878-4390-b040-e2d7c272e4d0)|![Screenshot 2025-02-26 at 3 51 33 PM](https://github.com/user-attachments/assets/06b5f90d-64ee-4f88-b293-842feb799487)|
