### PR TITLE
Refactor "Layout" block support UI to use ToolsPanel instead of PanelBody

### DIFF
--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -13,8 +13,9 @@ import { useSelect } from '@wordpress/data';
 import {
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 	ToggleControl,
-	PanelBody,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -28,7 +29,11 @@ import { useSettings } from '../components/use-settings';
 import { getLayoutType, getLayoutTypes } from '../layouts';
 import { useBlockEditingMode } from '../components/block-editing-mode';
 import { LAYOUT_DEFINITIONS } from '../layouts/definitions';
-import { useBlockSettings, useStyleOverride } from './utils';
+import {
+	useBlockSettings,
+	useStyleOverride,
+	useToolsPanelDropdownMenuProps,
+} from './utils';
 import { unlock } from '../lock-unlock';
 
 const layoutBlockSupportKey = 'layout';
@@ -152,6 +157,7 @@ function LayoutPanelPure( {
 		};
 	}, [] );
 	const blockEditingMode = useBlockEditingMode();
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	if ( blockEditingMode !== 'default' ) {
 		return null;
@@ -225,12 +231,48 @@ function LayoutPanelPure( {
 	const onChangeLayout = ( newLayout ) =>
 		setAttributes( { layout: newLayout } );
 
+	// Generate default values for ToolsPanel settings reset
+	const defaultBlockLayoutValue = {
+		...defaultBlockLayout,
+		contentSize: false,
+		wideSize: false,
+		justifyContent: undefined,
+		orientation: undefined,
+		allowSizingOnChildren: true,
+		type:
+			defaultBlockLayout?.type ||
+			( allowInheriting ? 'constrained' : 'default' ),
+	};
+
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ __( 'Layout' ) }>
+				<ToolsPanel
+					label={ __( 'Layout' ) }
+					resetAll={ () => {
+						setAttributes( {
+							layout: {
+								...defaultBlockLayoutValue,
+							},
+						} );
+					} }
+					dropdownMenuProps={ dropdownMenuProps }
+				>
 					{ showInheritToggle && (
-						<>
+						<ToolsPanelItem
+							label={ __( 'Inner blocks use content width' ) }
+							__nextHasNoMarginBottom
+							isShownByDefault
+							hasValue={ () =>
+								!! (
+									layout?.type !==
+									defaultBlockLayoutValue?.type
+								)
+							}
+							onDeselect={ () =>
+								onChangeType( defaultBlockLayoutValue?.type )
+							}
+						>
 							<ToggleControl
 								__nextHasNoMarginBottom
 								label={ __( 'Inner blocks use content width' ) }
@@ -261,35 +303,95 @@ function LayoutPanelPure( {
 										  )
 								}
 							/>
-						</>
+						</ToolsPanelItem>
 					) }
 
 					{ ! inherit && allowSwitching && (
-						<LayoutTypeSwitcher
-							type={ blockLayoutType }
-							onChange={ onChangeType }
-						/>
+						<ToolsPanelItem
+							label={ __( 'Layout Switcher' ) }
+							__nextHasNoMarginBottom
+							isShownByDefault
+							hasValue={ () =>
+								!! (
+									layout?.type !==
+									defaultBlockLayoutValue?.type
+								)
+							}
+							onDeselect={ () =>
+								onChangeType( defaultBlockLayoutValue?.type )
+							}
+						>
+							<LayoutTypeSwitcher
+								type={ blockLayoutType }
+								onChange={ onChangeType }
+							/>
+						</ToolsPanelItem>
 					) }
 
 					{ layoutType && layoutType.name !== 'default' && (
-						<layoutType.inspectorControls
-							layout={ usedLayout }
-							onChange={ onChangeLayout }
-							layoutBlockSupport={ blockSupportAndThemeSettings }
-							name={ blockName }
-							clientId={ clientId }
-						/>
+						<ToolsPanelItem
+							label={ __( 'Layout' ) }
+							__nextHasNoMarginBottom
+							isShownByDefault
+							hasValue={ () =>
+								!! (
+									usedLayout?.contentSize ||
+									usedLayout?.wideSize ||
+									usedLayout?.justifyContent ||
+									usedLayout?.orientation
+								)
+							}
+							onDeselect={ () =>
+								onChangeLayout( {
+									type: layout.type,
+									...defaultBlockLayoutValue,
+								} )
+							}
+						>
+							<layoutType.inspectorControls
+								layout={ usedLayout }
+								onChange={ onChangeLayout }
+								layoutBlockSupport={
+									blockSupportAndThemeSettings
+								}
+								name={ blockName }
+								clientId={ clientId }
+							/>
+						</ToolsPanelItem>
 					) }
+
 					{ constrainedType && displayControlsForLegacyLayouts && (
-						<constrainedType.inspectorControls
-							layout={ usedLayout }
-							onChange={ onChangeLayout }
-							layoutBlockSupport={ blockSupportAndThemeSettings }
-							name={ blockName }
-							clientId={ clientId }
-						/>
+						<ToolsPanelItem
+							label={ __( 'Layout' ) }
+							__nextHasNoMarginBottom
+							isShownByDefault
+							hasValue={ () =>
+								!! (
+									usedLayout?.contentSize ||
+									usedLayout?.wideSize ||
+									usedLayout?.justifyContent ||
+									usedLayout?.orientation
+								)
+							}
+							onDeselect={ () =>
+								onChangeLayout( {
+									type: layout.type,
+									...defaultBlockLayoutValue,
+								} )
+							}
+						>
+							<constrainedType.inspectorControls
+								layout={ usedLayout }
+								onChange={ onChangeLayout }
+								layoutBlockSupport={
+									blockSupportAndThemeSettings
+								}
+								name={ blockName }
+								clientId={ clientId }
+							/>
+						</ToolsPanelItem>
 					) }
-				</PanelBody>
+				</ToolsPanel>
 			</InspectorControls>
 			{ ! inherit && layoutType && (
 				<layoutType.toolBarControls

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -4,7 +4,10 @@
 import { getBlockSupport } from '@wordpress/blocks';
 import { memo, useMemo, useEffect, useId, useState } from '@wordpress/element';
 import { useDispatch, useRegistry } from '@wordpress/data';
-import { createHigherOrderComponent } from '@wordpress/compose';
+import {
+	createHigherOrderComponent,
+	useViewportMatch,
+} from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 
 /**
@@ -715,4 +718,17 @@ export function createBlockSaveFilter( features ) {
 			return props;
 		}
 	);
+}
+
+export function useToolsPanelDropdownMenuProps() {
+	const isMobile = useViewportMatch( 'medium', '<' );
+	return ! isMobile
+		? {
+				popoverProps: {
+					placement: 'left-start',
+					// For non-mobile, inner sidebar width (248px) - button width (24px) - border (1px) + padding (16px) + spacing (20px)
+					offset: 259,
+				},
+		  }
+		: {};
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Convert the "Layout" panel of the Layout block support to use the ToolsPanel instead of PanelBody

Closes https://github.com/WordPress/gutenberg/issues/67949

## Screenshots or screencast <!-- if applicable -->
|Before|After|
|-|-|
|<img width="1889" height="994" alt="Buttons Block Before" src="https://github.com/user-attachments/assets/55a314be-ad0b-4318-9ef5-af6eeb16551c" />|<img width="1585" height="709" alt="Buttons Block After" src="https://github.com/user-attachments/assets/105ab400-f9d0-48fd-a2b2-fe78dc2894c5" />|
|<img width="1886" height="739" alt="Columns Before" src="https://github.com/user-attachments/assets/a9370840-0747-4d23-afed-ec53681a36d3" />|<img width="1888" height="838" alt="Columns After" src="https://github.com/user-attachments/assets/9ae5fe8c-bfab-475f-833a-1f69eda091e6" />|
|<img width="1889" height="852" alt="Group Block Before" src="https://github.com/user-attachments/assets/29199560-ddaf-4166-88b8-0bc0a9b53572" />|<img width="1890" height="950" alt="Group Block After" src="https://github.com/user-attachments/assets/cb55fd80-8e13-45c6-a113-2d9956b1856d" />|
