### PR TITLE
Site Editor: Fix template lookup preloading for non-draft pages

### DIFF
--- a/backport-changelog/6.8/8441.md
+++ b/backport-changelog/6.8/8441.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/8441
+
+* https://github.com/WordPress/gutenberg/pull/69400

--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -26,8 +26,8 @@ function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 				if ( 'page' === $post->post_type ) {
 					$paths[] = add_query_arg(
 						'slug',
-						// @see https://github.com/WordPress/gutenberg/blob/489f6067c623926bce7151a76755bb68d8e22ea7/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js#L139-L140
-						'page-' . $post->post_name,
+						// @see https://github.com/WordPress/gutenberg/blob/e093fefd041eb6cc4a4e7f67b92ab54fd75c8858/packages/core-data/src/private-selectors.ts#L244-L254
+						empty( $post->post_name ) ? 'page' : 'page-' . $post->post_name,
 						'/wp/v2/templates/lookup'
 					);
 				}
@@ -68,8 +68,8 @@ function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 		 * See the call to `canUser()`, under `useGlobalStylesUserConfig()` in `packages/edit-site/src/components/use-global-styles-user-config/index.js`.
 		 * Please ensure that the equivalent check is kept in sync with this preload path.
 		 */
-		$context = current_user_can( 'edit_theme_options' ) ? 'edit' : 'view';
-		$paths[] = "/wp/v2/global-styles/$global_styles_id?context=$context";
+		$rest_context = current_user_can( 'edit_theme_options' ) ? 'edit' : 'view';
+		$paths[] = "/wp/v2/global-styles/$global_styles_id?context=$rest_context";
 
 		// Used by getBlockPatternCategories in useBlockEditorSettings.
 		$paths[] = '/wp/v2/block-patterns/categories';
@@ -94,6 +94,7 @@ function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 			)
 		);
 	}
+
 	return $paths;
 }
 add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_block_editor_preload_paths_6_8', 10, 2 );

--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -69,7 +69,7 @@ function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 		 * Please ensure that the equivalent check is kept in sync with this preload path.
 		 */
 		$rest_context = current_user_can( 'edit_theme_options' ) ? 'edit' : 'view';
-		$paths[] = "/wp/v2/global-styles/$global_styles_id?context=$rest_context";
+		$paths[]      = "/wp/v2/global-styles/$global_styles_id?context=$rest_context";
 
 		// Used by getBlockPatternCategories in useBlockEditorSettings.
 		$paths[] = '/wp/v2/block-patterns/categories';


### PR DESCRIPTION
## What?
Discovered while re-testing: https://github.com/WordPress/wordpress-develop/pull/8441.

Fixes the `slug` for preloading page templates and adds a handler for draft pages.

## Why?
The pages with draft status might not have a `slug` available; the client code handles this, but it was missing from the preloading logic.

## Testing Instructions
1. Open the published draft page in the Site Editor.
2. The `lookup` endpoint should be correctly preloaded.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2025-03-04 at 11 19 57](https://github.com/user-attachments/assets/0a9a9f2a-dad6-417b-880d-b9da8d8e3470)
