### PR TITLE
Format Library: Add Replace button to inline image

### DIFF
--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -13,7 +13,7 @@ import {
 	TextareaControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { insertObject, useAnchor } from '@wordpress/rich-text';
 import {
 	MediaUpload,
@@ -44,23 +44,32 @@ export const image = {
 
 function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 	const { style, alt, className } = activeObjectAttributes;
-	const width = style?.replace( /\D/g, '' );
-
-	const [ editedValues, setEditedValues ] = useState( {
-		width,
-		alt: alt || '',
-	} );
-
+	const currentWidth = style?.replace( /\D/g, '' );
+	const currentAlt = alt || '';
 	const imageId = className?.replace( /wp-image-(\d+)/, '$1' );
 
-	useEffect( () => {
-		setEditedValues( {
-			width: style?.replace( /\D/g, '' ),
-			alt: alt || '',
-		} );
-	}, [ style, alt ] );
+	const [ formState, setFormState ] = useState( {
+		values: {
+			width: currentWidth,
+			alt: currentAlt,
+		},
+		lastReplaced: null,
+	} );
 
-	const hasChanged = editedValues.width !== width || editedValues.alt !== alt;
+	const updateFormValue = ( key, newValue ) => {
+		setFormState( ( state ) => ( {
+			values: { ...state.values, [ key ]: newValue },
+			lastReplaced: null,
+		} ) );
+	};
+
+	const comparisonValues = formState.lastReplaced || {
+		width: currentWidth,
+		alt: currentAlt,
+	};
+	const hasChanged =
+		formState.values.width !== comparisonValues.width ||
+		formState.values.alt !== comparisonValues.alt;
 
 	const popoverAnchor = useAnchor( {
 		editableContentElement: contentRef.current,
@@ -75,6 +84,16 @@ function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 	} ) => {
 		const newWidth = Math.min( imgWidth, 150 );
 		const newReplacements = value.replacements.slice();
+
+		const newValues = {
+			width: newWidth,
+			alt: newAlt || '',
+		};
+
+		setFormState( {
+			values: newValues,
+			lastReplaced: newValues,
+		} );
 
 		newReplacements[ value.start ] = {
 			type: name,
@@ -108,10 +127,10 @@ function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 						type: name,
 						attributes: {
 							...activeObjectAttributes,
-							style: editedValues.width
-								? `width: ${ editedValues.width }px;`
+							style: formState.values.width
+								? `width: ${ formState.values.width }px;`
 								: '',
-							alt: editedValues.alt,
+							alt: formState.values.alt,
 						},
 					};
 
@@ -120,6 +139,11 @@ function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 						replacements: newReplacements,
 					} );
 
+					setFormState( ( state ) => ( {
+						...state,
+						lastReplaced: null,
+					} ) );
+
 					event.preventDefault();
 				} }
 			>
@@ -127,25 +151,19 @@ function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 					<NumberControl
 						__next40pxDefaultSize
 						label={ __( 'Width' ) }
-						value={ editedValues.width }
+						value={ formState.values.width }
 						min={ 1 }
-						onChange={ ( newWidth ) => {
-							setEditedValues( {
-								...editedValues,
-								width: newWidth,
-							} );
-						} }
+						onChange={ ( newWidth ) =>
+							updateFormValue( 'width', newWidth )
+						}
 					/>
 					<TextareaControl
 						label={ __( 'Alternative text' ) }
 						__nextHasNoMarginBottom
-						value={ editedValues.alt }
-						onChange={ ( newAlt ) => {
-							setEditedValues( {
-								...editedValues,
-								alt: newAlt,
-							} );
-						} }
+						value={ formState.values.alt }
+						onChange={ ( newAlt ) =>
+							updateFormValue( 'alt', newAlt )
+						}
 						help={
 							<>
 								<ExternalLink

--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -13,7 +13,7 @@ import {
 	TextareaControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { insertObject, useAnchor } from '@wordpress/rich-text';
 import {
 	MediaUpload,
@@ -45,13 +45,50 @@ export const image = {
 function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 	const { style, alt } = activeObjectAttributes;
 	const width = style?.replace( /\D/g, '' );
-	const [ editedWidth, setEditedWidth ] = useState( width );
-	const [ editedAlt, setEditedAlt ] = useState( alt );
-	const hasChanged = editedWidth !== width || editedAlt !== alt;
+
+	const [ editedValues, setEditedValues ] = useState( {
+		width,
+		alt: alt || '',
+	} );
+
+	useEffect( () => {
+		setEditedValues( {
+			width: style?.replace( /\D/g, '' ),
+			alt: alt || '',
+		} );
+	}, [ style, alt ] );
+
+	const hasChanged = editedValues.width !== width || editedValues.alt !== alt;
+
 	const popoverAnchor = useAnchor( {
 		editableContentElement: contentRef.current,
 		settings: image,
 	} );
+
+	const handleImageReplace = ( {
+		id,
+		url: newUrl,
+		alt: newAlt,
+		width: imgWidth,
+	} ) => {
+		const newWidth = Math.min( imgWidth, 150 );
+		const newReplacements = value.replacements.slice();
+
+		newReplacements[ value.start ] = {
+			type: name,
+			attributes: {
+				className: `wp-image-${ id }`,
+				style: `width: ${ newWidth }px;`,
+				url: newUrl,
+				alt: newAlt || '',
+			},
+		};
+
+		onChange( {
+			...value,
+			replacements: newReplacements,
+		} );
+	};
 
 	return (
 		<Popover
@@ -69,10 +106,10 @@ function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 						type: name,
 						attributes: {
 							...activeObjectAttributes,
-							style: editedWidth
-								? `width: ${ editedWidth }px;`
+							style: editedValues.width
+								? `width: ${ editedValues.width }px;`
 								: '',
-							alt: editedAlt,
+							alt: editedValues.alt,
 						},
 					};
 
@@ -88,18 +125,24 @@ function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 					<NumberControl
 						__next40pxDefaultSize
 						label={ __( 'Width' ) }
-						value={ editedWidth }
+						value={ editedValues.width }
 						min={ 1 }
 						onChange={ ( newWidth ) => {
-							setEditedWidth( newWidth );
+							setEditedValues( {
+								...editedValues,
+								width: newWidth,
+							} );
 						} }
 					/>
 					<TextareaControl
 						label={ __( 'Alternative text' ) }
 						__nextHasNoMarginBottom
-						value={ editedAlt }
+						value={ editedValues.alt }
 						onChange={ ( newAlt ) => {
-							setEditedAlt( newAlt );
+							setEditedValues( {
+								...editedValues,
+								alt: newAlt,
+							} );
 						} }
 						help={
 							<>
@@ -121,6 +164,21 @@ function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 						}
 					/>
 					<HStack justify="right">
+						<MediaUploadCheck>
+							<MediaUpload
+								allowedTypes={ ALLOWED_MEDIA_TYPES }
+								onSelect={ handleImageReplace }
+								render={ ( { open } ) => (
+									<Button
+										variant="secondary"
+										onClick={ open }
+										size="compact"
+									>
+										{ __( 'Replace' ) }
+									</Button>
+								) }
+							/>
+						</MediaUploadCheck>
 						<Button
 							disabled={ ! hasChanged }
 							accessibleWhenDisabled

--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -43,13 +43,15 @@ export const image = {
 };
 
 function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
-	const { style, alt } = activeObjectAttributes;
+	const { style, alt, className } = activeObjectAttributes;
 	const width = style?.replace( /\D/g, '' );
 
 	const [ editedValues, setEditedValues ] = useState( {
 		width,
 		alt: alt || '',
 	} );
+
+	const imageId = className?.replace( /wp-image-(\d+)/, '$1' );
 
 	useEffect( () => {
 		setEditedValues( {
@@ -168,6 +170,7 @@ function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 							<MediaUpload
 								allowedTypes={ ALLOWED_MEDIA_TYPES }
 								onSelect={ handleImageReplace }
+								value={ imageId }
 								render={ ( { open } ) => (
 									<Button
 										variant="secondary"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/25909

This PR adds a "Replace" button to the inline image format popover in the Gutenberg editor. Currently, once an inline image is inserted, there's no easy way to replace it with another image without removing it completely and inserting a new one. This enhancement improves the user experience by making image replacement more discoverable and intuitive, similar to how image blocks work.

## Testing Instructions
1. Create a new post or page in the Gutenberg editor
2. Insert a paragraph block and type some text
3. Select "Inline Image" from the format options
4. Select an image from the Media Library and insert it into your text
5. Click on the inserted inline image to select it
6. In the popover that appears, verify that there is a "Replace" button
7. Click the "Replace" button and select a different image from the Media Library

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/6603c952-3c00-4638-85f3-2b74a6ba2b45


