### PR TITLE
Background Image Panel: fix focus loss

### DIFF
--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -249,6 +249,7 @@ function BackgroundImageControls( {
 	onResetImage = noop,
 	displayInPanel,
 	defaultValues,
+	containerRef,
 } ) {
 	const [ isUploading, setIsUploading ] = useState( false );
 	const { getSettings } = useSelect( blockEditorStore );
@@ -256,7 +257,6 @@ function BackgroundImageControls( {
 	const { id, title, url } = style?.background?.backgroundImage || {
 		...inheritedValue?.background?.backgroundImage,
 	};
-	const replaceContainerRef = useRef();
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const onUploadError = ( message ) => {
 		createErrorNotice( message, { type: 'snackbar' } );
@@ -324,6 +324,8 @@ function BackgroundImageControls( {
 			} )
 		);
 		setIsUploading( false );
+		// Close the dropdown and focus the toggle button.
+		closeAndFocus();
 	};
 
 	// Drag and drop callback, restricting image to one.
@@ -342,14 +344,19 @@ function BackgroundImageControls( {
 	const hasValue = hasBackgroundImageValue( style );
 
 	const closeAndFocus = () => {
-		const [ toggleButton ] = focus.tabbable.find(
-			replaceContainerRef.current
-		);
-		// Focus the toggle button and close the dropdown menu.
-		// This ensures similar behaviour as to selecting an image, where the dropdown is
-		// closed and focus is redirected to the dropdown toggle button.
-		toggleButton?.focus();
-		toggleButton?.click();
+		// Use requestAnimationFrame to ensure DOM updates are complete
+		window.requestAnimationFrame( () => {
+			const [ toggleButton ] = focus.tabbable.find(
+				containerRef?.current
+			);
+			if ( ! toggleButton ) {
+				return;
+			}
+			// Focus the toggle button and close the dropdown menu.
+			// This ensures similar behaviour as to selecting an image, where the dropdown is
+			// closed and focus is redirected to the dropdown toggle button.
+			toggleButton.focus();
+		} );
 	};
 
 	const onRemove = () =>
@@ -363,10 +370,7 @@ function BackgroundImageControls( {
 		title || getFilename( url ) || __( 'Add background image' );
 
 	return (
-		<div
-			ref={ replaceContainerRef }
-			className="block-editor-global-styles-background-panel__image-tools-panel-item"
-		>
+		<div className="block-editor-global-styles-background-panel__image-tools-panel-item">
 			{ isUploading && <LoadingSpinner /> }
 			<MediaReplaceFlow
 				mediaId={ id }
@@ -697,9 +701,11 @@ export default function BackgroundImagePanel( {
 			settings?.background?.backgroundRepeat );
 
 	const [ isDropDownOpen, setIsDropDownOpen ] = useState( false );
+	const containerRef = useRef();
 
 	return (
 		<div
+			ref={ containerRef }
 			className={ clsx(
 				'block-editor-global-styles-background-panel__inspector-media-replace-container',
 				{
@@ -727,6 +733,7 @@ export default function BackgroundImagePanel( {
 							} }
 							onRemoveImage={ () => setIsDropDownOpen( false ) }
 							defaultValues={ defaultValues }
+							containerRef={ containerRef }
 						/>
 						<BackgroundSizeControls
 							onChange={ onChange }
@@ -747,6 +754,7 @@ export default function BackgroundImagePanel( {
 						resetBackground();
 					} }
 					onRemoveImage={ () => setIsDropDownOpen( false ) }
+					containerRef={ containerRef }
 				/>
 			) }
 		</div>


### PR DESCRIPTION
## What?
Closes #69745

Fixes focus management in the Background Image Control component by improving ref handling and focus timing.

## Why?
The focus was not being properly maintained after image operations in the Background Image Control because:
1. The ref was being created but not properly attached to the parent container as it unmounted.
2. Focus timing issues occurred during DOM updates and state changes
3. The component structure made it difficult to reliably find and focus the toggle button

## How?
- Moved the `containerRef` attachment to the parent container div in `BackgroundImagePanel`
- Ensured proper ref propagation through component hierarchy
- Modified the `closeAndFocus` function to use `requestAnimationFrame` for reliable timing
- Removed the immediate click operation after focus (as that didn't feel consistent with other settings)
- Added proper null checks for the container ref
- Added `closeAndFocus` handler call to `onSelectMedia` flow to ensure that focus returns correctly.

The architectural change of moving the ref to the parent container provides a more reliable way to find focusable elements within the component's DOM structure.

## Testing Instructions (keyboard)
1. Open any post, add "group block"
3. Open the Inspector and navigate to "background image"
4. Click "Add background image" and select an image, complete the flow for adding image
5. Verify that focus returns to the toggle button (preview button) after image selection
6. Click the toggle button to open the dropdown
7. Click "Reset" via modal
8. Verify that focus returns to the toggle button
9. Repeat steps 4-8 multiple times to ensure consistent behavior

The focus should consistently return to the toggle button after any image operation (select/reset/remove) and the dropdown should close properly.

## ScreenCast

https://q7utzrengv.ufs.sh/f/Wgl9eBAmTj29aD9Oh8fFRjF31d07GtqsWNpK4IXH6Z9OnbyQ