### PR TITLE
Hide empty categories and tags panel in prepublish panel

### DIFF
--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -51,7 +51,17 @@ function PostPublishPanelPrepublish( { children } ) {
 			siteHome: siteData.home && filterURLForDisplay( siteData.home ),
 		};
 	}, [] );
+	const categories = useSelect( ( select ) =>
+		select( coreStore ).getEntityRecords( 'taxonomy', 'category', {
+			per_page: -1,
+		} )
+	);
 
+	const tags = useSelect( ( select ) =>
+		select( coreStore ).getEntityRecords( 'taxonomy', 'post_tag', {
+			per_page: -1,
+		} )
+	);
 	let siteIcon = (
 		<Icon className="components-site-icon" size="36px" icon={ wordpress } />
 	);
@@ -88,7 +98,6 @@ function PostPublishPanelPrepublish( { children } ) {
 			'Double-check your settings before publishing.'
 		);
 	}
-
 	return (
 		<div className="editor-post-publish-panel__prepublish">
 			<div>
@@ -138,8 +147,8 @@ function PostPublishPanelPrepublish( { children } ) {
 				</>
 			) }
 			<MaybePostFormatPanel />
-			<MaybeTagsPanel />
-			<MaybeCategoryPanel />
+			{ tags && tags.length > 0 && <MaybeTagsPanel /> }
+			{ categories && categories.length > 0 && <MaybeCategoryPanel /> }
 			{ children }
 		</div>
 	);


### PR DESCRIPTION
## What?
#69452

Hide the categories and tags panel in the prepublish panel if there are no tags or categories.


## Testing Instructions
Go to User Preferences in the WordPress editor.
Enable Pre-Publish Checks if not already enabled.
2. Test with Tags and Extra Categories
Create a new draft post and click Publish.
The Pre-Publish Panel should suggest adding categories and tags if none are selected.
3. Test with Only "Uncategorized" and No Tags
Create a new draft post and click Publish.
The Pre-Publish Panel should not show category or tag suggestions.
4. Verify Expected Behavior
Ensure the panel behaves consistently across tests.
Confirm that publishing works without issues.
Report any unexpected behavior with steps to reproduce.


## Screenshots or screencast
See, the tags panel is not showing, but the category is visible by default, and there is an uncategorized category.
<img width="278" alt="image" src="https://github.com/user-attachments/assets/c1eda5d4-a9fb-4a83-8632-16671c9f8a97" />



