### PR TITLE
Fix focus loss when deleting a menu from Navigation block Inspector

### DIFF
--- a/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
@@ -7,7 +7,7 @@ import {
 } from '@wordpress/components';
 import { store as coreStore, useEntityId } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { useState, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 export default function NavigationMenuDeleteControl( { onDelete } ) {
@@ -15,9 +15,22 @@ export default function NavigationMenuDeleteControl( { onDelete } ) {
 		useState( false );
 	const id = useEntityId( 'postType', 'wp_navigation' );
 	const { deleteEntityRecord } = useDispatch( coreStore );
+	const containerRef = useRef();
+
+	const handleDelete = () => {
+		if ( containerRef.current ) {
+			containerRef.current.tabIndex = -1;
+			containerRef.current.focus();
+		}
+
+		deleteEntityRecord( 'postType', 'wp_navigation', id, {
+			force: true,
+		} );
+		onDelete();
+	};
 
 	return (
-		<>
+		<div ref={ containerRef }>
 			<Button
 				__next40pxDefaultSize
 				className="wp-block-navigation-delete-menu-button"
@@ -32,12 +45,7 @@ export default function NavigationMenuDeleteControl( { onDelete } ) {
 			{ isConfirmDialogVisible && (
 				<ConfirmDialog
 					isOpen
-					onConfirm={ () => {
-						deleteEntityRecord( 'postType', 'wp_navigation', id, {
-							force: true,
-						} );
-						onDelete();
-					} }
+					onConfirm={ handleDelete }
 					onCancel={ () => {
 						setIsConfirmDialogVisible( false );
 					} }
@@ -49,6 +57,6 @@ export default function NavigationMenuDeleteControl( { onDelete } ) {
 					) }
 				</ConfirmDialog>
 			) }
-		</>
+		</div>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/59790

This PR fixes an accessibility issue where keyboard focus is lost when deleting a navigation menu from the block inspector.


## Testing Instructions
1. Go to the Site editor and select a Navigation block that has a menu.
2. In the block inspector, go to the Settings tab > scroll down to Advanced, open it.
3. Click the 'Delete menu' button.
4. Confirm deletion in the dialog.
5. Verify that focus remains in a predictable location in the UI.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/f05e66f1-5bca-4047-b19c-c80e88332778


