### PR TITLE
iAPI: Fix the changelog to include PR 70296 in 6.25

### DIFF
--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## 6.25.0 (2025-06-04)
 
+### Bug Fixes
+
+-   Fix `store()` types to support typing it without passing a store part. ([#70296](https://github.com/WordPress/gutenberg/pull/70296))
+
 ## 6.24.0 (2025-05-22)
 
 ## 6.23.0 (2025-05-07)


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Adds a missing changelog entry for the bug fix made in #70296, which was released in version 6.25.0 of the `@wordpress/interactivity` package.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

A changelog entry was missing in the bug fix PR.