### PR TITLE
Pre-publish panel: Do not show suggestions for tags and categories if there are none

### DIFF
--- a/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
@@ -17,15 +17,8 @@ function MaybeCategoryPanel() {
 	const hasSiteCategories = useSelect( ( select ) => {
 		const { getEntityRecords } = select( coreStore );
 		const categories =
-			getEntityRecords( 'taxonomy', 'category', { per_page: -1 } ) || [];
-		const defaultCategoryId = select( coreStore ).getEntityRecord(
-			'root',
-			'site'
-		)?.default_category;
-
-		return categories.some(
-			( category ) => category.id !== defaultCategoryId
-		);
+			getEntityRecords( 'taxonomy', 'category', { per_page: 2 } ) || [];
+		return categories.length > 1;
 	}, [] );
 
 	const hasNoCategory = useSelect( ( select ) => {

--- a/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
@@ -14,6 +14,20 @@ import HierarchicalTermSelector from '../post-taxonomies/hierarchical-term-selec
 import { store as editorStore } from '../../store';
 
 function MaybeCategoryPanel() {
+	const hasSiteCategories = useSelect( ( select ) => {
+		const { getEntityRecords } = select( coreStore );
+		const categories =
+			getEntityRecords( 'taxonomy', 'category', { per_page: -1 } ) || [];
+		const defaultCategoryId = select( coreStore ).getEntityRecord(
+			'root',
+			'site'
+		)?.default_category;
+
+		return categories.some(
+			( category ) => category.id !== defaultCategoryId
+		);
+	}, [] );
+
 	const hasNoCategory = useSelect( ( select ) => {
 		const postType = select( editorStore ).getCurrentPostType();
 		const { canUser, getEntityRecord } = select( coreStore );
@@ -52,6 +66,7 @@ function MaybeCategoryPanel() {
 					defaultCategory?.id === categories[ 0 ] ) )
 		);
 	}, [] );
+
 	const [ shouldShowPanel, setShouldShowPanel ] = useState( false );
 	useEffect( () => {
 		// We use state to avoid hiding the panel if the user edits the categories
@@ -61,7 +76,11 @@ function MaybeCategoryPanel() {
 		}
 	}, [ hasNoCategory ] );
 
-	if ( ! shouldShowPanel ) {
+	// We only want to show the category panel:
+	// if the post type supports categories,
+	// if the site has categories other than the default category,
+	// and if the post has no other categories than the default category.
+	if ( ! shouldShowPanel || ! hasSiteCategories ) {
 		return null;
 	}
 

--- a/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
@@ -14,14 +14,7 @@ import HierarchicalTermSelector from '../post-taxonomies/hierarchical-term-selec
 import { store as editorStore } from '../../store';
 
 function MaybeCategoryPanel() {
-	const hasSiteCategories = useSelect( ( select ) => {
-		const { getEntityRecords } = select( coreStore );
-		const categories =
-			getEntityRecords( 'taxonomy', 'category', { per_page: 2 } ) || [];
-		return categories.length > 1;
-	}, [] );
-
-	const hasNoCategory = useSelect( ( select ) => {
+	const { hasNoCategory, hasSiteCategories } = useSelect( ( select ) => {
 		const postType = select( editorStore ).getCurrentPostType();
 		const { canUser, getEntityRecord } = select( coreStore );
 		const categoriesTaxonomy = getEntityRecord(
@@ -46,18 +39,28 @@ function MaybeCategoryPanel() {
 			select( editorStore ).getEditedPostAttribute(
 				categoriesTaxonomy.rest_base
 			);
+		const siteCategories = postTypeSupportsCategories
+			? !! select( coreStore ).getEntityRecords( 'taxonomy', 'category', {
+					exclude: [ defaultCategoryId ],
+					per_page: 1,
+			  } )?.length
+			: false;
 
 		// This boolean should return true if everything is loaded
 		// ( categoriesTaxonomy, defaultCategory )
 		// and the post has not been assigned a category different than "uncategorized".
-		return (
+		const noCategory =
 			!! categoriesTaxonomy &&
 			!! defaultCategory &&
 			postTypeSupportsCategories &&
 			( categories?.length === 0 ||
 				( categories?.length === 1 &&
-					defaultCategory?.id === categories[ 0 ] ) )
-		);
+					defaultCategory?.id === categories[ 0 ] ) );
+
+		return {
+			hasNoCategory: noCategory,
+			hasSiteCategories: siteCategories,
+		};
 	}, [] );
 
 	const [ shouldShowPanel, setShouldShowPanel ] = useState( false );

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -34,28 +34,43 @@ const TagsPanel = () => {
 };
 
 const MaybeTagsPanel = () => {
-	const { hasTags, isPostTypeSupported } = useSelect( ( select ) => {
-		const postType = select( editorStore ).getCurrentPostType();
-		const tagsTaxonomy = select( coreStore ).getEntityRecord(
-			'root',
-			'taxonomy',
-			'post_tag'
-		);
-		const _isPostTypeSupported = tagsTaxonomy?.types?.includes( postType );
-		const areTagsFetched = tagsTaxonomy !== undefined;
-		const tags =
-			tagsTaxonomy &&
-			select( editorStore ).getEditedPostAttribute(
-				tagsTaxonomy.rest_base
+	const { postHasTags, siteHasTags, isPostTypeSupported } = useSelect(
+		( select ) => {
+			const postType = select( editorStore ).getCurrentPostType();
+			const tagsTaxonomy = select( coreStore ).getEntityRecord(
+				'root',
+				'taxonomy',
+				'post_tag'
 			);
-		return {
-			hasTags: !! tags?.length,
-			isPostTypeSupported: areTagsFetched && _isPostTypeSupported,
-		};
-	}, [] );
-	const [ hadTagsWhenOpeningThePanel ] = useState( hasTags );
+			const _isPostTypeSupported =
+				tagsTaxonomy?.types?.includes( postType );
+			const areTagsFetched = tagsTaxonomy !== undefined;
+			const tags =
+				tagsTaxonomy &&
+				select( editorStore ).getEditedPostAttribute(
+					tagsTaxonomy.rest_base
+				);
+			const siteTags = select( coreStore ).getEntityRecords(
+				'taxonomy',
+				'post_tag',
+				{ per_page: 1 }
+			);
 
-	if ( ! isPostTypeSupported ) {
+			return {
+				postHasTags: !! tags?.length,
+				siteHasTags: !! siteTags?.length,
+				isPostTypeSupported: areTagsFetched && _isPostTypeSupported,
+			};
+		},
+		[]
+	);
+	const [ hadTagsWhenOpeningThePanel ] = useState( postHasTags );
+
+	/**
+	 * We only want to show the tag panel if the post type supports
+	 * tags and the site has tags.
+	 */
+	if ( ! isPostTypeSupported || ! siteHasTags ) {
 		return null;
 	}
 
@@ -63,9 +78,9 @@ const MaybeTagsPanel = () => {
 	 * We only want to show the tag panel if the post didn't have
 	 * any tags when the user hit the Publish button.
 	 *
-	 * We can't use the prop.hasTags because it'll change to true
+	 * We can't use the prop.postHasTags because it'll change to true
 	 * if the user adds a new tag within the pre-publish panel.
-	 * This would force a re-render and a new prop.hasTags check,
+	 * This would force a re-render and a new prop.postHasTags check,
 	 * hiding this panel and keeping the user from adding
 	 * more than one tag.
 	 */

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -50,15 +50,17 @@ const MaybeTagsPanel = () => {
 				select( editorStore ).getEditedPostAttribute(
 					tagsTaxonomy.rest_base
 				);
-			const siteTags = select( coreStore ).getEntityRecords(
-				'taxonomy',
-				'post_tag',
-				{ per_page: 1 }
-			);
+			const siteTags = _isPostTypeSupported
+				? !! select( coreStore ).getEntityRecords(
+						'taxonomy',
+						'post_tag',
+						{ per_page: 1 }
+				  )?.length
+				: false;
 
 			return {
 				postHasTags: !! tags?.length,
-				siteHasTags: !! siteTags?.length,
+				siteHasTags: siteTags,
 				isPostTypeSupported: areTagsFetched && _isPostTypeSupported,
 			};
 		},


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->https://github.com/WordPress/gutenberg/issues/69452

Update the conditions that determine if the pre-publish panel should show suggestions to add categories or tags.

- If there are no tags on the site, then don't show the suggestion to add tags.
- If there are no categories other than the default on the site, then don't show the suggestion to add categories.

## Why?

>Right now, we suggest adding tags and categories to every page. Every time someone creates a new tag that way, we create a new URL on the internet that needs to be crawled, when really that page might not be very useful at all.

## Testing Instructions

First, enable the pre-publish checks in the user preference.
There should be no regressions on sites where there are tags and extra categories:
Create a new draft post. Select "Publish".
The pre-publish panel should show suggestions to add categories and tags.

On sites where there are no tags or extra categories:
Create a new draft post. Select "Publish".
The pre-publish panel should not show suggestions to add categories and tags.

## Screenshots or screencast <!-- if applicable -->

After, if there are no tags or extra categories on the site:
![A screenshot of the block editor pre-publish check without suggestions to add tags or categories](https://github.com/user-attachments/assets/f17ac902-340d-457a-8b2b-a744fd0ecc6a)


