### PR TITLE
Table Of Contents: Include headings exclusively within the `core/post-content` block

### DIFF
--- a/packages/block-library/src/table-of-contents/hooks.js
+++ b/packages/block-library/src/table-of-contents/hooks.js
@@ -18,6 +18,7 @@ function getLatestHeadings( select, clientId ) {
 		getBlockName,
 		getClientIdsWithDescendants,
 		getBlocksByName,
+		getBlockOrder,
 	} = select( blockEditorStore );
 
 	// FIXME: @wordpress/block-library should not depend on @wordpress/editor.
@@ -31,8 +32,27 @@ function getLatestHeadings( select, clientId ) {
 	const isPaginated = getBlocksByName( 'core/nextpage' ).length !== 0;
 	const { onlyIncludeCurrentPage } = getBlockAttributes( clientId ) ?? {};
 
+	// Get post-content block client ID.
+	const postContentBlocks = getBlocksByName( 'core/post-content' );
+	const postContentClientId = postContentBlocks?.[ 0 ];
+
+	const getPostContentDescendantBlocks = ( rootClientId ) => {
+		const children = getBlockOrder( rootClientId );
+		const descendants = [ ...children ];
+
+		for ( const childClientId of children ) {
+			descendants.push(
+				...getPostContentDescendantBlocks( childClientId )
+			);
+		}
+
+		return descendants;
+	};
+
 	// Get the client ids of all blocks in the editor.
-	const allBlockClientIds = getClientIdsWithDescendants();
+	const allBlockClientIds = !! postContentClientId
+		? getPostContentDescendantBlocks( postContentClientId )
+		: getClientIdsWithDescendants();
 
 	// If onlyIncludeCurrentPage is true, calculate the page (of a paginated post) this block is part of, so we know which headings to include; otherwise, skip the calculation.
 	let tocPage = 1;

--- a/packages/block-library/src/table-of-contents/hooks.js
+++ b/packages/block-library/src/table-of-contents/hooks.js
@@ -13,8 +13,12 @@ import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 function getLatestHeadings( select, clientId ) {
-	const { getBlockAttributes, getBlockName, getBlocksByName, getBlockOrder } =
-		select( blockEditorStore );
+	const {
+		getBlockAttributes,
+		getBlockName,
+		getBlocksByName,
+		getClientIdsOfDescendants,
+	} = select( blockEditorStore );
 
 	// FIXME: @wordpress/block-library should not depend on @wordpress/editor.
 	// Blocks can be loaded into a *non-post* block editor, so to avoid
@@ -28,26 +32,10 @@ function getLatestHeadings( select, clientId ) {
 	const { onlyIncludeCurrentPage } = getBlockAttributes( clientId ) ?? {};
 
 	// Get post-content block client ID.
-	const postContentBlocks = getBlocksByName( 'core/post-content' );
-	const postContentClientId = postContentBlocks?.[ 0 ];
-
-	const getPostContentDescendantBlocks = ( rootClientId ) => {
-		const children = getBlockOrder( rootClientId );
-		const descendants = [];
-
-		for ( const childClientId of children ) {
-			descendants.push( childClientId );
-			descendants.push(
-				...getPostContentDescendantBlocks( childClientId )
-			);
-		}
-
-		return descendants;
-	};
+	const [ postContentClientId = '' ] = getBlocksByName( 'core/post-content' );
 
 	// Get the client ids of all blocks in the editor.
-	const allBlockClientIds =
-		getPostContentDescendantBlocks( postContentClientId );
+	const allBlockClientIds = getClientIdsOfDescendants( postContentClientId );
 
 	// If onlyIncludeCurrentPage is true, calculate the page (of a paginated post) this block is part of, so we know which headings to include; otherwise, skip the calculation.
 	let tocPage = 1;

--- a/packages/block-library/src/table-of-contents/hooks.js
+++ b/packages/block-library/src/table-of-contents/hooks.js
@@ -33,9 +33,10 @@ function getLatestHeadings( select, clientId ) {
 
 	const getPostContentDescendantBlocks = ( rootClientId ) => {
 		const children = getBlockOrder( rootClientId );
-		const descendants = [ ...children ];
+		const descendants = [];
 
 		for ( const childClientId of children ) {
+			descendants.push( childClientId );
 			descendants.push(
 				...getPostContentDescendantBlocks( childClientId )
 			);

--- a/packages/block-library/src/table-of-contents/hooks.js
+++ b/packages/block-library/src/table-of-contents/hooks.js
@@ -13,13 +13,8 @@ import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 function getLatestHeadings( select, clientId ) {
-	const {
-		getBlockAttributes,
-		getBlockName,
-		getClientIdsWithDescendants,
-		getBlocksByName,
-		getBlockOrder,
-	} = select( blockEditorStore );
+	const { getBlockAttributes, getBlockName, getBlocksByName, getBlockOrder } =
+		select( blockEditorStore );
 
 	// FIXME: @wordpress/block-library should not depend on @wordpress/editor.
 	// Blocks can be loaded into a *non-post* block editor, so to avoid
@@ -50,9 +45,8 @@ function getLatestHeadings( select, clientId ) {
 	};
 
 	// Get the client ids of all blocks in the editor.
-	const allBlockClientIds = !! postContentClientId
-		? getPostContentDescendantBlocks( postContentClientId )
-		: getClientIdsWithDescendants();
+	const allBlockClientIds =
+		getPostContentDescendantBlocks( postContentClientId );
 
 	// If onlyIncludeCurrentPage is true, calculate the page (of a paginated post) this block is part of, so we know which headings to include; otherwise, skip the calculation.
 	let tocPage = 1;


### PR DESCRIPTION
## What?
Closes #69359 

This PR updates the logic to ensure the `Table of Contents` block only considers `Heading` elements within the `core/post-content` block. Previously, it included all headings on the page, including those in the `Header` and `Footer`, which could lead to unintended results.

## Why?

Including `Heading` elements from outside the `core/post-content` block—such as those in the `Header` and `Footer`—in the `Table of Contents` block is not ideal, as it should strictly focus on the main content. The block should serve its intended purpose of summarizing the structure of the post by tabulating only the `Heading` tags used within the post content.

## How?

The previous implementation used `getClientIdsWithDescendants` to get the client IDs of all the blocks in the editor. When the `Show Template` mode is toggled ( `template-locked` editing mode ), this selector literally returns all the blocks within the editor. That includes the `Header`, `Footer`, and the blocks within the `Template`. This behavior causes the bug mentioned above.

The current PR updates the usage to use `getClientIdsOfDescendants ` to exclusively get the nested blocks within the `post-content` using its `Client ID`. If the `Client ID` becomes undefined or an empty string for some reason ( e.g. when editing mode is set to post-only ), in such a scenario, it gracefully falls back to return the `top-level` blocks.

## Testing Instructions

1. Add `Heading` elements to the `Header`, `Footer`, or within the `Template`.  
2. Create a **new page**.  
3. Insert the **Table of Contents (TOC) block**.  
4. Add `Heading` elements inside the post content.  
5. Verify that the TOC block only includes headings from the post content and excludes those from the `Header`, `Footer`, or `Template`.  
6. Toggle **Show Template** and confirm that the behavior remains consistent.

## Screenshots

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/d1f61960-d8bb-4fd0-9169-901cd0f4d79d)|![after](https://github.com/user-attachments/assets/642b712b-2300-4343-a7ec-e75d3cf5e321)|

**_Testing edge cases_**
![recursion-test](https://github.com/user-attachments/assets/0c954043-3ad4-4e23-82c6-03d48bdc7fbc)
