### PR TITLE
Block Library: Add `div` wrapper to query pagination previous/next links

### DIFF
--- a/packages/block-library/src/query-pagination-next/edit.js
+++ b/packages/block-library/src/query-pagination-next/edit.js
@@ -17,31 +17,33 @@ export default function QueryPaginationNextEdit( {
 } ) {
 	const displayArrow = arrowMap[ paginationArrow ];
 	return (
-		<a
-			href="#pagination-next-pseudo-link"
-			onClick={ ( event ) => event.preventDefault() }
-			{ ...useBlockProps() }
-		>
-			{ showLabel && (
-				<PlainText
-					__experimentalVersion={ 2 }
-					tagName="span"
-					aria-label={ __( 'Next page link' ) }
-					placeholder={ __( 'Next Page' ) }
-					value={ label }
-					onChange={ ( newLabel ) =>
-						setAttributes( { label: newLabel } )
-					}
-				/>
-			) }
-			{ displayArrow && (
-				<span
-					className={ `wp-block-query-pagination-next-arrow is-arrow-${ paginationArrow }` }
-					aria-hidden
-				>
-					{ displayArrow }
-				</span>
-			) }
-		</a>
+		<div { ...useBlockProps() }>
+			<a
+				href="#pagination-next-pseudo-link"
+				onClick={ ( event ) => event.preventDefault() }
+				{ ...useBlockProps() }
+			>
+				{ showLabel && (
+					<PlainText
+						__experimentalVersion={ 2 }
+						tagName="span"
+						aria-label={ __( 'Next page link' ) }
+						placeholder={ __( 'Next Page' ) }
+						value={ label }
+						onChange={ ( newLabel ) =>
+							setAttributes( { label: newLabel } )
+						}
+					/>
+				) }
+				{ displayArrow && (
+					<span
+						className={ `wp-block-query-pagination-next-arrow is-arrow-${ paginationArrow }` }
+						aria-hidden
+					>
+						{ displayArrow }
+					</span>
+				) }
+			</a>
+		</div>
 	);
 }

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -83,7 +83,15 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		}
 	}
 
-	return $content;
+	if ( empty( $content ) ) {
+		return '';
+	}
+
+	return sprintf(
+		'<div %1$s>%2$s</div>',
+		$wrapper_attributes,
+		$content
+	);
 }
 
 /**

--- a/packages/block-library/src/query-pagination-previous/edit.js
+++ b/packages/block-library/src/query-pagination-previous/edit.js
@@ -17,31 +17,33 @@ export default function QueryPaginationPreviousEdit( {
 } ) {
 	const displayArrow = arrowMap[ paginationArrow ];
 	return (
-		<a
-			href="#pagination-previous-pseudo-link"
-			onClick={ ( event ) => event.preventDefault() }
-			{ ...useBlockProps() }
-		>
-			{ displayArrow && (
-				<span
-					className={ `wp-block-query-pagination-previous-arrow is-arrow-${ paginationArrow }` }
-					aria-hidden
-				>
-					{ displayArrow }
-				</span>
-			) }
-			{ showLabel && (
-				<PlainText
-					__experimentalVersion={ 2 }
-					tagName="span"
-					aria-label={ __( 'Previous page link' ) }
-					placeholder={ __( 'Previous Page' ) }
-					value={ label }
-					onChange={ ( newLabel ) =>
-						setAttributes( { label: newLabel } )
-					}
-				/>
-			) }
-		</a>
+		<div { ...useBlockProps() }>
+			<a
+				href="#pagination-previous-pseudo-link"
+				onClick={ ( event ) => event.preventDefault() }
+				{ ...useBlockProps() }
+			>
+				{ displayArrow && (
+					<span
+						className={ `wp-block-query-pagination-previous-arrow is-arrow-${ paginationArrow }` }
+						aria-hidden
+					>
+						{ displayArrow }
+					</span>
+				) }
+				{ showLabel && (
+					<PlainText
+						__experimentalVersion={ 2 }
+						tagName="span"
+						aria-label={ __( 'Previous page link' ) }
+						placeholder={ __( 'Previous Page' ) }
+						value={ label }
+						onChange={ ( newLabel ) =>
+							setAttributes( { label: newLabel } )
+						}
+					/>
+				) }
+			</a>
+		</div>
 	);
 }

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -76,7 +76,15 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 		}
 	}
 
-	return $content;
+	if ( empty( $content ) ) {
+		return '';
+	}
+
+	return sprintf(
+		'<div %1$s>%2$s</div>',
+		$wrapper_attributes,
+		$content
+	);
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Closes #69573

This PR adds a wrapper `<div>` to `core/query-pagination-previous` and `core/query-pagination-next` blocks, making them consistent with the structure of core/query-pagination-numbers.


## Why?
Currently, the "Previous" and "Next" pagination links render as naked <a> tags without wrapping `<div>`. This makes it impossible to style them using the `elements.link` section in theme.json and creates an inconsistency with `core/query-pagination-numbers` which does have a wrapping `<div>`.

## How?
Updated the `edit.js` files for both blocks to wrap their content in a `div`
Modified the PHP render functions to wrap the link content in a div while maintaining compatibility with enhanced pagination

## Testing Instructions
- Create a post with a Query block that has pagination enabled
- Inspect the HTML structure of the pagination using developer tools
- Verify that all pagination elements (Previous, Numbers, Next) have a consistent structure with div wrappers


## Screencast

### Before



https://github.com/user-attachments/assets/7ae0a897-7ad5-4c0c-8157-c1ac070ee775



### After




https://github.com/user-attachments/assets/dae7e057-3ffa-4b4a-a9fd-e69b7f006ee6

