### PR TITLE
[WP6.8] Site Editor: Set `IFRAME_REQUEST` constant for classic theme site preview

### DIFF
--- a/backport-changelog/6.8/8475.md
+++ b/backport-changelog/6.8/8475.md
@@ -1,0 +1,4 @@
+https://github.com/WordPress/wordpress-develop/pull/8475
+
+* https://github.com/WordPress/gutenberg/pull/69514
+* https://github.com/WordPress/gutenberg/pull/69535

--- a/lib/compat/wordpress-6.8/site-preview.php
+++ b/lib/compat/wordpress-6.8/site-preview.php
@@ -1,0 +1,14 @@
+<?php
+if ( ! function_exists( 'wp_initialize_site_preview_hooks' ) ) {
+	/**
+	 * Initialize site preview.
+	 *
+	 * This function sets IFRAME_REQUEST to true if the site preview parameter is set.
+	 */
+	function wp_initialize_site_preview_hooks() {
+		if ( ! defined( 'IFRAME_REQUEST' ) && isset( $_GET['wp_site_preview'] ) && 1 === (int) $_GET['wp_site_preview'] ) {
+			define( 'IFRAME_REQUEST', true );
+		}
+	}
+}
+add_action( 'init', 'wp_initialize_site_preview_hooks', 1 );

--- a/lib/compat/wordpress-6.8/site-preview.php
+++ b/lib/compat/wordpress-6.8/site-preview.php
@@ -6,7 +6,12 @@ if ( ! function_exists( 'wp_initialize_site_preview_hooks' ) ) {
 	 * This function sets IFRAME_REQUEST to true if the site preview parameter is set.
 	 */
 	function wp_initialize_site_preview_hooks() {
-		if ( ! defined( 'IFRAME_REQUEST' ) && isset( $_GET['wp_site_preview'] ) && 1 === (int) $_GET['wp_site_preview'] ) {
+		if (
+			! defined( 'IFRAME_REQUEST' ) &&
+			isset( $_GET['wp_site_preview'] ) &&
+			1 === (int) $_GET['wp_site_preview'] &&
+			current_user_can( 'edit_theme_options' )
+		) {
 			define( 'IFRAME_REQUEST', true );
 		}
 	}

--- a/lib/load.php
+++ b/lib/load.php
@@ -105,6 +105,7 @@ require __DIR__ . '/compat/wordpress-6.8/post.php';
 require __DIR__ . '/compat/wordpress-6.8/site-editor.php';
 require __DIR__ . '/compat/wordpress-6.8/class-gutenberg-rest-user-controller.php';
 require __DIR__ . '/compat/wordpress-6.8/block-template-utils.php';
+require __DIR__ . '/compat/wordpress-6.8/site-preview.php';
 
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';

--- a/packages/edit-site/src/components/editor/site-preview.js
+++ b/packages/edit-site/src/components/editor/site-preview.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { focus } from '@wordpress/dom';
+import { addQueryArgs } from '@wordpress/url';
 
 export default function SitePreview() {
 	const siteUrl = useSelect( ( select ) => {
@@ -16,7 +17,10 @@ export default function SitePreview() {
 	// If theme is block based, return the Editor, otherwise return the site preview.
 	return (
 		<iframe
-			src={ siteUrl }
+			src={ addQueryArgs( siteUrl, {
+				// Parameter for hiding the admin bar.
+				wp_site_preview: 1,
+			} ) }
 			title={ __( 'Site Preview' ) }
 			style={ {
 				display: 'block',
@@ -25,16 +29,8 @@ export default function SitePreview() {
 				backgroundColor: '#fff',
 			} }
 			onLoad={ ( event ) => {
-				// Hide the admin bar in the front-end preview.
-				const document = event.target.contentDocument;
-				document.getElementById( 'wpadminbar' ).remove();
-				document
-					.getElementsByTagName( 'html' )[ 0 ]
-					.setAttribute( 'style', 'margin-top: 0 !important;' );
-				document
-					.getElementsByTagName( 'body' )[ 0 ]
-					.classList.remove( 'admin-bar' );
 				// Make interactive elements unclickable.
+				const document = event.target.contentDocument;
 				const focusableElements = focus.focusable.find( document );
 				focusableElements.forEach( ( element ) => {
 					element.style.pointerEvents = 'none';


### PR DESCRIPTION
Related core PR: https://github.com/WordPress/wordpress-develop/pull/8475

## What?

This PR is for `wp/6.8` branch and includes the following two PRs:

- https://github.com/WordPress/gutenberg/pull/69514 (auto cherry-pick failed)
- https://github.com/WordPress/gutenberg/pull/69535

<!-- In a few words, what is the PR actually doing? -->

## Why?

#69514 was expected to be backported to the core (WP 6.8), but the auto-cherry-pick was failed. Then #69535 was submitted for a more ideal solution. This PR backports those two PR into the `wp/6.8` branch.

## Testing Instructions

Same as #69535.