### PR TITLE
Update and stabilize `userCanCreatePages ` to `canUserCreatePages`

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -227,7 +227,7 @@ function ButtonEdit( props ) {
 
 	const {
 		createPageEntity,
-		userCanCreatePages,
+		canUserCreatePages,
 		lockUrlControls = false,
 	} = useSelect(
 		( select ) => {
@@ -243,7 +243,7 @@ function ButtonEdit( props ) {
 
 			return {
 				createPageEntity: _settings.__experimentalCreatePageEntity,
-				userCanCreatePages: _settings.__experimentalUserCanCreatePages,
+				canUserCreatePages: _settings.canUserCreatePages,
 				lockUrlControls:
 					!! metadata?.bindings?.url &&
 					! blockBindingsSource?.canUserEditValue?.( {
@@ -443,7 +443,7 @@ function ButtonEdit( props ) {
 							createSuggestion={
 								createPageEntity && handleCreate
 							}
-							withCreateSuggestion={ userCanCreatePages }
+							withCreateSuggestion={ canUserCreatePages }
 							createSuggestionButtonText={ createButtonText }
 						/>
 					</Popover>

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -118,7 +118,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		hasUploadPermissions,
 		hiddenBlockTypes,
 		canUseUnfilteredHTML,
-		userCanCreatePages,
+		canUserCreatePages,
 		pageOnFront,
 		pageForPosts,
 		userPatternCategories,
@@ -179,7 +179,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 						kind: 'root',
 						name: 'media',
 					} ) ?? true,
-				userCanCreatePages: canUser( 'create', {
+				canUserCreatePages: canUser( 'create', {
 					kind: 'postType',
 					name: 'page',
 				} ),
@@ -243,7 +243,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 	 */
 	const createPageEntity = useCallback(
 		( options ) => {
-			if ( ! userCanCreatePages ) {
+			if ( ! canUserCreatePages ) {
 				return Promise.reject( {
 					message: __(
 						'You do not have permission to create Pages.'
@@ -252,7 +252,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 			}
 			return saveEntityRecord( 'postType', 'page', options );
 		},
-		[ saveEntityRecord, userCanCreatePages ]
+		[ saveEntityRecord, canUserCreatePages ]
 	);
 
 	const allowedBlockTypes = useMemo( () => {
@@ -319,7 +319,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 			outlineMode: ! isDistractionFree && postType === 'wp_template',
 			// Check these two properties: they were not present in the site editor.
 			__experimentalCreatePageEntity: createPageEntity,
-			__experimentalUserCanCreatePages: userCanCreatePages,
+			canUserCreatePages,
 			pageOnFront,
 			pageForPosts,
 			__experimentalPreferPatternsOnRoot: postType === 'wp_template',
@@ -354,7 +354,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		canUseUnfilteredHTML,
 		undo,
 		createPageEntity,
-		userCanCreatePages,
+		canUserCreatePages,
 		pageOnFront,
 		pageForPosts,
 		postType,

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -55,7 +55,7 @@ function InlineLinkUI( {
 
 	const { selectionChange } = useDispatch( blockEditorStore );
 
-	const { createPageEntity, userCanCreatePages, selectionStart } = useSelect(
+	const { createPageEntity, canUserCreatePages, selectionStart } = useSelect(
 		( select ) => {
 			const { getSettings, getSelectionStart } =
 				select( blockEditorStore );
@@ -63,7 +63,7 @@ function InlineLinkUI( {
 
 			return {
 				createPageEntity: _settings.__experimentalCreatePageEntity,
-				userCanCreatePages: _settings.__experimentalUserCanCreatePages,
+				canUserCreatePages: _settings.canUserCreatePages,
 				selectionStart: getSelectionStart(),
 			};
 		},
@@ -267,7 +267,7 @@ function InlineLinkUI( {
 				onRemove={ removeLink }
 				hasRichPreviews
 				createSuggestion={ createPageEntity && handleCreate }
-				withCreateSuggestion={ userCanCreatePages }
+				withCreateSuggestion={ canUserCreatePages }
 				createSuggestionButtonText={ createButtonText }
 				hasTextControl
 				settings={ LINK_SETTINGS }


### PR DESCRIPTION
## What?
Closes #35253
Related discussion: https://github.com/WordPress/gutenberg/issues/35253#issuecomment-2811606559

## Why?

Renames `userCanCreatePages ` to `canUserCreatePages` and stabilizes the property by removing the experimental prefix.

## How?

Renamed the property and updated all references to `canUserCreatePages`

