### PR TITLE
Upgrade Playwright to v1.51.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"@octokit/rest": "16.26.0",
 				"@octokit/types": "6.34.0",
 				"@octokit/webhooks-types": "5.8.0",
-				"@playwright/test": "1.49.1",
+				"@playwright/test": "1.51.1",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@react-native/babel-preset": "0.73.10",
 				"@react-native/metro-babel-transformer": "0.73.10",
@@ -8720,13 +8720,12 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.49.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
-			"integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
+			"version": "1.51.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.1.tgz",
+			"integrity": "sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==",
 			"dev": true,
-			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.49.1"
+				"playwright": "1.51.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -37903,13 +37902,12 @@
 			"dev": true
 		},
 		"node_modules/playwright": {
-			"version": "1.49.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
-			"integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+			"version": "1.51.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.1.tgz",
+			"integrity": "sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==",
 			"dev": true,
-			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.49.1"
+				"playwright-core": "1.51.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -37922,11 +37920,10 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.49.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
-			"integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+			"version": "1.51.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.1.tgz",
+			"integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==",
 			"dev": true,
-			"license": "Apache-2.0",
 			"bin": {
 				"playwright-core": "cli.js"
 			},
@@ -52385,7 +52382,7 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.49.1",
+				"@playwright/test": "^1.51.1",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.8.0",
-		"@playwright/test": "1.49.1",
+		"@playwright/test": "1.51.1",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@react-native/babel-preset": "0.73.10",
 		"@react-native/metro-babel-transformer": "0.73.10",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -95,7 +95,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"peerDependencies": {
-		"@playwright/test": "^1.49.1",
+		"@playwright/test": "^1.51.1",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
 	},

--- a/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
@@ -1069,7 +1069,9 @@ test.describe( 'Registered sources', () => {
 			await expect( initialButton ).toHaveText( 'Text Field Value' );
 			// Second block should be an empty paragraph block.
 			await expect( newEmptyButton ).toHaveText( '' );
-			await expect( newEmptyButton ).toBeEditable();
+			await expect(
+				newEmptyButton.getByRole( 'textbox' )
+			).toBeEditable();
 		} );
 		test( 'should show placeholder prompt when value is empty and can edit', async ( {
 			editor,


### PR DESCRIPTION
## What?
Upgrade Playwright to v1.51.1

## What's new?
* https://playwright.dev/docs/release-notes#version-151
* https://playwright.dev/docs/release-notes#version-150

## Testing Instructions
* Run any e2e test locally; the command should download new browsers and run the test successfully.
* CI checks are green.