### PR TITLE
Add Active class to currently selected Query Block

### DIFF
--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -27,9 +27,19 @@ const TEMPLATE = [
 	[ 'core/post-excerpt' ],
 ];
 
-function PostTemplateInnerBlocks( { classList } ) {
+function PostTemplateInnerBlocks( {
+	classList,
+	blockContext,
+	activeBlockContextId,
+} ) {
+	const isActive = blockContext.postId === activeBlockContextId;
+
 	const innerBlocksProps = useInnerBlocksProps(
-		{ className: clsx( 'wp-block-post', classList ) },
+		{
+			className: clsx( 'wp-block-post', classList, {
+				'is-active-post': isActive,
+			} ),
+		},
 		{ template: TEMPLATE, __unstableDisableLayoutClassNames: true }
 	);
 	return <li { ...innerBlocksProps } />;
@@ -243,6 +253,7 @@ export default function PostTemplateEdit( {
 			previewPostType,
 		]
 	);
+
 	const blockContexts = useMemo(
 		() =>
 			posts?.map( ( post ) => ( {
@@ -318,6 +329,10 @@ export default function PostTemplateEdit( {
 								blockContexts[ 0 ]?.postId ) ? (
 								<PostTemplateInnerBlocks
 									classList={ blockContext.classList }
+									blockContext={ blockContext } // Pass the whole context
+									activeBlockContextId={
+										activeBlockContextId
+									} // Pass the active ID
 								/>
 							) : null }
 							<MemoizedPostTemplateBlockPreview


### PR DESCRIPTION
## What?
Issue – https://github.com/WordPress/gutenberg/issues/47568

## Why?
This PR adds an active class to the currently selected query in a query block. It marks the actively selected post to provide custom styling. It uses the class `is-active-post` to mark the currently selected post.

## How?
When a Post Inner Block is rendered, the currently selected block post is determined based on the inner block status. It is a lightweight approach with no additional states required.

## Testing Instructions
1. Add a custom CSS for the class `is-active-post` in the theme editor file or using a style enqueue.
2. Add a new query block with any template selected.
3. Select an individual post inside the query block.
4. Observe your current CSS being applied to the active block.


## Screenshots or screencast <!-- if applicable -->

### Before
<img width="905" alt="Screenshot 2025-05-16 at 12 04 37" src="https://github.com/user-attachments/assets/cbe118fd-991e-4777-8b15-f54fab6382a8" />


### After
<img width="904" alt="Screenshot 2025-05-16 at 12 04 11" src="https://github.com/user-attachments/assets/d8f00d03-e6f8-4ca9-b02e-54b92a80e1ae" />

