### PR TITLE
Fix:  Incorrect Type of `wp_widget_factory` in `render_block_core_legacy_widget` Doc Block

### DIFF
--- a/packages/widgets/src/blocks/legacy-widget/index.php
+++ b/packages/widgets/src/blocks/legacy-widget/index.php
@@ -10,7 +10,7 @@
  *
  * @since 5.8.0
  *
- * @global int $wp_widget_factory.
+ * @global WP_Widget_Factory $wp_widget_factory.
  *
  * @param array $attributes The block attributes.
  *


### PR DESCRIPTION
- Updated the doc block of the render_block_core_legacy_widget function to specify the correct type for the global wp_widget_factory as WP_Widget_Factory

- Fixes #69774