### PR TITLE
ActionModal: Add support for customisable `focusOnMount`

### DIFF
--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -722,6 +722,23 @@ Example:
 }
 ```
 
+### `modalFocusOnMount`
+
+Specifies the focus on mount property of the modal.
+
+-	Type: `boolean` | `string`
+-	Optional
+-	Default: `true`
+-	One of: `true` | `false` | `'firstElement'` | `'firstContentElement'`
+
+Example:
+
+```js
+{
+	modalFocusOnMount: 'firstContentElement';
+}
+```
+
 ## Fields API
 
 ### `id`

--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -110,7 +110,7 @@ export function ActionModal< Item >( {
 			title={ action.modalHeader || label }
 			__experimentalHideHeader={ !! action.hideModalHeader }
 			onRequestClose={ closeModal }
-			focusOnMount={ action.modalFocusOnMount }
+			focusOnMount={ action.modalFocusOnMount ?? true }
 			size={ action.modalSize || 'medium' }
 			overlayClassName={ `dataviews-action-modal dataviews-action-modal__${ kebabCase(
 				action.id

--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -110,7 +110,7 @@ export function ActionModal< Item >( {
 			title={ action.modalHeader || label }
 			__experimentalHideHeader={ !! action.hideModalHeader }
 			onRequestClose={ closeModal }
-			focusOnMount="firstContentElement"
+			focusOnMount={ action.modalFocusOnMount }
 			size={ action.modalSize || 'medium' }
 			overlayClassName={ `dataviews-action-modal dataviews-action-modal__${ kebabCase(
 				action.id

--- a/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
@@ -582,6 +582,7 @@ export const actions: Action< SpaceObject >[] = [
 		isPrimary: true,
 		icon: trash,
 		hideModalHeader: true,
+		modalFocusOnMount: 'firstContentElement',
 		RenderModal: ( { items, closeModal } ) => {
 			return (
 				<VStack spacing="5">

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -8,6 +8,11 @@ import type { ReactElement, ComponentType } from 'react';
  */
 import type { SetSelection } from './private-types';
 
+/**
+ * WordPress dependencies
+ */
+import type { useFocusOnMount } from '@wordpress/compose';
+
 export type SortDirection = 'asc' | 'desc';
 
 /**
@@ -470,6 +475,13 @@ export interface ActionModal< Item > extends ActionBase< Item > {
 	 * @default 'medium'
 	 */
 	modalSize?: 'small' | 'medium' | 'large' | 'fill';
+
+	/**
+	 * The focus on mount property of the modal.
+	 */
+	modalFocusOnMount?:
+		| Parameters< typeof useFocusOnMount >[ 0 ]
+		| 'firstContentElement';
 }
 
 export interface ActionButton< Item > extends ActionBase< Item > {

--- a/packages/editor/src/components/post-actions/set-as-homepage.js
+++ b/packages/editor/src/components/post-actions/set-as-homepage.js
@@ -160,6 +160,7 @@ export const useSetAsHomepageAction = () => {
 
 				return true;
 			},
+			modalFocusOnMount: 'firstContentElement',
 			RenderModal: SetAsHomepageModal,
 		} ),
 		[ pageForPosts, pageOnFront ]

--- a/packages/editor/src/components/post-actions/set-as-posts-page.js
+++ b/packages/editor/src/components/post-actions/set-as-posts-page.js
@@ -157,6 +157,7 @@ export const useSetAsPostsPageAction = () => {
 
 				return true;
 			},
+			modalFocusOnMount: 'firstContentElement',
 			RenderModal: SetAsPostsPageModal,
 		} ),
 		[ pageForPosts, pageOnFront ]

--- a/packages/fields/src/actions/delete-post.tsx
+++ b/packages/fields/src/actions/delete-post.tsx
@@ -47,6 +47,7 @@ const deletePostAction: Action< Template | TemplatePart | Pattern > = {
 	},
 	supportsBulk: true,
 	hideModalHeader: true,
+	modalFocusOnMount: 'firstContentElement',
 	RenderModal: ( { items, closeModal, onActionPerformed } ) => {
 		const [ isBusy, setIsBusy ] = useState( false );
 		const isResetting = items.every(

--- a/packages/fields/src/actions/duplicate-pattern.tsx
+++ b/packages/fields/src/actions/duplicate-pattern.tsx
@@ -21,6 +21,7 @@ const duplicatePattern: Action< Pattern > = {
 	label: _x( 'Duplicate', 'action label' ),
 	isEligible: ( item ) => item.type !== 'wp_template_part',
 	modalHeader: _x( 'Duplicate pattern', 'action label' ),
+	modalFocusOnMount: 'firstContentElement',
 	RenderModal: ( { items, closeModal } ) => {
 		const [ item ] = items;
 		const duplicatedProps = useDuplicatePatternProps( {

--- a/packages/fields/src/actions/duplicate-post.tsx
+++ b/packages/fields/src/actions/duplicate-post.tsx
@@ -33,6 +33,7 @@ const duplicatePost: Action< BasePost > = {
 	isEligible( { status } ) {
 		return status !== 'trash';
 	},
+	modalFocusOnMount: 'firstContentElement',
 	RenderModal: ( { items, closeModal, onActionPerformed } ) => {
 		const [ item, setItem ] = useState< BasePost >( {
 			...items[ 0 ],

--- a/packages/fields/src/actions/duplicate-template-part.tsx
+++ b/packages/fields/src/actions/duplicate-template-part.tsx
@@ -24,6 +24,7 @@ const duplicateTemplatePart: Action< TemplatePart > = {
 	label: _x( 'Duplicate', 'action label' ),
 	isEligible: ( item ) => item.type === 'wp_template_part',
 	modalHeader: _x( 'Duplicate template part', 'action label' ),
+	modalFocusOnMount: 'firstContentElement',
 	RenderModal: ( { items, closeModal } ) => {
 		const [ item ] = items;
 		const blocks = useMemo( () => {

--- a/packages/fields/src/actions/permanently-delete-post.tsx
+++ b/packages/fields/src/actions/permanently-delete-post.tsx
@@ -35,6 +35,7 @@ const permanentlyDeletePost: Action< PostWithPermissions > = {
 		return status === 'trash' && permissions?.delete;
 	},
 	hideModalHeader: true,
+	modalFocusOnMount: 'firstContentElement',
 	RenderModal: ( { items, closeModal, onActionPerformed } ) => {
 		const [ isBusy, setIsBusy ] = useState( false );
 		const { createSuccessNotice, createErrorNotice } =

--- a/packages/fields/src/actions/rename-post.tsx
+++ b/packages/fields/src/actions/rename-post.tsx
@@ -35,6 +35,7 @@ const { PATTERN_TYPES } = unlock( patternsPrivateApis );
 const renamePost: Action< PostWithPermissions > = {
 	id: 'rename-post',
 	label: __( 'Rename' ),
+	modalFocusOnMount: 'firstContentElement',
 	isEligible( post ) {
 		if ( post.status === 'trash' ) {
 			return false;

--- a/packages/fields/src/actions/reorder-page.tsx
+++ b/packages/fields/src/actions/reorder-page.tsx
@@ -119,6 +119,7 @@ const reorderPage: Action< BasePost > = {
 	isEligible( { status } ) {
 		return status !== 'trash';
 	},
+	modalFocusOnMount: 'firstContentElement',
 	RenderModal: ReorderModal,
 };
 

--- a/packages/fields/src/actions/reset-post.tsx
+++ b/packages/fields/src/actions/reset-post.tsx
@@ -189,6 +189,7 @@ const resetPostAction: Action< Template | TemplatePart > = {
 	icon: backup,
 	supportsBulk: true,
 	hideModalHeader: true,
+	modalFocusOnMount: 'firstContentElement',
 	RenderModal: ( { items, closeModal, onActionPerformed } ) => {
 		const [ isBusy, setIsBusy ] = useState( false );
 

--- a/packages/fields/src/actions/trash-post.tsx
+++ b/packages/fields/src/actions/trash-post.tsx
@@ -39,6 +39,7 @@ const trashPost: Action< PostWithPermissions > = {
 	},
 	supportsBulk: true,
 	hideModalHeader: true,
+	modalFocusOnMount: 'firstContentElement',
 	RenderModal: ( { items, closeModal, onActionPerformed } ) => {
 		const [ isBusy, setIsBusy ] = useState( false );
 		const { createSuccessNotice, createErrorNotice } =


### PR DESCRIPTION
## What?
Closes #69265 

This PR makes the hardcoded `focusOnMount` prop on `ActionModal` customisable.

## Why?

Hardcoding `focusOnMount` to `firstContentElement` prioritizes focusing on the first focusable element. However, if no such element exists, the focus is lost, preventing the `Esc` key from closing the modal.

To avoid this, it's best to give developers control over `focusOnMount`, as relying solely on `firstContentElement` may not always be feasible.

Defaulting the `focusOnMount` to either `firstElement` or `firstContentElement` is debatable, but there were strong arguments made stating that the `ActionModal` should work always as expected by default. (Ref. https://github.com/WordPress/gutenberg/issues/69265#issuecomment-2716962044).

## How?

A new prop `modalFocusOnMount` is exposed.

## Testing Instructions

1. Start the storybook development server (`npm run storybook:dev`).
2. Remove `buttons` from `RenderModal` here: https://github.com/WordPress/gutenberg/blob/889858999783880fd73c3cf50164af18758a952c/packages/dataviews/src/components/dataviews/stories/fixtures.tsx#L578
3. Confirm that the `esc` keypress to close the modal works as expected.
