### PR TITLE
Details block: Add role attribute to summary

### DIFF
--- a/packages/block-library/src/details/block.json
+++ b/packages/block-library/src/details/block.json
@@ -15,7 +15,8 @@
 		"summary": {
 			"type": "rich-text",
 			"source": "rich-text",
-			"selector": "summary"
+			"selector": "summary",
+			"role": "content"
 		},
 		"name": {
 			"type": "string",


### PR DESCRIPTION
## What, Why, and How?
Part of #65778

This PR makes the Details block editable and visible in List View when within `contentOnly` mode, by assigning the `content` role to its summary attribute.

## Testing Instructions

1. Create a Group block and set the `templateLock` to `contentOnly` or copy the following HTML.

<details>

<summary>code</summary>


```
<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:details -->
<details class="wp-block-details"><summary>Details block example </summary><!-- wp:paragraph {"placeholder":"Type / to add a hidden block"} -->
<p>Example paragraph</p>
<!-- /wp:paragraph --></details>
<!-- /wp:details --></div>
<!-- /wp:group -->
```

</details>

2. Confirm that the details block is visible in the list view.
3. Confirm that the summary content can now be edited in `contentOnly` mode.

### Testing Instructions for Keyboard

Same.

## Screenshots

| Before | After |
| - | - |
| <img width="350" alt="before-image" src="https://github.com/user-attachments/assets/d3fcda88-eb47-44a2-8aae-23fea835932b" /> |  <img width="350" alt="after-image" src="https://github.com/user-attachments/assets/a18f22a6-d1bd-4c0d-a2cc-e15ac884fff6" /> |

## Screencast

https://github.com/user-attachments/assets/e18371d6-b66c-478c-829d-8b3e05fc19da
