### PR TITLE
Remove `@shopify/web-worker` Dependency from `packages/upload-media`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11331,12 +11331,6 @@
 				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
-		"node_modules/@remote-ui/rpc": {
-			"version": "1.4.5",
-			"resolved": "https://registry.npmjs.org/@remote-ui/rpc/-/rpc-1.4.5.tgz",
-			"integrity": "sha512-Cr+06niG/vmE4A9YsmaKngRuuVSWKMY42NMwtZfy+gctRWGu6Wj9BWuMJg5CEp+JTkRBPToqT5rqnrg1G/Wvow==",
-			"license": "MIT"
-		},
 		"node_modules/@samverschueren/stream-to-observable": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
@@ -11434,34 +11428,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/@shopify/web-worker": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/@shopify/web-worker/-/web-worker-6.4.0.tgz",
-			"integrity": "sha512-RvY1mgRyAqawFiYBvsBkek2pVK4GVpV9mmhWFCZXwx01usxXd2HMhKNTFeRYhSp29uoUcfBlKZAwCwQzt826tg==",
-			"license": "MIT",
-			"dependencies": {
-				"@remote-ui/rpc": "^1.2.5"
-			},
-			"engines": {
-				"node": ">=18.12.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0",
-				"webpack": "^5.38.0",
-				"webpack-virtual-modules": "^0.4.3 || ^0.5.0 || ^0.6.0"
-			},
-			"peerDependenciesMeta": {
-				"@babel/core": {
-					"optional": true
-				},
-				"webpack": {
-					"optional": true
-				},
-				"webpack-virtual-modules": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@sideway/address": {
@@ -52612,7 +52578,6 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
-				"@shopify/web-worker": "^6.4.0",
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/blob": "file:../blob",
 				"@wordpress/compose": "file:../compose",

--- a/packages/upload-media/package.json
+++ b/packages/upload-media/package.json
@@ -28,7 +28,6 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "7.25.7",
-		"@shopify/web-worker": "^6.4.0",
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/blob": "file:../blob",
 		"@wordpress/compose": "file:../compose",


### PR DESCRIPTION


## What?
Closes https://github.com/WordPress/gutenberg/issues/69254

Removes the deprecated `@shopify/web-worker` dependency from the `packages/upload-media` package.


## Why?
The `@shopify/web-worker` package is no longer being maintained or supported according to its NPM page. Removing this unused dependency helps future-proof our codebase

## How?

1. Ran the following command to remove the dependency


```
npm uninstall @shopify/web-worker -w packages/upload-media
```

2. Verified the package isn't used anywhere in the codebase by searching with :

```
grep -r "@shopify/web-worker" --include="*.js" --include="*.ts" --include="*.tsx" .
```

3. No results were found in the search, confirming the package wasn't actively used
4. Tested that media upload functionality continues to work correctly after removal
