### PR TITLE
Post Navigation Link: Reverse order of variations

### DIFF
--- a/packages/block-library/src/post-navigation-link/variations.js
+++ b/packages/block-library/src/post-navigation-link/variations.js
@@ -6,6 +6,22 @@ import { next, previous } from '@wordpress/icons';
 
 const variations = [
 	{
+		name: 'post-previous',
+		title: __( 'Previous Post' ),
+		description: __(
+			'Displays the post link that precedes the current post.'
+		),
+		icon: previous,
+		attributes: { type: 'previous' },
+		scope: [ 'inserter', 'transform' ],
+		example: {
+			attributes: {
+				label: __( 'Previous post' ),
+				arrow: 'arrow',
+			},
+		},
+	},
+	{
 		isDefault: true,
 		name: 'post-next',
 		title: __( 'Next Post' ),
@@ -18,22 +34,6 @@ const variations = [
 		example: {
 			attributes: {
 				label: __( 'Next post' ),
-				arrow: 'arrow',
-			},
-		},
-	},
-	{
-		name: 'post-previous',
-		title: __( 'Previous Post' ),
-		description: __(
-			'Displays the post link that precedes the current post.'
-		),
-		icon: previous,
-		attributes: { type: 'previous' },
-		scope: [ 'inserter', 'transform' ],
-		example: {
-			attributes: {
-				label: __( 'Previous post' ),
 				arrow: 'arrow',
 			},
 		},


### PR DESCRIPTION
## What?

Reverses the order of the variations of the Post Navigation Link block.

## Why?

The current order of the variations feels a bit odd. Generally, in LTR languages, the back should be on the left and the forward should be on the right.

## Testing Instructions

- Insert a Previous Post block or a Next Post block.
- Open the sidebar.
- Check the order of the variations

|Before|After|
|-|-|
| ![image](https://github.com/user-attachments/assets/2f071e2f-daf3-45a5-afc7-95b6b6efaa07) | ![image](https://github.com/user-attachments/assets/cf970ae1-f89d-4030-8c2f-480e14219b49) |
