### PR TITLE
Fix: Missing conversion from json styled variable to CSS variable

### DIFF
--- a/packages/style-engine/src/styles/utils.ts
+++ b/packages/style-engine/src/styles/utils.ts
@@ -98,7 +98,7 @@ export function generateBoxRules(
 		rules.push( {
 			selector: options?.selector,
 			key: ruleKeys.default,
-			value: boxStyle,
+			value: getCSSValueFromRawStyle( boxStyle ),
 		} );
 	} else {
 		const sideRules = individualProperties.reduce(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #69477 

This PR fixes a block validation error occurring when using preset-based styling, ( for some properties like border-radius), defined with CSS variables in the format `var:custom|border-radius|large`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Fix: Missing conversion from json styled variable to CSS variable

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open a post or page
2. Open the code editor and add the block with block-radius and CSS variable in the format `var:custom|border-radius|large`.
Example
```
<!-- wp:group {"style":{"border":{"radius":"var:custom|border-radius|large"}},"backgroundColor":"brand-accent-1","layout":{"type":"constrained"}} -->
<div class="wp-block-group has-brand-accent-1-background-color has-background" style="border-radius:var(--wp--custom--border-radius--large)"><!-- wp:paragraph -->
<p>test</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```
3. Confirm there's no block validation error

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Same

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before  | After |
| -------- | ------- |
| <img width="1468" alt="ss" src="https://github.com/user-attachments/assets/2be8a8b4-eaa5-4f32-b1da-481610cb8705" /> | <img width="1468" alt="image" src="https://github.com/user-attachments/assets/dd5928ee-5194-42eb-b408-f3cb83e1193d" /> |



