### PR TITLE
Testing: Skip failing post preview e2e tests

### DIFF
--- a/test/e2e/specs/editor/various/preview.spec.js
+++ b/test/e2e/specs/editor/various/preview.spec.js
@@ -9,7 +9,8 @@ test.use( {
 	},
 } );
 
-test.describe( 'Preview', () => {
+// Reason: https://core.trac.wordpress.org/ticket/56992#comment:22.
+test.describe.skip( 'Preview', () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
 	} );
@@ -214,7 +215,8 @@ test.describe( 'Preview', () => {
 	} );
 } );
 
-test.describe( 'Preview with Custom Fields enabled', () => {
+// Reason: https://core.trac.wordpress.org/ticket/56992#comment:22.
+test.describe.skip( 'Preview with Custom Fields enabled', () => {
 	test.beforeEach( async ( { admin, previewUtils } ) => {
 		await admin.createNewPost();
 		await previewUtils.toggleCustomFieldsOption( true );


### PR DESCRIPTION
## What?
PR temporarily skips post preview e2e tests until the WP core fixes the problem. See https://github.com/WordPress/gutenberg/issues/69403.

## Why?
Unblocks project development without risking regressions in different areas.

## Testing Instructions
All CI checks should be passing.
