### PR TITLE
feat: Add transform from Post Title block to Heading block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50028,6 +50028,7 @@
 				"@wordpress/date": "file:../date",
 				"@wordpress/deprecated": "file:../deprecated",
 				"@wordpress/dom": "file:../dom",
+				"@wordpress/editor": "14.24.0",
 				"@wordpress/element": "file:../element",
 				"@wordpress/escape-html": "file:../escape-html",
 				"@wordpress/hooks": "file:../hooks",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -54,6 +54,7 @@
 		"@wordpress/date": "file:../date",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",
+		"@wordpress/editor": "14.24.0",
 		"@wordpress/element": "file:../element",
 		"@wordpress/escape-html": "file:../escape-html",
 		"@wordpress/hooks": "file:../hooks",

--- a/packages/block-library/src/post-title/index.js
+++ b/packages/block-library/src/post-title/index.js
@@ -2,6 +2,9 @@
  * WordPress dependencies
  */
 import { title as icon } from '@wordpress/icons';
+import { createBlock } from '@wordpress/blocks';
+import { select } from '@wordpress/data';
+import { store as coreEditorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -18,6 +21,26 @@ export const settings = {
 	icon,
 	edit,
 	deprecated,
+
+	transforms: {
+		to: [
+			{
+				type: 'block',
+				blocks: [ 'core/heading' ],
+				transform: () => {
+					const postTitle =
+						select( coreEditorStore ).getEditedPostAttribute(
+							'title'
+						);
+
+					return createBlock( 'core/heading', {
+						content: postTitle || '',
+						level: 1,
+					} );
+				},
+			},
+		],
+	},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL --> https://github.com/WordPress/gutenberg/issues/52203

<!-- In a few words, what is the PR actually doing? -->This PR enables the core/post-title block to be transformed into a core/heading block while preserving the post title as the heading content.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, when a user transforms a Post Title block into a Heading block, the content is lost — resulting in an empty heading. Since the Post Title is a critical piece of content, this transform should carry over the actual post title text to maintain the intent and reduce friction in editing.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Uses the Gutenberg @wordpress/editor store to retrieve the current post title (getEditedPostAttribute('title')).
Applies this title as the content for the core/heading block during the transform.
Follows best practices by importing the store definition (not using string literals), satisfying @wordpress/data-no-store-string-literals.
Adds @wordpress/editor to the block’s dependencies to satisfy import/no-extraneous-dependencies.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open the post editor.
- Insert a Post Title block.
- Set the post title to something like: CNN News.
- Click on the block’s transform icon (toolbar).
- Choose Transform to → Heading.
- A Heading block should appear with the content CNN News.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. Use Tab or arrow keys to navigate to the Post Title block.
2. Use the block toolbar shortcut (Cmd + Option + T on Mac, or Ctrl + Alt + T on Windows/Linux) to open the block transform menu.
3. Arrow down to Heading and hit Enter.
4. Verify that the transformed Heading block now contains the post title content.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
