### PR TITLE
Fix: dynamic implementation of the block in editor.

### DIFF
--- a/packages/block-library/src/query-total/edit.js
+++ b/packages/block-library/src/query-total/edit.js
@@ -3,70 +3,121 @@
  */
 import { useBlockProps, BlockControls } from '@wordpress/block-editor';
 import { ToolbarGroup, ToolbarDropdownMenu } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
+import { useEntityRecords } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import { resultsFound, displayingResults } from './icons';
 
-export default function QueryTotalEdit( { attributes, setAttributes } ) {
+/**
+ * QueryTotalEdit component.
+ *
+ * @param {Object}   props               Component props.
+ * @param {Object}   props.attributes    Block attributes.
+ * @param {Function} props.setAttributes Block attributes setter.
+ * @param {Object}   props.context       Block context.
+ */
+export default function QueryTotalEdit( {
+	attributes,
+	setAttributes,
+	context,
+} ) {
 	const { displayType } = attributes;
-
-	// Block properties and classes.
 	const blockProps = useBlockProps();
 
-	const getButtonPositionIcon = () => {
-		switch ( displayType ) {
-			case 'total-results':
-				return resultsFound;
-			case 'range-display':
-				return displayingResults;
-		}
+	// Destructure query object from context with defaults.
+	const {
+		perPage = 10,
+		pages = 0,
+		offset = 0,
+		postType = 'post',
+		order = 'desc',
+		orderBy = 'date',
+		author,
+		search,
+		exclude = [],
+		sticky,
+		taxQuery = {},
+		parents = [],
+		format = [],
+	} = context?.query || {};
+
+	// Build query arguments for fetching posts.
+	const queryArgs = {
+		per_page: perPage,
+		page: pages > 0 ? pages : 1,
+		offset,
+		order,
+		orderby: orderBy,
+		...( author && { author } ),
+		...( search?.trim() && { search: search.trim() } ),
+		...( exclude.length && { exclude: exclude.join( ',' ) } ),
+		...( sticky && { sticky } ),
+		...( taxQuery.post_tag?.length && {
+			tags: taxQuery.post_tag.join( ',' ),
+		} ),
+		...( taxQuery.category?.length && {
+			categories: taxQuery.category.join( ',' ),
+		} ),
+		...( parents.length && { parent: parents.join( ',' ) } ),
+		...( format.length && { format: format.join( ',' ) } ),
 	};
 
+	// Fetch posts using the built queryArgs.
+	const { totalItems } = useEntityRecords( 'postType', postType, queryArgs );
+	const totalResults = totalItems || 0;
+	const currentPage = queryArgs.page;
+	const postsPerPage = queryArgs.per_page;
+
+	// Determine which icon to display based on the display type.
+	const getButtonPositionIcon = () =>
+		displayType === 'range-display' ? displayingResults : resultsFound;
+
+	// Define toolbar controls for switching between display modes.
 	const buttonPositionControls = [
 		{
 			role: 'menuitemradio',
 			title: __( 'Total results' ),
 			isActive: displayType === 'total-results',
 			icon: resultsFound,
-			onClick: () => {
-				setAttributes( { displayType: 'total-results' } );
-			},
+			onClick: () => setAttributes( { displayType: 'total-results' } ),
 		},
 		{
 			role: 'menuitemradio',
 			title: __( 'Range display' ),
 			isActive: displayType === 'range-display',
 			icon: displayingResults,
-			onClick: () => {
-				setAttributes( { displayType: 'range-display' } );
-			},
+			onClick: () => setAttributes( { displayType: 'range-display' } ),
 		},
 	];
 
-	// Controls for the block.
-	const controls = (
-		<BlockControls>
-			<ToolbarGroup>
-				<ToolbarDropdownMenu
-					icon={ getButtonPositionIcon() }
-					label={ __( 'Change display type' ) }
-					controls={ buttonPositionControls }
-				/>
-			</ToolbarGroup>
-		</BlockControls>
-	);
-
-	// Render output based on the selected display type.
+	// Render the display text dynamically.
 	const renderDisplay = () => {
+		if ( ! totalResults ) {
+			return <>{ __( 'No results found' ) }</>;
+		}
+
 		if ( displayType === 'total-results' ) {
-			return <>{ __( '12 results found' ) }</>;
+			/* translators: %1$d: number of results. */
+			return <>{ sprintf( __( '%1$d results found' ), totalResults ) }</>;
 		}
 
 		if ( displayType === 'range-display' ) {
-			return <>{ __( 'Displaying 1 – 10 of 12' ) }</>;
+			const start = ( currentPage - 1 ) * postsPerPage + 1;
+			const end = Math.min( currentPage * postsPerPage, totalResults );
+			return (
+				<>
+					{ sprintf(
+						// translators: %1$d: starting post number, %2$d: ending post number, %3$d: total results.
+						__( 'Displaying %1$d – %2$d of %3$d' ),
+						start,
+						end,
+						totalResults
+					) }
+				</>
+			);
 		}
 
 		return null;
@@ -74,7 +125,15 @@ export default function QueryTotalEdit( { attributes, setAttributes } ) {
 
 	return (
 		<div { ...blockProps }>
-			{ controls }
+			<BlockControls>
+				<ToolbarGroup>
+					<ToolbarDropdownMenu
+						icon={ getButtonPositionIcon() }
+						label={ __( 'Change display type' ) }
+						controls={ buttonPositionControls }
+					/>
+				</ToolbarGroup>
+			</BlockControls>
 			{ renderDisplay() }
 		</div>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #69488 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The Query total block was using the static data to display in the editor this PR will fix that by using the dynamic data by respecting the context provided by query loop block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- This PR will now dynamically add the data instead of static data.

