### PR TITLE
Feature: Add Parent Title new block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -534,6 +534,15 @@ Start with the basic building block of all narrative. ([Source](https://github.c
 -	**Supports:** __unstablePasteTextInline, anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fontSize, lineHeight), ~~className~~
 -	**Attributes:** align, content, direction, dropCap, placeholder
 
+## Parent Title
+
+Displays the title of the parent post, page, or any other content-type. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/parent-post-title))
+
+-	**Name:** core/parent-post-title
+-	**Category:** theme
+-	**Supports:** align (full, wide), color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** isLink, level, levelOptions, linkTarget, rel, textAlign
+
 ## Pattern Placeholder
 
 Show a block pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/pattern))

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -100,6 +100,7 @@ function gutenberg_reregister_core_block_types() {
 				'post-terms.php'                   => 'core/post-terms',
 				'post-time-to-read.php'            => 'core/post-time-to-read',
 				'post-title.php'                   => 'core/post-title',
+				'parent-post-title.php'            => 'core/parent-post-title',
 				'query.php'                        => 'core/query',
 				'post-template.php'                => 'core/post-template',
 				'query-no-results.php'             => 'core/query-no-results',

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -122,6 +122,7 @@ import * as textColumns from './text-columns';
 import * as verse from './verse';
 import * as video from './video';
 import * as footnotes from './footnotes';
+import * as parentPostTitle from './parent-post-title';
 
 import isBlockMetadataExperimental from './utils/is-block-metadata-experimental';
 
@@ -194,6 +195,7 @@ const getAllBlocks = () => {
 		templatePart,
 		avatar,
 		postTitle,
+		parentPostTitle,
 		postExcerpt,
 		postFeaturedImage,
 		postContent,

--- a/packages/block-library/src/parent-post-title/block.json
+++ b/packages/block-library/src/parent-post-title/block.json
@@ -1,0 +1,87 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "core/parent-post-title",
+	"title": "Parent Title",
+	"category": "theme",
+	"description": "Displays the title of the parent post, page, or any other content-type.",
+	"textdomain": "default",
+	"usesContext": [ "postId", "postType", "queryId" ],
+	"attributes": {
+		"textAlign": {
+			"type": "string"
+		},
+		"level": {
+			"type": "number",
+			"default": 2
+		},
+		"levelOptions": {
+			"type": "array"
+		},
+		"isLink": {
+			"type": "boolean",
+			"default": false,
+			"role": "content"
+		},
+		"rel": {
+			"type": "string",
+			"attribute": "rel",
+			"default": "",
+			"role": "content"
+		},
+		"linkTarget": {
+			"type": "string",
+			"default": "_self",
+			"role": "content"
+		}
+	},
+	"example": {
+		"viewportWidth": 350
+	},
+	"supports": {
+		"align": [ "wide", "full" ],
+		"html": false,
+		"color": {
+			"gradients": true,
+			"link": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true,
+				"link": true
+			}
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		},
+		"interactivity": {
+			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
+		}
+	},
+	"style": "wp-block-parent-post-title"
+}

--- a/packages/block-library/src/parent-post-title/edit.js
+++ b/packages/block-library/src/parent-post-title/edit.js
@@ -1,0 +1,220 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	AlignmentControl,
+	BlockControls,
+	InspectorControls,
+	useBlockProps,
+	HeadingLevelDropdown,
+	useBlockEditingMode,
+	Warning,
+} from '@wordpress/block-editor';
+import {
+	ToggleControl,
+	TextControl,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useEntityProp, store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+
+export default function ParentPostTitleEdit( {
+	attributes: { level, levelOptions, textAlign, isLink, rel, linkTarget },
+	setAttributes,
+	context: { postType, postId },
+} ) {
+	const blockProps = useBlockProps( {
+		className: clsx( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} ),
+	} );
+
+	const TagName = level === 0 ? 'p' : `h${ level }`;
+	const { parentPostId, supportsParent } = useSelect(
+		( select ) => {
+			const { getEditedEntityRecord, getPostType } = select( coreStore );
+			const _parentId = getEditedEntityRecord(
+				'postType',
+				postType,
+				postId
+			)?.parent;
+
+			return {
+				parentPostId: _parentId,
+				supportsParent:
+					getPostType( postType )?.supports?.parent ?? false,
+			};
+		},
+		[ postType, postId ]
+	);
+
+	const blockEditingMode = useBlockEditingMode();
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+	const [ fullTitle ] = useEntityProp(
+		'postType',
+		postType,
+		'title',
+		parentPostId
+	);
+	const [ link ] = useEntityProp(
+		'postType',
+		postType,
+		'link',
+		parentPostId
+	);
+
+	// Early return if the post type does not support parent posts.
+	if ( ! supportsParent ) {
+		return (
+			<div { ...blockProps }>
+				<Warning>
+					{ __(
+						'This block is not supported for the current post type.'
+					) }
+				</Warning>
+			</div>
+		);
+	}
+
+	let titleElement = <TagName { ...blockProps }>{ __( 'Title' ) }</TagName>;
+
+	if ( postType && parentPostId ) {
+		titleElement = (
+			<TagName
+				{ ...blockProps }
+				dangerouslySetInnerHTML={ { __html: fullTitle?.rendered } }
+			/>
+		);
+	}
+
+	if ( isLink && postType && parentPostId ) {
+		titleElement = (
+			<TagName { ...blockProps }>
+				<a
+					href={ link }
+					target={ linkTarget }
+					rel={ rel }
+					onClick={ ( event ) => event.preventDefault() }
+					dangerouslySetInnerHTML={ {
+						__html: fullTitle?.rendered,
+					} }
+				/>
+			</TagName>
+		);
+	}
+
+	return (
+		<>
+			{ blockEditingMode === 'default' && (
+				<>
+					<BlockControls group="block">
+						<HeadingLevelDropdown
+							value={ level }
+							options={ levelOptions }
+							onChange={ ( newLevel ) =>
+								setAttributes( { level: newLevel } )
+							}
+						/>
+						<AlignmentControl
+							value={ textAlign }
+							onChange={ ( nextAlign ) => {
+								setAttributes( { textAlign: nextAlign } );
+							} }
+						/>
+					</BlockControls>
+					<InspectorControls>
+						<ToolsPanel
+							label={ __( 'Settings' ) }
+							resetAll={ () => {
+								setAttributes( {
+									rel: '',
+									linkTarget: '_self',
+									isLink: false,
+								} );
+							} }
+							dropdownMenuProps={ dropdownMenuProps }
+						>
+							<ToolsPanelItem
+								label={ __( 'Make title a link' ) }
+								isShownByDefault
+								hasValue={ () => isLink }
+								onDeselect={ () =>
+									setAttributes( { isLink: false } )
+								}
+							>
+								<ToggleControl
+									__nextHasNoMarginBottom
+									label={ __( 'Make title a link' ) }
+									onChange={ () =>
+										setAttributes( { isLink: ! isLink } )
+									}
+									checked={ isLink }
+								/>
+							</ToolsPanelItem>
+							{ isLink && (
+								<>
+									<ToolsPanelItem
+										label={ __( 'Open in new tab' ) }
+										isShownByDefault
+										hasValue={ () =>
+											linkTarget === '_blank'
+										}
+										onDeselect={ () =>
+											setAttributes( {
+												linkTarget: '_self',
+											} )
+										}
+									>
+										<ToggleControl
+											__nextHasNoMarginBottom
+											label={ __( 'Open in new tab' ) }
+											onChange={ ( value ) =>
+												setAttributes( {
+													linkTarget: value
+														? '_blank'
+														: '_self',
+												} )
+											}
+											checked={ linkTarget === '_blank' }
+										/>
+									</ToolsPanelItem>
+									<ToolsPanelItem
+										label={ __( 'Link rel' ) }
+										isShownByDefault
+										hasValue={ () => !! rel }
+										onDeselect={ () =>
+											setAttributes( { rel: '' } )
+										}
+									>
+										<TextControl
+											__next40pxDefaultSize
+											__nextHasNoMarginBottom
+											label={ __( 'Link rel' ) }
+											value={ rel }
+											onChange={ ( newRel ) =>
+												setAttributes( { rel: newRel } )
+											}
+										/>
+									</ToolsPanelItem>
+								</>
+							) }
+						</ToolsPanel>
+					</InspectorControls>
+				</>
+			) }
+			{ titleElement }
+		</>
+	);
+}

--- a/packages/block-library/src/parent-post-title/edit.js
+++ b/packages/block-library/src/parent-post-title/edit.js
@@ -54,7 +54,8 @@ export default function ParentPostTitleEdit( {
 			return {
 				parentPostId: _parentId,
 				supportsParent:
-					getPostType( postType )?.supports?.parent ?? false,
+					getPostType( postType )?.supports?.[ 'page-attributes' ] ??
+					false,
 			};
 		},
 		[ postType, postId ]
@@ -62,7 +63,7 @@ export default function ParentPostTitleEdit( {
 
 	const blockEditingMode = useBlockEditingMode();
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
-	const [ fullTitle ] = useEntityProp(
+	const [ , , fullTitle ] = useEntityProp(
 		'postType',
 		postType,
 		'title',

--- a/packages/block-library/src/parent-post-title/index.js
+++ b/packages/block-library/src/parent-post-title/index.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { title as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import initBlock from '../utils/init-block';
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	icon,
+	edit,
+};
+
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/parent-post-title/index.php
+++ b/packages/block-library/src/parent-post-title/index.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Server-side rendering of the `core/parent-post-title` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/parent-post-title` block on the server.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the filtered parent post title for the current post wrapped inside "h1" tags.
+ */
+function render_block_core_parent_post_title( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$parent_id = wp_get_post_parent_id();
+
+	$title = get_the_title( $parent_id );
+
+	if ( ! $title ) {
+		return '';
+	}
+
+	$tag_name = 'h2';
+	if ( isset( $attributes['level'] ) ) {
+		$tag_name = 0 === $attributes['level'] ? 'p' : 'h' . (int) $attributes['level'];
+	}
+
+	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
+		$rel   = ! empty( $attributes['rel'] ) ? 'rel="' . esc_attr( $attributes['rel'] ) . '"' : '';
+		$title = sprintf( '<a href="%1$s" target="%2$s" %3$s>%4$s</a>', esc_url( get_the_permalink( $block->context['postId'] ) ), esc_attr( $attributes['linkTarget'] ), $rel, $title );
+	}
+
+	$classes = array();
+	if ( isset( $attributes['textAlign'] ) ) {
+		$classes[] = 'has-text-align-' . $attributes['textAlign'];
+	}
+	if ( isset( $attributes['style']['elements']['link']['color']['text'] ) ) {
+		$classes[] = 'has-link-color';
+	}
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
+
+	return sprintf(
+		'<%1$s %2$s>%3$s</%1$s>',
+		$tag_name,
+		$wrapper_attributes,
+		$title
+	);
+}
+
+/**
+ * Registers the `core/parent-post-title` block on the server.
+ */
+function register_block_core_parent_post_title() {
+	register_block_type_from_metadata(
+		__DIR__ . '/parent-post-title',
+		array(
+			'render_callback' => 'render_block_core_parent_post_title',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_parent_post_title' );

--- a/packages/block-library/src/parent-post-title/init.js
+++ b/packages/block-library/src/parent-post-title/init.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import { init } from './';
+
+export default init();

--- a/packages/block-library/src/parent-post-title/style.scss
+++ b/packages/block-library/src/parent-post-title/style.scss
@@ -1,0 +1,16 @@
+.wp-block-parent-post-title {
+	word-break: break-word;
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
+
+	:where(a) {
+		display: inline-block;
+		font-family: inherit;
+		font-size: inherit;
+		font-style: inherit;
+		font-weight: inherit;
+		letter-spacing: inherit;
+		line-height: inherit;
+		text-decoration: inherit;
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/70266

<!-- In a few words, what is the PR actually doing? -->

## Why?
Currently, there’s no way to dynamically show the parent page title on a child page within WordPress's block editor. Users managing content with hierarchical page structures would benefit from a block or shortcode that outputs the parent page title without needing custom code. [reference](https://github.com/WordPress/gutenberg/issues/70266#issue-3102129808)

## How?
Added a new core block `core/parent-post-title` in the block-library

## Testing Instructions for post types with parent support

1. Open any post/page.
2. Set Parent page/post if not set.
3. Insert the Parent Title block using block inserter.
4. It will display the title of parent

https://github.com/user-attachments/assets/575c7fe3-f292-4c8d-8ec6-6db137c4529e


## Testing Instructions for post types without parent support
1. Open any post/page.
4. Insert the Parent Title block using block inserter.
5. It will display a warning `This block is not supported for the current post type.`


https://github.com/user-attachments/assets/1b5ca01a-98e3-4a3c-93d0-c2da9b9ad9ca

