### PR TITLE
Editor: Optimize queries for 'useAllowSwitchingTemplates' hook

### DIFF
--- a/packages/editor/src/components/post-template/hooks.js
+++ b/packages/editor/src/components/post-template/hooks.js
@@ -31,17 +31,21 @@ export function useAllowSwitchingTemplates() {
 			} )
 				? getEntityRecord( 'root', 'site' )
 				: undefined;
-			const templates = getEntityRecords( 'postType', 'wp_template', {
-				per_page: -1,
-			} );
+
 			const isPostsPage = +postId === siteSettings?.page_for_posts;
+			const isFrontPage =
+				postType === 'page' && +postId === siteSettings?.page_on_front;
 			// If current page is set front page or posts page, we also need
 			// to check if the current theme has a template for it. If not
-			const isFrontPage =
-				postType === 'page' &&
-				+postId === siteSettings?.page_on_front &&
-				templates?.some( ( { slug } ) => slug === 'front-page' );
-			return ! isPostsPage && ! isFrontPage;
+			const templates = isFrontPage
+				? getEntityRecords( 'postType', 'wp_template', {
+						per_page: -1,
+				  } )
+				: [];
+			const hasFrontPage =
+				isFrontPage &&
+				!! templates?.some( ( { slug } ) => slug === 'front-page' );
+			return ! isPostsPage && ! hasFrontPage;
 		},
 		[ postId, postType ]
 	);


### PR DESCRIPTION
## What?
PR rearranges logic inside the `useAllowSwitchingTemplates` hook and avoids making unnecessary unbount template requests when opening "Template options"

## Why
When the current page is set as the Homepage, the only time hook needs to check the existence of the `front-page` template.

## Testing Instructions
1. Create a page.
2. Confirm that the "Change template" option is available.
3. Set the same page as the Homepage via Settings > Reading.
4. Confirm that the "Change template" option is still available.
5. Create a "Front Page" template.
6. Reopen the same page; the "Change template" option should be disabled.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2025-03-13 at 14 57 27](https://github.com/user-attachments/assets/d939ae5e-419c-4a01-a7fe-70c9656a919f)
