### PR TITLE
ARIA: Fix invalid `DropdownMenu` children structure

### DIFF
--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -86,15 +86,13 @@ function VariationsDropdown( {
 			toggleProps={ { iconPosition: 'right' } }
 		>
 			{ () => (
-				<div className={ `${ className }__container` }>
-					<MenuGroup>
-						<MenuItemsChoice
-							choices={ selectOptions }
-							value={ selectedValue }
-							onSelect={ onSelectVariation }
-						/>
-					</MenuGroup>
-				</div>
+				<MenuGroup className={ `${ className }__container` }>
+					<MenuItemsChoice
+						choices={ selectOptions }
+						value={ selectedValue }
+						onSelect={ onSelectVariation }
+					/>
+				</MenuGroup>
 			) }
 		</DropdownMenu>
 	);

--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -86,7 +86,7 @@ function VariationsDropdown( {
 			toggleProps={ { iconPosition: 'right' } }
 		>
 			{ () => (
-				<MenuGroup className={ `${ className }__container` }>
+				<MenuGroup>
 					<MenuItemsChoice
 						choices={ selectOptions }
 						value={ selectedValue }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menu/more-menu.js
@@ -45,47 +45,45 @@ export default function ScreenNavigationMoreMenu( props ) {
 				popoverProps={ POPOVER_PROPS }
 			>
 				{ ( { onClose } ) => (
-					<div>
-						<MenuGroup>
-							<MenuItem
-								onClick={ () => {
-									openRenameModal();
-									// Close the dropdown after opening the modal.
-									onClose();
-								} }
-							>
-								{ __( 'Rename' ) }
-							</MenuItem>
-							<MenuItem
-								onClick={ () => {
-									history.navigate(
-										`/wp_navigation/${ menuId }?canvas=edit`
-									);
-								} }
-							>
-								{ __( 'Edit' ) }
-							</MenuItem>
-							<MenuItem
-								onClick={ () => {
-									onDuplicate();
-									onClose();
-								} }
-							>
-								{ __( 'Duplicate' ) }
-							</MenuItem>
-							<MenuItem
-								isDestructive
-								onClick={ () => {
-									openDeleteConfirmDialog();
+					<MenuGroup>
+						<MenuItem
+							onClick={ () => {
+								openRenameModal();
+								// Close the dropdown after opening the modal.
+								onClose();
+							} }
+						>
+							{ __( 'Rename' ) }
+						</MenuItem>
+						<MenuItem
+							onClick={ () => {
+								history.navigate(
+									`/wp_navigation/${ menuId }?canvas=edit`
+								);
+							} }
+						>
+							{ __( 'Edit' ) }
+						</MenuItem>
+						<MenuItem
+							onClick={ () => {
+								onDuplicate();
+								onClose();
+							} }
+						>
+							{ __( 'Duplicate' ) }
+						</MenuItem>
+						<MenuItem
+							isDestructive
+							onClick={ () => {
+								openDeleteConfirmDialog();
 
-									// Close the dropdown after opening the modal.
-									onClose();
-								} }
-							>
-								{ __( 'Delete' ) }
-							</MenuItem>
-						</MenuGroup>
-					</div>
+								// Close the dropdown after opening the modal.
+								onClose();
+							} }
+						>
+							{ __( 'Delete' ) }
+						</MenuItem>
+					</MenuGroup>
 				) }
 			</DropdownMenu>
 			{ deleteConfirmDialogOpen && (


### PR DESCRIPTION


## What?
Related comment: https://github.com/WordPress/gutenberg/issues/67795#issuecomment-2701047913


## Why?
To improve code quality and accessibility by ensuring the correct child elements are used within `DropdownMenu`.

## How?
Removed the unnecessary div elements that were direct children of `DropdownMenu`.
