### PR TITLE
Scripts: Fix blocks manifest generation when directory name has space

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Fix: `--blocks-manifest` CLI flag doesn't work when the directory name has space ([#69766](https://github.com/WordPress/gutenberg/pull/69766)).
+
+
 ## 30.14.0 (2025-03-27)
 
 ### New Features

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -275,9 +275,9 @@ class BlocksManifestPlugin {
 	apply( compiler ) {
 		compiler.hooks.afterEmit.tap( 'BlocksManifest', () => {
 			exec(
-				`node ${ fromScriptsRoot(
+				`node "${ fromScriptsRoot(
 					'build-blocks-manifest'
-				) } --input="${ compiler.options.output.path }"`
+				) }" --input="${ compiler.options.output.path }"`
 			);
 		} );
 	}


### PR DESCRIPTION
## What?

Fixes https://github.com/WordPress/gutenberg/issues/69760
Follow-up https://github.com/WordPress/gutenberg/pull/69578

## Why?

If the scripts command has the `--blocks-manifest` flag, the `build-blocks-manifest` command is executed internally. However, if the scripts is executed inside the directory with spaces, the following incorrect command is generated:

```
node D:\Local Sites\test-block\node_modules\@wordpress\scripts\scripts\build-blocks-manifest.js --input="D:\Local Sites\test-block\build"
```

Because there is no quote, the following invalid command will actually be executed:

```
node D:\Local 
```

## Testing Instructions

- Create a directory with a space (e.g. `Local Sites`)
- Open the directory with your code editor
- Run `npx @wordpress/create-block test-block`
- cd `test-block`
- Run `npm run start` or `npm run build`
- ❌ Confirm that `Local Sites/test-block/build/` directory doesn't have `blocks-manifest.php` file
- Open the `Local Sites/test-block/node-modules/@wordpress/scripts/config/webpack.config.js` file and add changes that are the same as this PR
- Run `npm run start` or `npm run build` again
- ✅ Confirm that `Local Sites/test-block/build/` directory has `blocks-manifest.php` file

