### PR TITLE
FontSizePicker: Show min-max range for fluid font sizes in dropdown.

### DIFF
--- a/packages/components/src/font-size-picker/font-size-picker-select.tsx
+++ b/packages/components/src/font-size-picker/font-size-picker-select.tsx
@@ -26,7 +26,32 @@ const FontSizePickerSelect = ( props: FontSizePickerSelectProps ) => {
 		DEFAULT_OPTION,
 		...fontSizes.map( ( fontSize ) => {
 			let hint;
-			if ( isSimpleCssValue( fontSize.size ) ) {
+			if ( fontSize.fluid ) {
+				const hasMin = isSimpleCssValue( fontSize.fluid.min ?? '' );
+				const hasMax = isSimpleCssValue( fontSize.fluid.max ?? '' );
+
+				if ( hasMin && hasMax ) {
+					hint = sprintf(
+						// translators: 1: the minimum fluid font size value, 2: the maximum fluid font size value.
+						__( 'Fluid (%1$s - %2$s)' ),
+						fontSize.fluid.min,
+						fontSize.fluid.max
+					);
+				} else if ( hasMin ) {
+					hint = sprintf(
+						// translators: %s: the minimum fluid font size value.
+						__( 'Fluid ( >= %s)' ),
+						fontSize.fluid.min
+					);
+				} else if ( hasMax ) {
+					hint = sprintf(
+						// translators: %s: the maximum fluid font size value.
+						__( 'Fluid ( <= %s)' ),
+						fontSize.fluid.max
+					);
+				}
+			}
+			if ( ! hint && isSimpleCssValue( fontSize.size ) ) {
 				hint = String( fontSize.size );
 			}
 			return {

--- a/packages/components/src/font-size-picker/types.ts
+++ b/packages/components/src/font-size-picker/types.ts
@@ -96,6 +96,14 @@ export type FontSize = {
 	 * size. Used for the class generation process.
 	 */
 	slug: string;
+	/**
+	 * The `fluid` property is an optional object specifying min and max values for
+	 * fluid font sizes.
+	 */
+	fluid?: {
+		min?: string | number;
+		max?: string | number;
+	};
 };
 
 export type FontSizePickerSelectProps = Pick<


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #69939 

This PR updates the `FontSizePickerSelect` component to improve how fluid font size presets are displayed in the dropdown. Instead of using the `size` property as the hint, it now shows values from the `fluid` property (`min` and `max`) when they are available.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, the `FontSizePickerSelect` component uses the `size` property as the hint, even when the `fluid` property is present. However, the `size` may not accurately represent the rendered font size for fluid presets, as it is derived from the min–max fluid range.

This change helps reduce confusion by explicitly displaying the fluid font size range in the UI.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Updated the FontSizePickerSelect component to:

- Check for the presence of fluid.min and fluid.max
- Display:
  - `Fluid (min – max)` when both are defined
  - `Fluid (≥ min)` when only min is defined
  - `Fluid (≤ max)` when only max is defined

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Select a block like paragraph or heading
2. Open the Typography → Font Size settings
3. Verify that the dropdown hints use values from the `fluid` property when its present.
Note: Update `theme.json` to have atleast 6 sizes to enable the dropdown selector instead of toggle.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Same

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="283" alt="image" src="https://github.com/user-attachments/assets/be8ae583-766f-4a3a-9b45-3aedd093498b" /> | <img width="283" alt="image" src="https://github.com/user-attachments/assets/ba3e972c-8737-4b17-8c0e-7e391f16f374" /> |
