### PR TITLE
Fix: Footnotes not saved if Custom fields are enabled

### DIFF
--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -100,6 +100,9 @@ function register_block_core_footnotes_post_meta() {
 					'single'            => true,
 					'type'              => 'string',
 					'revisions_enabled' => true,
+					'auth_callback'     => function () {
+						return current_user_can( 'edit_posts' );
+					},
 				)
 			);
 		}
@@ -110,6 +113,26 @@ function register_block_core_footnotes_post_meta() {
  * order to catch them.
 */
 add_action( 'init', 'register_block_core_footnotes_post_meta', 20 );
+
+/**
+ * Marks the 'footnotes' meta key as protected.
+ *
+ * @since 20.7.0
+ *
+ * @param bool   $is_protected Whether the meta key is considered protected.
+ * @param string $meta_key     Meta key.
+ *
+ * @return bool Whether the meta key should be protected.
+ */
+function block_core_footnotes_is_meta_protected( $is_protected, $meta_key ) {
+	if ( 'footnotes' === $meta_key ) {
+		return true;
+	}
+	return $is_protected;
+}
+// Prevents the 'footnotes' meta field from appearing in the Custom Fields UI,
+// which can interfere with saving, see issue #54653.
+add_filter( 'is_protected_meta', 'block_core_footnotes_is_meta_protected', 10, 2 );
 
 /**
  * Adds the footnotes field to the revisions display.

--- a/packages/block-library/src/footnotes/index.php
+++ b/packages/block-library/src/footnotes/index.php
@@ -117,7 +117,7 @@ add_action( 'init', 'register_block_core_footnotes_post_meta', 20 );
 /**
  * Marks the 'footnotes' meta key as protected.
  *
- * @since 20.7.0
+ * @since 6.9.0
  *
  * @param bool   $is_protected Whether the meta key is considered protected.
  * @param string $meta_key     Meta key.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #54653 

This PR makes the `footnotes` meta protected.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When Custom Fields are enabled, the `footnotes` do not get updated when the post is saved. This issue occurs because changes made through the REST API (Gutenberg) are overridden by the Custom Fields

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The `footnotes` meta field is set to protected so it is not shown in the custom fields, and the `auth callback` is updated to allow editors to update the footnotes.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open a post or page and enable custom fields.
2. Add footnotes and save the post.
3. Check the page on the front end.
4. Confirm that the footnotes are present as expected. (This should work as expected when editing the post for the 2nd time or later.)

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <video src="https://github.com/user-attachments/assets/ac8ecfc2-4565-42b4-806b-346da483427d"> | <video src="https://github.com/user-attachments/assets/1894dd61-4917-4b3d-9026-3201df2f9b3f"> |
