### PR TITLE
ESLint: Implement `ARIA` Menu Pattern Enforcement via Linting for `DropdownMenu`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -185,6 +185,7 @@ module.exports = {
 		'@wordpress/react-no-unsafe-timeout': 'error',
 		'@wordpress/i18n-hyphenated-range': 'error',
 		'@wordpress/i18n-no-flanking-whitespace': 'error',
+		'@wordpress/dropdown-menu-children-rule': 'error',
 		'@wordpress/i18n-text-domain': [
 			'error',
 			{

--- a/packages/eslint-plugin/configs/custom.js
+++ b/packages/eslint-plugin/configs/custom.js
@@ -8,6 +8,7 @@ module.exports = {
 		'@wordpress/no-global-get-selection': 'error',
 		'@wordpress/no-unsafe-wp-apis': 'error',
 		'@wordpress/no-wp-process-env': 'error',
+		'@wordpress/dropdown-menu-children-rule': 'error',
 	},
 	overrides: [
 		{

--- a/packages/eslint-plugin/rules/__tests__/dropdown-menu-children-rule.js
+++ b/packages/eslint-plugin/rules/__tests__/dropdown-menu-children-rule.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { RuleTester } from 'eslint';
+
+/**
+ * Internal dependencies
+ */
+const rule = require( '../dropdown-menu-children-rule' );
+
+const ruleTester = new RuleTester( {
+	parser: require.resolve( '@babel/eslint-parser' ),
+	parserOptions: {
+		ecmaVersion: 2020,
+		sourceType: 'module',
+		requireConfigFile: false,
+	},
+} );
+
+ruleTester.run( 'dropdown-menu-child', rule, {
+	valid: [
+		`<DropdownMenu><MenuItem /></DropdownMenu>`,
+		`<DropdownMenu><MenuItemsChoice /></DropdownMenu>`,
+		`<DropdownMenu><MenuGroup /></DropdownMenu>`,
+	],
+
+	invalid: [
+		{
+			code: `<DropdownMenu><p>Some description text</p></DropdownMenu>`,
+			errors: [
+				{
+					message:
+						'Only `MenuItem`, `MenuItemsChoice`, or `MenuGroup` are allowed as children of the `<DropdownMenu>` component.',
+				},
+			],
+		},
+		{
+			code: `<DropdownMenu><div>Other content</div></DropdownMenu>`,
+			errors: [
+				{
+					message:
+						'Only `MenuItem`, `MenuItemsChoice`, or `MenuGroup` are allowed as children of the `<DropdownMenu>` component.',
+				},
+			],
+		},
+		{
+			code: `<DropdownMenu><MenuItem /><p>Some extraneous content</p></DropdownMenu>`,
+			errors: [
+				{
+					message:
+						'Only `MenuItem`, `MenuItemsChoice`, or `MenuGroup` are allowed as children of the `<DropdownMenu>` component.',
+				},
+			],
+		},
+	],
+} );

--- a/packages/eslint-plugin/rules/dropdown-menu-children-rule.js
+++ b/packages/eslint-plugin/rules/dropdown-menu-children-rule.js
@@ -1,0 +1,80 @@
+module.exports = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description:
+				'Ensure only allowed elements are children of DropdownMenu, including those returned by render props',
+			category: 'Best Practices',
+			recommended: false,
+		},
+		schema: [],
+		messages: {
+			invalidChild:
+				"'{{child}}' is not an allowed child of 'DropdownMenu'.",
+		},
+	},
+	create( context ) {
+		const allowedChildren = [
+			'MenuGroup',
+			'MenuItemsChoice',
+			'AspectRatioGroup',
+			'MenuItem',
+		];
+
+		function checkChildren( children ) {
+			children.forEach( ( child ) => {
+				if (
+					child.type === 'JSXElement' &&
+					! allowedChildren.includes( child.openingElement.name.name )
+				) {
+					context.report( {
+						node: child,
+						messageId: 'invalidChild',
+						data: {
+							child: child.openingElement.name.name,
+						},
+					} );
+				}
+			} );
+		}
+
+		function handleRenderProp( node ) {
+			if ( node.body && node.body.type === 'JSXElement' ) {
+				checkChildren( [ node.body ] );
+			} else if ( node.body && node.body.type === 'BlockStatement' ) {
+				node.body.body.forEach( ( statement ) => {
+					if (
+						statement.type === 'ReturnStatement' &&
+						statement.argument
+					) {
+						if ( statement.argument.type === 'JSXElement' ) {
+							checkChildren( [ statement.argument ] );
+						}
+					}
+				} );
+			}
+		}
+
+		return {
+			JSXElement( node ) {
+				if ( node.openingElement.name.name === 'DropdownMenu' ) {
+					node.children.forEach( ( child ) => {
+						if ( child.type === 'JSXElement' ) {
+							checkChildren( [ child ] );
+						} else if (
+							child.type === 'JSXExpressionContainer' &&
+							child.expression.type === 'ArrowFunctionExpression'
+						) {
+							handleRenderProp( child.expression );
+						} else if (
+							child.type === 'JSXExpressionContainer' &&
+							child.expression.type === 'FunctionExpression'
+						) {
+							handleRenderProp( child.expression.body );
+						}
+					} );
+				}
+			},
+		};
+	},
+};


### PR DESCRIPTION
## Work in Progress

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/67795

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
