### PR TITLE
Try replacing footnote links with footnote popovers

### DIFF
--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -23,13 +23,13 @@ function render_block_core_footnotes( $attributes, $content, $block ) {
 	}
 
 	if ( post_password_required( $block->context['postId'] ) ) {
-		return;
+		return '';
 	}
 
 	$footnotes = get_post_meta( $block->context['postId'], 'footnotes', true );
 
 	if ( ! $footnotes ) {
-		return;
+		return '';
 	}
 
 	$footnotes = json_decode( $footnotes, true );

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -39,20 +39,15 @@ function render_block_core_footnotes( $attributes, $content, $block ) {
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes();
-	$footnote_index     = 1;
 
 	$block_content = '';
 
 	foreach ( $footnotes as $footnote ) {
-		// Translators: %d: Integer representing the number of return links on the page.
-		$aria_label     = sprintf( __( 'Jump to footnote reference %1$d' ), $footnote_index );
 		$block_content .= sprintf(
-			'<li id="%1$s">%2$s <a href="#%1$s-link" aria-label="%3$s">↩︎</a></li>',
+			'<li id="%1$s" popover style="position-anchor: --fn-%1$s;">%2$s</li>',
 			$footnote['id'],
-			$footnote['content'],
-			$aria_label
+			$footnote['content']
 		);
-		++$footnote_index;
 	}
 
 	return sprintf(
@@ -77,6 +72,24 @@ function register_block_core_footnotes() {
 }
 add_action( 'init', 'register_block_core_footnotes' );
 
+/**
+ * Filters blocks to rewrite footnote links to be popovers instead.
+ *
+ * @param string $block_content Block content.
+ * @return string Filtered block content.
+ */
+function filter_blocks_to_rewrite_footnote_links( $block_content ) {
+	// TODO: Use the HTML API instead!
+	$block_content = preg_replace_callback(
+		':(?P<start_tag><sup data-fn="(?P<fn>[^"]+?)" class="fn">)<a[^>]+?>(?P<num>\d+)</a>(?P<end_tag></sup>):',
+		static function ( $matches ) {
+			return $matches['start_tag'] . sprintf( '<button popovertarget="%1$s" style="anchor-name: --fn-%1$s;">%2$s</button>', esc_attr( $matches['fn'] ), $matches['num'] ) . $matches['end_tag'];
+		},
+		$block_content
+	);
+	return $block_content;
+}
+add_filter( 'render_block', 'filter_blocks_to_rewrite_footnote_links' );
 
 /**
  * Registers the footnotes meta field required for footnotes to work.

--- a/packages/block-library/src/footnotes/style.scss
+++ b/packages/block-library/src/footnotes/style.scss
@@ -1,3 +1,20 @@
+sup.fn > button {
+	cursor: pointer;
+	font-family: inherit;
+	background: none;
+	border: none;
+	font-size: inherit;
+	margin: 0;
+	padding: 0;
+	text-decoration: underline;
+}
+
+.wp-block-footnotes [popover] {
+	max-width: var(--wp--style--global--content-size);
+	top: anchor(bottom);
+	justify-self: anchor-center;
+}
+
 // These styles are for backwards compatibility with the old footnotes anchors.
 // Can be removed in the future.
 .editor-styles-wrapper,

--- a/packages/block-library/src/footnotes/style.scss
+++ b/packages/block-library/src/footnotes/style.scss
@@ -11,6 +11,7 @@ sup.fn > button {
 
 .wp-block-footnotes [popover] {
 	max-width: var(--wp--style--global--content-size);
+	margin: 0;
 	top: anchor(bottom);
 	justify-self: anchor-center;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #54089

Experiment with replacing footnote links (which take the reader to the end of the content to read the footnote) with footnote buttons which open the footnote inline in a popover.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Clicking a link to access the footnote at the bottom of the content is disruptive to the reading flow. The other footnotes displayed can also be distracting to the reader. (And when returning from the footnote, there is also an accessibility issue: https://github.com/WordPress/gutenberg/issues/54727.) 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Now that the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) is [Baseline Newly available](https://web.dev/blog/popover-baseline) we can start to explore how we might leverage it in WordPress, particularly in frontend blocks. This is implemented here, along with the use of the [Anchor Positioning API](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_anchor_positioning) which is available in Chromium and Safari TP, but not yet in Firefox ([caniuse](https://caniuse.com/css-anchor-positioning)). Nevertheless, the Anchor Positioning API is [part of Interop 2025](https://web.dev/blog/interop-2025), so it should be available at some point this year. The great thing about the Popover API and the Anchor Positioning API is that there is no JavaScript involved. Everything is declarative in HTML and CSS.

## Testing Instructions

1. Add footnotes to a post.
2. View the post on the frontend.
3. Click on a footnote "link" (button).
4. See the footnote open inline as a popover instead of taking the reader to the end of the post.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. Tab to the footnote button and hit enter/space.
2. See the popover appear.
3. Continue pressing tab to access links in the footnote, if any.
4. Hit `ESC` to close the footnote popover.

## Screenshots or screencast <!-- if applicable -->

### Before

[Screen recording 2025-03-23 23.46.15.webm](https://github.com/user-attachments/assets/3163f8c1-2021-482e-aaf5-9ba0adfcea89)

### After

[Screen recording 2025-03-23 23.43.58.webm](https://github.com/user-attachments/assets/c2aa500d-e47a-4f3a-8c1f-423aa6a90430)
