### PR TITLE
Popover: Update Popover component documentation

### DIFF
--- a/packages/components/src/popover/README.md
+++ b/packages/components/src/popover/README.md
@@ -223,8 +223,19 @@ Possible values:
 
 Adjusts the size of the popover to prevent its contents from going out of view when meeting the viewport edges.
 
+**Note:** The `resize` and `shift` props are not intended to be used together. Enabling both can cause unexpected behavior.
+
 -   Required: No
 -   Default: `true`
+
+### `shift`: `boolean`
+
+Enables the `Popover` to shift in order to stay in view when meeting the viewport edges.
+
+**Note:** The `shift` and `resize` props are not intended to be used together. If you enable `shift`, set `resize` to `false`.
+
+-   Required: No
+-   Default: `false`
 
 ### `variant`: `'toolbar' | 'unstyled'`
 

--- a/packages/components/src/popover/types.ts
+++ b/packages/components/src/popover/types.ts
@@ -129,6 +129,8 @@ export type PopoverProps = {
 	/**
 	 * Adjusts the size of the popover to prevent its contents from going out of
 	 * view when meeting the viewport edges.
+	 * _Note: The `resize` and `shift` props are not intended to be used together.
+	 * Enabling both can cause unexpected behavior._
 	 *
 	 * @default true
 	 */
@@ -136,6 +138,8 @@ export type PopoverProps = {
 	/**
 	 * Enables the `Popover` to shift in order to stay in view when meeting the
 	 * viewport edges.
+	 * _Note: The `resize` and `shift` props are not intended to be used together.
+	 * Enabling both can cause unexpected behavior._
 	 *
 	 * @default false
 	 */


### PR DESCRIPTION
## What?
This PR addresses the documentation updates needed for the Popover component. The interaction between the `resize` and `shift` props can cause unexpected behavior when both are enabled simultaneously. This update clarifies their intended usage.
Closes: #68555
