### PR TITLE
added readme for block content overlay

### DIFF
--- a/packages/block-editor/src/components/block-content-overlay/README.md
+++ b/packages/block-editor/src/components/block-content-overlay/README.md
@@ -1,0 +1,58 @@
+# Block Content Overlay
+
+The `useBlockOverlayActive` hook provides functionality to determine if a block has an active overlay state. This is used to control block interaction and styling when certain operations are being performed on the block.
+
+## Development guidelines
+
+### Usage
+
+```jsx
+import { useBlockOverlayActive } from '@wordpress/block-editor';
+
+const MyBlockComponent = ({ clientId }) => {
+    const hasOverlay = useBlockOverlayActive(clientId);
+
+    return (
+        <div className={hasOverlay ? 'has-block-overlay' : ''}>
+            {/* Block content */}
+        </div>
+    );
+};
+```
+
+### Hook Parameters
+
+#### `clientId`
+- **Type:** `String`
+- **Required:** Yes
+- **Description:** The unique identifier for the block
+
+### Return Value
+
+- **Type:** `Boolean`
+- **Description:** Returns true if the block has an active overlay, false otherwise
+
+### Styling
+
+The component comes with default styles that handle the overlay appearance:
+
+```scss
+.block-editor-block-list__block.has-block-overlay {
+    cursor: default;
+
+    // Disable pointer events on nested blocks
+    .block-editor-block-list__block {
+        pointer-events: none;
+    }
+}
+```
+
+### Important Notes
+
+- This is an unstable API as indicated by the `__unstable` prefix in the store selector
+- The overlay state affects both the visual appearance and interaction behavior of blocks
+- Nested blocks within an overlay-active block will have pointer events disabled
+
+## Related Components
+
+Block Editor components are components that can be used to compose the UI of your block editor. They should be used under a [`BlockEditorProvider`](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/provider/README.md) in the components tree.


### PR DESCRIPTION
### PR Description

**What?**
Closes [Issue #52060](https://github.com/WordPress/gutenberg/issues/52060)

This PR adds a README.md file for the `block-content-overlay` component in the Gutenberg project.

**Why?**
The `block-content-overlay` component was missing a README.md file, which is important for providing documentation and clarity on the component's purpose and usage.

**How?**
- Created a new README.md file for the `block-content-overlay` component.
- Detailed the `useBlockOverlayActive` hook, including its usage, parameters, return values, and styling.
- Provided development guidelines and important notes about the component.

**Testing Instructions**
1. Navigate to the `block-content-overlay` component directory.
2. Ensure the new README.md file is present and contains relevant information about the component.
3. Review the content to verify it aligns with Gutenberg documentation standards.

**Testing Instructions for Keyboard**
- Navigate through the documentation using keyboard shortcuts to ensure accessibility.
