### PR TITLE
ToC: Fix related block attribute persistence

### DIFF
--- a/packages/block-library/src/table-of-contents/hooks.js
+++ b/packages/block-library/src/table-of-contents/hooks.js
@@ -142,8 +142,11 @@ function observeCallback( select, dispatch, clientId ) {
 
 	const headings = getLatestHeadings( select, clientId );
 	if ( ! fastDeepEqual( headings, attributes.headings ) ) {
-		__unstableMarkNextChangeAsNotPersistent();
-		updateBlockAttributes( clientId, { headings } );
+		// Executing the update in a microtask ensures that the non-persistent marker doesn't affect an attribute triggering the change.
+		window.queueMicrotask( () => {
+			__unstableMarkNextChangeAsNotPersistent();
+			updateBlockAttributes( clientId, { headings } );
+		} );
 	}
 }
 


### PR DESCRIPTION
## What?
Closes #67583

PR fixes a bug in the Table of Contents block where the Save button remained disabled even after making changes to the heading block.

## How
Execute the ToC block attribute sync via microtask to avoid leaking the non-persistent attribute update marker.

## Testing Instructions

1. Create a new post or edit an existing one in the Gutenberg editor.
2. Add a “Table of Contents” block to the post.
3. Add Heading blocks to the content. Save and reload.
4. Make a change to the Heading blocks (e.g., change the text).
5. Confirm that the Save button is enabled after the change.

### Testing Instructions for Keyboard
Same.
