### PR TITLE
Updated small typo in inline docs

### DIFF
--- a/packages/components/src/mobile/utils/get-px-from-css-unit.native.js
+++ b/packages/components/src/mobile/utils/get-px-from-css-unit.native.js
@@ -116,7 +116,7 @@ function isMathExpression( cssUnit ) {
  * Evaluates the math expression and return a px value.
  *
  * @param {string} cssUnit the cssUnit value being evaluated.
- * @return {string} return a converfted value to px.
+ * @return {string} return a converted value to px.
  */
 function evalMathExpression( cssUnit ) {
 	let errorFound = false;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
- Corrected Small typo in `packages/components/src/mobile/utils/get-px-from-css-unit.native.js` Line No 119 Used `converted` instead of `converfted`


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Small typo in `packages/components/src/mobile/utils/get-px-from-css-unit.native.js` Line No 119 inline docs

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Used `converted` instead of `converfted` 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open `packages/components/src/mobile/utils/get-px-from-css-unit.native.js` file
2. Go to Line no 119
3. See Typo


