### PR TITLE
Separator: Surfacing the HTML markup control

### DIFF
--- a/packages/block-library/src/separator/edit.js
+++ b/packages/block-library/src/separator/edit.js
@@ -8,7 +8,7 @@ import clsx from 'clsx';
  */
 import {
 	getColorClassName,
-	InspectorAdvancedControls,
+	InspectorControls,
 	useBlockProps,
 	__experimentalUseColorProps as useColorProps,
 } from '@wordpress/block-editor';
@@ -75,12 +75,12 @@ export default function SeparatorEdit( { attributes, setAttributes } ) {
 
 	return (
 		<>
-			<InspectorAdvancedControls>
+			<InspectorControls group="advanced">
 				<HtmlElementControl
 					tagName={ tagName }
 					setAttributes={ setAttributes }
 				/>
-			</InspectorAdvancedControls>
+			</InspectorControls>
 			<Wrapper
 				{ ...useBlockProps( {
 					className,

--- a/packages/block-library/src/separator/edit.js
+++ b/packages/block-library/src/separator/edit.js
@@ -7,26 +7,25 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import {
+	getColorClassName,
+	InspectorAdvancedControls,
+	InspectorControls,
+	useBlockProps,
+	__experimentalUseColorProps as useColorProps,
+} from '@wordpress/block-editor';
+import {
 	HorizontalRule,
 	SelectControl,
-	PanelBody,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
-import {
-	useBlockProps,
-	getColorClassName,
-	__experimentalUseColorProps as useColorProps,
-	InspectorControls,
-} from '@wordpress/block-editor';
-import { Platform } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import useDeprecatedOpacity from './use-deprecated-opacity';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+import useDeprecatedOpacity from './use-deprecated-opacity';
 
 const HtmlElementControl = ( { tagName, setAttributes } ) => {
 	return (
@@ -85,37 +84,32 @@ export default function SeparatorEdit( { attributes, setAttributes } ) {
 	return (
 		<>
 			<InspectorControls>
-				{ Platform.isNative ? (
-					<PanelBody title={ __( 'Settings' ) }>
+				<ToolsPanel
+					label={ __( 'Settings' ) }
+					resetAll={ () => {
+						setAttributes( { tagName: 'hr' } );
+					} }
+					dropdownMenuProps={ dropdownMenuProps }
+				>
+					<ToolsPanelItem
+						hasValue={ () => tagName !== 'hr' }
+						label={ __( 'HTML element' ) }
+						onDeselect={ () => setAttributes( { tagName: 'hr' } ) }
+						isShownByDefault
+					>
 						<HtmlElementControl
 							tagName={ tagName }
 							setAttributes={ setAttributes }
 						/>
-					</PanelBody>
-				) : (
-					<ToolsPanel
-						label={ __( 'Settings' ) }
-						resetAll={ () => {
-							setAttributes( { tagName: 'hr' } );
-						} }
-						dropdownMenuProps={ dropdownMenuProps }
-					>
-						<ToolsPanelItem
-							hasValue={ () => tagName !== 'hr' }
-							label={ __( 'HTML element' ) }
-							onDeselect={ () =>
-								setAttributes( { tagName: 'hr' } )
-							}
-							isShownByDefault
-						>
-							<HtmlElementControl
-								tagName={ tagName }
-								setAttributes={ setAttributes }
-							/>
-						</ToolsPanelItem>
-					</ToolsPanel>
-				) }
+					</ToolsPanelItem>
+				</ToolsPanel>
 			</InspectorControls>
+			<InspectorAdvancedControls>
+				<HtmlElementControl
+					tagName={ tagName }
+					setAttributes={ setAttributes }
+				/>
+			</InspectorAdvancedControls>
 			<Wrapper
 				{ ...useBlockProps( {
 					className,

--- a/packages/block-library/src/separator/edit.js
+++ b/packages/block-library/src/separator/edit.js
@@ -9,22 +9,15 @@ import clsx from 'clsx';
 import {
 	getColorClassName,
 	InspectorAdvancedControls,
-	InspectorControls,
 	useBlockProps,
 	__experimentalUseColorProps as useColorProps,
 } from '@wordpress/block-editor';
-import {
-	HorizontalRule,
-	SelectControl,
-	__experimentalToolsPanel as ToolsPanel,
-	__experimentalToolsPanelItem as ToolsPanelItem,
-} from '@wordpress/components';
+import { HorizontalRule, SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import useDeprecatedOpacity from './use-deprecated-opacity';
 
 const HtmlElementControl = ( { tagName, setAttributes } ) => {
@@ -57,7 +50,6 @@ export default function SeparatorEdit( { attributes, setAttributes } ) {
 	const colorProps = useColorProps( attributes );
 	const currentColor = colorProps?.style?.backgroundColor;
 	const hasCustomColor = !! style?.color?.background;
-	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	useDeprecatedOpacity( opacity, currentColor, setAttributes );
 
@@ -83,27 +75,6 @@ export default function SeparatorEdit( { attributes, setAttributes } ) {
 
 	return (
 		<>
-			<InspectorControls>
-				<ToolsPanel
-					label={ __( 'Settings' ) }
-					resetAll={ () => {
-						setAttributes( { tagName: 'hr' } );
-					} }
-					dropdownMenuProps={ dropdownMenuProps }
-				>
-					<ToolsPanelItem
-						hasValue={ () => tagName !== 'hr' }
-						label={ __( 'HTML element' ) }
-						onDeselect={ () => setAttributes( { tagName: 'hr' } ) }
-						isShownByDefault
-					>
-						<HtmlElementControl
-							tagName={ tagName }
-							setAttributes={ setAttributes }
-						/>
-					</ToolsPanelItem>
-				</ToolsPanel>
-			</InspectorControls>
 			<InspectorAdvancedControls>
 				<HtmlElementControl
 					tagName={ tagName }


### PR DESCRIPTION
## What?
Closes #70441

Reverts the HTML element control in the Separator block back to the Advanced Inspector panel to restore consistent UI patterns and improve overall usability.

## Why?

In PR #70185, the HTML element control was moved from the Advanced Inspector to the top-level Settings panel to improve accessibility. However, this change created a significant usability regression.

## How?

This PR reverts the UI changes from #70185 by:
- Moving the `HtmlElementControl` back to `InspectorAdvancedControls` 
- Keeping the helpful control itself (just moving its location)

## Testing Instructions

1. Open the WordPress block editor (post or page)
2. Insert a Separator block
3. Open the block settings in the sidebar
5. Click on the "Advanced" section at the bottom of the inspector
6. Verify that the "HTML element" control is present and functional
7. Test changing between `<hr>` and `<div>` options
8. Confirm the separator renders with the correct HTML element in both editor and frontend

## Screenshots or screencast

|Before (Current)|After (This PR)|
|-|-|
|![image](https://github.com/user-attachments/assets/1d4c3c2a-c3c4-4057-b32d-b0f80e93d6a7)|![image](https://github.com/user-attachments/assets/e3b62436-def1-4713-af4b-c8a104f7cf35)|