### PR TITLE
Fix: Update the static text and make them translatable in the Blocks example.

### DIFF
--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -39,7 +39,7 @@ export const settings = {
 			{
 				name: 'core/paragraph',
 				attributes: {
-					content: __( '<strong>Snow Patrol</strong>' ),
+					content: `<strong>${ __( 'Snow Patrol' ) }</strong>`,
 					align: 'center',
 				},
 			},

--- a/packages/block-library/src/details/index.js
+++ b/packages/block-library/src/details/index.js
@@ -20,7 +20,7 @@ export const settings = {
 	icon,
 	example: {
 		attributes: {
-			summary: 'La Mancha',
+			summary: __( 'La Mancha' ),
 			showContent: true,
 		},
 		innerBlocks: [

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -22,7 +22,7 @@ export const settings = {
 	icon,
 	example: {
 		attributes: {
-			citation: 'Julio Cortázar',
+			citation: __( 'Julio Cortázar' ),
 		},
 		innerBlocks: [
 			{

--- a/packages/block-library/src/table/index.js
+++ b/packages/block-library/src/table/index.js
@@ -48,7 +48,7 @@ export const settings = {
 							tag: 'td',
 						},
 						{
-							content: 'Jaco Pastorius',
+							content: __( 'Jaco Pastorius' ),
 							tag: 'td',
 						},
 						{
@@ -64,7 +64,7 @@ export const settings = {
 							tag: 'td',
 						},
 						{
-							content: 'Betty Carter',
+							content: __( 'Betty Carter' ),
 							tag: 'td',
 						},
 						{
@@ -80,7 +80,7 @@ export const settings = {
 							tag: 'td',
 						},
 						{
-							content: 'Bebo Valdés',
+							content: __( 'Bebo Valdés' ),
 							tag: 'td',
 						},
 						{


### PR DESCRIPTION
## What?

Fixes #69853

This PR updates example content in the blocks to make it translatable by replacing hardcoded text with translatable strings using the ` wp.i18n.__()` function.

## Why?

This PR is necessary because some example content in the blocks is currently hardcoded and not translatable, which prevents proper localization in different languages (e.g., Japanese). This update ensures that content can be properly localized for users in all locales.

## How?

Replacing hardcoded text in block examples with `wp.i18n.__()` for translation.