### PR TITLE
Fix: Show the author and author name examples in the Stylebook

### DIFF
--- a/packages/block-library/src/post-author-name/edit.js
+++ b/packages/block-library/src/post-author-name/edit.js
@@ -132,15 +132,15 @@ function PostAuthorNameEdit( {
 				</ToolsPanel>
 			</InspectorControls>
 			<div { ...blockProps }>
-				{ supportsAuthor
-					? displayAuthor
-					: sprintf(
+				{ ! supportsAuthor && postType !== undefined
+					? sprintf(
 							// translators: %s: Name of the post type e.g: "post".
 							__(
 								'This post type (%s) does not support the author.'
 							),
 							postType
-					  ) }
+					  )
+					: displayAuthor }
 			</div>
 		</>
 	);

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -99,7 +99,7 @@ function PostAuthorEdit( {
 	const showAuthorControl =
 		!! postId && ! isDescendentOfQueryLoop && authorOptions.length > 0;
 
-	if ( ! supportsAuthor ) {
+	if ( ! supportsAuthor && postType !== undefined ) {
 		return (
 			<div { ...blockProps }>
 				{ sprintf(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

The title of this PR is a bit misguiding because the code change is unrelated to the Stylebook.
But the expected result is for the post author and post author name blocks to show in the Stylebook.

Closes https://github.com/WordPress/gutenberg/issues/68513

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

https://github.com/WordPress/gutenberg/pull/67136 Added a bug fix to the two blocks, which meant that if the post type did not support the post author, there would be a notice displayed in the editor to inform the user.

This also lead to the notice showing when the post type is `undefined`. And the post type is `undefined` when you view the Stylebook.
There are exceptions where the post type is not undefined, and that is when editing a template for the single post or single page, and then opening the stylebook from within the Site Editor. But in these cases, the blocks already show their examples correctly.

I have made this code change based on the following:
- When the post type is undefined, no real user data will be shown, instead the block will show its _example_.
- So when the post type is undefined, there can't be a leak of author information.

## Testing Instructions
With any theme type: Confirm that there are no regressions when inserting a post author block when editing content, either post, page, or custom post type.

Classic theme:
Activate a classic theme that has support for the stylebook. For example, Twenty Fifteen.
Open Appearance > Design > Styles and look for the author and author name blocks. 
Confirm if the block shows with a basic example and not a message saying that the block is unsupported.

Block theme:
Activate a block theme, and test the stylebook in two places:
In the Site Editor, when editing different type of templates. -Open the Styles sidebar and open the Stylebook. 
Look for the author and author name blocks. 
Confirm if the block shows with a basic example and not a message saying that the block is unsupported.

Open the first screen of the Site Editor and choose Styles in the sidebar.
Open the Stylebook.
Open the blocks panel.
Look for the author and author name blocks. 
Confirm if the block shows with a basic example and not a message saying that the block is unsupported.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After (detail of the blocks only)|
|-|-|
| ![The blocks show a notice saying that the block is not supported](https://github.com/user-attachments/assets/228cc392-12ce-402f-aa6b-36790d547c8b) |![The blocks do not show a notice, the block example is used](https://github.com/user-attachments/assets/70daac36-e5d9-4c10-b8e7-40830e4ab4a8)|
