### PR TITLE
Core/File: Reduce specificity of pseudo-selector styles for better override support via theme.json

### DIFF
--- a/packages/block-library/src/file/style.scss
+++ b/packages/block-library/src/file/style.scss
@@ -35,7 +35,7 @@
 	padding: 0.5em 1em;
 	display: inline-block;
 
-	&:is(a) {
+	&:where(a) {
 		&:hover,
 		&:visited,
 		&:focus,


### PR DESCRIPTION
## What?
Closes #70342

This PR lowers the specificity of pseudo-selector styles within the `.wp-block-file__button` class to `0,1,0`, allowing them to be more easily overridden via `theme.json`.

## Why?

Previously, the `:visited` and `:hover` pseudo-selectors on file block buttons could not be overridden using `theme.json` due to higher specificity.

## How?

Replacing `&:is(a)` with `&:where(a)` preserved the styles while reducing specificity from `0,1,1` to `0,1,0`.

## Testing Instructions

1. Create a new post.
2. Add a file block.
3. Attach a file to it.
4. Use the following code and paste it under the `styles` key within `theme.json`.

<details>

<summary>Code</summary>

```json
"core/file": {
  "elements": {
	"button": {
		":hover": {
			"color": {
				"text": "#d34949"
			}
		},
		":visited": {
			"color": {
				"text": "#49d353"
			}
		}
	}
  }
}
```
</details>

5. Confirm that the hover and visited styles are properly applied on the front-end.

### Testing Instructions for Keyboard

Same.

## Screenshots or screencast

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/180d3ebe-dcc6-401c-9547-b0dff878df24)|![after](https://github.com/user-attachments/assets/b5cd2881-face-476c-aefb-d8968a433612)|
|![before](https://github.com/user-attachments/assets/20258b8a-2b6f-4fab-b837-0f4caba266d2)|![after](https://github.com/user-attachments/assets/de4d39f7-8c7e-47bb-9606-034dbf23645b)|