### PR TITLE
FormTokenField: fix filtering with full-width string

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,10 @@
 -   `ComboboxControl`: Handle Unicode characters when matching values ([#70180](https://github.com/WordPress/gutenberg/pull/70180)).
 -   `Toolbar`: Adjust colors for dark mode support ([#69278](https://github.com/WordPress/gutenberg/pull/69278)).
 
+### Bug Fixes
+
+-   `FormTokenField`: Fix filtering with full-width string ([#70232](https://github.com/WordPress/gutenberg/pull/70232)).
+
 ### Internal
 
 -   Expose `normalizeTextString` method as private API ([#70178](https://github.com/WordPress/gutenberg/pull/70178)).

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -513,7 +513,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 				( suggestion ) => ! normalizedValue.includes( suggestion )
 			);
 		} else {
-			match = match.toLocaleLowerCase();
+			match = match.normalize( 'NFKC' ).toLocaleLowerCase();
 
 			_suggestions.forEach( ( suggestion ) => {
 				const index = suggestion

--- a/packages/components/src/form-token-field/suggestions-list.tsx
+++ b/packages/components/src/form-token-field/suggestions-list.tsx
@@ -65,7 +65,9 @@ export function SuggestionsList<
 	};
 
 	const computeSuggestionMatch = ( suggestion: T ) => {
-		const matchText = displayTransform( match ).toLocaleLowerCase();
+		const matchText = displayTransform( match )
+			.normalize( 'NFKC' )
+			.toLocaleLowerCase();
 		if ( matchText.length === 0 ) {
 			return null;
 		}

--- a/packages/components/src/form-token-field/test/index.tsx
+++ b/packages/components/src/form-token-field/test/index.tsx
@@ -1279,10 +1279,15 @@ describe( 'FormTokenField', () => {
 			const user = userEvent.setup();
 
 			const suggestions = [
+				// Half-width characters
 				'WordPress',
-				'ＷｏｒｄＰｒｅｓｓ',
 				'Gutenberg',
+				// Full-width characters
+				'ＷｏｒｄＰｒｅｓｓ',
 				'Ｇｕｔｅｎｂｅｒｇ',
+				// Mixed characters
+				'WordＰｒｅｓｓ',
+				'Guteｎｂｅｒｇ',
 			];
 
 			render( <FormTokenFieldWithState suggestions={ suggestions } /> );
@@ -1295,6 +1300,7 @@ describe( 'FormTokenField', () => {
 			expectVisibleSuggestionsToBe( screen.getByRole( 'listbox' ), [
 				'WordPress',
 				'ＷｏｒｄＰｒｅｓｓ',
+				'WordＰｒｅｓｓ',
 			] );
 
 			// Search with full-width characters.
@@ -1304,6 +1310,7 @@ describe( 'FormTokenField', () => {
 			expectVisibleSuggestionsToBe( screen.getByRole( 'listbox' ), [
 				'Gutenberg',
 				'Ｇｕｔｅｎｂｅｒｇ',
+				'Guteｎｂｅｒｇ',
 			] );
 		} );
 

--- a/packages/components/src/form-token-field/test/index.tsx
+++ b/packages/components/src/form-token-field/test/index.tsx
@@ -1275,6 +1275,38 @@ describe( 'FormTokenField', () => {
 			expect( screen.queryByRole( 'listbox' ) ).not.toBeInTheDocument();
 		} );
 
+		it( 'should match suggestions with half-width and full-width characters', async () => {
+			const user = userEvent.setup();
+
+			const suggestions = [
+				'WordPress',
+				'ＷｏｒｄＰｒｅｓｓ',
+				'Gutenberg',
+				'Ｇｕｔｅｎｂｅｒｇ',
+			];
+
+			render( <FormTokenFieldWithState suggestions={ suggestions } /> );
+
+			const input = screen.getByRole( 'combobox' );
+
+			// Search with half-width characters.
+			await user.type( input, 'rdp' );
+
+			expectVisibleSuggestionsToBe( screen.getByRole( 'listbox' ), [
+				'WordPress',
+				'ＷｏｒｄＰｒｅｓｓ',
+			] );
+
+			// Search with full-width characters.
+			await user.clear( input );
+			await user.type( input, 'ｔｅｎ' );
+
+			expectVisibleSuggestionsToBe( screen.getByRole( 'listbox' ), [
+				'Gutenberg',
+				'Ｇｕｔｅｎｂｅｒｇ',
+			] );
+		} );
+
 		it( 'should re-render if suggestions change', async () => {
 			const user = userEvent.setup();
 


### PR DESCRIPTION
Follow-up: https://github.com/WordPress/gutenberg/pull/70180

## What?

This PR normalizes user input from full-width characters to half-width characters internally.

## Why?

In #70178, a process was added to normalize suggestions to half-width characters. This means that, for example, when searching for the half-width character string `WordPress`, it will match not only the half-width character string `WordPress` but also the full-width character string `ＷｏｒｄＰｒｅｓｓ`.

However, we did not normalize user input. As a result, when a user searches for the full-width character string `ＷｏｒｄＰｒｅｓｓ`, the full-width character string `ＷｏｒｄＰｒｅｓｓ` included in the suggestions will no longer match because it has already been normalized to half-width characters.

## How?

- Normalize user input from full-width characters to half-width characters
- Add a unit test to prevent a regression

## Testing Instructions

Make the following changes and launch the `FormTokenField` or `ComboboxControl` story:

```diff
diff --git a/packages/components/src/combobox-control/stories/index.story.tsx b/packages/components/src/combobox-control/stories/index.story.tsx
index f033742a33..bbbb126cf4 100644
--- a/packages/components/src/combobox-control/stories/index.story.tsx
+++ b/packages/components/src/combobox-control/stories/index.story.tsx
@@ -15,6 +15,8 @@ import ComboboxControl from '..';
 import type { ComboboxControlProps } from '../types';
 
 const countries = [
+       { name: 'WordPress', code: 'wp1' },
+       { name: 'ＷｏｒｄＰｒｅｓｓ', code: 'WP2' },
        { name: 'Afghanistan', code: 'AF' },
        { name: 'Åland Islands', code: 'AX' },
        { name: 'Albania', code: 'AL' },
diff --git a/packages/components/src/form-token-field/stories/index.story.tsx b/packages/components/src/form-token-field/stories/index.story.tsx
index 52daabe560..7e86f7927b 100644
--- a/packages/components/src/form-token-field/stories/index.story.tsx
+++ b/packages/components/src/form-token-field/stories/index.story.tsx
@@ -35,6 +35,8 @@ const meta: Meta< typeof FormTokenField > = {
 export default meta;
 
 const continents = [
+       'WordPress',
+       'ＷｏｒｄＰｒｅｓｓ',
        'Africa',
        'America',
        'Antarctica',
```

Or add `WordPress` and `ＷｏｒｄＰｒｅｓｓ` as post tags and open the post sidebar.

- Input the full-width character string `Ｗｏｒｄ`.
- Both `WordPress` and `ＷｏｒｄＰｒｅｓｓ` should match.
- The `Word` or `Ｗｏｒｄ` part should be in bold.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
| ![image](https://github.com/user-attachments/assets/29f8c22c-a3f5-4c11-b88f-edab7808027c) | ![image](https://github.com/user-attachments/assets/3afe716b-9780-42ed-9800-4b75cbc2871f) |
