### PR TITLE
Enable More block's "Read more" text editing in contentOnly mode

### DIFF
--- a/packages/block-library/src/more/block.json
+++ b/packages/block-library/src/more/block.json
@@ -10,7 +10,8 @@
 	"attributes": {
 		"customText": {
 			"type": "string",
-			"default": ""
+			"default": "",
+			"role": "content"
 		},
 		"noTeaser": {
 			"type": "boolean",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of: https://github.com/WordPress/gutenberg/issues/65778

This PR fixes an issue with the More block where users cannot edit the "Read more" text when the block is in contentOnly mode.

## How?
Added `role: "content"` to the customText attribute in the More block's block.json file to explicitly mark it as editable content even in restricted editing modes.

## Testing Instructions
1. Create a Group block
2. Set the Group block's templateLock attribute to "contentOnly"
3. Insert a More block inside this Group
4. Try to edit the "Read more" text

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/7599fac9-c50c-4574-8c13-b59302da023d


