### PR TITLE
Docs: Add Block Manager readme

### DIFF
--- a/packages/block-editor/src/components/block-manager/README.md
+++ b/packages/block-editor/src/components/block-manager/README.md
@@ -1,0 +1,50 @@
+# Block Manager
+
+The Block Manager component is a component that allows the user to manage the blocks in the editor. It provides a list of blocks that are currently in the editor, and allows the user to select a block to focus on it.
+
+## Table of contents
+
+1. [Development guidelines](#development-guidelines)
+2. [Related components](#related-components)
+
+## Development guidelines
+
+### Usage
+
+Renders a block manager component.
+
+```jsx
+import { BlockManager } from '@wordpress/block-editor';
+
+const MyBlockManager = () => (
+	<BlockManager
+		blockTypes={ blockTypes }
+		selectedBlockTypes={ selectedBlockTypes }
+		onChange={ onChange }
+	/>
+);
+```
+
+### Props
+
+### `blockTypes`
+
+-   **Type:** `Array`
+
+An array of block types that are currently in the editor.
+
+### `selectedBlockTypes`
+
+-   **Type:** `Array`
+
+An array of block types that are currently selected.
+
+### `onChange`
+
+-   **Type:** `Function`
+
+A function that is called when the user selects a block type. It receives an array of block types as an argument.
+
+## Related components
+
+Block Editor components are components that can be used to compose the UI of your block editor. Thus, they can only be used under a [BlockEditorProvider](https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/provider/README.md) in the components tree.


### PR DESCRIPTION


## What?
Part of https://github.com/WordPress/gutenberg/issues/22891


## Why?
This PR adds the Readme for Block Manager Component 


## Testing Instructions
None.

## Screenshots or screencast 

None.
