### PR TITLE
[WP6.8] Fix 'wp-polyfill' script dependents unit test

### DIFF
--- a/phpunit/script-dependencies-test.php
+++ b/phpunit/script-dependencies-test.php
@@ -4,7 +4,13 @@
  * @group script-dependencies
  */
 class Test_Script_Dependencies extends WP_UnitTestCase {
-	public $bundled_scripts = array( 'wp-upload-media' );
+	/**
+	 * The `wp-fileds` was accidintally bundled in WP 6.7, but removed later.
+	 * It's is listed here to avoid breaking previous WP version tests.
+	 *
+	 * @var array
+	 */
+	public $bundled_scripts = array( 'wp-upload-media', 'wp-fields' );
 
 	/**
 	 * Tests for accidental `wp-polyfill` script dependents.


### PR DESCRIPTION
## What?

Similar to #69912

Fix 'wp-polyfill' script dependents unit test failure occurring on `wp/6.8` branch.

## Why?

This unit test detects which other scripts depend on the `wp-polyfill` script and verifies that the list matches our expectations.

The `wp-fields` script was unintentionally bundled with WP 6.7, even though it should never have been included in core.

In addition, the unit test is executed on previous WordPress versions too. This means that in the `trunk` and `wp/6.8` branches, unit tests will be executed on WP 6.7 too.

Because WP 6.7 unintentionally includes the `wp-fields` script, we should ignore `wp-fields` in the `wp/6.8` branch, just like we would in the `trunk` branch.

## Testing Instructions

Let's see if CI checks are green.
