### PR TITLE
Editor: Better normalize strings for hierarchical term filtering

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,10 @@
 -   `ComboboxControl`: Handle Unicode characters when matching values ([#70180](https://github.com/WordPress/gutenberg/pull/70180)).
 -   `Toolbar`: Adjust colors for dark mode support ([#69278](https://github.com/WordPress/gutenberg/pull/69278)).
 
+### Internal
+
+-   Expose `normalizeTextString` method as private API ([#70178](https://github.com/WordPress/gutenberg/pull/70178)).
+
 ## 29.10.0 (2025-05-22)
 
 ### Enhancement

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -6,7 +6,7 @@ import { Menu } from './menu';
 import { ComponentsContext } from './context/context-system-provider';
 import Theme from './theme';
 import { Tabs } from './tabs';
-import { kebabCase } from './utils/strings';
+import { kebabCase, normalizeTextString } from './utils/strings';
 import { lock } from './lock-unlock';
 import Badge from './badge';
 
@@ -19,4 +19,5 @@ lock( privateApis, {
 	Menu,
 	kebabCase,
 	Badge,
+	normalizeTextString,
 } );

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -13,6 +13,7 @@ import {
 	Flex,
 	FlexItem,
 	SearchControl,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useDebounce } from '@wordpress/compose';
@@ -25,6 +26,7 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import { buildTermsTree } from '../../utils/terms';
 import { store as editorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 /**
  * Module Constants
@@ -36,10 +38,10 @@ const DEFAULT_QUERY = {
 	_fields: 'id,name,parent',
 	context: 'view',
 };
-
 const MIN_TERMS_COUNT_FOR_FILTER = 8;
-
 const EMPTY_ARRAY = [];
+
+const { normalizeTextString } = unlock( componentsPrivateApis );
 
 /**
  * Sort Terms by Selected.
@@ -132,7 +134,9 @@ export function getFilterMatcher( filterValue ) {
 		// (i.e. some child matched at some point in the tree) then return it.
 		if (
 			-1 !==
-				term.name.toLowerCase().indexOf( filterValue.toLowerCase() ) ||
+				normalizeTextString( term.name ).indexOf(
+					normalizeTextString( filterValue )
+				) ||
 			term.children.length > 0
 		) {
 			return term;


### PR DESCRIPTION
## What?
Closes #70169.
Related #70180.

PR improves unitcode handling when searching hierarchical terms in the editor.

## Why?
See #70169.

## How?
Expose `normalizeTextString` as a private API and use it for text normalization in the filter matcher.

## Testing Instructions
1. Create two new categories - `PlayStation 2` and `ＰｌａｙＳｔａｔｉｏｎ　２`. Note: Copy the names.
2. Open a post.
3. Try searching categories using the keyword "play".
4. Both newly created categories should show up in the results.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/a2360ab1-d730-493e-a7b8-7dc696b3be46

