### PR TITLE
Add support for border to navigation link

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -483,7 +483,7 @@ Add a page, link, or another item to your navigation. ([Source](https://github.c
 -	**Category:** design
 -	**Parent:** core/navigation
 -	**Allowed Blocks:** core/navigation-link, core/navigation-submenu, core/page-list
--	**Supports:** interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~, ~~reusable~~
+-	**Supports:** interactivity (clientNavigation), spacing (padding), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~, ~~reusable~~
 -	**Attributes:** description, id, isTopLevelLink, kind, label, opensInNewTab, rel, title, type, url
 
 ## Submenu

--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -77,6 +77,17 @@
 				"fontSize": true
 			}
 		},
+		"__experimentalBorder": {
+			"color": true,
+			"style": true,
+			"width": true
+		},
+		"spacing": {
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"padding": false
+			}
+		},
 		"renaming": false,
 		"interactivity": {
 			"clientNavigation": true


### PR DESCRIPTION
## What?
Closes #61746 – Nav Block: Add Support for Separator Block & Borders

This PR adds support for border and padding controls to the core/navigation-link block.

## Why?
Currently, there's no way to visually separate navigation links within the navigation block using borders. This enhancement allowing users to style navigation links with borders and spacing to better match custom designs.

## How?
- Updated the `block.json` of `core/navigation-link` to include support for:
  - `__experimentalBorder` with `color`, `style`, and `width`
  - `spacing.padding`

## Testing Instructions
1. Go to the Site Editor or create a new post/page.
2. Insert a Navigation block.
3. Add a few Navigation Link items inside it.
4. Select a Navigation Link and check the sidebar (Block settings).
5. Confirm you can now apply:
   a. Border color, width, and style
   b. Padding around each individual link

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2025-06-05 at 12 43 08 PM](https://github.com/user-attachments/assets/a6b72e00-baba-4e12-ae68-2ccaa87c079a)
![Screenshot 2025-06-05 at 12 43 42 PM](https://github.com/user-attachments/assets/42e67c1b-ac91-4c04-be94-7f771c3f2269)

