### PR TITLE
List Block: Remove unused __unstableMultilineWrapperTags field from block.json

### DIFF
--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -18,6 +18,7 @@
 			"type": "string",
 			"source": "html",
 			"selector": "ol,ul",
+			"multiline": "li",
 			"default": "",
 			"role": "content"
 		},

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -18,8 +18,6 @@
 			"type": "string",
 			"source": "html",
 			"selector": "ol,ul",
-			"multiline": "li",
-			"__unstableMultilineWrapperTags": [ "ol", "ul" ],
 			"default": "",
 			"role": "content"
 		},

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -12,7 +12,6 @@
 			"type": "string",
 			"source": "html",
 			"selector": "blockquote",
-			"multiline": "p",
 			"default": "",
 			"role": "content"
 		},

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -12,6 +12,7 @@
 			"type": "string",
 			"source": "html",
 			"selector": "blockquote",
+			"multiline": "p",
 			"default": "",
 			"role": "content"
 		},


### PR DESCRIPTION
Related to:

- #17845
- #54310


## What?

~The `multiline` field was previously necessary when using the `multiline` prop in the `RichText` component. However, since both the List and Quote blocks now use InnerBlocks, this field is no longer necessary.~

As for the `__unstableMultilineWrapperTags` field, its processing has been removed [here](https://github.com/WordPress/gutenberg/pull/54310/files?diff=unified&w=0#diff-295fd90562fbb697681f8c744c79fc59b32b1fccf163ea66a5fa3b285f412ab9L11) and it has no role.

## Why?

Code quality.

## Testing Instructions

Nothing.