### PR TITLE
CustomSelectControlV2: Make disabled cursor style consistent

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## Unreleased
 
-### Documentation 
+### Documentation
 
 -   `Popover`: Expose Popover TypeScript types for subcomponents. ([#69619](https://github.com/WordPress/gutenberg/pull/69619))
 
 ### Internal
 
 -   Update `gradient-parser` to version `1.0.2` ([#69783](https://github.com/WordPress/gutenberg/pull/69783)).
+-   `CustomSelectControlV2`: Make disabled cursor style consistent ([#69870](https://github.com/WordPress/gutenberg/pull/69870)).
 
 ### Bug Fixes
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Documentation
 
 -   `Popover`: Expose Popover TypeScript types for subcomponents. ([#69619](https://github.com/WordPress/gutenberg/pull/69619))
+-   `CustomSelectControlV2`: Make disabled cursor style consistent ([#69870](https://github.com/WordPress/gutenberg/pull/69870)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,7 +9,6 @@
 ### Internal
 
 -   Update `gradient-parser` to version `1.0.2` ([#69783](https://github.com/WordPress/gutenberg/pull/69783)).
--   `CustomSelectControlV2`: Make disabled cursor style consistent ([#69870](https://github.com/WordPress/gutenberg/pull/69870)).
 
 ### Bug Fixes
 

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -164,9 +164,10 @@ export const SelectItem = styled( Ariakit.SelectItem )(
 		padding-block: ${ space( 2 ) };
 		scroll-margin: ${ space( 1 ) };
 		user-select: none;
+		cursor: pointer;
 
 		&[aria-disabled='true'] {
-			cursor: not-allowed;
+			cursor: default;
 		}
 
 		&[data-active-item] {

--- a/packages/components/src/custom-select-control-v2/styles.ts
+++ b/packages/components/src/custom-select-control-v2/styles.ts
@@ -154,7 +154,7 @@ export const SelectItem = styled( Ariakit.SelectItem )(
 	}: {
 		size: NonNullable< CustomSelectButtonSize[ 'size' ] >;
 	} ) => css`
-		cursor: default;
+		cursor: pointer;
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
@@ -164,7 +164,6 @@ export const SelectItem = styled( Ariakit.SelectItem )(
 		padding-block: ${ space( 2 ) };
 		scroll-margin: ${ space( 1 ) };
 		user-select: none;
-		cursor: pointer;
 
 		&[aria-disabled='true'] {
 			cursor: default;


### PR DESCRIPTION
## What?

Follow up: https://github.com/WordPress/gutenberg/issues/63756

In `CustomSelectControlV2` items, show `cursor: pointer` when interactive and `cursor: default` when disabled.

## Why?
To make consistent with other components 

## Testing Instructions
1. Run `npm run storybook:dev`
2. Search for story for CustomSelectControlV2.
3. Here is the diff which needs to be added to add at least one disabled item

<details>
<summary> Code diff</summary>

```tsx

diff --git a/packages/components/src/custom-select-control-v2/stories/index.story.tsx b/packages/components/src/custom-select-control-v2/stories/index.story.tsx
index b65c599ec9..a0edf51639 100644
--- a/packages/components/src/custom-select-control-v2/stories/index.story.tsx
+++ b/packages/components/src/custom-select-control-v2/stories/index.story.tsx
@@ -74,7 +74,7 @@ Default.args = {
                        <CustomSelectControlV2.Item value="Blue">
                                <span style={ { color: 'blue' } }>Blue</span>
                        </CustomSelectControlV2.Item>
-                       <CustomSelectControlV2.Item value="Purple">
+                       <CustomSelectControlV2.Item aria-disabled="true" value="Purple">
                                <span style={ { color: 'purple' } }>Purple</span>
                        </CustomSelectControlV2.Item>
                        <CustomSelectControlV2.Item value="Pink">

```
</details>


## Screencast 

https://github.com/user-attachments/assets/17137aad-9ea8-4e34-8ab4-880deb76c551



