### PR TITLE
Enhance sandbox component to accept sandbox prop

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `useAutocomplete`: Fix autocomple UI flicker when deleting trigger prefix ([#69562](https://github.com/WordPress/gutenberg/pull/69562)).
 
+### Enhancement
+
+-   `SandBox`: Add `sandbox` prop ([#69617](https://github.com/WordPress/gutenberg/pull/69617))
+
 ## 29.6.0 (2025-03-13)
 
 ### Enhancement

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   `GradientPicker`: Add `selectedSlug` prop for slug-based selection and pass the selected preset's slug to `onChange`, so two presets sharing a gradient keep their identity ([#80554](https://github.com/WordPress/gutenberg/pull/80554)).
+-   `SandBox`: Add `allowPopups` prop to opt into `allow-popups` in the iframe's sandbox attribute ([#69617](https://github.com/WordPress/gutenberg/pull/69617)).
 
 ### Bug Fixes
 

--- a/packages/components/src/sandbox/index.tsx
+++ b/packages/components/src/sandbox/index.tsx
@@ -133,6 +133,7 @@ function SandBox( {
 	scripts = [],
 	onFocus,
 	tabIndex,
+	sandbox = 'allow-scripts allow-same-origin allow-presentation',
 }: SandBoxProps ) {
 	const ref = useRef< HTMLIFrameElement >();
 	const [ width, setWidth ] = useState( 0 );
@@ -284,7 +285,7 @@ function SandBox( {
 			title={ title }
 			tabIndex={ tabIndex }
 			className="components-sandbox"
-			sandbox="allow-scripts allow-same-origin allow-presentation"
+			sandbox={ sandbox }
 			onFocus={ onFocus }
 			width={ Math.ceil( width ) }
 			height={ Math.ceil( height ) }

--- a/packages/components/src/sandbox/index.tsx
+++ b/packages/components/src/sandbox/index.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -268,9 +273,9 @@ function IsolatedSandBox( {
 	const [ width, setWidth ] = useState( 0 );
 	const [ height, setHeight ] = useState( 0 );
 
-	const sandbox = `allow-scripts allow-presentation${
-		allowPopups ? ' allow-popups' : ''
-	}`;
+	const sandbox = clsx( 'allow-scripts', 'allow-presentation', {
+		'allow-popups': allowPopups,
+	} );
 
 	const srcDoc = useMemo(
 		() =>
@@ -393,9 +398,14 @@ function SameOriginSandBox( {
 	const [ width, setWidth ] = useState( 0 );
 	const [ height, setHeight ] = useState( 0 );
 
-	const sandbox = `allow-scripts allow-same-origin allow-presentation${
-		allowPopups ? ' allow-popups' : ''
-	}`;
+	const sandbox = clsx(
+		'allow-scripts',
+		'allow-same-origin',
+		'allow-presentation',
+		{
+			'allow-popups': allowPopups,
+		}
+	);
 
 	function isFrameAccessible() {
 		try {

--- a/packages/components/src/sandbox/index.tsx
+++ b/packages/components/src/sandbox/index.tsx
@@ -262,10 +262,15 @@ function IsolatedSandBox( {
 	scripts = [],
 	onFocus,
 	tabIndex,
+	allowPopups = false,
 }: SandBoxContentProps ) {
 	const ref = useRef< HTMLIFrameElement >( null );
 	const [ width, setWidth ] = useState( 0 );
 	const [ height, setHeight ] = useState( 0 );
+
+	const sandbox = `allow-scripts allow-presentation${
+		allowPopups ? ' allow-popups' : ''
+	}`;
 
 	const srcDoc = useMemo(
 		() =>
@@ -351,7 +356,7 @@ function IsolatedSandBox( {
 			title={ title }
 			tabIndex={ tabIndex }
 			className="components-sandbox"
-			sandbox="allow-scripts allow-presentation"
+			sandbox={ sandbox }
 			srcDoc={ srcDoc }
 			onFocus={ onFocus }
 			width={ Math.ceil( width ) }
@@ -382,10 +387,15 @@ function SameOriginSandBox( {
 	scripts = [],
 	onFocus,
 	tabIndex,
+	allowPopups = false,
 }: SandBoxContentProps ) {
 	const ref = useRef< HTMLIFrameElement >( null );
 	const [ width, setWidth ] = useState( 0 );
 	const [ height, setHeight ] = useState( 0 );
+
+	const sandbox = `allow-scripts allow-same-origin allow-presentation${
+		allowPopups ? ' allow-popups' : ''
+	}`;
 
 	function isFrameAccessible() {
 		try {
@@ -510,7 +520,7 @@ function SameOriginSandBox( {
 			title={ title }
 			tabIndex={ tabIndex }
 			className="components-sandbox"
-			sandbox="allow-scripts allow-same-origin allow-presentation"
+			sandbox={ sandbox }
 			onFocus={ onFocus }
 			width={ Math.ceil( width ) }
 			height={ Math.ceil( height ) }

--- a/packages/components/src/sandbox/test/index.tsx
+++ b/packages/components/src/sandbox/test/index.tsx
@@ -14,16 +14,27 @@ import { useState } from '@wordpress/element';
 import SandBox from '..';
 
 describe( 'SandBox', () => {
-	const TestWrapper = () => {
-		const [ html, setHtml ] = useState(
+	const TestWrapper = ( {
+		title,
+		sandbox,
+		html,
+	}: {
+		title: string;
+		sandbox?: string;
+		html?: string;
+	} ) => {
+		const initialHtml =
+			html ||
+			'<iframe title="Mock Iframe" src="https://super.embed"></iframe>';
+		const [ innerHtml, setInnerHtml ] = useState(
 			// MutationObserver implementation from JSDom does not work as intended
 			// with iframes so we need to ignore it for the time being.
 			'<script type="text/javascript">window.MutationObserver = null;</script>' +
-				'<iframe title="Mock Iframe" src="https://super.embed"></iframe>'
+				initialHtml
 		);
 
 		const updateHtml = () => {
-			setHtml(
+			setInnerHtml(
 				'<iframe title="Mock Iframe" src="https://another.super.embed"></iframe>'
 			);
 		};
@@ -33,13 +44,17 @@ describe( 'SandBox', () => {
 				<button onClick={ updateHtml } className="mock-button">
 					Mock Button
 				</button>
-				<SandBox html={ html } title="SandBox Title" />
+				<SandBox
+					html={ innerHtml }
+					title={ title }
+					sandbox={ sandbox }
+				/>
 			</div>
 		);
 	};
 
 	it( 'should rerender with new emdeded content if html prop changes', () => {
-		render( <TestWrapper /> );
+		render( <TestWrapper title="SandBox Title" /> );
 
 		const iframe =
 			screen.getByTitle< HTMLIFrameElement >( 'SandBox Title' );
@@ -66,6 +81,35 @@ describe( 'SandBox', () => {
 		expect( sandboxedIframe ).toHaveAttribute(
 			'src',
 			'https://another.super.embed'
+		);
+	} );
+
+	it( 'should render with the correct sandbox attribute when sandbox prop is not provided', () => {
+		render( <TestWrapper title="SandBox Title 2" /> );
+
+		const iframe =
+			screen.getByTitle< HTMLIFrameElement >( 'SandBox Title 2' );
+
+		expect( iframe ).toHaveAttribute(
+			'sandbox',
+			'allow-scripts allow-same-origin allow-presentation'
+		);
+	} );
+
+	it( 'should render with the correct sandbox attribute when sandbox prop is provided', () => {
+		render(
+			<TestWrapper
+				title="SandBox Title 3"
+				sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"
+			/>
+		);
+
+		const iframe =
+			screen.getByTitle< HTMLIFrameElement >( 'SandBox Title 3' );
+
+		expect( iframe ).toHaveAttribute(
+			'sandbox',
+			'allow-scripts allow-same-origin allow-presentation allow-popups'
 		);
 	} );
 } );

--- a/packages/components/src/sandbox/test/index.tsx
+++ b/packages/components/src/sandbox/test/index.tsx
@@ -49,6 +49,27 @@ describe( 'SandBox', () => {
 		);
 	} );
 
+	it( 'should not include allow-popups by default', () => {
+		render( <SandBox html="<p>Hello</p>" title="No Popups" /> );
+
+		const iframe = screen.getByTitle< HTMLIFrameElement >( 'No Popups' );
+
+		expect( iframe.getAttribute( 'sandbox' ) ).not.toContain(
+			'allow-popups'
+		);
+	} );
+
+	it( 'should include allow-popups when allowPopups is set', () => {
+		render( <SandBox html="<p>Hello</p>" title="Popups" allowPopups /> );
+
+		const iframe = screen.getByTitle< HTMLIFrameElement >( 'Popups' );
+
+		expect( iframe ).toHaveAttribute(
+			'sandbox',
+			'allow-scripts allow-presentation allow-popups'
+		);
+	} );
+
 	it( 'should set srcdoc with the provided html content', () => {
 		render( <SandBox html="<p>Hello</p>" title="Test Title" /> );
 

--- a/packages/components/src/sandbox/types.ts
+++ b/packages/components/src/sandbox/types.ts
@@ -37,4 +37,10 @@ export type SandBoxProps = {
 	 * @default 0
 	 */
 	tabIndex?: HTMLElement[ 'tabIndex' ];
+	/**
+	 * The `sandbox` attribute for the iframe.
+	 *
+	 * @default 'allow-scripts allow-same-origin allow-presentation'
+	 */
+	sandbox?: string;
 };

--- a/packages/components/src/sandbox/types.ts
+++ b/packages/components/src/sandbox/types.ts
@@ -11,6 +11,17 @@ export type SandBoxProps = {
 	 */
 	allowSameOrigin?: boolean;
 	/**
+	 * Whether to include `allow-popups` in the iframe's sandbox attribute.
+	 * When true, content inside the iframe is allowed to open new browsing
+	 * contexts (e.g. links that open in a new tab, or `window.open`).
+	 *
+	 * Enable this for previews whose content includes links that should be
+	 * followable, such as embeds.
+	 *
+	 * @default false
+	 */
+	allowPopups?: boolean;
+	/**
 	 * The HTML to render in the body of the iframe document.
 	 *
 	 * @default ''


### PR DESCRIPTION
## What?

Adds an optional `allowPopups` prop to the `SandBox` component, letting consumers opt into `allow-popups` in the iframe's `sandbox` attribute.

## Why?

The iframe in the `SandBox` component does not include `allow-popups` in its `sandbox` value. Because of this, links inside sandboxed content don't take users anywhere when clicked — the navigation is blocked.

Our actual goal is to use this in the Jetpack repo to fix the VideoPress blocks. Jetpack consumes the `@wordpress/components` npm library, so this needs to be released on npm before we can move on with the next part of the fix.

## How?

Since this PR was opened, `SandBox` was significantly refactored (#77212) and is now split into two internal variants, dispatched via the `allowSameOrigin` prop:

- `IsolatedSandBox` (default) — `sandbox="allow-scripts allow-presentation"`. `allow-same-origin` was deliberately dropped for user-controlled content (e.g. the HTML block) as a security hardening.
- `SameOriginSandBox` (`allowSameOrigin`) — `sandbox="allow-scripts allow-same-origin allow-presentation"`, for server-fetched oEmbed previews.

Neither variant includes `allow-popups`. Rather than expose a raw `sandbox` string override — which would let a caller pass `allow-same-origin` back into the isolated, user-controlled variant and quietly undo that hardening — this PR adds a targeted, opt-in `allowPopups?: boolean` prop (`@default false`). When set, `allow-popups` is appended to whichever variant's default `sandbox` attribute. This keeps with trunk's boolean-flag design (alongside `allowSameOrigin`) and preserves the existing security guarantees.

## Testing Instructions

1. Check the code and tests.
2. Make sure any block or other consumer of `SandBox` doesn't break (default behavior is unchanged when `allowPopups` is not passed).
3. Render a `SandBox` with `allowPopups` and confirm the iframe's `sandbox` attribute includes `allow-popups`, and that a link inside the sandboxed content can open.

### Testing Instructions for Keyboard

N/A

## Screenshots or screencast

N/A
