### PR TITLE
PreviewDropdown: There's no need to unlock the 'getRenderingMode' selector

### DIFF
--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -40,9 +40,12 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 		isTemplateHidden,
 		templateId,
 	} = useSelect( ( select ) => {
-		const { getDeviceType, getCurrentPostType, getCurrentTemplateId } =
-			select( editorStore );
-		const { getRenderingMode } = unlock( select( editorStore ) );
+		const {
+			getDeviceType,
+			getCurrentPostType,
+			getCurrentTemplateId,
+			getRenderingMode,
+		} = select( editorStore );
 		const { getEntityRecord, getPostType } = select( coreStore );
 		const { get } = select( preferencesStore );
 		const _currentPostType = getCurrentPostType();


### PR DESCRIPTION
## What?
This is a follow-up to #66514.

The `getRenderingMode` [selector is public](https://developer.wordpress.org/block-editor/reference-guides/data/data-core-editor/#getrenderingmode), so there's no need to unlock it.

## Testing Instructions
CI checks are passing.
