### PR TITLE
Shows the default icon when a custom variation does not have an icon.

### DIFF
--- a/packages/block-editor/src/components/block-switcher/block-variation-transformations.js
+++ b/packages/block-editor/src/components/block-switcher/block-variation-transformations.js
@@ -6,6 +6,7 @@ import {
 	getBlockMenuDefaultClassName,
 	cloneBlock,
 	store as blocksStore,
+	getBlockType,
 } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import { useState, useMemo } from '@wordpress/element';
@@ -61,6 +62,7 @@ const BlockVariationTransformations = ( {
 } ) => {
 	const [ hoveredTransformItemName, setHoveredTransformItemName ] =
 		useState();
+	const blockIcon = getBlockType( blocks[ 0 ].name ).icon;
 	return (
 		<>
 			{ hoveredTransformItemName && (
@@ -76,7 +78,10 @@ const BlockVariationTransformations = ( {
 			{ transformations?.map( ( item ) => (
 				<BlockVariationTransformationItem
 					key={ item.name }
-					item={ item }
+					item={ {
+						icon: blockIcon,
+						...item,
+					} }
 					onSelect={ onSelect }
 					setHoveredTransformItemName={ setHoveredTransformItemName }
 				/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Shows the default icon when a custom variation does not have an icon.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Block variation icons are optional, so if they are not set the default icon will be displayed for consistency.
https://developer.wordpress.org/block-editor/reference-guides/block-api/block-variations/#defining-a-block-variation

Steps for the problem to occur
1. Paste the following code into `packages/block-library/src/paragraph/index.js` to add a custom variation without icons to the paragraph block.
```JS
registerBlockVariation( 'core/paragraph', {
	name: 'add-paragraph-custom-variation',
	title: __( 'Custom Variation' ),
	// icon: 'star-empty',
	isActive: ( { className } ) => {
		return className === 'custom-variation-flag-class';
	},
	attributes: {
		style: {
			border: {
				color: '#8c8c8c',
				width: '1px',
			},
		},
		className: 'custom-variation-flag-class',
	},
	scope: [ 'inserter', 'transform', 'block' ],
} );
```
2. Default icon not showing when converting from toolbar

## How?
Changed to display default icon when converting from toolbar

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

https://github.com/user-attachments/assets/2464ac6d-5be9-4abb-a940-2bcf0e855f2e

### After

https://github.com/user-attachments/assets/d9a24f91-3bd1-43fb-919b-06449d1e97b7

