### PR TITLE
Components: Add disabled prop to `CheckBoxControl`

### DIFF
--- a/packages/components/src/checkbox-control/index.tsx
+++ b/packages/components/src/checkbox-control/index.tsx
@@ -53,6 +53,7 @@ export function CheckboxControl(
 		indeterminate,
 		help,
 		id: idProp,
+		disabled,
 		onChange,
 		...additionalProps
 	} = props;
@@ -89,8 +90,13 @@ export function CheckboxControl(
 		'inspector-checkbox-control',
 		idProp
 	);
-	const onChangeValue = ( event: ChangeEvent< HTMLInputElement > ) =>
+	const onChangeValue = ( event: ChangeEvent< HTMLInputElement > ) => {
+		if ( disabled ) {
+			return;
+		}
+
 		onChange( event.target.checked );
+	};
 
 	return (
 		<BaseControl
@@ -108,7 +114,14 @@ export function CheckboxControl(
 			className={ clsx( 'components-checkbox-control', className ) }
 		>
 			<HStack spacing={ 0 } justify="start" alignment="top">
-				<span className="components-checkbox-control__input-container">
+				<span
+					className={ clsx(
+						'components-checkbox-control__input-container',
+						{
+							'is-disabled': disabled,
+						}
+					) }
+				>
 					<input
 						ref={ ref }
 						id={ id }
@@ -116,6 +129,7 @@ export function CheckboxControl(
 						type="checkbox"
 						value="1"
 						onChange={ onChangeValue }
+						aria-disabled={ disabled }
 						checked={ checked }
 						aria-describedby={ !! help ? id + '__help' : undefined }
 						{ ...additionalProps }
@@ -137,7 +151,12 @@ export function CheckboxControl(
 				</span>
 				{ label && (
 					<label
-						className="components-checkbox-control__label"
+						className={ clsx(
+							'components-checkbox-control__label',
+							{
+								'is-disabled': disabled,
+							}
+						) }
 						htmlFor={ id }
 					>
 						{ label }

--- a/packages/components/src/checkbox-control/stories/index.story.tsx
+++ b/packages/components/src/checkbox-control/stories/index.story.tsx
@@ -27,6 +27,7 @@ const meta: Meta< typeof CheckboxControl > = {
 			control: false,
 		},
 		help: { control: { type: 'text' } },
+		disabled: { control: { type: 'boolean' } },
 	},
 	parameters: {
 		controls: {

--- a/packages/components/src/checkbox-control/style.scss
+++ b/packages/components/src/checkbox-control/style.scss
@@ -12,7 +12,10 @@
 .components-checkbox-control__label {
 	// Ensure label is aligned with checkbox along X axis
 	line-height: var(--checkbox-input-size);
-	cursor: pointer;
+
+	&:not(.is-disabled) {
+		cursor: pointer;
+	}
 }
 
 .components-checkbox-control__input[type="checkbox"] {
@@ -66,6 +69,11 @@
 	aspect-ratio: 1;
 	line-height: 1; // maintains proper height even with WP common.css
 	flex-shrink: 0;
+
+	// Disabled state:
+	&.is-disabled {
+		opacity: 0.3;
+	}
 }
 
 svg.components-checkbox-control__checked,

--- a/packages/components/src/checkbox-control/types.ts
+++ b/packages/components/src/checkbox-control/types.ts
@@ -36,4 +36,9 @@ export type CheckboxControlProps = Pick<
 	 * @deprecated
 	 */
 	heading?: ReactNode;
+	/**
+	 * If disabled is true the checkbox will be disabled and apply the appropriate
+	 * styles.
+	 */
+	disabled?: boolean;
 };


### PR DESCRIPTION
## What?
Adds support for disabled state in `CheckboxControl`. 
Closes https://github.com/WordPress/gutenberg/issues/59411


## Why?
Issue #59364 identified the need for a disabled state on `CheckboxControl` for better accessibility and user experience in forms.


## How?

1. Added styling for for the disabled state
2. Ensured onChange handler is bypassed when `aria-disabled` is true

## Testing Instructions

1. Run `npm run storybook:dev`
2. Navigate to the `CheckboxControl` component
3. Test different disabled states and verify styling
4. Ensure disabled checkboxes cannot be toggled
5. Test keyboard navigation with both regular and focusable disabled checkboxes

## Screencast

https://github.com/user-attachments/assets/2acef711-aa70-4dec-9d3f-06b8130a73af

 



