### PR TITLE
Stylelint: Customise warning message for `flex-direction` warning

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -10,8 +10,8 @@ module.exports = {
 				'flex-direction': '/^(?!(row|column)-reverse).*$/',
 			},
 			{
-				message:
-					'Avoid the flex-direction reverse values. For accessibility reasons, visual, reading, and DOM order must match. Only use the reverse values when they do not affect reading order, meaning, and interaction.',
+				message: ( property, value ) =>
+					`Avoid "${ value }" value for the "${ property }" property. For accessibility reasons, visual, reading, and DOM order must match. Only use the reverse values when they do not affect reading order, meaning, and interaction.`,
 			},
 		],
 		'declaration-property-value-disallowed-list': [


### PR DESCRIPTION
## What?
Followup: https://github.com/WordPress/gutenberg/pull/69590#pullrequestreview-2774854795

The warning message shown previously was static. This PR aims to make the Stylelint warning related to non-usage of `row-reverse/column-reverse` in `flex-direction` dynamic. This would improve the warnings and make them dynamic. first suggested in this issue https://github.com/WordPress/gutenberg/issues/63090

Originally reported here:

> Quoting insightful feedback from @mirka on https://github.com/WordPress/gutenberg/issues/63048#issuecomment-2203327154:
> 
> we'll probably want to convert the .stylelintrc.json to a .stylelintrc.js at this point, so we can configure the [message as a function](https://stylelint.io/user-guide/configure/#message) to show different warning messages for each violation. It looks like we'll also need to update our stylelint dependency to achieve that. Our repo is at stylelint 14.2, whereas the feature we need is [available](https://github.com/stylelint/stylelint/commit/e65d24423fc71575b82bf5b0fdd04624df107a60) from 14.5.0.
> 

## How?
After the Stylelint configuration was updated to JavaScript via https://github.com/WordPress/gutenberg/pull/69590, now custom warnings can be shown for custom rules.

## Testing Instructions
1. Checkout any file which already has a flex-direction property. 
2. Change the property from `row/column` to `row-reverse/column-reverse`. In short append reverse.
3. See if the warnings are dynamic.


## Screencast 

### Before

https://github.com/user-attachments/assets/6cb356b7-4126-48fc-af38-71e8c6db2bad



### After


https://github.com/user-attachments/assets/43e64686-a8e3-4a7d-a378-6b7cdb85e309


