### PR TITLE
DropZone: Allow overriding the default icon

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `ComboboxControl`: Handle Unicode characters when matching values ([#70180](https://github.com/WordPress/gutenberg/pull/70180)).
 -   `Toolbar`: Adjust colors for dark mode support ([#69278](https://github.com/WordPress/gutenberg/pull/69278)).
+-   `DropZone`: Allow overriding the default icon ([#70236](https://github.com/WordPress/gutenberg/pull/70236)).
 
 ### Internal
 

--- a/packages/components/src/drop-zone/index.tsx
+++ b/packages/components/src/drop-zone/index.tsx
@@ -43,7 +43,7 @@ import type { WordPressComponentProps } from '../context';
  */
 export function DropZoneComponent( {
 	className,
-	icon,
+	icon = upload,
 	label,
 	onFilesDrop,
 	onHTMLDrop,
@@ -125,7 +125,7 @@ export function DropZoneComponent( {
 			<div className="components-drop-zone__content">
 				<div className="components-drop-zone__content-inner">
 					<Icon
-						icon={ icon ? icon : upload }
+						icon={ icon }
 						className="components-drop-zone__content-icon"
 					/>
 					<span className="components-drop-zone__content-text">

--- a/packages/components/src/drop-zone/index.tsx
+++ b/packages/components/src/drop-zone/index.tsx
@@ -43,6 +43,7 @@ import type { WordPressComponentProps } from '../context';
  */
 export function DropZoneComponent( {
 	className,
+	icon,
 	label,
 	onFilesDrop,
 	onHTMLDrop,
@@ -124,7 +125,7 @@ export function DropZoneComponent( {
 			<div className="components-drop-zone__content">
 				<div className="components-drop-zone__content-inner">
 					<Icon
-						icon={ upload }
+						icon={ icon ? icon : upload }
 						className="components-drop-zone__content-icon"
 					/>
 					<span className="components-drop-zone__content-text">

--- a/packages/components/src/drop-zone/stories/index.story.tsx
+++ b/packages/components/src/drop-zone/stories/index.story.tsx
@@ -2,15 +2,30 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+
+/**
+ * WordPress dependencies
+ */
+import { upload, media } from '@wordpress/icons';
+
 /**
  * Internal dependencies
  */
 import DropZone from '..';
 
+const ICONS = { upload, media };
+
 const meta: Meta< typeof DropZone > = {
 	component: DropZone,
 	id: 'components-dropzone',
 	title: 'Components/Selection & Input/File Upload/DropZone',
+	argTypes: {
+		icon: {
+			control: { type: 'select' },
+			options: Object.keys( ICONS ),
+			mapping: ICONS,
+		},
+	},
 	parameters: {
 		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },

--- a/packages/components/src/drop-zone/types.ts
+++ b/packages/components/src/drop-zone/types.ts
@@ -7,6 +7,8 @@ export type DropZoneProps = {
 	className?: string;
 	/**
 	 * An icon to be shown within the drop zone area.
+	 *
+	 * @default "upload"
 	 */
 	icon?: JSX.Element;
 	/**

--- a/packages/components/src/drop-zone/types.ts
+++ b/packages/components/src/drop-zone/types.ts
@@ -6,6 +6,10 @@ export type DropZoneProps = {
 	 */
 	className?: string;
 	/**
+	 * An icon to be shown within the drop zone area.
+	 */
+	icon?: JSX.Element;
+	/**
 	 * A string to be shown within the drop zone area.
 	 *
 	 * @default `__( 'Drop files to upload' )`


### PR DESCRIPTION
## What?
Closes #14335.

PR introduces a new `icon` prop for the `DropZone` component and allows overriding the default upload icon.

This is a slightly different approach from the one proposed in the issue, but it allows content modification without consumers needing to worry about custom CSS.



## Testing Instructions
1. Run Storybook in dev mode - `npm run storybook:dev`
2. Test new `icon` prop for `DropZone` component.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/6f86eac6-558b-42c9-97ba-9026b051ca15

