### PR TITLE
Webpack: Remove `IS_GUTENBERG_PLUGIN` conditionals from `PHP` files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -125,6 +125,7 @@
 				"node-watch": "0.7.0",
 				"npm-run-all": "4.1.5",
 				"patch-package": "8.0.0",
+				"php-parser": "3.2.2",
 				"postcss": "8.4.38",
 				"postcss-loader": "6.2.1",
 				"postcss-local-keyframes": "^0.0.2",
@@ -37723,6 +37724,12 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
 			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
+		},
+		"node_modules/php-parser": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/php-parser/-/php-parser-3.2.2.tgz",
+			"integrity": "sha512-voj3rzCJmEbwHwH3QteON28wA6K+JbcaJEofyUZkUXmcViiXofjbSbcE5PtqtjX6nstnnAEYCFoRq0mkjP5/cg==",
+			"dev": true
 		},
 		"node_modules/phpegjs": {
 			"version": "1.0.0-beta7",

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
 		"node-watch": "0.7.0",
 		"npm-run-all": "4.1.5",
 		"patch-package": "8.0.0",
+		"php-parser": "3.2.2",
 		"postcss": "8.4.38",
 		"postcss-loader": "6.2.1",
 		"postcss-local-keyframes": "^0.0.2",

--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -14,6 +14,9 @@ const PhpFilePathsPlugin = require( '@wordpress/scripts/plugins/php-file-paths-p
  * Internal dependencies
  */
 const { baseConfig, plugins, stylesTransform } = require( './shared' );
+const {
+	removeGutenbergPluginConditionals,
+} = require( './utils/remove-gutenberg-code-in-php' );
 
 /**
  * We need to automatically rename some functions when they are called inside block files,
@@ -156,6 +159,11 @@ module.exports = [
 									),
 									( match ) => `${ match }_${ classSuffix }`
 								);
+
+								content =
+									removeGutenbergPluginConditionals(
+										content
+									);
 
 								// Within content, search for any function definitions. For
 								// each, replace every other reference to it in the file.

--- a/tools/webpack/utils/remove-gutenberg-code-in-php.js
+++ b/tools/webpack/utils/remove-gutenberg-code-in-php.js
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+const { Engine } = require( 'php-parser' );
+
+const phpEngine = new Engine( {
+	parser: {
+		debug: false,
+		locations: true,
+		extractDoc: false,
+		suppressErrors: false,
+	},
+	ast: {
+		withPositions: true,
+	},
+} );
+
+/**
+ * Checks if code contains the Gutenberg plugin conditional
+ *
+ * @param {string} codeString The PHP code to check
+ * @param {number} start      Start position
+ * @param {number} end        End position
+ * @return {boolean} Whether the code contains the conditional
+ */
+function containsGutenbergPluginCode( codeString, start, end ) {
+	const nodeCode = codeString.substring( start, end );
+	return nodeCode.includes( 'IS_GUTENBERG_PLUGIN' );
+}
+
+/**
+ * Recursively searches for if statements with the target conditional
+ *
+ * @param {Object} node           AST node
+ * @param {string} phpCode        Original PHP code
+ * @param {Array}  rangesToRemove Array to collect ranges for removal
+ */
+function findNodesToRemove( node, phpCode, rangesToRemove ) {
+	if ( ! node || typeof node !== 'object' ) {
+		return;
+	}
+
+	if ( node.kind === 'if' && node.loc ) {
+		const start = node.loc.start.offset;
+		const end = node.loc.end.offset;
+
+		if ( containsGutenbergPluginCode( phpCode, start, end ) ) {
+			rangesToRemove.push( { start, end } );
+			return;
+		}
+	}
+
+	if ( Array.isArray( node ) ) {
+		for ( const child of node ) {
+			findNodesToRemove( child, phpCode, rangesToRemove );
+		}
+	} else {
+		for ( const prop in node ) {
+			if (
+				Object.prototype.hasOwnProperty.call( node, prop ) &&
+				node[ prop ] &&
+				typeof node[ prop ] === 'object'
+			) {
+				findNodesToRemove( node[ prop ], phpCode, rangesToRemove );
+			}
+		}
+	}
+}
+
+/**
+ * Removes if statements containing IS_GUTENBERG_PLUGIN
+ *
+ * @param {string} phpCode The PHP code to process
+ * @return {string} The processed PHP code
+ */
+function removeGutenbergPluginConditionals( phpCode ) {
+	try {
+		const ast = phpEngine.parseCode( phpCode, 'index.php' );
+		const rangesToRemove = [];
+
+		findNodesToRemove( ast, phpCode, rangesToRemove );
+
+		if ( rangesToRemove.length === 0 ) {
+			return phpCode;
+		}
+
+		rangesToRemove.sort( ( a, b ) => b.start - a.start );
+
+		let result = phpCode;
+
+		for ( const { start, end } of rangesToRemove ) {
+			result = result.substring( 0, start ) + result.substring( end );
+		}
+
+		return result;
+	} catch ( error ) {
+		return phpCode;
+	}
+}
+
+module.exports = { removeGutenbergPluginConditionals };


### PR DESCRIPTION


## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/59240

Added AST-based parsing to remove IS_GUTENBERG_PLUGIN conditionals from PHP files during the webpack build process for core.

## Why?

- When code is backported from Gutenberg to WordPress core, we need to ensure plugin-specific conditionals don't get included.
- The `IS_GUTENBERG_PLUGIN` conditionals aren't needed in core context and should be removed to keep the codebase clean and optimized.

## How?

- I evaluated two approaches: regex-based matching and AST parsing. While regex works for simple cases, it struggles with multi-line and nested conditionals.
- I Used php-parser to transform code into an AST, identify if-statements containing `IS_GUTENBERG_PLUGIN`, and remove them precisely based on their source locations.

In Gutenberg, `IS_GUTENBERG_PLUGIN` appears in three locations:

1. block-library/ - PHP files for blocks
2. test/ - Test files not merged to core
3. vendor/ - Third-party code not merged to core

When backporting to WordPress core, only the `block-library/` content is merged (as `blocks/`), making it the focus for this PR.
The build process for blocks is handled in `tools/webpack/blocks.js`, which already performs PHP transformations. I integrated the conditional removal logic into this existing process, keeping the changes focused and minimal.

## Testing Instructions

1. Run `npm run build`
2. Check `build/block-library/blocks/navigation.php` and verify that `IS_GUTENBERG_PLUGIN` conditionals have been removed
3. Compare with the source files in `packages/block-library/src/navigation/index.php` to confirm the removal was successful
4. You'd find `IS_GUTENBERG_PLUGIN` conditionals in the `packages/block-library/src/navigation/index.php` but the same conditions would be excluded in the build, This when merged in the core, would eventually solve the root of the problem.

## Screencast

https://github.com/user-attachments/assets/e1cdee4d-ce9c-4913-bcfe-00552e48fbba


