### PR TITLE
Site Editor: Check user permissions before rendering export menu item

### DIFF
--- a/backport-changelog/6.9/8770.md
+++ b/backport-changelog/6.9/8770.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/8770
+
+* https://github.com/WordPress/gutenberg/pull/69971

--- a/lib/compat/wordpress-6.9/rest-api.php
+++ b/lib/compat/wordpress-6.9/rest-api.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * PHP and WordPress configuration compatibility functions for the Gutenberg
+ * editor plugin changes related to REST API.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Adds export theme link relation to the block theme responses.
+ *
+ * @param WP_REST_Response $response The response object.
+ * @param WP_Theme         $theme    Theme object used to create response.
+ * @return WP_REST_Response Modified response object.
+ */
+function gutenberg_rest_theme_export_link_rel( $response, $theme ) {
+	if ( ! empty( $response->get_links() ) && $theme->is_block_theme() ) {
+		$response->add_link(
+			'https://api.w.org/export-theme',
+			rest_url( 'wp-block-editor/v1/export' ),
+			array(
+				'targetHints' => array(
+					'allow' => current_user_can( 'export' ) ? array( 'GET' ) : array(),
+				),
+			)
+		);
+	}
+
+	return $response;
+}
+add_filter( 'rest_prepare_theme', 'gutenberg_rest_theme_export_link_rel', 10, 2 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -39,6 +39,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-6.8/rest-api.php';
 
 	// WordPress 6.9 compat.
+	require __DIR__ . '/compat/wordpress-6.9/rest-api.php';
 	require __DIR__ . '/compat/wordpress-6.9/class-gutenberg-hierarchical-sort.php';
 
 	// Plugin specific code.

--- a/packages/edit-site/src/components/more-menu/index.js
+++ b/packages/edit-site/src/components/more-menu/index.js
@@ -1,8 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 
 /**
@@ -15,14 +13,10 @@ import { unlock } from '../../lock-unlock';
 const { ToolsMoreMenuGroup, PreferencesModal } = unlock( editorPrivateApis );
 
 export default function MoreMenu() {
-	const isBlockBasedTheme = useSelect( ( select ) => {
-		return select( coreStore ).getCurrentTheme().is_block_theme;
-	}, [] );
-
 	return (
 		<>
 			<ToolsMoreMenuGroup>
-				{ isBlockBasedTheme && <SiteExport /> }
+				<SiteExport />
 				<WelcomeGuideMenuItem />
 			</ToolsMoreMenuGroup>
 			<PreferencesModal />

--- a/packages/edit-site/src/components/more-menu/site-export.js
+++ b/packages/edit-site/src/components/more-menu/site-export.js
@@ -12,9 +12,13 @@ import { store as noticesStore } from '@wordpress/notices';
 
 export default function SiteExport() {
 	const canExport = useSelect( ( select ) => {
-		return select( coreStore ).getCurrentTheme().is_block_theme;
-	}, [] );
+		const targetHints =
+			select( coreStore ).getCurrentTheme()?._links?.[
+				'wp:export-theme'
+			]?.[ 0 ]?.targetHints ?? {};
 
+		return !! targetHints.allow?.includes( 'GET' );
+	}, [] );
 	const { createErrorNotice } = useDispatch( noticesStore );
 
 	if ( ! canExport ) {

--- a/packages/edit-site/src/components/more-menu/site-export.js
+++ b/packages/edit-site/src/components/more-menu/site-export.js
@@ -5,12 +5,21 @@ import { __, _x } from '@wordpress/i18n';
 import { MenuItem } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { download } from '@wordpress/icons';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { downloadBlob } from '@wordpress/blob';
+import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
 
 export default function SiteExport() {
+	const canExport = useSelect( ( select ) => {
+		return select( coreStore ).getCurrentTheme().is_block_theme;
+	}, [] );
+
 	const { createErrorNotice } = useDispatch( noticesStore );
+
+	if ( ! canExport ) {
+		return null;
+	}
 
 	async function handleExport() {
 		try {


### PR DESCRIPTION
## What?
Closes #46661.
Supersedes #69107.
Related https://core.trac.wordpress.org/ticket/57379.

PR adds a user capability check for the Export feature in the Site Editor. Users without export capabilities will not be able to use this feature.

## How
Add a new link relation for the export endpoint and provide the required data for capability checks via `targetHints`. Suggested initially by @TimothyBJacobs - https://core.trac.wordpress.org/ticket/57379#comment:10.

## Testing Instructions
1. Temporarily remove the `export` cap for Administrators - `wp cap remove administrator export`.
2. Navigate to Site Editor and open the "Options" drop-down.
3. Confirm that the "Export" menu items aren't rendered.
4. Restore default caps for Administrators - `wp role reset administrator`

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast
![CleanShot 2025-02-08 at 20 26 10](https://github.com/user-attachments/assets/74d87b8a-b793-4e9e-94a9-76827001b549)