### PR TITLE
Fix:  The width stays 500px in wide or full alignments for Pocket Casts Embed

### DIFF
--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -39,6 +39,11 @@
 	position: relative;
 }
 
+.is-provider-pocket-casts .wp-block-embed__wrapper div {
+	max-width: 100% !important;
+	max-height: 350px !important;
+}
+
 // Add responsiveness to embeds with aspect ratios.
 .wp-embed-responsive .wp-has-aspect-ratio {
 	.wp-block-embed__wrapper::before {


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/69780

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast 

https://github.com/user-attachments/assets/79eaeba5-8b3d-45ae-b222-50af287d9d9e