### PR TITLE
Components: Fix Styling for `TextControl`and `TextAreaControl` in dark themes

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 -   `Guide`: Make next and previous button text customizable ([#69907](https://github.com/WordPress/gutenberg/pull/69907)).
 -   `Popover`: Introduce a virtual padding of `8px` to prevent it from hitting the viewport edge ([#69555](https://github.com/WordPress/gutenberg/pull/69555)).
+-   `TextControl`: Add theming support ([#69640](https://github.com/WordPress/gutenberg/pull/69640)).
+-   `TextAreaControl`: Add theming support ([#69640](https://github.com/WordPress/gutenberg/pull/69640)).
 
 ### Bug Fixes
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -49,11 +49,6 @@
 -   `Autocomplete`: Extracts `getNodeText` function into a separate file and adds unit tests ([#69135](https://github.com/WordPress/gutenberg/pull/69135)).
 -   `NumberControl`: update stepping to match HTML number input stepping ([#34566](https://github.com/WordPress/gutenberg/pull/34566)).
 
-### Enhancement
-
--   `TextControl`: Add theming support ([#69640](https://github.com/WordPress/gutenberg/pull/69640)).
--   `TextAreaControl`: Add theming support ([#69640](https://github.com/WordPress/gutenberg/pull/69640)).
-
 ## 29.6.0 (2025-03-13)
 
 ### Enhancement

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -36,8 +36,6 @@
 -   `Popover`: improve Storybook examples around onClose and onFocusOutside props. ([#69688](https://github.com/WordPress/gutenberg/pull/69688))
 -   `FormTokenField`: Add theming support ([#69638](https://github.com/WordPress/gutenberg/pull/69638)).
 -   `ComboboxControl`: Add theming support ([#69638](https://github.com/WordPress/gutenberg/pull/69638)).
--   `TextControl`: Add theming support ([#69640](https://github.com/WordPress/gutenberg/pull/69640)).
--   `TextAreaControl`: Add theming support ([#69640](https://github.com/WordPress/gutenberg/pull/69640)).
 
 ## 29.7.0 (2025-03-27)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,7 +7,7 @@
 -   `Guide`: Make next and previous button text customizable ([#69907](https://github.com/WordPress/gutenberg/pull/69907)).
 -   `Popover`: Introduce a virtual padding of `8px` to prevent it from hitting the viewport edge ([#69555](https://github.com/WordPress/gutenberg/pull/69555)).
 -   `TextControl`: Add theming support ([#69640](https://github.com/WordPress/gutenberg/pull/69640)).
--   `TextAreaControl`: Add theming support ([#69640](https://github.com/WordPress/gutenberg/pull/69640)).
+-   `TextareaControl`: Add theming support ([#69640](https://github.com/WordPress/gutenberg/pull/69640)).
 
 ### Bug Fixes
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -36,6 +36,8 @@
 -   `Popover`: improve Storybook examples around onClose and onFocusOutside props. ([#69688](https://github.com/WordPress/gutenberg/pull/69688))
 -   `FormTokenField`: Add theming support ([#69638](https://github.com/WordPress/gutenberg/pull/69638)).
 -   `ComboboxControl`: Add theming support ([#69638](https://github.com/WordPress/gutenberg/pull/69638)).
+-   `TextControl`: Add theming support ([#69640](https://github.com/WordPress/gutenberg/pull/69640)).
+-   `TextAreaControl`: Add theming support ([#69640](https://github.com/WordPress/gutenberg/pull/69640)).
 
 ## 29.7.0 (2025-03-27)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -47,6 +47,11 @@
 -   `Autocomplete`: Extracts `getNodeText` function into a separate file and adds unit tests ([#69135](https://github.com/WordPress/gutenberg/pull/69135)).
 -   `NumberControl`: update stepping to match HTML number input stepping ([#34566](https://github.com/WordPress/gutenberg/pull/34566)).
 
+### Enhancement
+
+-   `TextControl`: Add theming support ([#69640](https://github.com/WordPress/gutenberg/pull/69640)).
+-   `TextAreaControl`: Add theming support ([#69640](https://github.com/WordPress/gutenberg/pull/69640)).
+
 ## 29.6.0 (2025-03-13)
 
 ### Enhancement

--- a/packages/components/src/text-control/style.scss
+++ b/packages/components/src/text-control/style.scss
@@ -29,6 +29,13 @@
 		padding-left: $grid-unit-15;
 		padding-right: $grid-unit-15;
 	}
+
+	&:focus {
+		border-color: $components-color-accent;
+		box-shadow: 0 0 0 1.5px $components-color-accent;
+		// Windows High Contrast mode will show this outline, but not the box-shadow.
+		outline: 5px solid transparent;
+	}
 }
 
 .components-text-control__input[type="email"],

--- a/packages/components/src/text-control/style.scss
+++ b/packages/components/src/text-control/style.scss
@@ -16,6 +16,7 @@
 	height: $grid-unit-40;
 	// Override input style margin in WP forms.css.
 	margin: 0;
+	background-color: transparent;
 	@include input-control;
 
 	&.is-next-40px-default-size {

--- a/packages/components/src/text-control/style.scss
+++ b/packages/components/src/text-control/style.scss
@@ -16,7 +16,8 @@
 	height: $grid-unit-40;
 	// Override input style margin in WP forms.css.
 	margin: 0;
-	background-color: transparent;
+	background: transparent;
+	color: $components-color-foreground;
 	@include input-control;
 
 	&.is-next-40px-default-size {

--- a/packages/components/src/text-control/style.scss
+++ b/packages/components/src/text-control/style.scss
@@ -32,7 +32,7 @@
 
 	&:focus {
 		border-color: $components-color-accent;
-		box-shadow: 0 0 0 1.5px $components-color-accent;
+		box-shadow: 0 0 0 0.5px $components-color-accent;
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 5px solid transparent;
 	}

--- a/packages/components/src/text-control/style.scss
+++ b/packages/components/src/text-control/style.scss
@@ -31,10 +31,7 @@
 	}
 
 	&:focus {
-		border-color: $components-color-accent;
-		box-shadow: 0 0 0 0.5px $components-color-accent;
-		// Windows High Contrast mode will show this outline, but not the box-shadow.
-		outline: 5px solid transparent;
+		@include input-style__focus( $components-color-accent);
 	}
 }
 

--- a/packages/components/src/text-control/style.scss
+++ b/packages/components/src/text-control/style.scss
@@ -18,7 +18,7 @@
 	margin: 0;
 	background: $components-color-background;
 	color: $components-color-foreground;
-	@include input-control;
+	@include input-control( $components-color-accent);
 
 	&.is-next-40px-default-size {
 		height: $grid-unit-50;
@@ -28,10 +28,6 @@
 		// These values should be shared with the `controlPaddingX` in ./utils/config-values.js
 		padding-left: $grid-unit-15;
 		padding-right: $grid-unit-15;
-	}
-
-	&:focus {
-		@include input-style__focus( $components-color-accent);
 	}
 }
 

--- a/packages/components/src/text-control/style.scss
+++ b/packages/components/src/text-control/style.scss
@@ -16,7 +16,7 @@
 	height: $grid-unit-40;
 	// Override input style margin in WP forms.css.
 	margin: 0;
-	background: transparent;
+	background: $components-color-background;
 	color: $components-color-foreground;
 	@include input-control;
 

--- a/packages/components/src/textarea-control/styles/textarea-control-styles.ts
+++ b/packages/components/src/textarea-control/styles/textarea-control-styles.ts
@@ -37,7 +37,7 @@ export const StyledTextarea = styled.textarea`
 	display: block;
 	font-family: ${ font( 'default.fontFamily' ) };
 	line-height: 20px;
-	background: transparent;
+	background: ${ COLORS.theme.background };
 	color: ${ COLORS.theme.foreground };
 
 	// Vertical padding is to match the standard 40px control height when rows=1,

--- a/packages/components/src/textarea-control/styles/textarea-control-styles.ts
+++ b/packages/components/src/textarea-control/styles/textarea-control-styles.ts
@@ -37,6 +37,8 @@ export const StyledTextarea = styled.textarea`
 	display: block;
 	font-family: ${ font( 'default.fontFamily' ) };
 	line-height: 20px;
+	background: transparent;
+	color: ${ COLORS.theme.foreground };
 
 	// Vertical padding is to match the standard 40px control height when rows=1,
 	// in conjunction with the 20px line-height.

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -205,7 +205,7 @@
 
 				.components-textarea-control__input {
 					flex: 1 1 auto;
-					background-color: transparent;
+					background-color: $components-color-background;
 
 					// CSS input is always LTR regardless of language.
 					/*rtl:ignore*/

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -205,6 +205,8 @@
 
 				.components-textarea-control__input {
 					flex: 1 1 auto;
+					background-color: transparent;
+
 					// CSS input is always LTR regardless of language.
 					/*rtl:ignore*/
 					direction: ltr;

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -205,7 +205,6 @@
 
 				.components-textarea-control__input {
 					flex: 1 1 auto;
-					background-color: $components-color-background;
 
 					// CSS input is always LTR regardless of language.
 					/*rtl:ignore*/

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -205,7 +205,6 @@
 
 				.components-textarea-control__input {
 					flex: 1 1 auto;
-
 					// CSS input is always LTR regardless of language.
 					/*rtl:ignore*/
 					direction: ltr;


### PR DESCRIPTION


## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/69639

This PR introduces theming support for the `TextControl` and `TextAreaControl` components.


## Why?
This enhancement is necessary because the previous fixed styling approach left components visually inaccessible in dark mode environments, creating poor contrast and readability issues that compromised user experience.

## How?
The corresponding SCSS files have been updated to use theming.


## Testing Instructions

1. Run storybook locally. (npm run storybook:dev)
2. Navigate to the TextControl component.
3. Change the theme and confirm that there are no visibility issues.
4. Navigate to the TextAreaControl component, and repeat step 3.


## Screenshots



### TextControl
#### Light mode


|Before|After|
|-|-|
|<img width="608" alt="image" src="https://github.com/user-attachments/assets/9aedf5b9-166c-4ad9-99d8-a71ae428cc54" />|<img width="609" alt="image" src="https://github.com/user-attachments/assets/5adc95bf-e078-45bb-8b33-94077e4cb138" />|

#### Dark mode

|Before|After|
|-|-|
|<img width="607" alt="image" src="https://github.com/user-attachments/assets/3be66133-d196-4caf-aad5-159332ff86cb" />|<img width="602" alt="image" src="https://github.com/user-attachments/assets/95157951-a75f-42fb-a814-c9d09a97a755" />|



### TextAreaControl

#### Light mode

|Before|After|
|-|-|
|<img width="518" alt="image" src="https://github.com/user-attachments/assets/8b747776-7d22-41cf-8db9-2206cf8d1e09" />|<img width="526" alt="image" src="https://github.com/user-attachments/assets/b051b011-1471-4131-8b3c-587c8da0f181" />|

#### Dark mode

|Before|After|
|-|-|
|<img width="525" alt="image" src="https://github.com/user-attachments/assets/d2ad4f2e-0cad-46fd-a3c5-b8e89516a86d" />|<img width="607" alt="Screenshot 2025-03-20 at 7 22 26 PM" src="https://github.com/user-attachments/assets/47a50a11-0db3-4c2f-a2d1-c507e950530a" />|
