### PR TITLE
Editor: Add label in`TextareaControl` in CollabSidebar

### DIFF
--- a/packages/components/src/navigation/menu/menu-title-search.tsx
+++ b/packages/components/src/navigation/menu/menu-title-search.tsx
@@ -92,6 +92,7 @@ function MenuTitleSearch( {
 				onClose={ onClose }
 				ref={ inputRef }
 				value={ search }
+				label={ __( 'Search' ) }
 			/>
 		</MenuTitleSearchControlWrapper>
 	);

--- a/packages/components/src/navigation/menu/menu-title-search.tsx
+++ b/packages/components/src/navigation/menu/menu-title-search.tsx
@@ -92,7 +92,6 @@ function MenuTitleSearch( {
 				onClose={ onClose }
 				ref={ inputRef }
 				value={ search }
-				label={ __( 'Search' ) }
 			/>
 		</MenuTitleSearchControlWrapper>
 	);

--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -36,7 +36,8 @@ function CommentForm( { onSubmit, onCancel, thread, submitButtonText } ) {
 				__nextHasNoMarginBottom
 				value={ inputComment ?? '' }
 				onChange={ setInputComment }
-				aria-label={ __( 'Comment' ) }
+				label={ __( 'Comment' ) }
+				hideLabelFromVision
 			/>
 			<HStack alignment="left" spacing="3" justify="flex-start">
 				<Button

--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -7,7 +7,7 @@ import {
 	Button,
 	TextareaControl,
 } from '@wordpress/components';
-import { _x } from '@wordpress/i18n';
+import { _x, __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -36,6 +36,7 @@ function CommentForm( { onSubmit, onCancel, thread, submitButtonText } ) {
 				__nextHasNoMarginBottom
 				value={ inputComment ?? '' }
 				onChange={ setInputComment }
+				aria-label={ __( 'Comment text area' ) }
 			/>
 			<HStack alignment="left" spacing="3" justify="flex-start">
 				<Button

--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -36,7 +36,7 @@ function CommentForm( { onSubmit, onCancel, thread, submitButtonText } ) {
 				__nextHasNoMarginBottom
 				value={ inputComment ?? '' }
 				onChange={ setInputComment }
-				aria-label={ __( 'Comment text area' ) }
+				aria-label={ __( 'Comment' ) }
 			/>
 			<HStack alignment="left" spacing="3" justify="flex-start">
 				<Button


### PR DESCRIPTION
## What?

Part of: https://github.com/WordPress/gutenberg/issues/51740

I conducted an extensive search throughout the codebase to identify controls that are unlabeled and found 1 such instance:

1. `TextareaControl` in `CommentForm`

## Why?
All form controls must be labeled.

## How?
- Added label prop to `TextareaControl` in `CommentForm`. 

## Testing Instructions

1. Enable experimental inline commenting option under Gutenberg -> Experiments
3. Edit any post/page
4. Add any block, Click on more menu in block toolbar, Look for comment option.
5. It would open the thread in sidebar, Where you can add comment.
6. Observe that the aria-label is now there in the input container

## Screenshot

|Before|After|
|-|-|
|<img width="1469" alt="Screenshot 2025-05-15 at 5 56 18 PM" src="https://github.com/user-attachments/assets/81c9c3f5-9604-43a4-b7b8-46e05a8b198b" />|<img width="1470" alt="Screenshot 2025-05-15 at 5 57 26 PM" src="https://github.com/user-attachments/assets/2e6fc04e-3d37-491e-8fb2-7783136c9d21" />|

