### PR TITLE
Workflows: Try different SHA

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -76,14 +76,14 @@ jobs:
             - name: Compare performance with base branch
               if: github.event_name == 'push'
               # The base hash used here need to be a commit that is compatible with the current WP version
-              # The current one is 177c166a5eada898ad015f5efaf1c6fefa7042c4 and it needs to be updated every WP major release.
+              # The current one is 7f6a627a028f6c5013dc97df316e04e8fc39a4ef and it needs to be updated every WP major release.
               # It is used as a base comparison point to avoid fluctuation in the performance metrics.
               # See: https://developer.wordpress.org/block-editor/explanations/architecture/performance/#update-the-reference-commit.
               run: |
                   WP_VERSION="$(awk -F ': ' '/^Tested up to/{print $2}' readme.txt)"
                   IFS=. read -ra WP_VERSION_ARRAY <<< "$WP_VERSION"
                   WP_MAJOR="${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"
-                  ./bin/plugin/cli.js perf "$GITHUB_SHA" 177c166a5eada898ad015f5efaf1c6fefa7042c4 --tests-branch "$GITHUB_SHA" --wp-version "$WP_MAJOR"
+                  ./bin/plugin/cli.js perf "$GITHUB_SHA" 7f6a627a028f6c5013dc97df316e04e8fc39a4ef --tests-branch "$GITHUB_SHA" --wp-version "$WP_MAJOR"
 
             - name: Compare performance with custom branches
               if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -109,7 +109,7 @@ jobs:
                   CODEHEALTH_PROJECT_TOKEN: ${{ secrets.CODEHEALTH_PROJECT_TOKEN }}
               run: |
                   COMMITTED_AT="$(git show -s "$GITHUB_SHA" --format="%cI")"
-                  ./bin/log-performance-results.js "$CODEHEALTH_PROJECT_TOKEN" trunk "$GITHUB_SHA" c7722262e65a3f4d0f1a2d1ad29eccb2069509e4 "$COMMITTED_AT"
+                  ./bin/log-performance-results.js "$CODEHEALTH_PROJECT_TOKEN" trunk "$GITHUB_SHA" 7f6a627a028f6c5013dc97df316e04e8fc39a4ef "$COMMITTED_AT"
 
             - name: Archive debug artifacts (screenshots, HTML snapshots)
               uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3


### PR DESCRIPTION
## What?
Related #70023.

Try different SHA for the performance tests workflow. The current choice might have been too recent, and I don't see new commits in https://www.codevitals.run/project/gutenberg.

## How?
See https://developer.wordpress.org/block-editor/explanations/architecture/performance/#update-the-reference-commit.

## Testing Instructions
These changes are hard to test without merging.
