### PR TITLE
iAPI: Make storePart argument optional in overloads

### DIFF
--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -179,14 +179,14 @@ export function store< T extends object >(
 // Overload for when types are passed via generics and they contain state.
 export function store< T extends { state: object } >(
 	namespace: string,
-	storePart: ConvertPromisesToGenerators< DeepPartialState< T > >,
+	storePart?: ConvertPromisesToGenerators< DeepPartialState< T > >,
 	options?: StoreOptions
 ): Prettify< ConvertGeneratorsToPromises< T > >;
 
 // Overload for when types are passed via generics and they don't contain state.
 export function store< T extends object >(
 	namespace: string,
-	storePart: ConvertPromisesToGenerators< T >,
+	storePart?: ConvertPromisesToGenerators< T >,
 	options?: StoreOptions
 ): Prettify< ConvertGeneratorsToPromises< T > >;
 

--- a/packages/interactivity/src/test/store.ts
+++ b/packages/interactivity/src/test/store.ts
@@ -305,7 +305,14 @@ describe( 'Interactivity API', () => {
 				actions.incrementValue( 1 ) satisfies void;
 
 				const { actions: actions2 } = store< { actions: Actions } >(
-					'storeWithoutState'
+					'storeWithoutState',
+					{
+						actions: {
+							incrementValue( n ) {
+								state.someValue += n;
+							},
+						},
+					}
 				);
 
 				actions2.incrementValue( 1 ) satisfies void;

--- a/packages/interactivity/src/test/store.ts
+++ b/packages/interactivity/src/test/store.ts
@@ -281,6 +281,29 @@ describe( 'Interactivity API', () => {
 					myStore.state.nonExistent satisfies {};
 				};
 			} );
+
+			describe( 'a typed store can be returned without adding a new store part', () => {
+				type State = {
+					someValue: number;
+				};
+				type Actions = {
+					incrementValue: ( n: number ) => void;
+				};
+
+				const { state, actions } = store< {
+					state: State;
+					actions: Actions;
+				} >( 'storeWithState' );
+
+				state.someValue satisfies number;
+				actions.incrementValue( 1 ) satisfies void;
+
+				const { actions: actions2 } = store< { actions: Actions } >(
+					'storeWithoutState'
+				);
+
+				actions2.incrementValue( 1 ) satisfies void;
+			} );
 		} );
 	} );
 } );

--- a/packages/interactivity/src/test/store.ts
+++ b/packages/interactivity/src/test/store.ts
@@ -293,7 +293,13 @@ describe( 'Interactivity API', () => {
 				const { state, actions } = store< {
 					state: State;
 					actions: Actions;
-				} >( 'storeWithState' );
+				} >( 'storeWithState', {
+					actions: {
+						incrementValue( n ) {
+							state.someValue += n;
+						},
+					},
+				} );
 
 				state.someValue satisfies number;
 				actions.incrementValue( 1 ) satisfies void;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes `store()` types to support typing it without passing a store part. E.g.,

```ts
import { store } from '@wordpress/interactivity';

const otherStore = store<OtherStoreTypes>( 'other-store' );
```

Props to @luisherranz.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Developers could want to use `store` to get the state and actions of an external store. In that case, they don't need to pass any store part. We forgot to include this case in the improvements we made in [#64577](https://github.com/WordPress/gutenberg/pull/64577). 


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Simply making `storePart` optional when passing the full types.

The PR includes TypeScript tests.
