### PR TITLE
refactor: `RichTextShortcut` native component to functional react component

### DIFF
--- a/packages/block-editor/src/components/rich-text/shortcut.native.js
+++ b/packages/block-editor/src/components/rich-text/shortcut.native.js
@@ -1,10 +1,1 @@
-/**
- * WordPress dependencies
- */
-import { Component } from '@wordpress/element';
-
-export class RichTextShortcut extends Component {
-	render() {
-		return null;
-	}
-}
+export const RichTextShortcut = () => null;


### PR DESCRIPTION
## What?
See #22890 

This PR refactors `RichTextShortcut` native component from class-based component syntax to newer functional component syntax.

## Why?
Part of the ongoing effort to refactor all React class components to functional components (#22890). Class based components are no longer the recommended approach & instead functional syntax with hooks is more recommended.

## How?
- Converted class component to arrow function component
