### PR TITLE
Fix: Browser Warnings when closing keyboard shortcut modal

### DIFF
--- a/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/index.js
+++ b/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/index.js
@@ -28,7 +28,6 @@ const ShortcutList = ( { shortcuts } ) => (
 	 * Safari+VoiceOver won't announce the list otherwise.
 	 */
 	/* eslint-disable jsx-a11y/no-redundant-roles */
-
 	<ul
 		className="customize-widgets-keyboard-shortcut-help-modal__shortcut-list"
 		role="list"

--- a/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/index.js
+++ b/packages/customize-widgets/src/components/keyboard-shortcut-help-modal/index.js
@@ -13,6 +13,7 @@ import {
 	store as keyboardShortcutsStore,
 } from '@wordpress/keyboard-shortcuts';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -27,6 +28,7 @@ const ShortcutList = ( { shortcuts } ) => (
 	 * Safari+VoiceOver won't announce the list otherwise.
 	 */
 	/* eslint-disable jsx-a11y/no-redundant-roles */
+
 	<ul
 		className="customize-widgets-keyboard-shortcut-help-modal__shortcut-list"
 		role="list"
@@ -90,15 +92,18 @@ export default function KeyboardShortcutHelpModal( {
 	toggleModal,
 } ) {
 	const { registerShortcut } = useDispatch( keyboardShortcutsStore );
-	registerShortcut( {
-		name: 'core/customize-widgets/keyboard-shortcuts',
-		category: 'main',
-		description: __( 'Display these keyboard shortcuts.' ),
-		keyCombination: {
-			modifier: 'access',
-			character: 'h',
-		},
-	} );
+
+	useEffect( () => {
+		registerShortcut( {
+			name: 'core/customize-widgets/keyboard-shortcuts',
+			category: 'main',
+			description: __( 'Display these keyboard shortcuts.' ),
+			keyCombination: {
+				modifier: 'access',
+				character: 'h',
+			},
+		} );
+	}, [ registerShortcut ] );
 
 	useShortcut( 'core/customize-widgets/keyboard-shortcuts', toggleModal );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

Fixes #69928 

Fixes a React warning that occurred when the KeyboardShortcutHelpModal rendered and triggered a store update during render.

```
Warning: Cannot update a component (`DynamicShortcut`) while rendering a different component (`KeyboardShortcutHelpModal`). To locate the bad setState() call inside `KeyboardShortcutHelpModal`, follow the stack trace as described in https://reactjs.org/link/setstate-in-render Error Component Stack
    at KeyboardShortcutHelpModal (index.js:89:2)
    at MoreMenu (index.js:26:14)
    at div (<anonymous>)
    at ContextProvider (<anonymous>)
    at ScopedContextProvider (<anonymous>)
    at ContextProvider (<anonymous>)
    at ContextProvider (<anonymous>)
    at ScopedContextProvider (<anonymous>)
    at ContextProvider (<anonymous>)
    at ContextProvider (<anonymous>)
    at ContextProvider (<anonymous>)
    at ScopedContextProvider (<anonymous>)
    at ContextProvider (<anonymous>)
    at ContextProvider (<anonymous>)
    at LMDWO4NN.js:19:32
    at UnforwardedToolbarContainer (toolbar-container.tsx:21:4)
    at BaseContextSystemProvider (context-system-provider.js:94:39)
    at UnforwardedToolbar (index.tsx:24:3)
    at NavigableToolbar (index.js:207:2)
    at div (<anonymous>)
    at Header (index.js:23:2)
    at BlockRefsProvider (block-refs-provider.js:9:38)
    at Provider (index.tsx:59:2)
    at index.js:67:14
    at with-registry-provider.js:29:7
    at SidebarEditorProvider (sidebar-editor-provider.js:17:2)
    at SidebarBlockEditor (index.js:38:2)
    at ErrorBoundary (index.js:22:3)
    at FocusControl (index.js:20:41)
    at SidebarControls (index.js:9:2)
    at SlotFillProvider (slot-fill-provider.tsx:98:2)
    at SlotFillProvider (provider.tsx:110:37)
    at Provider (index.tsx:59:2)
    at CustomizeWidgets (index.js:17:2)
```


<!-- In a few words, what is the PR actually doing? -->

## Why?

- This happened because `registerShortcut()` was being called directly inside the render body of `KeyboardShortcutHelpModal`, which caused `keyboardShortcutsStore` to update while `DynamicShortcut` was also subscribed to it. This violates React's render purity and led to the warning. Please find [here](https://react.dev/learn/keeping-components-pure#side-effects-unintended-consequences:~:text=Side%20Effects%3A%20(un)intended%20consequences)

## How?

Moved the `registerShortcut()` call into a `useEffect()` hook to ensure it runs after the initial render rather than during render.

## Testing Instructions

- Open the browser console panel
- Activate Twenty Twenty-One
- Appearance > Customize > Widgets > Options button > Keyboard shortcuts
- Close the modal
- Confirm that there are no warnings in the browser console

<!-- ### Testing Instructions for Keyboard -->
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/4e6481a7-117a-4072-9b67-2691fcbf1cea


<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<!-- |Before|After|
|-|-| -->
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
