### PR TITLE
Docs: Clarify versions in WordPress page title.

### DIFF
--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -1,4 +1,4 @@
-# Versions in WordPress
+# Gutenberg versions in WordPress
 
 With each major release of WordPress a new version of Gutenberg is included. This has caused confusion over time as people have tried to figure out how to best debug problems and report bugs appropriately. To make this easier we have made this document to serve as a canonical list of the Gutenberg versions integrated into each major WordPress release. Of note, during the beta period of a WordPress release, additional bug fixes from later Gutenberg releases than those noted are added into the WordPress release where it is needed. If you want details about what's in each Gutenberg release outside of the high level items shared as part of major WordPress releases, please review the [release notes shared on Make Core](https://make.wordpress.org/core/tag/gutenberg-new/).
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2388,7 +2388,7 @@
 		"parent": "contributors"
 	},
 	{
-		"title": "Versions in WordPress",
+		"title": "Gutenberg versions in WordPress",
 		"slug": "versions-in-wordpress",
 		"markdown_source": "../docs/contributors/versions-in-wordpress.md",
 		"parent": "contributors"


### PR DESCRIPTION
## What?

Updates the "Versions in WordPress" page title to "Gutenberg versions in WordPress"

## Why?

Without Gutenberg in the title, on first glance it leaves the reader asking "versions of what?". At least it does if I am the reader. It's clearer in the HTML title "Versions in WordPress - Block Editor Handbook" but that's not readily human accessible.

## How?

* Updates the title on the page.
* The file name is unchanged to avoid the need for redirects.

## Testing Instructions

N/A

### Testing Instructions for Keyboard

N/A

## Screenshots or screencast <!-- if applicable -->

N/A