### PR TITLE
RichText Readme - Fix 404 URL To Mozilla Docs

### DIFF
--- a/packages/block-editor/src/components/rich-text/README.md
+++ b/packages/block-editor/src/components/rich-text/README.md
@@ -23,7 +23,7 @@ _Default: `div`._ The [tag name](https://www.w3.org/TR/html51/syntax.html#tag-na
 ### `placeholder: String`
 
 _Optional._ Placeholder text to show when the field is empty, similar to the
-[`input` and `textarea` attribute of the same name](https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/HTML5_updates#The_placeholder_attribute).
+[`input` and `textarea` attribute of the same name](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/placeholder).
 
 ### `disableLineBreaks: Boolean`
 


### PR DESCRIPTION
## What?

This PR fixes a broken (404) link in the documentation.

## Why?

The previous link was outdated and resulted in a 404 error. Updating it helps ensure readers are directed to the correct and current resource.

## How?

Replaced the outdated URL with the correct, working one.

## Testing Instructions

1. Open the file with the updated link.
2. Click the link.
3. Confirm that it opens the intended page and does not return a 404.

## Screenshots or screencast

N/A
