### PR TITLE
Fix: Remove an unnecessary `@return` tag from this filter docblock.

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -133,7 +133,6 @@ class WP_Navigation_Block_Renderer {
 		 * @since 6.5.0
 		 *
 		 * @param array $needs_list_item_wrapper The list of blocks that need a list item wrapper.
-		 * @return array The list of blocks that need a list item wrapper.
 		 */
 		$needs_list_item_wrapper = apply_filters( 'block_core_navigation_listable_blocks', static::$needs_list_item_wrapper );
 


### PR DESCRIPTION
## What?

This removes an unnecessary `@return` tags that slipped in.

## Why?

`@return` tags are not needed in docblocks for filters.

## Testing Instructions

N/A