### PR TITLE
Templates: Add back button & fix focus loss when navigating through template creation flow

### DIFF
--- a/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal-content.js
@@ -23,14 +23,9 @@ function AddCustomGenericTemplateModalContent( { createTemplate, onBack } ) {
 
 	// Set focus to the name input when the component mounts
 	useEffect( () => {
-		// Use requestAnimationFrame to ensure the DOM is fully rendered
-		const frameId = window.requestAnimationFrame( () => {
-			if ( inputRef.current ) {
-				inputRef.current.focus();
-			}
-		} );
-
-		return () => window.cancelAnimationFrame( frameId );
+		if ( inputRef.current ) {
+			inputRef.current.focus();
+		}
 	}, [] );
 
 	async function onCreateTemplate( event ) {

--- a/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal-content.js
@@ -6,7 +6,7 @@ import { paramCase as kebabCase } from 'change-case';
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	Button,
@@ -15,10 +15,24 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 
-function AddCustomGenericTemplateModalContent( { onClose, createTemplate } ) {
+function AddCustomGenericTemplateModalContent( { createTemplate, onBack } ) {
 	const [ title, setTitle ] = useState( '' );
 	const defaultTitle = __( 'Custom Template' );
 	const [ isBusy, setIsBusy ] = useState( false );
+	const inputRef = useRef();
+
+	// Set focus to the name input when the component mounts
+	useEffect( () => {
+		// Use requestAnimationFrame to ensure the DOM is fully rendered
+		const frameId = window.requestAnimationFrame( () => {
+			if ( inputRef.current ) {
+				inputRef.current.focus();
+			}
+		} );
+
+		return () => window.cancelAnimationFrame( frameId );
+	}, [] );
+
 	async function onCreateTemplate( event ) {
 		event.preventDefault();
 		if ( isBusy ) {
@@ -50,6 +64,7 @@ function AddCustomGenericTemplateModalContent( { onClose, createTemplate } ) {
 					onChange={ setTitle }
 					placeholder={ defaultTitle }
 					disabled={ isBusy }
+					ref={ inputRef }
 					help={ __(
 						// eslint-disable-next-line no-restricted-syntax -- 'sidebar' is a common web design term for layouts
 						'Describe the template, e.g. "Post with sidebar". A custom template can be manually applied to any post or page.'
@@ -62,11 +77,9 @@ function AddCustomGenericTemplateModalContent( { onClose, createTemplate } ) {
 					<Button
 						__next40pxDefaultSize
 						variant="tertiary"
-						onClick={ () => {
-							onClose();
-						} }
+						onClick={ onBack }
 					>
-						{ __( 'Cancel' ) }
+						{ __( 'Back' ) }
 					</Button>
 					<Button
 						__next40pxDefaultSize

--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
@@ -260,6 +260,15 @@ function AddCustomTemplateModalContent( { onSelect, entityForSuggestions } ) {
 						entityForSuggestions={ entityForSuggestions }
 						onSelect={ onSelect }
 					/>
+					<Flex justify="right">
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							onClick={ () => setShowSearchEntities( false ) }
+						>
+							{ __( 'Back' ) }
+						</Button>
+					</Flex>
 				</>
 			) }
 		</VStack>

--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
@@ -165,7 +165,11 @@ function SuggestionList( { entityForSuggestions, onSelect } ) {
 	);
 }
 
-function AddCustomTemplateModalContent( { onSelect, entityForSuggestions } ) {
+function AddCustomTemplateModalContent( {
+	onSelect,
+	entityForSuggestions,
+	onBack,
+} ) {
 	const [ showSearchEntities, setShowSearchEntities ] = useState(
 		entityForSuggestions.hasGeneralTemplate
 	);
@@ -247,6 +251,15 @@ function AddCustomTemplateModalContent( { onSelect, entityForSuggestions } ) {
 							</Text>
 						</FlexItem>
 					</Flex>
+					<Flex justify="right">
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							onClick={ onBack }
+						>
+							{ __( 'Back' ) }
+						</Button>
+					</Flex>
 				</>
 			) }
 			{ showSearchEntities && (
@@ -264,7 +277,15 @@ function AddCustomTemplateModalContent( { onSelect, entityForSuggestions } ) {
 						<Button
 							__next40pxDefaultSize
 							variant="tertiary"
-							onClick={ () => setShowSearchEntities( false ) }
+							onClick={ () => {
+								// If general template exists, go directly back to main screen
+								// instead of showing the choice screen
+								if ( entityForSuggestions.hasGeneralTemplate ) {
+									onBack();
+								} else {
+									setShowSearchEntities( false );
+								}
+							} }
 						>
 							{ __( 'Back' ) }
 						</Button>

--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
@@ -16,6 +16,7 @@ import {
 import { useEntityRecords } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useDebouncedInput } from '@wordpress/compose';
+import { focus } from '@wordpress/dom';
 
 /**
  * Internal dependencies
@@ -169,10 +170,23 @@ function AddCustomTemplateModalContent( {
 	onSelect,
 	entityForSuggestions,
 	onBack,
+	containerRef,
 } ) {
 	const [ showSearchEntities, setShowSearchEntities ] = useState(
 		entityForSuggestions.hasGeneralTemplate
 	);
+
+	// Focus on the first focusable element when the modal opens.
+	// We handle focus management in the parent modal, just need to focus on the first focusable element.
+	useEffect( () => {
+		if ( containerRef.current ) {
+			const [ firstFocusable ] = focus.focusable.find(
+				containerRef.current
+			);
+			firstFocusable?.focus();
+		}
+	}, [ showSearchEntities ] );
+
 	return (
 		<VStack
 			spacing={ 4 }

--- a/packages/edit-site/src/components/add-new-template/index.js
+++ b/packages/edit-site/src/components/add-new-template/index.js
@@ -16,7 +16,7 @@ import {
 	Icon,
 } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
-import { useState, memo } from '@wordpress/element';
+import { useState, memo, useRef, useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { useViewportMatch } from '@wordpress/compose';
@@ -41,6 +41,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { focus } from '@wordpress/dom';
 
 /**
  * Internal dependencies
@@ -162,7 +163,7 @@ function NewTemplateModal( { onClose } ) {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createErrorNotice, createSuccessNotice } =
 		useDispatch( noticesStore );
-
+	const containerRef = useRef( null );
 	const isMobile = useViewportMatch( 'medium', '<' );
 
 	const homeUrl = useSelect( ( select ) => {
@@ -179,6 +180,20 @@ function NewTemplateModal( { onClose } ) {
 			homeUrl + '/' + new Date().getFullYear()
 		),
 	};
+
+	useEffect( () => {
+		// Focus the first focusable element when component mounts or UI changes
+		// We don't want to focus on the other modals because they have their own focus management.
+		if (
+			containerRef.current &&
+			modalContent === modalContentMap.templatesList
+		) {
+			const [ firstFocusable ] = focus.focusable.find(
+				containerRef.current
+			);
+			firstFocusable?.focus();
+		}
+	}, [ modalContent ] );
 
 	async function createTemplate( template, isWPSuggestion = true ) {
 		if ( isSubmitting ) {
@@ -261,6 +276,7 @@ function NewTemplateModal( { onClose } ) {
 					? 'edit-site-custom-generic-template__modal'
 					: undefined
 			}
+			ref={ containerRef }
 		>
 			{ modalContent === modalContentMap.templatesList && (
 				<Grid
@@ -323,6 +339,7 @@ function NewTemplateModal( { onClose } ) {
 					onBack={ () =>
 						setModalContent( modalContentMap.templatesList )
 					}
+					containerRef={ containerRef }
 				/>
 			) }
 			{ modalContent === modalContentMap.customGenericTemplate && (

--- a/packages/edit-site/src/components/add-new-template/index.js
+++ b/packages/edit-site/src/components/add-new-template/index.js
@@ -324,8 +324,10 @@ function NewTemplateModal( { onClose } ) {
 			) }
 			{ modalContent === modalContentMap.customGenericTemplate && (
 				<AddCustomGenericTemplateModalContent
-					onClose={ onModalClose }
 					createTemplate={ createTemplate }
+					onBack={ () =>
+						setModalContent( modalContentMap.templatesList )
+					}
 				/>
 			) }
 		</Modal>

--- a/packages/edit-site/src/components/add-new-template/index.js
+++ b/packages/edit-site/src/components/add-new-template/index.js
@@ -320,6 +320,9 @@ function NewTemplateModal( { onClose } ) {
 				<AddCustomTemplateModalContent
 					onSelect={ createTemplate }
 					entityForSuggestions={ entityForSuggestions }
+					onBack={ () =>
+						setModalContent( modalContentMap.templatesList )
+					}
 				/>
 			) }
 			{ modalContent === modalContentMap.customGenericTemplate && (


### PR DESCRIPTION
Added by @t-hamano 

> [!NOTE]
> Don't forget to add @Sourav61, who worked in #69711,  as a co-author when merging this PR.

---

## What?
Closes #69711

Adds a Back button to the template creation flow and sets focus on the name input field when creating a custom template.

## Why?
When clicking the "Custom template" button, the focus is currently lost, causing accessibility issues for screen reader users. This PR fixes the focus management and improves the navigation flow by adding a Back button that allows users to return to the previous step without closing the entire modal.

## How?
- Added a Back button to the custom template modal that returns users to the template selection screen
- Implemented focus management using requestAnimationFrame to set focus on the name input field when the custom template modal opens
- Removed the redundant Cancel button to simplify the UI and make navigation more intuitive

## Testing Instructions
1. Open the Site Editor
2. Click on "Templates" in the navigation menu
3. Click the "Add Template" button
4. Click the "Custom template" button
5. Verify that focus is set on the Name input field
6. Click the "Back" button
7. Verify that you return to the template selection screen

### Testing Instructions for Keyboard
1. Open the Site Editor
2. Use Tab to navigate to the "Templates" option in the navigation menu and press Enter
3. Tab to the "Add Template" button and press Enter
4. Tab to the "Custom template" button and press Enter
5. Verify that focus is automatically set on the Name input field
6. Tab to the "Back" button and press Enter
7. Verify that you return to the template selection screen

## Screencast
https://q7utzrengv.ufs.sh/f/Wgl9eBAmTj29r0ltzJ9bvXLPnVf0wHAxqleM96uGDdWoCa3T