### PR TITLE
Fix: Improve warning message and add spacing in HTMLElementControl

### DIFF
--- a/packages/block-editor/src/components/block-inspector/style.scss
+++ b/packages/block-editor/src/components/block-inspector/style.scss
@@ -11,7 +11,8 @@
 	}
 
 	.components-base-control,
-	.components-radio-control {
+	.components-radio-control,
+	.block-editor-html-element-control {
 		&:where(:not(:last-child)) {
 			margin-bottom: $grid-unit-20;
 		}
@@ -20,7 +21,8 @@
 	// Reset unwanted margin-bottom from being applied to BaseControls within certain components.
 	.components-focal-point-picker-control,
 	.components-query-controls,
-	.components-range-control {
+	.components-range-control,
+	.block-editor-html-element-control {
 		.components-base-control {
 			margin-bottom: 0;
 		}

--- a/packages/block-editor/src/components/html-element-control/index.js
+++ b/packages/block-editor/src/components/html-element-control/index.js
@@ -100,7 +100,7 @@ export default function HTMLElementControl( {
 			{ tagName === 'main' && hasMainElementElsewhere && (
 				<Notice status="warning" isDismissible={ false }>
 					{ __(
-						'Multiple <main> elements detected. The duplicate may be in your content or in the page template. This is not valid HTML and may cause accessibility issues. Please change this HTML element.'
+						'Multiple <main> elements detected. The duplicate may be in your content or template. This is not valid HTML and may cause accessibility issues. Please change this HTML element.'
 					) }
 				</Notice>
 			) }

--- a/packages/block-editor/src/components/html-element-control/index.js
+++ b/packages/block-editor/src/components/html-element-control/index.js
@@ -86,7 +86,7 @@ export default function HTMLElementControl( {
 	} );
 
 	return (
-		<VStack spacing={ 2 }>
+		<VStack spacing={ 2 } className="block-editor-html-element-control">
 			<SelectControl
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize
@@ -100,7 +100,7 @@ export default function HTMLElementControl( {
 			{ tagName === 'main' && hasMainElementElsewhere && (
 				<Notice status="warning" isDismissible={ false }>
 					{ __(
-						'Multiple <main> elements detected. This is not valid HTML and may cause accessibility issues. Please change this HTML element.'
+						'Multiple <main> elements detected. The duplicate may be in your content or in the page template. This is not valid HTML and may cause accessibility issues. Please change this HTML element.'
 					) }
 				</Notice>
 			) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Follow up: https://github.com/WordPress/gutenberg/pull/69904#issuecomment-2830383271

This PR makes two small improvements to the `HTMLElementControl` component:

- Improves the warning message shown when duplicate `<main>` elements are detected, clarifying that the duplicate may be in the page template as well as in the content.
- Improves spacing


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![Screenshot 2025-04-16 at 2 52 44 PM](https://github.com/user-attachments/assets/d0b8cd85-2fd4-48da-9937-a4a37723ba37)|![Screenshot 2025-04-28 at 2 55 19 PM](https://github.com/user-attachments/assets/866830a7-3191-4de6-a499-2e25bbbda64d)|
