### PR TITLE
ComboboxControl: Allow additional `input` props

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -19,6 +19,7 @@
 -   `Popover`: improve Storybook examples around onClose and onFocusOutside props. ([#69688](https://github.com/WordPress/gutenberg/pull/69688))
 -   `FormTokenField`: Add theming support ([#69638](https://github.com/WordPress/gutenberg/pull/69638)).
 -   `ComboboxControl`: Add theming support ([#69638](https://github.com/WordPress/gutenberg/pull/69638)).
+-   `ComboboxControl`: Allow additional input props ([#69886](https://github.com/WordPress/gutenberg/pull/69886)).
 
 ## 29.7.0 (2025-03-27)
 

--- a/packages/components/src/combobox-control/index.tsx
+++ b/packages/components/src/combobox-control/index.tsx
@@ -35,6 +35,7 @@ import type { TokenInputProps } from '../form-token-field/types';
 import { useDeprecated36pxDefaultSizeProp } from '../utils/use-deprecated-props';
 import { withIgnoreIMEEvents } from '../utils/with-ignore-ime-events';
 import { maybeWarnDeprecated36pxSize } from '../utils/deprecated-36px-size';
+import type { WordPressComponentProps } from '../context';
 import Spinner from '../spinner';
 
 const noop = () => {};
@@ -114,7 +115,9 @@ const getIndexOfMatchingSuggestion = (
  * }
  * ```
  */
-function ComboboxControl( props: ComboboxControlProps ) {
+function ComboboxControl(
+	props: WordPressComponentProps< ComboboxControlProps, 'input', false >
+) {
 	const {
 		__nextHasNoMarginBottom = false,
 		__next40pxDefaultSize = false,
@@ -134,6 +137,7 @@ function ComboboxControl( props: ComboboxControlProps ) {
 		__experimentalRenderItem,
 		expandOnFocus = true,
 		placeholder,
+		...restProps
 	} = useDeprecated36pxDefaultSizeProp( props );
 
 	const [ value, setValue ] = useControlledValue( {
@@ -362,6 +366,7 @@ function ComboboxControl( props: ComboboxControlProps ) {
 									matchingSuggestions
 								) }
 								onChange={ onInputChange }
+								{ ...restProps }
 							/>
 						</FlexBlock>
 						{ isLoading && <Spinner /> }


### PR DESCRIPTION
## What?
Closes #69885

This PR adds support for passing additional `input` props to the `ComboboxControl` component.

## Why?

Currently, the `ComboboxControl` component does not support passing additional props to the underlying `input` element. Props such as `disabled` and `required` are examples of what consumers may want to use, as outlined in the related issue.

## How?

Since `ComboboxControl` uses `TokenInput`, which already supports additional props, simply accepting and forwarding these props allows consumers to use attributes like `required`, `disabled`, and other `input` props.

## Testing Instructions

1. Run the `storybook` server. (`npm run storybook:dev`)
2. Navigate to the `ComboboxControl` story in the codebase. (Ref. https://github.com/WordPress/gutenberg/blob/1b9916f442984b6414d76735a0293afeb7e78f3a/packages/components/src/combobox-control/stories/index.story.tsx#L84)
3. Try adding the `disabled` prop.
4. Confirm that the `ComboboxControl` becomes `disabled`.

### Testing Instructions for Keyboard

Same.
