### PR TITLE
Social Link: Use `placement` prop for popover positioning

### DIFF
--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -167,7 +167,7 @@ const SocialLinkEdit = ( {
 				// to edit this attribute.
 				<BlockControls group="other">
 					<Dropdown
-						popoverProps={ { position: 'bottom right' } }
+						popoverProps={ { placement: 'bottom-start' } }
 						renderToggle={ ( { isOpen, onToggle } ) => (
 							<ToolbarButton
 								onClick={ onToggle }


### PR DESCRIPTION
## What?

Part of: #44401

This PR updates the Dropdown component within the Social Link block to use the `placement` prop instead of the deprecated `position` prop for its popover.

## Why?

The `position` prop for the Popover component (used internally by Dropdown) has been deprecated in favor of placement. This change aligns the Social Link block with the current component API, ensuring future compatibility and preventing potential warnings or bugs related to deprecated code.

## How?

Replaced `popoverProps.position` with `popoverProps.placement` in the SocialLinkEdit component. The `bottom-start` value is the modern equivalent of the previous positioning.


## Testing Instructions

- Open a new post or page in the editor.
- Insert a "Social Icons" block and add a social link.
- Make sure the `contentOnly` mode is enabled and the labels are enabled (enable `Show text`)
- In the block toolbar that appears, click on the `Text` text on the right of the social logo 
- Verify that the dropdown menu appears correctly positioned below the button.



## Screencasts


| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/42fb6407-99e4-44d8-b10a-a4e3df415226) | ![image](https://github.com/user-attachments/assets/d2025497-1892-4da2-90dd-dda4a615310a) |

