### PR TITLE
Guide: Make `next` and `previous` button text customizable

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   `Guide`: Make next and previous button text customizable ([#69907](https://github.com/WordPress/gutenberg/pull/69907)).
+
 ## 29.8.0 (2025-04-11)
 
 ### Documentation 

--- a/packages/components/src/guide/README.md
+++ b/packages/components/src/guide/README.md
@@ -73,7 +73,7 @@ Use this to customize the label of the _Previous_ button shown on each page of t
 
 -   Type: `string`
 -   Required: No
--   Default: `'Next'`
+-   Default: `'Previous'`
 
 ### onFinish
 

--- a/packages/components/src/guide/README.md
+++ b/packages/components/src/guide/README.md
@@ -59,6 +59,22 @@ Use this to customize the label of the _Finish_ button shown at the end of the g
 -   Required: No
 -	Default: `'Finish'`
 
+### nextButtonText
+
+Use this to customize the label of the _Next_ button shown on each page of the guide.
+
+-   Type: `string`
+-   Required: No
+-   Default: `'Next'`
+
+### previousButtonText
+
+Use this to customize the label of the _Previous_ button shown on each page of the guide except the first.
+
+-   Type: `string`
+-   Required: No
+-   Default: `'Next'`
+
 ### onFinish
 
 A function which is called when the guide is finished. The guide is finished when the modal is closed or when the user clicks _Finish_ on the last page of the guide.

--- a/packages/components/src/guide/index.tsx
+++ b/packages/components/src/guide/index.tsx
@@ -55,6 +55,8 @@ function Guide( {
 	className,
 	contentLabel,
 	finishButtonText = __( 'Finish' ),
+	nextButtonText = __( 'Next' ),
+	previousButtonText = __( 'Previous' ),
 	onFinish,
 	pages = [],
 }: GuideProps ) {
@@ -146,7 +148,7 @@ function Guide( {
 							onClick={ goBack }
 							__next40pxDefaultSize
 						>
-							{ __( 'Previous' ) }
+							{ previousButtonText }
 						</Button>
 					) }
 					{ canGoForward && (
@@ -156,7 +158,7 @@ function Guide( {
 							onClick={ goForward }
 							__next40pxDefaultSize
 						>
-							{ __( 'Next' ) }
+							{ nextButtonText }
 						</Button>
 					) }
 					{ ! canGoForward && (

--- a/packages/components/src/guide/stories/index.story.tsx
+++ b/packages/components/src/guide/stories/index.story.tsx
@@ -20,6 +20,8 @@ const meta: Meta< typeof Guide > = {
 	argTypes: {
 		contentLabel: { control: 'text' },
 		finishButtonText: { control: 'text' },
+		nextButtonText: { control: 'text' },
+		previousButtonText: { control: 'text' },
 		onFinish: { action: 'onFinish' },
 	},
 };

--- a/packages/components/src/guide/types.ts
+++ b/packages/components/src/guide/types.ts
@@ -41,6 +41,18 @@ export type GuideProps = {
 	 */
 	finishButtonText?: string;
 	/**
+	 * Use this to customize the label of the _Next_ button shown on each page of the guide.
+	 *
+	 * @default 'Next'
+	 */
+	nextButtonText?: string;
+	/**
+	 * Use this to customize the label of the _Previous_ button shown on each page of the guide except the first.
+	 *
+	 * @default 'Previous'
+	 */
+	previousButtonText?: string;
+	/**
 	 * A function which is called when the guide is finished.
 	 */
 	onFinish: ModalProps[ 'onRequestClose' ];


### PR DESCRIPTION
## What?
Closes #69906

This PR introduces support for customizing the `next` and `previous` button text in the Guide component.

## Why?

Enhances text customization options for the `next` and `previous` buttons.

## How?

Two new properties `nextButtonText` and `previousButtonText` were added to the Guide component.

## Testing Instructions
1. Run storybook locally. (`npm run storybook:dev`)
2. Try adding `nextButtonText` and `previousButtonText` props [here](https://github.com/WordPress/gutenberg/blob/caec5092d896ef7c229880eb7dc021c51cdb008f/packages/components/src/guide/stories/index.story.tsx#L42).
3. Confirm the values appear correctly as the next and previous text in the Guide component.

### Testing Instructions for Keyboard
Same.
