### PR TITLE
iAPI: Introduce `AsyncAction` and `TypeYield` type helpers

### DIFF
--- a/docs/reference-guides/interactivity-api/core-concepts/using-typescript.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/using-typescript.md
@@ -481,7 +481,7 @@ There's something to keep in mind when using asynchronous actions. Just like wit
     	actions: {
     		*delayedOperation() {
     			// Example: state.counter is used as part of the yielded logic.
-    			yield fetch(`/api/counter-${state.counter}`);
+    			yield fetchCounterData( state.counter );
 
     			// And/or the final return value depends on state.
     			return state.counter + 1;
@@ -500,9 +500,9 @@ In such cases, TypeScript might issue a warning about a circular reference or de
     		counter: 0,
     	},
     	actions: {
-    		*delayedOperation(): AsyncAction<number> {
+    		*delayedOperation(): AsyncAction< number > {
     			// Now, this doesn't cause a circular reference.
-    			yield fetch(`/api/counter-${state.counter}`);
+    			yield fetchCounterData( state.counter );
     			// Now, this is correctly typed.
     			return state.counter;
     		},
@@ -511,6 +511,43 @@ In such cases, TypeScript might issue a warning about a circular reference or de
     ```
 
 That's it! The `AsyncAction<ReturnType>` helper is defined as `Generator<any, ReturnType, unknown>`. By using `any` for the type of values yielded by the generator, it helps break the circular reference, allowing TypeScript to correctly infer the types when `state` is involved in `yield` expressions or in the final return value. You only need to specify the final `ReturnType` of your asynchronous action.
+
+### Typing yielded values in asynchronous actions
+
+While `AsyncAction<ReturnType>` types the overall generator and its final return value, the value resolved by an individual `yield` expression within that generator might still be typed as `any`.
+
+If you need to ensure the correct type for a value that a `yield` expression resolves to (e.g., the result of a `fetch` call or another async operation), you can use the `TypeYield<T>` helper. This helper takes the type of the asynchronous function/operation being yielded (`T`) and resolves to the type of the value that the promise fulfills with.
+
+Let's expand the previous example. Suppose `fetch` returns a `Response` object, and then you process it to get data:
+
+    ```ts
+    import { store, type AsyncAction, type TypeYield } from '@wordpress/interactivity';
+
+    // Assume this function is defined elsewhere and fetches specific data.
+    const fetchCounterData = async ( counterValue: number ): Promise< { current: number, next: number } > => {
+        // internal logic...
+    };
+
+    const { state, actions } = store( 'myCounterPlugin', {
+    	state: {
+    		counter: 0,
+    	},
+    	actions: {
+    		*loadCounterData(): AsyncAction< void > {
+    			// Use TypeYield to correctly type the resolved value of the yield.
+    			const data = ( yield fetchCounterData( state.counter ) ) as TypeYield< typeof fetchCounterData >;
+
+    			// Now, `data` is correctly typed as { current: number, next: number }.
+    			console.log( data.current, data.next );
+
+    			// Update state based on the fetched data.
+    			state.counter = data.next;
+    		},
+    	},
+    } );
+    ```
+
+In this example, `(yield fetchCounterData(state.counter)) as TypeYield<typeof fetchCounterData>` ensures that the `data` constant is correctly typed as `{ current: number, next: number }`, matching the return type of `fetchCounterData`. This allows you to confidently access properties like `data.current` and `data.next` with type safety.
 
 ## Typing stores that are divided into multiple parts
 

--- a/docs/reference-guides/interactivity-api/core-concepts/using-typescript.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/using-typescript.md
@@ -503,8 +503,9 @@ In such cases, TypeScript might issue a warning about a circular reference or de
     		*delayedOperation(): AsyncAction< number > {
     			// Now, this doesn't cause a circular reference.
     			yield fetchCounterData( state.counter );
+
     			// Now, this is correctly typed.
-    			return state.counter;
+    			return state.counter + 1;
     		},
     	},
     } );
@@ -518,7 +519,7 @@ While `AsyncAction<ReturnType>` types the overall generator and its final return
 
 If you need to ensure the correct type for a value that a `yield` expression resolves to (e.g., the result of a `fetch` call or another async operation), you can use the `TypeYield<T>` helper. This helper takes the type of the asynchronous function/operation being yielded (`T`) and resolves to the type of the value that the promise fulfills with.
 
-Let's expand the previous example. Suppose `fetch` returns a `Response` object, and then you process it to get data:
+Suppose `fetchCounterData` returns a promise that resolves to an object:
 
     ```ts
     import { store, type AsyncAction, type TypeYield } from '@wordpress/interactivity';
@@ -547,7 +548,7 @@ Let's expand the previous example. Suppose `fetch` returns a `Response` object, 
     } );
     ```
 
-In this example, `(yield fetchCounterData(state.counter)) as TypeYield<typeof fetchCounterData>` ensures that the `data` constant is correctly typed as `{ current: number, next: number }`, matching the return type of `fetchCounterData`. This allows you to confidently access properties like `data.current` and `data.next` with type safety.
+In this example, `( yield fetchCounterData( state.counter ) ) as TypeYield< typeof fetchCounterData >` ensures that the `data` constant is correctly typed as `{ current: number, next: number }`, matching the return type of `fetchCounterData`. This allows you to confidently access properties like `data.current` and `data.next` with type safety.
 
 ## Typing stores that are divided into multiple parts
 

--- a/docs/reference-guides/interactivity-api/core-concepts/using-typescript.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/using-typescript.md
@@ -471,7 +471,7 @@ type Store = {
 };
 ```
 
-There's something to keep in mind when when using asynchronous actions. Just like with the derived state, if the asynchronous action needs to return a value and this value directly depends on some part of the global state, TypeScript will not be able to infer the type due to a circular reference.
+There's something to keep in mind when using asynchronous actions. Just like with the derived state, if an asynchronous action uses `state` within a `yield` expression (for example, by passing `state` to an async function that is then yielded) or if its return value depends on `state`, TypeScript might not be able to infer the types correctly due to a potential circular reference.
 
     ```ts
     const { state, actions } = store( 'myCounterPlugin', {
@@ -479,31 +479,38 @@ There's something to keep in mind when when using asynchronous actions. Just lik
     		counter: 0,
     	},
     	actions: {
-    		*delayedReturn() {
-    			yield new Promise( ( r ) => setTimeout( r, 1000 ) );
-    			return state.counter; // TypeScript can't infer this return type.
+    		*delayedOperation() {
+    			// Example: state.counter is used as part of the yielded logic.
+    			yield fetch(`/api/counter-${state.counter}`);
+
+    			// And/or the final return value depends on state.
+    			return state.counter + 1;
     		},
     	},
     } );
     ```
 
-    In this case, just as we did with the derived state, we must manually type the return value of the generator.
+In such cases, TypeScript might issue a warning about a circular reference or default to `any`. To solve this, you need to manually type the generator function. The Interactivity API provides a helper type, `AsyncAction<ReturnType>`, for this purpose.
 
     ```ts
+    import { store, type AsyncAction } from '@wordpress/interactivity';
+
     const { state, actions } = store( 'myCounterPlugin', {
     	state: {
     		counter: 0,
     	},
     	actions: {
-    		*delayedReturn(): Generator< unknown, number, unknown > {
-    			yield new Promise( ( r ) => setTimeout( r, 1000 ) );
-    			return state.counter; // Now this is correctly inferred.
+    		*delayedOperation(): AsyncAction<number> {
+    			// Now, this doesn't cause a circular reference.
+    			yield fetch(`/api/counter-${state.counter}`);
+    			// Now, this is correctly typed.
+    			return state.counter;
     		},
     	},
     } );
     ```
 
-    That's it! Remember that the return type of a Generator is the second generic argument: `Generator< unknown, ReturnType, unknown >`.
+That's it! The `AsyncAction<ReturnType>` helper is defined as `Generator<any, ReturnType, unknown>`. By using `any` for the type of values yielded by the generator, it helps break the circular reference, allowing TypeScript to correctly infer the types when `state` is involved in `yield` expressions or in the final return value. You only need to specify the final `ReturnType` of your asynchronous action.
 
 ## Typing stores that are divided into multiple parts
 

--- a/packages/interactivity-router/CHANGELOG.md
+++ b/packages/interactivity-router/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   Export `NavigateOptions` and `PrefetchOptions` types. ([#70315](https://github.com/WordPress/gutenberg/pull/70315))
 -   Support new styles and script modules on client-side navigation, including a new full-page client-side navigation mode. ([#70353](https://github.com/WordPress/gutenberg/pull/70353))
+-   Introduce `AsyncAction` and `TypeYield` type helpers. ([#70422](https://github.com/WordPress/gutenberg/pull/70422))
 
 ### Bug Fixes
 

--- a/packages/interactivity/src/index.ts
+++ b/packages/interactivity/src/index.ts
@@ -16,7 +16,13 @@ import { getNamespace } from './namespaces';
 import { parseServerData, populateServerData } from './store';
 import { proxifyState } from './proxies';
 
-export { store, getConfig, getServerState } from './store';
+export {
+	store,
+	getConfig,
+	getServerState,
+	type AsyncAction,
+	type TypeYield,
+} from './store';
 export { getContext, getServerContext, getElement } from './scopes';
 export {
 	withScope,

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -84,6 +84,9 @@ interface StoreOptions {
 	lock?: boolean | string;
 }
 
+export type AsyncAction< T > = Generator< any, T, unknown >;
+export type TypeYield< T extends ( ...args: any[] ) => Promise< any > > =
+	Awaited< ReturnType< T > >;
 type Prettify< T > = { [ K in keyof T ]: T[ K ] } & {};
 type DeepPartial< T > = T extends object
 	? { [ P in keyof T ]?: DeepPartial< T[ P ] > }

--- a/packages/interactivity/src/test/store.ts
+++ b/packages/interactivity/src/test/store.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { store } from '../store';
+import { store, type AsyncAction, type TypeYield } from '../store';
 
 describe( 'Interactivity API', () => {
 	describe( 'store', () => {
@@ -316,6 +316,42 @@ describe( 'Interactivity API', () => {
 				);
 
 				actions2.incrementValue( 1 ) satisfies void;
+			} );
+
+			describe( 'async actions can pass state to yields and type the yield returns', () => {
+				// eslint-disable-next-line no-unused-expressions
+				async () => {
+					type Store = {
+						state: {
+							someValue: string;
+						};
+						actions: {
+							asyncAction: () => Promise< number >;
+						};
+					};
+
+					const asyncFunction = async (
+						someValue: string
+					): Promise< string > => {
+						return someValue;
+					};
+
+					const { state, actions } = store< Store >( 'test', {
+						actions: {
+							*asyncAction(): AsyncAction< number > {
+								( yield asyncFunction(
+									state.someValue
+								) ) as TypeYield<
+									typeof asyncFunction
+								> satisfies string;
+
+								return 1;
+							},
+						},
+					} );
+
+					( await actions.asyncAction() ) satisfies number;
+				};
 			} );
 		} );
 	} );

--- a/packages/interactivity/src/test/store.ts
+++ b/packages/interactivity/src/test/store.ts
@@ -74,7 +74,7 @@ describe( 'Interactivity API', () => {
 							sync( n ) {
 								return n;
 							},
-							*async( n ): Generator< unknown, number, unknown > {
+							*async( n ): AsyncAction< number > {
 								const n1 = myStore.actions.sync( n );
 								return myStore.state.derived + n1 + n;
 							},
@@ -114,12 +114,17 @@ describe( 'Interactivity API', () => {
 							sync( n: number ) {
 								return n;
 							},
-							*async(
-								n: number
-							): Generator< unknown, number, number > {
+							*async( n: number ): AsyncAction< number > {
 								const n1: number =
-									yield myStore.actions.sync( n );
+									( yield myStore.actions.async2(
+										n
+									) ) as TypeYield<
+										typeof myStore.actions.async2
+									>;
 								return myStore.state.derived + n1 + n;
+							},
+							*async2( n: number ) {
+								return n;
 							},
 						},
 					};
@@ -161,12 +166,17 @@ describe( 'Interactivity API', () => {
 							sync( n: number ) {
 								return n;
 							},
-							*async(
-								n: number
-							): Generator< unknown, number, number > {
+							*async( n: number ): AsyncAction< number > {
 								const n1: number =
-									yield myStore.actions.sync( n );
+									( yield myStore.actions.async2(
+										n
+									) ) as TypeYield<
+										typeof myStore.actions.async2
+									>;
 								return myStore.state.derived + n1 + n;
+							},
+							*async2( n: number ) {
+								return n;
 							},
 						},
 					} );
@@ -191,6 +201,7 @@ describe( 'Interactivity API', () => {
 						actions: {
 							sync: ( n: number ) => number;
 							async: ( n: number ) => Promise< number >;
+							async2: ( n: number ) => AsyncAction< number >;
 						};
 						callbacks: {
 							existent: number;
@@ -202,10 +213,17 @@ describe( 'Interactivity API', () => {
 							sync( n ) {
 								return n;
 							},
-							*async( n ): Generator< unknown, number, number > {
+							*async( n ): AsyncAction< number > {
 								const n1: number =
-									yield myStore.actions.sync( n );
+									( yield myStore.actions.async2(
+										n
+									) ) as TypeYield<
+										typeof myStore.actions.async2
+									>;
 								return n1 + n;
+							},
+							*async2( n: number ) {
+								return n;
 							},
 						},
 						callbacks: {

--- a/packages/interactivity/src/test/store.ts
+++ b/packages/interactivity/src/test/store.ts
@@ -115,12 +115,11 @@ describe( 'Interactivity API', () => {
 								return n;
 							},
 							*async( n: number ): AsyncAction< number > {
-								const n1: number =
-									( yield myStore.actions.async2(
-										n
-									) ) as TypeYield<
-										typeof myStore.actions.async2
-									>;
+								const n1 = ( yield myStore.actions.async2(
+									n
+								) ) as TypeYield<
+									typeof myStore.actions.async2
+								> satisfies number;
 								return myStore.state.derived + n1 + n;
 							},
 							*async2( n: number ) {
@@ -167,12 +166,11 @@ describe( 'Interactivity API', () => {
 								return n;
 							},
 							*async( n: number ): AsyncAction< number > {
-								const n1: number =
-									( yield myStore.actions.async2(
-										n
-									) ) as TypeYield<
-										typeof myStore.actions.async2
-									>;
+								const n1 = ( yield myStore.actions.async2(
+									n
+								) ) as TypeYield<
+									typeof myStore.actions.async2
+								> satisfies number;
 								return myStore.state.derived + n1 + n;
 							},
 							*async2( n: number ) {
@@ -214,12 +212,11 @@ describe( 'Interactivity API', () => {
 								return n;
 							},
 							*async( n ): AsyncAction< number > {
-								const n1: number =
-									( yield myStore.actions.async2(
-										n
-									) ) as TypeYield<
-										typeof myStore.actions.async2
-									>;
+								const n1 = ( yield myStore.actions.async2(
+									n
+								) ) as TypeYield<
+									typeof myStore.actions.async2
+								> satisfies number;
 								return n1 + n;
 							},
 							*async2( n: number ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

> [!WARNING]
> This PR has been created on top of #70353. Wait for that PR to be merged before merging this one.

<!-- In a few words, what is the PR actually doing? -->
This PR introduces two new TypeScript helper types, `AsyncAction<ReturnType>` and `TypeYield<T>`, to the Interactivity API.

It also adds documentation for both helpers in the "Using TypeScript" guide, explaining their purpose and how to use them to solve common typing issues with asynchronous actions (generators).

Props to @luisherranz.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When working with asynchronous actions (defined as generators) in the Interactivity API and TypeScript, developers can encounter two main issues:

1.  **Circular References**: If `state` is used within a `yield` expression or if the generator's return value depends on `state`, TypeScript can struggle to infer types, leading to circular reference errors or types defaulting to `any`.
2.  **Typing Yielded Values**: Even if the overall generator type is correctly inferred or specified, the actual value resolved by an individual `yield` expression (e.g., the result of a fetched promise) is not accurately typed within the generator's scope, defaulting to `any`.

## How?

*   `AsyncAction<ReturnType>`: Defined as `Generator<any, ReturnType, unknown>`. 

    This helper allows developers to explicitly type the return value of an asynchronous action (generator). By using `any` for the yielded values, it helps break circular type dependencies when `state` is used within `yield` expressions or in the final return value.

*   `TypeYield<T extends (...args: any[]) => Promise<any>>`: Defined as `Awaited<ReturnType<T>>`. 

    This helper allows developers to explicitly type the value that a `yield` expression resolves to, by providing the type of the async function/operation being yielded.
