### PR TITLE
Update old URLs to new path-based URLs

### DIFF
--- a/packages/edit-post/src/components/more-menu/manage-patterns-menu-item.js
+++ b/packages/edit-post/src/components/more-menu/manage-patterns-menu-item.js
@@ -14,7 +14,7 @@ function ManagePatternsMenuItem() {
 			post_type: 'wp_block',
 		} );
 		const patternsUrl = addQueryArgs( 'site-editor.php', {
-			p: '/patterns',
+			p: '/pattern',
 		} );
 
 		// The site editor and templates both check whether the user has

--- a/packages/edit-post/src/components/more-menu/manage-patterns-menu-item.js
+++ b/packages/edit-post/src/components/more-menu/manage-patterns-menu-item.js
@@ -14,7 +14,7 @@ function ManagePatternsMenuItem() {
 			post_type: 'wp_block',
 		} );
 		const patternsUrl = addQueryArgs( 'site-editor.php', {
-			path: '/patterns',
+			p: '/patterns',
 		} );
 
 		// The site editor and templates both check whether the user has

--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -42,7 +42,7 @@ function PatternsManageButton( { clientId } ) {
 					name: 'wp_template',
 				} )
 					? addQueryArgs( 'site-editor.php', {
-							path: '/patterns',
+							p: '/pattern',
 					  } )
 					: addQueryArgs( 'edit.php', {
 							post_type: 'wp_block',

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -41,7 +41,7 @@ function ReusableBlocksManageButton( { clientId } ) {
 					name: 'wp_template',
 				} )
 					? addQueryArgs( 'site-editor.php', {
-							path: '/patterns',
+							p: '/pattern',
 					  } )
 					: addQueryArgs( 'edit.php', {
 							post_type: 'wp_block',


### PR DESCRIPTION
Closes: #69584 

## What?
## What?
Update old URL parameters to align with the site editor's current path-based URL structure.

## Why?
Currently, the site editor references the `p` GET parameter to determine which page to show, but there are still some URLs using old parameters (`path`, etc.).

## How?
Updated the URL query parameter from `path: '/patterns'` to `p: '/pattern'` in three files:
- `packages/edit-post/src/components/more-menu/manage-patterns-menu-item.js`
- `packages/patterns/src/components/patterns-manage-button.js`
- `packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js`

## Testing Instructions
1. Open the WordPress editor for a post or page
2. Click on the "More" menu (three dots in the top right)
3. Click on the "Manage patterns" option
4. Verify you are correctly taken to the patterns page

## Screencast 

https://github.com/user-attachments/assets/036bdc87-2340-41f2-92df-0d4175731728


https://github.com/user-attachments/assets/84d0f69d-c8bc-45ec-934b-0affcd925d96


https://github.com/user-attachments/assets/80c08351-1c6a-47d8-b4e3-048c0836f0de

