### PR TITLE
Add Revisions Block to Display Post Revision History

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -805,6 +805,15 @@ Displays the link of a post, page, or any other content-type. ([Source](https://
 -	**Supports:** color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** content, linkTarget
 
+## Revision
+
+Display the revision history ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/revision))
+
+-	**Name:** core/revision
+-	**Category:** theme
+-	**Supports:** align (full, wide), color (background, gradients, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** revisionLimit, showRevisionHistory, showTotalCount
+
 ## RSS
 
 Display entries from any RSS or Atom feed. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/rss))

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -110,7 +110,7 @@ function gutenberg_reregister_core_block_types() {
 				'query-title.php'                  => 'core/query-title',
 				'query-total.php'                  => 'core/query-total',
 				'read-more.php'                    => 'core/read-more',
-				'revision.php'                    => 'core/revision',
+				'revision.php'                     => 'core/revision',
 				'rss.php'                          => 'core/rss',
 				'search.php'                       => 'core/search',
 				'shortcode.php'                    => 'core/shortcode',

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -110,6 +110,7 @@ function gutenberg_reregister_core_block_types() {
 				'query-title.php'                  => 'core/query-title',
 				'query-total.php'                  => 'core/query-total',
 				'read-more.php'                    => 'core/read-more',
+				'revision.php'                    => 'core/revision',
 				'rss.php'                          => 'core/rss',
 				'search.php'                       => 'core/search',
 				'shortcode.php'                    => 'core/shortcode',

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -103,6 +103,7 @@ import * as queryTotal from './query-total';
 import * as quote from './quote';
 import * as reusableBlock from './block';
 import * as readMore from './read-more';
+import * as revision from './revision';
 import * as rss from './rss';
 import * as search from './search';
 import * as separator from './separator';
@@ -214,6 +215,7 @@ const getAllBlocks = () => {
 		queryNoResults,
 		queryTotal,
 		readMore,
+		revision,
 		comments,
 		commentAuthorName,
 		commentContent,

--- a/packages/block-library/src/revision/block.json
+++ b/packages/block-library/src/revision/block.json
@@ -1,0 +1,54 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "core/revision",
+	"title": "Revision",
+	"category": "theme",
+	"description": "Display the revision history",
+	"textdomain": "default",
+	"usesContext": [ "postId", "postType" ],
+	"attributes": {
+		"showTotalCount": {
+			"type": "boolean",
+			"default": true
+		},
+		"showRevisionHistory": {
+			"type": "boolean",
+			"default": true
+		},
+		"revisionLimit": {
+			"type": "integer",
+			"default": 10
+		}
+	},
+	"icon": "backup",
+	"supports": {
+		"align": [ "wide", "full" ],
+		"html": false,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
+		"color": {
+			"gradients": true,
+			"text": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		}
+	}
+}

--- a/packages/block-library/src/revision/edit.js
+++ b/packages/block-library/src/revision/edit.js
@@ -1,0 +1,103 @@
+/**
+ * WordPress dependencies
+ */
+import { PanelBody, ToggleControl, RangeControl } from '@wordpress/components';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+
+const RevisionEdit = ( { attributes, context, setAttributes } ) => {
+	const { postId, postType } = context;
+	const { showTotalCount, showRevisionHistory, revisionLimit } = attributes;
+	const blockProps = useBlockProps();
+
+	const { supportsRevision } = useSelect(
+		( select ) => {
+			const { getPostType } = select( coreStore );
+
+			return {
+				supportsRevision:
+					getPostType( postType )?.supports?.revisions ?? false,
+			};
+		},
+		[ postType ]
+	);
+
+	if ( ! supportsRevision ) {
+		return (
+			<div { ...blockProps }>
+				{ sprintf(
+					// translators: %s: Name of the post type e.g: "post".
+					__( 'This post type (%s) does not support the revisions.' ),
+					postType
+				) }
+			</div>
+		);
+	}
+
+	return (
+		<div { ...blockProps }>
+			<InspectorControls>
+				<PanelBody title="Revisions Block Settings">
+					<p>
+						{ sprintf(
+							// translators: %s: Id of the post type e.g: "100".
+							__( 'Displaying revisions for Post ID: %s' ),
+							postId
+						) }
+					</p>
+					<ToggleControl
+						label={ __( 'Show Total Revision Count' ) }
+						checked={ showTotalCount }
+						onChange={ () =>
+							setAttributes( {
+								showTotalCount: ! showTotalCount,
+							} )
+						}
+						__nextHasNoMarginBottom
+					/>
+					<ToggleControl
+						label={ __( 'Show Revision History' ) }
+						checked={ showRevisionHistory }
+						onChange={ () =>
+							setAttributes( {
+								showRevisionHistory: ! showRevisionHistory,
+							} )
+						}
+						__nextHasNoMarginBottom
+					/>
+					{ showRevisionHistory && (
+						<RangeControl
+							label={ __( 'Number of Revisions to Display' ) }
+							value={ revisionLimit }
+							onChange={ ( value ) =>
+								setAttributes( { revisionLimit: value } )
+							}
+							min={ 1 }
+							max={ 20 }
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+						/>
+					) }
+				</PanelBody>
+			</InspectorControls>
+			<div className="revisions-list">
+				{ showTotalCount && <p>{ __( 'Total Revisions: Count' ) }</p> }
+				{ showRevisionHistory && (
+					<>
+						{ __( 'Revision logs :' ) }
+						<ul>
+							<li>
+								<strong>{ __( 'Author' ) }</strong>
+								&nbsp;{ __( '- dd/mm/yy, hh:mm:ss' ) }
+							</li>
+						</ul>
+					</>
+				) }
+			</div>
+		</div>
+	);
+};
+
+export default RevisionEdit;

--- a/packages/block-library/src/revision/index.js
+++ b/packages/block-library/src/revision/index.js
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+import initBlock from '../utils/init-block';
+
+/* Block settings */
+const { name, icon } = metadata;
+export { metadata, name };
+
+export const settings = {
+	edit,
+	icon,
+};
+
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/revision/index.php
+++ b/packages/block-library/src/revision/index.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Server-side rendering of the `core/revision` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/revision` block on the server.
+ *
+ * @since 6.8.0
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string The rendered block content.
+ */
+function render_block_core_revision( $attributes, $content, $block ) {
+	if ( ! post_type_supports( $block->context['postType'], 'revisions' ) ) {
+		return '';
+	}
+	if ( ! is_single() ) {
+		return '';
+	}
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+	$post_id            = get_the_ID();
+	$revisions          = array_slice( wp_get_post_revisions( $post_id ), 0, $attributes['revisionLimit'] );
+
+	if ( empty( $revisions ) ) {
+		return '<p>' . esc_html__( 'No revisions yet.' ) . '</p>';
+	}
+
+	$output = '';
+
+	if ( ! empty( $attributes['showTotalCount'] ) ) {
+		$revision_count = count( $revisions );
+		$output        .= '<p>' . sprintf(
+			// translators: %s: total number of revisions.
+			esc_html__( 'Total Revisions: %d' ),
+			$revision_count
+		) . '</p>';
+	}
+
+	if ( ! empty( $attributes['showRevisionHistory'] ) ) {
+		$output .= '<p>' . esc_html__( 'Revision logs:' ) . '</p>';
+		$output .= '<ul class="wp-block-revisions-list">';
+		foreach ( $revisions as $revision ) {
+			$author = get_the_author_meta( 'display_name', $revision->post_author );
+			$date   = date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $revision->post_date ) );
+
+			$output .= '<li><strong>' . esc_html( $author ) . '</strong> - ' . esc_html( $date ) . '</li>';
+		}
+		$output .= '</ul>';
+	}
+
+	return sprintf(
+		'<div %1$s>%2$s</div>',
+		$wrapper_attributes,
+		$output
+	);
+}
+
+/**
+ * Registers the `core/revision` block.
+ *
+ * @since 6.8.0
+ */
+function register_block_core_revision() {
+	register_block_type_from_metadata(
+		__DIR__ . '/revision',
+		array(
+			'render_callback' => 'render_block_core_revision',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_revision' );

--- a/packages/block-library/src/revision/init.js
+++ b/packages/block-library/src/revision/init.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import { init } from './';
+
+export default init();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR introduces a Revisions Block that displays a list of revisions for the current post, page, or custom post type.
Closes #40389

<!-- In a few words, what is the PR actually doing? -->

## Why?
WordPress supports post revisions, but currently lacks a block-based way to visualize or output revision history on the front end or within block templates. Showing this information improves editorial transparency and can be useful in collaborative environments (e.g., newsroom sites, documentation pages).

## How?
1. Displays list of revisions with:

    - Date/time of each revision.
    - Author who made the change.

  
2. Displays total revision count:

    - Total number of revisions.
    
3. Set limit revisions:

    - Let the user choose how many recent revisions to display.

Conditionally Rendered: Only shown if revisions are enabled for the post type.

## Testing Instructions

1. Enable revisions for the post type you're testing with.
2. Make a few edits to a post or page to generate revisions.
3. Insert the Revisions Block into the template or post.
4. View the block output: revision list should show timestamps and authors.
5. Confirm that it hides when no revisions are present or disabled.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/1a1565b8-6650-49e8-ba56-fb025071766d

