### PR TITLE
Fix Correct alignment of third-level submenus in right-justified navigation

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -394,8 +394,8 @@ button.wp-block-navigation-item__content {
 		}
 		@include break-medium {
 			.wp-block-navigation__submenu-container {
-				left: auto;
-				right: 100%;
+				left: 100%;
+				right: auto;
 			}
 		}
 	}


### PR DESCRIPTION
## What?

Fixes #69868

This PR fixes the alignment issue with third-level submenus in right-justified navigation blocks.

## Why?

This fix resolves the issue where third-level dropdowns in right-justified navigation blocks would appear misaligned, with arrows pointing to the wrong side. This ensures consistent and correct positioning of nested menus.

## How?

Applied `left: 100%` and `right: auto` to properly align third-level submenus in right-justified navigation blocks.

## Testing Instructions

1. Create a navigation block with nested menus (parent > child > grandchild).

2. Set the "Justify Items Right" option.

3. View the site and test the dropdowns, ensuring that the third-level submenu aligns correctly to the right.