### PR TITLE
BlockPatternsExplorer: Hide scrollbar from sidebar if not scrollable

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -379,7 +379,7 @@ $block-inserter-tabs-height: 44px;
 		width: $sidebar-width;
 		padding: $grid-unit-30 $grid-unit-40 $grid-unit-40;
 		overflow-x: visible;
-		overflow-y: scroll;
+		overflow-y: auto;
 
 		&__categories-list__item {
 			display: block;


### PR DESCRIPTION
## What?

On Windows OS and Chrome browser, the scrollbar is always shown if `overflow-y: scroll` is applied even though the sidebar is not scrollable. This is a bit annoying.

## How?

Use `auto` instead of `scroll`

## Testing Instructions

- Open the post > Inserter > Patterns tab > Explore all patterns button
- Check the sidebar.

## Screenshots or screencast <!-- if applicable -->

| Before| After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/7c3d399b-a06b-4179-b6a6-fa7ae4db35c6) | ![image](https://github.com/user-attachments/assets/ba3f35a1-43ad-40cf-a90e-c3fbee6fbb31) |

