### PR TITLE
Fix: Global styles affect all form elements ( Form Block ) 

### DIFF
--- a/packages/block-library/src/form/block.json
+++ b/packages/block-library/src/form/block.json
@@ -62,7 +62,6 @@
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}
-		},
-		"__experimentalSelector": "form"
+		}
 	}
 }


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/56784

<!-- In a few words, what is the PR actually doing? -->

## Why?
The styles changes for the form element is affecting other block styles 

## How?
This PR removes the `"__experimentalSelector": "form"` from the form's block.json

## Testing Instructions
- Open any template in the Site Editor.
- Insert a form block into your template.
- Insert a block with form elements. Such as the Table block and the Embed block.
- Open the Global Styles and select Blocks > form.
- Change the style.
- The styles of form elements other than the form block should also change.


## Screenshots or screencast 

### Before
https://github.com/user-attachments/assets/8b235f73-0db2-43f0-b93a-fc6217e100a0

### After
https://github.com/user-attachments/assets/38f658e4-7a32-4128-9156-8b658c614f96
