### PR TITLE
[New block] bookmark archive

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -44,6 +44,14 @@ Reuse this design across your site. ([Source](https://github.com/WordPress/guten
 -	**Supports:** interactivity (clientNavigation), ~~customClassName~~, ~~html~~, ~~inserter~~, ~~renaming~~
 -	**Attributes:** content, ref
 
+## Bookmark/Like-archive
+
+Displays all bookmarked posts ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/bookmark-archive))
+
+-	**Name:** core/bookmark-archive
+-	**Category:** theme
+-	**Supports:** align (full, wide), color (background, gradients, text), interactivity, spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+
 ## Button
 
 Prompt visitors to take action with a button-style link. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/button))

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -15,6 +15,7 @@ function gutenberg_reregister_core_block_types() {
 		__DIR__ . '/../build/block-library/blocks/' => array(
 			'block_folders' => array(
 				'audio',
+				'bookmark-archive',
 				'button',
 				'buttons',
 				'freeform',
@@ -47,6 +48,7 @@ function gutenberg_reregister_core_block_types() {
 			'block_names'   => array(
 				'archives.php'                     => 'core/archives',
 				'avatar.php'                       => 'core/avatar',
+				'bookmark-archive.php'             => 'core/bookmark-archive',
 				'block.php'                        => 'core/block',
 				'button.php'                       => 'core/button',
 				'calendar.php'                     => 'core/calendar',

--- a/packages/block-library/src/bookmark-archive/block.json
+++ b/packages/block-library/src/bookmark-archive/block.json
@@ -1,0 +1,39 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "core/bookmark-archive",
+	"title": "Bookmark/Like-archive",
+	"category": "theme",
+	"description": "Displays all bookmarked posts",
+	"textdomain": "default",
+	"supports": {
+		"interactivity": true,
+		"align": [ "wide", "full" ],
+		"html": false,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
+		"color": {
+			"gradients": true,
+			"__experimentalDefaultControls": {
+				"text": true,
+				"background": true
+			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		}
+	},
+	"style": "wp-block-bookmark"
+}

--- a/packages/block-library/src/bookmark-archive/bookmarks-logged-out-user.js
+++ b/packages/block-library/src/bookmark-archive/bookmarks-logged-out-user.js
@@ -1,0 +1,94 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+document.addEventListener( 'DOMContentLoaded', function () {
+	const likedPostsElement = document.getElementById( 'liked-posts' );
+
+	// Get liked posts from localStorage for logged-out users.
+	const likedPosts = ( () => {
+		try {
+			return (
+				JSON.parse( window.localStorage.getItem( 'likedPosts' ) ) || []
+			);
+		} catch ( e ) {
+			likedPostsElement.innerHTML =
+				'<p>' + __( "Couldn't fetch posts." ) + '</p>';
+			return undefined;
+		}
+	} )();
+
+	if ( likedPosts === undefined ) {
+		// Exit if localStorage access failed.
+		return;
+	}
+	if ( likedPosts.length === 0 ) {
+		likedPostsElement.innerHTML =
+			'<p>' + __( 'No liked posts found.' ) + '</p>';
+		return;
+	}
+
+	const postsPerPage = 10;
+	const urlParams = new URLSearchParams( window.location.search );
+	const currentPage = parseInt( urlParams.get( 'paged' ) ) || 1;
+	const totalPages = Math.ceil( likedPosts.length / postsPerPage );
+
+	// Slice liked posts for current page.
+	const paginatedPosts = likedPosts.slice(
+		( currentPage - 1 ) * postsPerPage,
+		currentPage * postsPerPage
+	);
+
+	// Fetch post data from WordPress REST API.
+	fetch( `/wp-json/wp/v2/search?include=${ paginatedPosts.join( ',' ) }` )
+		.then( ( response ) => response.json() )
+		.then( ( posts ) => {
+			let output = '';
+			posts.forEach( ( post ) => {
+				output += `<li><h2><a href="${ post.url }">${ post.title }</a></h2></li>`;
+			} );
+
+			likedPostsElement.innerHTML = output;
+
+			// Add pagination.
+			likedPostsElement.insertAdjacentHTML(
+				'afterend',
+				generatePagination( currentPage, totalPages )
+			);
+		} )
+		.catch( () => {
+			likedPostsElement.innerHTML =
+				'<p>' + __( "Couldn't fetch posts." ) + '</p>';
+		} );
+
+	// Function to generate pagination links
+	function generatePagination( current, total ) {
+		if ( total <= 1 ) {
+			return ''; // No need for pagination if only one page.
+		}
+
+		let paginationHTML = '<div class="pagination">';
+		if ( current > 1 ) {
+			paginationHTML += `<a href="?paged=${
+				current - 1
+			}" class="prev page-numbers">« Previous</a>`;
+		}
+		for ( let i = 1; i <= total; i++ ) {
+			paginationHTML += ' ';
+			if ( i === current ) {
+				paginationHTML += `<span aria-current="page" class="page-numbers current">${ i }</span>`;
+			} else {
+				paginationHTML += `<a href="?paged=${ i }" class="page-numbers"">${ i }</a>`;
+			}
+		}
+		if ( current < total ) {
+			paginationHTML += ' ';
+			paginationHTML += `<a href="?paged=${
+				current + 1
+			}" class="next page-numbers">Next »</a>`;
+		}
+		paginationHTML += '</div>';
+		return paginationHTML;
+	}
+} );

--- a/packages/block-library/src/bookmark-archive/edit.js
+++ b/packages/block-library/src/bookmark-archive/edit.js
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+export default function BookmarkEdit() {
+	return (
+		<div { ...useBlockProps() }>
+			<h1>{ __( 'Your Liked Posts' ) }</h1>
+			<ul>
+				<li>
+					<h2>{ __( 'Title' ) }</h2>
+				</li>
+				<li>
+					<h2>{ __( 'Title' ) }</h2>
+				</li>
+			</ul>
+			<div className="pagination">
+				<span className="page-numbers current">
+					« { __( 'Previous' ) }{ ' ' }
+				</span>
+				<span className="page-numbers current">{ __( '1' ) }</span>
+				<span className="page-numbers">{ __( '2' ) }</span>
+				<span className="page-numbers">{ __( '3' ) }</span>
+				<span className="page-numbers">{ __( '4' ) }</span>
+				<span className="page-numbers">{ __( '5' ) }</span>
+				<span className="next page-numbers"> { __( 'Next' ) } »</span>
+			</div>
+		</div>
+	);
+}

--- a/packages/block-library/src/bookmark-archive/icons.js
+++ b/packages/block-library/src/bookmark-archive/icons.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/components';
+
+export const bookmark = (
+	<SVG
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		width="24"
+		height="24"
+		aria-hidden="true"
+		focusable="false"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+	>
+		<Path d="M6 2H18C18.5523 2 19 2.44772 19 3V21C19 21.5523 18.5523 22 18 22C17.7348 22 17.4804 21.8946 17.2929 21.7071L12 16.4142L6.70711 21.7071C6.51957 21.8946 6.26522 22 6 22C5.44772 22 5 21.5523 5 21V3C5 2.44772 5.44772 2 6 2Z" />
+	</SVG>
+);

--- a/packages/block-library/src/bookmark-archive/index.js
+++ b/packages/block-library/src/bookmark-archive/index.js
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+import initBlock from '../utils/init-block';
+import { bookmark } from './icons';
+
+/* Block settings. */
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	icon: bookmark,
+	edit,
+};
+
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/bookmark-archive/index.php
+++ b/packages/block-library/src/bookmark-archive/index.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Server-side rendering of the `core/bookmark` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `bookmark` block on the server.
+ *
+ * @since 6.8.0
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string The rendered block content.
+ */
+function render_block_core_bookmark_archive() {
+	$wrapper_attributes = get_block_wrapper_attributes();
+	$custom_content     = '<div ' . $wrapper_attributes . ' >';
+	$custom_content    .= '<h1>' . __( 'Your Liked Posts' ) . '</h1>';
+
+	if ( is_user_logged_in() ) {
+
+		// Fetch user's liked posts.
+		$current_user_id = get_current_user_id();
+		$liked_posts     = get_user_meta( $current_user_id, 'liked_posts', true ) ? get_user_meta( $current_user_id, 'liked_posts', true ) : array();
+		$paged           = get_query_var( 'paged' ) ? get_query_var( 'paged' ) : 1;
+
+		$query = new WP_Query(
+			array(
+				'post_type'      => 'any',
+				'post__in'       => ! empty( $liked_posts ) ? array_map( 'intval', $liked_posts ) : array( 0 ),
+				'orderby'        => 'post__in',
+				'posts_per_page' => 10,
+				'paged'          => $paged,
+			)
+		);
+
+		if ( $query->have_posts() ) {
+			$custom_content .= '<ul class="favorites-list">';
+			while ( $query->have_posts() ) {
+				$query->the_post();
+				$custom_content .= '<li><h2><a href="' . get_permalink() . '">' . get_the_title() . '</a></h2></li>';
+			}
+			$custom_content .= '</ul>';
+
+			$custom_content .= '<div class="pagination">';
+
+			$big             = 999999999; // Need an unlikely integer for pagination base.
+			$custom_content .= paginate_links(
+				array(
+					'base'      => str_replace( $big, '%#%', esc_url( get_pagenum_link( $big ) ) ),
+					'format'    => '?paged=%#%',
+					'current'   => max( 1, $paged ),
+					'total'     => $query->max_num_pages,
+					'prev_text' => '« Previous',
+					'next_text' => 'Next »',
+				)
+			);
+			$custom_content .= '</div>';
+
+			wp_reset_postdata();
+		} else {
+			$custom_content .= '<p>' . __( 'No liked posts found.' ) . '</p>';
+		}
+	} else {
+		wp_register_script( 'core-bookmarks-logged-out-user', '/wp-content/plugins/gutenberg/packages/block-library/src/bookmark-archive/bookmarks-logged-out-user.js', array(), filemtime( '/wp-content/plugins/gutenberg/packages/block-library/src/bookmark/bookmarks-logged-out-user.js' ), true );
+		wp_enqueue_script( 'core-bookmarks-logged-out-user' );
+		// Needed to inject liked posts using js when user is not logged in.
+		$custom_content .= '<ul id="liked-posts" class="liked-posts"></ul>';
+	}
+
+	$custom_content .= '</div>';
+
+	return $custom_content;
+}
+
+/**
+ * Registers the `bookmark-archive` block.
+ *
+ * @since 6.8.0
+ */
+function register_block_core_bookmark_archive() {
+	register_block_type_from_metadata(
+		__DIR__ . '/bookmark-archive',
+		array(
+			'render_callback' => 'render_block_core_bookmark_archive',
+		)
+	);
+}
+
+add_action( 'init', 'register_block_core_bookmark_archive' );

--- a/packages/block-library/src/bookmark-archive/init.js
+++ b/packages/block-library/src/bookmark-archive/init.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import { init } from './';
+
+export default init();

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -23,6 +23,7 @@ import {
 import * as archives from './archives';
 import * as avatar from './avatar';
 import * as audio from './audio';
+import * as bookmarkArchive from './bookmark-archive';
 import * as button from './button';
 import * as buttons from './buttons';
 import * as calendar from './calendar';
@@ -143,6 +144,7 @@ const getAllBlocks = () => {
 		// Register all remaining core blocks.
 		archives,
 		audio,
+		bookmarkArchive,
 		button,
 		buttons,
 		calendar,

--- a/test/integration/fixtures/blocks/core__bookmark-archive.html
+++ b/test/integration/fixtures/blocks/core__bookmark-archive.html
@@ -1,0 +1,2 @@
+<!-- wp:bookmark-archive /-->
+ 

--- a/test/integration/fixtures/blocks/core__bookmark-archive.json
+++ b/test/integration/fixtures/blocks/core__bookmark-archive.json
@@ -1,0 +1,8 @@
+[
+	{
+		"name": "core/bookmark-archive",
+		"isValid": true,
+		"attributes": {},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__bookmark-archive.parsed.json
+++ b/test/integration/fixtures/blocks/core__bookmark-archive.parsed.json
@@ -1,0 +1,9 @@
+[
+	{
+		"blockName": "core/bookmark-archive",
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__bookmark-archive.serialized.html
+++ b/test/integration/fixtures/blocks/core__bookmark-archive.serialized.html
@@ -1,0 +1,1 @@
+<!-- wp:bookmark-archive /-->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds a bookmarking/favorites system for WordPress posts, allowing users to save posts for later reading, like posts or wishlist products. The feature includes:

- A Bookmark Archive Block to display all bookmarked posts.

Splitting out from https://github.com/WordPress/gutenberg/pull/69660
Closes https://github.com/WordPress/gutenberg/issues/59524

This PR is an extension to this base [PR](https://github.com/WordPress/gutenberg/pull/70010)