### PR TITLE
Comment Template: Show placeholders when no comments exist in posts/pages

### DIFF
--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -291,7 +291,7 @@ export default function CommentTemplateEdit( {
 		);
 	}
 
-	if ( ! postId ) {
+	if ( ! postId || ! commentTree.length ) {
 		commentTree = getCommentsPlaceholder( {
 			perPage: commentsPerPage,
 			pageComments,


### PR DESCRIPTION
## What?
Closes #49842
Shows placeholder content for Comment Template blocks when editing posts or pages that have no comments, making child blocks visible and selectable in the editor.

## Why?
Currently, when adding a Comment Template block to a post or page with no comments, the child blocks (comment author, content, date, etc.) are not visible on the canvas. This makes it impossible to select and configure these blocks in the Block Inspector, creating a poor editing experience when designing comment layouts.

The Comment Template block already shows placeholders correctly in template contexts, but not when editing individual posts/pages with no comments.


## Testing Instructions
1. Create a new post or page
2. Insert a Comments block (which includes the Comment Template)
3. Verify that placeholder content is now visible on the canvas
4. Select child blocks (comment author name, comment content, etc.) from the List View
5. Confirm that the selected blocks are highlighted on the canvas and their settings appear in the Block Inspector
6. Test the same in a templates to ensure placeholders still work there


## Screenshots or screencast
### Before

https://github.com/user-attachments/assets/eb2d8fe4-f246-4d6d-9c4c-f3a88c763a01

### After

https://github.com/user-attachments/assets/99684ccd-5cf5-480a-8a97-5ff3d1657170



