### PR TITLE
Blocks: Remove legacy Post Comment block conversions

### DIFF
--- a/packages/blocks/src/api/parser/convert-legacy-block.js
+++ b/packages/blocks/src/api/parser/convert-legacy-block.js
@@ -49,17 +49,6 @@ export function convertLegacyBlockNameAndAttributes( name, attributes ) {
 		name = 'core/embed';
 	}
 
-	// Convert Post Comment blocks in existing content to Comment blocks.
-	// TODO: Remove these checks when WordPress 6.0 is released.
-	if ( name === 'core/post-comment-author' ) {
-		name = 'core/comment-author-name';
-	}
-	if ( name === 'core/post-comment-content' ) {
-		name = 'core/comment-content';
-	}
-	if ( name === 'core/post-comment-date' ) {
-		name = 'core/comment-date';
-	}
 	if ( name === 'core/comments-query-loop' ) {
 		name = 'core/comments';
 		const { className = '' } = newAttributes;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Related to PR: #36171
Removes legacy conversion logic for core/post-comment-* blocks, as it was meant to be removed after WordPress 6.0.

## Why?
- The code included a TODO to remove these checks after WP 6.0.
- WP is now at version 6.7.2, making this fallback logic redundant.

## How?
Removed the condition for conversions:
- core/post-comment-author → core/comment-author-name
- core/post-comment-content → core/comment-content
- core/post-comment-date → core/comment-date

## Testing Instructions
```bash
npm run test:unit   
```
