### PR TITLE
Fix Table of Contents block links on initial page save

### DIFF
--- a/packages/block-library/src/table-of-contents/hooks.js
+++ b/packages/block-library/src/table-of-contents/hooks.js
@@ -65,15 +65,7 @@ function getLatestHeadings( select, clientId ) {
 
 	/** The page (of a paginated post) a heading will be part of. */
 	let headingPage = 1;
-	let headingPageLink = null;
-
-	// If the core/editor store is available, we can add permalinks to the
-	// generated table of contents.
-	if ( typeof permalink === 'string' ) {
-		headingPageLink = isPaginated
-			? addQueryArgs( permalink, { page: headingPage } )
-			: permalink;
-	}
+	let headingPageLink = '';
 
 	for ( const blockClientId of allBlockClientIds ) {
 		const blockName = getBlockName( blockClientId );
@@ -120,9 +112,7 @@ function getLatestHeadings( select, clientId ) {
 						)
 					),
 					level: headingAttributes.level,
-					link: canBeLinked
-						? `${ headingPageLink }#${ headingAttributes.anchor }`
-						: null,
+					link: canBeLinked ? `#${ headingAttributes.anchor }` : null,
 				} );
 			}
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/43595

Fixes Table of Contents block links that don't work on initial page save.

## Testing Instructions
1. Set WordPress permalink structure to "Post name" (Settings > Permalinks)
2. Create a new Page
3. Add several heading blocks (H2, H3) with content
4. Add the Table of Contents block
5. Publish the page
6. View the published page
7. Verify TOC links work correctly on initial publish (no "Page not found" errors)
8. Also test in Preview mode to confirm links work there too

## Screenshots or screencast <!-- if applicable -->
### Before


https://github.com/user-attachments/assets/55f2cd5c-2f70-48ba-888a-8ef34c48bd4a

### After


https://github.com/user-attachments/assets/9a682d6c-0141-4625-944f-3f56050a49fd

