### PR TITLE
Archives block Drop-down issue

### DIFF
--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -4,7 +4,6 @@
 import {
 	ToggleControl,
 	SelectControl,
-	Disabled,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
@@ -126,13 +125,11 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 				</ToolsPanel>
 			</InspectorControls>
 			<div { ...useBlockProps() }>
-				<Disabled>
-					<ServerSideRender
-						block="core/archives"
-						skipBlockSupportAttributes
-						attributes={ attributes }
-					/>
-				</Disabled>
+				<ServerSideRender
+					block="core/archives"
+					skipBlockSupportAttributes
+					attributes={ attributes }
+				/>
 			</div>
 		</>
 	);

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -73,7 +73,7 @@ function render_block_core_archives( $attributes ) {
 			// Inject the dropdown script immediately after the select dropdown.
 			$block_content = preg_replace(
 				'#(?<=</select>)#',
-				build_dropdown_script_block_core_archives( $dropdown_id ),
+				block_core_archives_build_dropdown_script( $dropdown_id ),
 				$block_content,
 				1
 			);
@@ -125,7 +125,7 @@ function render_block_core_archives( $attributes ) {
  *
  * @return string Returns the dropdown onChange redirection script.
  */
-function build_dropdown_script_block_core_archives( $dropdown_id ) {
+function block_core_archives_build_dropdown_script( $dropdown_id ) {
 	ob_start();
 	?>
 	<script>

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -66,8 +66,18 @@ function render_block_core_archives( $attributes ) {
 		$show_label = empty( $attributes['showLabel'] ) ? ' screen-reader-text' : '';
 
 		$block_content = '<label for="' . $dropdown_id . '" class="wp-block-archives__label' . $show_label . '">' . esc_html( $title ) . '</label>
-		<select id="' . $dropdown_id . '" name="archive-dropdown" onchange="document.location.href=this.options[this.selectedIndex].value;">
+		<select id="' . $dropdown_id . '" name="archive-dropdown">
 		<option value="">' . esc_html( $label ) . '</option>' . $archives . '</select>';
+
+		if ( ! is_admin() ) {
+			// Inject the dropdown script immediately after the select dropdown.
+			$block_content = preg_replace(
+				'#(?<=</select>)#',
+				build_dropdown_script_block_core_archives( $dropdown_id ),
+				$block_content,
+				1
+			);
+		}
 
 		return sprintf(
 			'<div %1$s>%2$s</div>',
@@ -104,6 +114,36 @@ function render_block_core_archives( $attributes ) {
 		$wrapper_attributes,
 		$archives
 	);
+}
+
+/**
+ * Generates the inline script for an archives dropdown field.
+ *
+ * @since 6.9.0
+ *
+ * @param string $dropdown_id ID of the dropdown field.
+ *
+ * @return string Returns the dropdown onChange redirection script.
+ */
+function build_dropdown_script_block_core_archives( $dropdown_id ) {
+	ob_start();
+	?>
+	<script>
+	( function() {
+		var dropdown = document.getElementById( '<?php echo esc_js( $dropdown_id ); ?>' );
+		if ( ! dropdown ) {
+			return;
+		}
+		function onArchiveChange() {
+			if ( dropdown.options[ dropdown.selectedIndex ].value !== '' ) {
+				location.href = dropdown.options[ dropdown.selectedIndex ].value;
+			}
+		}
+		dropdown.onchange = onArchiveChange;
+	})();
+	</script>
+	<?php
+	return wp_get_inline_script_tag( str_replace( array( '<script>', '</script>' ), '', ob_get_clean() ) );
 }
 
 /**


### PR DESCRIPTION
## What?
Closes #13771

Fix Archives block dropdown functionality by making it interactive in the editor and functional on the frontend, aligning with the Category block behavior.

## Why?
The Archives block's "Display as Drop-down" option was not working properly. When users selected this option, the dropdown was rendered but was disabled and non-functional. This created a poor user experience and accessibility issues, as the dropdown appeared to be broken rather than clearly indicating its disabled state.

As discussed in issue #13771, the ideal solution is to make archive blocks work like category blocks - being both accessible and using the same interaction patterns for consistency across the editor.

## How?
The implementation includes two main changes:

1. **Editor Changes** (`packages/block-library/src/archives/edit.js`):
   - Removed the `Disabled` wrapper around the `ServerSideRender` component
   - Removed unused `Disabled` import
   - This allows the dropdown to be interactive in the editor, matching the behavior of the Category block

2. **Frontend Changes** (`packages/block-library/src/archives/index.php`):
   - Removed the inline `onchange` attribute from the select element
   - Added a new function `build_dropdown_script_block_core_archives()` that generates proper JavaScript for dropdown functionality
   - The script is only injected on the frontend (not in admin), ensuring the dropdown works correctly when the post is published
   - Used `wp_get_inline_script_tag()` for proper script injection following WordPress standards

## Testing Instructions
1. Open a post or page in the editor
2. Insert an Archives block
3. In the block settings panel, check "Display as Drop-down"
4. Verify that the dropdown is now interactive in the editor (you can click on it)
5. Save and view the post on the frontend
6. Click on the dropdown and select an archive date
7. Verify that the page redirects to the selected archive

## Screenshots or screencast
The dropdown now functions consistently between editor and frontend, matching the Category block behavior for improved user experience

### Before

https://github.com/user-attachments/assets/737dbf0a-d35c-4ccf-b58a-01cb75b1e670

### After

https://github.com/user-attachments/assets/61c06f5d-b37a-44fa-bcd7-e755248f5134




