### PR TITLE
ServerSideRender: Use `useLayoutEffect` to update `latestPropsRef`

### DIFF
--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -11,6 +11,7 @@ import {
 	RawHTML,
 	useCallback,
 	useEffect,
+	useLayoutEffect,
 	useRef,
 	useState,
 } from '@wordpress/element';
@@ -106,7 +107,10 @@ export default function ServerSideRender( props ) {
 	const prevProps = usePrevious( props );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const latestPropsRef = useRef( props );
-	latestPropsRef.current = props;
+
+	useLayoutEffect( () => {
+		latestPropsRef.current = props;
+	}, [ props ] );
 
 	const fetchData = useCallback( () => {
 		if ( ! isMountedRef.current ) {


### PR DESCRIPTION
## What, Why, and How?
Follow-up to https://github.com/WordPress/gutenberg/pull/69237
Related comment https://github.com/WordPress/gutenberg/pull/69237#issuecomment-2830381378

This PR wraps the `latestPropsRef` assignment within a layout effect.

Ref:
https://react.dev/learn/referencing-values-with-refs#best-practices-for-refs
https://www.epicreact.dev/the-latest-ref-pattern-in-react

## Testing Instructions

1. Create a new `Calendar` block.
2. Change the background and font size.
3. Ensure that the updates are reflected without reloading the page.

### Testing Instructions for Keyboard

Same.
