### PR TITLE
Site Editor: show save panel in mobile layout

### DIFF
--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -179,6 +179,8 @@ function Layout() {
 												{ areas.mobile }
 											</ErrorBoundary>
 										</SidebarContent>
+										<SaveHub />
+										<SavePanel />
 									</>
 								) : (
 									<ErrorBoundary>

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -74,6 +74,13 @@
 	.edit-site-sidebar-navigation-screen__main {
 		padding: 0 $grid-unit-15;
 	}
+
+	.edit-site-layout__content:has(.edit-site-page) & {
+		.edit-site-save-hub {
+			background: $white;
+			border-top-color: $gray-100;
+		}
+	}
 }
 
 .edit-site-layout__canvas-container {

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -74,13 +74,6 @@
 	.edit-site-sidebar-navigation-screen__main {
 		padding: 0 $grid-unit-15;
 	}
-
-	.edit-site-layout__content:has(.edit-site-page) & {
-		.edit-site-save-hub {
-			background: $white;
-			border-top-color: $gray-100;
-		}
-	}
 }
 
 .edit-site-layout__canvas-container {


### PR DESCRIPTION
## What?

This PR properly shows the save panel in the mobile layout.

Closes [#69415](https://github.com/WordPress/gutenberg/issues/69415)

## Why?

The save button will be visible when the same sidebar screen is shared on both desktop and mobile, i.e. `areas.sidebar` is defined and `areas.mobile` is not defined.

But when `areas.mobile` is defined, [this conditional statement](https://github.com/WordPress/gutenberg/blob/b8bf49dd32678c6d5b650ce396e1e2d3a4fbf6cb/packages/edit-site/src/components/layout/index.js#L115) is false and the save button won't be displayed. Instead it runs [this code](https://github.com/WordPress/gutenberg/blob/b8bf49dd32678c6d5b650ce396e1e2d3a4fbf6cb/packages/edit-site/src/components/layout/index.js#L166-L190), which has no save panel.

I think this is fundamentally a bug, but if `areas.mobile` is fortunately not defined then it's not recognized as a bug. But when `areas.mobile` is defined, like [here](https://github.com/WordPress/gutenberg/blob/b8bf49dd32678c6d5b650ce396e1e2d3a4fbf6cb/packages/edit-site/src/components/site-editor-routes/home.js#L13), the save panel disappears and it starts to feel like a bug.

## How?

Show the save panel when the canvas is not edit. This will cause visual changes on some screens but should match functionality in the desktop layout.

## Testing Instructions

- Narrow your browser width.
- Access the Site Editor.
- The following screens will have the Save button at the bottom:
  - All screens with a "black" background
  - Page list, Template list, Pattern list
- The Save button will not be visible on the editor canvas.
- After making a change to any entity, return to view mode and verify that the Save button works properly.

## Screenshots or screencast <!-- if applicable -->

Here are some example screens.

<details><summary>Design</summary>

http://localhost:8888/wp-admin/site-editor.php?p=%2F

![image](https://github.com/user-attachments/assets/03ac8b65-fd17-42c6-9865-48ecfa2fa94f)

</details> 

<details><summary>Pattern Category List</summary>

http://localhost:8888/wp-admin/site-editor.php?p=%2Fpattern

The categories are still scrollable and you should be able to access the full category items as before.

![image](https://github.com/user-attachments/assets/e9d72995-2a8d-40a2-b14c-e763a8f81eaa)

</details> 

<details><summary>Pattern List</summary>

http://localhost:8888/wp-admin/site-editor.php?p=%2Fpattern&postType=wp_block&categoryId=all-patterns

This screen is one of the biggest visual changes. Ideally, it should be on a white background, but this may be a bit tricky.

Make sure scrolling and pagination are working now as before.

![image](https://github.com/user-attachments/assets/ec394303-80c8-4ab5-8959-f3984e2dce65)

</details> 