### PR TITLE
`useDropZone`: Refactor docs to use the correct function syntax

### DIFF
--- a/packages/compose/src/hooks/use-drop-zone/README.md
+++ b/packages/compose/src/hooks/use-drop-zone/README.md
@@ -16,10 +16,10 @@ const WithWrapperDropZoneElement = () => {
 	const dropZoneRef = useDropZone(
 		{
 			dropZoneElement,
-			onDrop() => {
+			onDrop() {
 				console.log( 'Dropped within the drop zone.' );
 			},
-			onDragEnter() => {
+			onDragEnter() {
 				console.log( 'Dragging within the drop zone' );
 			}
 		}
@@ -37,10 +37,10 @@ const WithWrapperDropZoneElement = () => {
 const WithoutWrapperDropZoneElement = () => {
 	const dropZoneRef = useDropZone(
 		{
-			onDrop() => {
+			onDrop() {
 				console.log( 'Dropped within the drop zone.' );
 			},
-			onDragEnter() => {
+			onDragEnter() {
 				console.log( 'Dragging within the drop zone' );
 			}
 		}


### PR DESCRIPTION
## What, Why, and How?

This PR updates the README for `useDropZone` to fix incorrect function syntax in the example code. Previously, the example used an invalid arrow function syntax `onDrop() => {}`, which is not valid JavaScript.

Ref.
https://github.com/WordPress/gutenberg/blob/44dba3879e54f904a6c6ddf326b70ca5160e38ea/packages/compose/src/hooks/use-drop-zone/README.md?plain=1#L19-L21

<hr />

Found this while trying to implement `useDropZone`.
![bug](https://github.com/user-attachments/assets/6bb2b6c9-6117-4933-8fa9-84a6af08b61e)

<hr />

**_Incorrect Syntax:_**
```js
onDrop() => {
  console.log( 'Dropped within the drop zone.' );
}
```

**_Valid Alternatives:_**
```js
onDrop: () => {
  console.log( 'Dropped within the drop zone.' );
}
```

```js
onDrop() {
  console.log( 'Dropped within the drop zone.' );
}
```
