### PR TITLE
ToC: Fix condition for 'Limit heading levels'

### DIFF
--- a/packages/block-library/src/table-of-contents/edit.js
+++ b/packages/block-library/src/table-of-contents/edit.js
@@ -176,7 +176,7 @@ export default function TableOfContentsEdit( {
 							} )
 						}
 						help={
-							maxLevel
+							! maxLevel
 								? __(
 										'Including all heading levels in the table of contents.'
 								  )


### PR DESCRIPTION
## What?
Closes #69809.

PR fixes condition for "Limit heading levels" control for Table of Contents blocks.

## Testing Instructions
1. Open a post or page.
2. Add multiple headings with different levels.
3. Insert Table of Contents block.
4. Confirm that "Limit heading levels" controls displays following help text by default - `Including all heading levels in the table of contents.`.
5. Change the max heading level value.
6. Confirm that the help text changes into - `Only include headings up to and including this level.`

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2025-04-03 at 20 23 22](https://github.com/user-attachments/assets/b5aca34b-a943-4ad7-8d02-dc7c2c8d392f)

