### PR TITLE
Warning: Replace popoverProps.position to popoverProps.placement

### DIFF
--- a/packages/block-editor/src/components/warning/index.js
+++ b/packages/block-editor/src/components/warning/index.js
@@ -36,7 +36,7 @@ function Warning( { className, actions, children, secondaryActions } ) {
 									icon={ moreVertical }
 									label={ __( 'More options' ) }
 									popoverProps={ {
-										position: 'bottom left',
+										placement: 'bottom-end',
 										className:
 											'block-editor-warning__dropdown',
 									} }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Related to: https://github.com/WordPress/gutenberg/issues/44401

Replaces the deprecated position prop with the recommended placement prop in the Warning component’s Popover

## Why?
The position prop in Popover is deprecated.  This update ensures the component uses the latest API.

## Testing Instructions
1.	Run `npm run storybook:dev`.
2.	Navigate to block-editor/components/warning story.
3.	Interact with the “More options” (three dots) menu in the Warning.
4.	Ensure the dropdown appears in the correct position relative to the button.

## Screenshots or screencast <!-- if applicable -->

Before:

https://github.com/user-attachments/assets/0d7b432c-acb4-460f-8b6b-753f9dfaf862


After:

https://github.com/user-attachments/assets/00d77ad1-d717-4262-a761-c6604e8e78fd
