### PR TITLE
FormFileUpload: Extend audio accept MIME types for iOS compatibility

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-	`FormFileUpload`: Extend audio accept MIME types for iOS compatibility ([#70354](https://github.com/WordPress/gutenberg/pull/70354)).
+
 ### Internal
 
 -   `FormFileUpload`: Remove temporary fix for selecting .heic file in Chromium browsers ([#70383](https://github.com/WordPress/gutenberg/pull/70383)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--	`FormFileUpload`: Extend audio accept MIME types for iOS compatibility ([#70354](https://github.com/WordPress/gutenberg/pull/70354)).
+-   `FormFileUpload`: Extend audio accept MIME types for iOS compatibility ([#70354](https://github.com/WordPress/gutenberg/pull/70354)).
 
 ### Internal
 

--- a/packages/components/src/form-file-upload/index.tsx
+++ b/packages/components/src/form-file-upload/index.tsx
@@ -59,6 +59,12 @@ export function FormFileUpload( {
 		</Button>
 	);
 
+	// iOS browsers may not reliably handle 'audio/*' in the accept attribute.
+	// Adding explicit audio MIME types improves compatibility across all devices.
+	const compatAccept = accept?.includes( 'audio/*' )
+		? `${ accept }, audio/mp3, audio/x-m4a, audio/x-m4b, audio/x-m4p, audio/x-wav, audio/webm`
+		: accept;
+
 	return (
 		<div className="components-form-file-upload">
 			{ ui }
@@ -67,7 +73,7 @@ export function FormFileUpload( {
 				ref={ ref }
 				multiple={ multiple }
 				style={ { display: 'none' } }
-				accept={ accept }
+				accept={ compatAccept }
 				onChange={ onChange }
 				onClick={ onClick }
 				data-testid="form-file-upload-input"

--- a/packages/components/src/form-file-upload/index.tsx
+++ b/packages/components/src/form-file-upload/index.tsx
@@ -58,18 +58,26 @@ export function FormFileUpload( {
 			{ children }
 		</Button>
 	);
-	// @todo: Temporary fix a bug that prevents Chromium browsers from selecting ".heic" files
-	// from the file upload. See https://core.trac.wordpress.org/ticket/62268#comment:4.
-	// This can be removed once the Chromium fix is in the stable channel.
-	// Prevent Safari from adding "image/heic" and "image/heif" to the accept attribute.
+
 	const isSafari =
 		globalThis.window?.navigator.userAgent.includes( 'Safari' ) &&
 		! globalThis.window?.navigator.userAgent.includes( 'Chrome' ) &&
 		! globalThis.window?.navigator.userAgent.includes( 'Chromium' );
-	const compatAccept =
-		! isSafari && !! accept?.includes( 'image/*' )
-			? `${ accept }, image/heic, image/heif`
-			: accept;
+	let compatAccept = accept;
+
+	// @todo: Temporary fix a bug that prevents Chromium browsers from selecting ".heic" files
+	// from the file upload. See https://core.trac.wordpress.org/ticket/62268#comment:4.
+	// This can be removed once the Chromium fix is in the stable channel.
+	// Prevent Safari from adding "image/heic" and "image/heif" to the accept attribute.
+	if ( ! isSafari && !! accept?.includes( 'image/*' ) ) {
+		compatAccept = `${ accept }, image/heic, image/heif`;
+	}
+
+	// To ensure compatiblity with common audio formats on iOS Safari,
+	// explicitly append known MIME types for audio files.
+	if ( isSafari && !! accept?.includes( 'audio/*' ) ) {
+		compatAccept = `${ accept }, audio/mp3, audio/x-m4a, audio/x-m4b, audio/x-m4p, audio/x-wav, audio/webm`;
+	}
 
 	return (
 		<div className="components-form-file-upload">


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #70119 

<!-- In a few words, what is the PR actually doing? -->
This PR modifies the `accept` attribute for file uploads when `audio/*` is used by appending additional audio MIME types for better compatibility on iOS devices.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
iOS has inconsistent or incomplete support for the `accept="audio/*"` attribute in file inputs. It may not properly filter compatible audio types unless they are explicitly declared.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
When the current `accept` attribute includes `'audio/*'`, the code appends a list of common audio MIME types to the `accept` value. This ensures that file input dialog display all relevant and supported audio file types for selection.

## Testing Instructions
1. Open the editor on iOS
2. Add an Audio block
3. Click to open the file picker to select an audio file.
4. Ensure audio formats like `.mp3`, `.m4a`, `.wav`, `.webm` are selectable.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before (screencast):

https://github.com/user-attachments/assets/9f29460a-e9c8-47e7-bd6c-58791cb7d1d1

After (screencast):

https://github.com/user-attachments/assets/dbdceffc-c887-46ce-aace-1ce4a1c35402
