### PR TITLE
Fix: Missing comma in DataView docs example.

### DIFF
--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -296,7 +296,7 @@ const actions = [
 		label: 'View',
 		isPrimary: true,
 		icon: <Icon icon={ view } />,
-		isEligible: ( item ) => item.status === 'published'
+		isEligible: ( item ) => item.status === 'published',
 		callback: ( items ) => {
 			console.log( 'Viewing item:', items[0] );
 		},


### PR DESCRIPTION
## What?
There is a missing comma in the DataViews actions code example.

## How?

It adds the comma in!
