### PR TITLE
[WIP] Search Block: Fix jump on search block toggle expansion

### DIFF
--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -1,6 +1,10 @@
 $button-spacing-x: $grid-unit-10 + math.div($grid-unit-05, 2); // 10px
 $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 
+form.wp-block-search {
+	transition: width 3s ease !important;
+}
+
 .wp-block-search__button {
 	margin-left: $button-spacing-x;
 	word-break: normal;
@@ -30,6 +34,7 @@ $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 	display: flex;
 	flex: auto;
 	flex-wrap: nowrap;
+	justify-content: flex-end;
 	max-width: 100%;
 }
 
@@ -42,6 +47,9 @@ $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 	flex-grow: 1;
 	margin-left: 0;
 	margin-right: 0;
+	top: 0;
+	right: 0;
+	position: relative;
 	min-width: 3rem;
 	border: 1px solid $gray-600;
 	// !important used to forcibly prevent undesired application of


### PR DESCRIPTION
[WIP] This is an attempt to fix search block transition when it is expanded

## What?
Closes #70450
This PR fixes issues with Search Block expansion when using Button Only setting

## Why?
The jump in transition causes unnatural behavior for users

## How?
The cause was found to be a fixed width applied when the search block was toggled
The justify-content property on the inner wrapper was also found to contribute to input box to shift to left while the transition takes place

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
