### PR TITLE
Post Excerpt Block: Preserve newline characters in trimmed manual excerpts

### DIFF
--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -29,7 +29,7 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	$excerpt_length = $attributes['excerptLength'];
 	$excerpt        = get_the_excerpt( $block->context['postId'] );
 	if ( isset( $excerpt_length ) ) {
-		$excerpt = wp_trim_words_preserve_newlines( $excerpt, $excerpt_length );
+		$excerpt = block_core_post_excerpt_trim_words( $excerpt, $excerpt_length );
 	}
 
 	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . wp_kses_post( $attributes['moreText'] ) . '</a>' : '';
@@ -78,10 +78,11 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
  * @param  string $more Optional. What to append if the text is trimmed. Default '…'.
  * @return string The trimmed text with newlines preserved.
  */
-function wp_trim_words_preserve_newlines( $text, $num_words = 55, $more = null ) {
+function block_core_post_excerpt_trim_words( $text, $num_words = 55, $more = null ) {
 	if ( null === $more ) {
 		$more = __( '&hellip;' );
 	}
+
 	// Replace <br> tags with newlines temporarily,
 	// to retain manual breaks from editors.
 	$text      = str_replace( array( '<br>', '<br/>', '<br />' ), "\n", $text );

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -98,7 +98,10 @@ function block_core_post_excerpt_trim_words( $text, $num_words = 55, $more = nul
 		$words_array = array_slice( $words_array[0], 0, $num_words + 1 );
 		$sep         = '';
 	} else {
-		$words_array = preg_split( '/([ \t]+)/', $text, $num_words + 1, PREG_SPLIT_NO_EMPTY );
+		// Match words and optionally include trailing line breaks.
+		// Ensures newlines are preserved as part of the trimmed output.
+		preg_match_all( '/[^\s]+(?:[ \t]*[\n\r])?/', $text, $words_array );
+		$words_array = array_slice( $words_array[0], 0, $num_words + 1 );
 		$sep         = ' ';
 	}
 

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -29,7 +29,7 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	$excerpt_length = $attributes['excerptLength'];
 	$excerpt        = get_the_excerpt( $block->context['postId'] );
 	if ( isset( $excerpt_length ) ) {
-		$excerpt = wp_trim_words( $excerpt, $excerpt_length );
+		$excerpt = wp_trim_words_preserve_newlines( $excerpt, $excerpt_length );
 	}
 
 	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . wp_kses_post( $attributes['moreText'] ) . '</a>' : '';
@@ -64,6 +64,51 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	}
 	remove_filter( 'excerpt_more', $filter_excerpt_more );
 	return sprintf( '<div %1$s>%2$s</div>', $wrapper_attributes, $content );
+}
+
+/**
+ * Trims text to a given number of words, preserving newlines.
+ *
+ * Similar to wp_trim_words(), but avoids stripping line breaks and HTML <br> tags.
+ *
+ * @since 21.0.0
+ *
+ * @param  string $text The text to trim.
+ * @param  int    $num_words The maximum number of words. Default 55.
+ * @param  string $more Optional. What to append if the text is trimmed. Default '…'.
+ * @return string The trimmed text with newlines preserved.
+ */
+function wp_trim_words_preserve_newlines( $text, $num_words = 55, $more = null ) {
+	if ( null === $more ) {
+		$more = __( '&hellip;' );
+	}
+	// Replace <br> tags with newlines temporarily,
+	// to retain manual breaks from editors.
+	$text      = str_replace( array( '<br>', '<br/>', '<br />' ), "\n", $text );
+	$text      = strip_tags( $text );
+	$num_words = (int) $num_words;
+
+	if (
+		str_starts_with( wp_get_word_count_type(), 'characters' ) &&
+		preg_match( '/^utf\-?8$/i', get_option( 'blog_charset' ) )
+	) {
+		$text = trim( preg_replace( "/[^\S\n\r]+/", ' ', $text ), ' ' );
+		preg_match_all( '/./u', $text, $words_array );
+		$words_array = array_slice( $words_array[0], 0, $num_words + 1 );
+		$sep         = '';
+	} else {
+		$words_array = preg_split( '/([ \t]+)/', $text, $num_words + 1, PREG_SPLIT_NO_EMPTY );
+		$sep         = ' ';
+	}
+
+	if ( count( $words_array ) > $num_words ) {
+		array_pop( $words_array );
+		$text = implode( $sep, $words_array ) . $more;
+	} else {
+		$text = implode( $sep, $words_array );
+	}
+
+	return nl2br( $text );
 }
 
 /**

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -55,7 +55,7 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	}
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
 
-	$content               = '<p class="wp-block-post-excerpt__excerpt">' . $excerpt;
+	$content               = '<p class="wp-block-post-excerpt__excerpt">' . nl2br( wp_kses_post( $excerpt ) );
 	$show_more_on_new_line = ! isset( $attributes['showMoreOnNewLine'] ) || $attributes['showMoreOnNewLine'];
 	if ( $show_more_on_new_line && ! empty( $more_text ) ) {
 		$content .= '</p><p class="wp-block-post-excerpt__more-text">' . $more_text . '</p>';
@@ -109,7 +109,7 @@ function block_core_post_excerpt_trim_words( $text, $num_words = 55, $more = nul
 		$text = implode( $sep, $words_array );
 	}
 
-	return nl2br( $text );
+	return $text;
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #59914 

Preserve newline characters (`\n`) in manually written excerpts when using the Post Excerpt block. This update introduces a custom trimming function that retains line breaks while limiting the excerpt length as configured.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When users write multiline excerpts (in the sidebar or directly in the Post Excerpt block), they often expect line breaks to be respected. However, the existing implementation strips out `\n` characters and `<br>` tags during word trimming, causing all lines to collapse into one paragraph on the front end. The new change improves parity between the editor preview and frontend display

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Introduced a new helper function: `block_core_post_excerpt_trim_words()`
This function mirrors the behavior of `wp_trim_words()`, but avoids stripping newline characters by:
    - Preserving `<br>` tags from RichText editing by converting them to `\n` before processing
    - Replacing only spaces/tabs while keeping newline characters intact
- Used this function in the `render_block_core_post_excerpt()` callback instead of `wp_trim_words()` when trimming the excerpt text.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Add an Excerpt block to the post content.
2. In post settings in sidebar panel or in the excerpt block in editor, manually enter a multiline excerpt.
3. Save the post.
4. Visit the post in the frontend. The excerpt should preserve the original line breaks.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

https://github.com/user-attachments/assets/93337301-8804-4b75-874e-89437b55c592

### After

https://github.com/user-attachments/assets/2c497570-674d-4f36-9bab-1726cf07bd70


