### PR TITLE
Navigation in Site View: Automatically expand all options

### DIFF
--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -92,7 +92,7 @@ function ListViewComponent(
 		blocks,
 		dropZoneElement,
 		showBlockMovers = false,
-		isExpanded = true,
+		isExpanded = false,
 		showAppender = false,
 		blockSettingsMenu: BlockSettingsMenu = BlockSettingsDropdown,
 		rootClientId,

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -77,7 +77,7 @@ export const BLOCK_LIST_ITEM_HEIGHT = 32;
  * @param {Array}          props.blocks                 _deprecated_ Custom subset of block client IDs to be used instead of the default hierarchy.
  * @param {?HTMLElement}   props.dropZoneElement        Optional element to be used as the drop zone.
  * @param {?boolean}       props.showBlockMovers        Flag to enable block movers. Defaults to `false`.
- * @param {?boolean}       props.isExpanded             Flag to determine whether nested levels are expanded by default. Defaults to `false`.
+ * @param {?boolean}       props.isExpanded             Flag to determine whether nested levels are expanded by default. Defaults to `true`.
  * @param {?boolean}       props.showAppender           Flag to show or hide the block appender. Defaults to `false`.
  * @param {?ComponentType} props.blockSettingsMenu      Optional more menu substitution. Defaults to the standard `BlockSettingsDropdown` component.
  * @param {string}         props.rootClientId           The client id of the root block from which we determine the blocks to show in the list.

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -92,7 +92,7 @@ function ListViewComponent(
 		blocks,
 		dropZoneElement,
 		showBlockMovers = false,
-		isExpanded = false,
+		isExpanded = true,
 		showAppender = false,
 		blockSettingsMenu: BlockSettingsMenu = BlockSettingsDropdown,
 		rootClientId,

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -77,7 +77,7 @@ export const BLOCK_LIST_ITEM_HEIGHT = 32;
  * @param {Array}          props.blocks                 _deprecated_ Custom subset of block client IDs to be used instead of the default hierarchy.
  * @param {?HTMLElement}   props.dropZoneElement        Optional element to be used as the drop zone.
  * @param {?boolean}       props.showBlockMovers        Flag to enable block movers. Defaults to `false`.
- * @param {?boolean}       props.isExpanded             Flag to determine whether nested levels are expanded by default. Defaults to `true`.
+ * @param {?boolean}       props.isExpanded             Flag to determine whether nested levels are expanded by default. Defaults to `false`.
  * @param {?boolean}       props.showAppender           Flag to show or hide the block appender. Defaults to `false`.
  * @param {?ComponentType} props.blockSettingsMenu      Optional more menu substitution. Defaults to the standard `BlockSettingsDropdown` component.
  * @param {string}         props.rootClientId           The client id of the root block from which we determine the blocks to show in the list.

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/navigation-menu-content.js
@@ -102,6 +102,7 @@ export default function NavigationMenuContent( { rootClientId } ) {
 					onSelect={ offCanvasOnselect }
 					blockSettingsMenu={ LeafMoreMenu }
 					showAppender={ false }
+					isExpanded
 				/>
 			) }
 			<div className="edit-site-sidebar-navigation-screen-navigation-menus__helper-block-editor">


### PR DESCRIPTION
Closes #56346

## What?
This PR changes the default state of navigation submenus in Site View from collapsed to expanded, making all navigation options immediately visible to users without requiring manual expansion.

## Why?
When viewing the Navigation section in Site View, submenus are currently collapsed by default, requiring users to click on each section to see available options. This creates an unnecessary extra step for users trying to navigate the site structure. Having submenus expanded by default provides better discoverability and improves the overall user experience.

## Testing Instructions
1. Open the Site Editor
2. Navigate to the Site View
3. Observe the Navigation section
4. Verify that all submenus are now expanded by default

## Screenshots or screencast

### Before
https://github.com/user-attachments/assets/79050453-bb69-42b3-9959-0d7ae5a91ec4

### After
https://github.com/user-attachments/assets/1f1a4b57-e414-4387-9a7f-7814ce3a8b5e
