### PR TITLE
[WP6.8.1] Keyboard Shortcuts: Revert delete shortcut to `access + z`

### DIFF
--- a/packages/block-editor/src/components/keyboard-shortcuts/index.js
+++ b/packages/block-editor/src/components/keyboard-shortcuts/index.js
@@ -59,8 +59,8 @@ function KeyboardShortcutsRegister() {
 			category: 'block',
 			description: __( 'Remove the selected block(s).' ),
 			keyCombination: {
-				modifier: 'primaryShift',
-				character: 'backspace',
+				modifier: 'access',
+				character: 'z',
 			},
 		} );
 

--- a/packages/block-editor/src/components/rich-text/event-listeners/delete.js
+++ b/packages/block-editor/src/components/rich-text/event-listeners/delete.js
@@ -6,7 +6,7 @@ import { isCollapsed, isEmpty } from '@wordpress/rich-text';
 
 export default ( props ) => ( element ) => {
 	function onKeyDown( event ) {
-		const { keyCode, shiftKey, ctrlKey, metaKey } = event;
+		const { keyCode } = event;
 
 		if ( event.defaultPrevented ) {
 			return;
@@ -27,11 +27,6 @@ export default ( props ) => ( element ) => {
 				( isReverse && start !== 0 ) ||
 				( ! isReverse && end !== text.length )
 			) {
-				return;
-			}
-
-			// Exclude (command|ctrl)+shift+backspace as they are shortcuts for deleting blocks.
-			if ( shiftKey && ( ctrlKey || metaKey ) ) {
 				return;
 			}
 

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -276,7 +276,7 @@ test.describe( 'Navigation block', () => {
 			await pageUtils.pressKeys( 'ArrowDown' );
 
 			// remove the child link
-			await pageUtils.pressKeys( 'primaryShift+Backspace' );
+			await pageUtils.pressKeys( 'access+z' );
 
 			const submenuBlock2 = editor.canvas.getByRole( 'document', {
 				name: 'Block: Submenu',
@@ -494,7 +494,7 @@ test.describe( 'Navigation block', () => {
 		await pageUtils.pressKeys( 'ArrowDown', { times: 4 } );
 		await navigation.checkLabelFocus( 'wordpress.org' );
 		// Delete the nav link
-		await pageUtils.pressKeys( 'primaryShift+Backspace' );
+		await pageUtils.pressKeys( 'access+z' );
 		// Focus moved to sibling
 		await navigation.checkLabelFocus( 'Dog' );
 		// Add a link back so we can delete the first submenu link and see if focus returns to the parent submenu item
@@ -507,15 +507,15 @@ test.describe( 'Navigation block', () => {
 		await pageUtils.pressKeys( 'ArrowUp', { times: 2 } );
 		await navigation.checkLabelFocus( 'Dog' );
 		// Delete the nav link
-		await pageUtils.pressKeys( 'primaryShift+Backspace' );
+		await pageUtils.pressKeys( 'access+z' );
 		await pageUtils.pressKeys( 'ArrowDown' );
 		// Focus moved to parent submenu item
 		await navigation.checkLabelFocus( 'example.com' );
 		// Deleting this should move focus to the sibling item
-		await pageUtils.pressKeys( 'primaryShift+Backspace' );
+		await pageUtils.pressKeys( 'access+z' );
 		await navigation.checkLabelFocus( 'Cat' );
 		// Deleting with no more siblings should focus the navigation block again
-		await pageUtils.pressKeys( 'primaryShift+Backspace' );
+		await pageUtils.pressKeys( 'access+z' );
 		await expect( navBlock ).toBeFocused();
 		// Wait until the nav block inserter is visible before we continue.
 		await expect( navBlockInserter ).toBeVisible();

--- a/test/e2e/specs/editor/various/block-deletion.spec.js
+++ b/test/e2e/specs/editor/various/block-deletion.spec.js
@@ -134,7 +134,7 @@ test.describe( 'Block deletion', () => {
 		).toBeFocused();
 
 		// Remove the current paragraph via dedicated keyboard shortcut.
-		await pageUtils.pressKeys( 'primaryShift+Backspace' );
+		await pageUtils.pressKeys( 'access+z' );
 
 		// Ensure the last block was removed.
 		await expect.poll( editor.getBlocks ).toMatchObject( [

--- a/test/e2e/specs/editor/various/block-locking.spec.js
+++ b/test/e2e/specs/editor/various/block-locking.spec.js
@@ -133,7 +133,7 @@ test.describe( 'Block Locking', () => {
 		).toBeVisible();
 
 		await paragraph.click();
-		await pageUtils.pressKeys( 'primaryShift+Backspace' );
+		await pageUtils.pressKeys( 'access+z' );
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{

--- a/test/e2e/specs/editor/various/list-view.spec.js
+++ b/test/e2e/specs/editor/various/list-view.spec.js
@@ -812,8 +812,8 @@ test.describe( 'List View', () => {
 
 		// Delete remaining blocks.
 		// Keyboard shortcut should also work.
-		await pageUtils.pressKeys( 'primaryShift+Backspace' );
-		await pageUtils.pressKeys( 'primaryShift+Backspace' );
+		await pageUtils.pressKeys( 'access+z' );
+		await pageUtils.pressKeys( 'access+z' );
 		await expect
 			.poll(
 				listViewUtils.getBlocksWithA11yAttributes,
@@ -845,7 +845,7 @@ test.describe( 'List View', () => {
 				{ name: 'core/heading', selected: false },
 			] );
 
-		await pageUtils.pressKeys( 'primaryShift+Backspace' );
+		await pageUtils.pressKeys( 'access+z' );
 		await expect
 			.poll(
 				listViewUtils.getBlocksWithA11yAttributes,
@@ -868,11 +868,7 @@ test.describe( 'List View', () => {
 			.getByRole( 'gridcell', { name: 'File' } )
 			.getByRole( 'link' )
 			.focus();
-		for ( const keys of [
-			'Delete',
-			'Backspace',
-			'primaryShift+Backspace',
-		] ) {
+		for ( const keys of [ 'Delete', 'Backspace', 'access+z' ] ) {
 			await pageUtils.pressKeys( keys );
 			await expect
 				.poll(
@@ -1140,7 +1136,7 @@ test.describe( 'List View', () => {
 			optionsForFileMenu,
 			'Pressing Space should also open the menu dropdown'
 		).toBeVisible();
-		await pageUtils.pressKeys( 'primaryShift+Backspace' ); // Keyboard shortcut for Delete.
+		await pageUtils.pressKeys( 'access+z' ); // Keyboard shortcut for Delete.
 		await expect
 			.poll(
 				listViewUtils.getBlocksWithA11yAttributes,
@@ -1160,7 +1156,7 @@ test.describe( 'List View', () => {
 			optionsForFileMenu.getByRole( 'menuitem', { name: 'Delete' } ),
 			'The delete menu item should be hidden for locked blocks'
 		).toBeHidden();
-		await pageUtils.pressKeys( 'primaryShift+Backspace' );
+		await pageUtils.pressKeys( 'access+z' );
 		await expect
 			.poll(
 				listViewUtils.getBlocksWithA11yAttributes,

--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -375,7 +375,7 @@ test.describe( 'Template Part', () => {
 		await editor.selectBlocks( siteTitle );
 
 		// Remove the default site title block.
-		await pageUtils.pressKeys( 'primaryShift+Backspace' );
+		await pageUtils.pressKeys( 'access+z' );
 
 		// Insert a group block with a Site Title block inside.
 		await editor.insertBlock( {

--- a/test/e2e/specs/widgets/editing-widgets.spec.js
+++ b/test/e2e/specs/widgets/editing-widgets.spec.js
@@ -573,7 +573,7 @@ test.describe( 'Widgets screen', () => {
 			.getByRole( 'document', { name: 'Block: Paragraph' } )
 			.filter( { hasText: 'Second Paragraph' } )
 			.focus();
-		await pageUtils.pressKeys( 'primaryShift+Backspace' );
+		await pageUtils.pressKeys( 'access+z' );
 		await widgetsScreen.saveWidgets();
 
 		await expect.poll( widgetsScreen.getWidgetAreaBlocks ).toMatchObject( {


### PR DESCRIPTION
## What?

This PR is for the `wp/6.8` branch and is equivalent to #69931.

## How?

I simply cherry-picked #69931 (fe326a4dd7b2e6be51f6dd092114e27b4adc9071).

## Testing Instructions

### Testing Instructions for Keyboard

1. Create a new post.
2. Add some blocks.
3. Try deleting the blocks with the shortcut `ctrl + option + z` on `macOS` and `shift + alt + z` on `Windows`/`Linux`.
4. Confirm the block deletion works as expected.
