### PR TITLE
Site Editor: Improve back button labels for better context

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/index.js
@@ -16,7 +16,7 @@ import { chevronRight, chevronLeft } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
-import { useContext } from '@wordpress/element';
+import { useContext, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -65,6 +65,19 @@ export default function SidebarNavigationScreen( {
 	const backPath = backPathProp ?? location.state?.backPath;
 	const icon = isRTL() ? chevronRight : chevronLeft;
 
+	// Compute the back label from the back path.
+	const backLabel = useMemo( () => {
+		if ( ! backPath ) {
+			return;
+		}
+
+		const segments = backPath.split( '/' ).filter( Boolean );
+		const lastSegment = segments.pop();
+
+		// Default back label to "design" if no segments are found.
+		return lastSegment?.trim() || __( 'design' );
+	}, [ backPath ] );
+
 	return (
 		<>
 			<VStack
@@ -86,7 +99,15 @@ export default function SidebarNavigationScreen( {
 								navigate( 'back' );
 							} }
 							icon={ icon }
-							label={ __( 'Back' ) }
+							label={
+								backLabel
+									? sprintf(
+											/* translators: %s: back path label */
+											__( 'Back to %s' ),
+											backLabel
+									  )
+									: __( 'Back' )
+							}
 							showTooltip={ false }
 						/>
 					) }

--- a/test/e2e/specs/site-editor/navigation.spec.js
+++ b/test/e2e/specs/site-editor/navigation.spec.js
@@ -37,7 +37,7 @@ test.describe( 'Site editor navigation', () => {
 		await pageUtils.pressKeys( 'Enter' );
 		// We should be in the Pages sidebar
 		await expect(
-			page.getByRole( 'button', { name: 'Back', exact: true } )
+			page.getByRole( 'button', { name: 'Back' } )
 		).toBeFocused();
 		await pageUtils.pressKeys( 'Enter' );
 		// Go back to the main navigation


### PR DESCRIPTION
## What, Why, and How?
Closes #54628

This PR enhances the back buttons in the Site Editor by adding more descriptive context. This improvement benefits users, particularly those relying on screen readers, by clearly indicating the destination of the back action.

The back button label is dynamically generated based on the back path.

## Testing Instructions

1. Use a screen reader software.
2. Navigate to `Site Editor` > `Navigation`.
3. Focus on the back button, confirm the label says `Back to design`.
4. Navigate to a particular navigation item.
5. Focus on the back button again, confirm the label says `Back to navigation`.

### Testing Instructions for Keyboard
Same.

## Screencast

https://github.com/user-attachments/assets/96b4046f-81b9-48f3-8ac8-7770fbe413bf

Note: In my testing, I found this to work well on both classic and block themes.