### PR TITLE
wp-scripts:plugin-zip -- Add a `--include-src` argument to include the `src` folder.

### DIFF
--- a/packages/scripts/scripts/plugin-zip.js
+++ b/packages/scripts/scripts/plugin-zip.js
@@ -17,6 +17,7 @@ stdout.write( `Creating archive for \`${ name }\` plugin... 🎁\n\n` );
 const zip = new AdmZip();
 const zipRootFolderArg = getArgFromCLI( '--root-folder' );
 const noRootFolderArg = getArgFromCLI( '--no-root-folder' );
+const includeSrcFolder = getArgFromCLI( '--include-src' );
 let zipRootFolder = `${ name }/`;
 let files = [];
 
@@ -34,6 +35,7 @@ if ( hasPackageProp( 'files' ) ) {
 		[
 			'admin/**',
 			'build/**',
+			( includeSrcFolder !== undefined ) ? 'src/**' : null,
 			'includes/**',
 			'languages/**',
 			'public/**',

--- a/packages/scripts/scripts/plugin-zip.js
+++ b/packages/scripts/scripts/plugin-zip.js
@@ -35,7 +35,6 @@ if ( hasPackageProp( 'files' ) ) {
 		[
 			'admin/**',
 			'build/**',
-			( includeSrcFolder !== undefined ) ? 'src/**' : null,
 			'includes/**',
 			'languages/**',
 			'public/**',
@@ -50,6 +49,12 @@ if ( hasPackageProp( 'files' ) ) {
 			caseSensitiveMatch: false,
 		}
 	);
+
+	if ( includeSrcFolder !== undefined ) {
+		files = files.concat(
+			glob( 'src/**', { caseSensitiveMatch: false } )
+		);
+	}
 }
 
 if ( noRootFolderArg !== undefined ) {


### PR DESCRIPTION
## What?
This will make it easier to build with the src for future maintainability, as well as generating zip files that won't be rejected by the WordPress Plugin Directory Review process.

<!-- In a few words, what is the PR actually doing? -->

## Why?
It avoids having to manually build the zip for submitting to the plugin directory with something like

```
zip -r myplugin.zip myplugin -x "myplugin/.git/*" -x "myplugin/node_modules/*" -x "myplugin/.gitignore" -x "myplugin/.editorconfig" -x "myplugin/.DS_Store" 
```

## How?
Just adds a command line flag.

