### PR TITLE
DataViews: Add Icon Support to `Action Menus`

### DIFF
--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -14,7 +14,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from '@wordpress/element';
-import { moreVertical } from '@wordpress/icons';
+import { Icon, moreVertical } from '@wordpress/icons';
 import { useRegistry } from '@wordpress/data';
 
 /**
@@ -92,7 +92,14 @@ function MenuItemTrigger< Item >( {
 	const label =
 		typeof action.label === 'string' ? action.label : action.label( items );
 	return (
-		<Menu.Item disabled={ action.disabled } onClick={ onClick }>
+		<Menu.Item
+			disabled={ action.disabled }
+			onClick={ onClick }
+			{ ...( action.icon &&
+				action.isPrimary && {
+					prefix: <Icon icon={ action.icon } />,
+				} ) }
+		>
 			<Menu.ItemLabel>{ label }</Menu.ItemLabel>
 		</Menu.Item>
 	);


### PR DESCRIPTION
## What?

Closes #69421

This PR introduces optional icon support for action menu items in DataViews.

## Why?

Providing visual indicators for external links and reinforcing intent for certain actions (e.g., destructive actions) improves clarity and user experience.

## How?

The `prefix` prop within `MenuItemTrigger` is used to display `action.icon` when `action.icon` is defined and `action.isPrimary` is set to `true`.

## Testing Instructions

1. Navigate to `Editor` > `Pages`.
2. Set the `display` to `Table`.
3. Open the `Menu` by clicking on the `vertical ellipsis`.
4. Confirm the presence of the respective icons beside primary actions within the Menu.

## Screenshots 

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/c287db6a-3f38-491e-8e99-3ac64e31d0be)|![after](https://github.com/user-attachments/assets/866ccd6b-7a5c-435e-a1b3-94ccd2ab0885)|



