### PR TITLE
Fix DropdownMenu icon width for Firefox

### DIFF
--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -34,6 +34,10 @@
 			height: 1px;
 		}
 
+		svg {
+			min-width: $icon-size;
+		}
+
 		&.is-active {
 			svg,
 			.dashicon {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

When scrolling the DropdownMenu in Firefox, the icons appear small.

That's why I set `min-width`.
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

https://wordpress.github.io/gutenberg/?path=/docs/components-dropdownmenu--docs

DropdownMenu is used in a toolbar
![tool](https://github.com/user-attachments/assets/5dcec275-eeef-4d0a-9587-f29fe950d323)

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

https://github.com/user-attachments/assets/fb2e993c-4203-4129-9756-b92998b8b0af

(Environment: Mac OS, Firefox 137.0.2)

https://github.com/user-attachments/assets/453330be-584c-49df-8f67-cf310e699150

(Environment: Windows 10 Pro, Firefox is 137.0.2 )

This is reported not to occur on Windows 11.
https://github.com/WordPress/gutenberg/pull/69942#pullrequestreview-2779863226

### After

https://github.com/user-attachments/assets/98bb0cee-4553-43e7-b367-d1e60b70db55

(Environment: Mac OS, Firefox 137.0.2)
