### PR TITLE
Latest Posts Block: Include posts from child categories when parent is selected

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -114,10 +114,53 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 		( select ) => {
 			const { getEntityRecords, getUsers } = select( coreStore );
 			const settings = select( blockEditorStore ).getSettings();
-			const catIds =
+			const allCategories = getEntityRecords(
+				'taxonomy',
+				'category',
+				CATEGORIES_LIST_QUERY
+			);
+			const selectedCatIds =
 				categories && categories.length > 0
 					? categories.map( ( cat ) => cat.id )
 					: [];
+
+			let catIds = [ ...selectedCatIds ];
+
+			if ( allCategories && selectedCatIds.length > 0 ) {
+				const childrenMap = {};
+
+				allCategories.forEach( ( category ) => {
+					const parentId = category.parent;
+					if ( parentId ) {
+						if ( ! childrenMap[ parentId ] ) {
+							childrenMap[ parentId ] = [];
+						}
+						childrenMap[ parentId ].push( category.id );
+					}
+				} );
+
+				const getAllDescendants = ( parentIds ) => {
+					let descendants = [];
+					parentIds.forEach( ( parentId ) => {
+						const children = childrenMap[ parentId ] || [];
+						descendants = [ ...descendants, ...children ];
+						if ( children.length > 0 ) {
+							descendants = [
+								...descendants,
+								...getAllDescendants( children ),
+							];
+						}
+					} );
+					return descendants;
+				};
+
+				const childCatIds = getAllDescendants( selectedCatIds );
+
+				catIds = [
+					...new Set( [ ...selectedCatIds, ...childCatIds ] ),
+				];
+			}
+
 			const latestPostsQuery = Object.fromEntries(
 				Object.entries( {
 					categories: catIds,
@@ -143,11 +186,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 					'post',
 					latestPostsQuery
 				),
-				categoriesList: getEntityRecords(
-					'taxonomy',
-					'category',
-					CATEGORIES_LIST_QUERY
-				),
+				categoriesList: allCategories,
 				authorList: getUsers( USERS_LIST_QUERY ),
 			};
 		},


### PR DESCRIPTION
Closes #65332

## What?
This PR updates the Latest Posts Block to display posts from both parent and child categories when filtering by a parent category.

## Why?
Currently, when using the Latest Posts Block with a Category filter, posts assigned only to child categories are not displayed when filtering by their parent category. This is inconsistent with WordPress's default behavior on category archive pages, where parent category pages display posts from both the parent and all child categories.

This change makes the Latest Posts Block behavior match the expected WordPress category hierarchy behavior, providing a more intuitive experience for users.


## Testing Instructions
1. Create multiple categories with parent-child relationships
2. Create posts assigned only to the child categories (not to the parent)
3. Add a Latest Posts Block to a page
4. Select only the parent category in the block settings
5. Verify that posts from both the parent and child categories appear in the block


## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/8415aac8-e918-410e-b61e-ee7870050f48
