### PR TITLE
Format Library: Fix highlight background colors to use theme variables

### DIFF
--- a/packages/format-library/src/text-color/inline.js
+++ b/packages/format-library/src/text-color/inline.js
@@ -66,6 +66,20 @@ export function parseClassName( className = '', colorSettings ) {
 			);
 			accumulator.color = colorObject.color;
 		}
+		// Handle background color classes (has-{color-slug}-background-color).
+		if (
+			name.startsWith( 'has-' ) &&
+			name.endsWith( '-background-color' )
+		) {
+			const colorSlug = name
+				.replace( /^has-/, '' )
+				.replace( /-background-color$/, '' );
+			const colorObject = getColorObjectByAttributeValues(
+				colorSettings,
+				colorSlug
+			);
+			accumulator.backgroundColor = colorObject.color;
+		}
 		return accumulator;
 	}, {} );
 }
@@ -98,7 +112,21 @@ function setColors( value, name, colorSettings, colors ) {
 	const attributes = {};
 
 	if ( backgroundColor ) {
-		styles.push( [ 'background-color', backgroundColor ].join( ':' ) );
+		const backgroundColorObject = getColorObjectByColorValue(
+			colorSettings,
+			backgroundColor
+		);
+
+		if ( backgroundColorObject ) {
+			classNames.push(
+				getColorClassName(
+					'background-color',
+					backgroundColorObject.slug
+				)
+			);
+		} else {
+			styles.push( [ 'background-color', backgroundColor ].join( ':' ) );
+		}
 	} else {
 		// Override default browser color for mark element.
 		styles.push( [ 'background-color', transparentValue ].join( ':' ) );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/70025

This PR modifies the Highlight feature in the Format Library to use theme color variables for background colors, consistent with how text colors are already handled.
