### PR TITLE
Fixed post content rendering issue on latest post block

### DIFF
--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -178,7 +178,8 @@ function render_block_core_latest_posts( $attributes ) {
 		if ( isset( $attributes['displayPostContent'] ) && $attributes['displayPostContent']
 			&& isset( $attributes['displayPostContentRadio'] ) && 'full_post' === $attributes['displayPostContentRadio'] ) {
 
-			$post_content = html_entity_decode( $post->post_content, ENT_QUOTES, get_option( 'blog_charset' ) );
+			$post_content = apply_filters( 'the_content', get_the_content( null, false, $post ) );
+			$post_content = str_replace( ']]>', ']]&gt;', $post_content );
 
 			if ( post_password_required( $post ) ) {
 				$post_content = __( 'This content is password protected.' );
@@ -186,7 +187,7 @@ function render_block_core_latest_posts( $attributes ) {
 
 			$list_items_markup .= sprintf(
 				'<div class="wp-block-latest-posts__post-full-content">%1$s</div>',
-				wp_kses_post( $post_content )
+				$post_content
 			);
 		}
 

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -178,6 +178,7 @@ function render_block_core_latest_posts( $attributes ) {
 		if ( isset( $attributes['displayPostContent'] ) && $attributes['displayPostContent']
 			&& isset( $attributes['displayPostContentRadio'] ) && 'full_post' === $attributes['displayPostContentRadio'] ) {
 
+			/** This filter is documented in wp-includes/post-template.php */
 			$post_content = apply_filters( 'the_content', get_the_content( null, false, $post ) );
 			$post_content = str_replace( ']]>', ']]&gt;', $post_content );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
#69427 

In this PR, I fixed the post content rendering on the `latest-posts` block when the `displayPostContent` setting is enabled. 

## Why?
The issue was on the `latest-posts` block, the post content rendered with block comments, and those block contents were not parsed. In this fix, I used the filter to parse the content.

## Testing Instructions
- Create a few posts.
- Insert a latest posts block.
- Save and view the HTML of the latest posts block on the front of the site.

## Screenshots or screencast <!-- if applicable -->
Check the inspect element. 

|Before|After|
|-|-|
|![Screenshot 2025-03-06 at 3 34 35 PM](https://github.com/user-attachments/assets/0e266d6f-eb63-4f5d-80e5-d952ca28a355)|![Screenshot 2025-03-06 at 3 38 50 PM](https://github.com/user-attachments/assets/5ea1d7d0-162c-471a-a133-eed6e66b8da0)|


