### PR TITLE
Navigation Link, Navigation Submenu: Fix undefined key warning

### DIFF
--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -215,7 +215,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 
 	if ( is_post_type_archive() ) {
 		$queried_archive_link = get_post_type_archive_link( get_queried_object()->name );
-		if ( $attributes['url'] === $queried_archive_link ) {
+		if ( isset( $attributes['url'] ) && $attributes['url'] === $queried_archive_link ) {
 			$is_active = true;
 		}
 	}

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -213,9 +213,9 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	$kind        = empty( $attributes['kind'] ) ? 'post_type' : str_replace( '-', '_', $attributes['kind'] );
 	$is_active   = ! empty( $attributes['id'] ) && get_queried_object_id() === (int) $attributes['id'] && ! empty( get_queried_object()->$kind );
 
-	if ( is_post_type_archive() ) {
+	if ( is_post_type_archive() && ! empty( $attributes['url'] ) ) {
 		$queried_archive_link = get_post_type_archive_link( get_queried_object()->name );
-		if ( isset( $attributes['url'] ) && $attributes['url'] === $queried_archive_link ) {
+		if ( $attributes['url'] === $queried_archive_link ) {
 			$is_active = true;
 		}
 	}

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -88,7 +88,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 
 	if ( is_post_type_archive() ) {
 		$queried_archive_link = get_post_type_archive_link( get_queried_object()->name );
-		if ( $attributes['url'] === $queried_archive_link ) {
+		if ( isset( $attributes['url'] ) && $attributes['url'] === $queried_archive_link ) {
 			$is_active = true;
 		}
 	}

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -86,9 +86,9 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	$kind        = empty( $attributes['kind'] ) ? 'post_type' : str_replace( '-', '_', $attributes['kind'] );
 	$is_active   = ! empty( $attributes['id'] ) && get_queried_object_id() === (int) $attributes['id'] && ! empty( get_queried_object()->$kind );
 
-	if ( is_post_type_archive() ) {
+	if ( is_post_type_archive() && ! empty( $attributes['url'] ) ) {
 		$queried_archive_link = get_post_type_archive_link( get_queried_object()->name );
-		if ( isset( $attributes['url'] ) && $attributes['url'] === $queried_archive_link ) {
+		if ( $attributes['url'] === $queried_archive_link ) {
 			$is_active = true;
 		}
 	}


### PR DESCRIPTION
## What?
This pull request attempts to fix an undefined key warning.

## Why?
At a few WordPress websites I manage, I've been regularly seeing these kinds of errors generated for a while now:

```
[18-Apr-2025 07:53:08 UTC] PHP Warning:  Undefined array key "url" in /home/[REDACTED]/public_html/wp-includes/blocks/navigation-submenu.php on line 91
[18-Apr-2025 07:53:08 UTC] PHP Warning:  Undefined array key "url" in /home/[REDACTED]/public_html/wp-includes/blocks/navigation-submenu.php on line 91
[18-Apr-2025 21:45:39 UTC] PHP Warning:  Undefined array key "url" in /home/[REDACTED]/public_html/wp-includes/blocks/navigation-submenu.php on line 91
[18-Apr-2025 21:45:39 UTC] PHP Warning:  Undefined array key "url" in /home/[REDACTED]/public_html/wp-includes/blocks/navigation-submenu.php on line 91
[18-Apr-2025 21:49:35 UTC] PHP Warning:  Undefined array key "url" in /home/[REDACTED]/public_html/wp-includes/blocks/navigation-submenu.php on line 91
[18-Apr-2025 21:49:35 UTC] PHP Warning:  Undefined array key "url" in /home/[REDACTED]/public_html/wp-includes/blocks/navigation-submenu.php on line 91
[19-Apr-2025 00:17:29 UTC] PHP Warning:  Undefined array key "url" in /home/[REDACTED]/public_html/wp-includes/blocks/navigation-submenu.php on line 91
[19-Apr-2025 00:17:29 UTC] PHP Warning:  Undefined array key "url" in /home/[REDACTED]/public_html/wp-includes/blocks/navigation-submenu.php on line 91
[19-Apr-2025 00:17:29 UTC] PHP Warning:  Undefined array key "url" in /home/[REDACTED]/public_html/wp-includes/blocks/navigation-submenu.php on line 91
[19-Apr-2025 00:17:29 UTC] PHP Warning:  Undefined array key "url" in /home/[REDACTED]/public_html/wp-includes/blocks/navigation-submenu.php on line 91
[19-Apr-2025 08:46:34 UTC] PHP Warning:  Undefined array key "url" in /home/[REDACTED]/public_html/wp-includes/blocks/navigation-submenu.php on line 91
[19-Apr-2025 08:46:34 UTC] PHP Warning:  Undefined array key "url" in /home/[REDACTED]/public_html/wp-includes/blocks/navigation-submenu.php on line 91
[19-Apr-2025 10:20:02 UTC] PHP Warning:  Undefined array key "url" in /home/[REDACTED]/public_html/wp-includes/blocks/navigation-submenu.php on line 91
[19-Apr-2025 10:20:02 UTC] PHP Warning:  Undefined array key "url" in /home/[REDACTED]/public_html/wp-includes/blocks/navigation-submenu.php on line 91
[19-Apr-2025 10:58:54 UTC] PHP Warning:  Undefined array key "url" in /home/[REDACTED]/public_html/wp-includes/blocks/navigation-submenu.php on line 91
[19-Apr-2025 10:58:54 UTC] PHP Warning:  Undefined array key "url" in /home/[REDACTED]/public_html/wp-includes/blocks/navigation-submenu.php on line 91
```

Seeing as the solution seems simple enough and hasn't yet been implemented, I decided to try submitting a pull request here to address it (which, if accepted, I assume will eventually find its way upstream and into some future WordPress update at some point in the future).

Although I'm not entirely sure of the *exact* state and circumstances of the implementation at the time when the error occurs (i.e., the elements available to `$attributes`, as populated at the points where the function is called/invoked), a simple `isset()` check feels the most simple, direct, and logical solution for the problem. At most other points in the affected function where an element of `$attributes` is used, its use is similarly preceded by an `isset()` check; the exception which this pull request addresses is one of the very few exceptions. This pull request brings that exception into line with the various other points of use which are preceded by `isset()`.

## How?
Uses `isset()` to check the existence of the key before attempting to compare it.
