### PR TITLE
RSS Block: Decode HTML entities in feed titles before display

### DIFF
--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -46,7 +46,7 @@ function render_block_core_rss( $attributes ) {
 	}
 
 	foreach ( $rss_items as $item ) {
-		$title = esc_html( trim( strip_tags( $item->get_title() ) ) );
+		$title = esc_html( trim( strip_tags( html_entity_decode( $item->get_title(), ENT_QUOTES, get_option( 'blog_charset' ) ) ) ) );
 		if ( empty( $title ) ) {
 			$title = __( '(no title)' );
 		}

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -46,7 +46,7 @@ function render_block_core_rss( $attributes ) {
 	}
 
 	foreach ( $rss_items as $item ) {
-		$title = esc_html( trim( strip_tags( html_entity_decode( $item->get_title(), ENT_QUOTES, get_option( 'blog_charset' ) ) ) ) );
+		$title = esc_html( trim( strip_tags( html_entity_decode( $item->get_title() ) ) ) );
 		if ( empty( $title ) ) {
 			$title = __( '(no title)' );
 		}

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -47,6 +47,7 @@ function render_block_core_rss( $attributes ) {
 
 	foreach ( $rss_items as $item ) {
 		$title = esc_html( trim( strip_tags( html_entity_decode( $item->get_title() ) ) ) );
+
 		if ( empty( $title ) ) {
 			$title = __( '(no title)' );
 		}


### PR DESCRIPTION
## What?

Closes #70477
Follows the implementation of: https://github.com/WordPress/wordpress-develop/pull/9042 by @Infinite-Null 
Related Trac ticket: https://core.trac.wordpress.org/ticket/63611

Fixes RSS Block to properly handle HTML entities in feed titles by decoding them before stripping tags and escaping for display.

## Why?

RSS feeds from third-party sources sometimes include HTML entities in their titles. Currently, these entities are displayed as literal text instead of being properly decoded and stripped, resulting in unsightly `&lt;em&gt;` appearing in the rendered titles on the frontend.


## How?

Modified the title processing in `packages/block-library/src/rss/index.php` to:
1. First, decode HTML entities using `html_entity_decode()` with appropriate flags
2. Then strip HTML tags as before
3. Finally, escape the result for safe HTML output


## Testing Instructions
1. Create a new post or page in the editor
2. Add an RSS block
3. Use some RSS feed URL ([example URL](https://pubmed.ncbi.nlm.nih.gov/rss/search/16cUU5Jcud0BSYRzHgbqJGm_F6kq07gr9atM8kZoogUmZdX5oj/) )
4. Save and view the page on the frontend
5. Verify that everything works as expected


## Screenshots 



|Before|After|
|-|-|
|<img width="731" alt="Screenshot 2025-06-23 at 13 04 30" src="https://github.com/user-attachments/assets/0592b3c3-ad1b-4ddf-ab82-87f566f40fbf" />|<img width="698" alt="Screenshot 2025-06-23 at 13 05 00" src="https://github.com/user-attachments/assets/bf89d5c8-1380-424b-965d-9ff0f0712178" />|
