### PR TITLE
Upgrade Playwright to v1.54.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"@octokit/rest": "16.26.0",
 				"@octokit/types": "6.34.0",
 				"@octokit/webhooks-types": "5.8.0",
-				"@playwright/test": "1.54.1",
+				"@playwright/test": "1.54.2",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@react-native/babel-preset": "0.73.10",
 				"@react-native/metro-babel-transformer": "0.73.10",
@@ -8750,13 +8750,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.54.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.1.tgz",
-			"integrity": "sha512-FS8hQ12acieG2dYSksmLOF7BNxnVf2afRJdCuM1eMSxj6QTSE6G4InGF7oApGgDb65MX7AwMVlIkpru0yZA4Xw==",
+			"version": "1.54.2",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+			"integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.54.1"
+				"playwright": "1.54.2"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -38013,13 +38013,13 @@
 			"dev": true
 		},
 		"node_modules/playwright": {
-			"version": "1.54.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.1.tgz",
-			"integrity": "sha512-peWpSwIBmSLi6aW2auvrUtf2DqY16YYcCMO8rTVx486jKmDTJg7UAhyrraP98GB8BoPURZP8+nxO7TSd4cPr5g==",
+			"version": "1.54.2",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+			"integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.54.1"
+				"playwright-core": "1.54.2"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -38032,9 +38032,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.54.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.1.tgz",
-			"integrity": "sha512-Nbjs2zjj0htNhzgiy5wu+3w09YetDx5pkrpI/kZotDlDUaYk0HVA5xrBVPdow4SAUIlhgKcJeJg4GRKW6xHusA==",
+			"version": "1.54.2",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+			"integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -52070,7 +52070,7 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.54.1",
+				"@playwright/test": "^1.54.2",
 				"@wordpress/env": "^10.0.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"@octokit/rest": "16.26.0",
 				"@octokit/types": "6.34.0",
 				"@octokit/webhooks-types": "5.8.0",
-				"@playwright/test": "1.51.1",
+				"@playwright/test": "1.54.1",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@react-native/babel-preset": "0.73.10",
 				"@react-native/metro-babel-transformer": "0.73.10",
@@ -8750,12 +8750,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.51.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.1.tgz",
-			"integrity": "sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==",
+			"version": "1.54.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.1.tgz",
+			"integrity": "sha512-FS8hQ12acieG2dYSksmLOF7BNxnVf2afRJdCuM1eMSxj6QTSE6G4InGF7oApGgDb65MX7AwMVlIkpru0yZA4Xw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.51.1"
+				"playwright": "1.54.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -38012,12 +38013,13 @@
 			"dev": true
 		},
 		"node_modules/playwright": {
-			"version": "1.51.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.1.tgz",
-			"integrity": "sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==",
+			"version": "1.54.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.1.tgz",
+			"integrity": "sha512-peWpSwIBmSLi6aW2auvrUtf2DqY16YYcCMO8rTVx486jKmDTJg7UAhyrraP98GB8BoPURZP8+nxO7TSd4cPr5g==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.51.1"
+				"playwright-core": "1.54.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -38030,10 +38032,11 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.51.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.1.tgz",
-			"integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==",
+			"version": "1.54.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.1.tgz",
+			"integrity": "sha512-Nbjs2zjj0htNhzgiy5wu+3w09YetDx5pkrpI/kZotDlDUaYk0HVA5xrBVPdow4SAUIlhgKcJeJg4GRKW6xHusA==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"playwright-core": "cli.js"
 			},
@@ -52067,7 +52070,7 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.51.1",
+				"@playwright/test": "^1.54.1",
 				"@wordpress/env": "^10.0.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.8.0",
-		"@playwright/test": "1.51.1",
+		"@playwright/test": "1.54.1",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@react-native/babel-preset": "0.73.10",
 		"@react-native/metro-babel-transformer": "0.73.10",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.8.0",
-		"@playwright/test": "1.54.1",
+		"@playwright/test": "1.54.2",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@react-native/babel-preset": "0.73.10",
 		"@react-native/metro-babel-transformer": "0.73.10",

--- a/packages/e2e-tests/plugins/custom-grouping-block/index.js
+++ b/packages/e2e-tests/plugins/custom-grouping-block/index.js
@@ -1,16 +1,19 @@
 ( function () {
-	wp.blocks.registerBlockType( 'test/alternative-group-block', {
+	const el = wp.element.createElement;
+	const { InnerBlocks, useBlockProps } = wp.blockEditor;
+	const { createBlock, registerBlockType } = wp.blocks;
+
+	registerBlockType( 'test/alternative-group-block', {
+		apiVersion: 3,
 		title: 'Alternative Group Block',
 		category: 'design',
 		icon: 'yes',
-		edit() {
-			return wp.element.createElement( wp.blockEditor.InnerBlocks );
+		edit: function AlternativeGroupBlockEdit() {
+			return el( 'div', useBlockProps(), el( InnerBlocks ) );
 		},
 
 		save() {
-			return wp.element.createElement(
-				wp.blockEditor.InnerBlocks.Content
-			);
+			return el( InnerBlocks.Content );
 		},
 		transforms: {
 			from: [
@@ -21,7 +24,7 @@
 					__experimentalConvert( blocks ) {
 						const groupInnerBlocks = blocks.map(
 							( { name, attributes, innerBlocks } ) => {
-								return wp.blocks.createBlock(
+								return createBlock(
 									name,
 									attributes,
 									innerBlocks
@@ -29,7 +32,7 @@
 							}
 						);
 
-						return wp.blocks.createBlock(
+						return createBlock(
 							'test/alternative-group-block',
 							{},
 							groupInnerBlocks

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -95,7 +95,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"peerDependencies": {
-		"@playwright/test": "^1.54.1",
+		"@playwright/test": "^1.54.2",
 		"@wordpress/env": "^10.0.0",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -95,7 +95,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"peerDependencies": {
-		"@playwright/test": "^1.51.1",
+		"@playwright/test": "^1.54.1",
 		"@wordpress/env": "^10.0.0",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -34,6 +34,9 @@ test.describe( 'Buttons', () => {
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/buttons' );
+		await expect(
+			page.getByRole( 'option', { name: 'Buttons' } )
+		).toBeVisible();
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'Content' );
 
@@ -147,7 +150,9 @@ test.describe( 'Buttons', () => {
 		await editor.insertBlock( { name: 'core/buttons' } );
 		await page.keyboard.type( 'WordPress' );
 		await pageUtils.pressKeys( 'primary+k' );
-		await page.keyboard.type( 'https://www.wordpress.org/' );
+		await page
+			.getByRole( 'combobox', { name: 'Search or type URL' } )
+			.fill( 'https://www.wordpress.org/' );
 		await page.keyboard.press( 'Enter' );
 		// Make sure that the dialog is still opened, and that focus is retained
 		// within (focusing on the link preview).
@@ -174,7 +179,9 @@ test.describe( 'Buttons', () => {
 		await editor.insertBlock( { name: 'core/buttons' } );
 		await page.keyboard.type( 'WordPress' );
 		await pageUtils.pressKeys( 'primary+k' );
-		await page.keyboard.type( 'https://www.wordpress.org/' );
+		await page
+			.getByRole( 'combobox', { name: 'Search or type URL' } )
+			.fill( 'https://www.wordpress.org/' );
 		await page.keyboard.press( 'Enter' );
 
 		// Edit link.

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -42,7 +42,11 @@ test.describe( 'Links', () => {
 		await editor.clickBlockToolbarButton( 'Link' );
 
 		// Trigger the autocomplete suggestion list and select the first suggestion.
-		await page.keyboard.type( 'Post to create a' );
+		await page
+			.getByRole( 'combobox', {
+				name: 'Search or type URL',
+			} )
+			.fill( 'Post to create a' );
 		await page.getByRole( 'option', { name: titleText } ).click();
 
 		await expect.poll( editor.getBlocks ).toMatchObject( [
@@ -80,7 +84,11 @@ test.describe( 'Links', () => {
 		await editor.clickBlockToolbarButton( 'Link' );
 
 		// Type a URL.
-		await page.keyboard.type( 'https://wordpress.org/gutenberg' );
+		await page
+			.getByRole( 'combobox', {
+				name: 'Search or type URL',
+			} )
+			.fill( 'https://wordpress.org/gutenberg' );
 
 		// Submit the link.
 		await pageUtils.pressKeys( 'Enter' );
@@ -170,7 +178,11 @@ test.describe( 'Links', () => {
 		await editor.clickBlockToolbarButton( 'Link' );
 
 		// Type a URL.
-		await page.keyboard.type( 'https://wordpress.org/gutenberg' );
+		await page
+			.getByRole( 'combobox', {
+				name: 'Search or type URL',
+			} )
+			.fill( 'https://wordpress.org/gutenberg' );
 
 		// Click somewhere else - it doesn't really matter where.
 		await editor.canvas
@@ -441,7 +453,9 @@ test.describe( 'Links', () => {
 		await pageUtils.pressKeys( 'shiftAlt+ArrowLeft' );
 		await pageUtils.pressKeys( 'primary+K' );
 		const linkPopover = LinkUtils.getLinkPopover();
-		await page.keyboard.type( URL );
+		await page
+			.getByRole( 'combobox', { name: 'Search or type URL' } )
+			.fill( URL );
 		await pageUtils.pressKeys( 'Enter' );
 
 		await expect( linkPopover ).toBeVisible();
@@ -460,6 +474,9 @@ test.describe( 'Links', () => {
 		// Switch the Link UI into "Edit" mode via keyboard shortcut
 		// and check that the input has the correct value.
 		await pageUtils.pressKeys( 'primary+K' );
+		await expect(
+			page.getByRole( 'link', { name: 'The new Gutenberg editing' } )
+		).toBeFocused();
 		await pageUtils.pressKeys( 'Tab' );
 		await pageUtils.pressKeys( 'Enter' );
 
@@ -614,14 +631,13 @@ test.describe( 'Links', () => {
 
 		// Close the link control to return the caret to the canvas
 		const linkPopover = LinkUtils.getLinkPopover();
+		await page
+			.getByRole( 'combobox', { name: 'Search or type URL' } )
+			.fill( 'w.org' );
 
-		await page.keyboard.type( 'w.org' );
-
-		// Submit the link
+		// Submit the link and close the popover.
 		await page.keyboard.press( 'Enter' );
-
-		// Close the Link Popover.
-		await pageUtils.pressKeys( 'Escape' );
+		await page.keyboard.press( 'Escape' );
 
 		await expect( linkPopover ).toBeHidden();
 
@@ -679,12 +695,16 @@ test.describe( 'Links', () => {
 		} );
 		await page.keyboard.type( 'This is Gutenberg WordPress' );
 
+		const urlInput = page.getByRole( 'combobox', {
+			name: 'Search or type URL',
+		} );
+
 		// Select "WordPress".
 		await pageUtils.pressKeys( 'shiftAlt+ArrowLeft' );
 
 		// Create a link.
 		await pageUtils.pressKeys( 'primary+k' );
-		await page.keyboard.type( 'w.org' );
+		await urlInput.fill( 'w.org' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'Escape' );
 
@@ -697,7 +717,7 @@ test.describe( 'Links', () => {
 		// Create a link.
 		await pageUtils.pressKeys( 'primary+k' );
 
-		await page.keyboard.type( 'https://wordpress.org/plugins/gutenberg/' );
+		await urlInput.fill( 'https://wordpress.org/plugins/gutenberg/' );
 		await page.keyboard.press( 'Enter' );
 
 		// Press the "Edit" button
@@ -1056,7 +1076,11 @@ test.describe( 'Links', () => {
 			await editor.clickBlockToolbarButton( 'Link' );
 
 			// Type a URL.
-			await page.keyboard.type( 'https://wordpress.org/gutenberg' );
+			await page
+				.getByRole( 'combobox', {
+					name: 'Search or type URL',
+				} )
+				.fill( 'https://wordpress.org/gutenberg' );
 
 			// Click on the Submit button.
 			await pageUtils.pressKeys( 'Enter' );
@@ -1128,7 +1152,11 @@ test.describe( 'Links', () => {
 			await editor.clickBlockToolbarButton( 'Link' );
 
 			// Type a URL.
-			await page.keyboard.type( 'www.wordpress.org' );
+			await page
+				.getByRole( 'combobox', {
+					name: 'Search or type URL',
+				} )
+				.fill( 'www.wordpress.org' );
 
 			// Update the link.
 			await pageUtils.pressKeys( 'Enter' );
@@ -1208,7 +1236,11 @@ class LinkUtils {
 		await expect( linkPopover ).toBeVisible();
 
 		// Type a URL.
-		await this.page.keyboard.type( 'https://wordpress.org/gutenberg' );
+		await linkPopover
+			.getByRole( 'combobox', {
+				name: 'Search or type URL',
+			} )
+			.fill( 'https://wordpress.org/gutenberg' );
 
 		// Submit the link.
 		await this.pageUtils.pressKeys( 'Enter' );

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -746,7 +746,7 @@ test.describe( 'List (@firefox)', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/quote' } );
 		await page.keyboard.type( '/list' );
-		await page.keyboard.press( 'Enter' );
+		await page.getByRole( 'option', { name: 'List', exact: true } ).click();
 		await page.keyboard.type( 'aaa' );
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'Enter' );

--- a/test/e2e/specs/editor/blocks/quote.spec.js
+++ b/test/e2e/specs/editor/blocks/quote.spec.js
@@ -79,6 +79,9 @@ test.describe( 'Quote', () => {
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/quote' );
+		await expect(
+			page.getByRole( 'option', { name: 'Quote', exact: true } )
+		).toBeVisible();
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'I’m a quote' );
 		expect( await editor.getEditedPostContent() ).toBe(

--- a/test/e2e/specs/editor/blocks/spacer.spec.js
+++ b/test/e2e/specs/editor/blocks/spacer.spec.js
@@ -13,7 +13,9 @@ test.describe( 'Spacer', () => {
 		await editor.canvas
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
-		await page.keyboard.type( '/spacer' );
+		await editor.canvas
+			.getByRole( 'document', { name: 'Empty block' } )
+			.pressSequentially( '/spacer' );
 		await page.keyboard.press( 'Enter' );
 
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
@@ -27,7 +29,9 @@ test.describe( 'Spacer', () => {
 		await editor.canvas
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
-		await page.keyboard.type( '/spacer' );
+		await editor.canvas
+			.getByRole( 'document', { name: 'Empty block' } )
+			.pressSequentially( '/spacer' );
 		await page.keyboard.press( 'Enter' );
 
 		const resizableHandle = editor.canvas.locator(

--- a/test/e2e/specs/editor/blocks/spacer.spec.js
+++ b/test/e2e/specs/editor/blocks/spacer.spec.js
@@ -13,9 +13,10 @@ test.describe( 'Spacer', () => {
 		await editor.canvas
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
-		await editor.canvas
-			.getByRole( 'document', { name: 'Empty block' } )
-			.pressSequentially( '/spacer' );
+		await page.keyboard.type( '/spacer' );
+		await expect(
+			page.getByRole( 'option', { name: 'Spacer' } )
+		).toBeVisible();
 		await page.keyboard.press( 'Enter' );
 
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
@@ -29,9 +30,10 @@ test.describe( 'Spacer', () => {
 		await editor.canvas
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
-		await editor.canvas
-			.getByRole( 'document', { name: 'Empty block' } )
-			.pressSequentially( '/spacer' );
+		await page.keyboard.type( '/spacer' );
+		await expect(
+			page.getByRole( 'option', { name: 'Spacer' } )
+		).toBeVisible();
 		await page.keyboard.press( 'Enter' );
 
 		const resizableHandle = editor.canvas.locator(

--- a/test/e2e/specs/editor/plugins/block-variations.spec.js
+++ b/test/e2e/specs/editor/plugins/block-variations.spec.js
@@ -52,7 +52,7 @@ test.describe( 'Block variations', () => {
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/Large Quote' );
-		await page.keyboard.press( 'Enter' );
+		await page.getByRole( 'option', { name: 'Large Quote' } ).click();
 
 		await expect(
 			editor.canvas.getByRole( 'document', { name: 'Block: Quote' } )
@@ -88,9 +88,9 @@ test.describe( 'Block variations', () => {
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/Heading' );
-		await page.keyboard.press( 'Enter' );
+		await page.getByRole( 'option', { name: 'Heading' } ).click();
 		await page.keyboard.type( '/Success Message' );
-		await page.keyboard.press( 'Enter' );
+		await page.getByRole( 'option', { name: 'Success Message' } ).click();
 
 		await expect(
 			editor.canvas.getByRole( 'document', { name: 'Block: Paragraph' } )
@@ -105,7 +105,7 @@ test.describe( 'Block variations', () => {
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/Columns' );
-		await page.keyboard.press( 'Enter' );
+		await page.getByRole( 'option', { name: 'Columns' } ).click();
 
 		await editor.canvas
 			.getByRole( 'list', { name: 'Block variations' } )
@@ -130,7 +130,7 @@ test.describe( 'Block variations', () => {
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/Large Quote' );
-		await page.keyboard.press( 'Enter' );
+		await page.getByRole( 'option', { name: 'Large Quote' } ).click();
 
 		// Select the quote block.
 		await page.keyboard.press( 'ArrowUp' );
@@ -167,9 +167,9 @@ test.describe( 'Block variations', () => {
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/Heading' );
-		await page.keyboard.press( 'Enter' );
+		await page.getByRole( 'option', { name: 'Heading' } ).click();
 		await page.keyboard.type( '/Success Message' );
-		await page.keyboard.press( 'Enter' );
+		await page.getByRole( 'option', { name: 'Success Message' } ).click();
 
 		await expect(
 			page
@@ -203,9 +203,9 @@ test.describe( 'Block variations', () => {
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '/Heading' );
-		await page.keyboard.press( 'Enter' );
+		await page.getByRole( 'option', { name: 'Heading' } ).click();
 		await page.keyboard.type( '/Warning Message' );
-		await page.keyboard.press( 'Enter' );
+		await page.getByRole( 'option', { name: 'Warning Message' } ).click();
 
 		await expect(
 			page

--- a/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
+++ b/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
@@ -411,7 +411,10 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 					)
 				).toBeVisible();
 				await page.keyboard.press( 'Enter' );
-				await page.keyboard.type( ' test' );
+				// Autocompleter might continue matching right after insertion,
+				// Emulate typing speed to avoid that.
+				// Remove after https://github.com/WordPress/gutenberg/issues/42925 is resolved.
+				await page.keyboard.type( ' test', { delay: 100 } );
 				await page.keyboard.press( 'Enter' );
 			}
 

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -582,7 +582,7 @@ test.describe( 'Copy/cut/paste', () => {
 		} );
 
 		await pageUtils.pressKeys( 'primaryAlt+v' );
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/paragraph',
 				attributes: {

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -70,7 +70,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		await pageUtils.pressKeys( 'ArrowUp', { times: 4 } );
 		await page.keyboard.press( 'ArrowRight' );
 		// Select mid line one to mid line four.
-		await pageUtils.pressKeys( 'Shift+ArrowDown', { times: 3 } );
+		await pageUtils.pressKeys( 'Shift+ArrowDown', { times: 3, delay: 50 } );
 		// Delete the text to see if the selection was correct.
 		await page.keyboard.press( 'Backspace' );
 
@@ -1149,7 +1149,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		await page.keyboard.type( ']2' );
 		await page.keyboard.press( 'ArrowLeft' );
 		// Select everything between [].
-		await pageUtils.pressKeys( 'Shift+ArrowLeft', { times: 3 } );
+		await pageUtils.pressKeys( 'Shift+ArrowLeft', { times: 3, delay: 50 } );
 
 		// Ensure selection is in the correct place.
 		await page.keyboard.type( '|' );
@@ -1227,7 +1227,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 			.filter( { hasText: 'a' } )
 			.click();
 
-		await pageUtils.pressKeys( 'Shift+ArrowDown', { times: 2 } );
+		await pageUtils.pressKeys( 'Shift+ArrowDown', { times: 2, delay: 50 } );
 		await page.keyboard.press( 'Backspace' );
 
 		// Ensure selection is in the correct place.

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -1187,7 +1187,8 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 			.click();
 		await page.keyboard.press( 'ArrowLeft' );
 		// Select everything between [].
-		await pageUtils.pressKeys( 'Shift+ArrowLeft', { times: 5 } );
+		// Delay ensures selection can catch up.
+		await pageUtils.pressKeys( 'Shift+ArrowLeft', { times: 5, delay: 50 } );
 
 		await page.keyboard.press( 'Enter' );
 

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -1089,7 +1089,11 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 
 		await page.keyboard.press( 'ArrowLeft' );
 		// Select everything between [].
-		await pageUtils.pressKeys( 'Shift+ArrowLeft', { times: 5 } );
+		// Delay ensures selection can catch up.
+		await pageUtils.pressKeys( 'Shift+ArrowLeft', {
+			times: 5,
+			delay: 50,
+		} );
 
 		await page.keyboard.press( 'Delete' );
 
@@ -1119,7 +1123,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		// Delay ensures selection can catch up.
 		await pageUtils.pressKeys( 'Shift+ArrowLeft', {
 			times: 3,
-			delay: 100,
+			delay: 50,
 		} );
 
 		// Ensure selection is in the correct place.

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -1116,7 +1116,11 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		await page.keyboard.type( ']2' );
 		await page.keyboard.press( 'ArrowLeft' );
 		// Select everything between [].
-		await pageUtils.pressKeys( 'Shift+ArrowLeft', { times: 3 } );
+		// Delay ensures selection can catch up.
+		await pageUtils.pressKeys( 'Shift+ArrowLeft', {
+			times: 3,
+			delay: 100,
+		} );
 
 		// Ensure selection is in the correct place.
 		await page.keyboard.type( '|' );

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -1146,11 +1146,15 @@ class WritingFlowUtils {
 	}
 
 	async addDemoContent() {
-		await this.page.keyboard.press( 'Enter' );
-		await this.page.keyboard.type( 'First paragraph' );
-		await this.page.keyboard.press( 'Enter' );
-		await this.page.keyboard.type( '/columns' );
-		await this.page.keyboard.press( 'Enter' );
+		await this.editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content: 'First paragraph',
+			},
+		} );
+		await this.editor.insertBlock( {
+			name: 'core/columns',
+		} );
 		await this.editor.canvas
 			.locator( 'role=button[name="Two columns; equal split"i]' )
 			.click();

--- a/test/e2e/specs/interactivity/router-styles.spec.ts
+++ b/test/e2e/specs/interactivity/router-styles.spec.ts
@@ -304,8 +304,8 @@ test.describe( 'Router styles', () => {
 		// temporary error.
 		const linkPattern = '**/router-styles-red/style-from-link.css*';
 		await page.route( linkPattern, async ( route ) => {
+			await route.abort( 'failed' );
 			await page.unroute( linkPattern );
-			return route.abort( 'failed' );
 		} );
 
 		// Navigate to the page with the Red block


### PR DESCRIPTION
## What?
Upgrade Playwright to v1.54.2. Supersedes #69932.

## Debugging

* The failure affecting Interactivity API tests is a known issue and will be resolved in the next release - https://github.com/microsoft/playwright/issues/36585.

## What's new?
* https://playwright.dev/docs/release-notes#version-152
* https://playwright.dev/docs/release-notes#version-153
* https://playwright.dev/docs/release-notes#version-154

## Testing Instructions
* Run any e2e test locally; the command should download new browsers and run the test successfully.
* CI checks are green.