### PR TITLE
Enhance Search Block with Live Results Dropdown

### DIFF
--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -127,15 +127,15 @@ function render_block_core_search( $attributes ) {
 				</svg>';
 		}
 
-		$results_container = new WP_HTML_Tag_Processor( sprintf( '<div id="live-search-results" class="wp-block-search__live-result" data-wp-bind--hidden="!context.isSearchInputVisible" data-wp-bind--aria-hidden="!context.isSearchInputVisible" %s hidden></div>', $inline_styles['wrapper'] ) );
+		$results_container = new WP_HTML_Tag_Processor( '<div id="live-search-results" class="wp-block-search__live-result" data-wp-bind--hidden="!context.isSearchInputVisible" data-wp-bind--aria-hidden="!context.isSearchInputVisible" hidden></div>' );
 		// Inline JavaScript for live-search.
 		$inline_script = '<script>
 				const resultsContainer = document.getElementById( "live-search-results" );
 				const searchBox = document.getElementById( "' . esc_js( $input_id ) . '" );
-				resultsContainer.style.width = parseFloat( getComputedStyle(searchBox).width ) - 2 * parseFloat( getComputedStyle(searchBox).padding ) - 2 * parseFloat( getComputedStyle(searchBox).border ) + "px";
 				searchBox.addEventListener( "input", fetchSearchResults );
 				let searchTimeout;
 				function fetchSearchResults() {
+					resultsContainer.style.width = parseFloat( getComputedStyle(searchBox).width ) - 2 * parseFloat( getComputedStyle(searchBox).padding ) - 2 * parseFloat( getComputedStyle(searchBox).border ) + "px";
 					clearTimeout( searchTimeout );
 					searchTimeout = setTimeout( () => {
 						const input = searchBox.value.trim();
@@ -166,8 +166,7 @@ function render_block_core_search( $attributes ) {
 							} )
 							.catch( ( error ) => console.error( "Search error:", error ) );
 					}, 300 );
-				}
-			</script>';
+				}';
 		// Include the button element class.
 		$button_classes[] = wp_theme_get_element_class_name( 'button' );
 		$button           = new WP_HTML_Tag_Processor( sprintf( '<button type="submit" %s>%s</button>', $inline_styles['button'], $button_internal_markup ) );
@@ -230,6 +229,8 @@ function render_block_core_search( $attributes ) {
 			resultsContainer.style.display = "none";
 		} );';
 	}
+
+	$inline_script .= '</script>';
 
 	return sprintf(
 		'<form role="search" method="get" action="%1s" %2s %3s>%4s%5$s%6$s</form>',

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -127,6 +127,47 @@ function render_block_core_search( $attributes ) {
 				</svg>';
 		}
 
+		$results_container = new WP_HTML_Tag_Processor( sprintf( '<div id="live-search-results" class="wp-block-search__live-result" data-wp-bind--hidden="!context.isSearchInputVisible" data-wp-bind--aria-hidden="!context.isSearchInputVisible" %s hidden></div>', $inline_styles['wrapper'] ) );
+		// Inline JavaScript for live-search.
+		$inline_script = '<script>
+				const resultsContainer = document.getElementById( "live-search-results" );
+				const searchBox = document.getElementById( "' . esc_js( $input_id ) . '" );
+				resultsContainer.style.width = parseFloat( getComputedStyle(searchBox).width ) - 2 * parseFloat( getComputedStyle(searchBox).padding ) - 2 * parseFloat( getComputedStyle(searchBox).border ) + "px";
+				searchBox.addEventListener( "input", fetchSearchResults );
+				let searchTimeout;
+				function fetchSearchResults() {
+					clearTimeout( searchTimeout );
+					searchTimeout = setTimeout( () => {
+						const input = searchBox.value.trim();
+						if ( input.length < 2 ) {
+							resultsContainer.style.display = "none";
+							resultsContainer.innerHTML = "";
+							return;
+						}
+						resultsContainer.style.display = "block";
+						console.log(searchBox.offsetWidth);
+
+						fetch(
+							"' . esc_url( home_url( '/wp-json/wp/v2/search?search=' ) ) . '" +
+								encodeURIComponent( input )
+						)
+							.then( ( response ) => response.json() )
+							.then( ( data ) => {
+								console.log( data );
+								const resultsHTML = data.length
+									? data
+											.map(
+												( item ) =>
+													`<a href="${ item.url }">${ item.title }</a>`
+											)
+											.join( "<br>" )
+									: "<p>No results found</p>";
+								resultsContainer.innerHTML = resultsHTML;
+							} )
+							.catch( ( error ) => console.error( "Search error:", error ) );
+					}, 300 );
+				}
+			</script>';
 		// Include the button element class.
 		$button_classes[] = wp_theme_get_element_class_name( 'button' );
 		$button           = new WP_HTML_Tag_Processor( sprintf( '<button type="submit" %s>%s</button>', $inline_styles['button'], $button_internal_markup ) );
@@ -183,14 +224,21 @@ function render_block_core_search( $attributes ) {
 		 data-wp-on-async--keydown="actions.handleSearchKeydown"
 		 data-wp-on-async--focusout="actions.handleSearchFocusout"
 		';
+
+		$inline_script .= 'searchBox.addEventListener( "focusout", function () {
+			resultsContainer.innerHTML = "";
+			resultsContainer.style.display = "none";
+		} );';
 	}
 
 	return sprintf(
-		'<form role="search" method="get" action="%1s" %2s %3s>%4s</form>',
+		'<form role="search" method="get" action="%1s" %2s %3s>%4s%5$s%6$s</form>',
 		esc_url( home_url( '/' ) ),
 		$wrapper_attributes,
 		$form_directives,
-		$label . $field_markup
+		$label . $field_markup,
+		$results_container,
+		$inline_script
 	);
 }
 

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -137,3 +137,16 @@ $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 		float: right;
 	}
 }
+
+.wp-block-search__live-result {
+	border: 1px solid rgb(148, 148, 148);
+	border-radius: 0.33rem;
+	display: none;
+	margin-left: 0;
+	margin-right: 0;
+	min-width: 3rem;
+	padding: 8px;
+	position: absolute;
+	background: rgb(255, 255, 255);
+	z-index: 999;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR enhances the search block by introducing a live results dropdown.
Closes #62421

<!-- In a few words, what is the PR actually doing? -->

## Why?
Currently, WordPress search lacks real-time feedback while typing. This feature improves the user experience by:
- Allowing quick preview of search results without leaving the page.
- Reducing search errors by guiding users toward relevant queries.

## How?
Live Search Results Dropdown:

- Fetches and displays a small sample of actual results as the user types.

## Testing Instructions

1. Add the Search Block to a page.
2. Start typing in the search box and verify:
3. The dropdown displays live search results based on the query.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/766ac7bf-71be-4325-8d24-413d4aafbb86
