### PR TITLE
Fix: Image lightbox showing original image in synced pattern instead of overriden image

### DIFF
--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -43,6 +43,7 @@ const { state, actions, callbacks } = store(
 			},
 			get enlargedSrc() {
 				return (
+					state.currentImage.currentSrc ||
 					state.currentImage.uploadedSrc ||
 					'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
 				);


### PR DESCRIPTION

Fixed the image lightbox showing original image issue in synced pattern with overridden image

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #64716 <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
Previously, when opening the image lightbox, the image displayed was inconsistent—sometimes showing the original image instead of the expected overridden version. This issue caused confusion for users expecting a consistent visual experience when enlarging images.

## How?

- Adjusted the logic to ensure state.currentImage.uploadedSrc is used consistently when an enlarged image is available.
- Added fallback logic to prevent empty or incorrect images from being displayed.

## Testing Instructions
1. Create a synced pattern containing an image block.
2. Enable overrides for the image.
3. Insert the synced pattern on a page and replace the image with a new one.
4. Save and view the page on the front end.
5. The lightbox shows the original image from the synced pattern.
