### PR TITLE
Fix: Child Overflow Issue Due to Parent’s Border-Radius

### DIFF
--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -9,6 +9,9 @@
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 
+	// This block has a customizable border radius, so setting overflow to hidden will clip any content exceeding the rounded corners.
+	overflow: hidden;
+
 	&.has-media-on-the-right {
 		grid-template-columns: 1fr 50%;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #69596 

- This PR fixes an issue where child elements were overflowing beyond the parent container’s `border-radius`. The fix ensures that child elements remain within the rounded boundaries by applying `overflow: hidden` to the parent.


<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- When a parent container has `border-radius`, its child elements can visually extend beyond the rounded edges if `overflow` is not controlled. This issue caused unintended layout inconsistencies. By setting `overflow: hidden`, we ensure that child elements respect the parent’s rounded borders, leading to a more consistent UI.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Applied `overflow: hidden` to the parent container.
- Ensured that the fix does not affect other layout behaviors.
- Verified that child elements no longer extend beyond the parent's rounded borders.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page in the editor.
2. Add the media-text block and add a media and text.
3. Set the border radius of the block
4. Verify that the child elements does not overflow beyond the block’s rounded corners.

<!-- ### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
