### PR TITLE
Iframe: Don't enable for block themes in core if v2 blocks exist

### DIFF
--- a/packages/edit-post/src/components/layout/use-should-iframe.js
+++ b/packages/edit-post/src/components/layout/use-should-iframe.js
@@ -11,24 +11,26 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
  */
 import { unlock } from '../../lock-unlock';
 
+const isGutenbergPlugin = globalThis.IS_GUTENBERG_PLUGIN ? true : false;
+
 export function useShouldIframe() {
 	return useSelect( ( select ) => {
 		const { getEditorSettings, getCurrentPostType, getDeviceType } =
 			select( editorStore );
 		return (
-			// If the theme is block based, we ALWAYS use the iframe for
-			// consistency across the post and site editor. The iframe was
-			// introduced long before the sited editor and block themes, so
-			// these themes are expecting it.
-			getEditorSettings().__unstableIsBlockBasedTheme ||
-			// For classic themes, we also still want to iframe all the special
+			// If the theme is block based and the Gutenberg plugin is active,
+			// we ALWAYS use the iframe for consistency across the post and site
+			// editor.
+			( isGutenbergPlugin &&
+				getEditorSettings().__unstableIsBlockBasedTheme ) ||
+			// We also still want to iframe all the special
 			// editor features and modes such as device previews, zoom out, and
 			// template/pattern editing.
 			getDeviceType() !== 'Desktop' ||
 			[ 'wp_template', 'wp_block' ].includes( getCurrentPostType() ) ||
 			unlock( select( blockEditorStore ) ).isZoomOut() ||
-			// Finally, still iframe the editor for classic themes if all blocks
-			// are v3 (which means they are marked as iframe-compatible).
+			// Finally, still iframe the editor if all blocks are v3 (which means
+			// they are marked as iframe-compatible).
 			select( blocksStore )
 				.getBlockTypes()
 				.every( ( type ) => type.apiVersion >= 3 )


### PR DESCRIPTION
See the discussion starting here.

https://wordpress.slack.com/archives/C02QB2JS7/p1743389846950809?thread_ts=1743180353.421439&cid=C02QB2JS7

## What?

#66800 always forces the iframe post editor in core when the block theme is enabled.

We should eventually move completely to the iframe editor, but it seems there are still plugins that break in iframes.

This PR reverts #66800, which means we DON'T force the iframe editor when the following conditions are met:

- Post editor, desktop view
- Block theme is active
- Non-v3 blocks are registered

## Testing Instructions

- Change the following value to false to simulate the Gutenberg plugin being disabled:https://github.com/WordPress/gutenberg/blob/ed78217af0c07e79b20f24df4d589008f9c49e06/package.json#L22
- Install and activate [CoBlocks plugin](https://wordpress.org/plugins/coblocks/): This means that v2 blocks are registered
- Activate Block theme
- Open the post editor
- Use your browser developer tools to make sure the editor is NOT iframed.
- Change the value of `IS_GUTENBERG_PLUGIN` to `true` and build again.
- Open the post editor and make sure the editor is iframed.