### PR TITLE
Fix `URLPopover` input handling to properly update value

### DIFF
--- a/packages/block-editor/src/components/url-popover/stories/index.story.js
+++ b/packages/block-editor/src/components/url-popover/stories/index.story.js
@@ -20,6 +20,10 @@ const TestURLPopover = () => {
 	const close = () => setVisiblility( false );
 	const setTarget = () => {};
 
+	const handleUrlChange = ( event ) => {
+		setUrl( event.target.value );
+	};
+
 	return (
 		<>
 			<Button
@@ -40,7 +44,11 @@ const TestURLPopover = () => {
 					) }
 				>
 					<form onSubmit={ close }>
-						<input type="url" value={ url } onChange={ setUrl } />
+						<input
+							type="url"
+							value={ url }
+							onChange={ handleUrlChange }
+						/>
 						<Button
 							__next40pxDefaultSize
 							icon={ keyboardReturn }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes https://github.com/WordPress/gutenberg/issues/70155

<!-- In a few words, what is the PR actually doing? -->

## Why?

This PR fixes an issue where the `URLPopover` component was displaying "[object Object]" in the URL input field instead of the typed text. The problem was occurring because the onChange handler was incorrectly passing the entire event object to the state setter function instead of extracting the input value.


## How?
The fix involves creating a proper event handler function that extracts the value from the event object before updating the state.

## Testing Instructions

1. Open WordPress Storybook (npm run storybook:dev)
2. Search for "URLPopover" or navigate to the URLPopover story
3. Click on "Edit URL" to open the popover
4. Type in the URL field
5. Verify that the text you type is correctly displayed and stored
6. Submit the form and verify that the URL is correctly saved

## Screencast 




### Before 
https://github.com/user-attachments/assets/2edee90f-69ee-41dd-99e0-918cdd0318f8

### After 
https://github.com/user-attachments/assets/1a3868a0-20cb-4fca-9a78-52dbf5917f81

