### PR TITLE
Fix: Verse Block Preserves Text Formatting (italic, bold, etc.) on Paste

### DIFF
--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -57,7 +57,6 @@ export default function VerseEdit( {
 				onMerge={ mergeBlocks }
 				textAlign={ textAlign }
 				{ ...blockProps }
-				__unstablePastePlainText
 				__unstableOnSplitAtDoubleLineEnd={ () =>
 					insertBlocksAfter( createBlock( getDefaultBlockName() ) )
 				}


### PR DESCRIPTION
Closes #57624

## What?
This PR fixes an issue where text formatting (italic, bold, etc.) is stripped when pasting content into the Verse block.

## Why?
When pasting formatted verse (poetry) into the Verse block, whitespace is preserved but all text formatting is stripped out. This creates unnecessary work for content editors who then need to manually re-add all formatting.

The Paragraph block correctly retains text formatting on paste, and the Verse block should behave similarly since verse content (poetry, lyrics, etc.) often uses italics, bolds, and similar formatting.


## Testing Instructions
1. Create a post and insert an empty Verse block
2. Find a poem that includes italics, for example: https://www.poetryfoundation.org/poems/161828/luh-friends
3. Copy the poem's text and paste it into the empty Verse block
4. Verify that the italics are preserved (before this fix, they would be removed)

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast

### Before
https://github.com/user-attachments/assets/651936d4-f124-45fd-aa49-bb380ae04920

### After
https://github.com/user-attachments/assets/0a1f0592-fe67-4b7e-b25c-2b52583ce33c



