### PR TITLE
Fix: Update invalid JSON Schema link in README.md

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -40,7 +40,7 @@ For a specific version of the schema, replace `trunk` with `wp/X.X`:
 }
 ```
 
-Visual Studio Code and PhpStorm are two popular editors that work out of the box. However, some editors require a plugin installed, and not all editors recognize the `$schema` property. Check your editor's documentation for details. Additionally, [SchemaStore.org](https://www.schemastore.org/) and [JSON Schema](https://json-schema.org/implementations#editor) have lists of editors known to have support if your current editor is unsupported.
+Visual Studio Code and PhpStorm are two popular editors that work out of the box. However, some editors require a plugin installed, and not all editors recognize the `$schema` property. Check your editor's documentation for details. Additionally, [SchemaStore.org](https://www.schemastore.org/) and [JSON Schema](https://json-schema.org/tools) have lists of editors known to have support if your current editor is unsupported.
 
 ## Local Development
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -40,7 +40,7 @@ For a specific version of the schema, replace `trunk` with `wp/X.X`:
 }
 ```
 
-Visual Studio Code and PhpStorm are two popular editors that work out of the box. However, some editors require a plugin installed, and not all editors recognize the `$schema` property. Check your editor's documentation for details. Additionally, [SchemaStore.org](https://www.schemastore.org/) and [JSON Schema](https://json-schema.org/implementations#editors) have lists of editors known to have support if your current editor is unsupported.
+Visual Studio Code and PhpStorm are two popular editors that work out of the box. However, some editors require a plugin installed, and not all editors recognize the `$schema` property. Check your editor's documentation for details. Additionally, [SchemaStore.org](https://www.schemastore.org/) and [JSON Schema](https://json-schema.org/implementations#editor) have lists of editors known to have support if your current editor is unsupported.
 
 ## Local Development
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -40,7 +40,7 @@ For a specific version of the schema, replace `trunk` with `wp/X.X`:
 }
 ```
 
-Visual Studio Code and PhpStorm are two popular editors that work out of the box. However, some editors require a plugin installed, and not all editors recognize the `$schema` property. Check your editor's documentation for details. Additionally, [SchemaStore.org](https://www.schemastore.org/) and [JSON Schema](https://json-schema.org/implementations.html#editors) have lists of editors known to have support if your current editor is unsupported.
+Visual Studio Code and PhpStorm are two popular editors that work out of the box. However, some editors require a plugin installed, and not all editors recognize the `$schema` property. Check your editor's documentation for details. Additionally, [SchemaStore.org](https://www.schemastore.org/) and [JSON Schema](https://json-schema.org/implementations#editors) have lists of editors known to have support if your current editor is unsupported.
 
 ## Local Development
 


### PR DESCRIPTION
## what?
Closes #69504

This PR updates the broken JSON Schema link in README.md to point to the correct page listing editors that support JSON Schema.



## why?
The existing JSON Schema link in README.md was broken and led to an unreachable page. This could confuse users who rely on the documentation to find supported editors. Updating the link ensures that users are directed to the correct resource.

## how?

- Replaced the incorrect JSON Schema link with the correct one, [Json Schema](https://json-schema.org/tools)

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![Screenshot 2025-03-10 at 12 47 29 PM](https://github.com/user-attachments/assets/3b9adc07-da96-42cd-8a55-120c0f35ed02)|![Screenshot 2025-03-10 at 12 48 19 PM](https://github.com/user-attachments/assets/2053fd66-4088-4558-ab51-913fa716297e)|
