### PR TITLE
Playwright: update @playwright/test to version 1.52.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"@octokit/rest": "16.26.0",
 				"@octokit/types": "6.34.0",
 				"@octokit/webhooks-types": "5.8.0",
-				"@playwright/test": "1.51.1",
+				"@playwright/test": "1.52.0",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@react-native/babel-preset": "0.73.10",
 				"@react-native/metro-babel-transformer": "0.73.10",
@@ -8720,12 +8720,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.51.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.1.tgz",
-			"integrity": "sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==",
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+			"integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.51.1"
+				"playwright": "1.52.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -37819,12 +37820,13 @@
 			"dev": true
 		},
 		"node_modules/playwright": {
-			"version": "1.51.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.1.tgz",
-			"integrity": "sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==",
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+			"integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.51.1"
+				"playwright-core": "1.52.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -37837,10 +37839,11 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.51.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.1.tgz",
-			"integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==",
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+			"integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"playwright-core": "cli.js"
 			},
@@ -52299,7 +52302,7 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.51.1",
+				"@playwright/test": "^1.52.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.8.0",
-		"@playwright/test": "1.51.1",
+		"@playwright/test": "1.52.0",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@react-native/babel-preset": "0.73.10",
 		"@react-native/metro-babel-transformer": "0.73.10",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -95,7 +95,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"peerDependencies": {
-		"@playwright/test": "^1.51.1",
+		"@playwright/test": "^1.52.0",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
 	},

--- a/test/e2e/specs/editor/various/block-grouping.spec.js
+++ b/test/e2e/specs/editor/various/block-grouping.spec.js
@@ -367,7 +367,6 @@ test.describe( 'Block Grouping', () => {
 		test( 'should use registered grouping block for grouping interactions', async ( {
 			editor,
 			page,
-			pageUtils,
 			groupingUtils,
 		} ) => {
 			// Set custom Block as the Block to use for Grouping.
@@ -378,7 +377,17 @@ test.describe( 'Block Grouping', () => {
 			} );
 
 			await groupingUtils.insertBlocksOfSameType();
-			await pageUtils.pressKeys( 'primary+a', { times: 2 } );
+
+			await page
+				.getByRole( 'document', { name: 'Block: Paragraph' } )
+				.first()
+				.click();
+
+			// Use Shift+click to select a range.
+			await page.keyboard.down( 'Shift' );
+			await page.keyboard.press( 'ArrowDown' );
+			await page.keyboard.press( 'ArrowDown' );
+			await page.keyboard.up( 'Shift' );
 
 			// Group - this will use whichever Block is registered as the Grouping Block
 			// as opposed to "transformTo()" which uses whatever is passed to it. To

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -306,7 +306,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 
 		await page
 			.getByRole( 'document', { name: 'Block: Paragraph' } )
-			.click( { modifiers: [ 'Shift' ] } );
+			.dblclick( { modifiers: [ 'Shift' ] } );
 		await pageUtils.pressKeys( 'primary+a' );
 		await page.keyboard.type( 'new content' );
 


### PR DESCRIPTION
## What?
This PR updates the @playwright/test package to version 1.52.0

## What's new?

https://playwright.dev/docs/release-notes#version-152

### Breaking Changes (Source: Playwright version 1.52.0 release notes)

- Glob URL patterns in methods like [page.route()](https://playwright.dev/docs/api/class-page#page-route) do not support ? and [] anymore. We recommend using regular expressions instead.
- Method [route.continue()](https://playwright.dev/docs/api/class-route#route-continue) does not allow to override the Cookie header anymore. If a Cookie header is provided, it will be ignored, and the cookie will be loaded from the browser's cookie store. To set custom cookies, use [browserContext.addCookies()](https://playwright.dev/docs/api/class-browsercontext#browser-context-add-cookies).
- macOS 13 is now deprecated and will no longer receive WebKit updates. Please upgrade to a more recent macOS version to continue benefiting from the latest WebKit improvements.

## Testing Instructions

- Run an e2e test locally. New browsers should be downloaded, and the test should run successfully.
- Confirm that the CI checks are all passing.

P.S. This PR also temporarily fixes the failing [storybook smoke test](https://github.com/WordPress/gutenberg/actions/runs/14533046598/job/40776272752?pr=69937) (until the next playwright update occurs), which I believe would be caused by mismatching versions of `@playwright/tests`, inclusive of the `peerDependencies`.