### PR TITLE
Latest Posts: Only fetch necessary fields for categories

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -60,6 +60,7 @@ import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
  */
 const CATEGORIES_LIST_QUERY = {
 	per_page: -1,
+	_fields: 'id,name',
 	context: 'view',
 };
 const USERS_LIST_QUERY = {


### PR DESCRIPTION
## What?
PR updates query to fetch categories for the Latest Posts block to only get required fields.

## Why?
* Reduces amount of data sent over the wire.
* Prevents unnecessary data from serializing in post content. This is a progressive enhancement and will only change the data structure when the block is updated.

## Testing Instructions
1. Open a page.
2. Insert Latest Posts.
3. Confirm that category selection works as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|![CleanShot 2025-04-11 at 18 55 52](https://github.com/user-attachments/assets/a99ef23f-2b37-4f18-8f17-e663fe7e2d10)|![CleanShot 2025-04-11 at 18 56 32](https://github.com/user-attachments/assets/4a44c9e1-97d9-4c92-be30-f9c251cf5e83)|
