### PR TITLE
Components: Improve accessibility, discoverability of `ColorPicker` inputs

### DIFF
--- a/packages/components/src/color-picker/hsl-input.tsx
+++ b/packages/components/src/color-picker/hsl-input.tsx
@@ -64,7 +64,7 @@ export const HslInput = ( { color, onChange, enableAlpha }: HslInputProps ) => {
 			<InputWithSlider
 				min={ 0 }
 				max={ 359 }
-				label="Hue"
+				label="Hue (HSL H value)"
 				abbreviation="H"
 				value={ colorValue.h }
 				onChange={ ( nextH: number ) => {
@@ -95,7 +95,7 @@ export const HslInput = ( { color, onChange, enableAlpha }: HslInputProps ) => {
 				<InputWithSlider
 					min={ 0 }
 					max={ 100 }
-					label="Alpha"
+					label="Alpha (HSL A value)"
 					abbreviation="A"
 					value={ Math.trunc( 100 * colorValue.a ) }
 					onChange={ ( nextA: number ) => {

--- a/packages/components/src/color-picker/rgb-input.tsx
+++ b/packages/components/src/color-picker/rgb-input.tsx
@@ -48,7 +48,7 @@ export const RgbInput = ( { color, onChange, enableAlpha }: RgbInputProps ) => {
 				<InputWithSlider
 					min={ 0 }
 					max={ 100 }
-					label="Alpha"
+					label="Alpha (RGB A value)"
 					abbreviation="A"
 					value={ Math.trunc( a * 100 ) }
 					onChange={ ( nextA: number ) =>


### PR DESCRIPTION


## What?
Related comment / Follow-up: https://github.com/WordPress/gutenberg/pull/69203#discussion_r2028701941
Related comment: https://github.com/WordPress/gutenberg/pull/69203#discussion_r2072853894


## Why?
Improves organisation, labelling and discoverability of the Hue and Alpha input sliders in the ColorPicker component. Currently there are 2 input sliders for hue and alpha(when alpha is enabled in the component) this leads to 2 inputs with same aria labels and difficulty in picking either one of them. 

## How?
Modified the labels of the Hue to "Hue (HSL H value)" and Alpha TO "Alpha (<RGB/HSL> A value)".

## Testing Instructions

1. Run npm run storybook:dev to start the storybook server
2. Checkout the ColorPicker component 
3. Set `enableAlpha` to true for the component
4. Using Chrome Dev Tools verify the labels for the Hue sliders are different for both the hue inputs, same with alpha


## Screenshots or screencast 

https://github.com/user-attachments/assets/5c461190-c976-4061-a952-bc43cdaf6127

