### PR TITLE
InputControl: Ensure consistent placeholder color

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   `TextControl`: Ensures email and url inputs have consistent LTR alignment in RTL languages ([#68561](https://github.com/WordPress/gutenberg/pull/68561)).
+-   `InputControl`: Ensure consistent placeholder color ([#69334](https://github.com/WordPress/gutenberg/pull/69334)).
 
 ### Enhancement
 

--- a/packages/components/src/input-control/styles/input-control-styles.tsx
+++ b/packages/components/src/input-control/styles/input-control-styles.tsx
@@ -286,6 +286,15 @@ export const Input = styled.input< InputProps >`
 
 		&::-webkit-input-placeholder {
 			line-height: normal;
+			color: ${ COLORS.ui.darkGrayPlaceholder };
+		}
+
+		&::-moz-placeholder {
+			color: ${ COLORS.ui.darkGrayPlaceholder };
+		}
+
+		&:-ms-input-placeholder {
+			color: ${ COLORS.ui.darkGrayPlaceholder };
 		}
 
 		&[type='email'],

--- a/packages/components/src/input-control/styles/input-control-styles.tsx
+++ b/packages/components/src/input-control/styles/input-control-styles.tsx
@@ -285,7 +285,6 @@ export const Input = styled.input< InputProps >`
 		${ customPaddings }
 
 		&::-webkit-input-placeholder {
-			line-height: normal;
 			color: ${ COLORS.ui.darkGrayPlaceholder };
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Ensures InputControl sets a default placeholder color for consistency across browsers, matching TextareaControl.
Closes #69331

<!-- In a few words, what is the PR actually doing? -->

## Why?
Previously, InputControl relied on browser defaults, causing slight color variations. This update improves consistency and accessibility.

## How?
- Added COLORS.ui.darkGrayPlaceholder for placeholders in InputControl.
- Applied styles for -webkit, -moz, and -ms placeholders.

## Testing Instructions

- Open [Storybook – InputControl](https://wordpress.github.io/gutenberg/?path=/docs/components-experimental-inputcontrol--docs).
- Compare placeholder color in Chrome and Firefox.
- Verify consistency with [Storybook – TextareaControl](https://wordpress.github.io/gutenberg/?path=/docs/components-textareacontrol--docs).

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/db94b4e2-581e-4b26-a130-0b891c1b8e01)|![image](https://github.com/user-attachments/assets/17d81047-a1a2-4ce4-b2d4-9037aa91bb24)|
