### PR TITLE
Revert "Flip submenu indicator icon on submenu expansion (#70307)"

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -312,11 +312,6 @@ button.wp-block-navigation-item__content {
 	cursor: pointer;
 }
 
-// Flip submenu arrow icon when expanded.
-.wp-block-navigation-submenu__toggle[aria-expanded="true"] {
-	transform: scaleY(-1);
-}
-
 // When set to open on click, a button element is used.
 // We pad it to include the arrow icon in the clickable area.
 // The padding can be blanket for click, since you can't set click and hide the icon.


### PR DESCRIPTION
See #35636

## What?

#70307 enabled the Navigation block indicator icon to flip. However, this introduced unintended issues as reported in [this comment](https://github.com/WordPress/gutenberg/pull/70307#issuecomment-2943569282). I`d like to revert #70307 so that this issue will not be included in Gutenberg plugin 21.1.

A fix for this issue is currently in progress in #70334.