### PR TITLE
Account for tests env port being overridden from 8889 in PHP unit tests

### DIFF
--- a/phpunit/class-block-fixture-test.php
+++ b/phpunit/class-block-fixture-test.php
@@ -26,6 +26,9 @@ class Block_Fixture_Test extends WP_UnitTestCase {
 		$block = preg_replace( "/href=['\"]data:[^'\"]+['\"]/", 'href="https://wordpress.org/foo.jpg"', $block );
 		$block = preg_replace( '/url\(data:[^)]+\)/', 'url(https://wordpress.org/foo.jpg)', $block );
 
+		// Account for a wp-env override using a port other than 8889 for the tests environment.
+		$block = preg_replace( '#http://localhost:\d+/#', home_url( '/' ), $block );
+
 		add_filter( 'wp_kses_allowed_html', array( $this, 'filter_allowed_html' ) );
 		$kses_block = wp_kses_post( $block );
 		remove_filter( 'wp_kses_allowed_html', array( $this, 'filter_allowed_html' ) );

--- a/phpunit/class-wp-rest-global-styles-controller-gutenberg-test.php
+++ b/phpunit/class-wp-rest-global-styles-controller-gutenberg-test.php
@@ -166,7 +166,7 @@ class WP_REST_Global_Styles_Controller_Gutenberg_Test extends WP_Test_REST_Contr
 					),
 					'wp:theme-file' => array(
 						array(
-							'href'   => 'http://localhost:8889/wp-content/themes/emptytheme/img/1024x768_emptytheme_test_image.jpg',
+							'href'   => home_url( '/wp-content/themes/emptytheme/img/1024x768_emptytheme_test_image.jpg' ),
 							'name'   => 'file:./img/1024x768_emptytheme_test_image.jpg',
 							'target' => 'styles.background.backgroundImage.url',
 							'type'   => 'image/jpeg',


### PR DESCRIPTION
I have a `.wp-env.override.json` which uses a port other than 8889 for the tests environment:

```json
{
	"$schema": "./schemas/json/wp-env.json",
	"core": "../../../",
	"port": 8891,
	"testsPort": 8991,
	"env": {
		"development": {
			"phpmyadminPort": 9001
		}
	}
}
```

This causes test failures:

<details><summary>PHPUnit Test Output</summary>

```
There were 3 failures:

1) Block_Fixture_Test::test_kses_doesnt_change_fixtures with data set #77 ('<!-- wp:file {"href":"http://... -->\n', 'core__file__pdf-preview.seria...d.html')
Failed to match core__file__pdf-preview.serialized.html
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 '<!-- wp:file {"href":"http://localhost:8889/wp-content/uploads/2021/04/yolo.pdf","displayPreview":true,"previewHeight":370} -->
-<div class="wp-block-file"><object class="wp-block-file__embed" data="http://localhost:8889/wp-content/uploads/2021/04/yolo.pdf" type="application/pdf" style="width:100%;height:370px" aria-label="yolo"></object><a id="wp-block-file--media-_clientId_0" href="http://localhost:8889/wp-content/uploads/2021/04/yolo.pdf">yolo</a><a href="http://localhost:8889/wp-content/uploads/2021/04/yolo.pdf" class="wp-block-file__button wp-element-button" download aria-describedby="wp-block-file--media-_clientId_0">Download</a></div>
+<div class="wp-block-file"><object></object><a id="wp-block-file--media-_clientId_0" href="http://localhost:8889/wp-content/uploads/2021/04/yolo.pdf">yolo</a><a href="http://localhost:8889/wp-content/uploads/2021/04/yolo.pdf" class="wp-block-file__button wp-element-button" download aria-describedby="wp-block-file--media-_clientId_0">Download</a></div>
 <!-- /wp:file -->
 '

/var/www/html/wp-content/plugins/gutenberg/phpunit/class-block-fixture-test.php:39

2) Block_Fixture_Test::test_kses_doesnt_change_fixtures with data set #78 ('<!-- wp:file {"href":"http://... -->\n', 'core__file__pdf-preview__depr...d.html')
Failed to match core__file__pdf-preview__deprecated-1.serialized.html
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 '<!-- wp:file {"href":"http://localhost:8889/wp-content/uploads/2021/04/yolo.pdf","displayPreview":true,"previewHeight":370} -->
-<div class="wp-block-file"><object class="wp-block-file__embed" data="http://localhost:8889/wp-content/uploads/2021/04/yolo.pdf" type="application/pdf" style="width:100%;height:370px" aria-label="yolo"></object><a href="http://localhost:8889/wp-content/uploads/2021/04/yolo.pdf">yolo</a><a href="http://localhost:8889/wp-content/uploads/2021/04/yolo.pdf" class="wp-block-file__button wp-element-button" download>Download</a></div>
+<div class="wp-block-file"><object></object><a href="http://localhost:8889/wp-content/uploads/2021/04/yolo.pdf">yolo</a><a href="http://localhost:8889/wp-content/uploads/2021/04/yolo.pdf" class="wp-block-file__button wp-element-button" download>Download</a></div>
 <!-- /wp:file -->
 '

/var/www/html/wp-content/plugins/gutenberg/phpunit/class-block-fixture-test.php:39

3) WP_REST_Global_Styles_Controller_Gutenberg_Test::test_get_theme_items
Theme item should match expected schema
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
             )
             'wp:theme-file' => Array &5 (
                 0 => Array &6 (
-                    'href' => 'http://localhost:8889/wp-content/themes/emptytheme/img/1024x768_emptytheme_test_image.jpg'
+                    'href' => 'http://localhost:8991/wp-content/themes/emptytheme/img/1024x768_emptytheme_test_image.jpg'
                     'name' => 'file:./img/1024x768_emptytheme_test_image.jpg'
                     'target' => 'styles.background.backgroundImage.url'
                     'type' => 'image/jpeg'

/wordpress-phpunit/includes/abstract-testcase.php:994
/var/www/html/wp-content/plugins/gutenberg/phpunit/class-wp-rest-global-styles-controller-gutenberg-test.php:211
```

</details> 

This PR fixes the issue by using the current URL in the test fixtures.