### PR TITLE
CustomSelectControl: Use dynamic fill color for `check` icon

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `useAutocomplete`: Fix autocomple UI flicker when deleting trigger prefix ([#69562](https://github.com/WordPress/gutenberg/pull/69562)).
 -   `FormTokenField`: Use `color-mix` for disabled option selection background ([#69621](https://github.com/WordPress/gutenberg/pull/69621)).
+-   `CustomSelectControl`: Fix check icon color to adapt with dark theme ([#69626](https://github.com/WordPress/gutenberg/pull/69626)).
 
 ## 29.6.0 (2025-03-13)
 

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -214,6 +214,10 @@ export const SelectedItemCheck = styled( Ariakit.SelectItemCheck )`
 	align-items: center;
 	margin-inline-start: ${ space( 2 ) };
 
+	path {
+		fill: currentColor;
+	}
+
 	// Keep the checkmark vertically aligned at the top. Since the item text has a
 	// 28px line height and the checkmark is 24px tall, a (28-24)/2 = 2px margin
 	// is applied to keep the correct alignment between the text and the checkmark.

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -213,10 +213,7 @@ export const SelectedItemCheck = styled( Ariakit.SelectItemCheck )`
 	display: flex;
 	align-items: center;
 	margin-inline-start: ${ space( 2 ) };
-
-	path {
-		fill: currentColor;
-	}
+	fill: currentColor;
 
 	// Keep the checkmark vertically aligned at the top. Since the item text has a
 	// 28px line height and the checkmark is 24px tall, a (28-24)/2 = 2px margin


### PR DESCRIPTION
## What?
Closes #69625

The `Check` icon displayed next to the selected option does not adapt properly to the theme.

## Why?

Since no explicit fill value is applied, the `Check` icon defaults to its standard appearance.

## How?

A simple `fill: currentColor;` CSS rule fixed it.

## Testing Instructions

1. Open the local storybook server. (`npm run storybook:dev`)
2. Navigate to `CustomSelectControl`.
3. Verify the `Check` icon is visible across all the themes (especially dark theme).
4. Similarly, verify `CustomSelectControlV2` implementations.

## Screenshots

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/49ea6a00-b83d-4ec4-be8a-08f848ba6b8b)|![after](https://github.com/user-attachments/assets/c10e40d2-97f4-4bb0-b4bd-7d005b232756)|


