### PR TITLE
Fix: Update full height toggle icon

### DIFF
--- a/packages/block-editor/src/components/block-full-height-alignment-control/index.js
+++ b/packages/block-editor/src/components/block-full-height-alignment-control/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { ToolbarButton } from '@wordpress/components';
-import { fullscreen } from '@wordpress/icons';
+import { fullHeight } from '@wordpress/icons';
 
 function BlockFullHeightAlignmentControl( {
 	isActive,
@@ -14,7 +14,7 @@ function BlockFullHeightAlignmentControl( {
 	return (
 		<ToolbarButton
 			isActive={ isActive }
-			icon={ fullscreen }
+			icon={ fullHeight }
 			label={ label }
 			onClick={ () => onToggle( ! isActive ) }
 			disabled={ isDisabled }

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -310,3 +310,4 @@ export { default as verse } from './library/verse';
 export { default as video } from './library/video';
 export { default as widget } from './library/widget';
 export { default as wordpress } from './library/wordpress';
+export { default as fullHeight } from './library/full-height';

--- a/packages/icons/src/library/full-height.js
+++ b/packages/icons/src/library/full-height.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const fullHeight = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path
+			d="M6 4h12M6 20h12M12 7v10m0 0-3-3m3 3 3-3m-3-7 3 3m-3-3-3 3"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+	</SVG>
+);
+
+export default fullHeight;


### PR DESCRIPTION
Closes #55734 

## What?
This PR replaces the "full height" toggle icon in the Cover block with a new icon featuring arrows pointing up and down. This change addresses the confusion caused by using the same `fullscreen` icon for both the "full height" toggle and the lightbox's "full screen" toggle.

## Why?
Currently, the Cover block's "full height" toggle and the lightbox's "full screen" toggle use the same `fullscreen` icon. This can be confusing for users, as the two features serve different purposes. By introducing a distinct icon for the "full height" toggle, we improve clarity and usability.

## How?
- Added a new `fullHeight` icon using the `@wordpress/primitives` package.
- Updated the `BlockFullHeightAlignmentControl` component to use the new icon.
- Ensured the new icon aligns with Gutenberg's design language and accessibility standards.

## Testing Instructions
1. Open the editor and insert a Cover block.
2. Select the Cover block and observe the toolbar.
3. Verify that the "full height" toggle now displays the new icon (arrows pointing up and down).
4. Toggle the "full height" option and ensure it functions as expected.


## Screenshots or screencast <!-- if applicable -->


|Before|After|
|-|-|
|<img width="402" alt="before" src="https://github.com/user-attachments/assets/e4f850e6-7022-42d0-9d89-3907e44db6e7" />|<img width="373" alt="after" src="https://github.com/user-attachments/assets/8993496a-0782-40bb-8df8-9a1a8cd18156" />|
