### PR TITLE
Shortcode: Add role attribute to content in `block.json`

### DIFF
--- a/packages/block-library/src/shortcode/block.json
+++ b/packages/block-library/src/shortcode/block.json
@@ -9,7 +9,8 @@
 	"attributes": {
 		"text": {
 			"type": "string",
-			"source": "raw"
+			"source": "raw",
+			"role": "content"
 		}
 	},
 	"supports": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of: https://github.com/WordPress/gutenberg/issues/65778

<!-- In a few words, what is the PR actually doing? -->

## Why?
This PR enhances the editing experience of Shortcode block in contentOnly mode

## Testing Instructions
1. Create a Group block
2. Set the Group block's templateLock attribute to contentOnly
3. Insert the Shortcodel block inside the group
4. Verify that you can edit the content

## Screenshots or screencast

https://github.com/user-attachments/assets/7639fc24-ee05-4d09-b303-adfb8141059b

