### PR TITLE
Fix: Background wrapper for 'Button Inside' option 

### DIFF
--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -110,6 +110,8 @@ $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 :where(.wp-block-search__button-inside .wp-block-search__inside-wrapper) {
 	padding: $grid-unit-05;
 	border: 1px solid $gray-600;
+	background-color: $white;
+	border-radius: $radius-medium;
 	box-sizing: border-box;
 
 	.wp-block-search__input {

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -111,7 +111,6 @@ $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 	padding: $grid-unit-05;
 	border: 1px solid $gray-600;
 	background-color: $white;
-	border-radius: $radius-medium;
 	box-sizing: border-box;
 
 	.wp-block-search__input {


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/69375

<!-- In a few words, what is the PR actually doing? -->

## Why?
This PR updates the current implementation of button placed inside the search box 

## How?
This PR adds the necessary `background-color` and `border-radius` to enhance the 'button inside search box' design 

## Testing Instructions
- Add a new post 
- Add a 'Search' block to it 
- From the toolbar select the 'Button Inside' option 
- Notice that the button now looks better placed inside the search box

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="536" alt="image" src="https://github.com/user-attachments/assets/a77b5182-34ae-4d9e-9fc3-57e90742434a" /> | <img width="532" alt="image" src="https://github.com/user-attachments/assets/323caace-3a4b-42f9-9e3a-c5cd1bf95a2a" />|
