### PR TITLE
BaseControl: Update Prop docs

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,7 @@
 -   `ToggleGroupControl`: Fix active background for empty string value ([#69969](https://github.com/WordPress/gutenberg/pull/69969)).
 -   `ItemGroup`: Fix double border in `ItemGroup` when last item is focused ([#70021](https://github.com/WordPress/gutenberg/pull/70021)).
 -   `__experimentalUseCustomUnits `: Don't mutate 'ALL_CSS_UNITS' default value ([#70037](https://github.com/WordPress/gutenberg/pull/70037)).
+-   `BaseControl`: Fix documentation to clarify that the component doesn't support the `as` prop ([70064](https://github.com/WordPress/gutenberg/pull/70064)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -18,6 +18,7 @@
 -   `Icon`: Merge a consumer-supplied `style` prop with the icon's intrinsic styles instead of replacing them, so styles like `fill: none` on stroke-based icons survive unless the consumer overrides the same property explicitly. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
 -   `ItemGroup`: Drop the blanket `path { fill: currentColor }` rule that was overriding stroke-based icons' intended fill via inheritance bypass. Paths without an explicit fill still inherit `currentColor` from the surrounding SVG. Custom paths that specify a fill now retain it instead of being overridden by ItemGroup. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
 -   `Tip`: Preserve the intended yellow color after its icon became stroke-based. ([#78808](https://github.com/WordPress/gutenberg/pull/78808))
+-   `BaseControl`: Fix documentation to clarify that the component doesn't support the `as` prop ([#70064](https://github.com/WordPress/gutenberg/pull/70064)).
 
 ### Internal
 

--- a/packages/components/src/base-control/README.md
+++ b/packages/components/src/base-control/README.md
@@ -36,13 +36,6 @@ const MyCustomTextareaControl = ({ children, ...baseProps }) => (
 
 Start opting into the new margin-free styles that will become the default in a future version.
 
-### `as`
-
- - Type: `"symbol" | "object" | "label" | "a" | "abbr" | "address" | "area" | "article" | "aside" | "audio" | "b" | "base" | "bdi" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | ... 516 more ... | ("view" & FunctionComponent<...>)`
- - Required: No
-
-The HTML element or React component to render the component as.
-
 ### `className`
 
  - Type: `string`

--- a/packages/components/src/base-control/README.md
+++ b/packages/components/src/base-control/README.md
@@ -28,13 +28,6 @@ const MyCustomTextareaControl = ({ children, ...baseProps }) => (
 
 ## Props
 
-### `as`
-
- - Type: `"symbol" | "object" | "a" | "abbr" | "address" | "area" | "article" | "aside" | "audio" | "b" | ...`
- - Required: Yes
-
-The HTML element to render the component as.
-
 ### `className`
 
  - Type: `string`

--- a/packages/components/src/base-control/index.tsx
+++ b/packages/components/src/base-control/index.tsx
@@ -28,7 +28,7 @@ import { contextConnectWithoutRef, useContextSystem } from '../context';
 export { useBaseControlProps } from './hooks';
 
 const UnconnectedBaseControl = (
-	props: WordPressComponentProps< BaseControlProps, null >
+	props: WordPressComponentProps< BaseControlProps, null, false >
 ) => {
 	const {
 		__nextHasNoMarginBottom = false,

--- a/packages/components/src/base-control/index.tsx
+++ b/packages/components/src/base-control/index.tsx
@@ -10,13 +10,13 @@ import {
 	StyledHelp,
 	StyledVisualLabel,
 } from './styles/base-control-styles';
-import type { WordPressComponentProps } from '../context';
+import type { WordPressComponent, WordPressComponentProps } from '../context';
 import { contextConnectWithoutRef, useContextSystem } from '../context';
 
 export { useBaseControlProps } from './hooks';
 
 const UnconnectedBaseControl = (
-	props: WordPressComponentProps< BaseControlProps, null >
+	props: WordPressComponentProps< BaseControlProps, null, false >
 ) => {
 	const {
 		id,
@@ -84,6 +84,17 @@ const UnforwardedVisualLabel = (
 
 export const VisualLabel = forwardRef( UnforwardedVisualLabel );
 
+// `BaseControl` renders its own wrapper and doesn't forward props to an
+// underlying element, so the connected component is typed explicitly. Without
+// it, the non-polymorphic flag can't be recovered from a props type built with
+// a `null` element type, and the unsupported `as` prop leaks back into the
+// public type.
+const ConnectedBaseControl: WordPressComponent<
+	null,
+	BaseControlProps,
+	false
+> = contextConnectWithoutRef( UnconnectedBaseControl, 'BaseControl' );
+
 /**
  * `BaseControl` is a low-level component used to generate labels and help text for components handling user inputs.
  *
@@ -108,7 +119,7 @@ export const VisualLabel = forwardRef( UnforwardedVisualLabel );
  * ```
  */
 export const BaseControl = Object.assign(
-	contextConnectWithoutRef( UnconnectedBaseControl, 'BaseControl' ),
+	ConnectedBaseControl,
 
 	{
 		/**


### PR DESCRIPTION
Fixes #70063
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #70063

<!-- In a few words, what is the PR actually doing? -->
This PR fixes the documentation for the BaseControl component to clarify that it doesn't support the `as` prop, while its VisualLabel subcomponent does.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The prop docs for the BaseControl component incorrectly suggested that it takes an `as` prop due to the prop type definition. However, in reality, the `as` prop is not passed down to the internal wrapper component. This PR updates the documentation to correctly reflect the component's behavior.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Fixed  type in the `BaseControl` component and regenerated the README.md
- Added an entry in the CHANGELOG.md file to document this documentation fix

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Check the updated type in `packages/components/src/base-control/index.tsx`
2. Verify that the CHANGELOG.md entry correctly describes the fix
3. After the documentation is regenerated, verify that the BaseControl component's README.md correctly states that it doesn't support the `as` prop

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Not applicable as this is a documentation-only change.

## Screenshots or screencast <!-- if applicable -->
Not applicable as this is a documentation-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that `BaseControl` does not support the `as` prop.
  - Removed the unsupported `as` prop from the component’s documented properties.

- **Bug Fixes**
  - Corrected the public component type so the unsupported `as` prop is no longer exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->