### PR TITLE
Document Settings: Lazy load post authors' data

### DIFF
--- a/packages/editor/src/components/post-author/check.js
+++ b/packages/editor/src/components/post-author/check.js
@@ -2,14 +2,12 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import PostTypeSupportCheck from '../post-type-support-check';
 import { store as editorStore } from '../../store';
-import { AUTHORS_QUERY } from './constants';
 
 /**
  * Wrapper component that renders its children only if the post type supports the author.
@@ -21,20 +19,17 @@ import { AUTHORS_QUERY } from './constants';
  * supports the author or if there are no authors available.
  */
 export default function PostAuthorCheck( { children } ) {
-	const { hasAssignAuthorAction, hasAuthors } = useSelect( ( select ) => {
+	const { hasAssignAuthorAction } = useSelect( ( select ) => {
 		const post = select( editorStore ).getCurrentPost();
 		const canAssignAuthor = post?._links?.[ 'wp:action-assign-author' ]
 			? true
 			: false;
 		return {
 			hasAssignAuthorAction: canAssignAuthor,
-			hasAuthors: canAssignAuthor
-				? select( coreStore ).getUsers( AUTHORS_QUERY )?.length >= 1
-				: false,
 		};
 	}, [] );
 
-	if ( ! hasAssignAuthorAction || ! hasAuthors ) {
+	if ( ! hasAssignAuthorAction ) {
 		return null;
 	}
 

--- a/packages/editor/src/components/post-author/panel.js
+++ b/packages/editor/src/components/post-author/panel.js
@@ -6,6 +6,8 @@ import { Button, Dropdown } from '@wordpress/components';
 import { useState, useMemo } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -13,10 +15,16 @@ import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '
 import PostAuthorCheck from './check';
 import PostAuthorForm from './index';
 import PostPanelRow from '../post-panel-row';
-import { useAuthorsQuery } from './hook';
+import { BASE_QUERY } from './constants';
+import { store as editorStore } from '../../store';
 
 function PostAuthorToggle( { isOpen, onClick } ) {
-	const { postAuthor } = useAuthorsQuery();
+	const { postAuthor } = useSelect( ( select ) => {
+		const id = select( editorStore ).getEditedPostAttribute( 'author' );
+		return {
+			postAuthor: select( coreStore ).getUser( id, BASE_QUERY ),
+		};
+	}, [] );
 	const authorName =
 		decodeEntities( postAuthor?.name ) || __( '(No author)' );
 	return (

--- a/packages/editor/src/components/post-author/test/check.js
+++ b/packages/editor/src/components/post-author/test/check.js
@@ -19,7 +19,7 @@ jest.mock( '@wordpress/data/src/components/use-select', () => {
 	return mock;
 } );
 
-function setupUseSelectMock( hasAssignAuthorAction, hasAuthors ) {
+function setupUseSelectMock( hasAssignAuthorAction ) {
 	useSelect.mockImplementation( ( cb ) => {
 		return cb( () => ( {
 			getPostType: () => ( { supports: { author: true } } ),
@@ -29,28 +29,20 @@ function setupUseSelectMock( hasAssignAuthorAction, hasAuthors ) {
 					'wp:action-assign-author': hasAssignAuthorAction,
 				},
 			} ),
-			getUsers: () => Array( hasAuthors ? 1 : 0 ).fill( {} ),
 		} ) );
 	} );
 }
 
 describe( 'PostAuthorCheck', () => {
-	it( 'should not render anything if has no authors', () => {
-		setupUseSelectMock( false, true );
-
-		render( <PostAuthorCheck>authors</PostAuthorCheck> );
-		expect( screen.queryByText( 'authors' ) ).not.toBeInTheDocument();
-	} );
-
 	it( "should not render anything if doesn't have author action", () => {
-		setupUseSelectMock( true, false );
+		setupUseSelectMock( false );
 
 		render( <PostAuthorCheck>authors</PostAuthorCheck> );
 		expect( screen.queryByText( 'authors' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should render control', () => {
-		setupUseSelectMock( true, true );
+		setupUseSelectMock( true );
 
 		render( <PostAuthorCheck>authors</PostAuthorCheck> );
 		expect( screen.getByText( 'authors' ) ).toBeVisible();


### PR DESCRIPTION
## What?
Closes #27103.

PR updates `post-author` components to lazy load selection data. This became possible after recent refactoring in #61362.

## Why?
This should improve the initial editor loading time for sites with a large number of users.

## Testing Instructions
1. Open a post.
2. Confirm that no request is made for the `wp-json/wp/v2/users` endpoint.
3. Open the post author's popover.
4. Confirm that the authors are fetched and displayed in the popover.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/03279058-5fa0-4317-9631-b57bc6e185bd

