### PR TITLE
List Block: Refactor setting panel to use ToolsPanel

### DIFF
--- a/packages/block-library/src/list/ordered-list-settings.js
+++ b/packages/block-library/src/list/ordered-list-settings.js
@@ -5,11 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 import {
 	TextControl,
+	PanelBody,
 	ToggleControl,
 	SelectControl,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
+import { Platform } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -18,6 +20,78 @@ import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const OrderedListSettings = ( { setAttributes, reversed, start, type } ) => {
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+
+	if ( Platform.isNative ) {
+		return (
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings' ) }>
+					<SelectControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'List style' ) }
+						options={ [
+							{
+								label: __( 'Numbers' ),
+								value: 'decimal',
+							},
+							{
+								label: __( 'Uppercase letters' ),
+								value: 'upper-alpha',
+							},
+							{
+								label: __( 'Lowercase letters' ),
+								value: 'lower-alpha',
+							},
+							{
+								label: __( 'Uppercase Roman numerals' ),
+								value: 'upper-roman',
+							},
+							{
+								label: __( 'Lowercase Roman numerals' ),
+								value: 'lower-roman',
+							},
+						] }
+						value={ type }
+						onChange={ ( newValue ) =>
+							setAttributes( { type: newValue } )
+						}
+					/>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Start value' ) }
+						type="number"
+						onChange={ ( value ) => {
+							const int = parseInt( value, 10 );
+
+							setAttributes( {
+								// It should be possible to unset the value,
+								// e.g. with an empty string.
+								start: isNaN( int ) ? undefined : int,
+							} );
+						} }
+						value={
+							Number.isInteger( start )
+								? start.toString( 10 )
+								: ''
+						}
+						step="1"
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Reverse order' ) }
+						checked={ reversed || false }
+						onChange={ ( value ) => {
+							setAttributes( {
+								// Unset the attribute if not reversed.
+								reversed: value || undefined,
+							} );
+						} }
+					/>
+				</PanelBody>
+			</InspectorControls>
+		);
+	}
 
 	return (
 		<InspectorControls>

--- a/packages/block-library/src/list/ordered-list-settings.js
+++ b/packages/block-library/src/list/ordered-list-settings.js
@@ -5,73 +5,132 @@ import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 import {
 	TextControl,
-	PanelBody,
 	ToggleControl,
 	SelectControl,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 
-const OrderedListSettings = ( { setAttributes, reversed, start, type } ) => (
-	<InspectorControls>
-		<PanelBody title={ __( 'Settings' ) }>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ __( 'List style' ) }
-				options={ [
-					{
-						label: __( 'Numbers' ),
-						value: 'decimal',
-					},
-					{
-						label: __( 'Uppercase letters' ),
-						value: 'upper-alpha',
-					},
-					{
-						label: __( 'Lowercase letters' ),
-						value: 'lower-alpha',
-					},
-					{
-						label: __( 'Uppercase Roman numerals' ),
-						value: 'upper-roman',
-					},
-					{
-						label: __( 'Lowercase Roman numerals' ),
-						value: 'lower-roman',
-					},
-				] }
-				value={ type }
-				onChange={ ( newValue ) => setAttributes( { type: newValue } ) }
-			/>
-			<TextControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ __( 'Start value' ) }
-				type="number"
-				onChange={ ( value ) => {
-					const int = parseInt( value, 10 );
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
+const OrderedListSettings = ( { setAttributes, reversed, start, type } ) => {
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+
+	return (
+		<InspectorControls>
+			<ToolsPanel
+				label={ __( 'Settings' ) }
+				resetAll={ () => {
 					setAttributes( {
-						// It should be possible to unset the value,
-						// e.g. with an empty string.
-						start: isNaN( int ) ? undefined : int,
+						type: undefined,
+						start: undefined,
+						reversed: undefined,
 					} );
 				} }
-				value={ Number.isInteger( start ) ? start.toString( 10 ) : '' }
-				step="1"
-			/>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ __( 'Reverse order' ) }
-				checked={ reversed || false }
-				onChange={ ( value ) => {
-					setAttributes( {
-						// Unset the attribute if not reversed.
-						reversed: value || undefined,
-					} );
-				} }
-			/>
-		</PanelBody>
-	</InspectorControls>
-);
+				dropdownMenuProps={ dropdownMenuProps }
+			>
+				<ToolsPanelItem
+					label={ __( 'List style' ) }
+					isShownByDefault
+					hasValue={ () => !! type }
+					onDeselect={ () =>
+						setAttributes( {
+							type: undefined,
+						} )
+					}
+				>
+					<SelectControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'List style' ) }
+						options={ [
+							{
+								label: __( 'Numbers' ),
+								value: 'decimal',
+							},
+							{
+								label: __( 'Uppercase letters' ),
+								value: 'upper-alpha',
+							},
+							{
+								label: __( 'Lowercase letters' ),
+								value: 'lower-alpha',
+							},
+							{
+								label: __( 'Uppercase Roman numerals' ),
+								value: 'upper-roman',
+							},
+							{
+								label: __( 'Lowercase Roman numerals' ),
+								value: 'lower-roman',
+							},
+						] }
+						value={ type || 'decimal' }
+						onChange={ ( newValue ) =>
+							setAttributes( { type: newValue } )
+						}
+					/>
+				</ToolsPanelItem>
+				<ToolsPanelItem
+					label={ __( 'Start value' ) }
+					isShownByDefault
+					hasValue={ () => !! start }
+					onDeselect={ () =>
+						setAttributes( {
+							start: undefined,
+						} )
+					}
+				>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Start value' ) }
+						type="number"
+						onChange={ ( value ) => {
+							const int = parseInt( value, 10 );
+
+							setAttributes( {
+								// It should be possible to unset the value,
+								// e.g. with an empty string.
+								start: isNaN( int ) ? undefined : int,
+							} );
+						} }
+						value={
+							Number.isInteger( start )
+								? start.toString( 10 )
+								: ''
+						}
+						step="1"
+					/>
+				</ToolsPanelItem>
+				<ToolsPanelItem
+					label={ __( 'Reverse order' ) }
+					isShownByDefault
+					hasValue={ () => !! reversed }
+					onDeselect={ () =>
+						setAttributes( {
+							reversed: undefined,
+						} )
+					}
+				>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Reverse order' ) }
+						checked={ reversed || false }
+						onChange={ ( value ) => {
+							setAttributes( {
+								// Unset the attribute if not reversed.
+								reversed: value || undefined,
+							} );
+						} }
+					/>
+				</ToolsPanelItem>
+			</ToolsPanel>
+		</InspectorControls>
+	);
+};
 
 export default OrderedListSettings;

--- a/packages/block-library/src/list/ordered-list-settings.js
+++ b/packages/block-library/src/list/ordered-list-settings.js
@@ -18,39 +18,41 @@ import { Platform } from '@wordpress/element';
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
+const LIST_STYLE_OPTIONS = [
+	{
+		label: __( 'Numbers' ),
+		value: 'decimal',
+	},
+	{
+		label: __( 'Uppercase letters' ),
+		value: 'upper-alpha',
+	},
+	{
+		label: __( 'Lowercase letters' ),
+		value: 'lower-alpha',
+	},
+	{
+		label: __( 'Uppercase Roman numerals' ),
+		value: 'upper-roman',
+	},
+	{
+		label: __( 'Lowercase Roman numerals' ),
+		value: 'lower-roman',
+	},
+];
+
 const OrderedListSettings = ( { setAttributes, reversed, start, type } ) => {
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
-	if ( Platform.isNative ) {
-		return (
-			<InspectorControls>
+	return (
+		<InspectorControls>
+			{ Platform.isNative ? (
 				<PanelBody title={ __( 'Settings' ) }>
 					<SelectControl
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
 						label={ __( 'List style' ) }
-						options={ [
-							{
-								label: __( 'Numbers' ),
-								value: 'decimal',
-							},
-							{
-								label: __( 'Uppercase letters' ),
-								value: 'upper-alpha',
-							},
-							{
-								label: __( 'Lowercase letters' ),
-								value: 'lower-alpha',
-							},
-							{
-								label: __( 'Uppercase Roman numerals' ),
-								value: 'upper-roman',
-							},
-							{
-								label: __( 'Lowercase Roman numerals' ),
-								value: 'lower-roman',
-							},
-						] }
+						options={ LIST_STYLE_OPTIONS }
 						value={ type }
 						onChange={ ( newValue ) =>
 							setAttributes( { type: newValue } )
@@ -89,120 +91,95 @@ const OrderedListSettings = ( { setAttributes, reversed, start, type } ) => {
 						} }
 					/>
 				</PanelBody>
-			</InspectorControls>
-		);
-	}
-
-	return (
-		<InspectorControls>
-			<ToolsPanel
-				label={ __( 'Settings' ) }
-				resetAll={ () => {
-					setAttributes( {
-						type: undefined,
-						start: undefined,
-						reversed: undefined,
-					} );
-				} }
-				dropdownMenuProps={ dropdownMenuProps }
-			>
-				<ToolsPanelItem
-					label={ __( 'List style' ) }
-					isShownByDefault
-					hasValue={ () => !! type }
-					onDeselect={ () =>
+			) : (
+				<ToolsPanel
+					label={ __( 'Settings' ) }
+					resetAll={ () => {
 						setAttributes( {
 							type: undefined,
-						} )
-					}
-				>
-					<SelectControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						label={ __( 'List style' ) }
-						options={ [
-							{
-								label: __( 'Numbers' ),
-								value: 'decimal',
-							},
-							{
-								label: __( 'Uppercase letters' ),
-								value: 'upper-alpha',
-							},
-							{
-								label: __( 'Lowercase letters' ),
-								value: 'lower-alpha',
-							},
-							{
-								label: __( 'Uppercase Roman numerals' ),
-								value: 'upper-roman',
-							},
-							{
-								label: __( 'Lowercase Roman numerals' ),
-								value: 'lower-roman',
-							},
-						] }
-						value={ type || 'decimal' }
-						onChange={ ( newValue ) =>
-							setAttributes( { type: newValue } )
-						}
-					/>
-				</ToolsPanelItem>
-				<ToolsPanelItem
-					label={ __( 'Start value' ) }
-					isShownByDefault
-					hasValue={ () => !! start }
-					onDeselect={ () =>
-						setAttributes( {
 							start: undefined,
-						} )
-					}
-				>
-					<TextControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						label={ __( 'Start value' ) }
-						type="number"
-						onChange={ ( value ) => {
-							const int = parseInt( value, 10 );
-
-							setAttributes( {
-								// It should be possible to unset the value,
-								// e.g. with an empty string.
-								start: isNaN( int ) ? undefined : int,
-							} );
-						} }
-						value={
-							Number.isInteger( start )
-								? start.toString( 10 )
-								: ''
-						}
-						step="1"
-					/>
-				</ToolsPanelItem>
-				<ToolsPanelItem
-					label={ __( 'Reverse order' ) }
-					isShownByDefault
-					hasValue={ () => !! reversed }
-					onDeselect={ () =>
-						setAttributes( {
 							reversed: undefined,
-						} )
-					}
+						} );
+					} }
+					dropdownMenuProps={ dropdownMenuProps }
 				>
-					<ToggleControl
-						__nextHasNoMarginBottom
-						label={ __( 'Reverse order' ) }
-						checked={ reversed || false }
-						onChange={ ( value ) => {
+					<ToolsPanelItem
+						label={ __( 'List style' ) }
+						isShownByDefault
+						hasValue={ () => !! type }
+						onDeselect={ () =>
 							setAttributes( {
-								// Unset the attribute if not reversed.
-								reversed: value || undefined,
-							} );
-						} }
-					/>
-				</ToolsPanelItem>
-			</ToolsPanel>
+								type: undefined,
+							} )
+						}
+					>
+						<SelectControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={ __( 'List style' ) }
+							options={ LIST_STYLE_OPTIONS }
+							value={ type || 'decimal' }
+							onChange={ ( newValue ) =>
+								setAttributes( { type: newValue } )
+							}
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						label={ __( 'Start value' ) }
+						isShownByDefault
+						hasValue={ () => !! start }
+						onDeselect={ () =>
+							setAttributes( {
+								start: undefined,
+							} )
+						}
+					>
+						<TextControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={ __( 'Start value' ) }
+							type="number"
+							onChange={ ( value ) => {
+								const int = parseInt( value, 10 );
+
+								setAttributes( {
+									// It should be possible to unset the value,
+									// e.g. with an empty string.
+									start: isNaN( int ) ? undefined : int,
+								} );
+							} }
+							value={
+								Number.isInteger( start )
+									? start.toString( 10 )
+									: ''
+							}
+							step="1"
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						label={ __( 'Reverse order' ) }
+						isShownByDefault
+						hasValue={ () => !! reversed }
+						onDeselect={ () =>
+							setAttributes( {
+								reversed: undefined,
+							} )
+						}
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Reverse order' ) }
+							checked={ reversed || false }
+							onChange={ ( value ) => {
+								setAttributes( {
+									// Unset the attribute if not reversed.
+									reversed: value || undefined,
+								} );
+							} }
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
+			) }
 		</InspectorControls>
 	);
 };


### PR DESCRIPTION
## What?
Part of #67813

Make the settings panel more consistent with other blocks

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a list block
3. Open the settings panel
4. You can see that you can set it up just like before Ordered List.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| ![before](https://github.com/user-attachments/assets/22c20781-7d0d-43a6-a35e-e35412bbdfee) | ![after](https://github.com/user-attachments/assets/6516a714-16d8-4ade-9db5-51d11ccee3e8) | 

https://github.com/user-attachments/assets/efdb98d8-3ef4-4f8c-a043-a21ea1ff63fd

