### PR TITLE
Editor: Use disabled state for 'Change template' menu item

### DIFF
--- a/packages/editor/src/components/post-template/swap-template-button.js
+++ b/packages/editor/src/components/post-template/swap-template-button.js
@@ -20,9 +20,7 @@ export default function SwapTemplateButton( { onClick } ) {
 	const { postType, postId } = useEditedPostContext();
 	const availableTemplates = useAvailableTemplates( postType );
 	const { editEntityRecord } = useDispatch( coreStore );
-	if ( ! availableTemplates?.length ) {
-		return null;
-	}
+
 	const onTemplateSelect = async ( template ) => {
 		editEntityRecord(
 			'postType',
@@ -36,7 +34,11 @@ export default function SwapTemplateButton( { onClick } ) {
 	};
 	return (
 		<>
-			<MenuItem onClick={ () => setShowModal( true ) }>
+			<MenuItem
+				disabled={ ! availableTemplates?.length }
+				accessibleWhenDisabled
+				onClick={ () => setShowModal( true ) }
+			>
 				{ __( 'Change template' ) }
 			</MenuItem>
 			{ showModal && (

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -319,6 +319,6 @@ test.describe( 'Pages', () => {
 			page
 				.getByRole( 'menu', { name: 'Template options' } )
 				.getByText( 'Change template' )
-		).toHaveCount( 0 );
+		).toBeDisabled();
 	} );
 } );


### PR DESCRIPTION
## What?
Closes #55005.

PR updates the rendering logic for the 'Change template' menu item and disables it while templates for the current post type are being resolved. This avoids rendering menu items after the popover is open and prevents "popcorning".

## Testing Instructions
1. Open a page.
2. Throttle connection to slow 4G or 3G.
3. Open the "Template Options" popover.
4. Confirm that the "Change template" button is initially displayed in a disabled state.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/650d8748-84ab-4e7d-8930-6c5e4a544d47

**After**

https://github.com/user-attachments/assets/fe563af4-062e-4c0c-b6a9-363ba3daf7c3

