### PR TITLE
Removed Empty line and corrected typo in inline document

### DIFF
--- a/lib/experimental/navigation-theme-opt-in.php
+++ b/lib/experimental/navigation-theme-opt-in.php
@@ -179,7 +179,7 @@ add_filter( 'wp_nav_menu_objects', 'gutenberg_remove_block_nav_menu_items', 10 )
  *
  * @param array $menu_items The menu items to convert, sorted by each menu item's menu order.
  * @param array $menu_items_by_parent_id All menu items, indexed by their parent's ID.
-
+ *
  * @return array Updated menu items, sorted by each menu item's menu order.
  */
 function gutenberg_convert_menu_items_to_blocks(

--- a/packages/dom/src/dom/input-field-has-uncollapsed-selection.js
+++ b/packages/dom/src/dom/input-field-has-uncollapsed-selection.js
@@ -19,7 +19,7 @@ import isHTMLInputElement from './is-html-input-element';
  *
  * @param {Element} element The HTML element.
  *
- * @return {boolean} Whether the input/textareaa element has some "selection".
+ * @return {boolean} Whether the input/textarea element has some "selection".
  */
 export default function inputFieldHasUncollapsedSelection( element ) {
 	if ( ! isHTMLInputElement( element ) && ! isTextField( element ) ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
- There is Empty Line in Inline Document in `lib/experimental/navigation-theme-opt-in.php` file
- There is Small typo in `packages/dom/src/dom/input-field-has-uncollapsed-selection.js` file 
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Removed Empty Line in Inline Document in `lib/experimental/navigation-theme-opt-in.php` file
- Corrected small typo in inline document in `packages/dom/src/dom/input-field-has-uncollapsed-selection.js` file

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Removed Empty Line in Inline Document in `lib/experimental/navigation-theme-opt-in.php` file
- Corrected small typo in inline document in `packages/dom/src/dom/input-field-has-uncollapsed-selection.js` file

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open - `lib/experimental/navigation-theme-opt-in.php` file &  `packages/dom/src/dom/input-field-has-uncollapsed-selection.js` file
2. Go to line no 182 in `navigation-theme-opt-in.php` file and go to line no 22 in `packages/dom/src/dom/input-field-has-uncollapsed-selection.js` file
3. See Empty line & typo correction