### PR TITLE
Fix : Disable sidebar animation for List View

### DIFF
--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { forwardRef, useEffect } from '@wordpress/element';
+import { forwardRef, useEffect, useState } from '@wordpress/element';
 import {
 	__unstableMotion as motion,
 	__unstableAnimatePresence as AnimatePresence,
@@ -17,6 +17,8 @@ import {
 	useViewportMatch,
 	useResizeObserver,
 } from '@wordpress/compose';
+import { store as preferencesStore } from '@wordpress/preferences';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -90,12 +92,57 @@ function InterfaceSkeleton(
 		useResizeObserver();
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const disableMotion = useReducedMotion();
-	const defaultTransition = {
+	// Track whether this is the initial render or a subsequent interaction
+	const [ isInitialRender, setIsInitialRender ] = useState( true );
+	// Track if sidebar has been sized
+	const [ hasSidebarBeenSized, setHasSidebarBeenSized ] = useState( false );
+	// Get the preference for "Always open List View" preference.
+	const { get: getPreference } = useSelect( preferencesStore );
+	const showListViewByDefault = getPreference(
+		'core',
+		'showListViewByDefault'
+	);
+
+	// Create different transitions for initial vs subsequent renders
+	const initialTransition = { duration: 0 };
+	const animationTransition = {
 		type: 'tween',
 		duration: disableMotion ? 0 : ANIMATION_DURATION,
 		ease: [ 0.6, 0, 0.4, 1 ],
 	};
+
+	// Use the appropriate transition based on render state
+	const defaultTransition =
+		showListViewByDefault && isInitialRender
+			? initialTransition
+			: animationTransition;
+
 	useHTMLClass( 'interface-interface-skeleton__html-container' );
+
+	// When sidebar size changes and it has a width, mark initial rendering as complete
+	useEffect( () => {
+		if (
+			showListViewByDefault &&
+			isInitialRender &&
+			secondarySidebar &&
+			secondarySidebarSize.width > 0
+		) {
+			// Size has been detected, sidebar is ready
+			if ( ! hasSidebarBeenSized ) {
+				setHasSidebarBeenSized( true );
+				// Allow a single frame for the non-animated render to complete
+				window.requestAnimationFrame( () => {
+					setIsInitialRender( false );
+				} );
+			}
+		}
+	}, [
+		isInitialRender,
+		secondarySidebar,
+		secondarySidebarSize,
+		showListViewByDefault,
+		hasSidebarBeenSized,
+	] );
 
 	const defaultLabels = {
 		/* translators: accessibility text for the top bar landmark region. */
@@ -163,13 +210,19 @@ function InterfaceSkeleton(
 					</div>
 				) }
 				<div className="interface-interface-skeleton__body">
-					<AnimatePresence initial={ false }>
+					<AnimatePresence
+						initial={ showListViewByDefault && isInitialRender }
+					>
 						{ !! secondarySidebar && (
 							<NavigableRegion
 								className="interface-interface-skeleton__secondary-sidebar"
 								ariaLabel={ mergedLabels.secondarySidebar }
 								as={ motion.div }
-								initial="closed"
+								initial={
+									showListViewByDefault && isInitialRender
+										? 'open'
+										: 'closed'
+								}
 								animate="open"
 								exit="closed"
 								variants={ {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
- Closes #69240 
- Prevents sidebar animation on the first render, if the `Always open List View` preference is enabled.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- #69240 
- `The sidebar animation on first page load is a very distrqacting and unexpected experience. As an useer, I don't want to see anything that 'moves' on my screen when the page loads.`

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Create a state variable to track initial render and another for tracking if the sidebar has been resized
- Extract `Always open List View` preference to toggle this feature.
- Prevent animation for the `NavigableRegion` component when preference is enabled, its an initial render and the sidebar hasn't been resized.

## Screenshots or screencast <!-- if applicable -->
| `Previous Implementation` | `New Implementation` |
| --- | --- |
| https://github.com/user-attachments/assets/2101c804-e3b0-4a4c-bb19-ad24132b17f9 | https://github.com/user-attachments/assets/60acc922-2584-48e6-8fc0-86fd4c01bfe4 |