### PR TITLE
Add README for useMovingAnimation hook with usage and performance gui…

### DIFF
--- a/packages/block-editor/src/components/use-moving-animation/README.md
+++ b/packages/block-editor/src/components/use-moving-animation/README.md
@@ -1,0 +1,74 @@
+# Moving Animation Hook
+
+The `useMovingAnimation` hook provides smooth animations for block movement in the WordPress block editor. It handles block reordering, dragging, and insertion animations while respecting user preferences and performance constraints.
+
+## Development guidelines
+
+### Usage
+
+```jsx
+import { useMovingAnimation } from '@wordpress/block-editor';
+
+const MyBlock = ({ clientId }) => {
+    const ref = useMovingAnimation({
+        triggerAnimationOnChange: someValue,
+        clientId,
+    });
+
+    return (
+        <div ref={ref}>
+            {/* Block content */}
+        </div>
+    );
+};
+```
+
+### Parameters
+
+#### Options Object
+
+- **triggerAnimationOnChange**
+  - **Type:** `any`
+  - **Description:** Value that triggers the animation when changed
+
+- **clientId**
+  - **Type:** `string`
+  - **Description:** The unique identifier for the block
+
+### Return Value
+
+- **Type:** `RefObject`
+- **Description:** A ref object to attach to the block's DOM element
+
+### Animation Behavior
+
+The animation system works in three steps:
+1. Renders the element in its final position
+2. Takes a snapshot of the destination position
+3. Animates from the previous position using CSS transforms
+
+### Performance Considerations
+
+Animations are automatically disabled when:
+- User prefers reduced motion (`prefers-reduced-motion: reduce`)
+- User is typing (for insertion animations)
+- Block count exceeds `BLOCK_ANIMATION_THRESHOLD` (200 blocks)
+
+```javascript
+const BLOCK_ANIMATION_THRESHOLD = 200;
+```
+
+### Animation Configuration
+
+Default spring animation parameters:
+- Mass: 5
+- Tension: 2000
+- Friction: 200
+
+```javascript
+config: { mass: 5, tension: 2000, friction: 200 }
+```
+
+## Related Components
+
+Block Editor components are components that can be used to compose the UI of your block editor. They should be used under a [`BlockEditorProvider`](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/provider/README.md) in the components tree.


### PR DESCRIPTION
### PR Description

**What?**
Closes [Issue #52077](https://github.com/WordPress/gutenberg/issues/52077)

This PR adds a README.md file for the `use-moving-animation` component in the Gutenberg project.

**Why?**
The `use-moving-animation` component was missing a README.md file, which is important for providing documentation and clarity on the component's purpose and usage.

**How?**
- Created a new README.md file for the `use-moving-animation` component.
- Detailed the `useMovingAnimation` hook, including its usage, parameters, return values, and animation behavior.
- Provided development guidelines and important notes about the component.

**Testing Instructions**
1. Navigate to the `use-moving-animation` component directory.
2. Ensure the new README.md file is present and contains relevant information about the component.
3. Review the content to verify it aligns with Gutenberg documentation standards.

**Testing Instructions for Keyboard**
- Navigate through the documentation using keyboard shortcuts to ensure accessibility.
