### PR TITLE
Add support for custom label in archive dropdown

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -15,7 +15,7 @@ Display a date archive of your posts. ([Source](https://github.com/WordPress/gut
 -	**Name:** core/archives
 -	**Category:** widgets
 -	**Supports:** align, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** displayAsDropdown, label, showLabel, showPostCounts, type
+-	**Attributes:** displayAsDropdown, isEditor, label, showLabel, showPostCounts, type
 
 ## Audio
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -15,7 +15,7 @@ Display a date archive of your posts. ([Source](https://github.com/WordPress/gut
 -	**Name:** core/archives
 -	**Category:** widgets
 -	**Supports:** align, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** displayAsDropdown, showLabel, showPostCounts, type
+-	**Attributes:** displayAsDropdown, label, showLabel, showPostCounts, type
 
 ## Audio
 

--- a/packages/block-library/src/archives/block.json
+++ b/packages/block-library/src/archives/block.json
@@ -15,6 +15,10 @@
 			"type": "boolean",
 			"default": true
 		},
+		"label": {
+			"type": "string",
+			"default": "Archives"
+		},
 		"showPostCounts": {
 			"type": "boolean",
 			"default": false

--- a/packages/block-library/src/archives/block.json
+++ b/packages/block-library/src/archives/block.json
@@ -17,7 +17,11 @@
 		},
 		"label": {
 			"type": "string",
-			"default": "Archives"
+			"default": ""
+		},
+		"isEditor": {
+			"type": "boolean",
+			"default": false
 		},
 		"showPostCounts": {
 			"type": "boolean",

--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -7,12 +7,14 @@ import {
 	Disabled,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
-	TextControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	useBlockProps,
+	RichText,
+} from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
-import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -24,6 +26,10 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 		attributes;
 
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+
+	// Clone the attributes to avoid mutating the original object and add the `isEditor` property.
+	const propsAttributes = structuredClone( attributes );
+	propsAttributes.isEditor = true;
 
 	return (
 		<>
@@ -61,48 +67,25 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 					</ToolsPanelItem>
 
 					{ displayAsDropdown && (
-						<Fragment>
-							<ToolsPanelItem
+						<ToolsPanelItem
+							label={ __( 'Show label' ) }
+							isShownByDefault
+							hasValue={ () => ! showLabel }
+							onDeselect={ () =>
+								setAttributes( { showLabel: true } )
+							}
+						>
+							<ToggleControl
+								__nextHasNoMarginBottom
 								label={ __( 'Show label' ) }
-								isShownByDefault
-								hasValue={ () => ! showLabel }
-								onDeselect={ () =>
-									setAttributes( { showLabel: true } )
+								checked={ showLabel }
+								onChange={ () =>
+									setAttributes( {
+										showLabel: ! showLabel,
+									} )
 								}
-							>
-								<ToggleControl
-									__nextHasNoMarginBottom
-									label={ __( 'Show label' ) }
-									checked={ showLabel }
-									onChange={ () =>
-										setAttributes( {
-											showLabel: ! showLabel,
-										} )
-									}
-								/>
-							</ToolsPanelItem>
-							{ showLabel && (
-								<ToolsPanelItem
-									label={ __( 'Label' ) }
-									isShownByDefault
-									hasValue={ () => !! label }
-									onDeselect={ () =>
-										setAttributes( { label: '' } )
-									}
-								>
-									<TextControl
-										__nextHasNoMarginBottom
-										__next40pxDefaultSize
-										label={ __( 'Label' ) }
-										value={ label }
-										onChange={ ( value ) =>
-											setAttributes( { label: value } )
-										}
-										placeholder={ __( 'Archives' ) }
-									/>
-								</ToolsPanelItem>
-							) }
-						</Fragment>
+							/>
+						</ToolsPanelItem>
 					) }
 
 					<ToolsPanelItem
@@ -152,11 +135,24 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 				</ToolsPanel>
 			</InspectorControls>
 			<div { ...useBlockProps() }>
+				{ displayAsDropdown && showLabel && (
+					<RichText
+						tagName="label"
+						value={ label }
+						className="wp-block-archives__label"
+						// htmlFor={ instanceId }
+						onChange={ ( value ) =>
+							setAttributes( { label: value } )
+						}
+						placeholder={ __( 'Archives' ) }
+						aria-label={ __( 'Archives label' ) }
+					/>
+				) }
 				<Disabled>
 					<ServerSideRender
 						block="core/archives"
 						skipBlockSupportAttributes
-						attributes={ attributes }
+						attributes={ propsAttributes }
 					/>
 				</Disabled>
 			</div>

--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -7,10 +7,12 @@ import {
 	Disabled,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	TextControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
+import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -18,7 +20,8 @@ import ServerSideRender from '@wordpress/server-side-render';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 export default function ArchivesEdit( { attributes, setAttributes } ) {
-	const { showLabel, showPostCounts, displayAsDropdown, type } = attributes;
+	const { showLabel, label, showPostCounts, displayAsDropdown, type } =
+		attributes;
 
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
@@ -58,25 +61,48 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 					</ToolsPanelItem>
 
 					{ displayAsDropdown && (
-						<ToolsPanelItem
-							label={ __( 'Show label' ) }
-							isShownByDefault
-							hasValue={ () => ! showLabel }
-							onDeselect={ () =>
-								setAttributes( { showLabel: true } )
-							}
-						>
-							<ToggleControl
-								__nextHasNoMarginBottom
+						<Fragment>
+							<ToolsPanelItem
 								label={ __( 'Show label' ) }
-								checked={ showLabel }
-								onChange={ () =>
-									setAttributes( {
-										showLabel: ! showLabel,
-									} )
+								isShownByDefault
+								hasValue={ () => ! showLabel }
+								onDeselect={ () =>
+									setAttributes( { showLabel: true } )
 								}
-							/>
-						</ToolsPanelItem>
+							>
+								<ToggleControl
+									__nextHasNoMarginBottom
+									label={ __( 'Show label' ) }
+									checked={ showLabel }
+									onChange={ () =>
+										setAttributes( {
+											showLabel: ! showLabel,
+										} )
+									}
+								/>
+							</ToolsPanelItem>
+							{ showLabel && (
+								<ToolsPanelItem
+									label={ __( 'Label' ) }
+									isShownByDefault
+									hasValue={ () => !! label }
+									onDeselect={ () =>
+										setAttributes( { label: '' } )
+									}
+								>
+									<TextControl
+										__nextHasNoMarginBottom
+										__next40pxDefaultSize
+										label={ __( 'Label' ) }
+										value={ label }
+										onChange={ ( value ) =>
+											setAttributes( { label: value } )
+										}
+										placeholder={ __( 'Archives' ) }
+									/>
+								</ToolsPanelItem>
+							) }
+						</Fragment>
 					) }
 
 					<ToolsPanelItem

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -19,6 +19,7 @@
 function render_block_core_archives( $attributes ) {
 	$show_post_count = ! empty( $attributes['showPostCounts'] );
 	$type            = isset( $attributes['type'] ) ? $attributes['type'] : 'monthly';
+	$label           = isset( $attributes['label'] ) ? $attributes['label'] : __( 'Archives' );
 
 	$class = 'wp-block-archives-list';
 
@@ -27,7 +28,7 @@ function render_block_core_archives( $attributes ) {
 		$class = 'wp-block-archives-dropdown';
 
 		$dropdown_id = wp_unique_id( 'wp-block-archives-' );
-		$title       = __( 'Archives' );
+		$title       = $label;
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-archives.php */
 		$dropdown_args = apply_filters(

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -20,6 +20,7 @@ function render_block_core_archives( $attributes ) {
 	$show_post_count = ! empty( $attributes['showPostCounts'] );
 	$type            = isset( $attributes['type'] ) ? $attributes['type'] : 'monthly';
 	$label           = isset( $attributes['label'] ) ? $attributes['label'] : __( 'Archives' );
+	$is_editor	     = isset( $attributes['isEditor'] ) ? $attributes['isEditor'] : false;
 
 	$class = 'wp-block-archives-list';
 
@@ -28,7 +29,7 @@ function render_block_core_archives( $attributes ) {
 		$class = 'wp-block-archives-dropdown';
 
 		$dropdown_id = wp_unique_id( 'wp-block-archives-' );
-		$title       = $label;
+		$title       = ! empty( $label ) ? $label : __( 'Archives' );
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-archives.php */
 		$dropdown_args = apply_filters(
@@ -66,8 +67,13 @@ function render_block_core_archives( $attributes ) {
 
 		$show_label = empty( $attributes['showLabel'] ) ? ' screen-reader-text' : '';
 
-		$block_content = '<label for="' . $dropdown_id . '" class="wp-block-archives__label' . $show_label . '">' . esc_html( $title ) . '</label>
-		<select id="' . $dropdown_id . '" name="archive-dropdown" onchange="document.location.href=this.options[this.selectedIndex].value;">
+		$block_content = '';
+
+		if ( ! $is_editor ) {
+			$block_content .= '<label for="' . $dropdown_id . '" class="wp-block-archives__label' . $show_label . '">' . wp_kses_data( $title ) . '</label>';
+		}
+
+		$block_content .= '<select id="' . $dropdown_id . '" name="archive-dropdown" onchange="document.location.href=this.options[this.selectedIndex].value;">
 		<option value="">' . esc_html( $label ) . '</option>' . $archives . '</select>';
 
 		return sprintf(

--- a/packages/components/src/tree-select/README.md
+++ b/packages/components/src/tree-select/README.md
@@ -127,7 +127,7 @@ If this property is added, an option will be added with this label to represent 
 
 ### `onChange`
 
- - Type: `(value: NoInfer<V>, extra?: { event?: ChangeEvent<HTMLSelectElement>; }) => void`
+ - Type: `(value: string, extra?: { event?: ChangeEvent<HTMLSelectElement>; }) => void`
  - Required: No
 
 A function that receives the value of the new option that is being selected as input.
@@ -165,7 +165,7 @@ import {
 
 ### `selectedId`
 
- - Type: `NoInfer<V>`
+ - Type: `string`
  - Required: No
 
 The id of the currently selected node.

--- a/packages/components/src/tree-select/README.md
+++ b/packages/components/src/tree-select/README.md
@@ -127,7 +127,7 @@ If this property is added, an option will be added with this label to represent 
 
 ### `onChange`
 
- - Type: `(value: string, extra?: { event?: ChangeEvent<HTMLSelectElement>; }) => void`
+ - Type: `(value: NoInfer<V>, extra?: { event?: ChangeEvent<HTMLSelectElement>; }) => void`
  - Required: No
 
 A function that receives the value of the new option that is being selected as input.
@@ -165,7 +165,7 @@ import {
 
 ### `selectedId`
 
- - Type: `string`
+ - Type: `NoInfer<V>`
  - Required: No
 
 The id of the currently selected node.


### PR DESCRIPTION
[Fixes](https://github.com/WordPress/gutenberg/issues/57528)
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR makes the label above the Archives block dropdown editable by introducing a TextControl field in the block’s settings panel.

## Why?
Currently, when the Archives block is set to display as a dropdown, there is an option to show a label above it. However, this label is hardcoded as "Archives" and cannot be customized by the user.

## How?
1. Added a new label attribute to the block with a default value of "Archives":
```json
"label": {
  "type": "string",
  "default": "Archives"
}
```
2. Updated the edit function to include a TextControl UI component in the sidebar settings:
```js
<TextControl
  __nextHasNoMarginBottom
  __next40pxDefaultSize
  label={ __( 'Label' ) }
  value={ label }
  onChange={ ( value ) => setAttributes( { label: value } ) }
  placeholder={ __( 'Archives' ) }
/>
```

## Testing Instructions
1. Open the post or page editor.
2. Add the "Archives" block.
3. In the block settings sidebar, enable "Display as dropdown".
4. Enable "Show label".
5. Confirm that a TextControl appears allowing you to edit the label.

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2025-06-23 at 7 37 55 PM](https://github.com/user-attachments/assets/a24e401f-a285-4ad9-b53a-6517a57cb8a8)

![Screenshot 2025-06-23 at 1 53 22 PM](https://github.com/user-attachments/assets/47c5d431-6aeb-44c3-8b0a-6aa6a2112ebd)

