### PR TITLE
Documentation: Add `isPostSavingLocked ` example to doc block

### DIFF
--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -1042,6 +1042,27 @@ _Returns_
 
 Returns whether post saving is locked.
 
+_Usage_
+
+```jsx
+import { __ } from '@wordpress/i18n';
+import { store as editorStore } from '@wordpress/editor';
+import { useSelect } from '@wordpress/data';
+
+const ExampleComponent = () => {
+	const isSavingLocked = useSelect(
+		( select ) => select( editorStore ).isPostSavingLocked(),
+		[]
+	);
+
+	return isSavingLocked ? (
+		<p>{ __( 'Post saving is locked' ) }</p>
+	) : (
+		<p>{ __( 'Post saving is not locked' ) }</p>
+	);
+};
+```
+
 _Parameters_
 
 -   _state_ `Object`: Global application state.

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1053,6 +1053,26 @@ export function isPostLocked( state ) {
  *
  * @param {Object} state Global application state.
  *
+ * @example
+ * ```jsx
+ * import { __ } from '@wordpress/i18n';
+ * import { store as editorStore } from '@wordpress/editor';
+ * import { useSelect } from '@wordpress/data';
+ *
+ * const ExampleComponent = () => {
+ * 	const isSavingLocked = useSelect(
+ * 		( select ) => select( editorStore ).isPostSavingLocked(),
+ * 		[]
+ * 	);
+ *
+ * 	return isSavingLocked ? (
+ * 		<p>{ __( 'Post saving is locked' ) }</p>
+ * 	) : (
+ * 		<p>{ __( 'Post saving is not locked' ) }</p>
+ * 	);
+ * };
+ * ```
+ *
  * @return {boolean} Is locked.
  */
 export function isPostSavingLocked( state ) {


### PR DESCRIPTION
## What?
Related to: https://github.com/WordPress/gutenberg/issues/42125
PR: https://github.com/WordPress/gutenberg/pull/10649

This PR adds a JSDoc @example comment to the `isPostSavingLocked` selector, completing the documentation for the `lock and unlock post-saving API`.

## Why?
The post lock saving API was introduced in PR #10649, which includes the lockPostSaving and unlockPostSaving functions. Both of these functions have comprehensive JSDoc documentation with @example blocks, but the related `isPostSavingLocked` selector was missing its example documentation.

## How?
Added a JSDoc @example block to the isPostSavingLocked selector that demonstrates:
- How to use the selector with `useSelect` hook in a React component
- An example showing conditional rendering based on the selector's return value