### PR TITLE
Update styles to prevent overflow of content inside group block with flex layout

### DIFF
--- a/packages/block-library/src/group/style.scss
+++ b/packages/block-library/src/group/style.scss
@@ -1,6 +1,11 @@
 .wp-block-group {
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
+
+	&.is-layout-flex:not(.is-vertical) > * {
+		overflow-wrap: break-word;
+		word-break: break-word;
+	}
 }
 
 // We need this so groups with negative margins overlap as expected.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
<!-- Closes #ISSUE-NUMBER or URL -->

Fixes #50059 

This PR ensures that long unbroken text (like URLs or long words) inside .is-layout-flex row layout blocks does not cause horizontal overflow on narrow viewports. It adds consistent text-wrapping behavior to match what is already applied to column layouts.

<!-- In a few words, what is the PR actually doing? -->

## Why?

Currently, if a row layout block contains children with unbroken content (like long links or words), it can cause horizontal overflow, breaking the responsive layout. Column layout blocks already prevent this using overflow-wrap: break-word and word-break: break-word, but row layout blocks lack this protection. This update aligns both layout types to handle long content gracefully.

## How?

```
.is-layout-flex:not(.is-vertical) > * {
  overflow-wrap: break-word;
  word-break: break-word;
}
```

This CSS rule, targets direct children of row layout flex containers, ensuring that long words or unbroken strings wrap within their container boundaries and don’t overflow.

## Testing Instructions

1. Open a post or page in the block editor.

2. Insert a Group block and set its layout to "Row".

3. Add a Paragraph block inside the Group.

4. Paste in a long unbroken string (e.g., a long URL or continuous text with no spaces).

5. Resize the browser or preview on a narrow viewport.

6. Observe whether the text wraps correctly without overflowing the container.

<!-- ### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

<!-- ## Screenshots or screencast if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<!-- |Before|After| -->
<!-- |-|-| -->
<!-- |Before screenshot here | After screenshot here | -->

