### PR TITLE
Post Featured Image: Respect `aspectRatio` defined in `theme.json`

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -175,8 +175,8 @@ export default function PostFeaturedImageEdit( {
 				) }
 				withIllustration
 				style={ {
-					height: !! aspectRatio && '100%',
-					width: !! aspectRatio && '100%',
+					height: '100%',
+					width: '100%',
 					...borderProps.style,
 					...shadowProps.style,
 				} }
@@ -369,9 +369,9 @@ export default function PostFeaturedImageEdit( {
 	const imageStyles = {
 		...borderProps.style,
 		...shadowProps.style,
-		height: aspectRatio ? '100%' : height,
-		width: !! aspectRatio && '100%',
-		objectFit: !! ( height || aspectRatio ) && scale,
+		height: '100%',
+		width: '100%',
+		objectFit: scale,
 	};
 
 	/**

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -21,10 +21,14 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	}
 	$post_ID = $block->context['postId'];
 
-	$is_link        = isset( $attributes['isLink'] ) && $attributes['isLink'];
-	$size_slug      = isset( $attributes['sizeSlug'] ) ? $attributes['sizeSlug'] : 'post-thumbnail';
-	$attr           = get_block_core_post_featured_image_border_attributes( $attributes );
-	$overlay_markup = get_block_core_post_featured_image_overlay_element_markup( $attributes );
+	$is_link                = isset( $attributes['isLink'] ) && $attributes['isLink'];
+	$size_slug              = isset( $attributes['sizeSlug'] ) ? $attributes['sizeSlug'] : 'post-thumbnail';
+	$attr                   = get_block_core_post_featured_image_border_attributes( $attributes );
+	$overlay_markup         = get_block_core_post_featured_image_overlay_element_markup( $attributes );
+	$theme_block_dimensions = wp_get_global_styles(
+		array( 'dimensions' ),
+		array( 'block_name' => $block->name )
+	);
 
 	if ( $is_link ) {
 		if ( get_the_title( $post_ID ) ) {
@@ -41,7 +45,7 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	$extra_styles = '';
 
 	// Aspect ratio with a height set needs to override the default width/height.
-	if ( ! empty( $attributes['aspectRatio'] ) ) {
+	if ( ! empty( $attributes['aspectRatio'] ) || ! empty( $theme_block_dimensions['aspectRatio'] ) ) {
 		$extra_styles .= 'width:100%;height:100%;';
 	} elseif ( ! empty( $attributes['height'] ) ) {
 		$extra_styles .= "height:{$attributes['height']};";


### PR DESCRIPTION
## What?
Closes #69769

This PR addresses a bug that doesn't obey the default `aspectRatio` defined within `theme.json` for the `Post Featured Image` block.

## Why?

This happens because the `CSS Rules` are not being applied properly.

## How?

The conditions for `CSS Rule` application is updated and simplified.

## Testing Instructions

1. Add the following lines to `theme.json`:

<details>
<summary>theme.json</summary>

```json
"styles":  {
  "blocks":  {
    "core/post-featured-image": {
      "dimensions":  {
        "aspectRatio": "1"
      }
    }
  }
},
```
</details>

2. Assign a `Featured Image` to a post.
3. Add the `Post Featured Image` block.
4. Confirm the `aspectRatio` defined in `theme.json` for the block is obeyed in both the editor and the front-end.

### Testing Instructions for Keyboard
Same.

## Screencast

https://github.com/user-attachments/assets/5dfca19f-a395-4fa4-858e-b3f4e4b19943
