### PR TITLE
Add Query Block Filtering by Taxonomies having non_queryable as false.

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
@@ -50,7 +50,9 @@ const getTermIdByTermValue = ( terms, termValue ) => {
 export function TaxonomyControls( { onChange, query } ) {
 	const { postType, taxQuery } = query;
 
-	const taxonomies = useTaxonomies( postType );
+	const taxonomies = useTaxonomies( postType, {
+		allowPubliclyQueryable: true,
+	} );
 	if ( ! taxonomies || taxonomies.length === 0 ) {
 		return null;
 	}

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -147,10 +147,12 @@ export const usePostTypes = () => {
 /**
  * Hook that returns the taxonomies associated with a specific post type.
  *
- * @param {string} postType The post type from which to retrieve the associated taxonomies.
+ * @param {string}  postType                               The post type from which to retrieve the associated taxonomies.
+ * @param {Object?} options                                Configuration options for the hook.
+ * @param {boolean} [options.allowPubliclyQueryable=false] Whether to filter taxonomies by publicly_queryable.
  * @return {Object[]} An array of the associated taxonomies.
  */
-export const useTaxonomies = ( postType ) => {
+export const useTaxonomies = ( postType, options ) => {
 	const taxonomies = useSelect(
 		( select ) => {
 			const { getTaxonomies, getPostType } = select( coreStore );
@@ -165,11 +167,14 @@ export const useTaxonomies = ( postType ) => {
 		},
 		[ postType ]
 	);
+
 	return useMemo( () => {
-		return taxonomies?.filter(
-			( { visibility } ) => !! visibility?.publicly_queryable
+		return taxonomies?.filter( ( { visibility } ) =>
+			options.allowPubliclyQueryable
+				? true
+				: !! visibility?.publicly_queryable
 		);
-	}, [ taxonomies ] );
+	}, [ options.allowPubliclyQueryable, taxonomies ] );
 };
 
 /**

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -152,7 +152,10 @@ export const usePostTypes = () => {
  * @param {boolean} [options.allowPubliclyQueryable=false] Whether to filter taxonomies by publicly_queryable.
  * @return {Object[]} An array of the associated taxonomies.
  */
-export const useTaxonomies = ( postType, options ) => {
+export const useTaxonomies = (
+	postType,
+	options = { allowPubliclyQueryable: false }
+) => {
 	const taxonomies = useSelect(
 		( select ) => {
 			const { getTaxonomies, getPostType } = select( coreStore );


### PR DESCRIPTION
## What?
This PR allows the Query Block to be filtered with the taxonomies having non_queryable as false.

## Why?
Reference Issue: https://github.com/WordPress/gutenberg/issues/60301

## How?
I have added an extra option to maintain backwards compatibility with the recent change introduced to disallow non-Queryable Taxonomies. My implementation follows a whitelisting approach where we can pass `allowPubliclyQueryable` to the useTaxonomies hook.

## Testing Instructions
1. Ensure you have registered a custom taxonomy with non_queryable as false and bind it to your post type that will be used in the following step in Query Block.
2. Add a query loop block in the post.
3. Select the filters and go to taxonomies.
4. Ensure the custom taxonomy appears there.

