### PR TITLE
TypeScript: migrate dom-ready package to TS

### DIFF
--- a/packages/dom-ready/README.md
+++ b/packages/dom-ready/README.md
@@ -32,7 +32,7 @@ domReady( function () {
 
 _Parameters_
 
--   _callback_ `Callback`: A function to execute after the DOM is ready.
+-   _callback_ `() => void`: A function to execute after the DOM is ready.
 
 _Returns_
 

--- a/packages/dom-ready/src/index.ts
+++ b/packages/dom-ready/src/index.ts
@@ -1,21 +1,7 @@
 /**
- * @typedef {() => void} Callback
- *
- * TODO: Remove this typedef and inline `() => void` type.
- *
- * This typedef is used so that a descriptive type is provided in our
- * automatically generated documentation.
- *
- * An in-line type `() => void` would be preferable, but the generated
- * documentation is `null` in that case.
- *
- * @see https://github.com/WordPress/gutenberg/issues/18045
- */
-
-/**
  * Specify a function to execute when the DOM is fully loaded.
  *
- * @param {Callback} callback A function to execute after the DOM is ready.
+ * @param  callback A function to execute after the DOM is ready.
  *
  * @example
  * ```js
@@ -28,7 +14,7 @@
  *
  * @return {void}
  */
-export default function domReady( callback ) {
+export default function domReady( callback: () => void ): void {
 	if ( typeof document === 'undefined' ) {
 		return;
 	}
@@ -37,7 +23,8 @@ export default function domReady( callback ) {
 		document.readyState === 'complete' || // DOMContentLoaded + Images/Styles/etc loaded, so we call directly.
 		document.readyState === 'interactive' // DOMContentLoaded fires at this point, so we call directly.
 	) {
-		return void callback();
+		callback();
+		return;
 	}
 
 	// DOMContentLoaded has not fired yet, delay callback until then.

--- a/packages/dom-ready/src/test/index.test.ts
+++ b/packages/dom-ready/src/test/index.test.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import domReady from '../';
+import domReady from '..';
 
 describe( 'domReady', () => {
 	beforeAll( () => {
@@ -14,7 +14,7 @@ describe( 'domReady', () => {
 	describe( 'when document readystate is complete', () => {
 		it( 'should call the callback.', () => {
 			const callback = jest.fn( () => {} );
-			document.readyState = 'complete';
+			( document as any ).readyState = 'complete';
 			domReady( callback );
 			expect( callback ).toHaveBeenCalled();
 		} );
@@ -23,7 +23,7 @@ describe( 'domReady', () => {
 	describe( 'when document readystate is interactive', () => {
 		it( 'should call the callback.', () => {
 			const callback = jest.fn( () => {} );
-			document.readyState = 'interactive';
+			( document as any ).readyState = 'interactive';
 			domReady( callback );
 			expect( callback ).toHaveBeenCalled();
 		} );
@@ -32,7 +32,7 @@ describe( 'domReady', () => {
 	describe( 'when document readystate is still loading', () => {
 		it( 'should add the callback as an event listener to the DOMContentLoaded event.', () => {
 			const addEventListener = jest.fn( () => {} );
-			document.readyState = 'loading';
+			( document as any ).readyState = 'loading';
 			Object.defineProperty( document, 'addEventListener', {
 				value: addEventListener,
 			} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of https://github.com/WordPress/gutenberg/issues/67691

<!-- In a few words, what is the PR actually doing? -->
Migrating the dom-ready package to TypeScript.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To enhance DX and add type safety.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By porting the code and tests to TypeScript, inlining the `() => void` callback type and removing the obsolete `@typedef Callback`.

Since Doctrine was removed from `docgen` in PR #28615, the tooling now understands inline function types. This completes the original TODO to drop the `Callback` typedef and use `() => void` directly in JSDoc and signatures.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
Typecheck and unit tests.