### PR TITLE
Editor: expose dataviews field registration actions in private API

### DIFF
--- a/docs/private-apis.md
+++ b/docs/private-apis.md
@@ -309,6 +309,8 @@ Private actions:
 - `setIsReady`
 - `showBlockTypes`
 - `unregisterEntityAction`
+- `registerEntityField`
+- `unregisterEntityField`
 
 Private selectors:
 - `getEntityActions`

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1587,7 +1587,7 @@ _Parameters_
 
 Registers a new DataViews field.
 
-This is an experimental API and is subject to change. it's only available in the Gutenberg plugin for now.
+This is an experimental API and is subject to change.
 
 _Parameters_
 
@@ -1694,7 +1694,7 @@ _Parameters_
 
 Unregisters a DataViews field.
 
-This is an experimental API and is subject to change. it's only available in the Gutenberg plugin for now.
+This is an experimental API and is subject to change.
 
 _Parameters_
 

--- a/packages/editor/src/dataviews/api.js
+++ b/packages/editor/src/dataviews/api.js
@@ -59,38 +59,28 @@ export function unregisterEntityAction( kind, name, actionId ) {
  * Registers a new DataViews field.
  *
  * This is an experimental API and is subject to change.
- * it's only available in the Gutenberg plugin for now.
  *
  * @param {string} kind   Entity kind.
  * @param {string} name   Entity name.
  * @param {Field}  config Field configuration.
  */
 export function registerEntityField( kind, name, config ) {
-	const { registerEntityField: _registerEntityField } = unlock(
-		dispatch( editorStore )
-	);
-
-	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-		_registerEntityField( kind, name, config );
-	}
+	unlock( dispatch( editorStore ) ).registerEntityField( kind, name, config );
 }
 
 /**
  * Unregisters a DataViews field.
  *
  * This is an experimental API and is subject to change.
- * it's only available in the Gutenberg plugin for now.
  *
  * @param {string} kind    Entity kind.
  * @param {string} name    Entity name.
  * @param {string} fieldId Field ID.
  */
 export function unregisterEntityField( kind, name, fieldId ) {
-	const { unregisterEntityField: _unregisterEntityField } = unlock(
-		dispatch( editorStore )
+	unlock( dispatch( editorStore ) ).unregisterEntityField(
+		kind,
+		name,
+		fieldId
 	);
-
-	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-		_unregisterEntityField( kind, name, fieldId );
-	}
 }

--- a/packages/editor/src/dataviews/store/reducer.ts
+++ b/packages/editor/src/dataviews/store/reducer.ts
@@ -68,7 +68,7 @@ function actions( state: ActionState = {}, action: ReduxAction ) {
 	return state;
 }
 
-function fields( state: FieldsState = {}, action: ReduxAction ) {
+export function fields( state: FieldsState = {}, action: ReduxAction ) {
 	switch ( action.type ) {
 		case 'REGISTER_ENTITY_FIELD':
 			return {

--- a/packages/editor/src/dataviews/store/test/private-actions.js
+++ b/packages/editor/src/dataviews/store/test/private-actions.js
@@ -1,0 +1,71 @@
+/**
+ * WordPress dependencies
+ */
+import { createRegistry } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { registerEntityField, unregisterEntityField } from '../private-actions';
+import { store as editorStore } from '../../../store';
+import { unlock } from '../../../lock-unlock';
+
+function createRegistryWithStores() {
+	// Create a registry.
+	const registry = createRegistry();
+	// Register stores.
+	registry.register( editorStore );
+
+	return registry;
+}
+
+describe( 'registerEntityField', () => {
+	it( 'should be unlocked', () => {
+		const registry = createRegistryWithStores();
+		const action = unlock(
+			registry.dispatch( editorStore )
+		).registerEntityField( 'post', 'post', {
+			id: 'post',
+			label: 'Post',
+			render: () => null,
+			Edit: () => null,
+		} );
+		expect( action ).toBeDefined();
+	} );
+
+	it( 'should return the REGISTER_ENTITY_FIELD action', () => {
+		const config = {
+			id: 'post',
+			label: 'Post',
+			render: () => null,
+			Edit: () => null,
+		};
+		const result = registerEntityField( 'post', 'post', config );
+		expect( result ).toEqual( {
+			type: 'REGISTER_ENTITY_FIELD',
+			kind: 'post',
+			name: 'post',
+			config,
+		} );
+	} );
+} );
+
+describe( 'unregisterEntityField', () => {
+	it( 'should be unlocked', () => {
+		const registry = createRegistryWithStores();
+		const action = unlock(
+			registry.dispatch( editorStore )
+		).unregisterEntityField( 'post', 'post', 'post' );
+		expect( action ).toBeDefined();
+	} );
+
+	it( 'should return the UNREGISTER_ENTITY_FIELD action', () => {
+		const result = unregisterEntityField( 'post', 'post', 'post' );
+		expect( result ).toEqual( {
+			type: 'UNREGISTER_ENTITY_FIELD',
+			kind: 'post',
+			name: 'post',
+			fieldId: 'post',
+		} );
+	} );
+} );

--- a/packages/editor/src/dataviews/store/test/reducer.js
+++ b/packages/editor/src/dataviews/store/test/reducer.js
@@ -1,0 +1,42 @@
+/**
+ * Internal dependencies
+ */
+import { fields } from '../reducer';
+
+describe( 'fields', () => {
+	it( 'should return the initial state', () => {
+		expect(
+			fields( undefined, {
+				type: 'REGISTER_ENTITY_FIELD',
+				kind: 'post',
+				name: 'post',
+				config: { id: 'post', label: 'Post' },
+			} )
+		).toEqual( {
+			post: {
+				post: [ { id: 'post', label: 'Post' } ],
+			},
+		} );
+	} );
+
+	it( 'should unregister an entity field', () => {
+		const state = {
+			post: {
+				post: [ { id: 'post', label: 'Post' } ],
+			},
+		};
+
+		expect(
+			fields( state, {
+				type: 'UNREGISTER_ENTITY_FIELD',
+				kind: 'post',
+				name: 'post',
+				fieldId: 'post',
+			} )
+		).toEqual( {
+			post: {
+				post: [],
+			},
+		} );
+	} );
+} );


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

An exploratory PR to expose actions to register and unregister fields in the editor private API.

This is to provide a gentle introduction to field registration to enable testing and refinement. 

## Why?

There's currently no way for extenders to experiment with creating custom fields for dataviews outside of Gutenberg.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
