### PR TITLE
MediaPlaceholder: Fix potential error in 'handleBlocksDrop'

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -272,11 +272,11 @@ export function MediaPlaceholder( {
 			} )
 		).catch( ( err ) => onError( err ) );
 
-		if ( multiple ) {
-			onSelect( uploadedMediaList );
-		} else {
-			onSelect( uploadedMediaList[ 0 ] );
+		if ( ! uploadedMediaList?.length ) {
+			return;
 		}
+
+		onSelect( multiple ? uploadedMediaList : uploadedMediaList[ 0 ] );
 	}
 
 	const onUpload = ( event ) => {


### PR DESCRIPTION
## What?

PR updates `handleBlocksDrop` to avoid errors when `uploadedMediaList` is undefined or an empty array.

## Why?
Discovered this bug while debugging a separate issue. Please take a look at the testing instructions.

## Testing Instructions
1. Open a post or page.
2. Add an image block.
3. Open the inserter.
4. Switch to the Media tab and try dragging the image. Cancel the process after the dropzone is activated.
5. Switch to the Blocks tab and try dragging any block.
6. Notice that the dropzone is activated.
7. Drop this block should display an error notice, but not an actual error in the console.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2025-05-09 at 13 48 08](https://github.com/user-attachments/assets/3597d67b-9f06-4d75-91db-ec4fd0907746)
