### PR TITLE
Add ability to selectively remove middlewares from apiFetch

### DIFF
--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -67,6 +67,19 @@ function registerMiddleware( middleware ) {
 }
 
 /**
+ * Removes a middleware from the list of registered middlewares.
+ * If the middleware is not found, it does nothing.
+ *
+ * @param {import('./types').APIFetchMiddleware} middleware The middleware to remove.
+ */
+function removeMiddleware( middleware ) {
+	const index = middlewares.indexOf( middleware );
+	if ( index !== -1 ) {
+		middlewares.splice( index, 1 );
+	}
+}
+
+/**
  * Returns the list of registered middlewares.
  *
  * @return {import('./types').APIFetchMiddleware[]} The list of middlewares.
@@ -197,6 +210,7 @@ function apiFetch( options ) {
 
 apiFetch.use = registerMiddleware;
 apiFetch.getMiddlewares = getMiddlewares;
+apiFetch.removeMiddleware = removeMiddleware;
 apiFetch.setFetchHandler = setFetchHandler;
 
 apiFetch.createNonceMiddleware = createNonceMiddleware;

--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -67,6 +67,15 @@ function registerMiddleware( middleware ) {
 }
 
 /**
+ * Returns the list of registered middlewares.
+ *
+ * @return {import('./types').APIFetchMiddleware[]} The list of middlewares.
+ */
+function getMiddlewares() {
+	return middlewares;
+}
+
+/**
  * Checks the status of a response, throwing the Response as an error if
  * it is outside the 200 range.
  *
@@ -187,6 +196,7 @@ function apiFetch( options ) {
 }
 
 apiFetch.use = registerMiddleware;
+apiFetch.getMiddlewares = getMiddlewares;
 apiFetch.setFetchHandler = setFetchHandler;
 
 apiFetch.createNonceMiddleware = createNonceMiddleware;

--- a/packages/api-fetch/src/test/index.js
+++ b/packages/api-fetch/src/test/index.js
@@ -288,4 +288,24 @@ describe( 'apiFetch', () => {
 
 		apiFetch( expectedOptions );
 	} );
+
+	it( 'should remove a registered middleware', async () => {
+		const testMiddleware = jest.fn( ( options, next ) => next( options ) );
+		apiFetch.use( testMiddleware );
+
+		expect( apiFetch.getMiddlewares() ).toContain( testMiddleware );
+
+		apiFetch.removeMiddleware( testMiddleware );
+
+		expect( apiFetch.getMiddlewares() ).not.toContain( testMiddleware );
+	} );
+
+	it( 'should do nothing if removing a middleware that is not registered', () => {
+		const testMiddleware = jest.fn();
+		const initialMiddlewares = [ ...apiFetch.getMiddlewares() ];
+
+		apiFetch.removeMiddleware( testMiddleware );
+
+		expect( apiFetch.getMiddlewares() ).toEqual( initialMiddlewares );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #16805 

<!-- In a few words, what is the PR actually doing? -->
Added ability to selectively remove/unregister middleware(s) from `apiFetch`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There exists no way to remove middlewares used in `apiFetch` and this was a blocker in many use cases as discussed in length in #16805 

There was also an earlier PR (#16806) to fix this issue but was somehow closed without merging. The approach taken in this PR is slightly different.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Added a `getMiddleware()` function that returns the middlewares used to users.
- Added a `removeMiddleware()` function to remove middlewares using the middlewares returned from above.

## Testing
I have added a couple of tests in the tests file for this feature.