### PR TITLE
 ToggleGroupControl: Document and add disabled prop in types.ts

### DIFF
--- a/packages/components/src/toggle-group-control/stories/index.story.tsx
+++ b/packages/components/src/toggle-group-control/stories/index.story.tsx
@@ -142,3 +142,24 @@ Deselectable.args = {
 	...WithIcons.args,
 	isDeselectable: true,
 };
+
+/**
+ * This story demonstrates how individual options can be disabled.
+ */
+export const WithSomeDisabledOptions: StoryFn< typeof ToggleGroupControl > =
+	Template.bind( {} );
+WithSomeDisabledOptions.args = {
+	...Default.args,
+	label: 'Sort order (Disabled)',
+	children: [
+		{
+			value: 'asc',
+			label: 'A→Z',
+		},
+		{
+			value: 'desc',
+			label: 'Z→A',
+			disabled: true,
+		},
+	].map( mapPropsToOptionComponent ),
+};

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/README.md
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/README.md
@@ -25,3 +25,7 @@ The value of the `ToggleGroupControlOptionBase`.
 Whether to show a tooltip when hovering over the option. The tooltip will only show if a label for it is provided using the `aria-label` prop.
 
 -   Required: No
+
+### `disabled` : `boolean`
+
+Whether the option should be disabled.

--- a/packages/components/src/toggle-group-control/toggle-group-control-option/README.md
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option/README.md
@@ -53,3 +53,7 @@ The value of the `ToggleGroupControlOption`.
 Whether to show a tooltip when hovering over the option. The tooltip will attempt to use the `aria-label` prop text first, then the `label` prop text if no `aria-label` prop is found.
 
 -   Required: No
+
+### `disabled` : `boolean`
+
+Whether the option should be disabled.

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -25,11 +25,17 @@ export type ToggleGroupControlOptionBaseProps = {
 	 * @default false
 	 */
 	showTooltip?: boolean;
+	/**
+	 * Whether the option is disabled.
+	 *
+	 * @default false
+	 */
+	disabled?: boolean;
 };
 
 export type ToggleGroupControlOptionIconProps = Pick<
 	ToggleGroupControlOptionBaseProps,
-	'value'
+	'value' | 'disabled'
 > & {
 	/**
 	 * Icon displayed as the content of the option. Usually one of the icons from
@@ -44,7 +50,7 @@ export type ToggleGroupControlOptionIconProps = Pick<
 
 export type ToggleGroupControlOptionProps = Pick<
 	ToggleGroupControlOptionBaseProps,
-	'value' | 'showTooltip'
+	'value' | 'showTooltip' | 'disabled'
 > & {
 	/**
 	 * Label for the option. If needed, the `aria-label` prop can be used in addition


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Discovered while working on https://github.com/WordPress/gutenberg/issues/57862
Related comment: https://github.com/WordPress/gutenberg/issues/57862#issuecomment-2754181470

## Why?
This PR documents the disabled prop for ToggleGroupControlOption and adds proper TypeScript type definitions for better developer experience.

While PR #63450 added the functionality to disable individual options in ToggleGroupControl, this wasn't documented in the README or demonstrated in Storybook examples. Adding this documentation and proper TypeScript types improves discoverability and makes implementation more consistent with other components in the library.

## How?

I worked on the following improvements:

1. Added the disabled prop to the types.ts file for ToggleGroupControlOption
2. Updated the README documentation to include information about the disabled prop
3. Added a Storybook example demonstrating the disabled state similar to WithTooltip and WithIcons examples

These changes align with how other components like Button, FormToggle, and DropdownOption handle their disabled states.

