### PR TITLE
DOM: Add summary element to focusable elements

### DIFF
--- a/packages/dom/src/focusable.js
+++ b/packages/dom/src/focusable.js
@@ -39,6 +39,7 @@ function buildSelector( sequential ) {
 		'iframe:not([tabindex^="-"])',
 		'object',
 		'embed',
+		'summary',
 		'area[href]',
 		'[contenteditable]:not([contenteditable=false])',
 	].join( ',' );


### PR DESCRIPTION
Part of #70050

## What?

Adds `summary` element to the focusable elements defined in the `@wordpress/dom/package` so that the `focus.focusable.find()` method detects the element as a focusable element.

## Why?

This PR is needed to fix one of the issues reported on #70050.

## How?

Simply added the `summary` element. Note that this element only supports the [global attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes), so we don't need to check the `disabled` attribute.

## Testing Instructions

- Activate a classic theme.
- Create a new page and insert a Details block.
- Set the page as Homepage.
- Access Appearance > Design
- Confirm that clicking the summary element does nothing.