### PR TITLE
Group block: Automatically apply default padding when border is set.

### DIFF
--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -10,7 +10,7 @@ import {
 	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
-import { useRef } from '@wordpress/element';
+import { useRef, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { View } from '@wordpress/primitives';
 
@@ -87,6 +87,38 @@ function GroupEdit( { attributes, name, setAttributes, clientId } ) {
 		usedLayoutType: type,
 		hasInnerBlocks,
 	} );
+
+	// Automatically apply padding when border is set and no padding exists.
+	useEffect( () => {
+		const border = attributes?.style?.border;
+		const padding = attributes?.style?.spacing?.padding;
+
+		const hasBorder =
+			!! border?.width || !! border?.color || !! border?.style;
+		const hasPadding = !! (
+			padding?.top ||
+			padding?.right ||
+			padding?.bottom ||
+			padding?.left
+		);
+
+		if ( hasBorder && ! hasPadding ) {
+			setAttributes( {
+				style: {
+					...( attributes.style || {} ),
+					spacing: {
+						...( attributes.style?.spacing || {} ),
+						padding: {
+							top: '1rem',
+							right: '1rem',
+							bottom: '1rem',
+							left: '1rem',
+						},
+					},
+				},
+			} );
+		}
+	}, [ attributes.style, setAttributes ] );
 
 	// Default to the regular appender being rendered.
 	let renderAppender;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/34315
- Automatically adds a default padding (1rem) to the Group block when a border is set and no padding is already defined.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Currently, content inside a Group block appears cramped against the border when no padding is set. This fix improves the default user experience.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Uses a useEffect hook inside the Group component.
- Detects when a border (style.border.width) is present.
- If padding (style.spacing.padding) is absent, it sets a default padding of 1rem on all sides.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open the WordPress Block Editor.
2. Insert a Group block.
3. Add some inner content (like a Paragraph block).
4. Select the Group block and:
5. Go to Block settings → Border.
6. Set a border width (e.g., 6px).
7. Padding (1rem) is automatically added on all sides.
8. Inner content no longer hugs the border edge.
9. Now try manually setting padding in the Spacing panel.
10. Confirm: Auto-padding is not overridden if user padding exists.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. Insert a Group block using the keyboard:
2. Use /group → press Enter.
3. Navigate using Tab and Arrow keys to the Block Toolbar and Sidebar.
4. Open Block settings using keyboard:
5. Tab to Border panel, open it with Enter.
6. Use arrow keys to select border width.
7. Border applies.
8. Padding gets applied automatically.
9. Tab through the inner content to ensure it's still reachable and correctly laid out.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
|<img width="1280" alt="Screenshot 2025-06-20 at 6 26 25 PM" src="https://github.com/user-attachments/assets/67353268-86ca-4aef-9a30-7cd9146b5ef1" />|<img width="1280" alt="Screenshot 2025-06-20 at 6 25 29 PM" src="https://github.com/user-attachments/assets/40237628-7f9f-4c2f-b4d4-915534e10a9c" />|
