### PR TITLE
Add layout flow to text content in media and text block

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -453,7 +453,10 @@ function MediaTextEdit( {
 	} );
 
 	const innerBlocksProps = useInnerBlocksProps(
-		{ className: 'wp-block-media-text__content' },
+		{
+			className:
+				'wp-block-media-text__content is-layout-flow wp-block-media-text__content-is-layout-flow',
+		},
 		{ template: TEMPLATE, allowedBlocks }
 	);
 


### PR DESCRIPTION
## What?
Closes: https://github.com/WordPress/gutenberg/issues/70264

<!-- In a few words, what is the PR actually doing? -->

## Why?
This PR is necessary to fix the text content layout issue in the media and text block


## How?
Added the following classes to the text content part `is-layout-flow` and `wp-block-media-text__content-is-layout-flow.`

## Testing Instructions
- Add a Media Text block
- Add some content
- Notice now there is no more extra padding on top or bottom when vertically aligning the content 

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="696" alt="image" src="https://github.com/user-attachments/assets/11330657-39d1-475d-8006-25097404c843" /> | <img width="734" alt="image" src="https://github.com/user-attachments/assets/8ac1e337-39ea-4dcb-9fc8-0369f23b180c" /> |
