### PR TITLE
RSS Block: Add options to preserve source order and reverse items

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -812,7 +812,7 @@ Display entries from any RSS or Atom feed. ([Source](https://github.com/WordPres
 -	**Name:** core/rss
 -	**Category:** widgets
 -	**Supports:** align, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), ~~html~~
--	**Attributes:** blockLayout, columns, displayAuthor, displayDate, displayExcerpt, excerptLength, feedURL, itemsToShow
+-	**Attributes:** blockLayout, columns, displayAuthor, displayDate, displayExcerpt, excerptLength, feedURL, itemsToShow, preserveSourceOrder, reverseOrder
 
 ## Search
 

--- a/packages/block-library/src/rss/block.json
+++ b/packages/block-library/src/rss/block.json
@@ -39,6 +39,14 @@
 		"excerptLength": {
 			"type": "number",
 			"default": 55
+		},
+		"preserveSourceOrder": {
+			"type": "boolean",
+			"default": false
+		},
+		"reverseOrder": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -37,6 +37,8 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 		excerptLength,
 		feedURL,
 		itemsToShow,
+		preserveSourceOrder,
+		reverseOrder,
 	} = attributes;
 
 	function toggleAttribute( propName ) {
@@ -197,6 +199,22 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 							required
 						/>
 					) }
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Preserve source order' ) }
+						checked={ preserveSourceOrder }
+						onChange={ toggleAttribute( 'preserveSourceOrder' ) }
+						help={ __(
+							'Display items in the original order from the feed instead of sorting by date.'
+						) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Reverse order' ) }
+						checked={ reverseOrder }
+						onChange={ toggleAttribute( 'reverseOrder' ) }
+						help={ __( 'Display items in reverse order.' ) }
+					/>
 				</PanelBody>
 			</InspectorControls>
 			<div { ...blockProps }>

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -25,11 +25,20 @@ function render_block_core_rss( $attributes ) {
 		return '<div class="components-placeholder"><div class="notice notice-error"><strong>' . __( 'RSS Error:' ) . '</strong> ' . esc_html( $rss->get_error_message() ) . '</div></div>';
 	}
 
+	if ( isset( $attributes['preserveSourceOrder'] ) && $attributes['preserveSourceOrder'] ) {
+		$rss->enable_order_by_date( false );
+	}
+
 	if ( ! $rss->get_item_quantity() ) {
 		return '<div class="components-placeholder"><div class="notice notice-error">' . __( 'An error has occurred, which probably means the feed is down. Try again later.' ) . '</div></div>';
 	}
 
 	$rss_items  = $rss->get_items( 0, $attributes['itemsToShow'] );
+
+	if ( isset( $attributes['reverseOrder'] ) && $attributes['reverseOrder'] ) {
+		$rss_items = array_reverse( $rss_items );
+	}
+
 	$list_items = '';
 	foreach ( $rss_items as $item ) {
 		$title = esc_html( trim( strip_tags( $item->get_title() ) ) );


### PR DESCRIPTION
Closes #49207

## What?
This PR adds two new ordering options to the RSS block:

- "Preserve source order" toggle that maintains the original order from the feed
- "Reverse order" toggle that reverses the display order of feed items

## Why?
Currently, automatically reorders RSS feed items by date, which makes it difficult to:

- Maintain the original order specified by the feed source
- Display future events (like concerts, meetups, etc.) in chronological order

These new options provide users with more control over how feed items are ordered and displayed.


## Testing Instructions
1. Add an RSS block to a post or page
2. Enter a feed URL
3. Configure the block with the new options:
   - Toggle "Preserve source order" to maintain the original feed order
   - Toggle "Reverse order" to reverse the display order of items
4. Verify that the items display in the expected order based on the selected options
5. Test different combinations of both options to ensure they work together correctly

## Screenshots or screencast


https://github.com/user-attachments/assets/858e639c-74dd-4cdb-8c68-bdb876ddddbe

