### PR TITLE
Page List: Parent control query limit is too small

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -42,7 +42,7 @@ import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 // We only show the edit option when page count is <= MAX_PAGE_COUNT
 // Performance of Navigation Links is not good past this value.
-const MAX_PAGE_COUNT = 100;
+const MAX_PAGE_COUNT = 500;
 const NOOP = () => {};
 function BlockContent( {
 	blockProps,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines: https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #69608
<!-- In a few words, what is this PR actually doing? -->
Increases the Page List block parent control query limit from 100 to 500 pages.## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The Page List block currently cannot be used effectively on websites with more than 100 pages because the parent control dropdown is limited to showing only 100 pages. This makes it impossible for users to select parent pages that are deeper in the hierarchy or later in the alphabetical listing when there are more than 100 pages on the site.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR updates the `MAX_PAGE_COUNT` constant in the Page List block's edit.js file, increasing the limit from 100 to 500 pages. This allows the parent control dropdown to load and display up to 500 pages, making the block usable on larger websites.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Create or use a WordPress site with more than 100 pages
2. Edit a page and insert a Page List block
3. Click the "Parent Page" dropdown in the block settings
4. Verify that you can now see and select pages beyond the first 100 pages