### PR TITLE
LetterSpacingControl: Filter out percentage unit from available units

### DIFF
--- a/packages/block-editor/src/components/letter-spacing-control/index.js
+++ b/packages/block-editor/src/components/letter-spacing-control/index.js
@@ -32,10 +32,8 @@ export default function LetterSpacingControl( {
 	...otherProps
 } ) {
 	const [ availableUnits ] = useSettings( 'spacing.units' );
-
-	// In most contexts the letter-spacing cannot meaningfully be set to a
-	// percentage, since this is relative to the parent container. This
-	// unit is disabled from the UI.
+	// Letter-spacing does not support percentage units according to CSS specification.
+	// Only length values (px, em, rem, etc.) are valid for the letter-spacing property.
 	const filteredAvailableUnits = availableUnits
 		? availableUnits.filter( ( unit ) => unit !== '%' )
 		: [ 'px', 'em', 'rem' ];

--- a/packages/block-editor/src/components/letter-spacing-control/index.js
+++ b/packages/block-editor/src/components/letter-spacing-control/index.js
@@ -32,8 +32,15 @@ export default function LetterSpacingControl( {
 	...otherProps
 } ) {
 	const [ availableUnits ] = useSettings( 'spacing.units' );
+
+	// In most contexts the letter-spacing cannot meaningfully be set to a
+	// percentage, since this is relative to the parent container. This
+	// unit is disabled from the UI.
+	const filteredAvailableUnits = availableUnits
+		? availableUnits.filter( ( unit ) => unit !== '%' )
+		: [ 'px', 'em', 'rem' ];
 	const units = useCustomUnits( {
-		availableUnits: availableUnits || [ 'px', 'em', 'rem' ],
+		availableUnits: filteredAvailableUnits,
 		defaultValues: { px: 2, em: 0.2, rem: 0.2 },
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #70478

Remove percentage (%) unit option from letter-spacing typography control dropdown.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Users were seeing "%" as an available unit option in the letter-spacing typography control, but percentage values are not valid CSS units for the `letter-spacing` property. When users selected percentage values, their letter-spacing settings would not work, causing confusion and frustration.

The CSS `letter-spacing` property accepts length values (px, em, rem, etc.) but not percentage values, making the percentage option misleading and non-functional.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Modified the `LetterSpacingControl` component to filter out the `%` unit from the available units before passing them to the `useCustomUnits` hook. This follows the same pattern already used in the Spacer block control, which also filters out percentage units where they're not appropriate.

The change:
- Filters the `availableUnits` array to exclude `%` when units are provided from settings
- Maintains the existing fallback behavior when no settings are available
- Adds a descriptive comment explaining why percentage units are disabled

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Open a post or page in the block editor
2. Insert any block that supports typography settings (e.g., Paragraph, Heading, Button)
3. Open the block settings panel
4. Click on the Typography section
5. Locate the "Letter spacing" control
6. Click on the unit dropdown next to the letter spacing input
7. Verify that "%" is no longer listed as an available unit option
8. Confirm that other units (px, em, rem, vh, vw) are still available
9. Test that letter spacing values work correctly with the remaining units


## Screenshots or screencast <!-- if applicable -->
![image](https://github.com/user-attachments/assets/0698dbc0-0068-4ac5-90bc-7a8a4dd80cb3)

**After**: Letter spacing dropdown excludes "%" option, showing only functional units