### PR TITLE
Post Template: Add queryIndex context to child blocks

### DIFF
--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -246,7 +246,8 @@ export default function PostTemplateEdit( {
 	);
 	const blockContexts = useMemo(
 		() =>
-			posts?.map( ( post ) => ( {
+			posts?.map( ( post, queryIndex ) => ( {
+				queryIndex,
 				postType: post.type,
 				postId: post.id,
 				classList: post.class_list ?? '',

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -97,7 +97,8 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => trim( $classnames ) ) );
 
-	$content = '';
+	$content     = '';
+	$query_index = 0;
 	while ( $query->have_posts() ) {
 		$query->the_post();
 
@@ -110,9 +111,10 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 
 		$post_id              = get_the_ID();
 		$post_type            = get_post_type();
-		$filter_block_context = static function ( $context ) use ( $post_id, $post_type ) {
-			$context['postType'] = $post_type;
-			$context['postId']   = $post_id;
+		$filter_block_context = static function ( $context ) use ( $post_id, $post_type, $query_index ) {
+			$context['postType']   = $post_type;
+			$context['postId']     = $post_id;
+			$context['queryIndex'] = $query_index;
 			return $context;
 		};
 
@@ -129,6 +131,8 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 		$inner_block_directives = $enhanced_pagination ? ' data-wp-key="post-template-item-' . $post_id . '"' : '';
 
 		$content .= '<li' . $inner_block_directives . ' class="' . esc_attr( $post_classes ) . '">' . $block_content . '</li>';
+
+		++$query_index;
 	}
 
 	/*


### PR DESCRIPTION
## What?
Closes #69746

Adds `queryIndex` context to the core/post-template block, providing child blocks with their position in the query loop.


## Why?

Child blocks of post-template currently only receive `postId` and `postType` context, but have no way to know their position/index within the query. This is needed for:
- Listicle-style numbering (1st, 2nd, 3rd post)
- Conditional styling based on position
- Advanced curation workflows
- CSS nth-child targeting

## How?
- **Editor**: Added `queryIndex` to `blockContexts` using array index from posts.map()
- **Frontend**: Added `queryIndex` to block context filter using `$query_index` counter


## Testing Instructions
1. Create Query Loop block with Post Template
2. Add a child block that uses `queryIndex` context
3. Verify incremental numbering (0, 1, 2...) in both editor and frontend