### PR TITLE
FontLibraryModal: Remove temporary margin-bottom override

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
@@ -75,11 +75,6 @@ $footer-height: 70px;
 	}
 }
 
-// TODO: See if this can be removed after https://github.com/WordPress/gutenberg/issues/38730
-.font-library-modal__tabpanel-layout .components-base-control__field {
-	margin-bottom: 0;
-}
-
 .font-library-modal__fonts-title {
 	text-transform: uppercase;
 	font-size: 11px;


### PR DESCRIPTION

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
related to: [#38730](https://github.com/WordPress/gutenberg/issues/38730)
related comment: https://github.com/WordPress/gutenberg/pull/64283#discussion_r1707007346

<!-- In a few words, what is the PR actually doing? -->
Removes the temporary CSS rule that set `margin-bottom` to `0` for `.components-base-control__field` within the `.font-library-modal__tabpanel-layout`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This PR cleans up the codebase by removing the CSS rule that was added as a temporary fix. The issue #38730 has been resolved, and all instances of `BaseControl` now use the `__nextHasNoMarginBottom` property.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The CSS rule:
```css
// TODO: See if this can be removed after https://github.com/WordPress/gutenberg/issues/38730
.font-library-modal__tabpanel-layout .components-base-control__field {
    margin-bottom: 0;
}
```
has been removed from the codebase.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the font library modal.
2. Verify that the `margin-bottom` styling for `.components-base-control__field` elements within `.font-library-modal__tabpanel-layout` is correct and consistent with other components.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/fe81792c-4c17-4255-8733-33605ec5bcda

