### PR TITLE
File Block: Refactor setting panel to use ToolsPanel

### DIFF
--- a/packages/block-library/src/file/inspector.js
+++ b/packages/block-library/src/file/inspector.js
@@ -3,10 +3,11 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
-	PanelBody,
 	RangeControl,
 	SelectControl,
 	ToggleControl,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
 
@@ -14,6 +15,7 @@ import { InspectorControls } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import { MIN_PREVIEW_HEIGHT, MAX_PREVIEW_HEIGHT } from './edit';
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 export default function FileBlockInspector( {
 	hrefs,
@@ -28,6 +30,7 @@ export default function FileBlockInspector( {
 	changePreviewHeight,
 } ) {
 	const { href, textLinkHref, attachmentPage } = hrefs;
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	let linkDestinationOptions = [ { value: href, label: __( 'URL' ) } ];
 	if ( attachmentPage ) {
@@ -41,58 +44,109 @@ export default function FileBlockInspector( {
 		<>
 			<InspectorControls>
 				{ href.endsWith( '.pdf' ) && (
-					<PanelBody title={ __( 'PDF settings' ) }>
+					<ToolsPanel
+						label={ __( 'PDF settings' ) }
+						resetAll={ () => {
+							changeDisplayPreview( true );
+							changePreviewHeight( 600 );
+						} }
+						dropdownMenuProps={ dropdownMenuProps }
+					>
+						<ToolsPanelItem
+							label={ __( 'Show inline embed' ) }
+							isShownByDefault
+							hasValue={ () => ! displayPreview }
+							onDeselect={ () => changeDisplayPreview( true ) }
+						>
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={ __( 'Show inline embed' ) }
+								help={
+									displayPreview
+										? __(
+												"Note: Most phone and tablet browsers won't display embedded PDFs."
+										  )
+										: null
+								}
+								checked={ !! displayPreview }
+								onChange={ changeDisplayPreview }
+							/>
+						</ToolsPanelItem>
+						{ displayPreview && (
+							<ToolsPanelItem
+								label={ __( 'Height in pixels' ) }
+								isShownByDefault
+								hasValue={ () => previewHeight !== 600 }
+								onDeselect={ () => changePreviewHeight( 600 ) }
+							>
+								<RangeControl
+									__nextHasNoMarginBottom
+									__next40pxDefaultSize
+									label={ __( 'Height in pixels' ) }
+									min={ MIN_PREVIEW_HEIGHT }
+									max={ Math.max(
+										MAX_PREVIEW_HEIGHT,
+										previewHeight
+									) }
+									value={ previewHeight }
+									onChange={ changePreviewHeight }
+								/>
+							</ToolsPanelItem>
+						) }
+					</ToolsPanel>
+				) }
+
+				<ToolsPanel
+					label={ __( 'Settings' ) }
+					resetAll={ () => {
+						changeLinkDestinationOption( href );
+						changeOpenInNewWindow( false );
+						changeShowDownloadButton( true );
+					} }
+					dropdownMenuProps={ dropdownMenuProps }
+				>
+					<ToolsPanelItem
+						label={ __( 'Link to' ) }
+						isShownByDefault
+						hasValue={ () => textLinkHref !== href }
+						onDeselect={ () => changeLinkDestinationOption( href ) }
+					>
+						<SelectControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={ __( 'Link to' ) }
+							value={ textLinkHref }
+							options={ linkDestinationOptions }
+							onChange={ changeLinkDestinationOption }
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						label={ __( 'Open in new tab' ) }
+						isShownByDefault
+						hasValue={ () => !! openInNewWindow }
+						onDeselect={ () => changeOpenInNewWindow( false ) }
+					>
 						<ToggleControl
 							__nextHasNoMarginBottom
-							label={ __( 'Show inline embed' ) }
-							help={
-								displayPreview
-									? __(
-											"Note: Most phone and tablet browsers won't display embedded PDFs."
-									  )
-									: null
-							}
-							checked={ !! displayPreview }
-							onChange={ changeDisplayPreview }
+							label={ __( 'Open in new tab' ) }
+							checked={ openInNewWindow }
+							onChange={ changeOpenInNewWindow }
 						/>
-						{ displayPreview && (
-							<RangeControl
-								__nextHasNoMarginBottom
-								__next40pxDefaultSize
-								label={ __( 'Height in pixels' ) }
-								min={ MIN_PREVIEW_HEIGHT }
-								max={ Math.max(
-									MAX_PREVIEW_HEIGHT,
-									previewHeight
-								) }
-								value={ previewHeight }
-								onChange={ changePreviewHeight }
-							/>
-						) }
-					</PanelBody>
-				) }
-				<PanelBody title={ __( 'Settings' ) }>
-					<SelectControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						label={ __( 'Link to' ) }
-						value={ textLinkHref }
-						options={ linkDestinationOptions }
-						onChange={ changeLinkDestinationOption }
-					/>
-					<ToggleControl
-						__nextHasNoMarginBottom
-						label={ __( 'Open in new tab' ) }
-						checked={ openInNewWindow }
-						onChange={ changeOpenInNewWindow }
-					/>
-					<ToggleControl
-						__nextHasNoMarginBottom
+					</ToolsPanelItem>
+					<ToolsPanelItem
 						label={ __( 'Show download button' ) }
-						checked={ showDownloadButton }
-						onChange={ changeShowDownloadButton }
-					/>
-				</PanelBody>
+						isShownByDefault
+						hasValue={ () => ! showDownloadButton }
+						onDeselect={ () => changeShowDownloadButton( true ) }
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Show download button' ) }
+							checked={ showDownloadButton }
+							onChange={ changeShowDownloadButton }
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
 			</InspectorControls>
 		</>
 	);


### PR DESCRIPTION
## What?
Part of #67813

Make the settings panel more consistent with other blocks

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a file block
3. Open the settings panel
4. You can see that you can set it up just like before.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| ![before-1](https://github.com/user-attachments/assets/183789a2-76b9-4e0b-a261-97cffc9d310d) ![before-2](https://github.com/user-attachments/assets/d8428e79-1387-4303-89f2-b6e0fc185766) | ![after-2](https://github.com/user-attachments/assets/fef7e05a-fe74-4e1c-b8d4-83f7a45bf3fb) ![after-1](https://github.com/user-attachments/assets/75268da3-1dfa-4839-8809-afc3dc86332a)  | 

