### PR TITLE
Navigation block: put navigation menu container in `body`

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -768,6 +768,7 @@ function Navigation( {
 					isHiddenByDefault={ isHiddenByDefault }
 					overlayBackgroundColor={ overlayBackgroundColor }
 					overlayTextColor={ overlayTextColor }
+					navRef={ navRef }
 				>
 					<UnsavedInnerBlocks
 						createNavigationMenu={ createNavigationMenu }
@@ -927,6 +928,7 @@ function Navigation( {
 									overlayBackgroundColor
 								}
 								overlayTextColor={ overlayTextColor }
+								navRef={ navRef }
 							>
 								{ isEntityAvailable && (
 									<NavigationInnerBlocks

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -208,6 +208,15 @@ function Navigation( {
 	customPlaceholder: CustomPlaceholder = null,
 	__unstableLayoutClassNames: layoutClassNames,
 } ) {
+	// Manually “inherit” overlay colors from block because when overlaid the
+	// dialog is not a child and won’t inherit through CSS.
+	const usedOverlayTextColor = overlayTextColor.color
+		? overlayTextColor
+		: textColor;
+	const usedOverlayBackgroundColor = overlayBackgroundColor.color
+		? overlayBackgroundColor
+		: backgroundColor;
+
 	const {
 		openSubmenusOnClick,
 		overlayMenu,
@@ -766,8 +775,8 @@ function Navigation( {
 					icon={ icon }
 					isResponsive={ isResponsive }
 					isHiddenByDefault={ isHiddenByDefault }
-					overlayBackgroundColor={ overlayBackgroundColor }
-					overlayTextColor={ overlayTextColor }
+					overlayBackgroundColor={ usedOverlayBackgroundColor }
+					overlayTextColor={ usedOverlayTextColor }
 					navRef={ navRef }
 				>
 					<UnsavedInnerBlocks
@@ -925,9 +934,9 @@ function Navigation( {
 								isResponsive={ isResponsive }
 								isHiddenByDefault={ isHiddenByDefault }
 								overlayBackgroundColor={
-									overlayBackgroundColor
+									usedOverlayBackgroundColor
 								}
-								overlayTextColor={ overlayTextColor }
+								overlayTextColor={ usedOverlayTextColor }
 								navRef={ navRef }
 							>
 								{ isEntityAvailable && (

--- a/packages/block-library/src/navigation/edit/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/responsive-wrapper.js
@@ -15,6 +15,7 @@ import { getColorClassName } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import OverlayMenuIcon from './overlay-menu-icon';
+import { createPortal } from '@wordpress/element';
 
 export default function ResponsiveWrapper( {
 	children,
@@ -27,6 +28,7 @@ export default function ResponsiveWrapper( {
 	overlayTextColor,
 	hasIcon,
 	icon,
+	navRef,
 } ) {
 	if ( ! isResponsive ) {
 		return children;
@@ -75,6 +77,37 @@ export default function ResponsiveWrapper( {
 		} ),
 	};
 
+	const wrapper = (
+		<div
+			className={ responsiveContainerClasses }
+			style={ styles }
+			id={ modalId }
+		>
+			<div
+				className="wp-block-navigation__responsive-close"
+				tabIndex="-1"
+			>
+				<div { ...dialogProps }>
+					<Button
+						__next40pxDefaultSize
+						className="wp-block-navigation__responsive-container-close"
+						aria-label={ hasIcon && __( 'Close menu' ) }
+						onClick={ () => onToggle( false ) }
+					>
+						{ hasIcon && <Icon icon={ close } /> }
+						{ ! hasIcon && __( 'Close' ) }
+					</Button>
+					<div
+						className="wp-block-navigation__responsive-container-content"
+						id={ `${ modalId }-content` }
+					>
+						{ children }
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+
 	return (
 		<>
 			{ ! isOpen && (
@@ -89,35 +122,9 @@ export default function ResponsiveWrapper( {
 					{ ! hasIcon && __( 'Menu' ) }
 				</Button>
 			) }
-
-			<div
-				className={ responsiveContainerClasses }
-				style={ styles }
-				id={ modalId }
-			>
-				<div
-					className="wp-block-navigation__responsive-close"
-					tabIndex="-1"
-				>
-					<div { ...dialogProps }>
-						<Button
-							__next40pxDefaultSize
-							className="wp-block-navigation__responsive-container-close"
-							aria-label={ hasIcon && __( 'Close menu' ) }
-							onClick={ () => onToggle( false ) }
-						>
-							{ hasIcon && <Icon icon={ close } /> }
-							{ ! hasIcon && __( 'Close' ) }
-						</Button>
-						<div
-							className="wp-block-navigation__responsive-container-content"
-							id={ `${ modalId }-content` }
-						>
-							{ children }
-						</div>
-					</div>
-				</div>
-			</div>
+			{ isOpen && navRef.current
+				? createPortal( wrapper, navRef.current.ownerDocument.body )
+				: wrapper }
 		</>
 	);
 }

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -882,75 +882,83 @@ function block_core_navigation_build_css_colors( $attributes ) {
 	);
 
 	// Text color.
-	$has_named_text_color  = array_key_exists( 'textColor', $attributes );
-	$has_custom_text_color = array_key_exists( 'customTextColor', $attributes );
+	$used_named_text_color  = $attributes[ 'textColor' ] ?? false;
+	$used_custom_text_color = $attributes[ 'customTextColor' ] ?? false;
 
 	// If has text color.
-	if ( $has_custom_text_color || $has_named_text_color ) {
+	if ( $used_custom_text_color || $used_named_text_color ) {
 		// Add has-text-color class.
 		$colors['css_classes'][] = 'has-text-color';
 	}
 
-	if ( $has_named_text_color ) {
+	if ( $used_named_text_color ) {
 		// Add the color class.
-		$colors['css_classes'][] = sprintf( 'has-%s-color', $attributes['textColor'] );
-	} elseif ( $has_custom_text_color ) {
+		$colors['css_classes'][] = sprintf( 'has-%s-color', $used_named_text_color );
+	} elseif ( $used_custom_text_color ) {
 		// Add the custom color inline style.
-		$colors['inline_styles'] .= sprintf( 'color: %s;', $attributes['customTextColor'] );
+		$colors['inline_styles'] .= sprintf( 'color: %s;', $used_custom_text_color );
 	}
 
 	// Background color.
-	$has_named_background_color  = array_key_exists( 'backgroundColor', $attributes );
-	$has_custom_background_color = array_key_exists( 'customBackgroundColor', $attributes );
+	$used_named_background_color  = $attributes[ 'backgroundColor' ] ?? false;
+	$used_custom_background_color = $attributes[ 'customBackgroundColor' ] ?? false;
 
 	// If has background color.
-	if ( $has_custom_background_color || $has_named_background_color ) {
+	if ( $used_custom_background_color || $used_named_background_color ) {
 		// Add has-background class.
 		$colors['css_classes'][] = 'has-background';
 	}
 
-	if ( $has_named_background_color ) {
+	if ( $used_named_background_color ) {
 		// Add the background-color class.
-		$colors['css_classes'][] = sprintf( 'has-%s-background-color', $attributes['backgroundColor'] );
-	} elseif ( $has_custom_background_color ) {
+		$colors['css_classes'][] = sprintf( 'has-%s-background-color', $used_named_background_color );
+	} elseif ( $used_custom_background_color ) {
 		// Add the custom background-color inline style.
-		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $attributes['customBackgroundColor'] );
+		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $used_custom_background_color );
 	}
 
 	// Overlay text color.
-	$has_named_overlay_text_color  = array_key_exists( 'overlayTextColor', $attributes );
-	$has_custom_overlay_text_color = array_key_exists( 'customOverlayTextColor', $attributes );
+	// Manually “inherits” text color of the block because when overlaid the dialog is not a child
+	// and won’t inherit through CSS.
+	$used_named_overlay_text_color = $attributes['overlayTextColor'] ??
+		( ! array_key_exists('customOverlayTextColor', $attributes) ? $used_named_text_color : false );
+	$used_custom_overlay_text_color = $attributes['customOverlayTextColor'] ??
+		( ! array_key_exists('overlayTextColor', $attributes) ? $used_custom_text_color : false );
 
 	// If has overlay text color.
-	if ( $has_custom_overlay_text_color || $has_named_overlay_text_color ) {
+	if ( $used_custom_overlay_text_color || $used_named_overlay_text_color ) {
 		// Add has-text-color class.
 		$colors['overlay_css_classes'][] = 'has-text-color';
 	}
 
-	if ( $has_named_overlay_text_color ) {
+	if ( $used_named_overlay_text_color ) {
 		// Add the overlay color class.
-		$colors['overlay_css_classes'][] = sprintf( 'has-%s-color', $attributes['overlayTextColor'] );
-	} elseif ( $has_custom_overlay_text_color ) {
+		$colors['overlay_css_classes'][] = sprintf( 'has-%s-color', $used_named_overlay_text_color );
+	} elseif ( $used_custom_overlay_text_color ) {
 		// Add the custom overlay color inline style.
-		$colors['overlay_inline_styles'] .= sprintf( 'color: %s;', $attributes['customOverlayTextColor'] );
+		$colors['overlay_inline_styles'] .= sprintf( 'color: %s;', $used_custom_overlay_text_color );
 	}
 
 	// Overlay background color.
-	$has_named_overlay_background_color  = array_key_exists( 'overlayBackgroundColor', $attributes );
-	$has_custom_overlay_background_color = array_key_exists( 'customOverlayBackgroundColor', $attributes );
+	// Manually “inherits” background color of the block because when overlaid the dialog is not a
+	// child and won’t inherit through CSS.
+	$used_named_overlay_background_color = $attributes['overlayBackgroundColor'] ??
+		( ! array_key_exists('customOverlayBackgroundColor', $attributes) ? $used_named_background_color : false );
+	$used_custom_overlay_background_color = $attributes['customOverlayBackgroundColor'] ??
+		( ! array_key_exists('overlayBackgroundColor', $attributes) ? $used_custom_background_color : false );
 
 	// If has overlay background color.
-	if ( $has_custom_overlay_background_color || $has_named_overlay_background_color ) {
+	if ( $used_custom_overlay_background_color || $used_named_overlay_background_color ) {
 		// Add has-background class.
 		$colors['overlay_css_classes'][] = 'has-background';
 	}
 
-	if ( $has_named_overlay_background_color ) {
+	if ( $used_named_overlay_background_color ) {
 		// Add the overlay background-color class.
-		$colors['overlay_css_classes'][] = sprintf( 'has-%s-background-color', $attributes['overlayBackgroundColor'] );
-	} elseif ( $has_custom_overlay_background_color ) {
+		$colors['overlay_css_classes'][] = sprintf( 'has-%s-background-color', $used_named_overlay_background_color );
+	} elseif ( $used_custom_overlay_background_color ) {
 		// Add the custom overlay background-color inline style.
-		$colors['overlay_inline_styles'] .= sprintf( 'background-color: %s;', $attributes['customOverlayBackgroundColor'] );
+		$colors['overlay_inline_styles'] .= sprintf( 'background-color: %s;', $used_custom_overlay_background_color );
 	}
 
 	return $colors;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -502,7 +502,7 @@ class WP_Navigation_Block_Renderer {
 				data-wp-on--keydown="actions.handleMenuKeydown"
 			';
 			$responsive_container_directives         = '
-				data-wp-init="callbacks.mountMenu"
+				data-wp-init="callbacks.mountResponsiveContainer"
 				data-wp-class--has-modal-open="state.isMenuOpen"
 				data-wp-class--is-menu-open="state.isMenuOpen"
 				data-wp-watch="callbacks.initMenu"

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -502,6 +502,7 @@ class WP_Navigation_Block_Renderer {
 				data-wp-on--keydown="actions.handleMenuKeydown"
 			';
 			$responsive_container_directives         = '
+				data-wp-init="callbacks.mountMenu"
 				data-wp-class--has-modal-open="state.isMenuOpen"
 				data-wp-class--is-menu-open="state.isMenuOpen"
 				data-wp-watch="callbacks.initMenu"

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -736,14 +736,19 @@ button.wp-block-navigation-item__content {
 	position: relative;
 }
 
-// Adjust open dialog top margin when admin-bar is visible.
-// Needs to be scoped to .is-menu-open, or it will shift the position of any other navigations that may be present.
-.has-modal-open .admin-bar .is-menu-open.wp-block-navigation__responsive-container {
-	top: $admin-bar-height-big;
+.has-modal-open > .admin-bar > .is-menu-open.wp-block-navigation__responsive-container {
+	// Stay behind admin-bar.
+	z-index: 99998;
 
-	// Handle smaller admin-bar.
-	@include break-medium() {
-		top: $admin-bar-height;
+	// Adjust open dialog top margin when admin-bar is visible.
+	// Needs to be scoped to .is-menu-open, or it will shift the position of any other navigations that may be present.
+	.wp-block-navigation__responsive-dialog {
+		margin-top: $admin-bar-height-big;
+
+		// Handle smaller admin-bar.
+		@include break-medium() {
+			margin-top: $admin-bar-height;
+		}
 	}
 }
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -493,6 +493,16 @@ button.wp-block-navigation-item__content {
 		background-color: inherit !important;
 	}
 
+	// Default menu background and font color.
+	&:not(.has-background).is-menu-open {
+		background-color: #fff;
+	}
+
+	&:not(.has-text-color).is-menu-open {
+		color: #000;
+	}
+
+
 	// Overlay menu.
 	// Provide an opinionated default style for menu items inside.
 	// Inherit as much as we can regarding colors, fonts, sizes,
@@ -633,18 +643,6 @@ button.wp-block-navigation-item__content {
 		}
 	}
 }
-
-// Default menu background and font color.
-.wp-block-navigation:not(.has-background)
-.wp-block-navigation__responsive-container.is-menu-open {
-	background-color: #fff;
-}
-
-.wp-block-navigation:not(.has-text-color)
-.wp-block-navigation__responsive-container.is-menu-open {
-	color: #000;
-}
-
 
 // Overlay menu toggle button label
 .wp-block-navigation__toggle_button_label {

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -740,12 +740,12 @@ button.wp-block-navigation-item__content {
 
 // Adjust open dialog top margin when admin-bar is visible.
 // Needs to be scoped to .is-menu-open, or it will shift the position of any other navigations that may be present.
-.has-modal-open .admin-bar .is-menu-open .wp-block-navigation__responsive-dialog {
-	margin-top: $admin-bar-height-big;
+.has-modal-open .admin-bar .is-menu-open.wp-block-navigation__responsive-container {
+	top: $admin-bar-height-big;
 
 	// Handle smaller admin-bar.
 	@include break-medium() {
-		margin-top: $admin-bar-height;
+		top: $admin-bar-height;
 	}
 }
 

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -169,6 +169,7 @@ const { state, actions } = store(
 				if ( type === 'overlay' ) {
 					// Add a `has-modal-open` class to the <html> root.
 					document.documentElement.classList.add( 'has-modal-open' );
+					document.body.appendChild( state.responsiveContainer );
 				}
 			},
 
@@ -188,6 +189,7 @@ const { state, actions } = store(
 						document.documentElement.classList.remove(
 							'has-modal-open'
 						);
+						state.responsiveContainer.remove();
 					}
 				}
 			},
@@ -213,10 +215,8 @@ const { state, actions } = store(
 					focusableElements?.[ 0 ]?.focus();
 				}
 			},
-			mountMenu() {
-				if ( getContext().type === 'overlay' ) {
-					document.body.appendChild( getElement().ref );
-				}
+			mountResponsiveContainer() {
+				state.responsiveContainer = getElement().ref;
 			},
 		},
 	},

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -213,6 +213,11 @@ const { state, actions } = store(
 					focusableElements?.[ 0 ]?.focus();
 				}
 			},
+			mountMenu() {
+				if ( getContext().type === 'overlay' ) {
+					document.body.appendChild( getElement().ref );
+				}
+			},
 		},
 	},
 	{ lock: true }


### PR DESCRIPTION
## Status
Drafted because:
- I'm thinking to try an alternative of using the `<dialog>` element
- This should probably handle restoring the menu container into its original place upon viewport size becoming large enough that the menu is not overlaid
- The admin bar related styling may be worth changing. This could probably be a separate PR though.

## What?
Closes #69635

Ensures the Navigation block’s overlaid menu container is not confined by its parent/ancestor boxes.

## Why?
The overlaid content is expected to behave as a root/top level element able to overlay the entire document.

## How?
In the editor this uses `createPortal` to make the container a child of the `body` element. In the front end this uses `appendChild` to do the same.

## Testing Instructions
#69635 is an issue that is reproducible in Firefox or Safari so test with one of those browsers.

Here is markup for testing, though you’ll have to update the navigation for your site.
```html
<!-- wp:cover {"url":"https://pd.w.org/2021/05/97060b09513e73a89.38852584-2048x1536.jpeg","dimRatio":50,"customOverlayColor":"#001240","isUserOverlayColor":true,"minHeight":20,"minHeightUnit":"vw","sizeSlug":"full","style":{"border":{"radius":"99em","color":"#0069e9","width":"6px"}},"layout":{"type":"constrained"}} -->
<div class="wp-block-cover has-border-color" style="border-color:#0069e9;border-width:6px;border-radius:99em;min-height:20vw"><img class="wp-block-cover__image-background size-full" alt="" src="https://pd.w.org/2021/05/97060b09513e73a89.38852584-2048x1536.jpeg" data-object-fit="cover"/><span aria-hidden="true" class="wp-block-cover__background has-background-dim" style="background-color:#001240"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"style":{"position":{"type":"sticky","top":"0px"}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:navigation {"ref":4} /--></div>
<!-- /wp:group --></div></div>
<!-- /wp:cover -->
```

1. Open a post
2. Paste in the markup from above
3. Switch to "Mobile" device preview
4. Open the navigation menu inside the Cover block
5. Verify the overlaid menu appears as expected
6. View/Preview the post
7. Ensure the viewport is narrow enough that the navigation is in mobile/overlay mode
8. Open the navigation menu
9. Verify the overlaid menu appears as expected

## Screenshots or screencast

### Editor
|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/afe87a27-9f8d-416f-8543-91a571fefe59"/>|<video src="https://github.com/user-attachments/assets/9d69cc9e-7f8f-4c75-9621-546358cf3513"/>|

### Front end
|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/e8478adc-1d8c-4991-acd2-6889db9001d9"/>|<video src="https://github.com/user-attachments/assets/7f188d1b-319e-4ce5-b0ce-14b0cdabe85b"/>|