### PR TITLE
Patterns: delete unused property

### DIFF
--- a/packages/patterns/src/components/patterns-manage-button.js
+++ b/packages/patterns/src/components/patterns-manage-button.js
@@ -18,8 +18,7 @@ import { unlock } from '../lock-unlock';
 function PatternsManageButton( { clientId } ) {
 	const { canRemove, isVisible, managePatternsUrl } = useSelect(
 		( select ) => {
-			const { getBlock, canRemoveBlock, getBlockCount } =
-				select( blockEditorStore );
+			const { getBlock, canRemoveBlock } = select( blockEditorStore );
 			const { canUser } = select( coreStore );
 			const reusableBlock = getBlock( clientId );
 
@@ -33,7 +32,6 @@ function PatternsManageButton( { clientId } ) {
 						name: 'wp_block',
 						id: reusableBlock.attributes.ref,
 					} ),
-				innerBlockCount: getBlockCount( clientId ),
 				// The site editor and templates both check whether the user
 				// has edit_theme_options capabilities. We can leverage that here
 				// and omit the manage patterns link if the user can't access it.

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -17,8 +17,7 @@ import { store as reusableBlocksStore } from '../../store';
 function ReusableBlocksManageButton( { clientId } ) {
 	const { canRemove, isVisible, managePatternsUrl } = useSelect(
 		( select ) => {
-			const { getBlock, canRemoveBlock, getBlockCount } =
-				select( blockEditorStore );
+			const { getBlock, canRemoveBlock } = select( blockEditorStore );
 			const { canUser } = select( coreStore );
 			const reusableBlock = getBlock( clientId );
 
@@ -32,7 +31,6 @@ function ReusableBlocksManageButton( { clientId } ) {
 						name: 'wp_block',
 						id: reusableBlock.attributes.ref,
 					} ),
-				innerBlockCount: getBlockCount( clientId ),
 				// The site editor and templates both check whether the user
 				// has edit_theme_options capabilities. We can leverage that here
 				// and omit the manage patterns link if the user can't access it.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
innerBlockCount is an unused property.

This PR will eliminate the use of innerBlockCount.
#56323

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This results in cleaner code.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

![pattern](https://github.com/user-attachments/assets/105ffc87-4374-4c3f-988b-7134def8e5ad)

Detach and Manage work the same as before
