### PR TITLE
Allow Snackbar component to support two actions

### DIFF
--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -345,7 +345,7 @@ function block_core_social_link_services( $service = '', $field = '' ) {
 		return $services_data[ $service ];
 	}
 
-	return $services_data;
+	return apply_filters( 'social_link_services_data', $services_data );
 }
 
 /**

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -345,7 +345,7 @@ function block_core_social_link_services( $service = '', $field = '' ) {
 		return $services_data[ $service ];
 	}
 
-	return apply_filters( 'social_link_services_data', $services_data );
+	return $services_data;
 }
 
 /**

--- a/packages/components/src/snackbar/index.tsx
+++ b/packages/components/src/snackbar/index.tsx
@@ -116,13 +116,28 @@ function UnforwardedSnackbar(
 	const classes = clsx( className, 'components-snackbar', {
 		'components-snackbar-explicit-dismiss': !! explicitDismiss,
 	} );
-	if ( actions && actions.length > 1 ) {
-		// We need to inform developers that snackbar only accepts 1 action.
+	if ( actions && actions.length > 2 ) {
+		// We need to inform developers that snackbar only accepts up to 2 actions.
 		warning(
-			'Snackbar can only have one action. Use Notice if your message requires many actions.'
+			'Snackbar can only have up to two actions. Use Notice if your message requires more actions.'
 		);
-		// return first element only while keeping it inside an array
-		actions = [ actions[ 0 ] ];
+		// return first two elements only while keeping them inside an array
+		actions = actions.slice( 0, 2 );
+	}
+
+	if ( actions && actions.length > 0 ) {
+		const MAX_ACTION_LABEL_LENGTH = 20;
+		actions = actions.map( ( action ) => {
+			if (
+				action.label &&
+				action.label.length > MAX_ACTION_LABEL_LENGTH
+			) {
+				warning(
+					`Snackbar action label "${ action.label }" exceeds the recommended maximum length of ${ MAX_ACTION_LABEL_LENGTH } characters.`
+				);
+			}
+			return action;
+		} );
 	}
 
 	const snackbarContentClassnames = clsx( 'components-snackbar__content', {

--- a/packages/components/src/snackbar/test/index.tsx
+++ b/packages/components/src/snackbar/test/index.tsx
@@ -136,7 +136,27 @@ describe( 'Snackbar', () => {
 	} );
 
 	describe( 'actions', () => {
-		it( 'should render only the first action with a warning when multiple actions are passed', () => {
+		it( 'should render up to two actions without a warning', () => {
+			render(
+				<Snackbar
+					actions={ [
+						{ label: 'One', url: 'https://example.com' },
+						{ label: 'Two', url: 'https://example.com' },
+					] }
+				>
+					Message
+				</Snackbar>
+			);
+
+			const snackbar = screen.getByTestId( testId );
+			const actions = within( snackbar ).getAllByRole( 'link' );
+
+			expect( actions ).toHaveLength( 2 );
+			expect( actions[ 0 ] ).toHaveTextContent( 'One' );
+			expect( actions[ 1 ] ).toHaveTextContent( 'Two' );
+		} );
+
+		it( 'should render only the first two actions with a warning when more than two actions are passed', () => {
 			render(
 				<Snackbar
 					actions={ [
@@ -150,17 +170,18 @@ describe( 'Snackbar', () => {
 			);
 
 			expect( console ).toHaveWarnedWith(
-				'Snackbar can only have one action. Use Notice if your message requires many actions.'
+				'Snackbar can only have up to two actions. Use Notice if your message requires more actions.'
 			);
 
 			const snackbar = screen.getByTestId( testId );
-			const action = within( snackbar ).getByRole( 'link' );
+			const actions = within( snackbar ).getAllByRole( 'link' );
 
-			expect( action ).toBeVisible();
-			expect( action ).toHaveTextContent( 'One' );
+			expect( actions ).toHaveLength( 2 );
+			expect( actions[ 0 ] ).toHaveTextContent( 'One' );
+			expect( actions[ 1 ] ).toHaveTextContent( 'Two' );
 		} );
 
-		it( 'should be rendered as a link when the `url` prop is set', () => {
+		it( 'should render a single action correctly', () => {
 			render(
 				<Snackbar
 					actions={ [
@@ -218,6 +239,31 @@ describe( 'Snackbar', () => {
 				name: 'View post',
 			} );
 			expect( link ).toBeVisible();
+		} );
+
+		it( 'should handle clicking on the second action', async () => {
+			const onClick1 = jest.fn();
+			const onClick2 = jest.fn();
+
+			render(
+				<Snackbar
+					actions={ [
+						{ label: 'First Action', onClick: onClick1 },
+						{ label: 'Second Action', onClick: onClick2 },
+					] }
+				>
+					Post updated.
+				</Snackbar>
+			);
+
+			const snackbar = screen.getByTestId( testId );
+			const buttons = within( snackbar ).getAllByRole( 'button' );
+			const secondButton = buttons[ 1 ];
+
+			await click( secondButton );
+
+			expect( onClick2 ).toHaveBeenCalledTimes( 1 );
+			expect( onClick1 ).not.toHaveBeenCalled();
 		} );
 	} );
 


### PR DESCRIPTION
Closes #69603

## What?
This PR modifies the Snackbar component to support up to two actions instead of just one, enhancing user interaction capabilities.

## Why?
The current Snackbar component is limited to a single action button, which restricts user interactions in common scenarios. This change allows for more flexible and intuitive interactions such as:

- User feedback prompts: "Are you satisfied?" → Yes / No
- Critical undo actions: "Message sent" → Undo / View message
- Task confirmations: "Save changes?" → Save / Discard

This enhancement aligns with established UX patterns seen in many modern interfaces and eliminates the need for plugin authors to create workarounds.

## How?

1. Modified the validation logic to allow up to two actions instead of one
2. Updated the warning message to reflect the new limit
3. Added character length validation for action labels to keep the UI clean
4. Updated tests to verify the new functionality
