### PR TITLE
Enable Code block content editing in contentOnly

### DIFF
--- a/packages/block-library/src/code/block.json
+++ b/packages/block-library/src/code/block.json
@@ -11,7 +11,8 @@
 			"type": "rich-text",
 			"source": "rich-text",
 			"selector": "code",
-			"__unstablePreserveWhiteSpace": true
+			"__unstablePreserveWhiteSpace": true,
+			"role": "content"
 		}
 	},
 	"supports": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

This PR enhances the Code block to support editing of code content when the block is in contentOnly mode.
This enhancement was identified while working on https://github.com/WordPress/gutenberg/pull/70100

## Testing Instructions
1. Create a Group block
2. Set the Group block's templateLock attribute to "contentOnly"
3. Insert a Code block inside this Group
4. Try to edit the code content

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/926c5ea1-ec84-41c1-a0e6-777ec39831bd


