### PR TITLE
Table Block: Enhance contentOnly Editing Experience

### DIFF
--- a/packages/block-library/src/table/block.json
+++ b/packages/block-library/src/table/block.json
@@ -14,7 +14,8 @@
 		"caption": {
 			"type": "rich-text",
 			"source": "rich-text",
-			"selector": "figcaption"
+			"selector": "figcaption",
+			"role": "content"
 		},
 		"head": {
 			"type": "array",
@@ -30,7 +31,8 @@
 					"query": {
 						"content": {
 							"type": "rich-text",
-							"source": "rich-text"
+							"source": "rich-text",
+							"role": "content"
 						},
 						"tag": {
 							"type": "string",
@@ -75,7 +77,8 @@
 					"query": {
 						"content": {
 							"type": "rich-text",
-							"source": "rich-text"
+							"source": "rich-text",
+							"role": "content"
 						},
 						"tag": {
 							"type": "string",
@@ -120,7 +123,8 @@
 					"query": {
 						"content": {
 							"type": "rich-text",
-							"source": "rich-text"
+							"source": "rich-text",
+							"role": "content"
 						},
 						"tag": {
 							"type": "string",

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -16,6 +16,7 @@ import {
 	useBlockProps,
 	__experimentalUseColorProps as useColorProps,
 	__experimentalUseBorderProps as useBorderProps,
+	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import {
@@ -106,6 +107,7 @@ function TableEdit( {
 
 	const colorProps = useColorProps( attributes );
 	const borderProps = useBorderProps( attributes );
+	const blockEditingMode = useBlockEditingMode();
 
 	const tableRef = useRef();
 	const [ hasTableCreated, setHasTableCreated ] = useState( false );
@@ -455,7 +457,7 @@ function TableEdit( {
 
 	return (
 		<figure { ...useBlockProps( { ref: tableRef } ) }>
-			{ ! isEmpty && (
+			{ ! isEmpty && blockEditingMode !== 'contentOnly' && (
 				<>
 					<BlockControls group="block">
 						<AlignmentControl
@@ -605,7 +607,9 @@ function TableEdit( {
 					isSelected={ isSingleSelected }
 					insertBlocksAfter={ insertBlocksAfter }
 					label={ __( 'Table caption text' ) }
-					showToolbarButton={ isSingleSelected }
+					showToolbarButton={
+						isSingleSelected && blockEditingMode !== 'contentOnly'
+					}
 				/>
 			) }
 		</figure>

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -457,7 +457,7 @@ function TableEdit( {
 
 	return (
 		<figure { ...useBlockProps( { ref: tableRef } ) }>
-			{ ! isEmpty && blockEditingMode !== 'contentOnly' && (
+			{ ! isEmpty && blockEditingMode === 'default' && (
 				<>
 					<BlockControls group="block">
 						<AlignmentControl
@@ -608,7 +608,7 @@ function TableEdit( {
 					insertBlocksAfter={ insertBlocksAfter }
 					label={ __( 'Table caption text' ) }
 					showToolbarButton={
-						isSingleSelected && blockEditingMode !== 'contentOnly'
+						isSingleSelected && blockEditingMode === 'default'
 					}
 				/>
 			) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of: https://github.com/WordPress/gutenberg/issues/65778

Allows `contentOnly` editing in the Table block.


## Testing Instructions
1. Create a Group block
2. Set the Group block's templateLock attribute to "contentOnly"
3. Insert a Table block inside this Group
4. Verify you can edit the initial placeholder
5. Verify you can click into table cells and edit their content


## Screenshots or screencast <!-- if applicable -->



https://github.com/user-attachments/assets/55aa9271-97db-4c62-aaa8-af0a73a949ec


