### PR TITLE
Revert "Feature: Add `navigation.isLoading` state to core/router store (#67680)"

### DIFF
--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -223,7 +223,6 @@ interface Store {
 	state: {
 		url: string;
 		navigation: {
-			isLoading: boolean;
 			hasStarted: boolean;
 			hasFinished: boolean;
 		};
@@ -238,7 +237,6 @@ export const { state, actions } = store< Store >( 'core/router', {
 	state: {
 		url: window.location.href,
 		navigation: {
-			isLoading: false,
 			hasStarted: false,
 			hasFinished: false,
 		},
@@ -291,7 +289,6 @@ export const { state, actions } = store< Store >( 'core/router', {
 					return;
 				}
 
-				navigation.isLoading = true;
 				if ( loadingAnimation ) {
 					navigation.hasStarted = true;
 					navigation.hasFinished = false;
@@ -331,7 +328,6 @@ export const { state, actions } = store< Store >( 'core/router', {
 
 				// Update the navigation status once the the new page rendering
 				// has been completed.
-				navigation.isLoading = false;
 				if ( loadingAnimation ) {
 					navigation.hasStarted = false;
 					navigation.hasFinished = true;


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

This reverts commit e85937ff6868a4b35856845755636c39dbbc555a. (#67680)

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

After chatting with @luisherranz for a bit, this API is not through and future proof enough to release in 6.8
