### PR TITLE
DataViews List Layout: enhance hover styles to include expanded button state

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -30,7 +30,7 @@ div.dataviews-view-list {
 			}
 		}
 
-		&:where(.is-selected, .is-hovered, :focus-within) {
+		&:where(.is-selected, .is-hovered, :focus-within, :has(button[aria-expanded="true"])) {
 			.dataviews-view-list__item-actions {
 				flex-basis: min-content;
 				overflow: unset;


### PR DESCRIPTION
## What?
Closes #69570 

This PR fixes a bug where the `Action Menu` shifts layout and the `Trigger Button` disappears when the cursor moves out of the browser window after expanding the menu.

## Why?

1. When the cursor leaves the window, the `Trigger Button` disappears, making the `Menu` look orphaned and difficult to trace.  
2. Users with multiple displays may frequently experience layout shifts when moving the cursor between windows, leading to an unpolished experience.

## How?

The CSS rule is updated to ensure the menu behaves consistently when expanded, just as it does when the corresponding item is selected or hovered.
```css
&:where(.is-selected, .is-hovered, :focus-within, :has(button[aria-expanded="true"])) {
```

## Testing Instructions

1. Navigate to Appearance -> Editor -> Pages.
2. Make sure that the data is displayed in List Layout.
3. Click the Actions button and open the menu.
4. Move the cursor out of the window or to a different display.
5. Confirm that there's no layout shift and trigger buttons remain visible as expected.

### Testing Instructions for Keyboard
Same.

## Screencast

![fix](https://github.com/user-attachments/assets/55ca65ab-cc76-40b5-97d3-40420f3130f6)
