### PR TITLE
Remove trailing periods from Show or hide settings panel

### DIFF
--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -223,7 +223,7 @@ const getEditorCommandLoader = () =>
 
 		commands.push( {
 			name: 'core/open-settings-sidebar',
-			label: __( 'Show or hide the Settings panel.' ),
+			label: __( 'Show or hide the Settings panel' ),
 			icon: isRTL() ? drawerLeft : drawerRight,
 			callback: ( { close } ) => {
 				const activeSidebar = getActiveComplementaryArea( 'core' );

--- a/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
@@ -92,7 +92,7 @@ function EditorKeyboardShortcutsRegister() {
 		registerShortcut( {
 			name: 'core/editor/toggle-sidebar',
 			category: 'global',
-			description: __( 'Show or hide the Settings panel' ),
+			description: __( 'Show or hide the Settings panel.' ),
 			keyCombination: {
 				modifier: 'primaryShift',
 				character: ',',

--- a/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
@@ -92,7 +92,7 @@ function EditorKeyboardShortcutsRegister() {
 		registerShortcut( {
 			name: 'core/editor/toggle-sidebar',
 			category: 'global',
-			description: __( 'Show or hide the Settings panel.' ),
+			description: __( 'Show or hide the Settings panel' ),
 			keyCombination: {
 				modifier: 'primaryShift',
 				character: ',',


### PR DESCRIPTION
## What?
This PR removes the trailing period from the command palette description for the Settings panel toggle. 
Closes #69354

## Why?
Modified the string `Show or Hide the Settings panel.` to remove the trailing period. This ensures consistency in the command palette UI.

## Testing Instructions
1. Edit or create a new page
2. Open Command by `Super + k`
3. Search for  `show` and see if `Show or hide the Settings panel` has trailing period

## Screenshots
|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/d0e1ad67-d706-4fe8-b102-a98263380a8b)|![image](https://github.com/user-attachments/assets/b4a15ef5-b8a7-48df-846e-b5d7dc0a73d1)|
