### PR TITLE
Fix: save custom template with non-latin slug

### DIFF
--- a/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal-content.js
@@ -29,8 +29,8 @@ function AddCustomGenericTemplateModalContent( { onClose, createTemplate } ) {
 			await createTemplate(
 				{
 					slug:
-						'wp-custom-template-' +
-						kebabCase( title || defaultTitle ),
+						kebabCase( title || defaultTitle ) ||
+						'wp-custom-template',
 					title: title || defaultTitle,
 				},
 				false

--- a/packages/editor/src/components/post-template/create-new-template-modal.js
+++ b/packages/editor/src/components/post-template/create-new-template-modal.js
@@ -96,7 +96,7 @@ export default function CreateNewTemplateModal( { onClose } ) {
 			] );
 
 		const newTemplate = await createTemplate( {
-			slug: 'wp-custom-template-' + kebabCase( title || DEFAULT_TITLE ),
+			slug: kebabCase( title || DEFAULT_TITLE ) || 'wp-custom-template',
 			content: newTemplateContent,
 			title: title || DEFAULT_TITLE,
 		} );

--- a/packages/editor/src/components/post-template/create-new-template-modal.js
+++ b/packages/editor/src/components/post-template/create-new-template-modal.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { paramCase as kebabCase } from 'change-case';
+
+/**
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -12,7 +17,6 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { cleanForSlug } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -92,7 +96,7 @@ export default function CreateNewTemplateModal( { onClose } ) {
 			] );
 
 		const newTemplate = await createTemplate( {
-			slug: cleanForSlug( title || DEFAULT_TITLE ),
+			slug: 'wp-custom-template-' + kebabCase( title || DEFAULT_TITLE ),
 			content: newTemplateContent,
 			title: title || DEFAULT_TITLE,
 		} );


### PR DESCRIPTION
## What?

Similar to #38861
Closes #41214

Fix the error occurring in the post editor when creating a new template with non-latin slug

## Why?

In my understanding, templates and template parts don't allow non-Latin characters as a slug. `cleanForSlug()` function preserves non-latin characters, so an error occurs.

## How?

Use the same logic as [here](https://github.com/WordPress/gutenberg/blob/bdb16796eb85051b9d5d7b00fcb773973642a5e7/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal-content.js#L31-L33).

In the future, we may want to allow non-Latin characters.

## Testing Instructions

- Open the post editor
- Post sidebar > Post tab > Click the button next to the Template label
- Click the Create new template button
- Create custom template with non-latin characters (Example: テンプレート, 😄😄😄)
- Check the error message logged in the bowser console
- Access phpMyAdmin: http://localhost:9000/index.php?route=/sql&pos=0&db=wordpress&table=wp_posts
- Confirm that the template has been saved with the `wp-custom-template` slug
- If you create a template again with non-latin characters, the slug will be `wp-custom-template-2`.

