### PR TITLE
ToggleGroupControl: Fix active background for empty string value

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,9 +7,13 @@
 -   `Guide`: Make next and previous button text customizable ([#69907](https://github.com/WordPress/gutenberg/pull/69907)).
 -   `Popover`: Introduce a virtual padding of `8px` to prevent it from hitting the viewport edge ([#69555](https://github.com/WordPress/gutenberg/pull/69555)).
 
+### Bug Fixes
+
+-   `ToggleGroupControl`: Fix active background for empty string value ([#69969](https://github.com/WordPress/gutenberg/pull/69969)).
+
 ## 29.8.0 (2025-04-11)
 
-### Documentation 
+### Documentation
 
 -   `Popover`: Expose Popover TypeScript types for subcomponents. ([#69619](https://github.com/WordPress/gutenberg/pull/69619))
 

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -54,7 +54,7 @@ function UnconnectedToggleGroupControl(
 	const [ controlElement, setControlElement ] = useState< HTMLElement >();
 	const refs = useMergeRefs( [ setControlElement, forwardedRef ] );
 	const selectedRect = useTrackElementOffsetRect(
-		value || value === 0 ? selectedElement : undefined
+		value !== null && value !== undefined ? selectedElement : undefined
 	);
 	useAnimatedOffsetRect( controlElement, selectedRect, {
 		prefix: 'selected',


### PR DESCRIPTION
## What?
Closes #69925.
Similar to #66855.

PR fixes active `ToggleGroupControlOption` background when an empty string is provided, which seems to be a valid case, but was omitted from the check.

## Testing Instructions
1. Run a test plugin via DevTools console.
2. Confirm that the "None" option is correctly selected.
3. Switching between options works as before.

<details><summary>Details</summary>
<p>

```javascript
const {createElement: el, useState} = wp.element;
const {__experimentalToggleGroupControl: ToggleGroupControl, __experimentalToggleGroupControlOption: ToggleGroupControlOption} = wp.components;
const registerPlugin = wp.plugins.registerPlugin;
const PluginDocumentSettingPanel = wp.editor.PluginDocumentSettingPanel;

function TestToggleGroupControl() {
    const [value,setValue] = useState('');

    console.log(value);

    return el(PluginDocumentSettingPanel, {
        className: 'test-custom-select',
        title: 'Test Toggle Group Control',
        name: 'test-toggle-group-control'
    }, el(ToggleGroupControl, {
        label: "Test",
        value: value,
        isBlock: true,
        __nextHasNoMarginBottom: true,
        __next40pxDefaultSize: true,
        onChange: setValue
    }, el(ToggleGroupControlOption, {
        value: "",
        label: "None"
    }), el(ToggleGroupControlOption, {
        value: "next",
        label: "Next"
    })));
}

registerPlugin('test-toggle-group-control', {
    render: TestToggleGroupControl,
});
``` 

</p>
</details> 


### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2025-04-22 at 22 51 30](https://github.com/user-attachments/assets/144f6b35-01c6-4646-b500-25ee15d936d3)

