### PR TITLE
Code Quality: Fix Documentation inconsistencies in `Block Parser` classes

### DIFF
--- a/packages/block-serialization-default-parser/class-wp-block-parser-block.php
+++ b/packages/block-serialization-default-parser/class-wp-block-parser-block.php
@@ -62,7 +62,7 @@ class WP_Block_Parser_Block {
 	 *   'innerContent' => array( 'Before', null, 'Inner', null, 'After' ),
 	 * )
 	 *
-	 * @since 5.0.0array empty associative array
+	 * @since 5.0.0 array empty associative array
 	 * @var array
 	 */
 	public $innerContent; // phpcs:ignore WordPress.NamingConventions.ValidVariableName

--- a/packages/block-serialization-default-parser/class-wp-block-parser-block.php
+++ b/packages/block-serialization-default-parser/class-wp-block-parser-block.php
@@ -62,7 +62,7 @@ class WP_Block_Parser_Block {
 	 *   'innerContent' => array( 'Before', null, 'Inner', null, 'After' ),
 	 * )
 	 *
-	 * @since 4.2.0
+	 * @since 5.0.0array empty associative array
 	 * @var array
 	 */
 	public $innerContent; // phpcs:ignore WordPress.NamingConventions.ValidVariableName

--- a/packages/block-serialization-default-parser/class-wp-block-parser.php
+++ b/packages/block-serialization-default-parser/class-wp-block-parser.php
@@ -36,7 +36,7 @@ class WP_Block_Parser {
 	 * List of parsed blocks
 	 *
 	 * @since 5.0.0
-	 * @var WP_Block_Parser_Block[]
+	 * @var array[]
 	 */
 	public $output;
 
@@ -303,7 +303,7 @@ class WP_Block_Parser {
 	 * Returns a new block object for freeform HTML
 	 *
 	 * @internal
-	 * @since 3.9.0
+	 * @since 5.0.0
 	 *
 	 * @param string $inner_html HTML content of block.
 	 * @return WP_Block_Parser_Block freeform block object.


### PR DESCRIPTION

## What?
Closes  : https://github.com/WordPress/gutenberg/issues/47947
Related Trac ticket: [56581](https://core.trac.wordpress.org/ticket/56581) 

Related Changesets: Two changesets were previously added to core ([54193](https://core.trac.wordpress.org/changeset/54193), [54194](https://core.trac.wordpress.org/changeset/54194)), but were reverted in [54195](https://core.trac.wordpress.org/changeset/54195). The reversion occurred because these changes should first be made upstream in the Gutenberg repository and then backported to core to prevent test failures. During this process, [PR #48693](https://github.com/WordPress/gutenberg/pull/48693) was merged in Gutenberg, which split the relevant classes (included as related context).

Since this issue focuses on developer documentation and has been long-standing with a "needs-dev" tag, I analyzed the 6 mentioned places. Below is a summary of my findings, and I've addressed the necessary corrections in this PR.


| Item | Issue | Current Status | Action Needed |
|------|-------|----------------|--------------|
| `WP_Block_Parser::$empty_attrs` | Incorrect `@since` tag (early Gutenberg version) | Property does not exist | No action needed (property doesn't exist) Was removed in this PR https://github.com/WordPress/gutenberg/pull/54496 |
| `WP_Block_Parser::next_token()` | Illogical `@since` tags - mentions bug fix in 4.6.1 for function introduced in 5.0.0 | Still incorrect | Not corrected in this PR (doc comment is illogical - claims a bug fix in 4.6.1 for a function introduced in 5.0.0) |
| `WP_Block_Parser::freeform()` | Incorrect `@since` tag (early Gutenberg version) | Fixed to `@since 5.0.0` | Corrected in this PR ✅  |
| `WP_Block_Parser_Block::$innerContent` | Incorrect `@since` tag (4.2.0 - early Gutenberg version) | Fixed to `@since 5.0.0` | Corrected in this PR ✅ |
| `WP_Block_Parser::parse()` | Incorrect return type documentation | Was already correct | No action needed |
| `WP_Block_Parser::$output` | Incorrect return type documentation | Fixed to `array[]` | Corrected in this PR ✅  |



## Why?
Accurate documentation is essential for developers - this PR fixes incorrect version tags and return types to ensure reliable reference information.

## How?

This PR makes the following corrections:
- Updated `WP_Block_Parser::freeform()` to correctly have `@since 5.0.0`
- Updated `WP_Block_Parser_Block::$innerContent` to correctly have `@since 5.0.0` (was 4.2.0)
- Updated `WP_Block_Parser::$output` return type to be correctly documented as `array[]`

These changes ensure documentation correctly reflects that these components were introduced in WordPress 5.0.0 when Gutenberg was merged into Core, not during earlier Gutenberg plugin development.



