### PR TITLE
Fix error from popover scroll hook

### DIFF
--- a/packages/block-editor/src/components/block-popover/use-popover-scroll.js
+++ b/packages/block-editor/src/components/block-popover/use-popover-scroll.js
@@ -14,7 +14,7 @@ const scrollContainerCache = new WeakMap();
  * @param {Object} contentRef
  */
 function usePopoverScroll( contentRef ) {
-	return useRefEffect(
+	const effect = useRefEffect(
 		( node ) => {
 			function onWheel( event ) {
 				const { deltaX, deltaY } = event;
@@ -36,6 +36,7 @@ function usePopoverScroll( contentRef ) {
 		},
 		[ contentRef ]
 	);
+	return contentRef ? effect : null;
 }
 
 export default usePopoverScroll;


### PR DESCRIPTION
## What, why & how
Follow up to #68075 which fixed the ability to scroll “through” popovers but also introduced this error. The error wasn’t there in 6.7 (despite the feature being broken) so I’ve added the label for backporting to 6.8.

A simple fix to avoid errors logged in the console. This makes the `usePopoverScroll` hook return null in case its `contentRef` parameter is falsy. 

## Testing Instructions
1. Open a post or page
2. Insert a Cover block
3. Trigger a wheel event while hovering the Cover block’s resize handle
4. Verify no error was logged in the console
5. Verify that wheel scrolling while hovered over the block toolbar or in between inserters still works as expected

## Demonstration of errors this fixes

https://github.com/user-attachments/assets/15eabea2-73cf-4f9b-95ff-6d9f8677c427

## Note about potential redundant execution
The instances that surface this error are curious because `usePopoverScroll` is being called by `BlockPopover` which is being rendered into a slot that already calls `usePopoverScroll`. This creates the potential to add two `wheel` event listeners. Currently that doesn’t happen because `__unstableContentRef` isn’t provided (and that’s why it errors currently). This doesn’t seem too concerning anyway since even if the "wheel" listener were doubled up it would probably just make scrolling "through" the popover go twice as fast. It’s also unlikely that first-party popovers such as these will ever be providing `__unstableContentRef` and the public `BlockPopover` doesn’t support that prop. I’m noting this because it feels a little haphazard. There are various ways that we could safeguard against this but I decided against proposing anything more than this minimal change for now.
