### PR TITLE
Block drag & drop: Enable mouse click on input/textarea elements in Firefox

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-firefox-draggable-compatibility.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-firefox-draggable-compatibility.js
@@ -41,12 +41,15 @@ function restore( node ) {
 
 function down( event ) {
 	const { target } = event;
-	const { ownerDocument, isContentEditable } = target;
+	const { ownerDocument, isContentEditable, tagName } = target;
+	const isInputOrTextArea = [ 'INPUT', 'TEXTAREA' ].includes( tagName );
+
 	const nodes = nodesByDocument.get( ownerDocument );
 
-	if ( isContentEditable ) {
-		// Whenever an editable element is clicked, check which draggable
-		// blocks contain this element, and temporarily disable draggability.
+	if ( isContentEditable || isInputOrTextArea ) {
+		// Whenever an editable element or an input or textarea is clicked,
+		// check which draggable blocks contain this element, and temporarily
+		// disable draggability.
 		for ( const node of nodes ) {
 			if (
 				node.getAttribute( 'draggable' ) === 'true' &&
@@ -57,8 +60,8 @@ function down( event ) {
 			}
 		}
 	} else {
-		// Whenever a non-editable element is clicked, re-enable draggability
-		// for any blocks that were previously disabled.
+		// Whenever a non-editable element or an input or textarea is clicked,
+		// re-enable draggability for any blocks that were previously disabled.
 		for ( const node of nodes ) {
 			restore( node );
 		}
@@ -66,11 +69,11 @@ function down( event ) {
 }
 
 /**
- * In Firefox, the `draggable` and `contenteditable` attributes don't play well
- * together. When `contenteditable` is within a `draggable` element, selection
- * doesn't get set in the right place. The only solution is to temporarily
- * remove the `draggable` attribute clicking inside `contenteditable` elements.
- *
+ * In Firefox, the `draggable` and `contenteditable` or `input` or `textarea`
+ * elements don't play well together. When these elements are within a
+ * `draggable` element, selection doesn't get set in the right place. The only
+ * solution is to temporarily remove the `draggable` attribute clicking inside
+ * these elements.
  * @return {Function} Cleanup function.
  */
 export function useFirefoxDraggableCompatibility() {


### PR DESCRIPTION
Closes #69779

Related PRs:

- https://github.com/WordPress/gutenberg/pull/67305
- https://github.com/WordPress/gutenberg/pull/67439

cc @ellatrix @youknowriad 

## What?

This PR fixes an issue where when a block contains `input` or `textarea`, its values ​​cannot be selected with the mouseclick.

## Why?

This problem is related to the Firefox bug: - [965800 - Text cursor (caret) ignores mouse click on inputs with draggable parent](https://bugzilla.mozilla.org/show_bug.cgi?id=965800)

In Firefox, the `draggable` and `contenteditable` attributes don't play well. Therefore, there is logic inside it that removes the `draggable` attribute when you click inside the `contenteditable` element.

However, this logic does not apply to `input` and `textarea` elements, as they do not have the `contenteditable` attribute, even though they have text that is clickable with the mouse.

## How?

Add a check whether the clicked element is `input` or `textearea` element or not. I would have liked to use the [`isInputOrTextArea()` function](https://github.com/WordPress/gutenberg/blob/ed78217af0c07e79b20f24df4d589008f9c49e06/packages/dom/src/dom/is-input-or-text-area.js), but it's not exposed.

## Testing Instructions

- Open Firefox.

### Core Blocks

- Insert the Embed, Shortcode, and Custom HTML blocks.
- Insert a Paragraph block and switch to HTML editing mode.
- Confirm that you can select the text with the mouse.
- Confirm that the you can drag & drop a block as before (Example: Drag inside the embedded block and outside the text field.)

### HTML Native Elements

Paste the following code into the browser console panel. If you can't paste, access `about:config` and set `dom.event.clipboardevents.enabled` to `false`.

<details><summary>Code</summary>

```javascript
const { createElement } = wp.element;

wp.blocks.registerBlockType( 'test/test', {
	apiVersion: 3,
	title: 'Test Block',
	edit: () => {
		return createElement(
			'div',
			{
				...wp.blockEditor.useBlockProps(),
				style: {
					display: 'flex',
					flexDirection: 'column',
					gap: '10px',
				},
			},
			createElement( 'input', {
				type: 'text',
				value: 'Text input',
			} ),

			createElement( 'input', {
				type: 'number',
				value: '11111111',
			} ),
			createElement( 'textarea', {
				value: 'Textarea',
			} ),
			createElement( 'input', {
				type: 'color',
			} ),
			createElement( 'input', {
				type: 'file',
			} ),
			[ 1, 2, 3 ].map( ( num ) =>
				createElement(
					'div',
					{ key: num },
					createElement( 'input', {
						type: 'checkbox',
						value: num,
						name: 'checkbox',
						id: `checkbox-${ num }`,
					} ),
					createElement(
						'label',
						{ htmlFor: `checkbox-${ num }` },
						`Checkbox ${ num }`
					)
				)
			),
			[ 1, 2, 3 ].map( ( num ) =>
				createElement(
					'div',
					{ key: num },
					createElement( 'input', {
						type: 'radio',
						value: num,
						name: 'radio',
						id: `radio-${ num }`,
					} ),
					createElement(
						'label',
						{ htmlFor: `radio-${ num }` },
						`Radio ${ num }`
					)
				)
			),
			createElement(
				'select',
				{},
				createElement( 'option', { value: 'A' }, 'Option A' ),
				createElement( 'option', { value: 'B' }, 'Option B' ),
				createElement( 'option', { value: 'C' }, 'Option C' )
			),
			createElement(
				'button',
				{
					type: 'button',
					onClick: () => window.alert( 'Button clicked' ),
				},
				'Click Me'
			)
		);
	},
} );
```

</details> 

- Insert a Test block.
- Confirm that you can select the text in the following three elements:
  - `input[type="text"]
  - `input[type="number"]`
  - `textarea`

## Screenshots or screencast <!-- if applicable -->

### Berfore


https://github.com/user-attachments/assets/9eac11b8-5b02-4fa9-8d27-93dc99e7dca2

### After


https://github.com/user-attachments/assets/3e3e7041-1c12-4308-862c-de2926f7e6ef

