### PR TITLE
Tag Cloud: Remove unnecessary full-width padding

### DIFF
--- a/packages/block-library/src/tag-cloud/style.scss
+++ b/packages/block-library/src/tag-cloud/style.scss
@@ -7,11 +7,6 @@
 		justify-content: center;
 	}
 
-	&.alignfull {
-		padding-left: 1em;
-		padding-right: 1em;
-	}
-
 	a {
 		display: inline-block;
 		margin-right: 5px;


### PR DESCRIPTION
Closes #58886

## What?
Remove unnecessary padding for full-width Tag Cloud block

## Why?
The current implementation adds unexpected left and right padding when the Tag Cloud block is set to full width. This padding contradicts the expected full-width behavior and is no longer necessary with modern theme alignment techniques like `useRootPaddingAwareAlignments`.

The original padding was added in #27342, but the use case is no longer valid with current WordPress block editor capabilities.


## Testing Instructions
1. Create a new post or page in the WordPress block editor
2. Insert a Tag Cloud block
3. Set the Tag Cloud block to full width alignment
4. Verify that the block extends fully to the page edges without unexpected padding


## Screenshots or screencast <!-- if applicable -->

### Before
https://github.com/user-attachments/assets/b60724ff-76d4-43b6-bd01-c9648687ed28

### After
https://github.com/user-attachments/assets/337ffb8a-bfa5-45d8-9052-882898934b61





