### PR TITLE
List View: Enhance list view to display heading level with title

### DIFF
--- a/packages/block-editor/src/components/block-title/use-block-display-title.js
+++ b/packages/block-editor/src/components/block-title/use-block-display-title.js
@@ -54,12 +54,28 @@ export default function useBlockDisplayTitle( {
 			const label = getBlockLabel( blockType, attributes, context );
 			// If the label is defined we prioritize it over a possible block variation title match.
 			if ( label !== blockType.title ) {
+				if (
+					context === 'list-view' &&
+					blockType.name === 'core/heading'
+				) {
+					return `H${ attributes.level }: ${ label }`;
+				}
+
 				return label;
+			}
+
+			let title = blockType.title;
+
+			if (
+				context === 'list-view' &&
+				blockType.name === 'core/heading'
+			) {
+				title = `H${ attributes.level }: ${ title }`;
 			}
 
 			const match = getActiveBlockVariation( blockName, attributes );
 			// Label will fallback to the title if no label is defined for the current label context.
-			return match?.title || blockType.title;
+			return match?.title || title;
 		},
 		[ clientId, context ]
 	);

--- a/packages/block-editor/src/components/block-title/use-block-display-title.js
+++ b/packages/block-editor/src/components/block-title/use-block-display-title.js
@@ -54,28 +54,12 @@ export default function useBlockDisplayTitle( {
 			const label = getBlockLabel( blockType, attributes, context );
 			// If the label is defined we prioritize it over a possible block variation title match.
 			if ( label !== blockType.title ) {
-				if (
-					context === 'list-view' &&
-					blockType.name === 'core/heading'
-				) {
-					return `H${ attributes.level }: ${ label }`;
-				}
-
 				return label;
-			}
-
-			let title = blockType.title;
-
-			if (
-				context === 'list-view' &&
-				blockType.name === 'core/heading'
-			) {
-				title = `H${ attributes.level }: ${ title }`;
 			}
 
 			const match = getActiveBlockVariation( blockName, attributes );
 			// Label will fallback to the title if no label is defined for the current label context.
-			return match?.title || title;
+			return match?.title || blockType.title;
 		},
 		[ clientId, context ]
 	);

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -36,12 +36,14 @@ export const settings = {
 		// In the list view, use the block's content as the label.
 		// If the content is empty, fall back to the default label.
 		if ( context === 'list-view' ) {
-			if ( customName || hasContent ) {
-				const listViewTitle = customName || content;
-				return `H${ level }: ${ listViewTitle }`;
-			}
-
-			return `H${ level }: ${ __( 'Heading' ) }`;
+			const listViewTitle =
+				customName || ( hasContent ? content : __( 'Heading' ) );
+			return sprintf(
+				/* translators: list view text. 1: heading level. 2: heading content. */
+				__( '%1$s: %2$s' ),
+				`H${ level }`,
+				listViewTitle
+			);
 		}
 
 		if ( context === 'accessibility' ) {

--- a/packages/block-library/src/heading/index.js
+++ b/packages/block-library/src/heading/index.js
@@ -35,8 +35,13 @@ export const settings = {
 
 		// In the list view, use the block's content as the label.
 		// If the content is empty, fall back to the default label.
-		if ( context === 'list-view' && ( customName || hasContent ) ) {
-			return customName || content;
+		if ( context === 'list-view' ) {
+			if ( customName || hasContent ) {
+				const listViewTitle = customName || content;
+				return `H${ level }: ${ listViewTitle }`;
+			}
+
+			return `H${ level }: ${ __( 'Heading' ) }`;
 		}
 
 		if ( context === 'accessibility' ) {


### PR DESCRIPTION
## What?
This PR enhances the List View by displaying the heading level (H1, H2, etc.) alongside the heading title, making it easier to identify and navigate the heading hierarchy.
Closes #54631

## Why?
List View doesn't visually indicate heading levels, making it difficult for users to understand the document structure without selecting each heading individually.

### Testing Instructions for Keyboard
Testing Instructions for Keyboard

1. Create a new post
2. Add a heading to the post 
3. Open list view and verify whether the title of the heading is appended with heading level or not, like H1, H2, etc.

## Screenshot:

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/d70c4370-4d9b-4e62-a638-c79a5baf4e6c)|![image](https://github.com/user-attachments/assets/69f69078-ae99-4450-ab27-93bef438abd5)|
