### PR TITLE
Add preserveSiteUrl option to prevent port appending to the site URL

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -493,7 +493,7 @@ You can customize the WordPress installation, plugins and themes that the develo
 | `"phpmyadminPort"`   | `integer`      | `null`                                 | The port number for phpMyAdmin. If provided, you'll access phpMyAdmin through: http://localhost:<port>                           |
 | `"multisite"`        | `boolean`      | `false`                                | Whether to set up a multisite installation.                                                                                      |
 | `"lifecycleScripts"` | `Object`       | `"{}"`                                 | Mapping of commands that should be executed at certain points in the lifecycle.                                                   |
-| `"preserveUrls"`     | `boolean`      | `false`                                | Whether to prevent port numbers from being automatically appended to URLs.                                                      |
+| `"preserveSiteUrl"`  | `boolean`      | `false`                                | Whether to prevent port number from being appended to the site URL.                                                      |
 
 _Note: the port number environment variables (`WP_ENV_PORT` and `WP_ENV_TESTS_PORT`) take precedent over the .wp-env.json values._
 
@@ -565,11 +565,11 @@ These can be overridden by setting a value within the `config` configuration. Se
 
 Additionally, the values referencing a URL include the specified port for the given environment. So if you set `testsPort: 3000, port: 2000`, `WP_HOME` (for example) will be `http://localhost:3000` on the tests instance and `http://localhost:2000` on the development instance.
 
-You can prevent port numbers from being automatically appended to URLs by setting the `preserveUrls` option to `true`:
+You can prevent port number from being appended to the site URL by setting the `preserveSiteUrl` option to `true`:
 
 ```json
 {
-  "preserveUrls": true,
+  "preserveSiteUrl": true,
   "config": {
     "WP_SITEURL": "https://wp.local",
     "WP_HOME": "https://wp.local"
@@ -577,7 +577,7 @@ You can prevent port numbers from being automatically appended to URLs by settin
 }
 ```
 
-This is useful when working with custom domains and HTTPS setups where automatic port appending would break functionality.
+This is useful when working with custom domains and HTTPS setups where port appending would break functionality.
 
 ## Lifecycle Scripts
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -493,6 +493,7 @@ You can customize the WordPress installation, plugins and themes that the develo
 | `"phpmyadminPort"`   | `integer`      | `null`                                 | The port number for phpMyAdmin. If provided, you'll access phpMyAdmin through: http://localhost:<port>                           |
 | `"multisite"`        | `boolean`      | `false`                                | Whether to set up a multisite installation.                                                                                      |
 | `"lifecycleScripts"` | `Object`       | `"{}"`                                 | Mapping of commands that should be executed at certain points in the lifecycle.                                                   |
+| `"preserveUrls"`     | `boolean`      | `false`                                | Whether to prevent port numbers from being automatically appended to URLs.                                                      |
 
 _Note: the port number environment variables (`WP_ENV_PORT` and `WP_ENV_TESTS_PORT`) take precedent over the .wp-env.json values._
 
@@ -563,6 +564,20 @@ On the test instance, all of the above are still defined, but `WP_DEBUG` and `SC
 These can be overridden by setting a value within the `config` configuration. Setting it to `null` will prevent the constant being defined entirely.
 
 Additionally, the values referencing a URL include the specified port for the given environment. So if you set `testsPort: 3000, port: 2000`, `WP_HOME` (for example) will be `http://localhost:3000` on the tests instance and `http://localhost:2000` on the development instance.
+
+You can prevent port numbers from being automatically appended to URLs by setting the `preserveUrls` option to `true`:
+
+```json
+{
+  "preserveUrls": true,
+  "config": {
+    "WP_SITEURL": "https://wp.local",
+    "WP_HOME": "https://wp.local"
+  }
+}
+```
+
+This is useful when working with custom domains and HTTPS setups where automatic port appending would break functionality.
 
 ## Lifecycle Scripts
 

--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -53,6 +53,7 @@ const mergeConfigs = require( './merge-configs' );
  * @property {number}                    mysqlPort      The port to use for MySQL. Random if empty.
  * @property {number}                    phpmyadminPort The port to use for phpMyAdmin. If empty, disabled phpMyAdmin.
  * @property {boolean}                   multisite      Whether to set up a multisite installation.
+ * @property {boolean}                   preserveUrls   Whether to prevent port numbers from being automatically appended to URLs.
  * @property {Object}                    config         Mapping of wp-config.php constants to their desired values.
  * @property {Object.<string, WPSource>} mappings       Mapping of WordPress directories to local directories which should be mounted.
  * @property {string|null}               phpVersion     Version of PHP to use in the environments, of the format 0.0.
@@ -91,6 +92,7 @@ const DEFAULT_ENVIRONMENT_CONFIG = {
 	mysqlPort: null,
 	phpmyadminPort: null,
 	multisite: false,
+	preserveUrls: false,
 	mappings: {},
 	config: {
 		FS_METHOD: 'direct',
@@ -555,6 +557,10 @@ async function parseEnvironmentConfig(
 			},
 			{}
 		);
+	}
+
+	if ( config.preserveUrls !== undefined ) {
+		parsedConfig.preserveUrls = config.preserveUrls;
 	}
 
 	return parsedConfig;

--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -46,17 +46,17 @@ const mergeConfigs = require( './merge-configs' );
  * The environment-specific configuration options. (development/tests/etc)
  *
  * @typedef WPEnvironmentConfig
- * @property {WPSource}                  coreSource     The WordPress installation to load in the environment.
- * @property {WPSource[]}                pluginSources  Plugins to load in the environment.
- * @property {WPSource[]}                themeSources   Themes to load in the environment.
- * @property {number}                    port           The port to use.
- * @property {number}                    mysqlPort      The port to use for MySQL. Random if empty.
- * @property {number}                    phpmyadminPort The port to use for phpMyAdmin. If empty, disabled phpMyAdmin.
- * @property {boolean}                   multisite      Whether to set up a multisite installation.
- * @property {boolean}                   preserveUrls   Whether to prevent port numbers from being automatically appended to URLs.
- * @property {Object}                    config         Mapping of wp-config.php constants to their desired values.
- * @property {Object.<string, WPSource>} mappings       Mapping of WordPress directories to local directories which should be mounted.
- * @property {string|null}               phpVersion     Version of PHP to use in the environments, of the format 0.0.
+ * @property {WPSource}                  coreSource      The WordPress installation to load in the environment.
+ * @property {WPSource[]}                pluginSources   Plugins to load in the environment.
+ * @property {WPSource[]}                themeSources    Themes to load in the environment.
+ * @property {number}                    port            The port to use.
+ * @property {number}                    mysqlPort       The port to use for MySQL. Random if empty.
+ * @property {number}                    phpmyadminPort  The port to use for phpMyAdmin. If empty, disabled phpMyAdmin.
+ * @property {boolean}                   multisite       Whether to set up a multisite installation.
+ * @property {boolean}                   preserveSiteUrl Whether to prevent port number from being appended to the site URL.
+ * @property {Object}                    config          Mapping of wp-config.php constants to their desired values.
+ * @property {Object.<string, WPSource>} mappings        Mapping of WordPress directories to local directories which should be mounted.
+ * @property {string|null}               phpVersion      Version of PHP to use in the environments, of the format 0.0.
  */
 
 /**
@@ -92,7 +92,7 @@ const DEFAULT_ENVIRONMENT_CONFIG = {
 	mysqlPort: null,
 	phpmyadminPort: null,
 	multisite: false,
-	preserveUrls: false,
+	preserveSiteUrl: false,
 	mappings: {},
 	config: {
 		FS_METHOD: 'direct',
@@ -559,8 +559,8 @@ async function parseEnvironmentConfig(
 		);
 	}
 
-	if ( config.preserveUrls !== undefined ) {
-		parsedConfig.preserveUrls = config.preserveUrls;
+	if ( config.preserveSiteUrl !== undefined ) {
+		parsedConfig.preserveSiteUrl = config.preserveSiteUrl;
 	}
 
 	return parsedConfig;

--- a/packages/env/lib/config/post-process-config.js
+++ b/packages/env/lib/config/post-process-config.js
@@ -110,8 +110,8 @@ function appendPortToWPConfigs( config ) {
 				continue;
 			}
 
-			// Skip adding port if preserveUrls is set to true.
-			if ( config.env[ env ].preserveUrls === true ) {
+			// Skip adding port if preserveSiteUrl is set to true.
+			if ( config.env[ env ].preserveSiteUrl === true ) {
 				continue;
 			}
 

--- a/packages/env/lib/config/post-process-config.js
+++ b/packages/env/lib/config/post-process-config.js
@@ -110,6 +110,11 @@ function appendPortToWPConfigs( config ) {
 				continue;
 			}
 
+			// Skip adding port if preserveUrls is set to true.
+			if ( config.env[ env ].preserveUrls === true ) {
+				continue;
+			}
+
 			config.env[ env ].config[ option ] = addOrReplacePort(
 				config.env[ env ].config[ option ],
 				config.env[ env ].port,

--- a/packages/env/lib/config/test/post-process-config.js
+++ b/packages/env/lib/config/test/post-process-config.js
@@ -275,12 +275,12 @@ describe( 'postProcessConfig', () => {
 			} );
 		} );
 
-		it( 'should not add port to URLs when preserveUrls is true', () => {
+		it( 'should not add port to URLs when preserveSiteUrl is true', () => {
 			const processed = postProcessConfig( {
 				env: {
 					development: {
 						port: 123,
-						preserveUrls: true,
+						preserveSiteUrl: true,
 						config: {
 							WP_TESTS_DOMAIN: 'https://wp.local',
 							WP_SITEURL: 'https://wp.local',
@@ -289,7 +289,7 @@ describe( 'postProcessConfig', () => {
 					},
 					tests: {
 						port: 456,
-						preserveUrls: true,
+						preserveSiteUrl: true,
 						config: {
 							WP_TESTS_DOMAIN: 'https://wp.local',
 							WP_SITEURL: 'https://wp.local',
@@ -303,7 +303,7 @@ describe( 'postProcessConfig', () => {
 				env: {
 					development: {
 						port: 123,
-						preserveUrls: true,
+						preserveSiteUrl: true,
 						config: {
 							WP_TESTS_DOMAIN: 'https://wp.local',
 							WP_SITEURL: 'https://wp.local',
@@ -312,7 +312,7 @@ describe( 'postProcessConfig', () => {
 					},
 					tests: {
 						port: 456,
-						preserveUrls: true,
+						preserveSiteUrl: true,
 						config: {
 							WP_TESTS_DOMAIN: 'https://wp.local',
 							WP_SITEURL: 'https://wp.local',

--- a/packages/env/lib/config/test/post-process-config.js
+++ b/packages/env/lib/config/test/post-process-config.js
@@ -274,6 +274,54 @@ describe( 'postProcessConfig', () => {
 				},
 			} );
 		} );
+
+		it( 'should not add port to URLs when preserveUrls is true', () => {
+			const processed = postProcessConfig( {
+				env: {
+					development: {
+						port: 123,
+						preserveUrls: true,
+						config: {
+							WP_TESTS_DOMAIN: 'https://wp.local',
+							WP_SITEURL: 'https://wp.local',
+							WP_HOME: 'https://wp.local',
+						},
+					},
+					tests: {
+						port: 456,
+						preserveUrls: true,
+						config: {
+							WP_TESTS_DOMAIN: 'https://wp.local',
+							WP_SITEURL: 'https://wp.local',
+							WP_HOME: 'https://wp.local',
+						},
+					},
+				},
+			} );
+
+			expect( processed ).toEqual( {
+				env: {
+					development: {
+						port: 123,
+						preserveUrls: true,
+						config: {
+							WP_TESTS_DOMAIN: 'https://wp.local',
+							WP_SITEURL: 'https://wp.local',
+							WP_HOME: 'https://wp.local',
+						},
+					},
+					tests: {
+						port: 456,
+						preserveUrls: true,
+						config: {
+							WP_TESTS_DOMAIN: 'https://wp.local',
+							WP_SITEURL: 'https://wp.local',
+							WP_HOME: 'https://wp.local',
+						},
+					},
+				},
+			} );
+		} );
 	} );
 
 	describe( 'validatePortUniqueness', () => {

--- a/schemas/json/wp-env.json
+++ b/schemas/json/wp-env.json
@@ -70,6 +70,11 @@
 				"multisite": {
 					"description": "Whether to set up a multisite installation.",
 					"type": "boolean"
+				},
+				"preserveUrls": {
+					"description": "Whether to prevent port numbers from being automatically appended to URLs.",
+					"type": "boolean",
+					"default": false
 				}
 			}
 		},
@@ -83,7 +88,8 @@
 				"config",
 				"mappings",
 				"phpmyadminPort",
-				"multisite"
+				"multisite",
+				"preserveUrls"
 			]
 		}
 	},

--- a/schemas/json/wp-env.json
+++ b/schemas/json/wp-env.json
@@ -71,8 +71,8 @@
 					"description": "Whether to set up a multisite installation.",
 					"type": "boolean"
 				},
-				"preserveUrls": {
-					"description": "Whether to prevent port numbers from being automatically appended to URLs.",
+				"preserveSiteUrl": {
+					"description": "Whether to prevent port number from being appended to the site URL.",
 					"type": "boolean",
 					"default": false
 				}
@@ -89,7 +89,7 @@
 				"mappings",
 				"phpmyadminPort",
 				"multisite",
-				"preserveUrls"
+				"preserveSiteUrl"
 			]
 		}
 	},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes : https://github.com/WordPress/gutenberg/issues/69776

This PR adds a new `preserveSiteUrl` option to wp-env that prevent port number from being appended to the site URL in config values like `WP_SITEURL` and `WP_HOME`.

## Sample .wp-env.json
```json
{
  "preserveSiteUrl": true,
  "config": {
    "WP_SITEURL": "https://wp.local",
    "WP_HOME": "https://wp.local"
  }
}
```