### PR TITLE
Snackbar: Add support to open links in new tab

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   `Snackbar`: Add support to open links in a new tab ([#69905](https://github.com/WordPress/gutenberg/pull/69905)).
+
 ## 29.9.0 (2025-05-07)
 
 ### Enhancement

--- a/packages/components/src/notice/README.md
+++ b/packages/components/src/notice/README.md
@@ -145,6 +145,7 @@ An array of notice actions. Each member object should contain:
 
 - `label`: `string` containing the text of the button/link
 - `url`: `string` OR `onClick`: `( event: SyntheticEvent ) => void` to specify what the action does.
+- `openInNewTab`: `boolean` (optional) When set to `true`, opens the URL in a new browser tab.
 - `className`: `string` (optional) to add custom classes to the button styles.
 - `noDefaultClasses`: `boolean` (optional) A value of `true` will remove all default styling.
 - `variant`: `'primary' | 'secondary' | 'link'` (optional) You can denote a primary button action for a notice by passing a value of `primary`.

--- a/packages/components/src/notice/types.ts
+++ b/packages/components/src/notice/types.ts
@@ -20,7 +20,7 @@ type NoticeActionWithURL = CommonNoticeActionProps & {
 type NoticeActionWithOnClick = CommonNoticeActionProps & {
 	url?: never;
 	openInNewTab?: never;
-	onClick: MouseEventHandler< HTMLButtonElement >;
+	onClick: MouseEventHandler< HTMLButtonElement | HTMLAnchorElement >;
 };
 
 export type NoticeAction = NoticeActionWithURL | NoticeActionWithOnClick;

--- a/packages/components/src/notice/types.ts
+++ b/packages/components/src/notice/types.ts
@@ -14,10 +14,12 @@ type CommonNoticeActionProps = {
 // `onClick` will be ignored.
 type NoticeActionWithURL = CommonNoticeActionProps & {
 	url: string;
+	openInNewTab?: boolean;
 	onClick?: never;
 };
 type NoticeActionWithOnClick = CommonNoticeActionProps & {
 	url?: never;
+	openInNewTab?: never;
 	onClick: MouseEventHandler< HTMLButtonElement >;
 };
 

--- a/packages/components/src/snackbar/index.tsx
+++ b/packages/components/src/snackbar/index.tsx
@@ -25,6 +25,7 @@ import Button from '../button';
 import type { SnackbarProps } from './types';
 import type { NoticeAction } from '../notice/types';
 import type { WordPressComponentProps } from '../context';
+import ExternalLink from '../external-link';
 
 const NOTICE_TIMEOUT = 10000;
 
@@ -147,22 +148,34 @@ function UnforwardedSnackbar(
 					<div className="components-snackbar__icon">{ icon }</div>
 				) }
 				{ children }
-				{ actions.map( ( { label, onClick, url }, index ) => {
-					return (
-						<Button
-							__next40pxDefaultSize
-							key={ index }
-							href={ url }
-							variant="link"
-							onClick={ (
-								event: MouseEvent< HTMLButtonElement >
-							) => onActionClick( event, onClick ) }
-							className="components-snackbar__action"
-						>
-							{ label }
-						</Button>
-					);
-				} ) }
+				{ actions.map(
+					( { label, onClick, url, openInNewTab = false }, index ) =>
+						url !== undefined && openInNewTab ? (
+							<ExternalLink
+								key={ index }
+								href={ url }
+								onClick={ ( event ) => {
+									event.stopPropagation();
+								} }
+								className="components-snackbar__action"
+							>
+								{ label }
+							</ExternalLink>
+						) : (
+							<Button
+								__next40pxDefaultSize
+								key={ index }
+								href={ url }
+								variant="link"
+								onClick={ (
+									event: MouseEvent< HTMLButtonElement >
+								) => onActionClick( event, onClick ) }
+								className="components-snackbar__action"
+							>
+								{ label }
+							</Button>
+						)
+				) }
 				{ explicitDismiss && (
 					<span
 						role="button"

--- a/packages/components/src/snackbar/index.tsx
+++ b/packages/components/src/snackbar/index.tsx
@@ -154,9 +154,9 @@ function UnforwardedSnackbar(
 							<ExternalLink
 								key={ index }
 								href={ url }
-								onClick={ (
-									event: MouseEvent< HTMLAnchorElement >
-								) => onActionClick( event, onClick ) }
+								onClick={ ( event ) =>
+									onActionClick( event, onClick )
+								}
 								className="components-snackbar__action"
 							>
 								{ label }

--- a/packages/components/src/snackbar/index.tsx
+++ b/packages/components/src/snackbar/index.tsx
@@ -22,10 +22,10 @@ import warning from '@wordpress/warning';
  * Internal dependencies
  */
 import Button from '../button';
+import ExternalLink from '../external-link';
 import type { SnackbarProps } from './types';
 import type { NoticeAction } from '../notice/types';
 import type { WordPressComponentProps } from '../context';
-import ExternalLink from '../external-link';
 
 const NOTICE_TIMEOUT = 10000;
 

--- a/packages/components/src/snackbar/index.tsx
+++ b/packages/components/src/snackbar/index.tsx
@@ -81,7 +81,7 @@ function UnforwardedSnackbar(
 	}
 
 	function onActionClick(
-		event: MouseEvent< HTMLButtonElement >,
+		event: MouseEvent< HTMLButtonElement | HTMLAnchorElement >,
 		onClick: NoticeAction[ 'onClick' ]
 	) {
 		event.stopPropagation();
@@ -154,9 +154,9 @@ function UnforwardedSnackbar(
 							<ExternalLink
 								key={ index }
 								href={ url }
-								onClick={ ( event ) => {
-									event.stopPropagation();
-								} }
+								onClick={ (
+									event: MouseEvent< HTMLAnchorElement >
+								) => onActionClick( event, onClick ) }
 								className="components-snackbar__action"
 							>
 								{ label }

--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -45,7 +45,8 @@
 	}
 }
 
-.components-snackbar__action.components-button {
+.components-snackbar__action.components-button,
+.components-snackbar__action.components-external-link {
 	margin-left: $grid-unit-40;
 	color: $white;
 	flex-shrink: 0;

--- a/packages/components/src/snackbar/types.ts
+++ b/packages/components/src/snackbar/types.ts
@@ -56,7 +56,10 @@ export type SnackbarProps = Pick<
 		 *
 		 * @default []
 		 */
-		actions?: Pick< NoticeAction, 'label' | 'url' | 'onClick' >[];
+		actions?: Pick<
+			NoticeAction,
+			'label' | 'url' | 'onClick' | 'openInNewTab'
+		>[];
 	};
 
 export type SnackbarListProps = {

--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -216,6 +216,7 @@ export const saveDirtyEntities =
 								{
 									label: __( 'View site' ),
 									url: homeUrl,
+									openInNewTab: true,
 								},
 							],
 						} );

--- a/packages/editor/src/store/utils/notice-builder.js
+++ b/packages/editor/src/store/utils/notice-builder.js
@@ -58,6 +58,7 @@ export function getNotificationArgumentsForSaveSuccess( data ) {
 		actions.push( {
 			label: isDraft ? __( 'View Preview' ) : postType.labels.view_item,
 			url: post.link,
+			openInNewTab: true,
 		} );
 	}
 	return [

--- a/packages/editor/src/store/utils/test/notice-builder.js
+++ b/packages/editor/src/store/utils/test/notice-builder.js
@@ -70,7 +70,9 @@ describe( 'getNotificationArgumentsForSaveSuccess()', () => {
 				'updated',
 				{
 					...defaultExpectedAction,
-					actions: [ { label: 'view', url: 'some_link' } ],
+					actions: [
+						{ label: 'view', openInNewTab: true, url: 'some_link' },
+					],
 				},
 			],
 		],


### PR DESCRIPTION
## What?
Closes #59139

This PR enhances the Snackbar component by adding support for opening links in a new tab. Accordingly, the View Post, View Site, and View Preview links have been updated to open in a new tab by default.

## Why?

Opening these links (View Post, View Site, and View Preview) in a new tab improves the user experience by preserving the current editing context.

## How?

Consumers can now pass an `openInNewTab` boolean property to an action item to open that specific item in a new browser tab.

## Testing Instructions

1. Create a `Post`.
2. Write some content and publish it.
3. After publishing, a snackbar notification will appear.
4. Click on `View Post` in the snackbar notification.
5. Confirm that the link opens in a new tab.

### Testing Instructions for Keyboard

Same.

## Screencast

https://github.com/user-attachments/assets/e4035e27-ebb7-4013-a50b-3e58c74fd4ee