### PR TITLE
Commands: Update to modern Sass module system

### DIFF
--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -1,3 +1,4 @@
+@use "../../../base-styles/colors";
 @use "../../../base-styles/mixins";
 @use "../../../base-styles/variables";
 
@@ -33,7 +34,7 @@
 	.components-button {
 		height: variables.$grid-unit-70;
 		width: variables.$grid-unit-70;
-		border: variables.$border-width solid $gray-600;
+		border: variables.$border-width solid colors.$gray-600;
 		border-right: 0;
 		justify-content: center;
 		border-radius: variables.$radius-small 0 0 variables.$radius-small;
@@ -54,14 +55,14 @@
 		width: 100%;
 		padding: variables.$grid-unit-20 variables.$grid-unit-05;
 		outline: none;
-		color: $gray-900;
+		color: colors.$gray-900;
 		margin: 0;
 		font-size: 15px;
 		line-height: 28px;
 		border-radius: 0;
 
 		&::placeholder {
-			color: $gray-700;
+			color: colors.$gray-700;
 		}
 
 		&:focus {
@@ -75,26 +76,26 @@
 		cursor: pointer;
 		display: flex;
 		align-items: center;
-		color: $gray-900;
+		color: colors.$gray-900;
 		font-size: variables.$default-font-size;
 
 		&[aria-selected="true"],
 		&:active {
 			background: var(--wp-admin-theme-color);
-			color: $white;
+			color: colors.$white;
 
 			svg {
-				fill: $white;
+				fill: colors.$white;
 			}
 		}
 
 		&[aria-disabled="true"] {
-			color: $gray-600;
+			color: colors.$gray-600;
 			cursor: not-allowed;
 		}
 
 		svg {
-			fill: $gray-900;
+			fill: colors.$gray-900;
 		}
 
 		> div {
@@ -127,7 +128,7 @@
 		align-items: center;
 		justify-content: center;
 		white-space: pre-wrap;
-		color: $gray-900;
+		color: colors.$gray-900;
 		padding: variables.$grid-unit-10 0 variables.$grid-unit-40;
 	}
 

--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -1,14 +1,17 @@
+@use "../../../base-styles/mixins";
+@use "../../../base-styles/variables";
+
 // dirty hack to clean up modal
 .commands-command-menu {
-	border-radius: $grid-unit-05;
-	width: calc(100% - #{$grid-unit-40});
+	border-radius: variables.$grid-unit-05;
+	width: calc(100% - #{variables.$grid-unit-40});
 	margin: auto;
 	max-width: 400px;
 	position: relative;
-	top: calc(5% + #{$header-height});
+	top: calc(5% + #{variables.$header-height});
 
-	@include break-small() {
-		top: calc(10% + #{$header-height});
+	@include mixins.break-small() {
+		top: calc(10% + #{variables.$header-height});
 	}
 
 	.components-modal__content {
@@ -25,15 +28,15 @@
 .commands-command-menu__header {
 	display: flex;
 	align-items: center;
-	padding: 0 $grid-unit-20;
+	padding: 0 variables.$grid-unit-20;
 
 	.components-button {
-		height: $grid-unit-70;
-		width: $grid-unit-70;
-		border: $border-width solid $gray-600;
+		height: variables.$grid-unit-70;
+		width: variables.$grid-unit-70;
+		border: variables.$border-width solid $gray-600;
 		border-right: 0;
 		justify-content: center;
-		border-radius: $radius-small 0 0 $radius-small;
+		border-radius: variables.$radius-small 0 0 variables.$radius-small;
 
 		& + [cmdk-input] {
 			border-top-left-radius: 0;
@@ -49,7 +52,7 @@
 	[cmdk-input] {
 		border: none;
 		width: 100%;
-		padding: $grid-unit-20 $grid-unit-05;
+		padding: variables.$grid-unit-20 variables.$grid-unit-05;
 		outline: none;
 		color: $gray-900;
 		margin: 0;
@@ -68,12 +71,12 @@
 	}
 
 	[cmdk-item] {
-		border-radius: $radius-small;
+		border-radius: variables.$radius-small;
 		cursor: pointer;
 		display: flex;
 		align-items: center;
 		color: $gray-900;
-		font-size: $default-font-size;
+		font-size: variables.$default-font-size;
 
 		&[aria-selected="true"],
 		&:active {
@@ -95,13 +98,13 @@
 		}
 
 		> div {
-			min-height: $button-size-next-default-40px;
-			padding: $grid-unit-05;
-			padding-left: $grid-unit-50; // Account for commands without icons.
+			min-height: variables.$button-size-next-default-40px;
+			padding: variables.$grid-unit-05;
+			padding-left: variables.$grid-unit-50; // Account for commands without icons.
 		}
 
 		> .has-icon {
-			padding-left: $grid-unit;
+			padding-left: variables.$grid-unit;
 		}
 	}
 
@@ -111,11 +114,11 @@
 
 		// Ensures there is always padding bottom on the last group, when there are commands.
 		& [cmdk-list-sizer] > [cmdk-group]:last-child [cmdk-group-items]:not(:empty) {
-			padding-bottom: $grid-unit-10;
+			padding-bottom: variables.$grid-unit-10;
 		}
 
 		& [cmdk-list-sizer] > [cmdk-group] > [cmdk-group-items]:not(:empty) {
-			padding: 0 $grid-unit-10;
+			padding: 0 variables.$grid-unit-10;
 		}
 	}
 
@@ -125,11 +128,11 @@
 		justify-content: center;
 		white-space: pre-wrap;
 		color: $gray-900;
-		padding: $grid-unit-10 0 $grid-unit-40;
+		padding: variables.$grid-unit-10 0 variables.$grid-unit-40;
 	}
 
 	[cmdk-loading] {
-		padding: $grid-unit-20;
+		padding: variables.$grid-unit-20;
 	}
 
 	[cmdk-list-sizer] {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Relates to https://github.com/WordPress/gutenberg/issues/37044 and https://github.com/Automattic/wp-calypso/pull/103652

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The PR makes the Commands package compatible with the new Sass module system (https://sass-lang.com/blog/the-module-system-is-launched/).

This is a blocker for updating the `@wordpress` packages in the `wp-calypso` repo. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I used the `npx sass-migrator module division --verbose --migrate-deps packages/commands/src/components/style.scss` command to migrate the code.

## Testing Instructions

Build the Commands package and ensure there are no errors. There should be no visual changes.
