### PR TITLE
Move and update ButtonBlockAppender styles into component stylesheet + improvements

### DIFF
--- a/packages/block-editor/src/components/button-block-appender/content.scss
+++ b/packages/block-editor/src/components/button-block-appender/content.scss
@@ -27,15 +27,13 @@
 	}
 }
 
-
 // When the appender shows up in empty container blocks, such as Group and Columns, add an extra click state.
 .block-list-appender:only-child {
-	// One level of nesting
 	.is-layout-constrained.block-editor-block-list__block:not(.is-selected) > &,
 	.is-layout-flow.block-editor-block-list__block:not(.is-selected) > &,
-	// Legacy groups have an inner container so need to be targeted separately
-	.block-editor-block-list__block:not(.is-selected) > .is-layout-constrained.wp-block-group__inner-container > &,
-	.block-editor-block-list__block:not(.is-selected) > .is-layout-flow.wp-block-group__inner-container > & {
+	// Blocks with inner containers
+	.block-editor-block-list__block:not(.is-selected, .block-editor-block-list__layout) > .is-layout-constrained.block-editor-block-list__layout > &,
+	.block-editor-block-list__block:not(.is-selected, .block-editor-block-list__layout) > .is-layout-flow.block-editor-block-list__layout > & {
 		pointer-events: none;
 
 		&::after {
@@ -49,7 +47,7 @@
 			border: $border-width dashed currentColor;
 		}
 
-		.block-editor-inserter {
+		> .block-editor-inserter {
 			opacity: 0;
 
 			&:focus-within {
@@ -63,16 +61,16 @@
 			}
 
 			.block-editor-inserter {
-				visibility: visible;
+				opacity: 1;
 			}
 		}
 	}
 
 	// Hide the dashed outline in 2-level nested cases, so for example the dashed
 	// empty column is only shown when the columns block is selected.
-	.block-editor-block-list__block:not(.is-selected) > .block-editor-block-list__block > &::after {
+	/*.block-editor-block-list__block:not(.is-selected) > .block-editor-block-list__block > &::after {
 		border: none;
-	}
+	}*/
 
 	// Drop zone.
 	&.is-drag-over .block-editor-button-block-appender {
@@ -81,6 +79,61 @@
 		color: $light-gray-placeholder;
 		@media not ( prefers-reduced-motion ) {
 			transition: background-color 0.2s ease-in-out;
+		}
+	}
+}
+
+.block-editor-block-list__layout.is-layout-flex {
+	&:not(.is-vertical) > .block-list-appender:only-child {
+		flex: 1;
+		align-self: stretch;
+	}
+
+	&.is-vertical > .block-list-appender:only-child {
+		flex: 1;
+		width: 100%;
+	}
+
+	// Cap inserter button and dashed outline widths to indicate how the layout will distribute space/content. Exempt stretched vertical layouts.
+	&:not(.is-vertical.is-content-justification-stretch) > .block-list-appender:only-child {
+		> .block-editor-inserter,
+		&::after {
+			width: 200px;
+		}
+	}
+
+	&:not(.is-vertical).is-vertical-alignment-stretch > .block-list-appender:only-child
+	.block-editor-button-block-appender {
+		height: auto;
+	}
+
+	> .block-list-appender:only-child {
+		gap: inherit;
+		align-items: inherit;
+		justify-content: inherit;
+		flex-direction: inherit;
+
+		&,
+		.block-editor-inserter {
+			display: inherit;
+		}
+
+		&::after {
+			content: "";
+			display: inherit;
+			//flex: 1 0 $button-size-next-default-40px;
+			pointer-events: none;
+			min-height:
+				$button-size-next-default-40px - $border-width -
+				$border-width;
+			border: $border-width dashed currentColor;
+		}
+
+		// Let the parent be selectable in the placeholder area.
+		pointer-events: none;
+		.block-editor-inserter,
+		.block-editor-button-block-appender {
+			pointer-events: all;
 		}
 	}
 }

--- a/packages/block-editor/src/components/button-block-appender/content.scss
+++ b/packages/block-editor/src/components/button-block-appender/content.scss
@@ -66,12 +66,6 @@
 		}
 	}
 
-	// Hide the dashed outline in 2-level nested cases, so for example the dashed
-	// empty column is only shown when the columns block is selected.
-	/*.block-editor-block-list__block:not(.is-selected) > .block-editor-block-list__block > &::after {
-		border: none;
-	}*/
-
 	// Drop zone.
 	&.is-drag-over .block-editor-button-block-appender {
 		background-color: var(--wp-admin-theme-color);

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -101,6 +101,14 @@ export function useLayoutClasses( blockAttributes = {}, blockName = '' ) {
 		);
 	}
 
+	if ( usedLayout?.verticalAlignment ) {
+		layoutClassnames.push(
+			`is-vertical-alignment-${ kebabCase(
+				usedLayout.verticalAlignment
+			) }`
+		);
+	}
+
 	if ( usedLayout?.flexWrap && usedLayout.flexWrap === 'nowrap' ) {
 		layoutClassnames.push( 'is-nowrap' );
 	}

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -23,33 +23,3 @@
 	}
 }
 
-// Affect the appender of the Row and Stack variants.
-.wp-block-group.is-layout-flex.block-editor-block-list__block > .block-list-appender:only-child {
-	gap: inherit;
-
-	&,
-	.block-editor-default-block-appender__content,
-	.block-editor-inserter {
-		display: inherit;
-		width: 100%;
-		flex-direction: inherit;
-		flex: 1;
-	}
-
-	&::after {
-		content: "";
-		display: flex;
-		flex: 1 0 $button-size-next-default-40px;
-		pointer-events: none;
-		min-height: $button-size-next-default-40px - $border-width - $border-width;
-		border: $border-width dashed currentColor;
-	}
-
-	// Let the parent be selectable in the placeholder area.
-	pointer-events: none;
-	.block-editor-inserter,
-	.block-editor-button-block-appender {
-		pointer-events: all;
-	}
-}
-


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Fixes https://github.com/WordPress/gutenberg/issues/70179. Improves appender appearance at various layout configuartions.
<!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There are several issues with CSS related to the ButtonBlockAppender component. My main concern is that block developers will not be able to use it in a way that will be consistent with the core blocks, or even not use it at all. The styles are also not consistent across layout configurations that are offered by core blocks. To break down the issues:

- Appender is not placed correctly in flex layouts.
- Visual cue when dragging blocks over empty blocks not working as expected.
- Appender's **Click state** not working when nested (group in group or column in columns)
- Parts of CSS is in the group block's directory, but should be within the component directory.
- CSS selectors in component directory targeting group block specifically, but should be block-agnostic.
- Some old and unused CSS that can be removed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The solution is fairly simple. Relocated all styles for ButtonBlockAppender out of the group block’s CSS and into the component’s own stylesheet. Updated the CSS to ensure the appender elements appear where a block's content would appear, and extend layout.js to emit the new class names required by those styles. Addressed drag-over and click state issues. Cleaned up unused CSS related to the component. 

layout.js already emits classes that indicate horizontal flex alignment (justification), but does not emit anything for vertical flex alignment. The CSS fix in this PR requires a class that indicates if a block has vertical alignment stretched (is-vertical-alignment-stretch).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Play with empty group block or a block that supports inner blocks and layout and uses ButtonBlockAppender. Test switching layouts and setting min-height to see how styles adapt. Test how styles appear on column block.

<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->


## Screenshots or screencast <!-- if applicable -->
<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Flex layout improvement
#### Before
https://github.com/user-attachments/assets/12502556-c417-45ad-bb97-882569f61793

#### After
https://github.com/user-attachments/assets/f603d1a5-2cdc-4dc4-acef-206351a4af5b


### Drag-over fix
#### Before
https://github.com/user-attachments/assets/6ad6b1ab-9b4b-4762-8df3-b5cd784c3ef8

#### After
https://github.com/user-attachments/assets/af7bda93-a0f8-4b65-97e8-3611b9bdddcf


### Click state fix
#### Before
![nested-click-state-before](https://github.com/user-attachments/assets/ce508650-197b-4632-8924-3d816d569804)

#### After
![nested-click-state-after](https://github.com/user-attachments/assets/30ac5118-82f5-45c4-85ab-8b100a529971)
