### PR TITLE
resolve media and text radius issue to media

### DIFF
--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -143,3 +143,25 @@
 		}
 	}
 }
+
+// Ensure media-text block handles border-radius properly
+.wp-block-media-text[style*="border-radius"] {
+	figure {
+		border-top-left-radius: inherit;
+		border-bottom-left-radius: inherit;
+
+		img,
+		video {
+			border-radius: inherit; // Use the parent's border-radius by default
+		}
+	}
+
+	@media (max-width: 768px) {
+		figure {
+			border-top-left-radius: inherit;
+			border-top-right-radius: inherit;
+			border-bottom-left-radius: 0;
+			border-bottom-right-radius: 0;
+		}
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->
Resolve issue mentioned here :- #69596 
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The border radius doesn't go on top of the existing content, but underneath it.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR will resolve the mentioned issue.
