### PR TITLE
Refactor: `URLInputButton` component to functional react component

### DIFF
--- a/packages/block-editor/src/components/url-input/button.js
+++ b/packages/block-editor/src/components/url-input/button.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import {
 	Button,
 	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
@@ -14,73 +14,68 @@ import { link, keyboardReturn, arrowLeft } from '@wordpress/icons';
  */
 import URLInput from './';
 
-class URLInputButton extends Component {
-	constructor() {
-		super( ...arguments );
-		this.toggle = this.toggle.bind( this );
-		this.submitLink = this.submitLink.bind( this );
-		this.state = {
-			expanded: false,
-		};
-	}
+/**
+ * A button that toggles a URL input field for inserting or editing links.
+ *
+ * @param {Object}   props          Component properties.
+ * @param {string}   props.url      The current URL value.
+ * @param {Function} props.onChange Callback function to handle URL changes.
+ * @return {JSX.Element} The URL input button component.
+ */
+function URLInputButton( { url, onChange } ) {
+	const [ expanded, setExpanded ] = useState( false );
 
-	toggle() {
-		this.setState( { expanded: ! this.state.expanded } );
-	}
+	const toggle = () => {
+		setExpanded( ( prevExpanded ) => ! prevExpanded );
+	};
 
-	submitLink( event ) {
+	const submitLink = ( event ) => {
 		event.preventDefault();
-		this.toggle();
-	}
+		toggle();
+	};
 
-	render() {
-		const { url, onChange } = this.props;
-		const { expanded } = this.state;
-		const buttonLabel = url ? __( 'Edit link' ) : __( 'Insert link' );
-
-		return (
-			<div className="block-editor-url-input__button">
-				<Button
-					size="compact"
-					icon={ link }
-					label={ buttonLabel }
-					onClick={ this.toggle }
-					className="components-toolbar__control"
-					isPressed={ !! url }
-				/>
-				{ expanded && (
-					<form
-						className="block-editor-url-input__button-modal"
-						onSubmit={ this.submitLink }
-					>
-						<div className="block-editor-url-input__button-modal-line">
-							<Button
-								__next40pxDefaultSize
-								className="block-editor-url-input__back"
-								icon={ arrowLeft }
-								label={ __( 'Close' ) }
-								onClick={ this.toggle }
-							/>
-							<URLInput
-								value={ url || '' }
-								onChange={ onChange }
-								suffix={
-									<InputControlSuffixWrapper variant="control">
-										<Button
-											size="small"
-											icon={ keyboardReturn }
-											label={ __( 'Submit' ) }
-											type="submit"
-										/>
-									</InputControlSuffixWrapper>
-								}
-							/>
-						</div>
-					</form>
-				) }
-			</div>
-		);
-	}
+	return (
+		<div className="block-editor-url-input__button">
+			<Button
+				size="compact"
+				icon={ link }
+				label={ url ? __( 'Edit link' ) : __( 'Insert link' ) }
+				onClick={ toggle }
+				className="components-toolbar__control"
+				isPressed={ !! url }
+			/>
+			{ expanded && (
+				<form
+					className="block-editor-url-input__button-modal"
+					onSubmit={ submitLink }
+				>
+					<div className="block-editor-url-input__button-modal-line">
+						<Button
+							__next40pxDefaultSize
+							className="block-editor-url-input__back"
+							icon={ arrowLeft }
+							label={ __( 'Close' ) }
+							onClick={ toggle }
+						/>
+						<URLInput
+							value={ url || '' }
+							onChange={ onChange }
+							suffix={
+								<InputControlSuffixWrapper variant="control">
+									<Button
+										size="small"
+										icon={ keyboardReturn }
+										label={ __( 'Submit' ) }
+										type="submit"
+									/>
+								</InputControlSuffixWrapper>
+							}
+						/>
+					</div>
+				</form>
+			) }
+		</div>
+	);
 }
 
 /**

--- a/packages/block-editor/src/components/url-input/button.js
+++ b/packages/block-editor/src/components/url-input/button.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useReducer } from '@wordpress/element';
 import {
 	Button,
 	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
@@ -23,15 +23,14 @@ import URLInput from './';
  * @return {JSX.Element} The URL input button component.
  */
 function URLInputButton( { url, onChange } ) {
-	const [ expanded, setExpanded ] = useState( false );
-
-	const toggle = () => {
-		setExpanded( ( prevExpanded ) => ! prevExpanded );
-	};
+	const [ expanded, toggleExpanded ] = useReducer(
+		( isExpanded ) => ! isExpanded,
+		false
+	);
 
 	const submitLink = ( event ) => {
 		event.preventDefault();
-		toggle();
+		toggleExpanded();
 	};
 
 	return (
@@ -40,7 +39,7 @@ function URLInputButton( { url, onChange } ) {
 				size="compact"
 				icon={ link }
 				label={ url ? __( 'Edit link' ) : __( 'Insert link' ) }
-				onClick={ toggle }
+				onClick={ toggleExpanded }
 				className="components-toolbar__control"
 				isPressed={ !! url }
 			/>
@@ -55,7 +54,7 @@ function URLInputButton( { url, onChange } ) {
 							className="block-editor-url-input__back"
 							icon={ arrowLeft }
 							label={ __( 'Close' ) }
-							onClick={ toggle }
+							onClick={ toggleExpanded }
 						/>
 						<URLInput
 							value={ url || '' }


### PR DESCRIPTION
## What?

See #22890

This PR refactors `URLInputButton` component from class based component syntax to newer functional component syntax.

## Why?
Class based components are no longer the recommended approach & instead functional syntax with hooks is more recommended
The code becomes more readable & easier to make changes to 

## How?
- React hooks are used for component lifecycle methods
- Rest of component logic remains the same

## Testing Instructions

- To test this component try converting any text to link
- The toolbar button for adding link is provided by this component
- The component should behave same as before

## Screenshots or screencast
![image](https://github.com/user-attachments/assets/94b629a1-70c6-407a-8d0d-e0a45dd4386a)


I'm new to gutenberg contributions, feel free to provide suggestions for improvement & pointing out mistakes
Thanks!
