### PR TITLE
RSS Block: Add option to open links in new tab/window and control rel attributes

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -812,7 +812,7 @@ Display entries from any RSS or Atom feed. ([Source](https://github.com/WordPres
 -	**Name:** core/rss
 -	**Category:** widgets
 -	**Supports:** align, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), ~~html~~
--	**Attributes:** addNofollow, additionalRelAttributes, blockLayout, columns, displayAuthor, displayDate, displayExcerpt, excerptLength, feedURL, itemsToShow, openInNewTab
+-	**Attributes:** blockLayout, columns, displayAuthor, displayDate, displayExcerpt, excerptLength, feedURL, itemsToShow, linkRel, openInNewTab
 
 ## Search
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -812,7 +812,7 @@ Display entries from any RSS or Atom feed. ([Source](https://github.com/WordPres
 -	**Name:** core/rss
 -	**Category:** widgets
 -	**Supports:** align, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), ~~html~~
--	**Attributes:** blockLayout, columns, displayAuthor, displayDate, displayExcerpt, excerptLength, feedURL, itemsToShow, linkRel, openInNewTab
+-	**Attributes:** blockLayout, columns, displayAuthor, displayDate, displayExcerpt, excerptLength, feedURL, itemsToShow, openInNewTab, rel
 
 ## Search
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -812,7 +812,7 @@ Display entries from any RSS or Atom feed. ([Source](https://github.com/WordPres
 -	**Name:** core/rss
 -	**Category:** widgets
 -	**Supports:** align, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), ~~html~~
--	**Attributes:** blockLayout, columns, displayAuthor, displayDate, displayExcerpt, excerptLength, feedURL, itemsToShow
+-	**Attributes:** addNofollow, additionalRelAttributes, blockLayout, columns, displayAuthor, displayDate, displayExcerpt, excerptLength, feedURL, itemsToShow, openInNewTab
 
 ## Search
 

--- a/packages/block-library/src/rss/block.json
+++ b/packages/block-library/src/rss/block.json
@@ -44,11 +44,7 @@
 			"type": "boolean",
 			"default": false
 		},
-		"addNofollow": {
-			"type": "boolean",
-			"default": false
-		},
-		"additionalRelAttributes": {
+		"linkRel": {
 			"type": "string",
 			"default": ""
 		}

--- a/packages/block-library/src/rss/block.json
+++ b/packages/block-library/src/rss/block.json
@@ -44,9 +44,8 @@
 			"type": "boolean",
 			"default": false
 		},
-		"linkRel": {
-			"type": "string",
-			"default": ""
+		"rel": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/rss/block.json
+++ b/packages/block-library/src/rss/block.json
@@ -39,6 +39,18 @@
 		"excerptLength": {
 			"type": "number",
 			"default": 55
+		},
+		"openInNewTab": {
+			"type": "boolean",
+			"default": false
+		},
+		"addNofollow": {
+			"type": "boolean",
+			"default": false
+		},
+		"additionalRelAttributes": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -37,6 +37,9 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 		excerptLength,
 		feedURL,
 		itemsToShow,
+		openInNewTab,
+		addNofollow,
+		additionalRelAttributes,
 	} = attributes;
 
 	function toggleAttribute( propName ) {
@@ -197,6 +200,35 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 							required
 						/>
 					) }
+				</PanelBody>
+				<PanelBody title={ __( 'Link Settings' ) }>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Open links in new tab' ) }
+						checked={ openInNewTab }
+						onChange={ ( value ) =>
+							setAttributes( { openInNewTab: value } )
+						}
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Add nofollow to links' ) }
+						checked={ addNofollow }
+						onChange={ ( value ) =>
+							setAttributes( { addNofollow: value } )
+						}
+					/>
+					<InputControl
+						__next40pxDefaultSize
+						label={ __( 'Additional rel attributes' ) }
+						help={ __(
+							'Space-separated list of rel attributes (e.g., "sponsored ugc")'
+						) }
+						value={ additionalRelAttributes }
+						onChange={ ( value ) =>
+							setAttributes( { additionalRelAttributes: value } )
+						}
+					/>
 				</PanelBody>
 			</InspectorControls>
 			<div { ...blockProps }>

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -200,8 +200,7 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 							required
 						/>
 					) }
-				</PanelBody>
-				<PanelBody title={ __( 'Link Settings' ) }>
+
 					<ToggleControl
 						__nextHasNoMarginBottom
 						label={ __( 'Open links in new tab' ) }

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -14,6 +14,7 @@ import {
 	RangeControl,
 	ToggleControl,
 	ToolbarGroup,
+	TextControl,
 	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
@@ -38,7 +39,7 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 		feedURL,
 		itemsToShow,
 		openInNewTab,
-		linkRel,
+		rel,
 	} = attributes;
 
 	function toggleAttribute( propName ) {
@@ -208,18 +209,16 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 							setAttributes( { openInNewTab: value } )
 						}
 					/>
-					<InputControl
-						__next40pxDefaultSize
-						label={ __( 'Rel Attributes' ) }
-						help={ __(
-							'Space-separated list of rel attributes (e.g., "nofollow sponsored")'
-						) }
-						value={ linkRel }
-						onChange={ ( value ) =>
-							setAttributes( { linkRel: value } )
-						}
-					/>
 				</PanelBody>
+			</InspectorControls>
+			<InspectorControls group="advanced">
+				<TextControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ __( 'Link rel' ) }
+					value={ rel || '' }
+					onChange={ ( value ) => setAttributes( { rel: value } ) }
+				/>
 			</InspectorControls>
 			<div { ...blockProps }>
 				<Disabled>

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -38,8 +38,7 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 		feedURL,
 		itemsToShow,
 		openInNewTab,
-		addNofollow,
-		additionalRelAttributes,
+		linkRel,
 	} = attributes;
 
 	function toggleAttribute( propName ) {
@@ -209,23 +208,15 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 							setAttributes( { openInNewTab: value } )
 						}
 					/>
-					<ToggleControl
-						__nextHasNoMarginBottom
-						label={ __( 'Add nofollow to links' ) }
-						checked={ addNofollow }
-						onChange={ ( value ) =>
-							setAttributes( { addNofollow: value } )
-						}
-					/>
 					<InputControl
 						__next40pxDefaultSize
-						label={ __( 'Additional rel attributes' ) }
+						label={ __( 'Rel Attributes' ) }
 						help={ __(
-							'Space-separated list of rel attributes (e.g., "sponsored ugc")'
+							'Space-separated list of rel attributes (e.g., "nofollow sponsored")'
 						) }
-						value={ additionalRelAttributes }
+						value={ linkRel }
 						onChange={ ( value ) =>
-							setAttributes( { additionalRelAttributes: value } )
+							setAttributes( { linkRel: value } )
 						}
 					/>
 				</PanelBody>

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -32,26 +32,8 @@ function render_block_core_rss( $attributes ) {
 	$rss_items  = $rss->get_items( 0, $attributes['itemsToShow'] );
 	$list_items = '';
 
-	$link_attributes = '';
-	$rel_attributes  = array();
-
-	if ( ! empty( $attributes['openInNewTab'] ) ) {
-		$link_attributes .= ' target="_blank"';
-	}
-
-
-	if ( ! empty( $attributes['linkRel'] ) ) {
-		$rel_attributes = explode( ' ', $attributes['linkRel'] );
-		$rel_attributes = array_filter( array_map( 'sanitize_html_class', $rel_attributes ) );
-
-		if ( ! empty( $rel_attributes ) ) {
-			$link_attributes .= ' rel="' . esc_attr( implode( ' ', $rel_attributes ) ) . '"';
-		}
-	}
-
-	if ( ! empty( $rel_attributes ) ) {
-		$link_attributes .= ' rel="' . esc_attr( implode( ' ', array_unique( $rel_attributes ) ) ) . '"';
-	}
+	$open_in_new_tab = ! empty( $attributes['openInNewTab'] );
+	$rel             = ! empty( $attributes['rel'] ) ? trim( $attributes['rel'] ) : '';
 
 	foreach ( $rss_items as $item ) {
 		$title = esc_html( trim( strip_tags( $item->get_title() ) ) );
@@ -61,9 +43,18 @@ function render_block_core_rss( $attributes ) {
 		$link = $item->get_link();
 		$link = esc_url( $link );
 		if ( $link ) {
-			$title = "<a href='{$link}'{$link_attributes}>{$title}</a>";
+			$processor = new WP_HTML_Tag_Processor( "<a href='{$link}'>{$title}</a>" );
+			$processor->next_tag( 'a' );
+
+			if ( $open_in_new_tab ) {
+				$processor->set_attribute( 'target', '_blank' );
+				$processor->set_attribute( 'rel', trim( $rel . ' noopener nofollow' ) );
+			} elseif ( '' !== $rel ) {
+				$processor->set_attribute( 'rel', $rel );
+			}
+
+			$title = "<div class='wp-block-rss__item-title'>" . $processor->get_updated_html() . "</div>";
 		}
-		$title = "<div class='wp-block-rss__item-title'>{$title}</div>";
 
 		$date = '';
 		if ( $attributes['displayDate'] ) {

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -31,6 +31,32 @@ function render_block_core_rss( $attributes ) {
 
 	$rss_items  = $rss->get_items( 0, $attributes['itemsToShow'] );
 	$list_items = '';
+
+	$link_attributes = '';
+	$rel_attributes  = array();
+
+	if ( ! empty( $attributes['openInNewTab'] ) ) {
+		$link_attributes .= ' target="_blank"';
+		$rel_attributes[] = 'noopener noreferrer';
+	}
+
+	if ( ! empty( $attributes['addNofollow'] ) ) {
+		$rel_attributes[] = 'nofollow';
+	}
+
+	if ( ! empty( $attributes['additionalRelAttributes'] ) ) {
+		$additional_rels = explode( ' ', $attributes['additionalRelAttributes'] );
+		foreach ( $additional_rels as $rel ) {
+			if ( ! empty( trim( $rel ) ) ) {
+				$rel_attributes[] = sanitize_html_class( trim( $rel ) );
+			}
+		}
+	}
+
+	if ( ! empty( $rel_attributes ) ) {
+		$link_attributes .= ' rel="' . esc_attr( implode( ' ', array_unique( $rel_attributes ) ) ) . '"';
+	}
+
 	foreach ( $rss_items as $item ) {
 		$title = esc_html( trim( strip_tags( $item->get_title() ) ) );
 		if ( empty( $title ) ) {
@@ -39,7 +65,7 @@ function render_block_core_rss( $attributes ) {
 		$link = $item->get_link();
 		$link = esc_url( $link );
 		if ( $link ) {
-			$title = "<a href='{$link}'>{$title}</a>";
+			$title = "<a href='{$link}'{$link_attributes}>{$title}</a>";
 		}
 		$title = "<div class='wp-block-rss__item-title'>{$title}</div>";
 

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -47,11 +47,9 @@ function render_block_core_rss( $attributes ) {
 
 		if ( $open_in_new_tab ) {
 			$link_attributes .= ' target="_blank"';
+		}
 
-			if ( '' !== $rel ) {
-				$link_attributes .= ' rel="' . esc_attr( $rel ) . '"';
-			}
-		} elseif ( '' !== $rel ) {
+		if ( '' !== $rel ) {
 			$link_attributes .= ' rel="' . esc_attr( $rel ) . '"';
 		}
 

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -37,19 +37,15 @@ function render_block_core_rss( $attributes ) {
 
 	if ( ! empty( $attributes['openInNewTab'] ) ) {
 		$link_attributes .= ' target="_blank"';
-		$rel_attributes[] = 'noopener noreferrer';
 	}
 
-	if ( ! empty( $attributes['addNofollow'] ) ) {
-		$rel_attributes[] = 'nofollow';
-	}
 
-	if ( ! empty( $attributes['additionalRelAttributes'] ) ) {
-		$additional_rels = explode( ' ', $attributes['additionalRelAttributes'] );
-		foreach ( $additional_rels as $rel ) {
-			if ( ! empty( trim( $rel ) ) ) {
-				$rel_attributes[] = sanitize_html_class( trim( $rel ) );
-			}
+	if ( ! empty( $attributes['linkRel'] ) ) {
+		$rel_attributes = explode( ' ', $attributes['linkRel'] );
+		$rel_attributes = array_filter( array_map( 'sanitize_html_class', $rel_attributes ) );
+
+		if ( ! empty( $rel_attributes ) ) {
+			$link_attributes .= ' rel="' . esc_attr( implode( ' ', $rel_attributes ) ) . '"';
 		}
 	}
 

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -37,6 +37,14 @@ function render_block_core_rss( $attributes ) {
 
 	$link_attributes = '';
 
+	if ( $open_in_new_tab ) {
+		$link_attributes .= ' target="_blank"';
+	}
+
+	if ( '' !== $rel ) {
+		$link_attributes .= ' rel="' . esc_attr( $rel ) . '"';
+	}
+
 	foreach ( $rss_items as $item ) {
 		$title = esc_html( trim( strip_tags( $item->get_title() ) ) );
 		if ( empty( $title ) ) {
@@ -44,14 +52,6 @@ function render_block_core_rss( $attributes ) {
 		}
 		$link = $item->get_link();
 		$link = esc_url( $link );
-
-		if ( $open_in_new_tab ) {
-			$link_attributes .= ' target="_blank"';
-		}
-
-		if ( '' !== $rel ) {
-			$link_attributes .= ' rel="' . esc_attr( $rel ) . '"';
-		}
 
 		if ( $link ) {
 			$title = "<a href='{$link}'{$link_attributes}>{$title}</a>";

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -35,6 +35,8 @@ function render_block_core_rss( $attributes ) {
 	$open_in_new_tab = ! empty( $attributes['openInNewTab'] );
 	$rel             = ! empty( $attributes['rel'] ) ? trim( $attributes['rel'] ) : '';
 
+	$link_attributes = '';
+
 	foreach ( $rss_items as $item ) {
 		$title = esc_html( trim( strip_tags( $item->get_title() ) ) );
 		if ( empty( $title ) ) {
@@ -42,19 +44,18 @@ function render_block_core_rss( $attributes ) {
 		}
 		$link = $item->get_link();
 		$link = esc_url( $link );
-		if ( $link ) {
-			$processor = new WP_HTML_Tag_Processor( "<a href='{$link}'>{$title}</a>" );
-			$processor->next_tag( 'a' );
 
-			if ( $open_in_new_tab ) {
-				$processor->set_attribute( 'target', '_blank' );
-				$processor->set_attribute( 'rel', trim( $rel . ' noopener nofollow' ) );
-			} elseif ( '' !== $rel ) {
-				$processor->set_attribute( 'rel', $rel );
-			}
-
-			$title = "<div class='wp-block-rss__item-title'>" . $processor->get_updated_html() . "</div>";
+		if ( $open_in_new_tab ) {
+			$link_attributes .= ' target="_blank"';
+			$link_attributes .= ' rel="' . esc_attr( trim( $rel . ' noopener nofollow' ) ) . '"';
+		} elseif ( '' !== $rel ) {
+			$link_attributes .= ' rel="' . esc_attr( trim( $rel ) ) . '"';
 		}
+
+		if ( $link ) {
+			$title = "<a href='{$link}'{$link_attributes}>{$title}</a>";
+		}
+		$title = "<div class='wp-block-rss__item-title'>{$title}</div>";
 
 		$date = '';
 		if ( $attributes['displayDate'] ) {

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -47,9 +47,12 @@ function render_block_core_rss( $attributes ) {
 
 		if ( $open_in_new_tab ) {
 			$link_attributes .= ' target="_blank"';
-			$link_attributes .= ' rel="' . esc_attr( trim( $rel . ' noopener nofollow' ) ) . '"';
+
+			if ( '' !== $rel ) {
+				$link_attributes .= ' rel="' . esc_attr( $rel ) . '"';
+			}
 		} elseif ( '' !== $rel ) {
-			$link_attributes .= ' rel="' . esc_attr( trim( $rel ) ) . '"';
+			$link_attributes .= ' rel="' . esc_attr( $rel ) . '"';
 		}
 
 		if ( $link ) {

--- a/test/integration/fixtures/blocks/core__rss.json
+++ b/test/integration/fixtures/blocks/core__rss.json
@@ -10,7 +10,8 @@
 			"displayExcerpt": true,
 			"displayAuthor": true,
 			"displayDate": true,
-			"excerptLength": 20
+			"excerptLength": 20,
+			"openInNewTab": false
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
Closes #49285

## What?
This PR adds new options to the RSS block allowing users to:

- Open RSS feed links in a new tab/window
- Add custom rel attributes to links through a simple text input

## Why?
When linking to external websites through an RSS feed, users often want the ability to:
- Open links in a new tab to keep visitors on their site
- Add rel attributes for SEO or linking purposes


## Testing Instructions
1. Add an RSS block to a post or page
2. Enter a valid RSS feed URL
3. In the block sidebar, locate the "Settings" panel
4. Toggle "Open links in new tab" to ON and verify links open in a new tab
5. Add rel attributes like "nofollow sponsored" in the "Link Rel" field in Advanced panel
6. Verify that the HTML output includes all expected attributes

## Screenshots or screencast

https://github.com/user-attachments/assets/e6a9eb15-7cf1-4774-b460-3af953e4b306

