### PR TITLE
Add Copy Button to Code Block

### DIFF
--- a/packages/block-library/src/code/edit.js
+++ b/packages/block-library/src/code/edit.js
@@ -1,9 +1,14 @@
+/* eslint-env browser */
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+import { copySmall } from '@wordpress/icons';
+import { Button } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
 
 export default function CodeEdit( {
 	attributes,
@@ -13,23 +18,61 @@ export default function CodeEdit( {
 	mergeBlocks,
 } ) {
 	const blockProps = useBlockProps();
+	const { content } = attributes;
+	const { createNotice } = useDispatch( noticesStore );
+
+	const copyToClipboard = () => {
+		navigator?.clipboard
+			.writeText( content?.text )
+			.then( () => {
+				createNotice( 'info', __( 'Copied Code to clipboard.' ), {
+					isDismissible: true,
+					type: 'snackbar',
+				} );
+			} )
+			.catch( () => {
+				createNotice(
+					'error',
+					__( 'Could not copy code to clipboard.' ),
+					{
+						isDismissible: true,
+						type: 'snackbar',
+					}
+				);
+			} );
+	};
+
 	return (
 		<pre { ...blockProps }>
-			<RichText
-				tagName="code"
-				identifier="content"
-				value={ attributes.content }
-				onChange={ ( content ) => setAttributes( { content } ) }
-				onRemove={ onRemove }
-				onMerge={ mergeBlocks }
-				placeholder={ __( 'Write code…' ) }
-				aria-label={ __( 'Code' ) }
-				preserveWhiteSpace
-				__unstablePastePlainText
-				__unstableOnSplitAtDoubleLineEnd={ () =>
-					insertBlocksAfter( createBlock( getDefaultBlockName() ) )
-				}
-			/>
+			<div className="wp-block-code__container">
+				<RichText
+					tagName="code"
+					identifier="content"
+					value={ content }
+					onChange={ ( newContent ) =>
+						setAttributes( { content: newContent } )
+					}
+					onRemove={ onRemove }
+					onMerge={ mergeBlocks }
+					placeholder={ __( 'Write code…' ) }
+					aria-label={ __( 'Code' ) }
+					preserveWhiteSpace
+					__unstablePastePlainText
+					__unstableOnSplitAtDoubleLineEnd={ () =>
+						insertBlocksAfter(
+							createBlock( getDefaultBlockName() )
+						)
+					}
+				/>
+				<Button
+					__next40pxDefaultSize
+					icon={ copySmall }
+					onClick={ copyToClipboard }
+					label={ __( 'Copy' ) }
+					accessibleWhenDisabled
+					disabled={ ! content.text }
+				/>
+			</div>
 		</pre>
 	);
 }

--- a/packages/block-library/src/code/style.scss
+++ b/packages/block-library/src/code/style.scss
@@ -15,4 +15,10 @@
 		text-align: initial;
 		/*!rtl:end:ignore*/
 	}
+
+	.wp-block-code__container {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+	}
 }


### PR DESCRIPTION

## What?
Closes https://github.com/WordPress/gutenberg/issues/70018

## Why?
This PR is intended to add the copy button to the code block 

## How?
This PR adds the `<Button>` component in the code code block with the necessary `icon` , `onClick`, `label` and `disabled` prop for it to behave like Copy Button along with a `notice`.

## Testing Instructions
- Add a new post 
- Add the code block 
- Add some code to the code block 
- Notice a copy button placed on the top right of the code block, which  helps to copy the code 

## Screenshots or screencast 

https://github.com/user-attachments/assets/fa91e413-9c4f-45eb-ab27-d01940dd50f4