### PR TITLE
[Navigation Link block] - Enhance with rel attributes sync & add no-follow ui in link settings

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -484,7 +484,7 @@ Add a page, link, or another item to your navigation. ([Source](https://github.c
 -	**Parent:** core/navigation
 -	**Allowed Blocks:** core/navigation-link, core/navigation-submenu, core/page-list
 -	**Supports:** interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~, ~~reusable~~
--	**Attributes:** description, id, isTopLevelLink, kind, label, opensInNewTab, rel, title, type, url
+-	**Attributes:** description, id, isTopLevelLink, kind, label, rel, title, type, url
 
 ## Submenu
 

--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -28,10 +28,6 @@
 		"id": {
 			"type": "number"
 		},
-		"opensInNewTab": {
-			"type": "boolean",
-			"default": false
-		},
 		"url": {
 			"type": "string"
 		},

--- a/packages/block-library/src/navigation-link/constants.js
+++ b/packages/block-library/src/navigation-link/constants.js
@@ -1,0 +1,3 @@
+export const NEW_TAB_REL = 'noreferrer noopener';
+export const NEW_TAB_TARGET = '_blank';
+export const NOFOLLOW_REL = 'nofollow';

--- a/packages/block-library/src/navigation-link/deprecated.js
+++ b/packages/block-library/src/navigation-link/deprecated.js
@@ -1,0 +1,133 @@
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { NEW_TAB_REL, NOFOLLOW_REL } from './constants';
+
+// Migration function to convert old attributes to new rel-based structure
+const migrateToRelAttribute = ( attributes ) => {
+	const { opensInNewTab, nofollow, rel = '', ...restAttributes } = attributes;
+
+	// If no opensInNewTab or nofollow attributes exist, no migration needed
+	if ( opensInNewTab === undefined && nofollow === undefined ) {
+		return attributes;
+	}
+
+	let newRel = rel;
+
+	// Add new tab rel if opensInNewTab was true
+	if ( opensInNewTab && ! newRel.includes( NEW_TAB_REL ) ) {
+		newRel = newRel ? `${ newRel } ${ NEW_TAB_REL }` : NEW_TAB_REL;
+	}
+
+	// Add nofollow rel if nofollow was true
+	if ( nofollow && ! newRel.includes( NOFOLLOW_REL ) ) {
+		newRel = newRel ? `${ newRel } ${ NOFOLLOW_REL }` : NOFOLLOW_REL;
+	}
+
+	// Clean up extra spaces
+	newRel = newRel.trim().replace( /\s+/g, ' ' );
+
+	return {
+		...restAttributes,
+		rel: newRel || undefined,
+	};
+};
+
+// Version 2: Navigation link with opensInNewTab attribute (and potentially remaining nofollow)
+const v2 = {
+	attributes: {
+		label: {
+			type: 'string',
+		},
+		type: {
+			type: 'string',
+		},
+		description: {
+			type: 'string',
+		},
+		rel: {
+			type: 'string',
+		},
+		id: {
+			type: 'number',
+		},
+		opensInNewTab: {
+			type: 'boolean',
+			default: false,
+		},
+		url: {
+			type: 'string',
+		},
+		title: {
+			type: 'string',
+		},
+		kind: {
+			type: 'string',
+		},
+		isTopLevelLink: {
+			type: 'boolean',
+		},
+		nofollow: {
+			type: 'boolean',
+			default: false,
+		},
+	},
+	isEligible( attributes ) {
+		// This deprecation is eligible if the block has opensInNewTab attribute
+		// (nofollow might still exist from blocks that haven't been migrated from v1)
+		return attributes.opensInNewTab !== undefined;
+	},
+	migrate: migrateToRelAttribute,
+	save() {
+		// No save function needed since we're only migrating attributes
+		// The current save function will handle the migrated attributes
+		return null;
+	},
+};
+
+// Version 1: Original deprecation for nofollow attribute only
+const v1 = {
+	attributes: {
+		label: {
+			type: 'string',
+		},
+		type: {
+			type: 'string',
+		},
+		nofollow: {
+			type: 'boolean',
+		},
+		description: {
+			type: 'string',
+		},
+		id: {
+			type: 'number',
+		},
+		opensInNewTab: {
+			type: 'boolean',
+			default: false,
+		},
+		url: {
+			type: 'string',
+		},
+	},
+	isEligible( attributes ) {
+		return attributes.nofollow;
+	},
+	migrate( { nofollow, ...rest } ) {
+		return {
+			rel: nofollow ? 'nofollow' : '',
+			...rest,
+		};
+	},
+	save() {
+		return <InnerBlocks.Content />;
+	},
+};
+
+export default [ v2, v1 ];

--- a/packages/block-library/src/navigation-link/deprecated.js
+++ b/packages/block-library/src/navigation-link/deprecated.js
@@ -8,37 +8,7 @@ import { InnerBlocks } from '@wordpress/block-editor';
  */
 import { NEW_TAB_REL, NOFOLLOW_REL } from './constants';
 
-// Migration function to convert old attributes to new rel-based structure
-const migrateToRelAttribute = ( attributes ) => {
-	const { opensInNewTab, nofollow, rel = '', ...restAttributes } = attributes;
-
-	// If no opensInNewTab or nofollow attributes exist, no migration needed
-	if ( opensInNewTab === undefined && nofollow === undefined ) {
-		return attributes;
-	}
-
-	let newRel = rel;
-
-	// Add new tab rel if opensInNewTab was true
-	if ( opensInNewTab && ! newRel.includes( NEW_TAB_REL ) ) {
-		newRel = newRel ? `${ newRel } ${ NEW_TAB_REL }` : NEW_TAB_REL;
-	}
-
-	// Add nofollow rel if nofollow was true
-	if ( nofollow && ! newRel.includes( NOFOLLOW_REL ) ) {
-		newRel = newRel ? `${ newRel } ${ NOFOLLOW_REL }` : NOFOLLOW_REL;
-	}
-
-	// Clean up extra spaces
-	newRel = newRel.trim().replace( /\s+/g, ' ' );
-
-	return {
-		...restAttributes,
-		rel: newRel || undefined,
-	};
-};
-
-// Version 2: Navigation link with opensInNewTab attribute (and potentially remaining nofollow)
+// Version 2: Navigation link with opensInNewTab attribute
 const v2 = {
 	attributes: {
 		label: {
@@ -78,15 +48,43 @@ const v2 = {
 		},
 	},
 	isEligible( attributes ) {
-		// This deprecation is eligible if the block has opensInNewTab attribute
-		// (nofollow might still exist from blocks that haven't been migrated from v1)
 		return attributes.opensInNewTab !== undefined;
 	},
-	migrate: migrateToRelAttribute,
+	migrate: ( attributes ) => {
+		const {
+			opensInNewTab,
+			nofollow,
+			rel = '',
+			...restAttributes
+		} = attributes;
+
+		// If no opensInNewTab or nofollow attributes exist, no migration needed
+		if ( opensInNewTab === undefined && nofollow === undefined ) {
+			return attributes;
+		}
+
+		let newRel = rel;
+
+		// Add new tab rel if opensInNewTab was true
+		if ( opensInNewTab && ! newRel.includes( NEW_TAB_REL ) ) {
+			newRel = newRel ? `${ newRel } ${ NEW_TAB_REL }` : NEW_TAB_REL;
+		}
+
+		// Add nofollow rel if nofollow was true
+		if ( nofollow && ! newRel.includes( NOFOLLOW_REL ) ) {
+			newRel = newRel ? `${ newRel } ${ NOFOLLOW_REL }` : NOFOLLOW_REL;
+		}
+
+		// Clean up extra spaces
+		newRel = newRel.trim().replace( /\s+/g, ' ' );
+
+		return {
+			...restAttributes,
+			rel: newRel,
+		};
+	},
 	save() {
-		// No save function needed since we're only migrating attributes
-		// The current save function will handle the migrated attributes
-		return null;
+		return <InnerBlocks.Content />;
 	},
 };
 

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -381,7 +381,7 @@ export default function NavigationLinkEdit( {
 			__unstableMarkNextChangeAsNotPersistent();
 			transformToSubmenu();
 		}
-	}, [ hasChildren ] );
+	}, [ hasChildren ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	// If the LinkControl popover is open and the URL has changed, close the LinkControl and focus the label text.
 	useEffect( () => {
@@ -428,7 +428,7 @@ export default function NavigationLinkEdit( {
 			id: undefined,
 			kind: undefined,
 			type: undefined,
-			opensInNewTab: false,
+			rel: undefined,
 		} );
 
 		// Close the link editing UI.

--- a/packages/block-library/src/navigation-link/get-updated-link-attributes.js
+++ b/packages/block-library/src/navigation-link/get-updated-link-attributes.js
@@ -1,0 +1,51 @@
+/**
+ * Internal dependencies
+ */
+import { NEW_TAB_REL, NOFOLLOW_REL } from './constants';
+
+/**
+ * WordPress dependencies
+ */
+import { prependHTTP } from '@wordpress/url';
+
+/**
+ * Updates the link attributes.
+ *
+ * @param {Object}  attributes               The current block attributes.
+ * @param {string}  attributes.rel           The current link rel attribute.
+ * @param {string}  attributes.url           The current link url.
+ * @param {boolean} attributes.opensInNewTab Whether the link should open in a new window.
+ * @param {boolean} attributes.nofollow      Whether the link should be marked as nofollow.
+ */
+export function getUpdatedLinkAttributes( {
+	rel = '',
+	url = '',
+	opensInNewTab,
+	nofollow,
+} ) {
+	// Since `rel` is editable attribute, we need to check for existing values and proceed accordingly.
+	let updatedRel = rel;
+
+	if ( opensInNewTab ) {
+		updatedRel = updatedRel?.includes( NEW_TAB_REL )
+			? updatedRel
+			: updatedRel + ` ${ NEW_TAB_REL }`;
+	} else {
+		const relRegex = new RegExp( `\\b${ NEW_TAB_REL }\\s*`, 'g' );
+		updatedRel = updatedRel?.replace( relRegex, '' ).trim();
+	}
+
+	if ( nofollow ) {
+		updatedRel = updatedRel?.includes( NOFOLLOW_REL )
+			? updatedRel
+			: ( updatedRel + ` ${ NOFOLLOW_REL }` ).trim();
+	} else {
+		const relRegex = new RegExp( `\\b${ NOFOLLOW_REL }\\s*`, 'g' );
+		updatedRel = updatedRel?.replace( relRegex, '' ).trim();
+	}
+
+	return {
+		url: prependHTTP( url ),
+		rel: updatedRel || undefined,
+	};
+}

--- a/packages/block-library/src/navigation-link/index.js
+++ b/packages/block-library/src/navigation-link/index.js
@@ -3,7 +3,6 @@
  */
 import { _x } from '@wordpress/i18n';
 import { customLink as linkIcon } from '@wordpress/icons';
-import { InnerBlocks } from '@wordpress/block-editor';
 import { addFilter } from '@wordpress/hooks';
 
 /**
@@ -15,6 +14,7 @@ import edit from './edit';
 import save from './save';
 import { enhanceNavigationLinkVariations } from './hooks';
 import transforms from './transforms';
+import deprecated from './deprecated';
 
 const { name } = metadata;
 
@@ -43,49 +43,7 @@ export const settings = {
 		},
 	},
 
-	deprecated: [
-		{
-			isEligible( attributes ) {
-				return attributes.nofollow;
-			},
-
-			attributes: {
-				label: {
-					type: 'string',
-				},
-				type: {
-					type: 'string',
-				},
-				nofollow: {
-					type: 'boolean',
-				},
-				description: {
-					type: 'string',
-				},
-				id: {
-					type: 'number',
-				},
-				opensInNewTab: {
-					type: 'boolean',
-					default: false,
-				},
-				url: {
-					type: 'string',
-				},
-			},
-
-			migrate( { nofollow, ...rest } ) {
-				return {
-					rel: nofollow ? 'nofollow' : '',
-					...rest,
-				};
-			},
-
-			save() {
-				return <InnerBlocks.Content />;
-			},
-		},
-	],
+	deprecated,
 	transforms,
 };
 

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -239,14 +239,16 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		$html .= ' aria-current="page"';
 	}
 
-	if ( isset( $attributes['opensInNewTab'] ) && true === $attributes['opensInNewTab'] ) {
-		$html .= ' target="_blank"  ';
+	// Check if link should open in new tab based on rel attribute.
+	$rel              = isset( $attributes['rel'] ) ? $attributes['rel'] : '';
+	$opens_in_new_tab = strpos( $rel, 'noreferrer noopener' ) !== false;
+
+	if ( $opens_in_new_tab ) {
+		$html .= ' target="_blank"';
 	}
 
 	if ( isset( $attributes['rel'] ) ) {
 		$html .= ' rel="' . esc_attr( $attributes['rel'] ) . '"';
-	} elseif ( isset( $attributes['nofollow'] ) && $attributes['nofollow'] ) {
-		$html .= ' rel="nofollow"';
 	}
 
 	if ( isset( $attributes['title'] ) ) {

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -35,10 +35,23 @@ import { useInstanceId, useFocusOnMount } from '@wordpress/compose';
  * Internal dependencies
  */
 import { unlock } from '../lock-unlock';
+import { NOFOLLOW_REL, NEW_TAB_REL } from './constants';
+import { getUpdatedLinkAttributes } from './get-updated-link-attributes';
 
 const { PrivateQuickInserter: QuickInserter } = unlock(
 	blockEditorPrivateApis
 );
+
+const LINK_SETTINGS = [
+	...LinkControl.DEFAULT_LINK_SETTINGS,
+	{
+		id: 'nofollow',
+		title: createInterpolateElement(
+			__( 'Mark as <code>nofollow</code>' ),
+			{ code: <code /> }
+		),
+	},
+];
 
 /**
  * Given the Link block's type attribute, return the query params to give to
@@ -146,8 +159,12 @@ function LinkUIBlockInserter( { clientId, onBack } ) {
 }
 
 function UnforwardedLinkUI( props, ref ) {
-	const { label, url, opensInNewTab, type, kind } = props.link;
+	const { label, url, type, kind, rel } = props.link;
 	const postType = type || 'page';
+
+	// Derive opensInNewTab and nofollow from rel attribute
+	const opensInNewTab = rel?.includes( NEW_TAB_REL );
+	const nofollow = rel?.includes( NOFOLLOW_REL );
 
 	const [ addingBlock, setAddingBlock ] = useState( false );
 	const [ focusAddBlockButton, setFocusAddBlockButton ] = useState( false );
@@ -189,8 +206,9 @@ function UnforwardedLinkUI( props, ref ) {
 			url,
 			opensInNewTab,
 			title: label && stripHTML( label ),
+			nofollow,
 		} ),
-		[ label, opensInNewTab, url ]
+		[ label, opensInNewTab, url, nofollow ]
 	);
 
 	const dialogTitleId = useInstanceId(
@@ -230,6 +248,7 @@ function UnforwardedLinkUI( props, ref ) {
 						hasRichPreviews
 						value={ link }
 						showInitialSuggestions
+						settings={ LINK_SETTINGS }
 						withCreateSuggestion={ permissions.canCreate }
 						createSuggestion={ handleCreate }
 						createSuggestionButtonText={ ( searchTerm ) => {
@@ -257,7 +276,25 @@ function UnforwardedLinkUI( props, ref ) {
 						noDirectEntry={ !! type }
 						noURLSuggestion={ !! type }
 						suggestionsQuery={ getSuggestionsQuery( type, kind ) }
-						onChange={ props.onChange }
+						onChange={ ( {
+							url: newURL,
+							opensInNewTab: newOpensInNewTab,
+							nofollow: newNofollow,
+							...otherValues
+						} ) => {
+							const updatedAttributes = getUpdatedLinkAttributes(
+								{
+									rel: props.link.rel || '',
+									url: newURL,
+									opensInNewTab: newOpensInNewTab,
+									nofollow: newNofollow,
+								}
+							);
+							props.onChange( {
+								...otherValues,
+								...updatedAttributes,
+							} );
+						} }
 						onRemove={ props.onRemove }
 						onCancel={ props.onCancel }
 						renderControlBottom={ () =>

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -284,7 +284,7 @@ function UnforwardedLinkUI( props, ref ) {
 						} ) => {
 							const updatedAttributes = getUpdatedLinkAttributes(
 								{
-									rel: props.link.rel || '',
+									rel: props.link.rel,
 									url: newURL,
 									opensInNewTab: newOpensInNewTab,
 									nofollow: newNofollow,

--- a/packages/block-library/src/navigation-link/test/edit.js
+++ b/packages/block-library/src/navigation-link/test/edit.js
@@ -10,7 +10,7 @@ describe( 'edit', () => {
 		it( 'can update a post link', () => {
 			const setAttributes = jest.fn();
 			const linkSuggestion = {
-				opensInNewTab: false,
+				rel: undefined,
 				id: 1337,
 				url: 'https://wordpress.local/menu-test/',
 				kind: 'post-type',
@@ -22,7 +22,7 @@ describe( 'edit', () => {
 			expect( setAttributes ).toHaveBeenCalledWith( {
 				id: 1337,
 				label: 'Menu Test',
-				opensInNewTab: false,
+				rel: undefined,
 				kind: 'post-type',
 				type: 'post',
 				url: 'https://wordpress.local/menu-test/',
@@ -34,7 +34,7 @@ describe( 'edit', () => {
 			const linkSuggestion = {
 				id: 2,
 				kind: 'post-type',
-				opensInNewTab: false,
+				rel: undefined,
 				title: 'Sample Page',
 				type: 'page',
 				url: 'http://wordpress.local/sample-page/',
@@ -44,7 +44,7 @@ describe( 'edit', () => {
 				id: 2,
 				kind: 'post-type',
 				label: 'Sample Page',
-				opensInNewTab: false,
+				rel: undefined,
 				type: 'page',
 				url: 'http://wordpress.local/sample-page/',
 			} );
@@ -55,7 +55,7 @@ describe( 'edit', () => {
 			const linkSuggestion = {
 				id: 15,
 				kind: 'taxonomy',
-				opensInNewTab: false,
+				rel: undefined,
 				title: 'bar',
 				type: 'post_tag',
 				url: 'http://wordpress.local/tag/bar/',
@@ -64,7 +64,7 @@ describe( 'edit', () => {
 			expect( setAttributes ).toHaveBeenCalledWith( {
 				id: 15,
 				kind: 'taxonomy',
-				opensInNewTab: false,
+				rel: undefined,
 				label: 'bar',
 				type: 'tag',
 				url: 'http://wordpress.local/tag/bar/',
@@ -76,7 +76,7 @@ describe( 'edit', () => {
 			const linkSuggestion = {
 				id: 9,
 				kind: 'taxonomy',
-				opensInNewTab: false,
+				rel: undefined,
 				title: 'Cats',
 				type: 'category',
 				url: 'http://wordpress.local/category/cats/',
@@ -85,7 +85,7 @@ describe( 'edit', () => {
 			expect( setAttributes ).toHaveBeenCalledWith( {
 				id: 9,
 				kind: 'taxonomy',
-				opensInNewTab: false,
+				rel: undefined,
 				label: 'Cats',
 				type: 'category',
 				url: 'http://wordpress.local/category/cats/',
@@ -97,7 +97,7 @@ describe( 'edit', () => {
 			const linkSuggestion = {
 				id: 131,
 				kind: 'post-type',
-				opensInNewTab: false,
+				rel: undefined,
 				title: 'Fall',
 				type: 'portfolio',
 				url: 'http://wordpress.local/portfolio/fall/',
@@ -106,7 +106,7 @@ describe( 'edit', () => {
 			expect( setAttributes ).toHaveBeenCalledWith( {
 				id: 131,
 				kind: 'post-type',
-				opensInNewTab: false,
+				rel: undefined,
 				label: 'Fall',
 				type: 'portfolio',
 				url: 'http://wordpress.local/portfolio/fall/',
@@ -118,7 +118,7 @@ describe( 'edit', () => {
 			const linkSuggestion = {
 				id: 4,
 				kind: 'taxonomy',
-				opensInNewTab: false,
+				rel: undefined,
 				title: 'Portfolio Tag',
 				type: 'portfolio_tag',
 				url: 'http://wordpress.local/portfolio_tag/PortfolioTag/',
@@ -127,7 +127,7 @@ describe( 'edit', () => {
 			expect( setAttributes ).toHaveBeenCalledWith( {
 				id: 4,
 				kind: 'taxonomy',
-				opensInNewTab: false,
+				rel: undefined,
 				label: 'Portfolio Tag',
 				type: 'portfolio_tag',
 				url: 'http://wordpress.local/portfolio_tag/PortfolioTag/',
@@ -139,7 +139,7 @@ describe( 'edit', () => {
 			const linkSuggestion = {
 				id: 2,
 				kind: 'taxonomy',
-				opensInNewTab: false,
+				rel: undefined,
 				title: 'Portfolio Category',
 				type: 'portfolio_category',
 				url: 'http://wordpress.local/portfolio_category/Portfolio-category/',
@@ -148,7 +148,7 @@ describe( 'edit', () => {
 			expect( setAttributes ).toHaveBeenCalledWith( {
 				id: 2,
 				kind: 'taxonomy',
-				opensInNewTab: false,
+				rel: undefined,
 				label: 'Portfolio Category',
 				type: 'portfolio_category',
 				url: 'http://wordpress.local/portfolio_category/Portfolio-category/',
@@ -160,7 +160,7 @@ describe( 'edit', () => {
 			const linkSuggestion = {
 				id: 'video',
 				kind: 'taxonomy',
-				opensInNewTab: false,
+				rel: undefined,
 				title: 'Video',
 				type: 'post-format',
 				url: 'http://wordpress.local/type/video/',
@@ -170,7 +170,7 @@ describe( 'edit', () => {
 			// we do not persist this ID since we expect this value to be a post or term ID.
 			expect( setAttributes ).toHaveBeenCalledWith( {
 				kind: 'taxonomy',
-				opensInNewTab: false,
+				rel: undefined,
 				label: 'Video',
 				type: 'post_format',
 				url: 'http://wordpress.local/type/video/',
@@ -181,12 +181,12 @@ describe( 'edit', () => {
 			it( 'when typing a url, but not selecting a search suggestion', () => {
 				const setAttributes = jest.fn();
 				const linkSuggestion = {
-					opensInNewTab: false,
+					rel: undefined,
 					url: 'www.wordpress.org',
 				};
 				updateAttributes( linkSuggestion, setAttributes );
 				expect( setAttributes ).toHaveBeenCalledWith( {
-					opensInNewTab: false,
+					rel: undefined,
 					url: 'www.wordpress.org',
 					label: 'www.wordpress.org',
 					kind: 'custom',
@@ -197,14 +197,14 @@ describe( 'edit', () => {
 				const setAttributes = jest.fn();
 				const linkSuggestion = {
 					id: 'www.wordpress.org',
-					opensInNewTab: false,
+					rel: undefined,
 					title: 'www.wordpress.org',
 					type: 'URL',
 					url: 'http://www.wordpress.org',
 				};
 				updateAttributes( linkSuggestion, setAttributes );
 				expect( setAttributes ).toHaveBeenCalledWith( {
-					opensInNewTab: false,
+					rel: undefined,
 					label: 'www.wordpress.org',
 					kind: 'custom',
 					url: 'http://www.wordpress.org',
@@ -215,14 +215,14 @@ describe( 'edit', () => {
 				const setAttributes = jest.fn();
 				const linkSuggestion = {
 					id: 'mailto:foo@example.com',
-					opensInNewTab: false,
+					rel: undefined,
 					title: 'mailto:foo@example.com',
 					type: 'mailto',
 					url: 'mailto:foo@example.com',
 				};
 				updateAttributes( linkSuggestion, setAttributes );
 				expect( setAttributes ).toHaveBeenCalledWith( {
-					opensInNewTab: false,
+					rel: undefined,
 					label: 'mailto:foo@example.com',
 					kind: 'custom',
 					url: 'mailto:foo@example.com',
@@ -234,14 +234,14 @@ describe( 'edit', () => {
 				const setAttributes = jest.fn();
 				const linkSuggestion = {
 					id: '#foo',
-					opensInNewTab: false,
+					rel: undefined,
 					title: '#foo',
 					type: 'internal',
 					url: '#foo',
 				};
 				updateAttributes( linkSuggestion, setAttributes );
 				expect( setAttributes ).toHaveBeenCalledWith( {
-					opensInNewTab: false,
+					rel: undefined,
 					label: '#foo',
 					kind: 'custom',
 					url: '#foo',
@@ -253,14 +253,14 @@ describe( 'edit', () => {
 				const setAttributes = jest.fn();
 				const linkSuggestion = {
 					id: 'tel:5555555',
-					opensInNewTab: false,
+					rel: undefined,
 					title: 'tel:5555555',
 					type: 'tel',
 					url: 'tel:5555555',
 				};
 				updateAttributes( linkSuggestion, setAttributes );
 				expect( setAttributes ).toHaveBeenCalledWith( {
-					opensInNewTab: false,
+					rel: undefined,
 					label: 'tel:5555555',
 					kind: 'custom',
 					url: 'tel:5555555',
@@ -275,14 +275,14 @@ describe( 'edit', () => {
 				const setAttributes = jest.fn();
 				const linkSuggestion = {
 					id: 'www.wordpress.org/foo bar',
-					opensInNewTab: false,
+					rel: undefined,
 					title: '',
 					type: 'URL',
 					url: 'https://www.wordpress.org',
 				};
 				updateAttributes( linkSuggestion, setAttributes );
 				expect( setAttributes ).toHaveBeenCalledWith( {
-					opensInNewTab: false,
+					rel: undefined,
 					label: 'www.wordpress.org',
 					kind: 'custom',
 					url: 'https://www.wordpress.org',
@@ -292,14 +292,14 @@ describe( 'edit', () => {
 				const setAttributes = jest.fn();
 				const linkSuggestion = {
 					id: 'www.wordpress.org',
-					opensInNewTab: false,
+					rel: undefined,
 					title: 'Custom Title',
 					type: 'URL',
 					url: 'wordpress.org',
 				};
 				updateAttributes( linkSuggestion, setAttributes );
 				expect( setAttributes ).toHaveBeenCalledWith( {
-					opensInNewTab: false,
+					rel: undefined,
 					label: 'Custom Title',
 					kind: 'custom',
 					url: 'wordpress.org',
@@ -309,14 +309,14 @@ describe( 'edit', () => {
 				const setAttributes = jest.fn();
 				const linkSuggestion = {
 					id: 'www.wordpress.org',
-					opensInNewTab: false,
+					rel: undefined,
 					title: 'Custom Title',
 					type: 'URL',
 					url: 'https://wordpress.org',
 				};
 				updateAttributes( linkSuggestion, setAttributes );
 				expect( setAttributes ).toHaveBeenCalledWith( {
-					opensInNewTab: false,
+					rel: undefined,
 					label: 'Custom Title',
 					kind: 'custom',
 					url: 'https://wordpress.org',
@@ -327,14 +327,14 @@ describe( 'edit', () => {
 				const setAttributes = jest.fn();
 				const linkSuggestion = {
 					id: 'http://wordpress.org/?s=',
-					opensInNewTab: false,
+					rel: undefined,
 					title: 'Custom Title',
 					type: 'URL',
 					url: 'http://wordpress.org/?s=<>',
 				};
 				updateAttributes( linkSuggestion, setAttributes );
 				expect( setAttributes ).toHaveBeenCalledWith( {
-					opensInNewTab: false,
+					rel: undefined,
 					label: 'Custom Title',
 					kind: 'custom',
 					url: 'http://wordpress.org/?s=%3C%3E',
@@ -349,7 +349,7 @@ describe( 'edit', () => {
 					Object.assign( mockState, attr )
 				);
 				const linkSuggestion = {
-					opensInNewTab: false,
+					rel: undefined,
 					id: 1337,
 					url: 'https://wordpress.local/menu-test/',
 					kind: 'post-type',
@@ -361,7 +361,7 @@ describe( 'edit', () => {
 				expect( mockState ).toEqual( {
 					id: 1337,
 					label: 'Menu Test',
-					opensInNewTab: false,
+					rel: undefined,
 					kind: 'post-type',
 					type: 'post',
 					url: 'https://wordpress.local/menu-test/',
@@ -370,7 +370,7 @@ describe( 'edit', () => {
 				updateAttributes(
 					{
 						url: 'https://wordpress.local/menu-test/',
-						opensInNewTab: true,
+						rel: 'noreferrer noopener',
 					},
 					setAttributes,
 					mockState
@@ -378,7 +378,7 @@ describe( 'edit', () => {
 				expect( mockState ).toEqual( {
 					id: 1337,
 					label: 'Menu Test',
-					opensInNewTab: true,
+					rel: 'noreferrer noopener',
 					kind: 'post-type',
 					type: 'post',
 					url: 'https://wordpress.local/menu-test/',
@@ -390,7 +390,7 @@ describe( 'edit', () => {
 					Object.assign( mockState, attr )
 				);
 				const linkSuggestion = {
-					opensInNewTab: false,
+					rel: undefined,
 					id: 1337,
 					url: 'https://wordpress.local/menu-test/',
 					kind: 'post-type',
@@ -402,7 +402,7 @@ describe( 'edit', () => {
 				expect( mockState ).toEqual( {
 					id: 1337,
 					label: 'Menu Test',
-					opensInNewTab: false,
+					rel: undefined,
 					kind: 'post-type',
 					type: 'post',
 					url: 'https://wordpress.local/menu-test/',
@@ -411,7 +411,7 @@ describe( 'edit', () => {
 				updateAttributes(
 					{
 						url: 'https://wordpress.local/foo/',
-						opensInNewTab: false,
+						rel: undefined,
 					},
 					setAttributes,
 					mockState
@@ -419,7 +419,7 @@ describe( 'edit', () => {
 				expect( mockState ).toEqual( {
 					id: 1337,
 					label: 'Menu Test',
-					opensInNewTab: false,
+					rel: undefined,
 					kind: 'post-type',
 					type: 'post',
 					url: 'https://wordpress.local/foo/',

--- a/packages/block-library/src/navigation-link/test/get-updated-link-attributes.js
+++ b/packages/block-library/src/navigation-link/test/get-updated-link-attributes.js
@@ -1,0 +1,165 @@
+/**
+ * Internal dependencies
+ */
+import { getUpdatedLinkAttributes } from '../get-updated-link-attributes';
+
+describe( 'getUpdatedLinkAttributes method (navigation-link)', () => {
+	it( 'should correctly handle unassigned rel', () => {
+		const options = {
+			url: 'example.com',
+			opensInNewTab: true,
+			nofollow: false,
+		};
+
+		const result = getUpdatedLinkAttributes( options );
+
+		expect( result.url ).toEqual( 'http://example.com' );
+		expect( result.rel ).toEqual( 'noreferrer noopener' );
+	} );
+
+	it( 'should return empty rel value as undefined', () => {
+		const options = {
+			url: 'example.com',
+			opensInNewTab: false,
+			nofollow: false,
+		};
+
+		const result = getUpdatedLinkAttributes( options );
+
+		expect( result.url ).toEqual( 'http://example.com' );
+		expect( result.rel ).toEqual( undefined );
+	} );
+
+	it( 'should correctly handle rel with existing values', () => {
+		const options = {
+			url: 'example.com',
+			opensInNewTab: true,
+			nofollow: true,
+			rel: 'rel_value',
+		};
+
+		const result = getUpdatedLinkAttributes( options );
+
+		expect( result.url ).toEqual( 'http://example.com' );
+		expect( result.rel ).toEqual(
+			'rel_value noreferrer noopener nofollow'
+		);
+	} );
+
+	it( 'should correctly update link attributes with opensInNewTab', () => {
+		const options = {
+			url: 'example.com',
+			opensInNewTab: true,
+			nofollow: false,
+			rel: 'rel_value',
+		};
+
+		const result = getUpdatedLinkAttributes( options );
+
+		expect( result.url ).toEqual( 'http://example.com' );
+		expect( result.rel ).toEqual( 'rel_value noreferrer noopener' );
+	} );
+
+	it( 'should correctly update link attributes with nofollow', () => {
+		const options = {
+			url: 'example.com',
+			opensInNewTab: false,
+			nofollow: true,
+			rel: 'rel_value',
+		};
+
+		const result = getUpdatedLinkAttributes( options );
+
+		expect( result.url ).toEqual( 'http://example.com' );
+		expect( result.rel ).toEqual( 'rel_value nofollow' );
+	} );
+
+	it( 'should correctly update link attributes with nofollow without spacing', () => {
+		const options = {
+			url: 'example.com',
+			opensInNewTab: false,
+			nofollow: true,
+			rel: '',
+		};
+
+		const result = getUpdatedLinkAttributes( options );
+
+		expect( result.url ).toEqual( 'http://example.com' );
+		expect( result.rel ).toEqual( 'nofollow' );
+	} );
+
+	it( 'should correctly handle rel with existing nofollow values and remove duplicates', () => {
+		const options = {
+			url: 'example.com',
+			opensInNewTab: true,
+			nofollow: true,
+			rel: 'rel_value nofollow',
+		};
+
+		const result = getUpdatedLinkAttributes( options );
+
+		expect( result.url ).toEqual( 'http://example.com' );
+		expect( result.rel ).toEqual(
+			'rel_value nofollow noreferrer noopener'
+		);
+	} );
+
+	it( 'should correctly handle rel with existing new tab values and remove duplicates', () => {
+		const options = {
+			url: 'example.com',
+			opensInNewTab: true,
+			nofollow: false,
+			rel: 'rel_value noreferrer noopener',
+		};
+
+		const result = getUpdatedLinkAttributes( options );
+
+		expect( result.url ).toEqual( 'http://example.com' );
+		expect( result.rel ).toEqual( 'rel_value noreferrer noopener' );
+	} );
+
+	// NEW TEST: This is the key test case that was failing before our fix
+	it( 'should correctly remove all rel values when both options are false', () => {
+		const options = {
+			url: 'example.com',
+			opensInNewTab: false,
+			nofollow: false,
+			rel: 'noreferrer noopener nofollow',
+		};
+
+		const result = getUpdatedLinkAttributes( options );
+
+		expect( result.url ).toEqual( 'http://example.com' );
+		expect( result.rel ).toEqual( undefined );
+	} );
+
+	// NEW TEST: Mixed scenario
+	it( 'should correctly remove all rel values when both options are false with custom rel', () => {
+		const options = {
+			url: 'example.com',
+			opensInNewTab: false,
+			nofollow: false,
+			rel: 'custom-value noreferrer noopener nofollow another-custom',
+		};
+
+		const result = getUpdatedLinkAttributes( options );
+
+		expect( result.url ).toEqual( 'http://example.com' );
+		expect( result.rel ).toEqual( 'custom-value another-custom' );
+	} );
+
+	// NEW TEST: Partial removal
+	it( 'should correctly remove only new tab values when opensInNewTab is false', () => {
+		const options = {
+			url: 'example.com',
+			opensInNewTab: false,
+			nofollow: true,
+			rel: 'custom-value noreferrer noopener nofollow',
+		};
+
+		const result = getUpdatedLinkAttributes( options );
+
+		expect( result.url ).toEqual( 'http://example.com' );
+		expect( result.rel ).toEqual( 'custom-value nofollow' );
+	} );
+} );

--- a/packages/block-library/src/navigation-link/test/get-updated-link-attributes.js
+++ b/packages/block-library/src/navigation-link/test/get-updated-link-attributes.js
@@ -118,7 +118,6 @@ describe( 'getUpdatedLinkAttributes method (navigation-link)', () => {
 		expect( result.rel ).toEqual( 'rel_value noreferrer noopener' );
 	} );
 
-	// NEW TEST: This is the key test case that was failing before our fix
 	it( 'should correctly remove all rel values when both options are false', () => {
 		const options = {
 			url: 'example.com',
@@ -133,7 +132,6 @@ describe( 'getUpdatedLinkAttributes method (navigation-link)', () => {
 		expect( result.rel ).toEqual( undefined );
 	} );
 
-	// NEW TEST: Mixed scenario
 	it( 'should correctly remove all rel values when both options are false with custom rel', () => {
 		const options = {
 			url: 'example.com',
@@ -148,7 +146,6 @@ describe( 'getUpdatedLinkAttributes method (navigation-link)', () => {
 		expect( result.rel ).toEqual( 'custom-value another-custom' );
 	} );
 
-	// NEW TEST: Partial removal
 	it( 'should correctly remove only new tab values when opensInNewTab is false', () => {
 		const options = {
 			url: 'example.com',

--- a/packages/block-library/src/navigation-link/update-attributes.js
+++ b/packages/block-library/src/navigation-link/update-attributes.js
@@ -2,12 +2,7 @@
  * WordPress dependencies
  */
 import { escapeHTML } from '@wordpress/escape-html';
-import { prependHTTP, safeDecodeURI } from '@wordpress/url';
-
-/**
- * Internal dependencies
- */
-import { getUpdatedLinkAttributes } from './get-updated-link-attributes';
+import { safeDecodeURI } from '@wordpress/url';
 
 /**
  * @typedef {'post-type'|'custom'|'taxonomy'|'post-type-archive'} WPNavigationLinkKind
@@ -17,14 +12,13 @@ import { getUpdatedLinkAttributes } from './get-updated-link-attributes';
  *
  * @typedef {Object} WPNavigationLinkBlockAttributes
  *
- * @property {string}               [label]         Link text.
- * @property {WPNavigationLinkKind} [kind]          Kind is used to differentiate between term and post ids to check post draft status.
- * @property {string}               [type]          The type such as post, page, tag, category and other custom types.
- * @property {string}               [rel]           The relationship of the linked URL.
- * @property {number}               [id]            A post or term id.
- * @property {boolean}              [opensInNewTab] Sets link target to _blank when true.
- * @property {string}               [url]           Link href.
- * @property {string}               [title]         Link title attribute.
+ * @property {string}               [label] Link text.
+ * @property {WPNavigationLinkKind} [kind]  Kind is used to differentiate between term and post ids to check post draft status.
+ * @property {string}               [type]  The type such as post, page, tag, category and other custom types.
+ * @property {string}               [rel]   The relationship of the linked URL.
+ * @property {number}               [id]    A post or term id.
+ * @property {string}               [url]   Link href.
+ * @property {string}               [title] Link title attribute.
  */
 /**
  * Link Control onChange handler that updates block attributes when a setting is changed.
@@ -48,14 +42,10 @@ export const updateAttributes = (
 	const {
 		title: newLabel = '', // the title of any provided Post.
 		url: newUrl = '',
-		opensInNewTab,
-		nofollow,
 		id,
 		kind: newKind = originalKind,
 		type: newType = originalType,
-		rel: newRel,
-		linkTarget,
-		...otherValues
+		rel,
 	} = updatedValue;
 
 	const newLabelWithoutHttp = newLabel.replace( /http(s?):\/\//gi, '' );
@@ -95,31 +85,13 @@ export const updateAttributes = (
 		( ! newKind && ! isBuiltInType ) || newKind === 'custom';
 	const kind = isCustomLink ? 'custom' : newKind;
 
-	// If we have opensInNewTab or nofollow values, use getUpdatedLinkAttributes to handle rel properly
-	let finalRel = newRel;
-	let finalUrl = newUrl;
-	if ( opensInNewTab !== undefined || nofollow !== undefined ) {
-		const linkAttributes = getUpdatedLinkAttributes( {
-			rel: blockAttributes.rel || '',
-			url: newUrl,
-			opensInNewTab,
-			nofollow,
-		} );
-		finalRel = linkAttributes.rel;
-		finalUrl = linkAttributes.url; // This already has prependHTTP applied
-	} else if ( newUrl ) {
-		// Apply prependHTTP for URLs when opensInNewTab/nofollow are not being set
-		finalUrl = prependHTTP( newUrl );
-	}
-
 	setAttributes( {
 		// Passed `url` may already be encoded. To prevent double encoding, decodeURI is executed to revert to the original string.
-		...( finalUrl && { url: encodeURI( safeDecodeURI( finalUrl ) ) } ),
+		...( newUrl && { url: encodeURI( safeDecodeURI( newUrl ) ) } ),
 		...( label && { label } ),
-		...( finalRel !== undefined && { rel: finalRel } ),
+		...{ rel },
 		...( id && Number.isInteger( id ) && { id } ),
 		...( kind && { kind } ),
 		...( type && type !== 'URL' && { type } ),
-		...otherValues,
 	} );
 };

--- a/packages/block-library/src/navigation-link/update-attributes.js
+++ b/packages/block-library/src/navigation-link/update-attributes.js
@@ -2,7 +2,12 @@
  * WordPress dependencies
  */
 import { escapeHTML } from '@wordpress/escape-html';
-import { safeDecodeURI } from '@wordpress/url';
+import { prependHTTP, safeDecodeURI } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { getUpdatedLinkAttributes } from './get-updated-link-attributes';
 
 /**
  * @typedef {'post-type'|'custom'|'taxonomy'|'post-type-archive'} WPNavigationLinkKind
@@ -44,9 +49,13 @@ export const updateAttributes = (
 		title: newLabel = '', // the title of any provided Post.
 		url: newUrl = '',
 		opensInNewTab,
+		nofollow,
 		id,
 		kind: newKind = originalKind,
 		type: newType = originalType,
+		rel: newRel,
+		linkTarget,
+		...otherValues
 	} = updatedValue;
 
 	const newLabelWithoutHttp = newLabel.replace( /http(s?):\/\//gi, '' );
@@ -86,13 +95,31 @@ export const updateAttributes = (
 		( ! newKind && ! isBuiltInType ) || newKind === 'custom';
 	const kind = isCustomLink ? 'custom' : newKind;
 
+	// If we have opensInNewTab or nofollow values, use getUpdatedLinkAttributes to handle rel properly
+	let finalRel = newRel;
+	let finalUrl = newUrl;
+	if ( opensInNewTab !== undefined || nofollow !== undefined ) {
+		const linkAttributes = getUpdatedLinkAttributes( {
+			rel: blockAttributes.rel || '',
+			url: newUrl,
+			opensInNewTab,
+			nofollow,
+		} );
+		finalRel = linkAttributes.rel;
+		finalUrl = linkAttributes.url; // This already has prependHTTP applied
+	} else if ( newUrl ) {
+		// Apply prependHTTP for URLs when opensInNewTab/nofollow are not being set
+		finalUrl = prependHTTP( newUrl );
+	}
+
 	setAttributes( {
 		// Passed `url` may already be encoded. To prevent double encoding, decodeURI is executed to revert to the original string.
-		...( newUrl && { url: encodeURI( safeDecodeURI( newUrl ) ) } ),
+		...( finalUrl && { url: encodeURI( safeDecodeURI( finalUrl ) ) } ),
 		...( label && { label } ),
-		...( undefined !== opensInNewTab && { opensInNewTab } ),
+		...( finalRel !== undefined && { rel: finalRel } ),
 		...( id && Number.isInteger( id ) && { id } ),
 		...( kind && { kind } ),
 		...( type && type !== 'URL' && { type } ),
+		...otherValues,
 	} );
 };

--- a/test/integration/fixtures/blocks/core__navigation-link.json
+++ b/test/integration/fixtures/blocks/core__navigation-link.json
@@ -4,7 +4,6 @@
 		"isValid": true,
 		"attributes": {
 			"label": "WordPress",
-			"opensInNewTab": false,
 			"url": "https://wordpress.org/"
 		},
 		"innerBlocks": []

--- a/test/integration/fixtures/blocks/core__navigation-submenu.json
+++ b/test/integration/fixtures/blocks/core__navigation-submenu.json
@@ -13,7 +13,6 @@
 				"isValid": true,
 				"attributes": {
 					"label": "WordPress",
-					"opensInNewTab": false,
 					"url": "https://wordpress.org/"
 				},
 				"innerBlocks": []

--- a/test/integration/fixtures/blocks/core__navigation__deprecated-1.json
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated-1.json
@@ -17,7 +17,6 @@
 				"isValid": true,
 				"attributes": {
 					"label": "WordPress",
-					"opensInNewTab": false,
 					"url": "https://www.wordpress.org/"
 				},
 				"innerBlocks": []

--- a/test/integration/fixtures/blocks/core__navigation__deprecated.json
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated.json
@@ -23,7 +23,6 @@
 				"isValid": true,
 				"attributes": {
 					"label": "WordPress",
-					"opensInNewTab": false,
 					"url": "https://www.wordpress.org/"
 				},
 				"innerBlocks": []


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Simplifies navigation-link block attribute management by consolidating `opensInNewTab` and `nofollow` attributes into the `rel` attribute, following web standards and improving maintainability.

Also, Address #54091 and missing rel attributes for "opensInNewTab"

## Why?
The current navigation-link block stores link behavior in multiple separate attributes (`opensInNewTab` and `rel`), which creates:
- **Duplicate data management**: Same information stored in multiple places
- **Synchronization complexity**: Need to keep multiple attributes in sync ( which was not implemented previously)
- **Inconsistency with web standards**: The `rel` attribute is the standard way to control link behavior
- **Maintenance overhead**: More attributes to manage and test

This PR aligns the navigation-link block with:
- **Web standards**: Using `rel` as the single source of truth for link behavior
- **Button block patterns**: Following the same approach used in the core Button block

## How?
1. **Removed attributes from `block.json`**: Eliminated `opensInNewTab`
2. **Created utility function**: Added `getUpdatedLinkAttributes()` to manage `rel` attribute updates (see buttons)
3. **Updated editor logic**: Modified `link-ui.js` and `edit.js` to derive UI state from `rel` attribute
4. **Enhanced server-side rendering**: Updated `index.php` to derive `target="_blank"` from `rel` attribute
5. **Added deprecations**: Proper v1 (`nofollow`) and v2 (`opensInNewTab`) deprecations for backward compatibility

## Testing Instructions

#### Test Case 1: Link Creation with opensInNewTab

- Create a new post/page
- Add a Navigation Link block
- Set a link URL (e.g., "https://wordpress.org")
- Enable "Open in new tab" option
- Save and verify the link has target="_blank" and appropriate rel attributes

#### Test Case 2: Link Updates Preserve Attributes

- Create a Navigation Link with an existing post/page link
- Enable "Open in new tab"
- Change the link to a different post/page via the link picker
- Verify that:
  - The opensInNewTab attribute is preserved
  - The link updates correctly
  - No console errors occur

#### Test Case 3: Custom Link with nofollow

- Add a Navigation Link block
- Set a custom external URL
- Enable both "Open in new tab" and "Add nofollow" options
- Verify the rendered link has both target="_blank" and rel="noopener noreferrer nofollow"

#### Test Case 4: Attribute Removal

- Create a link with "Open in new tab" enabled
- Disable "Open in new tab"
- Verify the target and related rel attributes are properly removed

#### Test Case 5: Migrate Existing block to rel

- Disable gutenberg/checkout main, create a navigation link in a page/post.
- Enable "Open in new tab" and save.
- Enable gutenberg/checkout PR, go to page/post.
- Verify:
 - That page loads correctly.
 - Block is correctly migrated to use rel.
 - Shows the 'no follow' option in link control

## Screencast

https://q7utzrengv.ufs.sh/f/Wgl9eBAmTj29HWIBZta5ruEneg4WdOIZ2wYBvRTCl70xMKfS