### PR TITLE
Add "Back to Top" Block to Site Editor

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -35,6 +35,15 @@ Add a user’s avatar. ([Source](https://github.com/WordPress/gutenberg/tree/tru
 -	**Supports:** align, color (~~background~~, ~~text~~), filter (duotone), interactivity (clientNavigation), spacing (margin, padding), ~~alignWide~~, ~~html~~
 -	**Attributes:** isLink, linkTarget, size, userId
 
+## Back to Top
+
+Add a smooth scrolling back to top button to your content. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/back-to-top))
+
+-	**Name:** core/back-to-top
+-	**Category:** design
+-	**Supports:** border (color, radius, style, width), color (background, gradients, text), spacing (margin, padding)
+-	**Attributes:** buttonPosition, content, hasIcon, iconName, iconPosition, scrollDuration, scrollOffset, showText, smoothScroll
+
 ## Pattern
 
 Reuse this design across your site. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/block))

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -43,7 +43,6 @@ function gutenberg_reregister_core_block_types() {
 				'verse',
 				'video',
 				'embed',
-				// 'back-to-top',
 			),
 			'block_names'   => array(
 				'back-to-top.php' 				   => 'core/back-to-top',

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -43,8 +43,10 @@ function gutenberg_reregister_core_block_types() {
 				'verse',
 				'video',
 				'embed',
+				// 'back-to-top',
 			),
 			'block_names'   => array(
+				'back-to-top.php' 				   => 'core/back-to-top',
 				'archives.php'                     => 'core/archives',
 				'avatar.php'                       => 'core/avatar',
 				'block.php'                        => 'core/block',

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -32,7 +32,8 @@
 		"./image/view": "./build-module/image/view.js",
 		"./navigation/view": "./build-module/navigation/view.js",
 		"./query/view": "./build-module/query/view.js",
-		"./search/view": "./build-module/search/view.js"
+		"./search/view": "./build-module/search/view.js",
+		"./back-to-top/view": "./build-module/back-to-top/view.js"
 	},
 	"sideEffects": [
 		"build-style/**",

--- a/packages/block-library/src/back-to-top/block.json
+++ b/packages/block-library/src/back-to-top/block.json
@@ -1,0 +1,93 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "core/back-to-top",
+	"title": "Back to Top",
+	"category": "design",
+	"icon": "arrow-up-alt",
+	"description": "Add a smooth scrolling back to top button to your content.",
+	"attributes": {
+		"content": {
+			"type": "string",
+			"default": "Back to top"
+		},
+		"buttonPosition": {
+			"type": "string",
+			"default": "right"
+		},
+		"scrollOffset": {
+			"type": "number",
+			"default": 300
+		},
+		"scrollDuration": {
+			"type": "number",
+			"default": 500
+		},
+		"smoothScroll": {
+			"type": "boolean",
+			"default": true
+		},
+		"hasIcon": {
+			"type": "boolean",
+			"default": true
+		},
+		"iconName": {
+			"type": "string",
+			"default": "arrow-up-alt2"
+		},
+		"iconPosition": {
+			"type": "string",
+			"default": "before"
+		},
+		"showText": {
+			"type": "boolean",
+			"default": true
+		}
+	},
+	"supports": {
+		"color": {
+			"background": true,
+			"text": true,
+			"gradients": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"margin": true,
+				"padding": true
+			}
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"width": true,
+			"style": true
+		},
+		"border": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
+			}
+		}
+	},
+	"styles": [],
+	"editorScript": "file:./index.js",
+	"selectors": {
+		"root": ".wp-block-back-to-top",
+		"button": ".wp-block-back-to-top button"
+	},
+	"editorStyle": "file:./editor.scss",
+	"style": "file:./style.scss",
+	"viewScript": "file:./view.js"
+}

--- a/packages/block-library/src/back-to-top/edit.js
+++ b/packages/block-library/src/back-to-top/edit.js
@@ -1,0 +1,235 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import {
+	PanelBody,
+	SelectControl,
+	RangeControl,
+	ToggleControl,
+	TextControl,
+	Dashicon,
+} from '@wordpress/components';
+
+export default function Edit( { attributes, setAttributes } ) {
+	const {
+		content,
+		buttonPosition,
+		scrollOffset,
+		scrollDuration,
+		smoothScroll,
+		hasIcon,
+		iconName,
+		iconPosition,
+		showText,
+		borderRadius,
+		padding,
+	} = attributes;
+
+	const blockProps = useBlockProps( {
+		className: `wp-block-back-to-top-editor align-${ buttonPosition }`,
+		style: {
+			borderRadius: `${ borderRadius }px`,
+			padding: `${ padding }px`,
+		},
+	} );
+
+	const handleClick = ( e ) => {
+		e.preventDefault();
+
+		// Find the editor iframe
+		const editorIframe = document.querySelector(
+			'iframe[name="editor-canvas"]'
+		);
+
+		if ( editorIframe && editorIframe.contentWindow ) {
+			// Scroll the iframe content window
+			editorIframe.contentWindow.scrollTo( {
+				top: 0,
+				behavior: smoothScroll ? 'smooth' : 'auto',
+			} );
+
+			// Also scroll the main editor container for better UX
+			const editorContainer = document.querySelector(
+				'.interface-interface-skeleton__content'
+			);
+			if ( editorContainer ) {
+				editorContainer.scrollTo( {
+					top: 0,
+					behavior: smoothScroll ? 'smooth' : 'auto',
+				} );
+			}
+		}
+	};
+
+	// Available dashicons for the button
+	const iconOptions = [
+		{ label: __( 'Arrow Up Alt' ), value: 'arrow-up-alt' },
+		{ label: __( 'Arrow Up Alt 2' ), value: 'arrow-up-alt2' },
+		{ label: __( 'Caret Up' ), value: 'arrow-up' },
+	];
+
+	const buttonContent = (
+		<>
+			{ hasIcon && iconPosition === 'before' && (
+				<Dashicon icon={ iconName } />
+			) }
+			{ showText && (
+				<span className="wp-block-back-to-top-text">{ content }</span>
+			) }
+			{ hasIcon && iconPosition === 'after' && (
+				<Dashicon icon={ iconName } />
+			) }
+		</>
+	);
+
+	return (
+		<>
+			<button { ...blockProps } onClick={ handleClick }>
+				{ buttonContent }
+			</button>
+
+			<InspectorControls>
+				<PanelBody title={ __( 'Button Settings' ) }>
+					<TextControl
+						label={ __( 'Button Text' ) }
+						value={ content }
+						onChange={ ( value ) =>
+							setAttributes( { content: value } )
+						 }
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+					<SelectControl
+						label={ __( 'Button Position' ) }
+						value={ buttonPosition }
+						options={ [
+							{ label: __( 'Left' ), value: 'left' },
+							{ label: __( 'Center' ), value: 'center' },
+							{ label: __( 'Right' ), value: 'right' },
+						] }
+						onChange={ ( value ) =>
+							setAttributes( { buttonPosition: value } )
+						 }
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+				</PanelBody>
+
+				<PanelBody title={ __( 'Scroll Settings' ) }>
+					<RangeControl
+						label={ __( 'Scroll Offset' ) }
+						value={ scrollOffset }
+						onChange={ ( value ) =>
+							setAttributes( { scrollOffset: value } )
+						 }
+						min={ 100 }
+						max={ 1000 }
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+					<RangeControl
+						label={ __( 'Scroll Duration' ) }
+						value={ scrollDuration }
+						onChange={ ( value ) =>
+							setAttributes( { scrollDuration: value } )
+						 }
+						min={ 100 }
+						max={ 2000 }
+						step={ 100 }
+						__next40pxDefaultSize
+                        __nextHasNoMarginBottom
+					/>
+					<ToggleControl
+						label={ __( 'Smooth Scrolling' ) }
+						checked={ smoothScroll }
+						onChange={ () =>
+							setAttributes( { smoothScroll: ! smoothScroll } )
+						}
+						__nextHasNoMarginBottom
+					/>
+				</PanelBody>
+
+				<PanelBody title={ __( 'Icon Settings' ) }>
+					<ToggleControl
+						label={ __( 'Show Icon' ) }
+						checked={ hasIcon }
+						onChange={ () =>
+							setAttributes( { hasIcon: ! hasIcon } )
+						}
+						__nextHasNoMarginBottom
+					/>
+					<ToggleControl
+						label={ __( 'Show Text' ) }
+						checked={ showText }
+						onChange={ () =>
+							setAttributes( { showText: ! showText } )
+						}
+						__nextHasNoMarginBottom
+					/>
+					{ hasIcon && (
+						<>
+							<SelectControl
+								label={ __( 'Icon' ) }
+								value={ iconName }
+								options={ iconOptions }
+								onChange={ ( value ) =>
+									setAttributes( { iconName: value } )
+								}
+								__next40pxDefaultSize
+                                __nextHasNoMarginBottom
+							/>
+							{ showText && (
+								<SelectControl
+									label={ __( 'Icon Position' ) }
+									value={ iconPosition }
+									options={ [
+										{
+											label: __( 'Before Text' ),
+											value: 'before',
+										},
+										{
+											label: __( 'After Text' ),
+											value: 'after',
+										},
+									] }
+									onChange={ ( value ) =>
+										setAttributes( { iconPosition: value } )
+									}
+									__next40pxDefaultSize
+									__nextHasNoMarginBottom
+								/>
+							) }
+						</>
+					) }
+				</PanelBody>
+
+				<PanelBody title={ __( 'Style Settings' ) }>
+					<RangeControl
+						label={ __( 'Border Radius' ) }
+						value={ borderRadius }
+						onChange={ ( value ) =>
+							setAttributes( { borderRadius: value } )
+						}
+						min={ 0 }
+						max={ 50 }
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+					<RangeControl
+						label={ __( 'Padding' ) }
+						value={ padding }
+						onChange={ ( value ) =>
+							setAttributes( { padding: value } )
+						}
+						min={ 0 }
+						max={ 50 }
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+				</PanelBody>
+			</InspectorControls>
+		</>
+	);
+}

--- a/packages/block-library/src/back-to-top/edit.js
+++ b/packages/block-library/src/back-to-top/edit.js
@@ -4,193 +4,225 @@
 import { __ } from '@wordpress/i18n';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import {
-    PanelBody,
-    SelectControl,
-    RangeControl,
-    ToggleControl,
-    TextControl,
-    Dashicon,
+	PanelBody,
+	SelectControl,
+	RangeControl,
+	ToggleControl,
+	TextControl,
+	Dashicon,
 } from '@wordpress/components';
 
 // Icon options for the button
 const ICON_OPTIONS = [
-    { label: __('Arrow Up Alt'), value: 'arrow-up-alt' },
-    { label: __('Arrow Up Alt 2'), value: 'arrow-up-alt2' },
-    { label: __('Caret Up'), value: 'arrow-up' },
+	{ label: __( 'Arrow Up Alt' ), value: 'arrow-up-alt' },
+	{ label: __( 'Arrow Up Alt 2' ), value: 'arrow-up-alt2' },
+	{ label: __( 'Caret Up' ), value: 'arrow-up' },
 ];
 
-export default function Edit({ attributes, setAttributes }) {
-    const {
-        content,
-        buttonPosition = 'right',
-        scrollOffset,
-        scrollDuration,
-        smoothScroll,
-        hasIcon,
-        iconName,
-        iconPosition,
-        showText,
-    } = attributes; // Remove borderRadius and padding from destructuring
+export default function Edit( { attributes, setAttributes } ) {
+	const {
+		content,
+		buttonPosition = 'right',
+		scrollOffset,
+		scrollDuration,
+		smoothScroll,
+		hasIcon,
+		iconName,
+		iconPosition,
+		showText,
+	} = attributes; // Remove borderRadius and padding from destructuring
 
-    // Calculate position based on buttonPosition
-    const getPositionStyles = () => {
-        switch (buttonPosition) {
-            case 'left':
-                return { left: '20px' };
-            case 'center':
-                return { left: '50%', transform: 'translateX(-50%)' };
-            case 'right':
-            default:
-                return { right: '20px' };
-        }
-    };
+	// Calculate position based on buttonPosition
+	const getPositionStyles = () => {
+		switch ( buttonPosition ) {
+			case 'left':
+				return { left: '20px' };
+			case 'center':
+				return { left: '50%', transform: 'translateX(-50%)' };
+			case 'right':
+			default:
+				return { right: '20px' };
+		}
+	};
 
-    const blockProps = useBlockProps({
-        className: `wp-block-back-to-top-editor`,
-        style: {
-            position: 'fixed',
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            minWidth: '40px',
-            bottom: '20px',
-            gap: '0.5em',
-            backgroundColor: '#000',
-            color: '#fff',
-            cursor: 'pointer',
-            border: 'none',
-            ...getPositionStyles(),
-        },
-    });
+	const blockProps = useBlockProps( {
+		className: `wp-block-back-to-top-editor`,
+		style: {
+			position: 'fixed',
+			display: 'inline-flex',
+			alignItems: 'center',
+			justifyContent: 'center',
+			minWidth: '40px',
+			bottom: '20px',
+			gap: '0.5em',
+			cursor: 'pointer',
+			border: 'none',
+			...getPositionStyles(),
+		},
+	} );
 
-    const handleClick = (e) => {
-        e.preventDefault();
-        const editorIframe = document.querySelector('iframe[name="editor-canvas"]');
-        const editorContainer = document.querySelector('.interface-interface-skeleton__content');
+	const handleClick = ( e ) => {
+		e.preventDefault();
+		const editorIframe = document.querySelector(
+			'iframe[name="editor-canvas"]'
+		);
+		const editorContainer = document.querySelector(
+			'.interface-interface-skeleton__content'
+		);
 
-        if (editorIframe?.contentWindow) {
-            editorIframe.contentWindow.scrollTo({
-                top: 0,
-                behavior: smoothScroll ? 'smooth' : 'auto',
-            });
-        }
+		if ( editorIframe?.contentWindow ) {
+			editorIframe.contentWindow.scrollTo( {
+				top: 0,
+				behavior: smoothScroll ? 'smooth' : 'auto',
+			} );
+		}
 
-        if (editorContainer) {
-            editorContainer.scrollTo({
-                top: 0,
-                behavior: smoothScroll ? 'smooth' : 'auto',
-            });
-        }
-    };
+		if ( editorContainer ) {
+			editorContainer.scrollTo( {
+				top: 0,
+				behavior: smoothScroll ? 'smooth' : 'auto',
+			} );
+		}
+	};
 
-    const buttonContent = (
-        <>
-            {hasIcon && iconPosition === 'before' && <Dashicon icon={iconName} />}
-            {showText && <span className="wp-block-back-to-top-text">{content}</span>}
-            {hasIcon && iconPosition === 'after' && <Dashicon icon={iconName} />}
-        </>
-    );
+	const buttonContent = (
+		<>
+			{ hasIcon && iconPosition === 'before' && (
+				<Dashicon icon={ iconName } />
+			) }
+			{ showText && (
+				<span className="wp-block-back-to-top-text">{ content }</span>
+			) }
+			{ hasIcon && iconPosition === 'after' && (
+				<Dashicon icon={ iconName } />
+			) }
+		</>
+	);
 
-    return (
-        <>
-            <button {...blockProps} onClick={handleClick}>
-                {buttonContent}
-            </button>
+	return (
+		<>
+			<button { ...blockProps } onClick={ handleClick }>
+				{ buttonContent }
+			</button>
 
-            <InspectorControls>
-                {/* Button Settings */}
-                <PanelBody title={__('Button Settings')}>
-                    <TextControl
-                        label={__('Button Text')}
-                        value={content}
-                        onChange={(value) => setAttributes({ content: value })}
-                        __next40pxDefaultSize
-                        __nextHasNoMarginBottom
-                    />
-                    <SelectControl
-                        label={__('Button Position')}
-                        value={buttonPosition}
-                        options={[
-                            { label: __('Left'), value: 'left' },
-                            { label: __('Center'), value: 'center' },
-                            { label: __('Right'), value: 'right' },
-                        ]}
-                        onChange={(value) => setAttributes({ buttonPosition: value })}
-                        __next40pxDefaultSize
-                        __nextHasNoMarginBottom
-                    />
-                </PanelBody>
+			<InspectorControls>
+				{ /* Button Settings */ }
+				<PanelBody title={ __( 'Button Settings' ) }>
+					<TextControl
+						label={ __( 'Button Text' ) }
+						value={ content }
+						onChange={ ( value ) =>
+							setAttributes( { content: value } )
+						}
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+					<SelectControl
+						label={ __( 'Button Position' ) }
+						value={ buttonPosition }
+						options={ [
+							{ label: __( 'Left' ), value: 'left' },
+							{ label: __( 'Center' ), value: 'center' },
+							{ label: __( 'Right' ), value: 'right' },
+						] }
+						onChange={ ( value ) =>
+							setAttributes( { buttonPosition: value } )
+						}
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+				</PanelBody>
 
-                {/* Scroll Settings */}
-                <PanelBody title={__('Scroll Settings')}>
-                    <RangeControl
-                        label={__('Scroll Offset')}
-                        value={scrollOffset}
-                        onChange={(value) => setAttributes({ scrollOffset: value })}
-                        min={100}
-                        max={1000}
-                        __next40pxDefaultSize
-                        __nextHasNoMarginBottom
-                    />
-                    <RangeControl
-                        label={__('Scroll Duration')}
-                        value={scrollDuration}
-                        onChange={(value) => setAttributes({ scrollDuration: value })}
-                        min={100}
-                        max={2000}
-                        step={100}
-                        __next40pxDefaultSize
-                        __nextHasNoMarginBottom
-                    />
-                    <ToggleControl
-                        label={__('Smooth Scrolling')}
-                        checked={smoothScroll}
-                        onChange={() => setAttributes({ smoothScroll: !smoothScroll })}
-                        __nextHasNoMarginBottom
-                    />
-                </PanelBody>
+				{ /* Scroll Settings */ }
+				<PanelBody title={ __( 'Scroll Settings' ) }>
+					<RangeControl
+						label={ __( 'Scroll Offset' ) }
+						value={ scrollOffset }
+						onChange={ ( value ) =>
+							setAttributes( { scrollOffset: value } )
+						}
+						min={ 100 }
+						max={ 1000 }
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+					<RangeControl
+						label={ __( 'Scroll Duration' ) }
+						value={ scrollDuration }
+						onChange={ ( value ) =>
+							setAttributes( { scrollDuration: value } )
+						}
+						min={ 100 }
+						max={ 2000 }
+						step={ 100 }
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+					<ToggleControl
+						label={ __( 'Smooth Scrolling' ) }
+						checked={ smoothScroll }
+						onChange={ () =>
+							setAttributes( { smoothScroll: ! smoothScroll } )
+						}
+						__nextHasNoMarginBottom
+					/>
+				</PanelBody>
 
-                {/* Icon Settings */}
-                <PanelBody title={__('Icon Settings')}>
-                    <ToggleControl
-                        label={__('Show Icon')}
-                        checked={hasIcon}
-                        onChange={() => setAttributes({ hasIcon: !hasIcon })}
-                        __nextHasNoMarginBottom
-                    />
-                    <ToggleControl
-                        label={__('Show Text')}
-                        checked={showText}
-                        onChange={() => setAttributes({ showText: !showText })}
-                        __nextHasNoMarginBottom
-                    />
-                    {hasIcon && (
-                        <>
-                            <SelectControl
-                                label={__('Icon')}
-                                value={iconName}
-                                options={ICON_OPTIONS}
-                                onChange={(value) => setAttributes({ iconName: value })}
-                                __next40pxDefaultSize
-                                __nextHasNoMarginBottom
-                            />
-                            {showText && (
-                                <SelectControl
-                                    label={__('Icon Position')}
-                                    value={iconPosition}
-                                    options={[
-                                        { label: __('Before Text'), value: 'before' },
-                                        { label: __('After Text'), value: 'after' },
-                                    ]}
-                                    onChange={(value) => setAttributes({ iconPosition: value })}
-                                    __next40pxDefaultSize
-                                    __nextHasNoMarginBottom
-                                />
-                            )}
-                        </>
-                    )}
-                </PanelBody>
-            </InspectorControls>
-        </>
-    );
+				{ /* Icon Settings */ }
+				<PanelBody title={ __( 'Icon Settings' ) }>
+					<ToggleControl
+						label={ __( 'Show Icon' ) }
+						checked={ hasIcon }
+						onChange={ () =>
+							setAttributes( { hasIcon: ! hasIcon } )
+						}
+						__nextHasNoMarginBottom
+					/>
+					<ToggleControl
+						label={ __( 'Show Text' ) }
+						checked={ showText }
+						onChange={ () =>
+							setAttributes( { showText: ! showText } )
+						}
+						__nextHasNoMarginBottom
+					/>
+					{ hasIcon && (
+						<>
+							<SelectControl
+								label={ __( 'Icon' ) }
+								value={ iconName }
+								options={ ICON_OPTIONS }
+								onChange={ ( value ) =>
+									setAttributes( { iconName: value } )
+								}
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+							/>
+							{ showText && (
+								<SelectControl
+									label={ __( 'Icon Position' ) }
+									value={ iconPosition }
+									options={ [
+										{
+											label: __( 'Before Text' ),
+											value: 'before',
+										},
+										{
+											label: __( 'After Text' ),
+											value: 'after',
+										},
+									] }
+									onChange={ ( value ) =>
+										setAttributes( { iconPosition: value } )
+									}
+									__next40pxDefaultSize
+									__nextHasNoMarginBottom
+								/>
+							) }
+						</>
+					) }
+				</PanelBody>
+			</InspectorControls>
+		</>
+	);
 }

--- a/packages/block-library/src/back-to-top/edit.js
+++ b/packages/block-library/src/back-to-top/edit.js
@@ -12,7 +12,6 @@ import {
 	Dashicon,
 } from '@wordpress/components';
 
-// Icon options for the button
 const ICON_OPTIONS = [
 	{ label: __( 'Arrow Up Alt' ), value: 'arrow-up-alt' },
 	{ label: __( 'Arrow Up Alt 2' ), value: 'arrow-up-alt2' },
@@ -30,7 +29,7 @@ export default function Edit( { attributes, setAttributes } ) {
 		iconName,
 		iconPosition,
 		showText,
-	} = attributes; // Remove borderRadius and padding from destructuring
+	} = attributes;
 
 	// Calculate position based on buttonPosition
 	const getPositionStyles = () => {

--- a/packages/block-library/src/back-to-top/edit.js
+++ b/packages/block-library/src/back-to-top/edit.js
@@ -4,232 +4,193 @@
 import { __ } from '@wordpress/i18n';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import {
-	PanelBody,
-	SelectControl,
-	RangeControl,
-	ToggleControl,
-	TextControl,
-	Dashicon,
+    PanelBody,
+    SelectControl,
+    RangeControl,
+    ToggleControl,
+    TextControl,
+    Dashicon,
 } from '@wordpress/components';
 
-export default function Edit( { attributes, setAttributes } ) {
-	const {
-		content,
-		buttonPosition,
-		scrollOffset,
-		scrollDuration,
-		smoothScroll,
-		hasIcon,
-		iconName,
-		iconPosition,
-		showText,
-		borderRadius,
-		padding,
-	} = attributes;
+// Icon options for the button
+const ICON_OPTIONS = [
+    { label: __('Arrow Up Alt'), value: 'arrow-up-alt' },
+    { label: __('Arrow Up Alt 2'), value: 'arrow-up-alt2' },
+    { label: __('Caret Up'), value: 'arrow-up' },
+];
 
-	const blockProps = useBlockProps( {
-		className: `wp-block-back-to-top-editor align-${ buttonPosition }`,
-		style: {
-			borderRadius: `${ borderRadius }px`,
-			padding: `${ padding }px`,
-		},
-	} );
+export default function Edit({ attributes, setAttributes }) {
+    const {
+        content,
+        buttonPosition = 'right',
+        scrollOffset,
+        scrollDuration,
+        smoothScroll,
+        hasIcon,
+        iconName,
+        iconPosition,
+        showText,
+    } = attributes; // Remove borderRadius and padding from destructuring
 
-	const handleClick = ( e ) => {
-		e.preventDefault();
+    // Calculate position based on buttonPosition
+    const getPositionStyles = () => {
+        switch (buttonPosition) {
+            case 'left':
+                return { left: '20px' };
+            case 'center':
+                return { left: '50%', transform: 'translateX(-50%)' };
+            case 'right':
+            default:
+                return { right: '20px' };
+        }
+    };
 
-		// Find the editor iframe
-		const editorIframe = document.querySelector(
-			'iframe[name="editor-canvas"]'
-		);
+    const blockProps = useBlockProps({
+        className: `wp-block-back-to-top-editor`,
+        style: {
+            position: 'fixed',
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            minWidth: '40px',
+            bottom: '20px',
+            gap: '0.5em',
+            backgroundColor: '#000',
+            color: '#fff',
+            cursor: 'pointer',
+            border: 'none',
+            ...getPositionStyles(),
+        },
+    });
 
-		if ( editorIframe && editorIframe.contentWindow ) {
-			// Scroll the iframe content window
-			editorIframe.contentWindow.scrollTo( {
-				top: 0,
-				behavior: smoothScroll ? 'smooth' : 'auto',
-			} );
+    const handleClick = (e) => {
+        e.preventDefault();
+        const editorIframe = document.querySelector('iframe[name="editor-canvas"]');
+        const editorContainer = document.querySelector('.interface-interface-skeleton__content');
 
-			// Also scroll the main editor container for better UX
-			const editorContainer = document.querySelector(
-				'.interface-interface-skeleton__content'
-			);
-			if ( editorContainer ) {
-				editorContainer.scrollTo( {
-					top: 0,
-					behavior: smoothScroll ? 'smooth' : 'auto',
-				} );
-			}
-		}
-	};
+        if (editorIframe?.contentWindow) {
+            editorIframe.contentWindow.scrollTo({
+                top: 0,
+                behavior: smoothScroll ? 'smooth' : 'auto',
+            });
+        }
 
-	// Available dashicons for the button
-	const iconOptions = [
-		{ label: __( 'Arrow Up Alt' ), value: 'arrow-up-alt' },
-		{ label: __( 'Arrow Up Alt 2' ), value: 'arrow-up-alt2' },
-		{ label: __( 'Caret Up' ), value: 'arrow-up' },
-	];
+        if (editorContainer) {
+            editorContainer.scrollTo({
+                top: 0,
+                behavior: smoothScroll ? 'smooth' : 'auto',
+            });
+        }
+    };
 
-	const buttonContent = (
-		<>
-			{ hasIcon && iconPosition === 'before' && (
-				<Dashicon icon={ iconName } />
-			) }
-			{ showText && (
-				<span className="wp-block-back-to-top-text">{ content }</span>
-			) }
-			{ hasIcon && iconPosition === 'after' && (
-				<Dashicon icon={ iconName } />
-			) }
-		</>
-	);
+    const buttonContent = (
+        <>
+            {hasIcon && iconPosition === 'before' && <Dashicon icon={iconName} />}
+            {showText && <span className="wp-block-back-to-top-text">{content}</span>}
+            {hasIcon && iconPosition === 'after' && <Dashicon icon={iconName} />}
+        </>
+    );
 
-	return (
-		<>
-			<button { ...blockProps } onClick={ handleClick }>
-				{ buttonContent }
-			</button>
+    return (
+        <>
+            <button {...blockProps} onClick={handleClick}>
+                {buttonContent}
+            </button>
 
-			<InspectorControls>
-				<PanelBody title={ __( 'Button Settings' ) }>
-					<TextControl
-						label={ __( 'Button Text' ) }
-						value={ content }
-						onChange={ ( value ) =>
-							setAttributes( { content: value } )
-						 }
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-					/>
-					<SelectControl
-						label={ __( 'Button Position' ) }
-						value={ buttonPosition }
-						options={ [
-							{ label: __( 'Left' ), value: 'left' },
-							{ label: __( 'Center' ), value: 'center' },
-							{ label: __( 'Right' ), value: 'right' },
-						] }
-						onChange={ ( value ) =>
-							setAttributes( { buttonPosition: value } )
-						 }
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-					/>
-				</PanelBody>
-
-				<PanelBody title={ __( 'Scroll Settings' ) }>
-					<RangeControl
-						label={ __( 'Scroll Offset' ) }
-						value={ scrollOffset }
-						onChange={ ( value ) =>
-							setAttributes( { scrollOffset: value } )
-						 }
-						min={ 100 }
-						max={ 1000 }
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-					/>
-					<RangeControl
-						label={ __( 'Scroll Duration' ) }
-						value={ scrollDuration }
-						onChange={ ( value ) =>
-							setAttributes( { scrollDuration: value } )
-						 }
-						min={ 100 }
-						max={ 2000 }
-						step={ 100 }
-						__next40pxDefaultSize
+            <InspectorControls>
+                {/* Button Settings */}
+                <PanelBody title={__('Button Settings')}>
+                    <TextControl
+                        label={__('Button Text')}
+                        value={content}
+                        onChange={(value) => setAttributes({ content: value })}
+                        __next40pxDefaultSize
                         __nextHasNoMarginBottom
-					/>
-					<ToggleControl
-						label={ __( 'Smooth Scrolling' ) }
-						checked={ smoothScroll }
-						onChange={ () =>
-							setAttributes( { smoothScroll: ! smoothScroll } )
-						}
-						__nextHasNoMarginBottom
-					/>
-				</PanelBody>
+                    />
+                    <SelectControl
+                        label={__('Button Position')}
+                        value={buttonPosition}
+                        options={[
+                            { label: __('Left'), value: 'left' },
+                            { label: __('Center'), value: 'center' },
+                            { label: __('Right'), value: 'right' },
+                        ]}
+                        onChange={(value) => setAttributes({ buttonPosition: value })}
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                    />
+                </PanelBody>
 
-				<PanelBody title={ __( 'Icon Settings' ) }>
-					<ToggleControl
-						label={ __( 'Show Icon' ) }
-						checked={ hasIcon }
-						onChange={ () =>
-							setAttributes( { hasIcon: ! hasIcon } )
-						}
-						__nextHasNoMarginBottom
-					/>
-					<ToggleControl
-						label={ __( 'Show Text' ) }
-						checked={ showText }
-						onChange={ () =>
-							setAttributes( { showText: ! showText } )
-						}
-						__nextHasNoMarginBottom
-					/>
-					{ hasIcon && (
-						<>
-							<SelectControl
-								label={ __( 'Icon' ) }
-								value={ iconName }
-								options={ iconOptions }
-								onChange={ ( value ) =>
-									setAttributes( { iconName: value } )
-								}
-								__next40pxDefaultSize
+                {/* Scroll Settings */}
+                <PanelBody title={__('Scroll Settings')}>
+                    <RangeControl
+                        label={__('Scroll Offset')}
+                        value={scrollOffset}
+                        onChange={(value) => setAttributes({ scrollOffset: value })}
+                        min={100}
+                        max={1000}
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                    />
+                    <RangeControl
+                        label={__('Scroll Duration')}
+                        value={scrollDuration}
+                        onChange={(value) => setAttributes({ scrollDuration: value })}
+                        min={100}
+                        max={2000}
+                        step={100}
+                        __next40pxDefaultSize
+                        __nextHasNoMarginBottom
+                    />
+                    <ToggleControl
+                        label={__('Smooth Scrolling')}
+                        checked={smoothScroll}
+                        onChange={() => setAttributes({ smoothScroll: !smoothScroll })}
+                        __nextHasNoMarginBottom
+                    />
+                </PanelBody>
+
+                {/* Icon Settings */}
+                <PanelBody title={__('Icon Settings')}>
+                    <ToggleControl
+                        label={__('Show Icon')}
+                        checked={hasIcon}
+                        onChange={() => setAttributes({ hasIcon: !hasIcon })}
+                        __nextHasNoMarginBottom
+                    />
+                    <ToggleControl
+                        label={__('Show Text')}
+                        checked={showText}
+                        onChange={() => setAttributes({ showText: !showText })}
+                        __nextHasNoMarginBottom
+                    />
+                    {hasIcon && (
+                        <>
+                            <SelectControl
+                                label={__('Icon')}
+                                value={iconName}
+                                options={ICON_OPTIONS}
+                                onChange={(value) => setAttributes({ iconName: value })}
+                                __next40pxDefaultSize
                                 __nextHasNoMarginBottom
-							/>
-							{ showText && (
-								<SelectControl
-									label={ __( 'Icon Position' ) }
-									value={ iconPosition }
-									options={ [
-										{
-											label: __( 'Before Text' ),
-											value: 'before',
-										},
-										{
-											label: __( 'After Text' ),
-											value: 'after',
-										},
-									] }
-									onChange={ ( value ) =>
-										setAttributes( { iconPosition: value } )
-									}
-									__next40pxDefaultSize
-									__nextHasNoMarginBottom
-								/>
-							) }
-						</>
-					) }
-				</PanelBody>
-
-				<PanelBody title={ __( 'Style Settings' ) }>
-					<RangeControl
-						label={ __( 'Border Radius' ) }
-						value={ borderRadius }
-						onChange={ ( value ) =>
-							setAttributes( { borderRadius: value } )
-						}
-						min={ 0 }
-						max={ 50 }
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-					/>
-					<RangeControl
-						label={ __( 'Padding' ) }
-						value={ padding }
-						onChange={ ( value ) =>
-							setAttributes( { padding: value } )
-						}
-						min={ 0 }
-						max={ 50 }
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-					/>
-				</PanelBody>
-			</InspectorControls>
-		</>
-	);
+                            />
+                            {showText && (
+                                <SelectControl
+                                    label={__('Icon Position')}
+                                    value={iconPosition}
+                                    options={[
+                                        { label: __('Before Text'), value: 'before' },
+                                        { label: __('After Text'), value: 'after' },
+                                    ]}
+                                    onChange={(value) => setAttributes({ iconPosition: value })}
+                                    __next40pxDefaultSize
+                                    __nextHasNoMarginBottom
+                                />
+                            )}
+                        </>
+                    )}
+                </PanelBody>
+            </InspectorControls>
+        </>
+    );
 }

--- a/packages/block-library/src/back-to-top/editor.scss
+++ b/packages/block-library/src/back-to-top/editor.scss
@@ -1,0 +1,46 @@
+.wp-block-back-to-top-editor {
+	position: fixed;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 40px;
+	bottom: 20px; // Add bottom positioning
+
+	&.align-right {
+		right: 20px; // Increase right position to match front-end
+		left: 90%; // Ensure left is not affecting position
+	}
+
+	&.align-left {
+		left: 20px;
+		right: 90%; // Ensure right is not affecting position
+	}
+
+	&.align-center {
+		left: 50%; // Center properly
+		transform: translateX(-50%); // Fix center transform
+	}
+
+	// Editor selection styles
+	&.is-selected button {
+		outline: 2px solid var(--wp-admin-theme-color);
+	}
+
+	.dashicon {
+		display: inline-flex;
+		align-items: center;
+		margin: 0 4px;
+
+		&:first-child {
+			margin-left: 0;
+		}
+
+		&:last-child {
+			margin-right: 0;
+		}
+	}
+
+	.wp-block-back-to-top-text {
+		margin: 0 4px;
+	}
+}

--- a/packages/block-library/src/back-to-top/editor.scss
+++ b/packages/block-library/src/back-to-top/editor.scss
@@ -4,21 +4,21 @@
 	align-items: center;
 	justify-content: center;
 	min-width: 40px;
-	bottom: 20px; // Add bottom positioning
+	bottom: 20px;
 
 	&.align-right {
-		right: 20px; // Increase right position to match front-end
-		left: 90%; // Ensure left is not affecting position
+		right: 20px;
+		left: 90%;
 	}
 
 	&.align-left {
 		left: 20px;
-		right: 90%; // Ensure right is not affecting position
+		right: 90%;
 	}
 
 	&.align-center {
-		left: 50%; // Center properly
-		transform: translateX(-50%); // Fix center transform
+		left: 50%;
+		transform: translateX(-50%);
 	}
 
 	// Editor selection styles

--- a/packages/block-library/src/back-to-top/index.js
+++ b/packages/block-library/src/back-to-top/index.js
@@ -1,0 +1,37 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+import { arrowUp as icon } from '@wordpress/icons';
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import save from './save';
+import metadata from './block.json';
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	icon,
+	example: {
+		attributes: {
+			content: __( 'Back to top' ),
+			buttonPosition: 'right',
+		},
+	},
+	edit,
+	save,
+};
+
+export const privateApis = {};
+
+export const init = () => {
+	return registerBlockType( name, {
+		...metadata,
+		...settings,
+	} );
+};

--- a/packages/block-library/src/back-to-top/index.php
+++ b/packages/block-library/src/back-to-top/index.php
@@ -8,21 +8,30 @@
 /**
  * Renders the `core/back-to-top` block on the server.
  *
+ * @since 6.4.0
+ *
  * @param array  $attributes Block attributes.
  * @param string $content    Block default content.
  * @return string Returns the block content.
  */
-function render_block_core_back_to_top($attributes, $content) {
+function render_block_core_back_to_top( $attributes, $content ) {
     wp_enqueue_script_module(
         '@wordpress/block-library/back-to-top/view'
     );
     return $content;
 }
 
-register_block_type_from_metadata(
-	// wp_die('loading');
-    gutenberg_dir_path() . 'build/block-library/blocks/back-to-top',
-    array(
-        'render_callback' => 'render_block_core_back_to_top',
-    )
-);
+/**
+ * Registers the `core/back-to-top` block.
+ *
+ * @since 6.4.0
+ */
+function register_core_back_to_top_block() {
+    register_block_type_from_metadata(
+        dirname( __DIR__ ) . '/build/block-library/blocks/back-to-top',
+        array(
+            'render_callback' => 'render_block_core_back_to_top',
+        )
+    );
+}
+add_action( 'init', 'register_core_back_to_top_block' );

--- a/packages/block-library/src/back-to-top/index.php
+++ b/packages/block-library/src/back-to-top/index.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Server-side rendering of the `core/back-to-top` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/back-to-top` block on the server.
+ *
+ * @param array  $attributes Block attributes.
+ * @param string $content    Block default content.
+ * @return string Returns the block content.
+ */
+function render_block_core_back_to_top($attributes, $content) {
+    wp_enqueue_script_module(
+        '@wordpress/block-library/back-to-top/view'
+    );
+    return $content;
+}
+
+register_block_type_from_metadata(
+	// wp_die('loading');
+    gutenberg_dir_path() . 'build/block-library/blocks/back-to-top',
+    array(
+        'render_callback' => 'render_block_core_back_to_top',
+    )
+);

--- a/packages/block-library/src/back-to-top/init.js
+++ b/packages/block-library/src/back-to-top/init.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import { init } from './';
+
+export default init();

--- a/packages/block-library/src/back-to-top/save.js
+++ b/packages/block-library/src/back-to-top/save.js
@@ -1,0 +1,49 @@
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+export default function save( { attributes } ) {
+	const {
+		content,
+		buttonPosition,
+		scrollOffset,
+		scrollDuration,
+		smoothScroll,
+		hasIcon,
+		iconName,
+		iconPosition,
+		showText,
+	} = attributes;
+
+	const blockProps = useBlockProps.save( {
+		className: `wp-block-back-to-top align-${ buttonPosition }`,
+		'data-scroll-offset': scrollOffset,
+		'data-scroll-duration': scrollDuration,
+		'data-smooth-scroll': smoothScroll,
+	} );
+
+	const buttonContent = (
+		<>
+			{ hasIcon && iconPosition === 'before' && (
+				<span
+					className={ `dashicon dashicons dashicons-${ iconName }` }
+				/>
+			) }
+			{ showText && (
+				<span className="wp-block-back-to-top-text">{ content }</span>
+			) }
+			{ hasIcon && iconPosition === 'after' && (
+				<span
+					className={ `dashicon dashicons dashicons-${ iconName }` }
+				/>
+			) }
+		</>
+	);
+
+	return (
+		<button { ...blockProps } type="button">
+			{ buttonContent }
+		</button>
+	);
+}

--- a/packages/block-library/src/back-to-top/style.scss
+++ b/packages/block-library/src/back-to-top/style.scss
@@ -1,0 +1,82 @@
+.wp-block-back-to-top {
+	position: fixed;
+	z-index: 999;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 40px;
+	color: #fff;
+	cursor: pointer;
+	border: none;
+	border-radius: 4px;
+	padding: 10px;
+	transition: all 0.3s ease;
+	bottom: 20px;
+
+	button {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: fit-content;
+		background-color: #000;
+		color: #fff;
+		border: none;
+		border-radius: 0;
+		padding: 10px;
+		cursor: pointer;
+		transition:
+			opacity 0.3s ease-in-out,
+			visibility 0.3s ease-in-out;
+		text-decoration: none;
+	}
+}
+
+.wp-block-back-to-top:hover {
+	opacity: 0.9;
+}
+
+.wp-block-back-to-top .dashicon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 20px;
+	height: 20px;
+	margin: 0 4px;
+}
+
+.wp-block-back-to-top .dashicon:first-child {
+	margin-left: 0;
+}
+
+.wp-block-back-to-top .dashicon:last-child {
+	margin-right: 0;
+}
+
+.wp-block-back-to-top .wp-block-back-to-top-text {
+	margin: 0 4px;
+}
+
+.wp-block-back-to-top.align-right {
+	right: 20px;
+	left: auto;
+
+	button {
+		margin-left: auto;
+	}
+}
+
+.wp-block-back-to-top.align-left {
+	left: 20px;
+	right: auto;
+
+	button {
+		margin-right: auto;
+	}
+}
+
+.wp-block-back-to-top.align-center {
+	left: 50%;
+	transform: translateX(-50%);
+	display: flex;
+	justify-content: center;
+}

--- a/packages/block-library/src/back-to-top/view.js
+++ b/packages/block-library/src/back-to-top/view.js
@@ -1,0 +1,52 @@
+document.addEventListener( 'DOMContentLoaded', function () {
+	const backToTopButtons = document.querySelectorAll(
+		'.wp-block-back-to-top'
+	);
+
+	backToTopButtons.forEach( ( button ) => {
+		const scrollOffset = parseInt( button.dataset.scrollOffset || 300, 10 );
+
+		// Initial state
+		button.style.opacity = '0';
+		button.style.visibility = 'hidden';
+		button.style.transition =
+			'opacity 0.3s ease-in-out, visibility 0.3s ease-in-out';
+		button.style.position = 'fixed';
+		button.style.zIndex = '9999';
+
+		// Handle scroll
+		function handleScroll() {
+			if ( window.pageYOffset > scrollOffset ) {
+				button.style.visibility = 'visible';
+				button.style.opacity = '1';
+			} else {
+				button.style.opacity = '0';
+				button.style.visibility = 'hidden';
+			}
+		}
+
+		// Throttle scroll event
+		let ticking = false;
+		window.addEventListener( 'scroll', function () {
+			if ( ! ticking ) {
+				window.requestAnimationFrame( function () {
+					handleScroll();
+					ticking = false;
+				} );
+				ticking = true;
+			}
+		} );
+
+		// Handle click
+		button.addEventListener( 'click', function ( e ) {
+			e.preventDefault();
+			window.scrollTo( {
+				top: 0,
+				behavior: 'smooth',
+			} );
+		} );
+
+		// Initial check
+		handleScroll();
+	} );
+} );

--- a/packages/block-library/src/back-to-top/view.js
+++ b/packages/block-library/src/back-to-top/view.js
@@ -4,7 +4,13 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	);
 
 	backToTopButtons.forEach( ( button ) => {
+		// Get settings from data attributes
 		const scrollOffset = parseInt( button.dataset.scrollOffset || 300, 10 );
+		const scrollDuration = parseInt(
+			button.dataset.scrollDuration || 500,
+			10
+		);
+		const smoothScroll = button.dataset.smoothScroll !== 'false';
 
 		// Initial state
 		button.style.opacity = '0';
@@ -14,7 +20,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		button.style.position = 'fixed';
 		button.style.zIndex = '9999';
 
-		// Handle scroll
+		// Handle scroll visibility
 		function handleScroll() {
 			if ( window.pageYOffset > scrollOffset ) {
 				button.style.visibility = 'visible';
@@ -23,6 +29,31 @@ document.addEventListener( 'DOMContentLoaded', function () {
 				button.style.opacity = '0';
 				button.style.visibility = 'hidden';
 			}
+		}
+
+		// Smooth scroll with duration support
+		function smoothScrollToTop( duration ) {
+			const startPosition = window.pageYOffset;
+			const startTime = window.performance.now();
+
+			function scrollStep( currentTime ) {
+				const timeElapsed = currentTime - startTime;
+				const progress = Math.min( timeElapsed / duration, 1 );
+
+				// Easing function
+				const easeInOutCubic =
+					progress < 0.5
+						? 4 * progress * progress * progress
+						: 1 - Math.pow( -2 * progress + 2, 3 ) / 2;
+
+				window.scrollTo( 0, startPosition * ( 1 - easeInOutCubic ) );
+
+				if ( timeElapsed < duration ) {
+					window.requestAnimationFrame( scrollStep );
+				}
+			}
+
+			window.requestAnimationFrame( scrollStep );
 		}
 
 		// Throttle scroll event
@@ -40,10 +71,11 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		// Handle click
 		button.addEventListener( 'click', function ( e ) {
 			e.preventDefault();
-			window.scrollTo( {
-				top: 0,
-				behavior: 'smooth',
-			} );
+			if ( smoothScroll ) {
+				smoothScrollToTop( scrollDuration );
+			} else {
+				window.scrollTo( { top: 0 } );
+			}
 		} );
 
 		// Initial check

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -1,6 +1,7 @@
 @import "./archives/editor.scss";
 @import "./audio/editor.scss";
 @import "./avatar/editor.scss";
+@import "./back-to-top/editor.scss";
 @import "./button/editor.scss";
 @import "./buttons/editor.scss";
 @import "./categories/editor.scss";
@@ -84,4 +85,8 @@
 // Remove the browser default border for iframe in Custom HTML block, Embed block, etc.
 :where(.editor-styles-wrapper) iframe:not([frameborder]) {
 	border: 0;
+}
+
+.test {
+	font-size: large !important;
 }

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -122,7 +122,7 @@ import * as textColumns from './text-columns';
 import * as verse from './verse';
 import * as video from './video';
 import * as footnotes from './footnotes';
-
+import * as backToTop from './back-to-top';
 import isBlockMetadataExperimental from './utils/is-block-metadata-experimental';
 
 /**
@@ -141,6 +141,7 @@ const getAllBlocks = () => {
 		quote,
 
 		// Register all remaining core blocks.
+		backToTop,
 		archives,
 		audio,
 		button,

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -71,5 +71,7 @@
 @import "./verse/style.scss";
 @import "./video/style.scss";
 @import "./footnotes/style.scss";
+@import "./back-to-top/style.scss";
 
 @import "common.scss";
+


### PR DESCRIPTION
This pull request implements a **Back to Top** block for the WordPress Block Editor, addressing [Issue #50433](https://github.com/WordPress/gutenberg/issues/50433). The block allows users to easily add a highly customizable button to their pages, enabling quick navigation back to the top of the page.

#### Features:
- Customizable colors, typography, and background.
- Sticky and non-sticky options for better placement control.
- Designed to enhance user experience on long, single-column pages.

### How to use 

https://www.loom.com/share/508f6232ff2d48488978a95481063322?sid=091509b4-686c-48c0-b480-c95325dbfd17