### PR TITLE
Author, Author Name block: fix PHP warning error when there is no context

### DIFF
--- a/packages/block-library/src/post-author-name/index.php
+++ b/packages/block-library/src/post-author-name/index.php
@@ -26,7 +26,7 @@ function render_block_core_post_author_name( $attributes, $content, $block ) {
 		return '';
 	}
 
-	if ( ! post_type_supports( $block->context['postType'], 'author' ) ) {
+	if ( isset( $block->context['postType'] ) && ! post_type_supports( $block->context['postType'], 'author' ) ) {
 		return '';
 	}
 

--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -26,7 +26,7 @@ function render_block_core_post_author( $attributes, $content, $block ) {
 		return '';
 	}
 
-	if ( ! post_type_supports( $block->context['postType'], 'author' ) ) {
+	if ( isset( $block->context['postType'] ) && ! post_type_supports( $block->context['postType'], 'author' ) ) {
 		return '';
 	}
 


### PR DESCRIPTION
## What?

Follow-up #67136
Closes #69948

<!-- In a few words, what is the PR actually doing? -->

## Why?

Fixes PHP warning error when the Author and Author Name block have no context.

See #69948

## How?

Checks for the existence of a context. If it doesn't, it continues with further processing. That is, if the block isn't relevant for a particular post type, it will be rendered.

However, [the User REST API doesn't allow listing users if they have no posts written yet](https://github.com/t-hamano/wordpress-develop/blob/a04a13a1d0039b6054a4276def28eedecc9cb9ad/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php#L488). As a follow-up, we may also need to add a check for the number of posts a user has written, in accordance with the REST API specification, in both blocks.

## Testing Instructions

- Add a new user with the "Editor" role (This user has no posts).
- Add an Author Archives template:
<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
  ```html
  <main class="wp-block-group">
  <!-- wp:query-title {"type":"archive"} /-->
  <!-- wp:post-author /-->
  <!-- wp:post-author-name /-->
  </main>
  <!-- /wp:group -->
  ```
- Access http://localhost:8888/?author=2 (Change the `author` param value to the actual user id for the newly added user)
- Confirm that two blocks are rendered correctly and no PHP warning logs are displayed.
