### PR TITLE
Latest Posts block: Add missing @global PHP documentation

### DIFF
--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -33,8 +33,8 @@ function block_core_latest_posts_get_excerpt_length() {
  *
  * @since 5.0.0
  *
- * @global WP_Post $post Global post object.
- * @global int $block_core_latest_posts_excerpt_length Excerpt length set by the Latest Posts core block.
+ * @global WP_Post $post                                   Global post object.
+ * @global int     $block_core_latest_posts_excerpt_length Excerpt length set by the Latest Posts core block.
  *
  * @param array $attributes The block attributes.
  *

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -34,7 +34,7 @@ function block_core_latest_posts_get_excerpt_length() {
  * @since 5.0.0
  *
  * @global WP_Post $post Global post object.
- * @global int $block_core_latest_posts_excerpt_length Filters the excerpt length.
+ * @global int $block_core_latest_posts_excerpt_length Excerpt length set by the Latest Posts core block.
  *
  * @param array $attributes The block attributes.
  *

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -33,6 +33,9 @@ function block_core_latest_posts_get_excerpt_length() {
  *
  * @since 5.0.0
  *
+ * @global WP_Post $post Global post object.
+ * @global int $block_core_latest_posts_excerpt_length Filters the excerpt length.
+ * 
  * @param array $attributes The block attributes.
  *
  * @return string Returns the post content with latest posts added.

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -35,7 +35,7 @@ function block_core_latest_posts_get_excerpt_length() {
  *
  * @global WP_Post $post Global post object.
  * @global int $block_core_latest_posts_excerpt_length Filters the excerpt length.
- * 
+ *
  * @param array $attributes The block attributes.
  *
  * @return string Returns the post content with latest posts added.


### PR DESCRIPTION
What?
Added @global documentation in gutenberg/packages/block-library/src/latest-posts/index.php file.

Why?
@global documentation is missing in gutenberg/packages/block-library/src/latest-posts/index.php file.

How?
Testing Instructions
Open gutenberg/packages/block-library/src/latest-posts/index.php file
See @global documentation is missing

issue: https://github.com/WordPress/gutenberg/issues/69761