### PR TITLE
Components: Split `MenuItem` label and description for accessibility

### DIFF
--- a/packages/components/src/menu-item/index.tsx
+++ b/packages/components/src/menu-item/index.tsx
@@ -3,12 +3,12 @@
  */
 import type { ForwardedRef } from 'react';
 import clsx from 'clsx';
-import { v4 as uuidv4 } from 'uuid';
 
 /**
  * WordPress dependencies
  */
 import { cloneElement, forwardRef } from '@wordpress/element';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -38,27 +38,25 @@ function UnforwardedMenuItem(
 
 	className = clsx( 'components-menu-item__button', className );
 
-	const buttonProps = { ...restProps };
-	if ( info ) {
-		const labelId = `menu-item-label-${ uuidv4() }`;
-		const descriptionId = `menu-item-description-${ uuidv4() }`;
+	const descriptionId = useInstanceId(
+		UnforwardedMenuItem,
+		'menu-item-description'
+	);
 
+	const buttonProps = {
+		...( info ? { 'aria-describedby': descriptionId } : {} ),
+		...restProps,
+	};
+
+	if ( info ) {
 		children = (
 			<span className="components-menu-item__info-wrapper">
-				<span id={ labelId } className="components-menu-item__item">
-					{ children }
-				</span>
+				<span className="components-menu-item__item">{ children }</span>
 				<span className="components-menu-item__info" aria-hidden="true">
-					{ info }
-				</span>
-				<span id={ descriptionId } className="screen-reader-text">
 					{ info }
 				</span>
 			</span>
 		);
-
-		buttonProps[ 'aria-labelledby' ] = labelId;
-		buttonProps[ 'aria-describedby' ] = descriptionId;
 	}
 
 	if ( icon && typeof icon !== 'string' ) {
@@ -70,32 +68,38 @@ function UnforwardedMenuItem(
 	}
 
 	return (
-		<Button
-			__next40pxDefaultSize
-			ref={ ref }
-			// Make sure aria-checked matches spec https://www.w3.org/TR/wai-aria-1.1/#aria-checked
-			aria-checked={
-				role === 'menuitemcheckbox' || role === 'menuitemradio'
-					? isSelected
-					: undefined
-			}
-			role={ role }
-			icon={ iconPosition === 'left' ? icon : undefined }
-			className={ className }
-			{ ...buttonProps }
-		>
-			<span className="components-menu-item__item">{ children }</span>
-			{ ! suffix && (
-				<Shortcut
-					className="components-menu-item__shortcut"
-					shortcut={ shortcut }
-				/>
+		<>
+			<Button
+				__next40pxDefaultSize
+				ref={ ref }
+				aria-checked={
+					role === 'menuitemcheckbox' || role === 'menuitemradio'
+						? isSelected
+						: undefined
+				}
+				role={ role }
+				icon={ iconPosition === 'left' ? icon : undefined }
+				className={ className }
+				{ ...buttonProps }
+			>
+				{ children }
+				{ ! suffix && (
+					<Shortcut
+						className="components-menu-item__shortcut"
+						shortcut={ shortcut }
+					/>
+				) }
+				{ ! suffix && icon && iconPosition === 'right' && (
+					<Icon icon={ icon } />
+				) }
+				{ suffix }
+			</Button>
+			{ info && (
+				<span id={ descriptionId } className="screen-reader-text">
+					{ info }
+				</span>
 			) }
-			{ ! suffix && icon && iconPosition === 'right' && (
-				<Icon icon={ icon } />
-			) }
-			{ suffix }
-		</Button>
+		</>
 	);
 }
 

--- a/packages/components/src/menu-item/index.tsx
+++ b/packages/components/src/menu-item/index.tsx
@@ -51,7 +51,7 @@ function UnforwardedMenuItem(
 				<span className="components-menu-item__info" aria-hidden="true">
 					{ info }
 				</span>
-				<span id={ descriptionId } className="screen-reader-text ">
+				<span id={ descriptionId } className="screen-reader-text">
 					{ info }
 				</span>
 			</span>

--- a/packages/components/src/menu-item/index.tsx
+++ b/packages/components/src/menu-item/index.tsx
@@ -3,6 +3,7 @@
  */
 import type { ForwardedRef } from 'react';
 import clsx from 'clsx';
+import { v4 as uuidv4 } from 'uuid';
 
 /**
  * WordPress dependencies
@@ -32,18 +33,32 @@ function UnforwardedMenuItem(
 		isSelected,
 		role = 'menuitem',
 		suffix,
-		...buttonProps
+		...restProps
 	} = props;
 
 	className = clsx( 'components-menu-item__button', className );
 
+	const buttonProps = { ...restProps };
 	if ( info ) {
+		const labelId = `menu-item-label-${ uuidv4() }`;
+		const descriptionId = `menu-item-description-${ uuidv4() }`;
+
 		children = (
 			<span className="components-menu-item__info-wrapper">
-				<span className="components-menu-item__item">{ children }</span>
-				<span className="components-menu-item__info">{ info }</span>
+				<span id={ labelId } className="components-menu-item__item">
+					{ children }
+				</span>
+				<span className="components-menu-item__info" aria-hidden="true">
+					{ info }
+				</span>
+				<span id={ descriptionId } className="screen-reader-text">
+					{ info }
+				</span>
 			</span>
 		);
+
+		buttonProps[ 'aria-labelledby' ] = labelId;
+		buttonProps[ 'aria-describedby' ] = descriptionId;
 	}
 
 	if ( icon && typeof icon !== 'string' ) {

--- a/packages/components/src/menu-item/index.tsx
+++ b/packages/components/src/menu-item/index.tsx
@@ -51,7 +51,7 @@ function UnforwardedMenuItem(
 				<span className="components-menu-item__info" aria-hidden="true">
 					{ info }
 				</span>
-				<span id={ descriptionId } className="screen-reader-text">
+				<span id={ descriptionId } className="screen-reader-text ">
 					{ info }
 				</span>
 			</span>


### PR DESCRIPTION

## What?
Closes #58720

This PR updates the `MenuItem` component to properly separate its accessible name (children text) and accessible description (info text). Previously, both children and info were combined into the accessible name, leading to overly long and unclear labels for assistive technology users.

## Why?
The info text was incorrectly included in the accessible name, causing issues such as:

  - Overly long and confusing labels, making screen readers harder to use.
  - Difficulties with voice activation, as users had to speak the full label, including the extra info.


## How?

- Keeps children as the accessible name and references info via aria-describedby for a separate description.
- Uses aria-hidden="true" to prevent redundancy while preserving the visual design.

### Testing Instructions for Keyboard

1. Add a new post in the editor.
2. Insert an image block.
3. Click on the link or alignment options.
4. Using the Tab key, navigate down to a menu item that has both a dark label (the title) and a lighter label (the description).
5. Verify that the screen reader now correctly treats the dark label as the accessible name and the lighter label as the description.
6. Ensure that navigating with Tab and Arrow keys moves focus correctly between menu items.
7. Confirm that the name includes only the children, and the description (info) is announced separately.

## Screenshots

|Before|After|
|-|-|
|<img width="1470" alt="Screenshot 2025-02-28 at 10 37 46 PM" src="https://github.com/user-attachments/assets/81a48326-c350-4bfb-9b9e-730a5cc63172" />|<img width="1461" alt="Screenshot 2025-02-28 at 10 45 38 PM" src="https://github.com/user-attachments/assets/c1eacdf1-dd61-4386-a890-e1fd5a739509" />
|




|Before|After|
|-|-|
|<img width="1451" alt="Screenshot 2025-02-28 at 10 41 07 PM" src="https://github.com/user-attachments/assets/141851d1-ea6d-4d62-8888-43d3bec1f4c1" />|<img width="1470" alt="Screenshot 2025-02-28 at 10 35 56 PM" src="https://github.com/user-attachments/assets/06316850-9ec1-487a-a957-2cf8551c51a6" />|









