### PR TITLE
Custom HTML: Add role attribute to content in `block.json`

### DIFF
--- a/packages/block-library/src/html/block.json
+++ b/packages/block-library/src/html/block.json
@@ -10,7 +10,8 @@
 	"attributes": {
 		"content": {
 			"type": "string",
-			"source": "raw"
+			"source": "raw",
+			"role": "content"
 		}
 	},
 	"supports": {


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/65778

### What?
This PR enhances the editing experience of Custom HTML block in `contentOnly` mode

### Testing Instructions
1. Create a Group block
2. Set the Group block's `templateLock` attribute to `contentOnly`
3. Insert the custom html block inside the group
4. Verify that you can edit the content

### Screencast:

https://github.com/user-attachments/assets/d0aab6f4-8872-4fb0-b8ac-1db58bfbc3a0