### PR TITLE
Block Directory: Update metadata fields requested from server

### DIFF
--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -91,16 +91,20 @@ export const installBlockType =
 				'title',
 				'category',
 				'parent',
+				'ancestor',
 				'icon',
 				'description',
 				'keywords',
 				'attributes',
 				'provides_context',
 				'uses_context',
+				'selectors',
 				'supports',
 				'styles',
 				'example',
 				'variations',
+				'allowed_blocks',
+				'block_hooks',
 			];
 			await apiFetch( {
 				path: addQueryArgs( `/wp/v2/block-types/${ name }`, {


### PR DESCRIPTION
## What?
PR updates the fields' definition in the `installBlockType` action to include recently introduced block metadata. The definition should usually match the fields allowed by `getBlockSettingsFromMetadata`.

Note: REST API uses different casing for fields, which is later converted during registration.

https://github.com/WordPress/gutenberg/blob/trunk/packages/blocks/src/api/registration.js#L156-L175

## Why?
The action was requesting incomplete data from the server.

## Testing Instructions
1. Smoke test block registration from the library.
2. Confirm it works as expected.

