### PR TITLE
Comments Title: Display post type name in editor preview instead of hardcoded "Post Title"

### DIFF
--- a/packages/block-library/src/comments-title/edit.js
+++ b/packages/block-library/src/comments-title/edit.js
@@ -15,7 +15,7 @@ import {
 	HeadingLevelDropdown,
 } from '@wordpress/block-editor';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { useEntityProp } from '@wordpress/core-data';
+import { useEntityProp, store as coreStore } from '@wordpress/core-data';
 import {
 	ToggleControl,
 	__experimentalToolsPanel as ToolsPanel,
@@ -62,6 +62,15 @@ export default function Edit( {
 		return getSettings().__experimentalDiscussionSettings;
 	} );
 
+	// Get post type object to access the singular name.
+	const postTypeObject = useSelect(
+		( select ) => {
+			const { getPostType } = select( coreStore );
+			return postType ? getPostType( postType ) : null;
+		},
+		[ postType ]
+	);
+
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	useEffect( () => {
@@ -100,7 +109,14 @@ export default function Edit( {
 			.catch( () => {
 				setCommentsCount( 0 );
 			} );
-	}, [ postId ] );
+	}, [
+		commentsPerPage,
+		isSiteEditor,
+		pageComments,
+		postId,
+		threadComments,
+		threadCommentsDepth,
+	] );
 
 	const blockControls = (
 		<BlockControls group="block">
@@ -170,7 +186,18 @@ export default function Edit( {
 		</InspectorControls>
 	);
 
-	const postTitle = isSiteEditor ? __( '“Post Title”' ) : `"${ rawTitle }"`;
+	// Dynamically generate post title based on post type
+	const getPostTypeTitle = () => {
+		if ( isSiteEditor ) {
+			const postTypeName =
+				postTypeObject?.labels?.singular_name || __( 'Post' );
+			/* translators: %s: Post type name. */
+			return sprintf( __( '"%s Title"' ), postTypeName );
+		}
+		return `"${ rawTitle }"`;
+	};
+
+	const postTitle = getPostTypeTitle();
 
 	let placeholder;
 	if ( showCommentsCount && commentsCount !== undefined ) {


### PR DESCRIPTION
## What?
Closes #50169

Updates the Comments Title block to dynamically display the post type name in the editor preview instead of showing the hardcoded "Post Title" text.

## Why?
Currently, when editing templates for custom post types (like Movies, Products, etc.), the Comments Title block always shows "Post Title" in the preview, which is confusing and doesn't provide accurate context to users. This creates a poor user experience when working with custom post types, as users can't see how the block will actually appear for their specific content type.

## Testing Instructions
1. Create or edit a custom post type template (e.g., Single Movie template)
2. Add a Comments Title block to the template
3. Verify that the block preview shows "[Post Type] Title" instead of "Post Title"
4. Test with different post types to ensure the correct singular name is displayed
5. Test editing an actual post to ensure the real post title is still shown correctly
6. Verify that the block still functions properly when post type information is unavailable (should fallback to "Post Title")


## Screenshots or screencast

### Before

https://github.com/user-attachments/assets/37132869-c87d-4b71-b3ef-f18c00fa01e4


### After


https://github.com/user-attachments/assets/1f43ff2e-b724-405a-96b7-093182745791



