### PR TITLE
Fix: Remove the scrollbar issue when image lightbox is active

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -278,6 +278,16 @@
 		opacity: 0.9;
 	}
 
+	// When image lightbox is zoomed-in and active, prevent
+	// scrolling on the body
+	&.zoom.active {
+
+		body:has(&) {
+			overflow: hidden;
+			height: 100vh;
+		}
+	}
+
 	// When fading, make the image come in slightly slower
 	// or faster than the scrim to give a sense of depth.
 	&.active {


### PR DESCRIPTION
Fixed the image lightbox scrollbar issue when image lightbox is active

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #69527  <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
When the image lightbox is opened, the scrollbar is available even though there is no content to be displayed other than the image.

## How?

- Added appropriate css to remove the scrollbar when the image lightbox is active

## Testing Instructions

1. Add an Image block in the editor.
2. In the block toolbar, open Link settings and enable the Enlarge on Click option.
3. Preview the page and click on the image to open the lightbox with the .zoom.active class.
4. Scroll the page and observe that the scrollbar remains visible instead of being hidden.