### PR TITLE
Social Icons: Remove unused editor style

### DIFF
--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -16,21 +16,6 @@
 	padding: 0;
 }
 
-// Selected placeholder state.
-.wp-block-social-links .wp-block-social-links__social-prompt {
-	min-height: $button-size-small;
-	list-style: none;
-
-	// Show as block UI.
-	font-family: $default-font;
-	font-size: $default-font-size;
-	line-height: $button-size-small;
-	margin-top: auto;
-	margin-bottom: auto;
-	cursor: default;
-	padding-right: $grid-unit-10;
-}
-
 // Center flex items. This has an equivalent in style.scss.
 .wp-block[data-align="center"] > .wp-block-social-links,
 .wp-block.wp-block-social-links.aligncenter {


### PR DESCRIPTION
Follow-up #64877

## What?

The element with the CSS class name `.wp-block-social-links__social-prompt` has been removed [here](https://github.com/WordPress/gutenberg/pull/64877/files#diff-e8bb2aa0398e0a52cc8d3976e464ece02afab0b68f81fa3ca9194543590e999aL91). This style is no longer used anywhere.

## Testing Instructions

Nothing.