### PR TITLE
Docs: Add Inserter Draggable Blocks  component readme

### DIFF
--- a/packages/block-editor/src/components/inserter-draggable-blocks/README.md
+++ b/packages/block-editor/src/components/inserter-draggable-blocks/README.md
@@ -1,0 +1,61 @@
+
+# InserterDraggableBlocks
+
+The InserterDraggableBlocks component is a component that renders a list of draggable blocks that can be inserted into the editor. It is used in the Inserter component.
+
+
+## Table of contents
+
+1. [Development guidelines](#development-guidelines)
+2. [Related components](#related-components)
+
+
+## Development guidelines
+
+### Usage
+
+Renders a list of draggable blocks that can be inserted into the editor.
+
+```jsx
+import { InserterDraggableBlocks } from '@wordpress/block-editor';
+
+const MyInserterDraggableBlocks = () => (
+    <InserterDraggableBlocks />
+);
+```
+
+### Props
+
+### isEnabled
+
+**Type**: `boolean`
+
+Whether the inserter is enabled or not.
+
+### blocks
+
+**Type**: `Array`
+
+An array of blocks to be rendered in the inserter.
+
+### icon
+
+**Type**: `string`
+
+The icon to be rendered in the inserter.
+
+### children
+
+**Type**: `React.ReactNode`
+
+The children to be rendered in the inserter.
+
+### pattern
+
+**Type**: `string`
+
+The pattern to be rendered in the inserter.
+
+
+## Related components
+Block Editor components are components that can be used to compose the UI of your block editor. Thus, they can only be used under a [BlockEditorProvider](https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/provider/README.md) in the components tree.

--- a/packages/block-editor/src/components/inserter-draggable-blocks/README.md
+++ b/packages/block-editor/src/components/inserter-draggable-blocks/README.md
@@ -20,7 +20,14 @@ Renders a list of draggable blocks that can be inserted into the editor.
 import { InserterDraggableBlocks } from '@wordpress/block-editor';
 
 const MyInserterDraggableBlocks = () => (
-    <InserterDraggableBlocks />
+    return (
+        <InserterDraggableBlocks
+            blocks={ blocks }
+            icon={ icon }
+            isEnabled={ isEnabled }
+            pattern={ pattern }
+        />
+    );
 );
 ```
 


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/22891

## What?
Closes: https://github.com/WordPress/gutenberg/issues/52055

<!-- In a few words, what is the PR actually doing? -->

## Why?
This PR adds the README for Inserter Draggable Blocks component


## Testing Instructions
None.


## Screenshots or screencast 
None.
