### PR TITLE
Add documentation for useOnBlockDrop hook in block editor

### DIFF
--- a/packages/block-editor/src/components/use-on-block-drop/README.md
+++ b/packages/block-editor/src/components/use-on-block-drop/README.md
@@ -1,0 +1,83 @@
+# Block Drop Hook
+
+The `useOnBlockDrop` hook provides functionality for handling block drag and drop operations in the WordPress block editor, including dropping blocks, files, and HTML content.
+
+## Development guidelines
+
+### Usage
+
+```jsx
+import { useOnBlockDrop } from '@wordpress/block-editor';
+
+const MyDropTarget = ({ clientId, index }) => {
+    const onDrop = useOnBlockDrop(clientId, index, {
+        operation: 'insert',
+        nearestSide: 'right'
+    });
+
+    return (
+        <div onDrop={onDrop}>
+            {/* Drop target content */}
+        </div>
+    );
+};
+```
+
+### Hook Parameters
+
+#### `targetRootClientId`
+- **Type:** `string`
+- **Description:** The client ID of the block where dropped content will be inserted
+
+#### `targetBlockIndex`
+- **Type:** `number`
+- **Description:** The index position where dropped content will be inserted
+
+#### `options`
+- **Type:** `Object`
+- **Properties:**
+  - `operation` (`'insert'|'replace'|'group'`): The type of operation to perform
+  - `nearestSide` (`'left'|'right'`): Which side to insert relative to target
+
+### Supported Drop Types
+
+#### Block Drops
+- Move existing blocks
+- Insert new blocks from inserter
+- Group blocks when dropped on each other
+- Prevent recursive nesting
+
+#### File Drops
+- Handle media file uploads
+- Transform files to appropriate blocks
+- Respect media upload settings
+
+#### HTML Drops
+- Parse HTML content into blocks
+- Insert converted blocks at target location
+
+### Example Implementation
+
+```jsx
+import { useOnBlockDrop } from '@wordpress/block-editor';
+
+const BlockDropZone = ({ rootClientId, index }) => {
+    const onDrop = useOnBlockDrop(rootClientId, index, {
+        operation: 'group',
+        nearestSide: 'right'
+    });
+
+    return (
+        <div
+            onDrop={onDrop}
+            onDragOver={(e) => e.preventDefault()}
+        >
+            Drop blocks here
+        </div>
+    );
+};
+```
+
+## Related Components
+
+Block Editor components are components that can be used to compose the UI of your block editor. They should be used under a [`BlockEditorProvider`](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/provider/README.md) in the components tree.


### PR DESCRIPTION
### PR Description

**What?**
Closes [Issue #52078](https://github.com/WordPress/gutenberg/issues/52078)

This PR adds a README.md file for the `use-on-block-drop` component in the Gutenberg project.

**Why?**
The `use-on-block-drop` component was missing a README.md file, which is essential for providing documentation and clarity on the component's purpose and usage.

**How?**
- Created a new README.md file for the `use-on-block-drop` component.
- Detailed the `useOnBlockDrop` hook, including its usage, parameters, supported drop types, and example implementation.
- Provided development guidelines and important notes about the component.

**Testing Instructions**
1. Navigate to the `use-on-block-drop` component directory.
2. Ensure the new README.md file is present and contains relevant information about the component.
3. Review the content to verify it aligns with Gutenberg documentation standards.

