### PR TITLE
Editor: Add example usage for getCurrentPostId selector

### DIFF
--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -212,6 +212,21 @@ _Returns_
 
 Returns the ID of the post currently being edited, or null if the post has not yet been saved.
 
+_Usage_
+
+import { useSelect } from '@wordpress/data';
+
+function MyComponent() {
+const postId = useSelect( ( select ) => {
+return select( 'core/editor' ).getCurrentPostId();
+}, \[] );
+
+if ( postId !== null ) {
+return <div>Editing post with ID: { postId }</div>;
+}
+return <div>Creating new post</div>;
+}
+
 _Parameters_
 
 -   _state_ `Object`: Global application state.

--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -214,18 +214,24 @@ Returns the ID of the post currently being edited, or null if the post has not y
 
 _Usage_
 
+```jsx
+import { __ } from '@wordpress/i18n';
+import { store as editorStore } from '@wordpress/editor';
 import { useSelect } from '@wordpress/data';
 
-function MyComponent() {
-const postId = useSelect( ( select ) => {
-return select( 'core/editor' ).getCurrentPostId();
-}, \[] );
+const ExampleComponent = () => {
+	const postId = useSelect(
+		( select ) => select( editorStore ).getCurrentPostId(),
+		[]
+	);
 
-if ( postId !== null ) {
-return <div>Editing post with ID: { postId }</div>;
-}
-return <div>Creating new post</div>;
-}
+	return postId !== null ? (
+		<p>{ __( 'Current post ID: ' ) + postId }</p>
+	) : (
+		<p>{ __( 'No current post ID found.' ) }</p>
+	);
+};
+```
 
 _Parameters_
 

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -196,18 +196,24 @@ export function getCurrentPostType( state ) {
  * @param {Object} state Global application state.
  *
  * @example
+ * ```jsx
+ * import { __ } from '@wordpress/i18n';
+ * import { store as editorStore } from '@wordpress/editor';
  * import { useSelect } from '@wordpress/data';
  *
- * function MyComponent() {
- *   const postId = useSelect( ( select ) => {
- *     return select( 'core/editor' ).getCurrentPostId();
- *   }, [] );
+ * const ExampleComponent = () => {
+ * 	const postId = useSelect(
+ * 		( select ) => select( editorStore ).getCurrentPostId(),
+ * 		[]
+ * 	);
  *
- *   if ( postId !== null ) {
- *     return <div>Editing post with ID: { postId }</div>;
- *   }
- *   return <div>Creating new post</div>;
- * }
+ * 	return postId !== null ? (
+ * 		<p>{ __( 'Current post ID: ' ) + postId }</p>
+ * 	) : (
+ * 		<p>{ __( 'No current post ID found.' ) }</p>
+ * 	);
+ * };
+ * ```
  *
  * @return {?number} ID of current post.
  */

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -195,6 +195,20 @@ export function getCurrentPostType( state ) {
  *
  * @param {Object} state Global application state.
  *
+ * @example
+ * import { useSelect } from '@wordpress/data';
+ *
+ * function MyComponent() {
+ *   const postId = useSelect( ( select ) => {
+ *     return select( 'core/editor' ).getCurrentPostId();
+ *   }, [] );
+ *
+ *   if ( postId !== null ) {
+ *     return <div>Editing post with ID: { postId }</div>;
+ *   }
+ *   return <div>Creating new post</div>;
+ * }
+ *
  * @return {?number} ID of current post.
  */
 export function getCurrentPostId( state ) {

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -197,18 +197,24 @@ export function getCurrentPostType( state ) {
  * @param {Object} state Global application state.
  *
  * @example
+ * ```jsx
+ * import { __ } from '@wordpress/i18n';
+ * import { store as editorStore } from '@wordpress/editor';
  * import { useSelect } from '@wordpress/data';
  *
- * function MyComponent() {
- *   const postId = useSelect( ( select ) => {
- *     return select( 'core/editor' ).getCurrentPostId();
- *   }, [] );
+ * const ExampleComponent = () => {
+ * 	const postId = useSelect(
+ * 		( select ) => select( editorStore ).getCurrentPostId(),
+ * 		[]
+ * 	);
  *
- *   if ( postId !== null ) {
- *     return <div>Editing post with ID: { postId }</div>;
- *   }
- *   return <div>Creating new post</div>;
- * }
+ * 	return postId !== null ? (
+ * 		<p>{ __( 'Current post ID: ' ) + postId }</p>
+ * 	) : (
+ * 		<p>{ __( 'No current post ID found.' ) }</p>
+ * 	);
+ * };
+ * ```
  *
  * @return {?(number|string)} The current post ID (number) or template slug (string).
  */

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -196,6 +196,20 @@ export function getCurrentPostType( state ) {
  *
  * @param {Object} state Global application state.
  *
+ * @example
+ * import { useSelect } from '@wordpress/data';
+ *
+ * function MyComponent() {
+ *   const postId = useSelect( ( select ) => {
+ *     return select( 'core/editor' ).getCurrentPostId();
+ *   }, [] );
+ *
+ *   if ( postId !== null ) {
+ *     return <div>Editing post with ID: { postId }</div>;
+ *   }
+ *   return <div>Creating new post</div>;
+ * }
+ *
  * @return {?(number|string)} The current post ID (number) or template slug (string).
  */
 export function getCurrentPostId( state ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Related issue: https://github.com/WordPress/gutenberg/issues/42125
Related PR: https://github.com/WordPress/gutenberg/pull/1062

This PR adds a missing JSDoc `@example` comment to the `getCurrentPostId` selector,

## Why?
To improve developer documentation and maintain consistency with other selectors that include usage examples. The `@example` demonstrates how to properly use the `getCurrentPostId` selector with the `useSelect` hook
