### PR TITLE
iAPI: Fix duplicated nested regions

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/router-regions/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-regions/render.php
@@ -11,7 +11,7 @@
 <section>
 	<h2>Region 1</h2>
 	<div
-		data-wp-interactive='{"namespace": "router-regions"}'
+		data-wp-interactive="router-regions"
 		data-wp-router-region="region-1"
 	>
 		<p
@@ -55,7 +55,7 @@
 <section>
 	<h2>Region 2</h2>
 	<div
-		data-wp-interactive='{"namespace": "router-regions"}'
+		data-wp-interactive="router-regions"
 		data-wp-router-region="region-2"
 	>
 		<p
@@ -85,12 +85,24 @@
 			<section>
 				<h2>Nested region</h2>
 				<div
-					data-wp-interactive='{"namespace": "router-regions"}'
+					data-wp-interactive="router-regions"
 					data-wp-router-region="nested-region"
 				>
-					<p
-						data-testid="nested-region-ssr"
-					>content from page <?php echo $attributes['page']; ?></p>
+					<p data-testid="nested-region-ssr">
+						content from page <?php echo $attributes['page']; ?>
+					</p>
+
+					<ul
+						data-wp-interactive="router-regions"
+						data-wp-router-region="nested-region-2"
+					>
+						<template data-wp-each="state.items">
+							<li data-testid="nested-item" data-wp-key="context.item" data-wp-text="context.item"></li>	
+						</template>
+						<li data-testid="nested-item" data-wp-each-child>item 1</li>
+						<li data-testid="nested-item" data-wp-each-child>item 2</li>
+						<li data-testid="nested-item" data-wp-each-child>item 3</li>
+					</ul>
 				</div>
 			</section>
 		</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/router-regions/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-regions/render.php
@@ -51,7 +51,6 @@
 	>not hydrated</p>
 </div>
 
-
 <section>
 	<h2>Region 2</h2>
 	<div
@@ -74,7 +73,7 @@
 			data-wp-on--click="actions.counter.increment"
 		>NaN</button>
 
-		<div data-wp-ignore>
+		<div>
 			<div>
 				<p
 					data-testid="no-region-text-2"
@@ -92,10 +91,11 @@
 						content from page <?php echo $attributes['page']; ?>
 					</p>
 
-					<ul
-						data-wp-interactive="router-regions"
-						data-wp-router-region="nested-region-2"
-					>
+					<button data-testid="add-item" data-wp-on--click="actions.addItem">
+						Add item
+					</button>
+
+					<ul>
 						<template data-wp-each="state.items">
 							<li data-testid="nested-item" data-wp-key="context.item" data-wp-text="context.item"></li>	
 						</template>
@@ -108,3 +108,16 @@
 		</div>
 	</div>
 </section>
+
+<div data-wp-interactive="router-regions">
+	<div data-wp-router-region="invalid-region-1">
+		<p data-testid="invalid-region-text-1">
+			content from page <?php echo $attributes['page']; ?>
+		</p>
+	</div>
+	<div data-wp-interactive="router-regions" data-wp-router-region="invalid-region-2">
+		<p data-testid="invalid-region-text-2">
+			content from page <?php echo $attributes['page']; ?>
+		</p>
+	</div>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/router-regions/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-regions/view.js
@@ -45,5 +45,8 @@ const { state } = store( 'router-regions', {
 				}
 			},
 		},
+		addItem() {
+			state.items.push( `item ${ state.items.length + 1 }` );
+		},
 	},
 } );

--- a/packages/e2e-tests/plugins/interactive-blocks/router-regions/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-regions/view.js
@@ -14,6 +14,7 @@ const { state } = store( 'router-regions', {
 		counter: {
 			value: 0,
 		},
+		items: [ 'item 1', 'item 2', 'item 3' ],
 	},
 	actions: {
 		router: {

--- a/packages/interactivity-router/CHANGELOG.md
+++ b/packages/interactivity-router/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Prevents duplicating nested router regions after a client-side navigation. ([#70302](https://github.com/WordPress/gutenberg/pull/70302))
+
 ## 2.25.0 (2025-06-04)
 
 ## 2.24.0 (2025-05-22)

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -16,6 +16,9 @@ const {
 	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.'
 );
 
+const regionAttr = `data-${ directivePrefix }-router-region`;
+const interactiveAttr = `data-${ directivePrefix }-interactive`;
+
 interface NavigateOptions {
 	force?: boolean;
 	html?: string;
@@ -78,9 +81,10 @@ const fetchPage = async ( url: string, { html }: { html: string } ) => {
 const regionsToVdom: RegionsToVdom = async ( dom, { vdom } = {} ) => {
 	const regions = { body: undefined };
 	if ( navigationMode === 'regionBased' ) {
-		const attrName = `data-${ directivePrefix }-router-region`;
-		dom.querySelectorAll( `[${ attrName }]` ).forEach( ( region ) => {
-			const id = region.getAttribute( attrName );
+		dom.querySelectorAll(
+			`[${ interactiveAttr }][${ regionAttr }]:not([${ interactiveAttr }] [${ interactiveAttr }])`
+		).forEach( ( region ) => {
+			const id = region.getAttribute( regionAttr );
 			regions[ id ] = vdom?.has( region )
 				? vdom.get( region )
 				: toVdom( region );
@@ -94,13 +98,14 @@ const regionsToVdom: RegionsToVdom = async ( dom, { vdom } = {} ) => {
 // Render all interactive regions contained in the given page.
 const renderRegions = async ( page: Page ) => {
 	if ( navigationMode === 'regionBased' ) {
-		const attrName = `data-${ directivePrefix }-router-region`;
 		batch( () => {
 			populateServerData( page.initialData );
 			document
-				.querySelectorAll( `[${ attrName }]` )
+				.querySelectorAll(
+					`[${ interactiveAttr }][${ regionAttr }]:not([${ interactiveAttr }] [${ interactiveAttr }])`
+				)
 				.forEach( ( region ) => {
-					const id = region.getAttribute( attrName );
+					const id = region.getAttribute( regionAttr );
 					const fragment = getRegionRootFragment( region );
 					render( page.regions[ id ], fragment );
 				} );

--- a/test/e2e/specs/interactivity/router-regions.spec.ts
+++ b/test/e2e/specs/interactivity/router-regions.spec.ts
@@ -89,13 +89,18 @@ test.describe( 'Router regions', () => {
 
 	test( 'can be nested', async ( { page } ) => {
 		const nestedRegionSsr = page.getByTestId( 'nested-region-ssr' );
+		const innerContent = page.getByTestId( 'nested-item' );
+
 		await expect( nestedRegionSsr ).toHaveText( 'content from page 1' );
+		await expect( innerContent ).toHaveCount( 3 );
 
 		await page.getByTestId( 'next' ).click();
 		await expect( nestedRegionSsr ).toHaveText( 'content from page 2' );
+		await expect( innerContent ).toHaveCount( 3 );
 
 		await page.getByTestId( 'back' ).click();
 		await expect( nestedRegionSsr ).toHaveText( 'content from page 1' );
+		await expect( innerContent ).toHaveCount( 3 );
 	} );
 
 	test( 'Page title is updated 2', async ( { page } ) => {

--- a/test/e2e/specs/interactivity/router-regions.spec.ts
+++ b/test/e2e/specs/interactivity/router-regions.spec.ts
@@ -29,12 +29,10 @@ test.describe( 'Router regions', () => {
 		const region1Text = page.getByTestId( 'region-1-text' );
 		const region2Text = page.getByTestId( 'region-2-text' );
 		const noRegionText1 = page.getByTestId( 'no-region-text-1' );
-		const noRegionText2 = page.getByTestId( 'no-region-text-2' );
 
 		await expect( region1Text ).toHaveText( 'hydrated' );
 		await expect( region2Text ).toHaveText( 'hydrated' );
 		await expect( noRegionText1 ).toHaveText( 'not hydrated' );
-		await expect( noRegionText2 ).toHaveText( 'not hydrated' );
 	} );
 
 	test( 'should update after navigation', async ( { page } ) => {
@@ -97,10 +95,12 @@ test.describe( 'Router regions', () => {
 		await page.getByTestId( 'next' ).click();
 		await expect( nestedRegionSsr ).toHaveText( 'content from page 2' );
 		await expect( innerContent ).toHaveCount( 3 );
+		await page.getByTestId( 'add-item' ).click();
+		await expect( innerContent ).toHaveCount( 4 );
 
 		await page.getByTestId( 'back' ).click();
 		await expect( nestedRegionSsr ).toHaveText( 'content from page 1' );
-		await expect( innerContent ).toHaveCount( 3 );
+		await expect( innerContent ).toHaveCount( 4 );
 	} );
 
 	test( 'Page title is updated 2', async ( { page } ) => {
@@ -115,5 +115,33 @@ test.describe( 'Router regions', () => {
 		await expect( page ).toHaveTitle(
 			'router regions – page 1 – gutenberg'
 		);
+	} );
+
+	test( 'should not take into account regions that are not in the topmost `data-wp-interactive`.', async ( {
+		page,
+	} ) => {
+		const invalidRegionText1 = page.getByTestId( 'invalid-region-text-1' );
+		const invalidRegionText2 = page.getByTestId( 'invalid-region-text-2' );
+
+		await expect( invalidRegionText1 ).toHaveText( 'content from page 1' );
+		await expect( invalidRegionText2 ).toHaveText( 'content from page 1' );
+
+		await page.getByTestId( 'next' ).click();
+		// Waits until the navigation finishes so it doesn't read the text from
+		// the previous page.
+		await expect( page ).toHaveTitle(
+			'router regions – page 2 – gutenberg'
+		);
+		await expect( invalidRegionText1 ).toHaveText( 'content from page 1' );
+		await expect( invalidRegionText2 ).toHaveText( 'content from page 1' );
+
+		await page.getByTestId( 'back' ).click();
+		// Waits until the navigation finishes so it doesn't read the text from
+		// the previous page.
+		await expect( page ).toHaveTitle(
+			'router regions – page 1 – gutenberg'
+		);
+		await expect( invalidRegionText1 ).toHaveText( 'content from page 1' );
+		await expect( invalidRegionText2 ).toHaveText( 'content from page 1' );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Prevents duplicating nested router regions after a client-side navigation.

Nested regions may appear when an interactive block with a router region (e.g., the Query block) is placed within another interactive block with its router region (which could be another Query block instance). In this case, the nested router region is rendered twice: as part of the parent block's Preact application and as a separate Preact application, resulting in duplicated HTML.

Additionally, since a requirement of `data-wp-router-region` is that it must be in the top-most `data-wp-interactive` element, this PR ensures that it ignores all regions that do not meet this requirement.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Nested router regions should not be processed; only the top-most region should, as nested regions become part of the same Preact application.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Changing the selector to only take into account the regions that are not nested and that also include a top-most `data-wp-interactive` element.

The PR includes e2e tests for this bug fix.