### PR TITLE
Post Template Panel: Render `create-new-template-modal` over `post-template-panel`

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -130,6 +130,7 @@ $z-layers: (
 	".dataviews-action-modal": 1000001,
 	".editor-action-modal": 1000001,
 	".editor-post-template__swap-template-modal": 1000001,
+	".editor-post-template__create-template-modal": 1000001,
 	".edit-site-template-panel__replace-template-modal": 1000001,
 	".fields-controls__template-modal": 1000001,
 

--- a/packages/editor/src/components/post-template/create-new-template-modal.js
+++ b/packages/editor/src/components/post-template/create-new-template-modal.js
@@ -111,6 +111,7 @@ export default function CreateNewTemplateModal( { onClose } ) {
 			onRequestClose={ cancel }
 			focusOnMount="firstContentElement"
 			size="small"
+			overlayClassName="editor-post-template__create-template-modal"
 		>
 			<form
 				className="editor-post-template__create-form"

--- a/packages/editor/src/components/post-template/style.scss
+++ b/packages/editor/src/components/post-template/style.scss
@@ -2,6 +2,10 @@
 	z-index: z-index(".editor-post-template__swap-template-modal");
 }
 
+.editor-post-template__create-template-modal {
+	z-index: z-index(".editor-post-template__create-template-modal");
+}
+
 .editor-post-template__swap-template-modal-content .block-editor-block-patterns-list {
 	column-count: 2;
 	column-gap: $grid-unit-30;


### PR DESCRIPTION
## What?
Closes #69712

This PR fixes a bug where the **Post Template Panel** partially overlaps the **Create New Template** modal.

## Why?

The overlap prevents access to essential functionalities on certain devices.

## How?

A higher `z-index` was provided to the `create-new-template` modal.

## Testing Instructions

1. Set the browser width to `1400px` or use the `iPad Air (landscape)` dimensions from the responsive presets.
2. Create a new page and open it in editing mode.
3. In the page sidebar, click the button present beside the label `Template`.
4. Confirm that the `Create New Template` modal is now completely visible.
5. Also, confirm that the `Create` button is properly accessible.

### Testing Instructions for Keyboard
Same.

## Screenshots

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/0aa70012-e993-436a-bbad-7913104f2c36)|![after](https://github.com/user-attachments/assets/b37de19c-f1e7-4697-a166-fa248b6bedab)|


