### PR TITLE
Button Block: Add draft page creation capability

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -15,7 +15,13 @@ import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { useEffect, useState, useRef, useMemo } from '@wordpress/element';
+import {
+	useEffect,
+	useState,
+	useRef,
+	useMemo,
+	createInterpolateElement,
+} from '@wordpress/element';
 import {
 	TextControl,
 	ToolbarButton,
@@ -52,6 +58,49 @@ import {
 } from '@wordpress/blocks';
 import { useMergeRefs, useRefEffect } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { decodeEntities } from '@wordpress/html-entities';
+import {
+	store as coreStore,
+	useResourcePermissions,
+} from '@wordpress/core-data';
+
+/**
+ * Given the Link block's type attribute, return the query params to give to
+ * /wp/v2/search.
+ *
+ * @param {string} type Link block's type attribute.
+ * @param {string} kind Link block's entity of kind (post-type|taxonomy)
+ * @return {{ type?: string, subtype?: string }} Search query params.
+ */
+function getSuggestionsQuery( type, kind ) {
+	switch ( type ) {
+		case 'post':
+		case 'page':
+			return { type: 'post', subtype: type };
+		case 'category':
+			return { type: 'term', subtype: 'category' };
+		case 'tag':
+			return { type: 'term', subtype: 'post_tag' };
+		case 'post_format':
+			return { type: 'post-format' };
+		default:
+			if ( kind === 'taxonomy' ) {
+				return { type: 'term', subtype: type };
+			}
+			if ( kind === 'post-type' ) {
+				return { type: 'post', subtype: type };
+			}
+			return {
+				// for custom link which has no type
+				// always show pages as initial suggestions
+				initialSuggestionsSearchOptions: {
+					type: 'post',
+					subtype: 'page',
+					perPage: 20,
+				},
+			};
+	}
+}
 
 const LINK_SETTINGS = [
 	...LinkControl.DEFAULT_LINK_SETTINGS,
@@ -218,6 +267,28 @@ function ButtonEdit( props ) {
 	const opensInNewTab = linkTarget === NEW_TAB_TARGET;
 	const nofollow = !! rel?.includes( NOFOLLOW_REL );
 	const isLinkTag = 'a' === TagName;
+
+	const { saveEntityRecord } = useDispatch( coreStore );
+	const postType = 'page';
+	const permissions = useResourcePermissions( {
+		kind: 'postType',
+		name: postType,
+	} );
+
+	async function handleCreate( pageTitle ) {
+		const page = await saveEntityRecord( 'postType', postType, {
+			title: pageTitle,
+			status: 'draft',
+		} );
+
+		return {
+			id: page.id,
+			type: postType,
+			title: decodeEntities( page.title.rendered ),
+			url: page.link,
+			kind: 'post-type',
+		};
+	}
 
 	function startEditing( event ) {
 		event.preventDefault();
@@ -400,6 +471,27 @@ function ButtonEdit( props ) {
 							} }
 							forceIsEditingLink={ isEditingURL }
 							settings={ LINK_SETTINGS }
+							withCreateSuggestion={ permissions.canCreate }
+							createSuggestion={ handleCreate }
+							createSuggestionButtonText={ ( searchTerm ) => {
+								return createInterpolateElement(
+									sprintf(
+										/* translators: %s: search term. */
+										__(
+											'Create draft page: <mark>%s</mark>'
+										),
+										searchTerm
+									),
+									{
+										mark: <mark />,
+									}
+								);
+							} }
+							showInitialSuggestions
+							suggestionsQuery={ getSuggestionsQuery(
+								postType,
+								'post-type'
+							) }
 						/>
 					</Popover>
 				) }

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -59,44 +59,6 @@ import {
 import { useMergeRefs, useRefEffect } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 
-/**
- * Given the Link block's type attribute, return the query params to give to
- * /wp/v2/search.
- *
- * @param {string} type Link block's type attribute.
- * @param {string} kind Link block's entity of kind (post-type|taxonomy)
- * @return {{ type?: string, subtype?: string }} Search query params.
- */
-function getSuggestionsQuery( type, kind ) {
-	switch ( type ) {
-		case 'post':
-		case 'page':
-			return { type: 'post', subtype: type };
-		case 'category':
-			return { type: 'term', subtype: 'category' };
-		case 'tag':
-			return { type: 'term', subtype: 'post_tag' };
-		case 'post_format':
-			return { type: 'post-format' };
-		default:
-			if ( kind === 'taxonomy' ) {
-				return { type: 'term', subtype: type };
-			}
-			if ( kind === 'post-type' ) {
-				return { type: 'post', subtype: type };
-			}
-			return {
-				// for custom link which has no type
-				// always show pages as initial suggestions
-				initialSuggestionsSearchOptions: {
-					type: 'post',
-					subtype: 'page',
-					perPage: 20,
-				},
-			};
-	}
-}
-
 const LINK_SETTINGS = [
 	...LinkControl.DEFAULT_LINK_SETTINGS,
 	{
@@ -273,8 +235,7 @@ function ButtonEdit( props ) {
 				return {};
 			}
 
-			const { getSettings } = select( blockEditorStore );
-			const _settings = getSettings();
+			const _settings = select( blockEditorStore ).getSettings();
 
 			const blockBindingsSource = getBlockBindingsSource(
 				metadata?.bindings?.url?.source
@@ -484,11 +445,6 @@ function ButtonEdit( props ) {
 							}
 							withCreateSuggestion={ userCanCreatePages }
 							createSuggestionButtonText={ createButtonText }
-							showInitialSuggestions
-							suggestionsQuery={ getSuggestionsQuery(
-								'page',
-								'post-type'
-							) }
 						/>
 					</Popover>
 				) }

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -58,11 +58,6 @@ import {
 } from '@wordpress/blocks';
 import { useMergeRefs, useRefEffect } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { decodeEntities } from '@wordpress/html-entities';
-import {
-	store as coreStore,
-	useResourcePermissions,
-} from '@wordpress/core-data';
 
 /**
  * Given the Link block's type attribute, return the query params to give to
@@ -268,26 +263,62 @@ function ButtonEdit( props ) {
 	const nofollow = !! rel?.includes( NOFOLLOW_REL );
 	const isLinkTag = 'a' === TagName;
 
-	const { saveEntityRecord } = useDispatch( coreStore );
-	const postType = 'page';
-	const permissions = useResourcePermissions( {
-		kind: 'postType',
-		name: postType,
-	} );
+	const {
+		createPageEntity,
+		userCanCreatePages,
+		lockUrlControls = false,
+	} = useSelect(
+		( select ) => {
+			if ( ! isSelected ) {
+				return {};
+			}
+
+			const { getSettings } = select( blockEditorStore );
+			const _settings = getSettings();
+
+			const blockBindingsSource = getBlockBindingsSource(
+				metadata?.bindings?.url?.source
+			);
+
+			return {
+				createPageEntity: _settings.__experimentalCreatePageEntity,
+				userCanCreatePages: _settings.__experimentalUserCanCreatePages,
+				lockUrlControls:
+					!! metadata?.bindings?.url &&
+					! blockBindingsSource?.canUserEditValue?.( {
+						select,
+						context,
+						args: metadata?.bindings?.url?.args,
+					} ),
+			};
+		},
+		[ context, isSelected, metadata?.bindings?.url ]
+	);
 
 	async function handleCreate( pageTitle ) {
-		const page = await saveEntityRecord( 'postType', postType, {
+		const page = await createPageEntity( {
 			title: pageTitle,
 			status: 'draft',
 		} );
 
 		return {
 			id: page.id,
-			type: postType,
-			title: decodeEntities( page.title.rendered ),
+			type: page.type,
+			title: page.title.rendered,
 			url: page.link,
 			kind: 'post-type',
 		};
+	}
+
+	function createButtonText( searchTerm ) {
+		return createInterpolateElement(
+			sprintf(
+				/* translators: %s: search term. */
+				__( 'Create page: <mark>%s</mark>' ),
+				searchTerm
+			),
+			{ mark: <mark /> }
+		);
 	}
 
 	function startEditing( event ) {
@@ -319,29 +350,6 @@ function ButtonEdit( props ) {
 
 	const useEnterRef = useEnter( { content: text, clientId } );
 	const mergedRef = useMergeRefs( [ useEnterRef, richTextRef ] );
-
-	const { lockUrlControls = false } = useSelect(
-		( select ) => {
-			if ( ! isSelected ) {
-				return {};
-			}
-
-			const blockBindingsSource = getBlockBindingsSource(
-				metadata?.bindings?.url?.source
-			);
-
-			return {
-				lockUrlControls:
-					!! metadata?.bindings?.url &&
-					! blockBindingsSource?.canUserEditValue?.( {
-						select,
-						context,
-						args: metadata?.bindings?.url?.args,
-					} ),
-			};
-		},
-		[ context, isSelected, metadata?.bindings?.url ]
-	);
 
 	const [ fluidTypographySettings, layout ] = useSettings(
 		'typography.fluid',
@@ -471,25 +479,14 @@ function ButtonEdit( props ) {
 							} }
 							forceIsEditingLink={ isEditingURL }
 							settings={ LINK_SETTINGS }
-							withCreateSuggestion={ permissions.canCreate }
-							createSuggestion={ handleCreate }
-							createSuggestionButtonText={ ( searchTerm ) => {
-								return createInterpolateElement(
-									sprintf(
-										/* translators: %s: search term. */
-										__(
-											'Create draft page: <mark>%s</mark>'
-										),
-										searchTerm
-									),
-									{
-										mark: <mark />,
-									}
-								);
-							} }
+							createSuggestion={
+								createPageEntity && handleCreate
+							}
+							withCreateSuggestion={ userCanCreatePages }
+							createSuggestionButtonText={ createButtonText }
 							showInitialSuggestions
 							suggestionsQuery={ getSuggestionsQuery(
-								postType,
+								'page',
 								'post-type'
 							) }
 						/>


### PR DESCRIPTION
Closes #56163

## What?
This PR adds the ability to create draft pages directly from the button block in the navigation editor, similar to how it already works in the navigation link block.

## Why?
Currently, users can create a draft page from the custom link block in the navigation editor if the page doesn't exist, but this functionality isn't available in the button block. This PR addresses this inconsistency by implementing the same feature in the button block, providing a more consistent editing experience.

## How?
1. Adds draft page creation functionality to the button block's LinkControl component
2. Imports necessary components and utilities from WordPress core
3. Adds permission checks to control when the draft creation feature is available
4. Uses the same pattern already implemented in the navigation link block

## Testing Instructions
1. Create a new post or page
2. Insert a navigation block
3. Add a button block to the navigation
4. Click on the link icon in the toolbar to edit the link
5. In the link search field, enter a page name that doesn't exist yet
6. Verify that an option appears to "Create draft page: [your search term]"
7. Click on this option and verify that a draft page is created and linked

## Screenshots or screencast <!-- if applicable -->

### Before
https://github.com/user-attachments/assets/9acbf1d2-4f18-41cf-b203-96a868228bb8

### After
https://github.com/user-attachments/assets/6c0b43ec-e4b8-4f8b-940a-6662ce8f6a0f
