### PR TITLE
Use all entry points for wp-script start/build

### DIFF
--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -234,12 +234,12 @@ function getWebpackEntryPoints( buildType ) {
 	 * @return {Object<string,string>} The list of entry points.
 	 */
 	return () => {
-		// 1. Uses the recommended command format that lists entry points as paths to JavaScript files.
+		const entryPoints = {};
+
+		// 1. Collect all entry points from from the CLI arguments.
 		//    Example: `wp-scripts build one.js two.js`.
-		if ( process.env.WP_ENTRY ) {
-			return buildType === 'script'
-				? JSON.parse( process.env.WP_ENTRY )
-				: {};
+		if ( process.env.WP_ENTRY && 'script' === buildType ) {
+			Object.assign( entryPoints, JSON.parse( process.env.WP_ENTRY ) );
 		}
 
 		// Continues only if the source directory exists. Defaults to "src" if not explicitly set in the command.
@@ -247,7 +247,7 @@ function getWebpackEntryPoints( buildType ) {
 			warn(
 				`Source directory "${ getProjectSourcePath() }" was not found. Please confirm there is a "src" directory in the root or the value passed with "--output-path" is correct.`
 			);
-			return {};
+			return entryPoints;
 		}
 
 		// 2. Checks whether any block metadata files can be detected in the defined source directory.
@@ -261,8 +261,6 @@ function getWebpackEntryPoints( buildType ) {
 			const srcDirectory = fromProjectRoot(
 				getProjectSourcePath() + sep
 			);
-
-			const entryPoints = {};
 
 			for ( const blockMetadataFile of blockMetadataFiles ) {
 				const fileContents = readFileSync( blockMetadataFile );
@@ -344,16 +342,6 @@ function getWebpackEntryPoints( buildType ) {
 					entryPoints[ entryName ] = entryFilepath;
 				}
 			}
-
-			if ( Object.keys( entryPoints ).length > 0 ) {
-				return entryPoints;
-			}
-		}
-
-		// Don't do any further processing if this is a module build.
-		// This only respects *module block.json fields.
-		if ( buildType === 'module' ) {
-			return {};
 		}
 
 		// 3. Checks whether a standard file name can be detected in the defined source directory,
@@ -363,16 +351,15 @@ function getWebpackEntryPoints( buildType ) {
 			cwd: fromProjectRoot( getProjectSourcePath() ),
 		} );
 
-		if ( ! entryFile ) {
+		if ( entryFile ) {
+			entryPoints.index = entryFile;
+		} else {
 			warn(
 				`No entry file discovered in the "${ getProjectSourcePath() }" directory.`
 			);
-			return {};
 		}
 
-		return {
-			index: entryFile,
-		};
+		return entryPoints;
 	};
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #55936.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

wp-scripts build should work without any additional config in projects that have:

- multiple blocks inside the source directory (as designated by the presence of `block.json` file)
- any number of JS files directly in the source directory (instead of just the `index.js`). 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove all early returns and collect all resolved entry files into a single object.

- Ensures that all entry files are used for the webpack build.

- Specifying custom entry points shouldn't disable `**/block.json` parsing. If we do disable it by default, there should be a flag to enable it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Clone this sample repository https://github.com/kasparsd/wp-scripts-build-issues
2. Pull in this updated `wp-scripts` package version.
3. Run all builds and check that all expected files are built.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Not applicable -- this is a tooling update.
