### PR TITLE
Try using responsive images in dataview grid layouts

### DIFF
--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -47,6 +47,9 @@ type DataViewsContextType< Item > = {
 	isItemClickable: ( item: Item ) => boolean;
 	containerWidth: number;
 	containerRef: React.MutableRefObject< HTMLDivElement | null >;
+	resizeObserverRef:
+		| ( ( element?: HTMLDivElement | null ) => void )
+		| React.RefObject< HTMLDivElement >;
 	defaultLayouts: SupportedLayouts;
 	filters: NormalizedFilter[];
 	isShowingFilter: boolean;
@@ -72,6 +75,7 @@ const DataViewsContext = createContext< DataViewsContextType< any > >( {
 	renderItemLink: undefined,
 	containerWidth: 0,
 	containerRef: createRef(),
+	resizeObserverRef: () => {},
 	defaultLayouts: { list: {}, grid: {}, table: {} },
 	filters: [],
 	isShowingFilter: false,

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -8,7 +8,7 @@ import type { ReactNode, ComponentProps, ReactElement } from 'react';
  */
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useContext, useMemo, useRef, useState } from '@wordpress/element';
-import { useMergeRefs, useResizeObserver } from '@wordpress/compose';
+import { useResizeObserver } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -193,6 +193,7 @@ function DataViews< Item >( {
 				renderItemLink,
 				containerWidth,
 				containerRef,
+				resizeObserverRef,
 				defaultLayouts,
 				filters,
 				isShowingFilter,
@@ -200,10 +201,7 @@ function DataViews< Item >( {
 				perPageSizes,
 			} }
 		>
-			<div
-				className="dataviews-wrapper"
-				ref={ useMergeRefs( [ containerRef, resizeObserverRef ] ) }
-			>
+			<div className="dataviews-wrapper" ref={ containerRef }>
 				{ children ?? (
 					<DefaultUI
 						header={ header }

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -61,8 +61,8 @@ interface GridItemProps< Item > {
 	regularFields: NormalizedField< Item >[];
 	badgeFields: NormalizedField< Item >[];
 	hasBulkActions: boolean;
-	mediaAppearance: {
-		maxImageWidth: string;
+	config: {
+		size: string;
 	};
 }
 
@@ -82,7 +82,7 @@ function GridItem< Item >( {
 	regularFields,
 	badgeFields,
 	hasBulkActions,
-	mediaAppearance,
+	config,
 }: GridItemProps< Item > ) {
 	const { showTitle = true, showMedia = true, showDescription = true } = view;
 	const hasBulkAction = useHasAPossibleBulkAction( actions, item );
@@ -93,7 +93,7 @@ function GridItem< Item >( {
 		<mediaField.render
 			item={ item }
 			field={ mediaField }
-			mediaAppearance={ mediaAppearance }
+			config={ config }
 		/>
 	) : null;
 	const renderedTitleField =
@@ -297,6 +297,8 @@ function ViewGrid< Item >( {
 	const hasData = !! data?.length;
 	const hasBulkActions = useSomeItemHasAPossibleBulkAction( actions, data );
 	const usedPreviewSize = view.layout?.previewSize;
+	// This is the maximum width that an image can achieve in the grid.
+	const size = '900px';
 
 	const groupField = view.groupByField
 		? fields.find( ( f ) => f.id === view.groupByField )
@@ -331,16 +333,18 @@ function ViewGrid< Item >( {
 											groupName
 										) }
 									</h3>
-									<Grid
-										gap={ 8 }
-										columns={ 2 }
-										alignment="top"
+									<div
 										className={ clsx(
 											'dataviews-view-grid',
 											className
 										) }
-										style={ gridStyle }
+										style={ {
+											gridTemplateColumns:
+												usedPreviewSize &&
+												`repeat(auto-fill, minmax(${ usedPreviewSize }px, 1fr))`,
+										} }
 										aria-busy={ isLoading }
+										ref={ resizeObserverRef }
 									>
 										{ groupItems.map( ( item ) => {
 											return (
@@ -373,10 +377,13 @@ function ViewGrid< Item >( {
 													hasBulkActions={
 														hasBulkActions
 													}
+													config={ {
+														size,
+													} }
 												/>
 											);
 										} ) }
-									</Grid>
+									</div>
 								</VStack>
 							)
 						) }
@@ -387,13 +394,15 @@ function ViewGrid< Item >( {
 			{
 				// Render a single grid with all data.
 				hasData && ! dataByGroup && (
-					<Grid
-						gap={ 8 }
-						columns={ 2 }
-						alignment="top"
+					<div
 						className={ clsx( 'dataviews-view-grid', className ) }
-						style={ gridStyle }
+						style={ {
+							gridTemplateColumns:
+								usedPreviewSize &&
+								`repeat(auto-fill, minmax(${ usedPreviewSize }px, 1fr))`,
+						} }
 						aria-busy={ isLoading }
+						ref={ resizeObserverRef }
 					>
 						{ data.map( ( item ) => {
 							return (
@@ -414,10 +423,13 @@ function ViewGrid< Item >( {
 									regularFields={ regularFields }
 									badgeFields={ badgeFields }
 									hasBulkActions={ hasBulkActions }
+									config={ {
+										size,
+									} }
 								/>
 							);
 						} ) }
-					</Grid>
+					</div>
 				)
 			}
 			{

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -3,12 +3,15 @@
  */
 import clsx from 'clsx';
 import type { ComponentProps, ReactElement } from 'react';
+/**
+ * WordPress dependencies
+ */
+import { useContext } from '@wordpress/element';
 
 /**
  * WordPress dependencies
  */
 import {
-	__experimentalGrid as Grid,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Spinner,
@@ -39,6 +42,7 @@ import type {
 import type { SetSelection } from '../../private-types';
 import { ItemClickWrapper } from '../utils/item-click-wrapper';
 const { Badge } = unlock( componentsPrivateApis );
+import DataViewsContext from '../../components/dataviews-context';
 
 interface GridItemProps< Item > {
 	view: ViewGridType;
@@ -257,6 +261,7 @@ function ViewGrid< Item >( {
 	view,
 	className,
 }: ViewGridProps< Item > ) {
+	const { containerRef } = useContext( DataViewsContext );
 	const titleField = fields.find(
 		( field ) => field.id === view?.titleField
 	);
@@ -289,11 +294,6 @@ function ViewGrid< Item >( {
 	const hasData = !! data?.length;
 	const hasBulkActions = useSomeItemHasAPossibleBulkAction( actions, data );
 	const usedPreviewSize = view.layout?.previewSize;
-	const gridStyle = usedPreviewSize
-		? {
-				gridTemplateColumns: `repeat(auto-fill, minmax(${ usedPreviewSize }px, 1fr))`,
-		  }
-		: {};
 
 	const groupField = view.groupByField
 		? fields.find( ( f ) => f.id === view.groupByField )

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -38,7 +38,6 @@ import type {
 } from '../../types';
 import type { SetSelection } from '../../private-types';
 import { ItemClickWrapper } from '../utils/item-click-wrapper';
-import { useUpdatedPreviewSizeOnViewportChange } from './preview-size-picker';
 const { Badge } = unlock( componentsPrivateApis );
 
 interface GridItemProps< Item > {
@@ -288,12 +287,11 @@ function ViewGrid< Item >( {
 		{ regularFields: [], badgeFields: [] }
 	);
 	const hasData = !! data?.length;
-	const updatedPreviewSize = useUpdatedPreviewSizeOnViewportChange();
 	const hasBulkActions = useSomeItemHasAPossibleBulkAction( actions, data );
-	const usedPreviewSize = updatedPreviewSize || view.layout?.previewSize;
+	const usedPreviewSize = view.layout?.previewSize;
 	const gridStyle = usedPreviewSize
 		? {
-				gridTemplateColumns: `repeat(${ usedPreviewSize }, minmax(0, 1fr))`,
+				gridTemplateColumns: `repeat(auto-fill, minmax(${ usedPreviewSize }px, 1fr))`,
 		  }
 		: {};
 

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -62,7 +62,7 @@ interface GridItemProps< Item > {
 	badgeFields: NormalizedField< Item >[];
 	hasBulkActions: boolean;
 	config: {
-		size: string;
+		sizes: string;
 	};
 }
 
@@ -378,7 +378,7 @@ function ViewGrid< Item >( {
 														hasBulkActions
 													}
 													config={ {
-														size,
+														sizes: size,
 													} }
 												/>
 											);
@@ -424,7 +424,7 @@ function ViewGrid< Item >( {
 									badgeFields={ badgeFields }
 									hasBulkActions={ hasBulkActions }
 									config={ {
-										size,
+										sizes: size,
 									} }
 								/>
 							);

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -61,7 +61,9 @@ interface GridItemProps< Item > {
 	regularFields: NormalizedField< Item >[];
 	badgeFields: NormalizedField< Item >[];
 	hasBulkActions: boolean;
-	sizes: string;
+	mediaAppearance: {
+		maxImageWidth: string;
+	};
 }
 
 function GridItem< Item >( {
@@ -80,7 +82,7 @@ function GridItem< Item >( {
 	regularFields,
 	badgeFields,
 	hasBulkActions,
-	sizes,
+	mediaAppearance,
 }: GridItemProps< Item > ) {
 	const { showTitle = true, showMedia = true, showDescription = true } = view;
 	const hasBulkAction = useHasAPossibleBulkAction( actions, item );
@@ -88,7 +90,11 @@ function GridItem< Item >( {
 	const instanceId = useInstanceId( GridItem );
 	const isSelected = selection.includes( id );
 	const renderedMediaField = mediaField?.render ? (
-		<mediaField.render item={ item } field={ mediaField } sizes={ sizes } />
+		<mediaField.render
+			item={ item }
+			field={ mediaField }
+			mediaAppearance={ mediaAppearance }
+		/>
 	) : null;
 	const renderedTitleField =
 		showTitle && titleField?.render ? (

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -86,7 +86,7 @@ function GridItem< Item >( {
 	const instanceId = useInstanceId( GridItem );
 	const isSelected = selection.includes( id );
 	const renderedMediaField = mediaField?.render ? (
-		<mediaField.render item={ item } field={ mediaField } />
+		<mediaField.render item={ item } field={ mediaField } view={ view } />
 	) : null;
 	const renderedTitleField =
 		showTitle && titleField?.render ? (

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -297,7 +297,12 @@ function ViewGrid< Item >( {
 	const hasData = !! data?.length;
 	const hasBulkActions = useSomeItemHasAPossibleBulkAction( actions, data );
 	const usedPreviewSize = view.layout?.previewSize;
-	// This is the maximum width that an image can achieve in the grid.
+	/*
+	 * This is the maximum width that an image can achieve in the grid. The reasoning is:
+	 * The biggest min image width available is 430px (see /dataviews-layouts/grid/preview-size-picker.tsx).
+	 * Because the grid is responsive, once there is room for another column, the images shrink to accommodate it.
+	 * So each image will never grow past 2*430px plus a little more to account for the gaps.
+	 */
 	const size = '900px';
 
 	const groupField = view.groupByField

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -3,10 +3,6 @@
  */
 import clsx from 'clsx';
 import type { ComponentProps, ReactElement } from 'react';
-/**
- * WordPress dependencies
- */
-import { useContext } from '@wordpress/element';
 
 /**
  * WordPress dependencies
@@ -22,6 +18,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
 import { isAppleOS } from '@wordpress/keycodes';
+import { useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -29,6 +26,7 @@ import { isAppleOS } from '@wordpress/keycodes';
 import { unlock } from '../../lock-unlock';
 import ItemActions from '../../components/dataviews-item-actions';
 import DataViewsSelectionCheckbox from '../../components/dataviews-selection-checkbox';
+import DataViewsContext from '../../components/dataviews-context';
 import {
 	useHasAPossibleBulkAction,
 	useSomeItemHasAPossibleBulkAction,
@@ -42,7 +40,6 @@ import type {
 import type { SetSelection } from '../../private-types';
 import { ItemClickWrapper } from '../utils/item-click-wrapper';
 const { Badge } = unlock( componentsPrivateApis );
-import DataViewsContext from '../../components/dataviews-context';
 
 interface GridItemProps< Item > {
 	view: ViewGridType;
@@ -261,7 +258,7 @@ function ViewGrid< Item >( {
 	view,
 	className,
 }: ViewGridProps< Item > ) {
-	const { containerRef } = useContext( DataViewsContext );
+	const { resizeObserverRef } = useContext( DataViewsContext );
 	const titleField = fields.find(
 		( field ) => field.id === view?.titleField
 	);

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -61,6 +61,7 @@ interface GridItemProps< Item > {
 	regularFields: NormalizedField< Item >[];
 	badgeFields: NormalizedField< Item >[];
 	hasBulkActions: boolean;
+	sizes: string;
 }
 
 function GridItem< Item >( {
@@ -79,6 +80,7 @@ function GridItem< Item >( {
 	regularFields,
 	badgeFields,
 	hasBulkActions,
+	sizes,
 }: GridItemProps< Item > ) {
 	const { showTitle = true, showMedia = true, showDescription = true } = view;
 	const hasBulkAction = useHasAPossibleBulkAction( actions, item );
@@ -86,7 +88,7 @@ function GridItem< Item >( {
 	const instanceId = useInstanceId( GridItem );
 	const isSelected = selection.includes( id );
 	const renderedMediaField = mediaField?.render ? (
-		<mediaField.render item={ item } field={ mediaField } view={ view } />
+		<mediaField.render item={ item } field={ mediaField } sizes={ sizes } />
 	) : null;
 	const renderedTitleField =
 		showTitle && titleField?.render ? (

--- a/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
@@ -11,16 +11,49 @@ import { useContext } from '@wordpress/element';
 import DataViewsContext from '../../components/dataviews-context';
 import type { ViewGrid } from '../../types';
 
-const MIN_IMG_SIZE = 230;
-const MAX_IMG_SIZE = 430;
+const imageSizes = [
+	{
+		value: 230,
+		breakpoint: 1,
+	},
+	{
+		value: 290,
+		breakpoint: 1112, // at minimum image width, 4 images display at this container size
+	},
+	{
+		value: 350,
+		breakpoint: 1636, // at minimum image width, 6 images display at this container size
+	},
+	{
+		value: 430,
+		breakpoint: 588, // at minimum image width, 2 images display at this container size
+	},
+];
 
 export default function PreviewSizePicker() {
 	const context = useContext( DataViewsContext );
 	const view = context.view as ViewGrid;
-	if ( context.containerWidth < MIN_IMG_SIZE * 2 + 128 ) {
+
+	if ( context.containerWidth < 588 ) {
 		return null;
 	}
-	const previewSizeToUse = view.layout?.previewSize ?? 230;
+
+	const breakValues = imageSizes.filter( ( size ) => {
+		return context.containerWidth >= size.breakpoint;
+	} );
+
+	const previewSizeToUse = view.layout?.previewSize
+		? breakValues.findIndex(
+				( size ) => size.value === view.layout?.previewSize
+		  )
+		: 0;
+
+	const marks = breakValues.map( ( size, index ) => {
+		return {
+			value: index,
+		};
+	} );
+
 	return (
 		<RangeControl
 			__nextHasNoMarginBottom
@@ -28,18 +61,20 @@ export default function PreviewSizePicker() {
 			showTooltip={ false }
 			label={ __( 'Preview size' ) }
 			value={ previewSizeToUse }
-			min={ MIN_IMG_SIZE }
-			max={ MAX_IMG_SIZE }
+			min={ 0 }
+			max={ breakValues.length - 1 }
 			withInputField={ false }
-			onChange={ ( value = 230 ) => {
+			onChange={ ( value = 0 ) => {
 				context.onChangeView( {
 					...view,
 					layout: {
 						...view.layout,
-						previewSize: value,
+						previewSize: breakValues[ value ].value,
 					},
 				} );
 			} }
+			step={ 1 }
+			marks={ marks }
 		/>
 	);
 }

--- a/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
@@ -42,10 +42,15 @@ export default function PreviewSizePicker() {
 		return context.containerWidth >= size.breakpoint;
 	} );
 
+	// If the container has resized and the set preview size is no longer available,
+	// we reset it to the next smallest size.
 	const previewSizeToUse = view.layout?.previewSize
-		? breakValues.findIndex(
-				( size ) => size.value === view.layout?.previewSize
-		  )
+		? breakValues
+				.map( ( size, index ) => ( { ...size, index } ) )
+				.filter(
+					( size ) => size.value <= ( view.layout?.previewSize ?? 0 ) // We know the view.layout?.previewSize exists at this point but the linter doesn't seem to.
+				)
+				.sort( ( a, b ) => b.value - a.value )[ 0 ].index
 		: 0;
 
 	const marks = breakValues.map( ( size, index ) => {

--- a/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
@@ -3,7 +3,7 @@
  */
 import { RangeControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useMemo, useContext } from '@wordpress/element';
+import { useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -11,100 +11,35 @@ import { useMemo, useContext } from '@wordpress/element';
 import DataViewsContext from '../../components/dataviews-context';
 import type { ViewGrid } from '../../types';
 
-const viewportBreaks: {
-	[ key: string ]: { min: number; max: number; default: number };
-} = {
-	xhuge: { min: 3, max: 6, default: 6 },
-	huge: { min: 2, max: 4, default: 4 },
-	xlarge: { min: 2, max: 3, default: 3 },
-	large: { min: 1, max: 2, default: 2 },
-	mobile: { min: 1, max: 2, default: 2 },
-};
-
-/**
- * Breakpoints were adjusted from media queries breakpoints to account for
- * the sidebar width. This was done to match the existing styles we had.
- */
-const BREAKPOINTS = {
-	xhuge: 1520,
-	huge: 1140,
-	xlarge: 780,
-	large: 480,
-	mobile: 0,
-};
-
-function useViewPortBreakpoint() {
-	const containerWidth = useContext( DataViewsContext ).containerWidth;
-	for ( const [ key, value ] of Object.entries( BREAKPOINTS ) ) {
-		if ( containerWidth >= value ) {
-			return key;
-		}
-	}
-	return 'mobile';
-}
-
-export function useUpdatedPreviewSizeOnViewportChange() {
-	const view = useContext( DataViewsContext ).view as ViewGrid;
-	const viewport = useViewPortBreakpoint();
-	return useMemo( () => {
-		const previewSize = view.layout?.previewSize;
-		let newPreviewSize;
-		if ( ! previewSize ) {
-			return;
-		}
-		const breakValues = viewportBreaks[ viewport ];
-		if ( previewSize < breakValues.min ) {
-			newPreviewSize = breakValues.min;
-		}
-		if ( previewSize > breakValues.max ) {
-			newPreviewSize = breakValues.max;
-		}
-		return newPreviewSize;
-	}, [ viewport, view ] );
-}
+const MIN_IMG_SIZE = 230;
+const MAX_IMG_SIZE = 430;
 
 export default function PreviewSizePicker() {
-	const viewport = useViewPortBreakpoint();
 	const context = useContext( DataViewsContext );
 	const view = context.view as ViewGrid;
-	const breakValues = viewportBreaks[ viewport ];
-	const previewSizeToUse = view.layout?.previewSize || breakValues.default;
-	const marks = useMemo(
-		() =>
-			Array.from(
-				{ length: breakValues.max - breakValues.min + 1 },
-				( _, i ) => {
-					return {
-						value: breakValues.min + i,
-					};
-				}
-			),
-		[ breakValues ]
-	);
-	if ( viewport === 'mobile' ) {
+	if ( context.containerWidth < MIN_IMG_SIZE * 2 + 128 ) {
 		return null;
 	}
+	const previewSizeToUse = view.layout?.previewSize ?? 230;
 	return (
 		<RangeControl
 			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 			showTooltip={ false }
 			label={ __( 'Preview size' ) }
-			value={ breakValues.max + breakValues.min - previewSizeToUse }
-			marks={ marks }
-			min={ breakValues.min }
-			max={ breakValues.max }
+			value={ previewSizeToUse }
+			min={ MIN_IMG_SIZE }
+			max={ MAX_IMG_SIZE }
 			withInputField={ false }
-			onChange={ ( value = 0 ) => {
+			onChange={ ( value = 230 ) => {
 				context.onChangeView( {
 					...view,
 					layout: {
 						...view.layout,
-						previewSize: breakValues.max + breakValues.min - value,
+						previewSize: value,
 					},
 				} );
 			} }
-			step={ 1 }
 		/>
 	);
 }

--- a/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
@@ -14,7 +14,7 @@ import type { ViewGrid } from '../../types';
 const viewportBreaks: {
 	[ key: string ]: { min: number; max: number; default: number };
 } = {
-	xhuge: { min: 3, max: 6, default: 5 },
+	xhuge: { min: 3, max: 6, default: 6 },
 	huge: { min: 2, max: 4, default: 4 },
 	xlarge: { min: 2, max: 3, default: 3 },
 	large: { min: 1, max: 2, default: 2 },

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -117,7 +117,7 @@
 }
 
 .dataviews-view-grid.dataviews-view-grid {
-	grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+	grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
 	/**
 	 * Breakpoints were adjusted from media queries breakpoints to account for
 	 * the sidebar width. This was done to match the existing styles we had.

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -1,8 +1,19 @@
 .dataviews-view-grid {
 	margin-bottom: auto;
+	display: grid;
+	gap: $grid-unit-40;
 	grid-template-rows: max-content;
+	grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
 	padding: 0 $grid-unit-60 $grid-unit-30;
 	container-type: inline-size;
+	/**
+	 * Breakpoints were adjusted from media queries breakpoints to account for
+	 * the sidebar width. This was done to match the existing styles we had.
+	 */
+	@container (max-width: 480px) {
+		padding-left: $grid-unit-30;
+		padding-right: $grid-unit-30;
+	}
 
 	@media not (prefers-reduced-motion) {
 		transition: padding ease-out 0.1s;
@@ -113,18 +124,6 @@
 		&:not(:empty) {
 			padding-bottom: $grid-unit-15;
 		}
-	}
-}
-
-.dataviews-view-grid.dataviews-view-grid {
-	grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
-	/**
-	 * Breakpoints were adjusted from media queries breakpoints to account for
-	 * the sidebar width. This was done to match the existing styles we had.
-	 */
-	@container (max-width: 480px) {
-		padding-left: $grid-unit-30;
-		padding-right: $grid-unit-30;
 	}
 }
 

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -117,26 +117,14 @@
 }
 
 .dataviews-view-grid.dataviews-view-grid {
+	grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
 	/**
 	 * Breakpoints were adjusted from media queries breakpoints to account for
 	 * the sidebar width. This was done to match the existing styles we had.
 	 */
 	@container (max-width: 480px) {
-		grid-template-columns: repeat(1, minmax(0, 1fr));
 		padding-left: $grid-unit-30;
 		padding-right: $grid-unit-30;
-	}
-	@container (min-width: 480px) {
-		grid-template-columns: repeat(2, minmax(0, 1fr));
-	}
-	@container (min-width: 780px) {
-		grid-template-columns: repeat(3, minmax(0, 1fr));
-	}
-	@container (min-width: 1140px) {
-		grid-template-columns: repeat(4, minmax(0, 1fr));
-	}
-	@container (min-width: 1520px) {
-		grid-template-columns: repeat(5, minmax(0, 1fr));
 	}
 }
 

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -202,7 +202,7 @@ function ListItem< Item >( {
 				<mediaField.render
 					item={ item }
 					field={ mediaField }
-					sizes="52px"
+					mediaAppearance={ { maxImageWidth: '52px' } }
 				/>
 			</div>
 		) : null;

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -199,7 +199,11 @@ function ListItem< Item >( {
 	const renderedMediaField =
 		showMedia && mediaField?.render ? (
 			<div className="dataviews-view-list__media-wrapper">
-				<mediaField.render item={ item } field={ mediaField } />
+				<mediaField.render
+					item={ item }
+					field={ mediaField }
+					sizes="52px"
+				/>
 			</div>
 		) : null;
 

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -202,7 +202,7 @@ function ListItem< Item >( {
 				<mediaField.render
 					item={ item }
 					field={ mediaField }
-					mediaAppearance={ { maxImageWidth: '52px' } }
+					config={ { size: '52px' } }
 				/>
 			</div>
 		) : null;

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -202,7 +202,7 @@ function ListItem< Item >( {
 				<mediaField.render
 					item={ item }
 					field={ mediaField }
-					config={ { size: '52px' } }
+					config={ { sizes: '52px' } }
 				/>
 			</div>
 		) : null;

--- a/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
@@ -47,7 +47,7 @@ function ColumnPrimary< Item >( {
 					<mediaField.render
 						item={ item }
 						field={ mediaField }
-						mediaAppearance={ { maxImageWidth: '60px' } }
+						config={ { size: '32px' } }
 					/>
 				</div>
 			) }

--- a/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
@@ -47,7 +47,7 @@ function ColumnPrimary< Item >( {
 					<mediaField.render
 						item={ item }
 						field={ mediaField }
-						sizes="32px"
+						mediaAppearance={ { maxImageWidth: '32px' } }
 					/>
 				</div>
 			) }

--- a/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
@@ -47,7 +47,7 @@ function ColumnPrimary< Item >( {
 					<mediaField.render
 						item={ item }
 						field={ mediaField }
-						mediaAppearance={ { maxImageWidth: '32px' } }
+						mediaAppearance={ { maxImageWidth: '60px' } }
 					/>
 				</div>
 			) }

--- a/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
@@ -44,7 +44,11 @@ function ColumnPrimary< Item >( {
 		<HStack spacing={ 3 } justify="flex-start">
 			{ mediaField && (
 				<div className="dataviews-view-table__cell-content-wrapper dataviews-column-primary__media">
-					<mediaField.render item={ item } field={ mediaField } />
+					<mediaField.render
+						item={ item }
+						field={ mediaField }
+						sizes="32px"
+					/>
 				</div>
 			) }
 			<VStack spacing={ 0 }>

--- a/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
@@ -47,7 +47,7 @@ function ColumnPrimary< Item >( {
 					<mediaField.render
 						item={ item }
 						field={ mediaField }
-						config={ { size: '32px' } }
+						config={ { sizes: '32px' } }
 					/>
 				</div>
 			) }

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -629,6 +629,9 @@ export interface ViewListProps< Item > extends ViewBaseProps< Item > {
 
 export interface ViewGridProps< Item > extends ViewBaseProps< Item > {
 	view: ViewGrid;
+	containerRef?:
+		| ( ( element?: HTMLDivElement | null ) => void )
+		| React.RefObject< HTMLDivElement >;
 }
 
 export type ViewProps< Item > =

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -280,6 +280,7 @@ export type DataFormControlProps< Item > = {
 export type DataViewRenderFieldProps< Item > = {
 	item: Item;
 	field: NormalizedField< Item >;
+	view?: View;
 };
 
 /**

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -281,7 +281,7 @@ export type DataViewRenderFieldProps< Item > = {
 	item: Item;
 	field: NormalizedField< Item >;
 	config?: {
-		size: string;
+		sizes: string;
 	};
 };
 

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -629,9 +629,6 @@ export interface ViewListProps< Item > extends ViewBaseProps< Item > {
 
 export interface ViewGridProps< Item > extends ViewBaseProps< Item > {
 	view: ViewGrid;
-	containerRef?:
-		| ( ( element?: HTMLDivElement | null ) => void )
-		| React.RefObject< HTMLDivElement >;
 }
 
 export type ViewProps< Item > =

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -280,8 +280,8 @@ export type DataFormControlProps< Item > = {
 export type DataViewRenderFieldProps< Item > = {
 	item: Item;
 	field: NormalizedField< Item >;
-	mediaAppearance?: {
-		maxImageWidth: string;
+	config?: {
+		size: string;
 	};
 };
 

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -280,7 +280,9 @@ export type DataFormControlProps< Item > = {
 export type DataViewRenderFieldProps< Item > = {
 	item: Item;
 	field: NormalizedField< Item >;
-	sizes?: string;
+	mediaAppearance?: {
+		maxImageWidth: string;
+	};
 };
 
 /**

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -280,7 +280,7 @@ export type DataFormControlProps< Item > = {
 export type DataViewRenderFieldProps< Item > = {
 	item: Item;
 	field: NormalizedField< Item >;
-	view?: View;
+	sizes?: string;
 };
 
 /**

--- a/packages/fields/src/fields/featured-image/featured-image-view.tsx
+++ b/packages/fields/src/fields/featured-image/featured-image-view.tsx
@@ -23,7 +23,6 @@ export const FeaturedImageView = ( {
 		},
 		[ mediaId ]
 	);
-
 	const url = media?.source_url;
 
 	if ( url ) {
@@ -42,7 +41,7 @@ export const FeaturedImageView = ( {
 								.join( ', ' )
 						: undefined
 				}
-				sizes={ config?.size || '100vw' }
+				sizes={ config?.sizes || '100vw' }
 			/>
 		);
 	}

--- a/packages/fields/src/fields/featured-image/featured-image-view.tsx
+++ b/packages/fields/src/fields/featured-image/featured-image-view.tsx
@@ -12,7 +12,7 @@ import type { BasePost } from '../../types';
 
 export const FeaturedImageView = ( {
 	item,
-	mediaAppearance,
+	config,
 }: DataViewRenderFieldProps< BasePost > ) => {
 	const mediaId = item.featured_media;
 
@@ -42,7 +42,7 @@ export const FeaturedImageView = ( {
 								.join( ', ' )
 						: undefined
 				}
-				sizes={ mediaAppearance?.maxImageWidth || '100vw' }
+				sizes={ config?.size || '100vw' }
 			/>
 		);
 	}

--- a/packages/fields/src/fields/featured-image/featured-image-view.tsx
+++ b/packages/fields/src/fields/featured-image/featured-image-view.tsx
@@ -12,7 +12,7 @@ import type { BasePost } from '../../types';
 
 export const FeaturedImageView = ( {
 	item,
-	view,
+	sizes = '',
 }: DataViewRenderFieldProps< BasePost > ) => {
 	const mediaId = item.featured_media;
 
@@ -24,18 +24,7 @@ export const FeaturedImageView = ( {
 		[ mediaId ]
 	);
 
-	// Thumbnail will exist almost for sure, but better have a fallback anyway.
-	const thumbnailURL =
-		media?.media_details?.sizes?.thumbnail?.source_url || media?.source_url;
-	const url = view ? media?.source_url : thumbnailURL;
-
-	// @ts-ignore layout exists on ViewGrid; not sure what the problem is here.
-	const columnNumberSetting = view?.layout?.previewSize || 0;
-	let sizes =
-		'(max-width: 480px) 100vw, (max-width: 1080px) 50vw, (max-width: 1440px) 30vw, (max-width: 1920px) 25vw, 20vw';
-	if ( columnNumberSetting ) {
-		sizes = `(max-width: 480px) 100vw, ${ 100 / columnNumberSetting }vw`;
-	}
+	const url = media?.source_url;
 
 	if ( url ) {
 		return (
@@ -44,7 +33,7 @@ export const FeaturedImageView = ( {
 				src={ url }
 				alt=""
 				srcSet={
-					view && media?.media_details?.sizes
+					media?.media_details?.sizes
 						? Object.values( media.media_details.sizes )
 								.map(
 									( size: any ) =>
@@ -53,7 +42,7 @@ export const FeaturedImageView = ( {
 								.join( ', ' )
 						: undefined
 				}
-				sizes={ view && sizes }
+				sizes={ sizes }
 			/>
 		);
 	}

--- a/packages/fields/src/fields/featured-image/featured-image-view.tsx
+++ b/packages/fields/src/fields/featured-image/featured-image-view.tsx
@@ -12,7 +12,7 @@ import type { BasePost } from '../../types';
 
 export const FeaturedImageView = ( {
 	item,
-	sizes = '',
+	mediaAppearance,
 }: DataViewRenderFieldProps< BasePost > ) => {
 	const mediaId = item.featured_media;
 
@@ -42,7 +42,7 @@ export const FeaturedImageView = ( {
 								.join( ', ' )
 						: undefined
 				}
-				sizes={ sizes }
+				sizes={ mediaAppearance?.maxImageWidth || '100vw' }
 			/>
 		);
 	}

--- a/packages/fields/src/fields/featured-image/featured-image-view.tsx
+++ b/packages/fields/src/fields/featured-image/featured-image-view.tsx
@@ -12,6 +12,7 @@ import type { BasePost } from '../../types';
 
 export const FeaturedImageView = ( {
 	item,
+	view,
 }: DataViewRenderFieldProps< BasePost > ) => {
 	const mediaId = item.featured_media;
 
@@ -22,7 +23,19 @@ export const FeaturedImageView = ( {
 		},
 		[ mediaId ]
 	);
-	const url = media?.source_url;
+
+	// Thumbnail will exist almost for sure, but better have a fallback anyway.
+	const thumbnailURL =
+		media?.media_details?.sizes?.thumbnail?.source_url || media?.source_url;
+	const url = view ? media?.source_url : thumbnailURL;
+
+	// @ts-ignore layout exists on ViewGrid; not sure what the problem is here.
+	const columnNumberSetting = view?.layout?.previewSize || 0;
+	let sizes =
+		'(max-width: 480px) 100vw, (max-width: 1080px) 50vw, (max-width: 1440px) 30vw, (max-width: 1920px) 25vw, 20vw';
+	if ( columnNumberSetting ) {
+		sizes = `(max-width: 480px) 100vw, ${ 100 / columnNumberSetting }vw`;
+	}
 
 	if ( url ) {
 		return (
@@ -30,6 +43,17 @@ export const FeaturedImageView = ( {
 				className="fields-controls__featured-image-image"
 				src={ url }
 				alt=""
+				srcSet={
+					view && media?.media_details?.sizes
+						? Object.values( media.media_details.sizes )
+								.map(
+									( size: any ) =>
+										`${ size.source_url } ${ size.width }w`
+								)
+								.join( ', ' )
+						: undefined
+				}
+				sizes={ view && sizes }
 			/>
 		);
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I noticed that the `FeaturedImageView` component in dataviews (see `wp-admin/site-editor.php?p=%2Fpage`)  loads the full-sized image regardless of whether it's in list, table or grid mode. This means an unsuspecting user with multiple pages with featured images is potentially loading several megabytes of images even if they're displaying as tiny thumbnails.

## This PR
* Adds a `mediaAppearance` object prop to MediaField, with a `maxImageWidth` attribute, so we can pass in an appropriate image width from each layout type;
* Rewrites the grid layout logic to be responsive based on grid item widths, instead of using container queries to force column counts, so that we can reliably know the maximum image size to pass as `maxImageWidth`;
* The above step involved attaching the `resizeObserverRef` to dataviews context instead of passing it to the layout wrapper, so that it can be passed directly to each layout container as needed (currently only the grid layout needs it, and observing the container gives us a more accurate size than its wrapper, which might include a scrollbar)
* Changes `FeaturedImageView` to use the `maxImageWidth` prop from MediaField to determine the appropriate size of image to serve, using `srcset` and `sizes` attributes on the `img` tag.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Go to `wp-admin/site-editor.php?p=%2Fpage`
2. Check that all views load correctly sized images. An interesting test is to try different device pixel ratios in the browser's responsive tools; in grid view different image sizes may load for different ratios.
3. Try adjusting the preview size in grid view and check that it still resizes correctly.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="1476" alt="Screenshot 2025-06-23 at 6 30 04 pm" src="https://github.com/user-attachments/assets/6d2268ff-4d96-4700-9840-24ba505c1183" />

<img width="1590" alt="Screenshot 2025-06-23 at 6 31 18 pm" src="https://github.com/user-attachments/assets/3d983fbb-204e-46d1-bb0f-a8055a057e84" />

