### PR TITLE
iAPI Router: Fix dynamic imports on new visited pages

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-alpha/module-alpha-1.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-alpha/module-alpha-1.js
@@ -1,0 +1,1 @@
+export default 'alpha-1';

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-alpha/module-alpha-2.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-alpha/module-alpha-2.js
@@ -1,0 +1,1 @@
+export default 'alpha-2';

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-alpha/module.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-alpha/module.js
@@ -1,1 +1,0 @@
-export default 'alpha';

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-alpha/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-alpha/render.php
@@ -21,6 +21,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 		'data-testid'         => 'alpha-block',
 		'data-wp-interactive' => 'test/router-script-modules-alpha',
 		'data-wp-text'        => 'state.name',
+		'data-wp-on--click'   => 'actions.updateName',
 	)
 );
 ?>

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-alpha/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-alpha/render.php
@@ -7,22 +7,29 @@
  * @phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
  */
 
-$module_path = '/module.js';
-$module_url  = plugins_url( $module_path, __FILE__ );
-wp_register_script_module(
-	'test/router-script-modules-alpha',
-	$module_url,
-	array(),
-	filemtime( plugin_dir_path( __FILE__ ) . $module_path )
-);
+$modules = array( 'alpha-1', 'alpha-2' );
+
+foreach ( $modules as $module ) {
+	$module_path = '/module-' . $module . '.js';
+	wp_register_script_module(
+		'test/router-script-modules-' . $module,
+		plugins_url( $module_path, __FILE__ ),
+		array(),
+		filemtime( plugin_dir_path( __FILE__ ) . $module_path )
+	);
+}
 
 $wrapper_attributes = get_block_wrapper_attributes(
 	array(
 		'data-testid'         => 'alpha-block',
 		'data-wp-interactive' => 'test/router-script-modules-alpha',
-		'data-wp-text'        => 'state.name',
-		'data-wp-on--click'   => 'actions.updateName',
 	)
 );
 ?>
-<p <?php echo $wrapper_attributes; ?>></p>
+<div <?php echo $wrapper_attributes; ?>>
+	<span data-testid="text" data-wp-text="state.name"></span>
+	<button data-testid="static" data-wp-on--click="actions.updateFromStatic">Static</button>
+	<button data-testid="dynamic" data-wp-on--click="actions.updateFromDynamic">Dynamic</button>
+	<button data-testid="initial-static" data-wp-on--click="actions.updateFromInitialStatic">Static (initial)</button>
+	<button data-testid="initial-dynamic" data-wp-on--click="actions.updateFromInitialDynamic">Dynamic (initial)</button>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-alpha/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-alpha/view.asset.php
@@ -1,9 +1,14 @@
 <?php return array(
 	'dependencies' => array(
 		'@wordpress/interactivity',
-		'test/router-script-modules-alpha',
+		'test/router-script-modules-alpha-1',
+		'test/router-script-modules-initial-1',
 		array(
-			'id'     => 'test/router-script-modules-dynamic',
+			'id'     => 'test/router-script-modules-alpha-2',
+			'import' => 'dynamic',
+		),
+		array(
+			'id'     => 'test/router-script-modules-initial-2',
 			'import' => 'dynamic',
 		),
 	),

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-alpha/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-alpha/view.asset.php
@@ -2,5 +2,9 @@
 	'dependencies' => array(
 		'@wordpress/interactivity',
 		'test/router-script-modules-alpha',
+		array(
+			'id'     => 'test/router-script-modules-dynamic',
+			'import' => 'dynamic',
+		),
 	),
 );

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-alpha/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-alpha/view.js
@@ -9,9 +9,18 @@ import { store } from '@wordpress/interactivity';
 // eslint-disable-next-line import/no-unresolved
 import name from 'test/router-script-modules-alpha';
 
-store( 'test/router-script-modules-alpha', {
+const { state } = store( 'test/router-script-modules-alpha', {
 	state: {
 		name,
+	},
+	actions: {
+		*updateName() {
+			const { default: suffix } = yield import(
+				// eslint-disable-next-line import/no-unresolved
+				'test/router-script-modules-dynamic'
+			);
+			state.name += ` (${ suffix })`;
+		},
 	},
 } );
 

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-alpha/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-alpha/view.js
@@ -7,22 +7,37 @@ import { store } from '@wordpress/interactivity';
  * External dependencies
  */
 // eslint-disable-next-line import/no-unresolved
-import name from 'test/router-script-modules-alpha';
+import nameStatic from 'test/router-script-modules-alpha-1';
+// eslint-disable-next-line import/no-unresolved
+import nameInitialStatic from 'test/router-script-modules-initial-1';
 
 const { state } = store( 'test/router-script-modules-alpha', {
 	state: {
-		name,
+		name: 'alpha',
 	},
 	actions: {
-		*updateName() {
-			const { default: suffix } = yield import(
+		updateFromStatic() {
+			state.name = nameStatic;
+		},
+		updateFromInitialStatic() {
+			state.name = nameInitialStatic;
+		},
+		*updateFromDynamic() {
+			const { default: nameDynamic } = yield import(
 				// eslint-disable-next-line import/no-unresolved
-				'test/router-script-modules-dynamic'
+				'test/router-script-modules-alpha-2'
 			);
-			state.name += ` (${ suffix })`;
+			state.name = nameDynamic;
+		},
+		*updateFromInitialDynamic() {
+			const { default: nameInitialDynamic } = yield import(
+				// eslint-disable-next-line import/no-unresolved
+				'test/router-script-modules-initial-2'
+			);
+			state.name = nameInitialDynamic;
 		},
 	},
 } );
 
 const { actions } = store( 'test/router-script-modules' );
-actions.pushName?.( name );
+actions.pushName?.( state.name );

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-bravo/module-bravo-1.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-bravo/module-bravo-1.js
@@ -1,0 +1,1 @@
+export default 'bravo-1';

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-bravo/module-bravo-2.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-bravo/module-bravo-2.js
@@ -1,0 +1,1 @@
+export default 'bravo-2';

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-bravo/module.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-bravo/module.js
@@ -1,1 +1,0 @@
-export default 'bravo';

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-bravo/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-bravo/render.php
@@ -21,6 +21,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 		'data-testid'         => 'bravo-block',
 		'data-wp-interactive' => 'test/router-script-modules-bravo',
 		'data-wp-text'        => 'state.name',
+		'data-wp-on--click'   => 'actions.updateName',
 	)
 );
 ?>

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-bravo/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-bravo/render.php
@@ -7,22 +7,29 @@
  * @phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
  */
 
-$module_path = '/module.js';
-$module_url  = plugins_url( $module_path, __FILE__ );
-wp_register_script_module(
-	'test/router-script-modules-bravo',
-	$module_url,
-	array(),
-	filemtime( plugin_dir_path( __FILE__ ) . $module_path )
-);
+$modules = array( 'bravo-1', 'bravo-2' );
+
+foreach ( $modules as $module ) {
+	$module_path = '/module-' . $module . '.js';
+	wp_register_script_module(
+		'test/router-script-modules-' . $module,
+		plugins_url( $module_path, __FILE__ ),
+		array(),
+		filemtime( plugin_dir_path( __FILE__ ) . $module_path )
+	);
+}
 
 $wrapper_attributes = get_block_wrapper_attributes(
 	array(
 		'data-testid'         => 'bravo-block',
 		'data-wp-interactive' => 'test/router-script-modules-bravo',
-		'data-wp-text'        => 'state.name',
-		'data-wp-on--click'   => 'actions.updateName',
 	)
 );
 ?>
-<p <?php echo $wrapper_attributes; ?>></p>
+<div <?php echo $wrapper_attributes; ?>>
+	<span data-testid="text" data-wp-text="state.name"></span>
+	<button data-testid="static" data-wp-on--click="actions.updateFromStatic">Static</button>
+	<button data-testid="dynamic" data-wp-on--click="actions.updateFromDynamic">Dynamic</button>
+	<button data-testid="initial-static" data-wp-on--click="actions.updateFromInitialStatic">Static (initial)</button>
+	<button data-testid="initial-dynamic" data-wp-on--click="actions.updateFromInitialDynamic">Dynamic (initial)</button>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-bravo/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-bravo/view.asset.php
@@ -2,5 +2,9 @@
 	'dependencies' => array(
 		'@wordpress/interactivity',
 		'test/router-script-modules-bravo',
+		array(
+			'id'     => 'test/router-script-modules-dynamic',
+			'import' => 'dynamic',
+		),
 	),
 );

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-bravo/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-bravo/view.asset.php
@@ -1,9 +1,14 @@
 <?php return array(
 	'dependencies' => array(
 		'@wordpress/interactivity',
-		'test/router-script-modules-bravo',
+		'test/router-script-modules-bravo-1',
+		'test/router-script-modules-initial-1',
 		array(
-			'id'     => 'test/router-script-modules-dynamic',
+			'id'     => 'test/router-script-modules-bravo-2',
+			'import' => 'dynamic',
+		),
+		array(
+			'id'     => 'test/router-script-modules-initial-2',
 			'import' => 'dynamic',
 		),
 	),

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-bravo/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-bravo/view.js
@@ -9,9 +9,18 @@ import { store } from '@wordpress/interactivity';
 // eslint-disable-next-line import/no-unresolved
 import name from 'test/router-script-modules-bravo';
 
-store( 'test/router-script-modules-bravo', {
+const { state } = store( 'test/router-script-modules-bravo', {
 	state: {
 		name,
+	},
+	actions: {
+		*updateName() {
+			const { default: suffix } = yield import(
+				// eslint-disable-next-line import/no-unresolved
+				'test/router-script-modules-dynamic'
+			);
+			state.name += ` (${ suffix })`;
+		},
 	},
 } );
 

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-bravo/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-bravo/view.js
@@ -7,22 +7,37 @@ import { store } from '@wordpress/interactivity';
  * External dependencies
  */
 // eslint-disable-next-line import/no-unresolved
-import name from 'test/router-script-modules-bravo';
+import nameStatic from 'test/router-script-modules-bravo-1';
+// eslint-disable-next-line import/no-unresolved
+import nameInitialStatic from 'test/router-script-modules-initial-1';
 
 const { state } = store( 'test/router-script-modules-bravo', {
 	state: {
-		name,
+		name: 'bravo',
 	},
 	actions: {
-		*updateName() {
-			const { default: suffix } = yield import(
+		updateFromStatic() {
+			state.name = nameStatic;
+		},
+		updateFromInitialStatic() {
+			state.name = nameInitialStatic;
+		},
+		*updateFromDynamic() {
+			const { default: nameDynamic } = yield import(
 				// eslint-disable-next-line import/no-unresolved
-				'test/router-script-modules-dynamic'
+				'test/router-script-modules-bravo-2'
 			);
-			state.name += ` (${ suffix })`;
+			state.name = nameDynamic;
+		},
+		*updateFromInitialDynamic() {
+			const { default: nameInitialDynamic } = yield import(
+				// eslint-disable-next-line import/no-unresolved
+				'test/router-script-modules-initial-2'
+			);
+			state.name = nameInitialDynamic;
 		},
 	},
 } );
 
 const { actions } = store( 'test/router-script-modules' );
-actions.pushName?.( name );
+actions.pushName?.( state.name );

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-charlie/module-charlie-1.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-charlie/module-charlie-1.js
@@ -1,0 +1,1 @@
+export default 'charlie-1';

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-charlie/module-charlie-2.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-charlie/module-charlie-2.js
@@ -1,0 +1,1 @@
+export default 'charlie-2';

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-charlie/module.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-charlie/module.js
@@ -1,1 +1,0 @@
-export default 'charlie';

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-charlie/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-charlie/render.php
@@ -7,22 +7,29 @@
  * @phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
  */
 
-$module_path = '/module.js';
-$module_url  = plugins_url( $module_path, __FILE__ );
-wp_register_script_module(
-	'test/router-script-modules-charlie',
-	$module_url,
-	array(),
-	filemtime( plugin_dir_path( __FILE__ ) . $module_path )
-);
+$modules = array( 'charlie-1', 'charlie-2' );
+
+foreach ( $modules as $module ) {
+	$module_path = '/module-' . $module . '.js';
+	wp_register_script_module(
+		'test/router-script-modules-' . $module,
+		plugins_url( $module_path, __FILE__ ),
+		array(),
+		filemtime( plugin_dir_path( __FILE__ ) . $module_path )
+	);
+}
 
 $wrapper_attributes = get_block_wrapper_attributes(
 	array(
 		'data-testid'         => 'charlie-block',
 		'data-wp-interactive' => 'test/router-script-modules-charlie',
-		'data-wp-text'        => 'state.name',
-		'data-wp-on--click'   => 'actions.updateName',
 	)
 );
 ?>
-<p <?php echo $wrapper_attributes; ?>></p>
+<div <?php echo $wrapper_attributes; ?>>
+	<span data-testid="text" data-wp-text="state.name"></span>
+	<button data-testid="static" data-wp-on--click="actions.updateFromStatic">Static</button>
+	<button data-testid="dynamic" data-wp-on--click="actions.updateFromDynamic">Dynamic</button>
+	<button data-testid="initial-static" data-wp-on--click="actions.updateFromInitialStatic">Static (initial)</button>
+	<button data-testid="initial-dynamic" data-wp-on--click="actions.updateFromInitialDynamic">Dynamic (initial)</button>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-charlie/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-charlie/render.php
@@ -21,6 +21,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 		'data-testid'         => 'charlie-block',
 		'data-wp-interactive' => 'test/router-script-modules-charlie',
 		'data-wp-text'        => 'state.name',
+		'data-wp-on--click'   => 'actions.updateName',
 	)
 );
 ?>

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-charlie/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-charlie/view.asset.php
@@ -2,5 +2,9 @@
 	'dependencies' => array(
 		'@wordpress/interactivity',
 		'test/router-script-modules-charlie',
+		array(
+			'id'     => 'test/router-script-modules-dynamic',
+			'import' => 'dynamic',
+		),
 	),
 );

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-charlie/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-charlie/view.asset.php
@@ -1,9 +1,14 @@
 <?php return array(
 	'dependencies' => array(
 		'@wordpress/interactivity',
-		'test/router-script-modules-charlie',
+		'test/router-script-modules-charlie-1',
+		'test/router-script-modules-initial-1',
 		array(
-			'id'     => 'test/router-script-modules-dynamic',
+			'id'     => 'test/router-script-modules-charlie-2',
+			'import' => 'dynamic',
+		),
+		array(
+			'id'     => 'test/router-script-modules-initial-2',
 			'import' => 'dynamic',
 		),
 	),

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-charlie/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-charlie/view.js
@@ -9,9 +9,18 @@ import { store } from '@wordpress/interactivity';
 // eslint-disable-next-line import/no-unresolved
 import name from 'test/router-script-modules-charlie';
 
-store( 'test/router-script-modules-charlie', {
+const { state } = store( 'test/router-script-modules-charlie', {
 	state: {
 		name,
+	},
+	actions: {
+		*updateName() {
+			const { default: suffix } = yield import(
+				// eslint-disable-next-line import/no-unresolved
+				'test/router-script-modules-dynamic'
+			);
+			state.name += ` (${ suffix })`;
+		},
 	},
 } );
 

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-charlie/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-charlie/view.js
@@ -7,22 +7,37 @@ import { store } from '@wordpress/interactivity';
  * External dependencies
  */
 // eslint-disable-next-line import/no-unresolved
-import name from 'test/router-script-modules-charlie';
+import nameStatic from 'test/router-script-modules-charlie-1';
+// eslint-disable-next-line import/no-unresolved
+import nameInitialStatic from 'test/router-script-modules-initial-1';
 
 const { state } = store( 'test/router-script-modules-charlie', {
 	state: {
-		name,
+		name: 'charlie',
 	},
 	actions: {
-		*updateName() {
-			const { default: suffix } = yield import(
+		updateFromStatic() {
+			state.name = nameStatic;
+		},
+		updateFromInitialStatic() {
+			state.name = nameInitialStatic;
+		},
+		*updateFromDynamic() {
+			const { default: nameDynamic } = yield import(
 				// eslint-disable-next-line import/no-unresolved
-				'test/router-script-modules-dynamic'
+				'test/router-script-modules-charlie-2'
 			);
-			state.name += ` (${ suffix })`;
+			state.name = nameDynamic;
+		},
+		*updateFromInitialDynamic() {
+			const { default: nameInitialDynamic } = yield import(
+				// eslint-disable-next-line import/no-unresolved
+				'test/router-script-modules-initial-2'
+			);
+			state.name = nameInitialDynamic;
 		},
 	},
 } );
 
 const { actions } = store( 'test/router-script-modules' );
-actions.pushName?.( name );
+actions.pushName?.( state.name );

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-wrapper/module-dynamic.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-wrapper/module-dynamic.js
@@ -1,0 +1,1 @@
+export default 'dynamic';

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-wrapper/module-dynamic.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-wrapper/module-dynamic.js
@@ -1,1 +1,0 @@
-export default 'dynamic';

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-wrapper/module-initial-1.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-wrapper/module-initial-1.js
@@ -1,0 +1,1 @@
+export default 'initial-1';

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-wrapper/module-initial-2.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-wrapper/module-initial-2.js
@@ -1,0 +1,1 @@
+export default 'initial-2';

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-wrapper/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-wrapper/render.php
@@ -7,6 +7,15 @@
  * @phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
  */
 
+$module_path = '/module-dynamic.js';
+$module_url  = plugins_url( $module_path, __FILE__ );
+wp_register_script_module(
+	'test/router-script-modules-dynamic',
+	$module_url,
+	array(),
+	filemtime( plugin_dir_path( __FILE__ ) . $module_path )
+);
+
 $wrapper_attributes = get_block_wrapper_attributes();
 ?>
 <div <?php echo $wrapper_attributes; ?>>

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-wrapper/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-wrapper/render.php
@@ -6,15 +6,17 @@
  *
  * @phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
  */
+$modules = array( 'initial-1', 'initial-2' );
 
-$module_path = '/module-dynamic.js';
-$module_url  = plugins_url( $module_path, __FILE__ );
-wp_register_script_module(
-	'test/router-script-modules-dynamic',
-	$module_url,
-	array(),
-	filemtime( plugin_dir_path( __FILE__ ) . $module_path )
-);
+foreach ( $modules as $module ) {
+	$module_path = '/module-' . $module . '.js';
+	wp_register_script_module(
+		'test/router-script-modules-' . $module,
+		plugins_url( $module_path, __FILE__ ),
+		array(),
+		filemtime( plugin_dir_path( __FILE__ ) . $module_path )
+	);
+}
 
 $wrapper_attributes = get_block_wrapper_attributes();
 ?>

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-wrapper/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-wrapper/view.asset.php
@@ -5,5 +5,10 @@
 			'id'     => '@wordpress/interactivity-router',
 			'import' => 'dynamic',
 		),
+		'test/router-script-modules-initial-1',
+		array(
+			'id'     => 'test/router-script-modules-initial-2',
+			'import' => 'dynamic',
+		),
 	),
 );

--- a/packages/interactivity-router/CHANGELOG.md
+++ b/packages/interactivity-router/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Bug Fixes
 
 -   Prevents duplicating nested router regions after a client-side navigation. ([#70302](https://github.com/WordPress/gutenberg/pull/70302))
+-   Fix dynamic imports on new visited pages. ([#70489](https://github.com/WordPress/gutenberg/pull/70489))
 
 ## 2.25.0 (2025-06-04)
 

--- a/packages/interactivity-router/src/assets/dynamic-importmap/index.ts
+++ b/packages/interactivity-router/src/assets/dynamic-importmap/index.ts
@@ -80,4 +80,8 @@ export async function preloadWithMap( id: string, importMapIn: ImportMap ) {
 	} );
 }
 
-export { importPreloadedModule, type ModuleLoad } from './loader';
+export {
+	initialImportMap,
+	importPreloadedModule,
+	type ModuleLoad,
+} from './loader';

--- a/packages/interactivity-router/src/assets/dynamic-importmap/index.ts
+++ b/packages/interactivity-router/src/assets/dynamic-importmap/index.ts
@@ -30,7 +30,7 @@ type ImportMap = {
 const baseUrl = document.baseURI;
 const pageBaseUrl = baseUrl;
 
-Object.defineProperty( self, 'importShim', {
+Object.defineProperty( self, 'wpInteractivityRouterImport', {
 	value: importShim,
 	writable: false,
 	enumerable: false,

--- a/packages/interactivity-router/src/assets/dynamic-importmap/index.ts
+++ b/packages/interactivity-router/src/assets/dynamic-importmap/index.ts
@@ -30,6 +30,13 @@ type ImportMap = {
 const baseUrl = document.baseURI;
 const pageBaseUrl = baseUrl;
 
+Object.defineProperty( self, 'importShim', {
+	value: importShim,
+	writable: false,
+	enumerable: false,
+	configurable: false,
+} );
+
 async function importShim< Module = unknown >( id: string ) {
 	await initPromise;
 	return topLevelLoad< Module >( resolve( id, pageBaseUrl ), {

--- a/packages/interactivity-router/src/assets/dynamic-importmap/loader.ts
+++ b/packages/interactivity-router/src/assets/dynamic-importmap/loader.ts
@@ -190,8 +190,8 @@ function resolveDeps( load: ModuleLoad, seen: Record< string, any > ) {
 			}
 			// dynamic import
 			else {
-				pushStringTo( statementStart + 6 );
-				resolvedSource += `Shim(`;
+				pushStringTo( statementStart );
+				resolvedSource += `wpInteractivityRouterImport(`;
 				dynamicImportEndStack.push( statementEnd - 1 );
 				lastIndex = start;
 			}

--- a/packages/interactivity-router/src/assets/dynamic-importmap/loader.ts
+++ b/packages/interactivity-router/src/assets/dynamic-importmap/loader.ts
@@ -50,6 +50,19 @@ const skip = ( id ) =>
 const fetchCache: Record< string, Promise< ModuleLoad > > = {};
 export const registry = {};
 
+// Init registry with importamp content.
+Object.keys(
+	JSON.parse(
+		document.querySelector< HTMLScriptElement >(
+			'script#wp-importmap[type=importmap]'
+		).text
+	).imports
+).forEach( ( id ) => {
+	registry[ id ] = {
+		blobUrl: id,
+	};
+} );
+
 async function loadAll( load: ModuleLoad, seen: Record< string, any > ) {
 	if ( load.blobUrl || seen[ load.url ] ) {
 		return;

--- a/packages/interactivity-router/src/assets/dynamic-importmap/loader.ts
+++ b/packages/interactivity-router/src/assets/dynamic-importmap/loader.ts
@@ -38,26 +38,32 @@ export interface ModuleLoad {
 
 export const initPromise = lexer.init;
 
-const skip = ( id ) =>
-	Object.keys(
-		JSON.parse(
-			document.querySelector< HTMLScriptElement >(
-				'script#wp-importmap[type=importmap]'
-			).text
-		).imports
-	).includes( id );
+/**
+ * Script element containing the initial page's import map.
+ */
+const initialImportMapElement =
+	window.document.querySelector< HTMLScriptElement >(
+		'script#wp-importmap[type=importmap]'
+	);
+
+/**
+ * Data from the initial page's import map.
+ *
+ * Pages containing any of the imports present on the original page
+ * in their import maps should ignore them, as those imports would
+ * be handled natively.
+ */
+export const initialImportMap = initialImportMapElement
+	? JSON.parse( initialImportMapElement.text )
+	: { imports: {}, scopes: {} };
+
+const skip = ( id ) => Object.keys( initialImportMap.imports ).includes( id );
 
 const fetchCache: Record< string, Promise< ModuleLoad > > = {};
 export const registry = {};
 
 // Init registry with importamp content.
-Object.keys(
-	JSON.parse(
-		document.querySelector< HTMLScriptElement >(
-			'script#wp-importmap[type=importmap]'
-		).text
-	).imports
-).forEach( ( id ) => {
+Object.keys( initialImportMap.imports ).forEach( ( id ) => {
 	registry[ id ] = {
 		blobUrl: id,
 	};

--- a/packages/interactivity-router/src/assets/script-modules.ts
+++ b/packages/interactivity-router/src/assets/script-modules.ts
@@ -2,29 +2,11 @@
  * Internal dependencies
  */
 import {
+	initialImportMap,
 	importPreloadedModule,
 	preloadWithMap,
 	type ModuleLoad,
 } from './dynamic-importmap';
-
-/**
- * Script element containing the initial page's import map.
- */
-const initialImportMapElement =
-	window.document.querySelector< HTMLScriptElement >(
-		'script#wp-importmap[type=importmap]'
-	);
-
-/**
- * Data from the initial page's import map.
- *
- * Pages containing any of the imports present on the original page
- * in their import maps should ignore them, as those imports would
- * be handled natively.
- */
-const initialImportMap = initialImportMapElement
-	? JSON.parse( initialImportMapElement.text )
-	: { imports: {}, scopes: {} };
 
 /**
  * IDs of modules that should be resolved by the browser rather than

--- a/test/e2e/specs/interactivity/router-script-modules.spec.ts
+++ b/test/e2e/specs/interactivity/router-script-modules.spec.ts
@@ -93,12 +93,14 @@ test.describe( 'Router script modules', () => {
 			await page.getByTestId( 'link alpha' ).click();
 
 			// This element disappears when a navigation starts.
-			// It should be visible again after a successful navigation.
 			await expect( csn ).toBeHidden();
-			await expect( csn ).toBeVisible();
 
 			// Check the page title to ensure navigation was successful.
 			await expect( page ).toHaveTitle( 'alpha – gutenberg' );
+
+			// This should be visible again after a successful client-side
+			// navigation.
+			await expect( csn ).toBeVisible();
 
 			await expect( alpha ).toBeVisible();
 			await expect( bravo ).toBeHidden();
@@ -115,8 +117,8 @@ test.describe( 'Router script modules', () => {
 			await page.getByTestId( 'link bravo' ).click();
 
 			await expect( csn ).toBeHidden();
-			await expect( csn ).toBeVisible();
 			await expect( page ).toHaveTitle( 'bravo – gutenberg' );
+			await expect( csn ).toBeVisible();
 
 			await expect( alpha ).toBeHidden();
 			await expect( bravo ).toBeVisible();
@@ -130,8 +132,8 @@ test.describe( 'Router script modules', () => {
 			await page.getByTestId( 'link charlie' ).click();
 
 			await expect( csn ).toBeHidden();
-			await expect( csn ).toBeVisible();
 			await expect( page ).toHaveTitle( 'charlie – gutenberg' );
+			await expect( csn ).toBeVisible();
 
 			await expect( alpha ).toBeHidden();
 			await expect( bravo ).toBeHidden();
@@ -145,8 +147,8 @@ test.describe( 'Router script modules', () => {
 			await page.getByTestId( 'link all' ).click();
 
 			await expect( csn ).toBeHidden();
-			await expect( csn ).toBeVisible();
 			await expect( page ).toHaveTitle( 'all – gutenberg' );
+			await expect( csn ).toBeVisible();
 
 			await expect( alpha ).toBeVisible();
 			await expect( bravo ).toBeVisible();

--- a/test/e2e/specs/interactivity/router-script-modules.spec.ts
+++ b/test/e2e/specs/interactivity/router-script-modules.spec.ts
@@ -55,77 +55,112 @@ test.describe( 'Router script modules', () => {
 		await utils.deleteAllPosts();
 	} );
 
-	test( 'should handle modules from new blocks', async ( { page } ) => {
-		const requestedModules = [];
+	for ( const [ testId, buttonId, expectedValues ] of [
+		[
+			'static modules from new blocks',
+			'static',
+			{ alpha: 'alpha-1', bravo: 'bravo-1', charlie: 'charlie-1' },
+		],
+		[
+			'dynamic modules from new blocks',
+			'dynamic',
+			{ alpha: 'alpha-2', bravo: 'bravo-2', charlie: 'charlie-2' },
+		],
+		[
+			'static modules from initial page',
+			'initial-static',
+			{ alpha: 'initial-1', bravo: 'initial-1', charlie: 'initial-1' },
+		],
+		[
+			'dynamic modules from initial page',
+			'initial-dynamic',
+			{ alpha: 'initial-2', bravo: 'initial-2', charlie: 'initial-2' },
+		],
+	] as const ) {
+		test( `should handle ${ testId }`, async ( { page } ) => {
+			const requestedModules = [];
 
-		await page.route( '**/*.js*', async ( route ) => {
-			requestedModules.push( route.request().url() );
-			await route.continue();
+			await page.route( '**/*.js*', async ( route ) => {
+				requestedModules.push( route.request().url() );
+				await route.continue();
+			} );
+
+			const csn = page.getByTestId( 'client-side navigation' );
+			const alpha = page.getByTestId( 'alpha-block' );
+			const bravo = page.getByTestId( 'bravo-block' );
+			const charlie = page.getByTestId( 'charlie-block' );
+
+			await page.getByTestId( 'link alpha' ).click();
+
+			// This element disappears when a navigation starts.
+			// It should be visible again after a successful navigation.
+			await expect( csn ).toBeHidden();
+			await expect( csn ).toBeVisible();
+
+			// Check the page title to ensure navigation was successful.
+			await expect( page ).toHaveTitle( 'alpha – gutenberg' );
+
+			await expect( alpha ).toBeVisible();
+			await expect( bravo ).toBeHidden();
+			await expect( charlie ).toBeHidden();
+			await expect( alpha.getByTestId( 'text' ) ).toHaveText( 'alpha' );
+
+			// This click executes an action that does a dynamic import and
+			// modifies the block text.
+			await alpha.getByTestId( buttonId ).click();
+			await expect( alpha.getByTestId( 'text' ) ).toHaveText(
+				expectedValues.alpha
+			);
+
+			await page.getByTestId( 'link bravo' ).click();
+
+			await expect( csn ).toBeHidden();
+			await expect( csn ).toBeVisible();
+			await expect( page ).toHaveTitle( 'bravo – gutenberg' );
+
+			await expect( alpha ).toBeHidden();
+			await expect( bravo ).toBeVisible();
+			await expect( charlie ).toBeHidden();
+
+			await bravo.getByTestId( buttonId ).click();
+			await expect( bravo.getByTestId( 'text' ) ).toHaveText(
+				expectedValues.bravo
+			);
+
+			await page.getByTestId( 'link charlie' ).click();
+
+			await expect( csn ).toBeHidden();
+			await expect( csn ).toBeVisible();
+			await expect( page ).toHaveTitle( 'charlie – gutenberg' );
+
+			await expect( alpha ).toBeHidden();
+			await expect( bravo ).toBeHidden();
+			await expect( charlie ).toBeVisible();
+
+			await charlie.getByTestId( buttonId ).click();
+			await expect( charlie.getByTestId( 'text' ) ).toHaveText(
+				expectedValues.charlie
+			);
+
+			await page.getByTestId( 'link all' ).click();
+
+			await expect( csn ).toBeHidden();
+			await expect( csn ).toBeVisible();
+			await expect( page ).toHaveTitle( 'all – gutenberg' );
+
+			await expect( alpha ).toBeVisible();
+			await expect( bravo ).toBeVisible();
+			await expect( charlie ).toBeVisible();
+
+			await expect( alpha.getByTestId( 'text' ) ).toHaveText(
+				expectedValues.alpha
+			);
+			await expect( bravo.getByTestId( 'text' ) ).toHaveText(
+				expectedValues.bravo
+			);
+			await expect( charlie.getByTestId( 'text' ) ).toHaveText(
+				expectedValues.charlie
+			);
 		} );
-
-		const csn = page.getByTestId( 'client-side navigation' );
-		const alpha = page.getByTestId( 'alpha-block' );
-		const bravo = page.getByTestId( 'bravo-block' );
-		const charlie = page.getByTestId( 'charlie-block' );
-
-		await page.getByTestId( 'link alpha' ).click();
-
-		// This element disappears when a navigation starts.
-		// It should be visible again after a successful navigation.
-		await expect( csn ).toBeHidden();
-		await expect( csn ).toBeVisible();
-
-		// Check the page title to ensure navigation was successful.
-		await expect( page ).toHaveTitle( 'alpha – gutenberg' );
-
-		await expect( alpha ).toBeVisible();
-		await expect( bravo ).toBeHidden();
-		await expect( charlie ).toBeHidden();
-		await expect( alpha ).toHaveText( 'alpha' );
-
-		// This click executes an action that does a dynamic import and
-		// modifies the block text.
-		await alpha.click();
-		await expect( alpha ).toHaveText( 'alpha (dynamic)' );
-
-		await page.getByTestId( 'link bravo' ).click();
-
-		await expect( csn ).toBeHidden();
-		await expect( csn ).toBeVisible();
-		await expect( page ).toHaveTitle( 'bravo – gutenberg' );
-
-		await expect( alpha ).toBeHidden();
-		await expect( bravo ).toBeVisible();
-		await expect( charlie ).toBeHidden();
-
-		await bravo.click();
-		await expect( bravo ).toHaveText( 'bravo (dynamic)' );
-
-		await page.getByTestId( 'link charlie' ).click();
-
-		await expect( csn ).toBeHidden();
-		await expect( csn ).toBeVisible();
-		await expect( page ).toHaveTitle( 'charlie – gutenberg' );
-
-		await expect( alpha ).toBeHidden();
-		await expect( bravo ).toBeHidden();
-		await expect( charlie ).toBeVisible();
-
-		await charlie.click();
-		await expect( charlie ).toHaveText( 'charlie (dynamic)' );
-
-		await page.getByTestId( 'link all' ).click();
-
-		await expect( csn ).toBeHidden();
-		await expect( csn ).toBeVisible();
-		await expect( page ).toHaveTitle( 'all – gutenberg' );
-
-		await expect( alpha ).toBeVisible();
-		await expect( bravo ).toBeVisible();
-		await expect( charlie ).toBeVisible();
-
-		await expect( alpha ).toHaveText( 'alpha (dynamic)' );
-		await expect( bravo ).toHaveText( 'bravo (dynamic)' );
-		await expect( charlie ).toHaveText( 'charlie (dynamic)' );
-	} );
+	}
 } );

--- a/test/e2e/specs/interactivity/router-script-modules.spec.ts
+++ b/test/e2e/specs/interactivity/router-script-modules.spec.ts
@@ -81,6 +81,12 @@ test.describe( 'Router script modules', () => {
 		await expect( alpha ).toBeVisible();
 		await expect( bravo ).toBeHidden();
 		await expect( charlie ).toBeHidden();
+		await expect( alpha ).toHaveText( 'alpha' );
+
+		// This click executes an action that does a dynamic import and
+		// modifies the block text.
+		await alpha.click();
+		await expect( alpha ).toHaveText( 'alpha (dynamic)' );
 
 		await page.getByTestId( 'link bravo' ).click();
 
@@ -92,6 +98,9 @@ test.describe( 'Router script modules', () => {
 		await expect( bravo ).toBeVisible();
 		await expect( charlie ).toBeHidden();
 
+		await bravo.click();
+		await expect( bravo ).toHaveText( 'bravo (dynamic)' );
+
 		await page.getByTestId( 'link charlie' ).click();
 
 		await expect( csn ).toBeHidden();
@@ -102,6 +111,9 @@ test.describe( 'Router script modules', () => {
 		await expect( bravo ).toBeHidden();
 		await expect( charlie ).toBeVisible();
 
+		await charlie.click();
+		await expect( charlie ).toHaveText( 'charlie (dynamic)' );
+
 		await page.getByTestId( 'link all' ).click();
 
 		await expect( csn ).toBeHidden();
@@ -111,5 +123,9 @@ test.describe( 'Router script modules', () => {
 		await expect( alpha ).toBeVisible();
 		await expect( bravo ).toBeVisible();
 		await expect( charlie ).toBeVisible();
+
+		await expect( alpha ).toHaveText( 'alpha (dynamic)' );
+		await expect( bravo ).toHaveText( 'bravo (dynamic)' );
+		await expect( charlie ).toHaveText( 'charlie (dynamic)' );
 	} );
 } );


### PR DESCRIPTION
## What?

Fixes a bug in dynamic imports that was not covered by e2e tests.

## Why?

Modules from newly visited pages can have dynamic dependencies. As these pages can have different import maps, the modules are processed by the Interactivity Router to resolve their dependencies. The library on which our implementation is based uses a global function called [`importShim`](https://github.com/keller-mark/dynamic-importmap/blob/05543cf1a26f32ed0951b84ea808851b8e337ab7/src/index.js#L431). That function is in our code, but it's not globally accessible by mistake.

This can cause client-side navigation to fail occasionally when the full-page client-side navigation experimental feature is enabled, showing this error in the console:

```
Uncaught (in promise) ReferenceError: importShim is not defined
    at @wordpress/interactivity-router (interactivity-router":1:1)
    at __webpack_require__ (bootstrap:19:1)
    at async wrapped (utils.ts:168:14)
```

Additionally, modules listed in the initial import map fail whenever a new module attempts to import them dynamically.

## How?

Adding the missing function to `self` and initializing the modules that are present in the initial import map.

## Testing Instructions

1. In the admin panel of your test site, go to Gutenberg > Experiments and enable the full-page client-side navigation feature.
2. Visit a page or a post on your site.
3. Click on the link that directs to the homepage (or any other page with a Query block containing pagination blocks).
4. Hover on the Next Page block.
5. Without the bug fix, the console error mentioned above appears. Ensure it doesn't appear, and the navigation was successful.

There are new e2e tests to cover the missing cases.