### PR TITLE
Raw Handler: Handle presence of both markdown and block markup when pasting

### DIFF
--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -32,6 +32,7 @@ import brRemover from './br-remover';
 import { deepFilterHTML, isPlain, getBlockContentSchema } from './utils';
 import emptyParagraphRemover from './empty-paragraph-remover';
 import slackParagraphCorrector from './slack-paragraph-corrector';
+import { rawHandler } from '.';
 
 const log = ( ...args ) => window?.console?.log?.( ...args );
 
@@ -100,11 +101,21 @@ export function pasteHandler( {
 		const content = HTML ? HTML : plainText;
 
 		if ( content.indexOf( '<!-- wp:' ) !== -1 ) {
-			const parseResult = parse( content );
+			let parseResult = parse( markdownConverter( content ) );
 			const isSingleFreeFormBlock =
 				parseResult.length === 1 &&
 				parseResult[ 0 ].name === 'core/freeform';
 			if ( ! isSingleFreeFormBlock ) {
+				// Convert classic content to blocks.
+				parseResult = parseResult.flatMap( ( block ) => {
+					if ( 'core/freeform' === block.name ) {
+						const newBlock = rawHandler( {
+							HTML: block.originalContent,
+						} );
+						return newBlock;
+					}
+					return block;
+				} );
 				return parseResult;
 			}
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: #70065 

The PR handles the presence of both markdown and block markup when pasting.
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, when content containing both Markdown and block markup is pasted, it doesn’t parse as expected.
Example
~~~
```
<!-- wp:pattern {"slug":"twentytwentyfive/header"} /-->

```
~~~
The block markup inside the fenced code block is incorrectly rendered as content, rather than being treated as code.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The pasted content is now passed through a Markdown-to-HTML converter before block parsing begins. Additionally, After parsing any classic content is converted to blocks using the `rawHandler`.
This allows mixed content to be parsed correctly. For instance:

~~~
<!-- wp:pattern {"slug":"twentytwentyfive/header"} /-->
# Some heading
```
<!-- wp:pattern {"slug":"twentytwentyfive/header"} /-->
```
~~~

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open a post
2. Paste content containing a mix of Markdown and block markup to match format (cmd/ctrl + shift + v). Example:
~~~
<!-- wp:pattern {"slug":"twentytwentyfive/header"} /-->
# Some heading
```
<!-- wp:pattern {"slug":"twentytwentyfive/header"} /-->
```
~~~
3. Confirm that:
- The block markup outside the code block is parsed into blocks.
- The block markup inside the fenced code block is preserved as code and not parsed as a block.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="1470" alt="image" src="https://github.com/user-attachments/assets/61aed746-12ed-4645-8ac7-95d081e3b9b8" /> | <img width="1470" alt="image" src="https://github.com/user-attachments/assets/a9514642-f610-451f-8680-794576fe06e3" /> |
