### PR TITLE
Refactor: Convert native `Dropdown` to functional component

### DIFF
--- a/packages/components/src/dropdown/index.native.js
+++ b/packages/components/src/dropdown/index.native.js
@@ -1,10 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { useState, useEffect, useCallback, useMemo } from '@wordpress/element';
+import {
+	useState,
+	useEffect,
+	useCallback,
+	useMemo,
+	useRef,
+} from '@wordpress/element';
 
 const Dropdown = ( { renderContent, renderToggle, onToggle } ) => {
 	const [ isOpen, setIsOpen ] = useState( false );
+	const prevIsOpenRef = useRef( isOpen );
 
 	const toggle = useCallback( () => {
 		setIsOpen( ( prev ) => ! prev );
@@ -15,9 +22,13 @@ const Dropdown = ( { renderContent, renderToggle, onToggle } ) => {
 	}, [] );
 
 	useEffect( () => {
-		if ( onToggle ) {
+		// Only call `onToggle` when `isOpen` changes,
+		// avoiding a call on initial mount.
+		if ( prevIsOpenRef.current !== isOpen && onToggle ) {
 			onToggle( isOpen );
 		}
+
+		prevIsOpenRef.current = isOpen;
 
 		return () => {
 			if ( isOpen && onToggle ) {

--- a/packages/components/src/dropdown/index.native.js
+++ b/packages/components/src/dropdown/index.native.js
@@ -1,59 +1,41 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
+import { useState, useEffect, useCallback, useMemo } from '@wordpress/element';
 
-class Dropdown extends Component {
-	constructor() {
-		super( ...arguments );
+const Dropdown = ( { renderContent, renderToggle, onToggle } ) => {
+	const [ isOpen, setIsOpen ] = useState( false );
 
-		this.toggle = this.toggle.bind( this );
-		this.close = this.close.bind( this );
+	const toggle = useCallback( () => {
+		setIsOpen( ( prev ) => ! prev );
+	}, [] );
 
-		this.state = {
-			isOpen: false,
-		};
-	}
+	const close = useCallback( () => {
+		setIsOpen( false );
+	}, [] );
 
-	componentWillUnmount() {
-		const { isOpen } = this.state;
-		const { onToggle } = this.props;
-		if ( isOpen && onToggle ) {
-			onToggle( false );
-		}
-	}
-
-	componentDidUpdate( prevProps, prevState ) {
-		const { isOpen } = this.state;
-		const { onToggle } = this.props;
-		if ( prevState.isOpen !== isOpen && onToggle ) {
+	useEffect( () => {
+		if ( onToggle ) {
 			onToggle( isOpen );
 		}
-	}
 
-	toggle() {
-		this.setState( ( state ) => ( {
-			isOpen: ! state.isOpen,
-		} ) );
-	}
+		return () => {
+			if ( isOpen && onToggle ) {
+				onToggle( false );
+			}
+		};
+	}, [ isOpen, onToggle ] );
 
-	close() {
-		this.setState( { isOpen: false } );
-	}
+	const args = useMemo( () => {
+		return { isOpen, onToggle: toggle, onClose: close };
+	}, [ isOpen, toggle, close ] );
 
-	render() {
-		const { isOpen } = this.state;
-		const { renderContent, renderToggle } = this.props;
-
-		const args = { isOpen, onToggle: this.toggle, onClose: this.close };
-
-		return (
-			<>
-				{ renderToggle( args ) }
-				{ isOpen && renderContent( args ) }
-			</>
-		);
-	}
-}
+	return (
+		<>
+			{ renderToggle( args ) }
+			{ isOpen && renderContent( args ) }
+		</>
+	);
+};
 
 export default Dropdown;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Related #22890 

<!-- In a few words, what is the PR actually doing? -->
This PR converts the native `Dropdown` component from a class based implementation to a functional component using React hooks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To align with the modern React practices and improve consistency across the codebase by using functional component with React hooks. This also makes the component easier to maintain and test over time.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Replaced class based lifecycle methods with `useEffect`
- Used `useState`, `useCallback` and `useMemo` for state and memoization.
- Preserved all previous logic and behavior.
