### PR TITLE
Editor: Preload template lookup

### DIFF
--- a/backport-changelog/6.8/8441.md
+++ b/backport-changelog/6.8/8441.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/8441
 
 * https://github.com/WordPress/gutenberg/pull/69400
+* https://github.com/WordPress/gutenberg/pull/69454

--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -95,6 +95,20 @@ function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 		);
 	}
 
+	if ( 'core/edit-post' === $context->name ) {
+		$slug = 'page' === $context->post->post_type ? 'page' : 'single-' . $context->post->post_type;
+		if ( ! empty( $context->post->post_name ) ) {
+			$slug .= '-' . $context->post->post_name;
+		}
+
+		$paths[] = add_query_arg(
+			'slug',
+			// @see https://github.com/WordPress/gutenberg/blob/e093fefd041eb6cc4a4e7f67b92ab54fd75c8858/packages/core-data/src/private-selectors.ts#L244-L254
+			$slug,
+			'/wp/v2/templates/lookup'
+		);
+	}
+
 	return $paths;
 }
 add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_block_editor_preload_paths_6_8', 10, 2 );


### PR DESCRIPTION
## What?
This is similar to #66654.

PR adds a post-type single template lookup to the REST API preloaded paths.

## Why?
PR tries to optimize editor loading speed, especially when the default rendering mode is 'template-locked' and the editor has to wait for template resolution.

## Testing Instructions
1. Open a page.
2. Inspect requests using the DevTools Network tab.
3. Confirm that there's only one template lookup request (this is a different issue, and I plan to resolve it separately).

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2025-03-06 at 11 12 17](https://github.com/user-attachments/assets/6705ffcf-799e-411f-97c5-b37562c958a6)

