### PR TITLE
Fix shift+tab from post title

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -15,7 +15,7 @@ import { isInSameBlock, isInsideRootBlock } from '../../utils/dom';
 import { unlock } from '../../lock-unlock';
 
 export default function useTabNav() {
-	const container = /** @type {typeof useRef<HTMLElement>} */ ( useRef )();
+	const containerRef = /** @type {typeof useRef<HTMLElement>} */ ( useRef )();
 	const focusCaptureBeforeRef = useRef();
 	const focusCaptureAfterRef = useRef();
 
@@ -36,21 +36,21 @@ export default function useTabNav() {
 
 	function onFocusCapture( event ) {
 		const canvasElement =
-			container.current.ownerDocument === event.target.ownerDocument
-				? container.current
-				: container.current.ownerDocument.defaultView.frameElement;
+			containerRef.current.ownerDocument === event.target.ownerDocument
+				? containerRef.current
+				: containerRef.current.ownerDocument.defaultView.frameElement;
 
 		// Do not capture incoming focus if set by us in WritingFlow.
 		if ( noCaptureRef.current ) {
 			noCaptureRef.current = null;
 		} else if ( hasMultiSelection() ) {
-			container.current.focus();
+			containerRef.current.focus();
 		} else if ( getSelectedBlockClientId() ) {
 			if ( getLastFocus()?.current ) {
 				getLastFocus().current.focus();
 			} else {
 				// Handles when the last focus has not been set yet, or has been cleared by new blocks being added via the inserter.
-				container.current
+				containerRef.current
 					.querySelector(
 						`[data-block="${ getSelectedBlockClientId() }"]`
 					)
@@ -64,13 +64,13 @@ export default function useTabNav() {
 
 			// If we have section within the section root, focus the first one.
 			if ( sectionBlocks.length ) {
-				container.current
+				containerRef.current
 					.querySelector( `[data-block="${ sectionBlocks[ 0 ] }"]` )
 					.focus();
 			}
 			// If we don't have any section blocks, focus the section root.
 			else if ( sectionRootClientId ) {
-				container.current
+				containerRef.current
 					.querySelector( `[data-block="${ sectionRootClientId }"]` )
 					.focus();
 			} else {
@@ -82,7 +82,7 @@ export default function useTabNav() {
 				// eslint-disable-next-line no-bitwise
 				event.target.compareDocumentPosition( canvasElement ) &
 				event.target.DOCUMENT_POSITION_FOLLOWING;
-			const tabbables = focus.tabbable.find( container.current );
+			const tabbables = focus.tabbable.find( containerRef.current );
 			if ( tabbables.length ) {
 				const next = isBefore
 					? tabbables[ 0 ]
@@ -147,7 +147,7 @@ export default function useTabNav() {
 
 			const { target, shiftKey } = event;
 
-			if ( target === container.current ) {
+			if ( target === containerRef.current ) {
 				focusContainerAdjacent( shiftKey );
 				return;
 			}
@@ -216,7 +216,7 @@ export default function useTabNav() {
 				return;
 			}
 
-			if ( container.current === event.target ) {
+			if ( containerRef.current === event.target ) {
 				return;
 			}
 
@@ -245,7 +245,7 @@ export default function useTabNav() {
 		};
 	}, [] );
 
-	const mergedRefs = useMergeRefs( [ container, ref ] );
+	const mergedRefs = useMergeRefs( [ containerRef, ref ] );
 
 	return [ before, mergedRefs, after ];
 }

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -109,20 +109,6 @@ export default function useTabNav() {
 	);
 
 	const ref = useRefEffect( ( node ) => {
-		function focusContainerAdjacent( isBefore ) {
-			const to = isBefore ? focusCaptureBeforeRef : focusCaptureAfterRef;
-
-			// Disable focus capturing on the focus capture element, so it
-			// doesn't refocus this block and so it allows default behaviour
-			// (moving focus to the next tabbable element).
-			noCaptureRef.current = true;
-
-			// Focusing the focus capture element, which is located above and
-			// below the editor, should not scroll the page all the way up or
-			// down.
-			to.current.focus( { preventScroll: true } );
-		}
-
 		function onKeyDown( event ) {
 			if (
 				event.defaultPrevented ||
@@ -145,14 +131,8 @@ export default function useTabNav() {
 				return;
 			}
 
-			const { target, shiftKey } = event;
-
-			if ( target === containerRef.current ) {
-				focusContainerAdjacent( shiftKey );
-				return;
-			}
-
-			const direction = shiftKey ? 'findPrevious' : 'findNext';
+			const { target, shiftKey: isShift } = event;
+			const direction = isShift ? 'findPrevious' : 'findNext';
 			const nextTabbable = focus.tabbable[ direction ]( target );
 
 			// We want to constrain the tabbing to the block and its child blocks.
@@ -180,7 +160,17 @@ export default function useTabNav() {
 				return;
 			}
 
-			focusContainerAdjacent( shiftKey );
+			const next = isShift ? focusCaptureBeforeRef : focusCaptureAfterRef;
+
+			// Disable focus capturing on the focus capture element, so it
+			// doesn't refocus this block and so it allows default behaviour
+			// (moving focus to the next tabbable element).
+			noCaptureRef.current = true;
+
+			// Focusing the focus capture element, which is located above and
+			// below the editor, should not scroll the page all the way up or
+			// down.
+			next.current.focus( { preventScroll: true } );
 		}
 
 		function onFocusOut( event ) {

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -22,6 +22,7 @@ export default function useTabNav() {
 	const {
 		hasMultiSelection,
 		getSelectedBlockClientId,
+		getBlockCount,
 		getBlockOrder,
 		getLastFocus,
 		getSectionRootClientId,
@@ -174,6 +175,19 @@ export default function useTabNav() {
 
 		function onFocusOut( event ) {
 			setLastFocus( { ...getLastFocus(), current: event.target } );
+
+			const { ownerDocument } = node;
+
+			// If focus disappears due to there being no blocks, move focus to
+			// the writing flow wrapper.
+			if (
+				! event.relatedTarget &&
+				event.target.hasAttribute( 'data-block' ) &&
+				ownerDocument.activeElement === ownerDocument.body &&
+				getBlockCount() === 0
+			) {
+				node.focus();
+			}
 		}
 
 		// When tabbing back to an element in block list, this event handler prevents scrolling if the

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -22,7 +22,6 @@ export default function useTabNav() {
 	const {
 		hasMultiSelection,
 		getSelectedBlockClientId,
-		getBlockCount,
 		getBlockOrder,
 		getLastFocus,
 		getSectionRootClientId,
@@ -175,18 +174,6 @@ export default function useTabNav() {
 
 		function onFocusOut( event ) {
 			setLastFocus( { ...getLastFocus(), current: event.target } );
-
-			const { ownerDocument } = node;
-
-			// If focus disappears due to there being no blocks, move focus to
-			// the writing flow wrapper.
-			if (
-				! event.relatedTarget &&
-				ownerDocument.activeElement === ownerDocument.body &&
-				getBlockCount() === 0
-			) {
-				node.focus();
-			}
 		}
 
 		// When tabbing back to an element in block list, this event handler prevents scrolling if the

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -110,14 +110,7 @@ export default function useTabNav() {
 
 	const ref = useRefEffect( ( node ) => {
 		function onKeyDown( event ) {
-			if (
-				event.defaultPrevented ||
-				// Bails in case the focus capture elements aren’t present. They
-				// may be omitted to avoid silent tab stops in preview mode.
-				// See: https://github.com/WordPress/gutenberg/pull/59317
-				! focusCaptureAfterRef.current ||
-				! focusCaptureBeforeRef.current
-			) {
+			if ( event.defaultPrevented ) {
 				return;
 			}
 
@@ -128,6 +121,16 @@ export default function useTabNav() {
 			// Arrow keys can be used, and Tab and arrow keys can be used in
 			// Navigation mode (press Esc), to navigate through blocks.
 			if ( event.keyCode !== TAB ) {
+				return;
+			}
+
+			if (
+				// Bails in case the focus capture elements aren’t present. They
+				// may be omitted to avoid silent tab stops in preview mode.
+				// See: https://github.com/WordPress/gutenberg/pull/59317
+				! focusCaptureAfterRef.current ||
+				! focusCaptureBeforeRef.current
+			) {
 				return;
 			}
 
@@ -159,7 +162,6 @@ export default function useTabNav() {
 			) {
 				return;
 			}
-
 			const next = isShift ? focusCaptureBeforeRef : focusCaptureAfterRef;
 
 			// Disable focus capturing on the focus capture element, so it

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -890,6 +890,35 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		).toHaveClass( /is-selected/ );
 	} );
 
+	test( 'should focus preceding tabbable using shift+tab from post title and writing flow container', async ( {
+		editor,
+		page,
+	} ) => {
+		async function isPrecedingTabbableFocused() {
+			return await page.evaluate( () => {
+				const editorCanvasFrame =
+					window[ 'editor-canvas' ].frameElement;
+				const { focus } = window.wp.dom;
+				const tabbables = focus.tabbable.find( document.body );
+				// The tabbable to be checked isn’t the immediately preceding one
+				// because that’s the focus capture element.
+				const precedingIndex =
+					-2 + tabbables.indexOf( editorCanvasFrame );
+				return document.activeElement === tabbables[ precedingIndex ];
+			} );
+		}
+
+		await page.keyboard.press( 'Shift+Tab' );
+		expect( await isPrecedingTabbableFocused() ).toBe( true );
+
+		const editorCanvasBody = editor.canvas.locator( 'body' );
+		// Focuses the editor canvas body. In the editor the click doesn’t have
+		// to be on the element itself – just somewhere that won’t focus a block.
+		await editorCanvasBody.click();
+		await page.keyboard.press( 'Shift+Tab' );
+		expect( await isPrecedingTabbableFocused() ).toBe( true );
+	} );
+
 	test( 'should only consider the content as one tab stop', async ( {
 		editor,
 		page,

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -894,7 +894,9 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		editor,
 		page,
 	} ) => {
-		const optionsButton = page.locator( 'role=button[name="Options"i]' );
+		const optionsButton = page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Options' } );
 		await page.keyboard.press( 'Shift+Tab' );
 		await expect( optionsButton ).toBeFocused();
 

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -894,29 +894,16 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 		editor,
 		page,
 	} ) => {
-		async function isPrecedingTabbableFocused() {
-			return await page.evaluate( () => {
-				const editorCanvasFrame =
-					window[ 'editor-canvas' ].frameElement;
-				const { focus } = window.wp.dom;
-				const tabbables = focus.tabbable.find( document.body );
-				// The tabbable to be checked isn’t the immediately preceding one
-				// because that’s the focus capture element.
-				const precedingIndex =
-					-2 + tabbables.indexOf( editorCanvasFrame );
-				return document.activeElement === tabbables[ precedingIndex ];
-			} );
-		}
-
+		const optionsButton = page.locator( 'role=button[name="Options"i]' );
 		await page.keyboard.press( 'Shift+Tab' );
-		expect( await isPrecedingTabbableFocused() ).toBe( true );
+		await expect( optionsButton ).toBeFocused();
 
 		const editorCanvasBody = editor.canvas.locator( 'body' );
 		// Focuses the editor canvas body. In the editor the click doesn’t have
 		// to be on the element itself – just somewhere that won’t focus a block.
 		await editorCanvasBody.click();
 		await page.keyboard.press( 'Shift+Tab' );
-		expect( await isPrecedingTabbableFocused() ).toBe( true );
+		await expect( optionsButton ).toBeFocused();
 	} );
 
 	test( 'should only consider the content as one tab stop', async ( {


### PR DESCRIPTION
## What?
Closes #69486

Enables <kbd>shift</kbd>+<kbd>tab</kbd> from the post title (in "post-only" mode) to navigate to the preceding tab stop as expected.

## Why?
The inability to navigate to the previous tab stop from the post title breaks keyboard use and is a regression since WP 6.7.

## How?
- Avoids an error if focus capture elements are not present by returning early.
- Supports navigation from generic elements within the container, such as the post title, by removing an early return for no block selection.

## Testing Instructions

### E2E test
1. Checkout the first commit on this branch which adds an e2e test
2. Run the test:
    ```sh
    npm run test:e2e -- test/e2e/specs/editor/various/writing-flow.spec.js:893 
    ```
3. Confirm that it fails
4. Checkout the full branch again (`git switch -`)
5. Run the test
6. Confirm that it passes

### Testing Instructions for Keyboard
1. Open a post in "post-only" mode
2. Navigate to the post title
3. Press <kbd>shift</kbd>+<kbd>tab</kdb>
4. Confirm that focus moved to the preceding tab stop (could be the notice close button if one happens to be open but it’s probably the "Options" button).
5. Repeat these steps in a non-iframe context (activate a classic theme and have block registered that’s less than v3)

### General testing of tab navigation
1. Tab through the canvas and make sure it works as before
2. Go the other direction and make sure it works as before
3. Repeat these steps in a non-iframe context (activate a classic theme and have block registered that’s less than v3)