### PR TITLE
Refactor: Convert `withGlobalEvents` HOC to functional component

### DIFF
--- a/packages/compose/src/higher-order/with-global-events/index.js
+++ b/packages/compose/src/higher-order/with-global-events/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Component, forwardRef } from '@wordpress/element';
+import { useEffect, useRef, forwardRef } from '@wordpress/element';
 import deprecated from '@wordpress/deprecated';
 
 /**
@@ -43,27 +43,25 @@ export default function withGlobalEvents( eventTypesToHandlers ) {
 
 	// @ts-ignore We don't need to fix the type-related issues because this is deprecated.
 	return createHigherOrderComponent( ( WrappedComponent ) => {
-		class Wrapper extends Component {
-			constructor( /** @type {any} */ props ) {
-				super( props );
+		function Wrapper( /** @type {any} */ { ownProps, forwardedRef } ) {
+			/** @type {any} */
+			const wrappedRef = useRef( null );
 
-				this.handleEvent = this.handleEvent.bind( this );
-				this.handleRef = this.handleRef.bind( this );
-			}
-
-			componentDidMount() {
+			useEffect( () => {
 				Object.keys( eventTypesToHandlers ).forEach( ( eventType ) => {
-					listener.add( eventType, this );
+					listener.add( eventType, { handleEvent } );
 				} );
-			}
 
-			componentWillUnmount() {
-				Object.keys( eventTypesToHandlers ).forEach( ( eventType ) => {
-					listener.remove( eventType, this );
-				} );
-			}
+				return () => {
+					Object.keys( eventTypesToHandlers ).forEach(
+						( eventType ) => {
+							listener.remove( eventType, { handleEvent } );
+						}
+					);
+				};
+			}, [] );
 
-			handleEvent( /** @type {any} */ event ) {
+			function handleEvent( /** @type {any} */ event ) {
 				const handler =
 					eventTypesToHandlers[
 						/** @type {keyof GlobalEventHandlersEventMap} */ (
@@ -71,29 +69,22 @@ export default function withGlobalEvents( eventTypesToHandlers ) {
 						)
 						/* eslint-enable jsdoc/no-undefined-types */
 					];
-				if ( typeof this.wrappedRef[ handler ] === 'function' ) {
-					this.wrappedRef[ handler ]( event );
+				if (
+					wrappedRef.current &&
+					typeof wrappedRef.current[ handler ] === 'function'
+				) {
+					wrappedRef.current[ handler ]( event );
 				}
 			}
 
-			handleRef( /** @type {any} */ el ) {
-				this.wrappedRef = el;
-				// Any component using `withGlobalEvents` that is not setting a `ref`
-				// will cause `this.props.forwardedRef` to be `null`, so we need this
-				// check.
-				if ( this.props.forwardedRef ) {
-					this.props.forwardedRef( el );
+			function handleRef( /** @type {any} */ el ) {
+				wrappedRef.current = el;
+				if ( forwardedRef ) {
+					forwardedRef( el );
 				}
 			}
 
-			render() {
-				return (
-					<WrappedComponent
-						{ ...this.props.ownProps }
-						ref={ this.handleRef }
-					/>
-				);
-			}
+			return <WrappedComponent { ...ownProps } ref={ handleRef } />;
 		}
 
 		return forwardRef( ( props, ref ) => {


### PR DESCRIPTION
## What?
See https://github.com/WordPress/gutenberg/issues/22890

This PR refactors the `withGlobalEvents` higher-order component (HOC) from a class-based implementation to a functional component using React hooks.

## Why?
Class-based components are no longer the recommended approach in React.
Functional components with hooks are preferred as they offer:

* Better readability and simplicity
* Easier maintainability and testing
* Alignment with modern Gutenberg code standards

## How?
- Converted the internal `Wrapper` class to a functional component.
- Used `useEffect` to replace `componentDidMount` and `componentWillUnmount`.
- Replaced `this.wrappedRef` with `useRef`.
- Preserved all original logic, including global listener binding and forwarded ref handling.

## Testing Instructions
Run unit tests for the component:

   ```bash
npm run test:unit ./packages/compose/src/higher-order/with-global-events/test/index.js 
npm run test:unit ./packages/compose/src/higher-order/with-global-events/test/listener.js
   ```

## Screenshots or screencast 
N/A – this is a logic-only (non-visual) component.
