### PR TITLE
Docs: Add Tool Selector readme

### DIFF
--- a/packages/block-editor/src/components/tool-selector/README.md
+++ b/packages/block-editor/src/components/tool-selector/README.md
@@ -1,0 +1,46 @@
+# Tool Selector
+
+The `ToolSelector` component is a toolbar component that allows user to choose between simplified content tools (Write) and advanced visual editing tools (Design)/
+
+## Table of contents
+
+1. [Development guidelines](#development-guidelines)
+2. [Related components](#related-components)
+
+## Development guidelines
+
+### Usage
+
+Render the `ToolSelector` component within the `BlockEditorProvider` component.
+
+```jsx
+const MyCustomToolbar = () => {
+	return (
+		<NavigationToolbar>
+			<ToolbarItem>
+				<ToolbarItem as={ ToolSelector } />
+			</ToolbarItem>
+		</NavigationToolbar>
+	);
+};
+
+export default MyCustomToolbar;
+```
+
+### Props
+
+#### `props`
+
+-   Type: `Object`
+
+Props that can be passed to the `ToolSelector` component.
+
+#### `ref`
+
+-   Type: `React.RefObject<HTMLElement>`
+
+A ref object that can be used to access the underlying HTML element.
+
+## Related components
+
+Block Editor components are components that can be used to compose the UI of your block editor. Thus, they can only be used under a [BlockEditorProvider](https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/provider/README.md) in the components tree.

--- a/packages/block-editor/src/components/tool-selector/README.md
+++ b/packages/block-editor/src/components/tool-selector/README.md
@@ -1,6 +1,6 @@
 # Tool Selector
 
-The `ToolSelector` component is a toolbar component that allows user to choose between simplified content tools (Write) and advanced visual editing tools (Design)/
+The `ToolSelector` component is a toolbar component that allows user to choose between simplified content tools (Write) and advanced visual editing tools (Design).
 
 ## Table of contents
 

--- a/packages/block-editor/src/components/tool-selector/README.md
+++ b/packages/block-editor/src/components/tool-selector/README.md
@@ -14,6 +14,9 @@ The `ToolSelector` component is a toolbar component that allows user to choose b
 Render the `ToolSelector` component within the `BlockEditorProvider` component.
 
 ```jsx
+import { NavigableToolbar, ToolSelector } from '@wordpress/block-editor';
+import { ToolbarButton, ToolbarItem } from '@wordpress/components';
+
 const MyCustomToolbar = () => {
 	return (
 		<NavigationToolbar>


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/22891

## What?
Closes: https://github.com/WordPress/gutenberg/issues/52073

<!-- In a few words, what is the PR actually doing? -->

## Why?
This PR adds the Tool Selector Readme 

### Testing Instructions 
None.

## Screenshots or screencast 
None.
