### PR TITLE
Video: Add option to set a track as default

### DIFF
--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -139,7 +139,7 @@ function SingleTrackEditor( {
 					help={ __( 'Language tag (en, fr, etc.)' ) }
 				/>
 			</Grid>
-			<VStack spacing="8">
+			<VStack spacing="4">
 				<SelectControl
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom

--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -13,9 +13,11 @@ import {
 	Button,
 	TextControl,
 	SelectControl,
+	ToggleControl,
 	__experimentalGrid as Grid,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import {
 	MediaUpload,
@@ -26,6 +28,13 @@ import { upload, media } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 import { useState, useRef, useEffect } from '@wordpress/element';
 import { getFilename } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+
+const { Badge } = unlock( componentsPrivateApis );
 
 const ALLOWED_TYPES = [ 'text/vtt' ];
 
@@ -47,18 +56,21 @@ function TrackList( { tracks, onEditPress } ) {
 				className="block-library-video-tracks-editor__track-list-track"
 			>
 				<span>{ track.label }</span>
-				<Button
-					__next40pxDefaultSize
-					variant="tertiary"
-					onClick={ () => onEditPress( index ) }
-					aria-label={ sprintf(
-						/* translators: %s: Label of the video text track e.g: "French subtitles". */
-						_x( 'Edit %s', 'text tracks' ),
-						track.label
-					) }
-				>
-					{ __( 'Edit' ) }
-				</Button>
+				<HStack justify="flex-end">
+					{ track.default && <Badge>{ __( 'Default' ) }</Badge> }
+					<Button
+						__next40pxDefaultSize
+						variant="tertiary"
+						onClick={ () => onEditPress( index ) }
+						aria-label={ sprintf(
+							/* translators: %s: Label of the video text track e.g: "French subtitles". */
+							_x( 'Edit %s', 'text tracks' ),
+							track.label
+						) }
+					>
+						{ __( 'Edit' ) }
+					</Button>
+				</HStack>
 			</HStack>
 		);
 	} );
@@ -73,8 +85,20 @@ function TrackList( { tracks, onEditPress } ) {
 	);
 }
 
-function SingleTrackEditor( { track, onChange, onClose, onRemove } ) {
-	const { src = '', label = '', srcLang = '', kind = DEFAULT_KIND } = track;
+function SingleTrackEditor( {
+	track,
+	onChange,
+	onClose,
+	onRemove,
+	allowSettingDefault,
+} ) {
+	const {
+		src = '',
+		label = '',
+		srcLang = '',
+		kind = DEFAULT_KIND,
+		default: isDefaultTrack = false,
+	} = track;
 	const fileName = src.startsWith( 'blob:' ) ? '' : getFilename( src ) || '';
 	return (
 		<VStack
@@ -127,6 +151,19 @@ function SingleTrackEditor( { track, onChange, onClose, onRemove } ) {
 						onChange( {
 							...track,
 							kind: newKind,
+						} );
+					} }
+				/>
+				<ToggleControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ __( 'Set as default track' ) }
+					checked={ isDefaultTrack }
+					disabled={ ! allowSettingDefault }
+					onChange={ ( defaultTrack ) => {
+						onChange( {
+							...track,
+							default: defaultTrack,
 						} );
 					} }
 				/>
@@ -237,6 +274,10 @@ export default function TracksEditor( { tracks = [], onChange } ) {
 								);
 								setTrackBeingEdited( null );
 							} }
+							allowSettingDefault={
+								! tracks.some( ( track ) => track.default ) ||
+								tracks[ trackBeingEdited ].default
+							}
 						/>
 					);
 				}


### PR DESCRIPTION
## What?
Closes #37537

This PR adds an option to mark a particular track as the default track for the `video` block.

## Why?

Setting a track as default ensures it's the one automatically selected for playback, providing a consistent user experience.

## How?

This is done by setting the `default` property of the selected track to `true`.

## Testing Instructions

1. Create a new post.
2. Insert a `video` block.
3. Attach multiple tracks to the video block from the block toolbar.
4. Set a particular track as the default.
5. Confirm on the front-end that the default track (if set) gets displayed out of the box.
6. Also, confirm that at most, only a single track can be default.

### Testing Instructions for Keyboard
Same.

## Screencast

https://github.com/user-attachments/assets/1c35dcaa-28f3-48cf-93be-b0f72da61eee


