### PR TITLE
GitHub Actions: fix components changelog CI check

### DIFF
--- a/.github/workflows/check-components-changelog.yml
+++ b/.github/workflows/check-components-changelog.yml
@@ -24,7 +24,7 @@ jobs:
         name: Check CHANGELOG diff
         runs-on: ubuntu-latest
         permissions:
-          contents: read
+            contents: read
         steps:
             - name: 'Get PR commit count'
               env:
@@ -43,13 +43,13 @@ jobs:
             - name: Check CHANGELOG status
               env:
                   PR_NUMBER: ${{ github.event.number }}
-                  HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+                  BASE_SHA: ${{ github.event.pull_request.base.sha }}
               run: |
                   changelog_path="packages/components/CHANGELOG.md"
                   optional_check_notice="This isn't a required check, so if you think your changes are small enough that they don't warrant a CHANGELOG entry, please go ahead and merge without one."
 
                   # Fail if the PR doesn't touch the changelog
-                  if git diff --quiet "$HEAD_SHA" HEAD -- "$changelog_path"; then
+                  if git diff --quiet "$BASE_SHA" HEAD -- "$changelog_path"; then
                     echo "Please add a CHANGELOG entry to $changelog_path"
                     echo
                     echo "${optional_check_notice}"


### PR DESCRIPTION
## What?

There is CI that checks whether PRs that make changes to `@wordpress/components` package have updated CHANGELOG file.

We noticed that this CI isn't working even though we have added a correct changelog entry (Example: https://github.com/WordPress/gutenberg/pull/69969#issuecomment-2823187131).

This PR fixes the problem.

## Why?

As far as I know, this problem occurred as a result of #69126. We should check the diff against the base branch, but I think `github.event.pull_request.base.sha` was unexpectedly replaced with `github.event.pull_request.head.sha`.

https://github.com/WordPress/gutenberg/pull/69126/files#diff-7077ded14418b5bee6455b705ec9de4d9420d58c999f5b5e2fb66848f391a87cR46-R52

## Testing Instructions

We currently have no way to test this, but it should work.