### PR TITLE
Latest Posts: Add global variable documentation for `render_block_core_latest_posts`

### DIFF
--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -33,6 +33,9 @@ function block_core_latest_posts_get_excerpt_length() {
  *
  * @since 5.0.0
  *
+ * @global WP_Post $post                                  Global post object.
+ * @global int     $block_core_latest_posts_excerpt_length Excerpt length set by the Latest Posts core block.
+ *
  * @param array $attributes The block attributes.
  *
  * @return string Returns the post content with latest posts added.


### PR DESCRIPTION
## What?
Closes #69761 

This PR adds global documentation for the `render_block_core_latest_posts` function.

## Why?

The `render_block_core_latest_posts` function has missing global documentation.

## How?

Relevant doc strings are added.
