### PR TITLE
Make password protected input fields consistent.

### DIFF
--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -230,7 +230,7 @@ export default function PostStatus() {
 													'Password protected'
 												) }
 												help={ __(
-													'Only visible to those who know the password'
+													'Only visible to those who know the password.'
 												) }
 												checked={ showPassword }
 												onChange={

--- a/packages/editor/src/components/post-sticky/index.js
+++ b/packages/editor/src/components/post-sticky/index.js
@@ -29,7 +29,7 @@ export default function PostSticky() {
 			<CheckboxControl
 				className="editor-post-sticky__checkbox-control"
 				label={ __( 'Sticky' ) }
-				help={ __( 'Pin this post to the top of the blog' ) }
+				help={ __( 'Pin this post to the top of the blog.' ) }
 				checked={ postSticky }
 				onChange={ () => editPost( { sticky: ! postSticky } ) }
 				__nextHasNoMarginBottom

--- a/packages/editor/src/components/post-visibility/index.js
+++ b/packages/editor/src/components/post-visibility/index.js
@@ -6,6 +6,7 @@ import { useState } from '@wordpress/element';
 import {
 	VisuallyHidden,
 	__experimentalConfirmDialog as ConfirmDialog,
+	TextControl,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -70,8 +71,8 @@ export default function PostVisibility( { onClose } ) {
 		setHasPassword( true );
 	};
 
-	const updatePassword = ( event ) => {
-		editPost( { password: event.target.value } );
+	const updatePassword = ( value ) => {
+		editPost( { password: value } );
 	};
 
 	return (
@@ -110,22 +111,17 @@ export default function PostVisibility( { onClose } ) {
 					onChange={ setPasswordProtected }
 				/>
 				{ hasPassword && (
-					<div className="editor-post-visibility__password">
-						<VisuallyHidden
-							as="label"
-							htmlFor={ `editor-post-visibility__password-input-${ instanceId }` }
-						>
-							{ __( 'Create password' ) }
-						</VisuallyHidden>
-						<input
-							className="editor-post-visibility__password-input"
-							id={ `editor-post-visibility__password-input-${ instanceId }` }
-							type="text"
-							onChange={ updatePassword }
-							value={ password }
-							placeholder={ __( 'Use a secure password' ) }
-						/>
-					</div>
+					<TextControl
+						label={ __( 'Password' ) }
+						onChange={ updatePassword }
+						value={ password }
+						placeholder={ __( 'Use a secure password' ) }
+						type="text"
+						id={ `editor-post-visibility__password-input-${ instanceId }` }
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						maxLength={ 255 }
+					/>
 				) }
 			</fieldset>
 			<ConfirmDialog

--- a/packages/editor/src/components/post-visibility/style.scss
+++ b/packages/editor/src/components/post-visibility/style.scss
@@ -18,10 +18,4 @@
 	.editor-post-visibility__choice:last-child .editor-post-visibility__info {
 		margin-bottom: 0;
 	}
-
-	.editor-post-visibility__password .editor-post-visibility__password-input[type="text"] {
-		@include input-control;
-		margin-left: $grid-unit * 4;
-		width: calc(100% - #{$grid-unit * 4});
-	}
 }

--- a/packages/editor/src/components/post-visibility/utils.js
+++ b/packages/editor/src/components/post-visibility/utils.js
@@ -14,6 +14,6 @@ export const visibilityOptions = {
 	},
 	password: {
 		label: __( 'Password protected' ),
-		info: __( 'Only those with the password can view this post.' ),
+		info: __( 'Only visible to those who know the password.' ),
 	},
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/69439

<!-- In a few words, what is the PR actually doing? -->
The password protected input field and description in the pre-publish checks panel is inconsistent with the one in the Post Summary panel. Also, it doesn't use the 40ixels size.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
These input fields should both use a TextControl component with similar functionality, built-in styling and same labeling and descriptions to be consistent.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Uses a TextControl component.
- Removes some unnecessary styling.
- Uses consistent labeling and description.
- Nitpick: In the post summary panel, the descriptions of the Password protected setting and of hte Sticky setting were the only ones without a trailing period. Added it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Repeat the steps fro the issue https://github.com/WordPress/gutenberg/issues/69439
- Observe the input fields, labels and descriptions are consistent
- Test the password protected functionality in the pre-publish panel, publish. Test everything works as expected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/8eab8448-ba84-4ed7-84a6-7f8c55ea4d78)|![after](https://github.com/user-attachments/assets/c68eff70-30d1-4da3-aaf2-99091e980524)|


