### PR TITLE
Add the SrcSet Attribute for Image Block in the Editor

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -285,7 +285,6 @@ export default function Image( {
 		metadata,
 	} = attributes;
 	const [ imageElement, setImageElement ] = useState();
-	const [ srcSet, setSrcSet ] = useState( '' );
 	const [ resizeDelta, setResizeDelta ] = useState( null );
 	const [ pixelSize, setPixelSize ] = useState( {} );
 	const [ offsetTop, setOffsetTop ] = useState( 0 );
@@ -623,11 +622,11 @@ export default function Image( {
 		return individualSrc.join( ',' );
 	}
 
-	useEffect( () => {
+	const srcSet = useMemo( () => {
 		if ( image ) {
-			const extractedSrcSet = extractSrcSetFromMedia( image );
-			setSrcSet( extractedSrcSet );
+			return extractSrcSetFromMedia( image );
 		}
+		return '';
 	}, [ image ] );
 
 	const sizeControls = (

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -285,6 +285,7 @@ export default function Image( {
 		metadata,
 	} = attributes;
 	const [ imageElement, setImageElement ] = useState();
+	const [ srcSet, setSrcSet ] = useState( '' );
 	const [ resizeDelta, setResizeDelta ] = useState( null );
 	const [ pixelSize, setPixelSize ] = useState( {} );
 	const [ offsetTop, setOffsetTop ] = useState( 0 );
@@ -595,6 +596,39 @@ export default function Image( {
 			lightbox: undefined,
 		} );
 	};
+
+	function extractSrcSetFromMedia( media ) {
+		const mediaDetails = media?.media_details ?? {};
+		const sizes = Object.values( mediaDetails?.sizes ?? {} );
+
+		if ( ! media || 0 === sizes.length ) {
+			return '';
+		}
+
+		const sortedSizes = sizes.sort(
+			( sort1, sort2 ) => sort1.width - sort2.width
+		);
+
+		// Holds the individual url in format url width
+		const individualSrc = sortedSizes.map( ( size ) => {
+			const curWidth = size.width;
+			const curUrl = size.source_url;
+
+			if ( curWidth && curUrl ) {
+				return ` ${ curUrl } ${ curWidth }w `;
+			}
+			return undefined;
+		} );
+
+		return individualSrc.join( ',' );
+	}
+
+	useEffect( () => {
+		if ( image ) {
+			const extractedSrcSet = extractSrcSetFromMedia( image );
+			setSrcSet( extractedSrcSet );
+		}
+	}, [ image ] );
 
 	const sizeControls = (
 		<InspectorControls>
@@ -910,6 +944,7 @@ export default function Image( {
 			<>
 				<img
 					src={ temporaryURL || url }
+					srcSet={ srcSet ?? '' }
 					alt={ defaultedAlt }
 					onError={ onImageError }
 					onLoad={ onImageLoad }

--- a/test/e2e/specs/editor/plugins/image-size.spec.js
+++ b/test/e2e/specs/editor/plugins/image-size.spec.js
@@ -53,7 +53,7 @@ test.describe( 'changing image size', () => {
 		// Verify that the custom size was applied to the image.
 		await expect(
 			editor.canvas.locator( `role=img[name="${ filename }"]` )
-		).toHaveCSS( 'width', '499px' );
+		).toHaveCSS( 'width', '610px' );
 		await expect(
 			page.locator( 'role=spinbutton[name="Width"i]' )
 		).toHaveValue( '' );


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/46953.

## Why?
On the frontend the srset attribute for images is properly set but in the editor the same functionality is not replicated.

## How?
When a new image is selected in the image block, the srcset attribute is calculated and added to the image element.

## Testing Instructions
1. Open a new Page/Post.
2. Add an Image Block.
3. Select an existing Image from the Media Library or Upload a new Image.
4. Try changing the sizes of the image and ensure the closest size available is displayed.


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

#### Before
<img width="1470" alt="Screenshot 2025-05-12 at 13 14 49" src="https://github.com/user-attachments/assets/f118a3ec-ec31-4fbc-bad8-a2cbe6d23ca8" />


#### After
<img width="1470" alt="Screenshot 2025-05-12 at 13 14 33" src="https://github.com/user-attachments/assets/ae0b2249-20e8-4ae4-aeb8-c0c3bf5ee6ce" />
