### PR TITLE
Cover: Fix resizeable handle overlap over side panel on mobile view

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -7,7 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
-import { useEffect, useMemo, useRef } from '@wordpress/element';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { Placeholder, Spinner } from '@wordpress/components';
 import { compose, useResizeObserver } from '@wordpress/compose';
 import {
@@ -111,6 +111,9 @@ function CoverEdit( {
 		postId
 	);
 	const { getSettings } = useSelect( blockEditorStore );
+	const [ hasFocus, setHasFocus ] = useState( false );
+	const [ isResizing, setIsResizing ] = useState( false );
+	const [ isHovered, setIsHovered ] = useState( false );
 
 	const { __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
@@ -362,7 +365,13 @@ function CoverEdit( {
 	);
 
 	const ref = useRef();
-	const blockProps = useBlockProps( { ref } );
+	const blockProps = useBlockProps( {
+		ref,
+		onFocus: () => setHasFocus( true ),
+		onBlur: () => setHasFocus( false ),
+		onMouseEnter: () => setIsHovered( true ),
+		onMouseLeave: () => setIsHovered( false ),
+	} );
 
 	// Check for fontSize support before we pass a fontSize attribute to the innerBlocks.
 	const [ fontSizes ] = useSettings( 'typography.fontSizes' );
@@ -470,6 +479,7 @@ function CoverEdit( {
 		height,
 		minHeight: minHeightWithUnit,
 		onResizeStart: () => {
+			setIsResizing( true );
 			setAttributes( { minHeightUnit: 'px' } );
 			toggleSelection( false );
 		},
@@ -477,11 +487,14 @@ function CoverEdit( {
 			setAttributes( { minHeight: value } );
 		},
 		onResizeStop: ( newMinHeight ) => {
+			setIsResizing( false );
 			toggleSelection( true );
 			setAttributes( { minHeight: newMinHeight } );
 		},
 		// Hide the resize handle if an aspect ratio is set, as the aspect ratio takes precedence.
-		showHandle: ! attributes.style?.dimensions?.aspectRatio,
+		showHandle:
+			( hasFocus || isResizing || isHovered ) &&
+			! attributes.style?.dimensions?.aspectRatio,
 		size: resizableBoxDimensions,
 		width,
 	};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

<!-- In a few words, what is the PR actually doing? -->

See #69955

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
