### PR TITLE
Make region navigation more robust

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -481,7 +481,7 @@ function Layout( {
 		document.body.classList.remove( 'show-icon-labels' );
 	}
 
-	const navigateRegionsProps = useNavigateRegions();
+	const navigateRegionsRef = useNavigateRegions( { isGlobal: true } );
 
 	const className = clsx( 'edit-post-layout', 'is-mode-' + mode, {
 		'has-metaboxes': hasActiveMetaboxes,
@@ -568,11 +568,7 @@ function Layout( {
 			<ErrorBoundary canCopyContent>
 				<CommandMenu />
 				<WelcomeGuide postType={ currentPostType } />
-				<div
-					className={ navigateRegionsProps.className }
-					{ ...navigateRegionsProps }
-					ref={ navigateRegionsProps.ref }
-				>
+				<div ref={ navigateRegionsRef }>
 					<Editor
 						settings={ editorSettings }
 						initialEdits={ initialEdits }

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -61,7 +61,7 @@ function Layout() {
 	useCommands();
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const toggleRef = useRef();
-	const navigateRegionsProps = useNavigateRegions();
+	const navigateRegionsRef = useNavigateRegions( { isGlobal: true } );
 	const disableMotion = useReducedMotion();
 	const [ canvasResizer, canvasSize ] = useResizeObserver();
 	const isEditorLoading = useIsSiteEditorLoading();
@@ -96,16 +96,11 @@ function Layout() {
 			<CommandMenu />
 			{ canvas === 'view' && <SaveKeyboardShortcut /> }
 			<div
-				{ ...navigateRegionsProps }
-				ref={ navigateRegionsProps.ref }
-				className={ clsx(
-					'edit-site-layout',
-					navigateRegionsProps.className,
-					{
-						'is-full-canvas': canvas === 'edit',
-						'show-icon-labels': showIconLabels,
-					}
-				) }
+				ref={ navigateRegionsRef }
+				className={ clsx( 'edit-site-layout', {
+					'is-full-canvas': canvas === 'edit',
+					'show-icon-labels': showIconLabels,
+				} ) }
 			>
 				<div className="edit-site-layout__content">
 					{ /*


### PR DESCRIPTION
## What?
Enables region navigation shortcuts to work either when focus is lost or unset—the page just loaded.

## Why?
Currently, region navigation may be unexpectedly disabled. The prime example is probably right when the page has loaded the shortcut should work.

## How?
1. Extends `useNavigateRegions` with a `isGlobal` option that when set to `true` makes its keyboard event listeners be attached to the document instead of the element. 
2. Uses the above option in the Post and Site editors.

## Testing Instructions for Keyboard
1. Open either the site or post editor
3. Confirm the regions navigation shortcuts work


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
