### PR TITLE
wp-env: Add support for environment variables in wp-config.php

### DIFF
--- a/packages/env/lib/config/get-config-from-environment-vars.js
+++ b/packages/env/lib/config/get-config-from-environment-vars.js
@@ -25,6 +25,7 @@ const { checkPort, checkVersion, checkString } = require( './validate-config' );
  * @property {?string}                  phpVersion       An override for all environment's PHP version.
  * @property {?boolean}                 multisite        An override for if environmen should be multisite.
  * @property {?Object.<string, string>} lifecycleScripts An override for various lifecycle scripts.
+ * @property {?Object.<string, any>}    config           An override for various wp-config.php constants.
  */
 
 /**
@@ -49,6 +50,7 @@ module.exports = function getConfigFromEnvironmentVars( cacheDirectoryPath ) {
 			'WP_ENV_TESTS_PHPMYADMIN_PORT'
 		),
 		lifecycleScripts: getLifecycleScriptOverrides(),
+		config: getWpConfigOverrides(),
 	};
 
 	if ( process.env.WP_ENV_CORE ) {
@@ -121,4 +123,42 @@ function getLifecycleScriptOverrides() {
 	}
 
 	return lifecycleScripts;
+}
+
+/**
+ * Gets wp-config.php constant overrides from environment variables.
+ *
+ * @return {Object.<string, any>} The wp-config.php constants to override.
+ */
+function getWpConfigOverrides() {
+	const wpConfigOverrides = {};
+	const WP_ENV_CONFIG_PREFIX = 'WP_ENV_CONFIG_';
+
+	Object.keys( process.env ).forEach( ( key ) => {
+		if ( key.startsWith( WP_ENV_CONFIG_PREFIX ) ) {
+			const constantName = key.substring( WP_ENV_CONFIG_PREFIX.length );
+
+			if ( constantName ) {
+				let value = process.env[ key ];
+				if ( typeof value === 'string' ) {
+					if ( value.toLowerCase() === 'true' ) {
+						value = true;
+					} else if ( value.toLowerCase() === 'false' ) {
+						value = false;
+					} else if ( value.toLowerCase() === 'null' ) {
+						value = null;
+					} else if (
+						! isNaN( Number( value ) ) &&
+						value.trim() !== ''
+					) {
+						value = Number( value );
+					}
+				}
+
+				wpConfigOverrides[ constantName ] = value;
+			}
+		}
+	} );
+
+	return wpConfigOverrides;
 }

--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -312,6 +312,11 @@ function getEnvironmentVarOverrides( cacheDirectoryPath ) {
 		overrideConfig.env.tests.phpVersion = overrides.phpVersion;
 	}
 
+	if ( overrides.config && Object.keys( overrides.config ).length > 0 ) {
+		overrideConfig.env.development.config = overrides.config;
+		overrideConfig.env.tests.config = overrides.config;
+	}
+
 	return overrideConfig;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/32515

This PR enhances the `@wordpress/env` package by adding support for setting wp-config.php constants via environment variables. Set any wp-config.php constant using the `WP_ENV_CONFIG_` prefix.


