### PR TITLE
Fix: move HTMLElement control in separator block to Advanced Inspector

### DIFF
--- a/packages/block-library/src/separator/edit.js
+++ b/packages/block-library/src/separator/edit.js
@@ -6,27 +6,19 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import {
-	HorizontalRule,
-	SelectControl,
-	PanelBody,
-	__experimentalToolsPanel as ToolsPanel,
-	__experimentalToolsPanelItem as ToolsPanelItem,
-} from '@wordpress/components';
+import { HorizontalRule, SelectControl } from '@wordpress/components';
 import {
 	useBlockProps,
 	getColorClassName,
 	__experimentalUseColorProps as useColorProps,
-	InspectorControls,
+	InspectorAdvancedControls,
 } from '@wordpress/block-editor';
-import { Platform } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import useDeprecatedOpacity from './use-deprecated-opacity';
-import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const HtmlElementControl = ( { tagName, setAttributes } ) => {
 	return (
@@ -58,7 +50,6 @@ export default function SeparatorEdit( { attributes, setAttributes } ) {
 	const colorProps = useColorProps( attributes );
 	const currentColor = colorProps?.style?.backgroundColor;
 	const hasCustomColor = !! style?.color?.background;
-	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	useDeprecatedOpacity( opacity, currentColor, setAttributes );
 
@@ -84,38 +75,12 @@ export default function SeparatorEdit( { attributes, setAttributes } ) {
 
 	return (
 		<>
-			<InspectorControls>
-				{ Platform.isNative ? (
-					<PanelBody title={ __( 'Settings' ) }>
-						<HtmlElementControl
-							tagName={ tagName }
-							setAttributes={ setAttributes }
-						/>
-					</PanelBody>
-				) : (
-					<ToolsPanel
-						label={ __( 'Settings' ) }
-						resetAll={ () => {
-							setAttributes( { tagName: 'hr' } );
-						} }
-						dropdownMenuProps={ dropdownMenuProps }
-					>
-						<ToolsPanelItem
-							hasValue={ () => tagName !== 'hr' }
-							label={ __( 'HTML element' ) }
-							onDeselect={ () =>
-								setAttributes( { tagName: 'hr' } )
-							}
-							isShownByDefault
-						>
-							<HtmlElementControl
-								tagName={ tagName }
-								setAttributes={ setAttributes }
-							/>
-						</ToolsPanelItem>
-					</ToolsPanel>
-				) }
-			</InspectorControls>
+			<InspectorAdvancedControls>
+				<HtmlElementControl
+					tagName={ tagName }
+					setAttributes={ setAttributes }
+				/>
+			</InspectorAdvancedControls>
 			<Wrapper
 				{ ...useBlockProps( {
 					className,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

Moves the HTML Element selector from the Inspector controls to the Advanced Inspector

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It is an advanced use case. In any other block where we allow users to change the tag name it also happens under advanced. And having this in the general settings tab makes it much harder to get to all the styles options.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Using the `InspectorAdvancedControls` slot instead of the `InspectorControls`
