### PR TITLE
Featured Image: Don't render empty Resolution tools panel if media is not set

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -320,13 +320,15 @@ export default function PostFeaturedImageEdit( {
 							/>
 						</ToolsPanelItem>
 					) }
-					<FeaturedImageResolutionTool
-						image={ media }
-						value={ sizeSlug }
-						onChange={ ( nextSizeSlug ) =>
-							setAttributes( { sizeSlug: nextSizeSlug } )
-						}
-					/>
+					{ !! media && (
+						<FeaturedImageResolutionTool
+							image={ media }
+							value={ sizeSlug }
+							onChange={ ( nextSizeSlug ) =>
+								setAttributes( { sizeSlug: nextSizeSlug } )
+							}
+						/>
+					) }
 				</ToolsPanel>
 			</InspectorControls>
 		</>


### PR DESCRIPTION
Found while reviewing #69730

## What?

Fixes unintended "Resolution" menu item displayed in the Settings dropdown.

<!-- In a few words, what is the PR actually doing? -->

## Why?

The Resolution dropdown needs options that are based on the actual media sizes. However,  if it has no image assigned yet, we can't determine any size options. As a result, the empty resolution tools panel is rendered, and the Settings dropdown has an unexpected menu item.

## How?

Render the panel only when it has a media assigned.

## Testing Instructions

- Open a new post
- Insert a Featured Image block
- Confirm that Settings panel dropdown doesn't include the "Resolution" option
- Add media to the block
- Confirm that the Resolution tools panel item is rendered

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
| ![image](https://github.com/user-attachments/assets/cb239193-74a3-4c06-acc9-cc0aed2cb68d) | ![image](https://github.com/user-attachments/assets/e220d709-ecc6-44a7-b7b8-8bd1f752c76a) |
 
