### PR TITLE
Global Styles: Move `Randomize colors` button to Edit Palette panel

### DIFF
--- a/packages/edit-site/src/components/global-styles/color-palette-panel.js
+++ b/packages/edit-site/src/components/global-styles/color-palette-panel.js
@@ -59,17 +59,30 @@ export default function ColorPalettePanel( { name } ) {
 			className="edit-site-global-styles-color-palette-panel"
 			spacing={ 8 }
 		>
-			{ !! themeColors && !! themeColors.length && (
-				<PaletteEdit
-					canReset={ themeColors !== baseThemeColors }
-					canOnlyChangeValues
-					colors={ themeColors }
-					onChange={ setThemeColors }
-					paletteLabel={ __( 'Theme' ) }
-					paletteLabelHeadingLevel={ 3 }
-					popoverProps={ popoverProps }
-				/>
-			) }
+			<VStack spacing={ 4 }>
+				{ !! themeColors && !! themeColors.length && (
+					<PaletteEdit
+						canReset={ themeColors !== baseThemeColors }
+						canOnlyChangeValues
+						colors={ themeColors }
+						onChange={ setThemeColors }
+						paletteLabel={ __( 'Theme' ) }
+						paletteLabelHeadingLevel={ 3 }
+						popoverProps={ popoverProps }
+					/>
+				) }
+				{ window.__experimentalEnableColorRandomizer &&
+					themeColors?.length > 0 && (
+						<Button
+							__next40pxDefaultSize
+							variant="secondary"
+							icon={ shuffle }
+							onClick={ randomizeThemeColors }
+						>
+							{ __( 'Randomize colors' ) }
+						</Button>
+					) }
+			</VStack>
 			{ !! defaultColors &&
 				!! defaultColors.length &&
 				!! defaultPaletteEnabled && (
@@ -82,17 +95,6 @@ export default function ColorPalettePanel( { name } ) {
 						paletteLabelHeadingLevel={ 3 }
 						popoverProps={ popoverProps }
 					/>
-				) }
-			{ window.__experimentalEnableColorRandomizer &&
-				themeColors?.length > 0 && (
-					<Button
-						__next40pxDefaultSize
-						variant="secondary"
-						icon={ shuffle }
-						onClick={ randomizeThemeColors }
-					>
-						{ __( 'Randomize colors' ) }
-					</Button>
 				) }
 			<PaletteEdit
 				colors={ customColors }

--- a/packages/edit-site/src/components/global-styles/color-palette-panel.js
+++ b/packages/edit-site/src/components/global-styles/color-palette-panel.js
@@ -5,15 +5,18 @@ import { useViewportMatch } from '@wordpress/compose';
 import {
 	__experimentalPaletteEdit as PaletteEdit,
 	__experimentalVStack as VStack,
+	Button,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { shuffle } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
 import ColorVariations from './variations/variations-color';
+import { useColorRandomizer } from './hooks';
 
 const { useGlobalSetting } = unlock( blockEditorPrivateApis );
 const mobilePopoverProps = { placement: 'bottom-start', offset: 8 };
@@ -49,6 +52,8 @@ export default function ColorPalettePanel( { name } ) {
 	const isMobileViewport = useViewportMatch( 'small', '<' );
 	const popoverProps = isMobileViewport ? mobilePopoverProps : undefined;
 
+	const [ randomizeThemeColors ] = useColorRandomizer();
+
 	return (
 		<VStack
 			className="edit-site-global-styles-color-palette-panel"
@@ -77,6 +82,17 @@ export default function ColorPalettePanel( { name } ) {
 						paletteLabelHeadingLevel={ 3 }
 						popoverProps={ popoverProps }
 					/>
+				) }
+			{ window.__experimentalEnableColorRandomizer &&
+				themeColors?.length > 0 && (
+					<Button
+						__next40pxDefaultSize
+						variant="secondary"
+						icon={ shuffle }
+						onClick={ randomizeThemeColors }
+					>
+						{ __( 'Randomize colors' ) }
+					</Button>
 				) }
 			<PaletteEdit
 				colors={ customColors }

--- a/packages/edit-site/src/components/global-styles/palette.js
+++ b/packages/edit-site/src/components/global-styles/palette.js
@@ -8,10 +8,9 @@ import {
 	__experimentalZStack as ZStack,
 	__experimentalVStack as VStack,
 	ColorIndicator,
-	Button,
 } from '@wordpress/components';
 import { isRTL, __ } from '@wordpress/i18n';
-import { Icon, shuffle, chevronLeft, chevronRight } from '@wordpress/icons';
+import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 import { useMemo } from '@wordpress/element';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
@@ -20,7 +19,6 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
  */
 import Subtitle from './subtitle';
 import { NavigationButtonAsItem } from './navigation-button';
-import { useColorRandomizer } from './hooks';
 import ColorIndicatorWrapper from './color-indicator-wrapper';
 import { unlock } from '../../lock-unlock';
 
@@ -37,8 +35,6 @@ function Palette( { name } ) {
 		'color.defaultPalette',
 		name
 	);
-
-	const [ randomizeThemeColors ] = useColorRandomizer();
 
 	const colors = useMemo(
 		() => [
@@ -87,17 +83,6 @@ function Palette( { name } ) {
 					</HStack>
 				</NavigationButtonAsItem>
 			</ItemGroup>
-			{ window.__experimentalEnableColorRandomizer &&
-				themeColors?.length > 0 && (
-					<Button
-						__next40pxDefaultSize
-						variant="secondary"
-						icon={ shuffle }
-						onClick={ randomizeThemeColors }
-					>
-						{ __( 'Randomize colors' ) }
-					</Button>
-				) }
 		</VStack>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -259,3 +259,10 @@
 		border-radius: $radius-small;
 	}
 }
+
+.edit-site-global-styles-color-palette-panel {
+	// Reduce spacing between Color palette and Randomize colors button
+	.components-button.is-secondary.has-icon.has-text {
+		margin-top: -16px;
+	}
+}

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -259,10 +259,3 @@
 		border-radius: $radius-small;
 	}
 }
-
-.edit-site-global-styles-color-palette-panel {
-	// Reduce spacing between Color palette and Randomize colors button
-	.components-button.is-secondary.has-icon.has-text {
-		margin-top: -16px;
-	}
-}


### PR DESCRIPTION
## What?

Closes #66169

This PR relocates the `Randomize colors` button from the main color palette overview to within the 'Edit Palette' panel in the Site Editor's Global Styles.


## Why?

Introduced in https://github.com/WordPress/gutenberg/pull/52315. Currently, the `Randomize colors` button is positioned outside the palette editing interface. These previews are limited to the first 5 colors, providing an incomplete view of the actual changes across the entire palette.

Moving the button inside the 'Edit Palette' panel allows users to see the randomization effect applied to the *entire* theme color palette displayed within that panel. This offers a clearer, more accurate, and more useful user experience for this feature.




## Testing Instructions

1.  Set a theme like Twenty Twenty-Four.
2.  Navigate to the Site Editor (Appearance > Editor).
3.  In the Site sidebar, select "Styles > Colors".
4.  In the "Colors" panel, observe the "Palette" section.
5.  Confirm that the 'Randomize colors' button is **no longer** present directly under the 'Edit palette' button.
6.  Click the 'Edit palette' button.
7.  The "Edit Palette" panel will open. Confirm the 'Randomize colors' button is now visible within this panel.
9.  Click the 'Randomize colors' button.
10. Observe that the theme colors randomization happens as intended.




## Screenshots or screencast 

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/3baa4b67-153f-44da-b316-169ae0d71a09)|![image](https://github.com/user-attachments/assets/2652dd03-e230-4ba3-950e-e77c59d049c7)|


