### PR TITLE
Update list of Gutenberg versions in WordPress versions

### DIFF
--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -6,6 +6,8 @@ If anything looks incorrect here, please bring it up in #core-editor in [WordPre
 
 | Gutenberg Versions | WordPress Version |
 | ------------------ | ----------------- |
+| 19.4-20.4          | 6.8               |
+| 18.6-19.3          | 6.7.2             |
 | 18.6-19.3          | 6.7.1             |
 | 18.6-19.3          | 6.7               |
 | 17.8-18.5          | 6.6.2             |


### PR DESCRIPTION
Fixes #69699


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add two more lines for 6.7.2 and 6.8

<!-- In a few words, what is the PR actually doing? -->

## Why?
for completeness and consistency 

## How?
update the markdown list

## Testing Instructions
documentation only 
