### PR TITLE
Fix: Duotone unset button

### DIFF
--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -124,9 +124,10 @@ function DuotonePanelPure( { style, setAttributes, name } ) {
 		return null;
 	}
 
-	const duotonePresetOrColors = ! Array.isArray( duotoneStyle )
-		? getColorsFromDuotonePreset( duotoneStyle, duotonePalette )
-		: duotoneStyle;
+	const duotonePresetOrColors =
+		duotoneStyle === 'unset' || Array.isArray( duotoneStyle )
+			? duotoneStyle
+			: getColorsFromDuotonePreset( duotoneStyle, duotonePalette );
 
 	return (
 		<>

--- a/packages/components/src/duotone-picker/duotone-picker.tsx
+++ b/packages/components/src/duotone-picker/duotone-picker.tsx
@@ -76,7 +76,7 @@ function DuotonePicker( {
 		[ colorPalette ]
 	);
 
-	const isUnset = value === 'unset' || value === undefined;
+	const isUnset = value === 'unset';
 	const unsetOptionLabel = __( 'Unset' );
 
 	const unsetOption = (

--- a/packages/components/src/duotone-picker/duotone-picker.tsx
+++ b/packages/components/src/duotone-picker/duotone-picker.tsx
@@ -76,7 +76,7 @@ function DuotonePicker( {
 		[ colorPalette ]
 	);
 
-	const isUnset = value === 'unset';
+	const isUnset = value === 'unset' || value === undefined;
 	const unsetOptionLabel = __( 'Unset' );
 
 	const unsetOption = (

--- a/packages/components/src/duotone-picker/style.scss
+++ b/packages/components/src/duotone-picker/style.scss
@@ -13,6 +13,10 @@
 		color: transparent;
 	}
 
+	&:hover:not(:disabled):not([aria-disabled="true"]) {
+		color: transparent;
+	}
+
 	&:not([aria-disabled="true"]):active {
 		color: transparent;
 	}


### PR DESCRIPTION
## What?
Closes #69980

## Why?
This PR is necessary to improve the behaviour of the default duotone unset button

## How?
This PR targets the class which sets the blue color to the unset button and sets the color to transparent 
It also adds the condition of `value === undefined` to `isUnset` to get the checked icon on the unset button 

## Testing Instructions
- Create a new post 
- Add an Image Block or any block that has 'Duotone' present 
- Open the Duotone from the right panel ( Styles > Filters > Duotone ) 
- Notice that now when we select a duotone option we get a checkmark and on hovering or selecting there is no blue color


## Screenshots or screencast 

https://github.com/user-attachments/assets/de5d86d2-0b5f-4dd1-86cf-749422a589a6
