### PR TITLE
Fix: Incorrect style handle in RTL style registration for wp-list-reusable-blocks

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -404,7 +404,7 @@ function gutenberg_register_packages_styles( $styles ) {
 		array( 'wp-components' ),
 		$version
 	);
-	$styles->add_data( 'wp-list-reusable-block', 'rtl', 'replace' );
+	$styles->add_data( 'wp-list-reusable-blocks', 'rtl', 'replace' );
 
 	gutenberg_override_style(
 		$styles,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
This PR fixes an issue in `gutenberg_override_style()` where the handle '`wp-list-reusable-block`' was incorrect. The correct handle '`wp-list-reusable-blocks`' is already used in the` gutenberg_override_style()` call. Mismatch would prevent RTL styles from being applied correctly.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It ensures that RTL support is added to the correctly registered style handle. Without this fix, the RTL version of the stylesheet won't be loaded in right-to-left languages (like Arabic, Hebrew, etc.) because WordPress can't find the correct style to apply RTL logic to.
