### PR TITLE
DataViews: Ensure consistent display of primary ellipsis in list layout

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -19,8 +19,7 @@ div.dataviews-view-list {
 			display: flex;
 			width: max-content;
 			flex: 0 0 auto;
-			gap: $grid-unit-10;
-			padding-inline-end: $grid-unit-05;
+			gap: $grid-unit-15 * 0.5; // 6px.
 
 			.components-button {
 				position: relative;

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -26,14 +26,14 @@ div.dataviews-view-list {
 				z-index: 1;
 			}
 
+			> div {
+				height: $button-size-small;
+			}
+
 			> :not(:last-child) {
 				flex: 0;
 				overflow: hidden;
 				width: 0;
-
-				> div {
-					height: $button-size-small;
-				}
 
 				.components-button {
 					opacity: 0;

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -17,24 +17,39 @@ div.dataviews-view-list {
 
 		.dataviews-view-list__item-actions {
 			display: flex;
-			flex: 0 0 auto;
 			width: max-content;
+			flex: 0 0 auto;
 			padding-inline-end: $grid-unit-05;
-
-			> div:not(:last-child) {
-				height: $button-size-small;
-				display: none;
-			}
 
 			.components-button {
 				position: relative;
 				z-index: 1;
 			}
+
+			> :not(:last-child) {
+				flex: 0;
+				overflow: hidden;
+				width: 0;
+
+				> div {
+					height: $button-size-small;
+				}
+
+				.components-button {
+					opacity: 0;
+				}
+			}
 		}
 
-		&:where(.is-selected, .is-hovered, :focus-within) .dataviews-view-list__item-actions {
-			> div:not(:last-child) {
-				display: flex;
+		&:where(.is-selected, .is-hovered, :focus-within) {
+			.dataviews-view-list__item-actions > :not(:last-child) {
+				flex-basis: min-content;
+				width: auto;
+				overflow: unset;
+
+				.components-button {
+					opacity: 1;
+				}
 			}
 		}
 

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -19,6 +19,7 @@ div.dataviews-view-list {
 			display: flex;
 			width: max-content;
 			flex: 0 0 auto;
+			gap: $grid-unit-10;
 			padding-inline-end: $grid-unit-05;
 
 			.components-button {

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -19,7 +19,7 @@ div.dataviews-view-list {
 			display: flex;
 			width: max-content;
 			flex: 0 0 auto;
-			gap: $grid-unit-15 * 0.5; // 6px.
+			gap: $grid-unit-05;
 
 			.components-button {
 				position: relative;
@@ -34,10 +34,6 @@ div.dataviews-view-list {
 				flex: 0;
 				overflow: hidden;
 				width: 0;
-
-				.components-button {
-					opacity: 0;
-				}
 			}
 		}
 
@@ -46,10 +42,6 @@ div.dataviews-view-list {
 				flex-basis: min-content;
 				width: auto;
 				overflow: unset;
-
-				.components-button {
-					opacity: 1;
-				}
 			}
 		}
 

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -16,29 +16,25 @@ div.dataviews-view-list {
 		}
 
 		.dataviews-view-list__item-actions {
-			flex: 0;
-			overflow: hidden;
+			display: flex;
+			flex: 0 0 auto;
+			width: max-content;
+			padding-inline-end: $grid-unit-05;
 
-			> div {
+			> div:not(:last-child) {
 				height: $button-size-small;
+				display: none;
 			}
 
 			.components-button {
 				position: relative;
 				z-index: 1;
-				opacity: 0;
 			}
 		}
 
-		&:where(.is-selected, .is-hovered, :focus-within) {
-			.dataviews-view-list__item-actions {
-				flex-basis: min-content;
-				overflow: unset;
-				padding-inline-end: $grid-unit-05;
-
-				.components-button {
-					opacity: 1;
-				}
+		&:where(.is-selected, .is-hovered, :focus-within) .dataviews-view-list__item-actions {
+			> div:not(:last-child) {
+				display: flex;
 			}
 		}
 


### PR DESCRIPTION
## What?
Closes #69570

This PR ensures the primary ellipsis in DataViews list items is always visible, regardless of interaction states such as hover, focus, or selection — or even when idle.

## Why?

This improves accessibility, as noted [here](https://github.com/WordPress/gutenberg/issues/69570#issuecomment-2776136031) and addresses the linked issue.

## How?

Corresponding CSS rules were updated and refactored for simplicity.

## Testing Instructions

1. Navigate to Appearance -> Editor -> Pages.
2. Make sure that the data is displayed in List Layout.
3. Click the Actions button and open the menu.
4. Confirm that the primary ellipsis is always visible.

### Testing Instructions for Keyboard
Same

## Screencast

![pr](https://github.com/user-attachments/assets/94c27d64-2529-4b8a-9735-af27e2eef930)
