### PR TITLE
Fix: Allow resetting Social Links icon size to enable theme.json style overrides

### DIFF
--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -166,7 +166,7 @@ export function SocialLinksEdit( props ) {
 						setAttributes( {
 							openInNewTab: false,
 							showLabels: false,
-							size: 'has-normal-icon-size',
+							size: undefined,
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
@@ -178,7 +178,7 @@ export function SocialLinksEdit( props ) {
 						}
 						label={ __( 'Icon size' ) }
 						onDeselect={ () =>
-							setAttributes( { size: 'has-normal-icon-size' } )
+							setAttributes( { size: undefined } )
 						}
 					>
 						<SelectControl
@@ -187,7 +187,7 @@ export function SocialLinksEdit( props ) {
 							label={ __( 'Icon Size' ) }
 							onChange={ ( newSize ) => {
 								setAttributes( {
-									size: newSize,
+									size: newSize !== '' ? newSize : undefined,
 								} );
 							} }
 							value={ size ?? 'has-normal-icon-size' }

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -187,7 +187,7 @@ export function SocialLinksEdit( props ) {
 							label={ __( 'Icon Size' ) }
 							onChange={ ( newSize ) => {
 								setAttributes( {
-									size: newSize !== '' ? newSize : undefined,
+									size: newSize,
 								} );
 							} }
 							value={ size ?? 'has-normal-icon-size' }


### PR DESCRIPTION
## What?
Closes #70318  

This PR updates the `Social Links` block to support resetting the `icon size` attribute (`size`) to `undefined`, thereby allowing styles defined in `theme.json` to take effect even after the user manually selects a size in the UI.

## Why?
Currently, when a user selected an icon size (e.g., "Normal") in the Social Links block, the size attribute was set to a class (e.g., .has-normal-icon-size). This increased CSS specificity and prevented theme.json styles from overriding the icon size. There was also no way to reset the icon size to its default (undefined) via the UI, making it difficult to restore theme.json control without editing block code directly.

By setting the `size` attribute to `undefined`, we ensure the block reverts to its default style, respecting the `theme.json` configuration.

## How?
- Updated the reset and deselect logic for the icon size control in the Inspector sidebar:
  - The "Reset all" and "Icon size" reset actions now set `size: undefined` instead of `'has-normal-icon-size'`.
- This ensures that when the icon size is reset, the block no longer applies a specific size class, allowing theme.json styles to take effect as intended.

## Testing Instructions
1. Open a post or page in the editor.
2. Insert a Social Links block.
3. In the sidebar, set the icon size to "Large", "Small", etc.
4. Try to reset the icon size using the "Reset" button or the "Icon size" reset in the sidebar.
5. Confirm that the icon size resets to default and any theme.json settings are applied.

### Testing Instructions for Keyboard
- Use `Tab` to navigate to the Social Links block sidebar controls.
- Use keyboard to select and reset the icon size.
- Confirm that the reset works and theme.json styles are respected.

## Screencast

#### Before
https://github.com/user-attachments/assets/72053fe2-0c16-4596-8fdb-e8c9b57df6f9

#### After
https://github.com/user-attachments/assets/b577492d-8e5f-4d2f-83d1-2c5aa15460db
