### PR TITLE
Allow transforming Paragraph with single image to Image block

### DIFF
--- a/packages/block-library/src/image/transforms.js
+++ b/packages/block-library/src/image/transforms.js
@@ -210,6 +210,72 @@ const transforms = {
 				},
 			},
 		},
+		{
+			type: 'block',
+			blocks: [ 'core/paragraph' ],
+			isMatch: ( { content } ) => {
+				if ( ! content ) {
+					return false;
+				}
+				const trimmedContent = content.trim();
+				const { body } =
+					document.implementation.createHTMLDocument( '' );
+				body.innerHTML = trimmedContent;
+				return (
+					body.childNodes.length === 1 &&
+					body.firstChild.nodeName === 'IMG'
+				);
+			},
+			transform: ( { content } ) => {
+				const { body } =
+					document.implementation.createHTMLDocument( '' );
+				body.innerHTML = content.trim();
+				const imgElement = body.firstChild;
+
+				if ( ! imgElement ) {
+					return null;
+				}
+
+				const url = imgElement.getAttribute( 'src' );
+				const alt = imgElement.getAttribute( 'alt' ) || '';
+				const title = imgElement.getAttribute( 'title' );
+				const imgClassName = imgElement.getAttribute( 'class' ) || '';
+
+				let id;
+				const idMatches = /(?:^|\s)wp-image-(\d+)(?:$|\s)/.exec(
+					imgClassName
+				);
+				if ( idMatches ) {
+					id = Number( idMatches[ 1 ] );
+				}
+
+				const alignMatches =
+					/(?:^|\s)align(left|center|right|none)(?:$|\s)/.exec(
+						imgClassName
+					);
+				const align = alignMatches ? alignMatches[ 1 ] : undefined;
+
+				const imageAttributes = {
+					url,
+					alt,
+				};
+
+				if ( title ) {
+					imageAttributes.title = title;
+				}
+				if ( id ) {
+					imageAttributes.id = id;
+				}
+				if ( align ) {
+					imageAttributes.align = align;
+				}
+				if ( imgClassName ) {
+					imageAttributes.className = imgClassName;
+				}
+
+				return createBlock( 'core/image', imageAttributes );
+			},
+		},
 	],
 };
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of: https://github.com/WordPress/gutenberg/issues/63635

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
