### PR TITLE
[ Experimental Form ]: Add example block previews

### DIFF
--- a/packages/block-library/src/form-input/index.js
+++ b/packages/block-library/src/form-input/index.js
@@ -17,6 +17,7 @@ export const settings = {
 	edit,
 	save,
 	variations,
+	example: {},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/form-submission-notification/index.js
+++ b/packages/block-library/src/form-submission-notification/index.js
@@ -21,6 +21,7 @@ export const settings = {
 	edit,
 	save,
 	variations,
+	example: {},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/form-submit-button/index.js
+++ b/packages/block-library/src/form-submit-button/index.js
@@ -13,6 +13,7 @@ export { metadata, name };
 export const settings = {
 	edit,
 	save,
+	example: {},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/form/index.js
+++ b/packages/block-library/src/form/index.js
@@ -20,6 +20,7 @@ export const settings = {
 	edit,
 	save,
 	variations,
+	example: {},
 };
 
 export const init = () => {


### PR DESCRIPTION
## What?
Part of #64707 

This PR adds example previews to the experimental form and its ancestor blocks.

## Why?

The example previews will allow users to preview the form block and its ancestor blocks when hovering over items in the block list.

## How?

An `example` attribute has been introduced as part of the block registration process.

## Testing Instructions

1. Enable the `Gutenberg Plugin` and ensure `add Form and input blocks` is selected from Gutenberg's experiments.
2. Create a new post.
3. Open the block inserter.
4. Hover over `Experimental Form` block and confirm that the preview is displayed.
5. Hover over other ancestor blocks like form inputs such as `Checkbox Input` and confirm that the preview is displayed.

### Testing Instructions for Keyboard
Same.

## Screenshots

|Before|After|
|-|-|
|![form-before](https://github.com/user-attachments/assets/b5d3b141-84a9-42df-9e03-4c518a6a4e17)|![form-after](https://github.com/user-attachments/assets/861e4663-fe4c-49b0-b906-7d331c20d7b0)|
|![checkbox-input-before](https://github.com/user-attachments/assets/4aaee568-7027-4e8f-9001-0361975ad2b3)|![checkbox-input-after](https://github.com/user-attachments/assets/251e72b2-dc8c-4f29-8d51-7ca347737452)|
|![form-submission-success-before](https://github.com/user-attachments/assets/a1c9b983-f0ba-4751-b91d-84116f58d914)|![form-submission-after](https://github.com/user-attachments/assets/3807fc12-051b-40ab-877d-6a3afa72d8bd)|