### PR TITLE
Fix: Search block doesn't respect background and text color options

### DIFF
--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -50,14 +50,15 @@
 	},
 	"supports": {
 		"align": [ "left", "center", "right" ],
-		"color": {
-			"gradients": true,
-			"__experimentalSkipSerialization": true,
-			"__experimentalDefaultControls": {
+			"color": {
+			  "gradients": true,
+			  "__experimentalSkipSerialization": true,
+			  "__experimentalDefaultControls": {
 				"background": true,
 				"text": true
-			}
-		},
+			  },
+			  "button": true
+			},
 		"interactivity": true,
 		"typography": {
 			"__experimentalSkipSerialization": true,

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -131,6 +131,36 @@ export default function SearchEdit( {
 	}
 
 	const colorProps = useColorProps( attributes );
+
+	const getPresetColorClass = ( value, type ) => {
+		if ( ! value || typeof value !== 'string' ) {
+			return undefined;
+		}
+
+		const parts = value.split( '|' );
+		const slug = parts[ parts.length - 1 ];
+
+		if ( type === 'gradient' ) {
+			return `has-${ slug }-gradient-background`;
+		}
+
+		if ( type === 'background' ) {
+			return `has-${ slug }-background-color`;
+		}
+
+		if ( type === 'text' ) {
+			return `has-${ slug }-color`;
+		}
+	};
+
+	const bg = attributes.style?.elements?.button?.color?.background;
+	const text = attributes.style?.elements?.button?.color?.text;
+	const gradientBg = attributes.style?.elements?.button?.color?.gradient;
+
+	const bgClass = getPresetColorClass( bg, 'background' );
+	const textClass = getPresetColorClass( text, 'text' );
+	const gradientBgClass = getPresetColorClass( gradientBg, 'gradient' );
+
 	const [ fluidTypographySettings, layout ] = useSettings(
 		'typography.fluid',
 		'layout'
@@ -279,13 +309,15 @@ export default function SearchEdit( {
 		const textFieldClasses = clsx(
 			'wp-block-search__input',
 			isButtonPositionInside ? undefined : borderProps.className,
-			typographyProps.className
+			typographyProps.className,
+			colorProps.className
 		);
 		const textFieldStyles = {
 			...( isButtonPositionInside
 				? { borderRadius }
 				: borderProps.style ),
 			...typographyProps.style,
+			...colorProps.style,
 			textDecoration: undefined,
 		};
 
@@ -314,14 +346,15 @@ export default function SearchEdit( {
 		// If the button is inside the wrapper, the wrapper gets the border color styles/classes, not the button.
 		const buttonClasses = clsx(
 			'wp-block-search__button',
-			colorProps.className,
+			bgClass,
+			textClass,
+			gradientBgClass,
 			typographyProps.className,
 			isButtonPositionInside ? undefined : borderProps.className,
 			buttonUseIcon ? 'has-icon' : undefined,
 			__experimentalGetElementClassName( 'button' )
 		);
 		const buttonStyles = {
-			...colorProps.style,
 			...typographyProps.style,
 			...( isButtonPositionInside
 				? { borderRadius }

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -19,27 +19,27 @@ function render_block_core_search( $attributes ) {
 	// attributes to `__( 'Search' )` meaning that many posts contain `<!--
 	// wp:search /-->`. Support these by defaulting an undefined label and
 	// buttonText to `__( 'Search' )`.
-	$attributes = wp_parse_args(
+	$attributes           = wp_parse_args(
 		$attributes,
 		array(
 			'label'      => __( 'Search' ),
 			'buttonText' => __( 'Search' ),
 		)
 	);
-
-	$input_id            = wp_unique_id( 'wp-block-search__input-' );
-	$classnames          = classnames_for_block_core_search( $attributes );
-	$show_label          = ! empty( $attributes['showLabel'] );
-	$use_icon_button     = ! empty( $attributes['buttonUseIcon'] );
-	$show_button         = ( ! empty( $attributes['buttonPosition'] ) && 'no-button' === $attributes['buttonPosition'] ) ? false : true;
-	$button_position     = $show_button ? $attributes['buttonPosition'] : null;
-	$query_params        = ( ! empty( $attributes['query'] ) ) ? $attributes['query'] : array();
-	$button              = '';
-	$query_params_markup = '';
-	$inline_styles       = styles_for_block_core_search( $attributes );
-	$color_classes       = get_color_classes_for_block_core_search( $attributes );
-	$typography_classes  = get_typography_classes_for_block_core_search( $attributes );
-	$is_button_inside    = ! empty( $attributes['buttonPosition'] ) &&
+	$input_id             = wp_unique_id( 'wp-block-search__input-' );
+	$classnames           = classnames_for_block_core_search( $attributes );
+	$show_label           = ! empty( $attributes['showLabel'] );
+	$use_icon_button      = ! empty( $attributes['buttonUseIcon'] );
+	$show_button          = ( ! empty( $attributes['buttonPosition'] ) && 'no-button' === $attributes['buttonPosition'] ) ? false : true;
+	$button_position      = $show_button ? $attributes['buttonPosition'] : null;
+	$query_params         = ( ! empty( $attributes['query'] ) ) ? $attributes['query'] : array();
+	$button               = '';
+	$query_params_markup  = '';
+	$inline_styles        = styles_for_block_core_search( $attributes );
+	$color_classes        = get_color_classes_for_input_block_core_search( $attributes );
+	$button_color_classes = get_color_classes_for_button_block_core_search( $attributes );
+	$typography_classes   = get_typography_classes_for_block_core_search( $attributes );
+	$is_button_inside     = ! empty( $attributes['buttonPosition'] ) &&
 		'button-inside' === $attributes['buttonPosition'];
 	// Border color classes need to be applied to the elements that have a border color.
 	$border_color_classes = get_border_color_classes_for_block_core_search( $attributes );
@@ -68,6 +68,9 @@ function render_block_core_search( $attributes ) {
 	}
 	if ( ! empty( $typography_classes ) ) {
 		$input_classes[] = $typography_classes;
+	}
+	if ( ! empty( $color_classes ) ) {
+		$input_classes[] = $color_classes;
 	}
 	if ( $input->next_tag() ) {
 		$input->add_class( implode( ' ', $input_classes ) );
@@ -103,13 +106,12 @@ function render_block_core_search( $attributes ) {
 	if ( $show_button ) {
 		$button_classes         = array( 'wp-block-search__button' );
 		$button_internal_markup = '';
-		if ( ! empty( $color_classes ) ) {
-			$button_classes[] = $color_classes;
+		if ( ! empty( $button_color_classes ) ) {
+			$button_classes[] = $button_color_classes;
 		}
 		if ( ! empty( $typography_classes ) ) {
 			$button_classes[] = $typography_classes;
 		}
-
 		if ( ! $is_button_inside && ! empty( $border_color_classes ) ) {
 			$button_classes[] = $border_color_classes;
 		}
@@ -570,7 +572,7 @@ function get_border_color_classes_for_block_core_search( $attributes ) {
  *
  * @return string The color classnames to be applied to the block elements.
  */
-function get_color_classes_for_block_core_search( $attributes ) {
+function get_color_classes_for_input_block_core_search( $attributes ) {
 	$classnames = array();
 
 	// Text color.
@@ -601,6 +603,76 @@ function get_color_classes_for_block_core_search( $attributes ) {
 	}
 	if ( $has_named_gradient ) {
 		$classnames[] = sprintf( 'has-%s-gradient-background', $attributes['gradient'] );
+	}
+
+	return implode( ' ', $classnames );
+}
+/**
+ * Returns color classnames depending on whether there are named or custom text and background colors for input.
+ *
+ * @since 5.9.0
+ *
+ * @param array $attributes The block attributes.
+ *
+ * @return string The color classnames to be applied to the block elements.
+ */
+function get_color_classes_for_button_block_core_search( $attributes ) {
+	$classnames = array();
+
+	$color_text_name       = '';
+	$color_background_name = '';
+	$color_gradient_name   = '';
+
+	if (
+		isset( $attributes['style']['elements']['button']['color']['text'] ) &&
+		is_string( $attributes['style']['elements']['button']['color']['text'] )
+	) {
+		$full_value_text = $attributes['style']['elements']['button']['color']['text'];
+		if ( strpos( $full_value_text, '|' ) !== false ) {
+			$parts           = explode( '|', $full_value_text );
+			$color_text_name = end( $parts );
+		}
+	}
+
+	if (
+		isset( $attributes['style']['elements']['button']['color']['background'] ) &&
+		is_string( $attributes['style']['elements']['button']['color']['background'] )
+	) {
+		$full_value_background = $attributes['style']['elements']['button']['color']['background'];
+		if ( strpos( $full_value_background, '|' ) !== false ) {
+			$parts                 = explode( '|', $full_value_background );
+			$color_background_name = end( $parts );
+		}
+	}
+
+	if (
+		isset( $attributes['style']['elements']['button']['color']['gradient'] ) &&
+		is_string( $attributes['style']['elements']['button']['color']['gradient'] )
+	) {
+		$full_value_gradient = $attributes['style']['elements']['button']['color']['gradient'];
+		if ( strpos( $full_value_gradient, '|' ) !== false ) {
+			$parts               = explode( '|', $full_value_gradient );
+			$color_gradient_name = end( $parts );
+		}
+	}
+
+	// Add final classes.
+	if ( ! empty( $color_text_name ) ) {
+		$classnames[] = 'has-' . sanitize_title( $color_text_name ) . '-color';
+	} elseif ( ! empty( $full_value_text ) ) {
+		$classnames[] = 'has-text-color';
+	}
+
+	if ( ! empty( $color_background_name ) ) {
+		$classnames[] = 'has-' . sanitize_title( $color_background_name ) . '-background-color';
+	} elseif ( ! empty( $full_value_background ) ) {
+		$classnames[] = 'has-background';
+	}
+
+	if ( ! empty( $color_gradient_name ) ) {
+		$classnames[] = 'has-' . sanitize_title( $color_gradient_name ) . '-gradient-background';
+	} elseif ( ! empty( $full_value_gradient ) ) {
+		$classnames[] = 'has-gradient';
 	}
 
 	return implode( ' ', $classnames );


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/65343

<!-- In a few words, what is the PR actually doing? -->

## Why?
This PR adds support for applying text and background colors to the input field in the search block, and also introduces separate text and background color options for the search button.

## How?
- This PR firstly adds the support for `button` in the block.json 
- Added the `get_color_classes_for_button_block_core_search` for adding the button color functionality and updated an existing function name to `get_color_classes_for_input_block_core_search` 
- Added `getPresetColorClass` function for adding the relevant text and background colour classes on the editor side 

## Testing Instructions
- Add a new post 
- Add the `Search Block` 
- Go the right panel and visit the styles tab 
- Click on the ellipsis for the 'Color' option and select 'Button' from it 
- Now try to change the colours of the 'Text' , 'Background' and 'Button' to notice changes in colours of the input and search button   


## Screenshots or screencast 

https://github.com/user-attachments/assets/0228f028-250a-41e4-be54-51eb790d40c8
