### PR TITLE
Fix: Ensure consistent margin application for blocks with dynamic block appender

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -124,6 +124,12 @@ function gutenberg_get_layout_definitions() {
 					),
 				),
 				array(
+					'selector' => ':has(> .block-list-appender) > :nth-last-child(2)',
+					'rules'    => array(
+						'margin-block-end' => '0',
+					),
+				),
+				array(
 					'selector' => ' > *',
 					'rules'    => array(
 						'margin-block-start' => null,

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -117,7 +117,7 @@ $z-layers: (
 
 	// Show popovers above wp-admin menus and submenus and sidebar:
 	// #adminmenuwrap { z-index: 9990 }
-	".components-popover": 100000,
+	".components-popover": 1000000,
 
 	// Should be above the popover (dropdown)
 	".reusable-blocks-menu-items__convert-modal": 1000001,

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -117,7 +117,7 @@ $z-layers: (
 
 	// Show popovers above wp-admin menus and submenus and sidebar:
 	// #adminmenuwrap { z-index: 9990 }
-	".components-popover": 1000000,
+	".components-popover": 100000,
 
 	// Should be above the popover (dropdown)
 	".reusable-blocks-menu-items__convert-modal": 1000001,


### PR DESCRIPTION
Ensured consistent margin application for blocks when block list appender appears

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #61846  <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->
Fixes an issue where the .block-list-appender dynamically modifies the block structure, causing inconsistent margin application for blocks inside .is-layout-constrained containers. This ensures that margins are correctly applied even when the block appender is added or removed dynamically.

## Why?
Previously, when a block (e.g., Cover block) was inside a Group block with .is-layout-constrained, the following CSS rules were applied:
```
:root :where(.is-layout-constrained) > :first-child {
    margin-block-start: 0;
}

:root :where(.is-layout-constrained) > :last-child {
    margin-block-end: 0;
}
```

However, when selecting the Group block in the editor, the .block-list-appender gets appended to the group, making it the new :last-child, which removes the intended margin adjustments from the actual content block, causing a layout shift.

## How?

- Used :has(> .block-list-appender) to detect when a .block-list-appender is present inside .is-layout-constrained.
- Applied :nth-last-child(2) to target the second-to-last element, ensuring the last actual content block (not the appender) retains the correct margin styles.
- This prevents the .block-list-appender from disrupting the layout when dynamically added or removed

## Testing Instructions

1. Add a Cover block inside a Group block in the editor.
2. Apply margin styles via theme.json or global styles.
3. Observe the margins before and after selecting the Group block.