### PR TITLE
Docs: Added copy and code for style_data

### DIFF
--- a/docs/reference-guides/block-api/block-styles.md
+++ b/docs/reference-guides/block-api/block-styles.md
@@ -117,9 +117,9 @@ register_block_style(
                            'style' => 'solid',
                            'width' => '4px',
                            'radius' => '15px'
-						   )
-		   		)
-	   )
+                        )
+             )
+      )
 );
 ```
 Using the `style_data` property empowers the user to change it with the Global Styles UI via the **Editor > Styles**. The `style_data`property was added in WordPress 6.6.

--- a/docs/reference-guides/block-api/block-styles.md
+++ b/docs/reference-guides/block-api/block-styles.md
@@ -122,8 +122,7 @@ register_block_style(
 	   )
 );
 ```
-Using the `style_data` property, makes the block style no only available when editing content, but also via the **Editor > Styles** where users can modify the style to their needs.
-The `style_data`property was added in WordPress 6.6.
+Using the `style_data` property empowers the user to change it with the Global Styles UI via the **Editor > Styles**. The `style_data`property was added in WordPress 6.6.
 
 More information via WordPress 6.6 Dev Note: [Section Styles](https://make.wordpress.org/core/2024/06/24/section-styles/).
 Also on the WordPress Developer Blog: [Styling sections, nested elements, and more with Block Style Variations in WordPress 6.6](https://developer.wordpress.org/news/2024/06/styling-sections-nested-elements-and-more-with-block-style-variations-in-wordpress-6-6/)

--- a/docs/reference-guides/block-api/block-styles.md
+++ b/docs/reference-guides/block-api/block-styles.md
@@ -117,9 +117,9 @@ register_block_style(
                            'style' => 'solid',
                            'width' => '4px',
                            'radius' => '15px'
-                        )
-             )
-      )
+            )
+        )
+    )
 );
 ```
 Using the `style_data` property empowers the user to change it with the Global Styles UI via the **Editor > Styles**. The `style_data`property was added in WordPress 6.6.

--- a/docs/reference-guides/block-api/block-styles.md
+++ b/docs/reference-guides/block-api/block-styles.md
@@ -114,9 +114,13 @@ register_block_style(
            'style_data'=> array(
                            'border' => array(
                            'color' => '#f5bc42',
-                            'style' => 'solid',
-                            'width' => '4px',
-                            'radius' => '15px'
+                           'style' => 'solid',
+                           'width' => '4px',
+                           'radius' => '15px'
+						   )
+		   		)
+	   )
+);
 ```
 Using the `style_data` property, makes the block style no only available when editing content, but also via the **Editor > Styles** where users can modify the style to their needs.
 The `style_data`property was added in WordPress 6.6.

--- a/docs/reference-guides/block-api/block-styles.md
+++ b/docs/reference-guides/block-api/block-styles.md
@@ -64,12 +64,13 @@ The properties of the style array must include `name` and `label`:
 -   `name`: The identifier of the style used to compute a CSS class.
 -   `label`: A human-readable label for the style.
 
-Besides the two mandatory properties, the styles properties array should also include an `inline_style` or a `style_handle` property:
+Besides the two mandatory properties, the styles properties array should also include an `inline_style` or a `style_handle` or a `style_data`property:
 
 -   `inline_style`: Contains inline CSS code that registers the CSS class required for the style.
 -   `style_handle`: Contains the handle to an already registered style that should be enqueued in places where block styles are needed.
+-   `style_data`: Contains a theme.json-like notation in an array of style properties.
 
-It is also possible to set the `is_default` property to `true` to mark one of the block styles as the default one.
+It is also possible to set the `is_default` property to `true` to mark one of the block styles as the default one, should one be mising.
 
 The following code sample registers a style for the quote block named "Blue Quote", and provides an inline style that makes quote blocks with the "Blue Quote" style have blue color:
 
@@ -102,6 +103,26 @@ register_block_style(
     )
 );
 ```
+Another way is using the `style_data`property, as in below code example. It adds a block style to the image block with an orange border and slightly rounded corners.
+
+```php
+register_block_style(
+       array( 'core/image' ),
+       array(
+           'name'         => 'orange-border',
+           'label'        => __( 'Orange Border', 'pauli' ),
+           'style_data'=> array(
+                           'border' => array(
+                           'color' => '#f5bc42',
+                            'style' => 'solid',
+                            'width' => '4px',
+                            'radius' => '15px'
+```
+Using the `style_data` property, makes the block style no only available when editing content, but also via the **Editor > Styles** where users can modify the style to their needs.
+The `style_data`property was added in WordPress 6.6.
+
+More information via WordPress 6.6 Dev Note: [Section Styles](https://make.wordpress.org/core/2024/06/24/section-styles/).
+Also on the WordPress Developer Blog: [Styling sections, nested elements, and more with Block Style Variations in WordPress 6.6](https://developer.wordpress.org/news/2024/06/styling-sections-nested-elements-and-more-with-block-style-variations-in-wordpress-6-6/)
 
 ### unregister_block_style
 


### PR DESCRIPTION
## What?
Add explanation and code examples for fairly new style_data optional property for the PHP function register_block_style().

Fixes #69917

Will update the [Styles > register_block_style()](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-styles/#register_block_style) section of the Block Editor Handbook page.

## Why?
The property was added with WordPress 6.6 and missing on the docs page

## How?
I added a section to the particular part of the page.

## Testing Instructions
You can see the preview of the file by selecting "View file" from the tab Files changed