### PR TITLE
Update gradient-parser dependency from 0.1.5 to 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26571,6 +26571,14 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
 		},
+		"node_modules/gradient-parser": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-1.0.2.tgz",
+			"integrity": "sha512-gR6nY33xC9yJoH4wGLQtZQMXDi6RI3H37ERu7kQCVUzlXjNedpZM7xcA489Opwbq0BSGohtWGsWsntupmxelMg==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/grapheme-splitter": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
@@ -50469,7 +50477,7 @@
 				"deepmerge": "^4.3.0",
 				"fast-deep-equal": "^3.1.3",
 				"framer-motion": "^11.1.9",
-				"gradient-parser": "^1.0.2",
+				"gradient-parser": "1.0.2",
 				"highlight-words-core": "^1.2.2",
 				"is-plain-object": "^5.0.0",
 				"memize": "^2.1.0",
@@ -50504,14 +50512,6 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.3.tgz",
 			"integrity": "sha512-XDbrTSBlQV9nxE1GiDL3FaOPy4G/KaJkhDutBX48Kg8CYZMBARyyDFGCWfWJn4pobmInmwud1xxH7VJMAr0CKQ=="
-		},
-		"packages/components/node_modules/gradient-parser": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-1.0.2.tgz",
-			"integrity": "sha512-gR6nY33xC9yJoH4wGLQtZQMXDi6RI3H37ERu7kQCVUzlXjNedpZM7xcA489Opwbq0BSGohtWGsWsntupmxelMg==",
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"packages/components/node_modules/path-to-regexp": {
 			"version": "6.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26571,14 +26571,6 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
 		},
-		"node_modules/gradient-parser": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-0.1.5.tgz",
-			"integrity": "sha512-+uPlcVbjrKOnTzvz0MjTj7BfACj8OmxIa1moIjJV7btvhUMSJk0D47RfDCgDrZE3dYMz9Cf5xKJwnrKLjUq0KQ==",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/grapheme-splitter": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
@@ -50477,7 +50469,7 @@
 				"deepmerge": "^4.3.0",
 				"fast-deep-equal": "^3.1.3",
 				"framer-motion": "^11.1.9",
-				"gradient-parser": "^0.1.5",
+				"gradient-parser": "^1.0.2",
 				"highlight-words-core": "^1.2.2",
 				"is-plain-object": "^5.0.0",
 				"memize": "^2.1.0",
@@ -50512,6 +50504,14 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.3.tgz",
 			"integrity": "sha512-XDbrTSBlQV9nxE1GiDL3FaOPy4G/KaJkhDutBX48Kg8CYZMBARyyDFGCWfWJn4pobmInmwud1xxH7VJMAr0CKQ=="
+		},
+		"packages/components/node_modules/gradient-parser": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-1.0.2.tgz",
+			"integrity": "sha512-gR6nY33xC9yJoH4wGLQtZQMXDi6RI3H37ERu7kQCVUzlXjNedpZM7xcA489Opwbq0BSGohtWGsWsntupmxelMg==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"packages/components/node_modules/path-to-regexp": {
 			"version": "6.3.0",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Internal
+
+-   Update `gradient-parser` to version `1.0.2` ([#69783](https://github.com/WordPress/gutenberg/pull/69783)).
+
+
 ### Bug Fixes
 
 -   `Button`: Fix tertiary variant displaying incorrect text color in pressed and hover states ([#68542](https://github.com/WordPress/gutenberg/pull/68542)).

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -68,7 +68,7 @@
 		"deepmerge": "^4.3.0",
 		"fast-deep-equal": "^3.1.3",
 		"framer-motion": "^11.1.9",
-		"gradient-parser": "^0.1.5",
+		"gradient-parser": "^1.0.2",
 		"highlight-words-core": "^1.2.2",
 		"is-plain-object": "^5.0.0",
 		"memize": "^2.1.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -68,7 +68,7 @@
 		"deepmerge": "^4.3.0",
 		"fast-deep-equal": "^3.1.3",
 		"framer-motion": "^11.1.9",
-		"gradient-parser": "^1.0.2",
+		"gradient-parser": "1.0.2",
 		"highlight-words-core": "^1.2.2",
 		"is-plain-object": "^5.0.0",
 		"memize": "^2.1.0",


### PR DESCRIPTION
Closes: #69782

## What?
This PR updates the `gradient-parser` dependency from version 0.1.5 to 1.0.2 to fix an issue with parsing gradients that use size keywords (e.g., `closest-side`, `farthest-corner`).

Related to WordPress core ticket [#63205](https://core.trac.wordpress.org/ticket/63205)

## Why?
The current version of the `gradient-parser` library (0.1.5) fails to properly parse radial gradients that use size keywords like `closest-side`. This causes the CustomGradientPicker to display an error in the console and prevents the picker subcomponents from populating correctly.

This bug was fixed in version 1.0.0 of the gradient-parser library, and the current latest version is 1.0.2.

## Testing Instructions
1. Add a custom gradient to theme.json (settings.color.gradients) that uses a size keyword:
```json
{
  "gradient": "radial-gradient(closest-side at 15% 20%, red, blue)",
  "name": "Red to Blue",
  "slug": "red-to-blue"
}
```

2. Before the fix:

- Choose this gradient as a background for a block (e.g., Group block)
- Open the gradient picker
- The picker subcomponents (type, angle, linear picker) will not populate
- The JavaScript console will show an error: wp.components.CustomGradientPicker failed to parse the gradient with error Error: -side at 15% 20%, red, blue): Missing )

3. After the fix:

- The gradient picker should properly parse and display the gradient with the size keyword
- No errors should appear in the console
- All picker subcomponents should work correctly
