### PR TITLE
Freeform: Use where selector for block styling in non-iframe editor

### DIFF
--- a/packages/block-library/src/freeform/editor.scss
+++ b/packages/block-library/src/freeform/editor.scss
@@ -1,4 +1,4 @@
-.wp-block-freeform.block-library-rich-text__tinymce {
+:root :where(.wp-block-freeform.block-library-rich-text__tinymce) {
 	height: auto; /* Allow height of embed iframes to be calculated properly */
 	p,
 	li {


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #62892

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To reduce the CSS specificity of `core/freeform` CSS in a non-iframe editor.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Changed to: 
`:root :where(.wp-block-freeform.block-library-rich-text__tinymce) `

from:
`.wp-block-freeform.block-library-rich-text__tinymce` 


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->


1. Create a meta box (I used Advanced Custom Filed).
2. Activate API Version 2 Block (I used Advanced Editor Tools)
3. Make sure the editor is not an iframe.
4. Create link text in a block in core/freeform.
5. Check the CSS applied to the link text.
