### PR TITLE
UI Components: Add theme support for `FormTokenField` and `ComboboxControl`

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -151,10 +151,10 @@
 }
 
 
-@mixin input-style__focus() {
-	border-color: var(--wp-admin-theme-color);
+@mixin input-style__focus($accent-color: var(--wp-admin-theme-color)) {
+	border-color: $accent-color;
 	// Expand the default border focus style by .5px to be a total of 1.5px.
-	box-shadow: 0 0 0 0.5px var(--wp-admin-theme-color);
+	box-shadow: 0 0 0 0.5px $accent-color;
 	// Windows High Contrast mode will show this outline, but not the box-shadow.
 	outline: 2px solid transparent;
 }

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -259,7 +259,7 @@
 	}
 }
 
-@mixin input-control {
+@mixin input-control($accent-color: var(--wp-admin-theme-color)) {
 	font-family: $default-font;
 	padding: 6px 8px;
 	@include input-style__neutral();
@@ -275,7 +275,7 @@
 	}
 
 	&:focus {
-		@include input-style__focus();
+		@include input-style__focus($accent-color);
 	}
 
 	// Use opacity to work in various editor styles.

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 -   `Button`: Fix tertiary variant displaying incorrect text color in pressed and hover states ([#68542](https://github.com/WordPress/gutenberg/pull/68542)).
 
+### Enhancement
+
+-   `FormTokenField`: Add theming support ([#69638](https://github.com/WordPress/gutenberg/pull/69638)).
+-   `ComboboxControl`: Add theming support ([#69638](https://github.com/WordPress/gutenberg/pull/69638)).
+
 ## 29.7.0 (2025-03-27)
 
 ### Bug Fixes
@@ -15,11 +20,6 @@
 -   `CustomSelectControl`: Fix check icon color to adapt with dark theme ([#69626](https://github.com/WordPress/gutenberg/pull/69626)).
 -   `Autocomplete`: Extracts `getNodeText` function into a separate file and adds unit tests ([#69135](https://github.com/WordPress/gutenberg/pull/69135)).
 -   `NumberControl`: update stepping to match HTML number input stepping ([#34566](https://github.com/WordPress/gutenberg/pull/34566)).
-
-### Enhancement
-
--   `FormTokenField`: Add theming support ([#69638](https://github.com/WordPress/gutenberg/pull/69638)).
--   `ComboboxControl`: Add theming support ([#69638](https://github.com/WordPress/gutenberg/pull/69638)).
 
 ## 29.6.0 (2025-03-13)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -18,8 +18,8 @@
 
 ### Enhancement
 
--	`FormTokenField`: Add theming support ([#69638](https://github.com/WordPress/gutenberg/pull/69638)).
--	`ComboboxControl`: Add theming support ([#69638](https://github.com/WordPress/gutenberg/pull/69638)).
+-   `FormTokenField`: Add theming support ([#69638](https://github.com/WordPress/gutenberg/pull/69638)).
+-   `ComboboxControl`: Add theming support ([#69638](https://github.com/WordPress/gutenberg/pull/69638)).
 
 ## 29.6.0 (2025-03-13)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -16,6 +16,11 @@
 -   `Autocomplete`: Extracts `getNodeText` function into a separate file and adds unit tests ([#69135](https://github.com/WordPress/gutenberg/pull/69135)).
 -   `NumberControl`: update stepping to match HTML number input stepping ([#34566](https://github.com/WordPress/gutenberg/pull/34566)).
 
+### Enhancement
+
+-	`FormTokenField`: Add theming support ([#69638](https://github.com/WordPress/gutenberg/pull/69638)).
+-	`ComboboxControl`: Add theming support ([#69638](https://github.com/WordPress/gutenberg/pull/69638)).
+
 ## 29.6.0 (2025-03-13)
 
 ### Enhancement

--- a/packages/components/src/combobox-control/style.scss
+++ b/packages/components/src/combobox-control/style.scss
@@ -12,6 +12,8 @@ input.components-combobox-control__input[type="text"] {
 	margin: 0;
 	line-height: inherit;
 	min-height: auto;
+	background: inherit;
+	color: $components-color-foreground;
 
 	// Resolves Zooming on iOS devices
 	// https://github.com/WordPress/gutenberg/issues/27405
@@ -34,7 +36,10 @@ input.components-combobox-control__input[type="text"] {
 	padding: 0;
 
 	&:focus-within {
-		@include input-style__focus();
+		border-color: $components-color-accent;
+		box-shadow: 0 0 0 0.5px $components-color-accent;
+		outline: 2px solid transparent;
+		outline-offset: -2px;
 	}
 
 	.components-spinner {

--- a/packages/components/src/combobox-control/style.scss
+++ b/packages/components/src/combobox-control/style.scss
@@ -12,7 +12,7 @@ input.components-combobox-control__input[type="text"] {
 	margin: 0;
 	line-height: inherit;
 	min-height: auto;
-	background: inherit;
+	background: $components-color-background;
 	color: $components-color-foreground;
 
 	// Resolves Zooming on iOS devices
@@ -36,10 +36,7 @@ input.components-combobox-control__input[type="text"] {
 	padding: 0;
 
 	&:focus-within {
-		border-color: $components-color-accent;
-		box-shadow: 0 0 0 0.5px $components-color-accent;
-		outline: 2px solid transparent;
-		outline-offset: -2px;
+		@include input-style__focus($components-color-accent);
 	}
 
 	.components-spinner {

--- a/packages/components/src/combobox-control/style.scss
+++ b/packages/components/src/combobox-control/style.scss
@@ -28,7 +28,7 @@ input.components-combobox-control__input[type="text"] {
 }
 
 .components-combobox-control__suggestions-container {
-	@include input-control;
+	@include input-control($components-color-accent);
 	display: flex;
 	flex-wrap: wrap;
 	align-items: flex-start;

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -10,7 +10,10 @@
 	}
 
 	&.is-active {
-		@include input-style__focus();
+		border-color: $components-color-accent;
+		box-shadow: 0 0 0 0.5px $components-color-accent;
+		outline: 2px solid transparent;
+		outline-offset: -2px;
 	}
 
 	// Token input
@@ -27,7 +30,7 @@
 		min-width: 50px;
 		background: inherit;
 		border: 0;
-		color: $gray-900;
+		color: $components-color-foreground;
 		box-shadow: none;
 
 		// Resolves Zooming on iOS devices
@@ -168,7 +171,7 @@
 }
 
 .components-form-token-field__suggestion {
-	color: $gray-900;
+	color: $components-color-foreground;
 	display: block;
 	font-size: $default-font-size;
 	padding: $grid-unit-10 $grid-unit-15;
@@ -178,7 +181,7 @@
 
 	&.is-selected {
 		background: $components-color-accent;
-		color: $white;
+		color: $components-color-foreground-inverted;
 	}
 
 	&[aria-disabled="true"] {

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -10,10 +10,7 @@
 	}
 
 	&.is-active {
-		border-color: $components-color-accent;
-		box-shadow: 0 0 0 0.5px $components-color-accent;
-		outline: 2px solid transparent;
-		outline-offset: -2px;
+		@include input-style__focus($components-color-accent);
 	}
 
 	// Token input

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -1,5 +1,5 @@
 .components-form-token-field__input-container {
-	@include input-control();
+	@include input-control($components-color-accent);
 	width: 100%;
 	padding: 0;
 	cursor: text;


### PR DESCRIPTION
## What?
Part of https://github.com/WordPress/gutenberg/issues/69646
Follow up to https://github.com/WordPress/gutenberg/pull/69621
Related: https://github.com/WordPress/gutenberg/issues/69593#issuecomment-2729413510

This PR introduces theming support for the `FormTokenField` and `ComboboxControl` components.

## Why?

Previously, these components lacked dynamic theming, causing visibility issues in dark mode. This update ensures proper theme adaptation for improved readability and user experience.

## How?

The corresponding SCSS files have been updated to use theming.

## Testing Instructions
1. Run storybook locally. (`npm run storybook:dev`)
2. Navigate to the `FormTokenField` component. 
3. Change the theme and confirm that there are no visibility issues.
4. Navigate to the `ComboboxControl` component, and repeat step 3.

### Testing Instructions for Keyboard
Same

## Screenshots

### Combobox

|Before|After|
|-|-|
|![combobox-default-before](https://github.com/user-attachments/assets/ddcb188f-38f5-4135-8196-1a73126c2250)|![combobox-default-after](https://github.com/user-attachments/assets/e6f2144e-8f77-4d9a-a960-016f76dcc0b3)|
|![combobox-dark-before](https://github.com/user-attachments/assets/c5a67b7e-0aea-44aa-8b6f-35211f34d719)|![combobox-dark-after](https://github.com/user-attachments/assets/71c9cac6-c1f4-4db0-bb6a-4fab7111aa10)|

### FormTokenField

|Before|After|
|-|-|
|![formtoken-default-before](https://github.com/user-attachments/assets/10872a47-0676-46c9-af2f-a7952b78ed0b)|![formtokenfield-default-after](https://github.com/user-attachments/assets/acf47233-06cc-4da5-ac45-c8ab26348026)|
|![formtoken-dark-before](https://github.com/user-attachments/assets/fa26fb60-dcda-4a26-bb62-6ebb790e6aff)|![formtokenfield-dark-after](https://github.com/user-attachments/assets/11f0b53d-41b6-4f15-8e18-617a48f2637c)|





