### PR TITLE
ShadowsPanel: Remove `Flex Wrapper` from `Subtitle`

### DIFF
--- a/packages/edit-site/src/components/global-styles/shadows-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-panel.js
@@ -6,7 +6,6 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalItemGroup as ItemGroup,
 	Button,
-	Flex,
 	FlexItem,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
@@ -134,14 +133,9 @@ function ShadowList( {
 	return (
 		<VStack spacing={ 2 }>
 			<HStack justify="space-between">
-				<Flex
-					align="center"
-					className="edit-site-global-styles__shadows-panel__title"
-				>
-					<Subtitle level={ 3 }>{ label }</Subtitle>
-				</Flex>
-				{ canCreate && (
-					<FlexItem className="edit-site-global-styles__shadows-panel__options-container">
+				<Subtitle level={ 3 }>{ label }</Subtitle>
+				<FlexItem className="edit-site-global-styles__shadows-panel__options-container">
+					{ canCreate && (
 						<Button
 							size="small"
 							icon={ plus }
@@ -150,28 +144,28 @@ function ShadowList( {
 								handleAddShadow();
 							} }
 						/>
-					</FlexItem>
-				) }
-				{ !! shadows?.length && category === 'custom' && (
-					<Menu>
-						<Menu.TriggerButton
-							render={
-								<Button
-									size="small"
-									icon={ moreVertical }
-									label={ __( 'Shadow options' ) }
-								/>
-							}
-						/>
-						<Menu.Popover>
-							<Menu.Item onClick={ onReset }>
-								<Menu.ItemLabel>
-									{ __( 'Remove all custom shadows' ) }
-								</Menu.ItemLabel>
-							</Menu.Item>
-						</Menu.Popover>
-					</Menu>
-				) }
+					) }
+					{ !! shadows?.length && category === 'custom' && (
+						<Menu>
+							<Menu.TriggerButton
+								render={
+									<Button
+										size="small"
+										icon={ moreVertical }
+										label={ __( 'Shadow options' ) }
+									/>
+								}
+							/>
+							<Menu.Popover>
+								<Menu.Item onClick={ onReset }>
+									<Menu.ItemLabel>
+										{ __( 'Remove all custom shadows' ) }
+									</Menu.ItemLabel>
+								</Menu.Item>
+							</Menu.Popover>
+						</Menu>
+					) }
+				</FlexItem>
 			</HStack>
 			{ shadows.length > 0 && (
 				<ItemGroup isBordered isSeparated>

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -104,7 +104,6 @@
 	flex-shrink: 0;
 }
 
-.edit-site-global-styles__shadows-panel__title,
 .edit-site-global-styles__shadows-panel__options-container {
 	height: $grid-unit * 3;
 }


### PR DESCRIPTION
## What?
Closes #69538 

This PR aims to adjust the alignment of the `Add Shadow` button.

## Why?

The button appears slightly shifted to the right and the width of the wrapper container seems to be reduced.

## How?

This was fixed by removing the wrapping flex container as its usage was not required.

## Testing Instructions

1. Navigate to Appearance -> Editor -> Styles -> Shadows
2. Inspect the `Add Shadows` button and confirm it doesn't extend to the right.

### Testing Instructions for Keyboard
Same

## Screenshots

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/7179c243-4424-4400-b4d3-a1c8f82d1bd3)|![after](https://github.com/user-attachments/assets/6b24e178-a42f-49ea-aa77-c6b0212119d3)|
|![before](https://github.com/user-attachments/assets/4235f422-65db-4412-a9c0-d5b4bcf62452)|![after](https://github.com/user-attachments/assets/5a10ba68-08ac-46f9-841b-e71180bab4b2)|