### PR TITLE
Plugin: Fix deprecation for 'apply_block_hooks_to_content_from_post_object'

### DIFF
--- a/lib/compat/wordpress-6.8/blocks.php
+++ b/lib/compat/wordpress-6.8/blocks.php
@@ -26,7 +26,7 @@ if ( ! function_exists( 'apply_block_hooks_to_content_from_post_object' ) ) {
 	 *                               Default: 'insert_hooked_blocks'.
 	 * @return string The serialized markup.
 	 */
-	function apply_block_hooks_to_content_from_post_object( $content, WP_Post $post = null, $callback = 'insert_hooked_blocks' ) {
+	function apply_block_hooks_to_content_from_post_object( $content, $post = null, $callback = 'insert_hooked_blocks' ) {
 		// Default to the current post if no context is provided.
 		if ( null === $post ) {
 			$post = get_post();


### PR DESCRIPTION
## What?
Closes #69908

Syncs following change from core https://core.trac.wordpress.org/changeset/59839 and fixes deprecations notice for PHP 8.4..

## Testing Instructions
None.
