### PR TITLE
Enhancement: Display actual font names instead of ‘Aa’ indicator in typography elements.

### DIFF
--- a/packages/edit-site/src/components/global-styles/typography-elements.js
+++ b/packages/edit-site/src/components/global-styles/typography-elements.js
@@ -35,10 +35,14 @@ function ElementItem( { parentMenu, element, label } ) {
 	const [ fallbackBackgroundColor ] = useGlobalStyle( 'color.background' );
 	const [ gradientValue ] = useGlobalStyle( prefix + 'color.gradient' );
 	const [ color ] = useGlobalStyle( prefix + 'color.text' );
+	const displayFontName =
+		fontFamily?.split( ',' )[ 0 ]?.replace( /['"]/g, '' ).trim() ??
+		__( 'Default' );
 
 	return (
 		<NavigationButtonAsItem path={ parentMenu + '/typography/' + element }>
-			<HStack justify="flex-start">
+			<HStack justify="space-between">
+				<FlexItem>{ label }</FlexItem>
 				<FlexItem
 					className="edit-site-global-styles-screen-typography__indicator"
 					style={ {
@@ -50,13 +54,22 @@ function ElementItem( { parentMenu, element, label } ) {
 						color,
 						fontStyle,
 						fontWeight,
+						fontSize: '0.875rem',
+						padding: '0.25rem 0.5rem',
+						borderRadius: '0.25rem',
+						display: 'inline-block',
+						whiteSpace: 'nowrap',
+						overflow: 'visible',
+						textOverflow: 'initial',
+						minWidth: '120px',
+						maxWidth: '100%',
 						...extraStyles,
 					} }
+					title={ displayFontName }
 					aria-hidden="true"
 				>
-					{ __( 'Aa' ) }
+					{ displayFontName }
 				</FlexItem>
-				<FlexItem>{ label }</FlexItem>
 			</HStack>
 		</NavigationButtonAsItem>
 	);


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL --> https://github.com/WordPress/gutenberg/issues/59345

<!-- In a few words, what is the PR actually doing? -->
This PR replaces the generic “Aa” font indicator in the typography elements list with the actual font family names currently applied to each element (e.g., “Manrope”, “Fira Code”). It also fixes style issues to ensure the font names are displayed clearly and consistently without breaking the UI.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

1. The generic “Aa” indicator was not informative and caused confusion for users customizing typography.
2. Displaying actual font names improves clarity and usability, helping users quickly identify which fonts are applied.
3. Fixed styling issues ensure the font names render properly without layout breaks or overflow.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Replaced the static “Aa” label with a dynamic display of the font family name, trimmed to remove fallback fonts.
- Applied consistent styling (font size, max width, text overflow) to handle long font names gracefully.
- Updated the UI components to reflect these changes while maintaining accessibility and responsiveness.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Run the development build (npm run dev or equivalent).
2. Open the typography settings screen in the Gutenberg editor.
3. Verify the font indicators now display actual font family names for:
   - Text
   - Links
   - Headings
   - Captions
   - Buttons
4. Confirm no overflow or styling issues occur even with long font names.
5. Confirm that clicking each typography element navigates correctly.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

- Use Tab to navigate to each typography element item.
- Ensure the font name indicator is visually clear and remains readable when focused.
- Press Enter or Space on an item to verify it opens the correct typography submenu.
- Test keyboard navigation with screen readers if possible to confirm accessibility.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/4612408c-c794-4ba7-a32a-15a8b46450fc


<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="406" alt="Screenshot 2025-05-16 at 1 54 00 PM" src="https://github.com/user-attachments/assets/06560986-5ed9-407f-a54f-3f2bc897987f" /> | <img width="411" alt="Screenshot 2025-05-16 at 1 54 25 PM" src="https://github.com/user-attachments/assets/9b8f906f-4cd0-452d-8018-4b53b49cc3e5" />|
