### PR TITLE
Fix Notice component action button margins

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   `Notice`: Fix notice component spacing issue. ([#69430](https://github.com/WordPress/gutenberg/pull/69430))
+-   `Notice`: Fix notice component spacing issue when actions are present. ([#69430](https://github.com/WordPress/gutenberg/pull/69430))
 
 ## 30.9.0 (2025-11-26)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `Notice`: Fix notice component spacing issue. ([#69430](https://github.com/WordPress/gutenberg/pull/69430))
+
 ## 30.9.0 (2025-11-26)
 
 ### Bug Fixes
@@ -20,7 +24,6 @@
 -   `CustomSelectControl`: Fix the options with the same name are shown as the selected option ([#72189](https://github.com/WordPress/gutenberg/pull/72189)).
 -   `NumberControl`: Fix crash when min prop is string and step prop contains decimal ([#73107](https://github.com/WordPress/gutenberg/pull/73107)).
 -   `Modal`: Fix full-screen modal height to allow contents to scroll properly ([#73150](https://github.com/WordPress/gutenberg/pull/73150)).
-
 
 ### Internal
 

--- a/packages/components/src/notice/index.tsx
+++ b/packages/components/src/notice/index.tsx
@@ -111,53 +111,60 @@ function Notice( {
 			<VisuallyHidden>{ getStatusLabel( status ) }</VisuallyHidden>
 			<div className="components-notice__content">
 				{ children }
-				<div className="components-notice__actions">
-					{ actions.map(
-						(
-							{
-								className: buttonCustomClasses,
-								label,
-								isPrimary,
-								variant,
-								noDefaultClasses = false,
-								onClick,
-								url,
-							}: NoticeAction &
-								// `isPrimary` is a legacy prop included for
-								// backcompat, but `variant` should be used
-								// instead.
-								Pick< DeprecatedButtonProps, 'isPrimary' >,
-							index
-						) => {
-							let computedVariant = variant;
-							if ( variant !== 'primary' && ! noDefaultClasses ) {
-								computedVariant = ! url ? 'secondary' : 'link';
-							}
-							if (
-								typeof computedVariant === 'undefined' &&
-								isPrimary
-							) {
-								computedVariant = 'primary';
-							}
+				{ actions.length > 0 && (
+					<div className="components-notice__actions">
+						{ actions.map(
+							(
+								{
+									className: buttonCustomClasses,
+									label,
+									isPrimary,
+									variant,
+									noDefaultClasses = false,
+									onClick,
+									url,
+								}: NoticeAction &
+									// `isPrimary` is a legacy prop included for
+									// backcompat, but `variant` should be used
+									// instead.
+									Pick< DeprecatedButtonProps, 'isPrimary' >,
+								index
+							) => {
+								let computedVariant = variant;
+								if (
+									variant !== 'primary' &&
+									! noDefaultClasses
+								) {
+									computedVariant = ! url
+										? 'secondary'
+										: 'link';
+								}
+								if (
+									typeof computedVariant === 'undefined' &&
+									isPrimary
+								) {
+									computedVariant = 'primary';
+								}
 
-							return (
-								<Button
-									__next40pxDefaultSize
-									key={ index }
-									href={ url }
-									variant={ computedVariant }
-									onClick={ url ? undefined : onClick }
-									className={ clsx(
-										'components-notice__action',
-										buttonCustomClasses
-									) }
-								>
-									{ label }
-								</Button>
-							);
-						}
-					) }
-				</div>
+								return (
+									<Button
+										__next40pxDefaultSize
+										key={ index }
+										href={ url }
+										variant={ computedVariant }
+										onClick={ url ? undefined : onClick }
+										className={ clsx(
+											'components-notice__action',
+											buttonCustomClasses
+										) }
+									>
+										{ label }
+									</Button>
+								);
+							}
+						) }
+					</div>
+				) }
 			</div>
 			{ isDismissible && (
 				<Button

--- a/packages/components/src/notice/stories/index.story.tsx
+++ b/packages/components/src/notice/stories/index.story.tsx
@@ -89,7 +89,7 @@ WithActions.args = {
 };
 
 export const NoticeListSubcomponent: StoryFn< typeof NoticeList > = () => {
-	const exampleNotices = [
+	const exampleNotices: NoticeListProps[ 'notices' ] = [
 		{
 			id: 'second-notice',
 			content: 'second notice content',
@@ -97,6 +97,22 @@ export const NoticeListSubcomponent: StoryFn< typeof NoticeList > = () => {
 		{
 			id: 'first-notice',
 			content: 'first notice content',
+			actions: [
+				{
+					label: 'Click me!',
+					onClick: () => {},
+					variant: 'primary',
+				},
+				{
+					label: 'Or click me instead!',
+					onClick: () => {},
+				},
+				{
+					label: 'Or visit a link for more info',
+					url: 'https://wordpress.org',
+					variant: 'link',
+				},
+			],
 		},
 	];
 	const [ notices, setNotices ] = useState( exampleNotices );

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -49,7 +49,7 @@
 		vertical-align: initial;
 	}
 
-	margin-top: $grid-unit-10;
+	margin-top: $grid-unit-15;
 }
 
 .components-notice__dismiss {

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -42,14 +42,13 @@
 	display: flex;
 	flex-wrap: wrap;
 	gap: $grid-unit-15;
+	margin-top: $grid-unit-15;
 }
 
 .components-notice__action.components-button {
 	&.is-secondary {
 		vertical-align: initial;
 	}
-
-	margin-top: $grid-unit-15;
 }
 
 .components-notice__dismiss {

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -49,8 +49,6 @@
 		vertical-align: initial;
 	}
 
-	// When it has better support, this can be replaced
-	// with column-gap since these are flex items.
 	margin-top: $grid-unit-10;
 }
 

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -46,12 +46,6 @@
 	margin-top: $grid-unit-15;
 }
 
-.components-notice__action.components-button {
-	&.is-secondary {
-		vertical-align: initial;
-	}
-}
-
 .components-notice__dismiss {
 	color: $gray-700;
 
@@ -80,10 +74,5 @@
 		margin-top: $grid-unit-15;
 		margin-bottom: $grid-unit-15;
 		line-height: 2;
-	}
-
-	.components-notice__action.components-button {
-		display: block;
-		margin-left: 0;
 	}
 }

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -41,20 +41,17 @@
 .components-notice__actions {
 	display: flex;
 	flex-wrap: wrap;
+	gap: $grid-unit-15;
 }
 
 .components-notice__action.components-button {
-	&,
-	&.is-link {
-		margin-left: $grid-unit-15;
-	}
 	&.is-secondary {
 		vertical-align: initial;
 	}
 
 	// When it has better support, this can be replaced
 	// with column-gap since these are flex items.
-	margin-right: $grid-unit-10;
+	margin-top: $grid-unit-10;
 }
 
 .components-notice__dismiss {

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -41,6 +41,7 @@
 .components-notice__actions {
 	display: flex;
 	flex-wrap: wrap;
+	align-items: center;
 	gap: $grid-unit-15;
 	margin-top: $grid-unit-15;
 }

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -84,6 +84,5 @@
 	.components-notice__action.components-button {
 		display: block;
 		margin-left: 0;
-		margin-top: $grid-unit-10;
 	}
 }


### PR DESCRIPTION
Closes: #69426

## What?
Improves spacing in Notice component between content and action buttons.

## Why?
The spacing between the main content and action buttons in the Notice component was too tight, and there was no vertical spacing between multiple notice actions.

## Screenshots:

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/f47a273e-e095-4908-8e55-32f48d7fdca1)|![image](https://github.com/user-attachments/assets/bc9dfaf5-2d3d-48c9-afb0-42dc7e6be7d0)|
