### PR TITLE
Style Book: Enable support for showing individual block variations

### DIFF
--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -217,11 +217,11 @@ export function getExamplesForSinglePageUse( examples ) {
 }
 
 /**
- * Returns examples with variation styles applied.
+ * Applies a block variation to each example by updating its attributes.
  *
  * @param {Array}  examples  Array of examples
- * @param {string} variation The block variation
- * @return {Array} Updated array
+ * @param {string} variation Block variation name.
+ * @return {Array} Updated examples with variation applied.
  */
 function applyBlockVariationsToExamples( examples, variation ) {
 	if ( ! variation ) {
@@ -472,8 +472,8 @@ export const StyleBookPreview = ( { userConfig = {}, isStatic = false } ) => {
 		( category ) => category.slug === previewCategory
 	);
 
-	// If there's no category definition there may be a single block.
 	const filteredExamples = useMemo( () => {
+		// If there's no category definition there may be a single block.
 		if ( ! categoryDefinition ) {
 			return {
 				examples: [

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -51,11 +51,11 @@ import { getExamples } from './examples';
 import { store as siteEditorStore } from '../../store';
 import { useSection } from '../sidebar-global-styles-wrapper';
 import { GlobalStylesRenderer } from '../global-styles-renderer';
+import { getVariationClassName } from '../global-styles/utils';
 import {
 	STYLE_BOOK_COLOR_GROUPS,
 	STYLE_BOOK_PREVIEW_CATEGORIES,
 } from '../style-book/constants';
-import { getVariationClassName } from '../global-styles/utils';
 
 const {
 	ExperimentalBlockEditorProvider,

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -55,6 +55,7 @@ import {
 	STYLE_BOOK_COLOR_GROUPS,
 	STYLE_BOOK_PREVIEW_CATEGORIES,
 } from '../style-book/constants';
+import { getVariationClassName } from '../global-styles/utils';
 
 const {
 	ExperimentalBlockEditorProvider,
@@ -213,6 +214,31 @@ export function getExamplesForSinglePageUse( examples ) {
 	examplesForSinglePageUse.push( ...otherExamples );
 
 	return examplesForSinglePageUse;
+}
+
+/**
+ * Returns examples with variation styles applied.
+ *
+ * @param {Array}  examples  Array of examples
+ * @param {string} variation The block variation
+ * @return {Array} Updated array
+ */
+function applyBlockVariationsToExamples( examples, variation ) {
+	if ( ! variation ) {
+		return examples;
+	}
+
+	return examples.map( ( example ) => ( {
+		...example,
+		blocks: {
+			...example.blocks,
+			attributes: {
+				...example.blocks.attributes,
+				style: undefined,
+				className: getVariationClassName( variation ),
+			},
+		},
+	} ) );
 }
 
 function StyleBook( {
@@ -419,14 +445,20 @@ export const StyleBookPreview = ( { userConfig = {}, isStatic = false } ) => {
 	const examplesForSinglePageUse = getExamplesForSinglePageUse( examples );
 
 	let previewCategory = null;
+	let blockVariation = null;
 	if ( section.includes( '/colors' ) ) {
 		previewCategory = 'colors';
 	} else if ( section.includes( '/typography' ) ) {
 		previewCategory = 'text';
 	} else if ( section.includes( '/blocks' ) ) {
 		previewCategory = 'blocks';
-		const blockName =
-			decodeURIComponent( section ).split( '/blocks/' )[ 1 ];
+		let blockName = decodeURIComponent( section ).split( '/blocks/' )[ 1 ];
+
+		// The blockName can contain variations, if so, extract the variation.
+		if ( blockName?.includes( '/variations' ) ) {
+			[ blockName, blockVariation ] = blockName.split( '/variations/' );
+		}
+
 		if (
 			blockName &&
 			examples.find( ( example ) => example.name === blockName )
@@ -441,20 +473,42 @@ export const StyleBookPreview = ( { userConfig = {}, isStatic = false } ) => {
 	);
 
 	// If there's no category definition there may be a single block.
-	const filteredExamples = categoryDefinition
-		? getExamplesByCategory( categoryDefinition, examples )
-		: {
+	const filteredExamples = useMemo( () => {
+		if ( ! categoryDefinition ) {
+			return {
 				examples: [
 					examples.find(
 						( example ) => example.name === previewCategory
 					),
 				],
-		  };
+			};
+		}
 
-	// If there's no preview category, show all examples.
-	const displayedExamples = previewCategory
-		? filteredExamples
-		: { examples: examplesForSinglePageUse };
+		return getExamplesByCategory( categoryDefinition, examples );
+	}, [ categoryDefinition, examples, previewCategory ] );
+
+	const displayedExamples = useMemo( () => {
+		// If there's no preview category, show all examples.
+		if ( ! previewCategory ) {
+			return { examples: examplesForSinglePageUse };
+		}
+
+		if ( blockVariation ) {
+			return {
+				examples: applyBlockVariationsToExamples(
+					filteredExamples.examples,
+					blockVariation
+				),
+			};
+		}
+
+		return filteredExamples;
+	}, [
+		previewCategory,
+		examplesForSinglePageUse,
+		blockVariation,
+		filteredExamples,
+	] );
 
 	const { base: baseConfig } = useContext( GlobalStylesContext );
 	const goTo = getStyleBookNavigationFromPath( section );

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -230,6 +230,7 @@ function applyBlockVariationsToExamples( examples, variation ) {
 
 	return examples.map( ( example ) => ( {
 		...example,
+		variation,
 		blocks: {
 			...example.blocks,
 			attributes: {
@@ -420,7 +421,7 @@ export const StyleBookPreview = ( { userConfig = {}, isStatic = false } ) => {
 		);
 	};
 
-	const onSelect = ( blockName ) => {
+	const onSelect = ( blockName, isBlockVariation = false ) => {
 		if (
 			STYLE_BOOK_COLOR_GROUPS.find(
 				( group ) => group.slug === blockName
@@ -433,6 +434,10 @@ export const StyleBookPreview = ( { userConfig = {}, isStatic = false } ) => {
 		if ( blockName === 'typography' ) {
 			// Go to typography Global Styles.
 			onChangeSection( '/typography' );
+			return;
+		}
+
+		if ( isBlockVariation ) {
 			return;
 		}
 
@@ -657,7 +662,11 @@ const Examples = memo(
 							isSelected={ isSelected?.( example.name ) }
 							onClick={
 								!! onSelect
-									? () => onSelect( example.name )
+									? () =>
+											onSelect(
+												example.name,
+												!! example.variation
+											)
 									: null
 							}
 						/>


### PR DESCRIPTION
## What?
Closes #70447 

This PR updates the style book to display the selected block variations of individual blocks.

## Why?

Previously, the style book preview rendered the default view when a particular block variation was selected instead of rendering the block with the selected variation applied.

## How?

The bug mentioned above happened because the block name wasn't properly extracted from the code below, as the presence of variation within the section wasn't considered.

Ref.
https://github.com/WordPress/gutenberg/blob/de11ef92c9f6478fedb7bd5f56b1612943d5c7a9/packages/edit-site/src/components/style-book/index.js#L428

## Testing Instructions

1. Navigate to Appearance > Editor > Styles.
2. Open the Style Book by clicking on the eye button.
3. Select the Separator Block from all the blocks displayed in the preview.
4. From the available Style Variations, click on the Dots variation.
5. Confirm that the preview changes and adapts to the selected block variation.

### Testing Instructions for Keyboard
Same.

## Screencast

![PR Demo](https://github.com/user-attachments/assets/2a51c10c-a483-4209-8ffb-7b3c39587f5b)
