### PR TITLE
Social Links: Allow icon size to be reset and honor theme.json styles

### DIFF
--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -33,6 +33,7 @@ import { useSelect } from '@wordpress/data';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const sizeOptions = [
+	{ label: __( 'Default' ), value: '' },
 	{ label: __( 'Small' ), value: 'has-small-icon-size' },
 	{ label: __( 'Normal' ), value: 'has-normal-icon-size' },
 	{ label: __( 'Large' ), value: 'has-large-icon-size' },
@@ -166,19 +167,17 @@ export function SocialLinksEdit( props ) {
 						setAttributes( {
 							openInNewTab: false,
 							showLabels: false,
-							size: 'has-normal-icon-size',
+							size: undefined,
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
 						isShownByDefault
-						hasValue={ () =>
-							!! size && size !== 'has-normal-icon-size'
-						}
+						hasValue={ () => !! size }
 						label={ __( 'Icon size' ) }
 						onDeselect={ () =>
-							setAttributes( { size: 'has-normal-icon-size' } )
+							setAttributes( { size: undefined } )
 						}
 					>
 						<SelectControl
@@ -187,10 +186,10 @@ export function SocialLinksEdit( props ) {
 							label={ __( 'Icon Size' ) }
 							onChange={ ( newSize ) => {
 								setAttributes( {
-									size: newSize,
+									size: newSize === '' ? undefined : newSize,
 								} );
 							} }
-							value={ size ?? 'has-normal-icon-size' }
+							value={ size ?? '' }
 							options={ sizeOptions }
 						/>
 					</ToolsPanelItem>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #70318 

<!-- In a few words, what is the PR actually doing? -->

This PR updates the SocialLinksEdit component to:
- Introduce a "Default" option for icon size in the toolbar dropdown.
- Ensure the "Default" state maps to `undefined` in the size attribute instead of hardcoding `has-normal-icon-size`
- Ensure that resetting the size removes the `has-normal-icon-size` class.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, when the icon size is set and reset, the `has-normal-icon-size` class remains in the markup. This overrides custom styles set via theme.json or additional CSS due to higher specificity.

By introducing an explicit "Default" option that doesn't apply a class, this change ensures the block respects styles defined in theme.json. It also improves clarity in the UI, indicating when the default size is being used.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Added a "Default" option with an empty string value ('') to the SelectControl options.
- Updated logic to treat this as undefined internally.
- Ensured that selecting or resetting to "Default" results in no size class being written to the block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Insert a Social Links block into a post or page.
2. Open the block settings sidebar.
3. Expand the "Icon size" dropdown:
- Confirm that "Default" is now an option.
4. Select other sizes like Small, Normal, Large.
- Confirm the correct class is applied (e.g., .has-small-icon-size).
5. Switch back to "Default" or Reset the size:
- Confirm the class is removed from markup.
6. Add font size overrides in theme.json for the Social Links block.
- Confirm that they now apply correctly when "Default" is selected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Same

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
When the following style is added to theme.json

```
"core/social-links": {
		"typography": {
			"fontSize": "var(--wp--preset--font-size--x-large)"
		}
	},
```
After Icon size is reset

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/90c405cd-6b56-46f4-82cf-97d2f46b3dc4)|![image](https://github.com/user-attachments/assets/84c56ab2-4c32-4acb-b101-2fbb55f118a9)|
