### PR TITLE
TreeGrid: Set initial tabindex attributes for the roving tabindex

### DIFF
--- a/packages/components/src/tree-grid/roving-tab-index-context.ts
+++ b/packages/components/src/tree-grid/roving-tab-index-context.ts
@@ -9,6 +9,11 @@ const RovingTabIndexContext = createContext<
 			setLastFocusedElement: React.Dispatch<
 				React.SetStateAction< HTMLElement | undefined >
 			>;
+			// Add a flag to track if we've already set an initial item
+			hasInitialFocusableItem: boolean;
+			setHasInitialFocusableItem: React.Dispatch<
+				React.SetStateAction< boolean >
+			>;
 	  }
 	| undefined
 >( undefined );

--- a/packages/components/src/tree-grid/roving-tab-index-item.tsx
+++ b/packages/components/src/tree-grid/roving-tab-index-item.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useRef, forwardRef } from '@wordpress/element';
+import { useRef, forwardRef, useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -11,30 +11,60 @@ import type { RovingTabIndexItemProps } from './types';
 
 export const RovingTabIndexItem = forwardRef(
 	function UnforwardedRovingTabIndexItem(
-		{ children, as: Component, ...props }: RovingTabIndexItemProps,
+		{
+			children,
+			as: Component,
+			initiallyFocusable = false,
+			...props
+		}: RovingTabIndexItemProps & { initiallyFocusable?: boolean },
 		forwardedRef: React.ForwardedRef< any >
 	) {
 		const localRef = useRef< any >();
 		const ref = forwardedRef || localRef;
-		// @ts-expect-error - We actually want to throw an error if this is undefined.
-		const { lastFocusedElement, setLastFocusedElement } =
-			useRovingTabIndexContext();
+
+		const [ isFirstItem, setIsFirstItem ] = useState( false );
+
+		const {
+			lastFocusedElement,
+			setLastFocusedElement,
+			hasInitialFocusableItem,
+			setHasInitialFocusableItem,
+		} = useRovingTabIndexContext() ?? {};
+
+		useEffect( () => {
+			if ( initiallyFocusable ) {
+				setIsFirstItem( true );
+				setHasInitialFocusableItem?.( true );
+				return;
+			}
+
+			if ( ! hasInitialFocusableItem ) {
+				setIsFirstItem( true );
+				setHasInitialFocusableItem?.( true );
+			}
+		}, [
+			initiallyFocusable,
+			hasInitialFocusableItem,
+			setHasInitialFocusableItem,
+		] );
+
+		// Determine tabIndex
 		let tabIndex;
 
 		if ( lastFocusedElement ) {
 			tabIndex =
 				lastFocusedElement ===
-				// TODO: The original implementation simply used `ref.current` here, assuming
-				// that a forwarded ref would always be an object, which is not necessarily true.
-				// This workaround maintains the original runtime behavior in a type-safe way,
-				// but should be revisited.
 				( 'current' in ref ? ref.current : undefined )
 					? 0
 					: -1;
+		} else {
+			tabIndex = isFirstItem ? 0 : -1;
 		}
 
-		const onFocus: React.FocusEventHandler< HTMLElement > = ( event ) =>
+		const onFocus: React.FocusEventHandler< HTMLElement > = ( event ) => {
 			setLastFocusedElement?.( event.target );
+		};
+
 		const allProps = { ref, tabIndex, onFocus, ...props };
 
 		if ( typeof children === 'function' ) {

--- a/packages/components/src/tree-grid/roving-tab-index.tsx
+++ b/packages/components/src/tree-grid/roving-tab-index.tsx
@@ -21,12 +21,19 @@ export default function RovingTabIndex( {
 	const [ lastFocusedElement, setLastFocusedElement ] =
 		useState< HTMLElement >();
 
+	// Add state to track if we've already set an initial focusable item
+	const [ hasInitialFocusableItem, setHasInitialFocusableItem ] =
+		useState( false );
+
 	// Use `useMemo` to avoid creation of a new object for the providerValue
-	// on every render. Only create a new object when the `lastFocusedElement`
-	// value changes.
 	const providerValue = useMemo(
-		() => ( { lastFocusedElement, setLastFocusedElement } ),
-		[ lastFocusedElement ]
+		() => ( {
+			lastFocusedElement,
+			setLastFocusedElement,
+			hasInitialFocusableItem,
+			setHasInitialFocusableItem,
+		} ),
+		[ lastFocusedElement, hasInitialFocusableItem ]
 	);
 
 	return (

--- a/packages/components/src/tree-grid/types.ts
+++ b/packages/components/src/tree-grid/types.ts
@@ -66,6 +66,13 @@ export type RovingTabIndexItemProps = {
 	 * If `children` is not a function, this component will be used instead.
 	 */
 	as?: React.ComponentType< RovingTabIndexItemPassThruProps >;
+	/**
+	 * When true, this item will be the initially focusable item (tabIndex="0").
+	 * Only one item should have this set to true.
+	 *
+	 * @default false
+	 */
+	initiallyFocusable?: boolean;
 	[ key: string ]: any;
 };
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
