### PR TITLE
Fix Category List Block: Add optional chaining to taxonomy name

### DIFF
--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -125,7 +125,7 @@ export default function CategoriesEdit( {
 					<RichText
 						className="wp-block-categories__label"
 						aria-label={ __( 'Label text' ) }
-						placeholder={ taxonomy.name }
+						placeholder={ taxonomy?.name }
 						withoutInteractiveFormatting
 						value={ label }
 						onChange={ ( html ) =>
@@ -134,7 +134,7 @@ export default function CategoriesEdit( {
 					/>
 				) : (
 					<VisuallyHidden as="label" htmlFor={ selectId }>
-						{ label ? label : taxonomy.name }
+						{ label ? label : taxonomy?.name }
 					</VisuallyHidden>
 				) }
 				<select id={ selectId }>
@@ -142,7 +142,7 @@ export default function CategoriesEdit( {
 						{ sprintf(
 							/* translators: %s: taxonomy's singular name */
 							__( 'Select %s' ),
-							taxonomy.labels.singular_name
+							taxonomy?.labels?.singular_name
 						) }
 					</option>
 					{ categoriesList.map( ( category ) =>


### PR DESCRIPTION
Fixes #69697

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds optional chaining (?.) for the name and labels.singular_name properties in the taxonomy object to prevent potential undefined errors.

## Why?
Without optional chaining, the block may throw an error when the taxonomy data is unavailable or not properly set. This issue is noticeable when using the Category List block inside a pattern, particularly when enabling "Show as dropdown" and "Show empty values" options.

## How?
The implementation adds optional chaining in relevant areas where the taxonomy object or its properties are accessed:

- Placeholder text for the dropdown (placeholder={ taxonomy?.name })
- The VisuallyHidden label (label ? label : taxonomy?.name)
- Dropdown option text (sprintf( __( 'Select %s' ), taxonomy?.labels?.singular_name ))

These changes ensure that the block does not break when the taxonomy object is missing or incomplete.

## Testing Instructions
- Add a new pattern.
- Insert a Category List block into the pattern.
- Edit the label and enable Show as dropdown + Show empty values from the inspector panel.
- Add this pattern to the Site Editor and save the changes.
- Reload the editor and observe the Category List block.
- Previously, the block would sometimes show an error when the taxonomy data was unavailable. Now, it should function correctly without breaking.


## ScreenCast

If it does not load then it would show (undefined) - Rarely
![image](https://github.com/user-attachments/assets/69a90823-d90a-46ab-98e6-994f2238905e)
