### PR TITLE
fix: Front-end link doesn't match the style of other panels

### DIFF
--- a/packages/editor/src/components/post-url/index.js
+++ b/packages/editor/src/components/post-url/index.js
@@ -82,7 +82,7 @@ export default function PostURL( { onClose } ) {
 	return (
 		<div className="editor-post-url">
 			<InspectorPopoverHeader
-				title={ __( 'Slug' ) }
+				title={ __( 'Link' ) }
 				onClose={ onClose }
 			/>
 			<VStack spacing={ 3 }>

--- a/packages/editor/src/components/post-url/panel.js
+++ b/packages/editor/src/components/post-url/panel.js
@@ -3,10 +3,9 @@
  */
 import { useMemo, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { Dropdown, Button, ExternalLink } from '@wordpress/components';
+import { Dropdown, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { safeDecodeURIComponent } from '@wordpress/url';
-import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -22,20 +21,6 @@ import { store as editorStore } from '../../store';
  * @return {React.ReactNode} The rendered PostURLPanel component.
  */
 export default function PostURLPanel() {
-	const { isFrontPage } = useSelect( ( select ) => {
-		const { getCurrentPostId } = select( editorStore );
-		const { getEditedEntityRecord, canUser } = select( coreStore );
-		const siteSettings = canUser( 'read', {
-			kind: 'root',
-			name: 'site',
-		} )
-			? getEditedEntityRecord( 'root', 'site' )
-			: undefined;
-		const _id = getCurrentPostId();
-		return {
-			isFrontPage: siteSettings?.page_on_front === _id,
-		};
-	}, [] );
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
@@ -52,29 +37,21 @@ export default function PostURLPanel() {
 		[ popoverAnchor ]
 	);
 
-	const label = isFrontPage ? __( 'Link' ) : __( 'Slug' );
-
 	return (
 		<PostURLCheck>
-			<PostPanelRow label={ label } ref={ setPopoverAnchor }>
-				{ ! isFrontPage && (
-					<Dropdown
-						popoverProps={ popoverProps }
-						className="editor-post-url__panel-dropdown"
-						contentClassName="editor-post-url__panel-dialog"
-						focusOnMount
-						renderToggle={ ( { isOpen, onToggle } ) => (
-							<PostURLToggle
-								isOpen={ isOpen }
-								onClick={ onToggle }
-							/>
-						) }
-						renderContent={ ( { onClose } ) => (
-							<PostURL onClose={ onClose } />
-						) }
-					/>
-				) }
-				{ isFrontPage && <FrontPageLink /> }
+			<PostPanelRow label={ __( 'Slug' ) } ref={ setPopoverAnchor }>
+				<Dropdown
+					popoverProps={ popoverProps }
+					className="editor-post-url__panel-dropdown"
+					contentClassName="editor-post-url__panel-dialog"
+					focusOnMount
+					renderToggle={ ( { isOpen, onToggle } ) => (
+						<PostURLToggle isOpen={ isOpen } onClick={ onToggle } />
+					) }
+					renderContent={ ( { onClose } ) => (
+						<PostURL onClose={ onClose } />
+					) }
+				/>
 			</PostPanelRow>
 		</PostURLCheck>
 	);
@@ -101,24 +78,5 @@ function PostURLToggle( { isOpen, onClick } ) {
 		>
 			<>{ decodedSlug }</>
 		</Button>
-	);
-}
-
-function FrontPageLink() {
-	const { postLink } = useSelect( ( select ) => {
-		const { getCurrentPost } = select( editorStore );
-		return {
-			postLink: getCurrentPost()?.link,
-		};
-	}, [] );
-
-	return (
-		<ExternalLink
-			className="editor-post-url__front-page-link"
-			href={ postLink }
-			target="_blank"
-		>
-			{ postLink }
-		</ExternalLink>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #69577 

<!-- In a few words, what is the PR actually doing? -->
This PR fixes the bugs in front-end link mentioned in #69577

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR reverted the additional styles for front-end link introduced by #63669

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Set any page as the front page.
2. Open the page.
3. Check the post sidebar.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="281" alt="image" src="https://github.com/user-attachments/assets/f656d101-da4f-47b6-afcc-6e997f9a884a" />|<img width="281" alt="image" src="https://github.com/user-attachments/assets/27251c75-0736-4ebe-9064-eba9a85b18cb" />|
