### PR TITLE
Featured image block: migrate `aspectRatio` to block supports

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -640,8 +640,8 @@ Display a post's featured image. ([Source](https://github.com/WordPress/gutenber
 
 -	**Name:** core/post-featured-image
 -	**Category:** theme
--	**Supports:** align (center, full, left, right, wide), color (~~background~~, ~~text~~), filter (duotone), interactivity (clientNavigation), shadow (), spacing (margin, padding), ~~html~~
--	**Attributes:** aspectRatio, customGradient, customOverlayColor, dimRatio, gradient, height, isLink, linkTarget, overlayColor, rel, scale, sizeSlug, useFirstImageFromPost, width
+-	**Supports:** align (center, full, left, right, wide), color (~~background~~, ~~text~~), dimensions (aspectRatio), filter (duotone), interactivity (clientNavigation), shadow (), spacing (margin, padding), ~~html~~
+-	**Attributes:** customGradient, customOverlayColor, dimRatio, gradient, height, isLink, linkTarget, overlayColor, rel, scale, sizeSlug, useFirstImageFromPost, width
 
 ## Post Navigation Link
 

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -12,9 +12,6 @@
 			"default": false,
 			"role": "content"
 		},
-		"aspectRatio": {
-			"type": "string"
-		},
 		"width": {
 			"type": "string"
 		},
@@ -87,6 +84,9 @@
 		"shadow": {
 			"__experimentalSkipSerialization": true
 		},
+		"dimensions": {
+			"aspectRatio": true
+		},
 		"html": false,
 		"spacing": {
 			"margin": true,
@@ -101,6 +101,9 @@
 		"shadow": ".wp-block-post-featured-image img, .wp-block-post-featured-image .components-placeholder",
 		"filter": {
 			"duotone": ".wp-block-post-featured-image img, .wp-block-post-featured-image .wp-block-post-featured-image__placeholder, .wp-block-post-featured-image .components-placeholder__illustration, .wp-block-post-featured-image .components-placeholder::before"
+		},
+		"dimensions": {
+			"aspectRatio": ".wp-block-post-featured-image, .wp-block-post-featured-image img"
 		}
 	},
 	"editorStyle": "wp-block-post-featured-image-editor",

--- a/packages/block-library/src/post-featured-image/deprecated.js
+++ b/packages/block-library/src/post-featured-image/deprecated.js
@@ -1,0 +1,125 @@
+/**
+ * WordPress dependencies
+ */
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+
+const { cleanEmptyObject } = unlock( blockEditorPrivateApis );
+
+const migrateAspectRatio = ( attributes ) => {
+	if ( ! attributes.aspectRatio ) {
+		return attributes;
+	}
+	const { aspectRatio } = attributes;
+	return {
+		...attributes,
+		style: cleanEmptyObject( {
+			...attributes.style,
+			dimensions: {
+				...attributes.style?.dimensions,
+				aspectRatio,
+			},
+		} ),
+	};
+};
+
+const v1 = {
+	attributes: {
+		isLink: {
+			type: 'boolean',
+			default: false,
+			role: 'content',
+		},
+		aspectRatio: {
+			type: 'string',
+		},
+		width: {
+			type: 'string',
+		},
+		height: {
+			type: 'string',
+		},
+		scale: {
+			type: 'string',
+			default: 'cover',
+		},
+		sizeSlug: {
+			type: 'string',
+		},
+		rel: {
+			type: 'string',
+			attribute: 'rel',
+			default: '',
+			role: 'content',
+		},
+		linkTarget: {
+			type: 'string',
+			default: '_self',
+			role: 'content',
+		},
+		overlayColor: {
+			type: 'string',
+		},
+		customOverlayColor: {
+			type: 'string',
+		},
+		dimRatio: {
+			type: 'number',
+			default: 0,
+		},
+		gradient: {
+			type: 'string',
+		},
+		customGradient: {
+			type: 'string',
+		},
+		useFirstImageFromPost: {
+			type: 'boolean',
+			default: false,
+		},
+	},
+	supports: {
+		align: [ 'left', 'right', 'center', 'wide', 'full' ],
+		color: {
+			text: false,
+			background: false,
+		},
+		__experimentalBorder: {
+			color: true,
+			radius: true,
+			width: true,
+			__experimentalSkipSerialization: true,
+			__experimentalDefaultControls: {
+				color: true,
+				radius: true,
+				width: true,
+			},
+		},
+		filter: {
+			duotone: true,
+		},
+		shadow: {
+			__experimentalSkipSerialization: true,
+		},
+		html: false,
+		spacing: {
+			margin: true,
+			padding: true,
+		},
+		interactivity: {
+			clientNavigation: true,
+		},
+	},
+	save() {
+		return null;
+	},
+	migrate: migrateAspectRatio,
+	isEligible( { aspectRatio } ) {
+		return aspectRatio;
+	},
+};
+export default [ v1 ];

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -3,7 +3,6 @@
  */
 import { __, _x } from '@wordpress/i18n';
 import {
-	SelectControl,
 	__experimentalUnitControl as UnitControl,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
@@ -48,16 +47,15 @@ const scaleHelp = {
 
 const DimensionControls = ( {
 	clientId,
-	attributes: { aspectRatio, width, height, scale },
+	attributes: { width, height, scale },
 	setAttributes,
 } ) => {
-	const [ availableUnits, defaultRatios, themeRatios, showDefaultRatios ] =
-		useSettings(
-			'spacing.units',
-			'dimensions.aspectRatios.default',
-			'dimensions.aspectRatios.theme',
-			'dimensions.defaultAspectRatios'
-		);
+	const [ availableUnits ] = useSettings(
+		'spacing.units',
+		'dimensions.aspectRatios.default',
+		'dimensions.aspectRatios.theme',
+		'dimensions.defaultAspectRatios'
+	);
 	const units = useCustomUnits( {
 		availableUnits: availableUnits || [ 'px', '%', 'vw', 'em', 'rem' ],
 	} );
@@ -78,54 +76,10 @@ const DimensionControls = ( {
 	};
 	const scaleLabel = _x( 'Scale', 'Image scaling options' );
 
-	const showScaleControl =
-		height || ( aspectRatio && aspectRatio !== 'auto' );
-
-	const themeOptions = themeRatios?.map( ( { name, ratio } ) => ( {
-		label: name,
-		value: ratio,
-	} ) );
-
-	const defaultOptions = defaultRatios?.map( ( { name, ratio } ) => ( {
-		label: name,
-		value: ratio,
-	} ) );
-
-	const aspectRatioOptions = [
-		{
-			label: _x(
-				'Original',
-				'Aspect ratio option for dimensions control'
-			),
-			value: 'auto',
-		},
-		...( showDefaultRatios ? defaultOptions : [] ),
-		...( themeOptions ? themeOptions : [] ),
-	];
+	const showScaleControl = height;
 
 	return (
 		<>
-			<ToolsPanelItem
-				hasValue={ () => !! aspectRatio }
-				label={ __( 'Aspect ratio' ) }
-				onDeselect={ () => setAttributes( { aspectRatio: undefined } ) }
-				resetAllFilter={ () => ( {
-					aspectRatio: undefined,
-				} ) }
-				isShownByDefault
-				panelId={ clientId }
-			>
-				<SelectControl
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-					label={ __( 'Aspect ratio' ) }
-					value={ aspectRatio }
-					options={ aspectRatioOptions }
-					onChange={ ( nextAspectRatio ) =>
-						setAttributes( { aspectRatio: nextAspectRatio } )
-					}
-				/>
-			</ToolsPanelItem>
 			<ToolsPanelItem
 				className="single-column"
 				hasValue={ () => !! height }

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -157,7 +157,7 @@ export default function PostFeaturedImageEdit( {
 		media?.source_url;
 
 	const blockProps = useBlockProps( {
-		style: { width, height, aspectRatio },
+		style: { width, height },
 		className: clsx( {
 			'is-transient': temporaryURL,
 		} ),
@@ -389,7 +389,7 @@ export default function PostFeaturedImageEdit( {
 		...shadowProps.style,
 		height: aspectRatio ? '100%' : height,
 		width: !! aspectRatio && '100%',
-		objectFit: !! ( height || aspectRatio ) && scale,
+		objectFit: scale,
 	};
 
 	/**

--- a/packages/block-library/src/post-featured-image/index.js
+++ b/packages/block-library/src/post-featured-image/index.js
@@ -9,6 +9,7 @@ import { postFeaturedImage as icon } from '@wordpress/icons';
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
+import deprecated from './deprecated';
 
 const { name } = metadata;
 export { metadata, name };
@@ -16,6 +17,7 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
+	deprecated,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -41,6 +41,8 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	$extra_styles = '';
 
 	// Aspect ratio with a height set needs to override the default width/height.
+	// $attributes['aspectRatio'] is a legacy attribute.
+	// It will be migrated to $attributes['style']['dimensions']['aspectRatio'] but needs to remain for compatibility.
 	if ( ! empty( $attributes['aspectRatio'] ) ) {
 		$extra_styles .= 'width:100%;height:100%;';
 	} elseif ( ! empty( $attributes['height'] ) ) {

--- a/packages/block-library/src/post-featured-image/style.scss
+++ b/packages/block-library/src/post-featured-image/style.scss
@@ -13,6 +13,11 @@
 		box-sizing: border-box;
 	}
 
+	&.has-aspect-ratio img {
+		object-fit: cover;
+		height: 100%;
+	}
+
 	&.alignwide img,
 	&.alignfull img {
 		width: 100%;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #69769

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
There may be cases where you want to unify the default value for the aspectRatio of the Featured Image block across your site.
However, this is not currently implemented in the block support, so the default value cannot be changed in theme.json or in the global style settings for individual blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Featured image block migrate `aspectRatio` to block supports.

I'm currently achieving this style by specifying two selectors in block.jon, but this is unusual, so I'd like to know if there's a better way to do it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Go to post or page and place the Featured image block.
2. You can see that the `aspectRatio` can be set.
3. You can set a default `aspectRatio` for a block by going to the site editor.
4. You can set a default `aspectRatio` for blocks in theme.json.

playground url
https://playground.wordpress.net/?gutenberg-pr=69991

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before
https://github.com/user-attachments/assets/37193349-3ab0-40d5-9753-a0818cdf0ac7

### After

https://github.com/user-attachments/assets/ede6384d-b38d-4329-b57b-fd51abb5e599


https://github.com/user-attachments/assets/4a909ea5-a8d6-4094-bbe9-81c073f36036



