### PR TITLE
BlockEditor: Resolve `MediaReplaceFlow` UI text inconsistency

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -232,6 +232,9 @@ const MediaReplaceFlow = ( {
 								onChange={ ( { url } ) => {
 									onSelectURL( url );
 								} }
+								searchInputPlaceholder={ __(
+									'Paste or type URL'
+								) }
 							/>
 						</form>
 					) }

--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -110,7 +110,7 @@ describe( 'General media replace flow', () => {
 		);
 
 		const mediaURLInput = screen.getByRole( 'combobox', {
-			name: 'Search or type URL',
+			name: 'Paste or type URL',
 			expanded: false,
 		} );
 

--- a/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
@@ -697,7 +697,7 @@ test.describe( 'Registered sources', () => {
 				.getByRole( 'button', { name: 'Edit link', exact: true } )
 				.click();
 			await page
-				.getByPlaceholder( 'Search or type URL' )
+				.getByPlaceholder( 'Paste or type URL' )
 				.fill( testingImgSrc );
 			await pageUtils.pressKeys( 'Enter' );
 


### PR DESCRIPTION
## What?
Related to this issue: https://github.com/WordPress/gutenberg/issues/58507#issuecomment-2717885592

Changes the placeholder in MediaReplaceFlow from "Search or type URL" to "Paste or type URL" to accurately reflect current functionality.

## Why?
The MediaReplaceFlow component currently doesn't support search functionality, but the placeholder text incorrectly suggests it does. This change brings the placeholder text in line with the actual available features and maintains consistency with other similar components. Like "Insert from URL"


Search is set to false illustrated in the code below

https://github.com/WordPress/gutenberg/blob/8b88ada2fd675509bf0c39a55c23a75cc67987cb/packages/block-editor/src/components/media-replace-flow/index.js#L223-L236




## How?

Updated the placeholder text in the `MediaReplaceFlow` component to remove the reference to search functionality, as the "suggestions" option is set to false.





## Screenshots or screencast 

The `MediaReplaceFlow` does not have the search functionality but still search is mentioned in the placeholder

https://github.com/user-attachments/assets/9bf02be2-7191-4876-bf0b-daacb76b3431



|Before|After|
|-|-|
|<img width="718" alt="image" src="https://github.com/user-attachments/assets/dbf51218-da3b-4b64-902e-d9827e28b977" />|<img width="721" alt="image" src="https://github.com/user-attachments/assets/2625b430-f3fc-46d5-b28e-a7f2138ba6f7" />|
