### PR TITLE
Site Editor: Fix space on the left or right of the menu in mobile view

### DIFF
--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -68,6 +68,10 @@
 	.edit-site-sidebar__screen-wrapper {
 		padding: 0;
 	}
+
+	.edit-site-sidebar-navigation-screen__main {
+		padding: 0 $grid-unit-15;
+	}
 }
 
 .edit-site-layout__canvas-container {


### PR DESCRIPTION
## What?

Closes  #69156

Restores left and right spacing in the mobile layout of the site editor that was lost in the latest Gutenberg.

## Why?

This issue does not occur in desktop layouts. I think the root cause is that the hierarchy of elements in mobile layouts is very different from that of desktop.

Desktop:

```
- .edit-site-layout__sidebar
  - .edit-site-site-hub
  - .edit-site-sidebar__content
    - .edit-site-sidebar__screen-wrapper
      - .edit-site-sidebar-navigation-screen__main
        - .edit-site-sidebar-navigation-screen__title-icon
        - .edit-site-sidebar-navigation-screen__content
```

Mobile:

```
- .edit-site-layout__mobile
  - edit-site-sidebar__content
    - edit-site-sidebar__screen-wrapper
      - .edit-site-site-hub
  - .edit-site-sidebar-navigation-screen__main
    - .edit-site-sidebar-navigation-screen__title-icon
    - .edit-site-sidebar-navigation-screen__content"
```

## How?

I understand that the different hierarchy of elements is a result of enabling screen navigation in the mobile layout. For now, I only add left and right spacing to the mobile layout. In the future, once the components that make up the mobile layout are simplified, we may be able to make the sidebar in the mobile layout consistent with that of the desktop layout (See https://github.com/WordPress/gutenberg/pull/69172).

## Testing Instructions

- Narrow your browser size or simulate a mobile layout.
- In the site editor, make sure there is space on the left and right.
- Make sure no space is added outside of the sidebar screen, such as the editor canvas.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
| ![image](https://github.com/user-attachments/assets/31a2601d-2402-4534-bd0a-b0385f4575f1) | ![image](https://github.com/user-attachments/assets/898213e8-282a-44a4-8d4b-9ffb38296666) |




