### PR TITLE
Button Block: Add HTML Element selection in Advanced settings

### DIFF
--- a/packages/block-editor/src/components/html-element-control/messages.js
+++ b/packages/block-editor/src/components/html-element-control/messages.js
@@ -7,11 +7,17 @@ import { __ } from '@wordpress/i18n';
  * Messages providing helpful descriptions for HTML elements.
  */
 export const htmlElementMessages = {
+	a: __(
+		'The <a> element should be used for links that navigate to a different page or to a different section within the same page.'
+	),
 	article: __(
 		'The <article> element should represent a self-contained, syndicatable portion of the document.'
 	),
 	aside: __(
 		"The <aside> element should represent a portion of a document whose content is only indirectly related to the document's main content."
+	),
+	button: __(
+		'The <button> element should be used for interactive controls that perform an action on the current page, such as opening a modal or toggling content visibility.'
 	),
 	div: __(
 		'The <div> element should only be used if the block is a design element with no semantic meaning.'

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -10,6 +10,7 @@ import { NEW_TAB_TARGET, NOFOLLOW_REL } from './constants';
 import { getUpdatedLinkAttributes } from './get-updated-link-attributes';
 import removeAnchorTag from '../utils/remove-anchor-tag';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+import { unlock } from '../lock-unlock';
 
 /**
  * WordPress dependencies
@@ -47,6 +48,7 @@ import {
 	useBlockEditingMode,
 	getTypographyClassesAndStyles as useTypographyProps,
 	useSettings,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { displayShortcut, isKeyboardEvent, ENTER } from '@wordpress/keycodes';
 import { link, linkOff } from '@wordpress/icons';
@@ -58,6 +60,8 @@ import {
 } from '@wordpress/blocks';
 import { useMergeRefs, useRefEffect } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
+
+const { HTMLElementControl } = unlock( blockEditorPrivateApis );
 
 const LINK_SETTINGS = [
 	...LinkControl.DEFAULT_LINK_SETTINGS,
@@ -455,6 +459,17 @@ function ButtonEdit( props ) {
 				/>
 			</InspectorControls>
 			<InspectorControls group="advanced">
+				<HTMLElementControl
+					tagName={ tagName }
+					onChange={ ( value ) =>
+						setAttributes( { tagName: value } )
+					}
+					clientId={ clientId }
+					options={ [
+						{ label: __( 'Default (<a>)' ), value: 'a' },
+						{ label: '<button>', value: 'button' },
+					] }
+				/>
 				{ isLinkTag && (
 					<TextControl
 						__next40pxDefaultSize


### PR DESCRIPTION
## What?
resolves part of #63534

This PR adds an HTML Element selection dropdown to the Button block's Advanced settings panel, allowing users to choose between <a> (link) and `<button>` elements for better accessibility.

## Why?
Currently, the Button block only outputs links (`<a>` elements). Users frequently misinterpret its name and use it for actions that should be triggered by a true HTML button, not a link. This creates accessibility problems, particularly for screen reader users who rely on semantic HTML to understand page functionality.

This change makes it easier for users to create accessible interfaces without writing custom code, addressing a common issue found during accessibility audits.

## How?

- Added an HTMLElementControl component to the Button block's Advanced settings panel
- Added custom help messages for both `<a>` and `<button>` elements to educate users on proper usage
- Utilized the existing tagName attribute that was already present in the block.json file

## Testing Instructions

- Add a Button block to a post or page
- Select the Button block
- In the right sidebar, go to the "Advanced" panel
- You should see a new "HTML element" dropdown with two options:
  - Default (`<a>`)
  - `<button>`
- Select the `<button>` option
- The button should now be rendered as an HTML button element instead of a link
- When you select an element type, you should see a helpful description below the dropdown explaining when to use that element type

## Testing Instructions for Keyboard

- Add a Button block to a post or page
- Use Tab to navigate to the block settings sidebar
- Use Tab to navigate to the Advanced panel (press Enter to expand if collapsed)
- Continue tabbing to reach the HTML element dropdown
- Press Enter to open the dropdown
- Use arrow keys to select `<button>` option
- Press Enter to confirm selection
- Verify the help text appears below the dropdown
- Tab back to the editor and verify the button now uses the button element

## Screenshot

![image](https://github.com/user-attachments/assets/c51cbd6b-2950-4c5b-9b0d-e7d031a89c56)
![image](https://github.com/user-attachments/assets/599cb941-de57-46bc-8e1c-5797cb18f154)
![image](https://github.com/user-attachments/assets/fac21da2-c3f8-42d8-bec9-18f6f00e7ac0)
