### PR TITLE
Testing: Refactor 'Template hierarchy' e2e tests

### DIFF
--- a/test/e2e/specs/site-editor/template-hierarchy.spec.js
+++ b/test/e2e/specs/site-editor/template-hierarchy.spec.js
@@ -9,13 +9,17 @@ test.describe( 'Template hierarchy', () => {
 	} );
 
 	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.updateSiteSettings( {
+			show_on_front: 'posts',
+			page_on_front: 0,
+			page_for_posts: 0,
+		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
 		await Promise.all( [
-			requestUtils.updateSiteSettings( {
-				show_on_front: 'posts',
-				page_on_front: 0,
-				page_for_posts: 0,
-			} ),
 			requestUtils.activateTheme( 'twentytwentyone' ),
+			requestUtils.deleteAllPages(),
 		] );
 	} );
 

--- a/test/e2e/specs/site-editor/template-hierarchy.spec.js
+++ b/test/e2e/specs/site-editor/template-hierarchy.spec.js
@@ -9,30 +9,41 @@ test.describe( 'Template hierarchy', () => {
 	} );
 
 	test.afterEach( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
+		await Promise.all( [
+			requestUtils.updateSiteSettings( {
+				show_on_front: 'posts',
+				page_on_front: 0,
+				page_for_posts: 0,
+			} ),
+			requestUtils.activateTheme( 'twentytwentyone' ),
+		] );
 	} );
 
 	test( 'shows correct template with page on front option', async ( {
 		admin,
-		page,
 		editor,
+		page,
+		requestUtils,
 	} ) => {
-		await admin.visitAdminPage( 'options-reading.php' );
-		await page.click( 'input[name="show_on_front"][value="page"]' );
-		await page.selectOption( 'select[name="page_on_front"]', '2' );
-		await page.click( 'input[type="submit"]' );
+		const newPage = await requestUtils.createPage( {
+			title: 'Page on Front',
+			status: 'publish',
+			content:
+				'<!-- wp:paragraph --><p>This is a page on front</p><!-- /wp:paragraph -->',
+		} );
+		await requestUtils.updateSiteSettings( {
+			show_on_front: 'page',
+			page_on_front: newPage.id,
+			page_for_posts: 0,
+		} );
 		await admin.visitSiteEditor();
 		await editor.canvas.locator( 'body' ).click();
 
-		// The document bar should contain "Sample Page".
+		// Title block should contain "Page on Front"
 		await expect(
 			page
 				.getByRole( 'region', { name: 'Editor top bar' } )
-				.getByRole( 'button', { name: 'Sample Page · Homepage' } )
+				.getByRole( 'button', { name: 'Page on Front · Homepage' } )
 		).toBeVisible();
-
-		await admin.visitAdminPage( 'options-reading.php' );
-		await page.click( 'input[name="show_on_front"][value="posts"]' );
-		await page.click( 'input[type="submit"]' );
 	} );
 } );


### PR DESCRIPTION
## What?
PR refactors `test/e2e/specs/site-editor/template-hierarchy.spec.js` e2e tests to make them more resilient.

## Why?
* Using REST API to update settings should be preferred over UI in this particular case.
* The test assumes that the page with `ID=2` will always exist. This won't be true if the previous test in the same shard deletes all pages.

## Testing Instructions
```
npm run test:e2e -- test/e2e/specs/site-editor/template-hierarchy.spec.js
```

### Testing Instructions for Keyboard
Same.
