### PR TITLE
Latest Posts: Make Latest Posts block consistent with sticky posts display

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -126,6 +126,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 					orderby: orderBy,
 					per_page: postsToShow,
 					_embed: 'wp:featuredmedia',
+					ignore_sticky: true,
 				} ).filter( ( [ , value ] ) => typeof value !== 'undefined' )
 			);
 

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -45,7 +45,7 @@ function render_block_core_latest_posts( $attributes ) {
 		'post_status'         => 'publish',
 		'order'               => $attributes['order'],
 		'orderby'             => $attributes['orderBy'],
-		'ignore_sticky_posts' => true,
+		'ignore_sticky_posts' => false,
 		'no_found_rows'       => true,
 	);
 

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -45,7 +45,7 @@ function render_block_core_latest_posts( $attributes ) {
 		'post_status'         => 'publish',
 		'order'               => $attributes['order'],
 		'orderby'             => $attributes['orderBy'],
-		'ignore_sticky_posts' => false,
+		'ignore_sticky_posts' => true,
 		'no_found_rows'       => true,
 	);
 


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/69424

This PR addresses the inconsistency between how the Latest Posts block displays posts in the editor versus the front end. Previously, sticky posts would always appear at the top of the list in the editor, regardless of the sorting parameters, but would display in their chronological position on the front end.

The fix adds the `ignore_sticky: true` parameter to the post query in the editor, ensuring that sticky posts are treated the same in both contexts. They are displayed according to the selected ordering parameters rather than being prioritized at the top.

## Why?

The Latest Posts block should respect the specified ordering parameters and display posts consistently between the editor and the front end. The current inconsistency creates a confusing user experience where what users see in the editor doesn't match what visitors see on the published page.

## How?

This PR adds the `ignore_sticky: true` parameter to the query in the Latest Posts block's editor component.

## Testing Instructions

- Create several posts, and mark some of them as "sticky" 
- Create or edit a post
- Add a Latest Posts block to the page
- Observe how the posts are ordered in the editor - verify that sticky posts now appear in their chronological order, not at the top
- Publish or update the page
- View the page on the front end and verify that the post order matches what was shown in the editor
- In the block settings, try changing the sort order (oldest to newest, or A→Z) and verify that the sticky posts respect this ordering in both the editor and front end

## Screencast


https://github.com/user-attachments/assets/988d9c06-240f-4443-b033-2d36adb04103



