### PR TITLE
Query Loop: Don't overwrite the 'query.inherit' attribute value

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -5,11 +5,12 @@ import {
 	TextControl,
 	SelectControl,
 	RangeControl,
-	__experimentalToggleGroupControl as ToggleGroupControl,
-	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	Notice,
+	__experimentalVStack as VStack,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -113,8 +114,7 @@ export default function QueryInspectorControls( props ) {
 	}, [ querySearch, onChangeDebounced ] );
 
 	const orderByOptions = useOrderByOptions( postType );
-	const showInheritControl =
-		! isSingular && isControlAllowed( allowedControls, 'inherit' );
+	const showInheritControl = isControlAllowed( allowedControls, 'inherit' );
 	const showPostTypeControl =
 		! inherit && isControlAllowed( allowedControls, 'postType' );
 	const postTypeControlLabel = __( 'Post type' );
@@ -185,6 +185,10 @@ export default function QueryInspectorControls( props ) {
 	const showDisplayPanel =
 		showPostCountControl || showOffSetControl || showPagesControl;
 
+	// The block cannot inherit a default WordPress query in singular content (e.g., post, page, 404, blank).
+	// Warn users but still permit this type of query for exceptional cases in Classic and Hybrid themes.
+	const hasInheritanceWarning = isSingular && inherit;
+
 	return (
 		<>
 			{ showSettingsPanel && (
@@ -208,36 +212,48 @@ export default function QueryInspectorControls( props ) {
 							onDeselect={ () => setQuery( { inherit: true } ) }
 							isShownByDefault
 						>
-							<ToggleGroupControl
-								__next40pxDefaultSize
-								__nextHasNoMarginBottom
-								label={ __( 'Query type' ) }
-								isBlock
-								onChange={ ( value ) => {
-									setQuery( {
-										inherit: value === 'default',
-									} );
-								} }
-								help={
-									inherit
-										? __(
-												'Display a list of posts or custom post types based on the current template.'
-										  )
-										: __(
-												'Display a list of posts or custom post types based on specific criteria.'
-										  )
-								}
-								value={ !! inherit ? 'default' : 'custom' }
-							>
-								<ToggleGroupControlOption
-									value="default"
-									label={ __( 'Default' ) }
-								/>
-								<ToggleGroupControlOption
-									value="custom"
-									label={ __( 'Custom' ) }
-								/>
-							</ToggleGroupControl>
+							<VStack spacing={ 4 }>
+								<ToggleGroupControl
+									__next40pxDefaultSize
+									__nextHasNoMarginBottom
+									label={ __( 'Query type' ) }
+									isBlock
+									onChange={ ( value ) => {
+										setQuery( {
+											inherit: value === 'default',
+										} );
+									} }
+									help={
+										inherit
+											? __(
+													'Display a list of posts or custom post types based on the current template.'
+											  )
+											: __(
+													'Display a list of posts or custom post types based on specific criteria.'
+											  )
+									}
+									value={ !! inherit ? 'default' : 'custom' }
+								>
+									<ToggleGroupControlOption
+										value="default"
+										label={ __( 'Default' ) }
+									/>
+									<ToggleGroupControlOption
+										value="custom"
+										label={ __( 'Custom' ) }
+									/>
+								</ToggleGroupControl>
+								{ hasInheritanceWarning && (
+									<Notice
+										status="warning"
+										isDismissible={ false }
+									>
+										{ __(
+											'Cannot inherit the current template query when placed inside the singular content (e.g., post, page, 404, blank).'
+										) }
+									</Notice>
+								) }
+							</VStack>
 						</ToolsPanelItem>
 					) }
 

--- a/packages/block-library/src/query/edit/query-content.js
+++ b/packages/block-library/src/query/edit/query-content.js
@@ -132,6 +132,8 @@ export default function QueryContent( {
 			displayLayout: { ...displayLayout, ...newDisplayLayout },
 		} );
 
+	// The block cannot inherit a default WordPress query in singular content (e.g., post, page, 404, blank).
+	// Warn users but still permit this type of query for exceptional cases in Classic and Hybrid themes.
 	const hasInheritanceWarning = isSingular && inherit;
 
 	return (
@@ -195,7 +197,7 @@ export default function QueryContent( {
 						] }
 					>
 						{ __(
-							'Cannot inherit the global queries when placed inside the singular content'
+							'Cannot inherit the default WordPress query when placed inside the singular content (e.g., post, page, 404, blank).'
 						) }
 					</Warning>
 				</div>

--- a/packages/block-library/src/query/edit/query-content.js
+++ b/packages/block-library/src/query/edit/query-content.js
@@ -7,11 +7,12 @@ import { useEffect, useCallback } from '@wordpress/element';
 import {
 	BlockControls,
 	InspectorControls,
+	Warning,
 	useBlockProps,
 	store as blockEditorStore,
 	useInnerBlocksProps,
 } from '@wordpress/block-editor';
-import { SelectControl } from '@wordpress/components';
+import { Button, SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -101,21 +102,15 @@ export default function QueryContent( {
 		} else if ( ! query.perPage && postsPerPage ) {
 			newQuery.perPage = postsPerPage;
 		}
-		// We need to reset the `inherit` value if in a singular template, as queries
-		// are not inherited when in singular content (e.g. post, page, 404, blank).
-		if ( isSingular && query.inherit ) {
-			newQuery.inherit = false;
-		}
+
 		if ( !! Object.keys( newQuery ).length ) {
 			__unstableMarkNextChangeAsNotPersistent();
 			updateQuery( newQuery );
 		}
 	}, [
 		query.perPage,
-		query.inherit,
-		postsPerPage,
 		inherit,
-		isSingular,
+		postsPerPage,
 		__unstableMarkNextChangeAsNotPersistent,
 		updateQuery,
 	] );
@@ -136,6 +131,8 @@ export default function QueryContent( {
 		setAttributes( {
 			displayLayout: { ...displayLayout, ...newDisplayLayout },
 		} );
+
+	const hasInheritanceWarning = isSingular && inherit;
 
 	return (
 		<>
@@ -181,7 +178,30 @@ export default function QueryContent( {
 					clientId={ clientId }
 				/>
 			</InspectorControls>
-			<TagName { ...innerBlocksProps } />
+			{ hasInheritanceWarning ? (
+				<div { ...blockProps }>
+					<Warning
+						actions={ [
+							<Button
+								__next40pxDefaultSize
+								key="switch"
+								onClick={ () =>
+									updateQuery( { inherit: false } )
+								}
+								variant="primary"
+							>
+								{ __( 'Switch to Custom' ) }
+							</Button>,
+						] }
+					>
+						{ __(
+							'Cannot inherit the global queries when placed inside the singular content'
+						) }
+					</Warning>
+				</div>
+			) : (
+				<TagName { ...innerBlocksProps } />
+			) }
 		</>
 	);
 }

--- a/packages/block-library/src/query/edit/query-content.js
+++ b/packages/block-library/src/query/edit/query-content.js
@@ -7,12 +7,11 @@ import { useEffect, useCallback } from '@wordpress/element';
 import {
 	BlockControls,
 	InspectorControls,
-	Warning,
 	useBlockProps,
 	store as blockEditorStore,
 	useInnerBlocksProps,
 } from '@wordpress/block-editor';
-import { Button, SelectControl } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -132,10 +131,6 @@ export default function QueryContent( {
 			displayLayout: { ...displayLayout, ...newDisplayLayout },
 		} );
 
-	// The block cannot inherit a default WordPress query in singular content (e.g., post, page, 404, blank).
-	// Warn users but still permit this type of query for exceptional cases in Classic and Hybrid themes.
-	const hasInheritanceWarning = isSingular && inherit;
-
 	return (
 		<>
 			<EnhancedPaginationModal
@@ -180,30 +175,7 @@ export default function QueryContent( {
 					clientId={ clientId }
 				/>
 			</InspectorControls>
-			{ hasInheritanceWarning ? (
-				<div { ...blockProps }>
-					<Warning
-						actions={ [
-							<Button
-								__next40pxDefaultSize
-								key="switch"
-								onClick={ () =>
-									updateQuery( { inherit: false } )
-								}
-								variant="primary"
-							>
-								{ __( 'Switch to Custom' ) }
-							</Button>,
-						] }
-					>
-						{ __(
-							'Cannot inherit the default WordPress query when placed inside the singular content (e.g., post, page, 404, blank).'
-						) }
-					</Warning>
-				</div>
-			) : (
-				<TagName { ...innerBlocksProps } />
-			) }
+			<TagName { ...innerBlocksProps } />
 		</>
 	);
 }


### PR DESCRIPTION
## What?
Closes #67252
An alternative solution for #64746 reverts #65067.

PR updates a Query Loop block to display a warning when `inherited` queries aren't "allowed", instead of forcing this attribute value to `false`.

## Why?
This allows developers to use inherited queries in templates/pages when working with custom rewrites.

Calling `setAttributes` in life-cycle events should be avoided in 99% of cases unless the block really needs to enforce that attribute value. Introducing more conditions in the setting of the attributes creates more variables and makes these life-cycle events flaky. It doesn't allow changing behavior when the consumer knows what they're doing. Additionally, it can cause excessive re-renders and degrade performance.

## Todos
- [ ] Update the variation picker to use query inheritances based on `getQueryContextFromTemplate`.

## Testing Instructions
1. Insert a Query Loop block inside a single page, post, or CPT.
2. Confirm that the warning is displayed but still allows using the default query (`inherit: true`).
3. Switch query type to Custom.
4. Confirm that the warning is no longer displayed.
5. Insert a Query Loop block inside an archive template.
6. Confirm that the warning isn't displayed.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2025-04-04 at 15 33 06](https://github.com/user-attachments/assets/b9efe2d9-e2b7-485d-af5b-8486814c8fdf)
