### PR TITLE
Fix: Correct 'Displaying 1 – 0 of 0' issue when no results are found

### DIFF
--- a/packages/block-library/src/query-total/index.php
+++ b/packages/block-library/src/query-total/index.php
@@ -34,7 +34,7 @@ function render_block_core_query_total( $attributes, $content, $block ) {
 	$posts_per_page = (int) $query_to_use->get( 'posts_per_page' );
 
 	// Calculate the range of posts being displayed.
-	$start = ( $current_page - 1 ) * $posts_per_page + 1;
+	$start = ( 0 === $max_rows ) ? 0 : ( ( $current_page - 1 ) * $posts_per_page + 1 );
 	$end   = min( $start + $posts_per_page - 1, $max_rows );
 
 	// Prepare the display based on the `displayType` attribute.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #69662

<!-- In a few words, what is the PR actually doing? -->
Fixes the incorrect display of "Displaying 1 – 0 of 0" when no results are found by correctly setting the start value to 0.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When no posts are found, the display incorrectly shows "Displaying 1 – 0 of 0". This change ensures that it correctly shows "Displaying 0 – 0 of 0", providing a more accurate representation of empty results.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Used a ternary operator to check if $max_rows is 0.
- If $max_rows is 0, $start is set to 0 instead of 1.
- Other values ($end, $max_rows) remain unchanged, as they are already displayed correctly.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Create or open a page with a Query Loop block.
2. Ensure the block is configured to display posts.
3. Set up a scenario where the query returns zero results.
4. Change the Display type to "Range display".
5. Verify that in frontend the text now correctly displays "Displaying 0 – 0 of 0" instead of "Displaying 1 – 0 of 0".

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="1470" alt="Image" src="https://github.com/user-attachments/assets/39b11041-3a08-4a76-b45c-b1b912af1914" /> | <img width="1470" alt="Screenshot 2025-03-24 at 9 05 31 AM" src="https://github.com/user-attachments/assets/e9b79029-0ad6-4c97-9c87-afce0fff6b95" /> |

