### PR TITLE
Navigation Link: Don't check validity when block editing is disabled

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -108,7 +108,9 @@ const useIsInvalidLink = ( kind, type, id ) => {
 				return null;
 			}
 
-			// Avoid querying the post status if the block editing mode is disabled.
+			// Fetching the posts status is an "expensive" operation. Especially for sites with large navigations.
+			// When the block is rendered in a template or other disabled contexts we can skip this check in order
+			// to avoid all these additional requests that don't really add any value in that mode.
 			if ( blockEditingMode === 'disabled' ) {
 				return null;
 			}

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -26,6 +26,7 @@ import {
 	store as blockEditorStore,
 	getColorClassName,
 	useInnerBlocksProps,
+	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP, safeDecodeURI } from '@wordpress/url';
 import { useState, useEffect, useRef } from '@wordpress/element';
@@ -99,15 +100,23 @@ const useIsInvalidLink = ( kind, type, id ) => {
 	const isPostType =
 		kind === 'post-type' || type === 'post' || type === 'page';
 	const hasId = Number.isInteger( id );
+	const blockEditingMode = useBlockEditingMode();
+
 	const postStatus = useSelect(
 		( select ) => {
 			if ( ! isPostType ) {
 				return null;
 			}
+
+			// Avoid querying the post status if the block editing mode is disabled.
+			if ( blockEditingMode === 'disabled' ) {
+				return null;
+			}
+
 			const { getEntityRecord } = select( coreStore );
 			return getEntityRecord( 'postType', type, id )?.status;
 		},
-		[ isPostType, type, id ]
+		[ isPostType, blockEditingMode, type, id ]
 	);
 
 	// Check Navigation Link validity if:


### PR DESCRIPTION
## What?
Part of #42904.
Related #69563.

PR tries to reduce unnecessary HTTP requests made by the Navigation Link block when editing is disabled.

## Why?
The block checks the associated post status to hint at a link's validity, which isn't helpful if you can't edit the navigation menu.

## Testing Instructions
1. Create a Navigation menu with multiple links to page items.
2. Add it to the default header template part.
3. Open a page with "Show Template" enabled.
4. Inspect the network requests.
5. Confirm there are no HTTP requests made for each page item.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| ![CleanShot 2025-03-19 at 14 10 27](https://github.com/user-attachments/assets/ba3ea248-c5c1-413c-8556-438e12e9ab72) | ![CleanShot 2025-03-19 at 14 09 59](https://github.com/user-attachments/assets/ef869e7c-75fe-443e-aa13-905f3b512b2f) |