### PR TITLE
[WP6.8.1] Author, Author Name block: fix PHP warning error when there is no context

### DIFF
--- a/packages/block-library/src/post-author-name/index.php
+++ b/packages/block-library/src/post-author-name/index.php
@@ -26,7 +26,7 @@ function render_block_core_post_author_name( $attributes, $content, $block ) {
 		return '';
 	}
 
-	if ( ! post_type_supports( $block->context['postType'], 'author' ) ) {
+	if ( isset( $block->context['postType'] ) && ! post_type_supports( $block->context['postType'], 'author' ) ) {
 		return '';
 	}
 

--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -26,7 +26,7 @@ function render_block_core_post_author( $attributes, $content, $block ) {
 		return '';
 	}
 
-	if ( ! post_type_supports( $block->context['postType'], 'author' ) ) {
+	if ( isset( $block->context['postType'] ) && ! post_type_supports( $block->context['postType'], 'author' ) ) {
 		return '';
 	}
 


### PR DESCRIPTION
## What?

This PR is for the `wp/6.8` branch and is equivalent to #69949.

## How?

I simply cherry-picked #69949 (c94f1d7e051d89c5a7d632db651f9a5ada1d4b23).

## Testing Instructions

See #69949.