### PR TITLE
Fix: contributor/author synced pattern visibility

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -10,6 +10,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useRef, useMemo } from '@wordpress/element';
 import {
 	useEntityRecord,
+	useEntityRecords,
 	store as coreStore,
 	useEntityBlockEditor,
 } from '@wordpress/core-data';
@@ -32,7 +33,7 @@ import {
 	InnerBlocks,
 } from '@wordpress/block-editor';
 import { privateApis as patternsPrivateApis } from '@wordpress/patterns';
-import { getBlockBindingsSource } from '@wordpress/blocks';
+import { getBlockBindingsSource, parse } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -155,14 +156,44 @@ function ReusableBlockEdit( {
 	__unstableParentLayout: parentLayout,
 	setAttributes,
 } ) {
-	const { record, hasResolved } = useEntityRecord(
-		'postType',
-		'wp_block',
-		ref
+	const canUserEdit = useSelect(
+		( select ) =>
+			!! select( coreStore ).canUser( 'update', {
+				kind: 'postType',
+				name: 'wp_block',
+				id: ref,
+			} ),
+		[ ref ]
 	);
-	const [ blocks ] = useEntityBlockEditor( 'postType', 'wp_block', {
+
+	const entityRecord = useEntityRecord( 'postType', 'wp_block', ref );
+	const entityBlocks = useEntityBlockEditor( 'postType', 'wp_block', {
 		id: ref,
 	} );
+	const records = useEntityRecords( 'postType', 'wp_block', {
+		include: [ ref ],
+		context: 'view',
+	} );
+
+	const record = canUserEdit ? entityRecord?.record : records?.records?.[ 0 ];
+	const hasResolved = canUserEdit
+		? entityRecord?.hasResolved
+		: records?.hasResolved;
+
+	const blocks = useMemo( () => {
+		if ( canUserEdit ) {
+			return entityBlocks[ 0 ];
+		}
+		if ( record ) {
+			return parse(
+				'string' === typeof record.content?.raw
+					? record.content?.raw
+					: ''
+			);
+		}
+		return [];
+	}, [ canUserEdit, entityBlocks, record ] );
+
 	const isMissing = hasResolved && ! record;
 
 	const { __unstableMarkLastChangeAsPersistent } =


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #70222 

<!-- In a few words, what is the PR actually doing? -->
Fixes the "Block has been deleted or is unavailable." message shown for synced patterns when viewed by users without edit permissions for the synced pattern (e.g., Contributors or Authors).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, `useEntityRecord` and `useEntityBlockEditor` are used to retrieve the synced pattern in the `ReusableBlockEdit` component. These hooks call the endpoint `/index.php?rest_route=/wp/v2/blocks/id&context=edit&_locale=user` which returns a 403 error for contributors and authors who lack edit access to the pattern. That leads to the “Block has been deleted or is unavailable.” message until another endpoint updates the store with the blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

To prevent this, if the user lacks edit capabilities we fall back to using `useEntityRecords` to fetch the synced pattern, which does not produce a 403 error.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Log in as an admin, create a synced pattern, and add it to a post.
2. Log in as a contributor or author, and open the post containing the synced pattern.
3. Confirm that the message “Block has been deleted or is unavailable.” is not displayed for the pattern.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Same

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="1458" alt="image" src="https://github.com/user-attachments/assets/9811961b-a1cc-4c42-b2dc-36278fcf52ef" />| <img width="1458" alt="image" src="https://github.com/user-attachments/assets/1ae2da85-db3b-4331-a585-638ff30be39b" /> |
