### PR TITLE
Storybook: Update ToolbarItem and ToolbarDropdownMenu exports

### DIFF
--- a/packages/components/src/toolbar/toolbar-dropdown-menu/index.tsx
+++ b/packages/components/src/toolbar/toolbar-dropdown-menu/index.tsx
@@ -16,7 +16,7 @@ import ToolbarContext from '../toolbar-context';
 import DropdownMenu from '../../dropdown-menu';
 import type { DropdownMenuProps } from '../../dropdown-menu/types';
 
-function ToolbarDropdownMenu(
+function UnforwardedToolbarDropdownMenu(
 	props: DropdownMenuProps,
 	ref: ForwardedRef< any >
 ) {
@@ -44,4 +44,5 @@ function ToolbarDropdownMenu(
 	);
 }
 
-export default forwardRef( ToolbarDropdownMenu );
+export const ToolbarDropdownMenu = forwardRef( UnforwardedToolbarDropdownMenu );
+export default ToolbarDropdownMenu;

--- a/packages/components/src/toolbar/toolbar-item/index.tsx
+++ b/packages/components/src/toolbar/toolbar-item/index.tsx
@@ -16,7 +16,7 @@ import warning from '@wordpress/warning';
 import ToolbarContext from '../toolbar-context';
 import type { ToolbarItemProps } from './types';
 
-function ToolbarItem(
+function UnforwardedToolbarItem(
 	{ children, as: Component, ...props }: ToolbarItemProps,
 	ref: ForwardedRef< any >
 ) {
@@ -57,4 +57,5 @@ function ToolbarItem(
 	);
 }
 
-export default forwardRef( ToolbarItem );
+export const ToolbarItem = forwardRef( UnforwardedToolbarItem );
+export default ToolbarItem;


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/69616

<!-- In a few words, what is the PR actually doing? -->

## Why?
This PR resolves the issue of the ToolbarItem and ToolbarDropdownMenu components not showing their props in the [Storybook props table](https://wordpress.github.io/gutenberg/?path=/docs/components-toolbar--docs) for Toolbar

## How?
This PR updates the named exports of `ToolbarItem` and `ToolbarDropdownMenu` components

## Testing Instructions
- Run `npm run storybook:dev`
- Go to `Toolbar` component story
- Notice the `ToolbarItem` and `ToolbarDropdownMenu` now show their respective props with documentation

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<img width="876" alt="image" src="https://github.com/user-attachments/assets/1550872b-29ec-4238-b026-0add8214f832" />

<img width="848" alt="image" src="https://github.com/user-attachments/assets/4baf895c-6b6b-4b54-a4fb-8db8a2808121" />

