### PR TITLE
[Pullquote Block]: Reduce CSS specificity for the default cite element.

### DIFF
--- a/packages/block-library/src/pullquote/editor.scss
+++ b/packages/block-library/src/pullquote/editor.scss
@@ -12,6 +12,6 @@
 	}
 }
 
-.wp-block-pullquote .wp-block-pullquote__citation {
+.wp-block-pullquote__citation {
 	color: inherit;
 }

--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -74,5 +74,6 @@
 }
 
 .wp-block-pullquote__citation {
+	color: inherit;
 	display: block;
 }

--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -6,8 +6,7 @@
 	padding: 4em 0;
 
 	p,
-	blockquote,
-	cite {
+	blockquote {
 		color: inherit;
 	}
 
@@ -74,7 +73,6 @@
 	}
 }
 
-.wp-block-pullquote cite {
-	color: inherit;
+.wp-block-pullquote__citation {
 	display: block;
 }

--- a/packages/block-library/src/pullquote/theme.scss
+++ b/packages/block-library/src/pullquote/theme.scss
@@ -4,7 +4,6 @@
 	margin-bottom: 1.75em;
 	color: currentColor;
 
-	cite,
 	footer,
 	&__citation {
 		color: currentColor;

--- a/test/emptytheme/theme.json
+++ b/test/emptytheme/theme.json
@@ -8,6 +8,24 @@
 			"wideSize": "1100px"
 		}
 	},
+	"styles": {
+		"blocks": {
+			"core/pullquote": {
+				"elements": {
+					"cite": {
+						"color": {
+							"text": "#ff0000"
+						},
+						"typography": {
+							"fontSize": "30px",
+							"textTransform": "lowercase",
+							"fontStyle": "italic"
+						}
+					}
+				}
+			}
+		}
+	},
 	"customTemplates": [
 		{
 			"name": "custom-template",

--- a/test/emptytheme/theme.json
+++ b/test/emptytheme/theme.json
@@ -8,24 +8,6 @@
 			"wideSize": "1100px"
 		}
 	},
-	"styles": {
-		"blocks": {
-			"core/pullquote": {
-				"elements": {
-					"cite": {
-						"color": {
-							"text": "#ff0000"
-						},
-						"typography": {
-							"fontSize": "30px",
-							"textTransform": "lowercase",
-							"fontStyle": "italic"
-						}
-					}
-				}
-			}
-		}
-	},
 	"customTemplates": [
 		{
 			"name": "custom-template",


### PR DESCRIPTION

## What?
Closes https://github.com/WordPress/gutenberg/issues/70256

Reduces the specificity of the default block's CSS being applied to the Pullquote block, We are reducing it to 0,1,0 to keep it in par with the theme.json CSS (if applied) so that it can be over-riden by the theme developers.

## Why?
To allow override of the CSS styles from theme.json

## How?
Reduced the specifity of CSS applied by default to 0,1,0

## Testing Instructions
1. Activate the Emptytheme and update the theme.json using the following definition:

```
{
	"$schema": "../../schemas/json/theme.json",
	"version": 3,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		}
	},
	"styles": {
		"blocks": {
			"core/pullquote": {
				"elements": {
					"cite": {
						"color": {
							"text": "#ff0000"
						},
						"typography": {
							"fontSize": "30px",
							"textTransform": "lowercase",
							"fontStyle": "italic"
						}
					}
				}
			}
		}
	}
}
```
2. Insert a Pullquote block.
3. Confirm that the cite style has changed.

# Screenshots

### Editor
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/b11f6cff-b1d8-41ee-8914-815519d69d53" />

### Frontend
<img width="1467" alt="image" src="https://github.com/user-attachments/assets/12f6a440-e1fc-41ab-aebf-d8c7b7c9ef0b" />

