### PR TITLE
feat: Add More Collapsed Navigation Icon Options for Navigation Block

### DIFF
--- a/packages/block-library/src/navigation/edit/overlay-menu-icon.js
+++ b/packages/block-library/src/navigation/edit/overlay-menu-icon.js
@@ -1,12 +1,85 @@
 /**
  * WordPress dependencies
  */
-import { SVG, Rect } from '@wordpress/primitives';
+import { SVG, Rect, Path } from '@wordpress/primitives';
 import { Icon, menu } from '@wordpress/icons';
 
 export default function OverlayMenuIcon( { icon } ) {
 	if ( icon === 'menu' ) {
 		return <Icon icon={ menu } />;
+	}
+
+	if ( icon === 'quad-lines' ) {
+		return (
+			<SVG
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 24 24"
+				width="24"
+				height="24"
+				aria-hidden="true"
+				focusable="false"
+			>
+				<Rect x="10" y="17.2" width="14" height="1.6" />
+				<Rect x="10" y="13.2" width="14" height="1.6" />
+				<Rect x="10" y="9.2" width="14" height="1.6" />
+				<Rect x="10" y="5.2" width="14" height="1.6" />
+			</SVG>
+		);
+	}
+
+	if ( icon === 'menu-alt' ) {
+		return (
+			<SVG
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 24 24"
+				width="24"
+				height="24"
+			>
+				<Path
+					d="M4 6H20M7 12H17M9 18H15"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				/>
+			</SVG>
+		);
+	}
+
+	if ( icon === 'hamburger-2' ) {
+		return (
+			<SVG
+				width="24"
+				height="24"
+				viewBox="0 0 24 24"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<Path
+					d="M4 17H8M12 17H20M4 12H20M4 7H12M16 7H20"
+					stroke="currentColor"
+					stroke-width="1.5"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				/>
+			</SVG>
+		);
+	}
+
+	if ( icon === 'grid' ) {
+		return (
+			<SVG
+				fill="currentColor"
+				width="24"
+				height="24"
+				viewBox="0 0 16 16"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<Path
+					d="M0 0h4v4H0V0zm0 6h4v4H0V6zm0 6h4v4H0v-4zM6 0h4v4H6V0zm0 6h4v4H6V6zm0 6h4v4H6v-4zm6-12h4v4h-4V0zm0 6h4v4h-4V6zm0 6h4v4h-4v-4z"
+					fill-rule="evenodd"
+				/>
+			</SVG>
+		);
 	}
 
 	return (

--- a/packages/block-library/src/navigation/edit/overlay-menu-preview.js
+++ b/packages/block-library/src/navigation/edit/overlay-menu-preview.js
@@ -45,6 +45,26 @@ export default function OverlayMenuPreview( { setAttributes, hasIcon, icon } ) {
 					aria-label={ __( 'menu' ) }
 					label={ <OverlayMenuIcon icon="menu" /> }
 				/>
+				<ToggleGroupControlOption
+					value="menu-alt"
+					aria-label={ __( 'menu-alt' ) }
+					label={ <OverlayMenuIcon icon="menu-alt" /> }
+				/>
+				<ToggleGroupControlOption
+					value="quad-lines"
+					aria-label={ __( 'quad-lines' ) }
+					label={ <OverlayMenuIcon icon="quad-lines" /> }
+				/>
+				<ToggleGroupControlOption
+					value="grid"
+					aria-label={ __( 'grid' ) }
+					label={ <OverlayMenuIcon icon="grid" /> }
+				/>
+				<ToggleGroupControlOption
+					value="hamburger-2"
+					aria-label={ __( 'hamburger-2' ) }
+					label={ <OverlayMenuIcon icon="hamburger-2" /> }
+				/>
 			</ToggleGroupControl>
 		</>
 	);

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -482,13 +482,13 @@ class WP_Navigation_Block_Renderer {
 		if ( isset( $attributes['icon'] ) ) {
 			if ( 'menu' === $attributes['icon'] ) {
 				$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5 5v1.5h14V5H5zm0 7.8h14v-1.5H5v1.5zM5 19h14v-1.5H5V19z" /></svg>';
-			} else if ( 'quad-lines' === $attributes['icon'] ) {
+			} elseif ( 'quad-lines' === $attributes['icon'] ) {
 				$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M3 4h18a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2z"/><path d="M3 8h18a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2z"/><path d="M3 12h18a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2z"/><path d="M3 16h18a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2z"/></svg>';
-			} else if ( 'menu-alt' === $attributes['icon'] ) {
+			} elseif ( 'menu-alt' === $attributes['icon'] ) {
 				$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M4 6H20M7 12H17M9 18H15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>';
-			} else if ( 'hamburger-2' === $attributes['icon'] ) {
+			} elseif ( 'hamburger-2' === $attributes['icon'] ) {
 				$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M4 17H8M12 17H20M4 12H20M4 7H12M16 7H20" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>';
-			} else if ( 'grid' === $attributes['icon'] ) {
+			} elseif ( 'grid' === $attributes['icon'] ) {
 				$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h4v4H0V0zm0 6h4v4H0V6zm0 6h4v4H0v-4zM6 0h4v4H6V0zm0 6h4v4H6V6zm0 6h4v4H6v-4zm6-12h4v4h-4V0zm0 6h4v4h-4V6zm0 6h4v4h-4v-4z" fill-rule="evenodd"/></svg>';
 			}
 		}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -482,6 +482,14 @@ class WP_Navigation_Block_Renderer {
 		if ( isset( $attributes['icon'] ) ) {
 			if ( 'menu' === $attributes['icon'] ) {
 				$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5 5v1.5h14V5H5zm0 7.8h14v-1.5H5v1.5zM5 19h14v-1.5H5V19z" /></svg>';
+			} else if ( 'quad-lines' === $attributes['icon'] ) {
+				$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M3 4h18a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2z"/><path d="M3 8h18a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2z"/><path d="M3 12h18a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2z"/><path d="M3 16h18a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2z"/></svg>';
+			} else if ( 'menu-alt' === $attributes['icon'] ) {
+				$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M4 6H20M7 12H17M9 18H15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+			} else if ( 'hamburger-2' === $attributes['icon'] ) {
+				$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M4 17H8M12 17H20M4 12H20M4 7H12M16 7H20" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+			} else if ( 'grid' === $attributes['icon'] ) {
+				$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h4v4H0V0zm0 6h4v4H0V6zm0 6h4v4H0v-4zM6 0h4v4H6V0zm0 6h4v4H6V6zm0 6h4v4H6v-4zm6-12h4v4h-4V0zm0 6h4v4h-4V6zm0 6h4v4h-4v-4z" fill-rule="evenodd"/></svg>';
 			}
 		}
 		$toggle_button_content       = $should_display_icon_label ? $toggle_button_icon : __( 'Menu' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL --> https://github.com/WordPress/gutenberg/issues/61755

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This PR introduces additional icon options for the collapsed state of the Navigation block. It expands beyond the current two icons by allowing block users to choose from a broader set of icons, offering more flexibility in design and user interface customization.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Added new SVG icons inside `edit/overlay-menu-icon.js`, expanding the visual choices for the collapsed navigation menu.

- Updated `overlay-menu-preview.js` to include additional `ToggleGroupControlOption` entries for each new icon, allowing users to select them via the block editor UI.

- Modified `index.php` to render the correct icon on the front end based on the selected option, ensuring consistency between the editor preview and the published content.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open the block editor on any post or page.
2. Insert a Navigation block (or select an existing one).
3. In the block settings sidebar, enable the "Enable overlay menu on mobile" option to trigger the collapsed menu behavior.
4. Scroll to the "Overlay Menu Icon" section.
5. You should now see multiple icon options presented as toggle buttons.
6. Select each icon and verify:
    - The correct icon displays in the editor preview.
    - The icon reflects your selection when viewing the front end (after saving/publishing the page).
7. Save and preview the post/page. Confirm that the selected icon renders correctly on mobile (or when simulating a small screen).
8. Test switching between icons multiple times to ensure there are no regressions or persistence issues.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Navigate to the Navigation block using the Tab key.
2. Use Tab to focus on the Overlay Menu Icon toggle group.
3. Use Arrow keys (←/→) to move between the icon choices.
4. Press Enter or Space to select an icon.
5. Ensure the icon updates visually in the editor as expected.
6. Save the page and verify that the chosen icon is used on the front end, confirming that keyboard selection changes persist.

## Screenshots or screencast <!-- if applicable -->
https://www.loom.com/share/6d076126729144e492b85480debbe666?sid=0ccf0a44-13d3-4d20-b583-7b74770e3b74

