### PR TITLE
Add Text Alignment support for Button Block

### DIFF
--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -18,9 +18,6 @@
 			"type": "string",
 			"default": "button"
 		},
-		"textAlign": {
-			"type": "string"
-		},
 		"url": {
 			"type": "string",
 			"source": "attribute",
@@ -106,7 +103,8 @@
 			"__experimentalWritingMode": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
-			}
+			}, 
+			"textAlign": true
 		},
 		"reusable": false,
 		"shadow": {

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -32,7 +32,6 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import {
-	AlignmentControl,
 	BlockControls,
 	InspectorControls,
 	RichText,
@@ -44,7 +43,6 @@ import {
 	__experimentalGetShadowClassesAndStyles as useShadowProps,
 	__experimentalGetElementClassName,
 	store as blockEditorStore,
-	useBlockEditingMode,
 	getTypographyClassesAndStyles as useTypographyProps,
 	useSettings,
 } from '@wordpress/block-editor';
@@ -217,7 +215,6 @@ function ButtonEdit( props ) {
 		ref: useMergeRefs( [ setPopoverAnchor, ref ] ),
 		onKeyDown,
 	} );
-	const blockEditingMode = useBlockEditingMode();
 
 	const [ isEditingURL, setIsEditingURL ] = useState( false );
 	const isURLSet = !! url;
@@ -375,14 +372,6 @@ function ButtonEdit( props ) {
 				/>
 			</div>
 			<BlockControls group="block">
-				{ blockEditingMode === 'default' && (
-					<AlignmentControl
-						value={ textAlign }
-						onChange={ ( nextAlign ) => {
-							setAttributes( { textAlign: nextAlign } );
-						} }
-					/>
-				) }
 				{ ! isURLSet && isLinkTag && ! lockUrlControls && (
 					<ToolbarButton
 						name="link"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

### What ? 
Closes core/button for https://github.com/WordPress/gutenberg/issues/60763

## How ?
This PR adds the updated text alignment support in `block.json` for button block and moves away from the older textAlignment way which required code changes in `edit.js` as well 

## Testing Instructions
1. Add a new post 
2. Insert a button block 
3. Notice it has text alignment options 

## Screenshots or screencast 


https://github.com/user-attachments/assets/182fb11e-f72b-45af-9f7f-d2bf7746a390
