### PR TITLE
Block Editor: Allow editing invalid blocks as HTML

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -179,7 +179,7 @@ function BlockListBlock( {
 
 	let block;
 
-	if ( ! isValid && mode !== 'html' ) {
+	if ( ! isValid ) {
 		const saveContent = __unstableBlockSource
 			? serializeRawBlock( __unstableBlockSource )
 			: getSaveContent( blockType, attributes );

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -179,7 +179,7 @@ function BlockListBlock( {
 
 	let block;
 
-	if ( ! isValid ) {
+	if ( ! isValid && mode !== 'html' ) {
 		const saveContent = __unstableBlockSource
 			? serializeRawBlock( __unstableBlockSource )
 			: getSaveContent( blockType, attributes );

--- a/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-mode-toggle.js
@@ -14,7 +14,7 @@ import { store as blockEditorStore } from '../../store';
 const noop = () => {};
 
 export default function BlockModeToggle( { clientId, onToggle = noop } ) {
-	const { blockType, mode, isCodeEditingEnabled } = useSelect(
+	const { blockType, mode, enabled } = useSelect(
 		( select ) => {
 			const { getBlock, getBlockMode, getSettings } =
 				select( blockEditorStore );
@@ -23,7 +23,7 @@ export default function BlockModeToggle( { clientId, onToggle = noop } ) {
 			return {
 				mode: getBlockMode( clientId ),
 				blockType: block ? getBlockType( block.name ) : null,
-				isCodeEditingEnabled: getSettings().codeEditingEnabled,
+				enabled: getSettings().codeEditingEnabled && !! block?.isValid,
 			};
 		},
 		[ clientId ]
@@ -33,7 +33,7 @@ export default function BlockModeToggle( { clientId, onToggle = noop } ) {
 	if (
 		! blockType ||
 		! hasBlockSupport( blockType, 'html', true ) ||
-		! isCodeEditingEnabled
+		! enabled
 	) {
 		return null;
 	}

--- a/packages/block-editor/src/components/block-settings-menu/test/block-mode-toggle.js
+++ b/packages/block-editor/src/components/block-settings-menu/test/block-mode-toggle.js
@@ -20,7 +20,7 @@ function setupUseSelectMock( mode, blockType, codeEditingEnabled = true ) {
 		return {
 			mode,
 			blockType,
-			isCodeEditingEnabled: codeEditingEnabled,
+			enabled: codeEditingEnabled,
 		};
 	} );
 }


### PR DESCRIPTION
## What?
Closes #7743.

PR disables "Edit as HTML" for invalid blocks in favor of "Attempt recovery" as the primary action.

## Why?
The "Edit as HTML" toggle doesn't work on `trunk`.

I know that the issue suggests leaving the option available. Still, after the initial commit, I realized that it would delay invalid content feedback and leave blocks in HTML editing mode.

## Testing Instructions
1. Create a post.
2. Add a paragraph block with some text.
3. Edit block as HTML and remove the trailing `</p>` tag.
4. Move focus to the post title.
5. Confirm that the invalid content warning is displayed.
6. Open block options.
7. Confirm that the "Edit as HTML" menu item isn't displayed.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2025-04-15 at 09 43 48](https://github.com/user-attachments/assets/6c5d38a7-05c6-4b7f-8b14-512b3f0c3706)
