### PR TITLE
Block Editor: Prevent empty paragraph nesting into Group on Backspace

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1171,7 +1171,11 @@ export const mergeBlocks =
 		// remove it and select the preceding block (blockA).
 		// This handles the case where backspace on an empty paragraph
 		// should delete the paragraph, not merge it into a preceding container.
-		if ( blockB && isUnmodifiedDefaultBlock( blockB ) ) {
+		if (
+			blockB &&
+			isUnmodifiedDefaultBlock( blockB ) &&
+			! select.getBlockRootClientId( clientIdB )
+		) {
 			dispatch.removeBlock( clientIdB, true );
 			return;
 		}

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1167,6 +1167,15 @@ export const mergeBlocks =
 
 		const blockB = select.getBlock( clientIdB );
 
+		// If the block to be merged (blockB) is an unmodified default block,
+		// remove it and select the preceding block (blockA).
+		// This handles the case where backspace on an empty paragraph
+		// should delete the paragraph, not merge it into a preceding container.
+		if ( blockB && isUnmodifiedDefaultBlock( blockB ) ) {
+			dispatch.removeBlock( clientIdB, true );
+			return;
+		}
+
 		if (
 			! blockAType.merge &&
 			getBlockSupport( blockA.name, '__experimentalOnMerge' )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/65850
<!-- In a few words, what is the PR actually doing? -->
This PR fixes an inconsistent Backspace behavior where an empty default paragraph block would merge into a preceding Group block instead of being deleted.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1.  Open a post or page in the editor.
2.  Add a Group block.
3.  Click the empty area below the Group block (or press Enter after the Group block) to add a new default paragraph block.
4.  Ensure the new default paragraph block is selected and focused (it should be empty).
5.  Press the Backspace key.
**Expected Result:** The default paragraph block should be deleted, and the Group block should become selected. The paragraph should not move inside the Group block.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/430ec70a-82c2-45ee-814c-4dd9222e85f2

