### PR TITLE
Persist git credentials when publishing via lerna

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -66,7 +66,7 @@ jobs:
                   fetch-depth: 999
                   token: ${{ secrets.GUTENBERG_TOKEN }}
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
-                  persist-credentials: false
+                  persist-credentials: true
 
             - name: Configure git user name and email (for publishing)
               run: |


### PR DESCRIPTION
## What?

This reverts the change made in #69126 to the "Checkout (for publishing WP major version)" step.

## Why?

This step needs the git credentials persisted because it pushes tags back to GitHub.
