### PR TITLE
Latest Posts: Update content display labels to `Display post content` and `Content length`

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -229,7 +229,7 @@ function Controls( { attributes, setAttributes, postCount } ) {
 				{ displayPostContent && (
 					<ToolsPanelItem
 						hasValue={ () => displayPostContentRadio !== 'excerpt' }
-						label={ __( 'Show' ) }
+						label={ _x( 'Show', 'noun' ) }
 						onDeselect={ () =>
 							setAttributes( {
 								displayPostContentRadio: 'excerpt',
@@ -238,7 +238,7 @@ function Controls( { attributes, setAttributes, postCount } ) {
 						isShownByDefault
 					>
 						<RadioControl
-							label={ __( 'Show' ) }
+							label={ _x( 'Show', 'noun' ) }
 							selected={ displayPostContentRadio }
 							options={ [
 								{ label: __( 'Excerpt' ), value: 'excerpt' },

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -211,7 +211,7 @@ function Controls( { attributes, setAttributes, postCount } ) {
 			>
 				<ToolsPanelItem
 					hasValue={ () => !! displayPostContent }
-					label={ __( 'Post content' ) }
+					label={ __( 'Display post content' ) }
 					onDeselect={ () =>
 						setAttributes( { displayPostContent: false } )
 					}

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -219,7 +219,7 @@ function Controls( { attributes, setAttributes, postCount } ) {
 				>
 					<ToggleControl
 						__nextHasNoMarginBottom
-						label={ __( 'Post content' ) }
+						label={ __( 'Display post content' ) }
 						checked={ displayPostContent }
 						onChange={ ( value ) =>
 							setAttributes( { displayPostContent: value } )
@@ -238,7 +238,7 @@ function Controls( { attributes, setAttributes, postCount } ) {
 						isShownByDefault
 					>
 						<RadioControl
-							label={ _x( 'Show', 'noun' ) }
+							label={ __( 'Content Length' ) }
 							selected={ displayPostContentRadio }
 							options={ [
 								{ label: __( 'Excerpt' ), value: 'excerpt' },

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -229,7 +229,7 @@ function Controls( { attributes, setAttributes, postCount } ) {
 				{ displayPostContent && (
 					<ToolsPanelItem
 						hasValue={ () => displayPostContentRadio !== 'excerpt' }
-						label={ _x( 'Show', 'noun' ) }
+						label={ __( 'Content length' ) }
 						onDeselect={ () =>
 							setAttributes( {
 								displayPostContentRadio: 'excerpt',
@@ -238,7 +238,7 @@ function Controls( { attributes, setAttributes, postCount } ) {
 						isShownByDefault
 					>
 						<RadioControl
-							label={ __( 'Content Length' ) }
+							label={ __( 'Content length' ) }
 							selected={ displayPostContentRadio }
 							options={ [
 								{ label: __( 'Excerpt' ), value: 'excerpt' },


### PR DESCRIPTION
## What?


Closes #69838

Updates the Latest Posts block to use more descriptive and consistent labels for post content display options.



## Why?

The previous labels ("Show", "Post content") were ambiguous and inconsistent, which could confuse users and translators. This PR improves clarity and accessibility by using explicit labels like "Display post content" and "Content length".

## How?

- Changed the `ToggleControl` and `ToolsPanelItem` label from `Post content` to `Display post content`.

- Updated the label for the content length selection from `Show` to `Content length` in both `ToolsPanelItem` and `RadioControl`.

## Testing Instructions

- Add a Latest Posts block to a post or page in the block editor.
- In the block settings sidebar, look for the toggle labeled "Display post content".
- Enable the toggle and observe the "Content length" control for selecting Excerpt or Full post.
- Verify that all labels are updated and consistent, even in the ToolsPanel.

## Screenshots







|Before|After|
|-|-|
|<img width="539" alt="Screenshot 2025-04-22 at 12 44 45" src="https://github.com/user-attachments/assets/d2e238ae-aa90-4dbf-a8c9-e23c46d6c56c" />|<img width="547" alt="Screenshot 2025-04-22 at 12 44 15" src="https://github.com/user-attachments/assets/a5322661-3dba-4457-9afd-dab442ebb128" />|

