### PR TITLE
Developer Documentation: Update `VS Code` settings in contribution guide

### DIFF
--- a/docs/contributors/code/getting-started-with-code-contribution.md
+++ b/docs/contributors/code/getting-started-with-code-contribution.md
@@ -221,7 +221,7 @@ With the extension installed, ESLint will use the [.eslintrc.js](https://github.
 
 ```json
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
+        "source.fixAll.eslint": "explicit"
     },
 ```
 


### PR DESCRIPTION

## What?
Closes: N/A - Doc improvement submitted directly as PR.
Updates the `ESLint` code actions on save configuration example from boolean value (true) to string value ("explicit").

## Why?
VS Code shows warnings when using boolean values and recommends string values for better clarity. This change aligns with VS Code's latest guidance as documented in their [refactoring guide](https://code.visualstudio.com/docs/editor/refactoring#_code-actions-on-save) and implemented in [VS Code PR #201808](https://github.com/microsoft/vscode/pull/201808).


