### PR TITLE
ImageSizeControl: Use margin-free style

### DIFF
--- a/packages/block-editor/src/components/block-inspector/style.scss
+++ b/packages/block-editor/src/components/block-inspector/style.scss
@@ -12,7 +12,8 @@
 
 	.components-base-control,
 	.components-radio-control,
-	.block-editor-html-element-control {
+	.block-editor-html-element-control,
+	.block-editor-image-size-control {
 		&:where(:not(:last-child)) {
 			margin-bottom: $grid-unit-20;
 		}
@@ -22,7 +23,8 @@
 	.components-focal-point-picker-control,
 	.components-query-controls,
 	.components-range-control,
-	.block-editor-html-element-control {
+	.block-editor-html-element-control,
+	.block-editor-image-size-control {
 		.components-base-control {
 			margin-bottom: 0;
 		}

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -5,6 +5,7 @@ import {
 	SelectControl,
 	__experimentalNumberControl as NumberControl,
 	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
@@ -87,7 +88,7 @@ export default function ImageSizeControl( {
 	} );
 
 	return (
-		<>
+		<VStack className="block-editor-image-size-control" spacing="4">
 			{ imageSizeOptions && imageSizeOptions.length > 0 && (
 				<SelectControl
 					__nextHasNoMarginBottom
@@ -100,10 +101,9 @@ export default function ImageSizeControl( {
 				/>
 			) }
 			{ isResizable && (
-				<div className="block-editor-image-size-control">
-					<HStack align="baseline" spacing="3">
+				<>
+					<HStack align="baseline" spacing="4">
 						<NumberControl
-							className="block-editor-image-size-control__width"
 							label={ __( 'Width' ) }
 							value={ currentWidth }
 							min={ 1 }
@@ -113,7 +113,6 @@ export default function ImageSizeControl( {
 							size="__unstable-large"
 						/>
 						<NumberControl
-							className="block-editor-image-size-control__height"
 							label={ __( 'Height' ) }
 							value={ currentHeight }
 							min={ 1 }
@@ -146,8 +145,8 @@ export default function ImageSizeControl( {
 							);
 						} ) }
 					</ToggleGroupControl>
-				</div>
+				</>
 			) }
-		</>
+		</VStack>
 	);
 }

--- a/packages/block-editor/src/components/image-size-control/style.scss
+++ b/packages/block-editor/src/components/image-size-control/style.scss
@@ -1,8 +1,0 @@
-.block-editor-image-size-control {
-	margin-bottom: 1em;
-
-	.block-editor-image-size-control__width,
-	.block-editor-image-size-control__height {
-		margin-bottom: 1.115em;
-	}
-}

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -33,7 +33,6 @@
 @import "./components/grid/style.scss";
 @import "./components/height-control/style.scss";
 @import "./components/iframe/style.scss";
-@import "./components/image-size-control/style.scss";
 @import "./components/inserter-list-item/style.scss";
 @import "./components/inspector-controls-tabs/style.scss";
 @import "./components/inspector-popover-header/style.scss";


### PR DESCRIPTION
Found while reviewing #70200

## What?

Remove the margin styles from the `ImageSizeControl` component and apply a grid layout.

## Why?

The current implementation doesn't fit when this component is used inside the `ToolsPanelItem` component. This is because it resets margins as much as possible. As a result, as [this comment says](https://github.com/WordPress/gutenberg/pull/70200#issuecomment-2906016453), we cannot maintain the layout within a `ToolsPanelItem`.

Furthermore, the style based on the `em` units doesn't match Gutenberg's UI design.

## How?

- Remove all margin styles and apply a grid layout.
- Relocate the `.block-editor-image-size-control` CSS class to the root of the component.
- Apply a bottom margin via the parent Block Inspector component.

## Testing Instructions

- Add a Latest Post Block.
- Check the Featured image section panel.

## Screenshots or screencast <!-- if applicable -->

The visual change is subtle, but all spacing is now standardized to 16px.

|Before|After|
|-|-|
| ![before](https://github.com/user-attachments/assets/c1527667-4ebe-4d63-b779-f77045884496) | ![after](https://github.com/user-attachments/assets/9398c5a1-b41e-48dd-b86c-b8f5afb22930) |

