### PR TITLE
iAPI: Fix `wp-each` item contexts for objects with same key

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/directive-each/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-each/render.php
@@ -237,7 +237,7 @@
 			<p
 				data-testid="item"
 				data-wp-text="state.bookItem.title"
-				data-wp-on--click="actions.removeBook"
+				data-wp-on--click="actions.removeBookUsingDerivedState"
 			></p>
 		</template>
 		<!-- SSRed elements; they should be removed on hydration -->

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-each/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-each/render.php
@@ -213,6 +213,38 @@
 		<p data-testid="item" data-wp-each-child>banana</p>
 		<p data-testid="item" data-wp-each-child>cherimoya</p>
 	</div>
+
+	<div data-testid="item from derived state">
+		<button
+			data-testid="rotate" data-wp-on--click="actions.rotateBooks"
+		>Rotate</button>
+		<button
+			data-testid="add" data-wp-on--click="actions.addBook"
+		>Add</button>
+		<button
+			data-testid="replace" data-wp-on--click="actions.replaceBook"
+		>Replace</button>
+		<button
+			data-testid="modify" data-wp-on--click="actions.modifyBook"
+		>Modify</button>
+		<button
+			data-testid="replace-all" data-wp-on--click="actions.replaceAllBooks"
+		>Replace All</button>
+		<template
+			data-wp-each--book-item="state.books"
+			data-wp-each-key="state.bookItem.isbn"
+		>
+			<p
+				data-testid="item"
+				data-wp-text="state.bookItem.title"
+				data-wp-on--click="actions.removeBook"
+			></p>
+		</template>
+		<!-- SSRed elements; they should be removed on hydration -->
+		<p data-testid="item" data-wp-each-child>A Game of Thrones</p>
+		<p data-testid="item" data-wp-each-child>A Clash of Kings</p>
+		<p data-testid="item" data-wp-each-child>A Storm of Swords</p>
+	</div>
 </div>
 
 <hr>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-each/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-each/view.js
@@ -83,6 +83,9 @@ store( 'directive-each', {
 				isbn: '9780553573428',
 			},
 		],
+		get bookItem() {
+			return getContext().bookItem;
+		},
 	},
 	actions: {
 		removeBook() {
@@ -112,6 +115,9 @@ store( 'directive-each', {
 		modifyBook() {
 			const [ book ] = state.books;
 			book.title = book.title.toUpperCase();
+		},
+		replaceAllBooks() {
+			state.books = state.books.map( ( book ) => ( { ...book } ) );
 		},
 	},
 } );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-each/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-each/view.js
@@ -92,6 +92,10 @@ store( 'directive-each', {
 			const { book } = getContext();
 			state.books.splice( state.books.indexOf( book ), 1 );
 		},
+		removeBookUsingDerivedState() {
+			const book = state.bookItem;
+			state.books.splice( state.books.indexOf( book ), 1 );
+		},
 		rotateBooks() {
 			const book = state.books.pop();
 			state.books.splice( 0, 0, book );

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -220,26 +220,57 @@ const getGlobalEventDirective = (
 	};
 };
 
+const getEvaluatedItemKey = (
+	inheritedValue: any,
+	namespace: string,
+	item: unknown,
+	itemProp: string,
+	eachKey: DirectiveEntry[]
+) => {
+	const clientContextWithItem = {
+		...inheritedValue.client,
+		[ namespace ]: {
+			...inheritedValue.client[ namespace ],
+			[ itemProp ]: item,
+		},
+	};
+
+	const scope = {
+		...getScope(),
+		context: clientContextWithItem,
+		serverContext: inheritedValue.server,
+	};
+
+	return eachKey ? getEvaluate( { scope } )( eachKey[ 0 ] ) : item;
+};
+
 const useItemContexts = function* (
 	inheritedValue: any,
 	namespace: string,
 	items: Iterable< unknown >,
-	itemProp: string
+	itemProp: string,
+	eachKey: DirectiveEntry[]
 ) {
-	const { current: itemContexts } = useRef< any >( [] );
+	const { current: itemContexts } = useRef< any >( {} );
 
-	let index = 0;
 	for ( const item of items ) {
-		if ( ! itemContexts[ index ] ) {
-			itemContexts[ index ] = proxifyContext(
+		const key = getEvaluatedItemKey(
+			inheritedValue,
+			namespace,
+			item,
+			itemProp,
+			eachKey
+		);
+
+		if ( ! itemContexts[ key ] ) {
+			itemContexts[ key ] = proxifyContext(
 				proxifyState( namespace, {
 					[ itemProp ]: item,
 				} ),
 				inheritedValue.client[ namespace ]
 			);
 		}
-		yield [ item, itemContexts[ index ] ];
-		index += 1;
+		yield [ itemContexts[ key ], key ];
 	}
 };
 
@@ -879,10 +910,11 @@ export default () => {
 				inheritedValue,
 				namespace,
 				iterable,
-				itemProp
+				itemProp,
+				eachKey
 			);
 
-			for ( const [ item, itemContext ] of itemContexts ) {
+			for ( const [ itemContext, key ] of itemContexts ) {
 				const mergedContext = {
 					client: {
 						...inheritedValue.client,
@@ -890,15 +922,6 @@ export default () => {
 					},
 					server: { ...inheritedValue.server },
 				};
-
-				const scope = {
-					...getScope(),
-					context: mergedContext.client,
-					serverContext: mergedContext.server,
-				};
-				const key = eachKey
-					? getEvaluate( { scope } )( eachKey[ 0 ] )
-					: item;
 
 				result.push(
 					createElement(

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -220,6 +220,29 @@ const getGlobalEventDirective = (
 	};
 };
 
+const useItemContexts = function* (
+	inheritedValue: any,
+	namespace: string,
+	items: Iterable< unknown >,
+	itemProp: string
+) {
+	const { current: itemContexts } = useRef< any >( [] );
+
+	let index = 0;
+	for ( const item of items ) {
+		if ( ! itemContexts[ index ] ) {
+			itemContexts[ index ] = proxifyContext(
+				proxifyState( namespace, {
+					[ itemProp ]: item,
+				} ),
+				inheritedValue.client[ namespace ]
+			);
+		}
+		yield [ item, itemContexts[ index ] ];
+		index += 1;
+	}
+};
+
 /**
  * Creates a directive that adds an async event listener to the global window or
  * document object.
@@ -852,14 +875,14 @@ export default () => {
 
 			const result: VNode< any >[] = [];
 
-			for ( const item of iterable ) {
-				// Shadows a previous item with the same key.
-				const itemContext = proxifyContext(
-					proxifyState( namespace, {
-						[ itemProp ]: item,
-					} ),
-					inheritedValue.client[ namespace ]
-				);
+			const itemContexts = useItemContexts(
+				inheritedValue,
+				namespace,
+				iterable,
+				itemProp
+			);
+
+			for ( const [ item, itemContext ] of itemContexts ) {
 				const mergedContext = {
 					client: {
 						...inheritedValue.client,

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -220,13 +220,30 @@ const getGlobalEventDirective = (
 	};
 };
 
-const getEvaluatedItemKey = (
+/**
+ * Obtains the given item key based on the passed `eachKey` entry. Used by the
+ * `wp-each` directive.
+ *
+ * The item key is computed using `getEvaluate` with a mocked scope simulating
+ * the specific context that inner directives will inherit, i.e., including the
+ * item under the corresponding item prop.
+ *
+ * @param inheritedValue Inherited context value.
+ * @param namespace      Namespace for the `wp-each` directive.
+ * @param item           Item from the list of items pointed by `wp-each`.
+ * @param itemProp       Prop in which the item is accessible from the context.
+ * @param eachKey        Directive entry pointing to the item's key.
+ * @return The evaluated key for the passed item.
+ */
+const evaluateItemKey = (
 	inheritedValue: any,
 	namespace: string,
 	item: unknown,
 	itemProp: string,
-	eachKey: DirectiveEntry[]
+	eachKey?: DirectiveEntry
 ) => {
+	// Construct a client context with the item. Note that accessing the item
+	// prop is not reactive, as this simulated context is not proxified.
 	const clientContextWithItem = {
 		...inheritedValue.client,
 		[ namespace ]: {
@@ -235,26 +252,41 @@ const getEvaluatedItemKey = (
 		},
 	};
 
+	// Scope must contain the client and the server contexts.
 	const scope = {
 		...getScope(),
 		context: clientContextWithItem,
 		serverContext: inheritedValue.server,
 	};
 
-	return eachKey ? getEvaluate( { scope } )( eachKey[ 0 ] ) : item;
+	// If passed, evaluate `eachKey` entry with the simulated scope. Return
+	// `item` otherwhise.
+	return eachKey ? getEvaluate( { scope } )( eachKey ) : item;
 };
 
+/**
+ * Generates an `Iterable` from the passed items that returns, for each item, a
+ * tuple with the item, its context and its evaluated key. Used by the `wp-each`
+ * directive.
+ *
+ * @param inheritedValue Inherited context value.
+ * @param namespace      Namespace for the `wp-each` directive.
+ * @param items          List of items pointed by `wp-each`.
+ * @param itemProp       Prop in which items are accessible from the context.
+ * @param eachKey        Directive entry pointing to the item's key.
+ * @return Generator that yields items along with their context and key.
+ */
 const useItemContexts = function* (
 	inheritedValue: any,
 	namespace: string,
 	items: Iterable< unknown >,
 	itemProp: string,
-	eachKey: DirectiveEntry[]
-) {
+	eachKey?: DirectiveEntry
+): Generator< [ context: any, key: any ] > {
 	const { current: itemContexts } = useRef< any >( {} );
 
 	for ( const item of items ) {
-		const key = getEvaluatedItemKey(
+		const key = evaluateItemKey(
 			inheritedValue,
 			namespace,
 			item,
@@ -911,7 +943,7 @@ export default () => {
 				namespace,
 				iterable,
 				itemProp,
-				eachKey
+				eachKey?.[ 0 ]
 			);
 
 			for ( const [ itemContext, key ] of itemContexts ) {

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -282,7 +282,7 @@ const useItemContexts = function* (
 	items: Iterable< unknown >,
 	itemProp: string,
 	eachKey?: DirectiveEntry
-): Generator< [ context: any, key: any ] > {
+): Generator< [ item: unknown, context: any, key: any ] > {
 	const { current: itemContexts } = useRef< any >( {} );
 
 	for ( const item of items ) {
@@ -297,12 +297,15 @@ const useItemContexts = function* (
 		if ( ! itemContexts[ key ] ) {
 			itemContexts[ key ] = proxifyContext(
 				proxifyState( namespace, {
-					[ itemProp ]: item,
+					// Inits the item prop in the context to shadow it in case
+					// it was inherited from the parent context. The actual
+					// value is set in the `wp-each` directive later on.
+					[ itemProp ]: undefined,
 				} ),
 				inheritedValue.client[ namespace ]
 			);
 		}
-		yield [ itemContexts[ key ], key ];
+		yield [ item, itemContexts[ key ], key ];
 	}
 };
 
@@ -946,7 +949,7 @@ export default () => {
 				eachKey?.[ 0 ]
 			);
 
-			for ( const [ itemContext, key ] of itemContexts ) {
+			for ( const [ item, itemContext, key ] of itemContexts ) {
 				const mergedContext = {
 					client: {
 						...inheritedValue.client,
@@ -954,6 +957,9 @@ export default () => {
 					},
 					server: { ...inheritedValue.server },
 				};
+
+				// Sets the item after proxifying the context.
+				mergedContext.client[ namespace ][ itemProp ] = item;
 
 				result.push(
 					createElement(

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -283,7 +283,7 @@ const useItemContexts = function* (
 	itemProp: string,
 	eachKey?: DirectiveEntry
 ): Generator< [ item: unknown, context: any, key: any ] > {
-	const { current: itemContexts } = useRef< any >( {} );
+	const { current: itemContexts } = useRef< Map< any, any > >( new Map() );
 
 	for ( const item of items ) {
 		const key = evaluateItemKey(
@@ -294,18 +294,21 @@ const useItemContexts = function* (
 			eachKey
 		);
 
-		if ( ! itemContexts[ key ] ) {
-			itemContexts[ key ] = proxifyContext(
-				proxifyState( namespace, {
-					// Inits the item prop in the context to shadow it in case
-					// it was inherited from the parent context. The actual
-					// value is set in the `wp-each` directive later on.
-					[ itemProp ]: undefined,
-				} ),
-				inheritedValue.client[ namespace ]
+		if ( ! itemContexts.has( key ) ) {
+			itemContexts.set(
+				key,
+				proxifyContext(
+					proxifyState( namespace, {
+						// Inits the item prop in the context to shadow it in case
+						// it was inherited from the parent context. The actual
+						// value is set in the `wp-each` directive later on.
+						[ itemProp ]: undefined,
+					} ),
+					inheritedValue.client[ namespace ]
+				)
 			);
 		}
-		yield [ item, itemContexts[ key ], key ];
+		yield [ item, itemContexts.get( key ), key ];
 	}
 };
 


### PR DESCRIPTION
## What?

Fixes a bug in the `wp-each` directive related to item contexts that affects derived state props inside the template. The bug arises when these conditions are met:
-   List items are objects.
-   Directives inside the `wp-each` template access the current item through a getter.
-   The template element has a `wp-each-key` directive pointing to a specific item prop.
-   Items from the list are replaced with new objects with the same keys.

When the template element re-renders, the items' reactive contexts are instantiated again, while the internal signals associated with the getters continue to be subscribed to the old reactive contexts.

It can be tested with the following example in a Custom HTML block:

```html
<ul data-wp-interactive="example">
  <button data-wp-on--click="actions.replaceAll">Replace all</button>
  <template data-wp-each="state.someList" data-wp-each-key="state.currentItem.text">
    <li>
        <span data-wp-text="state.currentItem.text"></span>:
        <span data-wp-text="state.isItemInList"></span>
    </li>
  </template>
</ul>
<script type="module">
import { store, getContext } from '@wordpress/interactivity';

const { state } = store( 'example', {
    state: {
        someList: [{ text: 'hi' }, { text: 'hola' }],
        get currentItem() {
            return getContext().item;
        },
        get isItemInList() {
            return state.someList.includes( state.currentItem )
                ? 'included'
                : 'not included';
        }
    },
    actions: {
        replaceAll() {
            state.someList = [{ text: 'olá' }, { text: 'hola' }]
        },
    },
} );
</script>
```

When you click on the `Replace all` button, the `state.isItemInList` getter would return "not included" for the second item. If you click again, both items will show "not included".

## Why?

The bug appeared in WooCommerce while working on an iAPI-powered Minicart block.
Related issue: https://github.com/woocommerce/woocommerce/issues/58673.

This could affect other developers using the Interactivity API.

## How?

This bug fix maintains the same reactive contexts for items with the same key when the template element is re-rendered.

For that, it implements the hook `useItemContexts` and the function `evaluateItemKey`, used by the `wp-each` directive implementation.

## Testing Instructions

1. In a page, add a Custom HTML block component with the content above.
2. Visit that page.
3. Click on the button `Replace All`.
4. Ensure items with the same previous text show  "included" instead of "not included".
