### PR TITLE
Components: Add direction prop for `RadioControl` component

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Enhancement
 
--   `ComboboxControl`: Add direction prop. ([#70120](https://github.com/WordPress/gutenberg/pull/70120)).
+-   `ComboboxControl`: Add direction prop ([#70120](https://github.com/WordPress/gutenberg/pull/70120)).
 
 ## 29.11.0 (2025-06-04)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `FormFileUpload`: Remove temporary fix for selecting .heic file in Chromium browsers ([#70383](https://github.com/WordPress/gutenberg/pull/70383)).
 
+### Enhancement
+
+-   `ComboboxControl`: Add direction prop. ([#70120](https://github.com/WordPress/gutenberg/pull/70120)).
+
 ## 29.11.0 (2025-06-04)
 
 ### Enhancement

--- a/packages/components/src/radio-control/README.md
+++ b/packages/components/src/radio-control/README.md
@@ -115,6 +115,15 @@ The value property of the currently selected option.
 
 -   Required: No
 
+#### `direction`: `'horizontal' | 'vertical'`
+
+Controls the layout direction of the radio buttons.
+
+-   Use 'horizontal' to display options in a row.
+-   Use 'vertical' (default) to display them in a column.
+
+-   Required: No
+
 ## Related components
 
 -   To select one or more items from a set, use the `CheckboxControl` component.

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -62,6 +62,7 @@ export function RadioControl(
 	const {
 		label,
 		className,
+		direction = 'vertical',
 		selected,
 		help,
 		onChange,
@@ -101,6 +102,7 @@ export function RadioControl(
 				spacing={ 3 }
 				className={ clsx( 'components-radio-control__group-wrapper', {
 					'has-help': !! help,
+					'is-horizontal': direction === 'horizontal',
 				} ) }
 			>
 				{ options.map( ( option, index ) => (

--- a/packages/components/src/radio-control/stories/index.story.tsx
+++ b/packages/components/src/radio-control/stories/index.story.tsx
@@ -30,6 +30,10 @@ const meta: Meta< typeof RadioControl > = {
 		help: {
 			control: { type: 'text' },
 		},
+		direction: {
+			control: 'radio',
+			options: [ 'horizontal', 'vertical' ],
+		},
 	},
 	parameters: {
 		controls: {

--- a/packages/components/src/radio-control/style.scss
+++ b/packages/components/src/radio-control/style.scss
@@ -11,6 +11,11 @@
 	margin-block-end: $grid-unit-15;
 }
 
+.components-radio-control__group-wrapper.is-horizontal {
+	flex-direction: row;
+	justify-content: flex-start;
+}
+
 .components-radio-control__option {
 	display: grid;
 	grid-template-columns: auto 1fr;

--- a/packages/components/src/radio-control/style.scss
+++ b/packages/components/src/radio-control/style.scss
@@ -14,6 +14,7 @@
 .components-radio-control__group-wrapper.is-horizontal {
 	flex-direction: row;
 	justify-content: flex-start;
+	flex-wrap: wrap;
 }
 
 .components-radio-control__option {

--- a/packages/components/src/radio-control/test/index.tsx
+++ b/packages/components/src/radio-control/test/index.tsx
@@ -274,4 +274,38 @@ describe.each( [
 			);
 		} );
 	} );
+
+	describe( 'layout direction', () => {
+		it( 'should apply vertical layout when direction is not provided (default)', () => {
+			const onChangeSpy = jest.fn();
+
+			render(
+				<Component { ...defaultProps } onChange={ onChangeSpy } />
+			);
+
+			const groupWrapper = screen
+				.getByRole( 'group' )
+				// eslint-disable-next-line testing-library/no-node-access
+				.querySelector( '.components-radio-control__group-wrapper' );
+
+			expect( groupWrapper ).not.toHaveClass( 'is-horizontal' );
+		} );
+
+		it( 'should apply horizontal layout when direction="horizontal"', () => {
+			const onChangeSpy = jest.fn();
+			render(
+				<Component
+					{ ...defaultProps }
+					direction="horizontal"
+					onChange={ onChangeSpy }
+				/>
+			);
+			const groupWrapper = screen
+				.getByRole( 'group' )
+				// eslint-disable-next-line testing-library/no-node-access
+				.querySelector( '.components-radio-control__group-wrapper' );
+
+			expect( groupWrapper ).toHaveClass( 'is-horizontal' );
+		} );
+	} );
 } );

--- a/packages/components/src/radio-control/types.ts
+++ b/packages/components/src/radio-control/types.ts
@@ -36,6 +36,8 @@ export type RadioControlProps = Pick<
 	/**
 	 * Layout direction for the radio options.
 	 * Use 'horizontal' to display options in a row, or 'vertical' (default) for column layout.
+	 *
+	 * @default 'vertical'
 	 */
-	direction?: 'horizontal' | 'vertical';
+	direction?: 'vertical' | 'horizontal';
 };

--- a/packages/components/src/radio-control/types.ts
+++ b/packages/components/src/radio-control/types.ts
@@ -33,4 +33,9 @@ export type RadioControlProps = Pick<
 	 * The value property of the currently selected option.
 	 */
 	selected?: string;
+	/**
+	 * Layout direction for the radio options.
+	 * Use 'horizontal' to display options in a row, or 'vertical' (default) for column layout.
+	 */
+	direction?: 'horizontal' | 'vertical';
 };


### PR DESCRIPTION


## What?

Closes https://github.com/WordPress/gutenberg/issues/46103

Adds a new `direction` prop to the `RadioControl` component to control the layout direction (`horizontal` or `vertical`).


## Why?
Previously, consumers had to override internal styles to change the layout direction. This approach was fragile and could break with internal changes. Introducing a `direction` prop makes the layout more predictable and customizable.


## How?

- Added `direction` prop with support for `'horizontal'` and `'vertical'` values.
- Applied direction as a class (`is-horizontal`) on the group wrapper.
- Defaulted to `vertical` for backward compatibility.
- Added tests to verify layout behavior.

## Testing Instructions

1. Open the Storybook.
2. In the controls panel, select the direction prop using the radio options (vertical or horizontal).
3. Observe that the RadioControl updates its layout accordingly—displaying options in a row when horizontal is selected.

## Screenshot

|Vertical|Horizontal|
|-|-|
|<img width="355" alt="image" src="https://github.com/user-attachments/assets/7eafd1d1-985a-4ca2-bc9f-24e2eee963a5" />|<img width="355" alt="image" src="https://github.com/user-attachments/assets/2ff37402-9e5c-4d4f-9ec5-25efff71134e" />|
