### PR TITLE
Fix: Write Mode / Zoom Out: Dark toolbar inconsistency

### DIFF
--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -11,13 +11,14 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { forwardRef } from '@wordpress/element';
+import { forwardRef, useEffect } from '@wordpress/element';
 import { Icon, edit as editIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 const selectIcon = (
 	<SVG
@@ -31,11 +32,22 @@ const selectIcon = (
 );
 
 function ToolSelector( props, ref ) {
-	const mode = useSelect(
-		( select ) => select( blockEditorStore ).__unstableGetEditorMode(),
-		[]
-	);
+	const { mode, isZoomOut } = useSelect( ( select ) => {
+		const editorMode = select( blockEditorStore ).__unstableGetEditorMode();
+		const zoomOut = unlock( select( blockEditorStore ) ).isZoomOut();
+		return {
+			mode: editorMode,
+			isZoomOut: zoomOut,
+		};
+	}, [] );
+
 	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
+
+	useEffect( () => {
+		if ( isZoomOut ) {
+			__unstableSetEditorMode( 'edit' );
+		}
+	}, [ isZoomOut, __unstableSetEditorMode ] );
 
 	return (
 		<Dropdown
@@ -50,6 +62,8 @@ function ToolSelector( props, ref ) {
 					onClick={ onToggle }
 					/* translators: button label text should, if possible, be under 16 characters. */
 					label={ __( 'Tools' ) }
+					disabled={ isZoomOut }
+					accessibleWhenDisabled
 				/>
 			) }
 			popoverProps={ { placement: 'bottom-start' } }


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/67409

<!-- In a few words, what is the PR actually doing? -->

## Why?

This PR improves the compatibility between Write Mode and Zoom Out functionality, ensuring they work seamlessly together.

## How?
This PR disables the write mode experiment when the site editor is zoomed out and by default selects the 'Design' mode so that user sees the toolbar in light mode 

## Testing Instructions
- Enable the write mode experiment (Admin sidebar > Gutenberg > Experiments)
- Open the site editor and edit a template
- Click the Zoom out button on the topbar
- Notice on Zoom Out, the write mode is disabled 
- User can only see 'Design' Mode when zoomed out ( light theme )  

## Screenshots or screencast 

https://github.com/user-attachments/assets/464dc55f-ee2c-45ff-bfcd-0ab4369e2217
