### PR TITLE
Dependency Extraction Webpack Plugin: Prevent assets with empty buffer from breaking with JS error

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -225,6 +225,12 @@ class DependencyExtractionWebpackPlugin {
 			// This allows us to look for magic comments.
 			chunkFiles.sort().forEach( ( filename ) => {
 				const asset = compilation.getAsset( filename );
+
+				// Prevents the compilation from failing with JS error, let webpack report the not-found files properly.
+				if ( typeof asset.source.buffer !== 'function' ) { 
+					return;
+				}
+				
 				const content = asset.source.buffer();
 
 				const wpMagicComments =


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves the problem where if a particular asset has an non-function as the buffer it would throw a JS error, which prevents Webpack from continuing, this resolves the problem from ignoring files that have no buffer.

## Why?
It lets Webpack handle empty/not-found files it's own way and avoids a crash.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
Not super sure how to reproduce just yet. I know I faced this locally with certain and found that this solves the problem. 
