### PR TITLE
Image block: Omit max width observer element in galleries

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -116,9 +116,9 @@ export function ImageEdit( {
 	// Only observe the max width from the parent container when the parent layout is not flex nor grid.
 	// This won't work for them because the container width changes with the image.
 	// TODO: Find a way to observe the container width for flex and grid layouts.
+	const layoutType = parentLayout?.type || parentLayout?.default?.type;
 	const isMaxWidthContainerWidth =
-		! parentLayout ||
-		( parentLayout.type !== 'flex' && parentLayout.type !== 'grid' );
+		! layoutType || ( layoutType !== 'flex' && layoutType !== 'grid' );
 	const [ maxWidthObserver, maxContentWidth ] = useMaxWidthObserver();
 
 	const [ placeholderResizeListener, { width: placeholderWidth } ] =
@@ -452,7 +452,7 @@ export function ImageEdit( {
 					context={ context }
 					clientId={ clientId }
 					blockEditingMode={ blockEditingMode }
-					parentLayoutType={ parentLayout?.type }
+					parentLayoutType={ layoutType }
 					maxContentWidth={ maxContentWidth }
 				/>
 				<MediaPlaceholder


### PR DESCRIPTION
## What?
Closes #69566

When an Image block is inside a gallery, omits an element that may cause layout issues and is unnecessary in that context already.

## Why?
- The element serves no purpose when the Image block is not resizable as is the case in Gallery blocks.
- The element’s presence can interfere with Gallery styling.

## How?
Modifies the existing condition for rendering the element to account for the Gallery block’s layout definition.

## Testing Instructions
1. Open a post
2. Paste in this test markup:
	<details><summary>Images in various containers including Gallery</summary>

	```html
	<!-- wp:paragraph {"fontSize":"small"} -->
	<p class="has-small-font-size">key:<br>✅ contexts that should have the element<br>🚫 context that should not have the element</p>
	<!-- /wp:paragraph -->

	<!-- wp:paragraph -->
	<p>no parent ✅</p>
	<!-- /wp:paragraph -->

	<!-- wp:image {"width":"645px","height":"auto","aspectRatio":"1.7777777777777777","scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
	<figure class="wp-block-image size-large is-resized"><img src="https://placehold.co/200x200/crimson/white?text=%23" alt="" style="aspect-ratio:1.7777777777777777;object-fit:cover;width:645px;height:auto"/></figure>
	<!-- /wp:image -->

	<!-- wp:paragraph -->
	<p>columns ✅</p>
	<!-- /wp:paragraph -->

	<!-- wp:columns -->
	<div class="wp-block-columns"><!-- wp:column {"width":"33.34%"} -->
	<div class="wp-block-column" style="flex-basis:33.34%"><!-- wp:image {"scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
	<figure class="wp-block-image size-large"><img src="https://placehold.co/200x200/crimson/white?text=%23" alt="" style="object-fit:cover"/></figure>
	<!-- /wp:image --></div>
	<!-- /wp:column -->

	<!-- wp:column {"width":"33.34%"} -->
	<div class="wp-block-column" style="flex-basis:33.34%"><!-- wp:image {"scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
	<figure class="wp-block-image size-large"><img src="https://placehold.co/200x200/crimson/white?text=%23" alt="" style="object-fit:cover"/></figure>
	<!-- /wp:image --></div>
	<!-- /wp:column -->

	<!-- wp:column {"width":"33.33%"} -->
	<div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:image {"scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
	<figure class="wp-block-image size-large"><img src="https://placehold.co/200x200/crimson/white?text=%23" alt="" style="object-fit:cover"/></figure>
	<!-- /wp:image --></div>
	<!-- /wp:column --></div>
	<!-- /wp:columns -->

	<!-- wp:paragraph -->
	<p>grid 🚫</p>
	<!-- /wp:paragraph -->

	<!-- wp:group {"allowResize":"inspector","layout":{"type":"grid"}} -->
	<div class="wp-block-group"><!-- wp:image {"scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
	<figure class="wp-block-image size-large"><img src="https://placehold.co/200x200/crimson/white?text=%23" alt="" style="object-fit:cover"/></figure>
	<!-- /wp:image -->

	<!-- wp:image {"scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
	<figure class="wp-block-image size-large"><img src="https://placehold.co/200x200/crimson/white?text=%23" alt="" style="object-fit:cover"/></figure>
	<!-- /wp:image --></div>
	<!-- /wp:group -->

	<!-- wp:paragraph -->
	<p>stack 🚫</p>
	<!-- /wp:paragraph -->

	<!-- wp:group {"allowResize":"inspector","layout":{"type":"flex","orientation":"vertical"}} -->
	<div class="wp-block-group"><!-- wp:image {"scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
	<figure class="wp-block-image size-large"><img src="https://placehold.co/200x200/crimson/white?text=%23" alt="" style="object-fit:cover"/></figure>
	<!-- /wp:image --></div>
	<!-- /wp:group -->

	<!-- wp:paragraph -->
	<p>row 🚫</p>
	<!-- /wp:paragraph -->

	<!-- wp:group {"allowResize":"inspector","layout":{"type":"flex","flexWrap":"nowrap"}} -->
	<div class="wp-block-group"><!-- wp:image {"scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
	<figure class="wp-block-image size-large"><img src="https://placehold.co/200x200/crimson/white?text=%23" alt="" style="object-fit:cover"/></figure>
	<!-- /wp:image --></div>
	<!-- /wp:group -->

	<!-- wp:paragraph -->
	<p>gallery parent 🚫</p>
	<!-- /wp:paragraph -->

	<!-- wp:gallery {"columns":4,"linkTo":"none"} -->
	<figure class="wp-block-gallery has-nested-images columns-4 is-cropped"><!-- wp:image {"scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
	<figure class="wp-block-image size-large"><img src="https://placehold.co/200x200/crimson/white?text=%23" alt="" style="object-fit:cover"/></figure>
	<!-- /wp:image -->

	<!-- wp:image {"scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
	<figure class="wp-block-image size-large"><img src="https://placehold.co/200x200/crimson/white?text=%23" alt="" style="object-fit:cover"/></figure>
	<!-- /wp:image -->

	<!-- wp:image {"scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
	<figure class="wp-block-image size-large"><img src="https://placehold.co/200x200/crimson/white?text=%23" alt="" style="object-fit:cover"/></figure>
	<!-- /wp:image -->

	<!-- wp:image {"scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
	<figure class="wp-block-image size-large"><img src="https://placehold.co/200x200/crimson/white?text=%23" alt="" style="object-fit:cover"/></figure>
	<!-- /wp:image -->

	<!-- wp:image {"scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
	<figure class="wp-block-image size-large"><img src="https://placehold.co/200x200/crimson/white?text=%23" alt="" style="object-fit:cover"/></figure>
	<!-- /wp:image -->

	<!-- wp:image {"scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
	<figure class="wp-block-image size-large"><img src="https://placehold.co/200x200/crimson/white?text=%23" alt="" style="object-fit:cover"/></figure>
	<!-- /wp:image -->

	<!-- wp:image {"scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
	<figure class="wp-block-image size-large"><img src="https://placehold.co/200x200/crimson/white?text=%23" alt="" style="object-fit:cover"/></figure>
	<!-- /wp:image -->

	<!-- wp:image {"scale":"cover","sizeSlug":"large","linkDestination":"none"} -->
	<figure class="wp-block-image size-large"><img src="https://placehold.co/200x200/crimson/white?text=%23" alt="" style="object-fit:cover"/></figure>
	<!-- /wp:image --></figure>
	<!-- /wp:gallery -->
	```
	</details>

3. For the first Image block and for one Image block in each container:
    1. Select an Image block
    2. Inspect (dev tools) the selected Image block
    3. Verify the expected absence or presence of the observer element which is a sibling after the `figure`. Presence looks like this: <img width="758" alt="max-width-observer-element" src="https://github.com/user-attachments/assets/a03bb352-b267-463d-b7ba-9709bb527b13" />

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
