### PR TITLE
ColorPalette components: Changed Props from `__experimentalIsRenderedInSidebar` to `isRenderedLeftStart`

### DIFF
--- a/packages/components/src/color-palette/index.tsx
+++ b/packages/components/src/color-palette/index.tsx
@@ -13,6 +13,7 @@ import clsx from 'clsx';
 import { useInstanceId } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useMemo, useState, forwardRef } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -135,7 +136,7 @@ function MultiplePalettes( {
 }
 
 export function CustomColorPickerDropdown( {
-	isRenderedInSidebar,
+	isRenderedLeftStart,
 	popoverProps: receivedPopoverProps,
 	...props
 }: CustomColorPickerDropdownProps ) {
@@ -146,7 +147,7 @@ export function CustomColorPickerDropdown( {
 			// scrollbars while dragging the color picker's handle close to the
 			// popover edge.
 			resize: false,
-			...( isRenderedInSidebar
+			...( isRenderedLeftStart
 				? {
 						// When in the sidebar: open to the left (stacking),
 						// leaving the same gap as the parent popover.
@@ -160,7 +161,7 @@ export function CustomColorPickerDropdown( {
 				  } ),
 			...receivedPopoverProps,
 		} ),
-		[ isRenderedInSidebar, receivedPopoverProps ]
+		[ isRenderedLeftStart, receivedPopoverProps ]
 	);
 
 	return (
@@ -186,6 +187,7 @@ function UnforwardedColorPalette(
 		onChange,
 		value,
 		__experimentalIsRenderedInSidebar = false,
+		isRenderedLeftStart = false,
 		headingLevel = 2,
 		'aria-label': ariaLabel,
 		'aria-labelledby': ariaLabelledby,
@@ -260,11 +262,23 @@ function UnforwardedColorPalette(
 		ariaLabelledby
 	);
 
+	let _isRenderedLeftStart = isRenderedLeftStart;
+	if ( !! __experimentalIsRenderedInSidebar ) {
+		deprecated(
+			'`__experimentalIsRenderedInSidebar` prop in wp.components.ColorPalette',
+			{
+				since: '6.8',
+				alternative: '`isRenderedLeftStart` prop',
+			}
+		);
+		_isRenderedLeftStart = __experimentalIsRenderedInSidebar;
+	}
+
 	return (
 		<VStack spacing={ 3 } ref={ forwardedRef } { ...additionalProps }>
 			{ ! disableCustomColors && (
 				<CustomColorPickerDropdown
-					isRenderedInSidebar={ __experimentalIsRenderedInSidebar }
+					isRenderedLeftStart={ _isRenderedLeftStart }
 					renderContent={ renderCustomColorPicker }
 					renderToggle={ ( { isOpen, onToggle } ) => (
 						<VStack

--- a/packages/components/src/color-palette/types.ts
+++ b/packages/components/src/color-palette/types.ts
@@ -40,7 +40,8 @@ export type MultiplePalettesProps = PaletteProps & {
 };
 
 export type CustomColorPickerDropdownProps = DropdownProps & {
-	isRenderedInSidebar: boolean;
+	isRenderedInSidebar?: boolean;
+	isRenderedLeftStart?: boolean;
 };
 
 export type ColorPaletteProps = Pick< PaletteProps, 'onChange' > & {
@@ -102,6 +103,12 @@ export type ColorPaletteProps = Pick< PaletteProps, 'onChange' > & {
 	 * @default false
 	 */
 	__experimentalIsRenderedInSidebar?: boolean;
+	/**
+	 * Whether this is rendered in the sidebar.
+	 *
+	 * @default false
+	 */
+	isRenderedLeftStart?: boolean;
 } & (
 		| {
 				/**

--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -143,7 +143,7 @@ function ColorPicker( { name, property, value, onChange } ) {
 				);
 			} }
 			// Prevent the text and color picker from overlapping.
-			__experimentalIsRenderedInSidebar
+			isRenderedLeftStart
 		/>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
I will correct it according to the comment in the PR below.
https://github.com/WordPress/gutenberg/pull/69169#issuecomment-2688179009

Changed Props from `__experimentalIsRenderedInSidebar` to `isRenderedLeftStart`

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

`__experimentalIsRenderedInSidebar` is not a good prop name, so change it to `isRenderedLeftStart`.

The names of the props are based on the placement.
https://github.com/WordPress/gutenberg/blob/4e3b75923e733809f0dcd4e0fbc47313f137d4d9/packages/components/src/color-palette/index.tsx#L149-L161


I will migrate `__experimentalIsRenderedInSidebar` to `isRenderedLeftStart` for components other than `packages/format-library/src/text-color/inline.js` in a separate branch.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a Paragraph block.
3. Inline text color selection works as before.
4. Sidebar colors also work as before, and you'll get a deprecation warning in the console.

