### PR TITLE
ServerSideRender: Colocate delayed spinner logic

### DIFF
--- a/packages/server-side-render/CHANGELOG.md
+++ b/packages/server-side-render/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   The `LoadingResponsePlaceholder` prop will no longer receive `showLoader`. The spinner rendering logic is now located in the same component ([#70147](https://github.com/WordPress/gutenberg/pull/70147)).
+
 ## 5.23.0 (2025-05-07)
 
 ### Bug Fixes

--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -69,7 +69,22 @@ function DefaultErrorResponsePlaceholder( { response, className } ) {
 	return <Placeholder className={ className }>{ errorMessage }</Placeholder>;
 }
 
-function DefaultLoadingResponsePlaceholder( { children, showLoader } ) {
+function DefaultLoadingResponsePlaceholder( { children, isLoading } ) {
+	const [ showLoader, setShowLoader ] = useState( false );
+
+	useEffect( () => {
+		if ( ! isLoading ) {
+			setShowLoader( false );
+			return;
+		}
+
+		// Schedule showing the Spinner after 1 second.
+		const timeout = setTimeout( () => {
+			setShowLoader( true );
+		}, 1000 );
+		return () => clearTimeout( timeout );
+	}, [ isLoading ] );
+
 	return (
 		<div style={ { position: 'relative' } }>
 			{ showLoader && (
@@ -101,7 +116,6 @@ export default function ServerSideRender( props ) {
 	} = props;
 
 	const isMountedRef = useRef( false );
-	const [ showLoader, setShowLoader ] = useState( false );
 	const fetchRequestRef = useRef();
 	const [ response, setResponse ] = useState( null );
 	const prevProps = usePrevious( props );
@@ -126,11 +140,6 @@ export default function ServerSideRender( props ) {
 		} = latestPropsRef.current;
 
 		setIsLoading( true );
-
-		// Schedule showing the Spinner after 1 second.
-		const timeout = setTimeout( () => {
-			setShowLoader( true );
-		}, 1000 );
 
 		let sanitizedAttributes =
 			attributes &&
@@ -185,9 +194,6 @@ export default function ServerSideRender( props ) {
 					fetchRequest === fetchRequestRef.current
 				) {
 					setIsLoading( false );
-					// Cancel the timeout to show the Spinner.
-					setShowLoader( false );
-					clearTimeout( timeout );
 				}
 			} ) );
 
@@ -221,7 +227,7 @@ export default function ServerSideRender( props ) {
 
 	if ( isLoading ) {
 		return (
-			<LoadingResponsePlaceholder { ...props } showLoader={ showLoader }>
+			<LoadingResponsePlaceholder { ...props } isLoading={ isLoading }>
 				{ hasResponse && ! hasError && (
 					<RawHTML className={ className }>{ response }</RawHTML>
 				) }


### PR DESCRIPTION
## What?
PR updates `ServerSideRender` and moves the delayed snipper logic inside the loading placeholder component.

## Why?
* There's no need to rerender the whole component just to display a delayed spinner.
* Allows consumers to opt out of the behavior by providing a custom `LoadingResponsePlaceholder`.

## Testing Instructions
1. Open a post or page.
2. Insert the Archives block
3. Throttle Network to slow 3G.
4. Toggle any Archives block's controls.
5. Confirm that the loading spinner is displayed after a slight (1-second) delay.

### Testing Instructions for Keyboard
Same.
