### PR TITLE
ColorPicker: Add a visual cue when the value is copied

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancement
 
 -   `Snackbar`: Add support to open links in a new tab ([#69905](https://github.com/WordPress/gutenberg/pull/69905)).
+-   `ColorPicker`: Add a visual cue when the value is copied ([#70083](https://github.com/WordPress/gutenberg/pull/70083)).
 
 ## 29.9.0 (2025-05-07)
 

--- a/packages/components/src/color-picker/color-copy-button.tsx
+++ b/packages/components/src/color-picker/color-copy-button.tsx
@@ -3,7 +3,7 @@
  */
 import { useCopyToClipboard } from '@wordpress/compose';
 import { useState, useEffect, useRef } from '@wordpress/element';
-import { copy } from '@wordpress/icons';
+import { copy, check } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -55,8 +55,8 @@ export const ColorCopyButton = ( props: ColorCopyButtonProps ) => {
 		};
 	}, [] );
 
-	const label =
-		copiedColor === color.toHex() ? __( 'Copied!' ) : __( 'Copy' );
+	const isCopied = copiedColor === color.toHex();
+	const label = isCopied ? __( 'Copied!' ) : __( 'Copy' );
 
 	return (
 		<Tooltip delay={ 0 } hideOnClick={ false } text={ label }>
@@ -64,7 +64,7 @@ export const ColorCopyButton = ( props: ColorCopyButtonProps ) => {
 				size="compact"
 				aria-label={ label }
 				ref={ copyRef }
-				icon={ copy }
+				icon={ isCopied ? check : copy }
 				showTooltip={ false }
 			/>
 		</Tooltip>


### PR DESCRIPTION
## What?
Related #57157.

PR updates ColorPicker and adds a visual cue when the value is copied.

## Why?
This is a common UI  pattern, alongside changing the accessible label text.

## Testing Instructions
1. Open a post or page.
2. Insert a paragraph block.
3. Select a color and open a color picker.
4. Confirm that the icon changes from `copy` to `check` when the value is copied.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/fda5d924-6126-4713-ae1e-0cdebc26d123

