### PR TITLE
Social Icons: Remove custom placeholder state

### DIFF
--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -64,9 +64,15 @@ export function SocialLinksEdit( props ) {
 		size,
 	} = attributes;
 
-	const hasSelectedChild = useSelect(
-		( select ) =>
-			select( blockEditorStore ).hasSelectedInnerBlock( clientId ),
+	const { hasSocialIcons, hasSelectedChild } = useSelect(
+		( select ) => {
+			const { getBlockCount, hasSelectedInnerBlock } =
+				select( blockEditorStore );
+			return {
+				hasSocialIcons: getBlockCount( clientId ) > 0,
+				hasSelectedChild: hasSelectedInnerBlock( clientId ),
+			};
+		},
 		[ clientId ]
 	);
 
@@ -96,16 +102,6 @@ export function SocialLinksEdit( props ) {
 		}
 	}, [ logosOnly ] );
 
-	const SocialPlaceholder = (
-		<li className="wp-block-social-links__social-placeholder">
-			<div className="wp-block-social-links__social-placeholder-icons">
-				<div className="wp-social-link wp-social-link-twitter"></div>
-				<div className="wp-social-link wp-social-link-facebook"></div>
-				<div className="wp-social-link wp-social-link-instagram"></div>
-			</div>
-		</li>
-	);
-
 	// Fallback color values are used maintain selections in case switching
 	// themes and named colors in palette do not match.
 	const className = clsx( size, {
@@ -117,11 +113,13 @@ export function SocialLinksEdit( props ) {
 
 	const blockProps = useBlockProps( { className } );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		placeholder: ! isSelected && SocialPlaceholder,
 		templateLock: false,
 		orientation: attributes.layout?.orientation ?? 'horizontal',
 		__experimentalAppenderTagName: 'li',
-		renderAppender: hasAnySelected && InnerBlocks.ButtonBlockAppender,
+		renderAppender:
+			! hasSocialIcons || hasAnySelected
+				? InnerBlocks.ButtonBlockAppender
+				: undefined,
 	} );
 
 	const POPOVER_PROPS = {

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -12,51 +12,8 @@
 
 // Specificity for the following styles are fixed at 0-1-0 to match and be
 // overridable by global styles.
-:root :where(.wp-block-social-links),
-:root :where(.wp-block-social-links.is-style-logos-only .wp-block-social-links__social-placeholder .wp-social-link) {
+:root :where(.wp-block-social-links) {
 	padding: 0;
-}
-:root :where(.wp-block-social-links__social-placeholder .wp-social-link) {
-	padding: 0.25em;
-}
-:root :where(.wp-block-social-links.is-style-pill-shape .wp-block-social-links__social-placeholder .wp-social-link) {
-	padding-left: calc((2/3) * 1em);
-	padding-right: calc((2/3) * 1em);
-}
-
-// Placeholder/setup state.
-.wp-block-social-links__social-placeholder {
-	display: flex;
-	opacity: 0.8;
-	list-style: none;
-
-	// Use the first link to set the height.
-	> .wp-social-link {
-		// Use !important to keep the selector simple.
-		padding-left: 0 !important;
-		margin-left: 0 !important;
-		padding-right: 0 !important;
-		margin-right: 0 !important;
-		width: 0 !important;
-		visibility: hidden;
-	}
-
-	// Wrap the remaining placeholders in a container so the plus can overlap.
-	> .wp-block-social-links__social-placeholder-icons {
-		display: flex;
-	}
-
-	.wp-social-link::before {
-		content: "";
-		display: block;
-		width: 1em;
-		height: 1em;
-		border-radius: $radius-round;
-
-		.is-style-logos-only & {
-			background: currentColor;
-		}
-	}
 }
 
 // Selected placeholder state.


### PR DESCRIPTION
## What?
Closes #60202.
Closes #55296.

PR removes custom placeholder state for Social Icons block.

## Why?
Copied from #60202, props to @afercia.

- While I do understand the intent to _show something that resembles a sort of social icons preview, I'm not sure a placeholder should ever change dynamically in the first place. This is inconsistent with how many other placeholders work and I'd say it's unexpected and confusing
- To me, they just look like 3 colored squares. They don't suggest any particular meaning and I'm not sure they add great value.
- They are just empty `<div>` elements with a background color set. Note: they do contain a CSS generated `::before` pseudo element. It is not visible and it's not clear to me what its purpose is. Maybe a leftover. In the screenshot below I set a black background color on it to better illustrate:

## Testing Instructions
1. Open a post or page.
2. Add Social Icons block.
3. Confirm that the block appender button is displayed.
4. Add a couple of social icons and deselect the block.
5. Confirm that the appender button is hidden.


### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2025-04-04 at 16 03 21](https://github.com/user-attachments/assets/36b6dd38-e752-4ff6-a738-aefb0bd899e2)
