### PR TITLE
Classic theme site preview: Make all interactive elements unclickable

### DIFF
--- a/packages/edit-site/src/components/editor/site-preview.js
+++ b/packages/edit-site/src/components/editor/site-preview.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { focus } from '@wordpress/dom';
 
 export default function SitePreview() {
 	const siteUrl = useSelect( ( select ) => {
@@ -34,10 +35,8 @@ export default function SitePreview() {
 					.getElementsByTagName( 'body' )[ 0 ]
 					.classList.remove( 'admin-bar' );
 				// Make interactive elements unclickable.
-				const interactiveElements = document.querySelectorAll(
-					'a, button, input, details, audio'
-				);
-				interactiveElements.forEach( ( element ) => {
+				const focusableElements = focus.focusable.find( document );
+				focusableElements.forEach( ( element ) => {
 					element.style.pointerEvents = 'none';
 					element.tabIndex = -1;
 					element.setAttribute( 'aria-hidden', 'true' );


### PR DESCRIPTION
## What?

Found while working on #69474

This PR makes "all" interactive elements unclickable in the classic theme site preview.

## Why?

The current logic doesn't make interactive all elements unclickable. For example, textarea, content editable div, div element with tabindex="0":

https://github.com/user-attachments/assets/9ada3cdf-4bc0-4f38-ac05-982f85b8e070

## How?

Use `focus.focusable` method from `@wordpress/dom` package to check all interactive elements.

## Testing Instructions

- Activate Twenty Twenty-One.
- Set one page as HomePage.
- Insert a Custom HTML block with the following content into that page:
 ```
  <!-- wp:html -->
  <textarea>Textarea</textarea>
  <div contenteditable>Content editable div</div>
  <div tabindex="0">Focusable div</div>
  <!-- /wp:html -->
 ```
- Access Appearance > Design
- Confirm that you can't focus these interactive elements via the Tab key.
- Confirm that you can't click these interactive elements.