### PR TITLE
Base Styles: Update to modern Sass module system

### DIFF
--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
--   This package now requires Dart Sass. The legacy `sass` package is no longer supported ([#70135](https://github.com/WordPress/gutenberg/pull/70135)).
+-   This package now requires [Dart Sass](https://www.npmjs.com/package/sass) to compile. Legacy Sass compilers like [LibSass](https://sass-lang.com/blog/libsass-is-deprecated/) ([`node-sass`](https://www.npmjs.com/package/node-sass)) and [Ruby Sass](https://sass-lang.com/blog/ruby-sass-is-unsupported/) are no longer supported ([#70135](https://github.com/WordPress/gutenberg/pull/70135)).
 
 ## 5.23.0 (2025-05-07)
 

--- a/packages/base-styles/CHANGELOG.md
+++ b/packages/base-styles/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   This package now requires Dart Sass. The legacy `sass` package is no longer supported ([#70135](https://github.com/WordPress/gutenberg/pull/70135)).
+
 ## 5.23.0 (2025-05-07)
 
 ## 5.22.0 (2025-04-11)

--- a/packages/base-styles/README.md
+++ b/packages/base-styles/README.md
@@ -2,6 +2,8 @@
 
 Base SCSS utilities and variables for WordPress.
 
+Note: This package requires [Dart Sass](https://www.npmjs.com/package/sass) to compile. When using this package, make sure you are using Sass version 1.23.0 or later, which is based on Dart Sass.
+
 ## Installation
 
 Install the module
@@ -10,33 +12,29 @@ Install the module
 npm install @wordpress/base-styles --save-dev
 ```
 
-## Use
-
-### SCSS utilities and variables
+## Usage
 
 In your application's SCSS file, include styles like so:
 
 ```scss
-@import 'node_modules/@wordpress/base-styles/colors';
-@import 'node_modules/@wordpress/base-styles/variables';
-@import 'node_modules/@wordpress/base-styles/mixins';
-@import 'node_modules/@wordpress/base-styles/breakpoints';
-@import 'node_modules/@wordpress/base-styles/animations';
-@import 'node_modules/@wordpress/base-styles/z-index';
-@import 'node_modules/@wordpress/base-styles/default-custom-properties';
+@use '@wordpress/base-styles/colors';
+@use '@wordpress/base-styles/variables';
+@use '@wordpress/base-styles/mixins';
+@use '@wordpress/base-styles/breakpoints';
+@use '@wordpress/base-styles/animations';
+@use '@wordpress/base-styles/z-index';
+@use '@wordpress/base-styles/default-custom-properties';
 ```
 
-If you use [Webpack](https://webpack.js.org/) for your SCSS pipeline, you can use `~` to resolve to `node_modules`:
+Make sure to use namespaces when accessing utilities, variables, functions, etc. For example:
 
 ```scss
-@import '~@wordpress/base-styles/colors';
-```
+.selector {
+	color: colors.$gray-300;
 
-To make that work with [`sass`](https://www.npmjs.com/package/sass) or [`node-sass`](https://www.npmjs.com/package/node-sass) NPM modules without Webpack, you'd have to use [includePaths option](https://sass-lang.com/documentation/js-api#includepaths):
-
-```json
-{
-	"includePaths": [ "node_modules" ]
+	@include mixins.break-medium() {
+		font-size: variables.$font-size-large;
+	}
 }
 ```
 

--- a/packages/base-styles/_colors.native.scss
+++ b/packages/base-styles/_colors.native.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 /** @format */
 
 // Hugo's new WordPress shades of gray, from http://codepen.io/hugobaeta/pen/grJjVp.
@@ -41,23 +43,23 @@ $blue-30: #5198d9;
 
 // Grays
 $gray: #87a6bc;
-$gray-light: lighten($gray, 33%); //#f3f6f8
-$gray-dark: darken($gray, 38%); //#2e4453
+$gray-light: color.adjust($gray, $lightness: 33%); //#f3f6f8
+$gray-dark: color.adjust($gray, $lightness: -38%); //#2e4453
 $gray-900: #1a1a1a;
 $gray-700: #757575;
 
 // $gray-text: ideal for standard, non placeholder text
 // $gray-text-min: minimum contrast needed for WCAG 2.0 AA on white background
 $gray-text: $gray-dark;
-$gray-text-min: darken($gray, 18%); //#537994
+$gray-text-min: color.adjust($gray, $lightness: -18%); //#537994
 
 // Shades of gray
-$gray-lighten-10: lighten($gray, 10%); // #a8bece
-$gray-lighten-20: lighten($gray, 20%); // #c8d7e1
-$gray-lighten-30: lighten($gray, 30%); // #e9eff3
-$gray-darken-10: darken($gray, 10%);
-$gray-darken-20: darken($gray, 20%); // #4f748e
-$gray-darken-30: darken($gray, 30%); // #3d596d
+$gray-lighten-10: color.adjust($gray, $lightness: 10%); // #a8bece
+$gray-lighten-20: color.adjust($gray, $lightness: 20%); // #c8d7e1
+$gray-lighten-30: color.adjust($gray, $lightness: 30%); // #e9eff3
+$gray-darken-10: color.adjust($gray, $lightness: -10%);
+$gray-darken-20: color.adjust($gray, $lightness: -20%); // #4f748e
+$gray-darken-30: color.adjust($gray, $lightness: -30%); // #3d596d
 
 // Custom
 $toolbar-button: #7b9ab1;

--- a/packages/base-styles/_colors.native.scss
+++ b/packages/base-styles/_colors.native.scss
@@ -1,6 +1,6 @@
-@use "sass:color";
-
 /** @format */
+
+@use "sass:color";
 
 // Hugo's new WordPress shades of gray, from http://codepen.io/hugobaeta/pen/grJjVp.
 $black: #000;

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -1,8 +1,8 @@
-@use "functions";
-
 /**
  * Colors
  */
+
+@use "./functions";
 
 // WordPress grays.
 $black: #000;			// Use only when you truly need pure black. For UI, use $gray-900.

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -1,4 +1,4 @@
-@import "./functions";
+@use "functions";
 
 /**
  * Colors

--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -2,8 +2,6 @@
  * Colors
  */
 
-@use "./functions";
-
 // WordPress grays.
 $black: #000;			// Use only when you truly need pure black. For UI, use $gray-900.
 $gray-900: #1e1e1e;

--- a/packages/base-styles/_default-custom-properties.scss
+++ b/packages/base-styles/_default-custom-properties.scss
@@ -1,4 +1,5 @@
 @use "./mixins";
+@use "./functions";
 
 // It is important to include these styles in all built stylesheets.
 // This allows to CSS variables post CSS plugin to generate fallbacks.

--- a/packages/base-styles/_default-custom-properties.scss
+++ b/packages/base-styles/_default-custom-properties.scss
@@ -1,11 +1,13 @@
+@use "./mixins";
+
 // It is important to include these styles in all built stylesheets.
 // This allows to CSS variables post CSS plugin to generate fallbacks.
 // It also provides default CSS variables for npm package consumers.
 :root {
-	@include admin-scheme(#007cba);
 	--wp-block-synced-color: #7a00df;
 	--wp-block-synced-color--rgb: #{hex-to-rgb(#7a00df)};
 	// This CSS variable is not used in Gutenberg project,
 	// but is maintained for backwards compatibility.
 	--wp-bound-block-color: var(--wp-block-synced-color);
+	@include mixins.admin-scheme(#007cba);
 }

--- a/packages/base-styles/_default-custom-properties.scss
+++ b/packages/base-styles/_default-custom-properties.scss
@@ -5,7 +5,7 @@
 // It also provides default CSS variables for npm package consumers.
 :root {
 	--wp-block-synced-color: #7a00df;
-	--wp-block-synced-color--rgb: #{hex-to-rgb(#7a00df)};
+	--wp-block-synced-color--rgb: #{functions.hex-to-rgb(#7a00df)};
 	// This CSS variable is not used in Gutenberg project,
 	// but is maintained for backwards compatibility.
 	--wp-bound-block-color: var(--wp-block-synced-color);

--- a/packages/base-styles/_functions.scss
+++ b/packages/base-styles/_functions.scss
@@ -8,5 +8,11 @@
 @use "sass:color";
 
 @function hex-to-rgb($hex) {
-	@return color.channel($hex, "red", $space: rgb), color.channel($hex, "green", $space: rgb), color.channel($hex, "blue", $space: rgb);
+	/*
+	 * We should use the color.channel() function instead of color.red(), color.green(), color.blue().
+	 * However, the Sass currently used by the Gutenberg project does not support color.channel().
+	 * We should update to color.channel() once the entire Gutenberg project has completed the migration to
+	 * Dart Sass and the Sass version is updated.
+	 */
+	@return color.red($hex), color.green($hex), color.blue($hex);
 }

--- a/packages/base-styles/_functions.scss
+++ b/packages/base-styles/_functions.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 /**
 *  Converts a hex value into the rgb equivalent.
 *
@@ -5,5 +7,5 @@
 * @return {string} comma separated rgb values
 */
 @function hex-to-rgb($hex) {
-	@return red($hex), green($hex), blue($hex);
+	@return color.red($hex), color.green($hex), color.blue($hex);
 }

--- a/packages/base-styles/_functions.scss
+++ b/packages/base-styles/_functions.scss
@@ -8,5 +8,5 @@
 @use "sass:color";
 
 @function hex-to-rgb($hex) {
-	@return color.red($hex), color.green($hex), color.blue($hex);
+	@return color.channel($hex, "red", $space: rgb), color.channel($hex, "green", $space: rgb), color.channel($hex, "blue", $space: rgb);
 }

--- a/packages/base-styles/_functions.scss
+++ b/packages/base-styles/_functions.scss
@@ -6,13 +6,19 @@
 */
 
 @use "sass:color";
+@use "sass:meta";
 
 @function hex-to-rgb($hex) {
 	/*
-	 * We should use the color.channel() function instead of color.red(), color.green(), color.blue().
-	 * However, the Sass currently used by the Gutenberg project does not support color.channel().
-	 * We should update to color.channel() once the entire Gutenberg project has completed the migration to
-	 * Dart Sass and the Sass version is updated.
+	 * TODO: `color.{red|green|blue}` will trigger a deprecation warning in Dart Sass,
+	 * but the Sass used by the Gutenberg project doesn't support `color.channel()` yet,
+	 * so we can't migrate to it at this time.
+	 * In the future, after the Gutenberg project has been fully migrated to Dart Sass,
+	 * Remove this conditional statement and use only `color.channel()`.
 	 */
-	@return color.red($hex), color.green($hex), color.blue($hex);
+	@if meta.function-exists("channel", "color") {
+		@return color.channel($hex, "red"), color.channel($hex, "green"), color.channel($hex, "blue");
+	} @else {
+		@return color.red($hex), color.green($hex), color.blue($hex);
+	}
 }

--- a/packages/base-styles/_functions.scss
+++ b/packages/base-styles/_functions.scss
@@ -1,11 +1,12 @@
-@use "sass:color";
-
 /**
 *  Converts a hex value into the rgb equivalent.
 *
 * @param {string} hex - the hexadecimal value to convert
 * @return {string} comma separated rgb values
 */
+
+@use "sass:color";
+
 @function hex-to-rgb($hex) {
 	@return color.red($hex), color.green($hex), color.blue($hex);
 }

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -376,7 +376,10 @@
 	min-width: variables.$radio-input-size-sm;
 	max-width: variables.$radio-input-size-sm;
 	position: relative;
-	@include input-control;
+
+	@media not (prefers-reduced-motion) {
+		transition: box-shadow 0.1s linear;
+	}
 
 	@include break-small() {
 		height: variables.$radio-input-size;

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -264,13 +264,13 @@
 }
 
 @mixin input-control($accent-color: var(--wp-admin-theme-color)) {
-	@include input-style__neutral();
 	font-family: variables.$default-font;
 	padding: 6px 8px;
 	/* Fonts smaller than 16px causes mobile safari to zoom. */
 	font-size: variables.$mobile-text-min-font-size;
 	/* Override core line-height. To be reviewed. */
 	line-height: normal;
+	@include input-style__neutral();
 
 	@include break-small {
 		font-size: variables.$default-font-size;
@@ -297,11 +297,11 @@
 }
 
 @mixin checkbox-control {
-	@include input-control;
 	border: variables.$border-width solid colors.$gray-900;
 	margin-right: variables.$grid-unit-15;
 	transition: none;
 	border-radius: variables.$radius-small;
+	@include input-control;
 
 	&:focus {
 		box-shadow: 0 0 0 (variables.$border-width * 2) colors.$white, 0 0 0 (variables.$border-width * 2 + variables.$border-width-focus-fallback) var(--wp-admin-theme-color);
@@ -367,7 +367,6 @@
 }
 
 @mixin radio-control {
-	@include input-control;
 	border: variables.$border-width solid colors.$gray-900;
 	margin-right: variables.$grid-unit-15;
 	transition: none;
@@ -377,6 +376,7 @@
 	min-width: variables.$radio-input-size-sm;
 	max-width: variables.$radio-input-size-sm;
 	position: relative;
+	@include input-control;
 
 	@include break-small() {
 		height: variables.$radio-input-size;

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -1,5 +1,7 @@
-@import "./functions";
-@import "./long-content-fade";
+@use "sass:color";
+@use "functions";
+@use "long-content-fade";
+@use "sass:math";
 
 /**
  * Typography
@@ -507,12 +509,12 @@
 	// Define RGB equivalents for use in rgba function.
 	// Hexadecimal css vars do not work in the rgba function.
 	--wp-admin-theme-color: #{$color-primary};
-	--wp-admin-theme-color--rgb: #{hex-to-rgb($color-primary)};
+	--wp-admin-theme-color--rgb: #{functions.hex-to-rgb($color-primary)};
 	// Darker shades.
-	--wp-admin-theme-color-darker-10: #{darken($color-primary, 5%)};
-	--wp-admin-theme-color-darker-10--rgb: #{hex-to-rgb(darken($color-primary, 5%))};
-	--wp-admin-theme-color-darker-20: #{darken($color-primary, 10%)};
-	--wp-admin-theme-color-darker-20--rgb: #{hex-to-rgb(darken($color-primary, 10%))};
+	--wp-admin-theme-color-darker-10: #{color.adjust($color-primary, $lightness: -5%)};
+	--wp-admin-theme-color-darker-10--rgb: #{functions.hex-to-rgb(color.adjust($color-primary, $lightness: -5%))};
+	--wp-admin-theme-color-darker-20: #{color.adjust($color-primary, $lightness: -10%)};
+	--wp-admin-theme-color-darker-20--rgb: #{functions.hex-to-rgb(color.adjust($color-primary, $lightness: -10%))};
 
 	// Focus style width.
 	// Avoid rounding issues by showing a whole 2px for 1x screens, and 1.5px on high resolution screens.

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -1,11 +1,11 @@
-@use "sass:color";
-@use "functions";
-@use "long-content-fade";
-@use "sass:math";
-
 /**
  * Typography
  */
+
+@use "sass:color";
+@use "sass:math";
+@use "./functions";
+@use "./long-content-fade";
 
 @mixin _text-heading() {
 	font-family: $font-family-headings;

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -4,71 +4,74 @@
 
 @use "sass:color";
 @use "sass:math";
+@use "./variables";
+@use "./colors";
+@use "./breakpoints";
 @use "./functions";
 @use "./long-content-fade";
 
 @mixin _text-heading() {
-	font-family: $font-family-headings;
-	font-weight: $font-weight-medium;
+	font-family: variables.$font-family-headings;
+	font-weight: variables.$font-weight-medium;
 }
 
 @mixin _text-body() {
-	font-family: $font-family-body;
-	font-weight: $font-weight-regular;
+	font-family: variables.$font-family-body;
+	font-weight: variables.$font-weight-regular;
 }
 
 @mixin heading-small() {
 	@include _text-heading();
-	font-size: $font-size-x-small;
-	line-height: $font-line-height-x-small;
+	font-size: variables.$font-size-x-small;
+	line-height: variables.$font-line-height-x-small;
 }
 
 @mixin heading-medium() {
 	@include _text-heading();
-	font-size: $font-size-medium;
-	line-height: $font-line-height-small;
+	font-size: variables.$font-size-medium;
+	line-height: variables.$font-line-height-small;
 }
 
 @mixin heading-large() {
 	@include _text-heading();
-	font-size: $font-size-large;
-	line-height: $font-line-height-small;
+	font-size: variables.$font-size-large;
+	line-height: variables.$font-line-height-small;
 }
 
 @mixin heading-x-large() {
 	@include _text-heading();
-	font-size: $font-size-x-large;
-	line-height: $font-line-height-medium;
+	font-size: variables.$font-size-x-large;
+	line-height: variables.$font-line-height-medium;
 }
 
 @mixin heading-2x-large() {
 	@include _text-heading();
-	font-size: $font-size-2x-large;
-	line-height: $font-line-height-2x-large;
+	font-size: variables.$font-size-2x-large;
+	line-height: variables.$font-line-height-2x-large;
 }
 
 @mixin body-small() {
 	@include _text-body();
-	font-size: $font-size-small;
-	line-height: $font-line-height-x-small;
+	font-size: variables.$font-size-small;
+	line-height: variables.$font-line-height-x-small;
 }
 
 @mixin body-medium() {
 	@include _text-body();
-	font-size: $font-size-medium;
-	line-height: $font-line-height-small;
+	font-size: variables.$font-size-medium;
+	line-height: variables.$font-line-height-small;
 }
 
 @mixin body-large() {
 	@include _text-body();
-	font-size: $font-size-large;
-	line-height: $font-line-height-medium;
+	font-size: variables.$font-size-large;
+	line-height: variables.$font-line-height-medium;
 }
 
 @mixin body-x-large() {
 	@include _text-body();
-	font-size: $font-size-x-large;
-	line-height: $font-line-height-x-large;
+	font-size: variables.$font-size-x-large;
+	line-height: variables.$font-line-height-x-large;
 }
 
 /**
@@ -76,55 +79,55 @@
  */
 
 @mixin break-xhuge() {
-	@media (min-width: #{ ($break-xhuge) }) {
+	@media (min-width: #{ (breakpoints.$break-xhuge) }) {
 		@content;
 	}
 }
 
 @mixin break-huge() {
-	@media (min-width: #{ ($break-huge) }) {
+	@media (min-width: #{ (breakpoints.$break-huge) }) {
 		@content;
 	}
 }
 
 @mixin break-wide() {
-	@media (min-width: #{ ($break-wide) }) {
+	@media (min-width: #{ (breakpoints.$break-wide) }) {
 		@content;
 	}
 }
 
 @mixin break-xlarge() {
-	@media (min-width: #{ ($break-xlarge) }) {
+	@media (min-width: #{ (breakpoints.$break-xlarge) }) {
 		@content;
 	}
 }
 
 @mixin break-large() {
-	@media (min-width: #{ ($break-large) }) {
+	@media (min-width: #{ (breakpoints.$break-large) }) {
 		@content;
 	}
 }
 
 @mixin break-medium() {
-	@media (min-width: #{ ($break-medium) }) {
+	@media (min-width: #{ (breakpoints.$break-medium) }) {
 		@content;
 	}
 }
 
 @mixin break-small() {
-	@media (min-width: #{ ($break-small) }) {
+	@media (min-width: #{ (breakpoints.$break-small) }) {
 		@content;
 	}
 }
 
 @mixin break-mobile() {
-	@media (min-width: #{ ($break-mobile) }) {
+	@media (min-width: #{ (breakpoints.$break-mobile) }) {
 		@content;
 	}
 }
 
 @mixin break-zoomed-in() {
-	@media (min-width: #{ ($break-zoomed-in) }) {
+	@media (min-width: #{ (breakpoints.$break-zoomed-in) }) {
 		@content;
 	}
 }
@@ -134,7 +137,7 @@
  */
 
 @mixin block-toolbar-button-style__focus() {
-	box-shadow: inset 0 0 0 $border-width $white, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+	box-shadow: inset 0 0 0 variables.$border-width colors.$white, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 
 	// Windows High Contrast mode will show this outline, but not the box-shadow.
 	outline: 2px solid transparent;
@@ -143,13 +146,12 @@
 // Tabs, Inputs, Square buttons.
 @mixin input-style__neutral() {
 	box-shadow: 0 0 0 transparent;
+	border-radius: variables.$radius-small;
+	border: variables.$border-width solid colors.$gray-600;
 
 	@media not (prefers-reduced-motion) {
 		transition: box-shadow 0.1s linear;
 	}
-
-	border-radius: $radius-small;
-	border: $border-width solid $gray-600;
 }
 
 
@@ -170,7 +172,7 @@
 
 
 @mixin button-style-outset__focus($focus-color) {
-	box-shadow: 0 0 0 var(--wp-admin-border-width-focus) $white, 0 0 0 calc(2 * var(--wp-admin-border-width-focus)) $focus-color;
+	box-shadow: 0 0 0 var(--wp-admin-border-width-focus) colors.$white, 0 0 0 calc(2 * var(--wp-admin-border-width-focus)) $focus-color;
 
 	// Windows High Contrast mode will show this outline, but not the box-shadow.
 	outline: 2px solid transparent;
@@ -186,18 +188,18 @@
 	#{$selector} { /* Set left position when auto-fold is not on the body element. */
 		left: 0;
 
-		@media (min-width: #{ ($break-medium + 1) }) {
-			left: $admin-sidebar-width;
+		@media (min-width: #{ (breakpoints.$break-medium + 1) }) {
+			left: variables.$admin-sidebar-width;
 		}
 	}
 
 	.auto-fold #{$selector} { /* Auto fold is when on smaller breakpoints, nav menu auto collapses. */
-		@media (min-width: #{ ($break-medium + 1) }) {
-			left: $admin-sidebar-width-collapsed;
+		@media (min-width: #{ (breakpoints.$break-medium + 1) }) {
+			left: variables.$admin-sidebar-width-collapsed;
 		}
 
-		@media (min-width: #{ ($break-large + 1) }) {
-			left: $admin-sidebar-width;
+		@media (min-width: #{ (breakpoints.$break-large + 1) }) {
+			left: variables.$admin-sidebar-width;
 		}
 	}
 
@@ -205,8 +207,8 @@
 	.folded #{$selector} {
 		left: 0;
 
-		@media (min-width: #{ ($break-medium + 1) }) {
-			left: $admin-sidebar-width-collapsed;
+		@media (min-width: #{ (breakpoints.$break-medium + 1) }) {
+			left: variables.$admin-sidebar-width-collapsed;
 		}
 	}
 
@@ -227,11 +229,11 @@
 
 @mixin caption-style-theme() {
 	color: #555;
-	font-size: $default-font-size;
+	font-size: variables.$default-font-size;
 	text-align: center;
 
 	.is-dark-theme & {
-		color: $light-gray-placeholder;
+		color: colors.$light-gray-placeholder;
 	}
 }
 
@@ -262,16 +264,16 @@
 }
 
 @mixin input-control($accent-color: var(--wp-admin-theme-color)) {
-	font-family: $default-font;
-	padding: 6px 8px;
 	@include input-style__neutral();
-
+	font-family: variables.$default-font;
+	padding: 6px 8px;
 	/* Fonts smaller than 16px causes mobile safari to zoom. */
-	font-size: $mobile-text-min-font-size;
+	font-size: variables.$mobile-text-min-font-size;
 	/* Override core line-height. To be reviewed. */
 	line-height: normal;
+
 	@include break-small {
-		font-size: $default-font-size;
+		font-size: variables.$default-font-size;
 		/* Override core line-height. To be reviewed. */
 		line-height: normal;
 	}
@@ -282,27 +284,27 @@
 
 	// Use opacity to work in various editor styles.
 	&::-webkit-input-placeholder {
-		color: $dark-gray-placeholder;
+		color: colors.$dark-gray-placeholder;
 	}
 
 	&::-moz-placeholder {
-		color: $dark-gray-placeholder;
+		color: colors.$dark-gray-placeholder;
 	}
 
 	&:-ms-input-placeholder {
-		color: $dark-gray-placeholder;
+		color: colors.$dark-gray-placeholder;
 	}
 }
 
 @mixin checkbox-control {
 	@include input-control;
-	border: $border-width solid $gray-900;
-	margin-right: $grid-unit-15;
+	border: variables.$border-width solid colors.$gray-900;
+	margin-right: variables.$grid-unit-15;
 	transition: none;
-	border-radius: $radius-small;
+	border-radius: variables.$radius-small;
 
 	&:focus {
-		box-shadow: 0 0 0 ($border-width * 2) $white, 0 0 0 ($border-width * 2 + $border-width-focus-fallback) var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 (variables.$border-width * 2) colors.$white, 0 0 0 (variables.$border-width * 2 + variables.$border-width-focus-fallback) var(--wp-admin-theme-color);
 
 		// Only visible in Windows High Contrast mode.
 		outline: 2px solid transparent;
@@ -321,7 +323,7 @@
 	&:checked::before,
 	&[aria-checked="mixed"]::before {
 		margin: -3px -5px;
-		color: $white;
+		color: colors.$white;
 
 		@include break-medium() {
 			margin: -4px 0 0 -5px;
@@ -355,8 +357,8 @@
 
 	&[aria-disabled="true"],
 	&:disabled {
-		background: $gray-100;
-		border-color: $gray-300;
+		background: colors.$gray-100;
+		border-color: colors.$gray-300;
 		cursor: default;
 
 		// Override style inherited from wp-admin. Required to avoid degraded appearance on different backgrounds.
@@ -366,45 +368,45 @@
 
 @mixin radio-control {
 	@include input-control;
-	border: $border-width solid $gray-900;
-	margin-right: $grid-unit-15;
+	border: variables.$border-width solid colors.$gray-900;
+	margin-right: variables.$grid-unit-15;
 	transition: none;
-	border-radius: $radius-round;
-	width: $radio-input-size-sm;
-	height: $radio-input-size-sm;
-	min-width: $radio-input-size-sm;
-	max-width: $radio-input-size-sm;
+	border-radius: variables.$radius-round;
+	width: variables.$radio-input-size-sm;
+	height: variables.$radio-input-size-sm;
+	min-width: variables.$radio-input-size-sm;
+	max-width: variables.$radio-input-size-sm;
 	position: relative;
 
 	@include break-small() {
-		height: $radio-input-size;
-		width: $radio-input-size;
-		min-width: $radio-input-size;
-		max-width: $radio-input-size;
+		height: variables.$radio-input-size;
+		width: variables.$radio-input-size;
+		min-width: variables.$radio-input-size;
+		max-width: variables.$radio-input-size;
 	}
 
 	&:checked::before {
 		box-sizing: inherit;
-		width: math.div($radio-input-size-sm, 2);
-		height: math.div($radio-input-size-sm, 2);
+		width: math.div(variables.$radio-input-size-sm, 2);
+		height: math.div(variables.$radio-input-size-sm, 2);
 		position: absolute;
 		top: 50%;
 		left: 50%;
 		transform: translate(-50%, -50%);
 		margin: 0;
-		background-color: $white;
+		background-color: colors.$white;
 
 		// This border serves as a background color in Windows High Contrast mode.
-		border: 4px solid $white;
+		border: 4px solid colors.$white;
 
 		@include break-small() {
-			width: math.div($radio-input-size, 2);
-			height: math.div($radio-input-size, 2);
+			width: math.div(variables.$radio-input-size, 2);
+			height: math.div(variables.$radio-input-size, 2);
 		}
 	}
 
 	&:focus {
-		box-shadow: 0 0 0 ($border-width * 2) $white, 0 0 0 ($border-width * 2 + $border-width-focus-fallback) var(--wp-admin-theme-color);
+		box-shadow: 0 0 0 (variables.$border-width * 2) colors.$white, 0 0 0 (variables.$border-width * 2 + variables.$border-width-focus-fallback) var(--wp-admin-theme-color);
 
 		// Only visible in Windows High Contrast mode.
 		outline: 2px solid transparent;
@@ -435,29 +437,29 @@
 	&:focus {
 		color: var(--wp-admin-theme-color--rgb);
 		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color, #007cba);
-		border-radius: $radius-small;
+		border-radius: variables.$radius-small;
 	}
 }
 
 // The editor input reset with increased specificity to avoid theme styles bleeding in.
 @mixin editor-input-reset() {
-	font-family: $editor-html-font !important;
-	color: $gray-900 !important;
-	background: $white !important;
-	padding: $grid-unit-15 !important;
-	border: $border-width solid $gray-900 !important;
+	font-family: variables.$editor-html-font !important;
+	color: colors.$gray-900 !important;
+	background: colors.$white !important;
+	padding: variables.$grid-unit-15 !important;
+	border: variables.$border-width solid colors.$gray-900 !important;
 	box-shadow: none !important;
-	border-radius: $radius-small !important;
+	border-radius: variables.$radius-small !important;
 
 	// Fonts smaller than 16px causes mobile safari to zoom.
-	font-size: $mobile-text-min-font-size !important;
+	font-size: variables.$mobile-text-min-font-size !important;
 	@include break-small {
-		font-size: $default-font-size !important;
+		font-size: variables.$default-font-size !important;
 	}
 
 	&:focus {
 		border-color: var(--wp-admin-theme-color) !important;
-		box-shadow: 0 0 0 ($border-width-focus-fallback - $border-width) var(--wp-admin-theme-color) !important;
+		box-shadow: 0 0 0 (variables.$border-width-focus-fallback - variables.$border-width) var(--wp-admin-theme-color) !important;
 
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent !important;
@@ -469,7 +471,7 @@
  */
 
 @mixin wp-admin-reset( $content-container ) {
-	background: $white;
+	background: colors.$white;
 
 	#wpcontent {
 		padding-left: 0;
@@ -496,7 +498,7 @@
 
 	ul#adminmenu a.wp-has-current-submenu::after,
 	ul#adminmenu > li.current > a.current::after {
-		border-right-color: $white;
+		border-right-color: colors.$white;
 	}
 
 	.media-frame select.attachment-filters:last-of-type {

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -6,7 +6,7 @@
  * For example, don't add rules to this sheet that affect block visuals. It's purely for UI.
  */
 
-@import "./colors";
+@use "colors";
 
 /**
  * Fonts & basic variables.
@@ -77,16 +77,16 @@ $radius-round: 50%;     // For circles and ovals.
  */
 
 // For sections and containers that group related content and controls, which may overlap other content. Example: Preview Frame.
-$elevation-x-small: 0 1px 1px rgba($black, 0.03), 0 1px 2px rgba($black, 0.02), 0 3px 3px rgba($black, 0.02), 0 4px 4px rgba($black, 0.01);
+$elevation-x-small: 0 1px 1px rgba(colors.$black, 0.03), 0 1px 2px rgba(colors.$black, 0.02), 0 3px 3px rgba(colors.$black, 0.02), 0 4px 4px rgba(colors.$black, 0.01);
 
 // For components that provide contextual feedback without being intrusive. Generally non-interruptive. Example: Tooltips, Snackbar.
-$elevation-small: 0 1px 2px rgba($black, 0.05), 0 2px 3px rgba($black, 0.04), 0 6px 6px rgba($black, 0.03), 0 8px 8px rgba($black, 0.02);
+$elevation-small: 0 1px 2px rgba(colors.$black, 0.05), 0 2px 3px rgba(colors.$black, 0.04), 0 6px 6px rgba(colors.$black, 0.03), 0 8px 8px rgba(colors.$black, 0.02);
 
 // For components that offer additional actions. Example: Menus, Command Palette
-$elevation-medium: 0 2px 3px rgba($black, 0.05), 0 4px 5px rgba($black, 0.04), 0 12px 12px rgba($black, 0.03), 0 16px 16px rgba($black, 0.02);
+$elevation-medium: 0 2px 3px rgba(colors.$black, 0.05), 0 4px 5px rgba(colors.$black, 0.04), 0 12px 12px rgba(colors.$black, 0.03), 0 16px 16px rgba(colors.$black, 0.02);
 
 // For components that confirm decisions or handle necessary interruptions. Example: Modals.
-$elevation-large: 0 5px 15px rgba($black, 0.08), 0 15px 27px rgba($black, 0.07), 0 30px 36px rgba($black, 0.04), 0 50px 43px rgba($black, 0.02);
+$elevation-large: 0 5px 15px rgba(colors.$black, 0.08), 0 15px 27px rgba(colors.$black, 0.07), 0 30px 36px rgba(colors.$black, 0.04), 0 50px 43px rgba(colors.$black, 0.02);
 
 /**
  * Dimensions.

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -6,7 +6,7 @@
  * For example, don't add rules to this sheet that affect block visuals. It's purely for UI.
  */
 
-@use "colors";
+@use "./colors";
 
 /**
  * Fonts & basic variables.

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 // Stores a list of z-index values in a central location.  For clarity, when a
 // specific value is needed, add a comment explaining why (what other rules the
 // value is designed to work with).
@@ -217,8 +219,8 @@ $z-layers: (
 );
 
 @function z-index( $key ) {
-	@if map-has-key( $z-layers, $key ) {
-		@return map-get( $z-layers, $key );
+	@if map.has-key( $z-layers, $key ) {
+		@return map.get( $z-layers, $key );
 	}
 
 	@error "Error: Specified z-index `#{$key}` does not exist in the mapping";


### PR DESCRIPTION
Closes #37044

## What?

Update the `@wordpress/base-styles` package to be compatible with [the Sass module system](https://sass-lang.com/blog/the-module-system-is-launched/).

## Why?

The current base-styles package uses legacy import statements that are considered deprecated in Dart Sass. Therefore, consumers using this package are forced to use the legacy Sass compiler and cannot use Dart Sass.

Furthermore, this is also an obstacle to the Gutenberg project itself in migrating to the Dart Sass format in the future.

## How?

- Run the following command to auto-migrate deprecated formats to recommend formats first:
  ```
  npx sass-migrator module division --migrate-deps packages/base-styles/*.scss
  ``` 
- Fix to prevent build errors in Gutenberg projects and external projects that use this package.
- Update CHANGELOG and README

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

- Build the Gutenberg project to ensure there are no errors. There should be no visual changes.
- I've created [a test repository](https://github.com/t-hamano/base-styles-mixin-test) that assumes that the base-styles package is used in an external project. Follow the README to test your build.
- Review [the README file](https://github.com/WordPress/gutenberg/blob/test/run-sass-migrator/packages/base-styles/README.md) to see if it provides sufficient and understandable information for consumers.
