### PR TITLE
Color Picker: Improve color picker slider focus styles

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   `ColorPicker`: Improve color picker slider focus styles for better keyboard navigation accessibility ([#70146](https://github.com/WordPress/gutenberg/pull/70146)).
+
 ### Bug Fixes
 
 -   `FormFileUpload`: Extend audio accept MIME types for iOS compatibility ([#70354](https://github.com/WordPress/gutenberg/pull/70354)).

--- a/packages/components/src/color-picker/styles.ts
+++ b/packages/components/src/color-picker/styles.ts
@@ -91,6 +91,16 @@ export const ColorfulWrapper = styled.div`
 
 		// Shown instead of box-shadow to Windows high contrast mode.
 		outline: 2px solid transparent;
+
+		@media not ( prefers-reduced-motion ) {
+			transition: transform ${ CONFIG.transitionDurationFast } ease-in-out;
+		}
+	}
+
+	.react-colorful__interactive:focus .react-colorful__pointer {
+		box-shadow: 0 0 0 ${ CONFIG.borderWidthFocus } ${ CONFIG.surfaceColor };
+		border: ${ CONFIG.borderWidthFocus } solid black;
+		transform: translate( -50%, -50% ) scale( 1.5 );
 	}
 
 	.react-colorful__pointer-fill {


### PR DESCRIPTION
## What?

Closes #50874

Enhances the color picker's slider knob focus styles to make them more visible and accessible for keyboard navigation.

## Why?

The previous focus style was insufficient - it only scaled the knob slightly, making it hard to see which slider was focused when navigating with the keyboard. This improvement addresses accessibility concerns by making the focus state much more visible.

## How?

- Added a white border and black outline to the slider knobs when focused
- Increased the scale transformation to `1.5x`
- Added a smooth transition for the transform effect (with prefers-reduced-motion support)
- Maintained the existing scaling behavior but enhanced it with proper borders

## Testing Instructions
1. Go to the Site editor
2. Edit the color palette
3. Click on a color button to open the color picker
4. Use the Tab key to navigate between the sliders
5. Observe that the focused slider knob now has a clear white border with black outline and is enlarged compared to the earlier behavior


## Screencast

### Before 


https://github.com/user-attachments/assets/0b48360a-5ef4-4673-a671-9ed7eb0d9bb1



### After 






https://github.com/user-attachments/assets/7b5bc31b-7a37-4154-80b2-72e51b20ca70



