### PR TITLE
FIX: Image stretch on width more than container size

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -125,6 +125,13 @@
 	}
 }
 
+.wp-block-image .components-resizable-box__container img {
+	display: block;
+	height: auto;
+	width: inherit;
+	max-width: 100%;
+}
+
 // Variations
 :root :where(.wp-block-image.is-style-rounded img, .wp-block-image .is-style-rounded img) {
 	// We use an absolute pixel to prevent the oval shape that a value of 50% would give
@@ -285,17 +292,20 @@
 		@media not (prefers-reduced-motion) {
 			animation: both turn-on-visibility 0.25s;
 		}
+
 		img {
 			@media not (prefers-reduced-motion) {
 				animation: both turn-on-visibility 0.35s;
 			}
 		}
 	}
+
 	&.show-closing-animation {
 		&:not(.active) {
 			@media not (prefers-reduced-motion) {
 				animation: both turn-off-visibility 0.35s;
 			}
+
 			img {
 				@media not (prefers-reduced-motion) {
 					animation: both turn-off-visibility 0.25s;
@@ -310,6 +320,7 @@
 				opacity: 1;
 				visibility: visible;
 				animation: none;
+
 				.lightbox-image-container {
 					animation: lightbox-zoom-in 0.4s;
 					// Override fade animation for image
@@ -317,13 +328,16 @@
 						animation: none;
 					}
 				}
+
 				.scrim {
 					animation: turn-on-visibility 0.4s forwards;
 				}
 			}
+
 			&.show-closing-animation {
 				&:not(.active) {
 					animation: none;
+
 					.lightbox-image-container {
 						animation: lightbox-zoom-out 0.4s;
 						// Override fade animation for image
@@ -331,6 +345,7 @@
 							animation: none;
 						}
 					}
+
 					.scrim {
 						animation: turn-off-visibility 0.4s forwards;
 					}

--- a/packages/components/src/resizable-box/style.scss
+++ b/packages/components/src/resizable-box/style.scss
@@ -28,6 +28,7 @@ $resize-handler-container-size: $resize-handler-size + ($grid-unit-05 * 2); // M
 // Make the image inside the resize to get the full width
 .components-resizable-box__container > img {
 	width: inherit;
+	height: auto;
 }
 
 // This is the "visible" resize handle - the circle part


### PR DESCRIPTION
## What?
Closes: https://github.com/WordPress/gutenberg/issues/70250
Fix image block aspect ratio distortion when resizing beyond container width

## Why?
When users resize an image block beyond the container width in the block editor, the image becomes vertically stretched and distorted, breaking the aspect ratio. This creates a visual inconsistency between the editor and frontend, where the frontend correctly maintains aspect ratio but the editor shows a distorted image.
The issue is caused by height: inherit in the ResizableBox CSS rule, which forces the image to take the manually set height value even when the width is constrained by the container. This affects user experience as the editor preview doesn't match the actual frontend appearance.

## How?
- Changes height: inherit to height: auto - This allows the image to maintain its aspect ratio when width is constrained
- Keeps width: inherit - This maintains the existing width behavior for resize functionality

## Screenshots or screencast <!-- if applicable -->
|Before|After|
|-|-|
|
![image](https://github.com/user-attachments/assets/84e7c766-d1b3-4a4e-a41b-f077fab77ba5)
|![image](https://github.com/user-attachments/assets/b76d4e87-2c4b-492b-b7bc-d8002ac31ee6)|
