### PR TITLE
Block Directory: Fix metadata of new innerBlocks of a installed block not propagated to the editor

### DIFF
--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -87,6 +87,7 @@ export const installBlockType =
 
 			// Ensures that the block metadata is propagated to the editor when registered on the server.
 			const metadataFields = [
+				'name',
 				'api_version',
 				'title',
 				'category',
@@ -103,23 +104,32 @@ export const installBlockType =
 				'variations',
 			];
 			await apiFetch( {
-				path: addQueryArgs( `/wp/v2/block-types/${ name }`, {
+				path: addQueryArgs( `/wp/v2/block-types/`, {
 					_fields: metadataFields,
 				} ),
 			} )
 				// Ignore when the block is not registered on the server.
 				.catch( () => {} )
 				.then( ( response ) => {
-					if ( ! response ) {
+					if ( ! response && ! Array.isArray( response ) ) {
 						return;
 					}
-					unstable__bootstrapServerSideBlockDefinitions( {
-						[ name ]: Object.fromEntries(
-							Object.entries( response ).filter( ( [ key ] ) =>
-								metadataFields.includes( key )
-							)
-						),
-					} );
+					const blockDefinitions = Object.fromEntries(
+						response.map( ( blockItem ) => [
+							blockItem.name,
+							Object.fromEntries(
+								Object.entries( blockItem ).filter(
+									( [ key ] ) =>
+										metadataFields.includes( key )
+								)
+							),
+						] )
+					);
+
+					// Bootstrap all retrieved block definitions
+					unstable__bootstrapServerSideBlockDefinitions(
+						blockDefinitions
+					);
 				} );
 
 			await loadAssets();

--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -92,6 +92,7 @@ export const installBlockType =
 				'title',
 				'category',
 				'parent',
+				'ancestor',
 				'icon',
 				'description',
 				'keywords',
@@ -102,6 +103,8 @@ export const installBlockType =
 				'styles',
 				'example',
 				'variations',
+				'blockHooks',
+				'allowedBlocks',
 			];
 			await apiFetch( {
 				path: addQueryArgs( `/wp/v2/block-types/`, {
@@ -114,6 +117,7 @@ export const installBlockType =
 					if ( ! response && ! Array.isArray( response ) ) {
 						return;
 					}
+
 					const blockDefinitions = Object.fromEntries(
 						response.map( ( blockItem ) => [
 							blockItem.name,
@@ -126,9 +130,56 @@ export const installBlockType =
 						] )
 					);
 
-					// Bootstrap all retrieved block definitions
+					const installedDefinition = blockDefinitions[ name ];
+					if ( ! installedDefinition ) {
+						return;
+					}
+
+					const { allowedBlocks = [] } = installedDefinition;
+
+					let blocksToBootstrap = {};
+					if (
+						Array.isArray( allowedBlocks ) &&
+						allowedBlocks.length > 0
+					) {
+						blocksToBootstrap = allowedBlocks.reduce(
+							( acc, blockName ) => {
+								if (
+									! blockName.startsWith( 'core/' ) &&
+									blockDefinitions[ blockName ]
+								) {
+									acc[ blockName ] =
+										blockDefinitions[ blockName ];
+								}
+								return acc;
+							},
+							{}
+						);
+
+						blocksToBootstrap[ name ] = installedDefinition;
+					} else {
+						const childBlocks = Object.entries(
+							blockDefinitions
+						).filter( ( [ , def ] ) => {
+							function includesBlockName( defProp ) {
+								if ( Array.isArray( defProp ) ) {
+									return defProp.includes( name );
+								}
+								return false;
+							}
+
+							return (
+								includesBlockName( def.parent ) ||
+								includesBlockName( def.ancestor )
+							);
+						} );
+
+						blocksToBootstrap = Object.fromEntries( childBlocks );
+
+						blocksToBootstrap[ name ] = installedDefinition;
+					}
 					unstable__bootstrapServerSideBlockDefinitions(
-						blockDefinitions
+						blocksToBootstrap
 					);
 				} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #69315 


<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
PR fixes the Block Directory installation bug which causes failing registration of innerBlocks of newly installed block until the page is refreshed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

When a new block is installed propagating all registered blocks metadata to the editor instead of just newly installed block.

The ideal case would be propagating only new block and innerBlocks used in that block, but I am unable to achieve it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open new post or page
2. Open block inserter
3. Search 'Slider' find "Slider" block by Lovro Hrust and install it
4. Confirm the block is present without showing error message for innerBlock (makeiteasy/slide).

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
|<img width="1470" alt="image" src="https://github.com/user-attachments/assets/3432f71a-2a0c-4b2d-a799-15b379b5f3f1" />| <img width="1470" alt="image" src="https://github.com/user-attachments/assets/40bdee6d-9aaa-4f8a-ad71-e180d77c7cd6" />|
