### PR TITLE
Fix: Space visualizer showing previous value

### DIFF
--- a/packages/block-editor/src/hooks/spacing-visualizer.js
+++ b/packages/block-editor/src/hooks/spacing-visualizer.js
@@ -27,13 +27,16 @@ function SpacingVisualizer( { clientId, value, computeStyle, forceShow } ) {
 			return;
 		}
 		// It's not sufficient to read the computed spacing value when value.spacing changes as
-		// useEffect may run before the browser recomputes CSS. We therefore combine
-		// useLayoutEffect and two rAF calls to ensure that we read the spacing after the current
-		// paint but before the next paint.
-		// See https://github.com/WordPress/gutenberg/pull/59227.
-		window.requestAnimationFrame( () =>
-			window.requestAnimationFrame( updateStyle )
-		);
+		// useEffect may run before the browser recomputes CSS. So we use a MutationObserver to track style/class changes.
+		// Fixes issue where visualizer applies previous margin/padding due to delayed style updates in Chromium based browsers.
+		const observer = new window.MutationObserver( updateStyle );
+		observer.observe( blockElement, {
+			attributes: true,
+			attributeFilter: [ 'style', 'class' ],
+		} );
+		return () => {
+			observer.disconnect();
+		};
 	}, [ blockElement, value ] );
 
 	const previousValueRef = useRef( value );

--- a/packages/block-editor/src/hooks/spacing-visualizer.js
+++ b/packages/block-editor/src/hooks/spacing-visualizer.js
@@ -1,13 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	useState,
-	useRef,
-	useLayoutEffect,
-	useEffect,
-	useReducer,
-} from '@wordpress/element';
+import { useState, useRef, useEffect, useReducer } from '@wordpress/element';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
@@ -22,13 +16,13 @@ function SpacingVisualizer( { clientId, value, computeStyle, forceShow } ) {
 		computeStyle( blockElement )
 	);
 
-	useLayoutEffect( () => {
+	// It's not sufficient to read the block’s computed style when `value` changes because
+	// the effect would run before the block’s style has updated. Thus observing mutations
+	// to the block’s attributes is used to trigger updates to the visualizer’s styles.
+	useEffect( () => {
 		if ( ! blockElement ) {
 			return;
 		}
-		// It's not sufficient to read the computed spacing value when value.spacing changes as
-		// useEffect may run before the browser recomputes CSS. So we use a MutationObserver to track style/class changes.
-		// Fixes issue where visualizer applies previous margin/padding due to delayed style updates in Chromium based browsers.
 		const observer = new window.MutationObserver( updateStyle );
 		observer.observe( blockElement, {
 			attributes: true,
@@ -37,7 +31,7 @@ function SpacingVisualizer( { clientId, value, computeStyle, forceShow } ) {
 		return () => {
 			observer.disconnect();
 		};
-	}, [ blockElement, value ] );
+	}, [ blockElement ] );
 
 	const previousValueRef = useRef( value );
 	const [ isActive, setIsActive ] = useState( false );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #63191 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes the issue that Margin and Padding visualizer shows the previous value. This issue doesn't occur in Safari but occurs in Chromium based browsers.

Related PR  #59227


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Use `MutationObserver` to observe the changes in block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open a post or page.
2. Insert a block and tweak the margin or padding styles.
3. The Space visualizer should appear accurately.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Same

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <video src= "https://github.com/user-attachments/assets/0f6d09cf-b432-450e-93c0-af2eb26516fe" >   |  <video src= "https://github.com/user-attachments/assets/e44df82d-694e-49ea-bfe8-7e44e266f183" >  |




