### PR TITLE
Create Block: Add `--textdomain` flag to create block tool

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   Add support for `--textdomain` flag to create block tool ([#69802](https://github.com/WordPress/gutenberg/pull/69802)).
+
 ## 4.65.0 (2025-04-11)
 
 ## 4.64.0 (2025-03-27)

--- a/packages/create-block/lib/index.js
+++ b/packages/create-block/lib/index.js
@@ -63,6 +63,7 @@ program
 		'disable integration with `@wordpress/scripts` package'
 	)
 	.option( '--wp-env', 'enable integration with `@wordpress/env` package' )
+	.option( '--textdomain <value>', 'text domain for internationalization' )
 	.action(
 		async (
 			slug,
@@ -77,6 +78,7 @@ program
 				wpEnv,
 				variant,
 				targetDir,
+				textdomain,
 			}
 		) => {
 			try {
@@ -110,6 +112,7 @@ program
 						wpScripts,
 						wpEnv,
 						targetDir,
+						textdomain,
 					} ).filter( ( [ , value ] ) => value !== undefined )
 				);
 
@@ -158,7 +161,7 @@ program
 							'description',
 							'dashicon',
 							'category',
-							! plugin && 'textdomain',
+							! plugin && ! textdomain && 'textdomain',
 						].filter( Boolean ),
 						variant,
 						optionsValues
@@ -215,6 +218,9 @@ program
 		log.info( `  $ ${ commandName } todo-list` );
 		log.info(
 			`  $ ${ commandName } todo-list --template es5 --title "TODO List"`
+		);
+		log.info(
+			`  $ ${ commandName } todo-list --no-plugin --textdomain=my-plugin`
 		);
 	} )
 	.parse( process.argv );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add a `--textdomain` parameter option to the create block tool.
Closes: #69798

<!-- In a few words, what is the PR actually doing? -->

## Why?
Currently, when creating blocks with the `--no-plugin` parameter in non-interactive mode, the block slug is automatically used as the textdomain. This is problematic when developing a plugin with multiple blocks.

## Testing Instructions
1. Checkout this PR : 
```bash
gh pr checkout #69802
```
2. Create a block with explicit textdomain: 
```bash
node ./packages/create-block/index.js test-block --no-plugin --textdomain=my-custom-domain
```

3. Create a block without textdomain (should use slug): 
```bash
node ../packages/create-block/index.js another-block --no-plugin
```

## Screencast:
https://github.com/user-attachments/assets/186a0868-7675-4309-a5e1-1f23a44ee5f4
