### PR TITLE
Workflows: Ignore 'block-serialization-default-parser' for manual backports

### DIFF
--- a/.github/workflows/check-backport-changelog.yml
+++ b/.github/workflows/check-backport-changelog.yml
@@ -15,6 +15,7 @@ on:
             - '!phpunit/blocks/**'
             - 'packages/**/*.php'
             - '!packages/block-library/**'
+            - '!packages/block-serialization-default-parser/**'
             - '!packages/e2e-tests/**'
 jobs:
     check:


### PR DESCRIPTION
## What?
PR adds `block-serialization-default-parser` to the ignored paths for the "Verify Core Backport Changelog" workflow.

## Why?
Changes from this package are automatically synced during package updates. See:

https://github.com/WordPress/wordpress-develop/blob/99186cb02f97f367ad859eeba278cfc962904c71/tools/webpack/packages.js#L126-L133

## Testing Instructions
Confirm that the ignore pattern is correct. Testing these changes without merging the workflow is difficult.
