### PR TITLE
RSS: Refactor setting panel to use `ToolsPanel`

### DIFF
--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -9,19 +9,25 @@ import {
 import {
 	Button,
 	Disabled,
-	PanelBody,
 	Placeholder,
 	RangeControl,
 	ToggleControl,
 	ToolbarGroup,
 	TextControl,
 	__experimentalInputControl as InputControl,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { grid, list, edit, rss } from '@wordpress/icons';
 import { __, _x } from '@wordpress/i18n';
 import { prependHTTP } from '@wordpress/url';
 import ServerSideRender from '@wordpress/server-side-render';
+
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const DEFAULT_MIN_ITEMS = 1;
 const DEFAULT_MAX_ITEMS = 20;
@@ -41,6 +47,8 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 		openInNewTab,
 		rel,
 	} = attributes;
+
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	function toggleAttribute( propName ) {
 		return () => {
@@ -141,75 +149,153 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 				<ToolbarGroup controls={ toolbarControls } />
 			</BlockControls>
 			<InspectorControls>
-				<PanelBody title={ __( 'Settings' ) }>
-					<RangeControl
-						__nextHasNoMarginBottom
-						__next40pxDefaultSize
+				<ToolsPanel
+					label={ __( 'Settings' ) }
+					resetAll={ () => {
+						setAttributes( {
+							itemsToShow: 5,
+							displayAuthor: false,
+							displayDate: false,
+							displayExcerpt: false,
+							excerptLength: 55,
+							columns: 3,
+							openInNewTab: false,
+						} );
+					} }
+					dropdownMenuProps={ dropdownMenuProps }
+				>
+					<ToolsPanelItem
 						label={ __( 'Number of items' ) }
-						value={ itemsToShow }
-						onChange={ ( value ) =>
-							setAttributes( { itemsToShow: value } )
-						}
-						min={ DEFAULT_MIN_ITEMS }
-						max={ DEFAULT_MAX_ITEMS }
-						required
-					/>
-					<ToggleControl
-						__nextHasNoMarginBottom
+						hasValue={ () => itemsToShow !== 5 }
+						onDeselect={ () => setAttributes( { itemsToShow: 5 } ) }
+						isShownByDefault
+					>
+						<RangeControl
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+							label={ __( 'Number of items' ) }
+							value={ itemsToShow }
+							onChange={ ( value ) =>
+								setAttributes( { itemsToShow: value } )
+							}
+							min={ DEFAULT_MIN_ITEMS }
+							max={ DEFAULT_MAX_ITEMS }
+							required
+						/>
+					</ToolsPanelItem>
+
+					<ToolsPanelItem
 						label={ __( 'Display author' ) }
-						checked={ displayAuthor }
-						onChange={ toggleAttribute( 'displayAuthor' ) }
-					/>
-					<ToggleControl
-						__nextHasNoMarginBottom
+						hasValue={ () => displayAuthor !== false }
+						onDeselect={ () =>
+							setAttributes( { displayAuthor: false } )
+						}
+						isShownByDefault
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Display author' ) }
+							checked={ displayAuthor }
+							onChange={ toggleAttribute( 'displayAuthor' ) }
+						/>
+					</ToolsPanelItem>
+
+					<ToolsPanelItem
 						label={ __( 'Display date' ) }
-						checked={ displayDate }
-						onChange={ toggleAttribute( 'displayDate' ) }
-					/>
-					<ToggleControl
-						__nextHasNoMarginBottom
+						hasValue={ () => displayDate !== false }
+						onDeselect={ () =>
+							setAttributes( { displayDate: false } )
+						}
+						isShownByDefault
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Display date' ) }
+							checked={ displayDate }
+							onChange={ toggleAttribute( 'displayDate' ) }
+						/>
+					</ToolsPanelItem>
+
+					<ToolsPanelItem
 						label={ __( 'Display excerpt' ) }
-						checked={ displayExcerpt }
-						onChange={ toggleAttribute( 'displayExcerpt' ) }
-					/>
+						hasValue={ () => displayExcerpt !== false }
+						onDeselect={ () =>
+							setAttributes( { displayExcerpt: false } )
+						}
+						isShownByDefault
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Display excerpt' ) }
+							checked={ displayExcerpt }
+							onChange={ toggleAttribute( 'displayExcerpt' ) }
+						/>
+					</ToolsPanelItem>
+
 					{ displayExcerpt && (
-						<RangeControl
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
+						<ToolsPanelItem
 							label={ __( 'Max number of words in excerpt' ) }
-							value={ excerptLength }
-							onChange={ ( value ) =>
-								setAttributes( { excerptLength: value } )
+							hasValue={ () => excerptLength !== 55 }
+							onDeselect={ () =>
+								setAttributes( { excerptLength: 55 } )
 							}
-							min={ 10 }
-							max={ 100 }
-							required
-						/>
-					) }
-					{ blockLayout === 'grid' && (
-						<RangeControl
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-							label={ __( 'Columns' ) }
-							value={ columns }
-							onChange={ ( value ) =>
-								setAttributes( { columns: value } )
-							}
-							min={ 2 }
-							max={ 6 }
-							required
-						/>
+							isShownByDefault
+						>
+							<RangeControl
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
+								label={ __( 'Max number of words in excerpt' ) }
+								value={ excerptLength }
+								onChange={ ( value ) =>
+									setAttributes( { excerptLength: value } )
+								}
+								min={ 10 }
+								max={ 100 }
+								required
+							/>
+						</ToolsPanelItem>
 					) }
 
-					<ToggleControl
-						__nextHasNoMarginBottom
+					{ blockLayout === 'grid' && (
+						<ToolsPanelItem
+							label={ __( 'Columns' ) }
+							hasValue={ () => columns !== 3 }
+							onDeselect={ () => setAttributes( { columns: 3 } ) }
+							isShownByDefault
+						>
+							<RangeControl
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
+								label={ __( 'Columns' ) }
+								value={ columns }
+								onChange={ ( value ) =>
+									setAttributes( { columns: value } )
+								}
+								min={ 2 }
+								max={ 6 }
+								required
+							/>
+						</ToolsPanelItem>
+					) }
+
+					<ToolsPanelItem
 						label={ __( 'Open links in new tab' ) }
-						checked={ openInNewTab }
-						onChange={ ( value ) =>
-							setAttributes( { openInNewTab: value } )
+						hasValue={ () => openInNewTab !== false }
+						onDeselect={ () =>
+							setAttributes( { openInNewTab: false } )
 						}
-					/>
-				</PanelBody>
+						isShownByDefault
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Open links in new tab' ) }
+							checked={ openInNewTab }
+							onChange={ ( value ) =>
+								setAttributes( { openInNewTab: value } )
+							}
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
 			</InspectorControls>
 			<InspectorControls group="advanced">
 				<TextControl

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -158,7 +158,7 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 							displayDate: false,
 							displayExcerpt: false,
 							excerptLength: 55,
-							columns: 3,
+							columns: 2,
 							openInNewTab: false,
 						} );
 					} }
@@ -186,7 +186,7 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 
 					<ToolsPanelItem
 						label={ __( 'Display author' ) }
-						hasValue={ () => displayAuthor !== false }
+						hasValue={ () => !! displayAuthor }
 						onDeselect={ () =>
 							setAttributes( { displayAuthor: false } )
 						}
@@ -202,7 +202,7 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 
 					<ToolsPanelItem
 						label={ __( 'Display date' ) }
-						hasValue={ () => displayDate !== false }
+						hasValue={ () => !! displayDate }
 						onDeselect={ () =>
 							setAttributes( { displayDate: false } )
 						}
@@ -218,7 +218,7 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 
 					<ToolsPanelItem
 						label={ __( 'Display excerpt' ) }
-						hasValue={ () => displayExcerpt !== false }
+						hasValue={ () => !! displayExcerpt }
 						onDeselect={ () =>
 							setAttributes( { displayExcerpt: false } )
 						}
@@ -259,8 +259,8 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 					{ blockLayout === 'grid' && (
 						<ToolsPanelItem
 							label={ __( 'Columns' ) }
-							hasValue={ () => columns !== 3 }
-							onDeselect={ () => setAttributes( { columns: 3 } ) }
+							hasValue={ () => columns !== 2 }
+							onDeselect={ () => setAttributes( { columns: 2 } ) }
 							isShownByDefault
 						>
 							<RangeControl
@@ -280,7 +280,7 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 
 					<ToolsPanelItem
 						label={ __( 'Open links in new tab' ) }
-						hasValue={ () => openInNewTab !== false }
+						hasValue={ () => !! openInNewTab }
 						onDeselect={ () =>
 							setAttributes( { openInNewTab: false } )
 						}


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/70205

Refactors the RSS block's "Settings" panel to use the modern `ToolsPanel` component instead of the deprecated PanelBody.

## Why?

This change:

- Brings consistency with newer block implementations
- Adds standardized reset controls
- Improves user experience with unified panel behavior

## How?

- Replaced PanelBody with ToolsPanel in inspector controls
- Wrapped individual controls in ToolsPanelItem components
- Implemented proper reset handlers for all attributes
- Added conditional rendering within the `ToolsPanel` structure
- Maintained existing functionality while modernizing the UI

## Testing Instructions

- Add an RSS block to a post/page
- Configure various settings:
- Open links in a new tab
- Verify all controls work as expected
- Use the panel menu to reset individual settings and all functionality


## Screencast

### Before


https://github.com/user-attachments/assets/de1d7ac5-6575-4a27-95ca-aee7858202e1



### After


https://github.com/user-attachments/assets/207f7474-a76b-4bdc-a7e4-40a14484dea6



