### PR TITLE
Navigation Link: Add `dropdownMenuProps` and a `resetAll` function

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -42,6 +42,7 @@ import { useMergeRefs, usePrevious } from '@wordpress/compose';
 import { LinkUI } from './link-ui';
 import { updateAttributes } from './update-attributes';
 import { getColors } from '../navigation/edit/utils';
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const DEFAULT_BLOCK = { name: 'core/navigation-link' };
 const NESTING_BLOCK_NAMES = [
@@ -175,8 +176,20 @@ function getMissingText( type ) {
  */
 function Controls( { attributes, setAttributes, setIsLabelFieldFocused } ) {
 	const { label, url, description, rel } = attributes;
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	return (
-		<ToolsPanel label={ __( 'Settings' ) }>
+		<ToolsPanel
+			label={ __( 'Settings' ) }
+			resetAll={ () => {
+				setAttributes( {
+					label: '',
+					url: '',
+					description: '',
+					rel: '',
+				} );
+			} }
+			dropdownMenuProps={ dropdownMenuProps }
+		>
 			<ToolsPanelItem
 				hasValue={ () => !! label }
 				label={ __( 'Text' ) }


### PR DESCRIPTION
## What, Why, and How?
Closes #70504

This PR adds the `resetAll` function and integrates `dropdownMenuProps` in `ToolsPanel` component

## Testing Instructions

1. Within a navigation block, add a custom link block.
2. Confirm that the `ToolsPanel` dropdown opens to the left side of the sidebar.

### Testing Instructions for Keyboard

Same.

## Screenshots 

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/942e22b3-5452-4c37-8a70-c3f4e583c89c)|![after](https://github.com/user-attachments/assets/2aba8ab9-6c8a-4a99-a34c-4aff132f7417)|


