### PR TITLE
Components: Fixed broken className test for `NumberControl`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `QueryControls`: Add menu_order sorting option if supported by the post type. ([#68781](https://github.com/WordPress/gutenberg/pull/68781)).
 
+## Internal
+
+-   `NumberControl`: Fixed className test to properly verify className application. ([#69540](https://github.com/WordPress/gutenberg/pull/69540)).
+
 ### Bug Fixes
 
 -   `Button`: Remove fixed width from small and compact buttons with icons ([#69378](https://github.com/WordPress/gutenberg/pull/69378)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 -   `QueryControls`: Add menu_order sorting option if supported by the post type. ([#68781](https://github.com/WordPress/gutenberg/pull/68781)).
 
-## Internal
+### Internal
 
 -   `NumberControl`: Fixed className test to properly verify className application. ([#69540](https://github.com/WordPress/gutenberg/pull/69540)).
 

--- a/packages/components/src/number-control/test/index.tsx
+++ b/packages/components/src/number-control/test/index.tsx
@@ -40,8 +40,21 @@ describe( 'NumberControl', () => {
 		} );
 
 		it( 'should render custom className', () => {
-			render( <NumberControl className="hello" /> );
-			expect( screen.getByRole( 'spinbutton' ) ).toBeVisible();
+			const { container: withoutClassName } = render( <NumberControl /> );
+
+			const { container: withClassName } = render(
+				<NumberControl className="hello" />
+			);
+
+			expect(
+				// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+				withoutClassName.querySelector( '.components-number-control' )
+			).not.toHaveClass( 'hello' );
+
+			expect(
+				// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+				withClassName.querySelector( '.components-number-control' )
+			).toHaveClass( 'hello' );
 		} );
 	} );
 


### PR DESCRIPTION


## What?
Fixed the className test for NumberControl component that wasn't actually testing className application.

Discovered while working in this:  https://github.com/WordPress/gutenberg/issues/36742#issuecomment-2714186679
Related issue: https://github.com/WordPress/gutenberg/issues/36742


## Why?
The previous test was only checking if the component was visible (`toBeVisible()`) but not verifying whether the className was actually being applied to the component.


## How?

1. Implemented a proper test that compares two rendered instances (with and without className)
2. Added specific assertions to verify the className is correctly applied when provided
3. Ensured the test actually tests what its name suggests


### Took inspiration from the `UnitControl` test:

 **See how `UnitControl` tests the classname** 

https://github.com/WordPress/gutenberg/blob/8aa8c141297227ef4ae333fea2a4d46a052600f4/packages/components/src/unit-control/test/index.tsx#L101-L116



## Testing Instructions

1. Run the test suite for the NumberControl component
2. Verify that all tests pass successfully

To run the tests:

```shell
npm run test:unit packages/components/src/number-control/test/
```


## Screenshots or screencast 

https://github.com/user-attachments/assets/40381c2f-6b94-486c-94fa-b7acad0af126


