### PR TITLE
Enhance : Make logo inherit the site background/gradient

### DIFF
--- a/packages/edit-post/src/components/back-button/fullscreen-mode-close.js
+++ b/packages/edit-post/src/components/back-button/fullscreen-mode-close.js
@@ -101,7 +101,7 @@ function FullscreenModeClose( { showTooltip, icon, href, initialPost } ) {
 			<img
 				className="edit-post-fullscreen-mode-close-site-icon__image"
 				alt={ __( 'Site Icon' ) }
-				className="edit-post-fullscreen-mode-close_site-icon" // Apply global bg styles here
+				className="edit-post-fullscreen-mode-close_site-icon"
 				src={ siteIconUrl }
 			/>
 		);

--- a/packages/edit-post/src/components/back-button/fullscreen-mode-close.js
+++ b/packages/edit-post/src/components/back-button/fullscreen-mode-close.js
@@ -101,7 +101,6 @@ function FullscreenModeClose( { showTooltip, icon, href, initialPost } ) {
 			<img
 				className="edit-post-fullscreen-mode-close-site-icon__image"
 				alt={ __( 'Site Icon' ) }
-				className="edit-post-fullscreen-mode-close_site-icon"
 				src={ siteIconUrl }
 			/>
 		);

--- a/packages/edit-post/src/components/back-button/fullscreen-mode-close.js
+++ b/packages/edit-post/src/components/back-button/fullscreen-mode-close.js
@@ -18,6 +18,15 @@ import { wordpress, arrowUpLeft } from '@wordpress/icons';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { useReducedMotion } from '@wordpress/compose';
+import {
+	privateApis as blockEditorPrivateApis,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+const { globalStylesDataKey } = unlock( blockEditorPrivateApis );
 
 const siteIconVariants = {
 	edit: {
@@ -44,14 +53,21 @@ const toggleHomeIconVariants = {
 };
 
 function FullscreenModeClose( { showTooltip, icon, href, initialPost } ) {
+	const globalStyles = useSelect( ( select ) => {
+		const settings = select( blockEditorStore ).getSettings();
+		return settings[ globalStylesDataKey ];
+	}, [] );
+
 	const { isRequestingSiteIcon, postType, siteIconUrl } = useSelect(
 		( select ) => {
 			const { getCurrentPostType } = select( editorStore );
 			const { getEntityRecord, getPostType, isResolving } =
 				select( coreStore );
+
 			const siteData =
 				getEntityRecord( 'root', '__unstableBase', undefined ) || {};
 			const _postType = initialPost?.type || getCurrentPostType();
+
 			return {
 				isRequestingSiteIcon: isResolving( 'getEntityRecord', [
 					'root',
@@ -85,6 +101,7 @@ function FullscreenModeClose( { showTooltip, icon, href, initialPost } ) {
 			<img
 				className="edit-post-fullscreen-mode-close-site-icon__image"
 				alt={ __( 'Site Icon' ) }
+				className="edit-post-fullscreen-mode-close_site-icon" // Apply global bg styles here
 				src={ siteIconUrl }
 			/>
 		);
@@ -134,6 +151,12 @@ function FullscreenModeClose( { showTooltip, icon, href, initialPost } ) {
 				href={ buttonHref }
 				label={ buttonLabel }
 				showTooltip={ showTooltip }
+				style={ {
+					background: globalStyles?.color?.gradient
+						? globalStyles?.color?.gradient
+						: globalStyles?.color?.background,
+					color: globalStyles?.color?.text,
+				} }
 				tooltipPosition="middle right"
 			>
 				<motion.div variants={ ! disableMotion && siteIconVariants }>

--- a/packages/edit-post/src/components/back-button/style.scss
+++ b/packages/edit-post/src/components/back-button/style.scss
@@ -44,6 +44,28 @@
 		img {
 			background: $gray-900;
 			display: block;
+			position: absolute;
+			top: 9px;
+			right: 9px;
+			bottom: 9px + $border-width; // Height of toolbar in edit-post (not edit-site) is 61px tall.
+			left: 9px;
+			border-radius: $radius-small + $border-width + $border-width;
+		}
+
+		// Hover color.
+		&:hover::before {
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $gray-700;
+		}
+
+		&.has-icon:hover::before {
+			box-shadow: none;
+		}
+
+		// Lightened spot color focus.
+		&:focus::before {
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) rgba($white, 0.1), inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		}
+	}
 		}
 	}
 }
@@ -99,6 +121,10 @@
 		background-color: hsla(0, 0%, 100%, 0.6);
 		-webkit-backdrop-filter: saturate(180%) blur(15px);
 		backdrop-filter: saturate(180%) blur(15px);
+	}
+	
+	.edit-post-fullscreen-mode-close_site-icon:hover {
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $gray-700;
 	}
 }
 

--- a/packages/edit-post/src/components/back-button/style.scss
+++ b/packages/edit-post/src/components/back-button/style.scss
@@ -124,7 +124,7 @@
 	}
 	
 	.edit-post-fullscreen-mode-close_site-icon:hover {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $gray-700;
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus);
 	}
 }
 

--- a/packages/edit-post/src/components/back-button/style.scss
+++ b/packages/edit-post/src/components/back-button/style.scss
@@ -13,22 +13,17 @@
 
 	.components-button {
 		color: $white;
-		height: 100%;
-		width: 100%;
+		height: $header-height;
+		width: $header-height;
 		border-radius: 0;
 		overflow: hidden;
 		padding: 0;
 		display: flex;
 		align-items: center;
 		align-self: stretch;
-		border: none;
-		color: $white;
-		border-radius: 0;
-		height: $header-height;
-		width: $header-height;
-		position: relative;
-
 		justify-content: center;
+		border: none;
+		position: relative;
 		&:hover,
 		&:active {
 			color: $white;
@@ -64,8 +59,6 @@
 		// Lightened spot color focus.
 		&:focus::before {
 			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) rgba($white, 0.1), inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-		}
-	}
 		}
 	}
 }
@@ -122,7 +115,7 @@
 		-webkit-backdrop-filter: saturate(180%) blur(15px);
 		backdrop-filter: saturate(180%) blur(15px);
 	}
-	
+
 	.edit-post-fullscreen-mode-close_site-icon:hover {
 		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus);
 	}

--- a/packages/edit-post/src/components/back-button/style.scss
+++ b/packages/edit-post/src/components/back-button/style.scss
@@ -20,6 +20,14 @@
 		padding: 0;
 		display: flex;
 		align-items: center;
+		align-self: stretch;
+		border: none;
+		color: $white;
+		border-radius: 0;
+		height: $header-height;
+		width: $header-height;
+		position: relative;
+
 		justify-content: center;
 		&:hover,
 		&:active {

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -22,7 +22,10 @@ import { store as noticesStore } from '@wordpress/notices';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { decodeEntities } from '@wordpress/html-entities';
 import { Icon, arrowUpLeft } from '@wordpress/icons';
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import {
+	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
@@ -121,6 +124,12 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 	// deprecated sync state with url
 	useSyncDeprecatedEntityIntoState( entity );
 	const { postType, postId, context } = entity;
+	const { globalStylesDataKey } = unlock( blockEditorPrivateApis );
+	const globalStyles = useSelect( ( select ) => {
+		const settings = select( blockEditorStore ).getSettings();
+		return settings[ globalStylesDataKey ];
+	}, [] );
+
 	const { isBlockBasedTheme, hasSiteIcon } = useSelect( ( select ) => {
 		const { getCurrentTheme, getEntityRecord } = select( coreDataStore );
 		const siteData = getEntityRecord( 'root', '__unstableBase', undefined );
@@ -277,7 +286,21 @@ export default function EditSiteEditor( { isHomeRoute = false } ) {
 											<motion.div
 												variants={ siteIconVariants }
 											>
-												<SiteIcon className="edit-site-editor__view-mode-toggle-icon" />
+												<SiteIcon
+													className="edit-site-editor__view-mode-toggle-icon"
+													style={ {
+														background: globalStyles
+															?.color?.gradient
+															? globalStyles
+																	?.color
+																	?.gradient
+															: globalStyles
+																	?.color
+																	?.background,
+														color: globalStyles
+															?.color?.text,
+													} }
+												/>
 											</motion.div>
 										</Button>
 										<motion.div

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -56,7 +56,6 @@
 	.edit-site-editor__view-mode-toggle-icon {
 		svg,
 		img {
-			background: $gray-900;
 			display: block;
 		}
 	}

--- a/packages/edit-site/src/components/site-icon/index.js
+++ b/packages/edit-site/src/components/site-icon/index.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 import { wordpress } from '@wordpress/icons';
 import { store as coreDataStore } from '@wordpress/core-data';
 
-function SiteIcon( { className } ) {
+function SiteIcon( { className, style } ) {
 	const { isRequestingSite, siteIconUrl } = useSelect( ( select ) => {
 		const { getEntityRecord } = select( coreDataStore );
 		const siteData = getEntityRecord( 'root', '__unstableBase', undefined );
@@ -29,7 +29,10 @@ function SiteIcon( { className } ) {
 
 	const icon = siteIconUrl ? (
 		<img
-			className="edit-site-site-icon__image"
+			className={ clsx(
+				'edit-site-site-icon__image',
+				! style?.background && 'edit-site-site-icon__image_background'
+			) }
 			alt={ __( 'Site Icon' ) }
 			src={ siteIconUrl }
 		/>
@@ -42,7 +45,10 @@ function SiteIcon( { className } ) {
 	);
 
 	return (
-		<div className={ clsx( className, 'edit-site-site-icon' ) }>
+		<div
+			className={ clsx( className, 'edit-site-site-icon' ) }
+			style={ style }
+		>
 			{ icon }
 		</div>
 	);

--- a/packages/edit-site/src/components/site-icon/style.scss
+++ b/packages/edit-site/src/components/site-icon/style.scss
@@ -16,12 +16,15 @@
 	width: 100%;
 	height: 100%;
 	object-fit: cover;
-	background: #333;
 	aspect-ratio: 1 / 1;
 
 	.edit-site-layout.is-full-canvas & {
 		border-radius: 0;
 	}
+}
+
+.edit-site-site-icon__image_background {
+	background: #333;
 }
 
 .edit-site-editor__view-mode-toggle button:focus {


### PR DESCRIPTION
## Fixes #49501

## What?
When a user uploads an image to the Site Logo block for the first time, a square crop of that image is also used as the Site Icon. In common setups—like sites with white logos on transparent backgrounds and dark text—this results in a barely visible site icon.

To solve this, we apply the site's background color behind the site logo image directly via inline styles. This ensures that the logo maintains its intended contrast regardless of transparency in both site editor and post editor.


## Why?
- Improves visual accessibility and brand clarity by preserving the intended logo contrast (if logo is still not visible then user could adjust background color/gradiant of site.
- Prevents a poor user experience where the site icon appears invisible or unclear due to a transparent or white logo without a contrasting background.

## How?
I used the internal globalStylesDataKey from the block editor’s private APIs to fetch the global styles set in the Site Editor. Then, we applied the background and text color directly to the image element within the Site Logo block using inline styles:
```
import {
	privateApis as blockEditorPrivateApis,
	store as blockEditorStore,
} from '@wordpress/block-editor';
import { unlock } from '../../lock-unlock';

const { globalStylesDataKey } = unlock(blockEditorPrivateApis);

const globalStyles = useSelect((select) => {
	const settings = select(blockEditorStore).getSettings();
	return settings[globalStylesDataKey];
}, []);

style={{
	background: globalStyles?.color?.gradient
		? globalStyles?.color?.gradient
		: globalStyles?.color?.background, // apply the gradiant, color to background of icon
	color: globalStyles?.color?.text, // apply the color for border on hover
}}

```

This ensures the logo always renders on a background consistent with the site's design system. 

# ScreenShots
![image](https://github.com/user-attachments/assets/4d1492c9-f9c7-440f-9962-33347c9c8f68)
![image](https://github.com/user-attachments/assets/2952197f-637c-4c6d-8346-b0d8f031b7d5)
![image](https://github.com/user-attachments/assets/0a33855e-35ce-4abb-bcea-f29a2c4b82db)
