### PR TITLE
Keyboard shortcut to lock selected blocks

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1371,6 +1371,14 @@ _Parameters_
 -   _rootClientId_ `?string`: Optional root client ID of block list on which to append.
 -   _index_ `?number`: Optional index where to insert the default block.
 
+### lockBlock
+
+Action that locks/unlocks a block.
+
+_Parameters_
+
+-   _clientIds_ `string[]`:
+
 ### mergeBlocks
 
 Action that merges two blocks.

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -79,6 +79,7 @@ export default function BlockTools( {
 
 	const {
 		duplicateBlocks,
+		lockBlock,
 		removeBlocks,
 		replaceBlocks,
 		insertAfterBlock,
@@ -129,6 +130,12 @@ export default function BlockTools( {
 			if ( clientIds.length ) {
 				event.preventDefault();
 				duplicateBlocks( clientIds );
+			}
+		} else if ( isMatch( 'core/block-editor/toggle-lock', event ) ) {
+			const clientIds = getSelectedBlockClientIds();
+			if ( clientIds.length ) {
+				event.preventDefault();
+				lockBlock( clientIds );
 			}
 		} else if ( isMatch( 'core/block-editor/remove', event ) ) {
 			const clientIds = getSelectedBlockClientIds();

--- a/packages/block-editor/src/components/keyboard-shortcuts/index.js
+++ b/packages/block-editor/src/components/keyboard-shortcuts/index.js
@@ -29,8 +29,8 @@ function KeyboardShortcutsRegister() {
 			category: 'block',
 			description: __( 'Lock/Unlock the selected block.' ),
 			keyCombination: {
-				modifier: 'primaryShift',
-				character: 'k',
+				modifier: 'primaryAlt',
+				character: 'l',
 			},
 		} );
 

--- a/packages/block-editor/src/components/keyboard-shortcuts/index.js
+++ b/packages/block-editor/src/components/keyboard-shortcuts/index.js
@@ -25,6 +25,16 @@ function KeyboardShortcutsRegister() {
 		} );
 
 		registerShortcut( {
+			name: 'core/block-editor/toggle-lock',
+			category: 'block',
+			description: __( 'Lock/Unlock the selected block.' ),
+			keyCombination: {
+				modifier: 'primaryShift',
+				character: 'k',
+			},
+		} );
+
+		registerShortcut( {
 			name: 'core/block-editor/cut',
 			category: 'block',
 			description: __( 'Cut the selected block(s).' ),

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1757,6 +1757,41 @@ export const duplicateBlocks =
 	};
 
 /**
+ * Action that locks/unlocks a block.
+ *
+ * @param {string[]} clientIds
+ */
+export const lockBlock =
+	( clientIds ) =>
+	( { select, dispatch } ) => {
+		if ( ! clientIds || clientIds.length === 0 ) {
+			return;
+		}
+
+		const blocks = select.getBlocksByClientId( clientIds );
+		if ( blocks.some( ( block ) => ! block ) ) {
+			return;
+		}
+
+		const isCurrentlyLocked = blocks.some(
+			( block ) =>
+				block?.attributes?.lock?.move ||
+				block?.attributes?.lock?.remove ||
+				block?.attributes?.lock?.edit
+		);
+
+		const newLock = isCurrentlyLocked
+			? { move: false, remove: false, edit: false }
+			: { move: true, remove: true, edit: true };
+
+		dispatch(
+			updateBlockAttributes( clientIds, {
+				lock: newLock,
+			} )
+		);
+	};
+
+/**
  * Action that inserts a default block before a given block.
  *
  * @param {string} clientId


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #42228 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This PR adds support for toggling block locking using a keyboard shortcut. This provides users with a quicker and more accessible way to control the locking status of selected blocks directly from the keyboard.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This feature is implemented by a new action in the `block-library` store called `lockBlock`. This action takes an array of client IDs, determines the current lock status of the selected blocks, and toggles the `lock` attribute for the specified blocks.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open a post or page in the block editor.
2. Insert one or more blocks (eg- Paragraph, Heading, etc).
3. Select the blocks.
4. Use the keyboard shortcut (Windows, Linux: `Alt + Ctrl + L` or MacOS: `Option + Cmd + L`) to toggle the lock status.
5. Observe the behavior: The selected blocks should now be locked (preventing moving, removing, or editing), or if already locked, they should become unlocked.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Open an editor, insert and select blocks.
2. Press the keyboard shortcut for toggling block lock (Windows, Linux: `Alt + Ctrl + L` or MacOS: `Option + Cmd + L`).
3. Verify that the blocks are locked/unlocked.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/a62d2be5-f1e8-4957-a3dd-ced6974ad657


