### PR TITLE
Added readme for insertor menu extension

### DIFF
--- a/packages/block-editor/src/components/inserter-menu-extension/README.md
+++ b/packages/block-editor/src/components/inserter-menu-extension/README.md
@@ -1,0 +1,45 @@
+# Inserter Menu Extension
+
+The `InserterMenuExtension` component provides a slot/fill mechanism to extend the block inserter menu with additional content. This unstable API allows developers to inject custom UI elements into the block inserter menu.
+
+## Development guidelines
+
+### Usage
+
+```jsx
+import InserterMenuExtension from '@wordpress/block-editor';
+
+// Adding content to the inserter menu
+const MyInserterExtension = () => (
+    <InserterMenuExtension>
+        <div>Custom Inserter Content</div>
+    </InserterMenuExtension>
+);
+
+// Rendering the slot where extensions will appear
+const InserterWithExtensions = () => (
+    <div className="block-editor-inserter">
+        <InserterMenuExtension.Slot />
+    </div>
+);
+```
+
+### Component Structure
+
+The component uses WordPress's SlotFill system with:
+- A `Fill` component (`InserterMenuExtension`)
+- A corresponding `Slot` component (`InserterMenuExtension.Slot`)
+
+### Props
+
+The component accepts all props that can be passed to a standard SlotFill component.
+
+### Important Notes
+
+- This is an unstable API as indicated by the `__unstable` prefix
+- Changes might occur in future versions
+- Should be used with caution in production environments
+
+## Related Components
+
+Block Editor components are components that can be used to compose the UI of your block editor. They should be used under a [`BlockEditorProvider`](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/provider/README.md) in the components tree.


### PR DESCRIPTION
### PR Description

**What?**
Closes [Issue #52058](https://github.com/WordPress/gutenberg/issues/52058)

This PR adds a README.md file for the `inserter-menu-extension` component in the Gutenberg project.

**Why?**
The `inserter-menu-extension` component was missing a README.md file, which is important for providing documentation and clarity on the component's purpose and usage.

**How?**
- Created a new README.md file for the `inserter-menu-extension` component.
- Followed the structure and content style of the [alignment-control README](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/alignment-control/README.md) as a reference.

**Testing Instructions**
1. Navigate to the `inserter-menu-extension` component directory.
2. Ensure the new README.md file is present and contains relevant information about the component.
3. Review the content to verify it aligns with Gutenberg documentation standards.

**Testing Instructions for Keyboard**
- Navigate through the documentation using keyboard shortcuts to ensure accessibility.

