### PR TITLE
Testing: Fix e2e and performance tests

### DIFF
--- a/test/e2e/specs/site-editor/block-style-variations.spec.js
+++ b/test/e2e/specs/site-editor/block-style-variations.spec.js
@@ -204,21 +204,12 @@ test.describe( 'Block Style Variations', () => {
 		const revisionIframe = page.frameLocator( '[name="revisions"]' );
 
 		const revisionFirstGroup = revisionIframe
-			.getByRole( 'document', {
-				name: 'Block: Content',
-			} )
 			.locator( '[data-type="core/group"]' )
 			.first();
 		const revisionSecondGroup = revisionIframe
-			.getByRole( 'document', {
-				name: 'Block: Content',
-			} )
 			.locator( '[data-type="core/group"]' )
 			.nth( 1 );
 		const revisionThirdGroup = revisionIframe
-			.getByRole( 'document', {
-				name: 'Block: Content',
-			} )
 			.locator( '[data-type="core/group"]' )
 			.nth( 2 );
 

--- a/test/e2e/specs/site-editor/command-center.spec.js
+++ b/test/e2e/specs/site-editor/command-center.spec.js
@@ -22,7 +22,6 @@ test.describe( 'Site editor command palette', () => {
 
 	test( 'Open the command palette and navigate to the page create page', async ( {
 		page,
-		editor,
 	} ) => {
 		await page
 			.getByRole( 'button', { name: 'Open command palette' } )
@@ -34,9 +33,9 @@ test.describe( 'Site editor command palette', () => {
 			/\/wp-admin\/site-editor.php\?p=%2Fpage%2F(\d+)&canvas=edit/
 		);
 		await expect(
-			editor.canvas
-				.getByLabel( 'Block: Title' )
-				.locator( '[data-rich-text-placeholder="No title"]' )
+			page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'No title · Page' } )
 		).toBeVisible();
 	} );
 

--- a/test/e2e/specs/site-editor/template-hierarchy.spec.js
+++ b/test/e2e/specs/site-editor/template-hierarchy.spec.js
@@ -22,11 +22,14 @@ test.describe( 'Template hierarchy', () => {
 		await page.selectOption( 'select[name="page_on_front"]', '2' );
 		await page.click( 'input[type="submit"]' );
 		await admin.visitSiteEditor();
+		await editor.canvas.locator( 'body' ).click();
 
-		// Title block should contain "Sample Page"
+		// The document bar should contain "Sample Page".
 		await expect(
-			editor.canvas.locator( 'role=document[name="Block: Title"]' )
-		).toContainText( 'Sample Page' );
+			page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'Sample Page · Homepage' } )
+		).toBeVisible();
 
 		await admin.visitAdminPage( 'options-reading.php' );
 		await page.click( 'input[name="show_on_front"][value="posts"]' );

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -160,10 +160,6 @@ test.describe( 'Site Editor Performance', () => {
 				await toggleSidebarButton.click();
 			}
 
-			await canvas
-				.getByRole( 'document', { name: /Block:( Post)? Content/ } )
-				.click();
-
 			const paragraph = canvas.getByRole( 'document', {
 				name: /Empty block/i,
 			} );


### PR DESCRIPTION
## What?
Fixes e2e and performance tests that are failing on the trunk after reverting the new default rendering mode for Pages.

## Testing Instructions
CI checks should be green.
