### PR TITLE
PostPublishPanel: Fix post title overflow

### DIFF
--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -129,6 +129,7 @@
 .post-publish-panel__postpublish .components-panel__body {
 	border-bottom: $border-width solid $gray-200;
 	border-top: none;
+	word-break: break-word;
 }
 
 .post-publish-panel__postpublish-buttons {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes an issue where long words in the post title do not break into a new line in the PostPublishPanel, causing overflow.
Closes: #69803

<!-- In a few words, what is the PR actually doing? -->

## Why?
When a post title contains a word with an long length, it does not wrap within the PostPublishPanel, leading to layout issues. This fix ensures proper word wrapping, improving readability and UI consistency.

## How?
Added word-break: break-word; to the .post-publish-panel__postpublish .components-panel__body CSS rule to enforce word breaking for long words.

## Testing Instructions
1.	Create a new post.
2.	Enter a long single-word title (e.g., Supercalifragilisticexpialidocious... repeated multiple times).
3.	Open the PostPublishPanel by clicking the “Publish” button.
4.	Verify that the title text wraps correctly without overflowing the panel.

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/user-attachments/assets/adf75cc8-1f49-4cba-a960-12639330011c

After:

https://github.com/user-attachments/assets/7cacf880-ba9c-4e78-be5e-ea52e19c4bc5