### PR TITLE
Site Editor: Hide admin bar in classic theme site preview

### DIFF
--- a/backport-changelog/6.8/8475.md
+++ b/backport-changelog/6.8/8475.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/8475
+
+* https://github.com/WordPress/gutenberg/pull/69514

--- a/lib/compat/wordpress-6.8/admin-bar.php
+++ b/lib/compat/wordpress-6.8/admin-bar.php
@@ -30,3 +30,18 @@ function gutenberg_wp_admin_bar_edit_site_menu( $wp_admin_bar ) {
 }
 
 add_action( 'admin_bar_menu', 'gutenberg_wp_admin_bar_edit_site_menu', 41 );
+
+/**
+ * Hide the admin bar in the classic theme site preview.
+ *
+ * @param bool $show_admin_bar Whether to show the admin bar.
+ * @return bool
+ */
+function gutenberg_hide_admin_bar_in_site_preview( $show_admin_bar ) {
+	if ( isset( $_GET['wp_site_preview'] ) && 1 === (int) $_GET['wp_site_preview'] ) {
+		return false;
+	}
+	return $show_admin_bar;
+}
+
+add_filter( 'show_admin_bar', 'gutenberg_hide_admin_bar_in_site_preview' );

--- a/lib/compat/wordpress-6.8/admin-bar.php
+++ b/lib/compat/wordpress-6.8/admin-bar.php
@@ -31,17 +31,16 @@ function gutenberg_wp_admin_bar_edit_site_menu( $wp_admin_bar ) {
 
 add_action( 'admin_bar_menu', 'gutenberg_wp_admin_bar_edit_site_menu', 41 );
 
-/**
- * Hide the admin bar in the classic theme site preview.
- *
- * @param bool $show_admin_bar Whether to show the admin bar.
- * @return bool
- */
-function gutenberg_hide_admin_bar_in_site_preview( $show_admin_bar ) {
-	if ( isset( $_GET['wp_site_preview'] ) && 1 === (int) $_GET['wp_site_preview'] ) {
-		return false;
+if ( ! function_exists( 'wp_initialize_site_preview_hooks' ) ) {
+	/**
+	 * Add filter to hide the admin bar.
+	 *
+	 * This filter is used to hide the admin bar in classic theme site previews in the site editor.
+	 */
+	function wp_initialize_site_preview_hooks() {
+		if ( isset( $_GET['wp_site_preview'] ) && 1 === (int) $_GET['wp_site_preview'] ) {
+			add_filter( 'show_admin_bar', '__return_false' );
+		}
 	}
-	return $show_admin_bar;
 }
-
-add_filter( 'show_admin_bar', 'gutenberg_hide_admin_bar_in_site_preview' );
+add_action( 'init', 'wp_initialize_site_preview_hooks', 1 );

--- a/packages/edit-site/src/components/editor/site-preview.js
+++ b/packages/edit-site/src/components/editor/site-preview.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { addQueryArgs } from '@wordpress/url';
 
 export default function SitePreview() {
 	const siteUrl = useSelect( ( select ) => {
@@ -12,10 +13,12 @@ export default function SitePreview() {
 		return siteData?.home;
 	}, [] );
 
-	// If theme is block based, return the Editor, otherwise return the site preview.
 	return (
 		<iframe
-			src={ siteUrl }
+			src={ addQueryArgs( siteUrl, {
+				// Parameter for hiding the admin bar.
+				wp_site_preview: 1,
+			} ) }
 			title={ __( 'Site Preview' ) }
 			style={ {
 				display: 'block',
@@ -24,16 +27,8 @@ export default function SitePreview() {
 				backgroundColor: '#fff',
 			} }
 			onLoad={ ( event ) => {
-				// Hide the admin bar in the front-end preview.
-				const document = event.target.contentDocument;
-				document.getElementById( 'wpadminbar' ).remove();
-				document
-					.getElementsByTagName( 'html' )[ 0 ]
-					.setAttribute( 'style', 'margin-top: 0 !important;' );
-				document
-					.getElementsByTagName( 'body' )[ 0 ]
-					.classList.remove( 'admin-bar' );
 				// Make interactive elements unclickable.
+				const document = event.target.contentDocument;
 				const interactiveElements = document.querySelectorAll(
 					'a, button, input, details, audio'
 				);


### PR DESCRIPTION
## What? How?
Alternatives to #69480
Closes #69474

This PR adds the `wp_site_preview=1` parameter to the classic site preview iframe src to prevent the admin bar from appearing.

## Why?

The current logic attempts to remove the admin bar via the `onLoad` prop.  In my understanding, the `onLoad` prop is executed _after_ the iframe content is loaded. Therefore, the admin bar will be displayed for a short time until the content is fully loaded.

## How?

This problem can be solved by injecting some CSS, but it would be best to hide the admin bar itself. This PR hooks the `show_admin_bar` filter based on the GET parameter `wp_site_preview=1`, 

> [!NOTE]
> We're still in discussion about whether to move [this JS code](https://github.com/WordPress/gutenberg/pull/69514/files#diff-5157be05782b5768425fe097e360b0ec4263679f14ed925073ac8283eaa1d02fR32-R39) into the core. See https://github.com/WordPress/wordpress-develop/pull/8475#issuecomment-2708397289 for more details.

## Testing Instructions

- Activate Twenty Twenty-One.
- Access Appearance > Design.
- Confirm that the admin bar isn't displayed within the site preview.
- Reload your browser a few times and check again.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/cd420fe0-5a21-4a45-8ff3-9267d9f433a9

