### PR TITLE
Comments Pagination: Remove unwanted bottom margin from links

### DIFF
--- a/packages/block-library/src/comments-pagination/editor.scss
+++ b/packages/block-library/src/comments-pagination/editor.scss
@@ -11,14 +11,3 @@ $pagination-margin: 0.5em;
 	}
 }
 
-.wp-block-comments-pagination {
-	> .wp-block-comments-pagination-next,
-	> .wp-block-comments-pagination-previous,
-	> .wp-block-comments-pagination-numbers {
-		font-size: inherit;
-		&:last-child {
-			/*rtl:ignore*/
-			margin-right: 0;
-		}
-	}
-}

--- a/packages/block-library/src/comments-pagination/editor.scss
+++ b/packages/block-library/src/comments-pagination/editor.scss
@@ -11,3 +11,10 @@ $pagination-margin: 0.5em;
 	}
 }
 
+.wp-block-comments-pagination {
+	> .wp-block-comments-pagination-next,
+	> .wp-block-comments-pagination-previous,
+	> .wp-block-comments-pagination-numbers {
+		font-size: inherit;
+	}
+}

--- a/packages/block-library/src/comments-pagination/editor.scss
+++ b/packages/block-library/src/comments-pagination/editor.scss
@@ -8,9 +8,6 @@ $pagination-margin: 0.5em;
 :where(.editor-styles-wrapper) {
 	.wp-block-comments-pagination {
 		max-width: 100%;
-		&.block-editor-block-list__layout {
-			margin: 0;
-		}
 	}
 }
 
@@ -18,14 +15,6 @@ $pagination-margin: 0.5em;
 	> .wp-block-comments-pagination-next,
 	> .wp-block-comments-pagination-previous,
 	> .wp-block-comments-pagination-numbers {
-		// Override editor auto block margins.
-		margin-left: 0;
-		margin-top: $pagination-margin;
-
-		/*rtl:ignore*/
-		margin-right: $pagination-margin;
-		margin-bottom: $pagination-margin;
-
 		font-size: inherit;
 		&:last-child {
 			/*rtl:ignore*/

--- a/packages/block-library/src/comments-pagination/style.scss
+++ b/packages/block-library/src/comments-pagination/style.scss
@@ -7,7 +7,6 @@ $pagination-margin: 0.5em;
 		/*rtl:ignore*/
 		margin-right: $pagination-margin;
 		margin-bottom: 0;
-
 		font-size: inherit;
 		&:last-child {
 			/*rtl:ignore*/

--- a/packages/block-library/src/comments-pagination/style.scss
+++ b/packages/block-library/src/comments-pagination/style.scss
@@ -4,14 +4,7 @@ $pagination-margin: 0.5em;
 	> .wp-block-comments-pagination-next,
 	> .wp-block-comments-pagination-previous,
 	> .wp-block-comments-pagination-numbers {
-		/*rtl:ignore*/
-		margin-right: $pagination-margin;
-		margin-bottom: 0;
 		font-size: inherit;
-		&:last-child {
-			/*rtl:ignore*/
-			margin-right: 0;
-		}
 	}
 	.wp-block-comments-pagination-previous-arrow {
 		margin-right: 1ch;

--- a/packages/block-library/src/comments-pagination/style.scss
+++ b/packages/block-library/src/comments-pagination/style.scss
@@ -6,7 +6,7 @@ $pagination-margin: 0.5em;
 	> .wp-block-comments-pagination-numbers {
 		/*rtl:ignore*/
 		margin-right: $pagination-margin;
-		margin-bottom: $pagination-margin;
+		margin-bottom: 0;
 
 		font-size: inherit;
 		&:last-child {


### PR DESCRIPTION
### Description

This pull request addresses [Issue #62114](https://github.com/WordPress/gutenberg/issues/62114) by removing the unwanted bottom margin from the Comments Pagination block links (`Comments Next Page`, `Comments Previous Page`, and `Comments Page Numbers`). The default margin created misalignments in themes and could not be easily overridden via Global Styles, `theme.json`, or custom CSS.

#### What’s changed

- Removed the default bottom margin from the pagination links in the Comments Pagination block by targeting the `.wp-block-comments-pagination` container and its direct child link elements.
- Ensured that the fix is scoped specifically to the Comments Pagination block to avoid unintended side effects on other components.

#### Rationale

- The bottom margin was not necessary for the block's layout and created consistent styling issues across themes.
- This update brings alignment with user expectations and improves the visual consistency of comment pagination within block themes.

#### How to test

1. Add the Comments Pagination block to a post or template.
2. View the block on the frontend and in the editor.
3. Confirm that the unwanted bottom margin is removed from the pagination links and that the block aligns correctly with surrounding elements.

#### Related

- Closes #62114
- Similar to the approach discussed in #51299
