### PR TITLE
E2E/DataViewsListLayout: Run tests after loading the data

### DIFF
--- a/test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
+++ b/test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
@@ -32,6 +32,9 @@ test.describe( 'Dataviews List Layout', () => {
 	} );
 
 	test( 'Items list is reachable via TAB', async ( { page } ) => {
+		// Make sure the items have loaded before reaching for the 1st item in the list.
+		await expect( page.getByRole( 'grid' ) ).toBeVisible();
+
 		// Start the sequence on the search component.
 		await page.getByRole( 'searchbox', { name: 'Search' } ).click();
 
@@ -51,8 +54,6 @@ test.describe( 'Dataviews List Layout', () => {
 			page.getByRole( 'button', { name: 'View options' } )
 		).toBeFocused();
 
-		// Make sure the items have loaded before reaching for the 1st item in the list.
-		await expect( page.getByRole( 'grid' ) ).toBeVisible();
 		await page.keyboard.press( 'Tab' );
 		await expect(
 			page.getByRole( 'grid' ).getByRole( 'button' ).first()
@@ -62,6 +63,9 @@ test.describe( 'Dataviews List Layout', () => {
 	test( 'Navigates from items list to preview via TAB, and vice versa', async ( {
 		page,
 	} ) => {
+		// Make sure the items have loaded before reaching for the 1st item in the list.
+		await expect( page.getByRole( 'grid' ) ).toBeVisible();
+
 		// Start the sequence on the search component.
 		await page.getByRole( 'searchbox', { name: 'Search' } ).click();
 
@@ -75,8 +79,6 @@ test.describe( 'Dataviews List Layout', () => {
 			.getByRole( 'button' )
 			.first();
 
-		// Make sure the items have loaded before reaching for the 1st item in the list.
-		await expect( page.getByRole( 'grid' ) ).toBeVisible();
 		await page.keyboard.press( 'Tab' );
 		await expect( firstItem ).toBeFocused();
 
@@ -96,6 +98,9 @@ test.describe( 'Dataviews List Layout', () => {
 	test( 'Navigates the items list via UP/DOWN arrow keys', async ( {
 		page,
 	} ) => {
+		// Make sure the items have loaded before reaching for the 1st item in the list.
+		await expect( page.getByRole( 'grid' ) ).toBeVisible();
+
 		// Start the sequence on the search component.
 		await page.getByRole( 'searchbox', { name: 'Search' } ).click();
 
@@ -103,9 +108,6 @@ test.describe( 'Dataviews List Layout', () => {
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
-
-		// Make sure the items have loaded before reaching for the 1st item in the list.
-		await expect( page.getByRole( 'grid' ) ).toBeVisible();
 		await page.keyboard.press( 'Tab' );
 
 		// Use arrow up/down to move through the list.
@@ -119,6 +121,9 @@ test.describe( 'Dataviews List Layout', () => {
 	test( 'Actions are reachable via RIGHT/LEFT arrow keys', async ( {
 		page,
 	} ) => {
+		// Make sure the items have loaded before reaching for the 1st item in the list.
+		await expect( page.getByRole( 'grid' ) ).toBeVisible();
+
 		// Start the sequence on the search component.
 		await page.getByRole( 'searchbox', { name: 'Search' } ).click();
 
@@ -126,9 +131,6 @@ test.describe( 'Dataviews List Layout', () => {
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
-
-		// Make sure the items have loaded before reaching for the 1st item in the list.
-		await expect( page.getByRole( 'grid' ) ).toBeVisible();
 		await page.keyboard.press( 'Tab' );
 
 		// Use right/left arrow keys to move horizontally.
@@ -160,6 +162,9 @@ test.describe( 'Dataviews List Layout', () => {
 	test( 'Navigates the list via UP/DOWN arrow keys from action buttons', async ( {
 		page,
 	} ) => {
+		// Make sure the items have loaded before reaching for the 1st item in the list.
+		await expect( page.getByRole( 'grid' ) ).toBeVisible();
+
 		// Start the sequence on the search component.
 		await page.getByRole( 'searchbox', { name: 'Search' } ).click();
 
@@ -167,9 +172,6 @@ test.describe( 'Dataviews List Layout', () => {
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
-
-		// Make sure the items have loaded before reaching for the 1st item in the list.
-		await expect( page.getByRole( 'grid' ) ).toBeVisible();
 		await page.keyboard.press( 'Tab' );
 
 		// Use arrow up/down to move through the list from the edit primary action button.


### PR DESCRIPTION
## What?

The tests under `dataviews-list-layout-keyboard` fails when run locally.

To run it, use the following command:
 ```npm run test:e2e:debug -- test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js```
 
However, I'm still unsure how it's currently passing on the `trunk` branch. I've tested it on multiple machines (with the latest Trunk + latest WP), and the tests have consistently failed locally across all of them.

## Why?

These tests validate keyboard interactions within the `dataviews` list layout, focusing mainly on focus assertions. However, a page load delay causes incomplete rendering—specifically, the `Filter` button, `Add Page` button, and `Pages` text appear only once the data loads or shortly before.

Ref:
<img width="1392" alt="bug" src="https://github.com/user-attachments/assets/787e30be-8c34-4861-884f-3158328c95bd" />

As a result, the `Tab` key often lands on the iframe incorrectly—since the `Filter` button isn't rendered yet, its focus is skipped, but an extra `Tab` press is still registered.

## How?

This can be resolved by waiting for the data to load before triggering key presses. It’s a more reliable approach overall and fixes the failing tests locally.

## Testing Instructions
1. Open the playwright debugger by using the following command.

```
npm run test:e2e:debug -- test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
```

2. Run all available tests.
3. Confirm that no test fails locally.

### Testing Instructions for Keyboard
Same.

## Screenshots

### Before

<img width="1392" alt="before" src="https://github.com/user-attachments/assets/0537573e-3e79-4018-9ae6-ff4ca3e0dc37" />

### After

<img width="1392" alt="after" src="https://github.com/user-attachments/assets/26995b2c-e9d8-40a2-a338-f989fbb601be" />

P.S. I’ve confirmed the tests were run locally on the latest trunk branch with a fresh WordPress installation.
