### PR TITLE
Global Styles: Add support for loading `CSS` from external files in `theme.json`

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2846,6 +2846,43 @@ class WP_Theme_JSON_Gutenberg {
 	}
 
 	/**
+	 * Enqueues a CSS file for a block using wp_enqueue_block_style().
+	 *
+	 * @param string $block_name The block name.
+	 * @param string $file_path  Relative path to the CSS file.
+	 * @return bool Whether the file was successfully enqueued.
+	 */
+	private function enqueue_block_css_file( $block_name, $file_path ) {
+		if ( empty( $block_name ) || empty( $file_path ) ) {
+			return false;
+		}
+		
+		$theme_directory = get_template_directory();
+		$theme_uri = get_template_directory_uri();
+		
+		$absolute_path = path_join( $theme_directory, $file_path );
+
+		if( ! file_exists( $absolute_path ) ) {
+			return false;
+		}
+		
+		$file_url = path_join( $theme_uri, $file_path );
+		
+		$handle = 'theme-json-' . sanitize_title( $block_name ) . '-css-' . md5( $file_path );
+		
+		wp_enqueue_block_style(
+			$block_name,
+			array(
+				'handle' => $handle,
+				'src'    => $file_url,
+				'path'   => $absolute_path,
+			)
+		);
+		
+		return true;
+	}
+
+	/**
 	 * Gets the CSS rules for a particular block from theme.json.
 	 *
 	 * @since 6.1.0
@@ -2903,7 +2940,16 @@ class WP_Theme_JSON_Gutenberg {
 				$style_variation_declarations[ $style_variation['selector'] ] = static::compute_style_properties( $style_variation_node, $settings, null, $this->theme_json );
 				// Store custom CSS for the style variation.
 				if ( isset( $style_variation_node['css'] ) ) {
-					$style_variation_custom_css[ $style_variation['selector'] ] = $this->process_blocks_custom_css( $style_variation_node['css'], $style_variation['selector'] );
+					// Check if CSS is a file path reference. Enqueue the CSS file or process as regular inline CSS.
+					if ( is_string( $style_variation_node['css'] ) && 0 === strpos( $style_variation_node['css'], 'file:' ) ) {
+						$file_path = trim( substr( $style_variation_node['css'], 5 ) );
+						
+						$block_name = isset( $block_metadata['name'] ) ? $block_metadata['name'] : '';
+						
+						$this->enqueue_block_css_file( $block_name, $file_path );
+					} else {
+						$style_variation_custom_css[ $style_variation['selector'] ] = $this->process_blocks_custom_css( $style_variation_node['css'], $style_variation['selector'] );
+					}
 				}
 			}
 		}
@@ -3066,7 +3112,16 @@ class WP_Theme_JSON_Gutenberg {
 
 		// 7. Generate and append any custom CSS rules.
 		if ( isset( $node['css'] ) && ! $is_root_selector ) {
-			$block_rules .= $this->process_blocks_custom_css( $node['css'], $selector );
+			// Check if CSS is a file path reference. Enqueue the CSS file or process as regular inline CSS.
+			if ( is_string( $node['css'] ) && 0 === strpos( $node['css'], 'file:' ) ) {
+				$file_path = trim( substr( $node['css'], 5 ) );
+				
+				$block_name = isset( $block_metadata['name'] ) ? $block_metadata['name'] : '';
+				
+				$this->enqueue_block_css_file( $block_name, $file_path );
+			} else {
+				$block_rules .= $this->process_blocks_custom_css( $node['css'], $selector );
+			}
 		}
 
 		return $block_rules;

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2858,7 +2858,7 @@ class WP_Theme_JSON_Gutenberg {
 		}
 
 		$theme_directory = get_template_directory();
-		$theme_uri = get_template_directory_uri();
+		$theme_uri       = get_template_directory_uri();
 
 		$absolute_path = path_join( $theme_directory, $file_path );
 
@@ -2945,7 +2945,7 @@ class WP_Theme_JSON_Gutenberg {
 						$file_path = trim( substr( $style_variation_node['css'], 5 ) );
 
 						$block_name = isset( $block_metadata['name'] ) ? $block_metadata['name'] : '';
-						
+
 						$this->enqueue_block_css_file( $block_name, $file_path );
 					} else {
 						$style_variation_custom_css[ $style_variation['selector'] ] = $this->process_blocks_custom_css( $style_variation_node['css'], $style_variation['selector'] );
@@ -3115,9 +3115,9 @@ class WP_Theme_JSON_Gutenberg {
 			// Check if CSS is a file path reference. Enqueue the CSS file or process as regular inline CSS.
 			if ( is_string( $node['css'] ) && 0 === strpos( $node['css'], 'file:' ) ) {
 				$file_path = trim( substr( $node['css'], 5 ) );
-				
+
 				$block_name = isset( $block_metadata['name'] ) ? $block_metadata['name'] : '';
-				
+
 				$this->enqueue_block_css_file( $block_name, $file_path );
 			} else {
 				$block_rules .= $this->process_blocks_custom_css( $node['css'], $selector );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2856,20 +2856,20 @@ class WP_Theme_JSON_Gutenberg {
 		if ( empty( $block_name ) || empty( $file_path ) ) {
 			return false;
 		}
-		
+
 		$theme_directory = get_template_directory();
 		$theme_uri = get_template_directory_uri();
-		
+
 		$absolute_path = path_join( $theme_directory, $file_path );
 
 		if( ! file_exists( $absolute_path ) ) {
 			return false;
 		}
-		
+
 		$file_url = path_join( $theme_uri, $file_path );
-		
+
 		$handle = 'theme-json-' . sanitize_title( $block_name ) . '-css-' . md5( $file_path );
-		
+
 		wp_enqueue_block_style(
 			$block_name,
 			array(
@@ -2878,7 +2878,7 @@ class WP_Theme_JSON_Gutenberg {
 				'path'   => $absolute_path,
 			)
 		);
-		
+
 		return true;
 	}
 
@@ -2943,7 +2943,7 @@ class WP_Theme_JSON_Gutenberg {
 					// Check if CSS is a file path reference. Enqueue the CSS file or process as regular inline CSS.
 					if ( is_string( $style_variation_node['css'] ) && 0 === strpos( $style_variation_node['css'], 'file:' ) ) {
 						$file_path = trim( substr( $style_variation_node['css'], 5 ) );
-						
+
 						$block_name = isset( $block_metadata['name'] ) ? $block_metadata['name'] : '';
 						
 						$this->enqueue_block_css_file( $block_name, $file_path );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2862,7 +2862,7 @@ class WP_Theme_JSON_Gutenberg {
 
 		$absolute_path = path_join( $theme_directory, $file_path );
 
-		if( ! file_exists( $absolute_path ) ) {
+		if ( ! file_exists( $absolute_path ) ) {
 			return false;
 		}
 


### PR DESCRIPTION


## What?
Closes: https://github.com/WordPress/gutenberg/issues/69484

This PR adds a new feature to theme.json that allows theme authors to load CSS for blocks from external files instead of embedding it directly in the theme.json file. This is done through a new `file:` prefix syntax in the css property.

## Why?
This enhancement allows theme authors to organize their CSS in dedicated files, and use it in the theme.json

## How?
The implementation adds support for a special file: prefix in the css property value in theme.json. When detected, the code:

1. Extracts the relative file path
2. Resolves it to an absolute path within the theme directory
3. Uses WordPress's built-in `wp_enqueue_block_style()` function to properly enqueue the file
4. Applies the same approach for both block-level CSS and block style variations

This keeps the implementation simple while leveraging existing WordPress functions for style enqueueing, ensuring compatibility with the WordPress CSS loading system.

## Testing Instructions
1. Create a new theme or use an existing theme with a theme.json file I used `test/emptytheme`
2. Activate the `emptytheme` in `Appearance > Themes > Empty Theme`
3. Add the following to your theme's theme.json file:

```json
"styles": {
  "blocks": {
    "core/navigation": {
      "css": "file:./assets/css/navigation.css"
    },
    "core/paragraph": {
      "css": "file:./assets/css/paragraph.css"
    }
  }
}
```

4. Create the CSS files `/assets/css/navigation.css` and `/assets/css/paragraph.css`

- /assets/css/navigation.css
```css
.wp-block-navigation {
  border: 5px solid #d41ad1;
  background-color: #a7d5ee;
}
```

- /assets/css/paragraph.css
```css
.wp-block-paragraph {
  background-color: rgb(183, 21, 118);
}
```
5. Create a page with navigation and paragraph blocks
6. View the page and verify the CSS is applied correctly


## Screenshots or screencast 

A comprehensive video of how I tested this feature locally:

https://github.com/user-attachments/assets/44f12502-9687-4066-9e58-bd8ad14534d1


