### PR TITLE
Blocks: Remove TODO for post comment block conversion

### DIFF
--- a/packages/blocks/src/api/parser/convert-legacy-block.js
+++ b/packages/blocks/src/api/parser/convert-legacy-block.js
@@ -50,7 +50,6 @@ export function convertLegacyBlockNameAndAttributes( name, attributes ) {
 	}
 
 	// Convert Post Comment blocks in existing content to Comment blocks.
-	// TODO: Remove these checks when WordPress 6.0 is released.
 	if ( name === 'core/post-comment-author' ) {
 		name = 'core/comment-author-name';
 	}


### PR DESCRIPTION
Follow up: https://github.com/WordPress/gutenberg/pull/69739

Removes an TODO comment related to removing post comment block conversions after WordPress 6.0.

As discussed in [#69739](https://github.com/WordPress/gutenberg/pull/69739), since legacy content using these blocks may still exist, the conversion logic is being retained. The comment is no longer relevant and may cause confusion.