### PR TITLE
Excerpt Block: Add character count option

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -634,7 +634,7 @@ Display the excerpt. ([Source](https://github.com/WordPress/gutenberg/tree/trunk
 -	**Name:** core/post-excerpt
 -	**Category:** theme
 -	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** excerptLength, moreText, showMoreOnNewLine, textAlign
+-	**Attributes:** countType, excerptLength, moreText, showMoreOnNewLine, textAlign
 
 ## Featured Image
 

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -20,6 +20,10 @@
 		"excerptLength": {
 			"type": "number",
 			"default": 55
+		},
+		"countType": {
+			"type": "string",
+			"default": "words"
 		}
 	},
 	"usesContext": [ "postId", "postType", "queryId" ],

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -19,6 +19,7 @@ import {
 import {
 	ToggleControl,
 	RangeControl,
+	SelectControl,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
@@ -36,7 +37,13 @@ import {
 const ELLIPSIS = '…';
 
 export default function PostExcerptEditor( {
-	attributes: { textAlign, moreText, showMoreOnNewLine, excerptLength },
+	attributes: {
+		textAlign,
+		moreText,
+		showMoreOnNewLine,
+		excerptLength,
+		countType,
+	},
 	setAttributes,
 	isSelected,
 	context: { postId, postType, queryId },
@@ -142,7 +149,7 @@ export default function PostExcerptEditor( {
 			identifier="moreText"
 			className="wp-block-post-excerpt__more-link"
 			tagName="a"
-			aria-label={ __( '“Read more” link text' ) }
+			aria-label={ __( '"Read more" link text' ) }
 			placeholder={ __( 'Add "read more" link text' ) }
 			value={ moreText }
 			onChange={ ( newMoreText ) =>
@@ -164,11 +171,17 @@ export default function PostExcerptEditor( {
 	).trim();
 
 	let trimmedExcerpt = '';
-	if ( wordCountType === 'words' ) {
+
+	// Determine trimming logic based on countType setting
+	if ( countType === 'characters' ) {
+		// Character count logic - including spaces
 		trimmedExcerpt = rawOrRenderedExcerpt
-			.split( ' ', excerptLength )
-			.join( ' ' );
-	} else if ( wordCountType === 'characters_excluding_spaces' ) {
+			.split( '', excerptLength )
+			.join( '' );
+	} else if (
+		wordCountType === 'characters_excluding_spaces' ||
+		countType === 'characters_excluding_spaces'
+	) {
 		/*
 		 * 1. Split the excerpt at the character limit,
 		 * then join the substrings back into one string.
@@ -188,10 +201,17 @@ export default function PostExcerptEditor( {
 		trimmedExcerpt = rawOrRenderedExcerpt
 			.split( '', excerptLength + numberOfSpaces )
 			.join( '' );
-	} else if ( wordCountType === 'characters_including_spaces' ) {
+	} else if (
+		wordCountType === 'characters_including_spaces' ||
+		countType === 'characters_including_spaces'
+	) {
 		trimmedExcerpt = rawOrRenderedExcerpt
 			.split( '', excerptLength )
 			.join( '' );
+	} else {
+		trimmedExcerpt = rawOrRenderedExcerpt
+			.split( ' ', excerptLength )
+			.join( ' ' );
 	}
 
 	const isTrimmed = trimmedExcerpt !== rawOrRenderedExcerpt;
@@ -218,6 +238,19 @@ export default function PostExcerptEditor( {
 				: trimmedExcerpt + ELLIPSIS }
 		</p>
 	);
+
+	// Get appropriate label for excerpt length based on count type
+	const getExcerptLengthLabel = () => {
+		if (
+			countType === 'characters' ||
+			countType === 'characters_including_spaces' ||
+			countType === 'characters_excluding_spaces'
+		) {
+			return __( 'Max number of characters' );
+		}
+		return __( 'Max number of words' );
+	};
+
 	return (
 		<>
 			<BlockControls>
@@ -235,6 +268,7 @@ export default function PostExcerptEditor( {
 						setAttributes( {
 							showMoreOnNewLine: true,
 							excerptLength: 55,
+							countType: 'words',
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
@@ -258,9 +292,36 @@ export default function PostExcerptEditor( {
 							}
 						/>
 					</ToolsPanelItem>
+
+					<ToolsPanelItem
+						hasValue={ () => countType !== 'words' }
+						label={ __( 'Count type' ) }
+						onDeselect={ () =>
+							setAttributes( { countType: 'words' } )
+						}
+						isShownByDefault
+					>
+						<SelectControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={ __( 'Count type' ) }
+							value={ countType }
+							options={ [
+								{ label: __( 'Words' ), value: 'words' },
+								{
+									label: __( 'Characters' ),
+									value: 'characters',
+								},
+							] }
+							onChange={ ( value ) => {
+								setAttributes( { countType: value } );
+							} }
+						/>
+					</ToolsPanelItem>
+
 					<ToolsPanelItem
 						hasValue={ () => excerptLength !== 55 }
-						label={ __( 'Max number of words' ) }
+						label={ getExcerptLengthLabel() }
 						onDeselect={ () =>
 							setAttributes( { excerptLength: 55 } )
 						}
@@ -269,13 +330,25 @@ export default function PostExcerptEditor( {
 						<RangeControl
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
-							label={ __( 'Max number of words' ) }
+							label={ getExcerptLengthLabel() }
 							value={ excerptLength }
 							onChange={ ( value ) => {
 								setAttributes( { excerptLength: value } );
 							} }
-							min="10"
-							max="100"
+							min={
+								countType === 'characters' ||
+								countType === 'characters_including_spaces' ||
+								countType === 'characters_excluding_spaces'
+									? '10'
+									: '10'
+							}
+							max={
+								countType === 'characters' ||
+								countType === 'characters_including_spaces' ||
+								countType === 'characters_excluding_spaces'
+									? '300'
+									: '100'
+							}
 						/>
 					</ToolsPanelItem>
 				</ToolsPanel>

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -27,9 +27,19 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	* wp_trim_words is used instead.
 	*/
 	$excerpt_length = $attributes['excerptLength'];
-	$excerpt        = get_the_excerpt( $block->context['postId'] );
+	$count_type = isset( $attributes['countType'] ) ? $attributes['countType'] : 'words';
+	$excerpt = get_the_excerpt( $block->context['postId'] );
+
 	if ( isset( $excerpt_length ) ) {
-		$excerpt = wp_trim_words( $excerpt, $excerpt_length );
+		if ( $count_type === 'characters' ) {
+			// Trim by characters
+			if ( mb_strlen( $excerpt ) > $excerpt_length ) {
+				$excerpt = mb_substr( $excerpt, 0, $excerpt_length );
+			}
+		} else {
+			// Default: trim by words
+			$excerpt = wp_trim_words( $excerpt, $excerpt_length );
+		}
 	}
 
 	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . wp_kses_post( $attributes['moreText'] ) . '</a>' : '';


### PR DESCRIPTION
Closes #53824

## What?
This PR adds a character count option to the Excerpt Block as an alternative to the existing word count functionality, allowing theme designers to control excerpt lengths more precisely.

## Why?
As noted in issue #53824, using word count for excerpts results in unpredictable lengths due to different word sizes. This makes it difficult for theme designers to create consistent grid layouts where cards need to be the same size. Character count provides a more predictable measure for controlling excerpt length, resulting in more consistent designs.


## Testing Instructions
1. Add an Excerpt Block to a post or page
2. In the block settings sidebar, note the new "Count type" dropdown option
3. Switch between "Words" and "Characters" count types
4. Observe how the "Max number of words" label changes to "Max number of characters"
5. Verify that when using character count, the excerpt is trimmed precisely to the specified number of characters
6. Test with different excerpt lengths to ensure both modes work correctly

## Screenshots or screencast

https://github.com/user-attachments/assets/c8e36c84-606c-4f2e-92fb-6808b0c9b14f

