### PR TITLE
Block Editor: Clarify 'clientId' prop use for 'HTMLElementControl'

### DIFF
--- a/packages/block-editor/src/components/html-element-control/index.js
+++ b/packages/block-editor/src/components/html-element-control/index.js
@@ -22,7 +22,7 @@ import { htmlElementMessages } from './messages';
  * @param {Object}   props          Component props.
  * @param {string}   props.tagName  The current HTML tag name.
  * @param {Function} props.onChange Function to call when the tag is changed.
- * @param {string}   props.clientId The client ID of the current block.
+ * @param {string}   props.clientId Optional. The client ID of the block. Used to check for existing <main> elements.
  * @param {Array}    props.options  SelectControl options (optional).
  *
  * @return {Component} The HTML element select control with validation.

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -465,7 +465,6 @@ function ButtonEdit( props ) {
 					onChange={ ( value ) =>
 						setAttributes( { tagName: value } )
 					}
-					clientId={ clientId }
 					options={ [
 						{ label: __( 'Default (<a>)' ), value: 'a' },
 						{ label: '<button>', value: 'button' },

--- a/packages/block-library/src/comments/edit/comments-inspector-controls.js
+++ b/packages/block-library/src/comments/edit/comments-inspector-controls.js
@@ -17,7 +17,6 @@ const { HTMLElementControl } = unlock( blockEditorPrivateApis );
 export default function CommentsInspectorControls( {
 	attributes: { tagName },
 	setAttributes,
-	clientId,
 } ) {
 	return (
 		<InspectorControls>
@@ -27,7 +26,6 @@ export default function CommentsInspectorControls( {
 					onChange={ ( value ) =>
 						setAttributes( { tagName: value } )
 					}
-					clientId={ clientId }
 					options={ [
 						{ label: __( 'Default (<div>)' ), value: 'div' },
 						{ label: '<section>', value: 'section' },

--- a/packages/block-library/src/separator/edit.js
+++ b/packages/block-library/src/separator/edit.js
@@ -24,11 +24,7 @@ import { unlock } from '../lock-unlock';
 
 const { HTMLElementControl } = unlock( blockEditorPrivateApis );
 
-export default function SeparatorEdit( {
-	attributes,
-	setAttributes,
-	clientId,
-} ) {
+export default function SeparatorEdit( { attributes, setAttributes } ) {
 	const { backgroundColor, opacity, style, tagName } = attributes;
 	const colorProps = useColorProps( attributes );
 	const currentColor = colorProps?.style?.backgroundColor;
@@ -64,7 +60,6 @@ export default function SeparatorEdit( {
 					onChange={ ( value ) =>
 						setAttributes( { tagName: value } )
 					}
-					clientId={ clientId }
 					options={ [
 						{ label: __( 'Default (<hr>)' ), value: 'hr' },
 						{ label: '<div>', value: 'div' },


### PR DESCRIPTION
## What?
PR updates JSDoc for `HTMLElementControl` and clarifies use for `clientId` prop. I've also removed it from blocks where it's not needed.

## Why?
Code gets copied and pasted, so we should avoid passing unnecessary props to the components.

## Testing Instructions
1. Confirm that the HTML element control works as before.