### PR TITLE
Fix: render_block_core_site_title function doc has missing return type

### DIFF
--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -12,12 +12,12 @@
  *
  * @param array $attributes The block attributes.
  *
- * @return null|string The render.
+ * @return string The render.
  */
 function render_block_core_site_title( $attributes ) {
 	$site_title = get_bloginfo( 'name' );
 	if ( ! trim( $site_title ) ) {
-		return;
+		return '';
 	}
 
 	$tag_name = 'h1';

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -12,7 +12,7 @@
  *
  * @param array $attributes The block attributes.
  *
- * @return string The render.
+ * @return null|string The render.
  */
 function render_block_core_site_title( $attributes ) {
 	$site_title = get_bloginfo( 'name' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/70268

<!-- In a few words, what is the PR actually doing? -->

## Why?
`render_block_core_site_title` function doc should be updated. Though the return type is set string, it also return null on line 20;

`
if (  !  trim( $site_title )  )  {
     return;
}
`

## How?
I have updated the doc as per return type.

## Screenshots or screencast

![image](https://github.com/user-attachments/assets/51285a3a-5137-429e-9465-0d04dc4b9817)
