### PR TITLE
Editor: Fix 'slug' editing in 'template-locked' mode

### DIFF
--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -195,7 +195,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					_defaultMode === 'template-locked'
 						? hasTemplate
 						: _defaultMode !== undefined;
-				// Wait until the default more is retrieved and start rendering canvas.
+				// Wait until the default mode is retrieved and start rendering canvas.
 				const isRenderingModeReady = _defaultMode !== undefined;
 
 				return {

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -195,9 +195,8 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					_defaultMode === 'template-locked'
 						? hasTemplate
 						: _defaultMode !== undefined;
-				// Wait until rendering mode defaults setup is complete.
-				const isRenderingModeReady =
-					_defaultMode !== undefined && _mode === _defaultMode;
+				// Wait until the default more is retrieved and start rendering canvas.
+				const isRenderingModeReady = _defaultMode !== undefined;
 
 				return {
 					editorSettings: getEditorSettings(),

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -182,6 +182,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 				} = unlock( select( editorStore ) );
 				const { getEntitiesConfig } = select( coreStore );
 
+				const _mode = getRenderingMode();
 				const _defaultMode = getDefaultRenderingMode( post.type );
 				/**
 				 * To avoid content "flash", wait until rendering mode has been resolved.
@@ -190,16 +191,21 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 				 * - Wait for template to be resolved if the default mode is 'template-locked'.
 				 * - Wait for default mode to be resolved otherwise.
 				 */
-				const hasResolvedMode =
+				const hasResolvedDefaultMode =
 					_defaultMode === 'template-locked'
 						? hasTemplate
 						: _defaultMode !== undefined;
+				// Wait until rendering mode defaults setup is complete.
+				const isRenderingModeReady =
+					_defaultMode !== undefined && _mode === _defaultMode;
 
 				return {
 					editorSettings: getEditorSettings(),
-					isReady: __unstableIsEditorReady() && hasResolvedMode,
-					mode: getRenderingMode(),
-					defaultMode: _defaultMode,
+					isReady: __unstableIsEditorReady(),
+					mode: isRenderingModeReady ? _mode : undefined,
+					defaultMode: hasResolvedDefaultMode
+						? _defaultMode
+						: undefined,
 					selection: getEditorSelection(),
 					postTypeEntities:
 						post.type === 'wp_template'


### PR DESCRIPTION
## What?
Fixes #69509.

PR fixes a regression in which editing a page slug causes the editor canvas to fully re-render, disrupting field editing.

## Why?
The editor provider only starts rendering its contents based on two conditions: `isReady` and `mode`; both need to be `truthy` for the contents to render.

Previously, I made `isReady` dependent on the `hasTemplate` condition to avoid rendering mode flash and wait until the editor resolved the template. This introduced the problem - changing the slug also recalculates the template ID for the current page, toggling `isReady` from true to false and back.

## How?
Rearrange conditions so that `isReady` and `mode` are not recalculated when the `hasTemplate` value changes.

P.S. I think the content "flash" became less noticeable after https://github.com/WordPress/gutenberg/pull/69454.

## Testing Instructions

1. Using a block theme.
2. Open a page.
3. Confirm that canvas loading hasn't regressed and that there's no post content flash.
4. Confirm you can edit the page slug and the editor doesn't remount.
5. Confirm no regression when loading content in `post-only` mode. Posts use this mode by default.

_Note:_ I tested with CPU throttling, and content loading differences are more noticeable.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

_The loading screencasts are taken with CPU throttling - 4x slowdown._

**Before**

https://github.com/user-attachments/assets/5ab8303d-e091-4be3-a64a-88ca38f2b79b

**After**

https://github.com/user-attachments/assets/8f3b3ee1-fc84-4500-a004-f0a73102d7d7

