### PR TITLE
Improve snackbar success notice UI with green accent and larger size.

### DIFF
--- a/packages/components/src/snackbar/style.scss
+++ b/packages/components/src/snackbar/style.scss
@@ -1,16 +1,18 @@
 .components-snackbar {
 	font-family: $default-font;
-	font-size: $default-font-size;
+	font-size: $default-font-size * 1.6;
 	background: rgba($black, 0.85); // Emulates #1e1e1e closely.
 	backdrop-filter: blur($grid-unit-20) saturate(180%);
 	border-radius: $radius-medium;
 	box-shadow: $elevation-small;
 	color: $white;
-	padding: $grid-unit-15 ($grid-unit-05 * 5);
+	padding: $grid-unit-15 ($grid-unit-05 * 6);
 	width: 100%;
-	max-width: 600px;
+	max-width: 700px;
 	box-sizing: border-box;
 	cursor: pointer;
+	border-left: 3px solid #28a745;
+	padding-left: $grid-unit-30;
 
 	// Re-enable pointer events, which are disabled by the
 	// .components-snackbar-list styles.
@@ -43,6 +45,11 @@
 		margin-left: $grid-unit-30;
 		cursor: pointer;
 	}
+}
+
+.components-snackbar.is-success {
+	border-left: 2.5px solid #28a745;
+	padding-left: $grid-unit-30; // Optional: increase left padding so text doesn’t get too close
 }
 
 .components-snackbar__action.components-button,

--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -123,7 +123,7 @@ export default function PostPublishPanelPostpublish( {
 	);
 
 	return (
-		<div className="post-publish-panel__postpublish">
+		<div className="post-publish-panel__postpublish is-success">
 			<PanelBody className="post-publish-panel__postpublish-header">
 				<ExternalLink ref={ postLinkRef } href={ link }>
 					{ decodeEntities( post.title ) || __( '(no title)' ) }

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -132,6 +132,13 @@
 	word-break: break-word;
 }
 
+.post-publish-panel__postpublish.is-success {
+	border-left: 2.5px;
+	border-style: solid;
+	border-color: #28a745;
+	padding-left: 12px;
+}
+
 .post-publish-panel__postpublish-buttons {
 	display: flex;
 	align-content: space-between;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of https://github.com/WordPress/gutenberg/issues/34306

<!-- In a few words, what is the PR actually doing? -->
- Improves the visual prominence of success notifications in the editor by:
- Increasing the snackbar size and padding
- Adding a green accent border for success messages

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Helps users more easily recognize successful post actions (like publishing or updating), enhancing clarity and feedback

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Overrides `.components-snackbar` styles and adds `.is-success` border and padding rules, aligned with WordPress design tokens.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open the block editor in WordPress.
2. Create a new post or page and enter some content.
3. Click Publish or Update.
4. Snackbar should appear with increased size and padding.
5. A green left border should appear, indicating success.
6. Snackbar should include clear text like “Post published.”
7. If a post link is included in the snackbar, a "View" button should appear.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. Press Tab repeatedly to navigate through the block editor.
2. After publishing a post, continue tabbing:
3. Snackbar should receive focus if it's the next interactive item.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
|<img width="1280" alt="Screenshot 2025-06-20 at 6 37 04 PM" src="https://github.com/user-attachments/assets/4b797f3f-9750-40e1-b11a-6f68bbac063b" />|<img width="1280" alt="Screenshot 2025-06-20 at 6 45 06 PM" src="https://github.com/user-attachments/assets/8bae0238-ccc5-4b93-a043-404584814475" />|
