### PR TITLE
Form Input: Convert Form Input block settings to ToolsPanel

### DIFF
--- a/packages/block-library/src/form-input/edit.js
+++ b/packages/block-library/src/form-input/edit.js
@@ -14,8 +14,12 @@ import {
 	__experimentalUseBorderProps as useBorderProps,
 	__experimentalUseColorProps as useColorProps,
 } from '@wordpress/block-editor';
-import { PanelBody, TextControl, CheckboxControl } from '@wordpress/components';
-
+import {
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+	TextControl,
+	CheckboxControl,
+} from '@wordpress/components';
 import { useRef } from '@wordpress/element';
 
 function InputFieldBlock( { attributes, setAttributes, className } ) {
@@ -34,34 +38,69 @@ function InputFieldBlock( { attributes, setAttributes, className } ) {
 	// Note: radio inputs aren't implemented yet.
 	const isCheckboxOrRadio = type === 'checkbox' || type === 'radio';
 
+	const defaultRequired = false;
+	const defaultInlineLabel = false;
+
+	const resetAllSettings = () => {
+		setAttributes( {
+			required: defaultRequired,
+			inlineLabel: defaultInlineLabel,
+		} );
+	};
+
 	const controls = (
 		<>
 			{ 'hidden' !== type && (
 				<InspectorControls>
-					<PanelBody title={ __( 'Settings' ) }>
-						{ 'checkbox' !== type && (
+					<ToolsPanel
+						label={ __( 'Settings' ) }
+						resetAll={ resetAllSettings }
+					>
+						{ type !== 'checkbox' && (
+							<ToolsPanelItem
+								hasValue={ () =>
+									inlineLabel !== defaultInlineLabel
+								}
+								label={ __( 'Inline label' ) }
+								onDeselect={ () =>
+									setAttributes( {
+										inlineLabel: defaultInlineLabel,
+									} )
+								}
+								isShownByDefault
+							>
+								<CheckboxControl
+									__nextHasNoMarginBottom
+									label={ __( 'Inline label' ) }
+									checked={ inlineLabel }
+									onChange={ ( newVal ) => {
+										setAttributes( {
+											inlineLabel: newVal,
+										} );
+									} }
+								/>
+							</ToolsPanelItem>
+						) }
+						<ToolsPanelItem
+							hasValue={ () => required !== defaultRequired }
+							label={ __( 'Required' ) }
+							onDeselect={ () =>
+								setAttributes( { required: defaultRequired } )
+							}
+							isShownByDefault
+						>
 							<CheckboxControl
 								__nextHasNoMarginBottom
-								label={ __( 'Inline label' ) }
-								checked={ inlineLabel }
+								label={ __( 'Required' ) }
+								checked={ required }
 								onChange={ ( newVal ) => {
 									setAttributes( {
-										inlineLabel: newVal,
+										required: newVal,
 									} );
 								} }
 							/>
-						) }
-						<CheckboxControl
-							__nextHasNoMarginBottom
-							label={ __( 'Required' ) }
-							checked={ required }
-							onChange={ ( newVal ) => {
-								setAttributes( {
-									required: newVal,
-								} );
-							} }
-						/>
-					</PanelBody>
+						</ToolsPanelItem>
+					</ToolsPanel>
 				</InspectorControls>
 			) }
 			<InspectorControls group="advanced">

--- a/packages/block-library/src/form-input/edit.js
+++ b/packages/block-library/src/form-input/edit.js
@@ -53,7 +53,7 @@ function InputFieldBlock( { attributes, setAttributes, className } ) {
 						resetAll={ () => {
 							setAttributes( {
 								inlineLabel: false,
-								required: true,
+								required: false,
 							} );
 						} }
 						dropdownMenuProps={ dropdownMenuProps }
@@ -82,9 +82,9 @@ function InputFieldBlock( { attributes, setAttributes, className } ) {
 
 						<ToolsPanelItem
 							label={ __( 'Required' ) }
-							hasValue={ () => ! required }
+							hasValue={ () => !! required }
 							onDeselect={ () =>
-								setAttributes( { required: true } )
+								setAttributes( { required: false } )
 							}
 							isShownByDefault
 						>

--- a/packages/block-library/src/form-input/edit.js
+++ b/packages/block-library/src/form-input/edit.js
@@ -15,17 +15,23 @@ import {
 	__experimentalUseColorProps as useColorProps,
 } from '@wordpress/block-editor';
 import {
-	__experimentalToolsPanel as ToolsPanel,
-	__experimentalToolsPanelItem as ToolsPanelItem,
 	TextControl,
 	CheckboxControl,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 function InputFieldBlock( { attributes, setAttributes, className } ) {
 	const { type, name, label, inlineLabel, required, placeholder, value } =
 		attributes;
 	const blockProps = useBlockProps();
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const ref = useRef();
 	const TagName = type === 'textarea' ? 'textarea' : 'input';
 
@@ -38,34 +44,26 @@ function InputFieldBlock( { attributes, setAttributes, className } ) {
 	// Note: radio inputs aren't implemented yet.
 	const isCheckboxOrRadio = type === 'checkbox' || type === 'radio';
 
-	const defaultRequired = false;
-	const defaultInlineLabel = false;
-
-	const resetAllSettings = () => {
-		setAttributes( {
-			required: defaultRequired,
-			inlineLabel: defaultInlineLabel,
-		} );
-	};
-
 	const controls = (
 		<>
 			{ 'hidden' !== type && (
 				<InspectorControls>
 					<ToolsPanel
 						label={ __( 'Settings' ) }
-						resetAll={ resetAllSettings }
+						resetAll={ () => {
+							setAttributes( {
+								inlineLabel: false,
+								required: true,
+							} );
+						} }
+						dropdownMenuProps={ dropdownMenuProps }
 					>
-						{ type !== 'checkbox' && (
+						{ 'checkbox' !== type && (
 							<ToolsPanelItem
-								hasValue={ () =>
-									inlineLabel !== defaultInlineLabel
-								}
 								label={ __( 'Inline label' ) }
+								hasValue={ () => !! inlineLabel }
 								onDeselect={ () =>
-									setAttributes( {
-										inlineLabel: defaultInlineLabel,
-									} )
+									setAttributes( { inlineLabel: false } )
 								}
 								isShownByDefault
 							>
@@ -81,11 +79,12 @@ function InputFieldBlock( { attributes, setAttributes, className } ) {
 								/>
 							</ToolsPanelItem>
 						) }
+
 						<ToolsPanelItem
-							hasValue={ () => required !== defaultRequired }
 							label={ __( 'Required' ) }
+							hasValue={ () => ! required }
 							onDeselect={ () =>
-								setAttributes( { required: defaultRequired } )
+								setAttributes( { required: true } )
 							}
 							isShownByDefault
 						>


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/70243

Refactors the Form Input block's settings panel to use `ToolsPanel` instead of `PanelBody` for improved UI consistency and enhanced reset functionality.

## Why?

This change aligns the Form Input block with the ongoing effort to standardize block inspector controls across Gutenberg using `ToolsPanel`. The `ToolsPanel` component provides a better user experience with reset capabilities, improved organization, and consistent UI patterns across all blocks.

## How?

- Replaced `PanelBody` with `ToolsPanel` in the InspectorControls
- Wrapped existing controls in `ToolsPanelItem` components
- Added `resetAll` functionality to reset both inline label and required settings to their defaults
- Added dropdown menu props for consistent UI behavior

## Testing Instructions

1. First, make sure the experimental feature `Blocks: add Form and input blocks` is turned ON
2. Open a post or page in the block editor
3. Insert a Form block
5. Select any input field block
6. Open the block inspector
7. Verify the "Settings" panel displays with ToolsPanel UI
8. Test the "Inline label" and "Required" control
10. Use the reset button to reset individual and all settings and verify that everything works as expected


## Screencast


### Before 


https://github.com/user-attachments/assets/ab4710d3-5021-4f42-881d-6580fc1a24fc




### After



https://github.com/user-attachments/assets/08ecb1e3-da4b-4704-b484-4c988eea1871



