### PR TITLE
Layouts: Update editor layout definitions to better select the first block

### DIFF
--- a/packages/block-editor/src/layouts/definitions.js
+++ b/packages/block-editor/src/layouts/definitions.js
@@ -34,7 +34,7 @@ export const LAYOUT_DEFINITIONS = {
 		],
 		spacingStyles: [
 			{
-				selector: ' > :first-child',
+				selector: ' > :nth-child(1 of .wp-block)',
 				rules: {
 					'margin-block-start': '0',
 				},
@@ -100,7 +100,7 @@ export const LAYOUT_DEFINITIONS = {
 		],
 		spacingStyles: [
 			{
-				selector: ' > :first-child',
+				selector: ' > :nth-child(1 of .wp-block)',
 				rules: {
 					'margin-block-start': '0',
 				},


### PR DESCRIPTION
## What?
Closes #69989

This PR fixes the unintentional top margin (`margin-block-start`) on the `post content` block when placed within the template query. (Likely introduced in https://github.com/WordPress/gutenberg/pull/66003)

## Why?

This happens because the following line tries to apply a top margin of `0 px` to the first child.
https://github.com/WordPress/gutenberg/blob/551c62f307088a935664d63e538163dc5dc813c8/packages/block-editor/src/layouts/definitions.js#L103

The problem occurs when there are multiple `<style>` and `<SVG>` elements before the first element within the editor. Refer to the following DOM structure:

![DOM](https://github.com/user-attachments/assets/0831f7c0-cecf-426e-9057-acf83d61a2d4)

These elements hold the preview styles related to the `content` block.

Ref.
https://github.com/WordPress/gutenberg/blob/05f769e0b52f3083a9e0db8c211e48082c1174d6/packages/block-library/src/post-content/edit.js#L59

## How?

Since all the blocks within the editor have a `.wp-block` class, we can update the selection logic to be:
`' > :nth-child(1 of .wp-block)'`

Because the `.wp-block` class is not present in the front-end and since the problem doesn't occur in there (as the `<style>` and `<svg>` tags are not rendered within the parent block), I didn't feel the need to update the rules for the corresponding PHP file.

## Testing Instructions

1. Create a new post, paste the following markup in the code editor, and save it.

<details>
<summary>Click to toggle the code</summary>

```
<!-- wp:group {"className":"is-style-section-4","style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40","top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
<div class="wp-block-group is-style-section-4" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:group {"style":{"layout":{"columnSpan":1,"rowSpan":1}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
<div class="wp-block-group"><!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"#29c8f8"}}}}} -->
<p class="has-link-color">Welcome to <a href="http://www.wordpress.org">WordPress</a>. This is your first post. Edit or delete it, then start writing! Welcome to WordPress. </p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"#3ee732"}}}}} -->
<p class="has-link-color">Welcome to WordPress. This is your first post. Edit or delete it, then start writing! Welcome to <a href="http://wordpress.org">WordPress</a>. </p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:buttons {"style":{"layout":{"columnSpan":2,"rowSpan":1}},"layout":{"type":"flex","justifyContent":"center"}} -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```
</details>

2. From `wp-admin`, navigate to Appearance > Editor > Templates > Blog Home.

3. Confirm that the `Post Content` block has no extra margin on top and looks exactly like the front-end.

### Testing Instructions for Keyboard

Same.

## Screenshots

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/1761ddfc-0575-4ae2-917b-1811c717e0ca)|![after](https://github.com/user-attachments/assets/c01a8dc2-3301-4e21-80cf-a39a00e62a94)|


