### PR TITLE
Editor: Optimize selector queries for Homepage and Posts Page actions

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -26,21 +26,26 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 
 	const { canManageOptions, hasFrontPageTemplate } = useSelect(
 		( select ) => {
-			const { getEntityRecords } = select( coreStore );
-			const templates = getEntityRecords( 'postType', 'wp_template', {
-				per_page: -1,
+			const { getEntityRecords, canUser } = select( coreStore );
+			const canUpdateSettings = canUser( 'update', {
+				kind: 'root',
+				name: 'site',
 			} );
+			const templates =
+				'page' === postType && canUpdateSettings
+					? getEntityRecords( 'postType', 'wp_template', {
+							per_page: -1,
+					  } )
+					: [];
 
 			return {
-				canManageOptions: select( coreStore ).canUser( 'update', {
-					kind: 'root',
-					name: 'site',
-				} ),
+				canManageOptions: canUpdateSettings,
 				hasFrontPageTemplate: !! templates?.find(
 					( template ) => template?.slug === 'front-page'
 				),
 			};
-		}
+		},
+		[ postType ]
 	);
 
 	const setAsHomepageAction = useSetAsHomepageAction();


### PR DESCRIPTION
## What?
This is a follow-up to #65426.

PR avoids making unnecessary REST API requests when a post type cannot be set as Homepage or Posts Page or when a user doesn't have proper capabilities.

## Why?
Reduces the number of HTTP requests when opening a post or any other post type, except page.

## Testing Instructions
1. Open a post.
2. Confirm there's no list templates request.
3. Open a published page.
4. Confirm you can set it as Homepage or Posts Page.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
|Before|After|
|-|-|
|![CleanShot 2025-03-06 at 12 21 48](https://github.com/user-attachments/assets/5ed3bbc1-e1d2-455d-b4b5-c7dcc25a04f2)|![CleanShot 2025-03-06 at 12 22 02](https://github.com/user-attachments/assets/109143cc-63eb-45dc-9d54-c2414e3eda0a)|

![CleanShot 2025-03-06 at 12 28 47](https://github.com/user-attachments/assets/cc6a8387-f139-47c1-9ff5-36347f8f92f6)
