### PR TITLE
Button: Avoid focus loss when unlinking using keyboard

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -388,23 +388,18 @@ function ButtonEdit( props ) {
 							} }
 						/>
 					) }
-					{ ! isURLSet && isLinkTag && ! lockUrlControls && (
+					{ isLinkTag && ! lockUrlControls && (
 						<ToolbarButton
 							name="link"
-							icon={ link }
-							title={ __( 'Link' ) }
-							shortcut={ displayShortcut.primary( 'k' ) }
-							onClick={ startEditing }
-						/>
-					) }
-					{ isURLSet && isLinkTag && ! lockUrlControls && (
-						<ToolbarButton
-							name="link"
-							icon={ linkOff }
-							title={ __( 'Unlink' ) }
-							shortcut={ displayShortcut.primaryShift( 'k' ) }
-							onClick={ unlink }
-							isActive
+							icon={ ! isURLSet ? link : linkOff }
+							title={ ! isURLSet ? __( 'Link' ) : __( 'Unlink' ) }
+							shortcut={
+								! isURLSet
+									? displayShortcut.primary( 'k' )
+									: displayShortcut.primaryShift( 'k' )
+							}
+							onClick={ ! isURLSet ? startEditing : unlink }
+							isActive={ isURLSet }
 						/>
 					) }
 				</BlockControls>


### PR DESCRIPTION
## What?
PR fixes the loss when unlinking the button block using the keyboard. Previously, a different `ToolbarButton` component was mounted based on the `isURLSet` state. Reusing the same `ToolbarButton` and toggling props avoids this problem.

## Testing Instructions
1. Open a post or page.
2. Add a button and a link to it.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/0d85e935-ee46-4630-ab68-eaecdd4b8097

