### PR TITLE
Video: add aria-label for uncaptioned video in save function

### DIFF
--- a/packages/block-library/src/video/save.js
+++ b/packages/block-library/src/video/save.js
@@ -6,6 +6,7 @@ import {
 	useBlockProps,
 	__experimentalGetElementClassName,
 } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -37,6 +38,11 @@ export default function save( { attributes } ) {
 					preload={ preload !== 'metadata' ? preload : undefined }
 					src={ src }
 					playsInline={ playsInline }
+					aria-label={
+						RichText.isEmpty( caption )
+							? __( 'Uncaptioned video' )
+							: undefined
+					}
 				>
 					<Tracks tracks={ tracks } />
 				</video>


### PR DESCRIPTION
## What?

Closes #70297 

Add `aria-label` to the `<video>` element in the Video block when no caption is provided.

## Why?

To improve accessibility for screen reader users. Previously, when a video block lacked a caption, screen readers would receive no contextual information about the video content. This change provides a default label `"Uncaptioned video"` in such cases, improving clarity and compliance with accessibility standards.

## How?

-   Check if the `caption` attribute is empty using `RichText.isEmpty`.
-   If empty, apply a fallback `aria-label` with the value `__('Uncaptioned video')`.
-   If a caption is present, omit the `aria-label` so the screen reader can rely on the figcaption.
    

## Testing Instructions

1.  Open a post or page in the block editor.
2.  Insert a Video block.
3.  Upload or set a video source (e.g., `.mp4`).
4.  **Do not** enter a caption.
5.  Save the post and inspect the front-end output.
6.  Confirm that the `<video>` element includes `aria-label="Uncaptioned video"`.
7.  Add a caption and save again.
8.  Confirm that the `aria-label` is no longer present when the caption exists.

## Screenshots or screencast

### Before
No `aria-label` when no caption present

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/d36ddc63-8a0e-49bd-b2c3-8e82d0de75d0" />


### After
`aria-label="Uncaptioned video"` added to `<video>` element

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/62909f0e-ae66-4811-ab41-0d4e6a70af37" />

