### PR TITLE
Navigation Block: Flip submenu indicator icon on submenu expansion

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -312,6 +312,11 @@ button.wp-block-navigation-item__content {
 	cursor: pointer;
 }
 
+// Flip submenu arrow icon when expanded.
+.wp-block-navigation-submenu__toggle[aria-expanded="true"] {
+	transform: scaleY(-1);
+}
+
 // When set to open on click, a button element is used.
 // We pad it to include the arrow icon in the clickable area.
 // The padding can be blanket for click, since you can't set click and hide the icon.


### PR DESCRIPTION
## What?
Closes #35636

## Why?
Currently, opening a submenu does not change the downward arrow icon. Ideally, the icon should flip upward to indicate the submenu is expanded.

## How?
When a submenu is expanded (aria-expanded="true"), the downward arrow icon now flips upward using a transform: scaleY(-1) CSS rule.
This change was added to packages/block-library/src/navigation/style.scss and enhances the user experience by providing a clearer visual cue of the submenu's open state.

## Testing Instructions

- Open a post or page in the editor.
- Insert a Navigation block.
- Add a menu item with a submenu (child items).
- Click the parent menu item to open the submenu.
- Observe the arrow icon. It should flip upward when the submenu is open and return to downward when closed.

## Screenshots or screencast
Before
https://github.com/user-attachments/assets/a19abfbe-0145-4bd7-87c8-b6e12549b351

After
https://github.com/user-attachments/assets/e39ba6d5-780b-413a-994e-393f051e3a11