### PR TITLE
Site Editor: Make the text "Custom Styles" translatable

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -182,7 +182,7 @@ export const rootEntitiesConfig = [
 		baseURL: '/wp/v2/global-styles',
 		baseURLParams: { context: 'edit' },
 		plural: 'globalStylesVariations', // Should be different from name.
-		getTitle: ( record ) => record?.title?.rendered || record?.title,
+		getTitle: () => __( 'Custom Styles' ),
 		getRevisionsUrl: ( parentId, revisionId ) =>
 			`/wp/v2/global-styles/${ parentId }/revisions${
 				revisionId ? '/' + revisionId : ''


### PR DESCRIPTION
## What?

Closes https://core.trac.wordpress.org/ticket/63150

This PR applies the translate function to the text "Custom Styles" in the pre-publish sidebar in the site editor.

![global-styles-pre-save-panel-ja](https://github.com/user-attachments/assets/0b670e93-0297-4283-b495-25e22818f78f)


## Why?

In the site editor, there is the pre-save panel that shows dirty entities, such as templates, template parts, global styles, etc.

The global styles is a kind of a post, so the `post_title` field is referenced. As you can see in https://core.trac.wordpress.org/changeset/52282, this title is not translatable because the hard-coded English text is stored in the database.

## How?

In the root entities config, update the `getTitle()` function so that it can get the translated text. My understanding is that this title is not used anywhere else except in the pre-save panel, so it should be fine to always return the translated text.

## Testing Instructions

We can't test this PR for now, because the text is not localized yet in all languages. However, you can temporarily change the text to test whether the context is really reflected in the panel.