### PR TITLE
Components: add `placement` prop to replace `position` in `RangeControl`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 -   `TextControl`: Improve theming support ([#70910](https://github.com/WordPress/gutenberg/pull/70910)).
 
+### Internal
+
+-	`RangeControl`: Add placement prop to replace position ([#70326](https://github.com/WordPress/gutenberg/pull/70326)).
+
 ## 30.0.0 (2025-07-23)
 
 ### Breaking Changes

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -314,7 +314,7 @@ function UnforwardedRangeControl(
 						<SimpleTooltip
 							className="components-range-control__tooltip"
 							inputRef={ inputRef }
-							tooltipPlacement="top"
+							tooltipPlacement="bottom"
 							renderTooltipContent={ renderTooltipContent }
 							show={ isCurrentlyFocused || showTooltip }
 							style={ offsetStyle }

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -314,7 +314,7 @@ function UnforwardedRangeControl(
 						<SimpleTooltip
 							className="components-range-control__tooltip"
 							inputRef={ inputRef }
-							tooltipPlacement="bottom"
+							tooltipPlacement="top"
 							renderTooltipContent={ renderTooltipContent }
 							show={ isCurrentlyFocused || showTooltip }
 							style={ offsetStyle }

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -314,7 +314,7 @@ function UnforwardedRangeControl(
 						<SimpleTooltip
 							className="components-range-control__tooltip"
 							inputRef={ inputRef }
-							tooltipPosition="bottom"
+							tooltipPlacement="top"
 							renderTooltipContent={ renderTooltipContent }
 							show={ isCurrentlyFocused || showTooltip }
 							style={ offsetStyle }

--- a/packages/components/src/range-control/styles/range-control-styles.ts
+++ b/packages/components/src/range-control/styles/range-control-styles.ts
@@ -283,8 +283,8 @@ const tooltipShow = ( { show }: TooltipProps ) => {
 	`;
 };
 
-const tooltipPosition = ( { position }: TooltipProps ) => {
-	const isBottom = position === 'bottom';
+const tooltipPosition = ( { placement }: TooltipProps ) => {
+	const isBottom = placement === 'bottom';
 
 	if ( isBottom ) {
 		return css`

--- a/packages/components/src/range-control/styles/range-control-styles.ts
+++ b/packages/components/src/range-control/styles/range-control-styles.ts
@@ -283,7 +283,7 @@ const tooltipShow = ( { show }: TooltipProps ) => {
 	`;
 };
 
-const tooltipPosition = ( { placement }: TooltipProps ) => {
+const tooltipPlacement = ( { placement }: TooltipProps ) => {
 	const isBottom = placement === 'bottom';
 
 	if ( isBottom ) {
@@ -312,7 +312,7 @@ export const Tooltip = styled.span< TooltipProps >`
 
 	${ tooltipShow };
 
-	${ tooltipPosition };
+	${ tooltipPlacement };
 	${ rtl(
 		{ transform: 'translateX(-50%)' },
 		{ transform: 'translateX(50%)' }

--- a/packages/components/src/range-control/tooltip.tsx
+++ b/packages/components/src/range-control/tooltip.tsx
@@ -22,7 +22,7 @@ export default function SimpleTooltip(
 	const {
 		className,
 		inputRef,
-		tooltipPosition,
+		tooltipPlacement,
 		show = false,
 		style = {},
 		value = 0,
@@ -30,7 +30,7 @@ export default function SimpleTooltip(
 		zIndex = 100,
 		...restProps
 	} = props;
-	const position = useTooltipPosition( { inputRef, tooltipPosition } );
+	const placement = useTooltipPlacement( { inputRef, tooltipPlacement } );
 	const classes = clsx( 'components-simple-tooltip', className );
 	const styles = {
 		...style,
@@ -42,7 +42,7 @@ export default function SimpleTooltip(
 			{ ...restProps }
 			aria-hidden="false"
 			className={ classes }
-			position={ position }
+			placement={ placement }
 			show={ show }
 			role="tooltip"
 			style={ styles }
@@ -52,26 +52,26 @@ export default function SimpleTooltip(
 	);
 }
 
-function useTooltipPosition( { inputRef, tooltipPosition }: TooltipProps ) {
-	const [ position, setPosition ] = useState< string >();
+function useTooltipPlacement( { inputRef, tooltipPlacement }: TooltipProps ) {
+	const [ placement, setPlacement ] = useState< string >();
 
-	const setTooltipPosition = useCallback( () => {
+	const setTooltipPlacement = useCallback( () => {
 		if ( inputRef && inputRef.current ) {
-			setPosition( tooltipPosition );
+			setPlacement( tooltipPlacement );
 		}
-	}, [ tooltipPosition, inputRef ] );
+	}, [ tooltipPlacement, inputRef ] );
 
 	useEffect( () => {
-		setTooltipPosition();
-	}, [ setTooltipPosition ] );
+		setTooltipPlacement();
+	}, [ setTooltipPlacement ] );
 
 	useEffect( () => {
-		window.addEventListener( 'resize', setTooltipPosition );
+		window.addEventListener( 'resize', setTooltipPlacement );
 
 		return () => {
-			window.removeEventListener( 'resize', setTooltipPosition );
+			window.removeEventListener( 'resize', setTooltipPlacement );
 		};
 	} );
 
-	return position;
+	return placement;
 }

--- a/packages/components/src/range-control/types.ts
+++ b/packages/components/src/range-control/types.ts
@@ -269,9 +269,9 @@ export type ThumbProps = {
 
 export type TooltipProps = {
 	show?: boolean;
-	position?: string;
+	placement?: string;
 	inputRef?: MutableRefObject< HTMLElement | undefined >;
-	tooltipPosition?: string;
+	tooltipPlacement?: string;
 	value?: ControlledRangeValue;
 	renderTooltipContent?: (
 		value?: ControlledRangeValue


### PR DESCRIPTION


## What?
Part of: https://github.com/WordPress/gutenberg/issues/44401

Replaces the `position={...}` prop used in the Tooltip styled component with the `placement` prop.

## Why?

Since `Tooltip` uses the placement prop after the deprecation of the position prop, it would make sense to have uniformity and consistency in the remaining codebase by using the same placement prop for Tooltip positioning. This instance in `RangeControl` uses a locally made `Tooltip` and was using the position prop, so I replaced it with placement

## How?
This is an internal prop, so I simply changed it from position to placement in the corresponding places

## Testing Instructions
Since this is a code quality improvement, it would not have testing as such, but it can be tested in Storybook:

1. Run `npm run storybook:dev`
2. Checkout the `RangeControl` component
3. Enable the tooltip 
4. Verify that it works correctly
5. Additionally, you can test by replacing bottom with top in this [place](https://github.com/WordPress/gutenberg/blob/0a9e950f0370616571d50a8ce2cd977f5f500f80/packages/components/src/range-control/index.tsx#L317) and refresh Storybook to see if the position changes to top


