### PR TITLE
UI Components: Add theme support for Toolbar

### DIFF
--- a/packages/components/src/toolbar/toolbar-group/style.scss
+++ b/packages/components/src/toolbar/toolbar-group/style.scss
@@ -1,7 +1,7 @@
 .components-toolbar-group {
 	min-height: $block-toolbar-height;
-	border-right: $border-width solid $gray-900;
-	background-color: $white;
+	border-right: $border-width solid $components-color-foreground;
+	background-color: $components-color-background;
 	display: inline-flex;
 	flex-shrink: 0;
 	flex-wrap: wrap;

--- a/packages/components/src/toolbar/toolbar/style.scss
+++ b/packages/components/src/toolbar/toolbar/style.scss
@@ -1,6 +1,6 @@
 .components-accessible-toolbar {
 	display: inline-flex;
-	border: $border-width solid $gray-900;
+	border: $border-width solid $components-color-foreground;
 	border-radius: $radius-small;
 	flex-shrink: 0;
 
@@ -79,7 +79,7 @@
 			}
 
 			&::before {
-				background: $gray-900;
+				background: $components-color-foreground;
 			}
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #69646  <!-- #ISSUE-NUMBER or URL -->

This PR introduces theming support for Toolbar component

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Previously the Toolbar component lacks theming support and hard to read particularly in the dark-mode.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
Run storybook locally. (npm run storybook:dev)
Navigate to the `Toolbar` component.
Change the theme and confirm that there are no visibility issues.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Same

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Default theme

|Before|After|
|-|-|
| <img width="517" alt="image" src="https://github.com/user-attachments/assets/1e9e7fdf-19f1-41f6-b831-68f0d2d70c24" /> | <img width="517" alt="image" src="https://github.com/user-attachments/assets/c9a56558-256f-4488-b0b5-8edfb0eae8fc" /> |

Dark theme

|Before|After|
|-|-|
| <img width="540" alt="image" src="https://github.com/user-attachments/assets/d477801f-87e3-49c3-9578-018ceac6552c" /> | <img width="540" alt="image" src="https://github.com/user-attachments/assets/916e7dc2-818c-48b1-b471-08ecd0876488" /> |

