### PR TITLE
[Block-API] Add Support for Limiting Block Usage Within Parent

### DIFF
--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -53,10 +53,40 @@ export default function BlockActions( {
 					);
 				} ),
 				canDuplicate: blocks.every( ( block ) => {
+					if ( ! block ) {
+						return false;
+					}
+
+					// Check if block supports uniqueWithin: 'parent'.
+					const isUniqueInParent = hasBlockSupport(
+						block.name,
+						'uniqueWithin'
+					);
+
+					if ( isUniqueInParent ) {
+						const currentRootClientId = getBlockRootClientId(
+							block.clientId
+						);
+						const siblingBlocks =
+							select( blockEditorStore ).getBlocks(
+								currentRootClientId
+							);
+						const sameTypeCount = siblingBlocks.filter(
+							( sibling ) => sibling.name === block.name
+						).length;
+
+						// Block already exists in parent, can't duplicate
+						if ( sameTypeCount >= 1 ) {
+							return false;
+						}
+					}
+
 					return (
-						!! block &&
 						hasBlockSupport( block.name, 'multiple', true ) &&
-						canInsertBlockType( block.name, rootClientId )
+						canInsertBlockType(
+							block.name,
+							getBlockRootClientId( block.clientId )
+						)
 					);
 				} ),
 			};

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1737,12 +1737,24 @@ const canInsertBlockTypeUnmemoized = (
 		);
 	}
 
-	const canInsert =
+	let canInsert =
 		hasBlockAllowedAncestor &&
 		( ( hasParentAllowedBlock === null &&
 			hasBlockAllowedParent === null ) ||
 			hasParentAllowedBlock === true ||
 			hasBlockAllowedParent === true );
+
+	const isUniqueInParent = hasBlockSupport( blockType.name, 'uniqueWithin' );
+
+	if ( isUniqueInParent ) {
+		const siblingBlocks = getBlocks( state, rootClientId );
+		const alreadyExistsInParent = siblingBlocks.some(
+			( block ) => block.name === blockType.name
+		);
+		if ( alreadyExistsInParent ) {
+			canInsert = false;
+		}
+	}
 
 	if ( ! canInsert ) {
 		return canInsert;
@@ -2023,13 +2035,14 @@ const calculateFrecency = ( time, count ) => {
  * in a specific context. It's used for building items for Inserter and available
  * block Transfroms list.
  *
- * @param {Object} state              Editor state.
- * @param {Object} options            Options object for handling the building of a block type.
- * @param {string} options.buildScope The scope for which the item is going to be used.
+ * @param {Object}  state              Editor state.
+ * @param {Object}  options            Options object for handling the building of a block type.
+ * @param {string}  options.buildScope The scope for which the item is going to be used.
+ * @param {?string} rootClientId
  * @return {Function} Function returns an item to be shown in a specific context (Inserter|Transforms list).
  */
 const buildBlockTypeItem =
-	( state, { buildScope = 'inserter' } ) =>
+	( state, { buildScope = 'inserter' }, rootClientId ) =>
 	( blockType ) => {
 		const id = blockType.name;
 
@@ -2039,6 +2052,20 @@ const buildBlockTypeItem =
 				state,
 				getClientIdsWithDescendants( state )
 			).some( ( { name } ) => name === blockType.name );
+		}
+		const isUniqueInParent = hasBlockSupport(
+			blockType.name,
+			'uniqueWithin'
+		);
+
+		if ( isUniqueInParent ) {
+			const siblingBlocks = getBlocks( state, rootClientId );
+			const alreadyExistsInParent = siblingBlocks.some(
+				( block ) => block.name === blockType.name
+			);
+			if ( alreadyExistsInParent ) {
+				isDisabled = true;
+			}
 		}
 
 		const { time, count = 0 } = getInsertUsage( state, id ) || {};
@@ -2141,9 +2168,13 @@ export const getInserterItems = createRegistrySelector( ( select ) =>
 						.map( buildReusableBlockInserterItem )
 				: [];
 
-			const buildBlockTypeInserterItem = buildBlockTypeItem( state, {
-				buildScope: 'inserter',
-			} );
+			const buildBlockTypeInserterItem = buildBlockTypeItem(
+				state,
+				{
+					buildScope: 'inserter',
+				},
+				rootClientId
+			);
 
 			let blockTypeInserterItems = getBlockTypes()
 				.filter( ( blockType ) =>
@@ -2263,6 +2294,7 @@ export const getBlockTransformItems = createRegistrySelector( ( select ) =>
 				: [ blocks ];
 			const buildBlockTypeTransformItem = buildBlockTypeItem( state, {
 				buildScope: 'transform',
+				rootClientId,
 			} );
 			const blockTypeTransformItems = getBlockTypes()
 				.filter( ( blockType ) =>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Introduces the ability to Limit Block Usage Within Parent, allowing a block (e.g., a "Login" button) to appear only once within the parent block.
Closes https://github.com/WordPress/gutenberg/issues/38958

## Why?
WordPress currently supports limiting a block’s usage to once per post/page via supports: { multiple: false }. But this limitation is too broad for nuanced layout structures. This enhancement allows greater design flexibility and cleaner content authoring by preventing UI redundancy within defined structural boundaries.

Example Use Case

- You have multiple Navigation blocks on a page (e.g., header and footer).
- You want to only allow one "Login" block per Navigation, not per page.
- With this feature, you can enforce that constraint per context, avoiding duplicate actions in a single section.

## How?

- Add a new meta `uniqueWithin` which can be set to `true` or `false`.
- Prevent redundant insertion, dragging & duplication of block if it already exists in a parent.

## Testing Instructions

1. Register a test block with uniqueWithin: true.
2. Add two Navigation blocks to a post/page.
3. Try inserting the limited block into both — it should work once per Navigation.
4. Try inserting a second one in the same Navigation.

<!--## Screenshots or screencast  if applicable -->
