### PR TITLE
Fix: Add muted Next and Previous links as fallback

### DIFF
--- a/packages/block-library/src/post-navigation-link/index.php
+++ b/packages/block-library/src/post-navigation-link/index.php
@@ -116,6 +116,45 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 		$content = $get_link_function( $format, $link );
 	}
 
+	if ( empty( $content ) ) {
+		$label_text = 'next' === $navigation_type ? __( 'Next' ) : __( 'Previous' );
+	
+		// Setup arrow if needed
+		$arrow_html = '';
+		if ( isset( $attributes['arrow'] ) && 'none' !== $attributes['arrow'] && isset( $arrow_map[ $attributes['arrow'] ] ) ) {
+			$arrow = $arrow_map[ $attributes['arrow'] ][ $navigation_type ];
+	
+			if ( 'next' === $navigation_type ) {
+				$arrow_html = sprintf(
+					'<span class="wp-block-post-navigation-link__arrow-next is-arrow-%1$s" aria-hidden="true">%2$s</span>',
+					esc_attr( $attributes['arrow'] ),
+					esc_html( $arrow )
+				);
+			} else {
+				$arrow_html = sprintf(
+					'<span class="wp-block-post-navigation-link__arrow-previous is-arrow-%1$s" aria-hidden="true">%2$s</span>',
+					esc_attr( $attributes['arrow'] ),
+					esc_html( $arrow )
+				);
+			}
+		}
+	
+		// Build content with arrow and label
+		if ( 'next' === $navigation_type ) {
+			$content = sprintf(
+				'<span class="post-navigation-link__no-post">%1$s%2$s</span>',
+				esc_html( $label_text ),
+				$arrow_html
+			);
+		} else {
+			$content = sprintf(
+				'<span class="post-navigation-link__no-post">%1$s%2$s</span>',
+				$arrow_html,
+				esc_html( $label_text )
+			);
+		}
+	}
+
 	return sprintf(
 		'<div %1$s>%2$s</div>',
 		$wrapper_attributes,

--- a/packages/block-library/src/post-navigation-link/index.php
+++ b/packages/block-library/src/post-navigation-link/index.php
@@ -118,12 +118,12 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 
 	if ( empty( $content ) ) {
 		$label_text = 'next' === $navigation_type ? __( 'Next' ) : __( 'Previous' );
-	
+
 		// Setup arrow if needed
 		$arrow_html = '';
 		if ( isset( $attributes['arrow'] ) && 'none' !== $attributes['arrow'] && isset( $arrow_map[ $attributes['arrow'] ] ) ) {
 			$arrow = $arrow_map[ $attributes['arrow'] ][ $navigation_type ];
-	
+
 			if ( 'next' === $navigation_type ) {
 				$arrow_html = sprintf(
 					'<span class="wp-block-post-navigation-link__arrow-next is-arrow-%1$s" aria-hidden="true">%2$s</span>',
@@ -138,7 +138,7 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 				);
 			}
 		}
-	
+
 		// Build content with arrow and label
 		if ( 'next' === $navigation_type ) {
 			$content = sprintf(

--- a/packages/block-library/src/post-navigation-link/style.scss
+++ b/packages/block-library/src/post-navigation-link/style.scss
@@ -24,4 +24,8 @@
 	&.has-text-align-left[style*="writing-mode: vertical-lr"] {
 		rotate: 180deg;
 	}
+
+	.post-navigation-link__no-post {
+		color: #b5b5b5;
+	}
 }


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/69994

<!-- In a few words, what is the PR actually doing? -->

## Why?
This PR is necessary to add muted 'Next' and 'Previous' links instead of not rendering any content on the frontend when `Post Navigation Link` Block is added to the first or the last post.

## How?
This PR introduces a default `$content` which has `Next` and `Previous` Text along with the arrow

## Testing Instructions
- Add a new post 
- Add the `Next Post` Block to it 
- Save the post and check the frontend 
- Notice now that the `Next` text is rendered in the muted state instead of not appearing at all 

## Screenshots or screencast 

https://github.com/user-attachments/assets/19cf7296-084a-4b9e-a9f7-1a452a458e7d


