### PR TITLE
Feat: Render non-editable preview of navigation block for editors

### DIFF
--- a/lib/compat/wordpress-6.8/class-gutenberg-rest-posts-controller-6-8.php
+++ b/lib/compat/wordpress-6.8/class-gutenberg-rest-posts-controller-6-8.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Posts_Controller_6_6 class
+ *
+ * @package    gutenberg
+ */
+
+/**
+ * Gutenberg_REST_Posts_Controller_6_6 class
+ *
+ * `wp_navigation` currently only allow access to administrators with the
+ * `edit_theme_options` capability. In order to allow other roles to also view the templates,
+ * we need to override the permissions check for the REST API endpoints.
+ */
+class Gutenberg_REST_Posts_Controller_6_6 extends WP_REST_Posts_Controller {
+
+	/**
+	 * Checks if a given request has access to read posts of type:
+	 *  - `wp_navigation`
+	 *
+	 * @since 6.8
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( 'wp_navigation' !== $this->post_type ) {
+			return parent::get_items_permissions_check( $request );
+		}
+
+		if ( current_user_can( 'edit_posts' ) ) {
+			return true;
+		}
+
+		foreach ( get_post_types( array( 'show_in_rest' => true ), 'objects' ) as $post_type ) {
+			if ( current_user_can( $post_type->cap->edit_posts ) ) {
+				return true;
+			}
+		}
+
+		return parent::get_items_permissions_check( $request );
+	}
+
+	/**
+	 * Checks if a given request has access to read posts of type:
+	 *  - `wp_navigation`
+	 *
+	 * @since 6.8
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( 'wp_navigation' !== $this->post_type ) {
+			return parent::get_item_permissions_check( $request );
+		}
+		
+		if ( current_user_can( 'edit_posts' ) ) {
+			return true;
+		}
+		foreach ( get_post_types( array( 'show_in_rest' => true ), 'objects' ) as $post_type ) {
+			if ( current_user_can( $post_type->cap->edit_posts ) ) {
+				return true;
+			}
+		}
+
+		return parent::get_item_permissions_check( $request );
+	}
+}

--- a/lib/compat/wordpress-6.8/rest-api.php
+++ b/lib/compat/wordpress-6.8/rest-api.php
@@ -178,3 +178,22 @@ function gutenberg_register_rest_theme_fields() {
 	);
 }
 add_action( 'rest_api_init', 'gutenberg_register_rest_theme_fields' );
+
+/**
+ * Hook in to the navigation post type and modify the
+ * access control for the rest endpoint to allow lower user roles to access
+ * the templates and template parts.
+ *
+ * @param array  $args Current registered post type args.
+ * @param string $post_type Name of post type.
+ *
+ * @return array
+ */
+function gutenberg_api_posts_access_controller( $args, $post_type ) {
+	if ( 'wp_navigation' === $post_type ) {
+		$args['rest_controller_class'] = 'Gutenberg_REST_Posts_Controller_6_6';
+	}
+	return $args;
+}
+
+add_filter( 'register_post_type_args', 'gutenberg_api_posts_access_controller', 10, 2 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -43,6 +43,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 
 	// WordPress 6.8 compat.
 	require __DIR__ . '/compat/wordpress-6.8/rest-api.php';
+	require __DIR__ . '/compat/wordpress-6.8/class-gutenberg-rest-posts-controller-6-8.php';
 
 	// WordPress 6.9 compat.
 	require __DIR__ . '/compat/wordpress-6.9/class-gutenberg-hierarchical-sort.php';

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -940,6 +940,7 @@ function Navigation( {
 										}
 										templateLock={ templateLock }
 										orientation={ orientation }
+										postId={ ref }
 									/>
 								) }
 							</ResponsiveWrapper>

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -1,11 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { useEntityBlockEditor } from '@wordpress/core-data';
+import { useEntityBlockEditor, store as coreStore } from '@wordpress/core-data';
 import {
 	useInnerBlocksProps,
 	InnerBlocks,
 	store as blockEditorStore,
+	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
@@ -16,7 +17,39 @@ import { useMemo } from '@wordpress/element';
 import PlaceholderPreview from './placeholder/placeholder-preview';
 import { DEFAULT_BLOCK, PRIORITIZED_INSERTER_BLOCKS } from '../constants';
 
-export default function NavigationInnerBlocks( {
+function NonEditableNavigationInnerBlocks( {
+	hasCustomPlaceholder,
+	orientation,
+	templateLock,
+} ) {
+	useBlockEditingMode( 'disabled' );
+
+	const [ blocks ] = useEntityBlockEditor( 'postType', 'wp_navigation' );
+
+	const showPlaceholder = ! hasCustomPlaceholder && ! blocks?.length;
+	const placeholder = useMemo( () => <PlaceholderPreview />, [] );
+
+	const innerBlocksProps = useInnerBlocksProps(
+		{
+			className: 'wp-block-navigation__container',
+		},
+		{
+			value: blocks,
+			onInput: () => {},
+			onChange: () => {},
+			orientation,
+			templateLock,
+			renderAppender: false,
+			placeholder: showPlaceholder ? placeholder : undefined,
+			__experimentalCaptureToolbars: true,
+			__unstableDisableLayoutClassNames: true,
+		}
+	);
+
+	return <div { ...innerBlocksProps } />;
+}
+
+function EditableNavigationInnerBlocks( {
 	clientId,
 	hasCustomPlaceholder,
 	orientation,
@@ -107,4 +140,48 @@ export default function NavigationInnerBlocks( {
 	);
 
 	return <div { ...innerBlocksProps } />;
+}
+
+export default function NavigationInnerBlocks( {
+	clientId,
+	hasCustomPlaceholder,
+	orientation,
+	templateLock,
+	postId,
+} ) {
+	const { canViewNavigation, canEditNavigation } = useSelect(
+		( select ) => {
+			return {
+				canViewNavigation: !! select( coreStore ).canUser( 'read', {
+					kind: 'postType',
+					name: 'wp_navigation',
+					id: postId,
+				} ),
+				canEditNavigation: !! select( coreStore ).canUser( 'update', {
+					kind: 'postType',
+					name: 'wp_navigation',
+					id: postId,
+				} ),
+			};
+		},
+		[ postId ]
+	);
+
+	if ( ! canViewNavigation ) {
+		return null;
+	}
+
+	const NavigationInnerBlocksComponent = canEditNavigation
+		? EditableNavigationInnerBlocks
+		: NonEditableNavigationInnerBlocks;
+
+	return (
+		<NavigationInnerBlocksComponent
+			clientId={ clientId }
+			hasCustomPlaceholder={ hasCustomPlaceholder }
+			orientation={ orientation }
+			templateLock={ templateLock }
+			postId={ postId }
+		/>
+	);
 }


### PR DESCRIPTION
## Devnote
* Please go through the discussions on #69794 and #69806 first.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #60809

Merges: #69794 and #69806
<!-- In a few words, what is the PR actually doing? -->

Adds a new non-editable mode to the Navigation block that renders the block list as disabled and non-editable.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This mode will be needed to render a preview of navigation block for users (e.g. editors) that can view a navigation block but not edit it. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
1. Modify the navigation rest endpoint to allow any user role with the edit_post capability to view entities.
    * Overwriting the `get_items_permissions_check` and `get_item_permissions_check` methods of the `rest_controller_class` of the `wp_navigation` post type to check whether the current user can edit_posts.
2. Adding a user capability check before rendering the editable Navigation block preview and for users that cannot edit it rendering an alternative locked down mode.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
1. Login as admin role.
3. Insert Navigation block.
4. Logout and login as editor role.
5. Go to the post, take over.
6. You'll see that you can see the block but can't select or edit it.