### PR TITLE
Components: Fix autocomple UI flicker when deleting trigger prefix

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `useAutocomplete`: Fix autocomple UI flicker when deleting trigger prefix ([#69562](https://github.com/WordPress/gutenberg/pull/69562)).
+
 ## 29.6.0 (2025-03-13)
 
 ### Enhancement

--- a/packages/components/src/autocomplete/index.tsx
+++ b/packages/components/src/autocomplete/index.tsx
@@ -12,6 +12,7 @@ import {
 	useState,
 	useRef,
 	useMemo,
+	flushSync,
 } from '@wordpress/element';
 import { useInstanceId, useMergeRefs, useRefEffect } from '@wordpress/compose';
 import {
@@ -256,7 +257,8 @@ export function useAutocomplete( {
 	useEffect( () => {
 		if ( ! textContent ) {
 			if ( autocompleter ) {
-				reset();
+				// @todo: Explain why this is necessary.
+				window.queueMicrotask( () => flushSync( reset ) );
 			}
 			return;
 		}

--- a/packages/components/src/autocomplete/index.tsx
+++ b/packages/components/src/autocomplete/index.tsx
@@ -257,7 +257,9 @@ export function useAutocomplete( {
 	useEffect( () => {
 		if ( ! textContent ) {
 			if ( autocompleter ) {
-				// @todo: Explain why this is necessary.
+				// Reset the state synchronously to ensure timely DOM updates without flickering.
+				// The `flushSync` can't be called directly in the effect without scheduling.
+				// See: https://github.com/WordPress/gutenberg/pull/69562.
 				window.queueMicrotask( () => flushSync( reset ) );
 			}
 			return;

--- a/packages/components/src/autocomplete/index.tsx
+++ b/packages/components/src/autocomplete/index.tsx
@@ -12,7 +12,6 @@ import {
 	useState,
 	useRef,
 	useMemo,
-	flushSync,
 } from '@wordpress/element';
 import { useInstanceId, useMergeRefs, useRefEffect } from '@wordpress/compose';
 import {
@@ -257,10 +256,7 @@ export function useAutocomplete( {
 	useEffect( () => {
 		if ( ! textContent ) {
 			if ( autocompleter ) {
-				// Reset the state synchronously to ensure timely DOM updates without flickering.
-				// The `flushSync` can't be called directly in the effect without scheduling.
-				// See: https://github.com/WordPress/gutenberg/pull/69562.
-				window.queueMicrotask( () => flushSync( reset ) );
+				reset();
 			}
 			return;
 		}
@@ -398,12 +394,13 @@ export function useAutocomplete( {
 		? `components-autocomplete-item-${ instanceId }-${ selectedKey }`
 		: null;
 	const hasSelection = record.start !== undefined;
+	const showPopover = !! textContent && hasSelection && !! AutocompleterUI;
 
 	return {
 		listBoxId,
 		activeId,
 		onKeyDown: withIgnoreIMEEvents( handleKeyDown ),
-		popover: hasSelection && AutocompleterUI && (
+		popover: showPopover && (
 			<AutocompleterUI
 				className={ className }
 				filterValue={ filterValue }


### PR DESCRIPTION
## What?

PR fixes autocomple UI flicker (or ghost) when deleting trigger prefix.

## Why?
When deleting the trigger prefix, the autocomplete popover should be closed immediately.

Also, this has been grinding my gears for years now. 😄

## How?
Synchronously flush the state reset and ensure the DOM is updated on time.

Another logical option here would be using `useLayoutEffect` instead of `useEffect`, but since autocompleters are potential bottlenecks for typing, I thought this solution was safer.

Ref: https://react.dev/reference/react/useEffect#my-effect-does-something-visual-and-i-see-a-flicker-before-it-runs.

## Testing Instructions
1. Create a post.
2. Open the blocks autocompleter. Type - `/`
3. Delete the `/` trigger.
4. Confirm that the autocompleter is immediately closed and there's no flicker in the left corner.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/2cf47c58-46e5-47c7-8207-22b00a2e9e36

**After**

https://github.com/user-attachments/assets/0f266731-dba6-4d38-bc64-eb415df3ed5f

