### PR TITLE
Navigation Block: Rotate submenu indicator icons on submenu expansion

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -312,6 +312,12 @@ button.wp-block-navigation-item__content {
 	cursor: pointer;
 }
 
+// Flip submenu arrow icon when expanded.
+.wp-block-navigation-submenu__toggle[aria-expanded="true"] + .wp-block-navigation__submenu-icon,
+.wp-block-navigation__submenu-icon[aria-expanded="true"] {
+	transform: rotate(180deg);
+}
+
 // When set to open on click, a button element is used.
 // We pad it to include the arrow icon in the clickable area.
 // The padding can be blanket for click, since you can't set click and hide the icon.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -319,8 +319,8 @@ button.wp-block-navigation-item__content {
 // - Without it: aria-expanded is on the icon itself.
 //
 // Both selectors are needed to handle both cases.
-.wp-block-navigation-submenu__toggle[aria-expanded="true"] + .wp-block-navigation__submenu-icon,
-.wp-block-navigation__submenu-icon[aria-expanded="true"] {
+.wp-block-navigation-submenu__toggle[aria-expanded="true"] + .wp-block-navigation__submenu-icon > svg,
+.wp-block-navigation__submenu-icon[aria-expanded="true"] > svg {
 	transform: rotate(180deg);
 }
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -310,18 +310,14 @@ button.wp-block-navigation-item__content {
 
 .wp-block-navigation-submenu__toggle {
 	cursor: pointer;
-}
 
-// Rotate submenu icon when open.
-//
-// Two structures:
-// - With "open on click" option enabled: aria-expanded is on the button, icon is it's next sibling.
-// - Without it: aria-expanded is on the icon itself.
-//
-// Both selectors are needed to handle both cases.
-.wp-block-navigation-submenu__toggle[aria-expanded="true"] + .wp-block-navigation__submenu-icon > svg,
-.wp-block-navigation__submenu-icon[aria-expanded="true"] > svg {
-	transform: rotate(180deg);
+	// Rotate submenu icon when open.
+	&[aria-expanded="true"] {
+		+ .wp-block-navigation__submenu-icon > svg,
+		> svg {
+			transform: rotate(180deg);
+		}
+	}
 }
 
 // When set to open on click, a button element is used.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -312,7 +312,13 @@ button.wp-block-navigation-item__content {
 	cursor: pointer;
 }
 
-// Flip submenu arrow icon when expanded.
+// Rotate submenu icon when open.
+//
+// Two structures:
+// - With "open on click" option enabled: aria-expanded is on the button, icon is it's next sibling.
+// - Without it: aria-expanded is on the icon itself.
+//
+// Both selectors are needed to handle both cases.
 .wp-block-navigation-submenu__toggle[aria-expanded="true"] + .wp-block-navigation__submenu-icon,
 .wp-block-navigation__submenu-icon[aria-expanded="true"] {
 	transform: rotate(180deg);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes  #35636 
Follow up to #70307 #70334 #70427 
<!-- In a few words, what is the PR actually doing? -->
Adds visual feedback to the Navigation block submenu toggle by rotating the nested submenu indicator icon when it is expanded and makes sure that the submenu label does not get inverted along with the icon.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, opening a submenu does not change the downward arrow icon. Ideally, the icon should flip in the opposite direction to indicate the submenu is expanded. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Rotates submenu icons using `transform: rotate(180deg)` when `aria-expanded="true"` is set on the toggle.
- Uses `rotate()` to correctly support horizontally and vertically expanding nested submenus.
- With "Open on click" option enabled: `aria-expanded` is on the button and the icon is it's next sibling while with "Open on click" disabled: `aria-expanded` is on the icon itself. This PR takes care of both structures while adding css rulesets.

## Testing Instructions
1. Open a post or page in the editor.
2. Insert a **Navigation** block.
3. Add a menu item with a submenu (child items).
4. Add **nested submenus** under one of the child items.
5. Click the parent item to expand the submenu.
6. Observe the submenu arrow icon:
   * It should **rotate away from** the submenu when expanded.
   * It should **return to point toward** the submenu when collapsed.
7. Enable "Open on click" on the **Navigation** block and repeat step 6.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

https://github.com/user-attachments/assets/56b45ef5-df29-495c-8e32-5b4ced3f7ade


### After

https://github.com/user-attachments/assets/059ddf64-00b3-41fc-b389-74ed3917e007

*note: The padding issue seen above in the nested submenu block item ("Open on click" enabled) is not caused by this PR. I'll create an issue for that shortly.