### PR TITLE
SuggestionsList: Remove unused code

### DIFF
--- a/packages/components/src/form-token-field/suggestions-list.tsx
+++ b/packages/components/src/form-token-field/suggestions-list.tsx
@@ -37,7 +37,6 @@ export function SuggestionsList<
 		( listNode ) => {
 			// only have to worry about scrolling selected suggestion into view
 			// when already expanded.
-			let rafId: number | undefined;
 			if (
 				selectedIndex > -1 &&
 				scrollIntoView &&
@@ -49,12 +48,6 @@ export function SuggestionsList<
 					inline: 'nearest',
 				} );
 			}
-
-			return () => {
-				if ( rafId !== undefined ) {
-					cancelAnimationFrame( rafId );
-				}
-			};
 		},
 		[ selectedIndex, scrollIntoView ]
 	);


### PR DESCRIPTION
## What?
PR removes the leftover ref effect cleanup and `cancelAnimationFrame` call, which was never executed since `rafId` is always `undefined`.

Related PRs: #44573 and #59085, the latter removed rAF call.

## Testing Instructions
None.
