### PR TITLE
Workflows: Ignore 'widgets' for manual backports

### DIFF
--- a/.github/workflows/check-backport-changelog.yml
+++ b/.github/workflows/check-backport-changelog.yml
@@ -16,6 +16,7 @@ on:
             - 'packages/**/*.php'
             - '!packages/block-library/**'
             - '!packages/block-serialization-default-parser/**'
+            - '!packages/widgets/**'
             - '!packages/e2e-tests/**'
 jobs:
     check:


### PR DESCRIPTION
Similar to #69791

## What?

`@wordpress/widgets` package includes two dynamic blocks:

- Legacy Widget (core/legacy-widget)
- Widget Group (core/widget-group)

PHP files for server-side rendering are automatically synced during package update, so we don't need to manually backport these files. See:

https://github.com/WordPress/wordpress-develop/blob/ed2f2ecd3fa043eca3a064a95fcb4830b5c0765c/tools/webpack/blocks.js#L39-L42

## Testing Instructions

Confirm that the ignore pattern is correct. Testing these changes without merging the workflow is difficult.
