### PR TITLE
Details Block: Fix keyboard accessibility issues and allow list view selection to show up inner blocks

### DIFF
--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -11,7 +11,6 @@ import {
 import {
 	TextControl,
 	ToggleControl,
-	VisuallyHidden,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	privateApis as componentsPrivateApis,
@@ -130,14 +129,11 @@ function DetailsEdit( { attributes, setAttributes, clientId } ) {
 					onKeyDown={ withIgnoreIMEEvents( handleSummaryKeyDown ) }
 					onKeyUp={ handleSummaryKeyUp }
 				>
-					<VisuallyHidden id={ instanceId }>
-						{ __(
-							'Press Enter to expand or collapse the details.'
-						) }
-					</VisuallyHidden>
 					<RichText
 						identifier="summary"
-						aria-label={ __( 'Write summary' ) }
+						aria-label={ __(
+							'Write summary. Press Enter to expand or collapse the details.'
+						) }
 						aria-describedby={ instanceId }
 						placeholder={ placeholder || __( 'Write summary…' ) }
 						withoutInteractiveFormatting

--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -62,6 +62,13 @@ function DetailsEdit( { attributes, setAttributes, clientId } ) {
 		}
 	};
 
+	// Prevent spacebar from toggling <details> while typing.
+	const handleSummaryKeyUp = ( event ) => {
+		if ( event.key === ' ' ) {
+			event.preventDefault();
+		}
+	};
+
 	return (
 		<>
 			<InspectorControls>
@@ -118,6 +125,7 @@ function DetailsEdit( { attributes, setAttributes, clientId } ) {
 			>
 				<summary
 					onKeyDown={ withIgnoreIMEEvents( handleSummaryKeyDown ) }
+					onKeyUp={ handleSummaryKeyUp }
 				>
 					<RichText
 						identifier="summary"

--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -13,7 +13,6 @@ import {
 	ToggleControl,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
-	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
@@ -23,9 +22,6 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
-import { unlock } from '../lock-unlock';
-
-const { withIgnoreIMEEvents } = unlock( componentsPrivateApis );
 
 const TEMPLATE = [
 	[
@@ -124,8 +120,8 @@ function DetailsEdit( { attributes, setAttributes, clientId } ) {
 				onToggle={ ( event ) => setIsOpen( event.target.open ) }
 			>
 				<summary
-					onKeyDown={ withIgnoreIMEEvents( handleSummaryKeyDown ) }
-					onKeyUp={ withIgnoreIMEEvents( handleSummaryKeyUp ) }
+					onKeyDown={ handleSummaryKeyDown }
+					onKeyUp={ handleSummaryKeyUp }
 				>
 					<RichText
 						identifier="summary"

--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -42,9 +42,7 @@ function DetailsEdit( { attributes, setAttributes, clientId } ) {
 	const { name, showContent, summary, allowedBlocks, placeholder } =
 		attributes;
 	const instanceId = useInstanceId( DetailsEdit, 'details-edit-desc' );
-	const blockProps = useBlockProps( {
-		'aria-describedby': instanceId,
-	} );
+	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
 		__experimentalCaptureToolbars: true,
@@ -140,6 +138,7 @@ function DetailsEdit( { attributes, setAttributes, clientId } ) {
 					<RichText
 						identifier="summary"
 						aria-label={ __( 'Write summary' ) }
+						aria-describedby={ instanceId }
 						placeholder={ placeholder || __( 'Write summary…' ) }
 						withoutInteractiveFormatting
 						value={ summary }

--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -13,6 +13,7 @@ import {
 	ToggleControl,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
@@ -22,6 +23,9 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+import { unlock } from '../lock-unlock';
+
+const { withIgnoreIMEEvents } = unlock( componentsPrivateApis );
 
 const TEMPLATE = [
 	[
@@ -50,6 +54,13 @@ function DetailsEdit( { attributes, setAttributes, clientId } ) {
 			select( blockEditorStore ).hasSelectedInnerBlock( clientId, true ),
 		[ clientId ]
 	);
+
+	const handleSummaryKeyDown = ( event ) => {
+		if ( event.key === 'Enter' && ! event.shiftKey ) {
+			setIsOpen( ( prevIsOpen ) => ! prevIsOpen );
+			event.preventDefault();
+		}
+	};
 
 	return (
 		<>
@@ -106,13 +117,7 @@ function DetailsEdit( { attributes, setAttributes, clientId } ) {
 				onToggle={ ( event ) => setIsOpen( event.target.open ) }
 			>
 				<summary
-					onKeyDown={ ( event ) => {
-						if ( event.key === 'ArrowDown' ) {
-							setIsOpen( true );
-						} else if ( event.key === 'ArrowUp' && isOpen ) {
-							setIsOpen( false );
-						}
-					} }
+					onKeyDown={ withIgnoreIMEEvents( handleSummaryKeyDown ) }
 				>
 					<RichText
 						identifier="summary"

--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -18,7 +18,6 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -40,7 +39,6 @@ const TEMPLATE = [
 function DetailsEdit( { attributes, setAttributes, clientId } ) {
 	const { name, showContent, summary, allowedBlocks, placeholder } =
 		attributes;
-	const instanceId = useInstanceId( DetailsEdit, 'details-edit-desc' );
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
@@ -134,7 +132,6 @@ function DetailsEdit( { attributes, setAttributes, clientId } ) {
 						aria-label={ __(
 							'Write summary. Press Enter to expand or collapse the details.'
 						) }
-						aria-describedby={ instanceId }
 						placeholder={ placeholder || __( 'Write summary…' ) }
 						withoutInteractiveFormatting
 						value={ summary }

--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -13,6 +13,7 @@ import {
 	ToggleControl,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
@@ -22,6 +23,9 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+import { unlock } from '../lock-unlock';
+
+const { withIgnoreIMEEvents } = unlock( componentsPrivateApis );
 
 const TEMPLATE = [
 	[
@@ -120,7 +124,7 @@ function DetailsEdit( { attributes, setAttributes, clientId } ) {
 				onToggle={ ( event ) => setIsOpen( event.target.open ) }
 			>
 				<summary
-					onKeyDown={ handleSummaryKeyDown }
+					onKeyDown={ withIgnoreIMEEvents( handleSummaryKeyDown ) }
 					onKeyUp={ handleSummaryKeyUp }
 				>
 					<RichText

--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -16,12 +16,12 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
-import { useSelect } from '@wordpress/data';
 
 const TEMPLATE = [
 	[

--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -6,6 +6,7 @@ import {
 	useBlockProps,
 	useInnerBlocksProps,
 	InspectorControls,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
 	TextControl,
@@ -20,6 +21,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+import { useSelect } from '@wordpress/data';
 
 const TEMPLATE = [
 	[
@@ -30,7 +32,7 @@ const TEMPLATE = [
 	],
 ];
 
-function DetailsEdit( { attributes, setAttributes } ) {
+function DetailsEdit( { attributes, setAttributes, isSelected, clientId } ) {
 	const { name, showContent, summary, allowedBlocks, placeholder } =
 		attributes;
 	const blockProps = useBlockProps();
@@ -41,6 +43,15 @@ function DetailsEdit( { attributes, setAttributes } ) {
 	} );
 	const [ isOpen, setIsOpen ] = useState( showContent );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+
+	// Check if the inner blocks are selected.
+	const hasSelectedInnerBlock = useSelect(
+		( select ) =>
+			select( blockEditorStore ).hasSelectedInnerBlock( clientId, true ),
+		[ clientId ]
+	);
+
+	const shouldRenderChildren = hasSelectedInnerBlock || isSelected || isOpen;
 
 	return (
 		<>
@@ -93,10 +104,19 @@ function DetailsEdit( { attributes, setAttributes } ) {
 			</InspectorControls>
 			<details
 				{ ...innerBlocksProps }
-				open={ isOpen }
+				open={ isOpen || hasSelectedInnerBlock }
 				onToggle={ ( event ) => setIsOpen( event.target.open ) }
 			>
-				<summary>
+				<summary
+					onKeyDown={ ( event ) => {
+						event.preventDefault();
+						if ( event.key === 'ArrowDown' ) {
+							setIsOpen( true );
+						} else if ( event.key === 'ArrowUp' && isOpen ) {
+							setIsOpen( false );
+						}
+					} }
+				>
 					<RichText
 						identifier="summary"
 						aria-label={ __( 'Write summary' ) }
@@ -108,7 +128,7 @@ function DetailsEdit( { attributes, setAttributes } ) {
 						}
 					/>
 				</summary>
-				{ innerBlocksProps.children }
+				{ shouldRenderChildren && innerBlocksProps.children }
 			</details>
 		</>
 	);

--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -32,7 +32,7 @@ const TEMPLATE = [
 	],
 ];
 
-function DetailsEdit( { attributes, setAttributes, isSelected, clientId } ) {
+function DetailsEdit( { attributes, setAttributes, clientId } ) {
 	const { name, showContent, summary, allowedBlocks, placeholder } =
 		attributes;
 	const blockProps = useBlockProps();
@@ -50,8 +50,6 @@ function DetailsEdit( { attributes, setAttributes, isSelected, clientId } ) {
 			select( blockEditorStore ).hasSelectedInnerBlock( clientId, true ),
 		[ clientId ]
 	);
-
-	const shouldRenderChildren = hasSelectedInnerBlock || isSelected || isOpen;
 
 	return (
 		<>
@@ -109,7 +107,6 @@ function DetailsEdit( { attributes, setAttributes, isSelected, clientId } ) {
 			>
 				<summary
 					onKeyDown={ ( event ) => {
-						event.preventDefault();
 						if ( event.key === 'ArrowDown' ) {
 							setIsOpen( true );
 						} else if ( event.key === 'ArrowUp' && isOpen ) {
@@ -128,7 +125,7 @@ function DetailsEdit( { attributes, setAttributes, isSelected, clientId } ) {
 						}
 					/>
 				</summary>
-				{ shouldRenderChildren && innerBlocksProps.children }
+				{ innerBlocksProps.children }
 			</details>
 		</>
 	);

--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -11,6 +11,7 @@ import {
 import {
 	TextControl,
 	ToggleControl,
+	VisuallyHidden,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	privateApis as componentsPrivateApis,
@@ -18,6 +19,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -39,7 +41,10 @@ const TEMPLATE = [
 function DetailsEdit( { attributes, setAttributes, clientId } ) {
 	const { name, showContent, summary, allowedBlocks, placeholder } =
 		attributes;
-	const blockProps = useBlockProps();
+	const instanceId = useInstanceId( DetailsEdit, 'details-edit-desc' );
+	const blockProps = useBlockProps( {
+		'aria-describedby': instanceId,
+	} );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
 		__experimentalCaptureToolbars: true,
@@ -127,6 +132,11 @@ function DetailsEdit( { attributes, setAttributes, clientId } ) {
 					onKeyDown={ withIgnoreIMEEvents( handleSummaryKeyDown ) }
 					onKeyUp={ handleSummaryKeyUp }
 				>
+					<VisuallyHidden id={ instanceId }>
+						{ __(
+							'Press Enter to expand or collapse the details.'
+						) }
+					</VisuallyHidden>
 					<RichText
 						identifier="summary"
 						aria-label={ __( 'Write summary' ) }

--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -125,7 +125,7 @@ function DetailsEdit( { attributes, setAttributes, clientId } ) {
 			>
 				<summary
 					onKeyDown={ withIgnoreIMEEvents( handleSummaryKeyDown ) }
-					onKeyUp={ handleSummaryKeyUp }
+					onKeyUp={ withIgnoreIMEEvents( handleSummaryKeyUp ) }
 				>
 					<RichText
 						identifier="summary"

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -26,6 +26,7 @@
 ### Internal
 
 -   Clarify `withIgnoreIMEEvents` documentation to reflect support for all keyboard event handlers ([#70098](https://github.com/WordPress/gutenberg/pull/70098)).
+-   Mark `withIgnoreIMEEvents()` function as private API ([#70056](https://github.com/WordPress/gutenberg/pull/70056)).
 
 ## 29.9.0 (2025-05-07)
 
@@ -46,7 +47,6 @@
 ### Internal
 
 -   `ColorPicker`: Add tests for Alpha slider functionality ([#69203](https://github.com/WordPress/gutenberg/pull/69203)).
--   Mark `withIgnoreIMEEvents()` function as private API ([#70056](https://github.com/WordPress/gutenberg/pull/70056)).
 
 ## 29.8.0 (2025-04-11)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -46,6 +46,7 @@
 ### Internal
 
 -   `ColorPicker`: Add tests for Alpha slider functionality ([#69203](https://github.com/WordPress/gutenberg/pull/69203)).
+-   Mark `withIgnoreIMEEvents()` function as private API ([#70056](https://github.com/WordPress/gutenberg/pull/70056)).
 
 ## 29.8.0 (2025-04-11)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Internal
 
 -   Expose `normalizeTextString` method as private API ([#70178](https://github.com/WordPress/gutenberg/pull/70178)).
+-   Mark `withIgnoreIMEEvents()` function as private API ([#70056](https://github.com/WordPress/gutenberg/pull/70056)).
 
 ## 29.10.0 (2025-05-22)
 
@@ -26,7 +27,6 @@
 ### Internal
 
 -   Clarify `withIgnoreIMEEvents` documentation to reflect support for all keyboard event handlers ([#70098](https://github.com/WordPress/gutenberg/pull/70098)).
--   Mark `withIgnoreIMEEvents()` function as private API ([#70056](https://github.com/WordPress/gutenberg/pull/70056)).
 
 ## 29.9.0 (2025-05-07)
 

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -7,6 +7,7 @@ import { ComponentsContext } from './context/context-system-provider';
 import Theme from './theme';
 import { Tabs } from './tabs';
 import { kebabCase, normalizeTextString } from './utils/strings';
+import { withIgnoreIMEEvents } from './utils/with-ignore-ime-events';
 import { lock } from './lock-unlock';
 import Badge from './badge';
 
@@ -18,6 +19,7 @@ lock( privateApis, {
 	Theme,
 	Menu,
 	kebabCase,
+	withIgnoreIMEEvents,
 	Badge,
 	normalizeTextString,
 } );

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -7,7 +7,6 @@ import { ComponentsContext } from './context/context-system-provider';
 import Theme from './theme';
 import { Tabs } from './tabs';
 import { kebabCase, normalizeTextString } from './utils/strings';
-import { withIgnoreIMEEvents } from './utils/with-ignore-ime-events';
 import { lock } from './lock-unlock';
 import Badge from './badge';
 
@@ -19,7 +18,6 @@ lock( privateApis, {
 	Theme,
 	Menu,
 	kebabCase,
-	withIgnoreIMEEvents,
 	Badge,
 	normalizeTextString,
 } );

--- a/test/e2e/specs/editor/blocks/details.spec.js
+++ b/test/e2e/specs/editor/blocks/details.spec.js
@@ -18,6 +18,14 @@ test.describe( 'Details', () => {
 			attributes: {
 				summary: 'Details summary',
 			},
+			innerBlocks: [
+				{
+					name: 'core/paragraph',
+					attributes: {
+						content: 'Details content',
+					},
+				},
+			],
 		} );
 
 		// Open the details block.
@@ -25,15 +33,15 @@ test.describe( 'Details', () => {
 
 		// The inner block should be visible.
 		await expect(
-			editor.canvas.getByRole( 'document', { name: 'Empty block' } )
-		).toBeVisible();
+			editor.canvas.getByRole( 'document', { name: 'Block: Paragraph' } )
+		).toContainText( 'Details content' );
 
 		// Close the details block.
 		await page.keyboard.press( 'Enter' );
 
 		// The inner block should be hidden.
 		await expect(
-			editor.canvas.getByRole( 'document', { name: 'Empty block' } )
+			editor.canvas.getByRole( 'document', { name: 'Block: Paragraph' } )
 		).toBeHidden();
 	} );
 
@@ -80,5 +88,56 @@ test.describe( 'Details', () => {
 		await expect(
 			editor.canvas.getByRole( 'document', { name: 'Empty block' } )
 		).toBeHidden();
+	} );
+
+	test( 'selecting hidden blocks in list view expands details and focuses content', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		// Insert a details block.
+		await editor.insertBlock( {
+			name: 'core/details',
+			attributes: {
+				summary: 'Details summary',
+			},
+			innerBlocks: [
+				{
+					name: 'core/paragraph',
+					attributes: {
+						content: 'Details content',
+					},
+				},
+			],
+		} );
+
+		const listView = page.getByRole( 'treegrid', {
+			name: 'Block navigation structure',
+		} );
+
+		// Open the list view.
+		await pageUtils.pressKeys( 'access+o' );
+
+		// Verify inner blocks appear in the list view.
+		await page.keyboard.press( 'ArrowRight' );
+		await expect(
+			listView.getByRole( 'link', {
+				name: 'Paragraph',
+			} )
+		).toBeVisible();
+
+		// Verify the first inner block in the list view is focused.
+		await page.keyboard.press( 'ArrowDown' );
+		await expect(
+			listView.getByRole( 'link', {
+				name: 'Paragraph',
+			} )
+		).toBeFocused();
+
+		// Verify the first inner block in the editor canvas is focused.
+		await page.keyboard.press( 'Enter' );
+		await expect(
+			editor.canvas.getByRole( 'document', { name: 'Block: Paragraph' } )
+		).toBeFocused();
 	} );
 } );

--- a/test/e2e/specs/editor/blocks/details.spec.js
+++ b/test/e2e/specs/editor/blocks/details.spec.js
@@ -60,4 +60,25 @@ test.describe( 'Details', () => {
 			useInnerText: true,
 		} );
 	} );
+
+	test( 'typing space in summary rich-text should not toggle details', async ( {
+		editor,
+	} ) => {
+		// Insert a details block.
+		await editor.insertBlock( {
+			name: 'core/details',
+		} );
+
+		const summary = editor.canvas.getByRole( 'textbox', {
+			name: 'Write summary',
+		} );
+
+		// Type space in the summary rich-text.
+		await summary.type( ' ' );
+
+		// Verify the details block is not toggled.
+		await expect(
+			editor.canvas.getByRole( 'document', { name: 'Empty block' } )
+		).toBeHidden();
+	} );
 } );

--- a/test/e2e/specs/editor/blocks/details.spec.js
+++ b/test/e2e/specs/editor/blocks/details.spec.js
@@ -1,0 +1,63 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Details', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'can toggle hidden blocks by pressing enter', async ( {
+		editor,
+		page,
+	} ) => {
+		// Insert a details block with empty inner blocks.
+		await editor.insertBlock( {
+			name: 'core/details',
+			attributes: {
+				summary: 'Details summary',
+			},
+		} );
+
+		// Open the details block.
+		await page.keyboard.press( 'Enter' );
+
+		// The inner block should be visible.
+		await expect(
+			editor.canvas.getByRole( 'document', { name: 'Empty block' } )
+		).toBeVisible();
+
+		// Close the details block.
+		await page.keyboard.press( 'Enter' );
+
+		// The inner block should be hidden.
+		await expect(
+			editor.canvas.getByRole( 'document', { name: 'Empty block' } )
+		).toBeHidden();
+	} );
+
+	test( 'can create a multiline summary with Shift+Enter', async ( {
+		editor,
+		page,
+	} ) => {
+		// Insert a details block.
+		await editor.insertBlock( {
+			name: 'core/details',
+		} );
+
+		const summary = editor.canvas.getByRole( 'textbox', {
+			name: 'Write summary',
+		} );
+
+		// Add a multiline summary.
+		await summary.type( 'First line' );
+		await page.keyboard.press( 'Shift+Enter' );
+		await summary.type( 'Second line' );
+
+		// Verify the summary is multiline.
+		await expect( summary ).toHaveText( 'First line\nSecond line', {
+			useInnerText: true,
+		} );
+	} );
+} );


### PR DESCRIPTION
## What, Why, and How?
Closes #70047

This PR enhances keyboard interaction with the Details block, enabling users to expand inner blocks using the keyboard. It also fixes a bug that previously prevented selecting an inner block from the List View; clicking an inner block in the List View now correctly selects it in the editor canvas.

With this PR, pressing the down arrow key expands the inner blocks within the Details block, while pressing the up arrow key collapses them.

## Testing Instructions

1. Create a post and add the following block markup.

<details>

<summary>Code</summary>

```html
<!-- wp:paragraph -->
<p>First Paragraph Block</p>
<!-- /wp:paragraph -->

<!-- wp:details -->
<details class="wp-block-details">
<summary>Details Block Summary</summary>
<!-- wp:paragraph {"placeholder":"Type / to add a hidden block"} -->
<p>Details Block Content</p>
<!-- /wp:paragraph -->
<!-- wp:paragraph -->
<p>Details Block Content</p>
<!-- /wp:paragraph -->
</details>
<!-- /wp:details -->

<!-- wp:paragraph -->
<p>Second Paragraph Block</p>
<!-- /wp:paragraph -->
```

</details>

2. Try moving through the blocks with the arrow keys.
3. Confirm, the inner blocks within details are accessible using the keyboard.
4. Open the list view and expand the details block.
5. Confirm that clicking on an inner block within the list view opens and selects the inner block properly.

## Screencast

![pr-demo](https://github.com/user-attachments/assets/1b75f22b-5842-41fd-a70a-d1c1a6d93bdc)
