### PR TITLE
TypeScript: Converts HtmlEntities Package to TS

### DIFF
--- a/packages/html-entities/src/index.ts
+++ b/packages/html-entities/src/index.ts
@@ -1,4 +1,3 @@
-/** @type {HTMLTextAreaElement} */
 let _decodeTextArea: HTMLTextAreaElement | undefined;
 
 /**

--- a/packages/html-entities/src/index.ts
+++ b/packages/html-entities/src/index.ts
@@ -3,7 +3,7 @@ let _decodeTextArea: HTMLTextAreaElement | undefined;
 /**
  * Decodes the HTML entities from a given string.
  *
- * @param {string} html String that contain HTML entities.
+ * @param html String that contain HTML entities.
  *
  * @example
  * ```js
@@ -13,7 +13,7 @@ let _decodeTextArea: HTMLTextAreaElement | undefined;
  * console.log( result ); // result will be "á"
  * ```
  *
- * @return {string} The decoded string.
+ * @return The decoded string.
  */
 export function decodeEntities( html: string ): string {
 	// Not a string, or no entities to decode.

--- a/packages/html-entities/src/index.ts
+++ b/packages/html-entities/src/index.ts
@@ -56,5 +56,5 @@ export function decodeEntities( html: string ): string {
 	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent
 	 */
-	return /** @type {string} */ decoded;
+	return decoded;
 }

--- a/packages/html-entities/src/index.ts
+++ b/packages/html-entities/src/index.ts
@@ -1,5 +1,5 @@
 /** @type {HTMLTextAreaElement} */
-let _decodeTextArea;
+let _decodeTextArea: HTMLTextAreaElement | undefined;
 
 /**
  * Decodes the HTML entities from a given string.
@@ -16,7 +16,7 @@ let _decodeTextArea;
  *
  * @return {string} The decoded string.
  */
-export function decodeEntities( html ) {
+export function decodeEntities( html: string ): string {
 	// Not a string, or no entities to decode.
 	if ( 'string' !== typeof html || -1 === html.indexOf( '&' ) ) {
 		return html;
@@ -37,7 +37,7 @@ export function decodeEntities( html ) {
 	}
 
 	_decodeTextArea.innerHTML = html;
-	const decoded = _decodeTextArea.textContent;
+	const decoded = _decodeTextArea.textContent ?? '';
 	_decodeTextArea.innerHTML = '';
 
 	/**
@@ -57,5 +57,5 @@ export function decodeEntities( html ) {
 	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent
 	 */
-	return /** @type {string} */ ( decoded );
+	return /** @type {string} */ decoded;
 }

--- a/packages/html-entities/src/test/entities.ts
+++ b/packages/html-entities/src/test/entities.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { decodeEntities } from '../';
+import { decodeEntities } from '..';
 
 describe( 'decodeEntities', () => {
 	it( 'should not change html with no entities', () => {


### PR DESCRIPTION
## What?
Part of: https://github.com/WordPress/gutenberg/issues/67691
Migrating the HtmlEntities package to Typescript.

## Why?
Type safety.

## How?

## Testing Instructions
Typecheck and unit tests.
