### PR TITLE
Tooling: Fix `base-styles` rebuilds during `npm run dev` workflow

### DIFF
--- a/bin/packages/watch.js
+++ b/bin/packages/watch.js
@@ -63,6 +63,13 @@ function isSourceFile( filename ) {
 		.relative( process.cwd(), filename )
 		.replace( /\\/g, '/' );
 
+	// Special case for base-styles package root .scss files located outside the src/ folder.
+	// For this case we need to manually add the file to the build list, to be able to watch changes.
+	if ( /packages\/base-styles\/.*\.scss$/.test( relativePath ) ) {
+		filesToBuild.set( 'packages/base-styles/src/admin-schemes.scss', true );
+		return true;
+	}
+
 	return (
 		/\/src\/.+\.(js|json|scss|ts|tsx)$/.test( relativePath ) &&
 		! [


### PR DESCRIPTION


## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/55568 
Related comment: https://github.com/WordPress/gutenberg/issues/55568#issuecomment-1786968607

This PR adds functionality to automatically rebuild SCSS files in `base-styles/`. when base-styles partial files (like _colors.scss, _mixins.scss) are modified during `npm run dev`.


## Why?

- When working with SCSS partials in the base-styles package, changes to these files weren't automatically triggering rebuilds of the main files that import them (like admin-schemes.scss). 
- This meant developers had to manually rebuild or restart the dev server to see their changes, creating friction in the development workflow.

## How?

Modified the `isSourceFile` function as suggested in https://github.com/WordPress/gutenberg/issues/55568#issuecomment-1786968607. In a special case scenario, I am manually handling the base-styles.scss files, which are located outside the src/ folder, to ensure they are included in the build."

## Testing Instructions

1. Run npm run dev to start the development server
2. Open a base-styles partial file (e.g., `packages/base-styles/_mixins.scss`)
3. Make a simple change (e.g., modify a color value)
4. Save the file
5. Check that your changes are reflected in the compiled output without needing to restart the dev server. The files to check are ( `packages/base-styles/build-style/admin-schemes.css` )

## Screencast

### Before

Changes were not watched 

### After

https://github.com/user-attachments/assets/65343e2b-2d7a-4f19-83f6-dc8edafbf786




