### PR TITLE
Form Block: Add unique form id to form block

### DIFF
--- a/packages/block-library/src/form/block.json
+++ b/packages/block-library/src/form/block.json
@@ -19,6 +19,12 @@
 	"textdomain": "default",
 	"icon": "feedback",
 	"attributes": {
+		"formId": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "form",
+			"attribute": "id"
+		},
 		"submissionMethod": {
 			"type": "string",
 			"default": "email"

--- a/packages/block-library/src/form/components/useInstanceId.ts
+++ b/packages/block-library/src/form/components/useInstanceId.ts
@@ -1,0 +1,89 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+const instanceMap = new WeakMap< object, number >();
+
+/**
+ * Generates a 3-character sequence using numbers and lowercase letters.
+ *
+ * @return A random 3-character string.
+ */
+function generateSequence(): string {
+	const chars = '0123456789abcdefghijklmnopqrstuvwxyz';
+	let result = '';
+	for ( let i = 0; i < 3; i++ ) {
+		// eslint-disable-next-line no-restricted-syntax
+		result += chars.charAt( Math.floor( Math.random() * chars.length ) );
+	}
+	return result;
+}
+
+/**
+ * Creates a new id for a given object.
+ *
+ * @param object Object reference to create an id for.
+ * @param format Optional format type ('sequence' for xxx-yyy format).
+ * @return The instance id (index or xxx-yyy format).
+ */
+function createId( object: object, format?: string ): string | number {
+	const instances = instanceMap.get( object ) || 0;
+	instanceMap.set( object, instances + 1 );
+
+	if ( format === 'sequence' ) {
+		const firstPart = generateSequence();
+		const secondPart = generateSequence();
+	return `${ firstPart }-${ secondPart }`;
+	}
+
+	return instances;
+}
+
+/**
+ * Specify the useInstanceId *function* signatures.
+ *
+ * More accurately, useInstanceId distinguishes between three different
+ * signatures:
+ *
+ * 1. When only object is given, the returned value is a number
+ * 2. When object and prefix is given, the returned value is a string
+ * 3. When preferredId is given, the returned value is the type of preferredId
+ *
+ * @param object Object reference to create an id for.
+ */
+
+function useInstanceId( object: object ): number;
+function useInstanceId( object: object, prefix: string ): string;
+function useInstanceId< T extends string | number >(
+	object: object,
+	prefix: string,
+	preferredId?: T
+): T;
+
+/**
+ * Provides a unique instance ID.
+ *
+ * @param object        Object reference to create an id for.
+ * @param [prefix]      Prefix for the unique id.
+ * @param [preferredId] Default ID to use.
+ * @return The unique instance id.
+ */
+function useInstanceId(
+	object: object,
+	prefix?: string,
+	preferredId?: string | number
+): string | number {
+	return useMemo( () => {
+		if ( preferredId ) {
+			return preferredId;
+		}
+		const id = prefix === 'wpf' ?
+			createId( object, 'sequence' ) :
+			createId( object );
+
+		return prefix ? `${ prefix }-${ id }` : id;
+	}, [ object, preferredId, prefix ] );
+}
+
+export default useInstanceId;

--- a/packages/block-library/src/form/edit.js
+++ b/packages/block-library/src/form/edit.js
@@ -20,6 +20,9 @@ import {
 	formSubmissionNotificationError,
 } from './utils.js';
 
+// Use local useInstanceId
+import { default as useInstanceId } from './components/useInstanceId';
+
 const TEMPLATE = [
 	formSubmissionNotificationSuccess,
 	formSubmissionNotificationError,
@@ -51,8 +54,19 @@ const TEMPLATE = [
 ];
 
 const Edit = ( { attributes, setAttributes, clientId } ) => {
-	const { action, method, email, submissionMethod } = attributes;
-	const blockProps = useBlockProps();
+	const { action, method, email, submissionMethod, formId } = attributes;
+
+	// Use useInstanceId to generate a unique form id
+	const instanceId = useInstanceId( Edit, 'wpf' );
+	
+		setAttributes( {
+			formId: instanceId,
+			action: ''
+		} );
+
+	const blockProps = useBlockProps( {
+		id: formId
+	} );
 
 	const { hasInnerBlocks } = useSelect(
 		( select ) => {

--- a/packages/block-library/src/form/save.js
+++ b/packages/block-library/src/form/save.js
@@ -4,8 +4,11 @@
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const blockProps = useBlockProps.save();
-	const { submissionMethod } = attributes;
+	const { submissionMethod, formId } = attributes;
+
+	const blockProps = useBlockProps.save({
+		id: formId
+	});
 
 	return (
 		<form

--- a/test/integration/fixtures/blocks/core__form.html
+++ b/test/integration/fixtures/blocks/core__form.html
@@ -1,5 +1,5 @@
-<!-- wp:form -->
-<form class="wp-block-form" enctype="text/plain">
+<!-- wp:form {"formId":"wpf-abc-xyz"} -->
+<form class="wp-block-form" id="wpf-abc-xyz" enctype="text/plain">
 <!-- wp:form-input -->
 <div class="wp-block-form-input"><label class="wp-block-form-input__label"><span class="wp-block-form-input__label-content">Name</span><input class="wp-block-form-input__input" type="text" name="name" required aria-required="true"/></label></div>
 <!-- /wp:form-input -->

--- a/test/integration/fixtures/blocks/core__form.json
+++ b/test/integration/fixtures/blocks/core__form.json
@@ -3,8 +3,10 @@
 		"name": "core/form",
 		"isValid": true,
 		"attributes": {
+			"formId": "wpf-abc-xyz",
 			"submissionMethod": "email",
-			"method": "post"
+			"method": "post",
+			"action": ""
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__form.parsed.json
+++ b/test/integration/fixtures/blocks/core__form.parsed.json
@@ -1,7 +1,9 @@
 [
 	{
 		"blockName": "core/form",
-		"attrs": {},
+		"attrs": {
+			"formId": "wpf-abc-xyz"
+		},
 		"innerBlocks": [
 			{
 				"blockName": "core/form-input",
@@ -82,9 +84,9 @@
 				]
 			}
 		],
-		"innerHTML": "\n<form class=\"wp-block-form\" enctype=\"text/plain\">\n\n\n\n\n\n\n\n\n\n</form>\n",
+		"innerHTML": "\n<form class=\"wp-block-form\" id=\"wpf-abc-xyz\" enctype=\"text/plain\">\n\n\n\n\n\n\n\n\n\n</form>\n",
 		"innerContent": [
-			"\n<form class=\"wp-block-form\" enctype=\"text/plain\">\n",
+			"\n<form class=\"wp-block-form\" id=\"wpf-abc-xyz\" enctype=\"text/plain\">\n",
 			null,
 			"\n\n",
 			null,

--- a/test/integration/fixtures/blocks/core__form.serialized.html
+++ b/test/integration/fixtures/blocks/core__form.serialized.html
@@ -1,5 +1,5 @@
-<!-- wp:form -->
-<form class="wp-block-form" enctype="text/plain"><!-- wp:form-input -->
+<!-- wp:form {"formId":"wpf-abc-xyz"} -->
+<form class="wp-block-form" id="wpf-abc-xyz" enctype="text/plain"><!-- wp:form-input -->
 <div class="wp-block-form-input"><label class="wp-block-form-input__label"><span class="wp-block-form-input__label-content">Name</span><input class="wp-block-form-input__input" type="text" name="name" required aria-required="true"/></label></div>
 <!-- /wp:form-input -->
 


### PR DESCRIPTION
## What?
Add unique form id to form block
Closes https://github.com/WordPress/gutenberg/issues/70071

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
[Initial development of the experimental Form Block](https://github.com/WordPress/gutenberg/pull/44214) does not include a unique form id for each form block.

Analysis of [range of existing form plugins shows](https://blog.cf7skins.com/form-id/#Form-Plugin-Analysis) relatively consistent approach to adding a form id to all forms.

- All plugins generate a unique form id for each form
- Most commonly form ids are built from 3 parts separated by ‘-‘
- ‘wpf’ is suitable as starting part (**W**ord**P**ress **F**orm)
- 3 random generated characters are suitable following parts
- Most form plugins add the form id in the html form tag
- Some form plugins extend the form id to include a page or tab number e.g. ‘wpf-###-###-##’

Refer to [Form Plugin Analysis Results](https://blog.cf7skins.com/form-id/#Form-Plugin-Analysis-Results).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Add `<form id= “wpf-###-###”>` for each form & save this in the block attributes. 
- Use existing form Id if available, otherwise add unique form Id to attributes
- Unique form id generated in modified version of `useInstanceId.ts` available only in experiment

Refer to [Form ID Suggestion](https://blog.cf7skins.com/form-id/#Form-ID-Suggestion).

## Testing Instructions

1. Activate the **Form and Input blocks** option in **Experimental Settings**
2. Add an **Experimental Form Block** to post or page
3. Save post or page
4. View post or page on website frontend
5. Use Browser Tools to examine HTML of `<form>` tag
6. Confirm `<form>` tag includes `id="wpf-abc-xyz"` or similar

## Screenshots or screencast
Backend:

![2025-04-16_01b_form-id_Backend_reload-page](https://github.com/user-attachments/assets/55a14219-eb79-4728-8e66-7334b4d650b9)

Frontend:

![2025-04-16_02b_ form-id_Friontend_new-form](https://github.com/user-attachments/assets/dd5cfb1a-e150-4de7-8b50-0d09288e5b5f)

Related: #70071, #44214, #44186
