### PR TITLE
Block HTML: Add `box-sizing` property to prevent overflow

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -365,6 +365,7 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 	border: none;
 	outline: none;
 	border-radius: $radius-small;
+	box-sizing: border-box;
 	box-shadow: inset 0 0 0 $border-width $gray-900;
 	resize: none;
 	overflow: hidden;


### PR DESCRIPTION
## What?

Closes #70013

This PR addresses a bug where the colored outline (which marks selection) renders inside the block content's border for the Block HTML component.

## Why?

Happens because of a missing `box-sizing: border-box` property.

## How?

Added missing `box-sizing: border-box` property to Block HTML's Textarea.

## Testing Instructions
1. Create a new post.
2. Create a paragraph and try editing it as HTML.
3. Toggle List View and confirm that the colored outline matches the block's border.

### Testing Instructions for Keyboard
Same.

## Screenshots

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/eeeb208f-477b-429a-a335-6e8bafc01d9a)|![after](https://github.com/user-attachments/assets/1d10e046-0cc2-4b2e-a134-c3d5d23d56fe)|


