### PR TITLE
Add Small Formatting Option in Table Cell

### DIFF
--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -58,6 +58,7 @@ import {
 } from './state';
 import { Caption } from '../utils/caption';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+import { registerCustomFormatTypes } from './format.js';
 
 const ALIGNMENT_CONTROLS = [
 	{
@@ -92,6 +93,9 @@ function TSection( { name, ...props } ) {
 	const TagName = `t${ name }`;
 	return <TagName { ...props } />;
 }
+
+// Register the custom format types.
+registerCustomFormatTypes();
 
 function TableEdit( {
 	attributes,

--- a/packages/block-library/src/table/format.js
+++ b/packages/block-library/src/table/format.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { registerFormatType, toggleFormat } from '@wordpress/rich-text';
+import { RichTextToolbarButton } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+export const registerCustomFormatTypes = () => {
+	registerFormatType( 'custom-formats/small', {
+		title: __( 'Small' ),
+		tagName: 'small',
+		className: null,
+		edit: ( { isActive, onChange, value } ) => {
+			return (
+				<RichTextToolbarButton
+					icon="text" // You can use an appropriate icon from WordPress
+					title={ __( 'Small' ) }
+					onClick={ () => {
+						onChange(
+							toggleFormat( value, {
+								type: 'custom-formats/small',
+							} )
+						);
+					} }
+					isActive={ isActive }
+				/>
+			);
+		},
+	} );
+};


### PR DESCRIPTION
## What?
This PR adds the small formatting option in the table cell.

## Why?
Reference Issue: https://github.com/WordPress/gutenberg/issues/49744

## How?
I have registered a format type in the Formatting API to allow small formatting to be added in the block toolbar.

## Testing Instructions
1. Add the table block on the page.
2. Add some text in a cell and open the formatting dropdown.
3. Click on the small option and ensure the text converts to small text.

