### PR TITLE
Remove screencast.com embed block variation.

### DIFF
--- a/packages/block-library/src/embed/variations.js
+++ b/packages/block-library/src/embed/variations.js
@@ -252,14 +252,6 @@ const variations = [
 		attributes: { providerNameSlug: 'reverbnation', responsive: true },
 	},
 	{
-		name: 'screencast',
-		title: getTitle( 'Screencast' ),
-		icon: embedVideoIcon,
-		description: __( 'Embed Screencast content.' ),
-		patterns: [ /^https?:\/\/(www\.)?screencast\.com\/.+/i ],
-		attributes: { providerNameSlug: 'screencast', responsive: true },
-	},
-	{
 		name: 'scribd',
 		title: getTitle( 'Scribd' ),
 		icon: embedContentIcon,


### PR DESCRIPTION
## What?

Remove the screencast.com embed block variation.

Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?

A refactor of systems at screencast.com has broken existing embeds and removed the existing oembed endpoint.

`https://api.screencast.com/external/oembed` now returns a `410 Gone` response.

See the lengthy discussion on the WP-Dev ticket from [comment 35 onwards](https://core.trac.wordpress.org/ticket/61941#comment:35). 

WP-Dev Trac ticket: https://core.trac.wordpress.org/ticket/61941
Follow up to r40574 / https://github.com/wordPress/wordpress-develop/commit/9a2188dd560fe0e2f756c114939fdf7a099032ed


## How?

Deletes the variation.

## Testing Instructions

1. Ensure Screencast variation removed from inserter
2. Ensure typing `/screencast` does show block in editor

### Testing Instructions for Keyboard

## Screenshots or screencast <!-- if applicable -->

<img width="533" alt="Screenshot 2025-06-20 at 8 11 13 am" src="https://github.com/user-attachments/assets/68ebdeff-d68c-4066-9ad8-a3e3d4b228fd" />

