### PR TITLE
Comment Title: Refactor settings panel to use ToolsPanel

### DIFF
--- a/packages/block-library/src/comments-title/edit.js
+++ b/packages/block-library/src/comments-title/edit.js
@@ -135,9 +135,9 @@ export default function Edit( {
 				<ToolsPanelItem
 					label={ __( 'Show post title' ) }
 					isShownByDefault
-					hasValue={ () => showPostTitle }
+					hasValue={ () => ! showPostTitle }
 					onDeselect={ () =>
-						setAttributes( { showPostTitle: false } )
+						setAttributes( { showPostTitle: true } )
 					}
 				>
 					<ToggleControl
@@ -152,9 +152,9 @@ export default function Edit( {
 				<ToolsPanelItem
 					label={ __( 'Show comments count' ) }
 					isShownByDefault
-					hasValue={ () => showCommentsCount }
+					hasValue={ () => ! showCommentsCount }
 					onDeselect={ () =>
-						setAttributes( { showCommentsCount: false } )
+						setAttributes( { showCommentsCount: true } )
 					}
 				>
 					<ToggleControl

--- a/packages/block-library/src/comments-title/edit.js
+++ b/packages/block-library/src/comments-title/edit.js
@@ -16,11 +16,20 @@ import {
 } from '@wordpress/block-editor';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useEntityProp } from '@wordpress/core-data';
-import { PanelBody, ToggleControl } from '@wordpress/components';
+import {
+	ToggleControl,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 export default function Edit( {
 	attributes: {
@@ -52,6 +61,8 @@ export default function Edit( {
 		const { getSettings } = select( blockEditorStore );
 		return getSettings().__experimentalDiscussionSettings;
 	} );
+
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	useEffect( () => {
 		if ( isSiteEditor ) {
@@ -111,24 +122,51 @@ export default function Edit( {
 
 	const inspectorControls = (
 		<InspectorControls>
-			<PanelBody title={ __( 'Settings' ) }>
-				<ToggleControl
-					__nextHasNoMarginBottom
+			<ToolsPanel
+				label={ __( 'Settings' ) }
+				resetAll={ () => {
+					setAttributes( {
+						showPostTitle: true,
+						showCommentsCount: true,
+					} );
+				} }
+				dropdownMenuProps={ dropdownMenuProps }
+			>
+				<ToolsPanelItem
 					label={ __( 'Show post title' ) }
-					checked={ showPostTitle }
-					onChange={ ( value ) =>
-						setAttributes( { showPostTitle: value } )
+					isShownByDefault
+					hasValue={ () => showPostTitle }
+					onDeselect={ () =>
+						setAttributes( { showPostTitle: false } )
 					}
-				/>
-				<ToggleControl
-					__nextHasNoMarginBottom
+				>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show post title' ) }
+						checked={ showPostTitle }
+						onChange={ ( value ) =>
+							setAttributes( { showPostTitle: value } )
+						}
+					/>
+				</ToolsPanelItem>
+				<ToolsPanelItem
 					label={ __( 'Show comments count' ) }
-					checked={ showCommentsCount }
-					onChange={ ( value ) =>
-						setAttributes( { showCommentsCount: value } )
+					isShownByDefault
+					hasValue={ () => showCommentsCount }
+					onDeselect={ () =>
+						setAttributes( { showCommentsCount: false } )
 					}
-				/>
-			</PanelBody>
+				>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show comments count' ) }
+						checked={ showCommentsCount }
+						onChange={ ( value ) =>
+							setAttributes( { showCommentsCount: value } )
+						}
+					/>
+				</ToolsPanelItem>
+			</ToolsPanel>
 		</InspectorControls>
 	);
 


### PR DESCRIPTION
Closes  #70241

## What?
Refactored the Comment Title Block to use ToolsPanel instead of PanelBody.


## Screenshots or screencast <!-- if applicable -->

**Before:**

<img width="277" alt="Screenshot 2025-05-29 at 9 12 28 PM" src="https://github.com/user-attachments/assets/24d41a72-55ed-45b4-a3de-39958256f612" />

**After:**

https://github.com/user-attachments/assets/b5151d98-24ea-48a5-ab9b-ed4e45a149e5
