### PR TITLE
Fix: The List View sidebar needs a message

### DIFF
--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -13,6 +13,8 @@ import {
 } from '@wordpress/compose';
 import {
 	__experimentalTreeGrid as TreeGrid,
+	__experimentalSpacer as Spacer,
+	__experimentalText as Text,
 	VisuallyHidden,
 } from '@wordpress/components';
 import { AsyncModeProvider, useSelect } from '@wordpress/data';
@@ -342,11 +344,13 @@ function ListViewComponent(
 	// If there are no blocks to show and we're not showing the appender, instead show a message.
 	if ( ! clientIdsTree.length && ! showAppender ) {
 		return (
-			<p className="block-editor-list-view-empty">
-				{ __(
-					'No blocks added yet, open the block inserter to add one or start typing!'
-				) }
-			</p>
+			<Spacer padding={ 4 }>
+				<Text>
+					{ __(
+						'No blocks added yet, open the block inserter to add one or start typing!'
+					) }
+				</Text>
+			</Spacer>
 		);
 	}
 

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -343,7 +343,7 @@ function ListViewComponent(
 	if ( ! clientIdsTree.length && ! showAppender ) {
 		return (
 			<div className="block-editor-list-view-empty">
-				{ __( 'No block selected.' ) }
+				{ __( 'No block exists.' ) }
 			</div>
 		);
 	}

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -342,9 +342,11 @@ function ListViewComponent(
 	// If there are no blocks to show and we're not showing the appender, instead show a message.
 	if ( ! clientIdsTree.length && ! showAppender ) {
 		return (
-			<div className="block-editor-list-view-empty">
-				{ __( 'No block exists.' ) }
-			</div>
+			<p className="block-editor-list-view-empty">
+				{ __(
+					'No blocks added yet, open the block inserter to add one or start typing!'
+				) }
+			</p>
 		);
 	}
 

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -339,9 +339,13 @@ function ListViewComponent(
 		}
 	);
 
-	// If there are no blocks to show and we're not showing the appender, do not render the list view.
+	// If there are no blocks to show and we're not showing the appender, instead show a message.
 	if ( ! clientIdsTree.length && ! showAppender ) {
-		return null;
+		return (
+			<div className="block-editor-list-view-empty">
+				{ __( 'No block selected.' ) }
+			</div>
+		);
 	}
 
 	const describedById =

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -565,14 +565,6 @@ svg {
 	height: 32px;
 }
 
-.block-editor-list-view-empty {
-	display: flex;
-	justify-content: center;
-	height: 100%;
-	padding: 0 $grid-unit-60;
-	color: $gray-800;
-}
-
 .list-view-appender .block-editor-inserter__toggle {
 	background-color: $gray-900;
 	color: $white;

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -567,7 +567,6 @@ svg {
 
 .block-editor-list-view-empty {
 	display: flex;
-	align-items: center;
 	justify-content: center;
 	height: 100%;
 }

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -565,6 +565,13 @@ svg {
 	height: 32px;
 }
 
+.block-editor-list-view-empty {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+}
+
 .list-view-appender .block-editor-inserter__toggle {
 	background-color: $gray-900;
 	color: $white;

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -569,6 +569,8 @@ svg {
 	display: flex;
 	justify-content: center;
 	height: 100%;
+	padding: 0 $grid-unit-60;
+	color: $gray-800;
 }
 
 .list-view-appender .block-editor-inserter__toggle {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes https://github.com/WordPress/gutenberg/issues/69647

<!-- In a few words, what is the PR actually doing? -->

## Why?
This PR is necessary to add the 'No blocks added yet, open the block inserter to add one or start typing!' text when no block is selected in the block editor.

## How?
This PR adds the necessary text and styling required to display the above text. 

## Testing Instructions
1. Create a new post 
2. Click on Document Overview 
3. Notice that the 'List View' Tab has 'No block selected.' text when no block is selected.

## Screenshots or screencast

|Before|After|
|-|-|
| ![Screenshot 2025-03-21 at 11 30 44 AM](https://github.com/user-attachments/assets/82fe1e4d-4e49-4911-a078-d6f1eea235cf) | ![Screenshot 2025-03-26 at 9 05 37 AM](https://github.com/user-attachments/assets/0f17884f-c0e5-494e-8f8a-4fcd2af62077) |
