### PR TITLE
Featured Image Block: Prevent default action on image click to fix linking to post

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -398,7 +398,8 @@ export default function PostFeaturedImageEdit( {
 							label={ label }
 							showTooltip
 							tooltipPosition="top center"
-							onClick={ () => {
+							onClick={ ( e ) => {
+								e.preventDefault();
 								open();
 							} }
 						/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes #69714

## What?
Fixes an issue where the link inside the Featured Image block remains functional even when no image is set.

## Why?
Currently, if you click the button from the image placeholder without setting a featured image, the link still works. This is unexpected behavior and may lead to confusion.

A related PR: [#68775](https://github.com/WordPress/gutenberg/pull/68775)

## How?
- Add `PreventDefault` to button from further opening the link inside editor.

```JS
  <Button
  __next40pxDefaultSize
  icon={ upload }
  variant="primary"
  label={ label }
  showTooltip
  tooltipPosition="top center"
  onClick={ ( e ) => {
	   e.preventDefault();
	   open();
   } }
   />
```

## Testing Instructions

1. Open a post or page.
2. Insert a Featured Image block.
3. Setting a link without setting a featured image
4. When I try to add an image the link works.
 
## Screencast 

https://github.com/user-attachments/assets/f920e7f8-447d-4501-bef7-b483ba0b8457


