### PR TITLE
Spacer Block: use `flex-basis` to apply `DEFAULT_HEIGHT` in Flex Containers

### DIFF
--- a/packages/block-library/src/spacer/constants.js
+++ b/packages/block-library/src/spacer/constants.js
@@ -1,1 +1,2 @@
 export const MIN_SPACER_SIZE = 0;
+export const DEFAULT_HEIGHT = '100px';

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -184,7 +184,7 @@ const SpacerEdit = ( {
 	const sizeConditionalOnOrientation =
 		inheritedOrientation === 'horizontal'
 			? temporaryWidth || flexSize
-			: temporaryHeight || flexSize;
+			: temporaryHeight || flexSize || DEFAULT_HEIGHT;
 
 	const style = {
 		height:

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -23,7 +23,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
  */
 import { unlock } from '../lock-unlock';
 import SpacerControls from './controls';
-import { MIN_SPACER_SIZE } from './constants';
+import { DEFAULT_HEIGHT, MIN_SPACER_SIZE } from './constants';
 
 const { useSpacingSizes } = unlock( blockEditorPrivateApis );
 

--- a/packages/block-library/src/spacer/save.js
+++ b/packages/block-library/src/spacer/save.js
@@ -3,6 +3,11 @@
  */
 import { useBlockProps, getSpacingPresetCssVar } from '@wordpress/block-editor';
 
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_HEIGHT } from './constants';
+
 export default function save( { attributes } ) {
 	const { height = DEFAULT_HEIGHT, width, style } = attributes;
 	const { layout: { selfStretch } = {} } = style || {};

--- a/packages/block-library/src/spacer/save.js
+++ b/packages/block-library/src/spacer/save.js
@@ -4,7 +4,7 @@
 import { useBlockProps, getSpacingPresetCssVar } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { height, width, style } = attributes;
+	const { height = DEFAULT_HEIGHT, width, style } = attributes;
 	const { layout: { selfStretch } = {} } = style || {};
 	// If selfStretch is set to 'fill' or 'fit', don't set default height.
 	const finalHeight =


### PR DESCRIPTION
## What?
Closes #69414 
Follow Up: #68819

This PR addresses the regressions introduced by #68819.

## How?
Previously, the `height` property was used to apply a fallback default for `spacer blocks` within flex containers like `Stack` and `Row`. 

Ref.
https://github.com/WordPress/gutenberg/blob/d272c0ad4636ec3767c6eefa3f7e8b9ca5a8e04d/packages/block-library/src/spacer/save.js#L22

https://github.com/WordPress/gutenberg/blob/0daa060adc35805814e90ea84d42a12c51572628/packages/block-library/src/spacer/edit.js#L171-L173

However, flex containers should use `flex-basis` instead of `height`. This PR corrects the implementation and fixes the associated bug.

## Testing Instructions

**_Inserting a spacer inside a flex container_**
1. Install WP version to 6.7 and disable the Gutenberg plugin.
2. Insert Spacer block within Row/Stack.
3. Change "Width" to "Fill".
4. Save the post.
5. Activate the Gutenberg plugin.
6. Open the post.
7. Verify that the Spacer block works fine.

## Screencasts

**_Inserting "Hero, overlapped book cover with links" pattern from `twenty-twenty-five theme`_**

https://github.com/user-attachments/assets/007e1541-d541-4023-836f-4c75b91b8f92

**_Inserting spacer inside flex container (testing backward compatibility)_**

https://github.com/user-attachments/assets/5cfc482d-f973-4292-bae1-d8f0ccd25fba

