### PR TITLE
Fix max width observer hook for align left/right images

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -356,14 +356,16 @@ export function ImageEdit( {
 		ref: containerRef,
 		className: classes,
 	} );
-	// Only observe the max width from the parent container when the parent layout is not flex nor grid.
-	// This won't work for them because the container width changes with the image.
-	// TODO: Find a way to observe the container width for flex and grid layouts.
-	const isMaxWidthContainerWidth =
-		! parentLayout || ! SIZED_LAYOUTS.includes( parentLayout.type );
-	const [ maxWidthObserver, maxContentWidth ] = useMaxWidthObserver(
-		blockProps.className
-	);
+	const [ maxWidthObserver, maxContentWidth ] = useMaxWidthObserver( {
+		className: blockProps.className,
+		isActive:
+			isSingleSelected &&
+			// Only observe the max width from the parent container when the parent layout
+			// is not flex nor grid. This won't work for them because the container width
+			// changes with the image.
+			// TODO: Find a way to observe the container width for flex and grid layouts.
+			( ! parentLayout || ! SIZED_LAYOUTS.includes( parentLayout.type ) ),
+	} );
 
 	// Much of this description is duplicated from MediaPlaceholder.
 	const { lockUrlControls = false, lockUrlControlsMessage } = useSelect(
@@ -473,7 +475,7 @@ export function ImageEdit( {
 			{
 				// The listener cannot be placed as the first element as it will break the in-between inserter.
 				// See https://github.com/WordPress/gutenberg/blob/71134165868298fc15e22896d0c28b41b3755ff7/packages/block-editor/src/components/block-list/use-in-between-inserter.js#L120
-				isSingleSelected && isMaxWidthContainerWidth && maxWidthObserver
+				maxWidthObserver
 			}
 		</>
 	);

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -42,6 +42,7 @@ import {
 	LINK_DESTINATION_MEDIA,
 	LINK_DESTINATION_NONE,
 	ALLOWED_MEDIA_TYPES,
+	SIZED_LAYOUTS,
 } from './constants';
 
 export const pickRelevantMediaFiles = ( image, size ) => {
@@ -113,14 +114,6 @@ export function ImageEdit( {
 	const [ temporaryURL, setTemporaryURL ] = useState( attributes.blob );
 
 	const containerRef = useRef();
-	// Only observe the max width from the parent container when the parent layout is not flex nor grid.
-	// This won't work for them because the container width changes with the image.
-	// TODO: Find a way to observe the container width for flex and grid layouts.
-	const isMaxWidthContainerWidth =
-		! parentLayout ||
-		( parentLayout.type !== 'flex' && parentLayout.type !== 'grid' );
-	const [ maxWidthObserver, maxContentWidth ] = useMaxWidthObserver();
-
 	const [ placeholderResizeListener, { width: placeholderWidth } ] =
 		useResizeObserver();
 
@@ -363,6 +356,14 @@ export function ImageEdit( {
 		ref: containerRef,
 		className: classes,
 	} );
+	// Only observe the max width from the parent container when the parent layout is not flex nor grid.
+	// This won't work for them because the container width changes with the image.
+	// TODO: Find a way to observe the container width for flex and grid layouts.
+	const isMaxWidthContainerWidth =
+		! parentLayout || ! SIZED_LAYOUTS.includes( parentLayout.type );
+	const [ maxWidthObserver, maxContentWidth ] = useMaxWidthObserver(
+		blockProps.className
+	);
 
 	// Much of this description is duplicated from MediaPlaceholder.
 	const { lockUrlControls = false, lockUrlControlsMessage } = useSelect(

--- a/packages/block-library/src/image/use-max-width-observer.js
+++ b/packages/block-library/src/image/use-max-width-observer.js
@@ -1,17 +1,20 @@
 /**
  * WordPress dependencies
  */
-import { useRef } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { useResizeObserver } from '@wordpress/compose';
 
-function useMaxWidthObserver() {
-	const [ contentResizeListener, { width } ] = useResizeObserver();
-	const observerRef = useRef();
+function useMaxWidthObserver( className ) {
+	const [ usedMaxWidth, setUsedMaxWidth ] = useState();
+	const setResizeObserved = useResizeObserver( ( [ entry ] ) => {
+		setUsedMaxWidth( entry.contentRect.width );
+	} );
 
 	const maxWidthObserver = (
 		<div
-			// Some themes set max-width on blocks.
-			className="wp-block"
+			// The block’s class names need to be applied because the max-width
+			// may vary per theme styles (e.g. alignments).
+			className={ className }
 			aria-hidden="true"
 			style={ {
 				position: 'absolute',
@@ -20,13 +23,11 @@ function useMaxWidthObserver() {
 				height: 0,
 				margin: 0,
 			} }
-			ref={ observerRef }
-		>
-			{ contentResizeListener }
-		</div>
+			ref={ setResizeObserved }
+		/>
 	);
 
-	return [ maxWidthObserver, width ];
+	return [ maxWidthObserver, usedMaxWidth ];
 }
 
 export { useMaxWidthObserver };

--- a/packages/block-library/src/image/use-max-width-observer.js
+++ b/packages/block-library/src/image/use-max-width-observer.js
@@ -4,17 +4,24 @@
 import { useState } from '@wordpress/element';
 import { useResizeObserver } from '@wordpress/compose';
 
-function useMaxWidthObserver( className ) {
+function useMaxWidthObserver( { className, isActive } ) {
 	const [ usedMaxWidth, setUsedMaxWidth ] = useState();
 	const setResizeObserved = useResizeObserver( ( [ entry ] ) => {
 		setUsedMaxWidth( entry.contentRect.width );
 	} );
+	if ( ! isActive ) {
+		return [];
+	}
+	// The block’s alignment class names need to be applied because the max-width
+	// may vary by that. The base `wp-block` is needed for classic themes.
+	const usedClassName = className
+		.split( ' ' )
+		.filter( ( name ) => /^(wp-block|align[^\b]+)$/.test( name ) )
+		.join( ' ' );
 
 	const maxWidthObserver = (
 		<div
-			// The block’s class names need to be applied because the max-width
-			// may vary per theme styles (e.g. alignments).
-			className={ className }
+			className={ usedClassName }
 			aria-hidden="true"
 			style={ {
 				position: 'absolute',


### PR DESCRIPTION
## What?

In #63341 some logic was added to limit in-canvas resizing of images to be no wider than their container. It works quite well though there are some issues that sprang from it (like #69316 and #67506). Those issues are mostly avoided with #68666 but one remains and affects images that meet these conditions:
- They’re aligned left or right
- Their innate size is wider than the content width
- Their width is "auto"
- The theme doesn’t apply styles that limits their width e.g. (TT5, TT4, TT3, TT2).

The underlying cause is that the max-width of an image can vary depending on its alignment yet the hook measures an element that remains the same size regardless of the image’s alignment.

## Why?
The limitation of the images’s width in the above conditions is incorrect and causes the following problems:
- If the image’s size is **not** below the limit then the resize handles are misaligned with the image.
- If the image’s size is below the limit then resizing the image near the limit resets the width/height attributes to `auto` which causes a the image size to jump larger than the limit and the point above to occur.

## How?
Adds the block’s alignment class names to the element that the hook measures to determine the max-width. Also, because that makes for a little more work that doesn’t always need to happen, this extends the hook with an `isActive` prop so it can return early when the element is not going to be added.

## Testing Instructions
### Width limitation still works where it should
1. Paste in this Columns block with an image
   ```html
   <!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|20"}}}} -->
   <div class="wp-block-columns alignwide"><!-- wp:column {"width":"50%","style":{"border":{"width":"10px"}},"layout":{"type":"constrained"}} -->
   <div class="wp-block-column" style="border-width:10px;flex-basis:50%"><!-- wp:image {"aspectRatio":"1.2995249882919648","sizeSlug":"large","linkDestination":"none"} -->
   <figure class="wp-block-image size-large"><img src="https://pd.w.org/2021/05/97060b09513e73a89.38852584-2048x1536.jpeg" alt="" style="aspect-ratio:1.2995249882919648"/></figure>
   <!-- /wp:image --></div>
   <!-- /wp:column -->

   <!-- wp:column {"width":"50%","style":{"border":{"width":"10px"},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}}} -->
   <div class="wp-block-column" style="border-width:10px;padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30);flex-basis:50%"><!-- wp:paragraph -->
   <p>Borders applied to each column for visibility of their boundaries.</p>
   <!-- /wp:paragraph --></div>
   <!-- /wp:column --></div>
   <!-- /wp:columns -->
   ```
2. Resize the image with the drag handles
3. Confirm it is limited by the column’s width
4. Confirm when releasing the drag near or at the limit the size resets to "Auto"

### For unsized images aligned left or right, their width is limited or not depending on the active theme
1. Activate one of the following themes: TT5, TT4, TT3, TT2 
2. Open a Post or page
3. Paste in this image (it’s innate size is larger than the content width and it’s aligned left):
   ```html
   <!-- wp:image {"aspectRatio":"1.2995249882919648","sizeSlug":"large","linkDestination":"none","align":"left"} -->
   <figure class="wp-block-image alignleft size-large"><img src="https://pd.w.org/2021/05/97060b09513e73a89.38852584-2048x1536.jpeg" alt="" style="aspect-ratio:1.2995249882919648"/></figure>
   <!-- /wp:image -->
   ```
4. Confirm the resize handles are as expected (over the edges of the image)
5. Activate TT1 theme
6. Visit the previously tested post or re-paste the image into another
7. Confirm that the image’s width is limited (not by the container but by the theme’s styles).
8. Drag to resize the image and confirm that releasing near the limit resets the size to "Auto"


## Screenshots or screencast <!-- if applicable -->

### TT5
|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/8211a16f-e89d-4f76-8f0b-ef16e737df85"/>|<video src="https://github.com/user-attachments/assets/af9ff674-aa03-4141-85a5-9b8a7170ed76"/>|

### TT1
There’s actually no difference with this theme. It already works without this PR because the wrapper element added to align left/right images—through which the theme applies max-width styling to any child and that includes the element the hook measures.
|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/adecd996-c0ba-401c-895a-6014f92692b7"/>|<video src="https://github.com/user-attachments/assets/cfe35fe9-2eb4-4b94-a581-d1425e51ca20"/>|