### PR TITLE
Components: Update `ColorPicker` dropdown to display RGBA/HSLA labels when alpha is enabled

### DIFF
--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -33,12 +33,6 @@ import type { ColorPickerProps, ColorType } from './types';
 
 extend( [ namesPlugin ] );
 
-const options = [
-	{ label: 'RGB', value: 'rgb' as const },
-	{ label: 'HSL', value: 'hsl' as const },
-	{ label: 'Hex', value: 'hex' as const },
-];
-
 const UnconnectedColorPicker = (
 	props: ColorPickerProps,
 	forwardedRef: ForwardedRef< any >
@@ -75,6 +69,23 @@ const UnconnectedColorPicker = (
 	const [ colorType, setColorType ] = useState< ColorType >(
 		copyFormat || 'hex'
 	);
+
+	const options = useMemo( () => {
+		return [
+			{
+				label: enableAlpha ? 'RGBA' : 'RGB',
+				value: 'rgb' as const,
+			},
+			{
+				label: enableAlpha ? 'HSLA' : 'HSL',
+				value: 'hsl' as const,
+			},
+			{
+				label: 'Hex',
+				value: 'hex' as const,
+			},
+		];
+	}, [ enableAlpha ] );
 
 	return (
 		<ColorfulWrapper ref={ forwardedRef } { ...divProps }>


### PR DESCRIPTION

## What?
Closes : https://github.com/WordPress/gutenberg/issues/70075
This PR aims to fix option labels/values when the alpha prop is passed in the `ColorPicker` component.

## Why?
While this is a small change, it makes a significant difference in label accuracy. As HSL is not HSLA and RGB is not RGBA, having visual labels that correctly reflect the inputs below helps maintain consistency and improves the user experience.

## How?
I've updated the options object that holds the labels displayed in the `ColorPicker` dropdown and added conditionals to dynamically show RGBA/HSLA when alpha is enabled.


## Testing Instructions
1. Run `npm run storybook:dev`
2. Checkout the ColorPicker component
3. Now confirm that the dropdown options have been properly updated

## Screencast

### Before

https://github.com/user-attachments/assets/2650ecf3-10de-4614-b7d1-7decb436417e

### After

https://github.com/user-attachments/assets/9258577c-5957-42c7-8e84-ff79c213cefb

