### PR TITLE
Query: Add `role` attribute to content in block.json for `Query Loop` related blocks

### DIFF
--- a/packages/block-library/src/query-pagination-next/block.json
+++ b/packages/block-library/src/query-pagination-next/block.json
@@ -9,7 +9,8 @@
 	"textdomain": "default",
 	"attributes": {
 		"label": {
-			"type": "string"
+			"type": "string",
+			"role": "content"
 		}
 	},
 	"usesContext": [

--- a/packages/block-library/src/query-pagination-previous/block.json
+++ b/packages/block-library/src/query-pagination-previous/block.json
@@ -9,7 +9,8 @@
 	"textdomain": "default",
 	"attributes": {
 		"label": {
-			"type": "string"
+			"type": "string",
+			"role": "content"
 		}
 	},
 	"usesContext": [


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/65778

## What?

This PR enhances the editing experience of query-related blocks in contentOnly mode:
Blocks improved:

  - Query Pagination Previous
  - Query Pagination Next

## Testing Instructions

1. Create a Group block
2. Set the Group block's templateLock attribute to "contentOnly"
3. Insert the following blocks inside the group:
      -  Query Pagination Previous
      -  Query Pagination Next
4. Verify that you can edit the content of these blocks

## Screencast



https://github.com/user-attachments/assets/f6d4ca48-73cc-4363-9ecd-a635d1dcb266



