### PR TITLE
Fix issue #69517 - The latest posts block doesn't render the post blo…

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -5,6 +5,8 @@
 // an align items setting of normal.
 figure.wp-block-gallery.has-nested-images {
 	align-items: normal;
+	display: flex;
+	gap: var(--wp--style--gallery-gap-default, var(--gallery-block--gutter-size, var(--wp--style--block-gap, 0.5em)));
 }
 // Styles for current version of gallery block.
 .wp-block-gallery.has-nested-images {


### PR DESCRIPTION
…cks properly when displaying the post content


## What?
Closes #69517

This PR tries to solve PR by modifying CSS

## Why?
When we add the Latest Blocks to a page, activate the "Post content" and "Full post", I would expect to have the full post rendered properly as it works in the page, but it doesn't parse the blocks properly. Now I'm solving this.


## Testing Instructions
1- Add a gallery block to a post with at least 2 images.
2- Create a new page.
3- Add the "Latest Posts" block.
4- In the sidebar settings, check "Post content" and "Full post".
5- Check that the gallery have the images side by side as the original post.

## Screenshots or screencast

|![image](https://github.com/user-attachments/assets/dd3f8b98-d959-4740-9d12-49ff9ea5ce94)|![image](https://github.com/user-attachments/assets/33f77390-a895-4cc1-8354-151c6d967769)|
