### PR TITLE
RSS: Add role attribute to content in `block.json`

### DIFF
--- a/packages/block-library/src/rss/block.json
+++ b/packages/block-library/src/rss/block.json
@@ -18,7 +18,8 @@
 		},
 		"feedURL": {
 			"type": "string",
-			"default": ""
+			"default": "",
+			"role": "content"
 		},
 		"itemsToShow": {
 			"type": "number",


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/65778

### What?
This PR enhances the editing experience of the `RSS` block in `contentOnly` mode

### Testing Instructions
1. Create a Group block
2. Set the Group block's `templateLock` attribute to `contentOnly`
3. Insert the custom `RSS` block inside the group
4. Verify that you can edit the content

### Screencast:

https://github.com/user-attachments/assets/e4535593-a2b7-494f-8f8b-5059d947c8b4
