### PR TITLE
URL: Handle HTML entities and ampersand in 'cleanForSlug'

### DIFF
--- a/packages/url/README.md
+++ b/packages/url/README.md
@@ -68,7 +68,7 @@ _Returns_
 
 Performs some basic cleanup of a string for use as a post slug.
 
-This replicates some of what `sanitize_title()` does in WordPress core, but is only designed to approximate what the slug will be.
+This replicates some of what `sanitize_title_with_dashes()` does in WordPress core, but is only designed to approximate what the slug will be.
 
 Converts Latin-1 Supplement and Latin Extended-A letters to basic Latin letters. Removes combining diacritical marks. Converts whitespace, periods, and forward slashes to hyphens. Removes any remaining non-word characters except hyphens. Converts remaining string to lowercase. It does not account for octets, HTML entities, or other encoded characters.
 

--- a/packages/url/src/clean-for-slug.js
+++ b/packages/url/src/clean-for-slug.js
@@ -6,7 +6,7 @@ import removeAccents from 'remove-accents';
 /**
  * Performs some basic cleanup of a string for use as a post slug.
  *
- * This replicates some of what `sanitize_title()` does in WordPress core, but
+ * This replicates some of what `sanitize_title_with_dashes()` does in WordPress core, but
  * is only designed to approximate what the slug will be.
  *
  * Converts Latin-1 Supplement and Latin Extended-A letters to basic Latin
@@ -25,8 +25,12 @@ export function cleanForSlug( string ) {
 	}
 	return (
 		removeAccents( string )
+			// Convert &nbsp, &ndash, and &mdash to hyphens.
+			.replace( /(&nbsp;|&ndash;|&mdash;)/g, '-' )
 			// Convert each group of whitespace, periods, and forward slashes to a hyphen.
 			.replace( /[\s\./]+/g, '-' )
+			// Remove all HTML entities.
+			.replace( /&\S+?;/g, '' )
 			// Remove anything that's not a letter, number, underscore or hyphen.
 			.replace( /[^\p{L}\p{N}_-]+/gu, '' )
 			// Convert to lowercase

--- a/packages/url/src/test/index.js
+++ b/packages/url/src/test/index.js
@@ -1202,6 +1202,24 @@ describe( 'cleanForSlug', () => {
 		expect( cleanForSlug( 'the long - cat' ) ).toBe( 'the-long-cat' );
 		expect( cleanForSlug( 'the----long---cat' ) ).toBe( 'the-long-cat' );
 	} );
+
+	it( 'Should remove ampersands', () => {
+		expect( cleanForSlug( 'the long cat & dog' ) ).toBe(
+			'the-long-cat-dog'
+		);
+		expect(
+			cleanForSlug( 'the long cat &amp; a dog &amp;&amp; fish' )
+		).toBe( 'the-long-cat-a-dog-fish' );
+		expect( cleanForSlug( 'the long cat &amp;amp; dog' ) ).toBe(
+			'the-long-cat-amp-dog'
+		);
+	} );
+
+	it( 'Should remove HTML entities', () => {
+		expect(
+			cleanForSlug( 'No &nbsp; Entities> &ndash; Here &mdash;&lt;' )
+		).toBe( 'no-entities-here' );
+	} );
 } );
 
 describe( 'normalizePath', () => {


### PR DESCRIPTION
## What?
Closes #62543.
Supersedes #62549.
Supersedes #68813.

PR adds handlers for HTML entities and ampersands to the `cleanForSlug` method.

## Why?
Matches the logic and behavior of `sanitize_title_with_dashes`.

## Testing Instructions
1. Create a post.
2. Add the following title - `Ampersand &&& testing`.
3. Confirm that the generated slug preview doesn't contain ampersands.
4. Remaining cases are covered by unit tests.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2025-05-07 at 17 24 00](https://github.com/user-attachments/assets/0b86dce8-b90d-47ed-9833-643cf7078edb)
