### PR TITLE
Added readme for inserter listbox

### DIFF
--- a/packages/block-editor/src/components/inserter-listbox/README.md
+++ b/packages/block-editor/src/components/inserter-listbox/README.md
@@ -1,0 +1,48 @@
+# Inserter Listbox Row
+
+The `InserterListboxRow` component is part of the Inserter Listbox system that provides horizontal organization for block inserter items. It wraps the Composite.Group component with proper accessibility attributes for screen readers and keyboard navigation.
+
+## Development guidelines
+
+### Usage
+
+```jsx
+import { InserterListboxRow } from '@wordpress/block-editor';
+
+const MyBlockList = () => (
+    <InserterListboxGroup>
+        <InserterListboxRow>
+            <InserterListboxItem>Paragraph Block</InserterListboxItem>
+            <InserterListboxItem>Heading Block</InserterListboxItem>
+            <InserterListboxItem>Image Block</InserterListboxItem>
+        </InserterListboxRow>
+    </InserterListboxGroup>
+);
+```
+
+### Props
+
+#### `ref`
+- **Type:** `ForwardedRef`
+- **Description:** Forward ref to access the DOM node of the row container
+
+#### `children`
+- **Type:** `Node`
+- **Description:** Components to be rendered within the row
+
+The component also accepts all props supported by `Composite.Group`.
+
+### Structure
+
+The component renders a `Composite.Group` with:
+- `role="presentation"` for proper screen reader behavior
+- Forwarded ref for DOM access
+- Spreads additional props to the underlying group
+
+## Related Components
+
+- `InserterListbox` - The main wrapper component
+- `InserterListboxGroup` - Container for organizing rows
+- `InserterListboxItem` - Individual selectable items
+
+Must be used under a [`BlockEditorProvider`](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/provider/README.md).


### PR DESCRIPTION
What? Closes [Issue #52057](https://github.com/WordPress/gutenberg/issues/52057)

This PR adds a README.md file for the inserter-listbox component in the Gutenberg project.

Why? The inserter-listbox component was missing a README.md file, which is important for providing documentation and clarity on the component's purpose and usage.

How?

    Created a new README.md file for the inserter-listbox component.
    Followed the structure and content style of the [alignment-control README](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/alignment-control/README.md) as a reference.

Testing Instructions

    Navigate to the inserter-listbox component directory.
    Ensure the new README.md file is present and contains relevant information about the component.
    Review the content to verify it aligns with Gutenberg documentation standards.

Testing Instructions for Keyboard

    Navigate through the documentation using keyboard shortcuts to ensure accessibility.