### PR TITLE
Post Template Panel: Preserve parent modal when closing template creation dialog

### DIFF
--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -141,9 +141,7 @@ export default function BlockThemeControl( { id } ) {
 
 							<SwapTemplateButton onClick={ onClose } />
 							<ResetDefaultTemplate onClick={ onClose } />
-							{ canCreateTemplate && (
-								<CreateNewTemplate onClick={ onClose } />
-							) }
+							{ canCreateTemplate && <CreateNewTemplate /> }
 						</MenuGroup>
 						<MenuGroup>
 							<MenuItem

--- a/packages/editor/src/components/post-template/create-new-template.js
+++ b/packages/editor/src/components/post-template/create-new-template.js
@@ -13,7 +13,7 @@ import { useState } from '@wordpress/element';
 import CreateNewTemplateModal from './create-new-template-modal';
 import { useAllowSwitchingTemplates } from './hooks';
 
-export default function CreateNewTemplate( { onClick } ) {
+export default function CreateNewTemplate() {
 	const { canCreateTemplates } = useSelect( ( select ) => {
 		const { canUser } = select( coreStore );
 		return {
@@ -44,7 +44,6 @@ export default function CreateNewTemplate( { onClick } ) {
 				<CreateNewTemplateModal
 					onClose={ () => {
 						setIsCreateModalOpen( false );
-						onClick();
 					} }
 				/>
 			) }


### PR DESCRIPTION
## What?
Closes #69722

This PR fixes a focus loss issue when the template creation dialog is closed via the Escape key or the Cancel button.

## Why?

The issue occurs because, upon closing the modal, focus should return to its trigger button. However, closing the modal also closes the parent dropdown containing the trigger, leaving no element to receive focus—causing it to be lost entirely.

## How?

Similar to how the `Change Template` modal closes without affecting the parent dropdown, this PR ensures that closing the template creation dialog only dismisses the dialog itself. This prevents the parent dropdown from closing, allowing focus to be retained properly.

## Testing Instructions

1. Open a page.
2. Sidebar > Page tab.
3. Click the button next to the `Template` label.
4. Open the `Create new template` dialog.
5. Hit the `ESC` button or click the `Cancel` button.
6. Confirm that the parent dropdown is not closed and the focus is retained.

### Testing Instructions for Keyboard

Same.

## Screencast

https://github.com/user-attachments/assets/9351714a-d8c1-4c7a-b1ab-252cc19c1d5b
