### PR TITLE
Image: Fix outdated accessibility hint on native component

### DIFF
--- a/packages/components/src/mobile/image/index.native.js
+++ b/packages/components/src/mobile/image/index.native.js
@@ -282,7 +282,7 @@ const ImageComponent = ( {
 				accessible
 				disabled={ ! isSelected }
 				accessibilityLabel={ alt }
-				accessibilityHint={ __( 'Double tap and hold to edit' ) }
+				accessibilityHint={ __( 'Double tap to view larger.' ) }
 				accessibilityRole="imagebutton"
 				key={ url }
 				style={ imageContainerStyles }


### PR DESCRIPTION
## What?
This PR fixes the outdated accessiblity hint in native image component.

It was agreed to solve this issue in two steps in the issue discussion...
1. Update the hint to Double tap to view larger. to avoid confusion with the hold to edit message.
2. Introduce dynamic accessibility hints that consider the media states.

See #45124 

## Why?
Since the long press event was disabled in PR #40651

The current hint `Double tap and hold to edit.` is no longer relevant & needs to be replaced by `Double tap to view larger.`

## How?
This PR completes step 1 of the fix

Next step will be to add dynamic hints according to media states

## Testing Instructions [on mobile]
1. Add an Image or Media & Text block.
2. Add media to the block.
3. Enable Voice Over.
4. Move focus to the image.

## Screenshots or screencast
![image](https://github.com/user-attachments/assets/d471d12a-e0a9-42cc-9faa-cbbc80723b88)

Tested with iOS simulator, with iPhone 16 Plus iOS 18.5

Thanks!