### PR TITLE
Post Template: Don't rely on the default 'ignore_sticky' REST API value

### DIFF
--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -181,14 +181,15 @@ export default function PostTemplateEdit( {
 			 * Handle cases where sticky is set to `exclude` or `only`.
 			 * Which works as a `post__in/post__not_in` query for sticky posts.
 			 */
-			if ( sticky && sticky !== 'ignore' ) {
+			if ( [ 'exclude', 'only' ].includes( sticky ) ) {
 				query.sticky = sticky === 'only';
 			}
 
-			if ( sticky === 'ignore' ) {
+			// Empty string represents the default behavior of including sticky posts.
+			if ( [ '', 'ignore' ].includes( sticky ) ) {
 				// Remove any leftover sticky query parameter.
 				delete query.sticky;
-				query.ignore_sticky = true;
+				query.ignore_sticky = sticky === 'ignore';
 			}
 
 			// If `inherit` is truthy, adjust conditionally the query to create a better preview.


### PR DESCRIPTION
## What?
This is a follow-up to https://core.trac.wordpress.org/changeset/60197.

PR updates the REST API query in the Post Template block and always sets the `ignore_sticky` argument without relying on default values.

## Why?
Preserves existing behavior while avoiding bugs after [r60197](https://core.trac.wordpress.org/changeset/60197).

## Testing Instructions

1. Make the second or third latest post a sticky.
2. Create a page.
3. Add test query loop block.
4. Confirm that the Sticky post is displayed at the top.
5. Upgrade to WP 6.8.1.
6. Confirm that behavior remains the same.
7. Smoke test other sticky options; they should work as before.

<details><summary>Test Query</summary>
<p>

```html
<!-- wp:query {"queryId":31,"query":{"perPage":5,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"layout":{"type":"constrained"}} -->
<div class="wp-block-query"><!-- wp:post-template {"layout":{"type":"default"}} -->
<!-- wp:post-title /-->
<!-- /wp:post-template --></div>
<!-- /wp:query -->
``` 

</p>
</details> 

### Testing Instructions for Keyboard
Same.

## Screenshot
![CleanShot 2025-04-30 at 13 45 46](https://github.com/user-attachments/assets/992b0b31-b5ab-41f4-a844-7e6e2747224b)
