### PR TITLE
Social Icons: Fix effect dependencies

### DIFF
--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import {
 	BlockControls,
 	useInnerBlocksProps,
@@ -83,11 +83,11 @@ export function SocialLinksEdit( props ) {
 
 	// Remove icon background color when logos only style is selected or
 	// restore it when any other style is selected.
-	const backgroundBackupRef = useRef( {} );
 	useEffect( () => {
 		if ( logosOnly ) {
+			let restore;
 			setAttributes( ( prev ) => {
-				backgroundBackupRef.current = {
+				restore = {
 					iconBackgroundColor: prev.iconBackgroundColor,
 					iconBackgroundColorValue: prev.iconBackgroundColorValue,
 					customIconBackgroundColor: prev.customIconBackgroundColor,
@@ -98,8 +98,8 @@ export function SocialLinksEdit( props ) {
 					customIconBackgroundColor: undefined,
 				};
 			} );
-		} else {
-			setAttributes( { ...backgroundBackupRef.current } );
+
+			return () => setAttributes( { ...restore } );
 		}
 	}, [ logosOnly, setAttributes ] );
 

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -57,7 +57,6 @@ export function SocialLinksEdit( props ) {
 
 	const {
 		iconBackgroundColorValue,
-		customIconBackgroundColor,
 		iconColorValue,
 		openInNewTab,
 		showLabels,
@@ -87,20 +86,22 @@ export function SocialLinksEdit( props ) {
 	const backgroundBackupRef = useRef( {} );
 	useEffect( () => {
 		if ( logosOnly ) {
-			backgroundBackupRef.current = {
-				iconBackgroundColor,
-				iconBackgroundColorValue,
-				customIconBackgroundColor,
-			};
-			setAttributes( {
-				iconBackgroundColor: undefined,
-				customIconBackgroundColor: undefined,
-				iconBackgroundColorValue: undefined,
+			setAttributes( ( prev ) => {
+				backgroundBackupRef.current = {
+					iconBackgroundColor: prev.iconBackgroundColor,
+					iconBackgroundColorValue: prev.iconBackgroundColorValue,
+					customIconBackgroundColor: prev.customIconBackgroundColor,
+				};
+				return {
+					iconBackgroundColor: undefined,
+					iconBackgroundColorValue: undefined,
+					customIconBackgroundColor: undefined,
+				};
 			} );
 		} else {
 			setAttributes( { ...backgroundBackupRef.current } );
 		}
-	}, [ logosOnly ] );
+	}, [ logosOnly, setAttributes ] );
 
 	// Fallback color values are used maintain selections in case switching
 	// themes and named colors in palette do not match.


### PR DESCRIPTION
## What?
Closes #64896.

PR fixes missing dependencies `useEffect` ESLint warning for Social Icons block.

## How?
Use the new [updater function](https://github.com/WordPress/gutenberg/pull/69709) for `setAttributes` to store previous attribute values. This removes the need to list attributes as dependencies, which could cause triggering side effects unintentionally.

## Testing Instructions
1. Open a post or page.
2. Insert Social Icons block and add a couple of icons.
3. Set icon color and background colors.
4. Switch between styles.
5. Confirm that color values are retained and restored as needed.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/e6c8d94a-494a-42d4-9089-12916ff43665

