### PR TITLE
Try: Fix 'wp-polyfill' script dependents unit test

### DIFF
--- a/phpunit/script-dependencies-test.php
+++ b/phpunit/script-dependencies-test.php
@@ -4,7 +4,13 @@
  * @group script-dependencies
  */
 class Test_Script_Dependencies extends WP_UnitTestCase {
-	public $bundled_scripts = array( 'wp-upload-media' );
+	/**
+	 * The `wp-fileds` was accidintally bundled in WP 6.7, but removed later.
+	 * It's is listed here to avoid breaking previous WP version tests.
+	 *
+	 * @var array
+	 */
+	public $bundled_scripts = array( 'wp-upload-media', 'wp-fields' );
 
 	/**
 	 * Tests for accidental `wp-polyfill` script dependents.
@@ -38,7 +44,6 @@ class Test_Script_Dependencies extends WP_UnitTestCase {
 			'wp-edit-site',
 			'wp-core-data',
 			'wp-editor',
-			'wp-fields',
 			'wp-router',
 			'wp-url',
 			'wp-widgets',

--- a/phpunit/script-dependencies-test.php
+++ b/phpunit/script-dependencies-test.php
@@ -38,6 +38,7 @@ class Test_Script_Dependencies extends WP_UnitTestCase {
 			'wp-edit-site',
 			'wp-core-data',
 			'wp-editor',
+			'wp-fields',
 			'wp-router',
 			'wp-url',
 			'wp-widgets',


### PR DESCRIPTION
## What?
Tries to fix failing PHP Unit test - https://github.com/WordPress/gutenberg/actions/runs/14487412649/job/40636044213?pr=68733.

## Testing Instructions
CI checks are green.