### PR TITLE
Components: Add size prop to `RangeControl`

### DIFF
--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -98,6 +98,7 @@ function UnforwardedRangeControl(
 		value: valueProp,
 		withInputField = true,
 		__shouldNotWarnDeprecated36pxSize,
+		size = 'default',
 		...otherProps
 	} = props;
 
@@ -235,9 +236,19 @@ function UnforwardedRangeControl(
 	maybeWarnDeprecated36pxSize( {
 		componentName: 'RangeControl',
 		__next40pxDefaultSize,
-		size: undefined,
+		size,
 		__shouldNotWarnDeprecated36pxSize,
 	} );
+
+	const translatedSize = ( () => {
+		if ( __next40pxDefaultSize && size === 'default' ) {
+			return 'default';
+		}
+		if ( ! __next40pxDefaultSize && size === 'default' ) {
+			return 'compact';
+		}
+		return size;
+	} )();
 
 	return (
 		<BaseControl
@@ -252,6 +263,7 @@ function UnforwardedRangeControl(
 			<Root
 				className="components-range-control__root"
 				__next40pxDefaultSize={ __next40pxDefaultSize }
+				size={ translatedSize }
 			>
 				{ beforeIcon && (
 					<BeforeIconWrapper>
@@ -339,11 +351,7 @@ function UnforwardedRangeControl(
 						onBlur={ handleOnInputNumberBlur }
 						onChange={ handleOnChange }
 						shiftStep={ shiftStep }
-						size={
-							__next40pxDefaultSize
-								? '__unstable-large'
-								: 'default'
-						}
+						size={ translatedSize }
 						__unstableInputWidth={
 							__next40pxDefaultSize ? space( 20 ) : space( 16 )
 						}

--- a/packages/components/src/range-control/stories/index.story.tsx
+++ b/packages/components/src/range-control/stories/index.story.tsx
@@ -41,6 +41,10 @@ const meta: Meta< typeof RangeControl > = {
 		onMouseLeave: { control: false },
 		onMouseMove: { control: false },
 		railColor: { control: { type: 'color' } },
+		size: {
+			control: { type: 'select' },
+			options: [ 'default', 'compact' ],
+		},
 		step: { control: { type: 'number' } },
 		trackColor: { control: { type: 'color' } },
 		type: { control: { type: 'check' }, options: [ 'stepper' ] },

--- a/packages/components/src/range-control/styles/range-control-styles.ts
+++ b/packages/components/src/range-control/styles/range-control-styles.ts
@@ -27,12 +27,21 @@ const rangeHeight = () =>
 	css( { height: rangeHeightValue, minHeight: rangeHeightValue } );
 const thumbSize = 12;
 
+type SizeType = 'compact' | 'default';
+const getSizeHeight = ( size: SizeType ) => {
+	const sizes = {
+		compact: 32,
+		default: 40,
+	};
+	return sizes[ size ];
+};
+
 const deprecatedHeight = ( {
 	__next40pxDefaultSize,
 }: Pick< RangeControlProps, '__next40pxDefaultSize' > ) =>
 	! __next40pxDefaultSize && css( { minHeight: rangeHeightValue } );
 
-type RootProps = Pick< RangeControlProps, '__next40pxDefaultSize' >;
+type RootProps = Pick< RangeControlProps, '__next40pxDefaultSize' | 'size' >;
 export const Root = styled.div< RootProps >`
 	-webkit-tap-highlight-color: transparent;
 	align-items: center;
@@ -42,7 +51,7 @@ export const Root = styled.div< RootProps >`
 	position: relative;
 	touch-action: none;
 	width: 100%;
-	min-height: 40px;
+	min-height: ${ ( { size = 'default' } ) => getSizeHeight( size ) }px;
 	/* TODO: remove after removing the __next40pxDefaultSize prop */
 	${ deprecatedHeight };
 `;

--- a/packages/components/src/range-control/types.ts
+++ b/packages/components/src/range-control/types.ts
@@ -240,6 +240,12 @@ export type RangeControlProps = Pick<
 		 * @ignore
 		 */
 		__shouldNotWarnDeprecated36pxSize?: boolean;
+		/**
+		 * The size of the control.
+		 *
+		 * @default 'default'
+		 */
+		size?: 'default' | 'compact';
 	};
 
 export type RailProps = MarksProps & {


### PR DESCRIPTION

## What?
Closes https://github.com/WordPress/gutenberg/issues/64536

Adds a size prop to `RangeControl` supporting "default" (40px) and "compact" (32px) options.


## Why?
Currently the `RangeControl` renders at 40px by default and can be adjusted to 32px by removing `__next40pxDefaultSize`. This addition provides a more explicit API for controlling component size, aligning with standard sizing conventions and improving component consistency, across the repo.

## How?
Added `size` prop

## Testing Instructions


1. Run `npm run storybook:dev`
2. Search for "RangeControl"
3. Toggle the size option to test both "default" and "compact" sizes
4. Verify that the heights match the expected 40px and 32px respectively




## Screencast 

https://github.com/user-attachments/assets/6c766fa1-3a98-4693-aa2d-7b43cb85d533



