### PR TITLE
Comments Pagination Block: Refactor settings panel to use ToolsPanel

### DIFF
--- a/packages/block-library/src/comments-pagination/edit.js
+++ b/packages/block-library/src/comments-pagination/edit.js
@@ -10,7 +10,10 @@ import {
 	Warning,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
-import { PanelBody } from '@wordpress/components';
+import {
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -73,14 +76,28 @@ export default function QueryPaginationEdit( {
 		<>
 			{ hasNextPreviousBlocks && (
 				<InspectorControls>
-					<PanelBody title={ __( 'Settings' ) }>
-						<CommentsPaginationArrowControls
-							value={ paginationArrow }
-							onChange={ ( value ) => {
-								setAttributes( { paginationArrow: value } );
-							} }
-						/>
-					</PanelBody>
+					<ToolsPanel
+						label={ __( 'Settings' ) }
+						resetAll={ () =>
+							setAttributes( { paginationArrow: 'none' } )
+						}
+					>
+						<ToolsPanelItem
+							label={ __( 'Show Arrow Controls' ) }
+							hasValue={ () => paginationArrow !== undefined }
+							onDeselect={ () =>
+								setAttributes( { paginationArrow: 'none' } )
+							}
+							isShownByDefault
+						>
+							<CommentsPaginationArrowControls
+								value={ paginationArrow }
+								onChange={ ( value ) => {
+									setAttributes( { paginationArrow: value } );
+								} }
+							/>
+						</ToolsPanelItem>
+					</ToolsPanel>
 				</InspectorControls>
 			) }
 			<div { ...innerBlocksProps } />

--- a/packages/block-library/src/comments-pagination/edit.js
+++ b/packages/block-library/src/comments-pagination/edit.js
@@ -83,7 +83,7 @@ export default function QueryPaginationEdit( {
 						}
 					>
 						<ToolsPanelItem
-							label={ __( 'Show Arrow Controls' ) }
+							label={ __( 'Arrow Controls' ) }
 							hasValue={ () => paginationArrow !== undefined }
 							onDeselect={ () =>
 								setAttributes( { paginationArrow: 'none' } )

--- a/packages/block-library/src/comments-pagination/edit.js
+++ b/packages/block-library/src/comments-pagination/edit.js
@@ -19,6 +19,7 @@ import {
  * Internal dependencies
  */
 import { CommentsPaginationArrowControls } from './comments-pagination-arrow-controls';
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const TEMPLATE = [
 	[ 'core/comments-pagination-previous' ],
@@ -48,6 +49,7 @@ export default function QueryPaginationEdit( {
 	}, [] );
 
 	const blockProps = useBlockProps();
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
 	} );
@@ -78,13 +80,14 @@ export default function QueryPaginationEdit( {
 				<InspectorControls>
 					<ToolsPanel
 						label={ __( 'Settings' ) }
+						dropdownMenuProps={ dropdownMenuProps }
 						resetAll={ () =>
 							setAttributes( { paginationArrow: 'none' } )
 						}
 					>
 						<ToolsPanelItem
-							label={ __( 'Arrow Controls' ) }
-							hasValue={ () => paginationArrow !== undefined }
+							label={ __( 'Arrow' ) }
+							hasValue={ () => paginationArrow !== 'none' }
 							onDeselect={ () =>
 								setAttributes( { paginationArrow: 'none' } )
 							}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Issue: https://github.com/WordPress/gutenberg/issues/70244
Part of: https://github.com/WordPress/gutenberg/issues/67813

## What?
Refactored Comments Pagination Block code to include ToolsPanel instead of PanelBody.

Closes #70244

<!-- In a few words, what is the PR actually doing? -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/212d0ea7-0b7f-419c-8fb9-2aecaf607110)|![image](https://github.com/user-attachments/assets/df85cdf7-07d8-4d1c-946f-9333b40d7451)|
