### PR TITLE
Site Tagline: Add role attribute to content in `block.json`

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -855,7 +855,7 @@ Describe in a few words what the site is about. The tagline can be used in searc
 -	**Name:** core/site-tagline
 -	**Category:** theme
 -	**Supports:** align (full, wide), color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** level, levelOptions, textAlign
+-	**Attributes:** content, level, levelOptions, textAlign
 
 ## Site Title
 

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -18,6 +18,13 @@
 		"levelOptions": {
 			"type": "array",
 			"default": [ 0, 1, 2, 3, 4, 5, 6 ]
+		},
+		"content": {
+			"type": "string",
+			"source": "html",
+			"selector": "p, h1, h2, h3, h4, h5, h6",
+			"default": "",
+			"role": "content"
 		}
 	},
 	"example": {


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/65778

## What?

This PR enhances the editing experience of the site tagline block, inside a group in the `contentOnly` mode



## Testing Instructions

- Create a Group block
- Set the Group block's `templateLock` attribute to `contentOnly`
- Insert the site tagline block inside the group
- Verify that you can edit the content


## Screencast

### Before 


https://github.com/user-attachments/assets/8e01d786-b66a-4a71-bd7d-aa390bdb3b47



### After 


https://github.com/user-attachments/assets/ad6f008b-7c3a-4d93-a15b-225eb6e55fcf


