### PR TITLE
Ensure the actual tests environment is used for e2e tests

### DIFF
--- a/packages/env/lib/config/load-config.js
+++ b/packages/env/lib/config/load-config.js
@@ -37,7 +37,7 @@ const postProcessConfig = require( './post-process-config' );
  *
  * @param {string} configDirectoryPath The directory we want to load the config from.
  *
- * @return {WPConfig} The config object we've loaded.
+ * @return {Promise<WPConfig>} The config object we've loaded.
  */
 module.exports = async function loadConfig( configDirectoryPath ) {
 	const configFilePath = getConfigFilePath( configDirectoryPath );

--- a/packages/scripts/config/playwright.config.js
+++ b/packages/scripts/config/playwright.config.js
@@ -10,6 +10,8 @@ process.env.STORAGE_STATE_PATH ??= path.join(
 	'storage-states/admin.json'
 );
 
+const baseUrl = new URL( process.env.WP_BASE_URL || 'http://localhost:8889' );
+
 const config = defineConfig( {
 	reporter: process.env.CI ? [ [ 'github' ] ] : [ [ 'list' ] ],
 	forbidOnly: !! process.env.CI,
@@ -25,7 +27,7 @@ const config = defineConfig( {
 		'{testDir}/{testFileDir}/__snapshots__/{arg}-{projectName}{ext}',
 	globalSetup: require.resolve( './playwright/global-setup.js' ),
 	use: {
-		baseURL: process.env.WP_BASE_URL || 'http://localhost:8889',
+		baseURL: baseUrl.href,
 		headless: true,
 		viewport: {
 			width: 960,
@@ -45,7 +47,7 @@ const config = defineConfig( {
 	},
 	webServer: {
 		command: 'npm run wp-env start',
-		port: 8889,
+		port: baseUrl.port,
 		timeout: 120_000, // 120 seconds.
 		reuseExistingServer: true,
 	},


### PR DESCRIPTION
By default the `tests` environment in `wp-env` uses the port `8889`. On my system, I am overriding this via `.wp-env.override.json` use a different port number for the `development` and `tests` environments:

```json
{
  "$schema": "./schemas/json/wp-env.json",
  "core": "../../../",
  "port": 8891,
  "testsPort": 8991,
  "env": {
    "development": {
      "phpmyadminPort": 9001
    },
    "tests": {
      "mappings": {
        "/wordpress-phpunit": "../../../../tests/phpunit"
      }
    }
  }
}
```

This is important to override because the `WordPress/wordpress-develop` repo also uses the `8889` port for its development environment. In this way the Gutenberg environment can run at the same time as the wordpress-develop environment.

Nevertheless, even though I overrode the `tests` port to be `8991`, I found that when I ran `npm run test:e2e` it would run the tests still on `http://localhost:8889`. **The result is that it clobbered the database of my wordpress-develop environment, leaving me with zero published posts and Twenty Twenty-One theme active.** The command fails as well with an error:

> Error: The plugin "gutenberg-test-plugin-disables-the-css-animations" isn't installed

This is expected given that the wordpress-develop environment is not the same as the Gutenberg test environment which has that plugin installed.

If I tried modifying the `.env` file in wordpress-develop to use a different port number, like 18889, then `npm run test:e2e` fails with:

> Error: Process from config.webServer exited early.

Also, this is expected because it is (erroneously) looking to use the test server at port `8889`, when according to my `.wp-env.override.json` it should be using port `8991`.

So this PR fixes the issue by loading up the current `WPConfig` in order to obtain the `envConfig.env.tests.port`. This is then passed to Playwright via the `WP_BASE_URL` environment variable if one is not already set.