### PR TITLE
FormFileUpload: Remove temporary fix for selecting .heic file in Chromium browsers

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   `FormFileUpload`: Remove temporary fix for selecting .heic file in Chromium browsers ([#70383](https://github.com/WordPress/gutenberg/pull/70383)).
+
 ## 29.11.0 (2025-06-04)
 
 ### Enhancement

--- a/packages/components/src/form-file-upload/index.tsx
+++ b/packages/components/src/form-file-upload/index.tsx
@@ -58,18 +58,6 @@ export function FormFileUpload( {
 			{ children }
 		</Button>
 	);
-	// @todo: Temporary fix a bug that prevents Chromium browsers from selecting ".heic" files
-	// from the file upload. See https://core.trac.wordpress.org/ticket/62268#comment:4.
-	// This can be removed once the Chromium fix is in the stable channel.
-	// Prevent Safari from adding "image/heic" and "image/heif" to the accept attribute.
-	const isSafari =
-		globalThis.window?.navigator.userAgent.includes( 'Safari' ) &&
-		! globalThis.window?.navigator.userAgent.includes( 'Chrome' ) &&
-		! globalThis.window?.navigator.userAgent.includes( 'Chromium' );
-	const compatAccept =
-		! isSafari && !! accept?.includes( 'image/*' )
-			? `${ accept }, image/heic, image/heif`
-			: accept;
 
 	return (
 		<div className="components-form-file-upload">
@@ -79,7 +67,7 @@ export function FormFileUpload( {
 				ref={ ref }
 				multiple={ multiple }
 				style={ { display: 'none' } }
-				accept={ compatAccept }
+				accept={ accept }
 				onChange={ onChange }
 				onClick={ onClick }
 				data-testid="form-file-upload-input"


### PR DESCRIPTION
Follow-up #66292

## What?

This PR removes a temporary fix for selecting ".heic" files in Chromium browsers.

## Why?

There was a bug that when applying `image/*` to a file input element, the .heic file could not be selected in Chromium browsers. This bug has been fixed in Chromium 132.

- [Chrome Dash: Add heic and heif to standard image types](https://chromiumdash.appspot.com/commit/8bc39c9f42b2413af14e177f0c29cfeaebd2d6b7)
- [Chrome 132  |  Release notes  |  Chrome for Developers](https://developer.chrome.com/release-notes/132)

It's been about 6 months since the stable release, so the temporary fix should be able to be removed.

## Testing Instructions

- Find and download a HEIC image.
- Insert an Image block.
- Press the Upload button.
- Make sure you can select the HEIC image.
