### PR TITLE
Post Title: Fix empty heading element when post_title is empty but get_the_title returns markup

### DIFF
--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -27,7 +27,7 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 	 */
 	$title = get_the_title();
 
-	if ( ! $title ) {
+	if ( ! $title || ! strip_tags( $title ) ) {
 		return '';
 	}
 


### PR DESCRIPTION
## What?
Closes #56465

Fix empty heading element when `post_title` is empty but `get_the_title` returns markup by checking for text content after stripping HTML tags.

## Why?
The Post Title block was outputting empty heading elements when plugins or themes filter `the_title` to add markup around an empty post title. This creates invalid HTML with headings that contain no text content, which can cause accessibility issues and semantic problems.

The specific issue occurred when:
1. A post has an empty title
2. A plugin/theme filters `the_title` to wrap the empty title with HTML markup (e.g., `<span class="p-name"></span>`)
3. The Post Title block would output something like `<h2><span class="p-name"></span></h2>` - an empty heading

This was particularly problematic with plugins like wp-uf2 (Microformats) that add semantic markup to post titles.

## How?
Updated the condition in `render_block_core_post_title()` to check not only if the title is empty, but also if the title has no text content after stripping HTML tags using `strip_tags()`.

The fix changes:
```php
if ( ! $title ) {
    return '';
}
```

To:
```php
if ( ! $title || ! strip_tags( $title ) ) {
    return '';
}
```

This ensures that if the title contains only HTML markup without any actual text content, the heading element will not be rendered at all, maintaining the original intention of not outputting empty headings.

## Testing Instructions
1. Create a new post without a title
2. Add a Query Loop block to a page with a Post Title block inside
3. Add the following code to your theme's `functions.php` or create a test plugin:
   ```php
   add_filter(
       'the_title',
       function( $title ) {
           return '<strong>' . $title . '</strong>';
       }
   );
   ```
4. View the frontend page and inspect the HTML
5. Verify that no empty heading element is rendered for the post with no title

Alternatively, test with the wp-uf2 (Microformats) plugin:
1. Install and activate the wp-uf2 plugin
2. Follow steps 1-2 above  
3. View the frontend and verify no empty `<h2><a href="..."><span class="p-name"></span></a></h2>` is rendered

## Screenshots or screencast

### Before


https://github.com/user-attachments/assets/b8f65ad4-1504-4f8f-855e-d833e26caaed



### After


https://github.com/user-attachments/assets/0225a41e-d7be-4fba-822e-9db9aeeb269b


