### PR TITLE
Docs: Remove misleading section from curating the editor experience

### DIFF
--- a/docs/how-to-guides/curating-the-editor-experience/disable-editor-functionality.md
+++ b/docs/how-to-guides/curating-the-editor-experience/disable-editor-functionality.md
@@ -24,14 +24,14 @@ You can also use [block filters](/docs/reference-guides/filters/block-filters.md
 
 ```php
 function example_modify_heading_levels_globally( $args, $block_type ) {
-	
+
 	if ( 'core/heading' !== $block_type ) {
 		return $args;
 	}
 
 	// Remove H1, H2, and H6.
 	$args['attributes']['levelOptions']['default'] = [ 3, 4, 5 ];
-	
+
 	return $args;
 }
 add_filter( 'register_block_type_args', 'example_modify_heading_levels_globally', 10, 2 );
@@ -90,19 +90,6 @@ wp.domReady( () => {
 ```
 
 This JavaScript should be enqueued much like the block variation example above. Refer to the [block styles](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-styles/) documentation for how to register and unregister styles using PHP.
-
-## Disable access to the Template Editor
-
-Whether you’re using theme.json in a Classic or Block theme, you can add the following to your `functions.php` file to remove access to the Template Editor that is available when editing posts or pages:
-
-```php
-function example_theme_support() {
-	remove_theme_support( 'block-templates');
-}
-add_action( 'after_setup_theme', 'example_theme_support' );
-```
-
-This prevents both the ability to create new block templates or edit them from within the Post Editor.
 
 ## Disable access to the Code Editor
 


### PR DESCRIPTION
## What?
Closes #63822.

PR removes the misleading "Disable access to the Template Editor" section from curating the editor experience documentation page.

## Why?
Removing theme support for `block-templates` entirely disables block templates for a theme, including rendering them on the frontend. The theme support flags shouldn't be used to restrict access to certain editor features.

## Testing Instructions
None.
