### PR TITLE
Form Block: Apply class names correctly in the block editor

### DIFF
--- a/packages/block-library/src/form/edit.js
+++ b/packages/block-library/src/form/edit.js
@@ -211,7 +211,6 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 			) }
 			<form
 				{ ...innerBlocksProps }
-				className="wp-block-form"
 				encType={ submissionMethod === 'email' ? 'text/plain' : null }
 			/>
 		</>


### PR DESCRIPTION
## What?

I noticed that because the class name prop is hard-coded, the block editor is not applying the proper CSS classes, and I couldn’t even select the block itself. This issue only occurs when the form block is nested. I don't know why it worked fine at the root level, but it was probably just a coincidence.

## How?

Remove the hard-coded classname.


Note: This PR is effectively a part of #55755, and the issues occurring on the frontend need to be fixed separately.

## Testing Instructions

- Insert a Form Block.
- Wrap the block with a Group block.
- Open the list view.
- Click the "Experimental Comment Form" row.
- Make sure you can select the block and that the block sidebar is visible.
- Click a block inside the Form block.
- Click the Parent Block Selection button on the left of the block toolbar.
- Make sure the Form block is selected.

## Screenshots or screencast <!-- if applicable -->

The following screencast shows the issue occurring in the trunk branch:

https://github.com/user-attachments/assets/69aab0e9-b60b-4473-9d74-00d03df58148


