### PR TITLE
Calendar block: Disable edit as HTML support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -69,7 +69,7 @@ A calendar of your site’s posts. ([Source](https://github.com/WordPress/gutenb
 
 -	**Name:** core/calendar
 -	**Category:** widgets
--	**Supports:** align, color (background, link, text), interactivity (clientNavigation), typography (fontSize, lineHeight)
+-	**Supports:** align, color (background, link, text), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** month, year
 
 ## Terms List

--- a/packages/block-library/src/calendar/block.json
+++ b/packages/block-library/src/calendar/block.json
@@ -17,6 +17,7 @@
 	},
 	"supports": {
 		"align": true,
+		"html": false,
 		"color": {
 			"link": true,
 			"__experimentalSkipSerialization": [ "text", "background" ],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR disables HTML editing support for Calendar blocks.

## Why?

Dynamic blocks do not require HTML editing. Editing the HTML will break the blocks.

https://github.com/user-attachments/assets/c55141a3-b4aa-4c28-945c-f5d35bfd843b



Make it consistent with other dynamic blocks

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open a Post or Page.
2. Insert a Calendar block.
3. Confirm "Edit as HTML" action isn't available in block Options.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
| ![before](https://github.com/user-attachments/assets/081a4c4f-219f-4cdb-8070-9f544f6a958b) | ![after](https://github.com/user-attachments/assets/6db927e2-df5f-4895-84ed-20c139c63cf4) |

