### PR TITLE
MediaPlaceholder: Fix Regression with media URL input type to allow a local URL path

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -47,7 +47,7 @@ const InsertFromURLPopover = ( {
 			<InputControl
 				__next40pxDefaultSize
 				label={ __( 'URL' ) }
-				type="text"
+				type="text" // Use text instead of URL to allow relative paths (e.g., /image/image.jpg)
 				className="block-editor-media-placeholder__url-input-form__input"
 				hideLabelFromVision
 				placeholder={ __( 'Paste or type URL' ) }

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -48,6 +48,7 @@ const InsertFromURLPopover = ( {
 				__next40pxDefaultSize
 				label={ __( 'URL' ) }
 				type="text"
+				className="block-editor-media-placeholder__url-input-form__input"
 				hideLabelFromVision
 				placeholder={ __( 'Paste or type URL' ) }
 				onChange={ onChange }

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -48,7 +48,6 @@ const InsertFromURLPopover = ( {
 				__next40pxDefaultSize
 				label={ __( 'URL' ) }
 				type="text" // Use text instead of URL to allow relative paths (e.g., /image/image.jpg)
-				className="block-editor-media-placeholder__url-input-form__input"
 				hideLabelFromVision
 				placeholder={ __( 'Paste or type URL' ) }
 				onChange={ onChange }

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -48,7 +48,6 @@ const InsertFromURLPopover = ( {
 				__next40pxDefaultSize
 				label={ __( 'URL' ) }
 				type="text"
-				className="block-editor-media-placeholder__url-input-form__input"
 				hideLabelFromVision
 				placeholder={ __( 'Paste or type URL' ) }
 				onChange={ onChange }

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -47,7 +47,7 @@ const InsertFromURLPopover = ( {
 			<InputControl
 				__next40pxDefaultSize
 				label={ __( 'URL' ) }
-				type="url"
+				type="text"
 				hideLabelFromVision
 				placeholder={ __( 'Paste or type URL' ) }
 				onChange={ onChange }

--- a/packages/block-editor/src/components/media-placeholder/style.scss
+++ b/packages/block-editor/src/components/media-placeholder/style.scss
@@ -5,8 +5,3 @@
 		width: 300px;
 	}
 }
-
-.block-editor-media-placeholder__url-input-form__input {
-	/* rtl:ignore */
-	direction: ltr;
-}

--- a/packages/block-editor/src/components/media-placeholder/style.scss
+++ b/packages/block-editor/src/components/media-placeholder/style.scss
@@ -4,10 +4,10 @@
 	@include break-small() {
 		width: 300px;
 	}
-}
 
-// Targeting input as we're using text instead of URLs for relative paths.
-.block-editor-media-placeholder__url-input-form input {
-	/* rtl:ignore */
-	direction: ltr;
+	input {
+		// Targeting input as we're using text instead of URLs for relative paths.
+		/* rtl:ignore */
+		direction: ltr;
+	}
 }

--- a/packages/block-editor/src/components/media-placeholder/style.scss
+++ b/packages/block-editor/src/components/media-placeholder/style.scss
@@ -6,6 +6,7 @@
 	}
 }
 
+// Targeting input as we're using text instead of URLs for relative paths.
 .block-editor-media-placeholder__url-input-form__input {
 	/* rtl:ignore */
 	direction: ltr;

--- a/packages/block-editor/src/components/media-placeholder/style.scss
+++ b/packages/block-editor/src/components/media-placeholder/style.scss
@@ -7,7 +7,7 @@
 }
 
 // Targeting input as we're using text instead of URLs for relative paths.
-.block-editor-media-placeholder__url-input-form__input {
+.block-editor-media-placeholder__url-input-form input {
 	/* rtl:ignore */
 	direction: ltr;
 }

--- a/packages/block-editor/src/components/media-placeholder/style.scss
+++ b/packages/block-editor/src/components/media-placeholder/style.scss
@@ -5,3 +5,8 @@
 		width: 300px;
 	}
 }
+
+.block-editor-media-placeholder__url-input-form__input {
+	/* rtl:ignore */
+	direction: ltr;
+}


### PR DESCRIPTION
Fixes #70041

and  reverts the change from the PR #68188 

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes the input to allow local urls (relative urls) instead of just urls.

<!-- In a few words, what is the PR actually doing? -->

## Why?
See https://github.com/WordPress/gutenberg/pull/29138

## ScreenCast

https://q7utzrengv.ufs.sh/f/Wgl9eBAmTj29hwWSma2m0qcVHXhKskEZB3wRSuFAejIdTNC8

