### PR TITLE
Fix Featured Image Overflow  when inside Column

### DIFF
--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -13,7 +13,8 @@
 			"role": "content"
 		},
 		"aspectRatio": {
-			"type": "string"
+			"type": "string",
+			"default": "auto"
 		},
 		"width": {
 			"type": "string"


### PR DESCRIPTION
## What?
This PR adds a default auto to the aspect ratio for the featured image to set the original aspect ratio as default.

## Why?
Reference Issue: https://github.com/WordPress/gutenberg/issues/52238

## How?
I have added the default property as auto for aspectRatio in block.json for post featured image.

## Testing Instructions
1. Create a new page and add a columns block with uneven division (eg 30/70)
2. Add the featured image to the shorter column. 
3. Save the post and view it on the frontend.
4. The image should properly fit inside the column without overflow issues.

