### PR TITLE
Fix : Calendar block: Colors do not change between global styles and `theme.json`

### DIFF
--- a/packages/block-library/src/calendar/block.json
+++ b/packages/block-library/src/calendar/block.json
@@ -25,7 +25,7 @@
 				"background": true,
 				"text": true
 			},
-			"__experimentalSelector": "table, th, td, caption"
+			"__experimentalSelector": "table, th"
 		},
 		"typography": {
 			"fontSize": true,

--- a/packages/block-library/src/calendar/block.json
+++ b/packages/block-library/src/calendar/block.json
@@ -25,7 +25,7 @@
 				"background": true,
 				"text": true
 			},
-			"__experimentalSelector": "table, th"
+			"__experimentalSelector": "table, th, td, caption"
 		},
 		"typography": {
 			"fontSize": true,

--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -28,7 +28,7 @@
 		}
 	}
 
-	&:where(:not(.has-text-color)) {
+	:where(table:not(.has-text-color)) {
 		color: #40464d;
 
 		// Keep the hard-coded border color for backward compatibility.

--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -19,19 +19,16 @@
 		width: 100%;
 		border-collapse: collapse;
 
-		&.has-background th,
-		&.has-background td {
+		&.has-background th {
 			background-color: inherit;
 		}
 
-		&.has-text-color th,
-		&.has-text-color td,
-		&.has-text-color caption {
+		&.has-text-color th {
 			color: inherit;
 		}
 	}
 
-	:where(table:not(.has-text-color)) {
+	&:where(:not(.has-text-color)) {
 		color: #40464d;
 
 		// Keep the hard-coded border color for backward compatibility.

--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -29,11 +29,14 @@
 			}
 		}
 
-		&.has-background th {
+		&.has-background th,
+		&.has-background td {
 			background-color: inherit;
 		}
 
-		&.has-text-color th {
+		&.has-text-color th,
+		&.has-text-color td,
+		&.has-text-color caption {
 			color: inherit;
 		}
 	}

--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -19,16 +19,6 @@
 		width: 100%;
 		border-collapse: collapse;
 
-		&:where(:not(.has-text-color)) {
-			color: #40464d;
-
-			// Keep the hard-coded border color for backward compatibility.
-			th,
-			td {
-				border-color: $gray-300;
-			}
-		}
-
 		&.has-background th,
 		&.has-background td {
 			background-color: inherit;
@@ -38,6 +28,16 @@
 		&.has-text-color td,
 		&.has-text-color caption {
 			color: inherit;
+		}
+	}
+
+	:where(table:not(.has-text-color)) {
+		color: #40464d;
+
+		// Keep the hard-coded border color for backward compatibility.
+		th,
+		td {
+			border-color: $gray-300;
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
- Closes https://github.com/WordPress/gutenberg/issues/69896

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Even if you set colors in the calendar block using global styles and theme.json, the colors of td and caption do not change.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Update the `__experimentalSelector` attribute for color support to include `td` and `caption`
- Add styles which inherit the `text color` if set via the `Editor` else pick the `color` set via `theme.json`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Update the theme.json in twentytwentyfive theme
2. Add the following snippet in the JSON under `styles ➡ blocks`
```
"core/calendar": {
	"color": {
		"text": "red"
	}
},
```
3. Create a post and add the calendar block
4. It should match the screenshot added in this PR

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<img width="746" alt="Screenshot 2025-05-22 at 2 03 12 PM" src="https://github.com/user-attachments/assets/016cf9bc-ebf5-4c12-a09d-1e5abc21124b" />

