### PR TITLE
Stylelint: Customise warning for `CSS` variables used outside `components` package 

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -19,8 +19,8 @@ module.exports = {
 				'/.*/': [ '/--wp-components-color-/' ],
 			},
 			{
-				message:
-					'--wp-components-color-* variables are not ready to be used outside of the components package.',
+				message: ( property, value ) =>
+					`Avoid using "${ value }" in "${ property }". --wp-components-color-* variables are not ready to be used outside of the components package.`,
 			},
 		],
 		'font-weight-notation': null,


### PR DESCRIPTION


## What?
Follow-up/Related: https://github.com/WordPress/gutenberg/pull/70057#issuecomment-2857332312

The warning message shown previously was static. This PR aims to make the Stylelint warning related to non-usage of `--wp-components-color-*` variables dynamic. ( Outside the `components/` package )


## How?
After the Stylelint configuration was updated to JavaScript via https://github.com/WordPress/gutenberg/pull/69590, now custom warnings can be shown for custom rules.

## Testing Instructions

1. Checkout any SCSS file located outside of the components package.
2. Add a color property with `--wp-components-color-accent` or any variable starting with `--wp-components-color-*`
3. Observe the warnings are dynamic.

## Screenshot 

<img width="823" alt="Screenshot 2025-05-13 at 3 35 51 PM" src="https://github.com/user-attachments/assets/df93655e-7306-42df-a04a-669a649553d8" />
