### PR TITLE
PatternsExplorerModal: Fix empty patterns in starter content category

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/pattern-list.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/pattern-list.js
@@ -21,6 +21,7 @@ import {
 	INSERTER_PATTERN_TYPES,
 	allPatternsCategory,
 	myPatternsCategory,
+	starterPatternsCategory,
 } from '../block-patterns-tab/utils';
 
 function PatternsListHeader( { filterValue, filteredBlockPatternsLength } ) {
@@ -82,6 +83,12 @@ function PatternList( {
 			if (
 				selectedCategory === myPatternsCategory.name &&
 				pattern.type === INSERTER_PATTERN_TYPES.user
+			) {
+				return true;
+			}
+			if (
+				selectedCategory === starterPatternsCategory.name &&
+				pattern.blockTypes?.includes( 'core/post-content' )
 			) {
 				return true;
 			}


### PR DESCRIPTION
## What?

Follow-up #66819

This PR properly displays starter patterns in the Pattern Explorer modal.

## Why? How?

I found that this modal is missing the logic to handle the starter content category. I add the same logic as the pattern category preview:

https://github.com/WordPress/gutenberg/blob/2a21c93ea046d02e766ee73ff62cd1220f017a9e/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js#L83-L88

## Testing Instructions

- Activate Twenty Twenty-Five.
- Open a post > Main inserter > Patterns tab > Explore all patterns 
- Click the "Starter content" category
- Four patterns should be shown.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before

![image](https://github.com/user-attachments/assets/2cefee94-7cd7-44f5-8d5a-b422eab07857)

### After

![image](https://github.com/user-attachments/assets/99c3528a-2b7f-46ca-8158-4f287ae2cf70)

