### PR TITLE
Gallery: Fix placeholder interaction in contentOnly mode

### DIFF
--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -19,19 +19,22 @@
 					"type": "string",
 					"source": "attribute",
 					"selector": "img",
-					"attribute": "src"
+					"attribute": "src",
+					"role": "content"
 				},
 				"fullUrl": {
 					"type": "string",
 					"source": "attribute",
 					"selector": "img",
-					"attribute": "data-full-url"
+					"attribute": "data-full-url",
+					"role": "content"
 				},
 				"link": {
 					"type": "string",
 					"source": "attribute",
 					"selector": "img",
-					"attribute": "data-link"
+					"attribute": "data-link",
+					"role": "content"
 				},
 				"alt": {
 					"type": "string",
@@ -44,12 +47,14 @@
 					"type": "string",
 					"source": "attribute",
 					"selector": "img",
-					"attribute": "data-id"
+					"attribute": "data-id",
+					"role": "content"
 				},
 				"caption": {
 					"type": "rich-text",
 					"source": "rich-text",
-					"selector": ".blocks-gallery-item__caption"
+					"selector": ".blocks-gallery-item__caption",
+					"role": "content"
 				}
 			}
 		},
@@ -75,7 +80,8 @@
 		"caption": {
 			"type": "rich-text",
 			"source": "rich-text",
-			"selector": ".blocks-gallery-caption"
+			"selector": ".blocks-gallery-caption",
+			"role": "content"
 		},
 		"imageCrop": {
 			"type": "boolean",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of: https://github.com/WordPress/gutenberg/issues/65778

This PR fixes an issue where the Gallery block's placeholder was not interactive when in contentOnly mode. The fix adds proper `role="content"` attributes to the relevant block attributes in block.json.

## Testing Instructions
1. Create a Group block
2. Set the Group block's templateLock attribute to "contentOnly"
3. Insert a Gallery block inside the group
4. Verify that:
    - The Gallery placeholder is visible and interactive
    - You can click the placeholder to add images
    - The "Add to Gallery" button works as expected
    - The block toolbar shows only content-related controls

## Screenshots or screencast <!-- if applicable -->
Before:

https://github.com/user-attachments/assets/0155d0a7-a9bd-4669-b3e3-c576ab44f07a


After:

https://github.com/user-attachments/assets/54b1d456-7c14-481c-84ac-9cb5a14281a3


