### PR TITLE
Add example doc comment

### DIFF
--- a/docs/reference-guides/data/data-core-edit-widgets.md
+++ b/docs/reference-guides/data/data-core-edit-widgets.md
@@ -140,6 +140,27 @@ _Returns_
 
 Returns whether widget saving is locked.
 
+_Usage_
+
+```jsx
+import { __ } from '@wordpress/i18n';
+import { store as widgetStore } from '@wordpress/edit-widgets';
+import { useSelect } from '@wordpress/data';
+
+const ExampleComponent = () => {
+	const isSavingLocked = useSelect(
+		( select ) => select( widgetStore ).isWidgetSavingLocked(),
+		[]
+	);
+
+	return isSavingLocked ? (
+		<p>{ __( 'Widget saving is locked' ) }</p>
+	) : (
+		<p>{ __( 'Widget saving is not locked' ) }</p>
+	);
+};
+```
+
 _Parameters_
 
 -   _state_ `Object`: Global application state.
@@ -165,6 +186,23 @@ _Returns_
 ### lockWidgetSaving
 
 Returns an action object used to signal that widget saving is locked.
+
+_Usage_
+
+```js
+import { store as widgetStore } from '@wordpress/edit-widgets';
+import { useDispatch } from '@wordpress/data';
+
+const ExampleComponent = () => {
+	const { lockWidgetSaving } = useDispatch( widgetStore );
+
+	return (
+		<Button onClick={ () => lockWidgetSaving( 'lockName' ) }>
+			{ __( 'Lock Widget Saving' ) }
+		</Button>
+	);
+};
+```
 
 _Parameters_
 
@@ -297,6 +335,23 @@ _Returns_
 ### unlockWidgetSaving
 
 Returns an action object used to signal that widget saving is unlocked.
+
+_Usage_
+
+```js
+import { store as widgetStore } from '@wordpress/edit-widgets';
+import { useDispatch } from '@wordpress/data';
+
+const ExampleComponent = () => {
+	const { unlockWidgetSaving } = useDispatch( widgetStore );
+
+	return (
+		<Button onClick={ () => unlockWidgetSaving( 'lockName' ) }>
+			{ __( 'Unlock Widget Saving' ) }
+		</Button>
+	);
+};
+```
 
 _Parameters_
 

--- a/docs/reference-guides/data/data-core-edit-widgets.md
+++ b/docs/reference-guides/data/data-core-edit-widgets.md
@@ -195,7 +195,6 @@ import { useDispatch } from '@wordpress/data';
 
 const ExampleComponent = () => {
 	const { lockWidgetSaving } = useDispatch( widgetStore );
-
 	return (
 		<Button onClick={ () => lockWidgetSaving( 'lockName' ) }>
 			{ __( 'Lock Widget Saving' ) }
@@ -344,7 +343,6 @@ import { useDispatch } from '@wordpress/data';
 
 const ExampleComponent = () => {
 	const { unlockWidgetSaving } = useDispatch( widgetStore );
-
 	return (
 		<Button onClick={ () => unlockWidgetSaving( 'lockName' ) }>
 			{ __( 'Unlock Widget Saving' ) }

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -437,6 +437,22 @@ export const moveBlockToWidgetArea =
  *
  * @param {string} lockName The lock name.
  *
+ * @example
+ * ```js
+ * import { store as widgetStore } from '@wordpress/edit-widgets';
+ * import { useDispatch } from '@wordpress/data';
+ *
+ * const ExampleComponent = () => {
+ *     const { unlockWidgetSaving } = useDispatch( widgetStore );
+ *
+ *     return (
+ *         <Button onClick={ () => unlockWidgetSaving('lockName') }>
+ *             { __( 'Unlock Widget Saving' ) }
+ *         </Button>
+ *     );
+ * };
+ * ```
+ *
  * @return {Object} Action object
  */
 export function unlockWidgetSaving( lockName ) {
@@ -450,6 +466,22 @@ export function unlockWidgetSaving( lockName ) {
  * Returns an action object used to signal that widget saving is locked.
  *
  * @param {string} lockName The lock name.
+ *
+ * @example
+ * ```js
+ * import { store as widgetStore } from '@wordpress/edit-widgets';
+ * import { useDispatch } from '@wordpress/data';
+ *
+ * const ExampleComponent = () => {
+ *     const { lockWidgetSaving } = useDispatch( widgetStore );
+ *
+ *     return (
+ *         <Button onClick={ () => lockWidgetSaving('lockName') }>
+ *             { __( 'Lock Widget Saving' ) }
+ *         </Button>
+ *     );
+ * };
+ * ```
  *
  * @return {Object} Action object
  */

--- a/packages/edit-widgets/src/store/actions.js
+++ b/packages/edit-widgets/src/store/actions.js
@@ -443,13 +443,12 @@ export const moveBlockToWidgetArea =
  * import { useDispatch } from '@wordpress/data';
  *
  * const ExampleComponent = () => {
- *     const { unlockWidgetSaving } = useDispatch( widgetStore );
- *
- *     return (
- *         <Button onClick={ () => unlockWidgetSaving('lockName') }>
- *             { __( 'Unlock Widget Saving' ) }
- *         </Button>
- *     );
+ * 	const { unlockWidgetSaving } = useDispatch( widgetStore );
+ * 	return (
+ * 		<Button onClick={ () => unlockWidgetSaving( 'lockName' ) }>
+ * 			{ __( 'Unlock Widget Saving' ) }
+ * 		</Button>
+ * 	);
  * };
  * ```
  *
@@ -473,13 +472,12 @@ export function unlockWidgetSaving( lockName ) {
  * import { useDispatch } from '@wordpress/data';
  *
  * const ExampleComponent = () => {
- *     const { lockWidgetSaving } = useDispatch( widgetStore );
- *
- *     return (
- *         <Button onClick={ () => lockWidgetSaving('lockName') }>
- *             { __( 'Lock Widget Saving' ) }
- *         </Button>
- *     );
+ * 	const { lockWidgetSaving } = useDispatch( widgetStore );
+ * 	return (
+ * 		<Button onClick={ () => lockWidgetSaving( 'lockName' ) }>
+ * 			{ __( 'Lock Widget Saving' ) }
+ * 		</Button>
+ * 	);
  * };
  * ```
  *

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -317,6 +317,26 @@ export function isListViewOpened( state ) {
  *
  * @param {Object} state Global application state.
  *
+ * @example
+ * ```jsx
+ * import { __ } from '@wordpress/i18n';
+ * import { store as widgetStore } from '@wordpress/edit-widgets';
+ * import { useSelect } from '@wordpress/data';
+ *
+ * const ExampleComponent = () => {
+ *     const isSavingLocked = useSelect(
+ *         (select) => select(widgetStore).isWidgetSavingLocked(),
+ *         []
+ *     );
+ *
+ *     return (
+ *         isSavingLocked ?
+ *             <p>{__('Widget saving is locked')}</p> :
+ *             <p>{__('Widget saving is not locked')}</p>
+ *     );
+ * };
+ * ```
+ *
  * @return {boolean} Is locked.
  */
 export function isWidgetSavingLocked( state ) {

--- a/packages/edit-widgets/src/store/selectors.js
+++ b/packages/edit-widgets/src/store/selectors.js
@@ -324,16 +324,16 @@ export function isListViewOpened( state ) {
  * import { useSelect } from '@wordpress/data';
  *
  * const ExampleComponent = () => {
- *     const isSavingLocked = useSelect(
- *         (select) => select(widgetStore).isWidgetSavingLocked(),
- *         []
- *     );
+ * 	const isSavingLocked = useSelect(
+ * 		( select ) => select( widgetStore ).isWidgetSavingLocked(),
+ * 		[]
+ * 	);
  *
- *     return (
- *         isSavingLocked ?
- *             <p>{__('Widget saving is locked')}</p> :
- *             <p>{__('Widget saving is not locked')}</p>
- *     );
+ * 	return isSavingLocked ? (
+ * 		<p>{ __( 'Widget saving is locked' ) }</p>
+ * 	) : (
+ * 		<p>{ __( 'Widget saving is not locked' ) }</p>
+ * 	);
  * };
  * ```
  *


### PR DESCRIPTION
## What?
Related to: #42125
PR: #69984

This PR adds the example doc comment for following:

### Selector:
- `isWidgetSavingLocked`
### Action:
- `lockWidgetSaving`
- `unlockWidgetSaving`

Which was introduced in PR: #69984