### PR TITLE
Fix: issue #69565 [wordpress/script] wp-scripts build-blocks-manifest removes manifest file on start

### DIFF
--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -12,6 +12,7 @@ const ReactRefreshWebpackPlugin = require( '@pmmmwh/react-refresh-webpack-plugin
 const TerserPlugin = require( 'terser-webpack-plugin' );
 const { realpathSync } = require( 'fs' );
 const { sync: glob } = require( 'fast-glob' );
+const exec = require('child_process').exec;
 
 /**
  * WordPress dependencies
@@ -48,6 +49,22 @@ const hasReactFastRefresh = hasArgInCLI( '--hot' ) && ! isProduction;
 const hasExperimentalModulesFlag = getAsBooleanFromENV(
 	'WP_EXPERIMENTAL_MODULES'
 );
+
+const BlockManifest = {
+	apply(compiler){
+		compiler.hooks.afterEmit.tap('BlockManifest', (compilation) =>{
+			exec(`wp-scripts build-blocks-manifest`, (error, stdout, stderr) => {
+				if (error){
+					console.error(`exec error: ${error}`);
+				}
+				console.log(`${stdout}`);
+				if (stderr){
+					console.error(`stderr: ${stderr}`);
+				}
+			});
+		});
+	}
+};
 
 const cssLoaders = [
 	{
@@ -403,6 +420,7 @@ const scriptConfig = {
 		// generated, and the default externals set.
 		! process.env.WP_NO_EXTERNALS &&
 			new DependencyExtractionWebpackPlugin(),
+		BlockManifest
 	].filter( Boolean ),
 };
 
@@ -479,6 +497,7 @@ if ( hasExperimentalModulesFlag ) {
 			! process.env.WP_NO_EXTERNALS &&
 				new DependencyExtractionWebpackPlugin(),
 			new BlockJsonDependenciesPlugin(),
+			BlockManifest
 		].filter( Boolean ),
 	};
 


### PR DESCRIPTION
## What?
Fixes issue [#69565](https://github.com/WordPress/gutenberg/issues/69565).

Updates the webpack.config.js in packages/scripts/config to correctly generate a block-manifest.php file on npm run start.

## Why?
Recent [updates](https://make.wordpress.org/core/2025/03/13/more-efficient-block-type-registration-in-6-8/) to @wordpress/create-block expect there to be a block-manifest.php file in order to register the block. The current webpack.config.js deletes this file when running `npm run start` which results in a critical error, because that file is now required.

## How?
I added a simple custom webpack plugin which utilizes [child_process.exec](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback) to run `wp-scripts build-blocks-manifest` after assets are compiled during `wp-scripts start`

## Testing Instructions
I'm unsure exactly how to test this due to the fact that create-block automatically npm installs the existing @wordpress/scripts package, but What I did was:
1. npx @wordpress/create-block test-block
2. locate webpack.config.js inside node_modules/@wordpress/scripts/config
3. replace existing webpack.config.js with my updated version
4. run `npm run start`
5. block-manifest.php is created inside build/test-block



