### PR TITLE
fix: update the logic of fetching current url in loginout block

### DIFF
--- a/packages/block-library/src/loginout/index.php
+++ b/packages/block-library/src/loginout/index.php
@@ -16,13 +16,9 @@
  */
 function render_block_core_loginout( $attributes ) {
 
+	// This current url fetching logic matches with the core: https://github.com/WordPress/WordPress/blob/6612d90f6c8ee9e917dc2dfcbcc24e120a5746ea/wp-includes/general-template.php#L528
 	// Build the redirect URL.
-	if ( ! isset( $_SERVER['REQUEST_URI'] ) || empty( $_SERVER['REQUEST_URI'] ) ) {
-		// Fallback to home URL if REQUEST_URI is not set.
-		$current_url = home_url();
-	} else {
-		$current_url = home_url( wp_unslash( sanitize_url( $_SERVER['REQUEST_URI'] ) ) );
-	}
+	$current_url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 
 	$classes  = is_user_logged_in() ? 'logged-in' : 'logged-out';
 	$contents = wp_loginout(

--- a/packages/block-library/src/loginout/index.php
+++ b/packages/block-library/src/loginout/index.php
@@ -16,8 +16,11 @@
  */
 function render_block_core_loginout( $attributes ) {
 
-	// This current url fetching logic matches with the core: https://github.com/WordPress/WordPress/blob/6612d90f6c8ee9e917dc2dfcbcc24e120a5746ea/wp-includes/general-template.php#L528
-	// Build the redirect URL.
+	/*
+	 * Build the redirect URL. This current url fetching logic matches with the core.
+	 *
+	 * @see https://github.com/WordPress/wordpress-develop/blob/6bf62e58d21739938f3bb3f9e16ba702baf9c2cc/src/wp-includes/general-template.php#L528.
+	 */
 	$current_url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 
 	$classes  = is_user_logged_in() ? 'logged-in' : 'logged-out';

--- a/packages/block-library/src/loginout/index.php
+++ b/packages/block-library/src/loginout/index.php
@@ -17,7 +17,12 @@
 function render_block_core_loginout( $attributes ) {
 
 	// Build the redirect URL.
-	$current_url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+	if ( ! isset( $_SERVER['REQUEST_URI'] ) || empty( $_SERVER['REQUEST_URI'] ) ) {
+		// Fallback to home URL if REQUEST_URI is not set.
+		$current_url = home_url();
+	} else {
+		$current_url = home_url( wp_unslash( sanitize_url( $_SERVER['REQUEST_URI'] ) ) );
+	}
 
 	$classes  = is_user_logged_in() ? 'logged-in' : 'logged-out';
 	$contents = wp_loginout(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/70024

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Our current method for retrieving the current URL is as follows:

```php
$current_url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
```

- https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/loginout/index.php#L20C2-L20C105

This approach relies on `is_ssl()` and `$_SERVER['HTTP_HOST']`, and it accesses `$_SERVER['HTTP_HOST']` without checking if it is set. It also lacks proper usage of `wp_unslash()` and sanitization.

## What is your proposed solution?

Why rely on `$_SERVER['HTTP_HOST']` and `is_ssl()` when we can construct the URL directly using:

```php
home_url( wp_unslash( sanitize_url( $_SERVER['REQUEST_URI'] ) ) )
```

This provides a more secure and WordPress-native approach.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- We are checking whether REQUEST_URI is set or not if it is not set then use home_url() if it is set then use home_url() with REQUEST_URI as it's path

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Add loginout block in your page or post.
2. After login or logout it should redirect to the page from where the request initiated
