### PR TITLE
Feat: Add responsive spacing settings

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -895,7 +895,7 @@ Add white space between blocks and customize its height. ([Source](https://githu
 -	**Name:** core/spacer
 -	**Category:** design
 -	**Supports:** anchor, interactivity (clientNavigation), spacing (margin)
--	**Attributes:** height, width
+-	**Attributes:** heightDesktop, heightMobile, heightTablet, width
 
 ## Table
 

--- a/packages/block-library/src/spacer/block.json
+++ b/packages/block-library/src/spacer/block.json
@@ -7,7 +7,15 @@
 	"description": "Add white space between blocks and customize its height.",
 	"textdomain": "default",
 	"attributes": {
-		"height": {
+		"heightDesktop": {
+			"type": "string",
+			"default": "100px"
+		},
+		"heightTablet": {
+			"type": "string",
+			"default": "100px"
+		},
+		"heightMobile": {
 			"type": "string",
 			"default": "100px"
 		},

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -87,7 +87,9 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 export default function SpacerControls( {
 	setAttributes,
 	orientation,
-	height,
+	heightDesktop,
+	heightTablet,
+	heightMobile,
 	width,
 	isResizing,
 } ) {
@@ -128,16 +130,40 @@ export default function SpacerControls( {
 					<ToolsPanelItem
 						label={ __( 'Height' ) }
 						isShownByDefault
-						hasValue={ () => height !== '100px' }
+						hasValue={ () =>
+							heightDesktop !== '100px' ||
+							heightTablet !== '100px' ||
+							heightMobile !== '100px'
+						}
 						onDeselect={ () =>
-							setAttributes( { height: '100px' } )
+							setAttributes( {
+								heightDesktop: '100px',
+								heightTablet: '100px',
+								heightMobile: '100px',
+							} )
 						}
 					>
 						<DimensionInput
-							label={ __( 'Height' ) }
-							value={ height }
+							label={ __( 'Desktop Height' ) }
+							value={ heightDesktop }
 							onChange={ ( nextHeight ) =>
-								setAttributes( { height: nextHeight } )
+								setAttributes( { heightDesktop: nextHeight } )
+							}
+							isResizing={ isResizing }
+						/>
+						<DimensionInput
+							label={ __( 'Tablet Height' ) }
+							value={ heightTablet }
+							onChange={ ( nextHeight ) =>
+								setAttributes( { heightTablet: nextHeight } )
+							}
+							isResizing={ isResizing }
+						/>
+						<DimensionInput
+							label={ __( 'Mobile Height' ) }
+							value={ heightMobile }
+							onChange={ ( nextHeight ) =>
+								setAttributes( { heightMobile: nextHeight } )
 							}
 							isResizing={ isResizing }
 						/>

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -13,6 +13,7 @@ import {
 	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
+import { store as viewportStore } from '@wordpress/viewport';
 import { ResizableBox } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import { View } from '@wordpress/primitives';
@@ -110,7 +111,39 @@ const SpacerEdit = ( {
 		! parentOrientation && isFlexLayout
 			? 'horizontal'
 			: parentOrientation || orientation;
-	const { height, width, style: blockStyle = {} } = attributes;
+	const {
+		heightDesktop,
+		heightTablet,
+		heightMobile,
+		width,
+		style: blockStyle = {},
+	} = attributes;
+
+	const viewport = useSelect( ( select ) => {
+		if ( select( viewportStore ).isViewportMatch( '< small' ) ) {
+			return 'mobile';
+		}
+
+		if ( select( viewportStore ).isViewportMatch( '< large' ) ) {
+			return 'tablet';
+		}
+
+		return 'desktop';
+	} );
+
+	const isMobile = viewport === 'mobile';
+	const isTablet = viewport === 'tablet';
+	const isDesktop = viewport === 'desktop';
+
+	let height = '100px';
+
+	if ( isMobile && heightMobile !== undefined ) {
+		height = heightMobile;
+	} else if ( isTablet && heightTablet !== undefined ) {
+		height = heightTablet;
+	} else if ( isDesktop && heightDesktop !== undefined ) {
+		height = heightDesktop;
+	}
 
 	const { layout = {} } = blockStyle;
 	const { selfStretch, flexSize } = layout;
@@ -143,7 +176,13 @@ const SpacerEdit = ( {
 			} );
 		}
 
-		setAttributes( { height: newHeight } );
+		if ( isMobile ) {
+			setAttributes( { heightMobile: newHeight } );
+		} else if ( isTablet ) {
+			setAttributes( { heightTablet: newHeight } );
+		} else {
+			setAttributes( { heightDesktop: newHeight } );
+		}
 		setTemporaryHeight( null );
 	};
 
@@ -361,7 +400,21 @@ const SpacerEdit = ( {
 			{ ! isFlexLayout && (
 				<SpacerControls
 					setAttributes={ setAttributes }
-					height={ temporaryHeight || height }
+					heightDesktop={
+						isDesktop
+							? temporaryHeight || attributes.heightDesktop
+							: attributes.heightDesktop
+					}
+					heightTablet={
+						isTablet
+							? temporaryHeight || attributes.heightTablet
+							: attributes.heightTablet
+					}
+					heightMobile={
+						isMobile
+							? temporaryHeight || attributes.heightMobile
+							: attributes.heightMobile
+					}
 					width={ temporaryWidth || width }
 					orientation={ inheritedOrientation }
 					isResizing={ isResizing }

--- a/packages/block-library/src/spacer/save.js
+++ b/packages/block-library/src/spacer/save.js
@@ -4,16 +4,27 @@
 import { useBlockProps, getSpacingPresetCssVar } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { height, width, style } = attributes;
+	const { heightMobile, heightTablet, heightDesktop, width, style } =
+		attributes;
 	const { layout: { selfStretch } = {} } = style || {};
+
+	const heights = {
+		'--wp-block-spacing-height-mobile':
+			getSpacingPresetCssVar( heightMobile ),
+		'--wp-block-spacing-height-tablet':
+			getSpacingPresetCssVar( heightTablet ),
+		'--wp-block-spacing-height-desktop':
+			getSpacingPresetCssVar( heightDesktop ),
+	};
+
 	// If selfStretch is set to 'fill' or 'fit', don't set default height.
-	const finalHeight =
-		selfStretch === 'fill' || selfStretch === 'fit' ? undefined : height;
+	const finalHeights =
+		selfStretch === 'fill' || selfStretch === 'fit' ? undefined : heights;
 	return (
 		<div
 			{ ...useBlockProps.save( {
 				style: {
-					height: getSpacingPresetCssVar( finalHeight ),
+					...finalHeights,
 					width: getSpacingPresetCssVar( width ),
 				},
 				'aria-hidden': true,

--- a/packages/block-library/src/spacer/style.scss
+++ b/packages/block-library/src/spacer/style.scss
@@ -1,3 +1,13 @@
 .wp-block-spacer {
 	clear: both;
+
+	height: var(--wp-block-spacing-height-desktop);
+
+	@media screen and (max-width: 960px) {
+		height: var(--wp-block-spacing-height-tablet);
+	}
+
+	@media screen and (max-width: 600px) {
+		height: var(--wp-block-spacing-height-mobile);
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
See #67620 

This PR adds settings to add height for individual devices:
1. Mobile (viewport < `small`)
2. Tablet (viewport < `large`)
3. Desktop (viewport >= `large`)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As mentioned in #67620, we cannot use same height for all three types of devices. Height for desktop would be too large for mobile. Hence, we need these settings.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR replace **Height** settings with three separate settings: 
1. **Desktop Height**
2. **Tablet Height**
3. **Mobile Height**

The `Spacer Block` will use the value based on the viewport. Also, when using `ResizableBox` for setting the height, it'll also refer to the viewport and only update the respective viewport height.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open a post or page.
2. Insert a `Spacer` block.
3. You can see different settings for device specific height.
4. Set different heights and save the changes.
5. View the changes by changing the viewport.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1408" alt="image" src="https://github.com/user-attachments/assets/7d38d6ef-033c-4e03-8fbf-33771237c485" />|<img width="1407" alt="image" src="https://github.com/user-attachments/assets/9cd5623e-c3d6-4782-9706-0661cb908648" />|
