### PR TITLE
Navigation block: fix submenu Escape key behavior

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -819,7 +819,7 @@ function block_core_navigation_add_directives_to_submenu( $tags, $block_attribut
 	) ) {
 		// Add directives to the parent `<li>`.
 		$tags->set_attribute( 'data-wp-interactive', 'core/navigation' );
-		$tags->set_attribute( 'data-wp-context', '{ "submenuOpenedBy": { "click": false, "hover": false, "focus": false }, "type": "submenu", "modal": null }' );
+		$tags->set_attribute( 'data-wp-context', '{ "submenuOpenedBy": { "click": false, "hover": false, "focus": false }, "type": "submenu", "modal": null, "previousFocus": null }' );
 		$tags->set_attribute( 'data-wp-watch', 'callbacks.initMenu' );
 		$tags->set_attribute( 'data-wp-on--focusout', 'actions.handleMenuFocusout' );
 		$tags->set_attribute( 'data-wp-on--keydown', 'actions.handleMenuKeydown' );

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -116,7 +116,8 @@ const { state, actions } = store(
 					getContext();
 				if ( state.menuOpenedBy.click ) {
 					// If Escape close the menu.
-					if ( event?.key === 'Escape' ) {
+					if ( event.key === 'Escape' ) {
+						event.stopPropagation(); // Keeps ancestor menus open.
 						actions.closeMenu( 'click' );
 						actions.closeMenu( 'focus' );
 						return;

--- a/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
@@ -256,6 +256,14 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			// Tab outside the complex submenu.
 			await page.keyboard.press( 'Tab' );
 			await expect( firstLevelElement ).toBeHidden();
+
+			// Test: nested submenu closes on ESC key and focuses ancestor menu item:
+			// See: https://github.com/WordPress/gutenberg/issues/69834
+			await complexSubmenuButton.click();
+			await nestedSubmenuButton.click();
+			await pageUtils.pressKeys( 'Escape' );
+			await expect( nestedSubmenuButton ).toBeHidden();
+			await expect( complexSubmenuButton ).toBeFocused();
 		} );
 
 		/**
@@ -343,6 +351,14 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			// Close the menu via click on the body
 			await page.click( 'body' );
 			await expect( firstLevelElement ).toBeHidden();
+
+			// Test: nested submenu closes on ESC key and focuses ancestor menu item:
+			// See: https://github.com/WordPress/gutenberg/issues/69834
+			await complexSubmenuButton.click();
+			await nestedSubmenuButton.click();
+			await pageUtils.pressKeys( 'Escape' );
+			await expect( nestedSubmenuButton ).toBeHidden();
+			await expect( complexSubmenuButton ).toBeFocused();
 
 			// Tests not covered: Tabbing to close menus
 		} );

--- a/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js
@@ -257,13 +257,14 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			await page.keyboard.press( 'Tab' );
 			await expect( firstLevelElement ).toBeHidden();
 
-			// Test: nested submenu closes on ESC key and focuses ancestor menu item:
+			// Test: nested submenu closes on ESC key and focuses parent menu item:
 			// See: https://github.com/WordPress/gutenberg/issues/69834
 			await complexSubmenuButton.click();
 			await nestedSubmenuButton.click();
+			await expect( secondLevelElement ).toBeVisible();
 			await pageUtils.pressKeys( 'Escape' );
-			await expect( nestedSubmenuButton ).toBeHidden();
-			await expect( complexSubmenuButton ).toBeFocused();
+			await expect( secondLevelElement ).toBeHidden();
+			await expect( nestedSubmenuButton ).toBeFocused();
 		} );
 
 		/**
@@ -352,13 +353,14 @@ test.describe( 'Navigation block - Frontend interactivity', () => {
 			await page.click( 'body' );
 			await expect( firstLevelElement ).toBeHidden();
 
-			// Test: nested submenu closes on ESC key and focuses ancestor menu item:
+			// Test: nested submenu closes on ESC key and focuses parent menu item:
 			// See: https://github.com/WordPress/gutenberg/issues/69834
 			await complexSubmenuButton.click();
 			await nestedSubmenuButton.click();
+			await expect( secondLevelElement ).toBeVisible();
 			await pageUtils.pressKeys( 'Escape' );
-			await expect( nestedSubmenuButton ).toBeHidden();
-			await expect( complexSubmenuButton ).toBeFocused();
+			await expect( secondLevelElement ).toBeHidden();
+			await expect( nestedSubmenuButton ).toBeFocused();
 
 			// Tests not covered: Tabbing to close menus
 		} );


### PR DESCRIPTION
## What?
Closes #69834 

When using the Escape key to close menus, this makes it only close one menu level at a time and focus the parent menu item.

## Why?
When using the Escape key to close menus: 
- Focus should not be lost when pressing Escape
- Only the last menu opened should close (not all parents).

## How?
- To fix the loss of focus, this adds `previousFocus` to the context (Interactivity API) of submenus. This makes each level have it’s own reference. Without this one `previousFocus` reference is shared by all levels and when set by a nested menu it overwrites the previous value causing it to be lost.
- To ensure only one menu level closes, this adds a `stopPropagation` call to the `keydown` handler (when Escape key was pressed).

## Testing Instructions

### Manually
Use the following HTML to create a Navigation with nested submenus:

<details><summary>HTML example</summary>

```html
<!-- wp:navigation-submenu {"label":"Top Level Menu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-submenu {"label":"1. Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-submenu {"label":"1.1. Nested Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-link {"label":"1.1.1 Further nested submenu item","url":"#","kind":"custom"} /-->

<!-- wp:navigation-link {"label":"1.1.2 Further nested submenu item","url":"#","kind":"custom"} /-->
<!-- /wp:navigation-submenu -->

<!-- wp:navigation-submenu {"label":"1.2. Nested Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-link {"label":"1.2.1 Further nested submenu item","url":"#","kind":"custom"} /-->

<!-- wp:navigation-link {"label":"1.2.2 Further nested submenu item","url":"#","kind":"custom"} /-->
<!-- /wp:navigation-submenu -->

<!-- wp:navigation-submenu {"label":"1.3. Nested Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-link {"label":"1.3.1 Further nested submenu item","url":"#","kind":"custom"} /-->

<!-- wp:navigation-link {"label":"1.3.2 Further nested submenu item","url":"#","kind":"custom"} /-->
<!-- /wp:navigation-submenu -->
<!-- /wp:navigation-submenu -->

<!-- wp:navigation-submenu {"label":"2. Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-submenu {"label":"2.1. Nested Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-link {"label":"2.1.1 Further nested submenu item","url":"#","kind":"custom"} /-->

<!-- wp:navigation-link {"label":"2.1.2 Further nested submenu item","url":"#","kind":"custom"} /-->
<!-- /wp:navigation-submenu -->

<!-- wp:navigation-submenu {"label":"2.2. Nested Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-link {"label":"2.2.1 Further nested submenu item","url":"#","kind":"custom"} /-->

<!-- wp:navigation-link {"label":"2.2.2 Further nested submenu item","url":"#","kind":"custom"} /-->
<!-- /wp:navigation-submenu -->

<!-- wp:navigation-submenu {"label":"2.3. Nested Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-link {"label":"2.3.1 Further nested submenu item","url":"#","kind":"custom"} /-->

<!-- wp:navigation-link {"label":"2.3.2 Further nested submenu item","url":"#","kind":"custom"} /-->
<!-- /wp:navigation-submenu -->
<!-- /wp:navigation-submenu -->
<!-- /wp:navigation-submenu -->

<!-- wp:navigation-submenu {"label":"Top Level Menu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-submenu {"label":"1. Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-submenu {"label":"1.1. Nested Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-link {"label":"1.1.1 Further nested submenu item","url":"#","kind":"custom"} /-->

<!-- wp:navigation-link {"label":"1.1.2 Further nested submenu item","url":"#","kind":"custom"} /-->
<!-- /wp:navigation-submenu -->

<!-- wp:navigation-submenu {"label":"1.2. Nested Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-link {"label":"1.2.1 Further nested submenu item","url":"#","kind":"custom"} /-->

<!-- wp:navigation-link {"label":"1.2.2 Further nested submenu item","url":"#","kind":"custom"} /-->
<!-- /wp:navigation-submenu -->

<!-- wp:navigation-submenu {"label":"1.3. Nested Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-link {"label":"1.3.1 Further nested submenu item","url":"#","kind":"custom"} /-->

<!-- wp:navigation-link {"label":"1.3.2 Further nested submenu item","url":"#","kind":"custom"} /-->
<!-- /wp:navigation-submenu -->
<!-- /wp:navigation-submenu -->

<!-- wp:navigation-submenu {"label":"2. Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-submenu {"label":"2.1. Nested Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-link {"label":"2.1.1 Further nested submenu item","url":"#","kind":"custom"} /-->

<!-- wp:navigation-link {"label":"2.1.2 Further nested submenu item","url":"#","kind":"custom"} /-->
<!-- /wp:navigation-submenu -->

<!-- wp:navigation-submenu {"label":"2.2. Nested Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-link {"label":"2.2.1 Further nested submenu item","url":"#","kind":"custom"} /-->

<!-- wp:navigation-link {"label":"2.2.2 Further nested submenu item","url":"#","kind":"custom"} /-->
<!-- /wp:navigation-submenu -->

<!-- wp:navigation-submenu {"label":"2.3. Nested Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-link {"label":"2.3.1 Further nested submenu item","url":"#","kind":"custom"} /-->

<!-- wp:navigation-link {"label":"2.3.2 Further nested submenu item","url":"#","kind":"custom"} /-->
<!-- /wp:navigation-submenu -->
<!-- /wp:navigation-submenu -->
<!-- /wp:navigation-submenu -->

<!-- wp:navigation-submenu {"label":"Top Level Menu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-submenu {"label":"1. Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-submenu {"label":"1.1. Nested Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-link {"label":"1.1.1 Further nested submenu item","url":"#","kind":"custom"} /-->

<!-- wp:navigation-link {"label":"1.1.2 Further nested submenu item","url":"#","kind":"custom"} /-->
<!-- /wp:navigation-submenu -->

<!-- wp:navigation-submenu {"label":"1.2. Nested Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-link {"label":"1.2.1 Further nested submenu item","url":"#","kind":"custom"} /-->

<!-- wp:navigation-link {"label":"1.2.2 Further nested submenu item","url":"#","kind":"custom"} /-->
<!-- /wp:navigation-submenu -->

<!-- wp:navigation-submenu {"label":"1.3. Nested Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-link {"label":"1.3.1 Further nested submenu item","url":"#","kind":"custom"} /-->

<!-- wp:navigation-link {"label":"1.3.2 Further nested submenu item","url":"#","kind":"custom"} /-->
<!-- /wp:navigation-submenu -->
<!-- /wp:navigation-submenu -->

<!-- wp:navigation-submenu {"label":"2. Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-submenu {"label":"2.1. Nested Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-link {"label":"2.1.1 Further nested submenu item","url":"#","kind":"custom"} /-->

<!-- wp:navigation-link {"label":"2.1.2 Further nested submenu item","url":"#","kind":"custom"} /-->
<!-- /wp:navigation-submenu -->

<!-- wp:navigation-submenu {"label":"2.2. Nested Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-link {"label":"2.2.1 Further nested submenu item","url":"#","kind":"custom"} /-->

<!-- wp:navigation-link {"label":"2.2.2 Further nested submenu item","url":"#","kind":"custom"} /-->
<!-- /wp:navigation-submenu -->

<!-- wp:navigation-submenu {"label":"2.3. Nested Submenu Item","url":"#","kind":"custom"} -->
<!-- wp:navigation-link {"label":"2.3.1 Further nested submenu item","url":"#","kind":"custom"} /-->

<!-- wp:navigation-link {"label":"2.3.2 Further nested submenu item","url":"#","kind":"custom"} /-->
<!-- /wp:navigation-submenu -->
<!-- /wp:navigation-submenu -->
<!-- /wp:navigation-submenu -->
```
</details> 

- Launch your screen reader.
- Access nested submenus with keyboard or pointer use.
- Press the Escape key.
- Confirm that the focus returns to the parent menu item of the closed menu.

### E2E
1. Checkout the first commit on this branch
   ```
   git checkout a936527a997120acd60d37ee5a5e9e319e17165a
   ```
2. Run the modified tests:
   ```
   npm run test:e2e test/e2e/specs/editor/blocks/navigation-frontend-interactivity.spec.js:136
   ```
3. Verify the tests fail
4. Checkout the next commit:
   ```
   git checkout 07142c240ddcbffb80d56958962bb855d20186bb
   ```
5. Repeat step 2
6. Verify the tests pass
7. Checkout the next commit
   ```
   git checkout e5d77fab0deca06b3a324f734826e25050610b63
   ```
8. Repeat step 2
9. Verify the tests fail
10. Checkout the full branch
    ```
    git switch fix/navigation-nested-menu-esc-key-focus-loss
    ```
11. Repeat step 2
12. Verify the tests pass

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
