### PR TITLE
Fix: Nested list indendation in editor for classic themes

### DIFF
--- a/packages/edit-post/src/classic.scss
+++ b/packages/edit-post/src/classic.scss
@@ -2,7 +2,7 @@
 // Specificity is kept at this level as many classic themes output
 // rules like figure { margin: 0; } which would break centering.
 // These rules should also not apply to direct children of flex layout blocks.
-.editor-styles-wrapper :where(:not(.is-layout-flex, .is-layout-grid)) > .wp-block:not(.wp-block-list .wp-block-list) {
+.editor-styles-wrapper :where(:not(.is-layout-flex, .is-layout-grid)) > .wp-block:where(:not(.wp-block-list .wp-block-list)) {
 	margin-left: auto;
 	margin-right: auto;
 }

--- a/packages/edit-post/src/classic.scss
+++ b/packages/edit-post/src/classic.scss
@@ -2,7 +2,7 @@
 // Specificity is kept at this level as many classic themes output
 // rules like figure { margin: 0; } which would break centering.
 // These rules should also not apply to direct children of flex layout blocks.
-.editor-styles-wrapper :where(:not(.is-layout-flex, .is-layout-grid)) > .wp-block {
+.editor-styles-wrapper :where(:not(.is-layout-flex, .is-layout-grid)) > .wp-block:not(.wp-block-list .wp-block-list) {
 	margin-left: auto;
 	margin-right: auto;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #69503 
Related https://wordpress.org/support/topic/list-block-no-visual-nested-indent/

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix nested list indentation in editor for classic themes.

This fixes the nested list indentation in the editor  for following themes.
-  2014, 15, 16, 17

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Prevents applying `margin-left:auto` and `margin-right: auto` to nested lists

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Activate Twenty Fifteen.
2. Create a new post and add a list block.
3. Add multiple list item and indent them with different depths.
4. Confirm that the nested list items are visually indented as expected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Same

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="1470" alt="image" src="https://github.com/user-attachments/assets/390a7b00-61d9-422c-906f-3ebee3fdafbe" /> | <img width="1470" alt="image" src="https://github.com/user-attachments/assets/299cfb3e-13e7-4432-9b39-90fcfd632d95" /> |
