### PR TITLE
Enhance `Action Modal` with Support for Additional Modal Props

### DIFF
--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -110,11 +110,15 @@ export function ActionModal< Item >( {
 			title={ action.modalHeader || label }
 			__experimentalHideHeader={ !! action.hideModalHeader }
 			onRequestClose={ closeModal }
-			focusOnMount="firstContentElement"
-			size="medium"
+			focusOnMount={
+				action.additionalModalProps?.focusOnMount ||
+				'firstContentElement'
+			}
+			size={ action.additionalModalProps?.size || 'medium' }
 			overlayClassName={ `dataviews-action-modal dataviews-action-modal__${ kebabCase(
 				action.id
 			) }` }
+			{ ...action.additionalModalProps }
 		>
 			<action.RenderModal items={ items } closeModal={ closeModal } />
 		</Modal>

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -7,6 +7,7 @@ import type { ReactElement, ComponentType } from 'react';
  * Internal dependencies
  */
 import type { SetSelection } from './private-types';
+import type { ModalProps } from '../../components/src/modal/types';
 
 export type SortDirection = 'asc' | 'desc';
 
@@ -463,6 +464,19 @@ export interface ActionModal< Item > extends ActionBase< Item > {
 	 * The header of the modal.
 	 */
 	modalHeader?: string;
+
+	/**
+	 * Additional modal props.
+	 */
+	additionalModalProps?: Omit<
+		ModalProps,
+		| keyof ActionBase< Item >
+		| 'children'
+		| 'onRequestClose'
+		| 'title'
+		| '__experimentalHideHeader'
+		| 'overlayClassName'
+	>;
 }
 
 export interface ActionButton< Item > extends ActionBase< Item > {


### PR DESCRIPTION
## What?
Closes #69265, #69294 
Alternate to #69302

Currently, `ActionModal`, which internally utilizes the `Modal` component, supports only a limited set of `Modal` customizations through exposed props like `modalHeader` and `hideModalHeader`. However, as more complex actions are being built, there's a growing demand to support the full range of `Modal` properties. Separate requests have already been made to include customizable `size` and `focusOnMount` props, as noted in the linked issues.  

To future-proof `ActionModal`, it's best to extend its support for all available `Modal` props, allowing for greater flexibility and customization.

## Why?

This approach would allow for greater customization of `Modal` by supporting additional props, enabling it to be tailored more precisely to specific requirements.


## How?

The `ActionModal` interface introduces a new prop, `additionalModalProp`, which allows the inclusion of `ModalProps` while excluding any that are conflicting or unnecessary.

This implementation should not break any previous usage of `DataViews`.

## Testing Instructions

1. Try adding `additionalModalProps` in any of the actions to be used within the storybook [example](https://github.com/WordPress/gutenberg/blob/d9fa3ac5a146f6ed47c7bb3d30baccf9bd0db632/packages/dataviews/src/components/dataviews/stories/fixtures.tsx#L585).
2. Run storybook. (`npm run storybook:dev`)
3. Verify if the prop updates are reflected in the `ActionModal`.

## Screenshot

![additional-props](https://github.com/user-attachments/assets/5d191fe8-6e6d-47f8-b56f-044891c86d00)
