### PR TITLE
iAPI: Export `NavigateOptions` and `PrefetchOptions` types

### DIFF
--- a/packages/interactivity-router/CHANGELOG.md
+++ b/packages/interactivity-router/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Export `NavigateOptions` and `PrefetchOptions` types. ([#70315](https://github.com/WordPress/gutenberg/pull/70315))
+
 ### Bug Fixes
 
 -   Prevents duplicating nested router regions after a client-side navigation. ([#70302](https://github.com/WordPress/gutenberg/pull/70302))

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -19,7 +19,7 @@ const {
 const regionAttr = `data-${ directivePrefix }-router-region`;
 const interactiveAttr = `data-${ directivePrefix }-interactive`;
 
-interface NavigateOptions {
+export interface NavigateOptions {
 	force?: boolean;
 	html?: string;
 	replace?: boolean;
@@ -28,7 +28,7 @@ interface NavigateOptions {
 	screenReaderAnnouncement?: boolean;
 }
 
-interface PrefetchOptions {
+export interface PrefetchOptions {
 	force?: boolean;
 	html?: string;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
This PR exports `NavigateOptions` and `PrefetchOptions` types from `interactivity-router`.

Props to @dinhtungdu 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

If `@wordpress/interactivity-router` is used in a store, and the store's type is exported, developers will need the two types mentioned above exported. Otherwise, TypeScript will fail to figure out the shape of them.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR exports needed type so TS can determine the shape of `actions.navigate()` and `actions.prefetch()` arguments
