### PR TITLE
Global Styles: Implement uniform header layout

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-sizes/font-sizes.js
+++ b/packages/edit-site/src/components/global-styles/font-sizes/font-sizes.js
@@ -69,9 +69,9 @@ function FontSizeGroup( {
 				/>
 			) }
 			<VStack spacing={ 4 }>
-				<HStack justify="space-between" align="center">
+				<HStack>
 					<Subtitle level={ 3 }>{ label }</Subtitle>
-					<FlexItem>
+					<FlexItem className="edit-site-global-styles__typography-panel__options-container">
 						{ origin === 'custom' && (
 							<Button
 								label={ __( 'Add font size' ) }

--- a/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
@@ -327,12 +327,7 @@ function ShadowEditor( { shadow, onChange } ) {
 		<>
 			<VStack spacing={ 2 }>
 				<HStack justify="space-between">
-					<Flex
-						align="center"
-						className="edit-site-global-styles__shadows-panel__title"
-					>
-						<Subtitle level={ 3 }>{ __( 'Shadows' ) }</Subtitle>
-					</Flex>
+					<Subtitle level={ 3 }>{ __( 'Shadows' ) }</Subtitle>
 					<FlexItem className="edit-site-global-styles__shadows-panel__options-container">
 						<Button
 							size="small"

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -104,7 +104,8 @@
 	flex-shrink: 0;
 }
 
-.edit-site-global-styles__shadows-panel__options-container {
+.edit-site-global-styles__shadows-panel__options-container,
+.edit-site-global-styles__typography-panel__options-container {
 	height: $grid-unit * 3;
 }
 


### PR DESCRIPTION
## What, Why, and How?

Closes #70462

This PR updates the header layout in both the `Font Size Panel` and the `Shadows Edit Panel` to ensure proper positioning.

## Testing Instructions

1. Navigate to `Appearance -> Editor -> Styles -> Typography`.
2. Confirm that the height of the header is `24px`.
3. Navigate to `Appearance -> Editor -> Styles -> Shadows -> Crisp`.
4. Confirm that the `Add Shadow` button represented by the `+` icon is properly aligned.

### Testing Instructions for Keyboard
Same.

## Screenshots

|Before|After|
|-|-|
|![drop-shadow-before](https://github.com/user-attachments/assets/95ae87fe-da69-4186-9c77-1b469a4b2822)|![drop-shadow-after](https://github.com/user-attachments/assets/128c3ea0-0eb6-43c5-9701-44319080b05c)|
|![before-font-size](https://github.com/user-attachments/assets/c88cbec6-03de-4089-a7c8-f369a657d529)|![after](https://github.com/user-attachments/assets/c8552e50-443f-4462-92c1-1be330f4d8f0)|




