### PR TITLE
Documentation: Add WP version note for 'setAttributes' updater function

### DIFF
--- a/docs/reference-guides/block-api/block-edit-save.md
+++ b/docs/reference-guides/block-api/block-edit-save.md
@@ -137,6 +137,8 @@ Why do this? In JavaScript, arrays and objects are passed by reference, so this 
 
 The `setAttribute` also supports an updater function as an argument. It must be a pure function, which takes current attributes as its only argument and returns updated attributes. This method is helpful when you want to update an value based on a previous state or when working with objects and arrays.
 
+_**Note:** Since WordPress 6.9._
+
 ```js
 // Toggle a setting when the user clicks the button.
 const toggleSetting = () =>


### PR DESCRIPTION
## What?
See: https://github.com/WordPress/gutenberg/pull/69709#discussion_r2020898745.

PR adds WP version documentation note for 'setAttributes' updater function.

## Testing Instructions
None.
