### PR TITLE
E2E: Add general E2E tests for `templateLock` functionality

### DIFF
--- a/test/e2e/specs/editor/various/block-template-lock.spec.js
+++ b/test/e2e/specs/editor/various/block-template-lock.spec.js
@@ -151,4 +151,114 @@ test.describe( 'Template Lock', () => {
 			await expect( paragraphLocator ).toHaveText( 'Edited - Col 1' );
 		} );
 	} );
+
+	test.describe( 'templateLock=false inside locked parent (Group block)', () => {
+		test.beforeEach( async ( { editor } ) => {
+			await editor.insertBlock( {
+				name: 'core/group',
+				attributes: {
+					templateLock: 'insert',
+					layout: { type: 'constrained' },
+				},
+				innerBlocks: [
+					{
+						name: 'core/columns',
+						attributes: { templateLock: false },
+						innerBlocks: [
+							{
+								name: 'core/column',
+								innerBlocks: [
+									{
+										name: 'core/paragraph',
+										attributes: {
+											content: 'Col 1',
+										},
+									},
+								],
+							},
+						],
+					},
+					{
+						name: 'core/paragraph',
+						attributes: {
+							content:
+								'Paragraph to enable moving of Columns block',
+						},
+					},
+				],
+			} );
+		} );
+
+		test( 'should prevent deleting the Columns block itself (due to parent lock)', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.selectBlocks(
+				editor.canvas.getByLabel( 'Block: Columns' )
+			);
+
+			await editor.clickBlockToolbarButton( 'Options' );
+
+			await expect(
+				page
+					.getByRole( 'menu', { name: 'Options' } )
+					.getByRole( 'menuitem', { name: 'Delete' } )
+			).toBeHidden();
+		} );
+
+		test( 'should allow moving the Columns block itself (due to parent lock)', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.selectBlocks(
+				editor.canvas.getByLabel( 'Block: Columns' )
+			);
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Move down' } )
+			).toBeVisible();
+		} );
+
+		test( 'should allow deleting inner Column blocks (own lock=false)', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.selectBlocks(
+				editor.canvas.getByLabel( 'Block: Column (1 of 1)' )
+			);
+
+			await editor.clickBlockToolbarButton( 'Options' );
+
+			await expect(
+				page
+					.getByRole( 'menu', { name: 'Options' } )
+					.getByRole( 'menuitem', { name: 'Delete' } )
+			).toBeVisible();
+		} );
+
+		test( 'should allow inserting blocks inside inner Column blocks (own lock=false)', async ( {
+			editor,
+		} ) => {
+			await editor.selectBlocks(
+				editor.canvas.getByLabel( 'Block: Column (1 of 1)' )
+			);
+
+			await expect(
+				editor.canvas.getByLabel( 'Add Block' )
+			).toBeVisible();
+		} );
+
+		test( 'should allow editing content inside inner Column blocks', async ( {
+			editor,
+			page,
+		} ) => {
+			const paragraphLocator = editor.canvas.getByText( 'Col 1' );
+			await editor.selectBlocks( paragraphLocator );
+
+			await page.keyboard.type( 'Edited - ' );
+			await expect( paragraphLocator ).toHaveText( 'Edited - Col 1' );
+		} );
+	} );
 } );

--- a/test/e2e/specs/editor/various/block-template-lock.spec.js
+++ b/test/e2e/specs/editor/various/block-template-lock.spec.js
@@ -118,14 +118,11 @@ test.describe( 'Template Lock', () => {
 			);
 		} );
 
-		// test( 'should prevent deleting columns', async ( { editor, page } ) => {
-		// 	await editor.clickBlockToolbarButton( 'Options' );
-		// 	await expect(
-		// 		page
-		// 			.getByRole( 'menu', { name: 'Options' } )
-		// 			.getByRole( 'menuitem', { name: 'Delete' } )
-		// 	).toBeHidden();
-		// } );
+		test( 'should prevent deleting columns', async ( { page } ) => {
+			await expect(
+				page.getByRole( 'menu', { name: 'Options' } )
+			).toBeHidden();
+		} );
 
 		test( 'should prevent moving columns', async ( { page } ) => {
 			await expect(

--- a/test/e2e/specs/editor/various/block-template-lock.spec.js
+++ b/test/e2e/specs/editor/various/block-template-lock.spec.js
@@ -1,0 +1,76 @@
+// test/e2e/specs/editor/various/block-template-lock.spec.js
+
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+test.describe( 'Template Lock', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPosts();
+	} );
+
+	const createColumnsBlockWithLock = ( templateLock ) => ( {
+		name: 'core/columns',
+		attributes: { templateLock },
+		innerBlocks: [
+			{
+				name: 'core/column',
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'Col 1' },
+					},
+				],
+			},
+			{
+				name: 'core/column',
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'Col 2' },
+					},
+				],
+			},
+		],
+	} );
+
+	test.describe( 'templateLock="all"', () => {
+		test.beforeEach( async ( { editor } ) => {
+			await editor.insertBlock( createColumnsBlockWithLock( 'all' ) );
+
+			await editor.selectBlocks(
+				editor.canvas.getByLabel( 'Block: Column (1 of 2)' )
+			);
+		} );
+
+		test( 'should prevent deleting columns', async ( { editor, page } ) => {
+			await editor.clickBlockToolbarButton( 'Options' );
+			await expect(
+				page
+					.getByRole( 'menu', { name: 'Options' } )
+					.getByRole( 'menuitem', { name: 'Delete' } )
+			).toBeHidden();
+		} );
+
+		test( 'should prevent moving columns', async ( { page } ) => {
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Move down' } )
+			).toBeHidden();
+		} );
+
+		test( 'should prevent inserting blocks inside columns', async ( {
+			editor,
+		} ) => {
+			await expect(
+				editor.canvas.getByLabel( 'Add Block' )
+			).toBeHidden();
+		} );
+	} );
+} );

--- a/test/e2e/specs/editor/various/block-template-lock.spec.js
+++ b/test/e2e/specs/editor/various/block-template-lock.spec.js
@@ -73,4 +73,39 @@ test.describe( 'Template Lock', () => {
 			).toBeHidden();
 		} );
 	} );
+
+	test.describe( 'templateLock="insert"', () => {
+		test.beforeEach( async ( { editor } ) => {
+			await editor.insertBlock( createColumnsBlockWithLock( 'insert' ) );
+
+			await editor.selectBlocks(
+				editor.canvas.getByLabel( 'Block: Column (1 of 2)' )
+			);
+		} );
+
+		test( 'should prevent deleting columns', async ( { editor, page } ) => {
+			await editor.clickBlockToolbarButton( 'Options' );
+			await expect(
+				page
+					.getByRole( 'menu', { name: 'Options' } )
+					.getByRole( 'menuitem', { name: 'Delete' } )
+			).toBeHidden();
+		} );
+
+		test( 'should allow moving columns', async ( { page } ) => {
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Move right' } )
+			).toBeVisible();
+		} );
+
+		test( 'should prevent inserting blocks inside columns', async ( {
+			editor,
+		} ) => {
+			await expect(
+				editor.canvas.getByLabel( 'Add Block' )
+			).toBeHidden();
+		} );
+	} );
 } );

--- a/test/e2e/specs/editor/various/block-template-lock.spec.js
+++ b/test/e2e/specs/editor/various/block-template-lock.spec.js
@@ -1,5 +1,3 @@
-// test/e2e/specs/editor/various/block-template-lock.spec.js
-
 /**
  * WordPress dependencies
  */
@@ -106,6 +104,54 @@ test.describe( 'Template Lock', () => {
 			await expect(
 				editor.canvas.getByLabel( 'Add Block' )
 			).toBeHidden();
+		} );
+	} );
+
+	test.describe( 'templateLock="contentOnly"', () => {
+		test.beforeEach( async ( { editor } ) => {
+			await editor.insertBlock(
+				createColumnsBlockWithLock( 'contentOnly' )
+			);
+
+			await editor.selectBlocks(
+				editor.canvas.getByLabel( 'Block: Column (1 of 2)' )
+			);
+		} );
+
+		// test( 'should prevent deleting columns', async ( { editor, page } ) => {
+		// 	await editor.clickBlockToolbarButton( 'Options' );
+		// 	await expect(
+		// 		page
+		// 			.getByRole( 'menu', { name: 'Options' } )
+		// 			.getByRole( 'menuitem', { name: 'Delete' } )
+		// 	).toBeHidden();
+		// } );
+
+		test( 'should prevent moving columns', async ( { page } ) => {
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Move down' } )
+			).toBeHidden();
+		} );
+
+		test( 'should prevent inserting blocks inside columns', async ( {
+			editor,
+		} ) => {
+			await expect(
+				editor.canvas.getByLabel( 'Add Block' )
+			).toBeHidden();
+		} );
+
+		test( 'should allow editing content inside columns', async ( {
+			editor,
+			page,
+		} ) => {
+			const paragraphLocator = editor.canvas.getByText( 'Col 1' );
+			await editor.selectBlocks( paragraphLocator );
+
+			await page.keyboard.type( 'Edited - ' );
+			await expect( paragraphLocator ).toHaveText( 'Edited - Col 1' );
 		} );
 	} );
 } );


### PR DESCRIPTION
## What?

Follow up to: #69089
Comment: https://github.com/WordPress/gutenberg/pull/69089#pullrequestreview-2828478270

Adds comprehensive E2E tests for template lock functionality in a new general test file `test/e2e/specs/editor/various/block-template-lock.spec.js`.

## Why?

As discussed in the original issue, template lock behavior should be consistent across all blocks that support it. Rather than duplicating tests in each block's test file, this PR creates a centralized location for testing general template lock behaviors that apply to all blocks.

## How?
- Creates a new test file `test/e2e/specs/editor/various/block-template-lock.spec.js`
- Tests all template lock modes: `"all"`, `"insert"`, `"contentOnly"`, and `false`
- Covers all scenarios


## Testing Instructions
- Run the new E2E tests: 
 
```
npm run test:e2e -- test/e2e/specs/editor/various/block-template-lock.spec.js
```

- Verify all tests pass


## Screenshots or screencast

N/A - This PR adds E2E tests without changing the user interface.