### PR TITLE
Create Block: Add `--textdomain`  in create-block README

### DIFF
--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -67,6 +67,7 @@ The rest of the configuration is set to all default values unless overridden wit
 --wp-scripts                 enable integration with `@wordpress/scripts` package
 --no-wp-scripts              disable integration with `@wordpress/scripts` package
 --wp-env                     enable integration with `@wordpress/env` package
+--textdomain <value>         text domain for internationalization
 -h, --help                   output usage information
 ```
 
@@ -106,6 +107,14 @@ With this argument, the `create-block` package will add to the generated plugin 
 
 ```bash
 $ npx @wordpress/create-block@latest --wp-env
+```
+
+#### `--textdomain`
+
+With this argument, the `create-block` package will a generate a block with the provided text domain. If not specified, the block’s slug is used as the default text domain.
+
+```bash
+$ npx @wordpress/create-block@latest block-name --textdomain=my-custom-domain
 ```
 
 #### `--help`

--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -114,7 +114,7 @@ $ npx @wordpress/create-block@latest --wp-env
 With this argument, the `create-block` package will a generate a block with the provided text domain. If not specified, the block’s slug is used as the default text domain.
 
 ```bash
-$ npx @wordpress/create-block@latest block-name --textdomain=my-custom-domain
+$ npx @wordpress/create-block@latest --textdomain my-custom-domain
 ```
 
 #### `--help`


### PR DESCRIPTION
## What?
This PR updates the README.md to document the new `--textdomain` flag that was added to the `create-block` tool in the previous PR (#69802).

## Why?
The previous PR added support for the `--textdomain` flag to the create-block tool, allowing users to specify a custom text domain for internationalization. This PR adds documentation to the README, ensuring users know how to use this new feature.
