### PR TITLE
Theme.json: Fix background image URL for elements

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -887,7 +887,6 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 					isset( $background_image_url ) &&
 					is_string( $background_image_url ) &&
 					// Skip if the src doesn't start with the placeholder, as there's nothing to replace.
-					// Test rerun.
 					str_starts_with( $background_image_url, $placeholder ) ) {
 					$file_type          = wp_check_filetype( $background_image_url );
 					$src_url            = str_replace( $placeholder, '', $background_image_url );

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -887,6 +887,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 					isset( $background_image_url ) &&
 					is_string( $background_image_url ) &&
 					// Skip if the src doesn't start with the placeholder, as there's nothing to replace.
+					// Test rerun.
 					str_starts_with( $background_image_url, $placeholder ) ) {
 					$file_type          = wp_check_filetype( $background_image_url );
 					$src_url            = str_replace( $placeholder, '', $background_image_url );

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -839,6 +839,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 *
 	 * @since 6.6.0
 	 * @since 6.7.0 Added support for resolving block styles.
+	 * @since 6.9.0 Added support for resolving element styles.
 	 *
 	 * @param WP_Theme_JSON_Gutenberg $theme_json A theme json instance.
 	 * @return array An array of resolved paths.
@@ -873,6 +874,33 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 					$resolved_theme_uri['type'] = $file_type['type'];
 				}
 				$resolved_theme_uris[] = $resolved_theme_uri;
+		}
+
+		// Element styles.
+		if ( ! empty( $theme_json_data['styles']['elements'] ) ) {
+			foreach ( $theme_json_data['styles']['elements'] as $element_name => $element_styles ) {
+				if ( ! isset( $element_styles['background']['backgroundImage']['url'] ) ) {
+					continue;
+				}
+				$background_image_url = $element_styles['background']['backgroundImage']['url'] ?? null;
+				if (
+					isset( $background_image_url ) &&
+					is_string( $background_image_url ) &&
+					// Skip if the src doesn't start with the placeholder, as there's nothing to replace.
+					str_starts_with( $background_image_url, $placeholder ) ) {
+					$file_type          = wp_check_filetype( $background_image_url );
+					$src_url            = str_replace( $placeholder, '', $background_image_url );
+					$resolved_theme_uri = array(
+						'name'   => $background_image_url,
+						'href'   => sanitize_url( get_theme_file_uri( $src_url ) ),
+						'target' => "styles.elements.{$element_name}.background.backgroundImage.url",
+					);
+					if ( isset( $file_type['type'] ) ) {
+						$resolved_theme_uri['type'] = $file_type['type'];
+					}
+					$resolved_theme_uris[] = $resolved_theme_uri;
+				}
+			}
 		}
 
 		// Block styles.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/69990

This PR fixes an issue where background image URLs defined in theme.json for elements (like headings, buttons, etc.) were not being properly converted from relative file paths to absolute URLs.

## How?
This fix adds support for element-level background images in the `get_resolved_theme_uris` method of the `WP_Theme_JSON_Resolver_Gutenberg` class.

Previously, the method only processed two types of background image paths:
- Top-level styles (`styles.background.backgroundImage.url`)
- Block-specific styles (`styles.blocks.{$block_name}.background.backgroundImage.url`)
This PR implementation handles element-level styles.

## Testing Instructions
1. Create a test WordPress theme with a theme.json file
2. Add a background image to the theme in an assets/images folder (e.g., background.png)
3. Add the following to your theme.json:
   ```json
   {
     "styles": {
       "elements": {
         "heading": {
           "background": {
             "backgroundImage": {
               "url": "file:./assets/images/background.png"
             }
           }
         }
       }
     }
   }
4. Activate the theme and create a page with some headings

