### PR TITLE
BlockBreadcrumb: Wrap text node in span tag

### DIFF
--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -82,7 +82,7 @@ function BlockBreadcrumb( { rootLabelText } ) {
 						{ rootLabel }
 					</Button>
 				) }
-				{ ! hasSelection && rootLabel }
+				{ ! hasSelection && <span>{ rootLabel }</span> }
 				{ !! clientId && (
 					<Icon
 						icon={ chevronRightSmall }

--- a/packages/block-editor/src/components/block-breadcrumb/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-breadcrumb/test/__snapshots__/index.js.snap
@@ -11,7 +11,9 @@ exports[`BlockBreadcrumb should render correctly 1`] = `
       aria-current="true"
       class="block-editor-block-breadcrumb__current"
     >
-      Document
+      <span>
+        Document
+      </span>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
## What?

Wrap the text node in the `BlockBreadcrumb` component with a span tag


Closes #69597

## Why?

The error that occurs is the following:

```
Uncaught NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
    at removeChild (react-dom.js?ver=18:11109:20)
    at commitDeletionEffectsOnFiber (react-dom.js?ver=18:24077:17)
    at commitDeletionEffects (react-dom.js?ver=18:24025:7)
    at recursivelyTraverseMutationEffects (react-dom.js?ver=18:24308:11)
    at commitMutationEffectsOnFiber (react-dom.js?ver=18:24395:11)
    at recursivelyTraverseMutationEffects (react-dom.js?ver=18:24322:9)
    at commitMutationEffectsOnFiber (react-dom.js?ver=18:24395:11)
    at recursivelyTraverseMutationEffects (react-dom.js?ver=18:24322:9)
    at commitMutationEffectsOnFiber (react-dom.js?ver=18:24342:11)
    at recursivelyTraverseMutationEffects (react-dom.js?ver=18:24322:9)
```

Probably, the translation feature of the Chrome browser dynamically updates the text nodes on the page, which causes the React DOM tree to get out of sync with the actual DOM tree.

## How?

Simply wrap the conditionally-rendered text node in a span tag.

## Testing Instructions

- Open the site editor.
- Open any template.
- Run the translation of the Chrome browser.
- Click any block.
- Confirm that no critical error occurs.

## Screenshots or screencast <!-- if applicable -->

### Before


https://github.com/user-attachments/assets/47a7751c-d896-4aa2-8aad-e8fe147897dd



### After


https://github.com/user-attachments/assets/7b67cde0-bd95-4715-b34e-a9e831c97022

