### PR TITLE
HTML Block: Remove space below textarea

### DIFF
--- a/packages/block-library/src/html/editor.scss
+++ b/packages/block-library/src/html/editor.scss
@@ -10,6 +10,7 @@
 	// The editing view for the HTML block is equivalent to block UI.
 	// Therefore we increase specificity to avoid theme styles bleeding in.
 	.block-editor-plain-text {
+		display: block;
 		box-sizing: border-box;
 		max-height: 250px;
 		@include editor-input-reset();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

The `PlainText` version 1 component renders an auto-growing `textarea` element. The textarea has a space below by default, which is an expected behaviour as an HTML element . However, this space is a bit annoying inside the HTML block.



## Testing Instructions

- Insert an HTML block.
- Focus or select the block.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/1900e2e1-47ea-4bb3-9e0d-00d43f89cace) | ![image](https://github.com/user-attachments/assets/b7d103da-ce5b-4bfe-8ba3-830a88f03371) |
| ![image](https://github.com/user-attachments/assets/2ed59a6b-153d-4580-b260-f9be8dd6008c) | ![image](https://github.com/user-attachments/assets/437624ef-1459-4c90-9b97-dc0fbb139d9f) |
