### PR TITLE
Image: Avoid stale URL when reselecting the same image from the library

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -262,10 +262,6 @@ export function ImageEdit( {
 			additionalAttributes = {
 				sizeSlug: newSize,
 			};
-		} else {
-			// Keep the same url when selecting the same file, so "Resolution"
-			// option is not changed.
-			additionalAttributes = { url };
 		}
 
 		// Check if default link setting should be used.


### PR DESCRIPTION
## What?
Closes #69965.

PR removes the condition for preserving the `url` attribute when selecting the same image from Media Library, which can cause subtle bugs as described in the linked issue.

The condition was initially introduced in #16125 to avoid resetting the image "Resolution" setting, but it's no longer necessary after #49982.

## Testing Instructions
1. Create a post.
2. Add two image blocks and select different images.
3. Using a code editor, update the image's `src` so that both blocks point to the same image.
4. Select the image block where `ID` and `src` don't match and click "Replace".
5. Confirm that the image points to the correct item in the media library (selection happens based on ID).
6. Select the same image from the library.
7. Confirm that the block now has the correct `src` URL.

### Testing Instructions for Keyboard
Same.