### PR TITLE
Document Outline: Disable selection for non-content headings

### DIFF
--- a/packages/editor/src/components/document-outline/item.js
+++ b/packages/editor/src/components/document-outline/item.js
@@ -6,32 +6,47 @@ import clsx from 'clsx';
 const TableOfContentsItem = ( {
 	children,
 	isValid,
+	isDisabled,
 	level,
 	href,
 	onSelect,
-} ) => (
-	<li
-		className={ clsx(
-			'document-outline__item',
-			`is-${ level.toLowerCase() }`,
-			{
-				'is-invalid': ! isValid,
-			}
-		) }
-	>
-		<a
-			href={ href }
-			className="document-outline__button"
-			onClick={ onSelect }
+} ) => {
+	function handleClick( event ) {
+		if ( isDisabled ) {
+			event.preventDefault();
+			return;
+		}
+		onSelect();
+	}
+
+	return (
+		<li
+			className={ clsx(
+				'document-outline__item',
+				`is-${ level.toLowerCase() }`,
+				{
+					'is-invalid': ! isValid,
+					'is-disabled': isDisabled,
+				}
+			) }
 		>
-			<span
-				className="document-outline__emdash"
-				aria-hidden="true"
-			></span>
-			<strong className="document-outline__level">{ level }</strong>
-			<span className="document-outline__item-content">{ children }</span>
-		</a>
-	</li>
-);
+			<a
+				href={ href }
+				className="document-outline__button"
+				aria-disabled={ isDisabled }
+				onClick={ handleClick }
+			>
+				<span
+					className="document-outline__emdash"
+					aria-hidden="true"
+				></span>
+				<strong className="document-outline__level">{ level }</strong>
+				<span className="document-outline__item-content">
+					{ children }
+				</span>
+			</a>
+		</li>
+	);
+};
 
 export default TableOfContentsItem;

--- a/packages/editor/src/components/document-outline/style.scss
+++ b/packages/editor/src/components/document-outline/style.scss
@@ -53,8 +53,10 @@
 	text-align: left;
 	border-radius: $radius-small;
 
+	&[aria-disabled="true"],
 	&:disabled {
 		cursor: default;
+		color: $gray-700;
 	}
 
 	&:focus {


### PR DESCRIPTION
## What?
Closes #69347.

PR prevents selecting heading blocks from a template when the editor renders in `template-locked` mode.

I've re-introduced the disabled state for document outline items (#14081). The disabled items cannot be selected and are lighter grey in color. The design changes are minimal; I tried to match existing design patterns.

## Why?
Blocks outside post content can't be edited or selected when viewing in `template-locked` mode.

## Testing Instructions
1. Using a block theme.
2. Update the page's template and add heading blocks inside the template.
3. Open a page and add heading blocks to the content.
4. Open the document outline.
5. Confirm that heading blocks from the template cannot be selected via the document outline.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|![CleanShot 2025-03-10 at 11 52 04](https://github.com/user-attachments/assets/5ea13ed3-b367-4926-8b8e-2d2e88220b4f)|![CleanShot 2025-03-10 at 11 50 12](https://github.com/user-attachments/assets/336d9970-fdd9-4f69-9b06-815db64cc3ea)|


