### PR TITLE
e2e: fix taxomomies test

### DIFF
--- a/test/e2e/specs/editor/various/taxonomies.spec.js
+++ b/test/e2e/specs/editor/various/taxonomies.spec.js
@@ -30,7 +30,7 @@ test.describe( 'Taxonomies', () => {
 
 		await page
 			.getByRole( 'button', {
-				name: 'Add New Category',
+				name: 'Add Category',
 				expanded: false,
 			} )
 			.click();


### PR DESCRIPTION
## What?

Related core ticket: https://core.trac.wordpress.org/changeset/60099

Update the button label for adding a category and resolve an e2e test failure.

> [!NOTE]
> I'm not sure we should backport this PR into `wp/6.8`, but adding the backport label just to be sure.

### Why?

The label of the button for adding a category has changed from "Add New Category" to "Add Category":

![image](https://github.com/user-attachments/assets/a6db37a7-52ca-44eb-bbd1-292d9beeb6c9)

## Testing Instructions

Checking CI results