### PR TITLE
Navigation Submenu: Allow editing of label under content locked parent

### DIFF
--- a/packages/block-library/src/navigation-submenu/block.json
+++ b/packages/block-library/src/navigation-submenu/block.json
@@ -9,7 +9,8 @@
 	"textdomain": "default",
 	"attributes": {
 		"label": {
-			"type": "string"
+			"type": "string",
+			"role": "content"
 		},
 		"type": {
 			"type": "string"


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/65778

## What?

This PR enhances the editing experience of the Navigation Submenu block inside a parent block locked in `contentOnly` mode.

## Testing Instructions

- Create a Group block
- Set the Group block's `templateLock` attribute to `contentOnly` ( `"templateLock":"contentOnly"` ) 
- Insert the Navigation block inside the group and inside the Navigation block, add a Navigation Submenu block
- Verify that you can edit the content

## Screencast
 
### Before 



https://github.com/user-attachments/assets/be43a3cb-8382-4661-8bc8-016ba29725f3



### After



https://github.com/user-attachments/assets/39a957a0-b597-41db-bacd-4c182a7f1184


