### PR TITLE
[WIP] Image: Do not render attachment link option if attachment pages are disabled

### DIFF
--- a/lib/compat/wordpress-6.9/rest-api.php
+++ b/lib/compat/wordpress-6.9/rest-api.php
@@ -29,3 +29,12 @@ function gutenberg_rest_theme_export_link_rel( $response, $theme ) {
 	return $response;
 }
 add_filter( 'rest_prepare_theme', 'gutenberg_rest_theme_export_link_rel', 10, 2 );
+
+// Adds a setting to indicate whether attachment pages are enabled.
+add_filter(
+	'block_editor_settings_all',
+	function ( $settings ) {
+		$settings['__unstableAttachmentPagesEnabled'] = (bool) get_option( 'wp_attachment_pages_enabled' );
+		return $settings;
+	}
+);

--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useRef, useEffect, useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import { focus } from '@wordpress/dom';
 import {
 	ToolbarButton,
@@ -26,6 +27,7 @@ import {
  * Internal dependencies
  */
 import URLPopover from './index';
+import { store as blockEditorStore } from '../../store';
 
 const LINK_DESTINATION_NONE = 'none';
 const LINK_DESTINATION_CUSTOM = 'custom';
@@ -61,6 +63,13 @@ const ImageURLInputUI = ( {
 
 	const autocompleteRef = useRef( null );
 	const wrapperRef = useRef();
+
+	const attachmentPagesEnabled = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getSettings()
+				.__unstableAttachmentPagesEnabled,
+		[]
+	);
 
 	useEffect( () => {
 		if ( ! wrapperRef.current ) {
@@ -176,7 +185,7 @@ const ImageURLInputUI = ( {
 				icon: image,
 			},
 		];
-		if ( mediaType === 'image' && mediaLink ) {
+		if ( mediaType === 'image' && mediaLink && attachmentPagesEnabled ) {
 			linkDestinations.push( {
 				linkDestination: LINK_DESTINATION_ATTACHMENT,
 				title: __( 'Link to attachment page' ),

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -86,6 +86,7 @@ const BLOCK_EDITOR_SETTINGS = [
 	'__unstableHasCustomAppender',
 	'__unstableResolvedAssets',
 	'__unstableIsBlockBasedTheme',
+	'__unstableAttachmentPagesEnabled',
 ];
 
 const {

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -845,6 +845,13 @@ test.describe( 'Image', () => {
 			} )
 		).toBeFocused();
 
+		// Enable attachment pages to make the "Link to attachment page" option available.
+		await page.evaluate( () => {
+			window.wp.data.dispatch( 'core/block-editor' ).updateSettings( {
+				__unstableAttachmentPagesEnabled: true,
+			} );
+		} );
+
 		// Select "Link to attachment page".
 		await pageUtils.pressKeys( 'Tab' );
 		await page.keyboard.press( 'Enter' );


### PR DESCRIPTION
## What?
Closes #70403

WP 6.4 introduced the database option `wp_attachment_pages_enabled` to control visibility/generation of attachment pages (Ref. https://make.wordpress.org/core/2023/10/16/changes-to-attachment-pages/ )

This PR uses the above option to conditionally render the "Link to attachment page" option within the `ImageURLInputUI` component.

## Why?

Currently, the Image block always displays the "Link to attachment page" option, even when `wp_attachment_pages_enabled` is set to 0 (i.e., attachment pages are disabled).

## How?

This PR exposes the `wp_attachment_pages_enabled` setting to the editor and uses it to conditionally display the "Link to attachment page" option in the Image block.

## Testing Instructions

1. Confirm that `wp_attachment_pages_enabled` is set to `0` (i.e., disabled).
2. Create a new post.
3. Insert a `core/image` block and attach an image.
4. From the `Link Control` within `Block Toolbar`, verify that the `Link to attachment page` option is not present.
5. Toggle `wp_attachment_pages_enabled` to `1` and confirm that the `Link to attachment page` is now accessible.

### Testing Instructions for Keyboard

Same.

## Screenshots

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/b2aca19d-bc4f-466c-b02a-290e7dab7d8d)|![after](https://github.com/user-attachments/assets/7084edb9-0886-4f5e-bc57-72a21dfe3d9d)|