### PR TITLE
Feat : Persist old data during loading in DataViews

### DIFF
--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -17,6 +17,7 @@ type DataViewsContextType< Item > = {
 	actions?: Action< Item >[];
 	data: Item[];
 	isLoading?: boolean;
+	keepPreviousData?: boolean;
 	paginationInfo: {
 		totalItems: number;
 		totalPages: number;

--- a/packages/dataviews/src/components/dataviews-layout/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layout/index.tsx
@@ -30,6 +30,7 @@ export default function DataViewsLayout() {
 		setOpenedFilter,
 		onClickItem,
 		isItemClickable,
+		keepPreviousData,
 	} = useContext( DataViewsContext );
 
 	const ViewComponent = VIEW_LAYOUTS.find( ( v ) => v.type === view.type )
@@ -43,6 +44,7 @@ export default function DataViewsLayout() {
 			getItemId={ getItemId }
 			getItemLevel={ getItemLevel }
 			isLoading={ isLoading }
+			keepPreviousData={ keepPreviousData }
 			onChangeView={ onChangeView }
 			onChangeSelection={ onChangeSelection }
 			selection={ selection }

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -38,6 +38,7 @@ type DataViewsProps< Item > = {
 	actions?: Action< Item >[];
 	data: Item[];
 	isLoading?: boolean;
+	keepPreviousData?: boolean;
 	paginationInfo: {
 		totalItems: number;
 		totalPages: number;
@@ -68,6 +69,7 @@ export default function DataViews< Item >( {
 	getItemId = defaultGetItemId,
 	getItemLevel,
 	isLoading = false,
+	keepPreviousData = false,
 	paginationInfo,
 	defaultLayouts,
 	selection: selectionProperty,
@@ -121,6 +123,7 @@ export default function DataViews< Item >( {
 				actions,
 				data,
 				isLoading,
+				keepPreviousData,
 				paginationInfo,
 				selection: _selection,
 				onChangeSelection: setSelectionWithChange,

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -9,6 +9,7 @@ import clsx from 'clsx';
 import { __ } from '@wordpress/i18n';
 import { Spinner } from '@wordpress/components';
 import { useEffect, useId, useRef, useState } from '@wordpress/element';
+import { usePrevious } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -210,6 +211,7 @@ function ViewTable< Item >( {
 	getItemId,
 	getItemLevel,
 	isLoading = false,
+	keepPreviousData,
 	onChangeView,
 	onChangeSelection,
 	selection,
@@ -234,6 +236,8 @@ function ViewTable< Item >( {
 	} );
 
 	const tableNoticeId = useId();
+	// We need to keep the previous data to render the table when the new data is loading.
+	const previousData = usePrevious( data );
 
 	if ( nextHeaderMenuToFocus ) {
 		// If we need to force focus, we short-circuit rendering here
@@ -277,6 +281,40 @@ function ViewTable< Item >( {
 				headerMenuRefs.current.delete( column );
 			}
 		};
+
+	/**
+	 * Render the table rows.
+	 *
+	 * @param items The items to render.
+	 *
+	 * @return The table rows.
+	 */
+	const renderTableRows = ( items: Item[] ) => {
+		return items.map( ( item, index ) => (
+			<TableRow
+				key={ getItemId( item ) }
+				item={ item }
+				level={
+					view.showLevels && typeof getItemLevel === 'function'
+						? getItemLevel( item )
+						: undefined
+				}
+				hasBulkActions={ hasBulkActions }
+				actions={ actions }
+				fields={ fields }
+				id={ getItemId( item ) || index.toString() }
+				view={ view }
+				titleField={ titleField }
+				mediaField={ mediaField }
+				descriptionField={ descriptionField }
+				selection={ selection }
+				getItemId={ getItemId }
+				onChangeSelection={ onChangeSelection }
+				onClickItem={ onClickItem }
+				isItemClickable={ isItemClickable }
+			/>
+		) );
+	};
 
 	return (
 		<>
@@ -363,33 +401,12 @@ function ViewTable< Item >( {
 						) }
 					</tr>
 				</thead>
-				<tbody>
-					{ hasData &&
-						data.map( ( item, index ) => (
-							<TableRow
-								key={ getItemId( item ) }
-								item={ item }
-								level={
-									view.showLevels &&
-									typeof getItemLevel === 'function'
-										? getItemLevel( item )
-										: undefined
-								}
-								hasBulkActions={ hasBulkActions }
-								actions={ actions }
-								fields={ fields }
-								id={ getItemId( item ) || index.toString() }
-								view={ view }
-								titleField={ titleField }
-								mediaField={ mediaField }
-								descriptionField={ descriptionField }
-								selection={ selection }
-								getItemId={ getItemId }
-								onChangeSelection={ onChangeSelection }
-								onClickItem={ onClickItem }
-								isItemClickable={ isItemClickable }
-							/>
-						) ) }
+				<tbody aria-busy={ keepPreviousData && isLoading }>
+					{ keepPreviousData &&
+						isLoading &&
+						previousData &&
+						renderTableRows( previousData ) }
+					{ hasData && ! isLoading && renderTableRows( data ) }
 				</tbody>
 			</table>
 			<div

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -136,6 +136,11 @@
 		.components-v-stack > .dataviews-view-table__cell-content-wrapper:not(:first-child) {
 			min-height: 0;
 		}
+
+		&[aria-busy="true"] {
+			opacity: 0.5;
+			pointer-events: none;
+		}
 	}
 	.dataviews-view-table-header-button {
 		padding: $grid-unit-05 $grid-unit-10;

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -494,6 +494,7 @@ export interface ViewBaseProps< Item > {
 	getItemId: ( item: Item ) => string;
 	getItemLevel?: ( item: Item ) => number;
 	isLoading?: boolean;
+	keepPreviousData?: boolean;
 	onChangeView: ( view: View ) => void;
 	onChangeSelection: SetSelection;
 	selection: string[];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
- Closes #69194 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- `In certain scenarios, consumers want to build this other experience (keep old data until new data has been loaded)`
- Allows user to modify the `DataViews component` as per the above scenario using a `prop`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Add new prop : `keepPreviousData`
- Use the `usePrevious` hook to maintain record of the previous data displayed in the `ViewTable` component
- Move the map function responsible for rendering multiple `TableRow` components to a reusable function

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a new `variant` for `DataViews Story`
2. Can be found here : `packages/dataviews/src/components/dataviews/stories/index.story.tsx`
3. Create the following variant : 
```
export const WithLoadingState = () => {
	const [ isLoading, setIsLoading ] = useState( true );
	const [ view, setView ] = useState< View >( {
		...DEFAULT_VIEW,
		fields: [ 'id', 'title', 'body', 'userId', 'categories', 'date' ],
	} );
	const [ displayData, setDisplayData ] = useState< typeof data >( [] );

	useEffect( () => {
		const fetchData = async () => {
			setIsLoading( true );
			try {
				const response = await fetch(
					'https://jsonplaceholder.typicode.com/posts'
				);
				if ( ! response.ok ) {
					throw new Error( 'Failed to fetch data' );
				}
				const posts = await response.json();
				// Transform the API data to match our data structure
				const transformedData = posts.map( ( post: any ) => ( {
					id: post.id,
					title: post.title,
					userId: post.userId,
					date: new Date(
						Date.now() - Math.random() * 10000000000
					).toISOString(),
				} ) );
				setDisplayData( transformedData );
			} catch ( error ) {
				console.error( 'Error fetching data:', error );
			} finally {
				setIsLoading( false );
			}
		};

		fetchData();
	}, [] );

	const { data: shownData, paginationInfo } = useMemo( () => {
		return filterSortAndPaginate( displayData, view, fields );
	}, [ displayData, view ] );

	const handleViewChange = async ( newView: View ) => {
		setView( newView );
		setIsLoading( true );
		try {
			// Simulate API delay when filters change
			await new Promise( ( resolve ) => setTimeout( resolve, 1000 ) );
		} finally {
			setIsLoading( false );
		}
	};

	return (
		<DataViews
			getItemId={ ( item ) => item.id.toString() }
			paginationInfo={ paginationInfo }
			data={ shownData }
			view={ view }
			fields={ [
				{
					id: 'id',
					label: 'ID',
					enableSorting: true,
					enableHiding: true,
				},
				{
					id: 'title',
					label: 'Title',
					enableSorting: true,
					enableHiding: true,
				},
				{
					id: 'userId',
					label: 'User ID',
					enableSorting: true,
					enableHiding: true,
				},
				{
					id: 'date',
					label: 'Date',
					enableSorting: true,
					enableHiding: true,
				},
			] }
			onChangeView={ handleViewChange }
			actions={ actions }
			isLoading={ isLoading }
			keepPreviousData
			defaultLayouts={ defaultLayouts }
			search={ true }
			onChangeSelection={ ( selection ) => {
				console.log( 'selection', selection );
			} }
			searchLabel="Search posts..."
		/>
	);
};
```
4. Search something from the records and see the previous data show up in a disabled manner
5. The new results would override the previously rendered data (disabled).