### PR TITLE
Editor: Enable starter pattern modal for all post types

### DIFF
--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -17,6 +17,7 @@ import { store as interfaceStore } from '@wordpress/interface';
 /**
  * Internal dependencies
  */
+import { TEMPLATE_POST_TYPE } from '../../store/constants';
 import { store as editorStore } from '../../store';
 
 export function useStartPatterns() {
@@ -144,14 +145,16 @@ export default function StartPageOptions() {
 	const { isEditedPostDirty, isEditedPostEmpty } = useSelect( editorStore );
 	const { isModalActive } = useSelect( interfaceStore );
 	const { enabled, postId } = useSelect( ( select ) => {
-		const { getCurrentPostId } = select( editorStore );
+		const { getCurrentPostId, getCurrentPostType } = select( editorStore );
 		const choosePatternModalEnabled = select( preferencesStore ).get(
 			'core',
 			'enableChoosePatternModal'
 		);
 		return {
 			postId: getCurrentPostId(),
-			enabled: choosePatternModalEnabled,
+			enabled:
+				choosePatternModalEnabled &&
+				TEMPLATE_POST_TYPE !== getCurrentPostType(),
 		};
 	}, [] );
 

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -144,15 +144,14 @@ export default function StartPageOptions() {
 	const { isEditedPostDirty, isEditedPostEmpty } = useSelect( editorStore );
 	const { isModalActive } = useSelect( interfaceStore );
 	const { enabled, postId } = useSelect( ( select ) => {
-		const { getCurrentPostId, getCurrentPostType } = select( editorStore );
+		const { getCurrentPostId } = select( editorStore );
 		const choosePatternModalEnabled = select( preferencesStore ).get(
 			'core',
 			'enableChoosePatternModal'
 		);
 		return {
 			postId: getCurrentPostId(),
-			enabled:
-				choosePatternModalEnabled && 'page' === getCurrentPostType(),
+			enabled: choosePatternModalEnabled,
 		};
 	}, [] );
 


### PR DESCRIPTION
## What?

Closes #69750
This PR fixes the starter pattern modal so it works for all post types, not just pages. It removes the restriction that was limiting the modal to only appear when creating new pages.


## Why?

Currently, the starter pattern modal only works when creating a new page, not when creating a new post or other post types. This regression was introduced in PR #66836 and not fully resolved in PR #69081.

The condition that determines whether to show the modal explicitly checks if the current post type is 'page', preventing it from working with posts or other content types even when patterns are properly configured for those types.

## How?

This PR removes the post type restriction in the enabled property of the StartPageOptions component, allowing the modal to appear for any post type when patterns are available.

## Testing Instructions

- Set up test patterns for both posts and pages 
- Create a new page (Pages -> Add New)
- Verify the starter pattern modal appears
- Create a new post (Posts -> Add New)
    - Without this fix, the modal would not appear
    - With this fix, the modal should now appear
    

## Screencast 

### Before



https://github.com/user-attachments/assets/b3194280-60bc-466a-b2c9-f33efc4626e8



### After





https://github.com/user-attachments/assets/f990dd85-c43e-4568-beef-5ba647738458


