### PR TITLE
Added Missing Trailing periods in Experiment Settings Page

### DIFF
--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -86,7 +86,7 @@ function gutenberg_initialize_experiments_settings() {
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',
 		array(
-			'label' => __( 'Disables the TinyMCE and Classic block', 'gutenberg' ),
+			'label' => __( 'Disables the TinyMCE and Classic block.', 'gutenberg' ),
 			'id'    => 'gutenberg-no-tinymce',
 		)
 	);


### PR DESCRIPTION
## What?
This PR adding the trailing period in the Experiment Settings Page 

## Why?
Modified the `Experiment Settings Page` to add the trailing period. This ensures consistency in the `Experiment Settings Page`.

## Testing Instructions
1. Open Experimental Settings Page
2. Go to `Blocks: disable TinyMCE and Classic block` Option
3. See for  `Disables the TinyMCE and Classic block` has missing trailing period

## Screenshots
|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/5cb87ad5-0433-4293-a450-24465a71aeb9)|![image](https://github.com/user-attachments/assets/4f360c11-068e-49ce-ab7d-3ed2d5017d73)|