### PR TITLE
Block Parser: Remove description for singular since tag

### DIFF
--- a/packages/block-serialization-default-parser/class-wp-block-parser-block.php
+++ b/packages/block-serialization-default-parser/class-wp-block-parser-block.php
@@ -62,7 +62,7 @@ class WP_Block_Parser_Block {
 	 *   'innerContent' => array( 'Before', null, 'Inner', null, 'After' ),
 	 * )
 	 *
-	 * @since 5.0.0 array empty associative array
+	 * @since 5.0.0
 	 * @var array
 	 */
 	public $innerContent; // phpcs:ignore WordPress.NamingConventions.ValidVariableName


### PR DESCRIPTION
## What?
A follow-up to #69785. I missed this when reviewing the PR, blaming it on a lack of coffee :)

PR removes description for `@since` tag. A singular tag when property was introduced doesn't need a description.

## Testing Instructions
CI checks are passing.
