### PR TITLE
Site Editor: add period to Design description

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -100,7 +100,7 @@ export default function SidebarNavigationScreenMain( { customDescription } ) {
 		);
 	} else {
 		description = __(
-			'Explore block styles and patterns to refine your site'
+			'Explore block styles and patterns to refine your site.'
 		);
 	}
 


### PR DESCRIPTION
## What?

Just to improve the consistency of wording.

## Testing Instructions

- Activate Twenty Twenty-One
- Access Appearance > Design


## Screenshots or screencast <!-- if applicable -->

![image](https://github.com/user-attachments/assets/d1fa334a-4e43-4eac-824d-7a85c518f523)
