### PR TITLE
Enhancement : Attach images to post uploaded in core/image block via media library

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -388,7 +388,7 @@ Insert an image to make a visual statement. ([Source](https://github.com/WordPre
 -	**Name:** core/image
 -	**Category:** media
 -	**Supports:** align (center, full, left, right, wide), anchor, color (~~background~~, ~~text~~), filter (duotone), interactivity, shadow (), spacing (margin)
--	**Attributes:** alt, aspectRatio, blob, caption, height, href, id, lightbox, linkClass, linkDestination, linkTarget, rel, scale, sizeSlug, title, url, width
+-	**Attributes:** alt, aspectRatio, blob, caption, height, href, id, lightbox, linkClass, linkDestination, linkTarget, rel, scale, sizeSlug, title, uploadedTo, url, width
 
 ## Latest Comments
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -50028,6 +50028,7 @@
 				"@wordpress/date": "file:../date",
 				"@wordpress/deprecated": "file:../deprecated",
 				"@wordpress/dom": "file:../dom",
+				"@wordpress/editor": "14.24.0",
 				"@wordpress/element": "file:../element",
 				"@wordpress/escape-html": "file:../escape-html",
 				"@wordpress/hooks": "file:../hooks",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -54,6 +54,7 @@
 		"@wordpress/date": "file:../date",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",
+		"@wordpress/editor": "14.24.0",
 		"@wordpress/element": "file:../element",
 		"@wordpress/escape-html": "file:../escape-html",
 		"@wordpress/hooks": "file:../hooks",

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -100,6 +100,10 @@
 			"source": "attribute",
 			"selector": "figure > a",
 			"attribute": "target"
+		},
+		"uploadedTo": {
+			"type": "number",
+			"default": 0
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -9,7 +9,12 @@ import clsx from 'clsx';
 import { isBlobURL, createBlobURL } from '@wordpress/blob';
 import { createBlock, getBlockBindingsSource } from '@wordpress/blocks';
 import { Placeholder } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import {
+	useDispatch,
+	useSelect,
+	subscribe,
+	select as editorSelect,
+} from '@wordpress/data';
 import {
 	BlockIcon,
 	useBlockProps,
@@ -19,11 +24,13 @@ import {
 	__experimentalGetShadowClassesAndStyles as getShadowClassesAndStyles,
 	useBlockEditingMode,
 } from '@wordpress/block-editor';
+import { store as postEditorStore } from '@wordpress/editor';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { image as icon, plugins as pluginsIcon } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
-import { useResizeObserver } from '@wordpress/compose';
+import { useResizeObserver, useDebounce } from '@wordpress/compose';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -109,11 +116,21 @@ export function ImageEdit( {
 		scale,
 		align,
 		metadata,
+		uploadedTo,
 	} = attributes;
 
 	const [ temporaryURL, setTemporaryURL ] = useState( attributes.blob );
 
 	const containerRef = useRef();
+
+	const {
+		getCurrentPostId,
+		isSavingPost,
+		isPublishingPost,
+		isAutosavingPost,
+	} = editorSelect( postEditorStore );
+
+	const postId = getCurrentPostId();
 	// Only observe the max width from the parent container when the parent layout is not flex nor grid.
 	// This won't work for them because the container width changes with the image.
 	// TODO: Find a way to observe the container width for flex and grid layouts.
@@ -228,6 +245,9 @@ export function ImageEdit( {
 			} );
 			setTemporaryURL();
 
+			// Detach media from post when the reset option is selected.
+			detachMediaFromPost();
+
 			return;
 		}
 
@@ -309,9 +329,108 @@ export function ImageEdit( {
 			...mediaAttributes,
 			...additionalAttributes,
 			linkDestination,
+			// set uploadedTo as the postId to which the media is attached or current postId if not attached to any post.
+			uploadedTo: media?.uploadedTo || postId,
 		} );
 		setTemporaryURL();
 	}
+
+	/**
+	 * Detach media from post when the reset option is selected.
+	 * Detach only if the media is attached to the current post.
+	 */
+	function detachMediaFromPost() {
+		if ( uploadedTo !== postId ) {
+			return;
+		}
+
+		apiFetch( {
+			path: `/wp/v2/media/${ id }`,
+			method: 'PATCH',
+			data: {
+				post: 0,
+			},
+		} );
+
+		setAttributes( {
+			uploadedTo: 0,
+		} );
+	}
+
+	/**
+	 * Attach media to post when the save option is selected.
+	 */
+	function attachMediaToPost() {
+		// Bail early if media ID doesn't exist.
+		if ( ! id ) {
+			return;
+		}
+
+		// Bail early if media is already attached to another post.
+		// Instead of early bail out, we set the uploadedTo to the current postId.
+		// This is to avoid updating attributes after the post is saved/published which ignores the new attributes.
+		if ( uploadedTo !== postId ) {
+			return;
+		}
+
+		// Attach media to post by updating via WP REST API.
+		apiFetch( {
+			path: `/wp/v2/media/${ id }`,
+			method: 'PATCH',
+			data: {
+				post: postId,
+			},
+		} );
+	}
+
+	// Debounce the attachMediaToPost function to avoid multiple calls.
+	const debouncedAttachMediaToPost = useDebounce( attachMediaToPost, 250 );
+
+	useEffect( () => {
+		// Prevent subscribing if the media ID doesn't exist.
+		if ( ! id ) {
+			return;
+		}
+
+		// Subscribe ONCE, when the block editor mounts.
+		const unsubscribe = subscribe( () => {
+			const isSaving = isSavingPost();
+			const isPublishing = isPublishingPost();
+			const isAutosaving = isAutosavingPost();
+
+			if ( ( isSaving || isPublishing ) && ! isAutosaving ) {
+				debouncedAttachMediaToPost();
+			}
+		} );
+
+		return () => unsubscribe();
+	}, [
+		id,
+		isSavingPost,
+		isPublishingPost,
+		isAutosavingPost,
+		debouncedAttachMediaToPost,
+	] );
+
+	// Detach media from post when the block is removed.
+	useEffect( () => {
+		// Clean up function to be called when the block is removed.
+		return () => {
+			// Bail early if the media is not attached to the current post.
+			if ( uploadedTo !== postId ) {
+				return;
+			}
+
+			// Detach media from post by updating via WP REST API.
+			apiFetch( {
+				path: `/wp/v2/media/${ id }`,
+				method: 'PATCH',
+				data: {
+					post: 0,
+				},
+			} );
+		};
+	}, [ uploadedTo, postId, id ] );
 
 	function onSelectURL( newURL ) {
 		if ( newURL !== url ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
- Closes : https://github.com/WordPress/gutenberg/issues/66663
- Attach image to post that is uploaded in core/image block via media library option.
- Detach the image when the block is removed or the reset option is selected.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- https://github.com/WordPress/gutenberg/issues/66663
- Images are not attached to the post when they are added via the media library option in the core/image block.
- The attachment only happens when the image is uploaded while the user is in editing a post.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Evaluate if the attachment is already attached to another post via its `uploadedTo` `media` parameter
- If not attached, when the post is `saved / published` the image will be attached to the post where its used.
- When either the `reset` option in the core/image block is selected or the block is removed, the image is detached from the post.
- The `attachment/detachment` process works via the `WP REST API` for `attachments`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Add dummy images in the media library of your WP installation.
2. Create a post and add an image block to it.
3. Select the `image` via `media library` option.
4. Save/Publish the post and go back to the `media library`.
5. You will see the image attached to that post.
6. If you remove the block or click the reset option in the core/image block, the image will be detached from the post.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/99c722cc-2183-4931-8761-b03cc19aaef8

