### PR TITLE
Add/inline typography

### DIFF
--- a/packages/format-library/src/default-formats.js
+++ b/packages/format-library/src/default-formats.js
@@ -15,6 +15,7 @@ import { keyboard } from './keyboard';
 import { unknown } from './unknown';
 import { language } from './language';
 import { nonBreakingSpace } from './non-breaking-space';
+import { inlineTypographyButton } from './inline-typography';
 
 export default [
 	bold,
@@ -31,4 +32,5 @@ export default [
 	unknown,
 	language,
 	nonBreakingSpace,
+	inlineTypographyButton,
 ];

--- a/packages/format-library/src/inline-typography/index.js
+++ b/packages/format-library/src/inline-typography/index.js
@@ -1,0 +1,251 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { toggleFormat, getActiveFormat, useAnchor } from '@wordpress/rich-text';
+import {
+	RichTextToolbarButton,
+	FontSizePicker,
+	__experimentalLetterSpacingControl as LetterSpacingControl,
+	LineHeightControl,
+	useSettings,
+} from '@wordpress/block-editor';
+import { Popover, SelectControl, Button } from '@wordpress/components';
+import { useState, useMemo } from '@wordpress/element';
+import { inlineTypography } from '@wordpress/icons';
+
+// Utility functions
+const serializeStyle = ( styleObj ) => {
+	return (
+		Object.entries( styleObj )
+			.filter( ( [ , value ] ) => value )
+			.map(
+				( [ key, value ] ) =>
+					key.replace( /([A-Z])/g, '-$1' ).toLowerCase() + ':' + value
+			)
+			.join( ';' ) + ';'
+	);
+};
+
+const parseStyle = ( styleString ) => {
+	const styleObj = {};
+	if ( styleString ) {
+		styleString.split( ';' ).forEach( ( style ) => {
+			const [ key, value ] = style.split( ':' );
+			if ( key && value ) {
+				const camelKey = key
+					.trim()
+					.replace( /-([a-z])/g, ( match, letter ) =>
+						letter.toUpperCase()
+					);
+				styleObj[ camelKey ] = value.trim();
+			}
+		} );
+	}
+	return styleObj;
+};
+
+// Constants
+const TEXT_TRANSFORM_OPTIONS = [
+	{ label: __( 'None' ), value: '' },
+	{ label: __( 'Uppercase' ), value: 'uppercase' },
+	{ label: __( 'Lowercase' ), value: 'lowercase' },
+	{ label: __( 'Capitalize' ), value: 'capitalize' },
+];
+
+const name = 'core/inline-typography';
+const title = __( 'Inline Typography' );
+
+const Edit = ( { isActive, value, onChange, contentRef } ) => {
+	const [ showSettings, setShowSettings ] = useState( false );
+	const activeFormat = getActiveFormat( value, name );
+	const computedStyles = useMemo( () => {
+		return activeFormat && activeFormat.attributes.style
+			? parseStyle( activeFormat.attributes.style )
+			: {};
+	}, [ activeFormat ] );
+
+	const {
+		fontFamily = '',
+		fontSize = '',
+		letterSpacing = '',
+		textTransform = '',
+		lineHeight = '',
+	} = computedStyles;
+	const themeFontFamiliesSetting = useSettings( 'typography.fontFamilies' );
+	// Check if it's an array and if its first element contains a "theme" property.
+	const themeFontFamilies = useMemo( () => {
+		if (
+			Array.isArray( themeFontFamiliesSetting ) &&
+			themeFontFamiliesSetting.length > 0 &&
+			themeFontFamiliesSetting[ 0 ].theme
+		) {
+			return themeFontFamiliesSetting[ 0 ].theme;
+		}
+		return [];
+	}, [ themeFontFamiliesSetting ] );
+	// If themeFontFamilies exist, use them; otherwise, use a static fallback.
+	const dynamicFontFamilyOptions = useMemo( () => {
+		const options = [ { label: __( 'Default' ), value: '' } ];
+		if ( themeFontFamilies.length > 0 ) {
+			themeFontFamilies.forEach( ( { fontName, fontFamilyName } ) => {
+				options.push( {
+					label: fontName,
+					value: fontFamilyName,
+				} );
+			} );
+		} else {
+			options.push(
+				{ label: 'Arial', value: 'Arial, sans-serif' },
+				{ label: 'Helvetica', value: 'Helvetica, sans-serif' },
+				{ label: 'Georgia', value: 'Georgia, serif' },
+				{
+					label: 'Times New Roman',
+					value: '"Times New Roman", Times, serif',
+				}
+			);
+		}
+		return options;
+	}, [ themeFontFamilies ] );
+
+	// Compute the popover's anchor using Gutenberg's useAnchor.
+	const popoverAnchor = useAnchor( {
+		editableContentElement: contentRef ? contentRef.current : null,
+		settings: { ...inlineTypographyButton, isActive },
+	} );
+
+	const updateInlineFormat = ( newStyles ) => {
+		const styleString = serializeStyle( newStyles );
+		let newValue = toggleFormat( value, { type: name } );
+		newValue = toggleFormat( newValue, {
+			type: name,
+			attributes: { style: styleString },
+		} );
+		onChange( newValue );
+	};
+
+	// onUpdate merges the new value into the computed styles.
+	const onUpdate = ( key, newVal ) => {
+		const updatedStyles = {
+			...computedStyles,
+			[ key ]: newVal,
+		};
+		updateInlineFormat( updatedStyles );
+	};
+
+	return (
+		<>
+			<RichTextToolbarButton
+				icon={ inlineTypography }
+				title={ title }
+				onClick={ () => {
+					if ( ! isActive ) {
+						onChange(
+							toggleFormat( value, {
+								type: name,
+								attributes: { style: '' },
+							} )
+						);
+					}
+					setShowSettings( true );
+				} }
+				isActive={ isActive }
+				role="menuitemcheckbox"
+			/>
+			{ showSettings && popoverAnchor && (
+				<Popover
+					anchor={ popoverAnchor }
+					position="bottom center"
+					onClose={ () => setShowSettings( false ) }
+				>
+					<div style={ { padding: '20px' } }>
+						<SelectControl
+							label={ __( 'Font' ) }
+							value={ fontFamily }
+							options={ dynamicFontFamilyOptions }
+							onChange={ ( newVal ) =>
+								onUpdate( 'fontFamily', newVal )
+							}
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+						/>
+						<div style={ { marginTop: '20px' } }>
+							<FontSizePicker
+								value={ fontSize }
+								fallbackFontSize={ 16 }
+								onChange={ ( newSize ) =>
+									onUpdate( 'fontSize', newSize )
+								}
+								__next40pxDefaultSize
+							/>
+						</div>
+						<div style={ { marginTop: '20px' } }>
+							<LetterSpacingControl
+								label={ __( 'Letter Spacing' ) }
+								value={ letterSpacing }
+								onChange={ ( newVal ) =>
+									onUpdate( 'letterSpacing', newVal )
+								}
+								__unstableInputWidth="auto"
+								__next40pxDefaultSize
+							/>
+						</div>
+						<div style={ { marginTop: '20px' } }>
+							<SelectControl
+								label={ __( 'Letter Case' ) }
+								value={ textTransform }
+								options={ TEXT_TRANSFORM_OPTIONS }
+								onChange={ ( newVal ) =>
+									onUpdate( 'textTransform', newVal )
+								}
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+							/>
+						</div>
+						<div
+							style={ { marginTop: '20px' } }
+							className="inline-typography__line-height"
+						>
+							<LineHeightControl
+								value={ lineHeight }
+								onChange={ ( newVal ) =>
+									onUpdate( 'lineHeight', newVal )
+								}
+								__next40pxDefaultSize
+							/>
+						</div>
+						<div
+							style={ {
+								marginTop: '20px',
+								display: 'flex',
+								justifyContent: 'end',
+							} }
+						>
+							<Button
+								isTertiary
+								onClick={ () => {
+									onChange(
+										toggleFormat( value, { type: name } )
+									);
+									setShowSettings( false );
+								} }
+								__next40pxDefaultSize
+							>
+								{ __( 'Remove' ) }
+							</Button>
+						</div>
+					</div>
+				</Popover>
+			) }
+		</>
+	);
+};
+
+export const inlineTypographyButton = {
+	name,
+	title,
+	tagName: 'span',
+	className: 'wp_block_inline_typography',
+	attributes: { style: 'style' },
+	edit: Edit,
+};

--- a/packages/format-library/src/inline-typography/index.js
+++ b/packages/format-library/src/inline-typography/index.js
@@ -88,12 +88,14 @@ const Edit = ( { isActive, value, onChange, contentRef } ) => {
 	const dynamicFontFamilyOptions = useMemo( () => {
 		const options = [ { label: __( 'Default' ), value: '' } ];
 		if ( themeFontFamilies.length > 0 ) {
-			themeFontFamilies.forEach( ( { fontName, fontFamilyName } ) => {
-				options.push( {
-					label: fontName,
-					value: fontFamilyName,
-				} );
-			} );
+			themeFontFamilies.forEach(
+				( { name: themeName, fontFamily: themeFont } ) => {
+					options.push( {
+						label: themeName,
+						value: themeFont,
+					} );
+				}
+			);
 		} else {
 			options.push(
 				{ label: 'Arial', value: 'Arial, sans-serif' },

--- a/packages/format-library/src/inline-typography/index.js
+++ b/packages/format-library/src/inline-typography/index.js
@@ -14,6 +14,11 @@ import { Popover, SelectControl, Button } from '@wordpress/components';
 import { useState, useMemo } from '@wordpress/element';
 import { inlineTypography } from '@wordpress/icons';
 
+/**
+ * Internal dependencies
+ */
+import { getTypographyFontSizeValue } from '../../../block-editor/src/components/global-styles/typography-utils';
+
 // Utility functions
 const serializeStyle = ( styleObj ) => {
 	return (
@@ -59,6 +64,7 @@ const title = __( 'Inline Typography' );
 const Edit = ( { isActive, value, onChange, contentRef } ) => {
 	const [ showSettings, setShowSettings ] = useState( false );
 	const activeFormat = getActiveFormat( value, name );
+	const originalFontSize = activeFormat?.attributes?.fontSize;
 	const computedStyles = useMemo( () => {
 		return activeFormat && activeFormat.attributes.style
 			? parseStyle( activeFormat.attributes.style )
@@ -67,7 +73,6 @@ const Edit = ( { isActive, value, onChange, contentRef } ) => {
 
 	const {
 		fontFamily = '',
-		fontSize = '',
 		letterSpacing = '',
 		textTransform = '',
 		lineHeight = '',
@@ -116,23 +121,98 @@ const Edit = ( { isActive, value, onChange, contentRef } ) => {
 		settings: { ...inlineTypographyButton, isActive },
 	} );
 
-	const updateInlineFormat = ( newStyles ) => {
+	const [ fontSizes, fluidSettings, layoutSettings ] = useSettings(
+		'typography.fontSizes',
+		'typography.fluid',
+		'layout'
+	);
+
+	// Process theme font sizes for FontSizePicker
+	const themeFontSizes = useMemo(
+		() =>
+			( fontSizes || [] ).map(
+				( { name: fontName, size, slug, fluid } ) => ( {
+					name: fontName,
+					size,
+					slug,
+					fluid,
+				} )
+			),
+		[ fontSizes ]
+	);
+
+	// Create an effective font size to pass to the FontSizePicker.
+	// If originalFontSize is a preset slug, we retrieve its numeric size.
+	const effectiveFontSize = useMemo( () => {
+		const preset = themeFontSizes.find(
+			( item ) => item.slug === originalFontSize
+		);
+		return preset ? preset.size : originalFontSize;
+	}, [ originalFontSize, themeFontSizes ] );
+
+	const updateInlineFormat = ( newStyles, newFontSize ) => {
 		const styleString = serializeStyle( newStyles );
+		const currentFontSize = activeFormat?.attributes?.fontSize;
+		const attributes = {
+			style: styleString,
+			fontSize: newFontSize !== undefined ? newFontSize : currentFontSize,
+		};
 		let newValue = toggleFormat( value, { type: name } );
 		newValue = toggleFormat( newValue, {
 			type: name,
-			attributes: { style: styleString },
+			attributes,
 		} );
 		onChange( newValue );
 	};
 
-	// onUpdate merges the new value into the computed styles.
 	const onUpdate = ( key, newVal ) => {
-		const updatedStyles = {
-			...computedStyles,
-			[ key ]: newVal,
-		};
-		updateInlineFormat( updatedStyles );
+		if ( key === 'fontSize' ) {
+			let fontSizeObject = themeFontSizes.find(
+				( size ) => size.slug === newVal
+			);
+			if ( ! fontSizeObject ) {
+				fontSizeObject = themeFontSizes.find(
+					( size ) => size.size === newVal
+				);
+			}
+
+			if ( fontSizeObject ) {
+				// Handle theme presets with their own fluid settings
+				const fluidValue = getTypographyFontSizeValue(
+					{
+						size: fontSizeObject.size,
+						fluid: fontSizeObject.fluid,
+					},
+					{
+						typography: { fluid: fluidSettings },
+						layout: layoutSettings,
+					}
+				);
+				updateInlineFormat(
+					{ ...computedStyles, fontSize: fluidValue },
+					fontSizeObject.slug
+				);
+			} else {
+				// Handle custom values with global fluid settings
+				const fluidValue = getTypographyFontSizeValue(
+					{ size: newVal },
+					{
+						typography: { fluid: fluidSettings },
+						layout: layoutSettings,
+					}
+				);
+
+				updateInlineFormat(
+					{ ...computedStyles, fontSize: fluidValue },
+					newVal
+				);
+			}
+		} else {
+			updateInlineFormat(
+				{ ...computedStyles, [ key ]: newVal },
+				activeFormat?.attributes?.fontSize
+			);
+		}
 	};
 
 	return (
@@ -173,7 +253,8 @@ const Edit = ( { isActive, value, onChange, contentRef } ) => {
 						/>
 						<div style={ { marginTop: '20px' } }>
 							<FontSizePicker
-								value={ fontSize }
+								fontSizes={ themeFontSizes }
+								value={ effectiveFontSize }
 								fallbackFontSize={ 16 }
 								onChange={ ( newSize ) =>
 									onUpdate( 'fontSize', newSize )
@@ -248,6 +329,6 @@ export const inlineTypographyButton = {
 	title,
 	tagName: 'span',
 	className: 'wp_block_inline_typography',
-	attributes: { style: 'style' },
+	attributes: { style: 'style', fontSize: 'data-font-size' },
 	edit: Edit,
 };

--- a/packages/format-library/src/inline-typography/index.js
+++ b/packages/format-library/src/inline-typography/index.js
@@ -160,7 +160,7 @@ const Edit = ( { isActive, value, onChange, contentRef } ) => {
 					position="bottom center"
 					onClose={ () => setShowSettings( false ) }
 				>
-					<div style={ { padding: '20px' } }>
+					<div style={ { padding: '20px', width: '235px' } }>
 						<SelectControl
 							label={ __( 'Font' ) }
 							value={ fontFamily }

--- a/packages/format-library/src/inline-typography/style.scss
+++ b/packages/format-library/src/inline-typography/style.scss
@@ -1,0 +1,5 @@
+.inline-typography__line-height {
+	.components-input-control__container {
+		width: 100%;
+	}
+}

--- a/packages/format-library/src/style.scss
+++ b/packages/format-library/src/style.scss
@@ -2,3 +2,4 @@
 @import "./link/style.scss";
 @import "./text-color/style.scss";
 @import "./language/style.scss";
+@import "./inline-typography/style.scss";

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -310,3 +310,4 @@ export { default as verse } from './library/verse';
 export { default as video } from './library/video';
 export { default as widget } from './library/widget';
 export { default as wordpress } from './library/wordpress';
+export { default as inlineTypography } from './library/inline-typography';

--- a/packages/icons/src/library/inline-typography.js
+++ b/packages/icons/src/library/inline-typography.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const inlineTypography = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path
+			fill="currentColor"
+			d="M5 4h14a1 1 0 011 1v14a1 1 0 01-1 1H5a1 1 0 01-1-1V5a1 1 0 011-1zm1 2v12h12V6H6zm2 2h8v2H8V8zm0 4h8v2H8v-2zm0 4h5v2H8v-2z"
+		/>
+	</SVG>
+);
+
+export default inlineTypography;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Closes https://github.com/WordPress/gutenberg/issues/69153
## What?
Addition of one Inline Typography under the inline controls to have ability to change the Typography related stylings for selected text.

## Why?
There are no way to change the font size, font family or other styling like letter spacing, text transform and line height of selected text in a paragraph block.

## Testing Instructions
1. Add content on the paragraph block.
2. Select the text for which you want to change the typography.
3. From the toolbar choose the Inline Typography under the inline controls.
4. Apply inline typography you want.
5. For removing the inline typography, click on the remove button.


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

**After**

https://github.com/user-attachments/assets/ae6306f2-94b3-4e98-a4cc-352cc1c3a7a3
