### PR TITLE
Navigation Link: Improve performance by only requesting entities when selected

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -325,8 +325,8 @@ export default function NavigationLinkEdit( {
 		isAtMaxNesting,
 		isTopLevelLink,
 		isParentOfSelectedBlock,
-		isRootBlockSelected,
 		hasChildren,
+		validateLinkStatus,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -337,28 +337,33 @@ export default function NavigationLinkEdit( {
 				getBlockParentsByBlockName,
 				getSelectedBlockClientId,
 			} = select( blockEditorStore );
+			const rootClientId = getBlockRootClientId( clientId );
+			const isTopLevel =
+				getBlockName( rootClientId ) === 'core/navigation';
 			const selectedBlockClientId = getSelectedBlockClientId();
-			const isRootParentSelected =
-				selectedBlockClientId && selectedBlockClientId !== clientId
-					? getBlockParentsByBlockName(
-							clientId,
-							'core/navigation'
-					  ).includes( selectedBlockClientId )
-					: false;
+			const rootNavigationClientId = isTopLevel
+				? rootClientId
+				: getBlockParentsByBlockName(
+						clientId,
+						'core/navigation'
+				  )[ 0 ];
+
+			// Enable when the root Navigation block is selected or any of its inner blocks.
+			const enableLinkStatusValidation =
+				selectedBlockClientId === rootNavigationClientId ||
+				hasSelectedInnerBlock( rootNavigationClientId, true );
 
 			return {
 				isAtMaxNesting:
 					getBlockParentsByBlockName( clientId, NESTING_BLOCK_NAMES )
 						.length >= maxNestingLevel,
-				isTopLevelLink:
-					getBlockName( getBlockRootClientId( clientId ) ) ===
-					'core/navigation',
+				isTopLevelLink: isTopLevel,
 				isParentOfSelectedBlock: hasSelectedInnerBlock(
 					clientId,
 					true
 				),
-				isRootBlockSelected: isRootParentSelected,
 				hasChildren: !! getBlockCount( clientId ),
+				validateLinkStatus: enableLinkStatusValidation,
 			};
 		},
 		[ clientId, maxNestingLevel ]
@@ -369,8 +374,7 @@ export default function NavigationLinkEdit( {
 		kind,
 		type,
 		id,
-		// Whether block link validation is enabled.
-		isSelected || isRootBlockSelected
+		validateLinkStatus
 	);
 
 	/**

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -100,7 +100,7 @@ const useIsDraggingWithin = ( elementRef ) => {
 	return isDraggingWithin;
 };
 
-const useIsInvalidLink = ( kind, type, id ) => {
+const useIsInvalidLink = ( kind, type, id, enabled ) => {
 	const isPostType =
 		kind === 'post-type' || type === 'post' || type === 'page';
 	const hasId = Number.isInteger( id );
@@ -115,14 +115,14 @@ const useIsInvalidLink = ( kind, type, id ) => {
 			// Fetching the posts status is an "expensive" operation. Especially for sites with large navigations.
 			// When the block is rendered in a template or other disabled contexts we can skip this check in order
 			// to avoid all these additional requests that don't really add any value in that mode.
-			if ( blockEditingMode === 'disabled' ) {
+			if ( blockEditingMode === 'disabled' || ! enabled ) {
 				return null;
 			}
 
 			const { getEntityRecord } = select( coreStore );
 			return getEntityRecord( 'postType', type, id )?.status;
 		},
-		[ isPostType, blockEditingMode, type, id ]
+		[ isPostType, blockEditingMode, enabled, type, id ]
 	);
 
 	// Check Navigation Link validity if:
@@ -295,8 +295,6 @@ export default function NavigationLinkEdit( {
 	clientId,
 } ) {
 	const { id, label, type, url, description, kind } = attributes;
-
-	const [ isInvalid, isDraft ] = useIsInvalidLink( kind, type, id );
 	const { maxNestingLevel } = context;
 
 	const {
@@ -327,6 +325,7 @@ export default function NavigationLinkEdit( {
 		isAtMaxNesting,
 		isTopLevelLink,
 		isParentOfSelectedBlock,
+		isRootBlockSelected,
 		hasChildren,
 	} = useSelect(
 		( select ) => {
@@ -336,7 +335,16 @@ export default function NavigationLinkEdit( {
 				getBlockRootClientId,
 				hasSelectedInnerBlock,
 				getBlockParentsByBlockName,
+				getSelectedBlockClientId,
 			} = select( blockEditorStore );
+			const selectedBlockClientId = getSelectedBlockClientId();
+			const isRootParentSelected =
+				selectedBlockClientId && selectedBlockClientId !== clientId
+					? getBlockParentsByBlockName(
+							clientId,
+							'core/navigation'
+					  ).includes( selectedBlockClientId )
+					: false;
 
 			return {
 				isAtMaxNesting:
@@ -349,12 +357,21 @@ export default function NavigationLinkEdit( {
 					clientId,
 					true
 				),
+				isRootBlockSelected: isRootParentSelected,
 				hasChildren: !! getBlockCount( clientId ),
 			};
 		},
 		[ clientId, maxNestingLevel ]
 	);
 	const { getBlocks } = useSelect( blockEditorStore );
+
+	const [ isInvalid, isDraft ] = useIsInvalidLink(
+		kind,
+		type,
+		id,
+		// Whether block link validation is enabled.
+		isSelected || isRootBlockSelected
+	);
 
 	/**
 	 * Transform to submenu block.


### PR DESCRIPTION
## What?
Closes #42904.
Related #69627.

PR improves Navigation Link block performance when loading editors and avoids preemptively requesting item status metadata.

This approach is similar to #17504.

## Why?
See: #42904 and #69563.

## Testing Instructions
1. Create a Navigation menu with multiple links to page items.
2. Add it to the default header template part.
3. Refresh that template part in the Site Editor.
4. Inspect the network requests.
5. Confirm there are no HTTP requests made for each page item.
6. Select the parent Navigation block or individual link item.
7. Confirm that status metadata is fetched.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| ![CleanShot 2025-03-19 at 14 10 27](https://github.com/user-attachments/assets/ba3ea248-c5c1-413c-8556-438e12e9ab72) | ![CleanShot 2025-03-19 at 14 09 59](https://github.com/user-attachments/assets/ef869e7c-75fe-443e-aa13-905f3b512b2f) |
