### PR TITLE
Table Block: Fix row insertion when header/footer exists but body is empty

### DIFF
--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -240,6 +240,32 @@ function TableEdit( {
 	 */
 	function onInsertRow( delta ) {
 		if ( ! selectedCell ) {
+			const {
+				head: headRows,
+				body: bodyRows,
+				foot: footRows,
+			} = attributes;
+			const hasHeader = headRows && headRows.length > 0;
+			const hasFooter = footRows && footRows.length > 0;
+			const hasEmptyBody = ! bodyRows || bodyRows.length === 0;
+
+			if ( ( hasHeader || hasFooter ) && hasEmptyBody ) {
+				setAttributes(
+					insertRow( attributes, {
+						sectionName: 'body',
+						rowIndex: 0,
+					} )
+				);
+				// Select the first cell of the new row
+				setSelectedCell( {
+					sectionName: 'body',
+					rowIndex: 0,
+					columnIndex: 0,
+					type: 'cell',
+				} );
+				return;
+			}
+
 			return;
 		}
 
@@ -368,13 +394,25 @@ function TableEdit( {
 		{
 			icon: tableRowBefore,
 			title: __( 'Insert row before' ),
-			isDisabled: ! selectedCell,
+			isDisabled:
+				! selectedCell &&
+				! (
+					( ( head && head.length > 0 ) ||
+						( foot && foot.length > 0 ) ) &&
+					( ! attributes.body || attributes.body.length === 0 )
+				),
 			onClick: onInsertRowBefore,
 		},
 		{
 			icon: tableRowAfter,
 			title: __( 'Insert row after' ),
-			isDisabled: ! selectedCell,
+			isDisabled:
+				! selectedCell &&
+				! (
+					( ( head && head.length > 0 ) ||
+						( foot && foot.length > 0 ) ) &&
+					( ! attributes.body || attributes.body.length === 0 )
+				),
 			onClick: onInsertRowAfter,
 		},
 		{


### PR DESCRIPTION
## What?
Follow up to #45526

Fixes the table block "Insert row" functionality when header and/or footer sections exist but the body section is empty.

## Why?
When a table has header/footer sections but no body rows, the "Insert row" controls become permanently disabled, preventing users from adding body content. This creates a poor user experience where users get stuck.

This issue occurs in two common scenarios:
1. **Block variations with pre-defined headers** - When developers create table variations with headers but no body rows
2. **Manual deletion** - When users accidentally delete all body rows from a table that has headers/footers

## How?
- **Enhanced `onInsertRow()` function**: Added logic to detect when no cell is selected AND header/footer exists AND body is empty, then automatically insert the first body row
- **Updated control states**: Modified `tableControls` array to enable "Insert row before/after" buttons in the special edge case

## Testing Instructions
1. Create a table with header section enabled
2. Delete all body rows manually
3. Try to insert new rows
4. ✅ "Insert row" buttons should be enabled and functional


## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/48e7f1a1-46ab-45d7-8488-536c01cc80c8" /> |<video src="https://github.com/user-attachments/assets/50d3372c-a641-49fa-9d21-d5cf3c74a1b0" />|
