### PR TITLE
Latest Posts: Embed author in response

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -79,6 +79,10 @@ function getFeaturedImageDetails( post, size ) {
 	};
 }
 
+function getCurrentAuthor( post ) {
+	return post._embedded?.author?.[ 0 ];
+}
+
 export default function LatestPostsEdit( { attributes, setAttributes } ) {
 	const instanceId = useInstanceId( LatestPostsEdit );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
@@ -125,7 +129,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 					order,
 					orderby: orderBy,
 					per_page: postsToShow,
-					_embed: 'wp:featuredmedia',
+					_embed: 'author,wp:featuredmedia',
 					ignore_sticky: true,
 				} ).filter( ( [ , value ] ) => typeof value !== 'undefined' )
 			);
@@ -555,9 +559,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 				{ displayPosts.map( ( post ) => {
 					const titleTrimmed = post.title.rendered.trim();
 					let excerpt = post.excerpt.rendered;
-					const currentAuthor = authorList?.find(
-						( author ) => author.id === post.author
-					);
+					const currentAuthor = getCurrentAuthor( post );
 
 					const excerptElement = document.createElement( 'div' );
 					excerptElement.innerHTML = excerpt;


### PR DESCRIPTION
## What?
PR updates the Latest Post block to get the author as an embedded value instead of doing a lookup in the `authorList` array.

## Why?
Embedded values are great but underutilized in the block editor.

## Testing Instructions
1. Open a page.
2. Insert the Latest Posts block.
3. Toggle "Display author name".
4. Confirm that posts author names are correctly displayed.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2025-04-11 at 19 17 52](https://github.com/user-attachments/assets/e209409b-00cd-462d-a53c-6aad65f923a3)

