### PR TITLE
Search: `wp-block-search__inside-wrapper` classname trailing spaces 

### DIFF
--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -158,16 +158,16 @@ function render_block_core_search( $attributes ) {
 	if ( $is_button_inside && ! empty( $border_color_classes ) ) {
 		$field_markup_classes[] = $border_color_classes;
 	}
-	$field_markup         = sprintf(
+	$field_markup       = sprintf(
 		'<div class="%s" %s>%s</div>',
 		implode( ' ', $field_markup_classes ),
 		$inline_styles['wrapper'],
 		$input . $query_params_markup . $button
 	);
-	$wrapper_attributes   = get_block_wrapper_attributes(
+	$wrapper_attributes = get_block_wrapper_attributes(
 		array( 'class' => $classnames )
 	);
-	$form_directives      = '';
+	$form_directives    = '';
 
 	// If it's interactive, add the directives.
 	if ( $is_expandable_searchfield ) {

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -160,7 +160,7 @@ function render_block_core_search( $attributes ) {
 	}
 	$field_markup       = sprintf(
 		'<div class="%s" %s>%s</div>',
-		implode( ' ', $field_markup_classes ),
+		esc_attr( implode( ' ', $field_markup_classes ) ),
 		$inline_styles['wrapper'],
 		$input . $query_params_markup . $button
 	);

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -152,10 +152,15 @@ function render_block_core_search( $attributes ) {
 		}
 	}
 
-	$field_markup_classes = $is_button_inside ? $border_color_classes : '';
+	$field_markup_classes = array(
+		'wp-block-search__inside-wrapper',
+	);
+	if ( $is_button_inside && ! empty( $border_color_classes ) ) {
+		$field_markup_classes[] = $border_color_classes;
+	}
 	$field_markup         = sprintf(
-		'<div class="wp-block-search__inside-wrapper %s" %s>%s</div>',
-		esc_attr( $field_markup_classes ),
+		'<div class="%s" %s>%s</div>',
+		implode( ' ', $field_markup_classes ),
 		$inline_styles['wrapper'],
 		$input . $query_params_markup . $button
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Include trimming in Search to make it more consistent with other blocks

Similar #68161 #68880 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a Search block.
3. The space after the class of `wp-block-search__inside-wrapper` is disappearing.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| ![before](https://github.com/user-attachments/assets/78e08e0a-00ae-4ee6-a49a-ef56b6196405) | ![after](https://github.com/user-attachments/assets/2ffba222-b329-4b24-91f5-cb79cbe98013) |

