### PR TITLE
Stylelint-config: Add stylelint-scss as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52463,7 +52463,8 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"stylelint": "^16.8.2"
+				"stylelint": "^16.8.2",
+				"stylelint-scss": "^6.4.0"
 			}
 		},
 		"packages/stylelint-config/node_modules/css-tree": {

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -39,7 +39,8 @@
 		"stylelint-config-recommended-scss": "^14.1.0"
 	},
 	"peerDependencies": {
-		"stylelint": "^16.8.2"
+		"stylelint": "^16.8.2",
+		"stylelint-scss": "^6.4.0"
 	},
 	"npmpackagejsonlint": {
 		"extends": "@wordpress/npm-package-json-lint-config",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #69684

PR adds missing dependencies for the @wordpress/stylelint-scss package.

## Testing Instructions
Verify that the change makes sense.