### PR TITLE
Add filter to allow other plugin behave like `core/post-content`

### DIFF
--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -17,6 +17,7 @@ import {
 	privateApis,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -108,6 +109,12 @@ const {
  */
 function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
+	const sectionBlockTypes = useMemo(
+		() => [
+			...applyFilters( 'editor.sectionBlockTypes', 'core/post-content' ),
+		],
+		[]
+	);
 	const {
 		allowRightClickOverrides,
 		blockTypes,
@@ -146,7 +153,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 
 			function getSectionRootBlock() {
 				if ( renderingMode === 'template-locked' ) {
-					return getBlocksByName( 'core/post-content' )?.[ 0 ] ?? '';
+					return getBlocksByName( sectionBlockTypes )?.[ 0 ] ?? '';
 				}
 
 				return (

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -110,9 +110,8 @@ const {
 function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const sectionBlockTypes = useMemo(
-		() => [
-			...applyFilters( 'editor.sectionBlockTypes', 'core/post-content' ),
-		],
+		() =>
+			applyFilters( 'editor.sectionBlockTypes', [ 'core/post-content' ] ),
 		[]
 	);
 	const {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add a new filter that allows `sectionRootClientId` to have an initial value when the editor is in `template-locked` rendering mode for blocks other than `core/post-content`.
Follow up  PR  #69759 

<!-- In a few words, what is the PR actually doing? -->

## Why?
The `editor.postContentBlockTypes` hook enables other blocks to behave like `core/post-content`. However, when users try to insert these blocks from the Sidebar Block Tab (or the Pattern tab), they encounter a “Block can’t be inserted” error.

## How?
Introduce a new filter called `editor.sectionBlockTypes` within `useBlockEditorSettings`. This filter ensures that the editor assigns an initial value to `sectionRootClientId` when operating in template-locked rendering mode.

## Screenshots or screencast <!-- if applicable -->

<img width="1706" alt="Screenshot 2025-03-31 at 08 31 16" src="https://github.com/user-attachments/assets/14cef08a-ed47-4d64-95b4-d81e4d433227" />
