### PR TITLE
Create Block: Add documentation for custom block namespace

### DIFF
--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -40,6 +40,19 @@ $ npx @wordpress/create-block@latest [options] [slug]
 
 When no `slug` is provided, the script will run in interactive mode and will start prompting for the input required (`slug`, title, namespace...) to scaffold the project.
 
+### Block Namespace
+
+By default, blocks are created with the `create-block` namespace. You should specify your own unique namespace:
+
+```bash
+$ npx @wordpress/create-block@latest my-block --namespace=my-namespace
+```
+
+This creates `my-namespace/my-block` instead of `create-block/my-block`.
+
+If you've already created a block, update the namespace in:
+- `block.json` - the `name` property
+
 ### `slug`
 
 The use of `slug` is optional.

--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -40,7 +40,7 @@ $ npx @wordpress/create-block@latest [options] [slug]
 
 When no `slug` is provided, the script will run in interactive mode and will start prompting for the input required (`slug`, title, namespace...) to scaffold the project.
 
-### Block Namespace
+### `namespace`
 
 By default, blocks are created with the `create-block` namespace. You should specify your own unique namespace:
 


### PR DESCRIPTION
## What?
Adds a brief section about block namespaces to the Create Block package documentation.
Closes: #42854

## Why?
When using `@wordpress/create-block`, the tool generates blocks with the default `create-block` namespace (e.g., `create-block/my-block`). This causes issues because:
- Multiple plugins end up using the same namespace
- Developers often don't realize they need to change it until after plugin submission

## How?
Added a concise "Block Namespace" section under Usage that:
- Explains that `create-block` is the default namespace
- Shows how to specify a custom namespace using the `--namespace` option
- Indicates where to update the namespace in existing blocks