### PR TITLE
Ensure SVG Images Without a Width Attribute Are Displayed Correctly in FocalPointPicker

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,7 @@
 -   `ToggleGroupControl`: Fix active background for empty string value ([#69969](https://github.com/WordPress/gutenberg/pull/69969)).
 -   `ItemGroup`: Fix double border in `ItemGroup` when last item is focused ([#70021](https://github.com/WordPress/gutenberg/pull/70021)).
 -   `__experimentalUseCustomUnits `: Don't mutate 'ALL_CSS_UNITS' default value ([#70037](https://github.com/WordPress/gutenberg/pull/70037)).
+-  `FocalPointPicker`: Fix SVG display when it doesn't provide a width attribute.
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,7 +14,7 @@
 -   `ToggleGroupControl`: Fix active background for empty string value ([#69969](https://github.com/WordPress/gutenberg/pull/69969)).
 -   `ItemGroup`: Fix double border in `ItemGroup` when last item is focused ([#70021](https://github.com/WordPress/gutenberg/pull/70021)).
 -   `__experimentalUseCustomUnits `: Don't mutate 'ALL_CSS_UNITS' default value ([#70037](https://github.com/WordPress/gutenberg/pull/70037)).
--  `FocalPointPicker`: Fix SVG display when it doesn't provide a width attribute.
+-  `FocalPointPicker`: Fix SVG display when it doesn't provide a width attribute ([#70061](https://github.com/WordPress/gutenberg/pull/70061))..
 
 ### Internal
 

--- a/packages/components/src/focal-point-picker/styles/focal-point-picker-style.ts
+++ b/packages/components/src/focal-point-picker/styles/focal-point-picker-style.ts
@@ -53,7 +53,7 @@ export const MediaContainer = styled.div`
 		max-width: 100%;
 		pointer-events: none;
 		user-select: none;
-		width: auto;
+		width: 100%;
 	}
 `;
 


### PR DESCRIPTION
### What?
This PR addresses and fixes [Issue #43869](https://github.com/WordPress/gutenberg/issues/43869), where SVG images without a width attribute were not displayed correctly in the `FocalPointPicker` component. The issue arose because such SVG images defaulted to `width: 0`, rendering them invisible in the UI. 

The fix ensures that SVG images are displayed properly by enforcing the following styles via CSS:
- `width: 100%` to make the SVG scale appropriately.
- `height: auto` to maintain the aspect ratio of the SVG.

### Why?
Previously, when an SVG image lacking a `width` attribute was uploaded and used with the `FocalPointPicker` component, the image would not display properly due to its width defaulting to `0`. This created a poor user experience, as users could not adjust the focal point for SVGs. The fix ensures consistency across different types of images used with the `FocalPointPicker` component.

### How?
The implementation involves:
1. Updating the styles applied to the `FocalPointPicker` component.
2. Adding CSS rules to enforce `width: 100%` and `height: auto` for SVG images, ensuring they are displayed properly while maintaining their aspect ratio.

### Testing Instructions
To test this PR:
1. Open the block editor in WordPress.
2. Add a block that uses the `FocalPointPicker` component (e.g., a Cover block).
3. Upload an SVG image that does not include a `width` attribute (e.g., use the SVG file provided in [Issue #43869](https://github.com/WordPress/gutenberg/issues/43869)).
4. Verify that:
   - The SVG image is displayed correctly within the `FocalPointPicker`.
   - Adjusting the focal point works as expected.
   - No regressions occur for other image types.

### Screenshots
| Before | After |
|--------|-------|
| ![Before Screenshot](https://github.com/user-attachments/assets/1560deaa-2fc1-4818-b0cb-d4e47231230b) | ![After Screenshot](https://github.com/user-attachments/assets/c046acc8-e243-4b2d-8981-a3562ee91ba2)|

### Additional Notes
This fix ensures compatibility and a better user experience for users working with SVG images in the block editor. It has been tested to verify that other image formats and features of the `FocalPointPicker` component are unaffected.

Closes #43869.

---