### PR TITLE
Editor: Honor rich/code editor settings when deriving the editor mode

### DIFF
--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -56,7 +56,6 @@ export default function EditorInterface( {
 } ) {
 	const {
 		mode,
-		isRichEditingEnabled,
 		isInserterOpened,
 		isListViewOpened,
 		isDistractionFree,
@@ -69,9 +68,16 @@ export default function EditorInterface( {
 		const editorSettings = getEditorSettings();
 		const postTypeLabel = getPostTypeLabel();
 
+		let _mode = select( editorStore ).getEditorMode();
+		if ( ! editorSettings.richEditingEnabled && _mode === 'visual' ) {
+			_mode = 'text';
+		}
+		if ( ! editorSettings.codeEditingEnabled && _mode === 'text' ) {
+			_mode = 'visual';
+		}
+
 		return {
-			mode: select( editorStore ).getEditorMode(),
-			isRichEditingEnabled: editorSettings.richEditingEnabled,
+			mode: _mode,
 			isInserterOpened: select( editorStore ).isInserterOpened(),
 			isListViewOpened: select( editorStore ).isListViewOpened(),
 			isDistractionFree: get( 'core', 'distractionFree' ),
@@ -148,23 +154,20 @@ export default function EditorInterface( {
 								editorCanvasView
 							) : (
 								<>
-									{ ! isPreviewMode &&
-										( mode === 'text' ||
-											! isRichEditingEnabled ) && (
-											<TextEditor
-												// We should auto-focus the canvas (title) on load.
-												// eslint-disable-next-line jsx-a11y/no-autofocus
-												autoFocus={ autoFocus }
-											/>
-										) }
+									{ ! isPreviewMode && mode === 'text' && (
+										<TextEditor
+											// We should auto-focus the canvas (title) on load.
+											// eslint-disable-next-line jsx-a11y/no-autofocus
+											autoFocus={ autoFocus }
+										/>
+									) }
 									{ ! isPreviewMode &&
 										! isLargeViewport &&
 										mode === 'visual' && (
 											<BlockToolbar hideDragHandle />
 										) }
 									{ ( isPreviewMode ||
-										( isRichEditingEnabled &&
-											mode === 'visual' ) ) && (
+										mode === 'visual' ) && (
 										<VisualEditor
 											styles={ styles }
 											contentRef={ contentRef }
@@ -187,7 +190,6 @@ export default function EditorInterface( {
 				! isDistractionFree &&
 				isLargeViewport &&
 				showBlockBreadcrumbs &&
-				isRichEditingEnabled &&
 				mode === 'visual' && (
 					<BlockBreadcrumb rootLabelText={ documentLabel } />
 				)


### PR DESCRIPTION
## What?
Closes #49211.

PR updates logic in the `EditorInterface` component to use `richEditingEnabled` and `codeEditingEnabled` settings when deriving the editor's mode.

The `editorMode` is a persistent global setting, and we shouldn't change it during editor initialization.

This matches the logic in the `ModeSwitcher` component:

https://github.com/WordPress/gutenberg/blob/26594055a5ddded2afd660a1faddeb533d9db90a/packages/editor/src/components/mode-switcher/index.js#L49-L55

## Why?
See #49211.

## Testing Instructions
1. Disable Code Editing for a post type, e.g., `page` (see snippet below).
2. Open the block editor in a post of post type `post`.
3. Switch to the Code editor.
4. Open the block editor in a post of post type `page`.
5. You are in the Code editor.

 ```php
 add_filter('block_editor_settings_all', function (
     array $editorSettings,
     WP_Block_Editor_Context $editorContext
 ) {
     if (get_post_type($editorContext->post) === 'page') {
         $editorSettings['codeEditingEnabled'] = false;
     }
     return $editorSettings;
 }, 10, 2);
 ```

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2025-05-07 at 22 38 14](https://github.com/user-attachments/assets/783345fd-9388-4a86-b2e0-019ee1a7b284)

