### PR TITLE
Docs: Add Child Layout Control Readme

### DIFF
--- a/packages/block-editor/src/components/caption/README.md
+++ b/packages/block-editor/src/components/caption/README.md
@@ -37,7 +37,7 @@ const BlockCaption = ( {
 
 ### Props
 
-The properties `isSelected`, `onBlur`, `onChange`, `onFocus`, `shouldDisplay`, `value`, `insertBlocksAfter` of this component are passed directly to their related props of its inner `<RichText>` component ([see detailed info about the RichText component's props](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/rich-text/README.md)).
+<!-- The properties `isSelected`, `onBlur`, `onChange`, `onFocus`, `shouldDisplay`, `value`, `insertBlocksAfter` of this component are passed directly to their related props of its inner `<RichText>` component ([see detailed info about the RichText component's props](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/rich-text/README.md)). -->
 
 ## Related components
 

--- a/packages/block-editor/src/components/caption/README.md
+++ b/packages/block-editor/src/components/caption/README.md
@@ -37,7 +37,7 @@ const BlockCaption = ( {
 
 ### Props
 
-<!-- The properties `isSelected`, `onBlur`, `onChange`, `onFocus`, `shouldDisplay`, `value`, `insertBlocksAfter` of this component are passed directly to their related props of its inner `<RichText>` component ([see detailed info about the RichText component's props](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/rich-text/README.md)). -->
+The properties `isSelected`, `onBlur`, `onChange`, `onFocus`, `shouldDisplay`, `value`, `insertBlocksAfter` of this component are passed directly to their related props of its inner `<RichText>` component ([see detailed info about the RichText component's props](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/rich-text/README.md)).
 
 ## Related components
 

--- a/packages/block-editor/src/components/child-layout-control/README.md
+++ b/packages/block-editor/src/components/child-layout-control/README.md
@@ -1,0 +1,90 @@
+
+# Child Layout Control
+
+A component that provides a form to edit the child layout of a block.
+
+
+## Table of contents
+
+1. [Development guidelines](#development-guidelines)
+2. [Related components](#related-components)
+
+
+## Development guidelines
+
+### Usage
+
+```jsx
+
+import { ChildLayoutControl } from '@wordpress/block-editor';
+
+const MyChildLayoutControl = () => {
+   const childLayout = {
+        alignment: 'left',
+        spacing: {
+            top: 10,
+            bottom: 10,
+        },
+   }
+	const setChildLayout = ( newChildLayout ) => {
+        // Update the child layout value.
+    };
+
+    return (
+        <ChildLayoutControl
+            value={ childLayout }
+            onChange={ setChildLayout }
+            parentLayout={ {
+                alignment: 'left',
+                spacing: {
+                    top: 10,
+                    bottom: 10,
+                },
+            } }
+            isShownByDefault={ true }
+            panelId="child-layout-control"
+        />
+    );
+};
+```
+
+### Props
+
+### value 
+
+- **Type**: `Object`
+- **Required**: Yes
+- **Default**: `{}`
+
+The child layout value.
+
+### onChange
+
+- **Type**: `Function`
+- **Required**: Yes
+
+Function called when the child layout value changes.
+
+### parentLayout
+
+- **Type**: `Object`
+- **Required**: Yes
+
+The parent layout value.
+
+### isShownByDefault
+
+- **Type**: `Boolean`
+- **Required**: No
+
+Whether the control should be shown by default.
+
+### panelId
+
+- **Type**: `String`
+- **Required**: Yes
+
+The panel ID.
+
+## Related components
+Block Editor components are components that can be used to compose the UI of your block editor. Thus, they can only be used under a [BlockEditorProvider](https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/provider/README.md) in the components tree.


### PR DESCRIPTION

## What?
Part of https://github.com/WordPress/gutenberg/issues/22891

## Why?
This PR adds the README for Child Layout Control Component

## Testing Instructions
None.

## Screenshots or screencast
None.