### PR TITLE
REST API: add has_theme_json field to WP_REST_Themes_Controller class

### DIFF
--- a/backport-changelog/6.9/8665.md
+++ b/backport-changelog/6.9/8665.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/8665
+
+* https://github.com/WordPress/gutenberg/pull/69857

--- a/lib/compat/wordpress-6.9/rest-api.php
+++ b/lib/compat/wordpress-6.9/rest-api.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * PHP and WordPress configuration compatibility functions for the Gutenberg
+ * editor plugin changes related to REST API.
+ *
+ * @package gutenberg
+ */
+
+
+/**
+ * Registers `has_theme_json` field for the active theme.
+ *
+ * Note: Backports into the wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php file.
+ *
+ * @return void
+ */
+function gutenberg_register_rest_theme_has_theme_json_fields() {
+	register_rest_field(
+		'theme',
+		'has_theme_json',
+		array(
+			'get_callback' => static function () {
+				return wp_theme_has_theme_json();
+			},
+			'schema'       => array(
+				'description' => __( 'Whether the theme has a theme.json file.' ),
+				'type'        => 'boolean',
+				'readonly'    => true,
+			),
+		)
+	);
+}
+add_action( 'rest_api_init', 'gutenberg_register_rest_theme_has_theme_json_fields' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -46,6 +46,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 
 	// WordPress 6.9 compat.
 	require __DIR__ . '/compat/wordpress-6.9/class-gutenberg-hierarchical-sort.php';
+	require __DIR__ . '/compat/wordpress-6.9/rest-api.php';
 
 	// Plugin specific code.
 	require_once __DIR__ . '/class-wp-rest-global-styles-controller-gutenberg.php';

--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -31,12 +31,10 @@ function AppLayout() {
 
 export default function App() {
 	useRegisterSiteEditorRoutes();
-	const { routes, currentTheme, editorSettings } = useSelect( ( select ) => {
+	const { routes, currentTheme } = useSelect( ( select ) => {
 		return {
 			routes: unlock( select( editSiteStore ) ).getRoutes(),
 			currentTheme: select( coreStore ).getCurrentTheme(),
-			// This is a temp solution until the has_theme_json value is available for the current theme.
-			editorSettings: select( editSiteStore ).getSettings(),
 		};
 	}, [] );
 
@@ -59,9 +57,9 @@ export default function App() {
 
 	const matchResolverArgsValue = useMemo(
 		() => ( {
-			siteData: { currentTheme, editorSettings },
+			siteData: { currentTheme },
 		} ),
-		[ currentTheme, editorSettings ]
+		[ currentTheme ]
 	);
 
 	return (

--- a/packages/edit-site/src/components/site-editor-routes/utils.js
+++ b/packages/edit-site/src/components/site-editor-routes/utils.js
@@ -8,7 +8,6 @@ export function isClassicThemeWithStyleBookSupport( siteData ) {
 	const isBlockTheme = siteData.currentTheme?.is_block_theme;
 	const supportsEditorStyles =
 		siteData.currentTheme?.theme_supports[ 'editor-styles' ];
-	// This is a temp solution until the has_theme_json value is available for the current theme.
-	const hasThemeJson = siteData.editorSettings?.supportsLayout;
+	const hasThemeJson = siteData.currentTheme?.has_theme_json;
 	return ! isBlockTheme && ( supportsEditorStyles || hasThemeJson );
 }

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -135,8 +135,7 @@ export const SiteHubMobile = memo(
 			const settings = getSettings();
 			const supportsEditorStyles =
 				currentTheme.theme_supports[ 'editor-styles' ];
-			// This is a temp solution until the has_theme_json value is available for the current theme.
-			const hasThemeJson = settings.supportsLayout;
+			const hasThemeJson = currentTheme.has_theme_json;
 
 			return {
 				dashboardLink: settings.__experimentalDashboardLink,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Core ticket: https://core.trac.wordpress.org/ticket/63253

See: https://github.com/WordPress/gutenberg/issues/68036#issuecomment-2703037573

## Why?

Currently, we are exposing Stylebook for the classic theme by checking [the value of `supportsLayout`](https://github.com/t-hamano/wordpress-develop/blob/ed2f2ecd3fa043eca3a064a95fcb4830b5c0765c/src/wp-admin/site-editor.php#L157) as one of the conditions. However, there is no guarantee that this setting will remain equivalent to `wp_theme_has_theme_json()` in the future.

We should expose the new `has_theme_json` field via the theme REST API.

## How?

Add a new `has_theme_json` field to the `WP_REST_Themes_Controller` class.

## Testing Instructions

- Run `wp.data.select('core').getCurrentTheme()` in the browser console.
- Confirm that the response includes the `has_theme_json` field.