### PR TITLE
Social Link block: Add automatic RSS feed link option

### DIFF
--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -27,6 +27,7 @@ import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
+	CheckboxControl,
 } from '@wordpress/components';
 import { useMergeRefs } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -44,8 +45,35 @@ const SocialLinkURLPopover = ( {
 	setPopover,
 	popoverAnchor,
 	clientId,
+	service,
 } ) => {
 	const { removeBlock } = useDispatch( blockEditorStore );
+
+	const hasRssFeedSuffix = url && url.endsWith( '/feed/' );
+
+	const [ useRssFeed, setUseRssFeed ] = useState( hasRssFeedSuffix );
+
+	const handleRssFeedToggle = ( checked ) => {
+		setUseRssFeed( checked );
+
+		const currentUrl = url || '';
+
+		if ( checked ) {
+			// When checked, add "/feed/" if it doesn't already exist
+			if ( ! currentUrl.endsWith( '/feed/' ) ) {
+				// Remove trailing slash if present before adding "/feed/"
+				const normalizedUrl = currentUrl.endsWith( '/' )
+					? currentUrl.slice( 0, -1 )
+					: currentUrl;
+
+				setAttributes( { url: `${ normalizedUrl }/feed/` } );
+			}
+		} else if ( currentUrl.endsWith( '/feed/' ) ) {
+			const urlWithoutFeed = currentUrl.slice( 0, -6 );
+			setAttributes( { url: urlWithoutFeed } );
+		}
+	};
+
 	return (
 		<URLPopover
 			anchor={ popoverAnchor }
@@ -66,9 +94,10 @@ const SocialLinkURLPopover = ( {
 				<div className="block-editor-url-input">
 					<URLInput
 						value={ url }
-						onChange={ ( nextURL ) =>
-							setAttributes( { url: nextURL } )
-						}
+						onChange={ ( nextURL ) => {
+							setAttributes( { url: nextURL } );
+							setUseRssFeed( nextURL.endsWith( '/feed/' ) );
+						} }
 						placeholder={ __( 'Enter social link' ) }
 						label={ __( 'Enter social link' ) }
 						hideLabelFromVision
@@ -96,6 +125,18 @@ const SocialLinkURLPopover = ( {
 							</InputControlSuffixWrapper>
 						}
 					/>
+					{ service === 'feed' && (
+						<div className="block-editor-url-input__rss-option">
+							<CheckboxControl
+								__nextHasNoMarginBottom
+								label={ __(
+									'Link to the RSS feed of this site'
+								) }
+								checked={ useRssFeed }
+								onChange={ handleRssFeedToggle }
+							/>
+						</div>
+					) }
 				</div>
 			</form>
 		</URLPopover>
@@ -275,6 +316,7 @@ const SocialLinkEdit = ( {
 						setPopover={ setPopover }
 						popoverAnchor={ popoverAnchor }
 						clientId={ clientId }
+						service={ service }
 					/>
 				) }
 			</li>

--- a/packages/block-library/src/social-link/editor.scss
+++ b/packages/block-library/src/social-link/editor.scss
@@ -44,3 +44,7 @@
 	// Corresponds to the size of the text control input in the block inspector.
 	width: 250px;
 }
+
+.block-editor-url-input__rss-option {
+	padding: 0.25em;
+}


### PR DESCRIPTION
Closes #52202

## What?
This PR adds a checkbox option "Link to the RSS feed of this site" when adding an RSS social icon, which automatically appends "/feed/" to the URL.

## Why?
When users add an RSS icon to their Social Icons block, they often need to manually enter the default WordPress feed URL ("/feed/"). Since this is the standard WordPress RSS feed path, providing an automatic option improves the user experience.


## Testing Instructions
1. Add a Social Icons block to a post or page
2. Add an RSS icon to the Social Icons block
3. Click on the RSS icon to open the URL popover
4. Notice the new checkbox "Link to the RSS feed of this site"
5. Enter a URL (e.g., "https://example.com/")
6. Check the checkbox and observe that "/feed/" is appended to the URL
7. Uncheck the checkbox and observe that "/feed/" is removed from the URL
8. Enter a URL that ends with "/feed/" manually and observe that the checkbox is automatically checked

## Screenshots or screencast

https://github.com/user-attachments/assets/a4f8477c-6e39-4ef9-bf45-5e1ff0e5008b

