### PR TITLE
Automated Testing: Fix Storybook build failure

### DIFF
--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -28,7 +28,7 @@ jobs:
               run: npm run storybook:build
 
             - name: Install Playwright dependencies
-              run: npx playwright install --with-deps
+              run: npx playwright install --with-deps chromium
 
             - name: Serve Storybook and run tests
               run: |

--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -28,7 +28,8 @@ jobs:
               run: npm run storybook:build
 
             - name: Install Playwright dependencies
-              run: npx playwright install --with-deps chromium
+              run: |
+                  npx --package=@playwright/test@1.51.1 playwright install --with-deps
 
             - name: Serve Storybook and run tests
               run: |

--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -27,12 +27,9 @@ jobs:
             - name: Build Storybook
               run: npm run storybook:build
 
-            - name: Install Playwright dependencies
-              run: |
-                  npx --package=@playwright/test@1.51.1 playwright install --with-deps
-
             - name: Serve Storybook and run tests
               run: |
+                  npx playwright install --with-deps
                   npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
                   "npx http-server ./storybook/build --port 50240 --silent" \
                   "npx wait-on tcp:127.0.0.1:50240 && \

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.8.0",
-		"@playwright/test": "1.51.0",
+		"@playwright/test": "1.51.1",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@react-native/babel-preset": "0.73.10",
 		"@react-native/metro-babel-transformer": "0.73.10",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.8.0",
-		"@playwright/test": "1.51.1",
+		"@playwright/test": "1.51.0",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@react-native/babel-preset": "0.73.10",
 		"@react-native/metro-babel-transformer": "0.73.10",


### PR DESCRIPTION
Investigating which CI is failing

## What?

I'm not sure of the root cause, but suddenly the GitHub Actions workflow for Storybook build started failing.

```
Run npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
  npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
  "npx http-server ./storybook/build --port 50[2](https://github.com/WordPress/gutenberg/actions/runs/14533046598/job/40776272752#step:6:2)40 --silent" \
  "npx wait-on tcp:127.0.0.1:50240 && \
  NODE_PATH=./node_modules \
  npx --package=@storybook/test-runner -- \
  test-storybook --url http://localhost:50240 --config-dir ./storybook"
  shell: /usr/bin/bash -e {0}
[SB] npm warn exec The following package was not found and will be installed: http-server@14.1.1
[TEST] npm warn exec The following package was not found and will be installed: @storybook/test-runner@0.22.0
[TEST] npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
[TEST] npm warn deprecated rimraf@[3](https://github.com/WordPress/gutenberg/actions/runs/14533046598/job/40776272752#step:6:3).0.2: Rimraf versions prior to v4 are no longer supported
[TEST] npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
[SB] (node:6609) [DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated
[SB] (Use `node --trace-deprecation ...` to show where the warning was created)
[TEST] Test Suites: 0 of 1[4](https://github.com/WordPress/gutenberg/actions/runs/14533046598/job/40776272752#step:6:4)1 total
[TEST] Tests:       0 total
[TEST] Snapshots:   0 total
[TEST] Time:        0.209 s
[TEST] Ran all test suites.
[TEST] Error: Executable doesn't exist at /home/runner/.cache/ms-playwright/chromium_headless_shell-1169/chrome-linux/headless_shell
[TEST] ╔═════════════════════════════════════════════════════════════════════════╗
[TEST] ║ Looks like Playwright Test or Playwright was just installed or updated. ║
[TEST] ║ Please run the following command to download new browsers:              ║
[TEST] ║                                                                         ║
[TEST] ║     npx playwright install                                              ║
[TEST] ║                                                                         ║
[TEST] ║ <3 Playwright Team                                                      ║
[TEST] ╚═════════════════════════════════════════════════════════════════════════╝ Failed to launch browser.
[TEST]     at executablePathOrDie (/home/runner/.npm/_npx/9d448bdacc8ce0[5](https://github.com/WordPress/gutenberg/actions/runs/14533046598/job/40776272752#step:6:5)a/node_modules/playwright-core/lib/server/registry/index.js:49[6](https://github.com/WordPress/gutenberg/actions/runs/14533046598/job/40776272752#step:6:6):15)
[TEST]     at Object.executablePathOrDie (/home/runner/.npm/_npx/9d448bdacc8ce05a/node_modules/playwright-core/lib/server/registry/index.js:52[7](https://github.com/WordPress/gutenberg/actions/runs/14533046598/job/40776272752#step:6:7):45)
[TEST]     at Chromium._launchProcess (/home/runner/.npm/_npx/9d44[8](https://github.com/WordPress/gutenberg/actions/runs/14533046598/job/40776272752#step:6:8)bdacc8ce05a/node_modules/playwright-core/lib/server/browserType.js:205:3[9](https://github.com/WordPress/gutenberg/actions/runs/14533046598/job/40776272752#step:6:10))
[TEST]     at async Chromium._innerLaunch (/home/runner/.npm/_npx/9d448bdacc8ce05a/node_modules/playwright-core/lib/server/browserType.js:135:70)
[TEST]     at async Chromium._innerLaunchWithRetries (/home/runner/.npm/_npx/9d448bdacc8ce05a/node_modules/playwright-core/lib/server/browserType.js:122:14)
[TEST]     at async ProgressController.run (/home/runner/.npm/_npx/9d448bdacc8ce05a/node_modules/playwright-core/lib/server/progress.js:80:22)
[TEST]     at async Chromium.launch (/home/runner/.npm/_npx/9d448bdacc8ce05a/node_modules/playwright-core/lib/server/browserType.js:87:21)
[TEST]     at async BrowserServerLauncherImpl.launchServer (/home/runner/.npm/_npx/9d448bdacc8ce05a/node_modules/playwright-core/lib/browserServerImpl.js:41:21)
[TEST]     at async BrowserType.launchServer (/home/runner/.npm/_npx/9d448bdacc8ce05a/node_modules/playwright-core/lib/client/browserType.js:71:[12](https://github.com/WordPress/gutenberg/actions/runs/14533046598/job/40776272752#step:6:13))
[TEST]     at async PlaywrightRunner.launchServer (/home/runner/.npm/_npx/9d448bdacc8ce05a/node_modules/jest-playwright-preset/lib/PlaywrightRunner.js:69:44)
[TEST] npx wait-on tcp:127.0.0.1:50240 && NODE_PATH=./node_modules npx --package=@storybook/test-runner -- test-storybook --url http://localhost:50240 --config-dir ./storybook exited with code 1
--> Sending SIGTERM to other processes..
[SB] npx http-server ./storybook/build --port 50240 --silent exited with code null
Error: Process completed with exit code 1.
```

## How?

Explicitly install Chromium.