### PR TITLE
HTML Anchors: Add tab index

### DIFF
--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -124,6 +124,7 @@ export default {
 export function addSaveProps( extraProps, blockType, attributes ) {
 	if ( hasBlockSupport( blockType, 'anchor' ) ) {
 		extraProps.id = attributes.anchor === '' ? null : attributes.anchor;
+		extraProps.tabIndex = -1;
 	}
 
 	return extraProps;


### PR DESCRIPTION
## What?
Adds tabIndex="-1" to non-interactive elements with HTML anchors to improve accessibility.
Closes: #70085

## Why?
When users navigate to HTML anchors, the browser scrolls to that element, but keyboard focus doesn't follow for elements.

## How?
Enhanced the `addSaveProps` function in `packages/block-editor/src/hooks/anchor.js` to add tabIndex="-1".

## Testing Instructions
1. Edit a page.
3. Go to the "Block" tab panel settings.
4. Activate the "Advanced" disclosure.
5. Add a word to the "HTML Anchor" field.
6. Add a link elsewhere on the page.
7. Set the link URL to match the HTML Anchor value (prefixed with a #).
8. View the page.
9. Activate the link you added.
10. See anchor element get focus and should have `tabindex = -1`, also see the active element after pressing the internal linked anchor by using below console code:
```
document.activeElement
```

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/921f63a9-207b-44b1-835e-5b54eaf485da)|![image](https://github.com/user-attachments/assets/11a76887-46fa-4048-b3c7-4ab6447b2e2e)|
|![image](https://github.com/user-attachments/assets/37b512a8-4f9e-4b19-ad52-cf22e92322af)|![image](https://github.com/user-attachments/assets/9e825a73-9201-436a-8e7e-278a1fedc639)|
|![image](https://github.com/user-attachments/assets/7a4dadba-5798-45f6-9be9-98e8bef4497f)|![image](https://github.com/user-attachments/assets/1012b73b-fdb6-46b8-8fb0-1a02560ba292)|