### PR TITLE
Font Library: Fix missing trailing period in user message

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -344,7 +344,7 @@ function FontCollection( { slug } ) {
 								! fonts.length && (
 									<Text>
 										{ __(
-											'No fonts found. Try with a different search term'
+											'No fonts found. Try with a different search term.'
 										) }
 									</Text>
 								) }


### PR DESCRIPTION
## What, Why, and How?

This PR adds missing trailing periods.

I noticed that using trailing periods is a common pattern based on the examples below. This PR maintains consistency by ensuring that pattern is followed.

<img width="347" alt="example-1" src="https://github.com/user-attachments/assets/90d27a78-3b2a-432c-b939-05d369d5af7a" />

<img width="347" alt="example-2" src="https://github.com/user-attachments/assets/1a4e1877-c0a2-43ea-b72a-6a83b1b9a20f" />

## Screenshots

|Before|After|
|-|-|
|<img width="605" alt="before" src="https://github.com/user-attachments/assets/cc1ac1d2-c9b7-4c89-bd03-1a3501395f98" />|<img width="605" alt="after" src="https://github.com/user-attachments/assets/dbf916b9-33ee-496a-bae9-5d5992d84539" />|


