### PR TITLE
Site Title: Prevent saving and rendering a value made of only spaces

### DIFF
--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -56,7 +56,7 @@ export default function SiteTitleEdit( {
 
 	function setTitle( newTitle ) {
 		editEntityRecord( 'root', 'site', undefined, {
-			title: newTitle,
+			title: newTitle.trim(),
 		} );
 	}
 

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -16,7 +16,7 @@
  */
 function render_block_core_site_title( $attributes ) {
 	$site_title = get_bloginfo( 'name' );
-	if ( ! $site_title ) {
+	if ( ! $site_title || trim( $site_title ) === '' ) {
 		return;
 	}
 

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -16,7 +16,7 @@
  */
 function render_block_core_site_title( $attributes ) {
 	$site_title = get_bloginfo( 'name' );
-	if ( ! $site_title || trim( $site_title ) === '' ) {
+	if ( ! trim( $site_title ) ) {
 		return;
 	}
 


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/60467

Prevents the Site Title block from saving and rendering values made only of whitespace characters

## Why?

The Site Title block was inconsistent with the classic admin behavior - it would allow saving site titles with only spaces, which created empty links on the front end. Empty links are problematic for SEO and accessibility.
This inconsistency created a situation where:

- Classic admin wouldn't save site titles with only spaces
- The Site Title block would save them
- This would render an empty link on the frontend

## How?
The solution addresses the issue in two places:

- In the editor component (`edit.js`): Trim whitespace from the title before saving it
- In the PHP render callback (`index.php`): Skip rendering if the site title consists only of whitespace

## Testing Instructions

- Use a theme that has the Site Title block on one of its templates (e.g., Twenty Twenty-Four > Blog Home template)
- Go to the Site Editor and select the Site Title block
- Clear the title and enter only spaces
- Save the template
- Check the frontend - verify no empty link is rendered
- Check the classic admin (Settings > General) - verify the site title field is empty
- Try to enter only spaces in the classic admin site title field and save
- Verify the site title remains empty in both the classic admin and the Site Editor

## Screencast 

### Before 




https://github.com/user-attachments/assets/37b78c9c-1e72-4868-ab28-267715f49ced

### After

https://github.com/user-attachments/assets/9bb8d2af-a62d-453d-a4a8-ba0e6ef4a0d8



