### PR TITLE
Storybook: Refactor popover stories

### DIFF
--- a/packages/components/src/popover/stories/index.story.tsx
+++ b/packages/components/src/popover/stories/index.story.tsx
@@ -247,6 +247,7 @@ export const DynamicHeight: StoryObj< typeof Popover > = {
 		},
 	],
 	args: {
+		...Default.args,
 		children: (
 			<div
 				style={ {

--- a/packages/components/src/popover/stories/index.story.tsx
+++ b/packages/components/src/popover/stories/index.story.tsx
@@ -323,6 +323,7 @@ export const WithCloseHandlers: StoryObj< typeof Popover > = {
 		);
 	},
 	args: {
+		...Default.args,
 		focusOnMount: true,
 		children: (
 			<div style={ DEFAULT_POPOVER_CONTENT_STYLE }>

--- a/packages/components/src/popover/stories/index.story.tsx
+++ b/packages/components/src/popover/stories/index.story.tsx
@@ -32,6 +32,36 @@ const AVAILABLE_PLACEMENTS: PopoverProps[ 'placement' ][] = [
 	'overlay',
 ];
 
+// Common styles for reuse
+const FULLSCREEN_CONTAINER_STYLE = {
+	width: '300vw',
+	height: '300vh',
+	display: 'flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+};
+
+const DEFAULT_POPOVER_CONTENT_STYLE = {
+	width: '280px',
+	whiteSpace: 'normal' as const,
+};
+
+const DEFAULT_POPOVER_CONTENT = (
+	<div style={ DEFAULT_POPOVER_CONTENT_STYLE }>
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+		tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+		veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+		commodo consequat.
+	</div>
+);
+
+const COMPACT_POPOVER_CONTENT = (
+	<div style={ DEFAULT_POPOVER_CONTENT_STYLE }>
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+		tempor incididunt ut labore et dolore magna aliqua.
+	</div>
+);
+
 const meta: Meta< typeof Popover > = {
 	title: 'Components/Overlays/Popover',
 	id: 'components-popover',
@@ -105,15 +135,7 @@ export const Default: StoryObj< typeof Popover > = {
 			}, [] );
 
 			return (
-				<div
-					style={ {
-						width: '300vw',
-						height: '300vh',
-						display: 'flex',
-						alignItems: 'center',
-						justifyContent: 'center',
-					} }
-				>
+				<div style={ FULLSCREEN_CONTAINER_STYLE }>
 					<Button
 						variant="secondary"
 						onClick={ toggleVisible }
@@ -127,14 +149,7 @@ export const Default: StoryObj< typeof Popover > = {
 		},
 	],
 	args: {
-		children: (
-			<div style={ { width: '280px', whiteSpace: 'normal' } }>
-				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-				eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-				enim ad minim veniam, quis nostrud exercitation ullamco laboris
-				nisi ut aliquip ex ea commodo consequat.
-			</div>
-		),
+		children: DEFAULT_POPOVER_CONTENT,
 	},
 };
 
@@ -142,7 +157,6 @@ export const Unstyled: StoryObj< typeof Popover > = {
 	...Default,
 	args: {
 		...Default.args,
-
 		variant: 'unstyled',
 	},
 };
@@ -185,13 +199,7 @@ export const AllPlacements: StoryObj< typeof Popover > = {
 		},
 	},
 	args: {
-		...Default.args,
-		children: (
-			<div style={ { width: '280px', whiteSpace: 'normal' } }>
-				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-				eiusmod tempor incididunt ut labore et dolore magna aliqua.
-			</div>
-		),
+		children: COMPACT_POPOVER_CONTENT,
 		noArrow: false,
 		offset: 10,
 		resize: false,
@@ -239,7 +247,6 @@ export const DynamicHeight: StoryObj< typeof Popover > = {
 		},
 	],
 	args: {
-		...Default.args,
 		children: (
 			<div
 				style={ {
@@ -259,7 +266,7 @@ export const WithSlotOutsideIframe: StoryObj< typeof Popover > = {
 		<PopoverInsideIframeRenderedInExternalSlot { ...args } />
 	),
 	args: {
-		...Default.args,
+		children: DEFAULT_POPOVER_CONTENT,
 	},
 };
 
@@ -293,15 +300,7 @@ export const WithCloseHandlers: StoryObj< typeof Popover > = {
 		}, [] );
 
 		return (
-			<div
-				style={ {
-					width: '300vw',
-					height: '300vh',
-					display: 'flex',
-					alignItems: 'center',
-					justifyContent: 'center',
-				} }
-			>
+			<div style={ FULLSCREEN_CONTAINER_STYLE }>
 				<Button
 					variant="secondary"
 					onClick={ toggleVisible }
@@ -322,10 +321,9 @@ export const WithCloseHandlers: StoryObj< typeof Popover > = {
 		);
 	},
 	args: {
-		...Default.args,
 		focusOnMount: true,
 		children: (
-			<div style={ { width: '280px', whiteSpace: 'normal' } }>
+			<div style={ DEFAULT_POPOVER_CONTENT_STYLE }>
 				<p>
 					Clicking outside triggers the onFocusOutside callback prop.
 				</p>

--- a/packages/components/src/popover/stories/index.story.tsx
+++ b/packages/components/src/popover/stories/index.story.tsx
@@ -199,6 +199,7 @@ export const AllPlacements: StoryObj< typeof Popover > = {
 		},
 	},
 	args: {
+		...Default.args,
 		children: COMPACT_POPOVER_CONTENT,
 		noArrow: false,
 		offset: 10,


### PR DESCRIPTION
## What?
Closes: https://github.com/WordPress/gutenberg/issues/69878


## Why?
This PR is necessary to removed the repeated elements in the popover story 

## How?
This PR introduces constants like `DEFAULT_POPOVER_CONTENT_STYLE`, `FULLSCREEN_CONTAINER_STYLE`, `DEFAULT_POPOVER_CONTENT` and `COMPACT_POPOVER_CONTENT` to avoid the repetition 

## Testing Instructions
N/A


## Screenshots or screencast 
N/A
