### PR TITLE
Fix: Fix focus shift on opening of modal popup in templates

### DIFF
--- a/packages/edit-site/src/components/add-new-template/index.js
+++ b/packages/edit-site/src/components/add-new-template/index.js
@@ -16,7 +16,7 @@ import {
 	Icon,
 } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
-import { useState, memo } from '@wordpress/element';
+import { useState, memo, useRef, useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { useViewportMatch } from '@wordpress/compose';
@@ -246,6 +246,29 @@ function NewTemplateModal( { onClose } ) {
 		modalTitle = __( 'Create custom template' );
 	}
 
+	const modalRef = useRef( null );
+
+	useEffect( () => {
+		if (
+			modalRef.current &&
+			( modalContent === modalContentMap.customTemplate ||
+				modalContent === modalContentMap.customGenericTemplate )
+		) {
+			const firstFocusableElement = modalRef.current.querySelector(
+				'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+			);
+			if ( firstFocusableElement ) {
+				// To ensure the DOM updates before setting focus.
+				const timeoutId = setTimeout(
+					() => firstFocusableElement.focus(),
+					0
+				);
+
+				return () => clearTimeout( timeoutId );
+			}
+		}
+	}, [ modalContent ] );
+
 	return (
 		<Modal
 			title={ modalTitle }
@@ -255,6 +278,7 @@ function NewTemplateModal( { onClose } ) {
 				'edit-site-custom-template-modal':
 					modalContent === modalContentMap.customTemplate,
 			} ) }
+			ref={ modalRef }
 			onRequestClose={ onModalClose }
 			overlayClassName={
 				modalContent === modalContentMap.customGenericTemplate


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #69708

This PR ensures that when a modal is opened, the focus shifts to the first interactive element inside the modal, such as the close button or an input field.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, the focus behavior in some modals is inconsistent. In some cases, the parent container is not focusable due to tabindex=-1, preventing proper keyboard navigation. This fix ensures that focus lands on the first interactive element when the modal opens, improving accessibility and user experience.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

1. Used querySelector to find the first interactive element (button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])).
2. Wrapped the focus shift inside a setTimeout to ensure DOM readiness.
3. Added cleanup to useEffect to prevent memory leaks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Open the WordPress site editor.
2. Click on a button that triggers a modal (e.g., "Add Template -> Custom Template").
3. Verify that focus automatically moves to the first interactive element in the modal.
4. Navigate using the keyboard (Tab and Shift + Tab) to confirm expected behavior.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/94eed33f-56c7-44bc-ab11-7aaf62689e88
