### PR TITLE
loginout block: Add option to remove whitespace

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -436,7 +436,7 @@ Show login & logout links. ([Source](https://github.com/WordPress/gutenberg/tree
 -	**Name:** core/loginout
 -	**Category:** theme
 -	**Supports:** className, color (background, gradients, link, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
--	**Attributes:** displayLoginAsForm, redirectToCurrent
+-	**Attributes:** combineLoginLogout, displayLoginAsForm, redirectToCurrent
 
 ## Media & Text
 

--- a/packages/block-library/src/loginout/block.json
+++ b/packages/block-library/src/loginout/block.json
@@ -15,6 +15,10 @@
 		"redirectToCurrent": {
 			"type": "boolean",
 			"default": true
+		},
+		"combineLoginLogout": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"example": {

--- a/packages/block-library/src/loginout/edit.js
+++ b/packages/block-library/src/loginout/edit.js
@@ -14,7 +14,8 @@ import { __ } from '@wordpress/i18n';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 export default function LoginOutEdit( { attributes, setAttributes } ) {
-	const { displayLoginAsForm, redirectToCurrent } = attributes;
+	const { displayLoginAsForm, redirectToCurrent, combineLoginLogout } =
+		attributes;
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	return (
@@ -68,6 +69,27 @@ export default function LoginOutEdit( { attributes, setAttributes } ) {
 							}
 						/>
 					</ToolsPanelItem>
+					<ToolsPanelItem
+						label={ __(
+							'Use "Login" and "Logout" instead of "Log in" and "Log out"'
+						) }
+						isShownByDefault
+						hasValue={ () => combineLoginLogout }
+						onDeselect={ () =>
+							setAttributes( { combineLoginLogout: false } )
+						}
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Use single words' ) }
+							checked={ combineLoginLogout }
+							onChange={ () =>
+								setAttributes( {
+									combineLoginLogout: ! combineLoginLogout,
+								} )
+							}
+						/>
+					</ToolsPanelItem>
 				</ToolsPanel>
 			</InspectorControls>
 			<div
@@ -75,7 +97,9 @@ export default function LoginOutEdit( { attributes, setAttributes } ) {
 					className: 'logged-in',
 				} ) }
 			>
-				<a href="#login-pseudo-link">{ __( 'Log out' ) }</a>
+				<a href="#login-pseudo-link">
+					{ combineLoginLogout ? __( 'Logout' ) : __( 'Log out' ) }
+				</a>
 			</div>
 		</>
 	);

--- a/packages/block-library/src/loginout/index.php
+++ b/packages/block-library/src/loginout/index.php
@@ -34,6 +34,11 @@ function render_block_core_loginout( $attributes ) {
 		$contents = wp_login_form( array( 'echo' => false ) );
 	}
 
+	if ( ! empty( $attributes['combineLoginLogout'] ) ) {
+		$contents = str_replace( 'Log in', 'Login', $contents );
+		$contents = str_replace( 'Log out', 'Logout', $contents );
+	}
+
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
 
 	return '<div ' . $wrapper_attributes . '>' . $contents . '</div>';


### PR DESCRIPTION
Closes #53124

## What?
This PR introduces an option in the Login/Logout block to remove whitespace, allowing users to display "Login" and "Logout" instead of "Log in" and "Log out".

## Why?
Currently, the Login/Logout block separates "Log in" and "Log out" into two words by default. While this is grammatically correct, some users may prefer to display these terms as single words for consistency with branding or design preferences. This PR provides an option to toggle between the two formats.

## Testing Instructions
1. Open the Editor and add a Login/Logout block.
2. Open the block settings panel in the inspector sidebar.
3. Toggle the new setting "Use single words" to switch between "Log in" ↔ "Login" and "Log out" ↔ "Logout".
4. Save the post and view it on the frontend to confirm the text updates accordingly.

## Screenshots or screencast 
https://github.com/user-attachments/assets/dd678ee0-5852-43d0-92e9-a8134c37d9f3
