### PR TITLE
Fix flaky Typewriter e2e test

### DIFF
--- a/test/e2e/specs/editor/various/typewriter.spec.js
+++ b/test/e2e/specs/editor/various/typewriter.spec.js
@@ -32,9 +32,9 @@ test.describe( 'Typewriter', () => {
 		// The page shouldn't be scrolled when it's being filled.
 		await page.keyboard.press( 'Enter' );
 
-		expect( await typewriterUtils.getCaretPosition() ).toBeGreaterThan(
-			initialPosition
-		);
+		expect(
+			await typewriterUtils.getCaretPosition()
+		).toBeGreaterThanOrEqual( initialPosition );
 
 		// Create blocks until the typewriter effect kicks in.
 		while (
@@ -270,7 +270,7 @@ test.describe( 'Typewriter', () => {
 
 		const newTopPosition = await typewriterUtils.getCaretPosition();
 
-		expect( newTopPosition ).toBeGreaterThan( topPosition );
+		expect( newTopPosition ).toBeGreaterThanOrEqual( topPosition );
 
 		// Should maintain new caret position.
 		await page.keyboard.press( 'Enter' );


### PR DESCRIPTION
## What?
Closes #48533.

PR fixes the flaky Typewriter e2e test. Occasionally, new and old top positions are equal; account for this by using the `toBeGreaterThanOrEqual` assertion.

## Testing Instructions
CI checks should be green.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2025-03-19 at 11 19 44](https://github.com/user-attachments/assets/cdf8f962-91c4-458a-a245-3da95f361a03)

