### PR TITLE
[Post Navigation Link Block]: Allow Next / Previous Page blocks to entertain an icon-only or text-only display

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -650,7 +650,7 @@ Displays the next or previous post link that is adjacent to the current post. ([
 -	**Name:** core/post-navigation-link
 -	**Category:** theme
 -	**Supports:** color (background, link, text), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** arrow, label, linkLabel, showTitle, taxonomy, textAlign, type
+-	**Attributes:** arrow, label, linkLabel, showLabel, showTitle, taxonomy, textAlign, type
 
 ## Post Template
 

--- a/packages/block-library/src/post-navigation-link/block.json
+++ b/packages/block-library/src/post-navigation-link/block.json
@@ -32,6 +32,10 @@
 		"taxonomy": {
 			"type": "string",
 			"default": ""
+		},
+		"showLabel": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"usesContext": [ "postType" ],

--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -34,6 +34,7 @@ export default function PostNavigationLinkEdit( {
 		linkLabel,
 		arrow,
 		taxonomy,
+		showLabel,
 	},
 	setAttributes,
 } ) {
@@ -128,7 +129,14 @@ export default function PostNavigationLinkEdit( {
 						label={ __( 'Arrow' ) }
 						value={ arrow }
 						onChange={ ( value ) => {
-							setAttributes( { arrow: value } );
+							if ( value === 'none' ) {
+								setAttributes( {
+									showLabel: false,
+									arrow: value,
+								} );
+							} else {
+								setAttributes( { arrow: value } );
+							}
 						} }
 						help={ __(
 							'A decorative arrow for the next and previous link.'
@@ -157,6 +165,18 @@ export default function PostNavigationLinkEdit( {
 							) }
 						/>
 					</ToggleGroupControl>
+					{ arrow !== 'none' && (
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Show label text' ) }
+							checked={ !! showLabel }
+							onChange={ () =>
+								setAttributes( {
+									showLabel: ! showLabel,
+								} )
+							}
+						/>
+					) }
 				</PanelBody>
 			</InspectorControls>
 			<InspectorControls group="advanced">
@@ -192,17 +212,19 @@ export default function PostNavigationLinkEdit( {
 						{ displayArrow }
 					</span>
 				) }
-				<RichText
-					tagName="a"
-					identifier="label"
-					aria-label={ ariaLabel }
-					placeholder={ placeholder }
-					value={ label }
-					withoutInteractiveFormatting
-					onChange={ ( newLabel ) =>
-						setAttributes( { label: newLabel } )
-					}
-				/>
+				{ showLabel && (
+					<RichText
+						tagName="a"
+						identifier="label"
+						aria-label={ ariaLabel }
+						placeholder={ placeholder }
+						value={ label }
+						withoutInteractiveFormatting
+						onChange={ ( newLabel ) =>
+							setAttributes( { label: newLabel } )
+						}
+					/>
+				) }
 				{ showTitle && (
 					<a
 						href="#post-navigation-pseudo-link"

--- a/packages/block-library/src/post-navigation-link/index.php
+++ b/packages/block-library/src/post-navigation-link/index.php
@@ -15,112 +15,117 @@
  *
  * @return string Returns the next or previous post link that is adjacent to the current post.
  */
-function render_block_core_post_navigation_link( $attributes, $content ) {
-	if ( ! is_singular() ) {
-		return '';
-	}
+function render_block_core_post_navigation_link( $attributes, $content )
+{
+    if (! is_singular() ) {
+        return '';
+    }
 
-	// Get the navigation type to show the proper link. Available options are `next|previous`.
-	$navigation_type = isset( $attributes['type'] ) ? $attributes['type'] : 'next';
-	// Allow only `next` and `previous` in `$navigation_type`.
-	if ( ! in_array( $navigation_type, array( 'next', 'previous' ), true ) ) {
-		return '';
-	}
-	$classes = "post-navigation-link-$navigation_type";
-	if ( isset( $attributes['textAlign'] ) ) {
-		$classes .= " has-text-align-{$attributes['textAlign']}";
-	}
-	$wrapper_attributes = get_block_wrapper_attributes(
-		array(
-			'class' => $classes,
-		)
-	);
-	// Set default values.
-	$format = '%link';
-	$link   = 'next' === $navigation_type ? _x( 'Next', 'label for next post link' ) : _x( 'Previous', 'label for previous post link' );
-	$label  = '';
+    // Get the navigation type to show the proper link. Available options are `next|previous`.
+    $navigation_type = isset($attributes['type']) ? $attributes['type'] : 'next';
+    // Allow only `next` and `previous` in `$navigation_type`.
+    if (! in_array($navigation_type, array( 'next', 'previous' ), true) ) {
+        return '';
+    }
+    $classes = "post-navigation-link-$navigation_type";
+    if (isset($attributes['textAlign']) ) {
+        $classes .= " has-text-align-{$attributes['textAlign']}";
+    }
+    $wrapper_attributes = get_block_wrapper_attributes(
+        array(
+        'class' => $classes,
+        )
+    );
+    // Set default values.
+    $format = '%link';
+    $link   = 'next' === $navigation_type ? _x('Next', 'label for next post link') : _x('Previous', 'label for previous post link');
+    $label  = '';
 
-	// Only use hardcoded values here, otherwise we need to add escaping where these values are used.
-	$arrow_map = array(
-		'none'    => '',
-		'arrow'   => array(
-			'next'     => '→',
-			'previous' => '←',
-		),
-		'chevron' => array(
-			'next'     => '»',
-			'previous' => '«',
-		),
-	);
+    // Only use hardcoded values here, otherwise we need to add escaping where these values are used.
+    $arrow_map = array(
+    'none'    => '',
+    'arrow'   => array(
+    'next'     => '→',
+    'previous' => '←',
+    ),
+    'chevron' => array(
+    'next'     => '»',
+    'previous' => '«',
+    ),
+    );
 
-	// If a custom label is provided, make this a link.
-	// `$label` is used to prepend the provided label, if we want to show the page title as well.
-	if ( isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ) {
-		$label = "{$attributes['label']}";
-		$link  = $label;
-	}
+    // If a custom label is provided, make this a link.
+    // `$label` is used to prepend the provided label, if we want to show the page title as well.
+    if (isset($attributes['label']) && ! empty($attributes['label']) ) {
+        $label = "{$attributes['label']}";
+        $link  = $label;
+    }
 
-	// If we want to also show the page title, make the page title a link and prepend the label.
-	if ( isset( $attributes['showTitle'] ) && $attributes['showTitle'] ) {
-		/*
-		 * If the label link option is not enabled but there is a custom label,
-		 * display the custom label as text before the linked title.
-		 */
-		if ( ! $attributes['linkLabel'] ) {
-			if ( $label ) {
-				$format = '<span class="post-navigation-link__label">' . wp_kses_post( $label ) . '</span> %link';
-			}
-			$link = '%title';
-		} elseif ( isset( $attributes['linkLabel'] ) && $attributes['linkLabel'] ) {
-			// If the label link option is enabled and there is a custom label, display it before the title.
-			if ( $label ) {
-				$link = '<span class="post-navigation-link__label">' . wp_kses_post( $label ) . '</span> <span class="post-navigation-link__title">%title</span>';
-			} else {
-				/*
-				 * If the label link option is enabled and there is no custom label,
-				 * add a colon between the label and the post title.
-				 */
-				$label = 'next' === $navigation_type ? _x( 'Next:', 'label before the title of the next post' ) : _x( 'Previous:', 'label before the title of the previous post' );
-				$link  = sprintf(
-					'<span class="post-navigation-link__label">%1$s</span> <span class="post-navigation-link__title">%2$s</span>',
-					wp_kses_post( $label ),
-					'%title'
-				);
-			}
-		}
-	}
+    // If we want to also show the page title, make the page title a link and prepend the label.
+    if (isset($attributes['showTitle']) && $attributes['showTitle'] ) {
+        /*
+        * If the label link option is not enabled but there is a custom label,
+        * display the custom label as text before the linked title.
+        */
+        if (! $attributes['linkLabel'] ) {
+            if ($label ) {
+                $format = '<span class="post-navigation-link__label">' . wp_kses_post($label) . '</span> %link';
+            }
+            $link = '%title';
+        } elseif (isset($attributes['linkLabel']) && $attributes['linkLabel'] ) {
+            // If the label link option is enabled and there is a custom label, display it before the title.
+            if ($label ) {
+                $link = '<span class="post-navigation-link__label">' . wp_kses_post($label) . '</span> <span class="post-navigation-link__title">%title</span>';
+            } else {
+                /*
+                * If the label link option is enabled and there is no custom label,
+                * add a colon between the label and the post title.
+                */
+                $label = 'next' === $navigation_type ? _x('Next:', 'label before the title of the next post') : _x('Previous:', 'label before the title of the previous post');
+                $link  = sprintf(
+                    '<span class="post-navigation-link__label">%1$s</span> <span class="post-navigation-link__title">%2$s</span>',
+                    wp_kses_post($label),
+                    '%title'
+                );
+            }
+        }
+    }
 
-	// Display arrows.
-	if ( isset( $attributes['arrow'] ) && 'none' !== $attributes['arrow'] && isset( $arrow_map[ $attributes['arrow'] ] ) ) {
-		$arrow = $arrow_map[ $attributes['arrow'] ][ $navigation_type ];
+    // Display arrows.
+    if (isset($attributes['arrow']) && 'none' !== $attributes['arrow'] && isset($arrow_map[ $attributes['arrow'] ]) ) {
+        $arrow = $arrow_map[ $attributes['arrow'] ][ $navigation_type ];
 
-		if ( 'next' === $navigation_type ) {
-			$format = '%link<span class="wp-block-post-navigation-link__arrow-next is-arrow-' . $attributes['arrow'] . '" aria-hidden="true">' . $arrow . '</span>';
-		} else {
-			$format = '<span class="wp-block-post-navigation-link__arrow-previous is-arrow-' . $attributes['arrow'] . '" aria-hidden="true">' . $arrow . '</span>%link';
-		}
-	}
+        if ('next' === $navigation_type ) {
+            $format = '%link<span class="wp-block-post-navigation-link__arrow-next is-arrow-' . $attributes['arrow'] . '" aria-hidden="true">' . $arrow . '</span>';
+        } else {
+            $format = '<span class="wp-block-post-navigation-link__arrow-previous is-arrow-' . $attributes['arrow'] . '" aria-hidden="true">' . $arrow . '</span>%link';
+        }
+    }
 
-	/*
-	 * The dynamic portion of the function name, `$navigation_type`,
-	 * Refers to the type of adjacency, 'next' or 'previous'.
-	 *
-	 * @see https://developer.wordpress.org/reference/functions/get_previous_post_link/
-	 * @see https://developer.wordpress.org/reference/functions/get_next_post_link/
-	 */
-	$get_link_function = "get_{$navigation_type}_post_link";
+    /*
+    * The dynamic portion of the function name, `$navigation_type`,
+    * Refers to the type of adjacency, 'next' or 'previous'.
+    *
+    * @see https://developer.wordpress.org/reference/functions/get_previous_post_link/
+    * @see https://developer.wordpress.org/reference/functions/get_next_post_link/
+    */
+    $get_link_function = "get_{$navigation_type}_post_link";
 
-	if ( ! empty( $attributes['taxonomy'] ) ) {
-		$content = $get_link_function( $format, $link, true, '', $attributes['taxonomy'] );
-	} else {
-		$content = $get_link_function( $format, $link );
-	}
+    if (isset($attributes['showLabel']) && !$attributes['showLabel'] ) {
+        $link = '';
+    }
 
-	return sprintf(
-		'<div %1$s>%2$s</div>',
-		$wrapper_attributes,
-		$content
-	);
+    if (! empty($attributes['taxonomy']) ) {
+        $content = $get_link_function($format, $link, true, '', $attributes['taxonomy']);
+    } else {
+        $content = $get_link_function($format, $link);
+    }
+
+    return sprintf(
+        '<div %1$s>%2$s</div>',
+        $wrapper_attributes,
+        $content
+    );
 }
 
 /**
@@ -128,12 +133,13 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
  *
  * @since 5.9.0
  */
-function register_block_core_post_navigation_link() {
-	register_block_type_from_metadata(
-		__DIR__ . '/post-navigation-link',
-		array(
-			'render_callback' => 'render_block_core_post_navigation_link',
-		)
-	);
+function register_block_core_post_navigation_link()
+{
+    register_block_type_from_metadata(
+        __DIR__ . '/post-navigation-link',
+        array(
+        'render_callback' => 'render_block_core_post_navigation_link',
+        )
+    );
 }
-add_action( 'init', 'register_block_core_post_navigation_link' );
+add_action('init', 'register_block_core_post_navigation_link');


### PR DESCRIPTION
work in progress from #49266


## What?
This adds an extra display option to the Query Pagination block which allows users to hide the text for the pagination links. This then unlocks several display options for the pagination links:

- Text only
- Icon only
- Text + Icon


## Why?
Closes https://github.com/WordPress/gutenberg/issues/49266.

## How?
This adds a new boolean attribute, showLabel, to the Post navigation link block. The default value is true, and when set to false, it will hide the text labels.

- showLabel is controlled by a toggle control which is only displayed when an arrow icon type is selected. The attribute cannot be set to false if there is no paginationArrow set, to prevent the pagination link from being empty when no arrow or label is set.


## Testing Instructions
- In the editor, insert a Post Navigation Link block (Next post)
- Go to the block settings and toggle through the different arrow options
- Toggle between chevron and arrow, you will see an option to hide the label.
- Repeat with "none" and option should disappear and set to true.
