### PR TITLE
feat: Allow transforming Heading block into Site Title block

### DIFF
--- a/packages/block-library/src/heading/transforms.js
+++ b/packages/block-library/src/heading/transforms.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { createBlock, getBlockAttributes } from '@wordpress/blocks';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -104,6 +105,25 @@ const transforms = {
 						),
 					} )
 				),
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/site-title' ],
+			transform: ( attributes ) => {
+				const { content } = attributes;
+
+				if ( content ) {
+					apiFetch( {
+						path: '/wp/v2/settings',
+						method: 'POST',
+						data: { title: content },
+					} );
+				}
+
+				return createBlock( 'core/site-title' );
+			},
+			__experimentalLabel:
+				'Replace with Site Title (updates site settings)',
 		},
 	],
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
- Closes <!-- #ISSUE-NUMBER or URL --> https://github.com/WordPress/gutenberg/issues/58273
This PR adds a new block transform option that allows a core/heading block to be converted into a core/site-title block. When transformed, the content of the heading is used to update the site's title in WordPress settings.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, if a user inserts a Heading block in the footer (or anywhere) and later wants it to act as the dynamic site title, they must:
- Manually delete the heading,
- Re-insert a Site Title block, and
- Update site settings separately.

This transform streamlines that process by:
- Replacing the block with core/site-title, and
- Persisting the original heading content to WordPress's site title setting.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Adds a to transform in heading/transforms.js for the core/site-title block.
- Uses apiFetch to update /wp/v2/settings with the current heading content.
- Returns a new core/site-title block instance.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open the site editor or post editor.
2. Insert a Heading block (e.g., “CNN News”).
3. Open the block transform options.
4. Click "Replace with Site Title (updates site settings)".
5. Observe:
    - The block is replaced with a dynamic Site Title block.
    - Visit Settings → General or /wp-json/wp/v2/settings to confirm the site title is updated to “CNN News”.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. Navigate to the Heading block using Tab or arrow keys.
2. Use Ctrl + Option + Space (Mac) or Shift + F10 (Windows) to open the block transformation menu.
3. Use arrow keys to select the “Replace with Site Title” option.
4. Press Enter.
5. Confirm the block transforms and settings update successfully without mouse interaction.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
