### PR TITLE
Button: Avoid empty block control slot

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -326,7 +326,8 @@ function ButtonEdit( props ) {
 	} );
 
 	const hasNonContentControls = blockEditingMode === 'default';
-	const hasBlockControls = hasNonContentControls || ! lockUrlControls;
+	const hasBlockControls =
+		hasNonContentControls || ( isLinkTag && ! lockUrlControls );
 
 	return (
 		<>

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -325,6 +325,9 @@ function ButtonEdit( props ) {
 		},
 	} );
 
+	const hasNonContentControls = blockEditingMode === 'default';
+	const hasBlockControls = hasNonContentControls || ! lockUrlControls;
+
 	return (
 		<>
 			<div
@@ -374,35 +377,37 @@ function ButtonEdit( props ) {
 					identifier="text"
 				/>
 			</div>
-			<BlockControls group="block">
-				{ blockEditingMode === 'default' && (
-					<AlignmentControl
-						value={ textAlign }
-						onChange={ ( nextAlign ) => {
-							setAttributes( { textAlign: nextAlign } );
-						} }
-					/>
-				) }
-				{ ! isURLSet && isLinkTag && ! lockUrlControls && (
-					<ToolbarButton
-						name="link"
-						icon={ link }
-						title={ __( 'Link' ) }
-						shortcut={ displayShortcut.primary( 'k' ) }
-						onClick={ startEditing }
-					/>
-				) }
-				{ isURLSet && isLinkTag && ! lockUrlControls && (
-					<ToolbarButton
-						name="link"
-						icon={ linkOff }
-						title={ __( 'Unlink' ) }
-						shortcut={ displayShortcut.primaryShift( 'k' ) }
-						onClick={ unlink }
-						isActive
-					/>
-				) }
-			</BlockControls>
+			{ hasBlockControls && (
+				<BlockControls group="block">
+					{ hasNonContentControls && (
+						<AlignmentControl
+							value={ textAlign }
+							onChange={ ( nextAlign ) => {
+								setAttributes( { textAlign: nextAlign } );
+							} }
+						/>
+					) }
+					{ ! isURLSet && isLinkTag && ! lockUrlControls && (
+						<ToolbarButton
+							name="link"
+							icon={ link }
+							title={ __( 'Link' ) }
+							shortcut={ displayShortcut.primary( 'k' ) }
+							onClick={ startEditing }
+						/>
+					) }
+					{ isURLSet && isLinkTag && ! lockUrlControls && (
+						<ToolbarButton
+							name="link"
+							icon={ linkOff }
+							title={ __( 'Unlink' ) }
+							shortcut={ displayShortcut.primaryShift( 'k' ) }
+							onClick={ unlink }
+							isActive
+						/>
+					) }
+				</BlockControls>
+			) }
 			{ isLinkTag &&
 				isSelected &&
 				( isEditingURL || isURLSet ) &&


### PR DESCRIPTION
## What?
PR adds a check before rendering the block controls. This prevents a gap space, on rare occasions when "block controls" has no child components to render.

## Testing Instructions

1. Create a post.
2. Add buttons nested inside a `contentOnly` container.
3. Render button as an actual `button` element.
4. Confirm that no empty block controls slot is rendered.

<details><summary>Test blocks</summary>
<p>

```
<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"tagName":"button"} -->
<div class="wp-block-button"><button type="button" class="wp-block-button__link wp-element-button">Actual button</button></div>
<!-- /wp:button --></div>
<!-- /wp:buttons --></div>
<!-- /wp:group -->
``` 

</p>
</details> 

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
**Before**
![CleanShot 2025-05-23 at 15 16 05](https://github.com/user-attachments/assets/8813c1ae-429b-4fbb-9332-a622b3449107)

**After**
![CleanShot 2025-05-23 at 15 18 53](https://github.com/user-attachments/assets/9968a7f3-cda1-47bb-98d0-b72ddf5b7917)
