### PR TITLE
Block Library: Preserve text content in Media & Text/Image transforms

### DIFF
--- a/packages/block-library/src/media-text/transforms.js
+++ b/packages/block-library/src/media-text/transforms.js
@@ -8,14 +8,26 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/image' ],
-			transform: ( { alt, url, id, anchor } ) =>
-				createBlock( 'core/media-text', {
+			transform: ( { alt, url, id, anchor, caption } ) => {
+				const attributes = {
 					mediaAlt: alt,
 					mediaId: id,
 					mediaUrl: url,
 					mediaType: 'image',
 					anchor,
-				} ),
+				};
+
+				// If there's a caption, create a paragraph block with it
+				const innerBlocks = caption
+					? [ createBlock( 'core/paragraph', { content: caption } ) ]
+					: [];
+
+				return createBlock(
+					'core/media-text',
+					attributes,
+					innerBlocks
+				);
+			},
 		},
 		{
 			type: 'block',
@@ -104,12 +116,28 @@ const transforms = {
 			isMatch: ( { mediaType, mediaUrl } ) => {
 				return ! mediaUrl || mediaType === 'image';
 			},
-			transform: ( { mediaAlt, mediaId, mediaUrl, anchor } ) => {
+			transform: (
+				{ mediaAlt, mediaId, mediaUrl, anchor },
+				innerBlocks
+			) => {
+				const caption = innerBlocks?.length
+					? innerBlocks
+							.filter( ( block ) =>
+								[ 'core/paragraph', 'core/heading' ].includes(
+									block.name
+								)
+							)
+							.map( ( block ) => block.attributes.content || '' )
+							.join( ' ' )
+							.trim()
+					: '';
+
 				return createBlock( 'core/image', {
 					alt: mediaAlt,
 					id: mediaId,
 					url: mediaUrl,
 					anchor,
+					...( caption && { caption } ),
 				} );
 			},
 		},

--- a/packages/block-library/src/media-text/transforms.js
+++ b/packages/block-library/src/media-text/transforms.js
@@ -17,7 +17,6 @@ const transforms = {
 					anchor,
 				};
 
-				// If there's a caption, create a paragraph block with it
 				const innerBlocks = caption
 					? [ createBlock( 'core/paragraph', { content: caption } ) ]
 					: [];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of: https://github.com/WordPress/gutenberg/issues/63635

This PR ensures content preservation when transforming between Media & Text and Image blocks in both directions:
- **Media & Text → Image**: Text content from paragraphs and headings is preserved as the image caption
- **Image → Media & Text**: Image caption is preserved as a paragraph block

## Testing Instructions
### Testing Media & Text to Image transformation
- Insert a Media & Text block
- Add an image and some text content
- Transform the block to an Image block
- Verify the text content appears as the image caption
### Testing Image to Media & Text transformation
- Insert an Image block
- Add an image and a caption
- Transform the block to a Media & Text block
- Verify the caption appears as a paragraph in the text area

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Media & Text → Image
Before

https://github.com/user-attachments/assets/8e5e6fda-1621-4fb0-9328-88d2cf5ec92d

After

https://github.com/user-attachments/assets/6ee954e2-786a-42c3-acb0-96e662bc05fc


Image → Media & Text
Before

https://github.com/user-attachments/assets/e1cd44e2-b6bc-415c-ae8a-e7c76f0efc4d

After

https://github.com/user-attachments/assets/aa4c6a6c-07f4-4ba6-9499-0e4dab879a37

