### PR TITLE
Form: Convert Form block settings to ToolsPanel

### DIFF
--- a/packages/block-library/src/form/edit.js
+++ b/packages/block-library/src/form/edit.js
@@ -20,6 +20,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import {
 	formSubmissionNotificationSuccess,
 	formSubmissionNotificationError,
@@ -56,13 +57,13 @@ const TEMPLATE = [
 ];
 
 const Edit = ( { attributes, setAttributes, clientId } ) => {
-	const defaultSubmissionMethod = 'email';
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	const resetAllSettings = () => {
 		setAttributes( {
-			submissionMethod: defaultSubmissionMethod,
-			email: '',
-			action: '',
+			submissionMethod: 'email',
+			email: undefined,
+			action: undefined,
 			method: 'post',
 		} );
 	};
@@ -92,17 +93,16 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 		<>
 			<InspectorControls>
 				<ToolsPanel
+					dropdownMenuProps={ dropdownMenuProps }
 					label={ __( 'Settings' ) }
 					resetAll={ resetAllSettings }
 				>
 					<ToolsPanelItem
-						hasValue={ () =>
-							submissionMethod !== defaultSubmissionMethod
-						}
+						hasValue={ () => submissionMethod !== 'email' }
 						label={ __( 'Submissions method' ) }
 						onDeselect={ () =>
 							setAttributes( {
-								submissionMethod: defaultSubmissionMethod,
+								submissionMethod: 'email',
 							} )
 						}
 						isShownByDefault
@@ -139,12 +139,12 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 					</ToolsPanelItem>
 					{ submissionMethod === 'email' && (
 						<ToolsPanelItem
-							hasValue={ () => email !== '' }
+							hasValue={ () => !! email }
 							label={ __( 'Email for form submissions' ) }
 							onDeselect={ () =>
 								setAttributes( {
-									email: '',
-									action: '',
+									email: undefined,
+									action: undefined,
 									method: 'post',
 								} )
 							}

--- a/packages/block-library/src/form/edit.js
+++ b/packages/block-library/src/form/edit.js
@@ -57,12 +57,11 @@ const TEMPLATE = [
 
 const Edit = ( { attributes, setAttributes, clientId } ) => {
 	const defaultSubmissionMethod = 'email';
-	const defaultEmail = '';
 
 	const resetAllSettings = () => {
 		setAttributes( {
 			submissionMethod: defaultSubmissionMethod,
-			email: defaultEmail,
+			email: '',
 			action: '',
 			method: 'post',
 		} );
@@ -140,11 +139,11 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 					</ToolsPanelItem>
 					{ submissionMethod === 'email' && (
 						<ToolsPanelItem
-							hasValue={ () => email !== defaultEmail }
+							hasValue={ () => email !== '' }
 							label={ __( 'Email for form submissions' ) }
 							onDeselect={ () =>
 								setAttributes( {
-									email: defaultEmail,
+									email: '',
 									action: '',
 									method: 'post',
 								} )

--- a/packages/block-library/src/form/edit.js
+++ b/packages/block-library/src/form/edit.js
@@ -9,7 +9,12 @@ import {
 	InspectorControls,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { TextControl, SelectControl, PanelBody } from '@wordpress/components';
+import {
+	SelectControl,
+	TextControl,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -51,6 +56,18 @@ const TEMPLATE = [
 ];
 
 const Edit = ( { attributes, setAttributes, clientId } ) => {
+	const defaultSubmissionMethod = 'email';
+	const defaultEmail = '';
+
+	const resetAllSettings = () => {
+		setAttributes( {
+			submissionMethod: defaultSubmissionMethod,
+			email: defaultEmail,
+			action: '',
+			method: 'post',
+		} );
+	};
+
 	const { action, method, email, submissionMethod } = attributes;
 	const blockProps = useBlockProps();
 
@@ -75,58 +92,87 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ __( 'Settings' ) }>
-					<SelectControl
-						__nextHasNoMarginBottom
-						__next40pxDefaultSize
+				<ToolsPanel
+					label={ __( 'Settings' ) }
+					resetAll={ resetAllSettings }
+				>
+					<ToolsPanelItem
+						hasValue={ () =>
+							submissionMethod !== defaultSubmissionMethod
+						}
 						label={ __( 'Submissions method' ) }
-						options={ [
-							// TODO: Allow plugins to add their own submission methods.
-							{
-								label: __( 'Send email' ),
-								value: 'email',
-							},
-							{
-								label: __( '- Custom -' ),
-								value: 'custom',
-							},
-						] }
-						value={ submissionMethod }
-						onChange={ ( value ) =>
-							setAttributes( { submissionMethod: value } )
+						onDeselect={ () =>
+							setAttributes( {
+								submissionMethod: defaultSubmissionMethod,
+							} )
 						}
-						help={
-							submissionMethod === 'custom'
-								? __(
-										'Select the method to use for form submissions. Additional options for the "custom" mode can be found in the "Advanced" section.'
-								  )
-								: __(
-										'Select the method to use for form submissions.'
-								  )
-						}
-					/>
-					{ submissionMethod === 'email' && (
-						<TextControl
+						isShownByDefault
+					>
+						<SelectControl
 							__nextHasNoMarginBottom
 							__next40pxDefaultSize
-							autoComplete="off"
-							label={ __( 'Email for form submissions' ) }
-							value={ email }
-							required
-							onChange={ ( value ) => {
-								setAttributes( { email: value } );
-								setAttributes( {
-									action: `mailto:${ value }`,
-								} );
-								setAttributes( { method: 'post' } );
-							} }
-							help={ __(
-								'The email address where form submissions will be sent. Separate multiple email addresses with a comma.'
-							) }
-							type="email"
+							label={ __( 'Submissions method' ) }
+							options={ [
+								// TODO: Allow plugins to add their own submission methods.
+								{
+									label: __( 'Send email' ),
+									value: 'email',
+								},
+								{
+									label: __( '- Custom -' ),
+									value: 'custom',
+								},
+							] }
+							value={ submissionMethod }
+							onChange={ ( value ) =>
+								setAttributes( { submissionMethod: value } )
+							}
+							help={
+								submissionMethod === 'custom'
+									? __(
+											'Select the method to use for form submissions. Additional options for the "custom" mode can be found in the "Advanced" section.'
+									  )
+									: __(
+											'Select the method to use for form submissions.'
+									  )
+							}
 						/>
+					</ToolsPanelItem>
+					{ submissionMethod === 'email' && (
+						<ToolsPanelItem
+							hasValue={ () => email !== defaultEmail }
+							label={ __( 'Email for form submissions' ) }
+							onDeselect={ () =>
+								setAttributes( {
+									email: defaultEmail,
+									action: '',
+									method: 'post',
+								} )
+							}
+							isShownByDefault
+						>
+							<TextControl
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
+								autoComplete="off"
+								label={ __( 'Email for form submissions' ) }
+								value={ email }
+								required
+								onChange={ ( value ) => {
+									setAttributes( { email: value } );
+									setAttributes( {
+										action: `mailto:${ value }`,
+									} );
+									setAttributes( { method: 'post' } );
+								} }
+								help={ __(
+									'The email address where form submissions will be sent. Separate multiple email addresses with a comma.'
+								) }
+								type="email"
+							/>
+						</ToolsPanelItem>
 					) }
-				</PanelBody>
+				</ToolsPanel>
 			</InspectorControls>
 			{ submissionMethod !== 'email' && (
 				<InspectorControls group="advanced">

--- a/packages/block-library/src/form/edit.js
+++ b/packages/block-library/src/form/edit.js
@@ -155,7 +155,7 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 								__next40pxDefaultSize
 								autoComplete="off"
 								label={ __( 'Email for form submissions' ) }
-								value={ email }
+								value={ email || '' }
 								required
 								onChange={ ( value ) => {
 									setAttributes( { email: value } );


### PR DESCRIPTION
## What?
Refactors the Form block's settings panel to use `ToolsPanel` instead of `PanelBody`.

Closes #70242

<!-- In a few words, what is the PR actually doing? -->

## Why?
This change updates the Form block to align with the ongoing effort to standardize block inspector controls across Gutenberg using the ToolsPanel component. Leveraging ToolsPanel enhances the user experience by introducing reset functionality, improved control organization, and consistent UI patterns across all blocks.

## Testing Instructions
1. First, make sure the experimental feature `Blocks: add Form and input blocks` is turned ON
2. Open a post or page in the block editor
3. Insert a Form block
4. Open the block inspector
5. Verify the "Settings" panel displays with ToolsPanel UI

## Screenshots

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/7256fefd-b81d-45e1-aa25-cfb172381f99)|![image](https://github.com/user-attachments/assets/9c43b758-185b-477e-85a7-267d4c2a3845)|
