### PR TITLE
Allow extra options for rest requests in E2E utils

### DIFF
--- a/packages/e2e-test-utils-playwright/src/request-utils/blocks.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/blocks.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import type { RequestUtils } from './index';
+import type { RestOptions } from './rest';
 
 type CreateBlockPayload = {
 	date?: string;
@@ -19,11 +20,16 @@ type CreateBlockPayload = {
  *
  * @see https://developer.wordpress.org/rest-api/reference/blocks/#list-editor-blocks
  * @param this
+ * @param restOptions Optional REST options to override default settings.
  */
-export async function deleteAllBlocks( this: RequestUtils ) {
+export async function deleteAllBlocks(
+	this: RequestUtils,
+	restOptions?: Partial< RestOptions >
+) {
 	// List all blocks.
 	// https://developer.wordpress.org/rest-api/reference/blocks/#list-editor-blocks
 	const blocks = await this.rest( {
+		...restOptions,
 		path: '/wp/v2/blocks',
 		params: {
 			per_page: 100,
@@ -39,7 +45,8 @@ export async function deleteAllBlocks( this: RequestUtils ) {
 		blocks.map( ( block: { id: number } ) => ( {
 			method: 'DELETE',
 			path: `/wp/v2/blocks/${ block.id }?force=true`,
-		} ) )
+		} ) ),
+		restOptions
 	);
 }
 
@@ -48,13 +55,16 @@ export async function deleteAllBlocks( this: RequestUtils ) {
  *
  * @see https://developer.wordpress.org/rest-api/reference/blocks/#create-a-editor-block.
  * @param this
- * @param payload Block payload.
+ * @param payload     Block payload.
+ * @param restOptions Optional REST options to override default settings.
  */
 export async function createBlock(
 	this: RequestUtils,
-	payload: CreateBlockPayload
+	payload: CreateBlockPayload,
+	restOptions?: Partial< RestOptions >
 ) {
 	const block = await this.rest( {
+		...restOptions,
 		path: '/wp/v2/blocks',
 		method: 'POST',
 		data: { ...payload },

--- a/packages/e2e-test-utils-playwright/src/request-utils/comments.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/comments.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import type { RequestUtils } from './index';
+import type { RestOptions } from './rest';
 
 export interface Comment {
 	id: number;
@@ -24,12 +25,15 @@ export interface User {
  *
  * @param this
  * @param payload
+ * @param restOptions Optional REST options to override default settings.
  */
 export async function createComment(
 	this: RequestUtils,
-	payload: CreateCommentPayload
+	payload: CreateCommentPayload,
+	restOptions?: Partial< RestOptions >
 ) {
 	const currentUser = await this.rest< User >( {
+		...restOptions,
 		path: '/wp/v2/users/me',
 		method: 'GET',
 	} );
@@ -37,6 +41,7 @@ export async function createComment(
 	const author = currentUser.id;
 
 	const comment = await this.rest< Comment >( {
+		...restOptions,
 		method: 'POST',
 		path: '/wp/v2/comments',
 		data: { ...payload, author },
@@ -49,11 +54,16 @@ export async function createComment(
  * Delete all comments using the REST API.
  *
  * @param this
+ * @param restOptions Optional REST options to override default settings.
  */
-export async function deleteAllComments( this: RequestUtils ) {
+export async function deleteAllComments(
+	this: RequestUtils,
+	restOptions?: Partial< RestOptions >
+) {
 	// List all comments.
 	// https://developer.wordpress.org/rest-api/reference/comments/#list-comments
 	const comments = await this.rest( {
+		...restOptions,
 		path: '/wp/v2/comments',
 		params: {
 			per_page: 100,
@@ -68,6 +78,7 @@ export async function deleteAllComments( this: RequestUtils ) {
 	await Promise.all(
 		comments.map( ( comment: Comment ) =>
 			this.rest( {
+				...restOptions,
 				method: 'DELETE',
 				path: `/wp/v2/comments/${ comment.id }`,
 				params: {

--- a/packages/e2e-test-utils-playwright/src/request-utils/media.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/media.ts
@@ -7,6 +7,7 @@ import * as fs from 'fs';
  * Internal dependencies
  */
 import type { RequestUtils } from './index';
+import type { RestOptions } from './rest';
 
 export interface Media {
 	id: number;
@@ -26,9 +27,14 @@ export interface Media {
  *
  * @see https://developer.wordpress.org/rest-api/reference/media/#list-media
  * @param this
+ * @param restOptions Optional REST options to override default settings.
  */
-async function listMedia( this: RequestUtils ) {
+async function listMedia(
+	this: RequestUtils,
+	restOptions?: Partial< RestOptions >
+) {
 	const response = await this.rest< Media[] >( {
+		...restOptions,
 		method: 'GET',
 		path: '/wp/v2/media',
 		params: {
@@ -45,10 +51,12 @@ async function listMedia( this: RequestUtils ) {
  * @see https://developer.wordpress.org/rest-api/reference/media/#create-a-media-item
  * @param this
  * @param filePathOrData The path or data of the file being uploaded.
+ * @param restOptions    Optional REST options to override default settings.
  */
 async function uploadMedia(
 	this: RequestUtils,
-	filePathOrData: string | fs.ReadStream
+	filePathOrData: string | fs.ReadStream,
+	restOptions?: Partial< RestOptions >
 ) {
 	const file =
 		typeof filePathOrData === 'string'
@@ -56,6 +64,7 @@ async function uploadMedia(
 			: filePathOrData;
 
 	const response = await this.rest< Media >( {
+		...restOptions,
 		method: 'POST',
 		path: '/wp/v2/media',
 		multipart: {
@@ -71,10 +80,16 @@ async function uploadMedia(
  *
  * @see https://developer.wordpress.org/rest-api/reference/media/#delete-a-media-item
  * @param this
- * @param mediaId The ID of the media file.
+ * @param mediaId     The ID of the media file.
+ * @param restOptions Optional REST options to override default settings.
  */
-async function deleteMedia( this: RequestUtils, mediaId: number ) {
+async function deleteMedia(
+	this: RequestUtils,
+	mediaId: number,
+	restOptions?: Partial< RestOptions >
+) {
 	const response = await this.rest( {
+		...restOptions,
 		method: 'DELETE',
 		path: `/wp/v2/media/${ mediaId }`,
 		params: { force: true },
@@ -87,13 +102,17 @@ async function deleteMedia( this: RequestUtils, mediaId: number ) {
  * delete all media files.
  *
  * @param this
+ * @param restOptions Optional REST options to override default settings.
  */
-async function deleteAllMedia( this: RequestUtils ) {
-	const files = await this.listMedia();
+async function deleteAllMedia(
+	this: RequestUtils,
+	restOptions?: Partial< RestOptions >
+) {
+	const files = await this.listMedia( restOptions );
 
 	// The media endpoint doesn't support batch request yet.
 	const responses = await Promise.all(
-		files.map( ( media ) => this.deleteMedia( media.id ) )
+		files.map( ( media ) => this.deleteMedia( media.id, restOptions ) )
 	);
 
 	return responses;

--- a/packages/e2e-test-utils-playwright/src/request-utils/menus.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/menus.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import type { RequestUtils } from './index';
+import type { RestOptions } from './rest';
 
 export interface MenuData {
 	title: string;
@@ -16,10 +17,15 @@ export interface NavigationMenu {
 /**
  * Create a classic menu
  *
- * @param name Menu name.
+ * @param name        Menu name.
+ * @param restOptions Optional REST options to override default settings.
  * @return Menu content.
  */
-export async function createClassicMenu( this: RequestUtils, name: string ) {
+export async function createClassicMenu(
+	this: RequestUtils,
+	name: string,
+	restOptions?: Partial< RestOptions >
+) {
 	const menuItems = [
 		{
 			title: 'Custom link',
@@ -30,6 +36,7 @@ export async function createClassicMenu( this: RequestUtils, name: string ) {
 	];
 
 	const menu = await this.rest< NavigationMenu >( {
+		...restOptions,
 		method: 'POST',
 		path: `/wp/v2/menus/`,
 		data: {
@@ -47,7 +54,8 @@ export async function createClassicMenu( this: RequestUtils, name: string ) {
 				...menuItem,
 				parent: undefined,
 			},
-		} ) )
+		} ) ),
+		restOptions
 	);
 
 	return menu;
@@ -56,14 +64,17 @@ export async function createClassicMenu( this: RequestUtils, name: string ) {
 /**
  * Create a navigation menu
  *
- * @param menuData navigation menu post data.
+ * @param menuData    navigation menu post data.
+ * @param restOptions Optional REST options to override default settings.
  * @return Menu content.
  */
 export async function createNavigationMenu(
 	this: RequestUtils,
-	menuData: MenuData
+	menuData: MenuData,
+	restOptions?: Partial< RestOptions >
 ) {
 	return this.rest( {
+		...restOptions,
 		method: 'POST',
 		path: `/wp/v2/navigation/`,
 		data: {
@@ -76,9 +87,14 @@ export async function createNavigationMenu(
 /**
  * Delete all navigation and classic menus
  *
+ * @param restOptions Optional REST options to override default settings.
  */
-export async function deleteAllMenus( this: RequestUtils ) {
+export async function deleteAllMenus(
+	this: RequestUtils,
+	restOptions?: Partial< RestOptions >
+) {
 	const navMenus = await this.rest< NavigationMenu[] >( {
+		...restOptions,
 		path: `/wp/v2/navigation/`,
 		data: {
 			status: [
@@ -99,11 +115,13 @@ export async function deleteAllMenus( this: RequestUtils ) {
 			navMenus.map( ( menu ) => ( {
 				method: 'DELETE',
 				path: `/wp/v2/navigation/${ menu.id }?force=true`,
-			} ) )
+			} ) ),
+			restOptions
 		);
 	}
 
 	const classicMenus = await this.rest< NavigationMenu[] >( {
+		...restOptions,
 		path: `/wp/v2/menus/`,
 		data: {
 			status: [
@@ -124,7 +142,8 @@ export async function deleteAllMenus( this: RequestUtils ) {
 			classicMenus.map( ( menu ) => ( {
 				method: 'DELETE',
 				path: `/wp/v2/menus/${ menu.id }?force=true`,
-			} ) )
+			} ) ),
+			restOptions
 		);
 	}
 }
@@ -134,13 +153,16 @@ export async function deleteAllMenus( this: RequestUtils ) {
  *
  * @param  args
  * @param  args.status
+ * @param  restOptions Optional REST options to override default settings.
  * @return {string} Menu content.
  */
 export async function getNavigationMenus(
 	this: RequestUtils,
-	args: { status: 'publish' }
+	args: { status: 'publish' },
+	restOptions?: Partial< RestOptions >
 ) {
 	const navigationMenus = await this.rest< NavigationMenu[] >( {
+		...restOptions,
 		method: 'GET',
 		path: `/wp/v2/navigation/`,
 		data: args,

--- a/packages/e2e-test-utils-playwright/src/request-utils/pages.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/pages.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import type { RequestUtils } from './index';
+import type { RestOptions } from './rest';
 
 const PAGE_STATUS = [
 	'publish',
@@ -25,9 +26,14 @@ export type CreatePagePayload = {
 	date_gmt?: string;
 };
 
-export async function deletePage( this: RequestUtils, id: number ) {
+export async function deletePage(
+	this: RequestUtils,
+	id: number,
+	restOptions?: Partial< RestOptions >
+) {
 	// https://developer.wordpress.org/rest-api/reference/pages/#delete-a-page
 	return await this.rest( {
+		...restOptions,
 		method: 'DELETE',
 		path: `/wp/v2/pages/${ id }`,
 		params: {
@@ -40,11 +46,16 @@ export async function deletePage( this: RequestUtils, id: number ) {
  * Delete all pages using REST API.
  *
  * @param this
+ * @param restOptions Optional REST options to override default settings.
  */
-export async function deleteAllPages( this: RequestUtils ) {
+export async function deleteAllPages(
+	this: RequestUtils,
+	restOptions?: Partial< RestOptions >
+) {
 	// List all pages.
 	// https://developer.wordpress.org/rest-api/reference/pages/#list-pages
 	const pages = await this.rest< Page[] >( {
+		...restOptions,
 		path: '/wp/v2/pages',
 		params: {
 			per_page: 100,
@@ -56,7 +67,7 @@ export async function deleteAllPages( this: RequestUtils ) {
 	// Delete all pages one by one.
 	// "/wp/v2/pages" not yet supports batch requests.
 	await Promise.all(
-		pages.map( ( page ) => deletePage.call( this, page.id ) )
+		pages.map( ( page ) => deletePage.call( this, page.id, restOptions ) )
 	);
 }
 
@@ -64,14 +75,17 @@ export async function deleteAllPages( this: RequestUtils ) {
  * Create a new page.
  *
  * @param this
- * @param payload The page payload.
+ * @param payload     The page payload.
+ * @param restOptions Optional REST options to override default settings.
  */
 export async function createPage(
 	this: RequestUtils,
-	payload: CreatePagePayload
+	payload: CreatePagePayload,
+	restOptions?: Partial< RestOptions >
 ) {
 	// https://developer.wordpress.org/rest-api/reference/pages/#create-a-page
 	const page = await this.rest< Page >( {
+		...restOptions,
 		method: 'POST',
 		path: `/wp/v2/pages`,
 		data: { ...payload },

--- a/packages/e2e-test-utils-playwright/src/request-utils/patterns.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/patterns.ts
@@ -2,17 +2,23 @@
  * Internal dependencies
  */
 import type { RequestUtils } from './index';
+import type { RestOptions } from './rest';
 
 /**
  * Delete all pattern categories using REST API.
  *
  * @see https://developer.wordpress.org/rest-api/reference/categories/#list-categories
  * @param this
+ * @param restOptions Optional REST options to override default settings.
  */
-export async function deleteAllPatternCategories( this: RequestUtils ) {
+export async function deleteAllPatternCategories(
+	this: RequestUtils,
+	restOptions?: Partial< RestOptions >
+) {
 	// List all pattern categories.
 	// https://developer.wordpress.org/rest-api/reference/categories/#list-categories
 	const categories = await this.rest( {
+		...restOptions,
 		path: '/wp/v2/wp_pattern_category',
 		params: {
 			per_page: 100,
@@ -26,6 +32,7 @@ export async function deleteAllPatternCategories( this: RequestUtils ) {
 		categories.map( ( category: { id: number } ) => ( {
 			method: 'DELETE',
 			path: `/wp/v2/wp_pattern_category/${ category.id }?force=true`,
-		} ) )
+		} ) ),
+		restOptions
 	);
 }

--- a/packages/e2e-test-utils-playwright/src/request-utils/plugins.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/plugins.ts
@@ -7,6 +7,7 @@ import { paramCase as kebabCase } from 'change-case';
  * Internal dependencies
  */
 import type { RequestUtils } from './index';
+import type { RestOptions } from './rest';
 
 /**
  * Fetch the plugins from API and cache them in memory,
@@ -14,13 +15,19 @@ import type { RequestUtils } from './index';
  *
  * @param this
  * @param forceRefetch Force refetch the installed plugins to update the cache.
+ * @param restOptions  Optional REST options to override default settings.
  */
-async function getPluginsMap( this: RequestUtils, forceRefetch = false ) {
+async function getPluginsMap(
+	this: RequestUtils,
+	forceRefetch = false,
+	restOptions?: Partial< RestOptions >
+) {
 	if ( ! forceRefetch && this.pluginsMap ) {
 		return this.pluginsMap;
 	}
 
 	const plugins = await this.rest( {
+		...restOptions,
 		path: '/wp/v2/plugins',
 	} );
 	this.pluginsMap = {};
@@ -69,14 +76,20 @@ function getPluginFromMap(
 /**
  * Activates an installed plugin.
  *
- * @param this RequestUtils.
- * @param slug Plugin slug.
+ * @param this        RequestUtils.
+ * @param slug        Plugin slug.
+ * @param restOptions Optional REST options to override default settings.
  */
-async function activatePlugin( this: RequestUtils, slug: string ) {
-	const pluginsMap = await this.getPluginsMap();
+async function activatePlugin(
+	this: RequestUtils,
+	slug: string,
+	restOptions?: Partial< RestOptions >
+) {
+	const pluginsMap = await this.getPluginsMap( false, restOptions );
 	const plugin = getPluginFromMap( slug, pluginsMap );
 
 	await this.rest( {
+		...restOptions,
 		method: 'PUT',
 		path: `/wp/v2/plugins/${ plugin }`,
 		data: { status: 'active' },
@@ -86,14 +99,20 @@ async function activatePlugin( this: RequestUtils, slug: string ) {
 /**
  * Deactivates an active plugin.
  *
- * @param this RequestUtils.
- * @param slug Plugin slug.
+ * @param this        RequestUtils.
+ * @param slug        Plugin slug.
+ * @param restOptions Optional REST options to override default settings.
  */
-async function deactivatePlugin( this: RequestUtils, slug: string ) {
-	const pluginsMap = await this.getPluginsMap();
+async function deactivatePlugin(
+	this: RequestUtils,
+	slug: string,
+	restOptions?: Partial< RestOptions >
+) {
+	const pluginsMap = await this.getPluginsMap( false, restOptions );
 	const plugin = getPluginFromMap( slug, pluginsMap );
 
 	await this.rest( {
+		...restOptions,
 		method: 'PUT',
 		path: `/wp/v2/plugins/${ plugin }`,
 		data: { status: 'inactive' },

--- a/packages/e2e-test-utils-playwright/src/request-utils/posts.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/posts.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import type { RequestUtils } from './index';
+import type { RestOptions } from './rest';
 
 export interface Post {
 	id: number;
@@ -22,11 +23,16 @@ export interface CreatePostPayload {
  * Delete all posts using REST API.
  *
  * @param this
+ * @param restOptions Optional REST options to override default settings.
  */
-export async function deleteAllPosts( this: RequestUtils ) {
+export async function deleteAllPosts(
+	this: RequestUtils,
+	restOptions?: Partial< RestOptions >
+) {
 	// List all posts.
 	// https://developer.wordpress.org/rest-api/reference/posts/#list-posts
 	const posts = await this.rest< Post[] >( {
+		...restOptions,
 		path: '/wp/v2/posts',
 		params: {
 			per_page: 100,
@@ -41,6 +47,7 @@ export async function deleteAllPosts( this: RequestUtils ) {
 	await Promise.all(
 		posts.map( ( post ) =>
 			this.rest( {
+				...restOptions,
 				method: 'DELETE',
 				path: `/wp/v2/posts/${ post.id }`,
 				params: {
@@ -55,13 +62,16 @@ export async function deleteAllPosts( this: RequestUtils ) {
  * Creates a new post using the REST API.
  *
  * @param this
- * @param payload Post attributes.
+ * @param payload     Post attributes.
+ * @param restOptions Optional REST options to override default settings.
  */
 export async function createPost(
 	this: RequestUtils,
-	payload: CreatePostPayload
+	payload: CreatePostPayload,
+	restOptions?: Partial< RestOptions >
 ) {
 	const post = await this.rest< Post >( {
+		...restOptions,
 		method: 'POST',
 		path: `/wp/v2/posts`,
 		data: { ...payload },

--- a/packages/e2e-test-utils-playwright/src/request-utils/preferences.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/preferences.ts
@@ -2,14 +2,20 @@
  * Internal dependencies
  */
 import type { RequestUtils } from './index';
+import type { RestOptions } from './rest';
 
 /**
  * Reset user preferences
  *
- * @param this Request utils.
+ * @param this        Request utils.
+ * @param restOptions Optional REST options to override default settings.
  */
-export async function resetPreferences( this: RequestUtils ) {
+export async function resetPreferences(
+	this: RequestUtils,
+	restOptions?: Partial< RestOptions >
+) {
 	await this.rest( {
+		...restOptions,
 		path: '/wp/v2/users/me',
 		method: 'PUT',
 		data: {

--- a/packages/e2e-test-utils-playwright/src/request-utils/rest.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/rest.ts
@@ -184,7 +184,8 @@ export interface BatchRequest {
 
 async function batchRest< BatchResponse >(
 	this: RequestUtils,
-	requests: BatchRequest[]
+	requests: BatchRequest[],
+	restOptions?: Partial< RestOptions >
 ): Promise< BatchResponse[] > {
 	const maxBatchSize = await this.getMaxBatchSize();
 
@@ -193,7 +194,7 @@ async function batchRest< BatchResponse >(
 
 		const chunkResponses = await Promise.all(
 			chunks.map( ( chunkRequests ) =>
-				this.batchRest< BatchResponse >( chunkRequests )
+				this.batchRest< BatchResponse >( chunkRequests, restOptions )
 			)
 		);
 
@@ -204,6 +205,7 @@ async function batchRest< BatchResponse >(
 		failed?: string;
 		responses: BatchResponse[];
 	} >( {
+		...restOptions,
 		method: 'POST',
 		path: '/batch/v1',
 		data: {

--- a/packages/e2e-test-utils-playwright/src/request-utils/templates.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/templates.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import type { RequestUtils } from './index';
+import type { RestOptions } from './rest';
 
 type TemplateType = 'wp_template' | 'wp_template_part';
 
@@ -26,16 +27,21 @@ const PATH_MAPPING = {
  * Delete all the templates of given type.
  *
  * @param this
- * @param type - Template type to delete.
+ * @param type        - Template type to delete.
+ * @param restOptions Optional REST options to override default settings.
  */
-async function deleteAllTemplates( this: RequestUtils, type: TemplateType ) {
+async function deleteAllTemplates(
+	this: RequestUtils,
+	type: TemplateType,
+	restOptions?: Partial< RestOptions >
+) {
 	const path = PATH_MAPPING[ type ];
 
 	if ( ! path ) {
 		throw new Error( `Unsupported template type: ${ type }.` );
 	}
 
-	const templates = await this.rest< Template[] >( { path } );
+	const templates = await this.rest< Template[] >( { ...restOptions, path } );
 
 	for ( const template of templates ) {
 		if ( ! template?.id || ! template?.wp_id ) {
@@ -44,6 +50,7 @@ async function deleteAllTemplates( this: RequestUtils, type: TemplateType ) {
 
 		try {
 			await this.rest( {
+				...restOptions,
 				method: 'DELETE',
 				path: `${ path }/${ template.id }`,
 				params: { force: true },
@@ -63,15 +70,18 @@ async function deleteAllTemplates( this: RequestUtils, type: TemplateType ) {
  * Creates a new template using the REST API.
  *
  * @param this
- * @param type    Template type to delete.
- * @param payload Template attributes.
+ * @param type        Template type to delete.
+ * @param payload     Template attributes.
+ * @param restOptions Optional REST options to override default settings.
  */
 async function createTemplate(
 	this: RequestUtils,
 	type: TemplateType,
-	payload: CreateTemplatePayload
+	payload: CreateTemplatePayload,
+	restOptions?: Partial< RestOptions >
 ) {
 	const template = await this.rest< Template >( {
+		...restOptions,
 		method: 'POST',
 		path: PATH_MAPPING[ type ],
 		params: { ...payload, type, status: 'publish', is_wp_suggestion: true },

--- a/packages/e2e-test-utils-playwright/src/request-utils/themes.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/themes.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import type { RequestUtils } from './index';
+import type { RestOptions } from './rest';
 import { WP_BASE_URL } from '../config';
 
 const THEMES_URL = new URL( 'wp-admin/themes.php', WP_BASE_URL ).href;
@@ -51,13 +52,17 @@ async function activateTheme(
 }
 
 // https://developer.wordpress.org/rest-api/reference/themes/#definition
-async function getCurrentThemeGlobalStylesPostId( this: RequestUtils ) {
+async function getCurrentThemeGlobalStylesPostId(
+	this: RequestUtils,
+	restOptions?: Partial< RestOptions >
+) {
 	type ThemeItem = {
 		stylesheet: string;
 		status: string;
 		_links: { 'wp:user-global-styles': { href: string }[] };
 	};
 	const themes = await this.rest< ThemeItem[] >( {
+		...restOptions,
 		path: '/wp/v2/themes',
 	} );
 	let themeGlobalStylesId: string = '';
@@ -80,15 +85,18 @@ async function getCurrentThemeGlobalStylesPostId( this: RequestUtils ) {
 /**
  * Deletes all post revisions using the REST API.
  *
- * @param {}              this     RequestUtils.
- * @param {string|number} parentId Post attributes.
+ * @param {}              this        RequestUtils.
+ * @param {string|number} parentId    Post attributes.
+ * @param                 restOptions Optional REST options to override default settings.
  */
 async function getThemeGlobalStylesRevisions(
 	this: RequestUtils,
-	parentId: number | string
+	parentId: number | string,
+	restOptions?: Partial< RestOptions >
 ) {
 	// Lists all global styles revisions.
 	return await this.rest< Record< string, Object >[] >( {
+		...restOptions,
 		path: `/wp/v2/global-styles/${ parentId }/revisions`,
 		params: {
 			per_page: 100,

--- a/packages/e2e-test-utils-playwright/src/request-utils/users.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/users.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import type { RequestUtils } from './index';
+import type { RestOptions } from './rest';
 
 export interface User {
 	id: number;
@@ -32,9 +33,14 @@ export interface UserRequestData {
  *
  * @see https://developer.wordpress.org/rest-api/reference/users/#list-users
  * @param this
+ * @param restOptions Optional REST options to override default settings.
  */
-async function listUsers( this: RequestUtils ) {
+async function listUsers(
+	this: RequestUtils,
+	restOptions?: Partial< RestOptions >
+) {
 	const response = await this.rest< User[] >( {
+		...restOptions,
 		method: 'GET',
 		path: '/wp/v2/users',
 		params: {
@@ -50,9 +56,14 @@ async function listUsers( this: RequestUtils ) {
  *
  * @see https://developer.wordpress.org/rest-api/reference/users/#create-a-user
  * @param this
- * @param user User data to create.
+ * @param user        User data to create.
+ * @param restOptions Optional REST options to override default settings.
  */
-async function createUser( this: RequestUtils, user: UserData ) {
+async function createUser(
+	this: RequestUtils,
+	user: UserData,
+	restOptions?: Partial< RestOptions >
+) {
 	const userData: UserRequestData = {
 		username: user.username,
 		email: user.email,
@@ -75,6 +86,7 @@ async function createUser( this: RequestUtils, user: UserData ) {
 	}
 
 	const response = await this.rest< User >( {
+		...restOptions,
 		method: 'POST',
 		path: '/wp/v2/users',
 		data: userData,
@@ -88,10 +100,16 @@ async function createUser( this: RequestUtils, user: UserData ) {
  *
  * @see https://developer.wordpress.org/rest-api/reference/users/#delete-a-user
  * @param this
- * @param userId The ID of the user.
+ * @param userId      The ID of the user.
+ * @param restOptions Optional REST options to override default settings.
  */
-async function deleteUser( this: RequestUtils, userId: number ) {
+async function deleteUser(
+	this: RequestUtils,
+	userId: number,
+	restOptions?: Partial< RestOptions >
+) {
 	const response = await this.rest( {
+		...restOptions,
 		method: 'DELETE',
 		path: `/wp/v2/users/${ userId }`,
 		params: { force: true, reassign: 1 },
@@ -104,9 +122,13 @@ async function deleteUser( this: RequestUtils, userId: number ) {
  * Delete all users except main root user.
  *
  * @param this
+ * @param restOptions Optional REST options to override default settings.
  */
-async function deleteAllUsers( this: RequestUtils ) {
-	const users = await listUsers.bind( this )();
+async function deleteAllUsers(
+	this: RequestUtils,
+	restOptions?: Partial< RestOptions >
+) {
+	const users = await listUsers.bind( this )( restOptions );
 
 	// The users endpoint doesn't support batch request yet.
 	const responses = await Promise.all(
@@ -116,7 +138,9 @@ async function deleteAllUsers( this: RequestUtils ) {
 				( user: User ) =>
 					user.id !== 1 && user.name !== this.user.username
 			)
-			.map( ( user: User ) => deleteUser.bind( this )( user.id ) )
+			.map( ( user: User ) =>
+				deleteUser.bind( this )( user.id, restOptions )
+			)
 	);
 
 	return responses;

--- a/packages/e2e-test-utils-playwright/src/request-utils/widgets.js
+++ b/packages/e2e-test-utils-playwright/src/request-utils/widgets.js
@@ -2,24 +2,27 @@
  * Delete all the widgets in the widgets screen.
  *
  * @this {import('./index').RequestUtils}
+ * @param {Partial<import('./rest').RestOptions>} [restOptions] Optional REST options to override default settings.
  */
-export async function deleteAllWidgets() {
+export async function deleteAllWidgets( restOptions ) {
 	const [ widgets, sidebars ] = await Promise.all( [
-		this.rest( { path: '/wp/v2/widgets' } ),
-		this.rest( { path: '/wp/v2/sidebars' } ),
+		this.rest( { ...restOptions, path: '/wp/v2/widgets' } ),
+		this.rest( { ...restOptions, path: '/wp/v2/sidebars' } ),
 	] );
 
 	await this.batchRest(
 		widgets.map( ( widget ) => ( {
 			method: 'DELETE',
 			path: `/wp/v2/widgets/${ widget.id }?force=true`,
-		} ) )
+		} ) ),
+		restOptions
 	);
 
 	// The endpoint doesn't support batch requests yet.
 	await Promise.all(
 		sidebars.map( ( sidebar ) =>
 			this.rest( {
+				...restOptions,
 				method: 'POST',
 				path: `/wp/v2/sidebars/${ sidebar.id }`,
 				data: { id: sidebar.id, widgets: [] },
@@ -32,11 +35,17 @@ export async function deleteAllWidgets() {
  * Add a widget block to the widget area.
  *
  * @this {import('./index').RequestUtils}
- * @param {string} serializedBlock The serialized content of the inserted block HTML.
- * @param {string} widgetAreaId    The ID of the widget area.
+ * @param {string}                                serializedBlock The serialized content of the inserted block HTML.
+ * @param {string}                                widgetAreaId    The ID of the widget area.
+ * @param {Partial<import('./rest').RestOptions>} [restOptions]   Optional REST options to override default settings.
  */
-export async function addWidgetBlock( serializedBlock, widgetAreaId ) {
+export async function addWidgetBlock(
+	serializedBlock,
+	widgetAreaId,
+	restOptions
+) {
 	const { id: blockId } = await this.rest( {
+		...restOptions,
 		method: 'POST',
 		path: '/wp/v2/widgets',
 		data: {
@@ -49,6 +58,7 @@ export async function addWidgetBlock( serializedBlock, widgetAreaId ) {
 	} );
 
 	const { widgets } = await this.rest( {
+		...restOptions,
 		path: `/wp/v2/sidebars/${ widgetAreaId }`,
 	} );
 
@@ -59,6 +69,7 @@ export async function addWidgetBlock( serializedBlock, widgetAreaId ) {
 	updatedWidgets.add( blockId );
 
 	await this.rest( {
+		...restOptions,
 		method: 'PUT',
 		path: `/wp/v2/sidebars/${ widgetAreaId }`,
 		data: {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

Allow consumers of the playwright E2E utils to pass additional rest options to helpers that make requests

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We are experiencing [some flakiness in the WooCommerce E2E tests](https://github.com/woocommerce/woocommerce/issues/58749#event-18100806722) and I believe allowing consumers of the package to define a number of retries would be beneficial.

I don't think setting this at util level is a good idea as it's better not to assume what the user wants to do.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Each util that makes a `rest` request will get an additional, optional parameter that would contain options applicable to the rest request. It is spread into the request's options first, then overwritten with existing options.

Batch requests also have these options applied.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
