### PR TITLE
Navigation Link: Optimize 'getBlockParentsByBlockName' selector call

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -44,6 +44,10 @@ import { updateAttributes } from './update-attributes';
 import { getColors } from '../navigation/edit/utils';
 
 const DEFAULT_BLOCK = { name: 'core/navigation-link' };
+const NESTING_BLOCK_NAMES = [
+	'core/navigation-link',
+	'core/navigation-submenu',
+];
 
 /**
  * A React hook to determine if it's dragging within the target element.
@@ -336,10 +340,8 @@ export default function NavigationLinkEdit( {
 
 			return {
 				isAtMaxNesting:
-					getBlockParentsByBlockName( clientId, [
-						'core/navigation-link',
-						'core/navigation-submenu',
-					] ).length >= maxNestingLevel,
+					getBlockParentsByBlockName( clientId, NESTING_BLOCK_NAMES )
+						.length >= maxNestingLevel,
 				isTopLevelLink:
 					getBlockName( getBlockRootClientId( clientId ) ) ===
 					'core/navigation',


### PR DESCRIPTION
## What?
PR optimizes the `getBlockParentsByBlockName` selector call for the Navigation Link block by passing a stable array reference instead of a new one on each call. The `blockNames` value doesn't change and can be extracted into a constant.

## Why?
The `getBlockParentsByBlockName` is a memoized selector, which means that passing a different array on each call will create a new cache entry. Depending on a number of Navigation Link blocks and block editor store updates, accidental memory leaks can affect performance.

Related #68898.

## Testing Instructions
None. PR just extracts the array argument into a constant.
