### PR TITLE
Ensure Query Pagination Block Uses Correct Permalink in REST API

### DIFF
--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -59,7 +59,7 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		if ( $custom_query_max_pages && $custom_query_max_pages !== $page ) {
 			$content = sprintf(
 				'<a href="%1$s" %2$s>%3$s</a>',
-				esc_url( add_query_arg( $page_key, $page + 1 ) ),
+				esc_url( add_query_arg( $page_key, $page + 1, get_permalink() ) ),
 				$wrapper_attributes,
 				$label
 			);


### PR DESCRIPTION

## What?
When retrieving page content via the REST API, the Next/Previous pagination links in the Query Pagination block incorrectly use the REST API endpoint (/wp-json/wp/v2/pages/...) instead of the actual page permalink. This results in broken pagination links that don’t align with the site’s permalink structure. I have noticed this issue in Next and Previous Page links.

Expected Link - http://localhost:8888/test/?query-3-page=2
Actual Link - http://localhost:8888/wp-json/wp/v2/pages/13?query-3-page=2
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #69433 

<!-- In a few words, what is the PR actually doing? -->

## Why?
The frontend correctly generates pagination links using the page’s permalink.However, when fetching page content via the REST API, pagination links incorrectly use the API request URL instead of the post’s actual permalink. This may break headless WordPress setups and external API consumers who rely on REST responses.

## How?
Modified `render_block_core_query_pagination_next()` to use `get_permalink()` instead of relying on `$_SERVER['REQUEST_URI'].`
## Testing Instructions

1. Create a Page and add a Query Loop block with Pagination (Next/Previous Page).
2. Save the page and view it on the frontend – pagination links should be correct.
3. Make a REST API request to fetch the page content:
4. /wp-json/wp/v2/pages/{id}
5. Check the Next and Previous page links in the API response – it should be something like `http://localhost:8888/test/?query-3-page=2` instead of `http://localhost:8888/wp-json/wp/v2/pages/13?query-3-page=2`

### Testing Instructions for Keyboard
Not required
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
