### PR TITLE
Commen Date: Convert Comment Date block settings to ToolsPanel

### DIFF
--- a/packages/block-library/src/comment-date/edit.js
+++ b/packages/block-library/src/comment-date/edit.js
@@ -12,7 +12,11 @@ import {
 	useBlockProps,
 	__experimentalDateFormatPicker as DateFormatPicker,
 } from '@wordpress/block-editor';
-import { PanelBody, ToggleControl } from '@wordpress/components';
+import {
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+	ToggleControl,
+} from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 
 /**
@@ -41,23 +45,50 @@ export default function Edit( {
 		'date_format'
 	);
 
+	const defaultIsLink = false;
+	const defaultFormat = siteFormat;
+
+	const resetAll = () => {
+		setAttributes( {
+			format: undefined,
+			isLink: defaultIsLink,
+		} );
+	};
+
 	const inspectorControls = (
 		<InspectorControls>
-			<PanelBody title={ __( 'Settings' ) }>
-				<DateFormatPicker
-					format={ format }
-					defaultFormat={ siteFormat }
-					onChange={ ( nextFormat ) =>
-						setAttributes( { format: nextFormat } )
-					}
-				/>
-				<ToggleControl
-					__nextHasNoMarginBottom
+			<ToolsPanel label={ __( 'Settings' ) } resetAll={ resetAll }>
+				<ToolsPanelItem
+					hasValue={ () => format !== undefined }
+					label={ __( 'Date format' ) }
+					onDeselect={ () => setAttributes( { format: undefined } ) }
+					isShownByDefault
+				>
+					<DateFormatPicker
+						format={ format }
+						defaultFormat={ defaultFormat }
+						onChange={ ( nextFormat ) =>
+							setAttributes( { format: nextFormat } )
+						}
+					/>
+				</ToolsPanelItem>
+
+				<ToolsPanelItem
+					hasValue={ () => isLink !== defaultIsLink }
 					label={ __( 'Link to comment' ) }
-					onChange={ () => setAttributes( { isLink: ! isLink } ) }
-					checked={ isLink }
-				/>
-			</PanelBody>
+					onDeselect={ () =>
+						setAttributes( { isLink: defaultIsLink } )
+					}
+					isShownByDefault
+				>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Link to comment' ) }
+						onChange={ () => setAttributes( { isLink: ! isLink } ) }
+						checked={ isLink }
+					/>
+				</ToolsPanelItem>
+			</ToolsPanel>
 		</InspectorControls>
 	);
 

--- a/packages/block-library/src/comment-date/edit.js
+++ b/packages/block-library/src/comment-date/edit.js
@@ -20,6 +20,11 @@ import {
 import { __, _x } from '@wordpress/i18n';
 
 /**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+
+/**
  * Renders the `core/comment-date` block on the editor.
  *
  * @param {Object} props                   React props.
@@ -38,6 +43,8 @@ export default function Edit( {
 	setAttributes,
 } ) {
 	const blockProps = useBlockProps();
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+
 	let [ date ] = useEntityProp( 'root', 'comment', 'date', commentId );
 	const [ siteFormat = getDateSettings().formats.date ] = useEntityProp(
 		'root',
@@ -45,28 +52,27 @@ export default function Edit( {
 		'date_format'
 	);
 
-	const defaultIsLink = false;
-	const defaultFormat = siteFormat;
-
-	const resetAll = () => {
-		setAttributes( {
-			format: undefined,
-			isLink: defaultIsLink,
-		} );
-	};
-
 	const inspectorControls = (
 		<InspectorControls>
-			<ToolsPanel label={ __( 'Settings' ) } resetAll={ resetAll }>
+			<ToolsPanel
+				label={ __( 'Settings' ) }
+				resetAll={ () => {
+					setAttributes( {
+						format: undefined,
+						isLink: true,
+					} );
+				} }
+				dropdownMenuProps={ dropdownMenuProps }
+			>
 				<ToolsPanelItem
-					hasValue={ () => format !== undefined }
 					label={ __( 'Date format' ) }
+					hasValue={ () => format !== undefined }
 					onDeselect={ () => setAttributes( { format: undefined } ) }
 					isShownByDefault
 				>
 					<DateFormatPicker
 						format={ format }
-						defaultFormat={ defaultFormat }
+						defaultFormat={ siteFormat }
 						onChange={ ( nextFormat ) =>
 							setAttributes( { format: nextFormat } )
 						}
@@ -74,11 +80,9 @@ export default function Edit( {
 				</ToolsPanelItem>
 
 				<ToolsPanelItem
-					hasValue={ () => isLink !== defaultIsLink }
 					label={ __( 'Link to comment' ) }
-					onDeselect={ () =>
-						setAttributes( { isLink: defaultIsLink } )
-					}
+					hasValue={ () => ! isLink }
+					onDeselect={ () => setAttributes( { isLink: true } ) }
 					isShownByDefault
 				>
 					<ToggleControl


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/70238


Refactors the Comment Date block's settings panel to use `ToolsPanel` instead of `PanelBody` for improved UI consistency and enhanced functionality.

## Why?

This change aligns the Comment Date block with the ongoing effort to standardize block inspector controls across Gutenberg using `ToolsPanel`. The `ToolsPanel` component provides a better user experience with reset capabilities, improved organization, and consistent UI patterns across all blocks.

## How?
- Replaced `PanelBody` with `ToolsPanel` in the InspectorControls
- Wrapped existing controls in `ToolsPanelItem` components
- Added `resetAll` functionality to reset both format and link settings to their defaults
- Added dropdown menu props for consistent UI behavior

## Testing Instructions
1. Open comments-template block
2. Select the Comment Date block
3. Open the block inspector 
4. Verify the "Settings" panel displays with ToolsPanel UI
5. Test the "Date format" control - change format and verify it works
6. Test the "Link to comment" toggle - enable/disable and verify functionality
7. Use the reset button to reset all settings
8. Verify both controls reset to their default values



## Screenshots or screencast



### Before




https://github.com/user-attachments/assets/f8ea7537-8111-4c22-89df-1b7b177c3866


### After


https://github.com/user-attachments/assets/7da3133c-0b20-4e4d-bb7c-d52ed3baffe6



