### PR TITLE
Fix: Footnotes block editing in sync patterns

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -282,6 +282,7 @@ Display footnotes added to the page. ([Source](https://github.com/WordPress/gute
 -	**Name:** core/footnotes
 -	**Category:** text
 -	**Supports:** color (background, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~inserter~~, ~~multiple~~, ~~reusable~~
+-	**Attributes:** footnotes
 
 ## Form
 

--- a/packages/block-library/src/footnotes/block.json
+++ b/packages/block-library/src/footnotes/block.json
@@ -8,6 +8,23 @@
 	"keywords": [ "references" ],
 	"textdomain": "default",
 	"usesContext": [ "postId", "postType" ],
+	"attributes": {
+		"footnotes": {
+			"type": "array",
+			"default": [],
+			"items": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "string"
+					},
+					"content": {
+						"type": "string"
+					}
+				}
+			}
+		}
+	},
 	"supports": {
 		"__experimentalBorder": {
 			"radius": true,

--- a/packages/block-library/src/footnotes/edit.js
+++ b/packages/block-library/src/footnotes/edit.js
@@ -6,42 +6,100 @@ import { useEntityProp } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import { Placeholder } from '@wordpress/components';
 import { formatListNumbered as icon } from '@wordpress/icons';
+import { useState, useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 
-export default function FootnotesEdit( { context: { postType, postId } } ) {
+export default function FootnotesEdit( {
+	context,
+	attributes,
+	setAttributes,
+} ) {
+	// Fallback context detection using current post.
+	const currentPost = useSelect(
+		// eslint-disable-next-line @wordpress/data-no-store-string-literals
+		( select ) => select( 'core/editor' ).getCurrentPost(),
+		[]
+	);
+	const currentPostId = currentPost?.id;
+	const currentPostType = currentPost?.type || 'post';
+
+	// Prioritize passed context, then fallback to detected context.
+	const postType = context?.postType || currentPostType;
+	const postId = context?.postId || currentPostId;
+
 	const [ meta, updateMeta ] = useEntityProp(
 		'postType',
 		postType,
 		'meta',
 		postId
 	);
-	const footnotesSupported = 'string' === typeof meta?.footnotes;
-	const footnotes = meta?.footnotes ? JSON.parse( meta.footnotes ) : [];
+
+	const [ footnotes, setFootnotes ] = useState( () => {
+		const sources = [
+			attributes.footnotes,
+			meta?.footnotes ? JSON.parse( meta.footnotes ) : null,
+			[],
+		];
+
+		const validSource = sources.find(
+			( source ) => Array.isArray( source ) && source.length > 0
+		);
+
+		return validSource || [];
+	} );
+
+	useEffect( () => {
+		setAttributes( { footnotes } );
+	}, [ footnotes, setAttributes ] );
+
 	const blockProps = useBlockProps();
 
-	if ( ! footnotesSupported ) {
-		return (
-			<div { ...blockProps }>
-				<Placeholder
-					icon={ <BlockIcon icon={ icon } /> }
-					label={ __( 'Footnotes' ) }
-					instructions={ __(
-						'Footnotes are not supported here. Add this block to post or page content.'
-					) }
-				/>
-			</div>
+	const handleFootnoteChange = ( nextFootnote, id ) => {
+		const updatedFootnotes = footnotes.map( ( footnote ) =>
+			footnote.id === id
+				? { ...footnote, content: nextFootnote }
+				: footnote
 		);
-	}
 
-	if ( ! footnotes.length ) {
+		setFootnotes( updatedFootnotes );
+
+		if ( meta ) {
+			try {
+				updateMeta( {
+					...meta,
+					footnotes: JSON.stringify( updatedFootnotes ),
+				} );
+			} catch ( error ) {
+				// Silent error handling.
+			}
+		}
+	};
+
+	const addInitialFootnote = () => {
+		const newFootnote = {
+			id: `footnote-${ Date.now() }`,
+			content: __( 'Add your footnote text' ),
+		};
+		setFootnotes( [ newFootnote ] );
+	};
+
+	if ( ! footnotes || footnotes.length === 0 ) {
 		return (
 			<div { ...blockProps }>
 				<Placeholder
 					icon={ <BlockIcon icon={ icon } /> }
 					label={ __( 'Footnotes' ) }
 					instructions={ __(
-						'Footnotes found in blocks within this document will be displayed here.'
+						'No footnotes available. Click below to add your first footnote.'
 					) }
-				/>
+				>
+					<button
+						className="components-button is-primary"
+						onClick={ addInitialFootnote }
+					>
+						{ __( 'Add Footnote' ) }
+					</button>
+				</Placeholder>
 			</div>
 		);
 	}
@@ -74,21 +132,10 @@ export default function FootnotesEdit( { context: { postType, postId } } ) {
 								event.target.scrollIntoView();
 							}
 						} }
-						onChange={ ( nextFootnote ) => {
-							updateMeta( {
-								...meta,
-								footnotes: JSON.stringify(
-									footnotes.map( ( footnote ) => {
-										return footnote.id === id
-											? {
-													content: nextFootnote,
-													id,
-											  }
-											: footnote;
-									} )
-								),
-							} );
-						} }
+						onChange={ ( nextFootnote ) =>
+							handleFootnoteChange( nextFootnote, id )
+						}
+						placeholder={ __( 'Enter footnote text' ) }
 					/>{ ' ' }
 					<a href={ `#${ id }-link` }>↩︎</a>
 				</li>

--- a/packages/block-library/src/footnotes/edit.js
+++ b/packages/block-library/src/footnotes/edit.js
@@ -52,6 +52,7 @@ export default function FootnotesEdit( {
 		setAttributes( { footnotes } );
 	}, [ footnotes, setAttributes ] );
 
+	const footnotesSupported = 'string' === typeof meta?.footnotes;
 	const blockProps = useBlockProps();
 
 	const handleFootnoteChange = ( nextFootnote, id ) => {
@@ -75,13 +76,19 @@ export default function FootnotesEdit( {
 		}
 	};
 
-	const addInitialFootnote = () => {
-		const newFootnote = {
-			id: `footnote-${ Date.now() }`,
-			content: __( 'Add your footnote text' ),
-		};
-		setFootnotes( [ newFootnote ] );
-	};
+	if ( ! footnotesSupported ) {
+		return (
+			<div { ...blockProps }>
+				<Placeholder
+					icon={ <BlockIcon icon={ icon } /> }
+					label={ __( 'Footnotes' ) }
+					instructions={ __(
+						'Footnotes are not supported here. Add this block to post or page content.'
+					) }
+				/>
+			</div>
+		);
+	}
 
 	if ( ! footnotes || footnotes.length === 0 ) {
 		return (
@@ -92,14 +99,7 @@ export default function FootnotesEdit( {
 					instructions={ __(
 						'No footnotes available. Click below to add your first footnote.'
 					) }
-				>
-					<button
-						className="components-button is-primary"
-						onClick={ addInitialFootnote }
-					>
-						{ __( 'Add Footnote' ) }
-					</button>
-				</Placeholder>
+				/>
 			</div>
 		);
 	}

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -26,13 +26,17 @@ function render_block_core_footnotes( $attributes, $content, $block ) {
 		return;
 	}
 
-	$footnotes = get_post_meta( $block->context['postId'], 'footnotes', true );
+	$footnotes = ! empty( $attributes['footnotes'] )
+		? $attributes['footnotes']
+		: get_post_meta( $block->context['postId'], 'footnotes', true );
 
 	if ( ! $footnotes ) {
 		return;
 	}
 
-	$footnotes = json_decode( $footnotes, true );
+	if ( is_string( $footnotes ) ) {
+		$footnotes = json_decode( $footnotes, true );
+	}
 
 	if ( ! is_array( $footnotes ) || count( $footnotes ) === 0 ) {
 		return '';


### PR DESCRIPTION
Closes #60982

## What?
Fix Footnotes block editing in sync patterns

## Why?
Currently, when a Footnotes block is added to a Sync Pattern, users cannot edit the footnotes from either the Post/Page content or the Pattern editor. This significantly limits the usability of footnotes in reusable patterns.


## Testing Instructions
1. Create a new page or post
2. Add a Footnotes block to your content
3. Create a Group block containing the Footnotes block
4. Convert the Group block to a Sync Pattern
5. Verify you can edit footnotes:
   - In the original post/page
   - In the Sync Pattern
   - In other posts using the same pattern

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/ed7d3f04-27b9-4dd4-8d26-118a407925bf

### After

https://github.com/user-attachments/assets/6ad0521d-ddb2-4572-b4e0-43e837d93d2d


