### PR TITLE
Media: Invalidate entities when new media is uploaded

### DIFF
--- a/packages/editor/src/hooks/media-upload.js
+++ b/packages/editor/src/hooks/media-upload.js
@@ -3,9 +3,22 @@
  */
 import { addFilter } from '@wordpress/hooks';
 import { MediaUpload } from '@wordpress/media-utils';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+
+function MediaUploadWithCacheInvalidation( props ) {
+	const { invalidateResolutionForStoreSelector } = useDispatch( coreStore );
+	const { onClose: originalOnClose, ...rest } = props;
+
+	const onClose = ( ...onCloseArgs ) => {
+		invalidateResolutionForStoreSelector( 'getMediaItems' );
+		originalOnClose?.( ...onCloseArgs );
+	};
+	return <MediaUpload onClose={ onClose } { ...rest } />;
+}
 
 addFilter(
 	'editor.MediaUpload',
 	'core/editor/components/media-upload',
-	() => MediaUpload
+	() => MediaUploadWithCacheInvalidation
 );

--- a/packages/editor/src/utils/media-upload/index.js
+++ b/packages/editor/src/utils/media-upload/index.js
@@ -85,6 +85,9 @@ export default function mediaUpload( {
 			}
 			onFileChange?.( file );
 
+			// Files are initially received by `onFileChange` as a blob.
+			// After that the function is called a second time with the file as an entity.
+			// For core-data, we only care about receiving/invalidating entities.
 			const entityFiles = file.filter( ( _file ) => _file?.id );
 			if ( entityFiles?.length ) {
 				const invalidateCache = true;

--- a/packages/editor/src/utils/media-upload/index.js
+++ b/packages/editor/src/utils/media-upload/index.js
@@ -7,6 +7,7 @@ import { v4 as uuid } from 'uuid';
  * WordPress dependencies
  */
 import { select, dispatch } from '@wordpress/data';
+import { store as coreDataStore } from '@wordpress/core-data';
 import { uploadMedia } from '@wordpress/media-utils';
 
 /**
@@ -40,6 +41,7 @@ export default function mediaUpload( {
 	onSuccess,
 	multiple = true,
 } ) {
+	const { receiveEntityRecords } = dispatch( coreDataStore );
 	const { getCurrentPost, getEditorSettings } = select( editorStore );
 	const {
 		lockPostAutosaving,
@@ -82,6 +84,18 @@ export default function mediaUpload( {
 				clearSaveLock();
 			}
 			onFileChange?.( file );
+
+			const entityFiles = file.filter( ( _file ) => _file?.id );
+			if ( entityFiles?.length ) {
+				const invalidateCache = true;
+				receiveEntityRecords(
+					'root',
+					'media',
+					entityFiles,
+					undefined,
+					invalidateCache
+				);
+			}
 		},
 		onSuccess,
 		additionalData: {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #70397

This is a pragmatic attempt at a fix, in the smallest possible way, but there are still some remaining problems, which I'll document.

All this does is call `receiveEntityRecords` with the `true` `invalidateCache` flag whenever the `mediaUpload` util creates entities.

This `mediaUpload` util is used pretty widely, so this fixes the majority of issues with cache invalidation, but there are still quite a lot of other problems that I've discovered. I can log these as separate issues:

#### Inserter Media
When you upload a new image in the block editor canvas, the image doesn't immediately show up in the inserter, a user still needs to close and reopen the Media category.

I think this is because these 'inserter media categories' bypass `useSelect` and the `getEntitiyRecords` selector, so they're not implemented in a reactive way. They instead call the `getMediaItems` resolver via `resolveSelect` from an async function, so it 'pulls' from the core-data rather than have core-data 'push' to it:
https://github.com/WordPress/gutenberg/blob/8586e6357ff00fb46132624e65a721fc197af58b/packages/editor/src/components/media-categories/index.js#L150-L152

https://github.com/WordPress/gutenberg/blob/8586e6357ff00fb46132624e65a721fc197af58b/packages/editor/src/components/media-categories/index.js#L127-L139

#### Widget Editors
The widget editors don't use the `editor` package, they have their own separate implementation of `mediaUpload`. I haven't addressed it as it seems like low hanging fruit. For a start those editors don't actually implement the Inserter 'Media' tab properly (it always shows 'No results found'), and so it's possible the missing cache invalidation doesn't cause any bugs for users in those editors.
<img width="350" alt="Screenshot 2025-06-13 at 1 34 38 pm" src="https://github.com/user-attachments/assets/173e2464-b407-4773-964d-1f34668ce1fa" />

#### Image Block Cropping Tools
If you try cropping/editing an image using the image block's tools, this bypasses the `mediaUpload` function that I'm augmenting in this PR. It has its own `apiFetch`. The implementation has some red flags, like the way it uses a restricted import:
https://github.com/WordPress/gutenberg/blob/8586e6357ff00fb46132624e65a721fc197af58b/packages/block-editor/src/components/image-editor/use-save-image.js#L4-L6

It's also not possible to import from core-data in the block editor package, so cache invalidation isn't possible. These tools likely need their WordPress API usage extracted from the block editor package to a block editor setting.

## Testing Instructions
1. Delete all media from your media library 
2. Open up the post editor
3. Open the main inserter sidebar
4. Select the Media tab and notice there are no 'Images', you should only have the Openverse category by default
5. Drag an image file from Finder/Windows Explorer into the editor canvas
6. Note that you still only have the 'Openverse' category
7. Switch to the Blocks tab from Media and back again
8. Notice you now have an 'Images' category (if you test this against trunk, you'd still only have the Openverse category)
9. Click into the Images category
10. Drag another image file into the canvas
11. Switch between Openverse and Images category
12. Observe that the newly added image shows up in the inserter (again, in trunk this doesn't happen).

Also try repeating the above steps, but instead of dragging images into the canvas:
- Upload an image via the Image Block's Media Library Modal
- Upload an image via the Image Block's Upload option
