### PR TITLE
Replace CSS rotate property by transform: rotate()

### DIFF
--- a/packages/block-library/src/heading/style.scss
+++ b/packages/block-library/src/heading/style.scss
@@ -9,6 +9,6 @@ h6 {
 	}
 	&.has-text-align-right[style*="writing-mode"]:where([style*="vertical-rl"]),
 	&.has-text-align-left[style*="writing-mode"]:where([style*="vertical-lr"]) {
-		rotate: 180deg;
+		transform: rotate(180deg);
 	}
 }

--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -20,7 +20,7 @@
 
 .block-editor-block-list__block[data-type="core/paragraph"].has-text-align-right[style*="writing-mode: vertical-rl"],
 .block-editor-block-list__block[data-type="core/paragraph"].has-text-align-left[style*="writing-mode: vertical-lr"] {
-	rotate: 180deg;
+	transform: rotate(180deg);
 }
 
 // Hide the placeholder when the editor is in zoomed out mode.

--- a/packages/block-library/src/paragraph/style.scss
+++ b/packages/block-library/src/paragraph/style.scss
@@ -53,5 +53,5 @@ p.has-drop-cap.has-background {
 
 p.has-text-align-right[style*="writing-mode:vertical-rl"],
 p.has-text-align-left[style*="writing-mode:vertical-lr"] {
-	rotate: 180deg;
+	transform: rotate(180deg);
 }

--- a/packages/block-library/src/post-navigation-link/style.scss
+++ b/packages/block-library/src/post-navigation-link/style.scss
@@ -22,6 +22,6 @@
 
 	&.has-text-align-right[style*="writing-mode: vertical-rl"],
 	&.has-text-align-left[style*="writing-mode: vertical-lr"] {
-		rotate: 180deg;
+		transform: rotate(180deg);
 	}
 }

--- a/packages/components/src/custom-select-control/test/index.tsx
+++ b/packages/components/src/custom-select-control/test/index.tsx
@@ -22,7 +22,7 @@ const UncontrolledCustomSelectControl = (
 const customClassName = 'amber-skies';
 const customStyles = {
 	backgroundColor: 'rgb(127, 255, 212)',
-	rotate: '13deg',
+	transform: 'rotate(13deg)',
 };
 
 const props = {

--- a/packages/components/src/tabs/styles.ts
+++ b/packages/components/src/tabs/styles.ts
@@ -265,7 +265,7 @@ export const TabChevron = styled( Icon )`
 		}
 	}
 	&:dir( rtl ) {
-		rotate: 180deg;
+		transform: rotate(180deg);
 	}
 `;
 


### PR DESCRIPTION
## What?
Fix proposal for https://github.com/WordPress/gutenberg/issues/69532
The PR replace CSS rotate property by transform: rotate() because rotate is deprecated by the W3C validator.

## Why?
It's annoying to get those CSS errors in the W3C validator.

## How?
The PR replace CSS rotate property by transform: rotate().
