### PR TITLE
Refactor: Convert `BrowserURL` component from class to functional com…

### DIFF
--- a/packages/edit-post/src/components/browser-url/index.js
+++ b/packages/edit-post/src/components/browser-url/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useState, useEffect } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { withSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { store as editorStore } from '@wordpress/editor';
 
@@ -47,25 +47,17 @@ export function BrowserURL( { postId, postStatus } ) {
 	return null;
 }
 
-const BrowserURLWithSelect = () => {
-	const { postId, postStatus } = useSelect( ( select ) => {
-		const { getCurrentPost } = select( editorStore );
-		const post = getCurrentPost();
-		let { id, status, type } = post;
-		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
-			type
-		);
-		if ( isTemplate ) {
-			id = post.wp_id;
-		}
+export default withSelect( ( select ) => {
+	const { getCurrentPost } = select( editorStore );
+	const post = getCurrentPost();
+	let { id, status, type } = post;
+	const isTemplate = [ 'wp_template', 'wp_template_part' ].includes( type );
+	if ( isTemplate ) {
+		id = post.wp_id;
+	}
 
-		return {
-			postId: id,
-			postStatus: status,
-		};
-	}, [] );
-
-	return <BrowserURL postId={ postId } postStatus={ postStatus } />;
-};
-
-export default BrowserURLWithSelect;
+	return {
+		postId: id,
+		postStatus: status,
+	};
+} )( BrowserURL );

--- a/packages/edit-post/src/components/browser-url/index.js
+++ b/packages/edit-post/src/components/browser-url/index.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
-import { withSelect } from '@wordpress/data';
+import { useState, useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { store as editorStore } from '@wordpress/editor';
 
@@ -17,65 +17,55 @@ export function getPostEditURL( postId ) {
 	return addQueryArgs( 'post.php', { post: postId, action: 'edit' } );
 }
 
-export class BrowserURL extends Component {
-	constructor() {
-		super( ...arguments );
-
-		this.state = {
-			historyId: null,
-		};
-	}
-
-	componentDidUpdate( prevProps ) {
-		const { postId, postStatus } = this.props;
-		const { historyId } = this.state;
-
-		if (
-			( postId !== prevProps.postId || postId !== historyId ) &&
-			postStatus !== 'auto-draft' &&
-			postId
-		) {
-			this.setBrowserURL( postId );
-		}
-	}
-
-	/**
-	 * Replaces the browser URL with a post editor link for the given post ID.
-	 *
-	 * Note it is important that, since this function may be called when the
-	 * editor first loads, the result generated `getPostEditURL` matches that
-	 * produced by the server. Otherwise, the URL will change unexpectedly.
-	 *
-	 * @param {number} postId Post ID for which to generate post editor URL.
-	 */
-	setBrowserURL( postId ) {
-		window.history.replaceState(
-			{ id: postId },
-			'Post ' + postId,
-			getPostEditURL( postId )
-		);
-
-		this.setState( () => ( {
-			historyId: postId,
-		} ) );
-	}
-
-	render() {
-		return null;
-	}
+/**
+ * Replaces the browser URL with a post editor link for the given post ID.
+ *
+ * Note it is important that, since this function may be called when the
+ * editor first loads, the result generated `getPostEditURL` matches that
+ * produced by the server. Otherwise, the URL will change unexpectedly.
+ *
+ * @param {number} postId Post ID for which to generate post editor URL.
+ */
+function setBrowserURL( postId ) {
+	window.history.replaceState(
+		{ id: postId },
+		'Post ' + postId,
+		getPostEditURL( postId )
+	);
 }
 
-export default withSelect( ( select ) => {
-	const { getCurrentPost } = select( editorStore );
-	const post = getCurrentPost();
-	let { id, status, type } = post;
-	const isTemplate = [ 'wp_template', 'wp_template_part' ].includes( type );
-	if ( isTemplate ) {
-		id = post.wp_id;
-	}
+export function BrowserURL( { postId, postStatus } ) {
+	const [ historyId, setHistoryId ] = useState( null );
 
-	return {
-		postId: id,
-		postStatus: status,
-	};
-} )( BrowserURL );
+	useEffect( () => {
+		if ( postId !== historyId && postStatus !== 'auto-draft' && postId ) {
+			setBrowserURL( postId );
+			setHistoryId( postId );
+		}
+	}, [ postId, postStatus, historyId ] );
+
+	return null;
+}
+
+const BrowserURLWithSelect = () => {
+	const { postId, postStatus } = useSelect( ( select ) => {
+		const { getCurrentPost } = select( editorStore );
+		const post = getCurrentPost();
+		let { id, status, type } = post;
+		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
+			type
+		);
+		if ( isTemplate ) {
+			id = post.wp_id;
+		}
+
+		return {
+			postId: id,
+			postStatus: status,
+		};
+	}, [] );
+
+	return <BrowserURL postId={ postId } postStatus={ postStatus } />;
+};
+
+export default BrowserURLWithSelect;


### PR DESCRIPTION
## What?
See https://github.com/WordPress/gutenberg/issues/22890

This PR refactors the `BrowserURL` component from a class-based component to a functional component using React hooks.

## Why?
Class-based components are no longer the recommended approach in React.
Functional components with hooks are preferred as they offer:

* Better readability and simplicity
* Easier maintainability and testing
* Alignment with modern Gutenberg code standards

## How?
* Converted the class component to a functional component using `useEffect` and `useState`
* Preserved all original logic, including `setBrowserURL` and URL update conditions
* Used `withSelect` to inject `postId` and `postStatus` from the editor store as props

### Testing Instructions
Run unit tests for the component:

   ```bash
   npm run test:unit ./packages/edit-post/src/components/browser-url/test/index.js 
   ```

## Screenshots or screencast 
N/A – this is a logic-only (non-visual) component.
