### PR TITLE
Widget Screen: Problem with updating widgets

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -998,6 +998,7 @@ export const __unstableSplitSelection =
 
 		let tail = {
 			...blockB,
+			// Only preserve the original client ID if the end is different.
 			clientId:
 				blockA.clientId === blockB.clientId
 					? createBlock( blockB.name ).clientId
@@ -1005,10 +1006,6 @@ export const __unstableSplitSelection =
 			attributes: {
 				...blockB.attributes,
 				[ attributeKeyB ]: toHTMLString( { value: valueB } ),
-				// Add widget ID clearance for same-block splits
-				...( blockA.clientId === blockB.clientId && {
-					__internalWidgetId: undefined,
-				} ),
 			},
 		};
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -998,7 +998,6 @@ export const __unstableSplitSelection =
 
 		let tail = {
 			...blockB,
-			// Only preserve the original client ID if the end is different.
 			clientId:
 				blockA.clientId === blockB.clientId
 					? createBlock( blockB.name ).clientId
@@ -1006,6 +1005,10 @@ export const __unstableSplitSelection =
 			attributes: {
 				...blockB.attributes,
 				[ attributeKeyB ]: toHTMLString( { value: valueB } ),
+				// Add widget ID clearance for same-block splits
+				...( blockA.clientId === blockB.clientId && {
+					__internalWidgetId: undefined,
+				} ),
 			},
 		};
 

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -126,12 +126,14 @@ export const saveWidgetArea =
 				buildWidgetAreaPostId( widgetAreaId )
 			);
 
-		// Process blocks to reset paragraph widget IDs and prevent conflicts
+		/**
+		 * Process blocks to ensure unique widget IDs before saving.
+		 * Clears __internalWidgetId for all non-legacy widgets to prevent
+		 * conflicts during save operations.
+		 */
 		const processedBlocks = post.blocks.map( ( block ) => {
-			if (
-				block.name === 'core/paragraph' &&
-				block.attributes.__internalWidgetId
-			) {
+			// Skip legacy widgets as they handle their own IDs
+			if ( block.name !== 'core/legacy-widget' ) {
 				return {
 					...block,
 					attributes: {

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -126,6 +126,23 @@ export const saveWidgetArea =
 				buildWidgetAreaPostId( widgetAreaId )
 			);
 
+		// Process blocks to reset paragraph widget IDs and prevent conflicts
+		const processedBlocks = post.blocks.map( ( block ) => {
+			if (
+				block.name === 'core/paragraph' &&
+				block.attributes.__internalWidgetId
+			) {
+				return {
+					...block,
+					attributes: {
+						...block.attributes,
+						__internalWidgetId: undefined,
+					},
+				};
+			}
+			return block;
+		} );
+
 		// Get all widgets from this area
 		const areaWidgets = Object.values( widgets ).filter(
 			( { sidebar } ) => sidebar === widgetAreaId
@@ -136,7 +153,7 @@ export const saveWidgetArea =
 		// implemented using a function. WordPress doesn't support having more than one instance of these, if you try to
 		// save multiple instances of these in different sidebars you will run into undefined behaviors.
 		const usedReferenceWidgets = [];
-		const widgetsBlocks = post.blocks.filter( ( block ) => {
+		const widgetsBlocks = processedBlocks.filter( ( block ) => {
 			const { id } = block.attributes;
 
 			if ( block.name === 'core/legacy-widget' && id ) {

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -126,6 +126,25 @@ export const saveWidgetArea =
 				buildWidgetAreaPostId( widgetAreaId )
 			);
 
+		/**
+		 * Process blocks to ensure unique widget IDs before saving.
+		 * Clears __internalWidgetId for all non-legacy widgets to prevent
+		 * conflicts during save operations.
+		 */
+		const processedBlocks = post.blocks.map( ( block ) => {
+			// Skip legacy widgets as they handle their own IDs
+			if ( block.name !== 'core/legacy-widget' ) {
+				return {
+					...block,
+					attributes: {
+						...block.attributes,
+						__internalWidgetId: undefined,
+					},
+				};
+			}
+			return block;
+		} );
+
 		// Get all widgets from this area
 		const areaWidgets = Object.values( widgets ).filter(
 			( { sidebar } ) => sidebar === widgetAreaId
@@ -136,7 +155,7 @@ export const saveWidgetArea =
 		// implemented using a function. WordPress doesn't support having more than one instance of these, if you try to
 		// save multiple instances of these in different sidebars you will run into undefined behaviors.
 		const usedReferenceWidgets = [];
-		const widgetsBlocks = post.blocks.filter( ( block ) => {
+		const widgetsBlocks = processedBlocks.filter( ( block ) => {
 			const { id } = block.attributes;
 
 			if ( block.name === 'core/legacy-widget' && id ) {

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -126,25 +126,6 @@ export const saveWidgetArea =
 				buildWidgetAreaPostId( widgetAreaId )
 			);
 
-		/**
-		 * Process blocks to ensure unique widget IDs before saving.
-		 * Clears __internalWidgetId for all non-legacy widgets to prevent
-		 * conflicts during save operations.
-		 */
-		const processedBlocks = post.blocks.map( ( block ) => {
-			// Skip legacy widgets as they handle their own IDs
-			if ( block.name !== 'core/legacy-widget' ) {
-				return {
-					...block,
-					attributes: {
-						...block.attributes,
-						__internalWidgetId: undefined,
-					},
-				};
-			}
-			return block;
-		} );
-
 		// Get all widgets from this area
 		const areaWidgets = Object.values( widgets ).filter(
 			( { sidebar } ) => sidebar === widgetAreaId
@@ -155,7 +136,7 @@ export const saveWidgetArea =
 		// implemented using a function. WordPress doesn't support having more than one instance of these, if you try to
 		// save multiple instances of these in different sidebars you will run into undefined behaviors.
 		const usedReferenceWidgets = [];
-		const widgetsBlocks = processedBlocks.filter( ( block ) => {
+		const widgetsBlocks = post.blocks.filter( ( block ) => {
 			const { id } = block.attributes;
 
 			if ( block.name === 'core/legacy-widget' && id ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #69702.
Fixes an issue where pressing Enter within a paragraph block in the Widgets Editor would cause the save operation to hang indefinitely. The problem occurred when splitting paragraphs by adding line breaks between words.

## Why?
The root cause was duplicate `__internalWidgetId` values being maintained when a paragraph splits:
1. Both original and new paragraph kept same internal widget ID
2. Caused silent save failures
3. UI showed "Saving..." indefinitely

## How?
1. Resets `__internalWidgetId` for paragraph blocks before saving
2. Creates `processedBlocks` to maintain clean data flow
3. Uses `updatedPost` for consistency
4. Maintains all existing functionality

## Testing Instructions
1. Go to Appearance → Widgets
2. Add paragraph block and type text
3. Press Enter between words to split
4. Click "Update"
5. Verify:
   - Save completes successfully
   - Both paragraphs remain intact
   - No hanging "Saving..." state

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/ab39119c-0727-4e13-80a9-d56e27032f46
