### PR TITLE
Spacer: Revert height defaults to `100px` if left unset

### DIFF
--- a/packages/block-library/src/spacer/constants.js
+++ b/packages/block-library/src/spacer/constants.js
@@ -1,2 +1,1 @@
 export const MIN_SPACER_SIZE = 0;
-export const DEFAULT_HEIGHT = '100px';

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -23,7 +23,7 @@ import { View } from '@wordpress/primitives';
  * Internal dependencies
  */
 import { unlock } from '../lock-unlock';
-import { DEFAULT_HEIGHT, MIN_SPACER_SIZE } from './constants';
+import { MIN_SPACER_SIZE } from './constants';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const { useSpacingSizes } = unlock( blockEditorPrivateApis );
@@ -100,7 +100,7 @@ export default function SpacerControls( {
 				resetAll={ () => {
 					setAttributes( {
 						width: undefined,
-						height: DEFAULT_HEIGHT,
+						height: '100px',
 					} );
 				} }
 				dropdownMenuProps={ dropdownMenuProps }
@@ -128,9 +128,9 @@ export default function SpacerControls( {
 					<ToolsPanelItem
 						label={ __( 'Height' ) }
 						isShownByDefault
-						hasValue={ () => height !== DEFAULT_HEIGHT }
+						hasValue={ () => height !== '100px' }
 						onDeselect={ () =>
-							setAttributes( { height: DEFAULT_HEIGHT } )
+							setAttributes( { height: '100px' } )
 						}
 					>
 						<DimensionInput

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -23,7 +23,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
  */
 import { unlock } from '../lock-unlock';
 import SpacerControls from './controls';
-import { DEFAULT_HEIGHT, MIN_SPACER_SIZE } from './constants';
+import { MIN_SPACER_SIZE } from './constants';
 
 const { useSpacingSizes } = unlock( blockEditorPrivateApis );
 
@@ -169,13 +169,9 @@ const SpacerEdit = ( {
 
 	const getHeightForVerticalBlocks = () => {
 		if ( isFlexLayout ) {
-			return DEFAULT_HEIGHT;
+			return undefined;
 		}
-		return (
-			temporaryHeight ||
-			getSpacingPresetCssVar( height ) ||
-			DEFAULT_HEIGHT
-		);
+		return temporaryHeight || getSpacingPresetCssVar( height ) || undefined;
 	};
 
 	const getWidthForHorizontalBlocks = () => {
@@ -283,7 +279,7 @@ const SpacerEdit = ( {
 				const newSize =
 					getCustomValueFromPreset( width, spacingSizes ) ||
 					getCustomValueFromPreset( height, spacingSizes ) ||
-					DEFAULT_HEIGHT;
+					'100px';
 				setAttributesCovertly( {
 					width: '0px',
 					style: {
@@ -299,7 +295,7 @@ const SpacerEdit = ( {
 				const newSize =
 					getCustomValueFromPreset( height, spacingSizes ) ||
 					getCustomValueFromPreset( width, spacingSizes ) ||
-					DEFAULT_HEIGHT;
+					'100px';
 				setAttributesCovertly( {
 					height: '0px',
 					style: {

--- a/packages/block-library/src/spacer/save.js
+++ b/packages/block-library/src/spacer/save.js
@@ -3,11 +3,6 @@
  */
 import { useBlockProps, getSpacingPresetCssVar } from '@wordpress/block-editor';
 
-/**
- * Internal dependencies
- */
-import { DEFAULT_HEIGHT } from './constants';
-
 export default function save( { attributes } ) {
 	const { height, width, style } = attributes;
 	const { layout: { selfStretch } = {} } = style || {};
@@ -18,8 +13,7 @@ export default function save( { attributes } ) {
 		<div
 			{ ...useBlockProps.save( {
 				style: {
-					height:
-						getSpacingPresetCssVar( finalHeight ) || DEFAULT_HEIGHT,
+					height: getSpacingPresetCssVar( finalHeight ),
 					width: getSpacingPresetCssVar( width ),
 				},
 				'aria-hidden': true,


### PR DESCRIPTION
## What?
Reverts #68819

This PR reverts the changes made to `Spacer Block` under PR #68819.

## Why and How?

The changes in #68819 were introduced to fix a block validation error that occurred when an empty height value was saved. However, this led to compatibility issues (see #69414). This PR aims to revert that change to address those issues.

## Testing Instructions

**_Inserting a spacer inside a flex container_**

1. Install WP version to 6.7 and disable the Gutenberg plugin.
2. Insert Spacer block within Row/Stack.
3. Change "Width" to "Fill".
4. Save the post.
5. Activate the Gutenberg plugin.
6. Open the post.
7. Verify that the Spacer block works fine.