### PR TITLE
GMT Offset Issues in RSS Block According to Trac Report 62400

### DIFF
--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -43,15 +43,18 @@ function render_block_core_rss( $attributes ) {
 		}
 		$title = "<div class='wp-block-rss__item-title'>{$title}</div>";
 
-		$date = '';
-		if ( $attributes['displayDate'] ) {
-			$date = $item->get_date( 'U' );
+		$date_markup = '';
+		if ( ! empty( $attributes['displayDate'] ) ) {
+			$timestamp = $item->get_date( 'U' );
 
-			if ( $date ) {
-				$date = sprintf(
+			if ( $timestamp ) {
+				$gmt_offset = get_option( 'gmt_offset' );
+				$timestamp += (int) ( (float) $gmt_offset * HOUR_IN_SECONDS );
+
+				$date_markup = sprintf(
 					'<time datetime="%1$s" class="wp-block-rss__item-publish-date">%2$s</time> ',
-					esc_attr( date_i18n( 'c', $date ) ),
-					esc_attr( date_i18n( get_option( 'date_format' ), $date ) )
+					esc_attr( date_i18n( 'c', $timestamp ) ),
+					esc_html( date_i18n( get_option( 'date_format' ), $timestamp ) )
 				);
 			}
 		}
@@ -85,7 +88,7 @@ function render_block_core_rss( $attributes ) {
 			$excerpt = '<div class="wp-block-rss__item-excerpt">' . esc_html( $excerpt ) . '</div>';
 		}
 
-		$list_items .= "<li class='wp-block-rss__item'>{$title}{$date}{$author}{$excerpt}</li>";
+		$list_items .= "<li class='wp-block-rss__item'>{$title}{$date_markup}{$author}{$excerpt}</li>";
 	}
 
 	$classnames = array();

--- a/phpunit/blocks/render-block-rss-test.php
+++ b/phpunit/blocks/render-block-rss-test.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Tests for core/rss Gutenberg block.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ */
+
+/**
+ * Class for testing the core/rss Gutenberg block.
+ *
+ * @group blocks
+ */
+class Tests_Blocks_Render_Rss extends WP_UnitTestCase {
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		add_filter( 'wp_feed_cache_transient_lifetime', '__return_zero' );
+		add_filter( 'pre_http_request', array( $this, 'mock_http_request' ), 10, 3 );
+	}
+
+	/**
+	 * Mock HTTP request to return test feed data.
+	 *
+	 * @ticket 62400
+	 *
+	 * @param bool|array $response The existing response or false.
+	 * @param array      $args     The request arguments.
+	 * @param string     $url      The request URL.
+	 * @return array The mocked response.
+	 */
+	public function mock_http_request( $response, $args, $url ) {
+		if ( 'https://example.com/testrss.xml' !== $url ) {
+			return $response;
+		}
+
+		return array(
+			'headers'  => array(
+				'content-type' => 'application/rss+xml; charset=UTF-8',
+			),
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			'body'     => file_get_contents( __DIR__ . '/../data/feed/feed-with-gmt-offset.xml' ),
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'cookies'  => array(),
+			'filename' => null,
+		);
+	}
+
+	/**
+	 * Sets up the "core/rss" block context for testing.
+	 * This is needed to avoid null access in WP_Block_Supports::apply_block_supports().
+	 *
+	 * @ticket 62400
+	 */
+	private function setup_block_context() {
+		$block = array(
+			'blockName' => 'core/rss',
+			'attrs'     => array(),
+		);
+
+		$wp_block_supports = WP_Block_Supports::get_instance();
+		$reflection        = new ReflectionClass( $wp_block_supports );
+		$property          = $reflection->getProperty( 'block_to_render' );
+		$property->setAccessible( true );
+		$property->setValue( $wp_block_supports, $block );
+	}
+
+	/**
+	 * Test that the date in the RSS feed is correctly rendered in the HTML.
+	 *
+	 * @ticket 62400
+	 *
+	 * @covers ::render_block_core_rss
+	 */
+	public function test_rss_date_rendering() {
+
+		update_option( 'date_format', 'F j, Y' );
+		// We set to UTC+9 to test timezone conversion.
+		update_option( 'gmt_offset', 9 );
+
+		$this->setup_block_context();
+
+		// Mock RSS Attributes.
+		$attributes = array(
+			'feedURL'        => 'https://example.com/testrss.xml',
+			'itemsToShow'    => 2,
+			'displayExcerpt' => false,
+			'displayAuthor'  => false,
+			'displayDate'    => true,
+			'blockLayout'    => 'list',
+		);
+
+		$rendered_html = render_block_core_rss( $attributes );
+
+		$this->assertStringContainsString( '<time datetime=', $rendered_html, 'No time element found in rendered HTML' );
+
+		$this->assertStringContainsString( 'March 19, 2025', $rendered_html, 'Formatted date not found in rendered HTML' );
+
+		$this->assertMatchesRegularExpression( '/<time datetime="[^"]*2025-03-19[^"]*"/', $rendered_html, 'ISO datetime format missing expected date' );
+	}
+}

--- a/phpunit/blocks/render-block-rss-test.php
+++ b/phpunit/blocks/render-block-rss-test.php
@@ -77,7 +77,7 @@ class Tests_Blocks_Render_Rss extends WP_UnitTestCase {
 	 *
 	 * @ticket 62400
 	 *
-	 * @covers ::render_block_core_rss
+	 * @covers ::gutenberg_render_block_core_rss
 	 */
 	public function test_rss_date_rendering() {
 
@@ -97,7 +97,7 @@ class Tests_Blocks_Render_Rss extends WP_UnitTestCase {
 			'blockLayout'    => 'list',
 		);
 
-		$rendered_html = render_block_core_rss( $attributes );
+		$rendered_html = gutenberg_render_block_core_rss( $attributes );
 
 		$this->assertStringContainsString( '<time datetime=', $rendered_html, 'No time element found in rendered HTML' );
 

--- a/phpunit/blocks/render-block-rss-test.php
+++ b/phpunit/blocks/render-block-rss-test.php
@@ -26,7 +26,7 @@ class Tests_Blocks_Render_Rss extends WP_UnitTestCase {
 	/**
 	 * Mock HTTP request to return test feed data.
 	 *
-	 * @ticket 62400
+	 * @ticket 66970
 	 *
 	 * @param bool|array $response The existing response or false.
 	 * @param array      $args     The request arguments.
@@ -57,7 +57,7 @@ class Tests_Blocks_Render_Rss extends WP_UnitTestCase {
 	 * Sets up the "core/rss" block context for testing.
 	 * This is needed to avoid null access in WP_Block_Supports::apply_block_supports().
 	 *
-	 * @ticket 62400
+	 * @ticket 66970
 	 */
 	private function setup_block_context() {
 		$block = array(
@@ -75,7 +75,7 @@ class Tests_Blocks_Render_Rss extends WP_UnitTestCase {
 	/**
 	 * Test that the date in the RSS feed is correctly rendered in the HTML.
 	 *
-	 * @ticket 62400
+	 * @ticket 66970
 	 *
 	 * @covers ::gutenberg_render_block_core_rss
 	 */

--- a/phpunit/blocks/render-block-rss-test.php
+++ b/phpunit/blocks/render-block-rss-test.php
@@ -26,8 +26,6 @@ class Tests_Blocks_Render_Rss extends WP_UnitTestCase {
 	/**
 	 * Mock HTTP request to return test feed data.
 	 *
-	 * @ticket 66970
-	 *
 	 * @param bool|array $response The existing response or false.
 	 * @param array      $args     The request arguments.
 	 * @param string     $url      The request URL.
@@ -56,8 +54,6 @@ class Tests_Blocks_Render_Rss extends WP_UnitTestCase {
 	/**
 	 * Sets up the "core/rss" block context for testing.
 	 * This is needed to avoid null access in WP_Block_Supports::apply_block_supports().
-	 *
-	 * @ticket 66970
 	 */
 	private function setup_block_context() {
 		$block = array(

--- a/phpunit/blocks/render-block-rss-test.php
+++ b/phpunit/blocks/render-block-rss-test.php
@@ -43,7 +43,7 @@ class Tests_Blocks_Render_Rss extends WP_UnitTestCase {
 				'content-type' => 'application/rss+xml; charset=UTF-8',
 			),
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-			'body'     => file_get_contents( __DIR__ . '/../data/feed/feed-with-gmt-offset.xml' ),
+			'body'     => file_get_contents( GUTENBERG_DIR_TESTDATA . 'feed/feed-with-gmt-offset.xml' ),
 			'response' => array(
 				'code'    => 200,
 				'message' => 'OK',

--- a/phpunit/data/feed/feed-with-gmt-offset.xml
+++ b/phpunit/data/feed/feed-with-gmt-offset.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:media="http://search.yahoo.com/mrss/" xmlns:fn="https://www.publishwithfoundation.com/rss/2.0" xmlns:slash="http://purl.org/rss/1.0/modules/slash/" xmlns:wfw="http://wellformedweb.org/CommentAPI/" version="2.0">
+<channel>
+<title>Test RSS Feed</title>
+<link>https://www.example.com</link>
+<atom:link href="https://www.example.com/rss.xml" rel="self" type="application/rss+xml"/>
+<description>This is a test RSS feed for unit testing.</description>
+<language>en-us</language>
+<pubDate>Wed, 19 Mar 2025 00:00:01 -0700</pubDate>
+<lastBuildDate>Wed, 19 Mar 2025 03:58:04 -0700</lastBuildDate>
+<generator>Test</generator>
+<item>
+<title>Test Article 1</title>
+<link>https://www.example.com/article1</link>
+<guid isPermaLink="true">https://www.example.com/article1</guid>
+<dc:creator>Test Author</dc:creator>
+<description>This is a test article description.</description>
+<pubDate>Thu, 10 Mar 2025 04:00:00 -0700</pubDate>
+<source url="https://www.example.com">Test Source</source>
+</item>
+<item>
+<title>Test Article 2</title>
+<link>https://www.example.com/article2</link>
+<guid isPermaLink="true">https://www.example.com/article2</guid>
+<dc:creator>Test Author 2</dc:creator>
+<description>This is another test article description.</description>
+<pubDate>Wed, 18 Mar 2025 10:30:00 -0700</pubDate>
+<source url="https://www.example.com">Test Source</source>
+</item>
+</channel>
+</rss>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #66970.

There is a Wordpress issue 
https://core.trac.wordpress.org/ticket/62400
And a PR that was sorting this
https://github.com/WordPress/wordpress-develop/pull/8543

## Why?
The code was resolved in the wordpress core repo, but then @peterwilsoncc suggested me that blocks code is going now into the Gutenberg's repo. So this is just an extension of the OG code.

## Testing Instructions
I recommend checking my testing report
https://core.trac.wordpress.org/ticket/62400#comment:21
Which led me to create this patch

Both testing instructions, and a testing report + PHP Unit tests are included in both the track report and the `wordpress-develop` repo