### PR TITLE
REST API: Limit default templates and template part areas data access via index

### DIFF
--- a/backport-changelog/6.8/8422.md
+++ b/backport-changelog/6.8/8422.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/8422
+
+* https://github.com/WordPress/gutenberg/pull/69346

--- a/lib/compat/wordpress-6.8/rest-api.php
+++ b/lib/compat/wordpress-6.8/rest-api.php
@@ -48,7 +48,7 @@ function gutenberg_add_templates_default_data_to_index( WP_REST_Response $respon
 
 	$default_template_types = array();
 	foreach ( (array) get_default_block_template_types() as $slug => $template_type ) {
-		$template_type['slug'] = (string) $slug;
+		$template_type['slug']    = (string) $slug;
 		$default_template_types[] = $template_type;
 	}
 

--- a/lib/compat/wordpress-6.8/rest-api.php
+++ b/lib/compat/wordpress-6.8/rest-api.php
@@ -36,40 +36,28 @@ add_action(
 );
 
 /**
- * Adds the default template part areas to the REST API index.
- *
- * This function exposes the default template part areas through the WordPress REST API.
- * Note: This function backports into the wp-includes/rest-api/class-wp-rest-server.php file.
+ * Adds the default template types and template part areas to the REST API index.
  *
  * @param WP_REST_Response $response REST API response.
- * @return WP_REST_Response Modified REST API response with default template part areas.
+ * @return WP_REST_Response Modified REST API response.
  */
-function gutenberg_add_default_template_part_areas_to_index( WP_REST_Response $response ) {
-	$response->data['default_template_part_areas'] = get_allowed_block_template_part_areas();
-	return $response;
-}
-add_filter( 'rest_index', 'gutenberg_add_default_template_part_areas_to_index' );
-
-/**
- * Adds the default template types to the REST API index.
- *
- * This function exposes the default template types through the WordPress REST API.
- * Note: This function backports into the wp-includes/rest-api/class-wp-rest-server.php file.
- *
- * @param WP_REST_Response $response REST API response.
- * @return WP_REST_Response Modified REST API response with default template part areas.
- */
-function gutenberg_add_default_template_types_to_index( WP_REST_Response $response ) {
-	$indexed_template_types = array();
-	foreach ( get_default_block_template_types() as $slug => $template_type ) {
-		$template_type['slug']    = (string) $slug;
-		$indexed_template_types[] = $template_type;
+function gutenberg_add_template_defaults_to_index( WP_REST_Response $response ) {
+	if ( ! is_user_logged_in() ) {
+		return $response;
 	}
 
-	$response->data['default_template_types'] = $indexed_template_types;
+	$default_template_types = array();
+	foreach ( (array) get_default_block_template_types() as $slug => $template_type ) {
+		$template_type['slug'] = (string) $slug;
+		$default_template_types[] = $template_type;
+	}
+
+	$response->data['default_template_part_areas'] = get_allowed_block_template_part_areas();
+	$response->data['default_template_types']      = $default_template_types;
+
 	return $response;
 }
-add_filter( 'rest_index', 'gutenberg_add_default_template_types_to_index' );
+add_filter( 'rest_index', 'gutenberg_add_template_defaults_to_index' );
 
 /**
  * Adds the site reading options to the REST API index.

--- a/lib/compat/wordpress-6.8/rest-api.php
+++ b/lib/compat/wordpress-6.8/rest-api.php
@@ -41,7 +41,7 @@ add_action(
  * @param WP_REST_Response $response REST API response.
  * @return WP_REST_Response Modified REST API response.
  */
-function gutenberg_add_template_defaults_to_index( WP_REST_Response $response ) {
+function gutenberg_add_templates_default_data_to_index( WP_REST_Response $response ) {
 	if ( ! is_user_logged_in() ) {
 		return $response;
 	}
@@ -57,7 +57,7 @@ function gutenberg_add_template_defaults_to_index( WP_REST_Response $response ) 
 
 	return $response;
 }
-add_filter( 'rest_index', 'gutenberg_add_template_defaults_to_index' );
+add_filter( 'rest_index', 'gutenberg_add_templates_default_data_to_index' );
 
 /**
  * Adds the site reading options to the REST API index.


### PR DESCRIPTION
## What?
The PR limits access to the `default_template_part_areas` and `default_template_types` values. They are now only available to logged-in users.

## Why?

See https://core.trac.wordpress.org/ticket/62574#comment:16.

## Testing Instructions
1. Open a post.
2. Confirm that the `default_template_part_areas` and `default_template_types` values are returned when you run the base entity data selector. Selector - `wp.data.select( 'core' ).getUnstableBase();`.
3. Open an incognito window.
4. Visit the test URL below (replace the domain with your local site).
5. Confirm that values are no longer provided in the REST response.

```
https://gutenberg.test/wp-json/?_fields=description%2Cgmt_offset%2Chome%2Cname%2Csite_icon%2Csite_icon_url%2Csite_logo%2Ctimezone_string%2Cdefault_template_part_areas%2Cdefault_template_types%2Curl%2Cpage_for_posts%2Cpage_on_front%2Cshow_on_front&_locale=user
```

### Testing Instructions for Keyboard
Same.

## Screenshot
![CleanShot 2025-02-27 at 11 42 33](https://github.com/user-attachments/assets/e88a8a69-8ac3-4bfe-8f18-58df8f5d771f)

![CleanShot 2025-02-27 at 11 48 06](https://github.com/user-attachments/assets/94310dab-7be5-4626-bdd7-04c0b371af2e)



