### PR TITLE
ServerSideRender: Don't render the previous error response in loading state

### DIFF
--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -213,12 +213,12 @@ export default function ServerSideRender( props ) {
 
 	const hasResponse = !! response;
 	const hasEmptyResponse = response === '';
-	const hasError = response?.error;
+	const hasError = !! response?.error;
 
 	if ( isLoading ) {
 		return (
 			<LoadingResponsePlaceholder { ...props } showLoader={ showLoader }>
-				{ hasResponse && (
+				{ hasResponse && ! hasError && (
 					<RawHTML className={ className }>{ response }</RawHTML>
 				) }
 			</LoadingResponsePlaceholder>


### PR DESCRIPTION
## What?
Closes #69986.

PR hardens the check for `LoadingResponsePlaceholder` and avoids rendering a response when it contains an error.

## Why?
The `RawHTML` expects a response to be a string, not an error object. It also doesn't make sense to display previous content while loading, when the previous content was an error.

## Testing Instructions
1. Add an archives block to a post.
2. Emulate offline mode via devtools.
3. Toggle any control a couple of times.
4. Confirm that the block doesn't crash and the offline error is displayed correctly.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/30335e9a-61fd-4bf4-9bf7-574f109162da

