### PR TITLE
Navigation Block: Add transparency slider for submenu background

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -143,6 +143,7 @@ function ColorTools( {
 						onColorChange: setTextColor,
 						resetAllFilter: () => setTextColor(),
 						clearable: true,
+						enableAlpha: true,
 					},
 					{
 						colorValue: backgroundColor.color,
@@ -150,6 +151,7 @@ function ColorTools( {
 						onColorChange: setBackgroundColor,
 						resetAllFilter: () => setBackgroundColor(),
 						clearable: true,
+						enableAlpha: true,
 					},
 					{
 						colorValue: overlayTextColor.color,
@@ -157,6 +159,7 @@ function ColorTools( {
 						onColorChange: setOverlayTextColor,
 						resetAllFilter: () => setOverlayTextColor(),
 						clearable: true,
+						enableAlpha: true,
 					},
 					{
 						colorValue: overlayBackgroundColor.color,

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -164,6 +164,7 @@ function ColorTools( {
 						onColorChange: setOverlayBackgroundColor,
 						resetAllFilter: () => setOverlayBackgroundColor(),
 						clearable: true,
+						enableAlpha: true,
 					},
 				] }
 				panelId={ clientId }


### PR DESCRIPTION
Closes: #53487

## What?
This PR adds the ability to set a transparent background for Navigation Block submenus by enabling the alpha (transparency) channel in the color picker for the submenu background setting.

## Why?
Currently, users who want their submenu background to be transparent (to match the transparent background of the navigation block) have to use custom CSS. When no background color is set, submenus default to a white background, and the existing color picker doesn't allow for transparency settings.

This improvement creates a more intuitive user experience by allowing transparency to be set directly from the editor interface without requiring custom code.

## How?
The implementation adds the `enableAlpha: true` property to the color settings for the submenu & overlay background in the `ColorGradientSettingsDropdown` component. This enables the transparency slider in the WordPress color picker component, allowing users to select any level of transparency for submenu backgrounds.

## Testing Instructions
1. Create a new page/post and add a Navigation Block
2. Add a submenu item to the navigation
3. In the sidebar, under the Color panel, find the "Submenu & overlay background" color setting
Select a custom color
4. Verify that a transparency/opacity slider is now available
5. Adjust the transparency and check that the submenu background shows the correct transparency level

## Screenshots or screencast
### Before
https://github.com/user-attachments/assets/08bc1458-26d2-410d-8661-eef89f150e92

### After
https://github.com/user-attachments/assets/aa3e5658-ce4e-4e69-a6dc-db4f6e722bf5

