### PR TITLE
Fix: Site logo & image block takes huge space if we try to rotate it …

### DIFF
--- a/packages/block-editor/src/components/image-editor/cropper.js
+++ b/packages/block-editor/src/components/image-editor/cropper.js
@@ -9,6 +9,7 @@ import clsx from 'clsx';
  */
 import { Spinner } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -34,16 +35,19 @@ export default function ImageCropper( {
 		setPosition,
 		setCrop,
 		setZoom,
-		rotation,
 	} = useImageEditingContext();
-	const [ contentResizeListener, { width: clientWidth } ] =
-		useResizeObserver();
+	const [ contentHeight, setContentHeight ] = useState( height );
+	const [ contentWidth, setContentWidth ] = useState( width );
+	const effectContentRef = useResizeObserver(
+		( [ entry ] ) => {
+			setContentWidth( entry.borderBoxSize[ 0 ].inlineSize );
+			setContentHeight( entry.borderBoxSize[ 0 ].blockSize );
+		},
+		{ box: 'border-box' }
+	);
 
-	let editedHeight = height || ( clientWidth * naturalHeight ) / naturalWidth;
-
-	if ( rotation % 180 === 90 ) {
-		editedHeight = ( clientWidth * naturalWidth ) / naturalHeight;
-	}
+	const editedWidth = contentWidth || width || naturalWidth;
+	const editedHeight = contentHeight || height || naturalHeight;
 
 	const area = (
 		<div
@@ -56,9 +60,10 @@ export default function ImageCropper( {
 			) }
 			style={ {
 				...borderProps?.style,
-				width: width || clientWidth,
+				width: editedWidth,
 				height: editedHeight,
 			} }
+			ref={ effectContentRef }
 		>
 			<Cropper
 				image={ editedUrl || url }
@@ -82,10 +87,5 @@ export default function ImageCropper( {
 		</div>
 	);
 
-	return (
-		<>
-			{ contentResizeListener }
-			{ area }
-		</>
-	);
+	return <>{ area }</>;
 }


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/70311

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This PR will fix following issues:

1. After adding an image to site logo OR image block, if we try to rotate it, it takes very long spaces on top & bottom.
2. Fixed deprecated use of `useResizeObserver` API.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Select the site logo block
2. Add an image.
3. Click on Crop button from block control setting.
4. Click on the Rotate option.
5. Image will take now appropriate space.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
|Before|After|
|-|-|

|![image](https://github.com/user-attachments/assets/e7d6fa65-92c5-4bcc-a94e-53e95ddfb1dd)|![image](https://github.com/user-attachments/assets/8c39d20e-1c58-40d6-a4be-657148539b1b)|
|-|-|

