### PR TITLE
Video: Use a unique 'key' in the 'TrackList' component

### DIFF
--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -52,7 +52,7 @@ function TrackList( { tracks, onEditPress } ) {
 	const content = tracks.map( ( track, index ) => {
 		return (
 			<HStack
-				key={ index }
+				key={ track.src }
 				className="block-library-video-tracks-editor__track-list-track"
 			>
 				<span>{ track.label }</span>


### PR DESCRIPTION
## What?
PR updates the `TrackList` component to use track source as a unique key instead of the array index. Noticed while reviewing a related PR.

This also makes track list rendering more consistent.
https://github.com/WordPress/gutenberg/blob/68ce198624fe8f33f8b4c2f08a70c96b1f2939d4/packages/block-library/src/video/tracks.js#L3

## Why?
See: https://react.dev/learn/rendering-lists#rules-of-keys

## Testing Instructions
None. This is a minor improvement in code quality.
