### PR TITLE
Comment Template: Use fallback when there's an HTTP error

### DIFF
--- a/packages/block-library/src/comment-template/hooks.js
+++ b/packages/block-library/src/comment-template/hooks.js
@@ -107,13 +107,21 @@ const useDefaultPageIndex = ( { defaultPage, postId, perPage, queryArgs } ) => {
 			} ),
 			method: 'HEAD',
 			parse: false,
-		} ).then( ( res ) => {
-			const pages = parseInt( res.headers.get( 'X-WP-TotalPages' ) );
-			setDefaultPages( {
-				...defaultPages,
-				[ key ]: pages <= 1 ? 1 : pages, // If there are 0 pages, it means that there are no comments, but there is no 0th page.
+		} )
+			.then( ( res ) => {
+				const pages = parseInt( res.headers.get( 'X-WP-TotalPages' ) );
+				setDefaultPages( {
+					...defaultPages,
+					[ key ]: pages <= 1 ? 1 : pages, // If there are 0 pages, it means that there are no comments, but there is no 0th page.
+				} );
+			} )
+			.catch( () => {
+				// There's no 0th page, but we can't know the number of pages, fallback to 1.
+				setDefaultPages( {
+					...defaultPages,
+					[ key ]: 1,
+				} );
 			} );
-		} );
 	}, [ defaultPage, postId, perPage, setDefaultPages ] );
 
 	// The oldest one is always the first one.


### PR DESCRIPTION
## What?
Closes #69392.

PR adds an error handler to the `useDefaultPageIndex` hook and allows fallback to the "no comments" page when there's an HTTP error.

## Why?
This prevents the block from displaying an infinite loading state. It should also allow the e2e tests mentioned in #69392 to pass while the core fix is in progress.

## Testing Instructions
1. Using WP 6.8 Beta 1.
2. Add a comment template to the post.
3. Confirm that it doesn't display an infinite loading state.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2025-03-05 at 10 43 35](https://github.com/user-attachments/assets/f893cebc-313b-44c6-b939-3888b5179db9)

