### PR TITLE
REST API: Add additional default template data fields for the active theme

### DIFF
--- a/backport-changelog/6.8/8480.md
+++ b/backport-changelog/6.8/8480.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/8480
+
+* https://github.com/WordPress/gutenberg/pull/69417

--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -85,8 +85,6 @@ function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 				'site_icon_url',
 				'site_logo',
 				'timezone_string',
-				'default_template_part_areas',
-				'default_template_types',
 				'url',
 				'page_for_posts',
 				'page_on_front',

--- a/lib/compat/wordpress-6.8/rest-api.php
+++ b/lib/compat/wordpress-6.8/rest-api.php
@@ -123,7 +123,18 @@ function gutenberg_register_rest_theme_fields() {
 				'description' => __( 'A list of default template types.' ),
 				'type'        => 'array',
 				'items'       => array(
-					'type' => 'string',
+					'type'       => 'object',
+					'properties' => array(
+						'slug'        => array(
+							'type' => 'string',
+						),
+						'title'       => array(
+							'type' => 'string',
+						),
+						'description' => array(
+							'type' => 'string',
+						),
+					),
 				),
 			),
 		)
@@ -143,7 +154,24 @@ function gutenberg_register_rest_theme_fields() {
 				'description' => __( 'A list of allowed area values for template parts.' ),
 				'type'        => 'array',
 				'items'       => array(
-					'type' => 'string',
+					'type'       => 'object',
+					'properties' => array(
+						'area'        => array(
+							'type' => 'string',
+						),
+						'label'       => array(
+							'type' => 'string',
+						),
+						'description' => array(
+							'type' => 'string',
+						),
+						'icon'        => array(
+							'type' => 'string',
+						),
+						'area_tag'    => array(
+							'type' => 'string',
+						),
+					),
 				),
 			),
 		)

--- a/lib/compat/wordpress-6.8/rest-api.php
+++ b/lib/compat/wordpress-6.8/rest-api.php
@@ -36,42 +36,6 @@ add_action(
 );
 
 /**
- * Adds the default template part areas to the REST API index.
- *
- * This function exposes the default template part areas through the WordPress REST API.
- * Note: This function backports into the wp-includes/rest-api/class-wp-rest-server.php file.
- *
- * @param WP_REST_Response $response REST API response.
- * @return WP_REST_Response Modified REST API response with default template part areas.
- */
-function gutenberg_add_default_template_part_areas_to_index( WP_REST_Response $response ) {
-	$response->data['default_template_part_areas'] = get_allowed_block_template_part_areas();
-	return $response;
-}
-add_filter( 'rest_index', 'gutenberg_add_default_template_part_areas_to_index' );
-
-/**
- * Adds the default template types to the REST API index.
- *
- * This function exposes the default template types through the WordPress REST API.
- * Note: This function backports into the wp-includes/rest-api/class-wp-rest-server.php file.
- *
- * @param WP_REST_Response $response REST API response.
- * @return WP_REST_Response Modified REST API response with default template part areas.
- */
-function gutenberg_add_default_template_types_to_index( WP_REST_Response $response ) {
-	$indexed_template_types = array();
-	foreach ( get_default_block_template_types() as $slug => $template_type ) {
-		$template_type['slug']    = (string) $slug;
-		$indexed_template_types[] = $template_type;
-	}
-
-	$response->data['default_template_types'] = $indexed_template_types;
-	return $response;
-}
-add_filter( 'rest_index', 'gutenberg_add_default_template_types_to_index' );
-
-/**
  * Adds the site reading options to the REST API index.
  *
  * @param WP_REST_Response $response REST API response.
@@ -129,3 +93,60 @@ function gutenberg_modify_post_collection_query( $args, WP_REST_Request $request
 	return $args;
 }
 add_filter( 'rest_post_query', 'gutenberg_modify_post_collection_query', 10, 2 );
+
+/**
+ * Registers `default_template_types` and `default_template_part_areas` fields for the active theme.
+ *
+ * Note: Backports into the wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php file.
+ *
+ * @return void
+ */
+function gutenberg_register_rest_theme_fields() {
+	register_rest_field(
+		'theme',
+		'default_template_types',
+		array(
+			'get_callback' => static function ( $response_data ) {
+				if ( ! isset( $response_data['status'] ) || 'active' !== $response_data['status'] ) {
+					return null;
+				}
+
+				$default_template_types = array();
+				foreach ( get_default_block_template_types() as $slug => $template_type ) {
+					$template_type['slug']    = (string) $slug;
+					$default_template_types[] = $template_type;
+				}
+
+				return $default_template_types;
+			},
+			'schema'       => array(
+				'description' => __( 'A list of default template types.' ),
+				'type'        => 'array',
+				'items'       => array(
+					'type' => 'string',
+				),
+			),
+		)
+	);
+	register_rest_field(
+		'theme',
+		'default_template_part_areas',
+		array(
+			'get_callback' => static function ( $response_data ) {
+				if ( ! isset( $response_data['status'] ) || 'active' !== $response_data['status'] ) {
+					return null;
+				}
+
+				return get_allowed_block_template_part_areas();
+			},
+			'schema'       => array(
+				'description' => __( 'A list of allowed area values for template parts.' ),
+				'type'        => 'array',
+				'items'       => array(
+					'type' => 'string',
+				),
+			),
+		)
+	);
+}
+add_action( 'rest_api_init', 'gutenberg_register_rest_theme_fields' );

--- a/packages/block-library/src/navigation/use-template-part-area-label.js
+++ b/packages/block-library/src/navigation/use-template-part-area-label.js
@@ -36,24 +36,24 @@ export default function useTemplatePartAreaLabel( clientId ) {
 				return;
 			}
 
+			const { getCurrentTheme, getEditedEntityRecord } =
+				select( coreStore );
+
+			const currentTheme = getCurrentTheme();
 			const defaultTemplatePartAreas =
-				select( coreStore ).getEntityRecord( 'root', '__unstableBase' )
-					?.default_template_part_areas || [];
+				currentTheme?.default_template_part_areas || [];
 
 			const definedAreas = defaultTemplatePartAreas.map( ( item ) => ( {
 				...item,
 				icon: getTemplatePartIcon( item.icon ),
 			} ) );
 
-			const { getCurrentTheme, getEditedEntityRecord } =
-				select( coreStore );
-
 			for ( const templatePartClientId of parentTemplatePartClientIds ) {
 				const templatePartBlock = getBlock( templatePartClientId );
 
 				// The 'area' usually isn't stored on the block, but instead
 				// on the entity.
-				const { theme = getCurrentTheme()?.stylesheet, slug } =
+				const { theme = currentTheme?.stylesheet, slug } =
 					templatePartBlock.attributes;
 				const templatePartEntityId = createTemplatePartId(
 					theme,

--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -36,7 +36,7 @@ export function TemplatePartAdvancedControls( {
 
 	const defaultTemplatePartAreas = useSelect(
 		( select ) =>
-			select( coreStore ).getEntityRecord( 'root', '__unstableBase' )
+			select( coreStore ).getCurrentTheme()
 				?.default_template_part_areas || [],
 		[]
 	);

--- a/packages/block-library/src/template-part/edit/utils/hooks.js
+++ b/packages/block-library/src/template-part/edit/utils/hooks.js
@@ -137,7 +137,7 @@ export function useTemplatePartArea( area ) {
 	return useSelect(
 		( select ) => {
 			const definedAreas =
-				select( coreStore ).getEntityRecord( 'root', '__unstableBase' )
+				select( coreStore ).getCurrentTheme()
 					?.default_template_part_areas || [];
 
 			const selectedArea = definedAreas.find(

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -31,8 +31,6 @@ export const rootEntitiesConfig = [
 				'site_icon_url',
 				'site_logo',
 				'timezone_string',
-				'default_template_part_areas',
-				'default_template_types',
 				'url',
 				'page_for_posts',
 				'page_on_front',

--- a/packages/core-data/src/entity-types/base.ts
+++ b/packages/core-data/src/entity-types/base.ts
@@ -65,16 +65,6 @@ declare module './base-entity-records' {
 			 * Site URL.
 			 */
 			url: string;
-
-			/**
-			 * Default template part areas.
-			 */
-			default_template_part_areas?: Array< TemplatePartArea >;
-
-			/**
-			 * Default template types
-			 */
-			default_template_types?: Array< TemplateType >;
 		}
 	}
 }

--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -68,8 +68,7 @@ export const useExistingTemplates = () => {
 export const useDefaultTemplateTypes = () => {
 	return useSelect(
 		( select ) =>
-			select( coreStore ).getEntityRecord( 'root', '__unstableBase' )
-				?.default_template_types || [],
+			select( coreStore ).getCurrentTheme()?.default_template_types || [],
 		[]
 	);
 };

--- a/packages/edit-site/src/components/editor/use-editor-title.js
+++ b/packages/edit-site/src/components/editor/use-editor-title.js
@@ -19,8 +19,11 @@ const { getTemplateInfo } = unlock( editorPrivateApis );
 function useEditorTitle( postType, postId ) {
 	const { title, isLoaded } = useSelect(
 		( select ) => {
-			const { getEditedEntityRecord, hasFinishedResolution } =
-				select( coreStore );
+			const {
+				getEditedEntityRecord,
+				getCurrentTheme,
+				hasFinishedResolution,
+			} = select( coreStore );
 
 			if ( ! postId ) {
 				return { isLoaded: false };
@@ -33,10 +36,7 @@ function useEditorTitle( postType, postId ) {
 			);
 
 			const { default_template_types: templateTypes = [] } =
-				select( coreStore ).getEntityRecord(
-					'root',
-					'__unstableBase'
-				) ?? {};
+				getCurrentTheme() ?? {};
 
 			const templateInfo = getTemplateInfo( {
 				template: _record,

--- a/packages/edit-site/src/components/page-patterns/header.js
+++ b/packages/edit-site/src/components/page-patterns/header.js
@@ -32,7 +32,7 @@ export default function PatternsHeader( {
 	const { patternCategories } = usePatternCategories();
 	const templatePartAreas = useSelect(
 		( select ) =>
-			select( coreStore ).getEntityRecord( 'root', '__unstableBase' )
+			select( coreStore ).getCurrentTheme()
 				?.default_template_part_areas || [],
 		[]
 	);

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -25,8 +25,11 @@ const EMPTY_PATTERN_LIST = [];
 
 const selectTemplateParts = createSelector(
 	( select, categoryId, search = '' ) => {
-		const { getEntityRecords, isResolving: isResolvingSelector } =
-			select( coreStore );
+		const {
+			getEntityRecords,
+			getCurrentTheme,
+			isResolving: isResolvingSelector,
+		} = select( coreStore );
 
 		const query = { per_page: -1 };
 		const templateParts =
@@ -36,9 +39,7 @@ const selectTemplateParts = createSelector(
 		// In the case where a custom template part area has been removed we need
 		// the current list of areas to cross check against so orphaned template
 		// parts can be treated as uncategorized.
-		const knownAreas =
-			select( coreStore ).getEntityRecord( 'root', '__unstableBase' )
-				?.default_template_part_areas || [];
+		const knownAreas = getCurrentTheme()?.default_template_part_areas || [];
 
 		const templatePartAreas = knownAreas.map( ( area ) => area.area );
 
@@ -79,8 +80,7 @@ const selectTemplateParts = createSelector(
 			TEMPLATE_PART_POST_TYPE,
 			{ per_page: -1 },
 		] ),
-		select( coreStore ).getEntityRecord( 'root', '__unstableBase' )
-			?.default_template_part_areas,
+		select( coreStore ).getCurrentTheme()?.default_template_part_areas,
 	]
 );
 

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-template-part-areas.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-template-part-areas.js
@@ -17,7 +17,7 @@ const useTemplatePartsGroupedByArea = ( items ) => {
 
 	const templatePartAreas = useSelect(
 		( select ) =>
-			select( coreStore ).getEntityRecord( 'root', '__unstableBase' )
+			select( coreStore ).getCurrentTheme()
 				?.default_template_part_areas || [],
 		[]
 	);

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -74,6 +74,7 @@ export default function DocumentBar( props ) {
 		const {
 			getEditedEntityRecord,
 			getPostType,
+			getCurrentTheme,
 			isResolving: isResolvingSelector,
 		} = select( coreStore );
 		const _postType = getCurrentPostType();
@@ -85,8 +86,7 @@ export default function DocumentBar( props ) {
 		);
 
 		const { default_template_types: templateTypes = [] } =
-			select( coreStore ).getEntityRecord( 'root', '__unstableBase' ) ??
-			{};
+			getCurrentTheme() ?? {};
 
 		const _templateInfo = getTemplateInfo( {
 			templateTypes,

--- a/packages/editor/src/components/entities-saved-states/entity-record-item.js
+++ b/packages/editor/src/components/entities-saved-states/entity-record-item.js
@@ -36,10 +36,7 @@ export default function EntityRecordItem( { record, checked, onChange } ) {
 			);
 
 			const { default_template_types: templateTypes = [] } =
-				select( coreStore ).getEntityRecord(
-					'root',
-					'__unstableBase'
-				) ?? {};
+				select( coreStore ).getCurrentTheme() ?? {};
 
 			return {
 				entityRecordTitle: getTemplateInfo( {

--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -48,7 +48,7 @@ export default function PostCardPanel( {
 	);
 	const { postTitle, icon, labels } = useSelect(
 		( select ) => {
-			const { getEditedEntityRecord, getEntityRecord, getPostType } =
+			const { getEditedEntityRecord, getCurrentTheme, getPostType } =
 				select( coreStore );
 			const { getPostIcon } = unlock( select( editorStore ) );
 			let _title = '';
@@ -59,7 +59,7 @@ export default function PostCardPanel( {
 			);
 			if ( postIds.length === 1 ) {
 				const { default_template_types: templateTypes = [] } =
-					getEntityRecord( 'root', '__unstableBase' ) ?? {};
+					getCurrentTheme() ?? {};
 
 				const _templateInfo = [
 					TEMPLATE_POST_TYPE,

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -105,10 +105,8 @@ export const getPostIcon = createRegistrySelector(
 				postType === 'wp_template'
 			) {
 				const templateAreas =
-					select( coreStore ).getEntityRecord(
-						'root',
-						'__unstableBase'
-					)?.default_template_part_areas || [];
+					select( coreStore ).getCurrentTheme()
+						?.default_template_part_areas || [];
 
 				const areaData = templateAreas.find(
 					( item ) => options.area === item.area

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1709,11 +1709,10 @@ export const __experimentalGetDefaultTemplateTypes = createRegistrySelector(
 			{
 				since: '6.8',
 				alternative:
-					"select('core/core-data').getEntityRecord( 'root', '__unstableBase' )?.default_template_types",
+					"select('core/core-data').getCurrentTheme()?.default_template_types",
 			}
 		);
-		return select( coreStore ).getEntityRecord( 'root', '__unstableBase' )
-			?.default_template_types;
+		return select( coreStore ).getCurrentTheme()?.default_template_types;
 	}
 );
 
@@ -1732,12 +1731,12 @@ export const __experimentalGetDefaultTemplatePartAreas = createRegistrySelector(
 				{
 					since: '6.8',
 					alternative:
-						"select('core/core-data').getEntityRecord( 'root', '__unstableBase' )?.default_template_part_areas",
+						"select('core/core-data').getCurrentTheme()?.default_template_part_areas",
 				}
 			);
 
 			const areas =
-				select( coreStore ).getEntityRecord( 'root', '__unstableBase' )
+				select( coreStore ).getCurrentTheme()
 					?.default_template_part_areas || [];
 
 			return areas.map( ( item ) => {
@@ -1763,10 +1762,8 @@ export const __experimentalGetDefaultTemplateType = createRegistrySelector(
 					since: '6.8',
 				}
 			);
-			const templateTypes = select( coreStore ).getEntityRecord(
-				'root',
-				'__unstableBase'
-			)?.default_template_types;
+			const templateTypes =
+				select( coreStore ).getCurrentTheme()?.default_template_types;
 
 			if ( ! templateTypes ) {
 				return EMPTY_OBJECT;
@@ -1799,13 +1796,11 @@ export const __experimentalGetTemplateInfo = createRegistrySelector(
 				return EMPTY_OBJECT;
 			}
 
-			const templateTypes =
-				select( coreStore ).getEntityRecord( 'root', '__unstableBase' )
-					?.default_template_types || [];
+			const currentTheme = select( coreStore ).getCurrentTheme();
 
+			const templateTypes = currentTheme?.default_template_types || [];
 			const templateAreas =
-				select( coreStore ).getEntityRecord( 'root', '__unstableBase' )
-					?.default_template_part_areas || [];
+				currentTheme?.default_template_part_areas || [];
 
 			return getTemplateInfo( {
 				template,

--- a/packages/fields/src/components/create-template-part-modal/index.tsx
+++ b/packages/fields/src/components/create-template-part-modal/index.tsx
@@ -128,9 +128,7 @@ export function CreateTemplatePartModalContents( {
 
 	const defaultTemplatePartAreas = useSelect(
 		( select ) =>
-			select( coreStore ).getEntityRecord< {
-				default_template_part_areas: Array< TemplatePartArea >;
-			} >( 'root', '__unstableBase' )?.default_template_part_areas,
+			select( coreStore ).getCurrentTheme()?.default_template_part_areas,
 		[]
 	);
 
@@ -200,59 +198,61 @@ export function CreateTemplatePartModalContents( {
 						{ __( 'Area' ) }
 					</BaseControl.VisualLabel>
 					<div className="fields-create-template-part-modal__area-radio-group">
-						{ ( defaultTemplatePartAreas ?? [] ).map( ( item ) => {
-							const icon = getTemplatePartIcon( item.icon );
-							return (
-								<div
-									key={ item.area }
-									className="fields-create-template-part-modal__area-radio-wrapper"
-								>
-									<input
-										type="radio"
-										id={ getAreaRadioId(
-											item.area,
-											instanceId
-										) }
-										name={ `fields-create-template-part-modal__area-${ instanceId }` }
-										value={ item.area }
-										checked={ area === item.area }
-										onChange={ () => {
-											setArea( item.area );
-										} }
-										aria-describedby={ getAreaRadioDescriptionId(
-											item.area,
-											instanceId
-										) }
-									/>
-									<Icon
-										icon={ icon }
-										className="fields-create-template-part-modal__area-radio-icon"
-									/>
-									<label
-										htmlFor={ getAreaRadioId(
-											item.area,
-											instanceId
-										) }
-										className="fields-create-template-part-modal__area-radio-label"
+						{ ( defaultTemplatePartAreas ?? [] ).map(
+							( item: TemplatePartArea ) => {
+								const icon = getTemplatePartIcon( item.icon );
+								return (
+									<div
+										key={ item.area }
+										className="fields-create-template-part-modal__area-radio-wrapper"
 									>
-										{ item.label }
-									</label>
-									<Icon
-										icon={ check }
-										className="fields-create-template-part-modal__area-radio-checkmark"
-									/>
-									<p
-										className="fields-create-template-part-modal__area-radio-description"
-										id={ getAreaRadioDescriptionId(
-											item.area,
-											instanceId
-										) }
-									>
-										{ item.description }
-									</p>
-								</div>
-							);
-						} ) }
+										<input
+											type="radio"
+											id={ getAreaRadioId(
+												item.area,
+												instanceId
+											) }
+											name={ `fields-create-template-part-modal__area-${ instanceId }` }
+											value={ item.area }
+											checked={ area === item.area }
+											onChange={ () => {
+												setArea( item.area );
+											} }
+											aria-describedby={ getAreaRadioDescriptionId(
+												item.area,
+												instanceId
+											) }
+										/>
+										<Icon
+											icon={ icon }
+											className="fields-create-template-part-modal__area-radio-icon"
+										/>
+										<label
+											htmlFor={ getAreaRadioId(
+												item.area,
+												instanceId
+											) }
+											className="fields-create-template-part-modal__area-radio-label"
+										>
+											{ item.label }
+										</label>
+										<Icon
+											icon={ check }
+											className="fields-create-template-part-modal__area-radio-checkmark"
+										/>
+										<p
+											className="fields-create-template-part-modal__area-radio-description"
+											id={ getAreaRadioDescriptionId(
+												item.area,
+												instanceId
+											) }
+										>
+											{ item.description }
+										</p>
+									</div>
+								);
+							}
+						) }
 					</div>
 				</fieldset>
 				<HStack justify="right">


### PR DESCRIPTION
## What?
Closes #69195.
Fixes https://core.trac.wordpress.org/ticket/63055.

PR changes the method for exposing `default_template_types` and `default_template_part_areas` data via REST API. This data is now provided as additional fields for the active theme and consumed using the `getCurrentTheme` selector.

## Why?

It is based on the recent discussion in the core sync ticket - https://core.trac.wordpress.org/ticket/62574#comment:29.

## Testing Instructions
1. Open the Site Editor.
2. Navigate to Patterns.
3. Confirm that Template Parts are available in the sidebar.
4. Try adding a new template part.
5. Confirm that the Area options are correctly listed.
6. Navigate to Templates.
7. Try adding a new template.
8. Confirm that suggestions list templates like Front Page and Date Archives.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2025-03-05 at 09 23 24](https://github.com/user-attachments/assets/93a946c3-9466-4199-8176-8b3f3868cfd3)

![CleanShot 2025-03-05 at 09 23 44](https://github.com/user-attachments/assets/086615a3-b586-4c74-a2b1-6e8f8fd627a9)

