### PR TITLE
ComboboxControl: Handle Unicode characters when matching values

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   `ComboboxControl`: Handle Unicode characters when matching values ([#70180](https://github.com/WordPress/gutenberg/pull/70180)).
+
 ## 29.10.0 (2025-05-22)
 
 ### Enhancement

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -516,7 +516,10 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 			match = match.toLocaleLowerCase();
 
 			_suggestions.forEach( ( suggestion ) => {
-				const index = suggestion.toLocaleLowerCase().indexOf( match );
+				const index = suggestion
+					.normalize( 'NFKC' )
+					.toLocaleLowerCase()
+					.indexOf( match );
 				if ( normalizedValue.indexOf( suggestion ) === -1 ) {
 					if ( index === 0 ) {
 						startsWithMatch.push( suggestion );

--- a/packages/components/src/form-token-field/suggestions-list.tsx
+++ b/packages/components/src/form-token-field/suggestions-list.tsx
@@ -79,6 +79,7 @@ export function SuggestionsList<
 
 		const transformedSuggestion = displayTransform( suggestion );
 		const indexOfMatch = transformedSuggestion
+			.normalize( 'NFKC' )
 			.toLocaleLowerCase()
 			.indexOf( matchText );
 

--- a/packages/components/src/utils/strings.ts
+++ b/packages/components/src/utils/strings.ts
@@ -20,6 +20,7 @@ const ALL_UNICODE_DASH_CHARACTERS = new RegExp(
 
 export const normalizeTextString = ( value: string ): string => {
 	return removeAccents( value )
+		.normalize( 'NFKC' )
 		.toLocaleLowerCase()
 		.replace( ALL_UNICODE_DASH_CHARACTERS, '-' );
 };

--- a/packages/components/src/utils/test/strings.js
+++ b/packages/components/src/utils/test/strings.js
@@ -169,4 +169,14 @@ describe( 'normalizeTextString', () => {
 			'-'.repeat( dashCharacters.length )
 		);
 	} );
+
+	it( 'should normalize unicode to standard characters', () => {
+		expect( normalizeTextString( '①' ) ).toBe( '1' );
+		expect( normalizeTextString( 'Ⅸ' ) ).toBe( 'ix' );
+		expect( normalizeTextString( 'MC²' ) ).toBe( 'mc2' );
+		expect( normalizeTextString( 'ＰｌａｙＳｔａｔｉｏｎ　２' ) ).toBe(
+			'playstation 2'
+		);
+		expect( normalizeTextString( 'ＡＢＣ' ) ).toBe( 'abc' );
+	} );
 } );

--- a/packages/components/src/utils/test/strings.js
+++ b/packages/components/src/utils/test/strings.js
@@ -178,5 +178,6 @@ describe( 'normalizeTextString', () => {
 			'playstation 2'
 		);
 		expect( normalizeTextString( 'ＡＢＣ' ) ).toBe( 'abc' );
+		expect( normalizeTextString( 'Amélie' ) ).toBe( 'amelie' );
 	} );
 } );


### PR DESCRIPTION
## What?
Related #70169.

PR improves unicode handling in the `normalizeTextString` helper method, currently used by `ComboboxControl` component

## Why?
> It would probably be a good enhancement for search string normalization in general, not just taxonomy filtering. At least, wherever users are typing in their queries normally (instead of copy & pasting an exact string).

See: https://github.com/WordPress/gutenberg/issues/70169#issuecomment-2898408281.

## Testing Instructions
Confirm that new unit tests are correct and CI checks are passing.
