### PR TITLE
iAPI: Fix parsing of comments without siblings

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/tovdom/processing-instructions.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/tovdom/processing-instructions.js
@@ -1,5 +1,6 @@
 const processingInstructions = `
 	<div>
+		<div>Processing instruction is <?xpacket ##last-child## ?></div>
 		<?xpacket ##1## ?>
 		<div data-testid="it should keep this node between processing instructions">
 			Processing instructions inner node

--- a/packages/e2e-tests/plugins/interactive-blocks/tovdom/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/tovdom/render.php
@@ -12,6 +12,7 @@ $src_cdata    = $plugin_url . 'tovdom/cdata.js';
 
 <div data-wp-interactive="tovdom">
 	<div data-testid="it should delete comments">
+		<div>Comment is <!-- ##last-child## --></div>
 		<!-- ##1## -->
 		<div data-testid="it should keep this node between comments">
 			Comments inner node

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 -   Fix `store()` types to support typing it without passing a store part. ([#70296](https://github.com/WordPress/gutenberg/pull/70296))
 -   Fix captured errors in `withScope` for passed generators. ([#70303](https://github.com/WordPress/gutenberg/pull/70303))
+-   Fix parsing of HTML comments without siblings. ([#70304](https://github.com/WordPress/gutenberg/pull/70304))
 
 ## 6.24.0 (2025-05-22)
 

--- a/packages/interactivity/src/init.ts
+++ b/packages/interactivity/src/init.ts
@@ -25,7 +25,7 @@ export const getRegionRootFragment = ( region: Element ): ContainerNode => {
 };
 
 // Initial vDOM regions associated with its DOM element.
-export const initialVdom = new WeakMap< Element, ComponentChild[] >();
+export const initialVdom = new WeakMap< Element, ComponentChild >();
 
 // Initialize the router with the initial DOM.
 export const init = async () => {

--- a/packages/interactivity/src/test/vdom.ts
+++ b/packages/interactivity/src/test/vdom.ts
@@ -66,6 +66,9 @@ describe( 'toVdom', () => {
 			expect( toVdom( xml.querySelector( 'div' ) as Node ) ).toMatchVNode(
 				[ h( 'div', null, [ 'Test 1', 'CDATA content', 'Test 2' ] ) ]
 			);
+			expect( xml.querySelector( 'div' )?.outerHTML ).toBe(
+				'<div>Test 1CDATA contentTest 2</div>'
+			);
 		} );
 
 		it( 'should convert CDATA sections to text nodes and continue to their parent', () => {
@@ -81,6 +84,9 @@ describe( 'toVdom', () => {
 						h( 'div', null, [ 'Test 2' ] ),
 					] ),
 				]
+			);
+			expect( xml.querySelector( 'div' )?.outerHTML ).toBe(
+				'<div><div>Test 1CDATA content</div><div>Test 2</div></div>'
 			);
 		} );
 

--- a/packages/interactivity/src/test/vdom.ts
+++ b/packages/interactivity/src/test/vdom.ts
@@ -38,23 +38,21 @@ describe( 'toVdom', () => {
 	describe( 'Basic node types', () => {
 		it( 'should convert text nodes to strings', () => {
 			const textNode = createElementFromHTML( 'Hello World' );
-			expect( toVdom( textNode ) ).toMatchVNode( [ 'Hello World' ] );
+			expect( toVdom( textNode ) ).toMatchVNode( 'Hello World' );
 		} );
 
 		it( 'should convert element nodes to vDOM elements', () => {
 			const element = createElementFromHTML( '<div></div>' );
-			expect( toVdom( element ) ).toMatchVNode( [
-				h( 'div', null, [] ),
-			] );
+			expect( toVdom( element ) ).toMatchVNode( h( 'div', null, [] ) );
 		} );
 
 		it( 'should handle nested elements', () => {
 			const element = createElementFromHTML(
 				'<div><span>Test 1</span>Test 2</div>'
 			);
-			expect( toVdom( element ) ).toMatchVNode( [
-				h( 'div', null, [ h( 'span', null, [ 'Test 1' ] ), 'Test 2' ] ),
-			] );
+			expect( toVdom( element ) ).toMatchVNode(
+				h( 'div', null, [ h( 'span', null, [ 'Test 1' ] ), 'Test 2' ] )
+			);
 		} );
 
 		it( 'should convert CDATA sections to text nodes and continue to their siblings', () => {
@@ -64,7 +62,7 @@ describe( 'toVdom', () => {
 				'application/xml'
 			);
 			expect( toVdom( xml.querySelector( 'div' ) as Node ) ).toMatchVNode(
-				[ h( 'div', null, [ 'Test 1', 'CDATA content', 'Test 2' ] ) ]
+				h( 'div', null, [ 'Test 1', 'CDATA content', 'Test 2' ] )
 			);
 			expect( xml.querySelector( 'div' )?.outerHTML ).toBe(
 				'<div>Test 1CDATA contentTest 2</div>'
@@ -78,12 +76,10 @@ describe( 'toVdom', () => {
 				'application/xml'
 			);
 			expect( toVdom( xml.querySelector( 'div' ) as Node ) ).toMatchVNode(
-				[
-					h( 'div', null, [
-						h( 'div', null, [ 'Test 1', 'CDATA content' ] ),
-						h( 'div', null, [ 'Test 2' ] ),
-					] ),
-				]
+				h( 'div', null, [
+					h( 'div', null, [ 'Test 1', 'CDATA content' ] ),
+					h( 'div', null, [ 'Test 2' ] ),
+				] )
 			);
 			expect( xml.querySelector( 'div' )?.outerHTML ).toBe(
 				'<div><div>Test 1CDATA content</div><div>Test 2</div></div>'
@@ -94,9 +90,9 @@ describe( 'toVdom', () => {
 			const container = createElementFromHTML(
 				'<div>Test 1<!-- This is a comment --><div>Test 2</div></div>'
 			);
-			expect( toVdom( container ) ).toMatchVNode( [
-				h( 'div', null, [ 'Test 1', h( 'div', null, [ 'Test 2' ] ) ] ),
-			] );
+			expect( toVdom( container ) ).toMatchVNode(
+				h( 'div', null, [ 'Test 1', h( 'div', null, [ 'Test 2' ] ) ] )
+			);
 			expect( container.outerHTML ).toBe(
 				'<div>Test 1<div>Test 2</div></div>'
 			);
@@ -106,12 +102,12 @@ describe( 'toVdom', () => {
 			const container = createElementFromHTML(
 				'<div><div>Test 1<!-- This is a comment --><!-- This is another comment --></div><div>Test 2</div></div>'
 			);
-			expect( toVdom( container ) ).toMatchVNode( [
+			expect( toVdom( container ) ).toMatchVNode(
 				h( 'div', null, [
 					h( 'div', null, [ 'Test 1' ] ),
 					h( 'div', null, [ 'Test 2' ] ),
-				] ),
-			] );
+				] )
+			);
 			expect( container.outerHTML ).toBe(
 				'<div><div>Test 1</div><div>Test 2</div></div>'
 			);
@@ -121,12 +117,12 @@ describe( 'toVdom', () => {
 			const container = createElementFromHTML(
 				'<div><div>Test 1<!-- This is a comment --></div><div>Test 2</div></div>'
 			);
-			expect( toVdom( container ) ).toMatchVNode( [
+			expect( toVdom( container ) ).toMatchVNode(
 				h( 'div', null, [
 					h( 'div', null, [ 'Test 1' ] ),
 					h( 'div', null, [ 'Test 2' ] ),
-				] ),
-			] );
+				] )
+			);
 			expect( container.outerHTML ).toBe(
 				'<div><div>Test 1</div><div>Test 2</div></div>'
 			);
@@ -139,7 +135,7 @@ describe( 'toVdom', () => {
 				'application/xml'
 			);
 			expect( toVdom( xml.querySelector( 'div' ) as Node ) ).toMatchVNode(
-				[ h( 'div', null, [] ) ]
+				h( 'div', null, [] )
 			);
 			expect( xml.querySelector( 'div' )?.outerHTML ).toBe( '<div/>' );
 		} );
@@ -148,32 +144,32 @@ describe( 'toVdom', () => {
 			const template = createElementFromHTML(
 				`<template>Test</template>`
 			);
-			expect( toVdom( template ) ).toMatchVNode( [
+			expect( toVdom( template ) ).toMatchVNode(
 				h(
 					'template' as any,
 					{
-						content: [ [ 'Test' ] ],
+						content: [ 'Test' ],
 					},
 					[]
-				),
-			] );
+				)
+			);
 		} );
 
 		it( 'should remove comment nodes inside templates', () => {
 			const container = createElementFromHTML(
 				'<div><!-- This is a comment --><template><div>Test 1<!-- This is a comment --></div></template></div>'
 			);
-			expect( toVdom( container ) ).toMatchVNode( [
+			expect( toVdom( container ) ).toMatchVNode(
 				h( 'div', null, [
 					h(
 						'template' as any,
 						{
-							content: [ [ h( 'div', null, [ 'Test 1' ] ) ] ],
+							content: [ h( 'div', null, [ 'Test 1' ] ) ],
 						},
 						[]
 					),
-				] ),
-			] );
+				] )
+			);
 			expect( container.outerHTML ).toBe(
 				'<div><template><div>Test 1</div></template></div>'
 			);
@@ -185,7 +181,7 @@ describe( 'toVdom', () => {
 			const element = createElementFromHTML(
 				'<div id="test-id" class="test-class" data-test="test-value"></div>'
 			);
-			expect( toVdom( element ) ).toMatchVNode( [
+			expect( toVdom( element ) ).toMatchVNode(
 				h(
 					'div' as any,
 					{
@@ -194,17 +190,17 @@ describe( 'toVdom', () => {
 						'data-test': 'test-value',
 					},
 					[]
-				),
-			] );
+				)
+			);
 		} );
 
 		it( 'should skip ref attributes', () => {
 			const element = createElementFromHTML(
 				'<div id="test-id" ref="some-ref"></div>'
 			);
-			expect( toVdom( element ) ).toMatchVNode( [
-				h( 'div', { id: 'test-id' }, [] ),
-			] );
+			expect( toVdom( element ) ).toMatchVNode(
+				h( 'div', { id: 'test-id' }, [] )
+			);
 		} );
 
 		it( 'should warn about malformed directive names', () => {
@@ -229,7 +225,7 @@ describe( 'toVdom', () => {
 			const element = createElementFromHTML(
 				`<div data-wp-test-one data-wp-test-two="test value"></div>`
 			);
-			expect( toVdom( element ) ).toMatchVNode( [
+			expect( toVdom( element ) ).toMatchVNode(
 				h(
 					'div' as any,
 					{
@@ -253,15 +249,15 @@ describe( 'toVdom', () => {
 						},
 					},
 					[]
-				),
-			] );
+				)
+			);
 		} );
 
 		it( 'should parse JSON values in directives', () => {
 			const element = createElementFromHTML(
 				`<div data-wp-test='{"key": "value"}'></div>`
 			);
-			expect( toVdom( element ) ).toMatchVNode( [
+			expect( toVdom( element ) ).toMatchVNode(
 				h(
 					'div' as any,
 					{
@@ -277,15 +273,15 @@ describe( 'toVdom', () => {
 						},
 					},
 					[]
-				),
-			] );
+				)
+			);
 		} );
 
 		it( 'should handle malformed JSON and keep as string', () => {
 			const element = createElementFromHTML(
 				`<div data-wp-test="{malformed: json}"></div>`
 			);
-			expect( toVdom( element ) ).toMatchVNode( [
+			expect( toVdom( element ) ).toMatchVNode(
 				h(
 					'div' as any,
 					{
@@ -301,15 +297,15 @@ describe( 'toVdom', () => {
 						},
 					},
 					[]
-				),
-			] );
+				)
+			);
 		} );
 
 		it( 'should process directive suffixes', () => {
 			const element = createElementFromHTML(
 				`<div data-wp-test--one="test value 1" data-wp-test--two="test value 2"></div>`
 			);
-			expect( toVdom( element ) ).toMatchVNode( [
+			expect( toVdom( element ) ).toMatchVNode(
 				h(
 					'div' as any,
 					{
@@ -331,15 +327,15 @@ describe( 'toVdom', () => {
 						},
 					},
 					[]
-				),
-			] );
+				)
+			);
 		} );
 
 		it( 'should preserve values that JSON would parse but are not objects', () => {
 			const element = createElementFromHTML(
 				`<div data-wp-test--one='true' data-wp-test--two='"test value"'></div>`
 			);
-			expect( toVdom( element ) ).toMatchVNode( [
+			expect( toVdom( element ) ).toMatchVNode(
 				h(
 					'div' as any,
 					{
@@ -361,15 +357,15 @@ describe( 'toVdom', () => {
 						},
 					},
 					[]
-				),
-			] );
+				)
+			);
 		} );
 
 		it( 'should handle directives in template elements', () => {
 			const template = createElementFromHTML(
 				`<template data-wp-test="test value"><div></div></template>`
 			);
-			expect( toVdom( template ) ).toMatchVNode( [
+			expect( toVdom( template ) ).toMatchVNode(
 				h(
 					'template' as any,
 					{
@@ -383,45 +379,43 @@ describe( 'toVdom', () => {
 								},
 							],
 						},
-						content: [ [ h( 'div' as any, null, [] ) ] ],
+						content: [ h( 'div' as any, null, [] ) ],
 					},
 					[]
-				),
-			] );
+				)
+			);
 		} );
 
 		it( 'should handle directives inside template elements', () => {
 			const template = createElementFromHTML(
 				`<template><div data-wp-test="test value"></div></template>`
 			);
-			expect( toVdom( template ) ).toMatchVNode( [
+			expect( toVdom( template ) ).toMatchVNode(
 				h(
 					'template' as any,
 					{
 						content: [
-							[
-								h(
-									'div' as any,
-									{
-										'data-wp-test': 'test value',
-										__directives: {
-											test: [
-												{
-													namespace: null,
-													value: 'test value',
-													suffix: null,
-												},
-											],
-										},
+							h(
+								'div' as any,
+								{
+									'data-wp-test': 'test value',
+									__directives: {
+										test: [
+											{
+												namespace: null,
+												value: 'test value',
+												suffix: null,
+											},
+										],
 									},
-									[]
-								),
-							],
+								},
+								[]
+							),
 						],
 					},
 					[]
-				),
-			] );
+				)
+			);
 		} );
 	} );
 
@@ -430,7 +424,7 @@ describe( 'toVdom', () => {
 			const element = createElementFromHTML(
 				`<div data-wp-test="my-namespace::test value"></div>`
 			);
-			expect( toVdom( element ) ).toMatchVNode( [
+			expect( toVdom( element ) ).toMatchVNode(
 				h(
 					'div' as any,
 					{
@@ -446,15 +440,15 @@ describe( 'toVdom', () => {
 						},
 					},
 					[]
-				),
-			] );
+				)
+			);
 		} );
 
 		it( 'should parse JSON values with a custom namespace', () => {
 			const element = createElementFromHTML(
 				`<div data-wp-test='my-namespace::{"key": "value"}'></div>`
 			);
-			expect( toVdom( element ) ).toMatchVNode( [
+			expect( toVdom( element ) ).toMatchVNode(
 				h(
 					'div' as any,
 					{
@@ -470,15 +464,15 @@ describe( 'toVdom', () => {
 						},
 					},
 					[]
-				),
-			] );
+				)
+			);
 		} );
 
 		it( 'should use the default namespace provided in the same element', () => {
 			const element = createElementFromHTML(
 				`<div data-wp-interactive="my-namespace" data-wp-test="test value"></div>`
 			);
-			expect( toVdom( element ) ).toMatchVNode( [
+			expect( toVdom( element ) ).toMatchVNode(
 				h(
 					'div' as any,
 					{
@@ -495,15 +489,15 @@ describe( 'toVdom', () => {
 						},
 					},
 					[]
-				),
-			] );
+				)
+			);
 		} );
 
 		it( 'should override the default namespace provided in a parent element', () => {
 			const element = createElementFromHTML(
 				`<div data-wp-interactive="parent-namespace"><div data-wp-interactive="my-namespace" data-wp-test="test value"></div></div>`
 			);
-			expect( toVdom( element ) ).toMatchVNode( [
+			expect( toVdom( element ) ).toMatchVNode(
 				h(
 					'div' as any,
 					{
@@ -528,15 +522,15 @@ describe( 'toVdom', () => {
 							[]
 						),
 					]
-				),
-			] );
+				)
+			);
 		} );
 
 		it( 'should handle default namespaces provided in the a JSON object', () => {
 			const element = createElementFromHTML(
 				`<div data-wp-interactive='{ "namespace": "my-namespace" }' data-wp-test="test value"></div>`
 			);
-			expect( toVdom( element ) ).toMatchVNode( [
+			expect( toVdom( element ) ).toMatchVNode(
 				h(
 					'div' as any,
 					{
@@ -554,15 +548,15 @@ describe( 'toVdom', () => {
 						},
 					},
 					[]
-				),
-			] );
+				)
+			);
 		} );
 
 		it( 'should recover the parent default namespace after a closing element', () => {
 			const element = createElementFromHTML(
 				`<div data-wp-interactive="parent-namespace"><div data-wp-interactive="child-namespace"></div><div data-wp-test="test value"></div></div>`
 			);
-			expect( toVdom( element ) ).toMatchVNode( [
+			expect( toVdom( element ) ).toMatchVNode(
 				h(
 					'div' as any,
 					{
@@ -593,15 +587,15 @@ describe( 'toVdom', () => {
 							[]
 						),
 					]
-				),
-			] );
+				)
+			);
 		} );
 
 		it( 'should reset the default namespace after that last closing element', () => {
 			const element = createElementFromHTML(
 				`<div><div data-wp-interactive="my-namespace"></div><div data-wp-test="test value"></div></div>`
 			);
-			expect( toVdom( element ) ).toMatchVNode( [
+			expect( toVdom( element ) ).toMatchVNode(
 				h( 'div' as any, null, [
 					h(
 						'div' as any,
@@ -626,15 +620,15 @@ describe( 'toVdom', () => {
 						},
 						[]
 					),
-				] ),
-			] );
+				] )
+			);
 		} );
 
 		it( 'should override the default namespace with a custom one in the same element', () => {
 			const element = createElementFromHTML(
 				`<div data-wp-interactive="my-namespace" data-wp-test="custom-namespace::test value"></div>`
 			);
-			expect( toVdom( element ) ).toMatchVNode( [
+			expect( toVdom( element ) ).toMatchVNode(
 				h(
 					'div' as any,
 					{
@@ -651,15 +645,15 @@ describe( 'toVdom', () => {
 						},
 					},
 					[]
-				),
-			] );
+				)
+			);
 		} );
 
 		it( 'should override the default namespace with a custom one in a child element', () => {
 			const element = createElementFromHTML(
 				`<div data-wp-interactive="my-namespace"><div data-wp-test="custom-namespace::test value"></div></div>`
 			);
-			expect( toVdom( element ) ).toMatchVNode( [
+			expect( toVdom( element ) ).toMatchVNode(
 				h(
 					'div' as any,
 					{
@@ -683,50 +677,48 @@ describe( 'toVdom', () => {
 							[]
 						),
 					]
-				),
-			] );
+				)
+			);
 		} );
 
 		it( 'should pass down namespaces defined in template elements', () => {
 			const template = createElementFromHTML(
 				`<template data-wp-interactive="my-namespace"><div data-wp-test="test value"></div></template>`
 			);
-			expect( toVdom( template ) ).toMatchVNode( [
+			expect( toVdom( template ) ).toMatchVNode(
 				h(
 					'template' as any,
 					{
 						'data-wp-interactive': 'my-namespace',
 						content: [
-							[
-								h(
-									'div' as any,
-									{
-										'data-wp-test': 'test value',
-										__directives: {
-											test: [
-												{
-													namespace: 'my-namespace',
-													value: 'test value',
-													suffix: null,
-												},
-											],
-										},
+							h(
+								'div' as any,
+								{
+									'data-wp-test': 'test value',
+									__directives: {
+										test: [
+											{
+												namespace: 'my-namespace',
+												value: 'test value',
+												suffix: null,
+											},
+										],
 									},
-									[]
-								),
-							],
+								},
+								[]
+							),
 						],
 					},
 					[]
-				),
-			] );
+				)
+			);
 		} );
 
 		it( 'should pass down namespaces defined in template parents', () => {
 			const template = createElementFromHTML(
 				`<div data-wp-interactive="my-namespace"><template><div data-wp-test="test value"></div></template></div>`
 			);
-			expect( toVdom( template ) ).toMatchVNode( [
+			expect( toVdom( template ) ).toMatchVNode(
 				h(
 					'div' as any,
 					{
@@ -737,32 +729,30 @@ describe( 'toVdom', () => {
 							'template' as any,
 							{
 								content: [
-									[
-										h(
-											'div' as any,
-											{
-												'data-wp-test': 'test value',
-												__directives: {
-													test: [
-														{
-															namespace:
-																'my-namespace',
-															value: 'test value',
-															suffix: null,
-														},
-													],
-												},
+									h(
+										'div' as any,
+										{
+											'data-wp-test': 'test value',
+											__directives: {
+												test: [
+													{
+														namespace:
+															'my-namespace',
+														value: 'test value',
+														suffix: null,
+													},
+												],
 											},
-											[]
-										),
-									],
+										},
+										[]
+									),
 								],
 							},
 							[]
 						),
 					]
-				),
-			] );
+				)
+			);
 		} );
 	} );
 

--- a/packages/interactivity/src/test/vdom.ts
+++ b/packages/interactivity/src/test/vdom.ts
@@ -1,0 +1,747 @@
+/**
+ * External dependencies
+ */
+import { h } from 'preact';
+import type { VNode } from 'preact';
+
+/**
+ * Internal dependencies
+ */
+import { toVdom, hydratedIslands } from '../vdom';
+
+function createElementFromHTML( html: string ): HTMLElement {
+	const div = document.createElement( 'div' );
+	div.innerHTML = html.trim();
+	return div.firstChild as HTMLElement;
+}
+
+const normalizeVNode = ( obj: object ) =>
+	JSON.stringify( obj ).replace( /"__v":\d+/g, '"__v":null' );
+
+expect.extend( {
+	toMatchVNode( received: VNode, expected: VNode ) {
+		const pass = normalizeVNode( received ) === normalizeVNode( expected );
+		return {
+			pass,
+			message: () =>
+				pass ? "Expected VNodes don't match" : 'Expected VNode match',
+		};
+	},
+} );
+
+describe( 'toVdom', () => {
+	beforeEach( () => {
+		// @ts-ignore - Accessing private property for testing.
+		hydratedIslands._values = new WeakMap();
+	} );
+
+	describe( 'Basic node types', () => {
+		it( 'should convert text nodes to strings', () => {
+			const textNode = createElementFromHTML( 'Hello World' );
+			expect( toVdom( textNode ) ).toMatchVNode( [ 'Hello World' ] );
+		} );
+
+		it( 'should convert element nodes to vDOM elements', () => {
+			const element = createElementFromHTML( '<div></div>' );
+			expect( toVdom( element ) ).toMatchVNode( [
+				h( 'div', null, [] ),
+			] );
+		} );
+
+		it( 'should handle nested elements', () => {
+			const element = createElementFromHTML(
+				'<div><span>Test 1</span>Test 2</div>'
+			);
+			expect( toVdom( element ) ).toMatchVNode( [
+				h( 'div', null, [ h( 'span', null, [ 'Test 1' ] ), 'Test 2' ] ),
+			] );
+		} );
+
+		it( 'should convert CDATA sections to text nodes and continue to their siblings', () => {
+			const parser = new DOMParser();
+			const xml = parser.parseFromString(
+				'<div>Test 1<![CDATA[CDATA content]]>Test 2</div>',
+				'application/xml'
+			);
+			expect( toVdom( xml.querySelector( 'div' ) as Node ) ).toMatchVNode(
+				[ h( 'div', null, [ 'Test 1', 'CDATA content', 'Test 2' ] ) ]
+			);
+		} );
+
+		it( 'should convert CDATA sections to text nodes and continue to their parent', () => {
+			const parser = new DOMParser();
+			const xml = parser.parseFromString(
+				'<div><div>Test 1<![CDATA[CDATA content]]></div><div>Test 2</div></div>',
+				'application/xml'
+			);
+			expect( toVdom( xml.querySelector( 'div' ) as Node ) ).toMatchVNode(
+				[
+					h( 'div', null, [
+						h( 'div', null, [ 'Test 1', 'CDATA content' ] ),
+						h( 'div', null, [ 'Test 2' ] ),
+					] ),
+				]
+			);
+		} );
+
+		it( 'should remove comment nodes and continue to their siblings', () => {
+			const container = createElementFromHTML(
+				'<div>Test 1<!-- This is a comment --><div>Test 2</div></div>'
+			);
+			expect( toVdom( container ) ).toMatchVNode( [
+				h( 'div', null, [ 'Test 1', h( 'div', null, [ 'Test 2' ] ) ] ),
+			] );
+			expect( container.outerHTML ).toBe(
+				'<div>Test 1<div>Test 2</div></div>'
+			);
+		} );
+
+		it( 'should remove comment nodes and continue to their parents', () => {
+			const container = createElementFromHTML(
+				'<div><div>Test 1<!-- This is a comment --></div><div>Test 2</div></div>'
+			);
+			expect( toVdom( container ) ).toMatchVNode( [
+				h( 'div', null, [
+					h( 'div', null, [ 'Test 1' ] ),
+					h( 'div', null, [ 'Test 2' ] ),
+				] ),
+			] );
+			expect( container.outerHTML ).toBe(
+				'<div><div>Test 1</div><div>Test 2</div></div>'
+			);
+		} );
+
+		it( 'should remove processing instruction nodes', () => {
+			const parser = new DOMParser();
+			const xml = parser.parseFromString(
+				'<div><?xml-stylesheet type="text/css" href="style.css"?></div>',
+				'application/xml'
+			);
+			expect( toVdom( xml.querySelector( 'div' ) as Node ) ).toMatchVNode(
+				[ h( 'div', null, [] ) ]
+			);
+			expect( xml.querySelector( 'div' )?.outerHTML ).toBe( '<div/>' );
+		} );
+
+		it( 'should handle template elements', () => {
+			const template = createElementFromHTML(
+				`<template>Test</template>`
+			);
+			expect( toVdom( template ) ).toMatchVNode( [
+				h(
+					'template' as any,
+					{
+						content: [ [ 'Test' ] ],
+					},
+					[]
+				),
+			] );
+		} );
+	} );
+
+	describe( 'Attribute handling', () => {
+		it( 'should properly parse regular HTML attributes', () => {
+			const element = createElementFromHTML(
+				'<div id="test-id" class="test-class" data-test="test-value"></div>'
+			);
+			expect( toVdom( element ) ).toMatchVNode( [
+				h(
+					'div' as any,
+					{
+						id: 'test-id',
+						class: 'test-class',
+						'data-test': 'test-value',
+					},
+					[]
+				),
+			] );
+		} );
+
+		it( 'should skip ref attributes', () => {
+			const element = createElementFromHTML(
+				'<div id="test-id" ref="some-ref"></div>'
+			);
+			expect( toVdom( element ) ).toMatchVNode( [
+				h( 'div', { id: 'test-id' }, [] ),
+			] );
+		} );
+
+		it( 'should warn about malformed directive names', () => {
+			const console = global.console;
+			const originalWarn = console.warn;
+			console.warn = jest.fn();
+
+			toVdom(
+				createElementFromHTML( `<div data-wp-invalid[name]></div>` )
+			);
+
+			expect( console.warn ).toHaveBeenCalledWith(
+				`Found malformed directive name: data-wp-invalid[name].`
+			);
+
+			console.warn = originalWarn;
+		} );
+	} );
+
+	describe( 'Directive processing', () => {
+		it( 'should process simple directives', () => {
+			const element = createElementFromHTML(
+				`<div data-wp-test-one data-wp-test-two="test value"></div>`
+			);
+			expect( toVdom( element ) ).toMatchVNode( [
+				h(
+					'div' as any,
+					{
+						'data-wp-test-one': '',
+						'data-wp-test-two': 'test value',
+						__directives: {
+							'test-one': [
+								{
+									namespace: null,
+									value: '',
+									suffix: null,
+								},
+							],
+							'test-two': [
+								{
+									namespace: null,
+									value: 'test value',
+									suffix: null,
+								},
+							],
+						},
+					},
+					[]
+				),
+			] );
+		} );
+
+		it( 'should parse JSON values in directives', () => {
+			const element = createElementFromHTML(
+				`<div data-wp-test='{"key": "value"}'></div>`
+			);
+			expect( toVdom( element ) ).toMatchVNode( [
+				h(
+					'div' as any,
+					{
+						'data-wp-test': '{"key": "value"}',
+						__directives: {
+							test: [
+								{
+									namespace: null,
+									value: { key: 'value' },
+									suffix: null,
+								},
+							],
+						},
+					},
+					[]
+				),
+			] );
+		} );
+
+		it( 'should handle malformed JSON and keep as string', () => {
+			const element = createElementFromHTML(
+				`<div data-wp-test="{malformed: json}"></div>`
+			);
+			expect( toVdom( element ) ).toMatchVNode( [
+				h(
+					'div' as any,
+					{
+						'data-wp-test': '{malformed: json}',
+						__directives: {
+							test: [
+								{
+									namespace: null,
+									value: '{malformed: json}',
+									suffix: null,
+								},
+							],
+						},
+					},
+					[]
+				),
+			] );
+		} );
+
+		it( 'should process directive suffixes', () => {
+			const element = createElementFromHTML(
+				`<div data-wp-test--one="test value 1" data-wp-test--two="test value 2"></div>`
+			);
+			expect( toVdom( element ) ).toMatchVNode( [
+				h(
+					'div' as any,
+					{
+						'data-wp-test--one': 'test value 1',
+						'data-wp-test--two': 'test value 2',
+						__directives: {
+							test: [
+								{
+									namespace: null,
+									value: 'test value 1',
+									suffix: 'one',
+								},
+								{
+									namespace: null,
+									value: 'test value 2',
+									suffix: 'two',
+								},
+							],
+						},
+					},
+					[]
+				),
+			] );
+		} );
+
+		it( 'should preserve values that JSON would parse but are not objects', () => {
+			const element = createElementFromHTML(
+				`<div data-wp-test--one='true' data-wp-test--two='"test value"'></div>`
+			);
+			expect( toVdom( element ) ).toMatchVNode( [
+				h(
+					'div' as any,
+					{
+						'data-wp-test--one': 'true',
+						'data-wp-test--two': '"test value"',
+						__directives: {
+							test: [
+								{
+									namespace: null,
+									value: 'true',
+									suffix: 'one',
+								},
+								{
+									namespace: null,
+									value: '"test value"',
+									suffix: 'two',
+								},
+							],
+						},
+					},
+					[]
+				),
+			] );
+		} );
+
+		it( 'should handle directives in template elements', () => {
+			const template = createElementFromHTML(
+				`<template data-wp-test="test value"><div></div></template>`
+			);
+			expect( toVdom( template ) ).toMatchVNode( [
+				h(
+					'template' as any,
+					{
+						'data-wp-test': 'test value',
+						__directives: {
+							test: [
+								{
+									namespace: null,
+									value: 'test value',
+									suffix: null,
+								},
+							],
+						},
+						content: [ [ h( 'div' as any, null, [] ) ] ],
+					},
+					[]
+				),
+			] );
+		} );
+
+		it( 'should handle directives inside template elements', () => {
+			const template = createElementFromHTML(
+				`<template><div data-wp-test="test value"></div></template>`
+			);
+			expect( toVdom( template ) ).toMatchVNode( [
+				h(
+					'template' as any,
+					{
+						content: [
+							[
+								h(
+									'div' as any,
+									{
+										'data-wp-test': 'test value',
+										__directives: {
+											test: [
+												{
+													namespace: null,
+													value: 'test value',
+													suffix: null,
+												},
+											],
+										},
+									},
+									[]
+								),
+							],
+						],
+					},
+					[]
+				),
+			] );
+		} );
+	} );
+
+	describe( 'Namespaces', () => {
+		it( 'should process directives with a custom namespace', () => {
+			const element = createElementFromHTML(
+				`<div data-wp-test="my-namespace::test value"></div>`
+			);
+			expect( toVdom( element ) ).toMatchVNode( [
+				h(
+					'div' as any,
+					{
+						'data-wp-test': 'my-namespace::test value',
+						__directives: {
+							test: [
+								{
+									namespace: 'my-namespace',
+									value: 'test value',
+									suffix: null,
+								},
+							],
+						},
+					},
+					[]
+				),
+			] );
+		} );
+
+		it( 'should parse JSON values with a custom namespace', () => {
+			const element = createElementFromHTML(
+				`<div data-wp-test='my-namespace::{"key": "value"}'></div>`
+			);
+			expect( toVdom( element ) ).toMatchVNode( [
+				h(
+					'div' as any,
+					{
+						'data-wp-test': 'my-namespace::{"key": "value"}',
+						__directives: {
+							test: [
+								{
+									namespace: 'my-namespace',
+									value: { key: 'value' },
+									suffix: null,
+								},
+							],
+						},
+					},
+					[]
+				),
+			] );
+		} );
+
+		it( 'should use the default namespace provided in the same element', () => {
+			const element = createElementFromHTML(
+				`<div data-wp-interactive="my-namespace" data-wp-test="test value"></div>`
+			);
+			expect( toVdom( element ) ).toMatchVNode( [
+				h(
+					'div' as any,
+					{
+						'data-wp-interactive': 'my-namespace',
+						'data-wp-test': 'test value',
+						__directives: {
+							test: [
+								{
+									namespace: 'my-namespace',
+									value: 'test value',
+									suffix: null,
+								},
+							],
+						},
+					},
+					[]
+				),
+			] );
+		} );
+
+		it( 'should override the default namespace provided in a parent element', () => {
+			const element = createElementFromHTML(
+				`<div data-wp-interactive="parent-namespace"><div data-wp-interactive="my-namespace" data-wp-test="test value"></div></div>`
+			);
+			expect( toVdom( element ) ).toMatchVNode( [
+				h(
+					'div' as any,
+					{
+						'data-wp-interactive': 'parent-namespace',
+					},
+					[
+						h(
+							'div' as any,
+							{
+								'data-wp-interactive': 'my-namespace',
+								'data-wp-test': 'test value',
+								__directives: {
+									test: [
+										{
+											namespace: 'my-namespace',
+											value: 'test value',
+											suffix: null,
+										},
+									],
+								},
+							},
+							[]
+						),
+					]
+				),
+			] );
+		} );
+
+		it( 'should handle default namespaces provided in the a JSON object', () => {
+			const element = createElementFromHTML(
+				`<div data-wp-interactive='{ "namespace": "my-namespace" }' data-wp-test="test value"></div>`
+			);
+			expect( toVdom( element ) ).toMatchVNode( [
+				h(
+					'div' as any,
+					{
+						'data-wp-interactive':
+							'{ "namespace": "my-namespace" }',
+						'data-wp-test': 'test value',
+						__directives: {
+							test: [
+								{
+									namespace: 'my-namespace',
+									value: 'test value',
+									suffix: null,
+								},
+							],
+						},
+					},
+					[]
+				),
+			] );
+		} );
+
+		it( 'should recover the parent default namespace after a closing element', () => {
+			const element = createElementFromHTML(
+				`<div data-wp-interactive="parent-namespace"><div data-wp-interactive="child-namespace"></div><div data-wp-test="test value"></div></div>`
+			);
+			expect( toVdom( element ) ).toMatchVNode( [
+				h(
+					'div' as any,
+					{
+						'data-wp-interactive': 'parent-namespace',
+					},
+					[
+						h(
+							'div' as any,
+							{
+								'data-wp-interactive': 'child-namespace',
+							},
+							[]
+						),
+						h(
+							'div' as any,
+							{
+								'data-wp-test': 'test value',
+								__directives: {
+									test: [
+										{
+											namespace: 'parent-namespace',
+											value: 'test value',
+											suffix: null,
+										},
+									],
+								},
+							},
+							[]
+						),
+					]
+				),
+			] );
+		} );
+
+		it( 'should reset the default namespace after that last closing element', () => {
+			const element = createElementFromHTML(
+				`<div><div data-wp-interactive="my-namespace"></div><div data-wp-test="test value"></div></div>`
+			);
+			expect( toVdom( element ) ).toMatchVNode( [
+				h( 'div' as any, null, [
+					h(
+						'div' as any,
+						{
+							'data-wp-interactive': 'my-namespace',
+						},
+						[]
+					),
+					h(
+						'div' as any,
+						{
+							'data-wp-test': 'test value',
+							__directives: {
+								test: [
+									{
+										namespace: null,
+										value: 'test value',
+										suffix: null,
+									},
+								],
+							},
+						},
+						[]
+					),
+				] ),
+			] );
+		} );
+
+		it( 'should override the default namespace with a custom one in the same element', () => {
+			const element = createElementFromHTML(
+				`<div data-wp-interactive="my-namespace" data-wp-test="custom-namespace::test value"></div>`
+			);
+			expect( toVdom( element ) ).toMatchVNode( [
+				h(
+					'div' as any,
+					{
+						'data-wp-interactive': 'my-namespace',
+						'data-wp-test': 'custom-namespace::test value',
+						__directives: {
+							test: [
+								{
+									namespace: 'custom-namespace',
+									value: 'test value',
+									suffix: null,
+								},
+							],
+						},
+					},
+					[]
+				),
+			] );
+		} );
+
+		it( 'should override the default namespace with a custom one in a child element', () => {
+			const element = createElementFromHTML(
+				`<div data-wp-interactive="my-namespace"><div data-wp-test="custom-namespace::test value"></div></div>`
+			);
+			expect( toVdom( element ) ).toMatchVNode( [
+				h(
+					'div' as any,
+					{
+						'data-wp-interactive': 'my-namespace',
+					},
+					[
+						h(
+							'div' as any,
+							{
+								'data-wp-test': 'custom-namespace::test value',
+								__directives: {
+									test: [
+										{
+											namespace: 'custom-namespace',
+											value: 'test value',
+											suffix: null,
+										},
+									],
+								},
+							},
+							[]
+						),
+					]
+				),
+			] );
+		} );
+
+		it( 'should pass down namespaces defined in template elements', () => {
+			const template = createElementFromHTML(
+				`<template data-wp-interactive="my-namespace"><div data-wp-test="test value"></div></template>`
+			);
+			expect( toVdom( template ) ).toMatchVNode( [
+				h(
+					'template' as any,
+					{
+						'data-wp-interactive': 'my-namespace',
+						content: [
+							[
+								h(
+									'div' as any,
+									{
+										'data-wp-test': 'test value',
+										__directives: {
+											test: [
+												{
+													namespace: 'my-namespace',
+													value: 'test value',
+													suffix: null,
+												},
+											],
+										},
+									},
+									[]
+								),
+							],
+						],
+					},
+					[]
+				),
+			] );
+		} );
+
+		it( 'should pass down namespaces defined in template parents', () => {
+			const template = createElementFromHTML(
+				`<div data-wp-interactive="my-namespace"><template><div data-wp-test="test value"></div></template></div>`
+			);
+			expect( toVdom( template ) ).toMatchVNode( [
+				h(
+					'div' as any,
+					{
+						'data-wp-interactive': 'my-namespace',
+					},
+					[
+						h(
+							'template' as any,
+							{
+								content: [
+									[
+										h(
+											'div' as any,
+											{
+												'data-wp-test': 'test value',
+												__directives: {
+													test: [
+														{
+															namespace:
+																'my-namespace',
+															value: 'test value',
+															suffix: null,
+														},
+													],
+												},
+											},
+											[]
+										),
+									],
+								],
+							},
+							[]
+						),
+					]
+				),
+			] );
+		} );
+	} );
+
+	describe( 'Hydrated islands', () => {
+		it( 'should add a topmost island', () => {
+			const element = createElementFromHTML( `
+				<div data-wp-interactive="my-namespace"></div>
+			` );
+			toVdom( element );
+			expect( hydratedIslands.has( element ) ).toBe( true );
+		} );
+
+		it( 'should add nested islands', () => {
+			const outer = createElementFromHTML(
+				`<div data-wp-interactive="outer"><div data-wp-interactive="inner"></div></div>`
+			);
+			const inner = outer.querySelector( '[data-wp-interactive="inner"' );
+			toVdom( outer );
+			expect( hydratedIslands.has( outer ) ).toBe( true );
+			expect( hydratedIslands.has( inner! ) ).toBe( true );
+		} );
+	} );
+} );

--- a/packages/interactivity/src/test/vdom.ts
+++ b/packages/interactivity/src/test/vdom.ts
@@ -102,6 +102,21 @@ describe( 'toVdom', () => {
 			);
 		} );
 
+		it( 'should remove multiple comment nodes', () => {
+			const container = createElementFromHTML(
+				'<div><div>Test 1<!-- This is a comment --><!-- This is another comment --></div><div>Test 2</div></div>'
+			);
+			expect( toVdom( container ) ).toMatchVNode( [
+				h( 'div', null, [
+					h( 'div', null, [ 'Test 1' ] ),
+					h( 'div', null, [ 'Test 2' ] ),
+				] ),
+			] );
+			expect( container.outerHTML ).toBe(
+				'<div><div>Test 1</div><div>Test 2</div></div>'
+			);
+		} );
+
 		it( 'should remove comment nodes and continue to their parents', () => {
 			const container = createElementFromHTML(
 				'<div><div>Test 1<!-- This is a comment --></div><div>Test 2</div></div>'
@@ -142,6 +157,26 @@ describe( 'toVdom', () => {
 					[]
 				),
 			] );
+		} );
+
+		it( 'should remove comment nodes inside templates', () => {
+			const container = createElementFromHTML(
+				'<div><!-- This is a comment --><template><div>Test 1<!-- This is a comment --></div></template></div>'
+			);
+			expect( toVdom( container ) ).toMatchVNode( [
+				h( 'div', null, [
+					h(
+						'template' as any,
+						{
+							content: [ [ h( 'div', null, [ 'Test 1' ] ) ] ],
+						},
+						[]
+					),
+				] ),
+			] );
+			expect( container.outerHTML ).toBe(
+				'<div><template><div>Test 1</div></template></div>'
+			);
 		} );
 	} );
 

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -54,7 +54,7 @@ export const hydratedIslands = new WeakSet();
  * @param root The root element or node to start traversing on.
  * @return The resulting vDOM tree.
  */
-export function toVdom( root: Node ): Array< ComponentChild > {
+export function toVdom( root: Node ): ComponentChild {
 	const nodesToRemove = new Set< Node >();
 	const nodesToReplace = new Set< Node >();
 
@@ -63,24 +63,24 @@ export function toVdom( root: Node ): Array< ComponentChild > {
 		205 // TEXT + CDATA_SECTION + COMMENT + PROCESSING_INSTRUCTION + ELEMENT
 	);
 
-	function walk( node: Node ): [ ComponentChild | null ] {
+	function walk( node: Node ): ComponentChild | null {
 		const { nodeType } = node;
 
 		// TEXT_NODE (3)
 		if ( nodeType === 3 ) {
-			return [ ( node as Text ).data ];
+			return ( node as Text ).data;
 		}
 
 		// CDATA_SECTION_NODE (4)
 		if ( nodeType === 4 ) {
 			nodesToReplace.add( node );
-			return [ node.nodeValue ];
+			return node.nodeValue;
 		}
 
 		// COMMENT_NODE (8) || PROCESSING_INSTRUCTION_NODE (7)
 		if ( nodeType === 8 || nodeType === 7 ) {
 			nodesToRemove.add( node );
-			return [ null ];
+			return null;
 		}
 
 		const elementNode = node as HTMLElement;
@@ -175,7 +175,7 @@ export function toVdom( root: Node ): Array< ComponentChild > {
 			let child = treeWalker.firstChild();
 			if ( child ) {
 				while ( child ) {
-					const [ vnode ] = walk( child );
+					const vnode = walk( child );
 					if ( vnode ) {
 						children.push( vnode );
 					}
@@ -190,7 +190,7 @@ export function toVdom( root: Node ): Array< ComponentChild > {
 			namespaces.pop();
 		}
 
-		return [ h( localName, props, children ) ];
+		return h( localName, props, children );
 	}
 
 	const vdom = walk( treeWalker.currentNode );

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -47,6 +47,8 @@ const directiveParser = new RegExp(
 const nsPathRegExp = /^([\w_\/-]+)::(.+)$/;
 
 export const hydratedIslands = new WeakSet();
+const nodesToRemove = new Set< Node >();
+const nodesToReplace = new Set< Node >();
 
 /**
  * Recursive function that transforms a DOM tree into vDOM.
@@ -60,9 +62,7 @@ export function toVdom( root: Node ): Array< ComponentChild > {
 		205 // TEXT + CDATA_SECTION + COMMENT + PROCESSING_INSTRUCTION + ELEMENT
 	);
 
-	function walk(
-		node: Node
-	): [ ComponentChild ] | [ ComponentChild, Node | null ] {
+	function walk( node: Node ): [ ComponentChild | null ] {
 		const { nodeType } = node;
 
 		// TEXT_NODE (3)
@@ -72,18 +72,13 @@ export function toVdom( root: Node ): Array< ComponentChild > {
 
 		// CDATA_SECTION_NODE (4)
 		if ( nodeType === 4 ) {
-			const next = treeWalker.nextSibling();
-			( node as CDATASection ).replaceWith(
-				new window.Text( ( node as CDATASection ).nodeValue ?? '' )
-			);
-			return [ node.nodeValue, next ];
+			return [ node.nodeValue ];
 		}
 
 		// COMMENT_NODE (8) || PROCESSING_INSTRUCTION_NODE (7)
 		if ( nodeType === 8 || nodeType === 7 ) {
-			const next = treeWalker.nextSibling();
-			( node as Comment | ProcessingInstruction ).remove();
-			return [ null, next ];
+			nodesToRemove.add( node );
+			return [ null ];
 		}
 
 		const elementNode = node as HTMLElement;
@@ -178,11 +173,11 @@ export function toVdom( root: Node ): Array< ComponentChild > {
 			let child = treeWalker.firstChild();
 			if ( child ) {
 				while ( child ) {
-					const [ vnode, nextChild ] = walk( child );
+					const [ vnode ] = walk( child );
 					if ( vnode ) {
 						children.push( vnode );
 					}
-					child = nextChild || treeWalker.nextSibling();
+					child = treeWalker.nextSibling();
 				}
 				treeWalker.parentNode();
 			}
@@ -196,5 +191,18 @@ export function toVdom( root: Node ): Array< ComponentChild > {
 		return [ h( localName, props, children ) ];
 	}
 
-	return walk( treeWalker.currentNode );
+	const vdom = walk( treeWalker.currentNode );
+
+	nodesToRemove.forEach( ( node: Node ) =>
+		( node as Comment | ProcessingInstruction ).remove()
+	);
+	nodesToReplace.forEach( ( node: Node ) =>
+		( node as CDATASection ).replaceWith(
+			new window.Text( ( node as CDATASection ).nodeValue ?? '' )
+		)
+	);
+	nodesToRemove.clear();
+	nodesToReplace.clear();
+
+	return vdom;
 }

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -72,6 +72,7 @@ export function toVdom( root: Node ): Array< ComponentChild > {
 
 		// CDATA_SECTION_NODE (4)
 		if ( nodeType === 4 ) {
+			nodesToReplace.add( node );
 			return [ node.nodeValue ];
 		}
 

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -47,8 +47,6 @@ const directiveParser = new RegExp(
 const nsPathRegExp = /^([\w_\/-]+)::(.+)$/;
 
 export const hydratedIslands = new WeakSet();
-const nodesToRemove = new Set< Node >();
-const nodesToReplace = new Set< Node >();
 
 /**
  * Recursive function that transforms a DOM tree into vDOM.
@@ -57,6 +55,9 @@ const nodesToReplace = new Set< Node >();
  * @return The resulting vDOM tree.
  */
 export function toVdom( root: Node ): Array< ComponentChild > {
+	const nodesToRemove = new Set< Node >();
+	const nodesToReplace = new Set< Node >();
+
 	const treeWalker = document.createTreeWalker(
 		root,
 		205 // TEXT + CDATA_SECTION + COMMENT + PROCESSING_INSTRUCTION + ELEMENT
@@ -202,8 +203,6 @@ export function toVdom( root: Node ): Array< ComponentChild > {
 			new window.Text( ( node as CDATASection ).nodeValue ?? '' )
 		)
 	);
-	nodesToRemove.clear();
-	nodesToReplace.clear();
 
 	return vdom;
 }

--- a/test/e2e/specs/interactivity/directive-priorities.spec.ts
+++ b/test/e2e/specs/interactivity/directive-priorities.spec.ts
@@ -88,14 +88,14 @@ test.describe( 'Directives (w/ priority)', () => {
 		const nonExistentDirectives = page.getByTestId(
 			'non-existent-directives'
 		);
+		// The element type should not be a component.
 		expect(
-			await nonExistentDirectives.evaluate(
-				// This returns undefined if type is a component.
-				( node ) => {
-					return ( node as any ).__k.__k.__k[ 0 ].__k[ 0 ].__k[ 0 ]
-						.type;
-				}
-			)
-		).toBe( 'div' );
+			await nonExistentDirectives.evaluate( ( node ) => {
+				return ( node as any ).__k.__k.__k[ 0 ].__k[ 0 ];
+			} )
+		).toMatchObject( {
+			type: 'div',
+			props: { 'data-wp-non-existent-directive': '' },
+		} );
 	} );
 } );

--- a/test/e2e/specs/interactivity/tovdom.spec.ts
+++ b/test/e2e/specs/interactivity/tovdom.spec.ts
@@ -19,6 +19,7 @@ test.describe( 'toVdom', () => {
 	test( 'it should delete comments', async ( { page } ) => {
 		const el = page.getByTestId( 'it should delete comments' );
 		const c = await el.innerHTML();
+		expect( c ).not.toContain( '##last-child##' );
 		expect( c ).not.toContain( '##1##' );
 		expect( c ).not.toContain( '##2##' );
 		const el2 = page.getByTestId(
@@ -32,6 +33,7 @@ test.describe( 'toVdom', () => {
 			'it should delete processing instructions'
 		);
 		const c = await el.innerHTML();
+		expect( c ).not.toContain( '##last-child##' );
 		expect( c ).not.toContain( '##1##' );
 		expect( c ).not.toContain( '##2##' );
 		const el2 = page.getByTestId(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Fixes a bug where HTML comments appear at the end of an element (that is, they don't have a next sibling).  E.g.:

```html
<ul data-wp-interactive="example">
  <li>Item 1</li>
  <li>Item 2</li>
  <!-- End of list  (HTML comment without a next sibling) -->
</ul>
```

The `toVdom()` function was wrongly expecting a sibling after processed comments. The same thing happens for processing instructions and CDATA blocks since they are processed in the same way as comments.

Props to @luisherranz.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This case passed under the radar.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The `toVdom()` function now waits until the end of the current element processing to delete the comments (also delete the processing instructions and transform CDATA blocks into text). This prevents execution failure once the function reaches `treeWalker.parentNode()` and the parent doesn't exist (because the current node has been deleted or replaced).

Additionally, it is no longer necessary for `toVdom` (and internally `walk`) to return an array. This has been conveniently updated.

## Tests

The previous e2e tests have been updated, and a comprehensive unit test suite for `toVdom()` has been implemented.

