### PR TITLE
Block Library: Add missing transforms between Verse and Preformatted blocks

### DIFF
--- a/packages/block-library/src/preformatted/test/__snapshots__/transforms.native.js.snap
+++ b/packages/block-library/src/preformatted/test/__snapshots__/transforms.native.js.snap
@@ -29,3 +29,9 @@ exports[`Preformatted block transforms to Paragraph block 1`] = `
 <p>Some <em>preformatted</em> text...<br />And more!</p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`Preformatted block transforms to Verse block 1`] = `
+"<!-- wp:verse -->
+<pre class="wp-block-verse">Some <em>preformatted</em> text...<br>And more!</pre>
+<!-- /wp:verse -->"
+`;

--- a/packages/block-library/src/preformatted/test/__snapshots__/transforms.native.js.snap
+++ b/packages/block-library/src/preformatted/test/__snapshots__/transforms.native.js.snap
@@ -32,6 +32,6 @@ exports[`Preformatted block transforms to Paragraph block 1`] = `
 
 exports[`Preformatted block transforms to Verse block 1`] = `
 "<!-- wp:verse -->
-<pre class="wp-block-verse">Some <em>preformatted</em> text...<br>And more!</pre>
+<pre class="wp-block-verse">Some <em>preformatted</em> text...<br />And more!</pre>
 <!-- /wp:verse -->"
 `;

--- a/packages/block-library/src/preformatted/test/transforms.native.js
+++ b/packages/block-library/src/preformatted/test/transforms.native.js
@@ -16,7 +16,12 @@ const initialHtml = `
 <!-- /wp:preformatted -->`;
 
 const transformsWithInnerBlocks = [ 'Columns', 'Group' ];
-const blockTransforms = [ 'Paragraph', 'Code', ...transformsWithInnerBlocks ];
+const blockTransforms = [
+	'Paragraph',
+	'Code',
+	'Verse',
+	...transformsWithInnerBlocks,
+];
 
 setupCoreBlocks();
 

--- a/packages/block-library/src/preformatted/test/transforms.native.js
+++ b/packages/block-library/src/preformatted/test/transforms.native.js
@@ -16,12 +16,7 @@ const initialHtml = `
 <!-- /wp:preformatted -->`;
 
 const transformsWithInnerBlocks = [ 'Columns', 'Group' ];
-const blockTransforms = [
-	'Paragraph',
-	'Code',
-	'Verse',
-	...transformsWithInnerBlocks,
-];
+const blockTransforms = [ 'Paragraph', 'Code', ...transformsWithInnerBlocks ];
 
 setupCoreBlocks();
 

--- a/packages/block-library/src/preformatted/transforms.js
+++ b/packages/block-library/src/preformatted/transforms.js
@@ -7,7 +7,7 @@ const transforms = {
 	from: [
 		{
 			type: 'block',
-			blocks: [ 'core/code', 'core/paragraph' ],
+			blocks: [ 'core/code', 'core/paragraph', 'core/verse' ],
 			transform: ( { content, anchor } ) =>
 				createBlock( 'core/preformatted', {
 					content,
@@ -40,6 +40,15 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'core/code' ],
 			transform: ( attributes ) => createBlock( 'core/code', attributes ),
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/verse' ],
+			transform: ( { content, anchor } ) =>
+				createBlock( 'core/verse', {
+					content,
+					anchor,
+				} ),
 		},
 	],
 };

--- a/packages/block-library/src/preformatted/transforms.js
+++ b/packages/block-library/src/preformatted/transforms.js
@@ -44,11 +44,8 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/verse' ],
-			transform: ( { content, anchor } ) =>
-				createBlock( 'core/verse', {
-					content,
-					anchor,
-				} ),
+			transform: ( attributes ) =>
+				createBlock( 'core/verse', attributes ),
 		},
 	],
 };

--- a/packages/block-library/src/verse/test/__snapshots__/transforms.native.js.snap
+++ b/packages/block-library/src/verse/test/__snapshots__/transforms.native.js.snap
@@ -26,6 +26,6 @@ exports[`Verse block transforms to Paragraph block 1`] = `
 
 exports[`Verse block transforms to Preformatted block 1`] = `
 "<!-- wp:preformatted -->
-<pre class="wp-block-preformatted">Come<br>Home.</pre>
+<pre class="wp-block-preformatted">Come<br />Home.</pre>
 <!-- /wp:preformatted -->"
 `;

--- a/packages/block-library/src/verse/test/__snapshots__/transforms.native.js.snap
+++ b/packages/block-library/src/verse/test/__snapshots__/transforms.native.js.snap
@@ -23,3 +23,9 @@ exports[`Verse block transforms to Paragraph block 1`] = `
 <p>Come<br />Home.</p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`Verse block transforms to Preformatted block 1`] = `
+"<!-- wp:preformatted -->
+<pre class="wp-block-preformatted">Come<br>Home.</pre>
+<!-- /wp:preformatted -->"
+`;

--- a/packages/block-library/src/verse/test/transforms.native.js
+++ b/packages/block-library/src/verse/test/transforms.native.js
@@ -16,7 +16,11 @@ const initialHtml = `
 <!-- /wp:verse -->`;
 
 const transformsWithInnerBlocks = [ 'Columns', 'Group' ];
-const blockTransforms = [ 'Paragraph', ...transformsWithInnerBlocks ];
+const blockTransforms = [
+	'Paragraph',
+	'Preformatted',
+	...transformsWithInnerBlocks,
+];
 
 setupCoreBlocks();
 

--- a/packages/block-library/src/verse/test/transforms.native.js
+++ b/packages/block-library/src/verse/test/transforms.native.js
@@ -16,11 +16,7 @@ const initialHtml = `
 <!-- /wp:verse -->`;
 
 const transformsWithInnerBlocks = [ 'Columns', 'Group' ];
-const blockTransforms = [
-	'Paragraph',
-	'Preformatted',
-	...transformsWithInnerBlocks,
-];
+const blockTransforms = [ 'Paragraph', ...transformsWithInnerBlocks ];
 
 setupCoreBlocks();
 

--- a/packages/block-library/src/verse/transforms.js
+++ b/packages/block-library/src/verse/transforms.js
@@ -28,15 +28,6 @@ const transforms = {
 			transform: ( attributes ) =>
 				createBlock( 'core/paragraph', attributes ),
 		},
-		{
-			type: 'block',
-			blocks: [ 'core/preformatted' ],
-			transform: ( { content, anchor } ) =>
-				createBlock( 'core/preformatted', {
-					content,
-					anchor,
-				} ),
-		},
 	],
 };
 

--- a/packages/block-library/src/verse/transforms.js
+++ b/packages/block-library/src/verse/transforms.js
@@ -11,6 +11,15 @@ const transforms = {
 			transform: ( attributes ) =>
 				createBlock( 'core/verse', attributes ),
 		},
+		{
+			type: 'block',
+			blocks: [ 'core/preformatted' ],
+			transform: ( { content, anchor } ) =>
+				createBlock( 'core/verse', {
+					content,
+					anchor,
+				} ),
+		},
 	],
 	to: [
 		{
@@ -18,6 +27,15 @@ const transforms = {
 			blocks: [ 'core/paragraph' ],
 			transform: ( attributes ) =>
 				createBlock( 'core/paragraph', attributes ),
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/preformatted' ],
+			transform: ( { content, anchor } ) =>
+				createBlock( 'core/preformatted', {
+					content,
+					anchor,
+				} ),
 		},
 	],
 };

--- a/packages/block-library/src/verse/transforms.js
+++ b/packages/block-library/src/verse/transforms.js
@@ -11,15 +11,6 @@ const transforms = {
 			transform: ( attributes ) =>
 				createBlock( 'core/verse', attributes ),
 		},
-		{
-			type: 'block',
-			blocks: [ 'core/preformatted' ],
-			transform: ( { content, anchor } ) =>
-				createBlock( 'core/verse', {
-					content,
-					anchor,
-				} ),
-		},
 	],
 	to: [
 		{
@@ -27,15 +18,6 @@ const transforms = {
 			blocks: [ 'core/paragraph' ],
 			transform: ( attributes ) =>
 				createBlock( 'core/paragraph', attributes ),
-		},
-		{
-			type: 'block',
-			blocks: [ 'core/preformatted' ],
-			transform: ( { content, anchor } ) =>
-				createBlock( 'core/preformatted', {
-					content,
-					anchor,
-				} ),
 		},
 	],
 };

--- a/packages/block-library/src/verse/transforms.js
+++ b/packages/block-library/src/verse/transforms.js
@@ -28,6 +28,15 @@ const transforms = {
 			transform: ( attributes ) =>
 				createBlock( 'core/paragraph', attributes ),
 		},
+		{
+			type: 'block',
+			blocks: [ 'core/preformatted' ],
+			transform: ( { content, anchor } ) =>
+				createBlock( 'core/preformatted', {
+					content,
+					anchor,
+				} ),
+		},
 	],
 };
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of: https://github.com/WordPress/gutenberg/issues/63635

Add missing block transforms between Verse and Preformatted blocks.

## Why?
Currently, there's no way to transform between Verse and Preformatted blocks. Adding this transformation improves the editor experience.

## Testing Instructions
1. Add a Verse block to the editor and add some content
2. Select the block and open the block converter
3. Verify you can convert to a Preformatted block and the content is preserved
4. Similarly, add a Preformatted block, add content, and verify you can convert it to a Verse block

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/19bdf660-7295-4335-b47a-8470e0422e86


