### PR TITLE
Feature: Allow user to exclude headings from the ToC block in the editor.

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -912,7 +912,7 @@ Summarize your post with a list of headings. Add HTML anchors to Heading blocks 
 -	**Experimental:** true
 -	**Category:** design
 -	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** headings, maxLevel, onlyIncludeCurrentPage
+-	**Attributes:** headings, hiddenHeadings, maxLevel, onlyIncludeCurrentPage
 
 ## Tag Cloud
 

--- a/packages/block-library/src/table-of-contents/README.md
+++ b/packages/block-library/src/table-of-contents/README.md
@@ -1,0 +1,54 @@
+# Table of Contents - Heading Visibility Controls
+
+This enhancement adds the ability to control which headings appear in the Table of Contents block.
+
+## Features
+
+### 1. Individual Heading Controls
+
+When a Table of Contents block is present in the editor, each heading block will automatically show a new "Table of Contents" panel in the Inspector Controls with a toggle to control its visibility in the TOC.
+
+### 2. Centralized Management
+
+The Table of Contents block itself includes a "Heading Visibility" panel in its Inspector Controls, allowing you to manage all headings from one location.
+
+## How It Works
+
+### For Heading Blocks:
+
+1. Add a Table of Contents block to your post/page
+2. Any existing or new heading blocks will automatically show a "Table of Contents" panel in their Inspector Controls
+3. Use the "Show in Table of Contents" toggle to control visibility
+4. When the TOC block is removed, these controls automatically disappear
+
+### For Table of Contents Block:
+
+1. In the TOC block's Inspector Controls, you'll find a "Heading Visibility" panel
+2. This panel lists all headings in your post with individual toggles
+3. You can quickly show/hide multiple headings from this central location
+4. The "Reset All" option makes all headings visible again
+
+## Technical Implementation
+
+-   **No modifications to heading block core files**: All functionality is managed through the TOC block
+-   **Dynamic controls**: Heading controls only appear when a TOC block exists
+-   **Clean removal**: When TOC blocks are removed, all related controls disappear
+-   **Multiple TOC support**: Works correctly with multiple TOC blocks in the same post
+
+## Files Modified
+
+-   `table-of-contents/block.json` - Added `hiddenHeadings` attribute
+-   `table-of-contents/edit.js` - Added heading visibility management panel
+-   `table-of-contents/hooks.js` - Modified to filter out hidden headings
+-   `table-of-contents/index.js` - Added HOC registration
+-   `table-of-contents/heading-controls.js` - New component for heading controls
+-   `table-of-contents/with-heading-controls.js` - New HOC for adding controls to headings
+
+## Usage Example
+
+1. Create a post with several heading blocks
+2. Add a Table of Contents block
+3. Notice that each heading now has TOC visibility controls
+4. Hide some headings using either the individual controls or the centralized panel
+5. Observe that the TOC updates to reflect your choices
+6. Remove the TOC block and notice the heading controls disappear

--- a/packages/block-library/src/table-of-contents/block.json
+++ b/packages/block-library/src/table-of-contents/block.json
@@ -22,6 +22,13 @@
 		},
 		"maxLevel": {
 			"type": "number"
+		},
+		"hiddenHeadings": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			},
+			"default": []
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/table-of-contents/edit.js
+++ b/packages/block-library/src/table-of-contents/edit.js
@@ -43,13 +43,19 @@ import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
  * @param {HeadingData[]}                props.attributes.headings               The list of data for each heading in the post.
  * @param {boolean}                      props.attributes.onlyIncludeCurrentPage Whether to only include headings from the current page (if the post is paginated).
  * @param {number|undefined}             props.attributes.maxLevel               The maximum heading level to include, or null to include all levels.
+ * @param {string[]}                     props.attributes.hiddenHeadings         Array of heading content that should be hidden from TOC.
  * @param {string}                       props.clientId                          The client id.
  * @param {(attributes: Object) => void} props.setAttributes                     The set attributes function.
  *
  * @return {Component} The component.
  */
 export default function TableOfContentsEdit( {
-	attributes: { headings = [], onlyIncludeCurrentPage, maxLevel },
+	attributes: {
+		headings = [],
+		onlyIncludeCurrentPage,
+		maxLevel,
+		hiddenHeadings = [],
+	},
 	clientId,
 	setAttributes,
 } ) {
@@ -60,6 +66,29 @@ export default function TableOfContentsEdit( {
 		TableOfContentsEdit,
 		'table-of-contents'
 	);
+
+	// Get all heading blocks for the visibility controls
+	const { allHeadingBlocks } = useSelect( ( select ) => {
+		const { getBlocksByName, getBlockAttributes } =
+			select( blockEditorStore );
+		const headingIds = getBlocksByName( 'core/heading' );
+
+		const headingBlocks = headingIds
+			.map( ( headingId ) => {
+				const attributes = getBlockAttributes( headingId );
+				return {
+					content:
+						attributes?.content?.replace( /<[^>]*>?/g, '' ) ||
+						__( 'Untitled' ),
+					level: attributes?.level || 2,
+				};
+			} )
+			.filter( ( heading ) => heading.content.trim() !== '' );
+
+		return {
+			allHeadingBlocks: headingBlocks,
+		};
+	}, [] );
 
 	// If a user clicks to a link prevent redirection and show a warning.
 	const { createWarningNotice } = useDispatch( noticeStore );
@@ -85,6 +114,21 @@ export default function TableOfContentsEdit( {
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const headingTree = linearToNestedHeadingList( headings );
+
+	/**
+	 * Toggle the visibility of a heading in the table of contents.
+	 *
+	 * @param {string} headingContent Heading content to compare against hiddenHeadings.
+	 *
+	 * @return {void}
+	 */
+	const toggleHeadingVisibility = ( headingContent ) => {
+		const newHiddenHeadings = hiddenHeadings.includes( headingContent )
+			? hiddenHeadings.filter( ( id ) => id !== headingContent )
+			: [ ...hiddenHeadings, headingContent ];
+
+		setAttributes( { hiddenHeadings: newHiddenHeadings } );
+	};
 
 	const toolbarControls = canInsertList && (
 		<BlockControls>
@@ -187,6 +231,49 @@ export default function TableOfContentsEdit( {
 					/>
 				</ToolsPanelItem>
 			</ToolsPanel>
+			{ allHeadingBlocks.length > 0 && (
+				<ToolsPanel
+					label={ __( 'Heading Visibility' ) }
+					resetAll={ () => {
+						setAttributes( { hiddenHeadings: [] } );
+					} }
+					dropdownMenuProps={ dropdownMenuProps }
+				>
+					{ allHeadingBlocks.map( ( heading ) => (
+						<ToolsPanelItem
+							key={ heading.content }
+							hasValue={ () =>
+								hiddenHeadings.includes( heading.content )
+							}
+							label={ heading.content }
+							onDeselect={ () =>
+								toggleHeadingVisibility( heading.content )
+							}
+							isShownByDefault={ false }
+						>
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={ heading.content }
+								checked={
+									! hiddenHeadings.includes( heading.content )
+								}
+								onChange={ () =>
+									toggleHeadingVisibility( heading.content )
+								}
+								help={
+									! hiddenHeadings.includes( heading.content )
+										? __(
+												'This heading will appear in the table of contents.'
+										  )
+										: __(
+												'This heading will be hidden from the table of contents.'
+										  )
+								}
+							/>
+						</ToolsPanelItem>
+					) ) }
+				</ToolsPanel>
+			) }
 		</InspectorControls>
 	);
 

--- a/packages/block-library/src/table-of-contents/heading-controls.js
+++ b/packages/block-library/src/table-of-contents/heading-controls.js
@@ -1,0 +1,105 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useSelect, useDispatch } from '@wordpress/data';
+import {
+	InspectorControls,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+
+/**
+ * Component that adds TOC visibility controls to heading blocks.
+ *
+ * @param {Object} props         Component props.
+ * @param {string} props.content The heading block's content.
+ *
+ * @return {Component|null} The component or null if no TOC block exists.
+ */
+export default function HeadingTOCControls( { content } ) {
+	const {
+		tocBlocks,
+		isHiddenFromTOC,
+		getBlockAttributes: retrieveBlockAttributes,
+	} = useSelect(
+		( select ) => {
+			const { getBlocksByName, getBlockAttributes } =
+				select( blockEditorStore );
+			const tocBlockIds = getBlocksByName( 'core/table-of-contents' );
+
+			// Get hidden headings from all TOC blocks
+			let hiddenHeadings = [];
+			tocBlockIds.forEach( ( tocId ) => {
+				const tocAttributes = getBlockAttributes( tocId );
+				if ( tocAttributes?.hiddenHeadings ) {
+					hiddenHeadings = [
+						...hiddenHeadings,
+						...tocAttributes.hiddenHeadings,
+					];
+				}
+			} );
+
+			return {
+				tocBlocks: tocBlockIds,
+				isHiddenFromTOC: hiddenHeadings.includes( content ),
+				getBlockAttributes,
+			};
+		},
+		[ content ]
+	);
+
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	// If no TOC blocks exist, don't render controls
+	if ( tocBlocks.length === 0 ) {
+		return null;
+	}
+
+	const toggleTOCVisibility = ( isVisible ) => {
+		// Update all TOC blocks
+		tocBlocks.forEach( ( tocId ) => {
+			const tocAttributes = retrieveBlockAttributes( tocId );
+			const currentHiddenHeadings = tocAttributes?.hiddenHeadings || [];
+
+			let newHiddenHeadings;
+			if ( isVisible ) {
+				// Remove from hidden list
+				newHiddenHeadings = currentHiddenHeadings.filter(
+					( headingContent ) => headingContent !== content
+				);
+			} else {
+				// Add to hidden list
+				newHiddenHeadings = currentHiddenHeadings.includes( content )
+					? currentHiddenHeadings
+					: [ ...currentHiddenHeadings, content ];
+			}
+
+			updateBlockAttributes( tocId, {
+				hiddenHeadings: newHiddenHeadings,
+			} );
+		} );
+	};
+
+	return (
+		<InspectorControls>
+			<PanelBody title={ __( 'Table of Contents' ) }>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Show in Table of Contents' ) }
+					checked={ ! isHiddenFromTOC }
+					onChange={ toggleTOCVisibility }
+					help={
+						! isHiddenFromTOC
+							? __(
+									'This heading will appear in the Table of Contents.'
+							  )
+							: __(
+									'This heading will be hidden from the Table of Contents.'
+							  )
+					}
+				/>
+			</PanelBody>
+		</InspectorControls>
+	);
+}

--- a/packages/block-library/src/table-of-contents/hooks.js
+++ b/packages/block-library/src/table-of-contents/hooks.js
@@ -29,8 +29,11 @@ function getLatestHeadings( select, clientId ) {
 	const permalink = select( 'core/editor' ).getPermalink() ?? null;
 
 	const isPaginated = getBlocksByName( 'core/nextpage' ).length !== 0;
-	const { onlyIncludeCurrentPage, maxLevel } =
-		getBlockAttributes( clientId ) ?? {};
+	const {
+		onlyIncludeCurrentPage,
+		maxLevel,
+		hiddenHeadings = [],
+	} = getBlockAttributes( clientId ) ?? {};
 
 	// Get post-content block client ID.
 	const [ postContentClientId = '' ] = getBlocksByName( 'core/post-content' );
@@ -100,9 +103,18 @@ function getLatestHeadings( select, clientId ) {
 		else if ( ! onlyIncludeCurrentPage || headingPage === tocPage ) {
 			if ( blockName === 'core/heading' ) {
 				const headingAttributes = getBlockAttributes( blockClientId );
+				const headingContent = headingAttributes.content.replace(
+					/<[^>]*>?/g,
+					''
+				);
 
 				// Skip headings that are deeper than maxLevel
 				if ( maxLevel && headingAttributes.level > maxLevel ) {
+					continue;
+				}
+
+				// Skip headings that are set to be hidden in TOC
+				if ( hiddenHeadings.includes( headingContent ) ) {
 					continue;
 				}
 

--- a/packages/block-library/src/table-of-contents/index.js
+++ b/packages/block-library/src/table-of-contents/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { tableOfContents as icon } from '@wordpress/icons';
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -11,6 +12,7 @@ import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
 import save from './save';
+import withHeadingTOCControls from './with-heading-controls';
 
 const { name } = metadata;
 
@@ -74,4 +76,13 @@ export const settings = {
 	},
 };
 
-export const init = () => initBlock( { name, metadata, settings } );
+export const init = () => {
+	// Register the HOC to add TOC controls to heading blocks
+	addFilter(
+		'editor.BlockEdit',
+		'core/table-of-contents/with-heading-controls',
+		withHeadingTOCControls
+	);
+
+	return initBlock( { name, metadata, settings } );
+};

--- a/packages/block-library/src/table-of-contents/with-heading-controls.js
+++ b/packages/block-library/src/table-of-contents/with-heading-controls.js
@@ -1,0 +1,37 @@
+/**
+ * WordPress dependencies
+ */
+import { createHigherOrderComponent } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import HeadingTOCControls from './heading-controls';
+
+/**
+ * Higher-order component that adds TOC controls to heading blocks.
+ */
+const withHeadingTOCControls = createHigherOrderComponent( ( BlockEdit ) => {
+	return ( props ) => {
+		const { name } = props;
+
+		// Only add controls to heading blocks
+		if ( name !== 'core/heading' ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		return (
+			<>
+				<BlockEdit { ...props } />
+				<HeadingTOCControls
+					content={ props.attributes.content?.replace(
+						/<[^>]*>?/g,
+						''
+					) }
+				/>
+			</>
+		);
+	};
+}, 'withHeadingTOCControls' );
+
+export default withHeadingTOCControls;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
- Closes https://github.com/WordPress/gutenberg/issues/69200
- Allowing user to exclude headings from the ToC block for individual posts.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- As per [#69200](https://github.com/WordPress/gutenberg/issues/69200) "In the ToC block, there is currently no way to exclude a specific heading from the list."
- Give user more flexibility to exclude specific headings from the ToC block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
1. In the TOC block's Inspector Controls, you'll find a "Heading Visibility" panel
2. This panel lists all headings in your post with individual toggles
3. You can quickly show/hide multiple headings from this central location
4. The "Reset All" option makes all headings visible again
5. Any existing or new heading blocks will automatically show a "Table of Contents" panel in their Inspector Controls
6. When the TOC block is removed, these controls automatically disappear

### Technical implications
1. **No modifications to heading block core files**: All functionality is managed through the TOC block
2. **Dynamic controls**: Heading controls only appear when a TOC block exists
3. **Clean removal**: When TOC blocks are removed, all related controls disappear
4. **Multiple TOC support**: Works correctly with multiple TOC blocks in the same post

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a post with several heading blocks
2. Add a Table of Contents block
3. Notice that each heading now has TOC visibility controls
4. Hide some headings using either the individual controls or the centralized panel
5. Observe that the TOC updates to reflect your choices
6. Remove the TOC block and notice the heading controls disappear

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- NA

## Screenshots or screencast <!-- if applicable -->
[`Feature Screencast`](https://streamable.com/l57rbx)

