### PR TITLE
Fix: Update post-publish panel to use taxonomy label instead of hardcoded "Tags"

### DIFF
--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -14,15 +14,18 @@ import FlatTermSelector from '../post-taxonomies/flat-term-selector';
 import { store as editorStore } from '../../store';
 
 const TagsPanel = () => {
-	const tagLabel = useSelect( ( select ) => {
+	const tagLabels = useSelect( ( select ) => {
 		const taxonomy = select( coreStore ).getTaxonomy( 'post_tag' );
-		return taxonomy?.labels?.add_new_item ?? 'Add tag'; // fallback to 'Add tag'.
+		return taxonomy?.labels;
 	}, [] );
+
+	const addNewItem = tagLabels?.add_new_item ?? 'Add tag';
+	const tagLabel = tagLabels?.name ?? 'Tags';
 
 	const panelBodyTitle = [
 		__( 'Suggestion:' ),
 		<span className="editor-post-publish-panel__link" key="label">
-			{ tagLabel }
+			{ addNewItem }
 		</span>,
 	];
 
@@ -30,12 +33,11 @@ const TagsPanel = () => {
 		<PanelBody initialOpen={ false } title={ panelBodyTitle }>
 			<p>
 				{ sprintf(
-					// translators: %s is the taxonomy label to add a new term (e.g., "Add Tag").
+					// translators: %s is the taxonomy name (e.g., "Tags").
 					__(
-						'%s to help users and search engines navigate your site and find your content. Add a few keywords to describe your post.'
+						'%s help users and search engines navigate your site and find your content. Add a few keywords to describe your post.'
 					),
-					tagLabel[ 0 ].toUpperCase() +
-						tagLabel.slice( 1 ).toLowerCase()
+					tagLabel
 				) }
 			</p>
 			<FlatTermSelector slug="post_tag" __nextHasNoMarginBottom />

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -19,8 +19,8 @@ const TagsPanel = () => {
 		return taxonomy?.labels;
 	}, [] );
 
-	const addNewItem = tagLabels?.add_new_item ?? 'Add tag';
-	const tagLabel = tagLabels?.name ?? 'Tags';
+	const addNewItem = tagLabels?.add_new_item ?? __( 'Add tag' );
+	const tagLabel = tagLabels?.name ?? __( 'Tags' );
 
 	const panelBodyTitle = [
 		__( 'Suggestion:' ),

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { PanelBody } from '@wordpress/components';
@@ -14,18 +14,31 @@ import FlatTermSelector from '../post-taxonomies/flat-term-selector';
 import { store as editorStore } from '../../store';
 
 const TagsPanel = () => {
+	const tagLabel = useSelect( ( select ) => {
+		const taxonomy = select( coreStore ).getTaxonomy( 'post_tag' );
+		return taxonomy?.labels?.name ?? 'Tags'; // fallback to 'Tags'.
+	}, [] );
+
 	const panelBodyTitle = [
 		__( 'Suggestion:' ),
 		<span className="editor-post-publish-panel__link" key="label">
-			{ __( 'Add tags' ) }
+			{ sprintf(
+				// translators: %s is the taxonomy name (e.g., "Tags").
+				__( 'Add %s' ),
+				tagLabel
+			) }
 		</span>,
 	];
 
 	return (
 		<PanelBody initialOpen={ false } title={ panelBodyTitle }>
 			<p>
-				{ __(
-					'Tags help users and search engines navigate your site and find your content. Add a few keywords to describe your post.'
+				{ sprintf(
+					// translators: %s is the taxonomy name (e.g., "Tags").
+					__(
+						'%s help users and search engines navigate your site and find your content. Add a few keywords to describe your post.'
+					),
+					tagLabel
 				) }
 			</p>
 			<FlatTermSelector slug="post_tag" __nextHasNoMarginBottom />

--- a/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-tags-panel.js
@@ -16,17 +16,13 @@ import { store as editorStore } from '../../store';
 const TagsPanel = () => {
 	const tagLabel = useSelect( ( select ) => {
 		const taxonomy = select( coreStore ).getTaxonomy( 'post_tag' );
-		return taxonomy?.labels?.name ?? 'Tags'; // fallback to 'Tags'.
+		return taxonomy?.labels?.add_new_item ?? 'Add tag'; // fallback to 'Add tag'.
 	}, [] );
 
 	const panelBodyTitle = [
 		__( 'Suggestion:' ),
 		<span className="editor-post-publish-panel__link" key="label">
-			{ sprintf(
-				// translators: %s is the taxonomy name (e.g., "Tags").
-				__( 'Add %s' ),
-				tagLabel
-			) }
+			{ tagLabel }
 		</span>,
 	];
 
@@ -34,11 +30,12 @@ const TagsPanel = () => {
 		<PanelBody initialOpen={ false } title={ panelBodyTitle }>
 			<p>
 				{ sprintf(
-					// translators: %s is the taxonomy name (e.g., "Tags").
+					// translators: %s is the taxonomy label to add a new term (e.g., "Add Tag").
 					__(
-						'%s help users and search engines navigate your site and find your content. Add a few keywords to describe your post.'
+						'%s to help users and search engines navigate your site and find your content. Add a few keywords to describe your post.'
 					),
-					tagLabel
+					tagLabel[ 0 ].toUpperCase() +
+						tagLabel.slice( 1 ).toLowerCase()
 				) }
 			</p>
 			<FlatTermSelector slug="post_tag" __nextHasNoMarginBottom />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Fixes #22588  <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->
Updates the MaybeTagsPanel component in the post-publish panel to use the dynamic taxonomy label for the `post_tag` taxonomy instead of hardcoded strings like "Tags".

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Previously, the post-publish panel used hardcoded "Tags" strings in its UI, even if the `taxonomy_labels_post_tag` filter was used to rename the taxonomy (e.g., to "Keywords"). This led to inconsistencies between the main editor sidebar (which showed the correct custom label) and the pre-publish panel (which did not).

This PR resolves that by fetching the `labels.name` from the core data store via `useSelect` and using it in all strings via `sprintf()`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Introduced a `useSelect` call to get the `name` label of the `post_tag` taxonomy.
- Replaced all hardcoded “Tags” strings with `sprintf()` calls that dynamically insert the taxonomy label.

## Testing Instructions
1. Add something like the following to a plugin or your themes functions.php file.

```php
add_filter(
	'taxonomy_labels_post_tag',
	function( object $labels ): object {
		$singular_name = 'Keyword';
		$plural_name   = 'Keywords';
		return (object) [
			'name'                  => $plural_name,
			'singular_name'         => $singular_name,
			'menu_name'             => $plural_name,
			'all_items'             => "All {$plural_name}",
			'new_item_name'         => "New {$singular_name} Name",
			'add_new_item'          => "Add New {$singular_name}",
			'edit_item'             => "Edit {$singular_name}",
			'update_item'           => "Update {$singular_name}",
			'view_item'             => "View {$singular_name}",
			'add_or_remove_items'   => "Add or remove {$plural_name}",
			'search_items'          => "Search {$plural_name}",
			'not_found'             => "No {$plural_name} found",
			'no_terms'              => "No {$plural_name}",
			'items_list'            => "{$plural_name} list",
			'items_list_navigation' => "{$plural_name} list navigation",
		];
	}
);
```

2. Create a new post using Gutenberg.
3. See that "tags" are changed to "keywords" in the sidebar.
5. Don't add any tags/keywords before clicking on publish (and make sure to have the pre publish checks enabled). See that it says "Add Keywords" and "Keywords help users and search engines..." instead of "Add tags" etc. now

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before
<img width="1470" alt="Screenshot 2025-06-13 at 1 07 36 PM" src="https://github.com/user-attachments/assets/72765b93-6649-495f-a8fe-7834e51de3be" />

### After
<img width="1469" alt="Screenshot 2025-06-13 at 2 00 51 PM" src="https://github.com/user-attachments/assets/371bf089-4e18-46cd-aac6-7bb285d1fd83" />
