### PR TITLE
iAPI: Fix captured errors in `withScope` generators

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/generator-scope/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/generator-scope/render.php
@@ -14,4 +14,5 @@
 	<button type="button" data-wp-on--click="callbacks.resolve" data-testid="resolve">Async resolve</button>
 	<button type="button" data-wp-on--click="callbacks.reject" data-testid="reject">Async reject</button>
 	<button type="button" data-wp-on--click="callbacks.capture" data-testid="capture">Async capture</button>
+	<button type="button" data-wp-on--click="callbacks.captureThrow" data-testid="captureThrow">Async captureThrow</button>
 </div>

--- a/packages/e2e-tests/plugins/interactive-blocks/generator-scope/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/generator-scope/render.php
@@ -13,4 +13,5 @@
 	<input readonly data-wp-bind--value="context.result" data-testid="result" />
 	<button type="button" data-wp-on--click="callbacks.resolve" data-testid="resolve">Async resolve</button>
 	<button type="button" data-wp-on--click="callbacks.reject" data-testid="reject">Async reject</button>
+	<button type="button" data-wp-on--click="callbacks.capture" data-testid="capture">Async capture</button>
 </div>

--- a/packages/e2e-tests/plugins/interactive-blocks/generator-scope/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/generator-scope/render.php
@@ -15,4 +15,5 @@
 	<button type="button" data-wp-on--click="callbacks.reject" data-testid="reject">Async reject</button>
 	<button type="button" data-wp-on--click="callbacks.capture" data-testid="capture">Async capture</button>
 	<button type="button" data-wp-on--click="callbacks.captureThrow" data-testid="captureThrow">Async captureThrow</button>
+	<button type="button" data-wp-on--click="callbacks.captureReturnReject" data-testid="captureReturnReject">Async captureReturnReject</button>
 </div>

--- a/packages/e2e-tests/plugins/interactive-blocks/generator-scope/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/generator-scope/view.js
@@ -19,5 +19,14 @@ store( 'test/generator-scope', {
 				getContext().result = err.toString();
 			}
 		},
+		*capture() {
+			let value = yield Promise.resolve( 1 );
+			try {
+				value = yield Promise.reject( 2 );
+			} catch ( e ) {
+				value = yield Promise.resolve( 3 );
+			}
+			getContext().result = value;
+		},
 	},
 } );

--- a/packages/e2e-tests/plugins/interactive-blocks/generator-scope/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/generator-scope/view.js
@@ -39,5 +39,15 @@ const { callbacks } = store( 'test/generator-scope', {
 				getContext().result = err.toString();
 			}
 		},
+		*returnReject() {
+			return Promise.reject( new Error( '🔚' ) );
+		},
+		*captureReturnReject() {
+			try {
+				yield callbacks.returnReject();
+			} catch ( err ) {
+				getContext().result = err.toString();
+			}
+		},
 	},
 } );

--- a/packages/e2e-tests/plugins/interactive-blocks/generator-scope/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/generator-scope/view.js
@@ -3,7 +3,7 @@
  */
 import { store, getContext } from '@wordpress/interactivity';
 
-store( 'test/generator-scope', {
+const { callbacks } = store( 'test/generator-scope', {
 	callbacks: {
 		*resolve() {
 			try {
@@ -27,6 +27,17 @@ store( 'test/generator-scope', {
 				value = yield Promise.resolve( 3 );
 			}
 			getContext().result = value;
+		},
+		*throw() {
+			const value = yield Promise.resolve( '🤯' );
+			throw new Error( value );
+		},
+		*captureThrow() {
+			try {
+				yield callbacks.throw();
+			} catch ( err ) {
+				getContext().result = err.toString();
+			}
 		},
 	},
 } );

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 -   Fix `store()` types to support typing it without passing a store part. ([#70296](https://github.com/WordPress/gutenberg/pull/70296))
+-   Fix captured errors in `withScope` for passed generators. ([#70303](https://github.com/WordPress/gutenberg/pull/70303))
 
 ## 6.24.0 (2025-05-22)
 

--- a/packages/interactivity/src/test/utils.ts
+++ b/packages/interactivity/src/test/utils.ts
@@ -1,7 +1,9 @@
 /**
  * Internal dependencies
  */
-import { kebabToCamelCase } from '../utils';
+import { kebabToCamelCase, withScope } from '../utils';
+import { setScope, getScope, resetScope, type Scope } from '../scopes';
+import { setNamespace, getNamespace, resetNamespace } from '../namespaces';
 
 describe( 'Interactivity API', () => {
 	describe( 'kebabToCamelCase', () => {
@@ -23,6 +25,258 @@ describe( 'Interactivity API', () => {
 			expect( kebabToCamelCase( '-my-item' ) ).toBe( 'myItem' );
 			expect( kebabToCamelCase( 'my-item-' ) ).toBe( 'myItem' );
 			expect( kebabToCamelCase( '-my-item-' ) ).toBe( 'myItem' );
+		} );
+	} );
+
+	describe( 'withScope', () => {
+		const previousNamespace = 'previousNamespace';
+		const previousScope = {
+			evaluate: () => {},
+			context: {},
+			serverContext: {},
+			ref: { current: null },
+			attributes: {},
+		};
+
+		const dummyNamespace = 'testNamespace';
+		const dummyScope = {
+			evaluate: () => {},
+			context: { test: 'normal' },
+			serverContext: { test: 'normal' },
+			ref: { current: null },
+			attributes: {},
+		};
+
+		// Helper to mimic the wrapper used in state-proxy.ts and store-proxy.ts.
+		const dummyScopeAndNS = ( callback: () => any ) => {
+			setScope( dummyScope );
+			setNamespace( dummyNamespace );
+			try {
+				return callback();
+			} finally {
+				resetNamespace();
+				resetScope();
+			}
+		};
+
+		beforeEach( () => {
+			setScope( previousScope );
+			setNamespace( previousNamespace );
+		} );
+
+		afterEach( () => {
+			resetNamespace();
+			resetScope();
+		} );
+
+		it( 'should return a function when passed a normal function', () => {
+			function normalFn( x: number ) {
+				return x + 1;
+			}
+			const wrapped = withScope( normalFn );
+			expect( typeof wrapped ).toBe( 'function' );
+		} );
+
+		it( 'should call the original normal function', () => {
+			let called = false;
+			function normalFn( x: number ) {
+				called = true;
+				return x * 2;
+			}
+			const wrapped = dummyScopeAndNS( () => withScope( normalFn ) );
+			const result = wrapped( 5 );
+
+			expect( result ).toBe( 10 );
+			expect( called ).toBe( true );
+			// After invocation, scope and namespace are reset.
+			expect( getScope() ).toBe( previousScope );
+			expect( getNamespace() ).toBe( previousNamespace );
+		} );
+
+		it( 'should set the scope and namespace and restore them afterwards', () => {
+			let called = false;
+			let scope: Scope;
+			let namespace: string;
+			function normalFn( x: number ) {
+				called = true;
+				scope = getScope();
+				namespace = getNamespace();
+				return x * 2;
+			}
+			const wrapped = dummyScopeAndNS( () => withScope( normalFn ) );
+			const result = wrapped( 5 );
+
+			expect( result ).toBe( 10 );
+			expect( called ).toBe( true );
+			expect( scope! ).toBe( dummyScope );
+			expect( namespace! ).toBe( dummyNamespace );
+			// After invocation, scope and namespace are reset.
+			expect( getScope() ).toBe( previousScope );
+			expect( getNamespace() ).toBe( previousNamespace );
+		} );
+
+		it( 'should return an async function when passed a generator function', async () => {
+			function* gen() {
+				yield Promise.resolve( 'value' );
+				return 'done';
+			}
+			const wrapped = dummyScopeAndNS( () => withScope( gen ) );
+			const resultPromise = wrapped();
+
+			expect( resultPromise ).toBeInstanceOf( Promise );
+
+			const result = await resultPromise;
+
+			expect( result ).toBe( 'done' );
+			// After invocation, scope and namespace are reset.
+			expect( getScope() ).toBe( previousScope );
+			expect( getNamespace() ).toBe( previousNamespace );
+		} );
+
+		it( 'should execute a generator function step by step maintaining scope and namespace', async () => {
+			const steps: Array< { scope: any; namespace: string } > = [];
+			function* gen() {
+				steps.push( { scope: getScope(), namespace: getNamespace() } );
+				const a = yield Promise.resolve( 1 );
+				steps.push( { scope: getScope(), namespace: getNamespace() } );
+				const b = yield Promise.resolve( a + 1 );
+				steps.push( { scope: getScope(), namespace: getNamespace() } );
+				return b * 2;
+			}
+			const callback = dummyScopeAndNS( () => withScope( gen ) );
+			const result = await callback();
+
+			expect( result ).toBe( 4 );
+			steps.forEach( ( step ) => {
+				expect( step.scope ).toBe( dummyScope );
+				expect( step.namespace ).toBe( dummyNamespace );
+			} );
+			expect( getScope() ).toBe( previousScope );
+			expect( getNamespace() ).toBe( previousNamespace );
+		} );
+
+		it( 'should yield correct values when promises resolve in generator functions', async () => {
+			function* gen() {
+				const a = yield Promise.resolve( 3 );
+				const b = yield Promise.resolve( a + 2 );
+				return b;
+			}
+			const wrapped = dummyScopeAndNS( () => withScope( gen ) );
+			const result = await wrapped();
+			expect( result ).toBe( 5 );
+			expect( getScope() ).toBe( previousScope );
+			expect( getNamespace() ).toBe( previousNamespace );
+		} );
+
+		it( 'should return the resolved value when a promise is returned in generator functions', async () => {
+			function* gen() {
+				const a = yield Promise.resolve( 3 );
+				return Promise.resolve( a + 2 );
+			}
+			const wrapped = dummyScopeAndNS( () => withScope( gen ) );
+			const result = await wrapped();
+			expect( result ).toBe( 5 );
+			expect( getScope() ).toBe( previousScope );
+			expect( getNamespace() ).toBe( previousNamespace );
+		} );
+
+		it( 'should accept arguments in generator functions like in normal functions', async () => {
+			function* gen( ...values: number[] ) {
+				let result = 0;
+				for ( const value of values ) {
+					result += yield Promise.resolve( value );
+				}
+				return result;
+			}
+			const wrapped = dummyScopeAndNS( () => withScope( gen ) );
+			const result = await wrapped( 1, 2, 3, 4 );
+			expect( result ).toBe( 10 );
+			expect( getScope() ).toBe( previousScope );
+			expect( getNamespace() ).toBe( previousNamespace );
+		} );
+
+		it( 'should propagate errors thrown inside a generator function', async () => {
+			function* gen() {
+				throw new Error( 'Test Error' );
+			}
+			const wrapped = dummyScopeAndNS( () => withScope( gen ) );
+			await expect( wrapped() ).rejects.toThrow( 'Test Error' );
+			expect( getScope() ).toBe( previousScope );
+			expect( getNamespace() ).toBe( previousNamespace );
+		} );
+
+		it( 'should propagate errors when a generator function returns a rejected promise', async () => {
+			function* gen() {
+				return Promise.reject( new Error( 'Test Error' ) );
+			}
+			const wrapped = dummyScopeAndNS( () => withScope( gen ) );
+			await expect( wrapped() ).rejects.toThrow( 'Test Error' );
+			expect( getScope() ).toBe( previousScope );
+			expect( getNamespace() ).toBe( previousNamespace );
+		} );
+
+		it( 'should handle captured errors within generator execution and resume correctly', async () => {
+			function* gen() {
+				let a: number;
+				try {
+					a = yield Promise.reject( new Error( 'CatchMe' ) );
+				} catch ( e ) {
+					a = 10;
+				}
+				const b = yield Promise.resolve( a + 5 );
+				return b;
+			}
+			const wrapped = dummyScopeAndNS( () => withScope( gen ) );
+			const result = await wrapped();
+			expect( result ).toBe( 15 );
+			expect( getScope() ).toBe( previousScope );
+			expect( getNamespace() ).toBe( previousNamespace );
+		} );
+
+		it( 'should maintaining scope and namespace when a generator captures an error', async () => {
+			const steps: Array< { scope: any; namespace: string } > = [];
+			function* gen() {
+				let a: number;
+				try {
+					steps.push( {
+						scope: getScope(),
+						namespace: getNamespace(),
+					} );
+					a = yield Promise.reject( new Error( 'CatchMe' ) );
+				} catch ( e ) {
+					steps.push( {
+						scope: getScope(),
+						namespace: getNamespace(),
+					} );
+					a = 10;
+				}
+				steps.push( { scope: getScope(), namespace: getNamespace() } );
+				const b = yield Promise.resolve( a + 5 );
+				steps.push( { scope: getScope(), namespace: getNamespace() } );
+				return b;
+			}
+			const callback = dummyScopeAndNS( () => withScope( gen ) );
+			const result = await callback();
+
+			expect( result ).toBe( 15 );
+			steps.forEach( ( step ) => {
+				expect( step.scope ).toBe( dummyScope );
+				expect( step.namespace ).toBe( dummyNamespace );
+			} );
+			expect( getScope() ).toBe( previousScope );
+			expect( getNamespace() ).toBe( previousNamespace );
+		} );
+
+		it( 'should handle rejected promises within a generator function and throw after yielding', async () => {
+			function* gen() {
+				const a = yield Promise.resolve( 2 );
+				yield Promise.reject( new Error( 'FinalReject' ) );
+				return a;
+			}
+			const wrapped = dummyScopeAndNS( () => withScope( gen ) );
+			await expect( wrapped() ).rejects.toThrow( 'FinalReject' );
+			expect( getScope() ).toBe( previousScope );
+			expect( getNamespace() ).toBe( previousNamespace );
 		} );
 	} );
 } );

--- a/packages/interactivity/src/test/utils.ts
+++ b/packages/interactivity/src/test/utils.ts
@@ -77,23 +77,7 @@ describe( 'Interactivity API', () => {
 			expect( typeof wrapped ).toBe( 'function' );
 		} );
 
-		it( 'should call the original normal function', () => {
-			let called = false;
-			function normalFn( x: number ) {
-				called = true;
-				return x * 2;
-			}
-			const wrapped = dummyScopeAndNS( () => withScope( normalFn ) );
-			const result = wrapped( 5 );
-
-			expect( result ).toBe( 10 );
-			expect( called ).toBe( true );
-			// After invocation, scope and namespace are reset.
-			expect( getScope() ).toBe( previousScope );
-			expect( getNamespace() ).toBe( previousNamespace );
-		} );
-
-		it( 'should set the scope and namespace and restore them afterwards', () => {
+		it( 'should call the original function, set the scope and namespace and restore them afterwards', () => {
 			let called = false;
 			let scope: Scope;
 			let namespace: string;
@@ -133,7 +117,7 @@ describe( 'Interactivity API', () => {
 			expect( getNamespace() ).toBe( previousNamespace );
 		} );
 
-		it( 'should execute a generator function step by step maintaining scope and namespace', async () => {
+		it( 'should execute a generator function step by step and yield the correct values, maintaining scope and namespace', async () => {
 			const steps: Array< { scope: any; namespace: string } > = [];
 			function* gen() {
 				steps.push( { scope: getScope(), namespace: getNamespace() } );
@@ -151,19 +135,6 @@ describe( 'Interactivity API', () => {
 				expect( step.scope ).toBe( dummyScope );
 				expect( step.namespace ).toBe( dummyNamespace );
 			} );
-			expect( getScope() ).toBe( previousScope );
-			expect( getNamespace() ).toBe( previousNamespace );
-		} );
-
-		it( 'should yield correct values when promises resolve in generator functions', async () => {
-			function* gen() {
-				const a = yield Promise.resolve( 3 );
-				const b = yield Promise.resolve( a + 2 );
-				return b;
-			}
-			const wrapped = dummyScopeAndNS( () => withScope( gen ) );
-			const result = await wrapped();
-			expect( result ).toBe( 5 );
 			expect( getScope() ).toBe( previousScope );
 			expect( getNamespace() ).toBe( previousNamespace );
 		} );
@@ -215,25 +186,7 @@ describe( 'Interactivity API', () => {
 			expect( getNamespace() ).toBe( previousNamespace );
 		} );
 
-		it( 'should handle captured errors within generator execution and resume correctly', async () => {
-			function* gen() {
-				let a: number;
-				try {
-					a = yield Promise.reject( new Error( 'CatchMe' ) );
-				} catch ( e ) {
-					a = 10;
-				}
-				const b = yield Promise.resolve( a + 5 );
-				return b;
-			}
-			const wrapped = dummyScopeAndNS( () => withScope( gen ) );
-			const result = await wrapped();
-			expect( result ).toBe( 15 );
-			expect( getScope() ).toBe( previousScope );
-			expect( getNamespace() ).toBe( previousNamespace );
-		} );
-
-		it( 'should maintaining scope and namespace when a generator captures an error', async () => {
+		it( 'hould handle captured errors within generator execution and resume correctly, maintaining scope and namespace', async () => {
 			const steps: Array< { scope: any; namespace: string } > = [];
 			function* gen() {
 				let a: number;

--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -170,7 +170,11 @@ export function withScope( func: ( ...args: unknown[] ) => unknown ) {
 					error = e;
 				}
 				if ( it.done ) {
-					break;
+					if ( error ) {
+						throw error;
+					} else {
+						break;
+					}
 				}
 			}
 

--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -150,11 +150,13 @@ export function withScope( func: ( ...args: unknown[] ) => unknown ) {
 			const gen = func( ...args ) as Generator;
 			let value: any;
 			let it: any;
+			let error: any;
 			while ( true ) {
 				setNamespace( ns );
 				setScope( scope );
 				try {
-					it = gen.next( value );
+					it = error ? gen.throw( error ) : gen.next( value );
+					error = undefined;
 				} finally {
 					resetScope();
 					resetNamespace();
@@ -163,14 +165,8 @@ export function withScope( func: ( ...args: unknown[] ) => unknown ) {
 				try {
 					value = await it.value;
 				} catch ( e ) {
-					setNamespace( ns );
-					setScope( scope );
-					gen.throw( e );
-				} finally {
-					resetScope();
-					resetNamespace();
+					error = e;
 				}
-
 				if ( it.done ) {
 					break;
 				}

--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -157,6 +157,8 @@ export function withScope( func: ( ...args: unknown[] ) => unknown ) {
 				try {
 					it = error ? gen.throw( error ) : gen.next( value );
 					error = undefined;
+				} catch ( e ) {
+					throw e;
 				} finally {
 					resetScope();
 					resetNamespace();

--- a/test/e2e/specs/interactivity/async-actions.spec.ts
+++ b/test/e2e/specs/interactivity/async-actions.spec.ts
@@ -48,4 +48,14 @@ test.describe( 'async actions', () => {
 		await page.getByTestId( 'captureThrow' ).click();
 		await expect( resultInput ).toHaveValue( 'Error: 🤯' );
 	} );
+
+	test( 'Promise generator callbacks should throw when rejected promises are returned', async ( {
+		page,
+	} ) => {
+		const resultInput = page.getByTestId( 'result' );
+		await expect( resultInput ).toHaveValue( '' );
+
+		await page.getByTestId( 'captureReturnReject' ).click();
+		await expect( resultInput ).toHaveValue( 'Error: 🔚' );
+	} );
 } );

--- a/test/e2e/specs/interactivity/async-actions.spec.ts
+++ b/test/e2e/specs/interactivity/async-actions.spec.ts
@@ -28,4 +28,14 @@ test.describe( 'async actions', () => {
 		await page.getByTestId( 'reject' ).click();
 		await expect( resultInput ).toHaveValue( 'Error: 😘' );
 	} );
+
+	test( 'Promise generator callbacks should yield the correct value after captured errors', async ( {
+		page,
+	} ) => {
+		const resultInput = page.getByTestId( 'result' );
+		await expect( resultInput ).toHaveValue( '' );
+
+		await page.getByTestId( 'capture' ).click();
+		await expect( resultInput ).toHaveValue( '3' );
+	} );
 } );

--- a/test/e2e/specs/interactivity/async-actions.spec.ts
+++ b/test/e2e/specs/interactivity/async-actions.spec.ts
@@ -38,4 +38,14 @@ test.describe( 'async actions', () => {
 		await page.getByTestId( 'capture' ).click();
 		await expect( resultInput ).toHaveValue( '3' );
 	} );
+
+	test( 'Promise generator callbacks should be able to throw errors', async ( {
+		page,
+	} ) => {
+		const resultInput = page.getByTestId( 'result' );
+		await expect( resultInput ).toHaveValue( '' );
+
+		await page.getByTestId( 'captureThrow' ).click();
+		await expect( resultInput ).toHaveValue( 'Error: 🤯' );
+	} );
 } );


### PR DESCRIPTION
## What?

This PR fixes an issue in the `withScope` function when it creates wrappers around async actions and callbacks defined in a store. In particular, the wrapper passes the wrong value to the generator in a `yield` operator that appears after an error is caught.

Also, other fixes related to errors have been addressed:
- The wrapper now throws errors when the underlying generator's `next` or `throw` functions are called and they throw an error. This is the equivalent of an uncaught error in the generator's code.
- The wrapper now throws when the returned value (i.e., the final one with `return`) is a rejected promise, similar to async functions.

## Why?

Async functions in the store should properly allow error handling.

## Testing Instructions

E2E and unit tests have been added.
