### PR TITLE
Fix color transparency stacking in separator block

### DIFF
--- a/packages/block-library/src/separator/style.scss
+++ b/packages/block-library/src/separator/style.scss
@@ -6,6 +6,13 @@
 	border-left: none;
 	border-right: none;
 	border-bottom: none;
+
+	// Use background-color instead of border to avoid alpha stacking issues.
+	&.has-background:not(.is-style-dots) {
+		border: none !important;
+		background-color: currentColor;
+		height: 1px;
+	}
 }
 
 // Dots block style variation


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Closes #56264 

This PR updates the visual styling of the `core/separator` block to prevent unintended darkening or lightening effects when applying semi-transparent colors.

## Why?
When users apply colors with alpha transparency (e.g., `#00000033`), the current implementation renders the Separator block using both `background-color` and a `border`. This results in transparency stacking, visually compositing the same color twice, which makes the line appear darker or lighter than intended.

This issue has been reported in design and theme development contexts, particularly in cases where separators are styled with theme-defined palettes or inline color pickers.

## How?
- Replaced `border-top` with `background-color: currentColor`
- Set height: `1px` to visually define the separator thickness
- Removed all border properties

## Testing Instructions
1. Apply a semi-transparent color to a Separator block
2. Test different Separator styles (Default, Wide, Dots)
3. Confirm the transparency appears as intended (no stacking or darkening)
4. Inspect the DOM in the editor and frontend to confirm no `border` is applied and only `background-color` is responsible for visual styling.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<img width="927" alt="Screenshot 2025-06-05 at 3 14 49 PM" src="https://github.com/user-attachments/assets/b915e1e6-5385-484f-974b-3f1042c07a51" />|<img width="937" alt="Screenshot 2025-06-05 at 3 14 09 PM" src="https://github.com/user-attachments/assets/7daa1d38-f0be-4a97-80c6-4306764d9e33" />|