### PR TITLE
Adds transforms functionality to Post comments link and post comments number

### DIFF
--- a/packages/block-library/src/post-comments-count/index.js
+++ b/packages/block-library/src/post-comments-count/index.js
@@ -9,6 +9,7 @@ import { postCommentsCount as icon } from '@wordpress/icons';
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
+import transforms from './transforms';
 
 const { name } = metadata;
 export { metadata, name };
@@ -16,6 +17,7 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
+	transforms,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/post-comments-count/transforms.js
+++ b/packages/block-library/src/post-comments-count/transforms.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+const transforms = {
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/post-comments-link' ],
+			transform: () => {
+				return createBlock( 'core/post-comments-link' );
+			},
+		},
+	],
+};
+
+export default transforms;

--- a/packages/block-library/src/post-comments-count/transforms.js
+++ b/packages/block-library/src/post-comments-count/transforms.js
@@ -8,9 +8,9 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/post-comments-link' ],
-			transform: ( attributes ) => {
+			transform: ( { textAlign } ) => {
 				return createBlock( 'core/post-comments-link', {
-					textAlign: attributes.textAlign,
+					textAlign,
 				} );
 			},
 		},

--- a/packages/block-library/src/post-comments-count/transforms.js
+++ b/packages/block-library/src/post-comments-count/transforms.js
@@ -8,8 +8,10 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/post-comments-link' ],
-			transform: () => {
-				return createBlock( 'core/post-comments-link' );
+			transform: ( attributes ) => {
+				return createBlock( 'core/post-comments-link', {
+					textAlign: attributes.textAlign,
+				} );
 			},
 		},
 	],

--- a/packages/block-library/src/post-comments-link/index.js
+++ b/packages/block-library/src/post-comments-link/index.js
@@ -9,6 +9,7 @@ import { postCommentsCount as icon } from '@wordpress/icons';
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
+import transforms from './transforms';
 
 const { name } = metadata;
 export { metadata, name };
@@ -16,6 +17,7 @@ export { metadata, name };
 export const settings = {
 	edit,
 	icon,
+	transforms,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/post-comments-link/transforms.js
+++ b/packages/block-library/src/post-comments-link/transforms.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+const transforms = {
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/post-comments-count' ],
+			transform: () => {
+				return createBlock( 'core/post-comments-count' );
+			},
+		},
+	],
+};
+
+export default transforms;

--- a/packages/block-library/src/post-comments-link/transforms.js
+++ b/packages/block-library/src/post-comments-link/transforms.js
@@ -8,8 +8,10 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/post-comments-count' ],
-			transform: () => {
-				return createBlock( 'core/post-comments-count' );
+			transform: ( attributes ) => {
+				return createBlock( 'core/post-comments-count', {
+					textAlign: attributes.textAlign,
+				} );
 			},
 		},
 	],

--- a/packages/block-library/src/post-comments-link/transforms.js
+++ b/packages/block-library/src/post-comments-link/transforms.js
@@ -8,9 +8,9 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/post-comments-count' ],
-			transform: ( attributes ) => {
+			transform: ( { textAlign } ) => {
 				return createBlock( 'core/post-comments-count', {
-					textAlign: attributes.textAlign,
+					textAlign,
 				} );
 			},
 		},


### PR DESCRIPTION
## What?
Adds bidirectional transform support between Post Comments Link and Post Comments Number blocks.

Closes #53053

## Why?
The Post Comments Link and Post Comments Number blocks share similar functionality (both display comment-related information) but currently cannot be transformed into each other. This creates an inconsistent user experience where users need to delete one block and manually recreate the other to switch between displaying a comments link vs. comments count, losing all their styling and configuration in the process.


## Testing Instructions
1. Open a post or page in the block editor
2. Insert a Post Comments Link block
3. Click on the block toolbar's transform button (three horizontal dots with arrows)
4. Select "Post Comments Number" from the transform options
5. Verify the block transforms correctly and preserves all styling
6. Transform it back to Post Comments Link and verify styling is still preserved
7. Repeat the test starting with a Post Comments Number block

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/fd44094e-7d54-4195-97db-d979e911f37c




