### PR TITLE
Include title in the anchor tag for better user accessibility.

### DIFF
--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -78,6 +78,7 @@ export default function save( { attributes } ) {
 					href={ href }
 					target={ linkTarget }
 					rel={ newRel }
+					title={ title || undefined }
 				>
 					{ image }
 				</a>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #69496 


<!-- In a few words, what is the PR actually doing? -->
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This PR will reuse the title attribute in the image in the anchor link also so that when the user will hover over the image the tooltip will be appear.

## How?
<img width="596" alt="Screenshot 2025-03-09 at 7 04 01 PM" src="https://github.com/user-attachments/assets/b049ebd9-b05b-4949-a4eb-56437d299456" />

This PR will use the default attribute of the anchor link to populate the title of the image.



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Add the image block
2. Add the link and title attribute of the image
3. On the front end when you hover over the image you will see the tool tip.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
<img width="1210" alt="Screenshot 2025-03-09 at 6 54 09 PM" src="https://github.com/user-attachments/assets/2f34b7b5-3733-4bf5-bc95-8b2def709231" />

<img width="555" alt="Screenshot 2025-03-09 at 6 53 52 PM" src="https://github.com/user-attachments/assets/5ba0f293-ba44-4ce1-a1e7-c52261914563" />

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
