### PR TITLE
Remove "global" from styles variation in schema descriptions

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -2579,15 +2579,15 @@
 			"const": 3
 		},
 		"title": {
-			"description": "Title of the global styles variation. If not defined, the file name will be used.",
+			"description": "Title of the styles variation. If not defined, the file name will be used.",
 			"type": "string"
 		},
 		"slug": {
-			"description": "Slug of the global styles variation. If not defined, the kebab-case title will be used.",
+			"description": "Slug of the styles variation. If not defined, the kebab-case title will be used.",
 			"type": "string"
 		},
 		"description": {
-			"description": "Description of the global styles variation.",
+			"description": "Description of the styles variation.",
 			"type": "string"
 		},
 		"blockTypes": {


### PR DESCRIPTION
## What?

This PR updates the description for the `title`, `slug`, and `description` properties in the theme.json schema.

Since this schema is now used for [global style variations](https://developer.wordpress.org/themes/global-settings-and-styles/style-variations/) and [block style variations](https://developer.wordpress.org/themes/features/block-style-variations/), removing the term "global" makes the description universal.

## Testing Instructions

1. Open a WordPress project in VS Code or a similar editor.
2. Add or update a theme.json to include the `title`, `slug`, and `description` parameters.
3. Update the schema to point to the updated file.
4. Hover over the property to reveal the schema hint.

`"$schema": "../../plugins/gutenberg/schemas/json/theme.json"`, or similar.
