### PR TITLE
Data forms: achieve vertical spacing with vertical spacing rather than cell padding

### DIFF
--- a/packages/dataviews/src/dataforms-layouts/data-form-layout.tsx
+++ b/packages/dataviews/src/dataforms-layouts/data-form-layout.tsx
@@ -48,7 +48,7 @@ export function DataFormLayout< Item >( {
 	);
 
 	return (
-		<VStack spacing={ 2 }>
+		<VStack spacing={ 4 }>
 			{ normalizedFormFields.map( ( formField ) => {
 				const FieldLayout = getFormFieldLayout( formField.layout )
 					?.component;

--- a/packages/dataviews/src/dataforms-layouts/panel/style.scss
+++ b/packages/dataviews/src/dataforms-layouts/panel/style.scss
@@ -11,9 +11,9 @@
 	min-height: $grid-unit-40;
 	display: flex;
 	align-items: center;
-	padding: 6px 0; // Matches button to ensure alignment
 	line-height: $grid-unit-05 * 5;
 	hyphens: auto;
+	align-self: center;
 }
 
 .dataforms-layouts-panel__field-control {

--- a/packages/dataviews/src/dataforms-layouts/regular/style.scss
+++ b/packages/dataviews/src/dataforms-layouts/regular/style.scss
@@ -17,9 +17,9 @@
 	min-height: $grid-unit-40;
 	display: flex;
 	align-items: center;
-	padding: 6px 0; // Matches button to ensure alignment
 	line-height: $grid-unit-05 * 5;
 	hyphens: auto;
+	align-self: center;
 }
 
 .dataforms-layouts-regular__field-control {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR removes padding around data forms labels, and bumps up the VStack spacing gap to achieve vertical spacing.


## Why?

There is a misalignment between label and control.

The label padding is allegedly there to ensure alignment with a neighbouring button. However for read only fields, there might be no button. 

Furthermore, it's better to adjust padding using the container gap spacing rather than tweaking the padding on a single column for alignment.



## Testing Instructions

Fire up story book

`npm run storybook:dev`

And head to the Dataforms component: http://localhost:50240/?path=/story/dataviews-dataform--combined-fields

Play around with the variables, especially side views. Ensure that the label and controls align in the centre.


### Testing Instructions for Keyboard


|Before|After|
|-|-|
|<img width="707" alt="Screenshot 2025-06-16 at 2 36 05 pm" src="https://github.com/user-attachments/assets/716d934b-a673-4944-bb98-f6cfc9395ecf" />|<img width="695" alt="Screenshot 2025-06-16 at 2 36 10 pm" src="https://github.com/user-attachments/assets/48c21c9f-4641-431d-ae04-59c579d72444" />|
| <img width="711" alt="Screenshot 2025-06-16 at 2 28 52 pm" src="https://github.com/user-attachments/assets/5eb2a01b-585f-42bd-b618-cbf12cd1edd2" /> | <img width="750" alt="Screenshot 2025-06-16 at 2 29 55 pm" src="https://github.com/user-attachments/assets/cdd70c09-cf3e-442c-b7e1-d5e272cbfa73" /> |
| <img width="432" alt="Screenshot 2025-06-16 at 2 30 21 pm" src="https://github.com/user-attachments/assets/49dfc1f8-cca5-485e-9d96-74ad8cab1129" /> | <img width="434" alt="Screenshot 2025-06-16 at 2 30 25 pm" src="https://github.com/user-attachments/assets/179f1b09-918a-4c4e-b07e-67402bead672" /> |








