### PR TITLE
Editor: fix: missing default category on new posts

### DIFF
--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, _n, _x, sprintf } from '@wordpress/i18n';
-import { useMemo, useState } from '@wordpress/element';
+import { useMemo, useState, useEffect } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
 import {
 	Button,
@@ -163,6 +163,7 @@ export function HierarchicalTermSelector( { slug } ) {
 	const [ filterValue, setFilterValue ] = useState( '' );
 	const [ filteredTermsTree, setFilteredTermsTree ] = useState( [] );
 	const debouncedSpeak = useDebounce( speak, 500 );
+	const isCategoryTaxonomy = slug === 'category';
 
 	const {
 		hasCreateAction,
@@ -171,6 +172,9 @@ export function HierarchicalTermSelector( { slug } ) {
 		loading,
 		availableTerms,
 		taxonomy,
+		isNewPost,
+		defaultCategory,
+		hasSettingsLoaded,
 	} = useSelect(
 		( select ) => {
 			const { getCurrentPost, getEditedPostAttribute } =
@@ -203,6 +207,21 @@ export function HierarchicalTermSelector( { slug } ) {
 					getEntityRecords( 'taxonomy', slug, DEFAULT_QUERY ) ||
 					EMPTY_ARRAY,
 				taxonomy: _taxonomy,
+				isNewPost:
+					! getCurrentPost().id ||
+					select( editorStore ).isEditedPostNew(),
+				defaultCategory:
+					slug === 'category'
+						? select( coreStore ).getEntityRecord( 'root', 'site' )
+								?.default_category
+						: null,
+				hasSettingsLoaded:
+					slug === 'category'
+						? select( coreStore ).hasFinishedResolution(
+								'getEntityRecord',
+								[ 'root', 'site' ]
+						  )
+						: true,
 			};
 		},
 		[ slug ]
@@ -210,6 +229,27 @@ export function HierarchicalTermSelector( { slug } ) {
 
 	const { editPost } = useDispatch( editorStore );
 	const { saveEntityRecord } = useDispatch( coreStore );
+
+	// Set default category for new posts
+	useEffect( () => {
+		if (
+			isCategoryTaxonomy &&
+			isNewPost &&
+			! terms?.length &&
+			hasSettingsLoaded &&
+			defaultCategory
+		) {
+			editPost( { [ taxonomy.rest_base ]: [ defaultCategory ] } );
+		}
+	}, [
+		isNewPost,
+		terms,
+		hasSettingsLoaded,
+		defaultCategory,
+		editPost,
+		isCategoryTaxonomy,
+		taxonomy?.rest_base,
+	] );
 
 	const availableTermsTree = useMemo(
 		() => sortBySelected( buildTermsTree( availableTerms ), terms ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/32651

<!-- In a few words, what is the PR actually doing? -->
Automatically assigns the default category for new posts in the category taxonomy using the useEffect hook to set when no terms are present but only if it's a new post and settings have been loaded.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This solves the issue of default posts not automatically having the default category selected before being saved.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Uses useEffect to automatically set the default category if is a new post, a default category is assigned, and if settings have loaded.

## Testing Instructions
See https://github.com/WordPress/gutenberg/issues/32651 for testing information.

