### PR TITLE
Format Library: Ensure inline image with updates persist after removing the 'width'

### DIFF
--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -69,7 +69,9 @@ function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 						type: name,
 						attributes: {
 							...activeObjectAttributes,
-							style: width ? `width: ${ editedWidth }px;` : '',
+							style: editedWidth
+								? `width: ${ editedWidth }px;`
+								: '',
 							alt: editedAlt,
 						},
 					};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes [#69678](https://github.com/WordPress/gutenberg/issues/69678)

This PR ensures that the inline image width persists correctly when updated via the width popover. Previously, removing the width caused the style attribute to be lost, preventing future updates from applying correctly.

<!-- In a few words, what is the PR actually doing? -->

## Why?
When the width was removed and applied, the style attribute was cleared. Subsequent updates to width did not restore the style, leading to a persistent issue where the width couldn't be reapplied.

## How?

- Ensured style is correctly updated in onSubmit.
- Used the previous style value when width is empty instead of removing the attribute.
- Verified onChange is triggered properly with the new attributes.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Open a post or page in the editor.
2. Insert an inline image.
3. Open the width popover, remove the width, and click "Apply."
4. Refresh the page and verify the image no longer has a width.
5. Reopen the popover, enter a new width, and click "Apply."
6. Confirm that the width persists and updates correctly.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/9b7e39ce-e663-436b-8b38-f8e3d51c49be
