### PR TITLE
Template UI mu-plugin: Run filter after the setup_theme action

### DIFF
--- a/packages/e2e-tests/mu-plugins/enable-templates-ui.php
+++ b/packages/e2e-tests/mu-plugins/enable-templates-ui.php
@@ -10,15 +10,19 @@
 /**
  * Enable Templates & Template Parts post type UI during e2e testing.
  */
-add_filter(
-	'register_post_type_args',
-	static function ( $args, $name ) {
-		if ( in_array( $name, array( 'wp_template', 'wp_template_part' ), true ) ) {
-			$args['show_ui'] = wp_is_block_theme();
-		}
 
-		return $args;
-	},
-	20,
-	2
-);
+
+function gutenberg_enable_templates_ui() {
+	add_filter(
+		'register_post_type_args',
+		static function ( $args, $name ) {
+			if ( in_array( $name, array( 'wp_template', 'wp_template_part' ), true ) ) {
+				$args['show_ui'] = wp_is_block_theme();
+			}
+			return $args;
+		},
+		20,
+		2
+	);
+}
+add_action( 'setup_theme', 'gutenberg_enable_templates_ui' );


### PR DESCRIPTION
## What?

I noticed that some e2e tests that access the site editor are failing in _only_ the test environment. For example, Block themes do not have access to the Site Editor:

- ✅ http://localhost:8888/wp-admin/site-editor.php?p=%2Ftemplate
- ❌ http://localhost:8889/wp-admin/site-editor.php?p=%2Ftemplate

![templates](https://github.com/user-attachments/assets/8ffe578c-55c1-44c0-b295-83f88d160193)

## Why?

I identified the mu-plugin that enables templates UI is causing these errors. This mu-plugin is only activated in the test environment.

Somehow this `wp_is_block_theme()` seems to return `false`, although the active theme is block-based:

https://github.com/WordPress/gutenberg/blob/9f77c96c2a474d1f7f90589a8f6965644be9a5a4/packages/e2e-tests/mu-plugins/enable-templates-ui.php#L17

I'm not sure the root cause, but I think this core commit might be related: https://github.com/WordPress/wordpress-develop/commit/5f24c9dbb9bdd0c0bf42975a2ee007985a21e648

Anyway, let's see if CIs are passing if we remove the mu-plugin that enables templates ui.
