### PR TITLE
Enhanced hint for color picker #49259

### DIFF
--- a/packages/components/src/color-palette/index.tsx
+++ b/packages/components/src/color-palette/index.tsx
@@ -271,6 +271,11 @@ function UnforwardedColorPalette(
 							className="components-color-palette__custom-color-wrapper"
 							spacing={ 0 }
 						>
+							<span className="components-color-palette__custom-color-hint">
+								{ __(
+									'Preview of selected color - Click for custom color'
+								) }
+							</span>
 							<button
 								ref={ customColorPaletteCallbackRef }
 								className="components-color-palette__custom-color-button"

--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -75,3 +75,10 @@ $border-as-box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.2);
 		visibility: hidden;
 	}
 }
+
+.components-color-palette__custom-color-hint {
+	font-size: 12px;
+	color: #757575;
+	margin-bottom: 4px;
+	text-align: left;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes [#49259](https://github.com/WordPress/gutenberg/issues/49259)

This PR adds a hint to the color preview field in the Block Editor to help users understand that clicking it opens the custom color selector.

## Why?
This PR addresses an issue where users, particularly WordPress newcomers, find it non-intuitive that clicking the color preview field opens the custom color selector. Adding a simple hint above the field will improve user experience by making this functionality more discoverable.

## How?
- Modified the `PreviewField` component in `packages/edit-site/src/components/page-templates/fields.js` to include a hint text above the color preview field.
- Updated the relevant styles in `packages/block-library/src/navigation/editor.scss` to ensure the hint is displayed correctly.

## Testing Instructions
1. Open a post or page in the WordPress editor.
2. Insert a paragraph block.
3. Click in the Settings Sidebar on Color -> Background.
4. Verify that a hint text "Preview of selected color - Click for custom color" is displayed above the color preview field.
5. Click on the color preview field and ensure the custom color selector opens as expected.

### Testing Instructions for Keyboard
1. Navigate to the color preview field using the keyboard.
2. Verify the hint text is announced by screen readers.
3. Press Enter or Space to open the custom color selector.

## Screenshots or screencast

|Before|After|
|-|-|
|![Before](https://user-images.githubusercontent.com/32030147/226852677-6d602254-8966-433b-b317-5409715cad14.png)|<img width="271" alt="Screenshot 2025-04-09 at 12 26 03 PM" src="https://github.com/user-attachments/assets/aae78b89-48d3-4b24-a7bb-14c15ab78835" />|