### PR TITLE
Fix overflow of Highlighted white-space in Code Block

### DIFF
--- a/packages/block-library/src/code/edit.js
+++ b/packages/block-library/src/code/edit.js
@@ -21,7 +21,7 @@ export default function CodeEdit( {
 } ) {
 	const blockProps = useBlockProps();
 	const whiteSpaceStyle = SUPPORTS_BREAK_SPACES ? 'break-spaces' : 'pre-wrap';
-	
+
 	return (
 		<pre { ...blockProps }>
 			<RichText

--- a/packages/block-library/src/code/edit.js
+++ b/packages/block-library/src/code/edit.js
@@ -5,6 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 
+const SUPPORTS_BREAK_SPACES =
+	typeof CSS !== 'undefined' &&
+	// eslint-disable-next-line no-undef
+	CSS.supports &&
+	// eslint-disable-next-line no-undef
+	CSS.supports( 'white-space', 'break-spaces' );
+
 export default function CodeEdit( {
 	attributes,
 	setAttributes,
@@ -13,6 +20,8 @@ export default function CodeEdit( {
 	mergeBlocks,
 } ) {
 	const blockProps = useBlockProps();
+	const whiteSpaceStyle = SUPPORTS_BREAK_SPACES ? 'break-spaces' : 'pre-wrap';
+	
 	return (
 		<pre { ...blockProps }>
 			<RichText
@@ -29,6 +38,7 @@ export default function CodeEdit( {
 				__unstableOnSplitAtDoubleLineEnd={ () =>
 					insertBlocksAfter( createBlock( getDefaultBlockName() ) )
 				}
+				style={ { whiteSpace: whiteSpaceStyle } }
 			/>
 		</pre>
 	);

--- a/packages/block-library/src/code/style.scss
+++ b/packages/block-library/src/code/style.scss
@@ -14,5 +14,9 @@
 		direction: ltr;
 		text-align: initial;
 		/*!rtl:end:ignore*/
+
+		@supports (white-space: break-spaces) {
+            white-space: break-spaces;
+        }
 	}
 }

--- a/packages/block-library/src/code/style.scss
+++ b/packages/block-library/src/code/style.scss
@@ -16,7 +16,7 @@
 		/*!rtl:end:ignore*/
 
 		@supports (white-space: break-spaces) {
-            white-space: break-spaces;
-        }
+			white-space: break-spaces;
+		}
 	}
 }


### PR DESCRIPTION
## What?
Closes #69668 

Fixes the highlight issue for the frontend but does not seem to be working for editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, when text within a code block is highlighted and includes extra white space, it can overflow beyond the code box, which is not ideal. While this issue is uncommon, it negatively affects the overall UI experience when it does happen.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Changed the `white-space` property to `break-spaces` in the `style.scss` file.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Create a new Post
2. Insert a code block with extra white-spaces at the end of 1 line.
3. Highlight the code's background from the Block Controls Toolbar.
4. Verify that the highlight does not overflow the code block in the frontend.

## Screenshots

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1220" alt="Screenshot 2025-06-03 at 5 46 06 PM" src="https://github.com/user-attachments/assets/228daca9-607c-4aa3-9d79-a21e388e05ee" />|<img width="893" alt="Screenshot 2025-06-03 at 5 46 16 PM" src="https://github.com/user-attachments/assets/06140a98-818d-436a-b25d-b17af0aafb46" />|

## Note

While this solves the issue on the frontend, it is still not solved in the editor. Despite applying the css in `style.css`, it is overiden by inline styles of the **Code** block that adds `white-space: pre-wrap; min-width: 1px;` to the element:

<img width="286" alt="Screenshot 2025-06-03 at 5 49 22 PM" src="https://github.com/user-attachments/assets/793b1240-c284-42da-ba88-c28817d09a19" />

While I am searching the source of this inline style, any guidance would be helpful.

Thanks