### PR TITLE
Simplify color specifications from `rgba` to `rgb`

### DIFF
--- a/lib/theme.json
+++ b/lib/theme.json
@@ -65,7 +65,7 @@
 			"gradients": [
 				{
 					"name": "Vivid cyan blue to vivid purple",
-					"gradient": "linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)",
+					"gradient": "linear-gradient(135deg,rgb(6,147,227) 0%,rgb(155,81,224) 100%)",
 					"slug": "vivid-cyan-blue-to-vivid-purple"
 				},
 				{
@@ -75,12 +75,12 @@
 				},
 				{
 					"name": "Luminous vivid amber to luminous vivid orange",
-					"gradient": "linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%)",
+					"gradient": "linear-gradient(135deg,rgb(252,185,0) 0%,rgb(255,105,0) 100%)",
 					"slug": "luminous-vivid-amber-to-luminous-vivid-orange"
 				},
 				{
 					"name": "Luminous vivid orange to vivid red",
-					"gradient": "linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%)",
+					"gradient": "linear-gradient(135deg,rgb(255,105,0) 0%,rgb(207,46,46) 100%)",
 					"slug": "luminous-vivid-orange-to-vivid-red"
 				},
 				{
@@ -251,12 +251,12 @@
 				{
 					"name": "Outlined",
 					"slug": "outlined",
-					"shadow": "6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1)"
+					"shadow": "6px 6px 0px -3px rgb(255, 255, 255), 6px 6px rgb(0, 0, 0)"
 				},
 				{
 					"name": "Crisp",
 					"slug": "crisp",
-					"shadow": "6px 6px 0px rgba(0, 0, 0, 1)"
+					"shadow": "6px 6px 0px rgb(0, 0, 0)"
 				}
 			]
 		},

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -1161,12 +1161,12 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 				),
 				array(
 					'name'   => 'Outlined',
-					'shadow' => '6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1)',
+					'shadow' => '6px 6px 0px -3px rgb(255, 255, 255), 6px 6px rgb(0, 0, 0)',
 					'slug'   => 'outlined',
 				),
 				array(
 					'name'   => 'Crisp',
-					'shadow' => '6px 6px 0px rgba(0, 0, 0, 1)',
+					'shadow' => '6px 6px 0px rgb(0, 0, 0)',
 					'slug'   => 'crisp',
 				),
 			),


### PR DESCRIPTION
Currently, the theme.json that ships in core at `wp-includes/theme.json` default gradients are inconsistent in color specification -- a number of places it uses `rgba(#,#,#,1)` even though that is equivalent to just `rgb(#,#,#)` -- there is no rhyme or reason I can see as to why rgba is used here, so this is to trim a couple bytes by serving them up as rgb instead of rgba.

As there is no transparency here, it may be slightly more efficient to use hex?  But I'm fine leaving it as RGB for less code churn in core unless anyone feels strongly here.

## Why?
Simplifying color specifications in core boilerplates -- more consistency in code style standards.

## How?
Dropping the opacity specification when it's full opacity.

## Testing Instructions
* Shouldn't be much needed, gradients should show normally.

