### PR TITLE
Site Editor: Add `+ button` to add new entity like `page`, `pattern`, `template`

### DIFF
--- a/packages/edit-site/src/components/add-new-template/index.js
+++ b/packages/edit-site/src/components/add-new-template/index.js
@@ -149,7 +149,7 @@ const modalContentMap = {
 	customGenericTemplate: 3,
 };
 
-function NewTemplateModal( { onClose } ) {
+export function NewTemplateModal( { onClose } ) {
 	const [ modalContent, setModalContent ] = useState(
 		modalContentMap.templatesList
 	);

--- a/packages/edit-site/src/components/site-hub/add-entity-menu.js
+++ b/packages/edit-site/src/components/site-hub/add-entity-menu.js
@@ -1,0 +1,119 @@
+/**
+ * WordPress dependencies
+ */
+import { DropdownMenu, MenuItem, MenuGroup } from '@wordpress/components';
+import { plus } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { privateApis as editPatternsPrivateApis } from '@wordpress/patterns';
+
+/**
+ * Internal dependencies
+ */
+import AddNewPostModal from '../add-new-post';
+import { NewTemplateModal } from '../add-new-template';
+import { unlock } from '../../lock-unlock';
+import { PATTERN_TYPES } from '../../utils/constants';
+
+const { useHistory } = unlock( routerPrivateApis );
+const { CreatePatternModal } = unlock( editPatternsPrivateApis );
+
+const POPOVER_PROPS = {
+	position: 'bottom right',
+};
+
+export default function AddEntityMenu() {
+	const [ showAddPostModal, setShowAddPostModal ] = useState( false );
+	const [ showTemplateModal, setShowTemplateModal ] = useState( false );
+	const [ showPatternModal, setShowPatternModal ] = useState( false );
+	const history = useHistory();
+
+	const { canCreatePattern } = useSelect( ( select ) => {
+		const { canUser } = select( coreStore );
+		return {
+			canCreatePattern: canUser( 'create', {
+				kind: 'postType',
+				name: PATTERN_TYPES.user,
+			} ),
+		};
+	}, [] );
+
+	const handleNewPost = ( { type, id } ) => {
+		history.navigate( `/${ type }/${ id }?canvas=edit` );
+		setShowAddPostModal( false );
+	};
+
+	const handleCreatePattern = ( { pattern } ) => {
+		setShowPatternModal( false );
+		history.navigate(
+			`/${ PATTERN_TYPES.user }/${ pattern.id }?canvas=edit`
+		);
+	};
+
+	return (
+		<>
+			<DropdownMenu
+				label={ __( 'Add new' ) }
+				className="edit-site-site-hub_add_entity"
+				icon={ plus }
+				popoverProps={ POPOVER_PROPS }
+			>
+				{ ( { onClose } ) => (
+					<MenuGroup label={ __( 'Add new' ) }>
+						<MenuItem
+							onClick={ () => {
+								setShowAddPostModal( true );
+								onClose();
+							} }
+						>
+							{ __( 'Page' ) }
+						</MenuItem>
+						<MenuItem
+							onClick={ () => {
+								setShowTemplateModal( true );
+								onClose();
+							} }
+						>
+							{ __( 'Template' ) }
+						</MenuItem>
+						{ canCreatePattern && (
+							<MenuItem
+								onClick={ () => {
+									setShowPatternModal( true );
+									onClose();
+								} }
+							>
+								{ __( 'Pattern' ) }
+							</MenuItem>
+						) }
+					</MenuGroup>
+				) }
+			</DropdownMenu>
+
+			{ showAddPostModal && (
+				<AddNewPostModal
+					postType="page"
+					onSave={ handleNewPost }
+					onClose={ () => setShowAddPostModal( false ) }
+				/>
+			) }
+
+			{ showTemplateModal && (
+				<NewTemplateModal
+					onClose={ () => setShowTemplateModal( false ) }
+				/>
+			) }
+
+			{ showPatternModal && (
+				<CreatePatternModal
+					onClose={ () => setShowPatternModal( false ) }
+					onSuccess={ handleCreatePattern }
+					onError={ () => setShowPatternModal( false ) }
+				/>
+			) }
+		</>
+	);
+}

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -29,6 +29,7 @@ import { store as editSiteStore } from '../../store';
 import SiteIcon from '../site-icon';
 import { unlock } from '../../lock-unlock';
 import { SidebarNavigationContext } from '../sidebar';
+import AddEntityMenu from './add-entity-menu';
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 const SiteHub = memo(
@@ -105,6 +106,7 @@ const SiteHub = memo(
 								label={ __( 'Open command palette' ) }
 								shortcut={ displayShortcut.primary( 'k' ) }
 							/>
+							<AddEntityMenu />
 						</HStack>
 					</HStack>
 				</HStack>
@@ -231,6 +233,7 @@ export const SiteHubMobile = memo(
 								label={ __( 'Open command palette' ) }
 								shortcut={ displayShortcut.primary( 'k' ) }
 							/>
+							<AddEntityMenu />
 						</HStack>
 					</HStack>
 				</HStack>

--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -88,3 +88,9 @@
 		}
 	}
 }
+
+.edit-site-site-hub_add_entity {
+	svg {
+		fill: $gray-100;
+	}
+}


### PR DESCRIPTION


## What?
Closes: https://github.com/WordPress/gutenberg/issues/63378

Added a "+" dropdown menu to the Site Editor for creating Pages, Patterns, and Templates.

 ## Why?
Reduces clicks needed when creating content, mimicking the pattern in the wp-admin dashboard. Current implementation includes only entities already supported by Site Editor code.

## How?

Implemented a dropdown menu triggered by "+" icon that exposes creation options for Pages, Patterns, and Templates. The menu structure is designed to be easily extendable when support for Posts, Media, and Users is added in the site editor in future.


### Testing Instructions for Keyboard

1. Go to Appearance > Site Editor
2. Locate and click the "+" icon next to the search function
3. Test creating a new Page
4. Test creating a new Pattern
5. Test creating a new Template


## Screencast

https://github.com/user-attachments/assets/c07cd370-d5c5-441e-b00f-7c69a4088554


