### PR TITLE
block.json schema: Add role field

### DIFF
--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -185,6 +185,11 @@
 							"description": "Although attributes may be obtained from a post’s meta, meta attribute sources are considered deprecated; EntityProvider and related hook APIs should be used instead, as shown in the Create Meta Block how-to here:\n\nhttps://developer.wordpress.org/block-editor/how-to-guides/metabox/#step-2-add-meta-block",
 							"type": "string"
 						},
+						"role": {
+							"description": "Designates the conceptual type of the attribute.\n\nThe `content` value marks the attribute as user-editable content, and the `local` value marks the attribute as temporary and non-persistable.",
+							"type": "string",
+							"enum": [ "content", "local" ]
+						},
 						"default": {
 							"description": "A block attribute can contain a default value, which will be used if the type and source do not match anything within the block content.\n\nThe value is provided by the default field, and the value should match the expected format of the attribute."
 						}


### PR DESCRIPTION
See: https://github.com/WordPress/gutenberg/pull/65484#issuecomment-2378462036
Dev note: https://make.wordpress.org/core/2024/10/20/miscellaneous-block-editor-changes-in-wordpress-6-7/#stabilized-role-property-for-block-attributes

## What?

Add a missing `role` field.

## Why?

The `role` field was stabilized in WordPress 6.7, but was not exposed in the schema.

## Testing Instructions

Create the following JSON file to test code editor assistance:

```json
{
	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/refs/heads/block-json-schema-role/schemas/json/block.json",
	"apiVersion": 3,
	"title": "Test",
	"name": "core/test",
	"attributes": {
		"test": {
			"type": "string"
		}
	}
}
```

## Screenshots or screencast <!-- if applicable -->

![image](https://github.com/user-attachments/assets/9dd18767-60ca-4936-83d1-53c3842ea5d6)
