### PR TITLE
PostStatus: Prevent form submission from refreshing the page

### DIFF
--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -194,7 +194,12 @@ export default function PostStatus() {
 								title={ __( 'Status & visibility' ) }
 								onClose={ onClose }
 							/>
-							<form>
+							<form
+								onSubmit={ ( event ) => {
+									event.preventDefault();
+									onClose();
+								} }
+							>
 								<VStack spacing={ 4 }>
 									<RadioControl
 										className="editor-change-status__options"

--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -194,12 +194,7 @@ export default function PostStatus() {
 								title={ __( 'Status & visibility' ) }
 								onClose={ onClose }
 							/>
-							<form
-								onSubmit={ ( event ) => {
-									event.preventDefault();
-									onClose();
-								} }
-							>
+							<form>
 								<VStack spacing={ 4 }>
 									<RadioControl
 										className="editor-change-status__options"
@@ -262,6 +257,17 @@ export default function PostStatus() {
 														__next40pxDefaultSize
 														__nextHasNoMarginBottom
 														maxLength={ 255 }
+														onKeyDown={ (
+															event
+														) => {
+															if (
+																event.key ===
+																'Enter'
+															) {
+																event.preventDefault();
+																onClose();
+															}
+														} }
 													/>
 												</div>
 											) }

--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -194,7 +194,12 @@ export default function PostStatus() {
 								title={ __( 'Status & visibility' ) }
 								onClose={ onClose }
 							/>
-							<form>
+							<form
+								onSubmit={ ( event ) => {
+									event.preventDefault();
+									onClose();
+								} }
+							>
 								<VStack spacing={ 4 }>
 									<RadioControl
 										className="editor-change-status__options"
@@ -257,17 +262,6 @@ export default function PostStatus() {
 														__next40pxDefaultSize
 														__nextHasNoMarginBottom
 														maxLength={ 255 }
-														onKeyDown={ (
-															event
-														) => {
-															if (
-																event.key ===
-																'Enter'
-															) {
-																event.preventDefault();
-																onClose();
-															}
-														} }
 													/>
 												</div>
 											) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Closes: #69524

## What?
Fixes an issue where enabling password protection and entering a password in the “Status & Visibility” popover caused an unintended form submission, leading to a page refresh.




<!-- In a few words, what is the PR actually doing? -->

## Why?
When pressing Enter in the password input field, the browser attempted to submit the form, refreshing the page. Since the “Save Draft” and “Publish” buttons remain disabled unless there is content in the post (title or content)

## How?
•	Prevents default form submission behavior to stop the page from refreshing.

## Testing Instructions
1. Open the block editor and create a new post or page.
2.	Click on the link next to the “Status” label to open the “Status & Visibility” popover.
3.	Enable password protection and enter a password in the input field.
4.	Press Enter and confirm that:
	•	The page does not refresh.
	•	The popover closes as expected.
	•	The “Save Draft” button remains disabled if no content exists.
	• Use Keyboard shortcut to save the post
5.	Add content (title or body) and verify that the “Save Draft” button is enabled, allowing you to save the post with the password.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before:

https://github.com/user-attachments/assets/0efb5d6c-debf-4aee-8a97-5f207613db80

After:

https://github.com/user-attachments/assets/6f140039-3e94-418d-81a6-ec45a90a7dc6


