### PR TITLE
Navigation Block: fix inconsistent padding in nested submenus when "Open on click" is enabled

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -182,7 +182,7 @@ $navigation-icon-size: 24px;
 			> .wp-block-navigation-item__content {
 				display: flex;
 				flex-grow: 1;
-				padding-left: 1em;
+				padding: 0.5em;
 
 				// Right-align the chevron in submenus.
 				.wp-block-navigation__submenu-icon {

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -182,7 +182,7 @@ $navigation-icon-size: 24px;
 			> .wp-block-navigation-item__content {
 				display: flex;
 				flex-grow: 1;
-				padding: 0.5em;
+				padding: 0.5em 1em;
 
 				// Right-align the chevron in submenus.
 				.wp-block-navigation__submenu-icon {

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -182,6 +182,7 @@ $navigation-icon-size: 24px;
 			> .wp-block-navigation-item__content {
 				display: flex;
 				flex-grow: 1;
+				padding-left: 1em;
 
 				// Right-align the chevron in submenus.
 				.wp-block-navigation__submenu-icon {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #70463 
<!-- In a few words, what is the PR actually doing? -->
The left padding for nested submenu items in the navigation block is inconsistent when "Open on click" option is enabled for the navigation block. This PR fixes padding-left for the same.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
As reported in #70463, nested submenu toggle buttons inherit conflicting padding styles when “Open on click” is used. The base class `.wp-block-navigation-item.open-on-click .wp-block-navigation-submenu__toggle` applies a left padding of `0`, which removes the indentation for nested levels. This results in visual inconsistency compared to when “Open on click” is disabled.  
This commit restores appropriate left padding to maintain appropriate indentation for submenu items.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Restored padding by targeting submenu items within the .wp-block-navigation__submenu-container ensuring minimal specificity interference.

## Testing Instructions

1. Add navigation block to a post
2. Add a submenu block to the menu
3. Within that submenu, add a nested submenu
4. Enable Open on click via the sidebar settings
5. Save the post and check on front end
6. Verify the padding issue in the nested submenu

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before
<img width="528" alt="Screenshot 2025-06-16 at 4 14 57 PM" src="https://github.com/user-attachments/assets/fb6d6400-8a60-45e0-8b41-61eb0fe6cd1e" />

### After
<img width="535" alt="Screenshot 2025-06-18 at 4 46 31 PM" src="https://github.com/user-attachments/assets/2e1f37a6-5696-42ee-bde1-bac9d9d454bc" />
