### PR TITLE
Site Editor: Set `IFRAME_REQUEST` constant for classic theme site preview

### DIFF
--- a/backport-changelog/6.8/8475.md
+++ b/backport-changelog/6.8/8475.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/8475
 
 * https://github.com/WordPress/gutenberg/pull/69514
+* https://github.com/WordPress/gutenberg/pull/69535

--- a/lib/compat/wordpress-6.8/admin-bar.php
+++ b/lib/compat/wordpress-6.8/admin-bar.php
@@ -30,17 +30,3 @@ function gutenberg_wp_admin_bar_edit_site_menu( $wp_admin_bar ) {
 }
 
 add_action( 'admin_bar_menu', 'gutenberg_wp_admin_bar_edit_site_menu', 41 );
-
-if ( ! function_exists( 'wp_initialize_site_preview_hooks' ) ) {
-	/**
-	 * Add filter to hide the admin bar.
-	 *
-	 * This filter is used to hide the admin bar in classic theme site previews in the site editor.
-	 */
-	function wp_initialize_site_preview_hooks() {
-		if ( isset( $_GET['wp_site_preview'] ) && 1 === (int) $_GET['wp_site_preview'] ) {
-			add_filter( 'show_admin_bar', '__return_false' );
-		}
-	}
-}
-add_action( 'init', 'wp_initialize_site_preview_hooks', 1 );

--- a/lib/compat/wordpress-6.8/site-preview.php
+++ b/lib/compat/wordpress-6.8/site-preview.php
@@ -1,0 +1,14 @@
+<?php
+if ( ! function_exists( 'wp_initialize_site_preview_hooks' ) ) {
+	/**
+	 * Initialize site preview.
+	 *
+	 * This function sets IFRAME_REQUEST to true if the site preview parameter is set.
+	 */
+	function wp_initialize_site_preview_hooks() {
+		if ( ! defined( 'IFRAME_REQUEST' ) && isset( $_GET['wp_site_preview'] ) && 1 === (int) $_GET['wp_site_preview'] ) {
+			define( 'IFRAME_REQUEST', true );
+		}
+	}
+}
+add_action( 'init', 'wp_initialize_site_preview_hooks', 1 );

--- a/lib/compat/wordpress-6.8/site-preview.php
+++ b/lib/compat/wordpress-6.8/site-preview.php
@@ -6,7 +6,12 @@ if ( ! function_exists( 'wp_initialize_site_preview_hooks' ) ) {
 	 * This function sets IFRAME_REQUEST to true if the site preview parameter is set.
 	 */
 	function wp_initialize_site_preview_hooks() {
-		if ( ! defined( 'IFRAME_REQUEST' ) && isset( $_GET['wp_site_preview'] ) && 1 === (int) $_GET['wp_site_preview'] ) {
+		if (
+			! defined( 'IFRAME_REQUEST' ) &&
+			isset( $_GET['wp_site_preview'] ) &&
+			1 === (int) $_GET['wp_site_preview'] &&
+			current_user_can( 'edit_theme_options' )
+		) {
 			define( 'IFRAME_REQUEST', true );
 		}
 	}

--- a/lib/load.php
+++ b/lib/load.php
@@ -106,6 +106,7 @@ require __DIR__ . '/compat/wordpress-6.8/post.php';
 require __DIR__ . '/compat/wordpress-6.8/site-editor.php';
 require __DIR__ . '/compat/wordpress-6.8/class-gutenberg-rest-user-controller.php';
 require __DIR__ . '/compat/wordpress-6.8/block-template-utils.php';
+require __DIR__ . '/compat/wordpress-6.8/site-preview.php';
 
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';


### PR DESCRIPTION
## What?

Follow-up #69514
Related core PR: https://github.com/WordPress/wordpress-develop/pull/8475 

> [!NOTE]
> Don't add `Backport to WP 6.8 Beta/RC` label to this PR. This is because the auto cherry-pick has failed in #69514. I plan to submit another PR to the `wp/6.8` branch that includes this PR and #69514.

## Why?

In #69514, We added a get parameter to hide admin bar in the classic theme site preview.  However, we found that some plugins load code into the preview. 

## How?

To solve this problem, it seems best to define `IFRAME_REQUEST` instead of filtering `show_admin_bar` hook.

## Testing Instructions

- Activate Twenty Twenty-One.
- Install and activate https://ja.wordpress.org/plugins/query-monitor/ plugin.
- Access Appearance > Design.
- Confirm that the admin bar isn't displayed within the site preview.
- Confirm that the Query Monitor plugin doesn't load anything.
- Reload your browser a few times and check again.

|Before|After|
|-|-|
| ![image](https://github.com/user-attachments/assets/38e0f1d3-3a42-4f62-bc52-422c11089020)  | ![image](https://github.com/user-attachments/assets/24e4ec71-93fd-49ed-a523-615233c3ac55) |
