### PR TITLE
Query Loop: Fix 'undo trap' and improve debouncing for 'Keyword' control

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -99,13 +99,11 @@ export default function QueryInspectorControls( props ) {
 		setQuery( updateQuery );
 	};
 	const [ querySearch, setQuerySearch ] = useState( query.search );
-	const debouncedQuerySearch = useMemo(
-		() =>
-			debounce( ( newQuerySearch ) => {
-				setQuery( { search: newQuerySearch } );
-			}, 250 ),
-		[ setQuery ]
-	);
+	const debouncedQuerySearch = useMemo( () => {
+		return debounce( ( newQuerySearch ) => {
+			setQuery( { search: newQuerySearch } );
+		}, 250 );
+	}, [ setQuery ] );
 
 	const orderByOptions = useOrderByOptions( postType );
 	const showInheritControl = isControlAllowed( allowedControls, 'inherit' );

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -412,7 +412,10 @@ export default function QueryInspectorControls( props ) {
 						<ToolsPanelItem
 							hasValue={ () => !! querySearch }
 							label={ __( 'Keyword' ) }
-							onDeselect={ () => setQuerySearch( '' ) }
+							onDeselect={ () => {
+								setQuery( { search: '' } );
+								setQuerySearch( '' );
+							} }
 						>
 							<TextControl
 								__nextHasNoMarginBottom

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -15,7 +15,7 @@ import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import { debounce } from '@wordpress/compose';
-import { useEffect, useState, useMemo } from '@wordpress/element';
+import { useState, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -99,17 +99,13 @@ export default function QueryInspectorControls( props ) {
 		setQuery( updateQuery );
 	};
 	const [ querySearch, setQuerySearch ] = useState( query.search );
-	const onChangeDebounced = useMemo(
+	const debouncedQuerySearch = useMemo(
 		() =>
 			debounce( ( newQuerySearch ) => {
 				setQuery( { search: newQuerySearch } );
 			}, 250 ),
 		[ setQuery ]
 	);
-	useEffect( () => {
-		onChangeDebounced( querySearch );
-		return onChangeDebounced.cancel;
-	}, [ querySearch, onChangeDebounced ] );
 
 	const orderByOptions = useOrderByOptions( postType );
 	const showInheritControl = isControlAllowed( allowedControls, 'inherit' );
@@ -425,7 +421,10 @@ export default function QueryInspectorControls( props ) {
 								__next40pxDefaultSize
 								label={ __( 'Keyword' ) }
 								value={ querySearch }
-								onChange={ setQuerySearch }
+								onChange={ ( newQuerySearch ) => {
+									debouncedQuerySearch( newQuerySearch );
+									setQuerySearch( newQuerySearch );
+								} }
 							/>
 						</ToolsPanelItem>
 					) }

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -15,7 +15,7 @@ import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import { debounce } from '@wordpress/compose';
-import { useEffect, useState, useCallback } from '@wordpress/element';
+import { useEffect, useState, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -99,16 +99,15 @@ export default function QueryInspectorControls( props ) {
 		setQuery( updateQuery );
 	};
 	const [ querySearch, setQuerySearch ] = useState( query.search );
-	const onChangeDebounced = useCallback(
-		debounce( () => {
-			if ( query.search !== querySearch ) {
-				setQuery( { search: querySearch } );
-			}
-		}, 250 ),
-		[ querySearch, query.search ]
+	const onChangeDebounced = useMemo(
+		() =>
+			debounce( ( newQuerySearch ) => {
+				setQuery( { search: newQuerySearch } );
+			}, 250 ),
+		[ setQuery ]
 	);
 	useEffect( () => {
-		onChangeDebounced();
+		onChangeDebounced( querySearch );
 		return onChangeDebounced.cancel;
 	}, [ querySearch, onChangeDebounced ] );
 

--- a/packages/block-library/src/query/edit/inspector-controls/parent-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/parent-control.js
@@ -51,7 +51,7 @@ function ParentControl( { parents, postType, onChange } ) {
 				),
 			};
 		},
-		[ search, parents ]
+		[ search, postType, parents ]
 	);
 	const currentParents = useSelect(
 		( select ) => {
@@ -65,7 +65,7 @@ function ParentControl( { parents, postType, onChange } ) {
 				per_page: parents.length,
 			} );
 		},
-		[ parents ]
+		[ parents, postType ]
 	);
 	// Update the `value` state only after the selectors are resolved
 	// to avoid emptying the input when we're changing parents.

--- a/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
@@ -120,7 +120,7 @@ function TaxonomyItem( { taxonomy, termIds, onChange } ) {
 				),
 			};
 		},
-		[ search, termIds ]
+		[ search, taxonomy.slug, termIds ]
 	);
 	// `existingTerms` are the ones fetched from the API and their type is `{ id: number; name: string }`.
 	// They are used to extract the terms' names to populate the `FormTokenField` properly
@@ -137,7 +137,7 @@ function TaxonomyItem( { taxonomy, termIds, onChange } ) {
 				per_page: termIds.length,
 			} );
 		},
-		[ termIds ]
+		[ taxonomy.slug, termIds ]
 	);
 	// Update the `value` state only after the selectors are resolved
 	// to avoid emptying the input when we're changing terms.

--- a/packages/block-library/src/query/edit/query-content.js
+++ b/packages/block-library/src/query/edit/query-content.js
@@ -86,9 +86,18 @@ export default function QueryContent( {
 	// would cause to override previous wanted changes.
 	const updateQuery = useCallback(
 		( newQuery ) =>
-			setAttributes( ( prevAttributes ) => ( {
-				query: { ...prevAttributes.query, ...newQuery },
-			} ) ),
+			setAttributes( ( prevAttributes ) => {
+				// Avoid persisting changes if the new query is the same as the previous one.
+				const hasChanges = Object.keys( newQuery ).some(
+					( key ) => prevAttributes.query[ key ] !== newQuery[ key ]
+				);
+
+				return hasChanges
+					? {
+							query: { ...prevAttributes.query, ...newQuery },
+					  }
+					: prevAttributes;
+			} ),
 		[ setAttributes ]
 	);
 	useEffect( () => {

--- a/packages/block-library/src/query/edit/query-content.js
+++ b/packages/block-library/src/query/edit/query-content.js
@@ -86,18 +86,9 @@ export default function QueryContent( {
 	// would cause to override previous wanted changes.
 	const updateQuery = useCallback(
 		( newQuery ) =>
-			setAttributes( ( prevAttributes ) => {
-				// Avoid persisting changes if the new query is the same as the previous one.
-				const hasChanges = Object.keys( newQuery ).some(
-					( key ) => prevAttributes.query[ key ] !== newQuery[ key ]
-				);
-
-				return hasChanges
-					? {
-							query: { ...prevAttributes.query, ...newQuery },
-					  }
-					: prevAttributes;
-			} ),
+			setAttributes( ( prevAttributes ) => ( {
+				query: { ...prevAttributes.query, ...newQuery },
+			} ) ),
 		[ setAttributes ]
 	);
 	useEffect( () => {


### PR DESCRIPTION
## What?
I started this branch to fix some annoying ESLint warnings for the Query Loop block's controls, then realized that I could get rid of `useEffect`, which syncs local state and the `query.search` attribute.

Side note: I wonder if `updateQuery` optimization from 693f886d54fb06f42787f861fbfc7c55fb61b49e could be handy in the future. This is the downside of attribute objects; they will be marked as changed even if all values are the same. Related: #27323.

## How
Directly call `debouncedQuerySearch` when changing the Keyword control value.

## Testing Instructions
1. Create a page.
2. Add a Query Loop block and make it custom.
3. Start typing in the Keyword control.
4. Confirm that the input value stays in sync while the actual query refresh gets debounced.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2025-04-07 at 16 54 04](https://github.com/user-attachments/assets/d7b82ad5-d4d0-4a53-861e-af7b75281f63)

