### PR TITLE
Quote block: Fix  group transform behavior

### DIFF
--- a/packages/block-library/src/quote/transforms.js
+++ b/packages/block-library/src/quote/transforms.js
@@ -135,19 +135,22 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/group' ],
-			transform: ( { citation, anchor }, innerBlocks ) =>
-				createBlock(
+			transform: ( attributes, innerBlocks ) => {
+				const quoteBlock = createBlock(
+					'core/quote',
+					{
+						...attributes,
+						anchor: undefined,
+					},
+					innerBlocks
+				);
+
+				return createBlock(
 					'core/group',
-					{ anchor },
-					RichText.isEmpty( citation )
-						? innerBlocks
-						: [
-								...innerBlocks,
-								createBlock( 'core/paragraph', {
-									content: citation,
-								} ),
-						  ]
-				),
+					{ anchor: attributes.anchor },
+					[ quoteBlock ]
+				);
+			},
 		},
 	],
 	ungroup: ( { citation }, innerBlocks ) =>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/58042

Fixes an issue where grouping a Quote block would transform it into a Group block with the quote content converted to a Paragraph block.

## Why?
When users select the "Group" option from a Quote block's toolbar, the current behavior transforms the Quote block into a Group block and converts the quote content to a Paragraph block. This is unexpected behavior - the Quote block should be wrapped in a Group block while maintaining its original structure.

## Testing Instructions
1. Add a Quote block to the editor
2. Add some content and a citation
3. Select the Quote block
4. Click the "Group" option from the block toolbar
5. Verify:
   - The Quote block is now wrapped in a Group block
   - The quote content remains a Quote block (not converted to Paragraph)
   - The citation is preserved
   - All formatting is maintained

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/be928ee6-4a86-484f-bfb1-2345374b1414


