### PR TITLE
Fix: ensure submenu toggle in nested nav items doesn’t get flipped

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -228,6 +228,11 @@ $navigation-icon-size: 24px;
 			.wp-block-navigation__submenu-icon svg {
 				transform: rotate(-90deg);
 			}
+
+			// Reset the expanded state of the submenu toggle.
+			.wp-block-navigation-submenu__toggle[aria-expanded="true"] {
+				transform: scaleY(1);
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

Follow up to #70307

Ensure that the submenu toggle indicator doesn't get flipped for nested submenu items on larger viewports.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because they are rotated already to be horizontal instead of vertical.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adding an override in the media query
