### PR TITLE
Image Block: Preserve line breaks in media caption

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -137,15 +137,6 @@ export function ImageEdit( {
 		captionRef.current = caption;
 	}, [ caption ] );
 
-	useEffect( () => {
-		// Replacing `\n` with `<br />` ensures that line breaks are preserved,
-		// consistenctly in both the editor and the frontend.
-		if ( typeof caption === 'string' && caption.includes( '\n' ) ) {
-			const normalized = caption.replace( /\n/g, '<br />' );
-			setAttributes( { caption: normalized } );
-		}
-	}, [ caption, setAttributes ] );
-
 	const { __unstableMarkNextChangeAsNotPersistent, replaceBlock } =
 		useDispatch( blockEditorStore );
 
@@ -257,6 +248,18 @@ export function ImageEdit( {
 		}
 
 		let mediaAttributes = pickRelevantMediaFiles( media, newSize );
+
+		// Normalize newline characters in caption to <br />
+		// to preserve line breaks in both editor and frontend.
+		if (
+			typeof mediaAttributes.caption === 'string' &&
+			mediaAttributes.caption.includes( '\n' )
+		) {
+			mediaAttributes.caption = mediaAttributes.caption.replace(
+				/\n/g,
+				'<br />'
+			);
+		}
 
 		// If a caption text was meanwhile written by the user,
 		// make sure the text is not overwritten by empty captions.

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -257,7 +257,7 @@ export function ImageEdit( {
 		) {
 			mediaAttributes.caption = mediaAttributes.caption.replace(
 				/\n/g,
-				'<br />'
+				'<br>'
 			);
 		}
 

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -137,6 +137,15 @@ export function ImageEdit( {
 		captionRef.current = caption;
 	}, [ caption ] );
 
+	useEffect( () => {
+		// Replacing `\n` with `<br />` ensures that line breaks are preserved,
+		// consistenctly in both the editor and the frontend.
+		if ( typeof caption === 'string' && caption.includes( '\n' ) ) {
+			const normalized = caption.replace( /\n/g, '<br />' );
+			setAttributes( { caption: normalized } );
+		}
+	}, [ caption, setAttributes ] );
+
 	const { __unstableMarkNextChangeAsNotPersistent, replaceBlock } =
 		useDispatch( blockEditorStore );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #59911 

<!-- In a few words, what is the PR actually doing? -->
This PR ensures that newline characters (`\n`) in image captions, particularly when added via the Media Library are preserved and rendered correctly in both the editor and the frontend.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When an image caption is populated from the Media Library, it may include newline characters (`\n`). These appear as line breaks initially in the editor but are lost after a refresh, as `\n` gets converted to spaces. As a result, line breaks are not respected unless manually re-entered in the editor. confusing for users.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Added a `useEffect` in the `ImageEdit` component to detect when the caption is a string containing `\n`, and replace those newline characters with `<br />` before the data is passed to `Caption` component. This ensures consistent rendering by using proper HTML line breaks.

## Testing Instructions
1. Upload an image through Media Library and include a multi line caption (using Enter or Shift+Enter).
2. Insert the image into a post using the Image block.
3. Verify that the line breaks are respected in the editor.
4. Refresh the editor page.
5. Verify that the caption still retains line breaks in the editor.
6. Save the post and view it on the frontend.
7. Confirm that line breaks are correctly rendered on the frontend as well.

<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

https://github.com/user-attachments/assets/c96c0cbf-0873-4873-80d7-a42498cf592f

### After

https://github.com/user-attachments/assets/51248499-1b3e-4ce8-b765-02efe527da07
