### PR TITLE
Tools Panel: Add theme support

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 -   `FormTokenField`: Add theming support ([#69638](https://github.com/WordPress/gutenberg/pull/69638)).
 -   `ComboboxControl`: Add theming support ([#69638](https://github.com/WordPress/gutenberg/pull/69638)).
+-   `ToolsPanel`: Add theming support ([#69815](https://github.com/WordPress/gutenberg/pull/69815)).
 
 ## 29.7.0 (2025-03-27)
 

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -1,6 +1,6 @@
 .components-panel {
 	background: $white;
-	border: $border-width solid $gray-200;
+	border: $border-width solid $components-color-gray-200;
 
 	> .components-panel__header:first-child,
 	> .components-panel__body:first-child {

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -35,7 +35,9 @@ export const ToolsPanel = ( columns: number ) => css`
 	${ toolsPanelGrid.columns( columns ) }
 	${ toolsPanelGrid.spacing }
 
-	border-top: ${ CONFIG.borderWidth } solid ${ COLORS.gray[ 300 ] };
+	background: ${ COLORS.theme.background };
+	color: ${ COLORS.theme.foreground };
+	border-top: ${ CONFIG.borderWidth } solid ${ COLORS.theme.gray[ 200 ] };
 	margin-top: -1px;
 	padding: ${ space( 4 ) };
 `;
@@ -157,14 +159,14 @@ export const ResetLabel = styled.span`
 `;
 
 export const DefaultControlsItem = css`
-	color: ${ COLORS.gray[ 900 ] };
+	color: ${ COLORS.theme.foreground };
 
 	&&[aria-disabled='true'] {
-		color: ${ COLORS.gray[ 700 ] };
+		color: ${ COLORS.theme.gray[ 700 ] };
 		opacity: 1;
 
 		&:hover {
-			color: ${ COLORS.gray[ 700 ] };
+			color: ${ COLORS.theme.gray[ 700 ] };
 		}
 
 		${ ResetLabel } {


### PR DESCRIPTION
## What?
Part of #69646 

This pull request adds theme support to the `ToolsPanel` component.

## Why?

The component has visibility issues in Dark Themes.

## How?

1. Deprecated variables such as `COLORS.gray[ 700 ]` are replaced with `COLORS.theme.gray[ 700 ]`
2. Theme-based background and foreground are added to the component

## Testing Instructions

1. Run storybook locally. (`npm run storybook:dev`)
2. Navigate to the `ToolsPanel` component.
3. Change the theme and confirm that there are no visibility issues.

### Testing Instructions for Keyboard
Same

## Screenshots

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/688e657a-d64f-479b-baad-59d735ad67e2)|![after](https://github.com/user-attachments/assets/cf8d6b25-8960-4098-8eb2-d2419d8f6647)|


