### PR TITLE
Button: Remove fixed width from small and compact buttons with icons

### DIFF
--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -284,6 +284,9 @@ export default function CommentTemplateEdit( {
 	);
 
 	if ( ! topLevelComments ) {
+		if ( postId && commentQuery ) {
+			return <p { ...blockProps }>{ __( 'No results found.' ) }</p>;
+		}
 		return (
 			<p { ...blockProps }>
 				<Spinner />

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -284,9 +284,6 @@ export default function CommentTemplateEdit( {
 	);
 
 	if ( ! topLevelComments ) {
-		if ( postId && commentQuery ) {
-			return <p { ...blockProps }>{ __( 'No results found.' ) }</p>;
-		}
 		return (
 			<p { ...blockProps }>
 				<Spinner />

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 -   `TextControl`: Ensures email and url inputs have consistent LTR alignment in RTL languages ([#68561](https://github.com/WordPress/gutenberg/pull/68561)).
 -   `InputControl`: Ensure consistent placeholder color ([#69334](https://github.com/WordPress/gutenberg/pull/69334)).
+-   `Button`: Remove fixed width from small and compact buttons with icons ([#69378](https://github.com/WordPress/gutenberg/pull/69378)).
 
 ### Enhancement
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `Button`: Remove fixed width from small and compact buttons with icons ([#69378](https://github.com/WordPress/gutenberg/pull/69378)).
+
 ## 29.5.0 (2025-02-28)
 
 ### Documentation

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -16,7 +16,6 @@
 
 -   `TextControl`: Ensures email and url inputs have consistent LTR alignment in RTL languages ([#68561](https://github.com/WordPress/gutenberg/pull/68561)).
 -   `InputControl`: Ensure consistent placeholder color ([#69334](https://github.com/WordPress/gutenberg/pull/69334)).
--   `Button`: Remove fixed width from small and compact buttons with icons ([#69378](https://github.com/WordPress/gutenberg/pull/69378)).
 
 ### Enhancement
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -302,7 +302,6 @@
 
 		&.has-icon:not(.has-text) {
 			padding: 0;
-			width: $button-size-compact;
 			min-width: $button-size-compact;
 		}
 	}
@@ -315,7 +314,6 @@
 
 		&.has-icon:not(.has-text) {
 			padding: 0;
-			width: $button-size-small;
 			min-width: $button-size-small;
 		}
 	}


### PR DESCRIPTION
## What?

Closes #63247

This PR removes the fixed width from small and compact button variants when they contain icons but no text, relying on min-width for proper spacing.



## Why?


The current implementation assigns a fixed width to both small and compact button sizes when they have an icon but no text. However, this creates issues with the "Show button text labels" editor preference, which adds text via CSS-generated content. Since the button width is fixed, this generated text can overflow and overlap with surrounding content.

The fixed width appears unnecessary, as the icon size is already constrained. The existing `min-width` property is sufficient to maintain consistent button dimensions.

## How?

- Removed `width: $button-size-compact;` from the compact button style
- Removed `width: $button-size-small;` from the small button style

This allows buttons to naturally expand to fit their content, including when CSS-generated text is added via the "Show button text labels" preference.

## Testing Instructions

- Open the Post Editor
- Open the editor preferences (⋮ menu → Preferences)
- Enable "Show button text labels"
- Observe various buttons throughout the editor interface with the class `.is-compact` or `.is-small`
- Verify that all button labels display properly without overflowing


## Screenshot

Screenshot of the applied fixed width getting overridden everytime which can be safely removed - 


<img width="678" alt="Screenshot 2025-03-02 at 21 22 44" src="https://github.com/user-attachments/assets/f2008790-0ea2-4d00-8948-80dc0151902f" />

