### PR TITLE
Fix: Prevent text from being hyperlinked after removing a link

### DIFF
--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -161,6 +161,7 @@ function Edit( {
 	}
 
 	function onRemoveFormat() {
+		//Rerun.
 		const newValue = removeFormat( value, name );
 
 		const updatedValue = {

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -161,7 +161,16 @@ function Edit( {
 	}
 
 	function onRemoveFormat() {
-		onChange( removeFormat( value, name ) );
+		const newValue = removeFormat( value, name );
+
+		const updatedValue = {
+			...newValue,
+			activeFormats: [],
+			start: newValue.start,
+			end: newValue.end,
+		};
+
+		onChange( updatedValue );
 		speak( __( 'Link removed.' ), 'assertive' );
 	}
 

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -161,7 +161,6 @@ function Edit( {
 	}
 
 	function onRemoveFormat() {
-		//Rerun.
 		const newValue = removeFormat( value, name );
 
 		const updatedValue = {

--- a/packages/rich-text/src/component/event-listeners/delete.js
+++ b/packages/rich-text/src/component/event-listeners/delete.js
@@ -7,6 +7,7 @@ import { BACKSPACE, DELETE } from '@wordpress/keycodes';
  * Internal dependencies
  */
 import { remove } from '../../remove';
+import { isCollapsed } from '../../is-collapsed';
 
 export default ( props ) => ( element ) => {
 	function onKeyDown( event ) {
@@ -23,6 +24,16 @@ export default ( props ) => ( element ) => {
 
 		const currentValue = createRecord();
 		const { start, end, text } = currentValue;
+
+		if ( ! isCollapsed( currentValue ) ) {
+			const modifiedValue = {
+				...currentValue,
+				activeFormats: [],
+			};
+			handleChange( remove( modifiedValue ) );
+			event.preventDefault();
+			return;
+		}
 
 		// Always handle full content deletion ourselves.
 		if ( start === 0 && end !== 0 && end === text.length ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/16627

This PR fixes an issue where text would continue to be hyperlinked after removing a link. 

## Why?
When users remove a link from text and start typing again, the new text incorrectly inherits the link format. This happens:
1. When selecting linked text with a mouse and deleting with Delete/Backspace
2. When using the "Remove link" button to remove a link

## Testing Instructions
1. Open the block editor and create a paragraph with some text
2. Select a portion of the text and add a link to it
3. Test scenario 1 (Remove link button):
   - Click on the linked text
   - Click the "Remove link" button in the toolbar
   - Start typing where the link was
   - Verify the new text is not hyperlinked

4. Test scenario 2 (Mouse selection + Backspace/Delete):
   - Create another paragraph with linked text
   - Select the linked text with your mouse
   - Press Delete or Backspace to remove it
   - Start typing at that position
   - Verify the new text is not hyperlinked

5. Test scenario 3 (Backspace after link):
   - Create another paragraph with linked text
   - Place your cursor immediately after the linked text
   - Press Backspace repeatedly to remove the linked text
   - Start typing at that position
   - Verify the new text is not hyperlinked

## Screenshots or screencast <!-- if applicable -->
### Before

https://github.com/user-attachments/assets/39e4645b-d37d-4e16-9a0d-89238f754fbc

### After

https://github.com/user-attachments/assets/ca28bd4f-03de-4aaa-85b1-5996d064992c




