### PR TITLE
Button: Limit scope of width style for link

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -10,7 +10,6 @@ $blocks-block__margin: 0.5em;
 	word-break: break-word; // overflow-wrap doesn't work well if a link is wrapped in the div, so use word-break here.
 	box-sizing: border-box;
 	height: 100%;
-	width: 100%;
 	align-content: center;
 
 	&.aligncenter {

--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -82,6 +82,11 @@ $blocks-block__margin: 0.5em;
 			font-size: inherit;
 		}
 	}
+
+	// Needed to make the buttons stretch correctly in a vertical layout.
+	.wp-block-button__link {
+		width: 100%;
+	}
 }
 
 // Legacy buttons that did not come in a wrapping container.

--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -82,9 +82,4 @@
 			margin-left: 0.5em;
 		}
 	}
-
-	// Override the 100% width derived from the Button block
-	input[type="submit"] {
-		width: auto;
-	}
 }


### PR DESCRIPTION
Closes https://core.trac.wordpress.org/ticket/63373

Follow-up on #64770 and #69651

## What?

This PR changes the style selector for buttons to this:

```css
// From
.wp-block-button__link {
  width: 100%;
}

// To
.wp-block-buttons .wp-block-button__link {
  width: 100%;
}
```

## Why?

The `width: 100%` style is needed to stretch the buttons in the vertical layout. However, the `.wp-block-button__link` selector resulted in forcing the button's width to 100% width even though the button was not a child of a flex layout, such as in the following HTML:

```html
<p class="wp-block-button">
  <a class="wp-block-button__link" />
</p>
```

This problem occurred in the Post Comments Form block, so we fixed the problem in #69651. However, it's possible that consumers are using this button selector in other places as well.


## How?

Apply 100% width style to only the button links inside the buttons.

## Testing Instructions

- Insert a Buttons block.
- Change the justification to "Stretch items" and change the orientation to "Vertical".
- Confirm that buttons are correctly stretched.

![image](https://github.com/user-attachments/assets/e7b773c1-c03f-4e3c-b449-1d6c070dda62)

- Insert a Post Comments Form block.
- Confirm that the submit button isn't 100% width.

![image](https://github.com/user-attachments/assets/0ed5d0bd-c2d3-4790-b7d2-0ee845f1fd23)
