### PR TITLE
Block Library: Add embed shortcode to embed block conversion

### DIFF
--- a/packages/block-library/src/shortcode/edit.js
+++ b/packages/block-library/src/shortcode/edit.js
@@ -2,18 +2,81 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PlainText, useBlockProps } from '@wordpress/block-editor';
+import {
+	PlainText,
+	useBlockProps,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { useInstanceId } from '@wordpress/compose';
-import { Placeholder } from '@wordpress/components';
+import { Placeholder, Button, Notice } from '@wordpress/components';
 import { shortcode } from '@wordpress/icons';
+import { createBlock } from '@wordpress/blocks';
+import { useDispatch } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
 
-export default function ShortcodeEdit( { attributes, setAttributes } ) {
+/**
+ * Internal dependencies
+ */
+import { isEmbedShortcode, extractEmbedUrl } from './utils';
+
+export default function ShortcodeEdit( {
+	attributes,
+	setAttributes,
+	clientId,
+} ) {
 	const instanceId = useInstanceId( ShortcodeEdit );
 	const inputId = `blocks-shortcode-input-${ instanceId }`;
+	const { replaceBlock } = useDispatch( blockEditorStore );
+
+	const { hasEmbed, embedUrl } = useMemo( () => {
+		const isEmbed = isEmbedShortcode( attributes.text );
+		const url = isEmbed ? extractEmbedUrl( attributes.text ) : '';
+		return { hasEmbed: isEmbed, embedUrl: url };
+	}, [ attributes.text ] );
+
+	/**
+	 * Converts the shortcode block to an embed block.
+	 *
+	 * Creates a new embed block with the extracted URL and replaces
+	 * the current shortcode block with it.
+	 */
+	const convertToEmbed = () => {
+		const embedBlock = createBlock( 'core/embed', { url: embedUrl } );
+		replaceBlock( clientId, embedBlock );
+	};
 
 	return (
 		<div { ...useBlockProps() }>
 			<Placeholder icon={ shortcode } label={ __( 'Shortcode' ) }>
+				{ hasEmbed && (
+					<Notice
+						className="blocks-shortcode__notice"
+						status="info"
+						isDismissible={ false }
+					>
+						{ __(
+							'This embed shortcode can be converted to an embed block for a better editing experience with preview.'
+						) }
+						{ embedUrl && (
+							<p className="blocks-shortcode__url-preview">
+								{ __( 'Source:' ) } { embedUrl }
+							</p>
+						) }
+						<div className="blocks-shortcode__convert-button-wrapper">
+							<Button
+								variant="primary"
+								__next40pxDefaultSize
+								onClick={ convertToEmbed }
+								className="blocks-shortcode__convert-button"
+								aria-label={ __(
+									'Convert shortcode to embed block with preview'
+								) }
+							>
+								{ __( 'Convert to embed block' ) }
+							</Button>
+						</div>
+					</Notice>
+				) }
 				<PlainText
 					className="blocks-shortcode__textarea"
 					id={ inputId }

--- a/packages/block-library/src/shortcode/editor.scss
+++ b/packages/block-library/src/shortcode/editor.scss
@@ -6,3 +6,23 @@
 	resize: none;
 	@include editor-input-reset();
 }
+
+.blocks-shortcode__notice {
+	margin-bottom: 16px;
+
+	.blocks-shortcode__url-preview {
+		margin: 8px 0 4px;
+		font-family: monospace;
+		word-break: break-all;
+		font-size: 12px;
+		color: $gray-700;
+	}
+
+	.blocks-shortcode__convert-button-wrapper {
+		margin-top: 8px;
+	}
+
+	.blocks-shortcode__convert-button {
+		margin-top: 4px;
+	}
+}

--- a/packages/block-library/src/shortcode/transforms.js
+++ b/packages/block-library/src/shortcode/transforms.js
@@ -2,6 +2,12 @@
  * WordPress dependencies
  */
 import { removep, autop } from '@wordpress/autop';
+import { createBlock } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { isEmbedShortcode, extractEmbedUrl } from './utils';
 
 const transforms = {
 	from: [
@@ -24,6 +30,17 @@ const transforms = {
 				},
 			},
 			priority: 20,
+		},
+	],
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/embed' ],
+			isMatch: ( { text } ) => isEmbedShortcode( text ),
+			transform: ( { text } ) => {
+				const url = extractEmbedUrl( text );
+				return createBlock( 'core/embed', { url } );
+			},
 		},
 	],
 };

--- a/packages/block-library/src/shortcode/utils.js
+++ b/packages/block-library/src/shortcode/utils.js
@@ -1,0 +1,39 @@
+/**
+ * Utilities for the shortcode block.
+ */
+
+/**
+ * Regular expression that identifies embed shortcodes.
+ *
+ * @type {RegExp}
+ */
+export const EMBED_SHORTCODE_REGEX = /^\[embed\]\s*(.+?)\s*\[\/embed\]$/i;
+
+/**
+ * Extracts the URL from an embed shortcode string.
+ *
+ * @param {string} shortcodeText The embed shortcode text.
+ * @return {string}              The extracted URL or empty string.
+ */
+export function extractEmbedUrl( shortcodeText ) {
+	if ( ! shortcodeText ) {
+		return '';
+	}
+
+	const matches = shortcodeText.match( EMBED_SHORTCODE_REGEX );
+	if ( matches && matches[ 1 ] ) {
+		return matches[ 1 ].trim();
+	}
+
+	return '';
+}
+
+/**
+ * Checks if a string is an embed shortcode.
+ *
+ * @param {string} text The text to check.
+ * @return {boolean}    Whether the text is an embed shortcode.
+ */
+export function isEmbedShortcode( text ) {
+	return !! text && EMBED_SHORTCODE_REGEX.test( text );
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/13852

This PR implements the conversion of embed shortcodes to embed blocks in the editor. 
This PR addresses this issue by:

1. Adding a transformation from shortcode blocks with embed shortcodes to embed block.
2. Displaying a notification in the shortcode block UI when an embed shortcode is detected.
3. Providing a conversion button to transform the embed shortcode to a proper embed block with preview.

## Testing Instructions
1. Create a new post in the block editor
2. Add a Shortcode block to the page
3. Paste an embed shortcode into the block, for example:
```
[embed]https://vimeo.com/22439234[/embed]
```
4. Verify that you see a notification with the source URL and a "Convert to embed block" button
5. Click the "Convert to embed block" button
6. Verify that the shortcode block is replaced with an embed block showing a preview of the embedded content

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->


https://github.com/user-attachments/assets/e6904acf-1f2e-449f-923f-5151dec68412

