### PR TITLE
fix: site logo min width issue

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -284,7 +284,7 @@ const SiteLogo = ( {
 						onChange={ ( newWidth ) =>
 							setAttributes( { width: newWidth } )
 						}
-						min={ minWidth }
+						//min={ minWidth }
 						max={ maxWidthBuffer }
 						initialPosition={ Math.min(
 							defaultWidth,


### PR DESCRIPTION
## What?
#69253


## Why?
The site logo block had minimum width and height value limited to 20, but the user reported that he wanted to set any value. That's why I have removed the minimum value.

## Testing Instructions
1. Insert site logo block
2. Now try to resize it, and you can resize it to a minimum width and height of 0

Screenshot:
<img width="1231" alt="image" src="https://github.com/user-attachments/assets/1990e098-b180-4b8c-b859-7dbbe0255e40" />
