### PR TITLE
Block Tools: Prevent showing block toolbar when block interface is hidden

### DIFF
--- a/packages/block-editor/src/components/block-tools/use-show-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/use-show-block-tools.js
@@ -46,11 +46,11 @@ export function useShowBlockTools() {
 			editorMode !== 'navigation' &&
 			isEmptyDefaultBlock;
 		const _showBlockToolbarPopover =
+			! isBlockInterfaceHidden() &&
 			! getSettings().hasFixedToolbar &&
 			! _showEmptyBlockSideInserter &&
 			hasSelectedBlock &&
-			! isEmptyDefaultBlock &&
-			! isBlockInterfaceHidden();
+			! isEmptyDefaultBlock;
 
 		return {
 			showEmptyBlockSideInserter: _showEmptyBlockSideInserter,

--- a/packages/block-editor/src/components/block-tools/use-show-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/use-show-block-tools.js
@@ -25,6 +25,7 @@ export function useShowBlockTools() {
 			getSettings,
 			__unstableGetEditorMode,
 			isTyping,
+			isBlockInterfaceHidden,
 		} = unlock( select( blockEditorStore ) );
 
 		const clientId =
@@ -48,7 +49,8 @@ export function useShowBlockTools() {
 			! getSettings().hasFixedToolbar &&
 			! _showEmptyBlockSideInserter &&
 			hasSelectedBlock &&
-			! isEmptyDefaultBlock;
+			! isEmptyDefaultBlock &&
+			! isBlockInterfaceHidden();
 
 		return {
 			showEmptyBlockSideInserter: _showEmptyBlockSideInserter,


### PR DESCRIPTION
## What?
Closes #68711

This PR fixes a regression, likely introduced in [#56914](https://github.com/WordPress/gutenberg/pull/56914), that restores the visualizer's behavior of hiding the `Block Toolbar` when the `Block Interface` is hidden.

## Why?

An additional `isBlockInterfaceHidden()` check seems to have been omitted here: 
https://github.com/WordPress/gutenberg/blob/4ac0adec498b6fa057eda346bc9c46c451302f0e/packages/block-editor/src/components/block-tools/use-show-block-tools.js#L48

## How?

A check for `! isBlockInterfaceHidden()` was added while determining `_showBlockToolbarPopover`.

## Additional Context

If we choose not to fix this regression, we should at least clean up the following unused code:  

- The global state is updated via `hideBlockInterface` and `showBlockInterface`, but this serves no purpose since `isBlockInterfaceHidden()` is currently unused.

https://github.com/WordPress/gutenberg/blob/4ac0adec498b6fa057eda346bc9c46c451302f0e/packages/block-editor/src/hooks/dimensions.js#L34-L35

## Testing Instructions

1. Create a block.
2. Try adjusting its margin.
3. Confirm that the `Block Toolbar` hides when changing margins.

### Testing Instructions for Keyboard
Same.

## Screencast

![pr](https://github.com/user-attachments/assets/06cbc781-8522-4c7e-923c-23e2c7adc117)

