### PR TITLE
Add Left and Right Alignment Support to Separator Block Toolbar

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -827,8 +827,8 @@ Create a break between ideas or sections with a horizontal separator. ([Source](
 
 -	**Name:** core/separator
 -	**Category:** design
--	**Supports:** align (center, full, wide), anchor, color (background, gradients, ~~enableContrastChecker~~, ~~text~~), interactivity (clientNavigation), spacing (margin)
--	**Attributes:** opacity, tagName
+-	**Supports:** align (center, full, left, right, wide), anchor, color (background, gradients, ~~enableContrastChecker~~, ~~text~~), interactivity (clientNavigation), spacing (margin)
+-	**Attributes:** align, opacity, tagName
 
 ## Shortcode
 

--- a/packages/block-library/src/separator/block.json
+++ b/packages/block-library/src/separator/block.json
@@ -8,6 +8,9 @@
 	"keywords": [ "horizontal-line", "hr", "divider" ],
 	"textdomain": "default",
 	"attributes": {
+		"align": {
+			"type": "string"
+		},
 		"opacity": {
 			"type": "string",
 			"default": "alpha-channel"
@@ -20,7 +23,7 @@
 	},
 	"supports": {
 		"anchor": true,
-		"align": [ "center", "wide", "full" ],
+		"align": [ "center", "wide", "full", "left", "right" ],
 		"color": {
 			"enableContrastChecker": false,
 			"__experimentalSkipSerialization": true,

--- a/packages/block-library/src/separator/edit.js
+++ b/packages/block-library/src/separator/edit.js
@@ -29,7 +29,7 @@ export default function SeparatorEdit( {
 	setAttributes,
 	clientId,
 } ) {
-	const { backgroundColor, opacity, style, tagName } = attributes;
+	const { backgroundColor, opacity, style, tagName, align } = attributes;
 	const colorProps = useColorProps( attributes );
 	const currentColor = colorProps?.style?.backgroundColor;
 	const hasCustomColor = !! style?.color?.background;
@@ -73,7 +73,10 @@ export default function SeparatorEdit( {
 			</InspectorControls>
 			<Wrapper
 				{ ...useBlockProps( {
-					className,
+					className: clsx(
+						className,
+						align ? `align${ align }` : null
+					),
 					style: hasCustomColor ? styles : undefined,
 				} ) }
 			/>

--- a/packages/block-library/src/separator/save.js
+++ b/packages/block-library/src/separator/save.js
@@ -13,7 +13,7 @@ import {
 } from '@wordpress/block-editor';
 
 export default function separatorSave( { attributes } ) {
-	const { backgroundColor, style, opacity, tagName: Tag } = attributes;
+	const { backgroundColor, style, opacity, tagName: Tag, align } = attributes;
 	const customColor = style?.color?.background;
 	const colorProps = getColorClassesAndStyles( attributes );
 	// The hr support changing color using border-color, since border-color
@@ -30,7 +30,8 @@ export default function separatorSave( { attributes } ) {
 			'has-css-opacity': opacity === 'css',
 			'has-alpha-channel-opacity': opacity === 'alpha-channel',
 		},
-		colorProps.className
+		colorProps.className,
+		align ? `align${ align }` : null
 	);
 
 	const styles = {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/42103

<!-- In a few words, what is the PR actually doing? -->
This PR enables `left` and `right` alignment options in the Separator block toolbar, in addition to the existing center, wide, and full alignments.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The Separator block previously lacked the ability to align content to the left or right, which limited layout flexibility for themes and custom block use cases. Adding support for left and right aligns the block's behavior with other layout blocks and improves design consistency.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Updates block.json to include "left" and "right" in the supports.align array.
- Enhances `edit.js` and `save.js` to apply alignleft/alignright CSS classes via useBlockProps based on the align attribute.
- Ensures that the align attribute is respected both in the editor and frontend.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open the block editor and insert a Separator block.
2. Check the alignment toolbar: you should see Left, Center, Right, Wide, and Full options.
3. Switch between each alignment and confirm the block's position updates correctly in the editor and on the front-end.
4. Save and reload the post/page to verify persistence of alignment.
5. Check for style regressions when custom background color or tag name (`<hr>` or `<div>`) is selected.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Navigated to the alignment toolbar using Tab and Arrow Keys.
2. Confirmed alignment controls are operable via keyboard.
3. Checked that visual focus indicators are intact.
4. Verified that screen readers announce alignment options appropriately.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/2e427a1e-d4dd-4c40-8411-155fdd12b275
