### PR TITLE
Archives Block: Fix `showLabel` default state

### DIFF
--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -30,7 +30,7 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 					resetAll={ () => {
 						setAttributes( {
 							displayAsDropdown: false,
-							showLabel: false,
+							showLabel: true,
 							showPostCounts: false,
 							type: 'monthly',
 						} );
@@ -63,7 +63,7 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 							isShownByDefault
 							hasValue={ () => ! showLabel }
 							onDeselect={ () =>
-								setAttributes( { showLabel: false } )
+								setAttributes( { showLabel: true } )
 							}
 						>
 							<ToggleControl


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Follow up on #67841 #68757

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The default value of showLabel is true.
In tunk, pressing the reset button will not change anything.

https://github.com/WordPress/gutenberg/blob/908940378e103b69a76e1cd6268b9bb93a369c46/packages/block-library/src/archives/block.json#L14-L17

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Fixed incorrect initial value of reset button in archive block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a Archives block. 

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before

https://github.com/user-attachments/assets/407bb204-b345-45ca-b2d8-fa0b0d407152


After

https://github.com/user-attachments/assets/194dd992-1794-4984-962c-8c943359cb06


