### PR TITLE
DataViews: Always show primary action for list layout if hover isn't supported

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -45,6 +45,15 @@ div.dataviews-view-list {
 			}
 		}
 
+		@media (hover: none) {
+			// Show primary action on devices that do not support hover.
+			.dataviews-view-list__item-actions > :not(:last-child) {
+				flex-basis: min-content;
+				width: auto;
+				overflow: unset;
+			}
+		}
+
 		&.is-selected.is-selected {
 			border-top: 1px solid rgba(var(--wp-admin-theme-color--rgb), 0.12);
 


### PR DESCRIPTION
## What?
Follow up to #69846
Related https://github.com/WordPress/gutenberg/pull/69846#pullrequestreview-2752899435

This PR ensures the primary action button is shown by default on screens that do not support the hover media query.

## Why?

1. To make it consistent with the table layout.
2. To make the `Primary Action Button` accessible on devices that do not support `hover` media query. 

## How?

The corresponding visibility styles were added within the `@media (hover: none)` query.

## Testing Instructions

1. Navigate to Appearance -> Editor -> Pages.
2. Make sure that the data is displayed in List Layout.
3. Confirm that in Mobile Layout, the `Primary Action`, i.e., `Edit` is appropriately displayed.

### Testing Instructions for Keyboard
Same.

## Screenshots

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/a76b6930-3f64-455d-b264-515f63eb7add)|![after](https://github.com/user-attachments/assets/6c66fe91-b8af-48a1-9441-ada137d5e987)|


