### PR TITLE
Documentation: Fix missing `CSS` import in data basics tutorial code

### DIFF
--- a/docs/how-to-guides/data-basics/1-data-basics-setup.md
+++ b/docs/how-to-guides/data-basics/1-data-basics-setup.md
@@ -19,6 +19,7 @@ Go ahead and create these files using the following snippets:
 
 ```js
 import { createRoot } from 'react-dom';
+import './style.css';
 
 function MyFirstApp() {
 	return <span>Hello from JavaScript!</span>;

--- a/docs/how-to-guides/data-basics/2-building-a-list-of-pages.md
+++ b/docs/how-to-guides/data-basics/2-building-a-list-of-pages.md
@@ -366,6 +366,7 @@ import { SearchControl, Spinner } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
+import './style.css';
 
 function MyFirstApp() {
 	const [ searchTerm, setSearchTerm ] = useState( '' );


### PR DESCRIPTION


## What?
Closes: No issue (Small doc fix)

<!-- In a few words, what is the PR actually doing? -->

## Why?
The current code example in the data basics tutorial is missing the necessary CSS import statement in index.js, which prevents the styles from being included in the build process. Without this import, the style-index.css file isn't generated in the build directory, causing the PHP enqueue statement to reference a non-existent file.


## How?

Add the CSS import line to the index.js code example in the tutorial documentation. This ensures that when users follow the tutorial and run the build process, the CSS file will be properly processed and available for the PHP code to enqueue.

## Testing Instructions

1. Follow the tutorial steps to create the plugin [Link](https://developer.wordpress.org/block-editor/how-to-guides/data-basics/1-data-basics-setup/)
2. Run `npm start` to build the plugin
3. Verify that the `build/style-index.css` file is created
4. Activate the plugin in WordPress
5. Navigate to the "My first Gutenberg app" page


## Screenshots or screencast


https://github.com/user-attachments/assets/999bceb6-0507-403d-bdb1-c6b788b5f23c

