### PR TITLE
Fix URL input fields to reserve space for spinner icon and prevent text overlap

### DIFF
--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -7,13 +7,17 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { __, sprintf, _n } from '@wordpress/i18n';
-import { Component, createRef } from '@wordpress/element';
+import {
+	Component,
+	createRef,
+	cloneElement,
+	isValidElement,
+} from '@wordpress/element';
 import { UP, DOWN, ENTER, TAB } from '@wordpress/keycodes';
 import {
 	BaseControl,
 	Button,
 	__experimentalInputControl as InputControl,
-	Spinner,
 	withSpokenMessages,
 	Popover,
 } from '@wordpress/components';
@@ -445,6 +449,18 @@ class URLInput extends Component {
 			hideLabelFromVision,
 		};
 
+		const { suffix } = this.props;
+		const clonedSuffix =
+			suffix?.props?.children && isValidElement( suffix.props.children )
+				? cloneElement( suffix.props.children, {
+						...( loading && { isBusy: true } ),
+				  } )
+				: null;
+		const finalSuffix =
+			suffix && clonedSuffix
+				? cloneElement( suffix, { children: clonedSuffix } )
+				: suffix;
+
 		const inputProps = {
 			id: inputId,
 			value,
@@ -464,7 +480,7 @@ class URLInput extends Component {
 					? `${ suggestionOptionIdPrefix }-${ selectedSuggestion }`
 					: undefined,
 			ref: this.inputRef,
-			suffix: this.props.suffix,
+			suffix: finalSuffix,
 		};
 
 		if ( renderControl ) {
@@ -474,7 +490,6 @@ class URLInput extends Component {
 		return (
 			<BaseControl __nextHasNoMarginBottom { ...controlProps }>
 				<InputControl { ...inputProps } __next40pxDefaultSize />
-				{ loading && <Spinner /> }
 			</BaseControl>
 		);
 	}

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -443,7 +443,7 @@ class URLInput extends Component {
 			label,
 			className: clsx( 'block-editor-url-input', className, {
 				'is-full-width': isFullWidth,
-				'has-spinner': showInitialSuggestions && handleURLSuggestions,
+				'has-spinner': showInitialSuggestions || handleURLSuggestions,
 			} ),
 			hideLabelFromVision,
 		};

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -7,17 +7,13 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { __, sprintf, _n } from '@wordpress/i18n';
-import {
-	Component,
-	createRef,
-	cloneElement,
-	isValidElement,
-} from '@wordpress/element';
+import { Component, createRef } from '@wordpress/element';
 import { UP, DOWN, ENTER, TAB } from '@wordpress/keycodes';
 import {
 	BaseControl,
 	Button,
 	__experimentalInputControl as InputControl,
+	Spinner,
 	withSpokenMessages,
 	Popover,
 } from '@wordpress/components';
@@ -426,6 +422,8 @@ class URLInput extends Component {
 			instanceId,
 			placeholder = __( 'Paste URL or type to search' ),
 			__experimentalRenderControl: renderControl,
+			__experimentalShowInitialSuggestions: showInitialSuggestions,
+			__experimentalHandleURLSuggestions: handleURLSuggestions,
 			value = '',
 			hideLabelFromVision = false,
 		} = this.props;
@@ -445,21 +443,10 @@ class URLInput extends Component {
 			label,
 			className: clsx( 'block-editor-url-input', className, {
 				'is-full-width': isFullWidth,
+				'has-spinner': showInitialSuggestions && handleURLSuggestions,
 			} ),
 			hideLabelFromVision,
 		};
-
-		const { suffix } = this.props;
-		const clonedSuffix =
-			suffix?.props?.children && isValidElement( suffix.props.children )
-				? cloneElement( suffix.props.children, {
-						...( loading && { isBusy: true } ),
-				  } )
-				: null;
-		const finalSuffix =
-			suffix && clonedSuffix
-				? cloneElement( suffix, { children: clonedSuffix } )
-				: suffix;
 
 		const inputProps = {
 			id: inputId,
@@ -480,7 +467,7 @@ class URLInput extends Component {
 					? `${ suggestionOptionIdPrefix }-${ selectedSuggestion }`
 					: undefined,
 			ref: this.inputRef,
-			suffix: finalSuffix,
+			suffix: this.props.suffix,
 		};
 
 		if ( renderControl ) {
@@ -490,6 +477,7 @@ class URLInput extends Component {
 		return (
 			<BaseControl __nextHasNoMarginBottom { ...controlProps }>
 				<InputControl { ...inputProps } __next40pxDefaultSize />
+				{ loading && <Spinner /> }
 			</BaseControl>
 		);
 	}

--- a/packages/block-editor/src/components/url-input/style.scss
+++ b/packages/block-editor/src/components/url-input/style.scss
@@ -30,6 +30,10 @@ $input-size: 300px;
 	}
 }
 
+.block-editor-url-input .components-input-control__container .components-input-control__input {
+	padding-right: 30px !important;
+}
+
 // Suggestions
 .block-editor-url-input__suggestions {
 	max-height: 200px;

--- a/packages/block-editor/src/components/url-input/style.scss
+++ b/packages/block-editor/src/components/url-input/style.scss
@@ -22,15 +22,15 @@ $input-size: 300px;
 		}
 	}
 
+	&.has-spinner .components-input-control__input {
+		padding-right: $grid-unit-40;
+	}
+
 	.components-spinner {
 		position: absolute;
 		margin: 0;
 		top: calc(50% - #{$spinner-size} / 2);
 		right: $grid-unit;
-	}
-
-	&:has(.components-spinner) .components-input-control__input {
-		padding-right: $grid-unit-40;
 	}
 }
 

--- a/packages/block-editor/src/components/url-input/style.scss
+++ b/packages/block-editor/src/components/url-input/style.scss
@@ -30,8 +30,8 @@ $input-size: 300px;
 	}
 }
 
-.block-editor-url-input input {
-	padding-right: 30px !important;
+&:has(.components-spinner) .components-input-control__input {
+	padding-right: $grid-unit-40;
 }
 
 // Suggestions

--- a/packages/block-editor/src/components/url-input/style.scss
+++ b/packages/block-editor/src/components/url-input/style.scss
@@ -30,7 +30,7 @@ $input-size: 300px;
 	}
 }
 
-.block-editor-url-input .components-input-control__container .components-input-control__input {
+.block-editor-url-input input {
 	padding-right: 30px !important;
 }
 

--- a/packages/block-editor/src/components/url-input/style.scss
+++ b/packages/block-editor/src/components/url-input/style.scss
@@ -28,10 +28,10 @@ $input-size: 300px;
 		top: calc(50% - #{$spinner-size} / 2);
 		right: $grid-unit;
 	}
-}
 
-&:has(.components-spinner) .components-input-control__input {
-	padding-right: $grid-unit-40;
+	&:has(.components-spinner) .components-input-control__input {
+		padding-right: $grid-unit-40;
+	}
 }
 
 // Suggestions


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR addresses a UI issue where the spinner icon in URL input fields overlaps with and hides long user-entered text.
Closes https://github.com/WordPress/gutenberg/issues/58679

<!-- In a few words, what is the PR actually doing? -->

## Why?
URL input field do not reserve space for the spinner icon. As a result, during loading states, long URLs are partially hidden, which disrupts user experience and readability.

## How?
A simple padding was needed towards the left of the spinner

## Testing Instructions

1. Add a block (like Paragraph or Image) and start inserting a link.
2. In the URL input field, type a long URL.
3. Wait for the loading spinner to appear.
4. Verify that the spinner no longer overlaps the URL text.
5. Confirm layout stability and readability across both components.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| ![image](https://github.com/user-attachments/assets/8ace6798-20cb-4d3d-b0b4-5fad383a1c73) | <img width="435" alt="Screenshot 2025-05-15 at 6 30 56 PM" src="https://github.com/user-attachments/assets/ee60f902-6ab8-4e80-866b-18a7d8d071a6" /> |
