### PR TITLE
Fix site editor edit mode toggling and initial focus accessibility

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -95,6 +95,8 @@ $z-layers: (
 	// the multi-entity saving sidebar.
 	".edit-site-editor__toggle-save-panel": 100000,
 
+	".edit-site-editor__edit-mode-toggle": 1,
+
 	// Show sidebar in greater than small viewports above editor related elements
 	// but below #adminmenuback { z-index: 100 }
 	".interface-interface-skeleton__sidebar {greater than small}": 90,

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -230,6 +230,7 @@ function Iframe( {
 		iframeDocument,
 	} );
 
+	// useDisabled adds the `inert` HTML attribute to all the childe nodes.
 	const disabledRef = useDisabled( { isDisabled: ! readonly } );
 	const bodyRef = useMergeRefs( [
 		useBubbleEvents( iframeDocument ),

--- a/packages/edit-site/src/components/block-editor/use-editor-iframe-props.js
+++ b/packages/edit-site/src/components/block-editor/use-editor-iframe-props.js
@@ -39,6 +39,13 @@ export default function useEditorIframeProps() {
 		}
 	}, [ canvas ] );
 
+	const navigateToEditModeAndResetFocus = () => {
+		history.navigate( addQueryArgs( path, { canvas: 'edit' } ), {
+			transition: 'canvas-mode-edit-transition',
+		} );
+		window.document.activeElement?.blur();
+	};
+
 	// In view mode, make the canvas iframe be perceived and behave as a button
 	// to switch to edit mode, with a meaningful label and no title attribute.
 	const viewModeIframeProps = {
@@ -56,15 +63,10 @@ export default function useEditorIframeProps() {
 				! currentPostIsTrashed
 			) {
 				event.preventDefault();
-				history.navigate( addQueryArgs( path, { canvas: 'edit' } ), {
-					transition: 'canvas-mode-edit-transition',
-				} );
+				navigateToEditModeAndResetFocus();
 			}
 		},
-		onClick: () =>
-			history.navigate( addQueryArgs( path, { canvas: 'edit' } ), {
-				transition: 'canvas-mode-edit-transition',
-			} ),
+		onClick: () => navigateToEditModeAndResetFocus(),
 		onClickCapture: ( event ) => {
 			if ( currentPostIsTrashed ) {
 				event.preventDefault();

--- a/packages/edit-site/src/components/block-editor/use-editor-iframe-props.js
+++ b/packages/edit-site/src/components/block-editor/use-editor-iframe-props.js
@@ -1,85 +1,29 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
-import { ENTER, SPACE } from '@wordpress/keycodes';
-import { useState, useEffect } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-import { store as editorStore } from '@wordpress/editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
-import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
 
-const { useLocation, useHistory } = unlock( routerPrivateApis );
+const { useLocation } = unlock( routerPrivateApis );
 
 export default function useEditorIframeProps() {
-	const { query, path } = useLocation();
-	const history = useHistory();
+	const { query } = useLocation();
 	const { canvas = 'view' } = query;
-	const currentPostIsTrashed = useSelect( ( select ) => {
-		return (
-			select( editorStore ).getCurrentPostAttribute( 'status' ) ===
-			'trash'
-		);
-	}, [] );
-	const [ isFocused, setIsFocused ] = useState( false );
 
-	useEffect( () => {
-		if ( canvas === 'edit' ) {
-			setIsFocused( false );
-		}
-	}, [ canvas ] );
-
-	const navigateToEditModeAndResetFocus = () => {
-		history.navigate( addQueryArgs( path, { canvas: 'edit' } ), {
-			transition: 'canvas-mode-edit-transition',
-		} );
-		window.document.activeElement?.blur();
-	};
-
-	// In view mode, make the canvas iframe be perceived and behave as a button
-	// to switch to edit mode, with a meaningful label and no title attribute.
+	// In view mode, make the canvas iframe not focusable and omit the title attribute.
+	// Note: the `readonly` variable name could be improved to clarify it's not
+	// about the readonly HTML attribute.
 	const viewModeIframeProps = {
-		'aria-label': __( 'Edit' ),
-		'aria-disabled': currentPostIsTrashed,
-		title: null,
-		role: 'button',
-		tabIndex: 0,
-		onFocus: () => setIsFocused( true ),
-		onBlur: () => setIsFocused( false ),
-		onKeyDown: ( event ) => {
-			const { keyCode } = event;
-			if (
-				( keyCode === ENTER || keyCode === SPACE ) &&
-				! currentPostIsTrashed
-			) {
-				event.preventDefault();
-				navigateToEditModeAndResetFocus();
-			}
-		},
-		onClick: () => navigateToEditModeAndResetFocus(),
-		onClickCapture: ( event ) => {
-			if ( currentPostIsTrashed ) {
-				event.preventDefault();
-				event.stopPropagation();
-			}
-		},
+		tabIndex: -1,
 		readonly: true,
 	};
 
 	return {
-		className: clsx( 'edit-site-visual-editor__editor-canvas', {
-			'is-focused': isFocused && canvas === 'view',
-		} ),
+		className: 'edit-site-visual-editor__editor-canvas',
 		...( canvas === 'view' ? viewModeIframeProps : {} ),
 	};
 }

--- a/packages/edit-site/src/components/block-editor/use-editor-iframe-props.js
+++ b/packages/edit-site/src/components/block-editor/use-editor-iframe-props.js
@@ -1,25 +1,45 @@
 /**
  * WordPress dependencies
  */
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
 
-const { useLocation } = unlock( routerPrivateApis );
+const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 export default function useEditorIframeProps() {
-	const { query } = useLocation();
+	const history = useHistory();
+	const { query, path } = useLocation();
 	const { canvas = 'view' } = query;
+	const currentPostIsTrashed = useSelect( ( select ) => {
+		return (
+			select( editorStore ).getCurrentPostAttribute( 'status' ) ===
+			'trash'
+		);
+	}, [] );
 
 	// In view mode, make the canvas iframe not focusable and omit the title attribute.
-	// Note: the `readonly` variable name could be improved to clarify it's not
+	// Todo: the `readonly` variable name could be improved to clarify it's not
 	// about the readonly HTML attribute.
 	const viewModeIframeProps = {
 		tabIndex: -1,
 		readonly: true,
+		onClick: currentPostIsTrashed
+			? null
+			: () => {
+					history.navigate(
+						addQueryArgs( path, { canvas: 'edit' } ),
+						{
+							transition: 'canvas-mode-edit-transition',
+						}
+					);
+			  },
 	};
 
 	return {

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -295,7 +295,10 @@ export default function EditSiteEditor( {
 										animate="edit"
 										initial="edit"
 										whileHover="hover"
+										// All elements with tap listeners or whileTap receive tabindex="0".
+										// https://motion.dev/docs/react-upgrade-guide#9-0
 										whileTap="tap"
+										tabIndex="-1"
 									>
 										<Button
 											__next40pxDefaultSize

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -248,10 +248,10 @@ export default function EditSiteEditor( {
 		duration: disableMotion ? 0 : 0.2,
 	};
 
-	const handleEditModeToggle = () =>
-		history.navigate( addQueryArgs( location.path, { canvas: 'edit' } ), {
-			transition: 'canvas-mode-edit-transition',
-		} );
+	// We use the onClick on both the button (for keyboard) and on the iframe.
+	// The button uses `pointer-events: none` to allow to click the iframe behind it
+	// and preserve the scrolling behavior.
+	const { onClick } = iframeProps;
 
 	return ! isBlockBasedTheme && isHomeRoute ? (
 		<SitePreview />
@@ -272,11 +272,7 @@ export default function EditSiteEditor( {
 				<>
 					{ isViewMode && (
 						<button
-							onClick={
-								currentPostIsTrashed
-									? null
-									: handleEditModeToggle
-							}
+							onClick={ onClick }
 							aria-disabled={ currentPostIsTrashed }
 							type="button"
 							className="edit-site-editor__edit-mode-toggle"

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -81,3 +81,19 @@
 		backdrop-filter: saturate(180%) blur(15px);
 	}
 }
+
+.edit-site-editor__edit-mode-toggle {
+	position: absolute;
+	width: 100%;
+	height: 100%;
+	top: 0;
+	left: 0;
+	border: 0;
+	padding: 0;
+	background: rgba(255, 0, 0, 0.3);
+	z-index: z-index(".edit-site-editor__edit-mode-toggle");
+
+	&:not([aria-disabled="true"]) {
+		cursor: pointer;
+	}
+}

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -92,6 +92,7 @@
 	padding: 0;
 	background: rgba(255, 0, 0, 0.3);
 	z-index: z-index(".edit-site-editor__edit-mode-toggle");
+	pointer-events: none;
 
 	&:not([aria-disabled="true"]) {
 		cursor: pointer;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/69490
Closes https://github.com/WordPress/gutenberg/issues/59319
Closes https://github.com/WordPress/gutenberg/issues/57400

<!-- In a few words, what is the PR actually doing? -->
So far, this is a PR for testing purposes. I'd appreciate feedback and thoughts from @WordPress/gutenberg-core 


In the Site Editor 'view' mode, the editor canvas iframe is meant to be a preview. Clicking the whole area of the preview switches the editor to 'edit' mode. This is implemented by hacking around the `iframe` element adding a `role=button` to it, a click event callback etc, It's a hack with many problems for accessibility:
- Safari/VoiceOver users can't 
- When switching to edit mode, focus is still on the iframe with role=button but at the same time additional UI renders _before_ the iframe so that focus is on an unexpected place.

By using a native, transparent, button overlaid on top of the preview iframe, this PR tries a more standard approach.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- All users should be able to switch the Site editor to edit mode.
- Initial focus should be placed at the document root.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Uses a transparent button on top o fthe preview iframe.
So far, the button is semi-transparent for testing purposes. Ultimately, it should be fully transparent.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to the Site editor.
- Use the Tab key to navigate to the preview area.
- Actually, you will tab to the semi-transparent button.
- Press the Enter key.
- The editor switches to edit mode and the semi-transparent button is removed from the DOM. this is intentional so that a focus loss is _intentionally_ triggered to make the tab order start from the beginning of the document root.
- Press Tab and observe the tab sequence starts from the 'Open navigation' button )the WP logo).
- Open the navigation, navigate to various panels and sub-panels that use the 'view' mode and test you can switch the editor to edit mode by usign the keyboard.
- Use Safari and VoiceOver. 
- Navigate to the semi-transparent button and observe the button is announced as `Edit button`.
- Go to Pages > Trash > Switch the view to 'List' 
- Select a trashed page.
- Try to click the preview of navigate to it with the keyboard and activate and observe it does _not_ allow to edit a trashed page. This is the intended behavior implemented in https://github.com/WordPress/gutenberg/pull/60236

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
