### PR TITLE
update: helper text font size

### DIFF
--- a/packages/components/src/utils/font-values.js
+++ b/packages/components/src/utils/font-values.js
@@ -3,7 +3,7 @@ export default {
 		"-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
 	'default.fontSize': '13px',
 
-	'helpText.fontSize': '12px',
+	'helpText.fontSize': '14px',
 
 	mobileTextMinFontSize: '16px',
 };


### PR DESCRIPTION
## What?
Closes #69467

The helper text font size in the Visibility panel of the pre-publish checks has been updated, which now displays the help text in a font size of 12 pixels.



## Why?
>Overall, I'd think there should't be any text in the editor that uses a font size smaller than 13 pixels.
12 pixels is really too small in 2025. I'd even consider to raise any minimum font size to at least 14 pixels but for now 13px would be a good start.

## Testing Instructions

1. Create a new post
2. Click on status on sidebar panel
3. It will open a popover with a radio and checkbox list of pos status options.
4. See the helper text size increased 14px

## Screenshots or screencast 
<img width="331" alt="image" src="https://github.com/user-attachments/assets/f8a8cb85-8963-4236-9781-cf3cbe33a6df" />
