### PR TITLE
Pullquote block: Cannot override cite element style via theme.json

### DIFF
--- a/packages/block-library/src/pullquote/editor.scss
+++ b/packages/block-library/src/pullquote/editor.scss
@@ -12,6 +12,6 @@
 	}
 }
 
-.wp-block-pullquote .wp-block-pullquote__citation {
+.wp-block-pullquote__citation {
 	color: inherit;
 }

--- a/packages/block-library/src/pullquote/editor.scss
+++ b/packages/block-library/src/pullquote/editor.scss
@@ -11,3 +11,7 @@
 		font-style: normal;
 	}
 }
+
+.wp-block-pullquote .wp-block-pullquote__citation {
+	color: inherit;
+}

--- a/packages/block-library/src/pullquote/editor.scss
+++ b/packages/block-library/src/pullquote/editor.scss
@@ -11,7 +11,3 @@
 		font-style: normal;
 	}
 }
-
-.wp-block-pullquote .wp-block-pullquote__citation {
-	color: inherit;
-}

--- a/packages/block-library/src/pullquote/save.js
+++ b/packages/block-library/src/pullquote/save.js
@@ -23,7 +23,11 @@ export default function save( { attributes } ) {
 			<blockquote>
 				<RichText.Content tagName="p" value={ value } />
 				{ shouldShowCitation && (
-					<RichText.Content tagName="cite" value={ citation } />
+					<RichText.Content
+						tagName="cite"
+						className="wp-block-pullquote__citation"
+						value={ citation }
+					/>
 				) }
 			</blockquote>
 		</figure>

--- a/packages/block-library/src/pullquote/save.js
+++ b/packages/block-library/src/pullquote/save.js
@@ -23,11 +23,7 @@ export default function save( { attributes } ) {
 			<blockquote>
 				<RichText.Content tagName="p" value={ value } />
 				{ shouldShowCitation && (
-					<RichText.Content
-						tagName="cite"
-						className="wp-block-pullquote__citation"
-						value={ citation }
-					/>
+					<RichText.Content tagName="cite" value={ citation } />
 				) }
 			</blockquote>
 		</figure>

--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -6,8 +6,7 @@
 	padding: 4em 0;
 
 	p,
-	blockquote,
-	cite {
+	blockquote {
 		color: inherit;
 	}
 
@@ -74,7 +73,7 @@
 	}
 }
 
-.wp-block-pullquote cite {
+.wp-block-pullquote__citation {
 	color: inherit;
 	display: block;
 }

--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -73,7 +73,7 @@
 	}
 }
 
-.wp-block-pullquote__citation {
+.wp-block-pullquote :where(cite) {
 	color: inherit;
 	display: block;
 }

--- a/packages/block-library/src/pullquote/theme.scss
+++ b/packages/block-library/src/pullquote/theme.scss
@@ -4,7 +4,7 @@
 	margin-bottom: 1.75em;
 	color: currentColor;
 
-	cite,
+	:where(cite),
 	footer,
 	&__citation {
 		color: currentColor;

--- a/packages/block-library/src/pullquote/theme.scss
+++ b/packages/block-library/src/pullquote/theme.scss
@@ -5,7 +5,7 @@
 	color: currentColor;
 
 	:where(cite),
-	footer,
+	:where(footer),
 	&__citation {
 		color: currentColor;
 		text-transform: uppercase;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #70256 

<!-- In a few words, what is the PR actually doing? -->

## Why?
- The Pullquote block’s `<cite>` element style could not be overridden using theme.json due to overly broad or conflicting CSS specificity. This prevented theme developers from customizing citation styles as intended.

- This update follows the solution proposed by @t-hamano to resolve the issue by reducing the specificity of the class selector and ensuring `theme.json` styles can apply properly.

## How?
We updated the Pullquote block’s markup to apply a specific class (.wp-block-pullquote__citation) to the <cite> element and aligned corresponding styles in both editor.scss and style.scss. This change ensures that theme.json styles targeting the citation element are respected and not overridden unintentionally by default styles.

## Testing Instructions
1. Open an existing post or create a new one.
2. Insert a Pullquote block into the post.
3. Enter the required content, including the blockquote text and citation.
4. Use the block's sidebar settings to change the text color of the citation and content.
5. Save the post and preview it.
6. Verify whether your selected text color is being overridden by the color defined in the theme.json file.

To test theme-level control over the Pullquote block, use the following configuration in your theme.json file:
```
{
	"$schema": "../../schemas/json/theme.json",
	"version": 3,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		}
	},
	"styles": {
		"blocks": {
			"core/pullquote": {
				"elements": {
					"cite": {
						"color": {
							"text": "#ff0000"
						},
						"typography": {
							"fontSize": "30px",
							"textTransform": "lowercase",
							"fontStyle": "italic"
						}
					}
				}
			}
		}
	}
}
```

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![Pullquote-–-gutenberg-05-29-2025_03_08_PM (1)](https://github.com/user-attachments/assets/f6a764bc-a531-4451-be3e-248666e95814)|![Pullquote-–-gutenberg-05-29-2025_03_08_PM](https://github.com/user-attachments/assets/1115c8ce-ac8d-4397-b398-4799ce71e426)|
