### PR TITLE
Include blocks manifest build process in Webpack config to fix `create-block` bug with missing blocks manifest file

### DIFF
--- a/packages/create-block/lib/init-package-json.js
+++ b/packages/create-block/lib/init-package-json.js
@@ -45,8 +45,7 @@ module.exports = async ( {
 						build:
 							( isDynamicVariant
 								? 'wp-scripts build --webpack-copy-php'
-								: 'wp-scripts build' ) +
-							' && wp-scripts build-blocks-manifest',
+								: 'wp-scripts build' ) + ' --blocks-manifest',
 						format: 'wp-scripts format',
 						'lint:css': 'wp-scripts lint-style',
 						'lint:js': 'wp-scripts lint-js',
@@ -55,8 +54,7 @@ module.exports = async ( {
 						start:
 							( isDynamicVariant
 								? 'wp-scripts start --webpack-copy-php'
-								: 'wp-scripts start' ) +
-							' && wp-scripts build-blocks-manifest',
+								: 'wp-scripts start' ) + ' --blocks-manifest',
 					} ),
 					...( wpEnv && { env: 'wp-env' } ),
 					...customScripts,

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Add `--blocks-manifest` CLI flag to generate a PHP file containing block metadata from all `block.json` files in the project ([#79321](https://github.com/WordPress/gutenberg/pull/79321)).
+
 ## 30.13.0 (2025-03-13)
 
 ## 30.12.0 (2025-02-28)

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -89,6 +89,7 @@ This script automatically use the optimized config but sometimes you may want to
 -   `--webpack-bundle-analyzer` – enables visualization for the size of webpack output files with an interactive zoomable treemap.
 -   `--webpack-copy-php` – enables copying all PHP files from the source directory ( default is `src` ) and its subfolders to the output directory.
 -   `--webpack-no-externals` – disables scripts’ assets generation, and omits the list of default externals.
+-   `--blocks-manifest` – generates a PHP file containing block metadata from all `block.json` files in the project. This is useful for enhancing performance when registering multiple block types, as it allows you to use `wp_register_block_metadata_collection()` and `wp_register_block_types_from_metadata_collection()` in WordPress.
 -   `--source-path` – allows customization of the source directory. The default is the project root `.` when [entry points are listed](#listing-entry-points) in the command, or `src` otherwise.
 -   `--output-path` – allows customization of the output directory. The default is the `build` folder.
 
@@ -105,11 +106,7 @@ This script uses [webpack](https://webpack.js.org/) behind the scenes. It’ll l
 
 ### `build-blocks-manifest`
 
-This script generates a PHP file containing block metadata from all
-`block.json` files in the project. This is useful for enhancing performance
-when registering multiple block types, as it allows you to use
-`wp_register_block_metadata_collection()` and
-`wp_register_block_types_from_metadata_collection()` in WordPress.
+This script generates a PHP file containing block metadata from all `block.json` files in the project. This is useful for enhancing performance when registering multiple block types, as it allows you to use `wp_register_block_metadata_collection()` and `wp_register_block_types_from_metadata_collection()` in WordPress.
 
 Usage: `wp-scripts build-blocks-manifest [options]`
 
@@ -426,6 +423,7 @@ This script automatically use the optimized config but sometimes you may want to
 -   `--webpack-copy-php` – enables copying all PHP files from the source directory ( default is `src` ) and its subfolders to the output directory.
 -   `--webpack-devtool` – controls how source maps are generated. See options at https://webpack.js.org/configuration/devtool/#devtool.
 -   `--webpack-no-externals` – disables scripts’ assets generation, and omits the list of default externals.
+-   `--blocks-manifest` – generates a PHP file containing block metadata from all `block.json` files in the project. This is useful for enhancing performance when registering multiple block types, as it allows you to use `wp_register_block_metadata_collection()` and `wp_register_block_types_from_metadata_collection()` in WordPress.
 -   `--source-path` – allows customization of the source directory. The default is the project root `.` when [entry points are listed](#listing-entry-points) in the command, or `src` otherwise.
 -   `--output-path` – allows customization of the output directory. The default is the `build` folder.
 

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -12,6 +12,7 @@ const ReactRefreshWebpackPlugin = require( '@pmmmwh/react-refresh-webpack-plugin
 const TerserPlugin = require( 'terser-webpack-plugin' );
 const { realpathSync } = require( 'fs' );
 const { sync: glob } = require( 'fast-glob' );
+const { exec } = require( 'child_process' );
 
 /**
  * WordPress dependencies
@@ -45,6 +46,7 @@ if ( ! browserslist.findConfig( '.' ) ) {
 	target += ':' + fromConfigRoot( '.browserslistrc' );
 }
 const hasReactFastRefresh = hasArgInCLI( '--hot' ) && ! isProduction;
+const hasBlocksManifest = getAsBooleanFromENV( 'WP_BLOCKS_MANIFEST' );
 const hasExperimentalModulesFlag = getAsBooleanFromENV(
 	'WP_EXPERIMENTAL_MODULES'
 );
@@ -260,6 +262,22 @@ if ( baseConfig.devtool ) {
 	} );
 }
 
+/**
+ * Build blocks manifest.
+ */
+class BlocksManifestPlugin {
+	/**
+	 * Apply the plugin.
+	 *
+	 * @param {webpack.Compiler} compiler The compiler instance.
+	 */
+	apply( compiler ) {
+		compiler.hooks.afterEmit.tap( 'BlocksManifest', () => {
+			exec( 'wp-scripts build-blocks-manifest' );
+		} );
+	}
+}
+
 /** @type {webpack.Configuration} */
 const scriptConfig = {
 	...baseConfig,
@@ -397,6 +415,8 @@ const scriptConfig = {
 		} ),
 		// RtlCssPlugin to generate RTL CSS files.
 		new RtlCssPlugin(),
+		// Generate blocks manifest after changes.
+		hasBlocksManifest && new BlocksManifestPlugin(),
 		// React Fast Refresh.
 		hasReactFastRefresh && new ReactRefreshWebpackPlugin(),
 		// WP_NO_EXTERNALS global variable controls whether scripts' assets get

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -37,6 +37,7 @@ const {
 	getBlockJsonModuleFields,
 	getBlockJsonScriptFields,
 	fromProjectRoot,
+	fromScriptsRoot,
 } = require( '../utils' );
 
 const isProduction = process.env.NODE_ENV === 'production';
@@ -273,7 +274,11 @@ class BlocksManifestPlugin {
 	 */
 	apply( compiler ) {
 		compiler.hooks.afterEmit.tap( 'BlocksManifest', () => {
-			exec( 'wp-scripts build-blocks-manifest' );
+			exec(
+				`node ${ fromScriptsRoot(
+					'build-blocks-manifest'
+				) } --input="${ compiler.options.output.path }"`
+			);
 		} );
 	}
 }

--- a/packages/scripts/scripts/build-blocks-manifest.js
+++ b/packages/scripts/scripts/build-blocks-manifest.js
@@ -12,19 +12,17 @@ const chalk = require( 'chalk' );
  */
 const { getArgFromCLI } = require( '../utils' );
 
-// Set default paths
+// Parses command line arguments.
 const defaultInputDir = 'build';
-const defaultOutputFile = path.join( 'build', 'blocks-manifest.php' );
-
-// Parse command line arguments
 const inputDir = getArgFromCLI( '--input' ) || defaultInputDir;
+const defaultOutputFile = path.join( inputDir, 'blocks-manifest.php' );
 const outputFile = getArgFromCLI( '--output' ) || defaultOutputFile;
 
 const resolvedInputDir = path.resolve( process.cwd(), inputDir );
 if ( ! fs.existsSync( resolvedInputDir ) ) {
 	const ERROR = chalk.reset.inverse.bold.red( ' ERROR ' );
 	process.stdout.write(
-		`${ ERROR } Input directory "${ inputDir }" does not exist.\n`
+		`${ ERROR } Input directory "${ resolvedInputDir }" does not exist.\n`
 	);
 	process.exit( 1 );
 }

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -114,6 +114,7 @@ const hasPostCSSConfig = () =>
 const getWebpackArgs = () => {
 	// Gets all args from CLI without those prefixed with `--webpack`.
 	let webpackArgs = getArgsFromCLI( [
+		'--blocks-manifest',
 		'--experimental-modules',
 		'--source-path',
 		'--webpack',
@@ -144,6 +145,10 @@ const getWebpackArgs = () => {
 
 	if ( hasArgInCLI( '--webpack-no-externals' ) ) {
 		process.env.WP_NO_EXTERNALS = true;
+	}
+
+	if ( hasArgInCLI( '--blocks-manifest' ) ) {
+		process.env.WP_BLOCKS_MANIFEST = true;
 	}
 
 	const hasWebpackOutputOption =

--- a/packages/scripts/utils/index.js
+++ b/packages/scripts/utils/index.js
@@ -23,7 +23,12 @@ const {
 	hasPostCSSConfig,
 	hasPrettierConfig,
 } = require( './config' );
-const { fromProjectRoot, fromConfigRoot, hasProjectFile } = require( './file' );
+const {
+	fromConfigRoot,
+	fromProjectRoot,
+	fromScriptsRoot,
+	hasProjectFile,
+} = require( './file' );
 const { getPackageProp, hasPackageProp } = require( './package' );
 const {
 	getBlockJsonModuleFields,
@@ -31,8 +36,9 @@ const {
 } = require( './block-json' );
 
 module.exports = {
-	fromProjectRoot,
 	fromConfigRoot,
+	fromProjectRoot,
+	fromScriptsRoot,
 	getAsBooleanFromENV,
 	getArgFromCLI,
 	getArgsFromCLI,


### PR DESCRIPTION
## What?
Closes #69565

## How?
* Calls `wp-scripts build-blocks-manifest` as part of Webpack process if `--blocks-manifest` argument is present.
    * Major props to @itsseanl for the fix (see https://github.com/WordPress/gutenberg/issues/69565#issuecomment-2723382691). I basically just brought it into PR shape. :)
* Update `create-block`'s generated `package.json` to use that new `--blocks-manifest` argument instead of separately calling `wp-scripts build-blocks-manifest` which does not play well together with Webpack's own watch mode.

**Important:** These changes affect `@wordpress/scripts` and `@wordpress/create-block`, and ideally both packages are released with these changes at the same time.

That's because the `create-block` change depends on the `scripts` change.

## Testing Instructions
See #69565.