### PR TITLE
List View: Add E2E test to verify pasting block styles via keyboard

### DIFF
--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -597,6 +597,87 @@ test.describe( 'List View', () => {
 			] );
 	} );
 
+	test( 'should paste block styles using keyboard', async ( {
+		editor,
+		page,
+		pageUtils,
+		listViewUtils,
+		context,
+	} ) => {
+		// Grant clipboard access for copying and pasting styles between blocks.
+		await context.grantPermissions( [
+			'clipboard-read',
+			'clipboard-write',
+		] );
+
+		// Insert a block without styles.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content: 'First Block',
+			},
+		} );
+
+		// Insert a block with styles.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content: 'Second Block',
+				style: {
+					color: {
+						text: '#ff0000',
+						background: '#00ff00',
+					},
+				},
+			},
+		} );
+
+		// Copy the styles from the second block.
+		await editor.clickBlockToolbarButton( 'Options' );
+		await page
+			.getByRole( 'menu', { name: 'Options' } )
+			.getByRole( 'menuitem', {
+				name: 'Copy Styles',
+			} )
+			.click();
+
+		// Open List View.
+		await listViewUtils.openListView();
+
+		// Navigate to the block without styles.
+		await page.keyboard.press( 'ArrowUp' );
+
+		// Paste the copied styles.
+		await pageUtils.pressKeys( 'primaryAlt+v' );
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: 'First Block',
+					style: {
+						color: {
+							text: '#ff0000',
+							background: '#00ff00',
+						},
+					},
+				},
+			},
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: 'Second Block',
+					style: {
+						color: {
+							text: '#ff0000',
+							background: '#00ff00',
+						},
+					},
+				},
+			},
+		] );
+	} );
+
 	test( 'should cut and paste blocks using keyboard', async ( {
 		editor,
 		pageUtils,


### PR DESCRIPTION
## What, Why, and How?

Follow-up to #69196
Related discussion https://github.com/WordPress/gutenberg/pull/69196#issuecomment-2712606597

This PR adds an E2E Test which tests the keyboard shortcut `cmd(ctrl)+option(alt)+v` to paste styles from the List View.

## Testing Instructions

1. Run the following command in the terminal.
```npm run test:e2e-- test/e2e/specs/editor/various/list-view.spec.js:600```

2. Confirm that the test passes.

### Testing Instructions for Keyboard
Same.

## Screenshot

<img width="1470" alt="e2e" src="https://github.com/user-attachments/assets/4e3f39ff-50ad-4eff-8b9f-eaef265c2c49" />

