### PR TITLE
Post Title: Refactor settings panel to use ToolsPanel

### DIFF
--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -15,11 +15,21 @@ import {
 	HeadingLevelDropdown,
 	useBlockEditingMode,
 } from '@wordpress/block-editor';
-import { ToggleControl, TextControl, PanelBody } from '@wordpress/components';
+import {
+	ToggleControl,
+	TextControl,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 export default function PostTitleEdit( {
 	attributes: { level, levelOptions, textAlign, isLink, rel, linkTarget },
@@ -66,13 +76,13 @@ export default function PostTitleEdit( {
 		} ),
 	} );
 	const blockEditingMode = useBlockEditingMode();
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	let titleElement = <TagName { ...blockProps }>{ __( 'Title' ) }</TagName>;
 
 	if ( postType && postId ) {
 		titleElement = userCanEdit ? (
 			<PlainText
-				tagName={ TagName }
 				placeholder={ __( 'No title' ) }
 				value={ rawTitle }
 				onChange={ setTitle }
@@ -138,41 +148,82 @@ export default function PostTitleEdit( {
 						/>
 					</BlockControls>
 					<InspectorControls>
-						<PanelBody title={ __( 'Settings' ) }>
-							<ToggleControl
-								__nextHasNoMarginBottom
+						<ToolsPanel
+							label={ __( 'Settings' ) }
+							resetAll={ () => {
+								setAttributes( {
+									rel: '',
+									linkTarget: '_self',
+									isLink: false,
+								} );
+							} }
+							dropdownMenuProps={ dropdownMenuProps }
+						>
+							<ToolsPanelItem
 								label={ __( 'Make title a link' ) }
-								onChange={ () =>
-									setAttributes( { isLink: ! isLink } )
+								isShownByDefault
+								hasValue={ () => isLink }
+								onDeselect={ () =>
+									setAttributes( { isLink: false } )
 								}
-								checked={ isLink }
-							/>
+							>
+								<ToggleControl
+									__nextHasNoMarginBottom
+									label={ __( 'Make title a link' ) }
+									onChange={ () =>
+										setAttributes( { isLink: ! isLink } )
+									}
+									checked={ isLink }
+								/>
+							</ToolsPanelItem>
 							{ isLink && (
 								<>
-									<ToggleControl
-										__nextHasNoMarginBottom
+									<ToolsPanelItem
 										label={ __( 'Open in new tab' ) }
-										onChange={ ( value ) =>
+										isShownByDefault
+										hasValue={ () =>
+											linkTarget === '_blank'
+										}
+										onDeselect={ () =>
 											setAttributes( {
-												linkTarget: value
-													? '_blank'
-													: '_self',
+												linkTarget: '_self',
 											} )
 										}
-										checked={ linkTarget === '_blank' }
-									/>
-									<TextControl
-										__next40pxDefaultSize
-										__nextHasNoMarginBottom
+									>
+										<ToggleControl
+											__nextHasNoMarginBottom
+											label={ __( 'Open in new tab' ) }
+											onChange={ ( value ) =>
+												setAttributes( {
+													linkTarget: value
+														? '_blank'
+														: '_self',
+												} )
+											}
+											checked={ linkTarget === '_blank' }
+										/>
+									</ToolsPanelItem>
+									<ToolsPanelItem
 										label={ __( 'Link rel' ) }
-										value={ rel }
-										onChange={ ( newRel ) =>
-											setAttributes( { rel: newRel } )
+										isShownByDefault
+										hasValue={ () => !! rel }
+										onDeselect={ () =>
+											setAttributes( { rel: '' } )
 										}
-									/>
+									>
+										<TextControl
+											__next40pxDefaultSize
+											__nextHasNoMarginBottom
+											label={ __( 'Link rel' ) }
+											value={ rel }
+											onChange={ ( newRel ) =>
+												setAttributes( { rel: newRel } )
+											}
+										/>
+									</ToolsPanelItem>
 								</>
 							) }
-						</PanelBody>
+						</ToolsPanel>
 					</InspectorControls>
 				</>
 			) }

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -83,6 +83,7 @@ export default function PostTitleEdit( {
 	if ( postType && postId ) {
 		titleElement = userCanEdit ? (
 			<PlainText
+				tagName={ TagName }
 				placeholder={ __( 'No title' ) }
 				value={ rawTitle }
 				onChange={ setTitle }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Closes: #67939
Part of: #67813

## What?

Refactored the Post Title Block to use ToolsPanel instead of PanelBody.

## Screenshots or screencast <!-- if applicable -->
Before:

https://github.com/user-attachments/assets/c1527fee-5fcf-41e8-82e1-0c7549a6de2d

After:

https://github.com/user-attachments/assets/bf30540f-b0d4-42eb-9635-4a4706ea7241

---

> [!NOTE]  
> Don't forget to manually add @NidhiDhandhukiya74, who worked on https://github.com/WordPress/gutenberg/pull/67978, to the props list.