### PR TITLE
Embed Block: Refactor setting panel to use ToolsPanel

### DIFF
--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -267,6 +267,8 @@ const EmbedEdit = ( props ) => {
 				allowResponsive={ allowResponsive }
 				toggleResponsive={ toggleResponsive }
 				switchBackToURLInput={ () => setIsEditingURL( true ) }
+				html={ preview.html }
+				{ ...props }
 			/>
 			<figure
 				{ ...blockProps }

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -118,11 +118,9 @@ const EmbedEdit = ( props ) => {
 			responsive
 		);
 
-	const toggleResponsive = () => {
-		const { allowResponsive, className } = attributes;
+	function toggleResponsive( newAllowResponsive ) {
+		const { className } = attributes;
 		const { html } = preview;
-		const newAllowResponsive = ! allowResponsive;
-
 		setAttributes( {
 			allowResponsive: newAllowResponsive,
 			className: getClassNames(
@@ -131,7 +129,7 @@ const EmbedEdit = ( props ) => {
 				responsive && newAllowResponsive
 			),
 		} );
-	};
+	}
 
 	useEffect( () => {
 		if ( preview?.html || ! cannotEmbed || ! hasResolved ) {
@@ -267,8 +265,6 @@ const EmbedEdit = ( props ) => {
 				allowResponsive={ allowResponsive }
 				toggleResponsive={ toggleResponsive }
 				switchBackToURLInput={ () => setIsEditingURL( true ) }
-				html={ preview.html }
-				{ ...props }
 			/>
 			<figure
 				{ ...blockProps }

--- a/packages/block-library/src/embed/embed-controls.js
+++ b/packages/block-library/src/embed/embed-controls.js
@@ -67,7 +67,7 @@ const EmbedControls = ( {
 								! allowResponsive || ! blockSupportsResponsive
 							}
 							onDeselect={ () => {
-								toggleResponsive( true );
+								toggleResponsive( ! allowResponsive );
 							} }
 						>
 							<ToggleControl

--- a/packages/block-library/src/embed/embed-controls.js
+++ b/packages/block-library/src/embed/embed-controls.js
@@ -56,7 +56,7 @@ const EmbedControls = ( {
 					<ToolsPanel
 						label={ __( 'Media settings' ) }
 						resetAll={ () => {
-							toggleResponsive( ! allowResponsive );
+							toggleResponsive( true );
 						} }
 						dropdownMenuProps={ dropdownMenuProps }
 					>

--- a/packages/block-library/src/embed/embed-controls.js
+++ b/packages/block-library/src/embed/embed-controls.js
@@ -63,9 +63,7 @@ const EmbedControls = ( {
 						<ToolsPanelItem
 							label={ __( 'Media settings' ) }
 							isShownByDefault
-							hasValue={ () =>
-								! allowResponsive || ! blockSupportsResponsive
-							}
+							hasValue={ () => ! allowResponsive }
 							onDeselect={ () => {
 								toggleResponsive( ! allowResponsive );
 							} }

--- a/packages/block-library/src/embed/embed-controls.js
+++ b/packages/block-library/src/embed/embed-controls.js
@@ -75,9 +75,7 @@ const EmbedControls = ( {
 								label={ __( 'Resize for smaller devices' ) }
 								checked={ allowResponsive }
 								help={ getResponsiveHelp }
-								onChange={ ( v ) => {
-									toggleResponsive( v );
-								} }
+								onChange={ toggleResponsive }
 							/>
 						</ToolsPanelItem>
 					</ToolsPanel>

--- a/packages/block-library/src/embed/embed-controls.js
+++ b/packages/block-library/src/embed/embed-controls.js
@@ -16,7 +16,6 @@ import { edit } from '@wordpress/icons';
  * Internal dependencies
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
-import { getClassNames } from './util';
 
 function getResponsiveHelp( checked ) {
 	return checked
@@ -35,13 +34,8 @@ const EmbedControls = ( {
 	allowResponsive,
 	toggleResponsive,
 	switchBackToURLInput,
-	html,
-	attributes,
-	setAttributes,
 } ) => {
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
-	const { responsive, className } = attributes;
-	const newAllowResponsive = ! allowResponsive;
 
 	return (
 		<>
@@ -62,40 +56,28 @@ const EmbedControls = ( {
 					<ToolsPanel
 						label={ __( 'Media settings' ) }
 						resetAll={ () => {
-							setAttributes( {
-								allowResponsive: true,
-								className: getClassNames(
-									html,
-									className,
-									responsive && newAllowResponsive
-								),
-								responsive: true,
-							} );
+							toggleResponsive( ! allowResponsive );
 						} }
 						dropdownMenuProps={ dropdownMenuProps }
 					>
 						<ToolsPanelItem
 							label={ __( 'Media settings' ) }
 							isShownByDefault
-							hasValue={ () => ! allowResponsive || ! responsive }
-							onDeselect={ () =>
-								setAttributes( {
-									allowResponsive: true,
-									className: getClassNames(
-										html,
-										className,
-										responsive && newAllowResponsive
-									),
-									responsive: true,
-								} )
+							hasValue={ () =>
+								! allowResponsive || ! blockSupportsResponsive
 							}
+							onDeselect={ () => {
+								toggleResponsive( true );
+							} }
 						>
 							<ToggleControl
 								__nextHasNoMarginBottom
 								label={ __( 'Resize for smaller devices' ) }
 								checked={ allowResponsive }
 								help={ getResponsiveHelp }
-								onChange={ toggleResponsive }
+								onChange={ ( v ) => {
+									toggleResponsive( v );
+								} }
 							/>
 						</ToolsPanelItem>
 					</ToolsPanel>

--- a/packages/block-library/src/embed/embed-controls.js
+++ b/packages/block-library/src/embed/embed-controls.js
@@ -4,12 +4,19 @@
 import { __ } from '@wordpress/i18n';
 import {
 	ToolbarButton,
-	PanelBody,
 	ToggleControl,
 	ToolbarGroup,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
 import { edit } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+import { getClassNames } from './util';
 
 function getResponsiveHelp( checked ) {
 	return checked
@@ -28,37 +35,74 @@ const EmbedControls = ( {
 	allowResponsive,
 	toggleResponsive,
 	switchBackToURLInput,
-} ) => (
-	<>
-		<BlockControls>
-			<ToolbarGroup>
-				{ showEditButton && (
-					<ToolbarButton
-						className="components-toolbar__control"
-						label={ __( 'Edit URL' ) }
-						icon={ edit }
-						onClick={ switchBackToURLInput }
-					/>
-				) }
-			</ToolbarGroup>
-		</BlockControls>
-		{ themeSupportsResponsive && blockSupportsResponsive && (
-			<InspectorControls>
-				<PanelBody
-					title={ __( 'Media settings' ) }
-					className="blocks-responsive"
-				>
-					<ToggleControl
-						__nextHasNoMarginBottom
-						label={ __( 'Resize for smaller devices' ) }
-						checked={ allowResponsive }
-						help={ getResponsiveHelp }
-						onChange={ toggleResponsive }
-					/>
-				</PanelBody>
-			</InspectorControls>
-		) }
-	</>
-);
+	html,
+	attributes,
+	setAttributes,
+} ) => {
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+	const { responsive, className } = attributes;
+	const newAllowResponsive = ! allowResponsive;
+
+	return (
+		<>
+			<BlockControls>
+				<ToolbarGroup>
+					{ showEditButton && (
+						<ToolbarButton
+							className="components-toolbar__control"
+							label={ __( 'Edit URL' ) }
+							icon={ edit }
+							onClick={ switchBackToURLInput }
+						/>
+					) }
+				</ToolbarGroup>
+			</BlockControls>
+			{ themeSupportsResponsive && blockSupportsResponsive && (
+				<InspectorControls>
+					<ToolsPanel
+						label={ __( 'Media settings' ) }
+						resetAll={ () => {
+							setAttributes( {
+								allowResponsive: true,
+								className: getClassNames(
+									html,
+									className,
+									responsive && newAllowResponsive
+								),
+								responsive: true,
+							} );
+						} }
+						dropdownMenuProps={ dropdownMenuProps }
+					>
+						<ToolsPanelItem
+							label={ __( 'Media settings' ) }
+							isShownByDefault
+							hasValue={ () => ! allowResponsive || ! responsive }
+							onDeselect={ () =>
+								setAttributes( {
+									allowResponsive: true,
+									className: getClassNames(
+										html,
+										className,
+										responsive && newAllowResponsive
+									),
+									responsive: true,
+								} )
+							}
+						>
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={ __( 'Resize for smaller devices' ) }
+								checked={ allowResponsive }
+								help={ getResponsiveHelp }
+								onChange={ toggleResponsive }
+							/>
+						</ToolsPanelItem>
+					</ToolsPanel>
+				</InspectorControls>
+			) }
+		</>
+	);
+};
 
 export default EmbedControls;


### PR DESCRIPTION
## What?
Part of #67813

Make the settings panel more consistent with other blocks

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a embed block
3. Open the settings panel
4. You can see that you can set it up just like before Media settings.

```HTML
<!-- wp:embed /-->

<!-- wp:embed {"url":"https://www.youtube.com/watch?v=Ok6JKHMAkH8\u0026t","type":"video","providerNameSlug":"youtube","responsive":true,"className":"add wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube add wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
https://www.youtube.com/watch?v=Ok6JKHMAkH8&amp;t
</div></figure>
<!-- /wp:embed -->

<!-- wp:embed {"url":"https://twitter.com/WordPress/status/1902028052193792485","type":"rich","providerNameSlug":"twitter","responsive":true,"className":"add"} -->
<figure class="wp-block-embed is-type-rich is-provider-twitter wp-block-embed-twitter add"><div class="wp-block-embed__wrapper">
https://twitter.com/WordPress/status/1902028052193792485
</div></figure>
<!-- /wp:embed -->

<!-- wp:embed {"url":"https://wordpress.org/about/","type":"wp-embed","providerNameSlug":"wordpress-org"} -->
<figure class="wp-block-embed is-type-wp-embed is-provider-wordpress-org wp-block-embed-wordpress-org"><div class="wp-block-embed__wrapper">
https://wordpress.org/about/
</div></figure>
<!-- /wp:embed -->
```

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### before

https://github.com/user-attachments/assets/ac753c23-ab44-4c2f-a531-3496d47d283e

### after

https://github.com/user-attachments/assets/4aecf891-2fd3-4f7a-a72c-49983c34cee7

