### PR TITLE
Media List: Use 'placement' prop for popover positioning

### DIFF
--- a/packages/block-editor/src/components/inserter/media-tab/media-preview.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-preview.js
@@ -37,7 +37,7 @@ import { store as blockEditorStore } from '../../../store';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 const MEDIA_OPTIONS_POPOVER_PROPS = {
-	position: 'bottom left',
+	placement: 'bottom-end',
 	className:
 		'block-editor-inserter__media-list__item-preview-options__popover',
 };


### PR DESCRIPTION
## What?
Part of: https://github.com/WordPress/gutenberg/issues/44401

This PR updates the Dropdown component within the `media-preview.js` to use the placement prop instead of the deprecated position prop for its popover.

## Why?
The Popover component, used internally by Dropdown, has deprecated the position prop in favor of placement. This update brings `media-preview.js` in line with the latest standards.

## How?
Changed this:
```js
const MEDIA_OPTIONS_POPOVER_PROPS = {
        position: 'bottom left',
	className:
		'block-editor-inserter__media-list__item-preview-options__popover',
};
```

To:

```js
const MEDIA_OPTIONS_POPOVER_PROPS = {
	placement: 'bottom-end',
	className:
		'block-editor-inserter__media-list__item-preview-options__popover',
};
```
## Testing Instructions
To test this change, I made the following adjustments:
2. Go to Inserter > Openverse 
3. Select an image and click on the 3-dot menu:
4. Verify that report button is in right placement.

## Screenshots:
![image](https://github.com/user-attachments/assets/48584ec7-b4a3-4afa-9f83-14e52e9b5f21)
