### PR TITLE
Query Total: Add interactivity.clientNavigation block support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -784,7 +784,7 @@ Display the total number of results in a query. ([Source](https://github.com/Wor
 -	**Name:** core/query-total
 -	**Category:** theme
 -	**Ancestor:** core/query
--	**Supports:** align (full, wide), color (background, gradients, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** displayType
 
 ## Quote

--- a/packages/block-library/src/query-total/block.json
+++ b/packages/block-library/src/query-total/block.json
@@ -52,6 +52,9 @@
 				"width": true,
 				"style": true
 			}
+		},
+		"interactivity": {
+			"clientNavigation": true
 		}
 	},
 	"style": "wp-block-query-total"


### PR DESCRIPTION
## What?

Related:

- https://github.com/WordPress/gutenberg/pull/67629
- https://github.com/WordPress/gutenberg/pull/58132

Adds `interactivity.clientNavigation` support to the Query Total block in order to enable client navigation.

## Why?

The Query Total block is available only if the ancestor block is the Query Loop block, but we can't use the client navigation if the Query Loop block includes the Query Total block.

Screenshot - Notice modal when inserting the Query Total block into the Query Loop block with "Reload full page" disabled:

![image](https://github.com/user-attachments/assets/833072a0-f52c-42c4-a220-165586b041ea)

I don't see any reason why we can't add the interactivity support.

## Testing Instructions

- Insert a Query Loop block and Query Total block
- In the Query Loop block, disable "Reload full page" toggle
- In the Query Total block, change display type to "Range dispaly"
- Open the post on the frontend
- Make sure that client navigation works properly

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/3303e22e-baff-40b8-b27b-f7808872f554

