### PR TITLE
Avatar Block Exceeds Editor Width When 'Link to User Profile' Option is Enabled

### DIFF
--- a/packages/block-library/src/avatar/edit.js
+++ b/packages/block-library/src/avatar/edit.js
@@ -96,48 +96,70 @@ const ResizableAvatar = ( {
 			s: attributes?.size * 2,
 		}
 	);
+
+	const img = (
+		<>
+			<img
+				src={ doubledSizedSrc }
+				alt={ avatar.alt }
+				className={ clsx(
+					'avatar',
+					'avatar-' + attributes.size,
+					'photo',
+					'wp-block-avatar__image',
+					borderProps.className
+				) }
+				style={ borderProps.style }
+			/>
+		</>
+	);
+
+	let imgWrapper = img;
+
+	// Disable reason: Image itself is not meant to be interactive, but
+	// should direct focus to block.
+	if ( attributes.isLink ) {
+		imgWrapper = (
+			/* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */
+			<a
+				href="#avatar-pseudo-link"
+				className="wp-block-avatar__link"
+				onClick={ ( event ) => event.preventDefault() }
+			>
+				{ img }
+			</a>
+			/* eslint-enable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */
+		);
+	}
+
 	return (
 		<div { ...blockProps }>
-			<AvatarLinkWrapper isLink={ attributes.isLink }>
-				<ResizableBox
-					size={ {
-						width: attributes.size,
-						height: attributes.size,
-					} }
-					showHandle={ isSelected }
-					onResizeStop={ ( event, direction, elt, delta ) => {
-						setAttributes( {
-							size: parseInt(
-								attributes.size +
-									( delta.height || delta.width ),
-								10
-							),
-						} );
-					} }
-					lockAspectRatio
-					enable={ {
-						top: false,
-						right: ! isRTL(),
-						bottom: true,
-						left: isRTL(),
-					} }
-					minWidth={ avatar.minSize }
-					maxWidth={ avatar.maxSize }
-				>
-					<img
-						src={ doubledSizedSrc }
-						alt={ avatar.alt }
-						className={ clsx(
-							'avatar',
-							'avatar-' + attributes.size,
-							'photo',
-							'wp-block-avatar__image',
-							borderProps.className
-						) }
-						style={ borderProps.style }
-					/>
-				</ResizableBox>
-			</AvatarLinkWrapper>
+			<ResizableBox
+				size={ {
+					width: attributes.size,
+					height: attributes.size,
+				} }
+				showHandle={ isSelected }
+				onResizeStop={ ( event, direction, elt, delta ) => {
+					setAttributes( {
+						size: parseInt(
+							attributes.size + ( delta.height || delta.width ),
+							10
+						),
+					} );
+				} }
+				lockAspectRatio
+				enable={ {
+					top: false,
+					right: ! isRTL(),
+					bottom: true,
+					left: isRTL(),
+				} }
+				minWidth={ avatar.minSize }
+				maxWidth={ avatar.maxSize }
+			>
+				{ imgWrapper }
+			</ResizableBox>
 		</div>
 	);
 };
@@ -189,21 +211,6 @@ const UserEdit = ( { attributes, context, setAttributes, isSelected } ) => {
 				setAttributes={ setAttributes }
 			/>
 		</>
-	);
-};
-
-const AvatarLinkWrapper = ( { isLink, children } ) => {
-	if ( ! isLink ) {
-		return children;
-	}
-	return (
-		<a
-			href="#avatar-pseudo-link"
-			className="wp-block-avatar__link"
-			onClick={ ( event ) => event.preventDefault() }
-		>
-			{ children }
-		</a>
 	);
 };
 

--- a/packages/block-library/src/avatar/edit.js
+++ b/packages/block-library/src/avatar/edit.js
@@ -96,7 +96,6 @@ const ResizableAvatar = ( {
 			s: attributes?.size * 2,
 		}
 	);
-
 	return (
 		<div { ...blockProps }>
 			<AvatarLinkWrapper isLink={ attributes.isLink }>

--- a/packages/block-library/src/avatar/edit.js
+++ b/packages/block-library/src/avatar/edit.js
@@ -96,48 +96,53 @@ const ResizableAvatar = ( {
 			s: attributes?.size * 2,
 		}
 	);
+
 	return (
 		<div { ...blockProps }>
-			<ResizableBox
-				size={ {
-					width: attributes.size,
-					height: attributes.size,
-				} }
-				showHandle={ isSelected }
-				onResizeStop={ ( event, direction, elt, delta ) => {
-					setAttributes( {
-						size: parseInt(
-							attributes.size + ( delta.height || delta.width ),
-							10
-						),
-					} );
-				} }
-				lockAspectRatio
-				enable={ {
-					top: false,
-					right: ! isRTL(),
-					bottom: true,
-					left: isRTL(),
-				} }
-				minWidth={ avatar.minSize }
-				maxWidth={ avatar.maxSize }
-			>
-				<img
-					src={ doubledSizedSrc }
-					alt={ avatar.alt }
-					className={ clsx(
-						'avatar',
-						'avatar-' + attributes.size,
-						'photo',
-						'wp-block-avatar__image',
-						borderProps.className
-					) }
-					style={ borderProps.style }
-				/>
-			</ResizableBox>
+			<AvatarLinkWrapper isLink={ attributes.isLink }>
+				<ResizableBox
+					size={ {
+						width: attributes.size,
+						height: attributes.size,
+					} }
+					showHandle={ isSelected }
+					onResizeStop={ ( event, direction, elt, delta ) => {
+						setAttributes( {
+							size: parseInt(
+								attributes.size +
+									( delta.height || delta.width ),
+								10
+							),
+						} );
+					} }
+					lockAspectRatio
+					enable={ {
+						top: false,
+						right: ! isRTL(),
+						bottom: true,
+						left: isRTL(),
+					} }
+					minWidth={ avatar.minSize }
+					maxWidth={ avatar.maxSize }
+				>
+					<img
+						src={ doubledSizedSrc }
+						alt={ avatar.alt }
+						className={ clsx(
+							'avatar',
+							'avatar-' + attributes.size,
+							'photo',
+							'wp-block-avatar__image',
+							borderProps.className
+						) }
+						style={ borderProps.style }
+					/>
+				</ResizableBox>
+			</AvatarLinkWrapper>
 		</div>
 	);
 };
+
 const CommentEdit = ( { attributes, context, setAttributes, isSelected } ) => {
 	const { commentId } = context;
 	const blockProps = useBlockProps();
@@ -150,29 +155,13 @@ const CommentEdit = ( { attributes, context, setAttributes, isSelected } ) => {
 				attributes={ attributes }
 				selectUser={ false }
 			/>
-			{ attributes.isLink ? (
-				<a
-					href="#avatar-pseudo-link"
-					className="wp-block-avatar__link"
-					onClick={ ( event ) => event.preventDefault() }
-				>
-					<ResizableAvatar
-						attributes={ attributes }
-						avatar={ avatar }
-						blockProps={ blockProps }
-						isSelected={ isSelected }
-						setAttributes={ setAttributes }
-					/>
-				</a>
-			) : (
-				<ResizableAvatar
-					attributes={ attributes }
-					avatar={ avatar }
-					blockProps={ blockProps }
-					isSelected={ isSelected }
-					setAttributes={ setAttributes }
-				/>
-			) }
+			<ResizableAvatar
+				attributes={ attributes }
+				avatar={ avatar }
+				blockProps={ blockProps }
+				isSelected={ isSelected }
+				setAttributes={ setAttributes }
+			/>
 		</>
 	);
 };
@@ -193,30 +182,29 @@ const UserEdit = ( { attributes, context, setAttributes, isSelected } ) => {
 				avatar={ avatar }
 				setAttributes={ setAttributes }
 			/>
-			{ attributes.isLink ? (
-				<a
-					href="#avatar-pseudo-link"
-					className="wp-block-avatar__link"
-					onClick={ ( event ) => event.preventDefault() }
-				>
-					<ResizableAvatar
-						attributes={ attributes }
-						avatar={ avatar }
-						blockProps={ blockProps }
-						isSelected={ isSelected }
-						setAttributes={ setAttributes }
-					/>
-				</a>
-			) : (
-				<ResizableAvatar
-					attributes={ attributes }
-					avatar={ avatar }
-					blockProps={ blockProps }
-					isSelected={ isSelected }
-					setAttributes={ setAttributes }
-				/>
-			) }
+			<ResizableAvatar
+				attributes={ attributes }
+				avatar={ avatar }
+				blockProps={ blockProps }
+				isSelected={ isSelected }
+				setAttributes={ setAttributes }
+			/>
 		</>
+	);
+};
+
+const AvatarLinkWrapper = ( { isLink, children } ) => {
+	if ( ! isLink ) {
+		return children;
+	}
+	return (
+		<a
+			href="#avatar-pseudo-link"
+			className="wp-block-avatar__link"
+			onClick={ ( event ) => event.preventDefault() }
+		>
+			{ children }
+		</a>
 	);
 };
 

--- a/packages/block-library/src/avatar/editor.scss
+++ b/packages/block-library/src/avatar/editor.scss
@@ -7,3 +7,9 @@
 		margin: 0 auto;
 	}
 }
+
+.wp-block-avatar__link {
+	pointer-events: none;
+	display: block;
+	justify-self: start;
+}

--- a/packages/block-library/src/avatar/editor.scss
+++ b/packages/block-library/src/avatar/editor.scss
@@ -1,9 +1,3 @@
-.wp-block-avatar__image {
-	img {
-		width: 100%;
-	}
-}
-
 .wp-block-avatar {
 	&.aligncenter {
 		.components-resizable-box__container {
@@ -11,11 +5,11 @@
 		}
 	}
 
+	&__image {
+		width: 100%;
+	}
+
 	&__link {
 		pointer-events: none;
-
-		.components-resizable-box__handle {
-			pointer-events: auto;
-		}
 	}
 }

--- a/packages/block-library/src/avatar/editor.scss
+++ b/packages/block-library/src/avatar/editor.scss
@@ -1,9 +1,21 @@
-.wp-block-avatar__image img {
-	width: 100%;
+.wp-block-avatar__image {
+	img {
+		width: 100%;
+	}
 }
 
-.wp-block-avatar.aligncenter {
-	.components-resizable-box__container {
-		margin: 0 auto;
+.wp-block-avatar {
+	&.aligncenter {
+		.components-resizable-box__container {
+			margin: 0 auto;
+		}
+	}
+
+	&__link {
+		pointer-events: none;
+
+		.components-resizable-box__handle {
+			pointer-events: auto;
+		}
 	}
 }

--- a/packages/block-library/src/avatar/editor.scss
+++ b/packages/block-library/src/avatar/editor.scss
@@ -7,9 +7,3 @@
 		margin: 0 auto;
 	}
 }
-
-.wp-block-avatar__link {
-	pointer-events: none;
-	display: block;
-	justify-self: start;
-}

--- a/packages/block-library/src/avatar/style.scss
+++ b/packages/block-library/src/avatar/style.scss
@@ -9,4 +9,8 @@
 	&.aligncenter {
 		text-align: center;
 	}
+
+	&__link {
+		display: inline-block;
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #69180 
It fixes the Avatar block width issue in the editor when the "Link to User Profile" option is enabled. Currently, the block extends beyond the editor's maximum width constraints while maintaining correct frontend display.

<!-- In a few words, what is the PR actually doing? -->

## Why?
The Avatar block's wrapper element is not properly constrained within the editor's width boundaries when the link option is enabled. This creates an inconsistent editing experience, though the frontend display remains unaffected. The fix ensures visual consistency between the editor and frontend rendering.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Update the editor's HTML markup to fix the issue
- Ref used: Image block

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. Open the WordPress block editor
2. Add a new Avatar block to your post/page
3. In the block settings sidebar, enable the `Link to User Profile` option
4. Verify the Avatar block stays within the editor's maximum width
5. Preview the page to confirm the frontend display remains correct

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![Edit-Post-“Avatar-fix”-‹-gutenberg-—-WordPress-02-27-2025_05_09_PM](https://github.com/user-attachments/assets/59508bd0-e91a-4699-b73a-43e2c5e62153)|![Edit-Post-“Avatar-fix”-‹-gutenberg-—-WordPress-02-27-2025_05_01_PM](https://github.com/user-attachments/assets/c8fcc84c-33e8-49e8-901f-cbb5987bd9f6)|
