### PR TITLE
Fix image lightbox issues in new full client-side navigation logic

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -273,6 +273,7 @@ function block_core_image_print_lightbox_overlay() {
 		<div
 			class="wp-lightbox-overlay zoom"
 			data-wp-interactive="core/image"
+			data-wp-router-region='{ "id": "core/body", "attachTo": "body" }'
 			data-wp-key="wp-lightbox-overlay"
 			data-wp-context='{}'
 			data-wp-bind--role="state.roleAttribute"

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -279,7 +279,7 @@ function block_core_image_print_lightbox_overlay() {
 			data-wp-bind--aria-label="state.currentImage.ariaLabel"
 			data-wp-bind--aria-modal="state.ariaModal"
 			data-wp-class--active="state.overlayEnabled"
-			data-wp-class--show-closing-animation="state.showClosingAnimation"
+			data-wp-class--show-closing-animation="state.overlayOpened"
 			data-wp-watch="callbacks.setOverlayFocus"
 			data-wp-on--keydown="actions.handleKeydown"
 			data-wp-on-async--touchstart="actions.handleTouchStart"

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -204,6 +204,7 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 			JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
 		)
 	);
+	$p->set_attribute( 'data-wp-key', $unique_image_id );
 
 	// Image.
 	$p->next_tag( 'img' );
@@ -272,6 +273,7 @@ function block_core_image_print_lightbox_overlay() {
 		<div
 			class="wp-lightbox-overlay zoom"
 			data-wp-interactive="core/image"
+			data-wp-key="wp-lightbox-overlay"
 			data-wp-context='{}'
 			data-wp-bind--role="state.roleAttribute"
 			data-wp-bind--aria-label="state.currentImage.ariaLabel"

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -273,7 +273,7 @@ function block_core_image_print_lightbox_overlay() {
 		<div
 			class="wp-lightbox-overlay zoom"
 			data-wp-interactive="core/image"
-			data-wp-router-region='{ "id": "core/body", "attachTo": "body" }'
+			data-wp-router-region='{ "id": "core/image-overlay", "attachTo": "body" }'
 			data-wp-key="wp-lightbox-overlay"
 			data-wp-context='{}'
 			data-wp-bind--role="state.roleAttribute"

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -110,9 +110,6 @@ const { state, actions, callbacks } = store(
 			},
 			hideLightbox() {
 				if ( state.overlayEnabled ) {
-					// Starts the overlay closing animation. The showClosingAnimation
-					// class is used to avoid showing it on page load.
-					state.showClosingAnimation = true;
 					state.overlayEnabled = false;
 
 					// Waits until the close animation has completed before allowing a


### PR DESCRIPTION
> [!WARNING]
> **This PR is built on top of https://github.com/WordPress/gutenberg/pull/70353**, which includes the new logic for client-side navigation. The issues it solves are pretty hard to replicate in existing region-based navigation.
> 
> For testing purposes, in the mentioned branch, the full client-side navigation can be enabled using a filter like this:
> 
> ```php
> add_filter( 'wp_interactivity_experimental_full_page_client_navigation', 'activate_full_csn', 10, 2 );
> 
> function activate_full_csn() {
> 	return 'I acknowledge that full-page client-side navigation is still experimental and will probably change, breaking my plugin or website on its next version.';
> }
> ```

## What?

It solves a bunch of issues related to client-side navigation and the image lightbox.

### The lightbox closing animation triggers when navigating to a page with the lightbox enabled.

https://github.com/user-attachments/assets/302e3ec3-e281-4bbf-97ae-2c9fd95b0cad

_Testing instructions_
1. Go to a page with an image with lightbox.
2. Open and close the lightbox.
3. Go to a page without lightbox.
4. Go back to the page with lightbox.
5. Check the animation is not triggered.

_How?_
It changes the `hide` class to rely on `state.overlayOpened` instead of `state.showClosingAnimation`, and I've removed that property. According to [this comment](https://github.com/WordPress/gutenberg/compare/feature/iapi-new-client-side-navigation...fix/image-lightbox-issues-in-csn?expand=1#diff-540be71e7203e1f3a7c11c0cd06085f90b3b4a07f0e3bfa9efb17952d227ec96L113-L114), it was added because the animation was triggered the first time the page was loaded, but I have been testing it and I wasn't able to reproduce it in any browser.

### CSN breaks after going from an empty query loop to a page with lightbox enabled.

https://github.com/user-attachments/assets/db43cd5b-3e33-4668-bdb9-ef9891510c27

_Testing instructions_
1. Add a query loop without "Force page reload" enabled in the homepage.
2. Navigate to a page that doesn't exist like `http://localhost:8888/?query-1-page=999`.
3. Navigate to a page with a lightbox.
4. Check that the lightbox works as expected and it doesn't trigger an error like in the video.

_How?_
Using the `data-wp-key` directive solves this issue.

### Lightbox triggers incorrect image when opening and closing multiple images in a query loop.

https://github.com/user-attachments/assets/099bd3ca-d9bb-482a-8545-75d26e6f2382

_Testing instructions_
1. Create two posts with two different images with lightbox enabled.
2. Add a query loop of the posts, including the Post Content and put 1 item per page.
3. Go to the first page and open the lightbox.
4. Navigate to the second page and open the lightbox.
5. Check it opens the appropriate image and the issue shown in the video is fixed.

_How?_
Using the `data-wp-key` directive solves this issue.

----
Right now, it is really hard to replicate these issues with region-based client-side navigation because Post Content is not supported and it is tricky to replicate having different images in the query loop.

However, I added a `data-wp-router-region` to ensure this is not a problem in the future. This will also need some changes to the router JS logic that @DAreRodz will handle in the original PR.