### PR TITLE
Build Tooling: Add `monocart-reporter` to collect code coverage for e2e tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -120,6 +120,7 @@
 				"mkdirp": "3.0.1",
 				"mock-match-media": "0.4.2",
 				"moment-timezone-data-webpack-plugin": "1.5.1",
+				"monocart-reporter": "2.9.17",
 				"nock": "12.0.3",
 				"node-fetch": "2.7.0",
 				"node-watch": "0.7.0",
@@ -16275,6 +16276,56 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
+		"node_modules/acorn-loose": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.4.0.tgz",
+			"integrity": "sha512-M0EUka6rb+QC4l9Z3T0nJEzNOO7JcoJlYMrBlyBCiFSXRyxjLKayd4TbQs2FDRWQU1h9FR7QVNHt+PEaoNL5rQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.11.0"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-loose/node_modules/acorn": {
+			"version": "8.14.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-walk": {
+			"version": "8.3.4",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+			"integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.11.0"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-walk/node_modules/acorn": {
+			"version": "8.14.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/add-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
@@ -18826,6 +18877,20 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/cache-content-type": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
+			"integrity": "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-types": "^2.1.18",
+				"ylru": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
 		"node_modules/cacheable-lookup": {
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
@@ -20189,6 +20254,13 @@
 			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
 			"dev": true
 		},
+		"node_modules/console-grid": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/console-grid/-/console-grid-2.2.3.tgz",
+			"integrity": "sha512-+mecFacaFxGl+1G31IsCx41taUXuW2FxX+4xIE0TIPhgML+Jb9JFcBWGhhWerd1/vhScubdmHqTwOhB0KCUUAg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/constant-case": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
@@ -20540,6 +20612,30 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
 			"integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+		},
+		"node_modules/cookies": {
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+			"integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"depd": "~2.0.0",
+				"keygrip": "~1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/cookies/node_modules/depd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
 		},
 		"node_modules/copy-concurrently": {
 			"version": "1.0.5",
@@ -21846,6 +21942,13 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/deep-equal": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+			"integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/deep-extend": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -22346,6 +22449,13 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
 			"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
+		},
+		"node_modules/delegates": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/denodeify": {
 			"version": "1.2.1",
@@ -22862,6 +22972,13 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
 			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+		},
+		"node_modules/eight-colors": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/eight-colors/-/eight-colors-1.3.1.tgz",
+			"integrity": "sha512-7nXPYDeKh6DgJDR/mpt2G7N/hCNSGwwoPVmoI3+4TEwOb07VFN1WMPG0DFf6nMEjrkgdj8Og7l7IaEEk3VE6Zg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/ejs": {
 			"version": "3.1.10",
@@ -25344,11 +25461,12 @@
 			}
 		},
 		"node_modules/foreground-child": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-			"integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+			"license": "ISC",
 			"dependencies": {
-				"cross-spawn": "^7.0.0",
+				"cross-spawn": "^7.0.6",
 				"signal-exit": "^4.0.1"
 			},
 			"engines": {
@@ -27146,6 +27264,44 @@
 				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
+		"node_modules/http-assert": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+			"integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"deep-equal": "~1.0.1",
+				"http-errors": "~1.8.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/http-assert/node_modules/http-errors": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+			"integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"depd": "~1.1.2",
+				"inherits": "2.0.4",
+				"setprototypeof": "1.2.0",
+				"statuses": ">= 1.5.0 < 2",
+				"toidentifier": "1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/http-assert/node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/http-cache-semantics": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
@@ -28454,9 +28610,10 @@
 			}
 		},
 		"node_modules/istanbul-lib-coverage": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
-			"integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=8"
 			}
@@ -28485,16 +28642,17 @@
 			}
 		},
 		"node_modules/istanbul-lib-report": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-			"integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+			"integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"istanbul-lib-coverage": "^3.0.0",
-				"make-dir": "^3.0.0",
+				"make-dir": "^4.0.0",
 				"supports-color": "^7.1.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=10"
 			}
 		},
 		"node_modules/istanbul-lib-report/node_modules/has-flag": {
@@ -28503,6 +28661,21 @@
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/istanbul-lib-report/node_modules/make-dir": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/istanbul-lib-report/node_modules/supports-color": {
@@ -28530,9 +28703,10 @@
 			}
 		},
 		"node_modules/istanbul-reports": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
-			"integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+			"integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"html-escaper": "^2.0.0",
 				"istanbul-lib-report": "^3.0.0"
@@ -30013,6 +30187,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/keygrip": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+			"integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tsscmp": "1.0.6"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -30067,6 +30254,113 @@
 			"version": "0.34.0",
 			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.34.0.tgz",
 			"integrity": "sha512-tBECoUqNFbyAY4RrbqsBQqDFpGXAEbdD5QKr8kACx3+rnArmuuR22nKQWKazvp07N9yjTyDZaw/20UIH8tL9DQ=="
+		},
+		"node_modules/koa": {
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/koa/-/koa-2.16.1.tgz",
+			"integrity": "sha512-umfX9d3iuSxTQP4pnzLOz0HKnPg0FaUUIKcye2lOiz3KPu1Y3M3xlz76dISdFPQs37P9eJz1wUpcTS6KDPn9fA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "^1.3.5",
+				"cache-content-type": "^1.0.0",
+				"content-disposition": "~0.5.2",
+				"content-type": "^1.0.4",
+				"cookies": "~0.9.0",
+				"debug": "^4.3.2",
+				"delegates": "^1.0.0",
+				"depd": "^2.0.0",
+				"destroy": "^1.0.4",
+				"encodeurl": "^1.0.2",
+				"escape-html": "^1.0.3",
+				"fresh": "~0.5.2",
+				"http-assert": "^1.3.0",
+				"http-errors": "^1.6.3",
+				"is-generator-function": "^1.0.7",
+				"koa-compose": "^4.1.0",
+				"koa-convert": "^2.0.0",
+				"on-finished": "^2.3.0",
+				"only": "~0.0.2",
+				"parseurl": "^1.3.2",
+				"statuses": "^1.5.0",
+				"type-is": "^1.6.16",
+				"vary": "^1.1.2"
+			},
+			"engines": {
+				"node": "^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4"
+			}
+		},
+		"node_modules/koa-compose": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+			"integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/koa-convert": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-2.0.0.tgz",
+			"integrity": "sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"co": "^4.6.0",
+				"koa-compose": "^4.1.0"
+			},
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/koa-static-resolver": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/koa-static-resolver/-/koa-static-resolver-1.0.6.tgz",
+			"integrity": "sha512-ZX5RshSzH8nFn05/vUNQzqw32nEigsPa67AVUr6ZuQxuGdnCcTLcdgr4C81+YbJjpgqKHfacMBd7NmJIbj7fXw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/koa/node_modules/depd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/koa/node_modules/http-errors": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+			"integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"depd": "~1.1.2",
+				"inherits": "2.0.4",
+				"setprototypeof": "1.2.0",
+				"statuses": ">= 1.5.0 < 2",
+				"toidentifier": "1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/koa/node_modules/http-errors/node_modules/depd": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+			"integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/koa/node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/kuler": {
 			"version": "2.0.0",
@@ -32474,6 +32768,13 @@
 				"lz-string": "bin/bin.js"
 			}
 		},
+		"node_modules/lz-utils": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/lz-utils/-/lz-utils-2.1.0.tgz",
+			"integrity": "sha512-CMkfimAypidTtWjNDxY8a1bc1mJdyEh04V2FfEQ5Zh8Nx4v7k850EYa+dOWGn9hKG5xOyHP5MkuduAZCTHRvJw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/macos-release": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.2.0.tgz",
@@ -34518,6 +34819,80 @@
 				"semver": "bin/semver.js"
 			}
 		},
+		"node_modules/monocart-coverage-reports": {
+			"version": "2.12.3",
+			"resolved": "https://registry.npmjs.org/monocart-coverage-reports/-/monocart-coverage-reports-2.12.3.tgz",
+			"integrity": "sha512-Do3L+UUjwFjIqlRt1fffKKsOjU6wlOuNIhly/xBGa9t6hxet+OGjbWsAV3gOsvo7PWxSZioXFF7FOLHNYrkiMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.14.1",
+				"acorn-loose": "^8.4.0",
+				"acorn-walk": "^8.3.4",
+				"commander": "^13.1.0",
+				"console-grid": "^2.2.3",
+				"eight-colors": "^1.3.1",
+				"foreground-child": "^3.3.1",
+				"istanbul-lib-coverage": "^3.2.2",
+				"istanbul-lib-report": "^3.0.1",
+				"istanbul-reports": "^3.1.7",
+				"lz-utils": "^2.1.0",
+				"monocart-locator": "^1.0.2"
+			},
+			"bin": {
+				"mcr": "lib/cli.js"
+			}
+		},
+		"node_modules/monocart-coverage-reports/node_modules/acorn": {
+			"version": "8.14.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/monocart-coverage-reports/node_modules/commander": {
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+			"integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/monocart-locator": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/monocart-locator/-/monocart-locator-1.0.2.tgz",
+			"integrity": "sha512-v8W5hJLcWMIxLCcSi/MHh+VeefI+ycFmGz23Froer9QzWjrbg4J3gFJBuI/T1VLNoYxF47bVPPxq8ZlNX4gVCw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/monocart-reporter": {
+			"version": "2.9.17",
+			"resolved": "https://registry.npmjs.org/monocart-reporter/-/monocart-reporter-2.9.17.tgz",
+			"integrity": "sha512-mRlthOt/h6MRfUFYW3xQdxCOzwdBoHlQSuU68N50vZRG1XsMN1rBkBdAbAuh2VBnAfh5+tfMXv6teosp1gqi0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"console-grid": "^2.2.3",
+				"eight-colors": "^1.3.1",
+				"koa": "^2.16.0",
+				"koa-static-resolver": "^1.0.6",
+				"lz-utils": "^2.1.0",
+				"monocart-coverage-reports": "^2.12.3",
+				"monocart-locator": "^1.0.2",
+				"nodemailer": "^6.10.0"
+			},
+			"bin": {
+				"monocart": "lib/cli.js"
+			}
+		},
 		"node_modules/morgan": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
@@ -35156,6 +35531,16 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/nodemailer": {
+			"version": "6.10.1",
+			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+			"integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+			"dev": true,
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/nopt": {
@@ -36497,6 +36882,12 @@
 			"engines": {
 				"node": ">=4"
 			}
+		},
+		"node_modules/only": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
+			"integrity": "sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==",
+			"dev": true
 		},
 		"node_modules/open": {
 			"version": "6.4.0",
@@ -44904,6 +45295,16 @@
 			"integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
 			"license": "0BSD"
 		},
+		"node_modules/tsscmp": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+			"integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6.x"
+			}
+		},
 		"node_modules/tsutils": {
 			"version": "3.21.0",
 			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
@@ -47084,18 +47485,6 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/webpack-bundle-analyzer/node_modules/acorn-walk": {
-			"version": "8.3.4",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-			"integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-			"license": "MIT",
-			"dependencies": {
-				"acorn": "^8.11.0"
-			},
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/webpack-bundle-analyzer/node_modules/commander": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -48538,6 +48927,16 @@
 			"funding": {
 				"type": "GitHub Sponsors ❤",
 				"url": "https://github.com/sponsors/dmonad"
+			}
+		},
+		"node_modules/ylru": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/ylru/-/ylru-1.4.0.tgz",
+			"integrity": "sha512-2OQsPNEmBCvXuFlIni/a+Rn+R2pHW9INm0BxXJ4hVDA8TirqMj+J/Rp9ItLatT/5pZqWwefVrTQcHpixsxnVlA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.0.0"
 			}
 		},
 		"node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
 		"mkdirp": "3.0.1",
 		"mock-match-media": "0.4.2",
 		"moment-timezone-data-webpack-plugin": "1.5.1",
+		"monocart-reporter": "2.9.17",
 		"nock": "12.0.3",
 		"node-fetch": "2.7.0",
 		"node-watch": "0.7.0",

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -14,7 +14,16 @@ const config = defineConfig( {
 	...baseConfig,
 	reporter: process.env.CI
 		? [ [ 'github' ], [ './config/flaky-tests-reporter.ts' ] ]
-		: 'list',
+		: [
+				[ 'list' ],
+				[
+					'monocart-reporter',
+					{
+						name: 'Gutenberg E2E Tests',
+						outputFile: './artifacts/monocart-report/index.html',
+					},
+				],
+		  ],
 	workers: 1,
 	globalSetup: fileURLToPath(
 		new URL( './config/global-setup.ts', 'file:' + __filename ).href


### PR DESCRIPTION
## What?
Closes #64369

This PR introduces support for collecting code coverage data from end-to-end (E2E) tests using the `monocart-reporter`.

## Why?

Currently, there's no built-in mechanism for code coverage, and `monocart-reporter` provides detailed test reports to address this gap.

## How?

The Playwright configuration has been updated to include `monocart-reporter` as one of the test reporters.

## Testing Instructions

1. Run `e2e` tests locally.
`npm run test:e2e -- --shard=5/8;`

2. View the `e2e` report using the following command.
`npx monocart show-report artifacts/monocart-report/index.html`

3. Confirm that the report is served at `http://localhost:8090/index.html`

### Testing Instructions for Keyboard
Same

## Screenshot

![report](https://github.com/user-attachments/assets/10ab8ae2-02ad-48a2-8fea-e7875fdf8879)

