### PR TITLE
Social: Moves size settings to inspector controls

### DIFF
--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -173,7 +173,9 @@ export function SocialLinksEdit( props ) {
 				>
 					<ToolsPanelItem
 						isShownByDefault
-						hasValue={ () => size !== 'has-normal-icon-size' }
+						hasValue={ () =>
+							!! size && size !== 'has-normal-icon-size'
+						}
 						label={ __( 'Icon size' ) }
 						onDeselect={ () =>
 							setAttributes( { size: 'has-normal-icon-size' } )
@@ -183,9 +185,9 @@ export function SocialLinksEdit( props ) {
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
 							label={ __( 'Icon Size' ) }
-							onChange={ ( entry ) => {
+							onChange={ ( newSize ) => {
 								setAttributes( {
-									size: entry,
+									size: newSize,
 								} );
 							} }
 							value={ size ?? 'has-normal-icon-size' }

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -194,6 +194,23 @@ export function SocialLinksEdit( props ) {
 					</ToolsPanelItem>
 					<ToolsPanelItem
 						isShownByDefault
+						label={ __( 'Show text' ) }
+						hasValue={ () => !! showLabels }
+						onDeselect={ () =>
+							setAttributes( { showLabels: false } )
+						}
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Show text' ) }
+							checked={ showLabels }
+							onChange={ () =>
+								setAttributes( { showLabels: ! showLabels } )
+							}
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						isShownByDefault
 						label={ __( 'Open links in new tab' ) }
 						hasValue={ () => !! openInNewTab }
 						onDeselect={ () =>
@@ -208,23 +225,6 @@ export function SocialLinksEdit( props ) {
 								setAttributes( {
 									openInNewTab: ! openInNewTab,
 								} )
-							}
-						/>
-					</ToolsPanelItem>
-					<ToolsPanelItem
-						isShownByDefault
-						label={ __( 'Show text' ) }
-						hasValue={ () => !! showLabels }
-						onDeselect={ () =>
-							setAttributes( { showLabels: false } )
-						}
-					>
-						<ToggleControl
-							__nextHasNoMarginBottom
-							label={ __( 'Show text' ) }
-							checked={ showLabels }
-							onChange={ () =>
-								setAttributes( { showLabels: ! showLabels } )
 							}
 						/>
 					</ToolsPanelItem>

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 /**
  * External dependencies
  */
@@ -21,9 +19,8 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
-	PanelBody,
 	ToggleControl,
-	ToolbarDropdownMenu,
+	SelectControl,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
@@ -36,10 +33,10 @@ import { useSelect } from '@wordpress/data';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const sizeOptions = [
-	{ name: __( 'Small' ), value: 'has-small-icon-size' },
-	{ name: __( 'Normal' ), value: 'has-normal-icon-size' },
-	{ name: __( 'Large' ), value: 'has-large-icon-size' },
-	{ name: __( 'Huge' ), value: 'has-huge-icon-size' },
+	{ label: __( 'Small' ), value: 'has-small-icon-size' },
+	{ label: __( 'Normal' ), value: 'has-normal-icon-size' },
+	{ label: __( 'Large' ), value: 'has-large-icon-size' },
+	{ label: __( 'Huge' ), value: 'has-huge-icon-size' },
 ];
 
 export function SocialLinksEdit( props ) {
@@ -174,6 +171,31 @@ export function SocialLinksEdit( props ) {
 					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
+						hasValue={ () => !! size }
+						label={ __( 'Icon Size' ) }
+						onDeselect={ () =>
+							setAttributes( { size: 'has-normal-icon-size' } )
+						}
+						resetAllFilter={ () => ( {
+							size: 'has-normal-icon-size',
+						} ) }
+						isShownByDefault
+						panelId={ clientId }
+					>
+						<SelectControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={ __( 'Icon Size' ) }
+							onChange={ ( entry ) => {
+								setAttributes( {
+									size: entry,
+								} );
+							} }
+							value={ size ?? 'has-normal-icon-size' }
+							options={ sizeOptions }
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
 						isShownByDefault
 						label={ __( 'Open links in new tab' ) }
 						hasValue={ () => !! openInNewTab }
@@ -249,7 +271,7 @@ export function SocialLinksEdit( props ) {
 		</>
 	);
 }
-/* eslint-enable no-unused-vars */
+
 const iconColorAttributes = {
 	iconColor: 'icon-color',
 	iconBackgroundColor: 'icon-background-color',

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -166,21 +166,18 @@ export function SocialLinksEdit( props ) {
 						setAttributes( {
 							openInNewTab: false,
 							showLabels: false,
+							size: 'has-normal-icon-size',
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
-						hasValue={ () => !! size }
-						label={ __( 'Icon Size' ) }
+						isShownByDefault
+						hasValue={ () => size !== 'has-normal-icon-size' }
+						label={ __( 'Icon size' ) }
 						onDeselect={ () =>
 							setAttributes( { size: 'has-normal-icon-size' } )
 						}
-						resetAllFilter={ () => ( {
-							size: 'has-normal-icon-size',
-						} ) }
-						isShownByDefault
-						panelId={ clientId }
 					>
 						<SelectControl
 							__next40pxDefaultSize

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-unused-vars */
+
 /**
  * External dependencies
  */
@@ -8,7 +10,6 @@ import clsx from 'clsx';
  */
 import { useEffect } from '@wordpress/element';
 import {
-	BlockControls,
 	useInnerBlocksProps,
 	useBlockProps,
 	InspectorControls,
@@ -20,15 +21,13 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
-	MenuGroup,
-	MenuItem,
+	PanelBody,
 	ToggleControl,
 	ToolbarDropdownMenu,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { check } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -123,10 +122,6 @@ export function SocialLinksEdit( props ) {
 				: undefined,
 	} );
 
-	const POPOVER_PROPS = {
-		position: 'bottom right',
-	};
-
 	const colorSettings = [
 		{
 			// Use custom attribute as fallback to prevent loss of named color selection when
@@ -167,43 +162,6 @@ export function SocialLinksEdit( props ) {
 
 	return (
 		<>
-			<BlockControls group="other">
-				<ToolbarDropdownMenu
-					label={ __( 'Size' ) }
-					text={ __( 'Size' ) }
-					icon={ null }
-					popoverProps={ POPOVER_PROPS }
-				>
-					{ ( { onClose } ) => (
-						<MenuGroup>
-							{ sizeOptions.map( ( entry ) => {
-								return (
-									<MenuItem
-										icon={
-											( size === entry.value ||
-												( ! size &&
-													entry.value ===
-														'has-normal-icon-size' ) ) &&
-											check
-										}
-										isSelected={ size === entry.value }
-										key={ entry.value }
-										onClick={ () => {
-											setAttributes( {
-												size: entry.value,
-											} );
-										} }
-										onClose={ onClose }
-										role="menuitemradio"
-									>
-										{ entry.name }
-									</MenuItem>
-								);
-							} ) }
-						</MenuGroup>
-					) }
-				</ToolbarDropdownMenu>
-			</BlockControls>
 			<InspectorControls>
 				<ToolsPanel
 					label={ __( 'Settings' ) }
@@ -291,7 +249,7 @@ export function SocialLinksEdit( props ) {
 		</>
 	);
 }
-
+/* eslint-enable no-unused-vars */
 const iconColorAttributes = {
 	iconColor: 'icon-color',
 	iconBackgroundColor: 'icon-background-color',


### PR DESCRIPTION
Fixes: #65647 

## What?
This PR has changes covered in https://github.com/WordPress/gutenberg/pull/65729 with new **ToolsPanelItem** wrapper and it also resolves other merge conflicts present there.

## Why?
The Social Icons block has a 'size' setting that is placed in a toolbar dropdown menu labeled 'Size', but in other blocks it is there in inspector controls.

## How?
This PR moves the size settings to inspector controls.

## Testing Instructions
1. Add the Social Icons Block.
2. Size settings should be available in the inspector controls panel instead on block toolbar. 

## Screenshots or screencast 

https://github.com/user-attachments/assets/f8d4ce83-2cc6-4226-9be7-0d8aac81abf6



