### PR TITLE
Latest posts: change panel body to tools panel

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -408,7 +408,7 @@ function Controls( { attributes, setAttributes, postCount } ) {
 							/>
 						</ToolsPanelItem>
 						<ToolsPanelItem
-							hasValue={ () => featuredImageAlign }
+							hasValue={ () => !! featuredImageAlign }
 							label={ __( 'Image alignment' ) }
 							onDeselect={ () =>
 								setAttributes( {
@@ -447,7 +447,7 @@ function Controls( { attributes, setAttributes, postCount } ) {
 							</ToggleGroupControl>
 						</ToolsPanelItem>
 						<ToolsPanelItem
-							hasValue={ () => addLinkToFeaturedImage }
+							hasValue={ () => !! addLinkToFeaturedImage }
 							label={ __( 'Add link to featured image' ) }
 							onDeselect={ () =>
 								setAttributes( {

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -478,8 +478,8 @@ function Controls( { attributes, setAttributes, postCount } ) {
 						order: 'desc',
 						orderBy: 'date',
 						postsToShow: 5,
-						categories: [],
-						selectedAuthor: '',
+						categories: undefined,
+						selectedAuthor: undefined,
 						columns: 3,
 					} )
 				}
@@ -499,8 +499,8 @@ function Controls( { attributes, setAttributes, postCount } ) {
 							order: 'desc',
 							orderBy: 'date',
 							postsToShow: 5,
-							categories: [],
-							selectedAuthor: '',
+							categories: undefined,
+							selectedAuthor: undefined,
 						} )
 					}
 					isShownByDefault

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -522,7 +522,8 @@ function Controls( { attributes, setAttributes, postCount } ) {
 						selectedCategories={ categories }
 						onAuthorChange={ ( value ) =>
 							setAttributes( {
-								selectedAuthor: value,
+								selectedAuthor:
+									'' !== value ? Number( value ) : undefined,
 							} )
 						}
 						authorList={ authorList ?? [] }

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -7,7 +7,6 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import {
-	PanelBody,
 	Placeholder,
 	QueryControls,
 	RadioControl,
@@ -328,131 +327,239 @@ function Controls( { attributes, setAttributes, postCount } ) {
 					/>
 				</ToolsPanelItem>
 			</ToolsPanel>
-			<PanelBody title={ __( 'Featured image' ) }>
-				<ToggleControl
-					__nextHasNoMarginBottom
+			<ToolsPanel
+				label={ __( 'Featured image' ) }
+				resetAll={ () =>
+					setAttributes( {
+						displayFeaturedImage: false,
+						featuredImageAlign: undefined,
+						featuredImageSizeSlug: undefined,
+						featuredImageSizeWidth: undefined,
+						featuredImageSizeHeight: undefined,
+						addLinkToFeaturedImage: false,
+					} )
+				}
+				dropdownMenuProps={ dropdownMenuProps }
+			>
+				<ToolsPanelItem
+					hasValue={ () => displayFeaturedImage !== false }
 					label={ __( 'Display featured image' ) }
-					checked={ displayFeaturedImage }
-					onChange={ ( value ) =>
-						setAttributes( { displayFeaturedImage: value } )
+					onDeselect={ () =>
+						setAttributes( { displayFeaturedImage: false } )
 					}
-				/>
+					isShownByDefault
+				>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Display featured image' ) }
+						checked={ displayFeaturedImage }
+						onChange={ ( value ) =>
+							setAttributes( { displayFeaturedImage: value } )
+						}
+					/>
+				</ToolsPanelItem>
 				{ displayFeaturedImage && (
 					<>
-						<ImageSizeControl
-							onChange={ ( value ) => {
-								const newAttrs = {};
-								if ( value.hasOwnProperty( 'width' ) ) {
-									newAttrs.featuredImageSizeWidth =
-										value.width;
-								}
-								if ( value.hasOwnProperty( 'height' ) ) {
-									newAttrs.featuredImageSizeHeight =
-										value.height;
-								}
-								setAttributes( newAttrs );
-							} }
-							slug={ featuredImageSizeSlug }
-							width={ featuredImageSizeWidth }
-							height={ featuredImageSizeHeight }
-							imageWidth={ defaultImageWidth }
-							imageHeight={ defaultImageHeight }
-							imageSizeOptions={ imageSizeOptions }
-							imageSizeHelp={ __(
-								'Select the size of the source image.'
-							) }
-							onChangeImage={ ( value ) =>
+						<ToolsPanelItem
+							hasValue={ () =>
+								featuredImageSizeSlug !== undefined ||
+								featuredImageSizeWidth !== undefined ||
+								featuredImageSizeHeight !== undefined
+							}
+							label={ __( 'Image size' ) }
+							onDeselect={ () =>
 								setAttributes( {
-									featuredImageSizeSlug: value,
+									featuredImageSizeSlug: undefined,
 									featuredImageSizeWidth: undefined,
 									featuredImageSizeHeight: undefined,
 								} )
 							}
-						/>
-						<ToggleGroupControl
-							className="editor-latest-posts-image-alignment-control"
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-							label={ __( 'Image alignment' ) }
-							value={ featuredImageAlign || 'none' }
-							onChange={ ( value ) =>
-								setAttributes( {
-									featuredImageAlign:
-										value !== 'none' ? value : undefined,
-								} )
-							}
+							isShownByDefault
 						>
-							{ imageAlignmentOptions.map(
-								( { value, icon, label } ) => {
-									return (
-										<ToggleGroupControlOptionIcon
-											key={ value }
-											value={ value }
-											icon={ icon }
-											label={ label }
-										/>
-									);
+							<ImageSizeControl
+								onChange={ ( value ) => {
+									const newAttrs = {};
+									if ( value.hasOwnProperty( 'width' ) ) {
+										newAttrs.featuredImageSizeWidth =
+											value.width;
+									}
+									if ( value.hasOwnProperty( 'height' ) ) {
+										newAttrs.featuredImageSizeHeight =
+											value.height;
+									}
+									setAttributes( newAttrs );
+								} }
+								slug={ featuredImageSizeSlug }
+								width={ featuredImageSizeWidth }
+								height={ featuredImageSizeHeight }
+								imageWidth={ defaultImageWidth }
+								imageHeight={ defaultImageHeight }
+								imageSizeOptions={ imageSizeOptions }
+								imageSizeHelp={ __(
+									'Select the size of the source image.'
+								) }
+								onChangeImage={ ( value ) =>
+									setAttributes( {
+										featuredImageSizeSlug: value,
+										featuredImageSizeWidth: undefined,
+										featuredImageSizeHeight: undefined,
+									} )
 								}
-							) }
-						</ToggleGroupControl>
-						<ToggleControl
-							__nextHasNoMarginBottom
-							label={ __( 'Add link to featured image' ) }
-							checked={ addLinkToFeaturedImage }
-							onChange={ ( value ) =>
+							/>
+						</ToolsPanelItem>
+						<ToolsPanelItem
+							hasValue={ () => featuredImageAlign !== undefined }
+							label={ __( 'Image alignment' ) }
+							onDeselect={ () =>
 								setAttributes( {
-									addLinkToFeaturedImage: value,
+									featuredImageAlign: undefined,
 								} )
 							}
-						/>
+							isShownByDefault
+						>
+							<ToggleGroupControl
+								className="editor-latest-posts-image-alignment-control"
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
+								label={ __( 'Image alignment' ) }
+								value={ featuredImageAlign || 'none' }
+								onChange={ ( value ) =>
+									setAttributes( {
+										featuredImageAlign:
+											value !== 'none'
+												? value
+												: undefined,
+									} )
+								}
+							>
+								{ imageAlignmentOptions.map(
+									( { value, icon, label } ) => {
+										return (
+											<ToggleGroupControlOptionIcon
+												key={ value }
+												value={ value }
+												icon={ icon }
+												label={ label }
+											/>
+										);
+									}
+								) }
+							</ToggleGroupControl>
+						</ToolsPanelItem>
+						<ToolsPanelItem
+							hasValue={ () => addLinkToFeaturedImage === true }
+							label={ __( 'Add link to featured image' ) }
+							onDeselect={ () =>
+								setAttributes( {
+									addLinkToFeaturedImage: false,
+								} )
+							}
+							isShownByDefault
+						>
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={ __( 'Add link to featured image' ) }
+								checked={ addLinkToFeaturedImage }
+								onChange={ ( value ) =>
+									setAttributes( {
+										addLinkToFeaturedImage: value,
+									} )
+								}
+							/>
+						</ToolsPanelItem>
 					</>
 				) }
-			</PanelBody>
-			<PanelBody title={ __( 'Sorting and filtering' ) }>
-				<QueryControls
-					{ ...{ order, orderBy } }
-					numberOfItems={ postsToShow }
-					onOrderChange={ ( value ) =>
-						setAttributes( { order: value } )
+			</ToolsPanel>
+
+			<ToolsPanel
+				label={ __( 'Sorting and filtering' ) }
+				resetAll={ () =>
+					setAttributes( {
+						order: 'desc',
+						orderBy: 'date',
+						postsToShow: 5,
+						categories: [],
+						selectedAuthor: '',
+						columns: 3,
+					} )
+				}
+				dropdownMenuProps={ dropdownMenuProps }
+			>
+				<ToolsPanelItem
+					hasValue={ () =>
+						order !== 'desc' ||
+						orderBy !== 'date' ||
+						postsToShow !== 5 ||
+						categories?.length > 0 ||
+						selectedAuthor !== ''
 					}
-					onOrderByChange={ ( value ) =>
-						setAttributes( { orderBy: value } )
-					}
-					onNumberOfItemsChange={ ( value ) =>
-						setAttributes( { postsToShow: value } )
-					}
-					categorySuggestions={ categorySuggestions }
-					onCategoryChange={ selectCategories }
-					selectedCategories={ categories }
-					onAuthorChange={ ( value ) =>
+					label={ __( 'Sort and filter' ) }
+					onDeselect={ () =>
 						setAttributes( {
-							selectedAuthor:
-								'' !== value ? Number( value ) : undefined,
+							order: 'desc',
+							orderBy: 'date',
+							postsToShow: 5,
+							categories: [],
+							selectedAuthor: '',
 						} )
 					}
-					authorList={ authorList ?? [] }
-					selectedAuthorId={ selectedAuthor }
-				/>
+					isShownByDefault
+				>
+					<QueryControls
+						{ ...{ order, orderBy } }
+						numberOfItems={ postsToShow }
+						onOrderChange={ ( value ) =>
+							setAttributes( { order: value } )
+						}
+						onOrderByChange={ ( value ) =>
+							setAttributes( { orderBy: value } )
+						}
+						onNumberOfItemsChange={ ( value ) =>
+							setAttributes( { postsToShow: value } )
+						}
+						categorySuggestions={ categorySuggestions }
+						onCategoryChange={ selectCategories }
+						selectedCategories={ categories }
+						onAuthorChange={ ( value ) =>
+							setAttributes( {
+								selectedAuthor: value,
+							} )
+						}
+						authorList={ authorList ?? [] }
+						selectedAuthorId={ selectedAuthor }
+					/>
+				</ToolsPanelItem>
 
 				{ postLayout === 'grid' && (
-					<RangeControl
-						__nextHasNoMarginBottom
-						__next40pxDefaultSize
+					<ToolsPanelItem
+						hasValue={ () => columns !== 3 }
 						label={ __( 'Columns' ) }
-						value={ columns }
-						onChange={ ( value ) =>
-							setAttributes( { columns: value } )
+						onDeselect={ () =>
+							setAttributes( {
+								columns: 3,
+							} )
 						}
-						min={ 2 }
-						max={
-							! postCount
-								? MAX_POSTS_COLUMNS
-								: Math.min( MAX_POSTS_COLUMNS, postCount )
-						}
-						required
-					/>
+						isShownByDefault
+					>
+						<RangeControl
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+							label={ __( 'Columns' ) }
+							value={ columns }
+							onChange={ ( value ) =>
+								setAttributes( { columns: value } )
+							}
+							min={ 2 }
+							max={
+								! postCount
+									? MAX_POSTS_COLUMNS
+									: Math.min( MAX_POSTS_COLUMNS, postCount )
+							}
+							required
+						/>
+					</ToolsPanelItem>
 				) }
-			</PanelBody>
+			</ToolsPanel>
 		</>
 	);
 }

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -333,16 +333,16 @@ function Controls( { attributes, setAttributes, postCount } ) {
 					setAttributes( {
 						displayFeaturedImage: false,
 						featuredImageAlign: undefined,
-						featuredImageSizeSlug: undefined,
-						featuredImageSizeWidth: undefined,
-						featuredImageSizeHeight: undefined,
+						featuredImageSizeSlug: 'thumbnail',
+						featuredImageSizeWidth: null,
+						featuredImageSizeHeight: null,
 						addLinkToFeaturedImage: false,
 					} )
 				}
 				dropdownMenuProps={ dropdownMenuProps }
 			>
 				<ToolsPanelItem
-					hasValue={ () => displayFeaturedImage !== false }
+					hasValue={ () => !! displayFeaturedImage }
 					label={ __( 'Display featured image' ) }
 					onDeselect={ () =>
 						setAttributes( { displayFeaturedImage: false } )
@@ -362,16 +362,16 @@ function Controls( { attributes, setAttributes, postCount } ) {
 					<>
 						<ToolsPanelItem
 							hasValue={ () =>
-								featuredImageSizeSlug !== undefined ||
-								featuredImageSizeWidth !== undefined ||
-								featuredImageSizeHeight !== undefined
+								featuredImageSizeSlug !== 'thumbnail' ||
+								featuredImageSizeWidth !== null ||
+								featuredImageSizeHeight !== null
 							}
 							label={ __( 'Image size' ) }
 							onDeselect={ () =>
 								setAttributes( {
-									featuredImageSizeSlug: undefined,
-									featuredImageSizeWidth: undefined,
-									featuredImageSizeHeight: undefined,
+									featuredImageSizeSlug: 'thumbnail',
+									featuredImageSizeWidth: null,
+									featuredImageSizeHeight: null,
 								} )
 							}
 							isShownByDefault
@@ -408,7 +408,7 @@ function Controls( { attributes, setAttributes, postCount } ) {
 							/>
 						</ToolsPanelItem>
 						<ToolsPanelItem
-							hasValue={ () => featuredImageAlign !== undefined }
+							hasValue={ () => featuredImageAlign }
 							label={ __( 'Image alignment' ) }
 							onDeselect={ () =>
 								setAttributes( {
@@ -447,7 +447,7 @@ function Controls( { attributes, setAttributes, postCount } ) {
 							</ToggleGroupControl>
 						</ToolsPanelItem>
 						<ToolsPanelItem
-							hasValue={ () => addLinkToFeaturedImage === true }
+							hasValue={ () => addLinkToFeaturedImage }
 							label={ __( 'Add link to featured image' ) }
 							onDeselect={ () =>
 								setAttributes( {
@@ -491,7 +491,7 @@ function Controls( { attributes, setAttributes, postCount } ) {
 						orderBy !== 'date' ||
 						postsToShow !== 5 ||
 						categories?.length > 0 ||
-						selectedAuthor !== ''
+						!! selectedAuthor
 					}
 					label={ __( 'Sort and filter' ) }
 					onDeselect={ () =>


### PR DESCRIPTION
## What?

Closes #67931

## Why?

Following up on some additional work in refactoring block panels as per #67813 and a [comment for additional work](https://github.com/WordPress/gutenberg/issues/67931#issuecomment-2603965507).

## How?

Panels for `Feature image` and `Sorting and filtering` were removed and replaced with `ToolsPanel` and `ToolsPanelItem`.

## Testing Instructions

1. Open a post or page.
2. Insert a latest post block.
3. Change options in `Featured image` panel and use dropdown to reset options
4. Change options in `Sorting and filtering` panel and use dropdown to reset options

## Screenshots or screencast

|Before|After|
|-|-|
|<img width="279" alt="latest-posts-before" src="https://github.com/user-attachments/assets/1b02dcd3-7730-483a-8664-7413d62e01af" />|<img width="560" alt="latest-posts-after" src="https://github.com/user-attachments/assets/c3f09f1d-ebb5-41e3-9475-455806bf7f1c" />|




