### PR TITLE
Skip falling e2e tests

### DIFF
--- a/test/e2e/specs/editor/blocks/site-title.spec.js
+++ b/test/e2e/specs/editor/blocks/site-title.spec.js
@@ -14,7 +14,10 @@ test.describe( 'Site Title block', () => {
 		await requestUtils.updateSiteSettings( { title: originalSiteTitle } );
 	} );
 
-	test( 'Can edit the site title as admin', async ( {
+	// Reinstate once the patch that fixes the REST API endpoints is committed to core.
+	// https://core.trac.wordpress.org/ticket/41604.
+	// eslint-disable-next-line playwright/no-skipped-test
+	test.skip( 'Can edit the site title as admin', async ( {
 		admin,
 		editor,
 		page,

--- a/test/e2e/specs/editor/various/multi-entity-saving.spec.js
+++ b/test/e2e/specs/editor/various/multi-entity-saving.spec.js
@@ -25,7 +25,10 @@ test.describe( 'Editor - Multi-entity save flow', () => {
 		} );
 	} );
 
-	test( 'Save flow should work as expected', async ( {
+	// Reinstate once the patch that fixes the REST API endpoints is committed to core.
+	// https://core.trac.wordpress.org/ticket/41604.
+	// eslint-disable-next-line playwright/no-skipped-test
+	test.skip( 'Save flow should work as expected', async ( {
 		admin,
 		editor,
 		page,
@@ -146,7 +149,10 @@ test.describe( 'Editor - Multi-entity save flow', () => {
 		await expect( openSavePanel ).toBeEnabled();
 	} );
 
-	test( 'Site blocks should save individually', async ( {
+	// Reinstate once the patch that fixes the REST API endpoints is committed to core.
+	// https://core.trac.wordpress.org/ticket/41604.
+	// eslint-disable-next-line playwright/no-skipped-test
+	test.skip( 'Site blocks should save individually', async ( {
 		admin,
 		editor,
 		page,


### PR DESCRIPTION
## What?

See https://core.trac.wordpress.org/ticket/41604

## Why?

Due to [Changeset 60301](https://core.trac.wordpress.org/changeset/60301), an error occurs when a request to a configuration endpoint contains URL query parameters.

This causes some E2E tests to fail. To temporarily work around this, we will skip those failing tests.

## Testing Instructions

Nothing. Let's confirm all CIs are ✅.
