### PR TITLE
iAPI: Minor fixes to the Interactivity and Interactivity Router comments

### DIFF
--- a/packages/interactivity-router/src/assets/dynamic-importmap/index.ts
+++ b/packages/interactivity-router/src/assets/dynamic-importmap/index.ts
@@ -38,7 +38,7 @@ async function importShim< Module = unknown >( id: string ) {
 }
 
 /**
- * Import the module with the passed ID.
+ * Imports the module with the passed ID.
  *
  * The module is resolved against the internal dynamic import map,
  * extended with the passed import map.
@@ -56,7 +56,7 @@ export async function importWithMap< Module = unknown >(
 }
 
 /**
- * Preload the module with the passed ID along with its dependencies.
+ * Preloads the module with the passed ID along with its dependencies.
  *
  * The module is resolved against the internal dynamic import map,
  * extended with the passed import map.

--- a/packages/interactivity-router/src/assets/dynamic-importmap/loader.ts
+++ b/packages/interactivity-router/src/assets/dynamic-importmap/loader.ts
@@ -289,7 +289,7 @@ function getOrCreateLoad(
 const dynamicImport = ( u: string ) => import( /* webpackIgnore: true */ u );
 
 /**
- * Resolve the passed module URL and fetch the corresponding module
+ * Resolves the passed module URL and fetches the corresponding module
  * and their dependencies, returning a `ModuleLoad` object once all
  * of them have been fetched.
  *
@@ -312,7 +312,7 @@ export async function preloadModule(
 }
 
 /**
- * Import the module represented by the passed `ModuleLoad` instance.
+ * Imports the module represented by the passed `ModuleLoad` instance.
  *
  * @param load The `ModuleLoad` instance representing the module.
  * @return A promise with the imported module.
@@ -329,7 +329,7 @@ export async function importPreloadedModule< Module = unknown >(
 }
 
 /**
- * Import the module represented by the passed module URL.
+ * Imports the module represented by the passed module URL.
  *
  * The module URL and all its dependencies are resolved using the
  * current status of the internal dynamic import map.

--- a/packages/interactivity-router/src/assets/dynamic-importmap/resolver.ts
+++ b/packages/interactivity-router/src/assets/dynamic-importmap/resolver.ts
@@ -261,7 +261,7 @@ const baseUrl = document.baseURI;
 const pageBaseUrl = baseUrl;
 
 /**
- * Extend the internal dynamic import map with the passed one.
+ * Extends the internal dynamic import map with the passed one.
  *
  * @param importMapIn         Import map.
  * @param importMapIn.imports Imports declaration.
@@ -279,7 +279,7 @@ export function addImportMap( importMapIn: {
 }
 
 /**
- * Resolve the URL of the passed module ID against the current internal
+ * Resolves the URL of the passed module ID against the current internal
  * dynamic import map.
  *
  * @param id        Module ID.

--- a/packages/interactivity-router/src/assets/script-modules.ts
+++ b/packages/interactivity-router/src/assets/script-modules.ts
@@ -33,7 +33,7 @@ const initialImportMap = initialImportMapElement
 const resolvedScriptModules = new Set< string >();
 
 /**
- * Mark the specified module as natively resolved.
+ * Marks the specified module as natively resolved.
  * @param url Script module URL.
  */
 export const markScriptModuleAsResolved = ( url: string ) => {
@@ -41,7 +41,7 @@ export const markScriptModuleAsResolved = ( url: string ) => {
 };
 
 /**
- * Resolve and fetch modules present in the passed document, using the
+ * Resolves and fetches modules present in the passed document, using the
  * document's import map to resolve them.
  *
  * @param doc Document containing the modules to preload.
@@ -76,7 +76,7 @@ export const preloadScriptModules = ( doc: Document ) => {
 };
 
 /**
- * Import modules respresented by the passed `ScriptModuleLoad` instances.
+ * Imports modules respresented by the passed `ScriptModuleLoad` instances.
  *
  * @param modules Array of `MoudleLoad` instances.
  * @return Promise that resolves once all modules are imported.

--- a/packages/interactivity-router/src/assets/scs.ts
+++ b/packages/interactivity-router/src/assets/scs.ts
@@ -1,5 +1,5 @@
 /**
- * Calculate the Shortest Common Supersequence (SCS) of two sequences.
+ * Calculates the Shortest Common Supersequence (SCS) of two sequences.
  *
  * A supersequence is a sequence that contains both input sequences as subsequences.
  * The shortest common supersequence is the shortest possible such sequence.

--- a/packages/interactivity-router/src/assets/styles.ts
+++ b/packages/interactivity-router/src/assets/styles.ts
@@ -52,8 +52,8 @@ export const normalizeMedia = ( element: StyleElement ): StyleElement => {
  * shortest common supersequence algorithm, returning a list of
  * promises for all the elements in Y.
  *
- * If X is empty, it appends all the elements in Y to the passed
- * parent element or to `document.head` instead.
+ * If X is empty, it appends all elements in Y to the passed parent
+ * element or to `document.head` instead.
  *
  * The returned promises resolve once the corresponding style element
  * is loaded and ready. Those elements that are also in X return a

--- a/packages/interactivity-router/src/assets/styles.ts
+++ b/packages/interactivity-router/src/assets/styles.ts
@@ -6,7 +6,7 @@ import { shortestCommonSupersequence } from './scs';
 export type StyleElement = HTMLLinkElement | HTMLStyleElement;
 
 /**
- * Compare the passed style or link elements to check if they can be
+ * Compares the passed style or link elements to check if they can be
  * considered equal.
  *
  * @param a `<style>` or `<link>` element.
@@ -17,7 +17,7 @@ const areNodesEqual = ( a: StyleElement, b: StyleElement ): boolean =>
 	a.isEqualNode( b );
 
 /**
- * Normalized the passed style or link element, reverting the changes
+ * Normalizes the passed style or link element, reverting the changes
  * made by {@link prepareStylePromise|`prepareStylePromise`} to the
  * `data-original-media` and `media`.
  *
@@ -48,7 +48,7 @@ export const normalizeMedia = ( element: StyleElement ): StyleElement => {
 };
 
 /**
- * Add the minimun style elements from Y around those in X using a
+ * Adds the minimum style elements from Y around those in X using a
  * shortest common supersequence algorithm, returning a list of
  * promises for all the elements in Y.
  *
@@ -138,7 +138,7 @@ const stylePromiseCache = new WeakMap<
 >();
 
 /**
- * Prepare and return the corresponding `Promise` for the passed style
+ * Prepares and returns the corresponding `Promise` for the passed style
  * element.
  *
  * It returns the cached promise if it exists. Otherwise, constructs
@@ -206,7 +206,7 @@ const prepareStylePromise = (
 const styleSheetCache = new Map< string, Promise< StyleElement >[] >();
 
 /**
- * Prepare all style elements contained in the passed document.
+ * Prepares all style elements contained in the passed document.
  *
  * This function calls {@link updateStylesWithSCS|`updateStylesWithSCS`}
  * to insert only the minimum amount of style elements into the DOM, so
@@ -247,13 +247,13 @@ export const preloadStyles = (
 };
 
 /**
- * Traverse all style elements in the DOM, enabling only those included
+ * Traverses all style elements in the DOM, enabling only those included
  * in the passed list and disabling the others.
  *
  * If the style element has the `data-original-media` attribute, the
  * original `media` value is restored.
  *
- * @param styles List of style elements to apply
+ * @param styles List of style elements to apply.
  */
 export const applyStyles = ( styles: StyleElement[] ) => {
 	window.document

--- a/packages/interactivity-router/src/assets/test/scs.test.ts
+++ b/packages/interactivity-router/src/assets/test/scs.test.ts
@@ -4,8 +4,9 @@
 import { shortestCommonSupersequence } from '../scs';
 
 /**
- * Check the passed array is a contained sequence of the given
+ * Checks if the passed array is a contained sequence of the given
  * supersequence.
+ *
  * @param arr      Array.
  * @param superseq Supersequence.
  * @param isEqual  Optional comparator.

--- a/packages/interactivity-router/src/assets/test/styles.test.ts
+++ b/packages/interactivity-router/src/assets/test/styles.test.ts
@@ -10,8 +10,9 @@ import {
 } from '../styles';
 
 /**
- * Mock the `sheet` property or the for the
+ * Mocks the `sheet` property for the
  * passed HTMLStyleElement or HTMLLinkElement instance.
+ *
  * @param element          Style or Link element.
  * @param params           Values for certain props.
  * @param params.disabled  Value for the `sheet.disabled` prop.
@@ -34,7 +35,8 @@ const mockSheet = (
 };
 
 /**
- * Create an `HTMLStyleElement` instance for testing.
+ * Creates an `HTMLStyleElement` instance for testing.
+ *
  * @param id Value for the `id` attribute.
  * @return An `HTMLStyleElement` instance.
  */
@@ -46,7 +48,8 @@ const createStyleElement = ( id: string ): HTMLStyleElement => {
 };
 
 /**
- * Create an `HTMLLinkElement` instance for testing.
+ * Creates an `HTMLLinkElement` instance for testing.
+ *
  * @param id   Value for the `id` attribute.
  * @param href Value for the `href` attribute.
  * @return An `HTMLLinkElement` instance.

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -165,7 +165,7 @@ const renderPage = ( page: Page ) => {
 };
 
 /**
- * Load the given page forcing a full page reload.
+ * Loads the given page forcing a full page reload.
  *
  * The function returns a promise that won't resolve, useful to prevent any
  * potential feedback indicating that the navigation has finished while the new

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -385,7 +385,7 @@ export const { state, actions } = store< Store >( 'core/router', {
  * Announces a message to screen readers.
  *
  * This is a wrapper around the `@wordpress/a11y` package's `speak` function. It handles importing
- * the package on demand and should be used instead of calling `ally.speak` direacly.
+ * the package on demand and should be used instead of calling `ally.speak` directly.
  *
  * @param messageKey The message to be announced by assistive technologies.
  */

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -383,7 +383,7 @@ export const { state, actions } = store< Store >( 'core/router', {
  * Announces a message to screen readers.
  *
  * This is a wrapper around the `@wordpress/a11y` package's `speak` function. It handles importing
- * the package on demand and should be used instead of calling `ally.speak` directly.
+ * the package on demand and should be used instead of calling `a11y.speak` directly.
  *
  * @param messageKey The message to be announced by assistive technologies.
  */

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -194,8 +194,6 @@ window.addEventListener( 'popstate', async () => {
 } );
 
 // Initialize the router and cache the initial page using the initial vDOM.
-// Once this code is tested and more mature, the head should be updated for
-// region based navigation as well.
 window.document
 	.querySelectorAll< HTMLScriptElement >( 'script[type=module][src]' )
 	.forEach( ( { src } ) => markScriptModuleAsResolved( src ) );

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -30,7 +30,7 @@ import { getScope } from './scopes';
 import { proxifyState, proxifyContext, deepMerge } from './proxies';
 
 /**
- * Recursively clone the passed object.
+ * Recursively clones the passed object.
  *
  * @param source Source object.
  * @return Cloned object.
@@ -105,7 +105,7 @@ const ruleNewline = /\n+/g;
 const empty = ' ';
 
 /**
- * Convert a css style string into a object.
+ * Converts a css style string into a object.
  *
  * Made by Cristian Bote (@cristianbote) for Goober.
  * https://unpkg.com/browse/goober@2.1.13/src/core/astish.js

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -120,7 +120,7 @@ const directiveCallbacks: Record< string, DirectiveCallback > = {};
 const directivePriorities: Record< string, number > = {};
 
 /**
- * Register a new directive type in the Interactivity API runtime.
+ * Registers a new directive type in the Interactivity API runtime.
  *
  * @example
  * ```js

--- a/packages/interactivity/src/proxies/context.ts
+++ b/packages/interactivity/src/proxies/context.ts
@@ -44,7 +44,7 @@ const contextHandlers: ProxyHandler< object > = {
 };
 
 /**
- * Wrap a context object with a proxy to reproduce the context stack. The proxy
+ * Wraps a context object with a proxy to reproduce the context stack. The proxy
  * uses the passed `inherited` context as a fallback to look up for properties
  * that don't exist in the given context. Also, updated properties are modified
  * where they are defined, or added to the main context when they don't exist.

--- a/packages/interactivity/src/proxies/signals.ts
+++ b/packages/interactivity/src/proxies/signals.ts
@@ -119,7 +119,7 @@ export class PropSignal {
 	}
 
 	/**
-	 *  Update the internal signals for the value and the getter of the
+	 *  Updates the internal signals for the value and the getter of the
 	 *  corresponding prop.
 	 *
 	 * @param param0

--- a/packages/interactivity/src/proxies/state.ts
+++ b/packages/interactivity/src/proxies/state.ts
@@ -379,7 +379,7 @@ const deepMergeRecursive = (
 };
 
 /**
- * Recursively update prop values inside the passed `target` and nested plain
+ * Recursively updates prop values inside the passed `target` and nested plain
  * objects, using the values present in `source`. References to plain objects
  * are kept, only updating props containing primitives or arrays. Arrays are
  * replaced instead of merged or concatenated.

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -15,7 +15,7 @@ const storeConfigs = new Map();
 const serverStates = new Map();
 
 /**
- * Get the defined config for the store with the passed namespace.
+ * Gets the defined config for the store with the passed namespace.
  *
  * @param namespace Store's namespace from which to retrieve the config.
  * @return Defined config for the given namespace.
@@ -24,7 +24,7 @@ export const getConfig = ( namespace?: string ) =>
 	storeConfigs.get( namespace || getNamespace() ) || {};
 
 /**
- * Get the part of the state defined and updated from the server.
+ * Gets the part of the state defined and updated from the server.
  *
  * The object returned is read-only, and includes the state defined in PHP with
  * `wp_interactivity_state()`. When using `actions.navigate()`, this object is

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -61,7 +61,7 @@ interface StoreOptions {
 	 * Property to block/unblock private store namespaces.
 	 *
 	 * If the passed value is `true`, it blocks the given namespace, making it
-	 * accessible only trough the returned variables of the `store()` call. In
+	 * accessible only through the returned variables of the `store()` call. In
 	 * the case a lock string is passed, it also blocks the namespace, but can
 	 * be unblocked for other `store()` calls using the same lock string.
 	 *

--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -287,16 +287,17 @@ export function useCallback< T extends Function >(
 }
 
 /**
- * Pass a factory function and an array of inputs. `useMemo` will only recompute
- * the memoized value when one of the inputs has changed.
+ * Returns the memoized output of the passed factory function, allowing access
+ * to the current element's scope.
  *
  * This hook is equivalent to Preact's `useMemo` and makes the element's scope
  * available so functions like `getElement()` and `getContext()` can be used
- * inside the passed factory function.
+ * inside the passed factory function. Note that `useMemo` will only recompute
+ * the memoized value when one of the inputs has changed.
  *
  * @param factory Factory function that returns that value for memoization.
- * @param inputs  If present, the factory will only be run to recompute if
- *                the values in the list change (using `===`).
+ * @param inputs  If present, the factory will only be run to recompute if the
+ *                values in the list change (using `===`).
  *
  * @return The memoized value.
  */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

> [!WARNING]
> This PR has been created on top of #70353. Wait for that PR to be merged before merging this one.

<!-- In a few words, what is the PR actually doing? -->

Improves TSDoc comments to use third-person singular verbs. Additionally, corrects typos and other formatting errors.

## Why?

To adhere to the [WordPress JavaScript Documentation standard](https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/).

> Functions and closures are _third-person singular_ elements, meaning third-person singular verbs should be used to describe what each does.
