### PR TITLE
Fixed Position: adjust top position while logged

### DIFF
--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -159,15 +159,15 @@ html :where(img[class*="wp-image-"]) {
 	margin: 0 0 1em 0;
 }
 
-// Set the admin bar offset for sticky positioned blocks to the height of the admin bar.
-// This allows sticky positioned blocks to be positioned correctly when the admin bar is visible.
+// Set the admin bar offset for sticky and fixed positioned blocks to the height of the admin bar.
+// This allows sticky and fixed positioned blocks to be positioned correctly when the admin bar is visible.
 html :where(.is-position-sticky, .is-position-fixed) {
 	/* stylelint-disable length-zero-no-unit -- 0px is set explicitly so that it can be used in a calc value. */
 	--wp-admin--admin-bar--position-offset: var(--wp-admin--admin-bar--height, 0px);
 	/* stylelint-enable length-zero-no-unit */
 }
 
-// To support sticky positioning, reset the admin bar offset to 0px on mobile devices,
+// To support sticky and fixed positioning, reset the admin bar offset to 0px on mobile devices,
 // within the scope of the position classname. This is required because the admin bar
 // is not fixed to the top on mobile devices, but is fixed on viewports larger than 600px.
 @media screen and (max-width: 600px) {

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -161,7 +161,7 @@ html :where(img[class*="wp-image-"]) {
 
 // Set the admin bar offset for sticky positioned blocks to the height of the admin bar.
 // This allows sticky positioned blocks to be positioned correctly when the admin bar is visible.
-html :where(.is-position-sticky) {
+html :where(.is-position-sticky, .is-position-fixed) {
 	/* stylelint-disable length-zero-no-unit -- 0px is set explicitly so that it can be used in a calc value. */
 	--wp-admin--admin-bar--position-offset: var(--wp-admin--admin-bar--height, 0px);
 	/* stylelint-enable length-zero-no-unit */
@@ -171,7 +171,7 @@ html :where(.is-position-sticky) {
 // within the scope of the position classname. This is required because the admin bar
 // is not fixed to the top on mobile devices, but is fixed on viewports larger than 600px.
 @media screen and (max-width: 600px) {
-	html :where(.is-position-sticky) {
+	html :where(.is-position-sticky, .is-position-fixed) {
 		/* stylelint-disable length-zero-no-unit -- 0px is set explicitly so that it can be used in a calc value. */
 		--wp-admin--admin-bar--position-offset: 0px;
 		/* stylelint-enable length-zero-no-unit */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Related #47665

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

If an admin bar exists when in Fixed Position, elements will overlap with the admin bar, so adjust it in the same way as for sticky.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add the same style as sticky.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Add the following code to `gutenberg.php` etc. to support fixed.
```PHP
function add_fixed_theme_json_data( $theme_json ) {
	$get_data          = $theme_json->get_data();
	$add_position      = array(
		'fixed' => true,
	);
	$existing_position = isset( $get_data['settings']['position'] ) ? $get_data['settings']['position'] : array();
	$add_data          = array_merge(
		$existing_position,
		$add_position
	);
	$new_data          = array(
		'version'  => 3,
		'settings' => array(
			'position' => $add_data,
		),
	);
	return $theme_json->update_with( $new_data );
}
add_filter( 'wp_theme_json_data_theme',  'add_fixed_theme_json_data' );
```
2. Open a post or page. 
3. Place a group block and set the style>position>type attribute to fixed.
Or paste the following code into your code editor.
```HTML
<!-- wp:group {"style":{"position":{"type":"fixed","top":"0px"},"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}},"backgroundColor":"accent-2","layout":{"type":"constrained"}} -->
<div class="wp-block-group has-accent-2-background-color has-background" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:paragraph -->
<p>Fixed Group</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```
4.If you look at the front end, you can see that the top position is adjusted depending on whether or not the admin bar is present.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

https://github.com/user-attachments/assets/c34ff52a-af46-4183-b840-cca53380a7b9


### After

https://github.com/user-attachments/assets/1ec81456-3fe4-413b-b0e2-f0658ef837eb


