### PR TITLE
Fix/add muted previous and next post Navigation link as fallback

### DIFF
--- a/packages/block-library/src/post-navigation-link/index.php
+++ b/packages/block-library/src/post-navigation-link/index.php
@@ -20,28 +20,30 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 		return '';
 	}
 
-	// Get the navigation type to show the proper link. Available options are `next|previous`.
-	$navigation_type = isset( $attributes['type'] ) ? $attributes['type'] : 'next';
-	// Allow only `next` and `previous` in `$navigation_type`.
-	if ( ! in_array( $navigation_type, array( 'next', 'previous' ), true ) ) {
-		return '';
-	}
+	// Get the navigation type to show the proper link. 
+	$navigation_type = isset( $attributes['type'] ) && 'previous' === $attributes['type'] ? 'previous' : 'next';
+	
+	// Build classes once
 	$classes = "post-navigation-link-$navigation_type";
 	if ( isset( $attributes['textAlign'] ) ) {
 		$classes .= " has-text-align-{$attributes['textAlign']}";
 	}
+	
+	// Prepare wrapper attributes once
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
 			'class' => $classes,
 		)
 	);
-	// Set default values.
+	
+	// Set default values
 	$format = '%link';
-	$link   = 'next' === $navigation_type ? _x( 'Next', 'label for next post link' ) : _x( 'Previous', 'label for previous post link' );
-	$label  = '';
+	$is_next = 'next' === $navigation_type;
+	$link = $is_next ? _x( 'Next', 'label for next post link' ) : _x( 'Previous', 'label for previous post link' );
+	$label = '';
 
-	// Only use hardcoded values here, otherwise we need to add escaping where these values are used.
-	$arrow_map = array(
+	// Only use hardcoded arrow values
+	static $arrow_map = array(
 		'none'    => '',
 		'arrow'   => array(
 			'next'     => '→',
@@ -53,67 +55,84 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 		),
 	);
 
-	// If a custom label is provided, make this a link.
-	// `$label` is used to prepend the provided label, if we want to show the page title as well.
+	// Process label if provided
 	if ( isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ) {
-		$label = "{$attributes['label']}";
-		$link  = $label;
+		$label = $attributes['label'];
+		$link = $label;
 	}
 
-	// If we want to also show the page title, make the page title a link and prepend the label.
+	// Handle title display options
 	if ( isset( $attributes['showTitle'] ) && $attributes['showTitle'] ) {
-		/*
-		 * If the label link option is not enabled but there is a custom label,
-		 * display the custom label as text before the linked title.
-		 */
-		if ( ! $attributes['linkLabel'] ) {
+		$link_label = isset( $attributes['linkLabel'] ) && $attributes['linkLabel'];
+		
+		if ( ! $link_label ) {
+			// Label as text, title as link
 			if ( $label ) {
 				$format = '<span class="post-navigation-link__label">' . wp_kses_post( $label ) . '</span> %link';
 			}
 			$link = '%title';
-		} elseif ( isset( $attributes['linkLabel'] ) && $attributes['linkLabel'] ) {
-			// If the label link option is enabled and there is a custom label, display it before the title.
+		} else {
+			// Both label and title in link
 			if ( $label ) {
 				$link = '<span class="post-navigation-link__label">' . wp_kses_post( $label ) . '</span> <span class="post-navigation-link__title">%title</span>';
 			} else {
-				/*
-				 * If the label link option is enabled and there is no custom label,
-				 * add a colon between the label and the post title.
-				 */
-				$label = 'next' === $navigation_type ? _x( 'Next:', 'label before the title of the next post' ) : _x( 'Previous:', 'label before the title of the previous post' );
-				$link  = sprintf(
+				// Default label with colon
+				$default_label = $is_next ? _x( 'Next:', 'label before the title of the next post' ) : _x( 'Previous:', 'label before the title of the previous post' );
+				$link = sprintf(
 					'<span class="post-navigation-link__label">%1$s</span> <span class="post-navigation-link__title">%2$s</span>',
-					wp_kses_post( $label ),
+					wp_kses_post( $default_label ),
 					'%title'
 				);
 			}
 		}
 	}
 
-	// Display arrows.
-	if ( isset( $attributes['arrow'] ) && 'none' !== $attributes['arrow'] && isset( $arrow_map[ $attributes['arrow'] ] ) ) {
-		$arrow = $arrow_map[ $attributes['arrow'] ][ $navigation_type ];
-
-		if ( 'next' === $navigation_type ) {
-			$format = '%link<span class="wp-block-post-navigation-link__arrow-next is-arrow-' . $attributes['arrow'] . '" aria-hidden="true">' . $arrow . '</span>';
-		} else {
-			$format = '<span class="wp-block-post-navigation-link__arrow-previous is-arrow-' . $attributes['arrow'] . '" aria-hidden="true">' . $arrow . '</span>%link';
-		}
+	// Add arrow if needed
+	$arrow_type = isset( $attributes['arrow'] ) ? $attributes['arrow'] : 'none';
+	if ( 'none' !== $arrow_type && isset( $arrow_map[$arrow_type] ) ) {
+		$arrow = $arrow_map[$arrow_type][$navigation_type];
+		$arrow_html = sprintf(
+			'<span class="wp-block-post-navigation-link__arrow-%1$s is-arrow-%2$s" aria-hidden="true">%3$s</span>',
+			esc_attr( $navigation_type ),
+			esc_attr( $arrow_type ),
+			$arrow
+		);
+		
+		$format = $is_next ? '%link' . $arrow_html : $arrow_html . '%link';
 	}
 
-	/*
-	 * The dynamic portion of the function name, `$navigation_type`,
-	 * Refers to the type of adjacency, 'next' or 'previous'.
-	 *
-	 * @see https://developer.wordpress.org/reference/functions/get_previous_post_link/
-	 * @see https://developer.wordpress.org/reference/functions/get_next_post_link/
-	 */
+	// Get link function name once
 	$get_link_function = "get_{$navigation_type}_post_link";
-
+	
+	// Get the actual link content
 	if ( ! empty( $attributes['taxonomy'] ) ) {
 		$content = $get_link_function( $format, $link, true, '', $attributes['taxonomy'] );
 	} else {
 		$content = $get_link_function( $format, $link );
+	}
+
+	// Handle case when there's no adjacent post
+	if ( empty( $content ) ) {
+		$label_text = $is_next ? __( 'Next' ) : __( 'Previous' );
+		
+		// Setup arrow if needed
+		$arrow_html = '';
+		if ( 'none' !== $arrow_type && isset( $arrow_map[$arrow_type] ) ) {
+			$arrow = $arrow_map[$arrow_type][$navigation_type];
+			$arrow_html = sprintf(
+				'<span class="wp-block-post-navigation-link__arrow-%1$s is-arrow-%2$s" aria-hidden="true">%3$s</span>',
+				esc_attr( $navigation_type ),
+				esc_attr( $arrow_type ),
+				esc_html( $arrow )
+			);
+		}
+		
+		// Order elements based on direction
+		$content = sprintf(
+			'<span class="post-navigation-link__no-post">%1$s%2$s</span>',
+			$is_next ? esc_html( $label_text ) : $arrow_html,
+			$is_next ? $arrow_html : esc_html( $label_text )
+		);
 	}
 
 	return sprintf(

--- a/packages/block-library/src/post-navigation-link/index.php
+++ b/packages/block-library/src/post-navigation-link/index.php
@@ -20,29 +20,27 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 		return '';
 	}
 
-	// Get the navigation type to show the proper link. 
-	$navigation_type = isset( $attributes['type'] ) && 'previous' === $attributes['type'] ? 'previous' : 'next';
-	
-	// Build classes once
+	// Get the navigation type to show the proper link. Available options are `next|previous`.
+	$navigation_type = isset( $attributes['type'] ) ? $attributes['type'] : 'next';
+	// Allow only `next` and `previous` in `$navigation_type`.
+	if ( ! in_array( $navigation_type, array( 'next', 'previous' ), true ) ) {
+		return '';
+	}
 	$classes = "post-navigation-link-$navigation_type";
 	if ( isset( $attributes['textAlign'] ) ) {
 		$classes .= " has-text-align-{$attributes['textAlign']}";
 	}
-	
-	// Prepare wrapper attributes once
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
 			'class' => $classes,
 		)
 	);
-	
-	// Set default values
+	// Set default values.
 	$format = '%link';
-	$is_next = 'next' === $navigation_type;
-	$link = $is_next ? _x( 'Next', 'label for next post link' ) : _x( 'Previous', 'label for previous post link' );
-	$label = '';
+	$link   = 'next' === $navigation_type ? _x( 'Next', 'label for next post link' ) : _x( 'Previous', 'label for previous post link' );
+	$label  = '';
 
-	// Only use hardcoded arrow values
+	// Only use hardcoded values here, otherwise we need to add escaping where these values are used.
 	static $arrow_map = array(
 		'none'    => '',
 		'arrow'   => array(
@@ -55,84 +53,106 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 		),
 	);
 
-	// Process label if provided
+	// If a custom label is provided, make this a link.
+	// `$label` is used to prepend the provided label, if we want to show the page title as well.
 	if ( isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ) {
-		$label = $attributes['label'];
-		$link = $label;
+		$label = "{$attributes['label']}";
+		$link  = $label;
 	}
 
-	// Handle title display options
+	// If we want to also show the page title, make the page title a link and prepend the label.
 	if ( isset( $attributes['showTitle'] ) && $attributes['showTitle'] ) {
-		$link_label = isset( $attributes['linkLabel'] ) && $attributes['linkLabel'];
-		
-		if ( ! $link_label ) {
-			// Label as text, title as link
+		/*
+		 * If the label link option is not enabled but there is a custom label,
+		 * display the custom label as text before the linked title.
+		 */
+		if ( ! $attributes['linkLabel'] ) {
 			if ( $label ) {
 				$format = '<span class="post-navigation-link__label">' . wp_kses_post( $label ) . '</span> %link';
 			}
 			$link = '%title';
-		} else {
-			// Both label and title in link
+		} elseif ( isset( $attributes['linkLabel'] ) && $attributes['linkLabel'] ) {
+			// If the label link option is enabled and there is a custom label, display it before the title.
 			if ( $label ) {
 				$link = '<span class="post-navigation-link__label">' . wp_kses_post( $label ) . '</span> <span class="post-navigation-link__title">%title</span>';
 			} else {
-				// Default label with colon
-				$default_label = $is_next ? _x( 'Next:', 'label before the title of the next post' ) : _x( 'Previous:', 'label before the title of the previous post' );
-				$link = sprintf(
+				/*
+				 * If the label link option is enabled and there is no custom label,
+				 * add a colon between the label and the post title.
+				 */
+				$label = 'next' === $navigation_type ? _x( 'Next:', 'label before the title of the next post' ) : _x( 'Previous:', 'label before the title of the previous post' );
+				$link  = sprintf(
 					'<span class="post-navigation-link__label">%1$s</span> <span class="post-navigation-link__title">%2$s</span>',
-					wp_kses_post( $default_label ),
+					wp_kses_post( $label ),
 					'%title'
 				);
 			}
 		}
 	}
 
-	// Add arrow if needed
-	$arrow_type = isset( $attributes['arrow'] ) ? $attributes['arrow'] : 'none';
-	if ( 'none' !== $arrow_type && isset( $arrow_map[$arrow_type] ) ) {
-		$arrow = $arrow_map[$arrow_type][$navigation_type];
-		$arrow_html = sprintf(
-			'<span class="wp-block-post-navigation-link__arrow-%1$s is-arrow-%2$s" aria-hidden="true">%3$s</span>',
-			esc_attr( $navigation_type ),
-			esc_attr( $arrow_type ),
-			$arrow
-		);
-		
-		$format = $is_next ? '%link' . $arrow_html : $arrow_html . '%link';
+	// Display arrows.
+	if ( isset( $attributes['arrow'] ) && 'none' !== $attributes['arrow'] && isset( $arrow_map[ $attributes['arrow'] ] ) ) {
+		$arrow = $arrow_map[ $attributes['arrow'] ][ $navigation_type ];
+
+		if ( 'next' === $navigation_type ) {
+			$format = '%link<span class="wp-block-post-navigation-link__arrow-next is-arrow-' . $attributes['arrow'] . '" aria-hidden="true">' . $arrow . '</span>';
+		} else {
+			$format = '<span class="wp-block-post-navigation-link__arrow-previous is-arrow-' . $attributes['arrow'] . '" aria-hidden="true">' . $arrow . '</span>%link';
+		}
 	}
 
-	// Get link function name once
+	/*
+	 * The dynamic portion of the function name, `$navigation_type`,
+	 * Refers to the type of adjacency, 'next' or 'previous'.
+	 *
+	 * @see https://developer.wordpress.org/reference/functions/get_previous_post_link/
+	 * @see https://developer.wordpress.org/reference/functions/get_next_post_link/
+	 */
 	$get_link_function = "get_{$navigation_type}_post_link";
-	
-	// Get the actual link content
+
 	if ( ! empty( $attributes['taxonomy'] ) ) {
 		$content = $get_link_function( $format, $link, true, '', $attributes['taxonomy'] );
 	} else {
 		$content = $get_link_function( $format, $link );
 	}
 
-	// Handle case when there's no adjacent post
 	if ( empty( $content ) ) {
-		$label_text = $is_next ? __( 'Next' ) : __( 'Previous' );
-		
+		$label_text = 'next' === $navigation_type ? __( 'Next' ) : __( 'Previous' );
+	
 		// Setup arrow if needed
 		$arrow_html = '';
-		if ( 'none' !== $arrow_type && isset( $arrow_map[$arrow_type] ) ) {
-			$arrow = $arrow_map[$arrow_type][$navigation_type];
-			$arrow_html = sprintf(
-				'<span class="wp-block-post-navigation-link__arrow-%1$s is-arrow-%2$s" aria-hidden="true">%3$s</span>',
-				esc_attr( $navigation_type ),
-				esc_attr( $arrow_type ),
-				esc_html( $arrow )
+		if ( isset( $attributes['arrow'] ) && 'none' !== $attributes['arrow'] && isset( $arrow_map[ $attributes['arrow'] ] ) ) {
+			$arrow = $arrow_map[ $attributes['arrow'] ][ $navigation_type ];
+	
+			if ( 'next' === $navigation_type ) {
+				$arrow_html = sprintf(
+					'<span class="wp-block-post-navigation-link__arrow-next is-arrow-%1$s" aria-hidden="true">%2$s</span>',
+					esc_attr( $attributes['arrow'] ),
+					esc_html( $arrow )
+				);
+			} else {
+				$arrow_html = sprintf(
+					'<span class="wp-block-post-navigation-link__arrow-previous is-arrow-%1$s" aria-hidden="true">%2$s</span>',
+					esc_attr( $attributes['arrow'] ),
+					esc_html( $arrow )
+				);
+			}
+		}
+	
+		// Build content with arrow and label
+		if ( 'next' === $navigation_type ) {
+			$content = sprintf(
+				'<span class="post-navigation-link__no-post">%1$s%2$s</span>',
+				esc_html( $label_text ),
+				$arrow_html
+			);
+		} else {
+			$content = sprintf(
+				'<span class="post-navigation-link__no-post">%1$s%2$s</span>',
+				$arrow_html,
+				esc_html( $label_text )
 			);
 		}
-		
-		// Order elements based on direction
-		$content = sprintf(
-			'<span class="post-navigation-link__no-post">%1$s%2$s</span>',
-			$is_next ? esc_html( $label_text ) : $arrow_html,
-			$is_next ? $arrow_html : esc_html( $label_text )
-		);
 	}
 
 	return sprintf(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Issue #69994

<!-- In a few words, what is the PR actually doing? -->

## Why?

When users are viewing the first or last post, the Next Post or Previous Post block currently shows no content on the frontend. This can create confusion, as it may appear that the block is not functioning properly. To improve user clarity, it would be helpful to display a fallback message or disabled text to indicate that there is no next or previous post available. This simple enhancement would greatly enrich the user experience by providing clear and informative feedback.



## How?
This PR adds a default `$content` that includes both the Next and Previous text, along with the corresponding arrow.


### Some more optimization:
`static $arrow_map = array(...)` - By adding the static keyword, this array is created only once when the function is first called. On subsequent calls, the server reuses the existing array instead of creating a new one.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Create a new post.
2. Insert the Next Post Block into the content.
3. Save the post and preview it on the frontend.
4. Observe that the Next text is now displayed in a muted state, rather than being completely absent.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before and After:

![Screenshot 2025-04-28 222346](https://github.com/user-attachments/assets/7ac11e76-f46d-4ae8-b6c7-5af93a5442dc)
![Screenshot 2025-04-28 222327](https://github.com/user-attachments/assets/62acc1ca-4c8e-4ed9-b65d-bfa7b28317ef)


