### PR TITLE
Fix: Post excerpt overflows in 3 column layout of query loop 

### DIFF
--- a/packages/block-library/src/post-excerpt/style.scss
+++ b/packages/block-library/src/post-excerpt/style.scss
@@ -9,7 +9,8 @@
 
 // Zero out the margin on the excerpt paragraph, to match the body paragraphs.
 .wp-block-post-excerpt__excerpt {
-	word-wrap: break-word;
+	word-break: break-word;
+	hyphens: auto;
 	margin-top: 0;
 	margin-bottom: 0;
 }

--- a/packages/block-library/src/post-excerpt/style.scss
+++ b/packages/block-library/src/post-excerpt/style.scss
@@ -9,6 +9,7 @@
 
 // Zero out the margin on the excerpt paragraph, to match the body paragraphs.
 .wp-block-post-excerpt__excerpt {
+	word-wrap: break-word;
 	margin-top: 0;
 	margin-bottom: 0;
 }


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/69588

<!-- In a few words, what is the PR actually doing? -->

## Why?
This PR is necessary to avoid the overflow of text happening in post excerpt 

## How?
This PR adds the `word-break: break-word` and `hyphens: auto` to avoid the overflow of post excerpt 

## Testing Instructions
- Create a new post 
- Add a title to the post and some long words in the editor like `LoremIpsumLoremIpsumLoremIpsum`
- Save the post 
- Create a new post 
- Add a Query Block to it with 3 column layout 
- Save the post and notice on the frontend that the text overflow is no more 

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before | After |  
|--------|-------|  
| https://github.com/user-attachments/assets/b2f9b308-9354-443f-b808-ee120b1c1ec8  |  https://github.com/user-attachments/assets/d4bd0a79-92d8-4fe0-a514-7ab718321e74 |  




