### PR TITLE
Core Data: Update '__unstableBase' entity types

### DIFF
--- a/packages/core-data/src/entity-types/base.ts
+++ b/packages/core-data/src/entity-types/base.ts
@@ -65,6 +65,21 @@ declare module './base-entity-records' {
 			 * Site URL.
 			 */
 			url: string;
+
+			/**
+			 * Page for posts.
+			 */
+			page_for_posts: number;
+
+			/**
+			 * Page on front.
+			 */
+			page_on_front: number;
+
+			/**
+			 * Show on front.
+			 */
+			show_on_front: string;
 		}
 	}
 }


### PR DESCRIPTION
## What?
This is a follow-up to #69106.

PR adds type definitions of new `__unstableBase` entity properties introduced in #69106.

## Testing Instructions
CI checks are green.