### PR TITLE
Circular Option Picker: Use 'placement' prop for popover positioning

### DIFF
--- a/packages/components/src/circular-option-picker/stories/index.story.tsx
+++ b/packages/components/src/circular-option-picker/stories/index.story.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryFn } from '@storybook/react';
 /**
  * WordPress dependencies
  */
-import { useState, createContext, useContext } from '@wordpress/element';
+import { createContext, useContext, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
@@ -152,7 +152,7 @@ WithDropdownLinkAction.args = {
 	actions: (
 		<CircularOptionPicker.DropdownLinkAction
 			dropdownProps={ {
-				popoverProps: { position: 'top right' },
+				popoverProps: { placement: 'top-end' },
 				renderContent: () => (
 					<div>This is an example of a DropdownLinkAction.</div>
 				),


### PR DESCRIPTION
## **What?**
Part of: #44401

This PR updates the Circular Option Picker storybook to use the placement prop instead of the deprecated position prop for its popover.

## **Why?**
The Popover component, used internally by Dropdown, has deprecated the position prop in favor of placement. This update brings the Circular Option Picker storybook in line with the latest standards and maintains consistency with other updated components.

## **How?**
Updated the `popoverProps` within the Circular Option Picker storybook to use `placement: 'top-end'` instead of `position: 'top right'`.

## **Testing Instructions**
To test this change:

1. Open Storybook
2. Navigate to the Circular Option Picker component story
3. Go to `with DropdownLinkAction` story
4. Click on `learn more`

## **Screenshots:**
![image](https://github.com/user-attachments/assets/fd0374ba-ed6a-4962-8d3e-deb53930b29a)
