### PR TITLE
PostCommentsForm: Fix submit button width regression

### DIFF
--- a/packages/block-library/src/post-comments-form/editor.scss
+++ b/packages/block-library/src/post-comments-form/editor.scss
@@ -5,3 +5,7 @@
 		pointer-events: auto;
 	}
 }
+
+.wp-block-post-comments-form input[type="submit"] {
+	width: auto;
+}

--- a/packages/block-library/src/post-comments-form/editor.scss
+++ b/packages/block-library/src/post-comments-form/editor.scss
@@ -5,7 +5,3 @@
 		pointer-events: auto;
 	}
 }
-
-.wp-block-post-comments-form input[type="submit"] {
-	width: auto;
-}

--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -82,4 +82,8 @@
 			margin-left: 0.5em;
 		}
 	}
+
+	input[type="submit"] {
+		width: auto;
+	}
 }

--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -83,6 +83,7 @@
 		}
 	}
 
+	// Override the 100% width derived from the Button block
 	input[type="submit"] {
 		width: auto;
 	}


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/69637


Fixes the regression where post comment submit button stretch to full width.

<!-- In a few words, what is the PR actually doing? -->

## Why?
In WordPress 6.8, a change to button styling (width: 100%) caused an unintended side effect on `post-comments-form`submit button, making them stretch to full width.

## How?

Adds a targeted CSS rule to specifically override the width for submit button in `post-comments-form`

## Testing Instructions

1. Add a new post
2. Add comments form block
3. Observe the button to submit the comment (it will be full width)
4. Apply this patch
5. Verify the submit button now (does not have full width) the regression has been handled.

## Screenshots or screencast 

### Before 

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/30735c24-b89a-45ec-85d8-39d858348fd1" />


### WordPress 6.7.2

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/b29908be-e907-40cc-934e-bf9cd36470a3" />

### Current PR

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/497e8e3d-64ab-4823-b32b-7a5a20a11a89" />

After this change, we would have the button's width like how it was in WordPress 6.7.2 as shown in the above 2 screenshots. I tested this at 1440px width in Chrome developer tools.

