### PR TITLE
Post Publish Panel: Open view post links in a new tab

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/publish-post.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/publish-post.ts
@@ -34,9 +34,12 @@ export async function publishPost( this: Editor ) {
 	}
 
 	// Handle saving just the post.
-	await this.page.click(
-		'role=region[name="Editor publish"i] >> role=button[name="Publish"i]'
-	);
+	await this.page
+		.getByRole( 'region', {
+			name: 'Editor publish',
+		} )
+		.getByRole( 'button', { name: 'Publish', exact: true } )
+		.click();
 
 	await this.page
 		.getByRole( 'button', { name: 'Dismiss this notice' } )

--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -163,7 +163,6 @@ export default function PostPublishPanelPostpublish( {
 							icon={ external }
 							iconPosition="right"
 							target="_blank"
-							rel="noopener noreferrer"
 						>
 							{ viewPostLabel }
 							<VisuallyHidden as="span">

--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -1,7 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { PanelBody, Button, TextControl } from '@wordpress/components';
+import {
+	PanelBody,
+	Button,
+	TextControl,
+	ExternalLink,
+	VisuallyHidden,
+} from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useEffect, useState, useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
@@ -15,6 +21,7 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import PostScheduleLabel from '../post-schedule/label';
 import { store as editorStore } from '../../store';
+import { external } from '@wordpress/icons';
 
 const POSTNAME = '%postname%';
 const PAGENAME = '%pagename%';
@@ -118,9 +125,9 @@ export default function PostPublishPanelPostpublish( {
 	return (
 		<div className="post-publish-panel__postpublish">
 			<PanelBody className="post-publish-panel__postpublish-header">
-				<a ref={ postLinkRef } href={ link }>
+				<ExternalLink ref={ postLinkRef } href={ link }>
 					{ decodeEntities( post.title ) || __( '(no title)' ) }
-				</a>{ ' ' }
+				</ExternalLink>{ ' ' }
 				{ postPublishNonLinkHeader }
 			</PanelBody>
 			<PanelBody>
@@ -153,8 +160,18 @@ export default function PostPublishPanelPostpublish( {
 							variant="primary"
 							href={ link }
 							__next40pxDefaultSize
+							icon={ external }
+							iconPosition="right"
+							target="_blank"
+							rel="noopener noreferrer"
 						>
 							{ viewPostLabel }
+							<VisuallyHidden as="span">
+								{
+									/* translators: accessibility text */
+									__( '(opens in a new tab)' )
+								}
+							</VisuallyHidden>
 						</Button>
 					) }
 					<Button

--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -15,13 +15,13 @@ import { addQueryArgs, safeDecodeURIComponent } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useCopyToClipboard } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
+import { external } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import PostScheduleLabel from '../post-schedule/label';
 import { store as editorStore } from '../../store';
-import { external } from '@wordpress/icons';
 
 const POSTNAME = '%postname%';
 const PAGENAME = '%pagename%';

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -142,6 +142,7 @@
 	.components-button.has-icon {
 		justify-content: center;
 		flex: 1;
+		min-width: unset;
 	}
 
 	.components-clipboard-button {

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -138,7 +138,8 @@
 	flex-wrap: wrap;
 	gap: $grid-unit-20;
 
-	.components-button {
+	.components-button,
+	.components-button.has-icon {
 		justify-content: center;
 		flex: 1;
 	}

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -158,7 +158,6 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
             <a
               class="components-button is-next-40px-default-size is-primary has-icon"
               href="https://wordpress.local/sample-page/"
-              rel="noopener noreferrer"
               target="_blank"
             >
               <span
@@ -386,7 +385,6 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
             <a
               class="components-button is-next-40px-default-size is-primary has-icon"
               href="https://wordpress.local/sample-page/"
-              rel="noopener noreferrer"
               target="_blank"
             >
               <span

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -27,7 +27,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
   padding: 0;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -47,7 +47,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
   width: 100%;
 }
 
-.emotion-10>* {
+.emotion-12>* {
   min-width: 0;
 }
 
@@ -87,9 +87,22 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
           class="components-panel__body post-publish-panel__postpublish-header is-opened"
         >
           <a
+            class="components-external-link"
             href="https://wordpress.local/sample-page/"
+            rel="external noreferrer noopener"
+            target="_blank"
           >
-            (no title)
+            <span
+              class="components-external-link__contents"
+            >
+              (no title)
+            </span>
+            <span
+              aria-label="(opens in a new tab)"
+              class="components-external-link__icon"
+            >
+              ↗
+            </span>
           </a>
            
           is now live.
@@ -143,9 +156,32 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
             class="post-publish-panel__postpublish-buttons"
           >
             <a
-              class="components-button is-next-40px-default-size is-primary"
+              class="components-button is-next-40px-default-size is-primary has-icon"
               href="https://wordpress.local/sample-page/"
-            />
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <span
+                class="components-visually-hidden emotion-6 emotion-7"
+                data-wp-c16t="true"
+                data-wp-component="VisuallyHidden"
+                style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+              >
+                (opens in a new tab)
+              </span>
+              <svg
+                aria-hidden="true"
+                focusable="false"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M19.5 4.5h-7V6h4.44l-5.97 5.97 1.06 1.06L18 7.06v4.44h1.5v-7Zm-13 1a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-3H17v3a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h3V5.5h-3Z"
+                />
+              </svg>
+            </a>
             <a
               class="components-button is-next-40px-default-size is-secondary"
               href="post-new.php?"
@@ -164,7 +200,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is pu
           class="components-base-control__field emotion-2 emotion-3"
         >
           <div
-            class="components-flex components-h-stack emotion-10 emotion-11"
+            class="components-flex components-h-stack emotion-12 emotion-7"
             data-wp-c16t="true"
             data-wp-component="HStack"
           >
@@ -219,7 +255,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
   padding: 0;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -239,7 +275,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
   width: 100%;
 }
 
-.emotion-10>* {
+.emotion-12>* {
   min-width: 0;
 }
 
@@ -279,9 +315,22 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
           class="components-panel__body post-publish-panel__postpublish-header is-opened"
         >
           <a
+            class="components-external-link"
             href="https://wordpress.local/sample-page/"
+            rel="external noreferrer noopener"
+            target="_blank"
           >
-            (no title)
+            <span
+              class="components-external-link__contents"
+            >
+              (no title)
+            </span>
+            <span
+              aria-label="(opens in a new tab)"
+              class="components-external-link__icon"
+            >
+              ↗
+            </span>
           </a>
            
           is now live.
@@ -335,9 +384,32 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
             class="post-publish-panel__postpublish-buttons"
           >
             <a
-              class="components-button is-next-40px-default-size is-primary"
+              class="components-button is-next-40px-default-size is-primary has-icon"
               href="https://wordpress.local/sample-page/"
-            />
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <span
+                class="components-visually-hidden emotion-6 emotion-7"
+                data-wp-c16t="true"
+                data-wp-component="VisuallyHidden"
+                style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+              >
+                (opens in a new tab)
+              </span>
+              <svg
+                aria-hidden="true"
+                focusable="false"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M19.5 4.5h-7V6h4.44l-5.97 5.97 1.06 1.06L18 7.06v4.44h1.5v-7Zm-13 1a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-3H17v3a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h3V5.5h-3Z"
+                />
+              </svg>
+            </a>
             <a
               class="components-button is-next-40px-default-size is-secondary"
               href="post-new.php?"
@@ -356,7 +428,7 @@ exports[`PostPublishPanel should render the post-publish panel if the post is sc
           class="components-base-control__field emotion-2 emotion-3"
         >
           <div
-            class="components-flex components-h-stack emotion-10 emotion-11"
+            class="components-flex components-h-stack emotion-12 emotion-7"
             data-wp-c16t="true"
             data-wp-component="HStack"
           >

--- a/test/e2e/specs/editor/blocks/comments.spec.js
+++ b/test/e2e/specs/editor/blocks/comments.spec.js
@@ -76,11 +76,7 @@ test.describe( 'Comments', () => {
 		}
 
 		// Visit the post that was just published.
-		const postUrl = await page.getAttribute(
-			'role=region[name="Editor publish"] >> role=link[name=/View Post/i]',
-			'href'
-		);
-		await page.goto( postUrl );
+		await page.goto( `/?p=${ postId }` );
 
 		// We check that there is a previous comments page link.
 		await expect(
@@ -132,11 +128,7 @@ test.describe( 'Comments', () => {
 		}
 
 		// Visit the post that was just published.
-		const postUrl = await page.getAttribute(
-			'role=region[name="Editor publish"] >> role=link[name=/View Post/i]',
-			'href'
-		);
-		await page.goto( postUrl );
+		await page.goto( `/?p=${ postId }` );
 
 		// We check that there are no comments page link.
 		await expect(
@@ -199,11 +191,7 @@ test.describe( 'Comments', () => {
 		} );
 
 		// Visit the post that was just published.
-		const postUrl = await page.getAttribute(
-			'role=region[name="Editor publish"] >> role=link[name=/View Post/i]',
-			'href'
-		);
-		await page.goto( postUrl );
+		await page.goto( `/?p=${ postId }` );
 
 		// Check that the Comment Template block (an inner block) is rendered.
 		await expect(
@@ -232,11 +220,7 @@ test.describe( 'Comments', () => {
 		} );
 
 		// Visit the post that was just published.
-		const postUrl = await page.getAttribute(
-			'role=region[name="Editor publish"] >> role=link[name=/View Post/i]',
-			'href'
-		);
-		await page.goto( postUrl );
+		await page.goto( `/?p=${ postId }` );
 
 		// Check that the Comment Template block (an inner block) is NOT rendered.
 		await expect(

--- a/test/e2e/specs/editor/blocks/comments.spec.js
+++ b/test/e2e/specs/editor/blocks/comments.spec.js
@@ -76,9 +76,11 @@ test.describe( 'Comments', () => {
 		}
 
 		// Visit the post that was just published.
-		await page.click(
-			'role=region[name="Editor publish"] >> role=link[name="View Post"i]'
+		const postUrl = await page.getAttribute(
+			'role=region[name="Editor publish"] >> role=link[name=/View Post/i]',
+			'href'
 		);
+		await page.goto( postUrl );
 
 		// We check that there is a previous comments page link.
 		await expect(
@@ -130,9 +132,11 @@ test.describe( 'Comments', () => {
 		}
 
 		// Visit the post that was just published.
-		await page.click(
-			'role=region[name="Editor publish"] >> role=link[name="View Post"i]'
+		const postUrl = await page.getAttribute(
+			'role=region[name="Editor publish"] >> role=link[name=/View Post/i]',
+			'href'
 		);
+		await page.goto( postUrl );
 
 		// We check that there are no comments page link.
 		await expect(
@@ -195,9 +199,11 @@ test.describe( 'Comments', () => {
 		} );
 
 		// Visit the post that was just published.
-		await page.click(
-			'role=region[name="Editor publish"] >> role=link[name="View Post"i]'
+		const postUrl = await page.getAttribute(
+			'role=region[name="Editor publish"] >> role=link[name=/View Post/i]',
+			'href'
 		);
+		await page.goto( postUrl );
 
 		// Check that the Comment Template block (an inner block) is rendered.
 		await expect(
@@ -226,9 +232,11 @@ test.describe( 'Comments', () => {
 		} );
 
 		// Visit the post that was just published.
-		await page.click(
-			'role=region[name="Editor publish"] >> role=link[name="View Post"i]'
+		const postUrl = await page.getAttribute(
+			'role=region[name="Editor publish"] >> role=link[name=/View Post/i]',
+			'href'
 		);
+		await page.goto( postUrl );
 
 		// Check that the Comment Template block (an inner block) is NOT rendered.
 		await expect(

--- a/test/e2e/specs/editor/various/compatibility-classic-editor.spec.js
+++ b/test/e2e/specs/editor/various/compatibility-classic-editor.spec.js
@@ -24,9 +24,11 @@ test.describe( 'Compatibility with classic editor', () => {
 		// Publish Post
 		await editor.publishPost();
 		// View Post
-		await page.click(
-			'role=region[name="Editor publish"i] >> role=link[name="View post"i]'
+		const postUrl = await page.getAttribute(
+			'role=region[name="Editor publish"i] >> role=link[name=/View post/i]',
+			'href'
 		);
+		await page.goto( postUrl );
 
 		// Check the content doesn't contain <p> tags.
 		// No accessible selector for now.

--- a/test/e2e/specs/editor/various/compatibility-classic-editor.spec.js
+++ b/test/e2e/specs/editor/various/compatibility-classic-editor.spec.js
@@ -22,13 +22,9 @@ test.describe( 'Compatibility with classic editor', () => {
 		await page.keyboard.type( 'Random Link' );
 		await page.keyboard.type( '</a> ' );
 		// Publish Post
-		await editor.publishPost();
+		const postId = await editor.publishPost();
 		// View Post
-		const postUrl = await page.getAttribute(
-			'role=region[name="Editor publish"i] >> role=link[name=/View post/i]',
-			'href'
-		);
-		await page.goto( postUrl );
+		await page.goto( `/?p=${ postId }` );
 
 		// Check the content doesn't contain <p> tags.
 		// No accessible selector for now.

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -217,9 +217,10 @@ test.describe( 'Pattern Overrides', () => {
 			await editorPublishPanel
 				.getByRole( 'button', { name: 'Publish', exact: true } )
 				.click();
-			await editorPublishPanel
+			const postUrl = await editorPublishPanel
 				.getByRole( 'link', { name: 'View post' } )
-				.click();
+				.getAttribute( 'href' );
+			await page.goto( postUrl );
 
 			await expect( page.locator( 'p' ) ).toContainText( [
 				'I would word it this way',

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -207,20 +207,8 @@ test.describe( 'Pattern Overrides', () => {
 				},
 			] );
 
-			await page
-				.getByRole( 'region', { name: 'Editor top bar' } )
-				.getByRole( 'button', { name: 'Publish' } )
-				.click();
-			const editorPublishPanel = page.getByRole( 'region', {
-				name: 'Editor publish',
-			} );
-			await editorPublishPanel
-				.getByRole( 'button', { name: 'Publish', exact: true } )
-				.click();
-			const postUrl = await editorPublishPanel
-				.getByRole( 'link', { name: 'View post' } )
-				.getAttribute( 'href' );
-			await page.goto( postUrl );
+			const postId = await editor.publishPost();
+			await page.goto( `/?p=${ postId }` );
 
 			await expect( page.locator( 'p' ) ).toContainText( [
 				'I would word it this way',

--- a/test/e2e/specs/editor/various/publish-panel.spec.js
+++ b/test/e2e/specs/editor/various/publish-panel.spec.js
@@ -90,7 +90,7 @@ test.describe( 'Post publish panel', () => {
 			page
 				.getByRole( 'region', { name: 'Editor publish' } )
 				.locator( ':focus' )
-		).toHaveText( 'Test Post' );
+		).toContainText( 'Test Post' );
 	} );
 
 	test( 'should retain focus within the panel', async ( {


### PR DESCRIPTION
## What, Why, and How?
Closes #70126

This PR updates the `View Post` links in the `Post Publish Panel` to open in new tabs, ensuring a smoother editing workflow by preserving the current editor session.

## Testing Instructions

1. Create a new post.
2. Publish the post.
3. From the post publish panel, click on `View Post`.
4. Confirm that it opens up in a new tab.

### Testing Instructions for Keyboard

Same.

## Screenshots

|Before|After|
|-|-|
|<img width="279" alt="before" src="https://github.com/user-attachments/assets/a9904fef-dde9-4900-85b7-7a78a69cc6d6" />|<img width="279" alt="after" src="https://github.com/user-attachments/assets/0aa402da-0a55-44d3-a1a4-7a0211aaffe3" />|

## Screencast

https://github.com/user-attachments/assets/4693e65d-f976-443b-8581-0d2cb60fa955