### PR TITLE
Fix: Category renaming not reflected in Latest Posts block during page edit

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -42,7 +42,7 @@ import {
 import { store as coreStore } from '@wordpress/core-data';
 import { store as noticeStore } from '@wordpress/notices';
 import { useInstanceId } from '@wordpress/compose';
-import { createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -160,6 +160,30 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 			selectedAuthor,
 		]
 	);
+
+	// Update category names in attributes if they've changed.
+	useEffect( () => {
+		if ( categoriesList && categories && categories.length > 0 ) {
+			const categoriesNeedUpdate = categories.some( ( cat ) => {
+				const currentCategory = categoriesList.find(
+					( apiCat ) => apiCat.id === cat.id
+				);
+				return currentCategory && currentCategory.name !== cat.name;
+			} );
+
+			if ( categoriesNeedUpdate ) {
+				const updatedCategories = categories.map( ( cat ) => {
+					const currentCategory = categoriesList.find(
+						( apiCat ) => apiCat.id === cat.id
+					);
+					return currentCategory
+						? { ...cat, name: currentCategory.name }
+						: cat;
+				} );
+				setAttributes( { categories: updatedCategories } );
+			}
+		}
+	}, [ categoriesList, categories ] );
 
 	// If a user clicks to a link prevent redirection and show a warning.
 	const { createWarningNotice } = useDispatch( noticeStore );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/30256

This PR addresses issue #30256 where renaming a category doesn't update properly in existing Latest Posts blocks during page editing. When a category is renamed, the Latest Posts block continues to display the old category name until the page is refreshed or reopened.

## Testing Instructions
1. Create a test page with a Latest Posts block that displays posts from a specific category
2. Go to Categories and rename that category
3. Return to the page editor and verify the Latest Posts block immediately displays the updated category name