### PR TITLE
Test: improve document settings sidebar locator

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/open-document-settings-sidebar.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/open-document-settings-sidebar.ts
@@ -14,6 +14,7 @@ export async function openDocumentSettingsSidebar( this: Editor ) {
 		.getByRole( 'region', { name: 'Editor top bar' } )
 		.getByRole( 'button', {
 			name: 'Settings',
+			exact: true,
 			disabled: false,
 		} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/70330

<!-- In a few words, what is the PR actually doing? -->
Currently, the `editor.openDocumentSettingsSidebar()` of the `@wordpress/e2e-test-utils-playwright` uses this Locator to match the Open Settings Icon:

```
const toggleButton = this.page
		.getByRole( 'region', { name: 'Editor top bar' } )
		.getByRole( 'button', {
			name: 'Settings',
			disabled: false,
		} );
```

## Why?
It improves the usage for future tests and users that use this library outside the gutenberg repo (AKA myself).
## How?
This could be resolved by improving the locator as follows:

```
const toggleButton = this.page
		.getByRole( 'region', { name: 'Editor top bar' } )
		.getByRole( 'button', {
			name: 'Settings',
                        exact: true,
			disabled: false,
		} );
```

### Testing Instruction

this tests affects a helper function for the e2e tests, so if the CI passes, it is fine.
