### PR TITLE
Remove css grid rule causing the issue

### DIFF
--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -6,9 +6,6 @@
 	grid-template: auto / $header-height minmax(0, max-content) minmax(min-content, 1fr) $header-height;
 	&:has(> .editor-header__center) {
 		grid-template: auto / $header-height min-content 1fr min-content $header-height;
-		@include break-medium {
-			grid-template: auto / $header-height minmax(min-content, 2fr) 2.5fr minmax(min-content, 2fr) $header-height;
-		}
 	}
 	@include break-mobile {
 		gap: $grid-unit-20;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #68065

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This PR aims to fix "Draft saved" message colliding with the editor header button.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Tested various ways to apply CSS around this but came to the conclusion that the grid template rule inside media query is causing the issue and removed it. Content no longer collides with "Draft saved" message

## Testing Instructions
1. This issue only replicates with Firefox
2. Change WordPress localization to Germany (as per original issue instructions).
3. Other way to test it to change "Draft message" translations to something really ludicrous to really push this solution to its limit.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Sample screenshots from Firefox, Brave and Safari

<img width="624" alt="Screenshot 2025-04-27 at 21 29 07" src="https://github.com/user-attachments/assets/f37305db-f768-42f0-b014-2eb0c5ee0447" />

Firefox 👆

<img width="625" alt="Screenshot 2025-04-27 at 21 29 58" src="https://github.com/user-attachments/assets/a20e4d5f-a488-4f4f-b7d2-9ae776fb2ee2" />

Brave 👆

<img width="604" alt="Screenshot 2025-04-27 at 21 30 24" src="https://github.com/user-attachments/assets/994ed8fe-cb54-4754-8f6f-e64865f0d9ad" />

Safari 👆

Screenshots taken around the screen size described in the issue

<!-- If you would like to upload screenshots, feel free to use the table below when
 it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
