### PR TITLE
feat: Allow replacing Heading content with current Site Title

### DIFF
--- a/packages/block-library/src/heading/transforms.js
+++ b/packages/block-library/src/heading/transforms.js
@@ -2,12 +2,19 @@
  * WordPress dependencies
  */
 import { createBlock, getBlockAttributes } from '@wordpress/blocks';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
  */
 import { getLevelFromHeadingNodeName } from './shared';
 import { getTransformedMetadata } from '../utils/get-transformed-metadata';
+
+let cachedSiteTitle = '';
+
+apiFetch( { path: '/wp/v2/settings' } ).then( ( res ) => {
+	cachedSiteTitle = res?.title ?? '';
+} );
 
 const transforms = {
 	from: [
@@ -104,6 +111,20 @@ const transforms = {
 						),
 					} )
 				),
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/heading' ],
+			transform: ( attributes ) => {
+				// Fallback: if site title not loaded yet, retain original content
+				const newContent = cachedSiteTitle || attributes.content;
+
+				return createBlock( 'core/heading', {
+					...attributes,
+					content: newContent,
+				} );
+			},
+			__experimentalLabel: 'Replace content with Site Title',
 		},
 	],
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/58273

<!-- In a few words, what is the PR actually doing? -->
Adds a new transform option to update the content of a core/heading block using the site's current title (retrieved from /wp/v2/settings), without changing the block type.



## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This is a UX improvement for theme editing and site design:

- Users might add a Heading block with placeholder content.
- Later, they realize they want it to reflect the current site title without switching to a dynamic core/site-title block.

This transform keeps the block type static but replaces its content.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Fetches the current site title using apiFetch once when the file loads.

Adds a transform from core/heading → core/heading that overrides the block's content with the fetched site title.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open the site/post editor.
- Insert a Heading block with any content (e.g., “Placeholder”).
- Ensure your site title is something different (e.g., “CNN Network” in Settings).
- Open the transform menu for the block.
- Click "Replace content with Site Title".
- The block remains a Heading, but its content updates to “CNN Network”.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

- Navigate to the Heading block using keyboard (Tab or arrow keys).
- Open the transform menu using Shift + F10 or equivalent.
- Select and apply the “Replace content with Site Title” option.
- Confirm the text updates and block remains unchanged in type.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
