### PR TITLE
Shadow, Duotone: Fix reset button style

### DIFF
--- a/packages/block-editor/src/components/global-styles/filters-panel.js
+++ b/packages/block-editor/src/components/global-styles/filters-panel.js
@@ -124,7 +124,10 @@ const renderToggle =
 
 		const toggleProps = {
 			onClick: onToggle,
-			className: clsx( { 'is-open': isOpen } ),
+			className: clsx(
+				'block-editor-global-styles-filters-panel__dropdown-toggle',
+				{ 'is-open': isOpen }
+			),
 			'aria-expanded': isOpen,
 			ref: duotoneButtonRef,
 		};

--- a/packages/block-editor/src/components/global-styles/shadow-panel-components.js
+++ b/packages/block-editor/src/components/global-styles/shadow-panel-components.js
@@ -141,7 +141,10 @@ function renderShadowToggle( shadow, onShadowChange ) {
 
 		const toggleProps = {
 			onClick: onToggle,
-			className: clsx( { 'is-open': isOpen } ),
+			className: clsx(
+				'block-editor-global-styles__shadow-dropdown-toggle',
+				{ 'is-open': isOpen }
+			),
 			'aria-expanded': isOpen,
 			ref: shadowButtonRef,
 		};

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -25,14 +25,15 @@
 	display: block;
 	padding: 0;
 	position: relative;
+}
 
-	button {
-		width: 100%;
-		padding: $grid-unit-10;
+.block-editor-global-styles-filters-panel__dropdown-toggle,
+.block-editor-global-styles__shadow-dropdown-toggle {
+	width: 100%;
+	padding: $grid-unit-10;
 
-		&.is-open {
-			background-color: $gray-100;
-		}
+	&.is-open {
+		background-color: $gray-100;
 	}
 }
 


### PR DESCRIPTION
## What?

Follow-up #69378

This PR fixes the broken reset button style in the Duotone/Shadow panel.

## Why?

#69378 removed the width for compact/small buttons, as this caused the style for the dropdown toggle button below to be unintentionally applied to the reset button as well:

```css
.block-editor-global-styles-filters-panel__dropdown,
.block-editor-global-styles__shadow-dropdown {
	button {
		width: 100%;
	}
}
```

## How?

- Give the dropdown toggle a CSS class name.
- Use that selector to apply a width of 100% to it.

## Testing Instructions

- Insert an Image block.
- Apply duotone and shadow.
- Focus or hover the dropdown toggle to see the reset button style.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/c1642808-db33-42e6-ad42-12b873d45d3f) | ![image](https://github.com/user-attachments/assets/c645d98a-292d-43cc-b43d-d1b810a23d8f) |
| ![image](https://github.com/user-attachments/assets/e8b17822-fe52-4540-9b5b-b176e023745a) | ![image](https://github.com/user-attachments/assets/126d1375-5bd5-49ea-8a53-74d3902a04e0) | 