### PR TITLE
ComboboxControl: Replace `undefined` variable usage with `color-mix` for disabled selection

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   `useAutocomplete`: Fix autocomple UI flicker when deleting trigger prefix ([#69562](https://github.com/WordPress/gutenberg/pull/69562)).
+-   `FormTokenField`: Use `color-mix` for disabled option selection background ([#69621](https://github.com/WordPress/gutenberg/pull/69621)).
 
 ## 29.6.0 (2025-03-13)
 

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -186,7 +186,7 @@
 		color: $gray-600;
 
 		&.is-selected {
-			background-color: color-mix(in srgb, $components-color-accent 8%, transparent);
+			background: color-mix(in srgb, $components-color-accent 4%, transparent);
 		}
 	}
 

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -186,7 +186,7 @@
 		color: $gray-600;
 
 		&.is-selected {
-			background-color: $components-color-accent-transparent-40;
+			background-color: color-mix(in srgb, $components-color-accent 8%, transparent);
 		}
 	}
 

--- a/packages/components/src/utils/theme-variables.scss
+++ b/packages/components/src/utils/theme-variables.scss
@@ -4,10 +4,6 @@
 // `--wp-admin-theme-color`. If the `--wp-admin-theme-color` variable is not
 // defined, fallback to the default theme color (WP blueberry).
 $components-color-accent: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
-
-// Define accent color transparent variants.
-$components-color-accent-transparent-40: rgba(var(--wp-components-color-accent--rgb, var(--wp-admin-theme-color--rgb)), 0.04);
-
 $components-color-accent-darker-10: var(--wp-components-color-accent-darker-10, var(--wp-admin-theme-color-darker-10, #2145e6));
 $components-color-accent-darker-20: var(--wp-components-color-accent-darker-20, var(--wp-admin-theme-color-darker-20, #183ad6));
 


### PR DESCRIPTION
## What and Why?
Closes #69593 

This PR:
1. Removes the usage of the `--wp-components-color-accent--rgb` property as the `rgb` variant does not exist.
2. Removes the usage of `$components-color-accent-transparent-40` SASS variable in favor of `color-mix()`.
3. The background for disabled and selected/focused options on dark themes is now visible and looks as expected on `dark backgrounds`.

## How?

The corresponding `scss` file is updated to reflect the above changes. 

## Testing Instructions

1. Run the storybook dev server. (`npm run storybook:dev`)
2. Navigate to ComboboxControl.
3. Toggle the theme to dark mode.
4. Confirm the background is visible for selected/focused disabled options.

### Testing Instructions for Keyboard
Same.

## Screenshots

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/6dd09ad7-267c-4e2e-a6b6-a91fb2782166)|![after](https://github.com/user-attachments/assets/dac5e54e-31d8-48be-8dc2-a0655a550a2c)|

P.S. Please note that a tinted background (although faint) has been added to the first (disabled) option. The second option may appear invisible due to the lack of theming support, which will be addressed once theming is implemented for the component. (Ref. https://github.com/WordPress/gutenberg/issues/69593#issuecomment-2729413510)
