### PR TITLE
Components: Fix double border in `ItemGroup` when last item is focused

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug Fixes
 
 -   `ToggleGroupControl`: Fix active background for empty string value ([#69969](https://github.com/WordPress/gutenberg/pull/69969)).
+-   `ItemGroup`: Fix double border in `ItemGroup` when last item is focused ([#70021](https://github.com/WordPress/gutenberg/pull/70021)).
 
 ### Internal
 

--- a/packages/components/src/item-group/styles.ts
+++ b/packages/components/src/item-group/styles.ts
@@ -65,7 +65,7 @@ export const separated = css`
 		border-bottom: 1px solid ${ CONFIG.surfaceBorderColor };
 	}
 
-	> *:last-of-type > *:not( :focus ) {
+	> *:last-of-type > * {
 		border-bottom-color: transparent;
 	}
 `;

--- a/packages/components/src/item-group/test/__snapshots__/index.js.snap
+++ b/packages/components/src/item-group/test/__snapshots__/index.js.snap
@@ -115,7 +115,7 @@ Snapshot Diff:
   <div>
     <div
 -     class="components-item-group css-1iattls-PolymorphicDiv-rounded e19lxcc00"
-+     class="components-item-group css-zgfros-PolymorphicDiv-separated-rounded e19lxcc00"
++     class="components-item-group css-1hvp0tq-PolymorphicDiv-separated-rounded e19lxcc00"
       data-wp-c16t="true"
       data-wp-component="ItemGroup"
       role="list"


### PR DESCRIPTION

## What?
Closes https://github.com/WordPress/gutenberg/issues/61621

Fixes double border issue in `ItemGroup` when last item is focused.


## Why?
Previously, the border was only removed when the item was not focused, causing a double border when the last item received focus.


## How?
Modified the separated CSS to remove the bottom border on the last child item in all states rather than only in the non-focused state.

## Testing Instructions

1. Run `npm run storybook:dev` to start the storybook. 
2. Open the `ItemGroup` component in Storybook.
3. Emulate the `:focus` state on the last item using browser developer tools.
4. Verify the fix removes the double border when the last item is focused

## Notes

The snapshots for the tests need to be updated thats probably the reason why unit tests are failing. I am not aware on how to update them. I would appreciate some guidance here.

## Screenshots or screencast


### Before


https://github.com/user-attachments/assets/30b131fd-96c9-43e5-8b19-0bd564f6c70e



### After


https://github.com/user-attachments/assets/a95494ac-24cd-49d6-81cf-b2c9cf3d526d



