### PR TITLE
Command Palette: Add "Design" and "Styles" command for classic theme

### DIFF
--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -280,9 +280,13 @@ const getSiteEditorBasicNavigationCommands = () =>
 		const isSiteEditor = getPath( window.location.href )?.includes(
 			'site-editor.php'
 		);
-		const { isBlockBasedTheme, canCreateTemplate } = useSelect(
-			( select ) => {
+		const { isSupportEditorStyles, isBlockBasedTheme, canCreateTemplate } =
+			useSelect( ( select ) => {
 				return {
+					isSupportEditorStyles:
+						select( coreStore ).getCurrentTheme().theme_supports[
+							'editor-styles'
+						],
 					isBlockBasedTheme:
 						select( coreStore ).getCurrentTheme()?.is_block_theme,
 					canCreateTemplate: select( coreStore ).canUser( 'create', {
@@ -290,88 +294,107 @@ const getSiteEditorBasicNavigationCommands = () =>
 						name: 'wp_template',
 					} ),
 				};
-			},
-			[]
-		);
+			}, [] );
 		const commands = useMemo( () => {
 			const result = [];
 
-			if ( canCreateTemplate && isBlockBasedTheme ) {
-				result.push( {
-					name: 'core/edit-site/open-navigation',
-					label: __( 'Navigation' ),
-					icon: navigation,
-					callback: ( { close } ) => {
-						if ( isSiteEditor ) {
-							history.navigate( '/navigation' );
-						} else {
-							document.location = addQueryArgs(
-								'site-editor.php',
-								{
-									p: '/navigation',
-								}
-							);
-						}
-						close();
-					},
-				} );
+			if ( canCreateTemplate ) {
+				if ( isBlockBasedTheme ) {
+					result.push( {
+						name: 'core/edit-site/open-navigation',
+						label: __( 'Navigation' ),
+						icon: navigation,
+						callback: ( { close } ) => {
+							if ( isSiteEditor ) {
+								history.navigate( '/navigation' );
+							} else {
+								document.location = addQueryArgs(
+									'site-editor.php',
+									{
+										p: '/navigation',
+									}
+								);
+							}
+							close();
+						},
+					} );
 
-				result.push( {
-					name: 'core/edit-site/open-styles',
-					label: __( 'Styles' ),
-					icon: styles,
-					callback: ( { close } ) => {
-						if ( isSiteEditor ) {
-							history.navigate( '/styles' );
-						} else {
-							document.location = addQueryArgs(
-								'site-editor.php',
-								{
-									p: '/styles',
-								}
-							);
-						}
-						close();
-					},
-				} );
+					result.push( {
+						name: 'core/edit-site/open-styles',
+						label: __( 'Styles' ),
+						icon: styles,
+						callback: ( { close } ) => {
+							if ( isSiteEditor ) {
+								history.navigate( '/styles' );
+							} else {
+								document.location = addQueryArgs(
+									'site-editor.php',
+									{
+										p: '/styles',
+									}
+								);
+							}
+							close();
+						},
+					} );
 
-				result.push( {
-					name: 'core/edit-site/open-pages',
-					label: __( 'Pages' ),
-					icon: page,
-					callback: ( { close } ) => {
-						if ( isSiteEditor ) {
-							history.navigate( '/page' );
-						} else {
-							document.location = addQueryArgs(
-								'site-editor.php',
-								{
-									p: '/page',
-								}
-							);
-						}
-						close();
-					},
-				} );
+					result.push( {
+						name: 'core/edit-site/open-pages',
+						label: __( 'Pages' ),
+						icon: page,
+						callback: ( { close } ) => {
+							if ( isSiteEditor ) {
+								history.navigate( '/page' );
+							} else {
+								document.location = addQueryArgs(
+									'site-editor.php',
+									{
+										p: '/page',
+									}
+								);
+							}
+							close();
+						},
+					} );
 
-				result.push( {
-					name: 'core/edit-site/open-templates',
-					label: __( 'Templates' ),
-					icon: layout,
-					callback: ( { close } ) => {
-						if ( isSiteEditor ) {
-							history.navigate( '/template' );
-						} else {
-							document.location = addQueryArgs(
-								'site-editor.php',
-								{
-									p: '/template',
-								}
-							);
-						}
-						close();
-					},
-				} );
+					result.push( {
+						name: 'core/edit-site/open-templates',
+						label: __( 'Templates' ),
+						icon: layout,
+						callback: ( { close } ) => {
+							if ( isSiteEditor ) {
+								history.navigate( '/template' );
+							} else {
+								document.location = addQueryArgs(
+									'site-editor.php',
+									{
+										p: '/template',
+									}
+								);
+							}
+							close();
+						},
+					} );
+				} else if ( isSupportEditorStyles ) {
+					result.push( {
+						name: 'core/edit-site/open-stylebook',
+						label: __( 'Stylebook' ),
+						icon: styles,
+						callback: ( { close } ) => {
+							if ( isSiteEditor ) {
+								history.navigate( '/stylebook' );
+							} else {
+								document.location = addQueryArgs(
+									'site-editor.php',
+									{
+										p: '/stylebook',
+									}
+								);
+							}
+							close();
+						},
+					} );
+				}
 			}
 
 			result.push( {

--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -298,105 +298,6 @@ const getSiteEditorBasicNavigationCommands = () =>
 		const commands = useMemo( () => {
 			const result = [];
 
-			if ( canCreateTemplate ) {
-				if ( isBlockBasedTheme ) {
-					result.push( {
-						name: 'core/edit-site/open-navigation',
-						label: __( 'Navigation' ),
-						icon: navigation,
-						callback: ( { close } ) => {
-							if ( isSiteEditor ) {
-								history.navigate( '/navigation' );
-							} else {
-								document.location = addQueryArgs(
-									'site-editor.php',
-									{
-										p: '/navigation',
-									}
-								);
-							}
-							close();
-						},
-					} );
-
-					result.push( {
-						name: 'core/edit-site/open-styles',
-						label: __( 'Styles' ),
-						icon: styles,
-						callback: ( { close } ) => {
-							if ( isSiteEditor ) {
-								history.navigate( '/styles' );
-							} else {
-								document.location = addQueryArgs(
-									'site-editor.php',
-									{
-										p: '/styles',
-									}
-								);
-							}
-							close();
-						},
-					} );
-
-					result.push( {
-						name: 'core/edit-site/open-pages',
-						label: __( 'Pages' ),
-						icon: page,
-						callback: ( { close } ) => {
-							if ( isSiteEditor ) {
-								history.navigate( '/page' );
-							} else {
-								document.location = addQueryArgs(
-									'site-editor.php',
-									{
-										p: '/page',
-									}
-								);
-							}
-							close();
-						},
-					} );
-
-					result.push( {
-						name: 'core/edit-site/open-templates',
-						label: __( 'Templates' ),
-						icon: layout,
-						callback: ( { close } ) => {
-							if ( isSiteEditor ) {
-								history.navigate( '/template' );
-							} else {
-								document.location = addQueryArgs(
-									'site-editor.php',
-									{
-										p: '/template',
-									}
-								);
-							}
-							close();
-						},
-					} );
-				} else if ( isSupportEditorStyles ) {
-					result.push( {
-						name: 'core/edit-site/open-stylebook',
-						label: __( 'Stylebook' ),
-						icon: styles,
-						callback: ( { close } ) => {
-							if ( isSiteEditor ) {
-								history.navigate( '/stylebook' );
-							} else {
-								document.location = addQueryArgs(
-									'site-editor.php',
-									{
-										p: '/stylebook',
-									}
-								);
-							}
-							close();
-						},
-					} );
-				}
-			}
-
 			result.push( {
 				name: 'core/edit-site/open-patterns',
 				label: __( 'Patterns' ),
@@ -420,6 +321,107 @@ const getSiteEditorBasicNavigationCommands = () =>
 					}
 				},
 			} );
+
+			if ( ! canCreateTemplate ) {
+				return result;
+			}
+
+			if ( isBlockBasedTheme ) {
+				result.push( {
+					name: 'core/edit-site/open-navigation',
+					label: __( 'Navigation' ),
+					icon: navigation,
+					callback: ( { close } ) => {
+						if ( isSiteEditor ) {
+							history.navigate( '/navigation' );
+						} else {
+							document.location = addQueryArgs(
+								'site-editor.php',
+								{
+									p: '/navigation',
+								}
+							);
+						}
+						close();
+					},
+				} );
+
+				result.push( {
+					name: 'core/edit-site/open-styles',
+					label: __( 'Styles' ),
+					icon: styles,
+					callback: ( { close } ) => {
+						if ( isSiteEditor ) {
+							history.navigate( '/styles' );
+						} else {
+							document.location = addQueryArgs(
+								'site-editor.php',
+								{
+									p: '/styles',
+								}
+							);
+						}
+						close();
+					},
+				} );
+
+				result.push( {
+					name: 'core/edit-site/open-pages',
+					label: __( 'Pages' ),
+					icon: page,
+					callback: ( { close } ) => {
+						if ( isSiteEditor ) {
+							history.navigate( '/page' );
+						} else {
+							document.location = addQueryArgs(
+								'site-editor.php',
+								{
+									p: '/page',
+								}
+							);
+						}
+						close();
+					},
+				} );
+
+				result.push( {
+					name: 'core/edit-site/open-templates',
+					label: __( 'Templates' ),
+					icon: layout,
+					callback: ( { close } ) => {
+						if ( isSiteEditor ) {
+							history.navigate( '/template' );
+						} else {
+							document.location = addQueryArgs(
+								'site-editor.php',
+								{
+									p: '/template',
+								}
+							);
+						}
+						close();
+					},
+				} );
+			} else if ( isSupportEditorStyles ) {
+				result.push( {
+					name: 'core/edit-site/open-stylebook',
+					label: __( 'Stylebook' ),
+					icon: styles,
+					callback: ( { close } ) => {
+						if ( isSiteEditor ) {
+							history.navigate( '/stylebook' );
+						} else {
+							document.location = addQueryArgs(
+								'site-editor.php',
+								{
+									p: '/stylebook',
+								}
+							);
+						}
+						close();
+					},
+				} );
+			}
 
 			return result;
 		}, [ history, isSiteEditor, canCreateTemplate, isBlockBasedTheme ] );

--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -91,9 +91,13 @@ const getEditorCommandLoader = () =>
 		const { openModal, enableComplementaryArea, disableComplementaryArea } =
 			useDispatch( interfaceStore );
 		const { getCurrentPostId } = useSelect( editorStore );
-		const { isBlockBasedTheme, canCreateTemplate } = useSelect(
-			( select ) => {
+		const { isSupportEditorStyles, isBlockBasedTheme, canCreateTemplate } =
+			useSelect( ( select ) => {
 				return {
+					isSupportEditorStyles:
+						select( coreStore ).getCurrentTheme().theme_supports[
+							'editor-styles'
+						],
 					isBlockBasedTheme:
 						select( coreStore ).getCurrentTheme()?.is_block_theme,
 					canCreateTemplate: select( coreStore ).canUser( 'create', {
@@ -101,9 +105,8 @@ const getEditorCommandLoader = () =>
 						name: 'wp_template',
 					} ),
 				};
-			},
-			[]
-		);
+			}, [] );
+
 		const allowSwitchEditorMode =
 			isCodeEditingEnabled && isRichEditingEnabled;
 
@@ -285,14 +288,21 @@ const getEditorCommandLoader = () =>
 				},
 			} );
 		}
-		if ( canCreateTemplate && isBlockBasedTheme ) {
+		if (
+			canCreateTemplate &&
+			( isBlockBasedTheme || isSupportEditorStyles )
+		) {
+			const label = isBlockBasedTheme
+				? __( 'Open Site Editor' )
+				: __( 'Open Design' );
+
 			const isSiteEditor = getPath( window.location.href )?.includes(
 				'site-editor.php'
 			);
 			if ( ! isSiteEditor ) {
 				commands.push( {
 					name: 'core/go-to-site-editor',
-					label: __( 'Open Site Editor' ),
+					label,
 					callback: ( { close } ) => {
 						close();
 						document.location = 'site-editor.php';


### PR DESCRIPTION
## What?
This PR addresses issue by adding navigation commands for classic themes
Closes: #69854


## Why?
Currently, block themes have commands to access the Site Editor and Styles, but classic themes that support StyleBook lack equivalent navigation options. 

## How?
The implementation adds StyleBook navigation support for classic themes with the following approach:

1. Added detection for themes that support editor styles using `isSupportEditorStyles` flag
2. Modified navigation command logic to show appropriate options based on theme capabilities:
    - For block themes: Maintained existing command and all site editor navigation commands
    - For classic themes with editor styles: Added "Open Design" command and "Stylebook" navigation option   
    - For themes without editor styles support: No site editor commands shown

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/248d00b2-9628-4f46-bf78-b18d94755749

https://github.com/user-attachments/assets/6ef988af-fe3b-46f4-bfbb-9cefd3bb7a2f
