### PR TITLE
ESLint: Fix `dependency-group` rule to correctly enforce import grouping

### DIFF
--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -9,6 +9,7 @@ const { inc: semverInc } = require( 'semver' );
 const { rimraf } = require( 'rimraf' );
 const readline = require( 'readline' );
 const SimpleGit = require( 'simple-git' );
+const { join } = require( 'path' );
 
 /**
  * Internal dependencies
@@ -24,7 +25,6 @@ const {
 	calculateVersionBumpFromChangelog,
 	findPluginReleaseBranchName,
 } = require( './common' );
-const { join } = require( 'path' );
 const pluginConfig = require( '../config' );
 
 /**

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -6,13 +6,14 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { useCallback, Platform } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
 /**
  * Internal dependencies
  */
 import BackgroundImageControl from '../background-image-control';
 import { useToolsPanelDropdownMenuProps } from './utils';
 import { setImmutably } from '../../utils/object';
-import { __ } from '@wordpress/i18n';
 
 const DEFAULT_CONTROLS = {
 	backgroundImage: true,

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -21,6 +21,7 @@ import {
 } from '@wordpress/components';
 import { useCallback, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { reset as resetIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -30,7 +31,6 @@ import { useColorsPerOrigin, useGradientsPerOrigin } from './hooks';
 import { getValueFromVariable, useToolsPanelDropdownMenuProps } from './utils';
 import { setImmutably } from '../../utils/object';
 import { unlock } from '../../lock-unlock';
-import { reset as resetIcon } from '@wordpress/icons';
 
 export function useHasColorPanel( settings ) {
 	const hasTextPanel = useHasTextPanel( settings );

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -22,6 +22,7 @@ import { isShallowEqualObjects } from '@wordpress/is-shallow-equal';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { keyboardReturn } from '@wordpress/icons';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -34,7 +35,6 @@ import useCreatePage from './use-create-page';
 import useInternalValue from './use-internal-value';
 import { ViewerFill } from './viewer-slot';
 import { DEFAULT_LINK_SETTINGS } from './constants';
-import deprecated from '@wordpress/deprecated';
 
 /**
  * Default properties associated with a link control value.

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -3,6 +3,7 @@
  */
 import { forwardRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -11,7 +12,6 @@ import { URLInput } from '../';
 import LinkControlSearchResults from './search-results';
 import { CREATE_TYPE } from './constants';
 import useSearchHandler from './use-search-handler';
-import deprecated from '@wordpress/deprecated';
 
 // Must be a function as otherwise URLInput will default
 // to the fetchLinkSuggestions passed in block editor settings

--- a/packages/block-editor/src/components/link-control/search-results.js
+++ b/packages/block-editor/src/components/link-control/search-results.js
@@ -3,6 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { MenuGroup } from '@wordpress/components';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * External dependencies
@@ -15,7 +16,6 @@ import clsx from 'clsx';
 import LinkControlSearchCreate from './search-create-button';
 import LinkControlSearchItem from './search-item';
 import { CREATE_TYPE, LINK_ENTRY_TYPES } from './constants';
-import deprecated from '@wordpress/deprecated';
 
 function LinkControlSearchResults( {
 	withCreateSuggestion,

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -11,6 +11,7 @@ import { __experimentalHasSplitBorders as hasSplitBorders } from '@wordpress/com
 import { Platform, useCallback, useMemo } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -29,7 +30,6 @@ import {
 	BorderPanel as StylesBorderPanel,
 } from '../components/global-styles';
 import { store as blockEditorStore } from '../store';
-import { __ } from '@wordpress/i18n';
 
 export const BORDER_SUPPORT_KEY = '__experimentalBorder';
 export const SHADOW_SUPPORT_KEY = 'shadow';

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -1,4 +1,20 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import { __, _x, sprintf } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useBlockProps } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
+import { View } from '@wordpress/primitives';
+import { getAuthority } from '@wordpress/url';
+
+/**
  * Internal dependencies
  */
 import {
@@ -14,22 +30,6 @@ import { embedContentIcon } from './icons';
 import EmbedLoading from './embed-loading';
 import EmbedPlaceholder from './embed-placeholder';
 import EmbedPreview from './embed-preview';
-
-/**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
- * WordPress dependencies
- */
-import { __, _x, sprintf } from '@wordpress/i18n';
-import { useState, useEffect } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { useBlockProps } from '@wordpress/block-editor';
-import { store as coreStore } from '@wordpress/core-data';
-import { View } from '@wordpress/primitives';
-import { getAuthority } from '@wordpress/url';
 import { Caption } from '../utils/caption';
 
 const EmbedEdit = ( props ) => {

--- a/packages/block-library/src/embed/embed-preview.js
+++ b/packages/block-library/src/embed/embed-preview.js
@@ -1,9 +1,4 @@
 /**
- * Internal dependencies
- */
-import { getPhotoHtml } from './util';
-
-/**
  * External dependencies
  */
 import clsx from 'clsx';
@@ -20,6 +15,7 @@ import { getAuthority } from '@wordpress/url';
 /**
  * Internal dependencies
  */
+import { getPhotoHtml } from './util';
 import WpEmbedPreview from './wp-embed-preview';
 
 export default function EmbedPreview( {

--- a/packages/block-library/src/embed/test/index.native.js
+++ b/packages/block-library/src/embed/test/index.native.js
@@ -11,6 +11,7 @@ import {
 } from 'test/helpers';
 import { Platform } from 'react-native';
 import Clipboard from '@react-native-clipboard/clipboard';
+import { WebView } from 'react-native-webview';
 
 /**
  * WordPress dependencies
@@ -30,7 +31,6 @@ import { requestPreview } from '@wordpress/react-native-bridge';
  */
 import * as paragraph from '../../paragraph';
 import * as embed from '..';
-import { WebView } from 'react-native-webview';
 
 // Override modal mock to prevent unmounting it when is not visible.
 // This is required to be able to trigger onClose and onDismiss events when

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,13 +4,14 @@
 
 ## 29.8.0 (2025-04-11)
 
-### Documentation 
+### Documentation
 
 -   `Popover`: Expose Popover TypeScript types for subcomponents. ([#69619](https://github.com/WordPress/gutenberg/pull/69619))
 
 ### Internal
 
 -   Update `gradient-parser` to version `1.0.2` ([#69783](https://github.com/WordPress/gutenberg/pull/69783)).
+-   `Components`: Fix imported depedencies after correcting ESLint rule related to grouping imports([#69361](https://github.com/WordPress/gutenberg/pull/69361)).
 
 ### Bug Fixes
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   `Components`: Fix imported depedencies after correcting ESLint rule related to grouping imports([#69361](https://github.com/WordPress/gutenberg/pull/69361)).
+
 ## 29.8.0 (2025-04-11)
 
 ### Documentation
@@ -11,7 +15,6 @@
 ### Internal
 
 -   Update `gradient-parser` to version `1.0.2` ([#69783](https://github.com/WordPress/gutenberg/pull/69783)).
--   `Components`: Fix imported depedencies after correcting ESLint rule related to grouping imports([#69361](https://github.com/WordPress/gutenberg/pull/69361)).
 
 ### Bug Fixes
 

--- a/packages/components/src/autocomplete/autocompleter-ui.tsx
+++ b/packages/components/src/autocomplete/autocompleter-ui.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import clsx from 'clsx';
+import { createPortal } from 'react-dom';
 
 /**
  * WordPress dependencies
@@ -14,8 +15,8 @@ import {
 } from '@wordpress/element';
 import { useAnchor } from '@wordpress/rich-text';
 import { useDebounce, useMergeRefs, useRefEffect } from '@wordpress/compose';
-import { speak } from '@wordpress/a11y';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -24,7 +25,6 @@ import getDefaultUseItems from './get-default-use-items';
 import Button from '../button';
 import Popover from '../popover';
 import { VisuallyHidden } from '../visually-hidden';
-import { createPortal } from 'react-dom';
 import type { AutocompleterUIProps, KeyedOption, WPCompleter } from './types';
 
 type ListBoxProps = {

--- a/packages/components/src/box-control/utils.ts
+++ b/packages/components/src/box-control/utils.ts
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -13,7 +14,6 @@ import type {
 	CustomValueUnits,
 	Preset,
 } from './types';
-import deprecated from '@wordpress/deprecated';
 
 export const CUSTOM_VALUE_SETTINGS: CustomValueUnits = {
 	px: { max: 300, step: 1 },

--- a/packages/components/src/button/test/index.tsx
+++ b/packages/components/src/button/test/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
+import { press } from '@ariakit/test';
 
 /**
  * WordPress dependencies
@@ -15,7 +16,6 @@ import { plusCircle } from '@wordpress/icons';
 import _Button from '..';
 import Tooltip from '../../tooltip';
 import cleanupTooltip from '../../tooltip/test/utils';
-import { press } from '@ariakit/test';
 
 jest.mock( '../../icon', () => () => <div data-testid="test-icon" /> );
 

--- a/packages/components/src/color-picker/test/index.tsx
+++ b/packages/components/src/color-picker/test/index.tsx
@@ -3,6 +3,7 @@
  */
 import { fireEvent, screen, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { click } from '@ariakit/test';
 
 /**
  * WordPress dependencies
@@ -13,7 +14,6 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { ColorPicker } from '..';
-import { click } from '@ariakit/test';
 
 const hslaMatcher = expect.objectContaining( {
 	h: expect.any( Number ),

--- a/packages/components/src/custom-gradient-picker/gradient-bar/index.tsx
+++ b/packages/components/src/custom-gradient-picker/gradient-bar/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import clsx from 'clsx';
+import type { MouseEventHandler } from 'react';
 
 /**
  * WordPress dependencies
@@ -20,7 +21,6 @@ import type {
 	CustomGradientBarReducerAction,
 	CustomGradientBarIdleState,
 } from '../types';
-import type { MouseEventHandler } from 'react';
 
 const customGradientBarReducer = (
 	state: CustomGradientBarReducerState,

--- a/packages/components/src/dimension-control/index.tsx
+++ b/packages/components/src/dimension-control/index.tsx
@@ -7,6 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -17,7 +18,6 @@ import sizesTable, { findSizeBySlug } from './sizes';
 import type { DimensionControlProps, Size } from './types';
 import type { SelectControlSingleSelectionProps } from '../select-control/types';
 import { ContextSystemProvider } from '../context';
-import deprecated from '@wordpress/deprecated';
 import { maybeWarnDeprecated36pxSize } from '../utils/deprecated-36px-size';
 
 const CONTEXT_VALUE = {

--- a/packages/components/src/disabled/test/index.tsx
+++ b/packages/components/src/disabled/test/index.tsx
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
  */
 import Disabled from '../';
-import userEvent from '@testing-library/user-event';
 
 describe( 'Disabled', () => {
 	const Form = () => (

--- a/packages/components/src/duotone-picker/color-list-picker/index.tsx
+++ b/packages/components/src/duotone-picker/color-list-picker/index.tsx
@@ -4,6 +4,7 @@
 import { useState } from '@wordpress/element';
 import { swatch } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -13,7 +14,6 @@ import ColorPalette from '../../color-palette';
 import ColorIndicator from '../../color-indicator';
 import Icon from '../../icon';
 import type { ColorListPickerProps, ColorOptionProps } from './types';
-import { useInstanceId } from '@wordpress/compose';
 
 function ColorOption( {
 	label,

--- a/packages/components/src/focal-point-picker/index.tsx
+++ b/packages/components/src/focal-point-picker/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import clsx from 'clsx';
+import type { KeyboardEventHandler } from 'react';
 
 /**
  * WordPress dependencies
@@ -33,7 +34,6 @@ import type {
 	FocalPoint as FocalPointType,
 	FocalPointPickerProps,
 } from './types';
-import type { KeyboardEventHandler } from 'react';
 
 const GRID_OVERLAY_TIMEOUT = 600;
 

--- a/packages/components/src/menu/radio-item.tsx
+++ b/packages/components/src/menu/radio-item.tsx
@@ -8,6 +8,7 @@ import * as Ariakit from '@ariakit/react';
  */
 import { forwardRef, useContext } from '@wordpress/element';
 import { Icon } from '@wordpress/icons';
+import { SVG, Circle } from '@wordpress/primitives';
 
 /**
  * Internal dependencies
@@ -16,7 +17,6 @@ import type { WordPressComponentProps } from '../context';
 import { Context } from './context';
 import type { RadioItemProps } from './types';
 import * as Styled from './styles';
-import { SVG, Circle } from '@wordpress/primitives';
 
 const radioCheck = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">

--- a/packages/components/src/mobile/color-settings/palette.screen.native.js
+++ b/packages/components/src/mobile/color-settings/palette.screen.native.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { View, Text, TouchableWithoutFeedback } from 'react-native';
+import { useRoute, useNavigation } from '@react-navigation/native';
 
 /**
  * WordPress dependencies
@@ -9,7 +10,6 @@ import { View, Text, TouchableWithoutFeedback } from 'react-native';
 import { __ } from '@wordpress/i18n';
 import { useState, useContext } from '@wordpress/element';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
-import { useRoute, useNavigation } from '@react-navigation/native';
 
 /**
  * Internal dependencies
@@ -22,7 +22,6 @@ import { colorsUtils } from './utils';
 import PanelBody from '../../panel/body';
 import { BottomSheetContext } from '../bottom-sheet/bottom-sheet-context';
 import ColorControl from '../../color-control';
-
 import styles from './style.scss';
 
 const HIT_SLOP = { top: 8, bottom: 8, left: 8, right: 8 };

--- a/packages/components/src/modal/use-modal-exit-animation.ts
+++ b/packages/components/src/modal/use-modal-exit-animation.ts
@@ -3,12 +3,12 @@
  */
 import { useReducedMotion } from '@wordpress/compose';
 import { useCallback, useRef, useState } from '@wordpress/element';
+import warning from '@wordpress/warning';
 
 /**
  * Internal dependencies
  */
 import { CONFIG } from '../utils';
-import warning from '@wordpress/warning';
 
 // Animation duration (ms) extracted to JS in order to be used on a setTimeout.
 const FRAME_ANIMATION_DURATION = CONFIG.transitionDuration;

--- a/packages/components/src/navigator/navigator/component.tsx
+++ b/packages/components/src/navigator/navigator/component.tsx
@@ -9,6 +9,7 @@ import type { ForwardedRef } from 'react';
 import { useMemo, useReducer } from '@wordpress/element';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import warning from '@wordpress/warning';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -28,7 +29,6 @@ import type {
 	Screen,
 	NavigateToParentOptions,
 } from '../types';
-import deprecated from '@wordpress/deprecated';
 
 type MatchedPath = ReturnType< typeof patternMatch >;
 

--- a/packages/components/src/notice/list.native.js
+++ b/packages/components/src/notice/list.native.js
@@ -8,13 +8,13 @@ import { View } from 'react-native';
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import Notice from './';
 import styles from './style.scss';
-import { useCallback } from '@wordpress/element';
 
 function NoticeList() {
 	const { notices } = useSelect( ( select ) => {

--- a/packages/components/src/panel/row.tsx
+++ b/packages/components/src/panel/row.tsx
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import clsx from 'clsx';
+import type { ForwardedRef } from 'react';
 
 /**
  * WordPress dependencies
  */
 import { forwardRef } from '@wordpress/element';
-import type { ForwardedRef } from 'react';
 
 /**
  * Internal dependencies

--- a/packages/components/src/query-controls/category-select.tsx
+++ b/packages/components/src/query-controls/category-select.tsx
@@ -1,13 +1,13 @@
 /**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import { buildTermsTree } from './terms';
 import TreeSelect from '../tree-select';
-
-/**
- * WordPress dependencies
- */
-import { useMemo } from '@wordpress/element';
 import type { CategorySelectProps } from './types';
 
 export default function CategorySelect( {

--- a/packages/components/src/search-control/index.tsx
+++ b/packages/components/src/search-control/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import clsx from 'clsx';
+import type { ForwardedRef } from 'react';
 
 /**
  * WordPress dependencies
@@ -18,7 +19,6 @@ import deprecated from '@wordpress/deprecated';
 import Button from '../button';
 import type { WordPressComponentProps } from '../context/wordpress-component';
 import type { SearchControlProps, SuffixItemProps } from './types';
-import type { ForwardedRef } from 'react';
 import { ContextSystemProvider } from '../context';
 import { StyledInputControl, SuffixItemWrapper } from './styles';
 

--- a/packages/components/src/slot-fill/provider.tsx
+++ b/packages/components/src/slot-fill/provider.tsx
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
+import { observableMap } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -15,7 +16,6 @@ import type {
 	SlotFillProviderProps,
 	SlotKey,
 } from './types';
-import { observableMap } from '@wordpress/compose';
 
 function createSlotRegistry(): BaseSlotFillContext {
 	const slots = observableMap< SlotKey, BaseSlotInstance >();

--- a/packages/components/src/tabs/tab.tsx
+++ b/packages/components/src/tabs/tab.tsx
@@ -1,14 +1,14 @@
 /**
  * WordPress dependencies
  */
-
 import { forwardRef } from '@wordpress/element';
+import warning from '@wordpress/warning';
+import { chevronRight } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import type { TabProps } from './types';
-import warning from '@wordpress/warning';
 import { useTabsContext } from './context';
 import {
 	Tab as StyledTab,
@@ -16,7 +16,6 @@ import {
 	TabChevron as StyledTabChevron,
 } from './styles';
 import type { WordPressComponentProps } from '../context';
-import { chevronRight } from '@wordpress/icons';
 
 export const Tab = forwardRef<
 	HTMLButtonElement,

--- a/packages/components/src/tabs/tabpanel.tsx
+++ b/packages/components/src/tabs/tabpanel.tsx
@@ -7,14 +7,13 @@ import { useStoreState } from '@ariakit/react';
  * WordPress dependencies
  */
 import { forwardRef } from '@wordpress/element';
+import warning from '@wordpress/warning';
 
 /**
  * Internal dependencies
  */
 import type { TabPanelProps } from './types';
 import { TabPanel as StyledTabPanel } from './styles';
-
-import warning from '@wordpress/warning';
 import { useTabsContext } from './context';
 import type { WordPressComponentProps } from '../context';
 

--- a/packages/components/src/text/hook.ts
+++ b/packages/components/src/text/hook.ts
@@ -3,6 +3,7 @@
  */
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
+import type React from 'react';
 
 /**
  * WordPress dependencies
@@ -23,7 +24,6 @@ import { CONFIG, COLORS } from '../utils';
 import { getLineHeight } from './get-line-height';
 import { useCx } from '../utils/hooks/use-cx';
 import type { Props } from './types';
-import type React from 'react';
 
 /**
  * @param {import('../context').WordPressComponentProps<import('./types').Props, 'span'>} props

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -7,6 +7,7 @@ import type { ForwardedRef } from 'react';
  * WordPress dependencies
  */
 import { useMemo, useState } from '@wordpress/element';
+import { useMergeRefs } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -21,7 +22,6 @@ import * as styles from './styles';
 import { ToggleGroupControlAsRadioGroup } from './as-radio-group';
 import { ToggleGroupControlAsButtonGroup } from './as-button-group';
 import { useTrackElementOffsetRect } from '../../utils/element-rect';
-import { useMergeRefs } from '@wordpress/compose';
 import { useAnimatedOffsetRect } from '../../utils/hooks/use-animated-offset-rect';
 import { maybeWarnDeprecated36pxSize } from '../../utils/deprecated-36px-size';
 

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -4,6 +4,7 @@
 import { createSelector, createRegistrySelector } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import deprecated from '@wordpress/deprecated';
+import type { UndoManager } from '@wordpress/undo-manager';
 
 /**
  * Internal dependencies
@@ -23,7 +24,6 @@ import {
 	getUserPermissionCacheKey,
 } from './utils';
 import type * as ET from './entity-types';
-import type { UndoManager } from '@wordpress/undo-manager';
 
 // This is an incomplete, high-level approximation of the State type.
 // It makes the selectors slightly more safe, but is intended to evolve

--- a/packages/e2e-test-utils-playwright/src/page-utils/drag-files.ts
+++ b/packages/e2e-test-utils-playwright/src/page-utils/drag-files.ts
@@ -4,12 +4,12 @@
 import { readFile } from 'fs/promises';
 import { basename } from 'path';
 import { getType } from 'mime';
+import type { Locator } from '@playwright/test';
 
 /**
  * Internal dependencies
  */
 import type { PageUtils } from './index';
-import type { Locator } from '@playwright/test';
 
 type FileObject = {
 	name: string;

--- a/packages/edit-site/src/components/global-styles-sidebar/index.js
+++ b/packages/edit-site/src/components/global-styles-sidebar/index.js
@@ -13,6 +13,7 @@ import {
 } from '@wordpress/editor';
 import { useViewportMatch } from '@wordpress/compose';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -21,7 +22,6 @@ import { GlobalStylesUI } from '../global-styles';
 import { store as editSiteStore } from '../../store';
 import { GlobalStylesMenuSlot } from '../global-styles/ui';
 import { unlock } from '../../lock-unlock';
-import { store as coreStore } from '@wordpress/core-data';
 import DefaultSidebar from './default-sidebar';
 
 const { interfaceStore } = unlock( editorPrivateApis );

--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-card.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-card.js
@@ -10,12 +10,12 @@ import {
 	FlexItem,
 	Icon,
 } from '@wordpress/components';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import FontDemo from './font-demo';
-import { chevronLeft, chevronRight } from '@wordpress/icons';
 
 function FontCard( { font, onClick, variantsText, navigatorPath } ) {
 	const variantsCount = font.fontFace?.length || 1;

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -9,12 +9,12 @@ import a11yPlugin from 'colord/plugins/a11y';
  */
 import { store as blocksStore } from '@wordpress/blocks';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
-import { useSelect } from '@wordpress/data';
 
 const { useGlobalSetting, useGlobalStyle } = unlock( blockEditorPrivateApis );
 

--- a/packages/edit-site/src/components/global-styles/shadows-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-panel.js
@@ -18,6 +18,7 @@ import {
 	chevronRight,
 	moreVertical,
 } from '@wordpress/icons';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -27,7 +28,6 @@ import Subtitle from './subtitle';
 import { NavigationButtonAsItem } from './navigation-button';
 import ScreenHeader from './header';
 import { getNewIndexFromPresets } from './utils';
-import { useState } from '@wordpress/element';
 import ConfirmResetShadowDialog from './confirm-reset-shadow-dialog';
 
 const { useGlobalSetting } = unlock( blockEditorPrivateApis );

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -8,6 +8,7 @@ import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { addQueryArgs } from '@wordpress/url';
+import { useEvent } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -24,7 +25,6 @@ import {
 import { unlock } from '../../lock-unlock';
 import { useEditPostAction } from '../dataviews-actions';
 import { authorField, descriptionField, previewField } from './fields';
-import { useEvent } from '@wordpress/compose';
 
 const { usePostActions, templateTitleField } = unlock( editorPrivateApis );
 const { useHistory, useLocation } = unlock( routerPrivateApis );

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -13,6 +13,7 @@ import { store as coreDataStore } from '@wordpress/core-data';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useState, useMemo, useEffect } from '@wordpress/element';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -20,7 +21,6 @@ import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import Page from '../page';
 import { unlock } from '../../lock-unlock';
 import usePatternSettings from '../page-patterns/use-pattern-settings';
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 const { usePostFields, PostCardPanel } = unlock( editorPrivateApis );
 

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -17,12 +17,12 @@ import { __, isRTL } from '@wordpress/i18n';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
-import { addQueryArgs } from '@wordpress/url';
 
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
@@ -7,13 +7,13 @@ import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { addQueryArgs } from '@wordpress/url';
+import { layout } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import SidebarNavigationItem from '../sidebar-navigation-item';
 import { useAddedBy } from '../page-templates/hooks';
-import { layout } from '@wordpress/icons';
 import { TEMPLATE_POST_TYPE } from '../../utils/constants';
 import { unlock } from '../../lock-unlock';
 

--- a/packages/editor/src/components/offline-status/test/index.native.js
+++ b/packages/editor/src/components/offline-status/test/index.native.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { act, render, screen } from 'test/helpers';
+import { AccessibilityInfo } from 'react-native';
 
 /**
  * WordPress dependencies
@@ -15,7 +16,6 @@ import {
  * Internal dependencies
  */
 import OfflineStatus from '../index';
-import { AccessibilityInfo } from 'react-native';
 
 jest.mock( '../style.native.scss', () => ( {
 	'offline--icon': {

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -21,12 +21,12 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { ActionItem } from '@wordpress/interface';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
-import { store as blockEditorStore } from '@wordpress/block-editor';
 import PostPreviewButton from '../post-preview-button';
 import { unlock } from '../../lock-unlock';
 

--- a/packages/editor/src/private-apis.js
+++ b/packages/editor/src/private-apis.js
@@ -2,6 +2,11 @@
  * WordPress dependencies
  */
 import * as interfaceApis from '@wordpress/interface';
+import {
+	CreateTemplatePartModal,
+	patternTitleField,
+	templateTitleField,
+} from '@wordpress/fields';
 
 /**
  * Internal dependencies
@@ -23,11 +28,6 @@ import {
 	mergeBaseAndUserConfigs,
 	GlobalStylesProvider,
 } from './components/global-styles-provider';
-import {
-	CreateTemplatePartModal,
-	patternTitleField,
-	templateTitleField,
-} from '@wordpress/fields';
 import { registerCoreBlockBindingsSources } from './bindings/api';
 import { getTemplateInfo } from './utils/get-template-info';
 

--- a/packages/eslint-plugin/rules/__tests__/dependency-group.js
+++ b/packages/eslint-plugin/rules/__tests__/dependency-group.js
@@ -131,5 +131,54 @@ const { Component } = require( '@wordpress/element' );
  */
 const edit = require( './edit' );`,
 		},
+		{
+			code: `
+/**
+ * External dependencies
+ */
+import { camelCase } from 'change-case';
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import lodash from 'lodash';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import { __ } from '@wordpress/i18n';
+import utils from './utils';
+import constants from './constants';`,
+			errors: [
+				{
+					message: 'Dependencies should be properly grouped',
+				},
+			],
+			output: `
+/**
+ * External dependencies
+ */
+import { camelCase } from 'change-case';
+import clsx from 'clsx';
+import lodash from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import utils from './utils';
+import constants from './constants';`,
+		},
 	],
 } );

--- a/packages/eslint-plugin/rules/dependency-group.js
+++ b/packages/eslint-plugin/rules/dependency-group.js
@@ -152,6 +152,62 @@ module.exports = {
 			return { value };
 		}
 
+		/**
+		 * Checks if a group of imports needs reordering
+		 * @param {Array<[Node, string]>} candidates
+		 * @return {boolean} Whether the group needs reordering
+		 */
+		function checkNeedsReordering( candidates ) {
+			for ( const [ importNode, source ] of candidates ) {
+				if ( ! importNode.range ) {
+					continue;
+				}
+
+				const locality = getPackageLocality( source );
+				const importStart = importNode.range[ 0 ];
+
+				const isNotGrouped = candidates.some(
+					( [ otherNode, otherSource ] ) => {
+						if ( importNode === otherNode || ! otherNode.range ) {
+							return false;
+						}
+
+						const otherLocality = getPackageLocality( otherSource );
+						const otherStart = otherNode.range[ 0 ];
+
+						return candidates.some(
+							( [ middleNode, middleSource ] ) => {
+								if (
+									! middleNode.range ||
+									middleNode === importNode ||
+									middleNode === otherNode
+								) {
+									return false;
+								}
+
+								const middleLocality =
+									getPackageLocality( middleSource );
+								const middleStart = middleNode.range[ 0 ];
+
+								return (
+									locality === otherLocality &&
+									middleLocality !== locality &&
+									middleStart > importStart &&
+									middleStart < otherStart
+								);
+							}
+						);
+					}
+				);
+
+				if ( isNotGrouped ) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
 		return {
 			/**
 			 * @param {import('estree').Program} node Program node.
@@ -267,59 +323,7 @@ module.exports = {
 					groups[ locality ].push( [ importNode, source ] );
 				}
 
-				let needsReordering = false;
-				for ( const [ importNode, source ] of candidates ) {
-					// Skip if no range available
-					if ( ! importNode.range ) {
-						continue;
-					}
-
-					const locality = getPackageLocality( source );
-					const importStart = importNode.range[ 0 ];
-
-					const isNotGrouped = candidates.some(
-						( [ otherNode, otherSource ] ) => {
-							if (
-								importNode === otherNode ||
-								! otherNode.range
-							) {
-								return false;
-							}
-
-							const otherLocality =
-								getPackageLocality( otherSource );
-							const otherStart = otherNode.range[ 0 ];
-
-							return candidates.some(
-								( [ middleNode, middleSource ] ) => {
-									if (
-										! middleNode.range ||
-										middleNode === importNode ||
-										middleNode === otherNode
-									) {
-										return false;
-									}
-
-									const middleLocality =
-										getPackageLocality( middleSource );
-									const middleStart = middleNode.range[ 0 ];
-
-									return (
-										locality === otherLocality &&
-										middleLocality !== locality &&
-										middleStart > importStart &&
-										middleStart < otherStart
-									);
-								}
-							);
-						}
-					);
-
-					if ( isNotGrouped ) {
-						needsReordering = true;
-						break;
-					}
-				}
+				const needsReordering = checkNeedsReordering( candidates );
 
 				if ( needsReordering && candidates.length > 0 ) {
 					const firstImport = candidates[ 0 ][ 0 ];

--- a/packages/eslint-plugin/rules/dependency-group.js
+++ b/packages/eslint-plugin/rules/dependency-group.js
@@ -356,7 +356,10 @@ module.exports = {
 								'Internal',
 							];
 
+							// Group imports by locality.
 							const groups = groupImportsByLocality( candidates );
+
+							// Keep track of added comments to avoid duplication
 							const addedComments = new Set();
 
 							for ( const locality of localities ) {
@@ -366,6 +369,7 @@ module.exports = {
 									continue;
 								}
 
+								// Adds a comment for the locality if not already added.
 								if ( ! addedComments.has( locality ) ) {
 									if ( newText ) {
 										newText += '\n\n';
@@ -383,6 +387,8 @@ module.exports = {
 								newText += '\n';
 							}
 
+							// Added this to handle the case where there are comments before the first import.
+							// Helps in avoiding duplication of comments.
 							comments.forEach( ( comment ) => {
 								if (
 									comment.value.includes( 'dependencies' ) &&

--- a/packages/eslint-plugin/rules/dependency-group.js
+++ b/packages/eslint-plugin/rules/dependency-group.js
@@ -208,6 +208,27 @@ module.exports = {
 			return false;
 		}
 
+		/**
+		 * Groups imports by their locality type
+		 * @param {Array<[Node, string]>} candidates
+		 * @return {Record<WPPackageLocality, Array<[Node, string]>>} Grouped imports
+		 */
+		function groupImportsByLocality( candidates ) {
+			/** @type {Record<WPPackageLocality, Array<[Node, string]>>} */
+			const groups = {
+				WordPress: [],
+				External: [],
+				Internal: [],
+			};
+
+			for ( const [ importNode, source ] of candidates ) {
+				const locality = getPackageLocality( source );
+				groups[ locality ].push( [ importNode, source ] );
+			}
+
+			return groups;
+		}
+
 		return {
 			/**
 			 * @param {import('estree').Program} node Program node.
@@ -311,18 +332,6 @@ module.exports = {
 					} );
 				}
 
-				/** @type {Record<WPPackageLocality, Array<[Node, string]>>} */
-				const groups = {
-					WordPress: [],
-					External: [],
-					Internal: [],
-				};
-
-				for ( const [ importNode, source ] of candidates ) {
-					const locality = getPackageLocality( source );
-					groups[ locality ].push( [ importNode, source ] );
-				}
-
 				const needsReordering = checkNeedsReordering( candidates );
 
 				if ( needsReordering && candidates.length > 0 ) {
@@ -349,6 +358,8 @@ module.exports = {
 								'External',
 								'Internal',
 							];
+
+							const groups = groupImportsByLocality( candidates );
 
 							for ( const locality of localities ) {
 								if ( groups[ locality ].length > 0 ) {

--- a/packages/eslint-plugin/rules/dependency-group.js
+++ b/packages/eslint-plugin/rules/dependency-group.js
@@ -341,8 +341,8 @@ module.exports = {
 						return;
 					}
 
-					const startRange = firstImport.range;
-					const endRange = lastImport.range;
+					let startRange = firstImport.range[ 0 ];
+					const endRange = lastImport.range[ 1 ];
 
 					context.report( {
 						node: firstImport,
@@ -357,24 +357,48 @@ module.exports = {
 							];
 
 							const groups = groupImportsByLocality( candidates );
+							const addedComments = new Set();
 
 							for ( const locality of localities ) {
-								if ( groups[ locality ].length > 0 ) {
-									newText += `/**\n * ${ locality } dependencies\n */\n`;
-									for ( const [ importNode ] of groups[
-										locality
-									] ) {
-										newText +=
-											context
-												.getSourceCode()
-												.getText( importNode ) + '\n';
-									}
-									newText += '\n';
+								const imports = groups[ locality ];
+
+								if ( imports.length === 0 ) {
+									continue;
 								}
+
+								if ( ! addedComments.has( locality ) ) {
+									if ( newText ) {
+										newText += '\n\n';
+									}
+									newText += `/**\n * ${ locality } dependencies\n */\n`;
+									addedComments.add( locality );
+								}
+
+								for ( const [ importNode ] of imports ) {
+									newText +=
+										context
+											.getSourceCode()
+											.getText( importNode ) + '\n';
+								}
+								newText += '\n';
 							}
 
+							comments.forEach( ( comment ) => {
+								if (
+									comment.value.includes( 'dependencies' ) &&
+									comment.range &&
+									firstImport.range &&
+									comment.range[ 1 ] <= firstImport.range[ 0 ]
+								) {
+									startRange = Math.min(
+										startRange,
+										comment.range[ 0 ]
+									);
+								}
+							} );
+
 							return fixer.replaceTextRange(
-								[ startRange[ 0 ], endRange[ 1 ] ],
+								[ startRange, endRange ],
 								newText.trim()
 							);
 						},

--- a/packages/eslint-plugin/rules/dependency-group.js
+++ b/packages/eslint-plugin/rules/dependency-group.js
@@ -254,6 +254,120 @@ module.exports = {
 						},
 					} );
 				}
+
+				/** @type {Record<WPPackageLocality, Array<[Node, string]>>} */
+				const groups = {
+					WordPress: [],
+					External: [],
+					Internal: [],
+				};
+
+				for ( const [ importNode, source ] of candidates ) {
+					const locality = getPackageLocality( source );
+					groups[ locality ].push( [ importNode, source ] );
+				}
+
+				let needsReordering = false;
+				for ( const [ importNode, source ] of candidates ) {
+					// Skip if no range available
+					if ( ! importNode.range ) {
+						continue;
+					}
+
+					const locality = getPackageLocality( source );
+					const importStart = importNode.range[ 0 ];
+
+					const isNotGrouped = candidates.some(
+						( [ otherNode, otherSource ] ) => {
+							if (
+								importNode === otherNode ||
+								! otherNode.range
+							) {
+								return false;
+							}
+
+							const otherLocality =
+								getPackageLocality( otherSource );
+							const otherStart = otherNode.range[ 0 ];
+
+							return candidates.some(
+								( [ middleNode, middleSource ] ) => {
+									if (
+										! middleNode.range ||
+										middleNode === importNode ||
+										middleNode === otherNode
+									) {
+										return false;
+									}
+
+									const middleLocality =
+										getPackageLocality( middleSource );
+									const middleStart = middleNode.range[ 0 ];
+
+									return (
+										locality === otherLocality &&
+										middleLocality !== locality &&
+										middleStart > importStart &&
+										middleStart < otherStart
+									);
+								}
+							);
+						}
+					);
+
+					if ( isNotGrouped ) {
+						needsReordering = true;
+						break;
+					}
+				}
+
+				if ( needsReordering && candidates.length > 0 ) {
+					const firstImport = candidates[ 0 ][ 0 ];
+					const lastImport = candidates[ candidates.length - 1 ][ 0 ];
+
+					// Early return if ranges are not available
+					if ( ! firstImport.range || ! lastImport.range ) {
+						return;
+					}
+
+					// TypeScript now knows these ranges exist
+					const startRange = firstImport.range;
+					const endRange = lastImport.range;
+
+					context.report( {
+						node: firstImport,
+						message: 'Dependencies should be properly grouped',
+						fix( fixer ) {
+							let newText = '';
+							/** @type {Array<WPPackageLocality>} */
+							const localities = [
+								'WordPress',
+								'External',
+								'Internal',
+							];
+
+							for ( const locality of localities ) {
+								if ( groups[ locality ].length > 0 ) {
+									newText += `/**\n * ${ locality } dependencies\n */\n`;
+									for ( const [ importNode ] of groups[
+										locality
+									] ) {
+										newText +=
+											context
+												.getSourceCode()
+												.getText( importNode ) + '\n';
+									}
+									newText += '\n';
+								}
+							}
+
+							return fixer.replaceTextRange(
+								[ startRange[ 0 ], endRange[ 1 ] ],
+								newText.trim()
+							);
+						},
+					} );
+				}
 			},
 		};
 	},

--- a/packages/eslint-plugin/rules/dependency-group.js
+++ b/packages/eslint-plugin/rules/dependency-group.js
@@ -337,13 +337,10 @@ module.exports = {
 				if ( needsReordering && candidates.length > 0 ) {
 					const firstImport = candidates[ 0 ][ 0 ];
 					const lastImport = candidates[ candidates.length - 1 ][ 0 ];
-
-					// Early return if ranges are not available
 					if ( ! firstImport.range || ! lastImport.range ) {
 						return;
 					}
 
-					// TypeScript now knows these ranges exist
 					const startRange = firstImport.range;
 					const endRange = lastImport.range;
 
@@ -354,8 +351,8 @@ module.exports = {
 							let newText = '';
 							/** @type {Array<WPPackageLocality>} */
 							const localities = [
-								'WordPress',
 								'External',
+								'WordPress',
 								'Internal',
 							];
 

--- a/packages/eslint-plugin/rules/dependency-group.js
+++ b/packages/eslint-plugin/rules/dependency-group.js
@@ -372,7 +372,7 @@ module.exports = {
 								// Adds a comment for the locality if not already added.
 								if ( ! addedComments.has( locality ) ) {
 									if ( newText ) {
-										newText += '\n\n';
+										newText += '\n';
 									}
 									newText += `/**\n * ${ locality } dependencies\n */\n`;
 									addedComments.add( locality );
@@ -384,7 +384,6 @@ module.exports = {
 											.getSourceCode()
 											.getText( importNode ) + '\n';
 								}
-								newText += '\n';
 							}
 
 							// Added this to handle the case where there are comments before the first import.

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -3,6 +3,7 @@
  */
 import RouteRecognizer from 'route-recognizer';
 import { createBrowserHistory } from 'history';
+import type { ReactNode } from 'react';
 
 /**
  * WordPress dependencies
@@ -20,11 +21,6 @@ import {
 	buildQueryString,
 } from '@wordpress/url';
 import { useEvent } from '@wordpress/compose';
-
-/**
- * Internal dependencies
- */
-import type { ReactNode } from 'react';
 
 const history = createBrowserHistory();
 interface Route {

--- a/storybook/stories/playground/zoom-out/index.js
+++ b/storybook/stories/playground/zoom-out/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import contentCss from '!!raw-loader!../../../../packages/block-editor/build-style/content.css';
+
+/**
  * WordPress dependencies
  */
 import { useEffect, useState } from '@wordpress/element';
@@ -17,8 +22,6 @@ import { parse } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { editorStyles } from '../editor-styles';
-// eslint-disable-next-line @wordpress/dependency-group
-import contentCss from '!!raw-loader!../../../../packages/block-editor/build-style/content.css';
 import { pattern } from './pattern';
 
 // Temporary hack to access private APIs before stabilizing zoom level.

--- a/test/integration/full-content/full-content.test.js
+++ b/test/integration/full-content/full-content.test.js
@@ -20,6 +20,13 @@ import {
 } from '@wordpress/block-library';
 import prettierConfig from '@wordpress/prettier-config';
 
+/* eslint-disable no-restricted-syntax */
+import * as form from '@wordpress/block-library/src/form';
+import * as formInput from '@wordpress/block-library/src/form-input';
+import * as formSubmitButton from '@wordpress/block-library/src/form-submit-button';
+import * as formSubmissionNotification from '@wordpress/block-library/src/form-submission-notification';
+/* eslint-enable no-restricted-syntax */
+
 /**
  * Internal dependencies
  */
@@ -34,13 +41,6 @@ import {
 	writeBlockFixtureJSON,
 	writeBlockFixtureSerializedHTML,
 } from '../fixtures';
-
-/* eslint-disable no-restricted-syntax */
-import * as form from '@wordpress/block-library/src/form';
-import * as formInput from '@wordpress/block-library/src/form-input';
-import * as formSubmitButton from '@wordpress/block-library/src/form-submit-button';
-import * as formSubmissionNotification from '@wordpress/block-library/src/form-submission-notification';
-/* eslint-enable no-restricted-syntax */
 
 const blockBasenames = getAvailableBlockFixturesBasenames();
 


### PR DESCRIPTION
## What?
Fixes the dependency-group ESLint rule to correctly enforce import order in WordPress projects.

Closes #17050

<!-- In a few words, what is the PR actually doing? -->

## Why?
The rule was not properly enforcing the expected grouping of imports, allowing misordered imports to pass linting. 

## How?

- Fixed the logic in the dependency-group rule to correctly detect and enforce import order across all dependency groups.



## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/990995a4-7ec3-4819-aad7-b5d3b8932817

### After

https://github.com/user-attachments/assets/202db1d1-b158-4a89-b6e2-5d2abbaed98c





