### PR TITLE
Post Author: Optimize and improve user control queries

### DIFF
--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -91,25 +91,34 @@ function PostAuthorEdit( {
 	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
-	const { authorId, authorDetails, supportsAuthor } = useSelect(
-		( select ) => {
-			const { getEditedEntityRecord, getUser, getPostType } =
-				select( coreStore );
-			const _authorId = getEditedEntityRecord(
-				'postType',
-				postType,
-				postId
-			)?.author;
+	const { authorId, authorDetails, canAssignAuthor, supportsAuthor } =
+		useSelect(
+			( select ) => {
+				const { getEditedEntityRecord, getUser, getPostType } =
+					select( coreStore );
+				const currentPost = getEditedEntityRecord(
+					'postType',
+					postType,
+					postId
+				);
+				const _authorId = currentPost?.author;
 
-			return {
-				authorId: _authorId,
-				authorDetails: _authorId ? getUser( _authorId ) : null,
-				supportsAuthor:
-					getPostType( postType )?.supports?.author ?? false,
-			};
-		},
-		[ postType, postId ]
-	);
+				return {
+					authorId: _authorId,
+					authorDetails: _authorId
+						? getUser( _authorId, { context: 'view' } )
+						: null,
+					supportsAuthor:
+						getPostType( postType )?.supports?.author ?? false,
+					canAssignAuthor: currentPost?._links?.[
+						'wp:action-assign-author'
+					]
+						? true
+						: false,
+				};
+			},
+			[ postType, postId ]
+		);
 
 	const { editEntityRecord } = useDispatch( coreStore );
 
@@ -145,7 +154,8 @@ function PostAuthorEdit( {
 		} );
 	};
 
-	const showAuthorControl = !! postId && ! isDescendentOfQueryLoop;
+	const showAuthorControl =
+		!! postId && ! isDescendentOfQueryLoop && canAssignAuthor;
 
 	if ( ! supportsAuthor && postType !== undefined ) {
 		return (

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -21,9 +21,10 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { debounce } from '@wordpress/compose';
-import { useState } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -58,14 +59,38 @@ function AuthorCombobox( { value, onChange } ) {
 		[ filterValue ]
 	);
 
-	const authorOptions = authors?.length
-		? authors.map( ( { id, name } ) => {
-				return {
-					value: id,
-					label: name,
-				};
-		  } )
-		: [];
+	const authorOptions = useMemo( () => {
+		const fetchedAuthors = ( authors ?? [] ).map( ( author ) => {
+			return {
+				value: author.id,
+				label: decodeEntities( author.name ),
+			};
+		} );
+
+		// Ensure the current author is included in the list.
+		const foundAuthor = fetchedAuthors.findIndex(
+			( fetchedAuthor ) => value?.id === fetchedAuthor.value
+		);
+
+		let currentAuthor = [];
+		if ( foundAuthor < 0 && value ) {
+			currentAuthor = [
+				{
+					value: value.id,
+					label: decodeEntities( value.name ),
+				},
+			];
+		} else if ( foundAuthor < 0 && ! value ) {
+			currentAuthor = [
+				{
+					value: 0,
+					label: __( '(No author)' ),
+				},
+			];
+		}
+
+		return [ ...currentAuthor, ...fetchedAuthors ];
+	}, [ authors, value ] );
 
 	return (
 		<ComboboxControl
@@ -73,7 +98,7 @@ function AuthorCombobox( { value, onChange } ) {
 			__nextHasNoMarginBottom
 			label={ __( 'Author' ) }
 			options={ authorOptions }
-			value={ value }
+			value={ value?.id }
 			onFilterValueChange={ debounce( setFilterValue, 300 ) }
 			onChange={ onChange }
 			allowReset={ false }
@@ -91,34 +116,32 @@ function PostAuthorEdit( {
 	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
-	const { authorId, authorDetails, canAssignAuthor, supportsAuthor } =
-		useSelect(
-			( select ) => {
-				const { getEditedEntityRecord, getUser, getPostType } =
-					select( coreStore );
-				const currentPost = getEditedEntityRecord(
-					'postType',
-					postType,
-					postId
-				);
-				const _authorId = currentPost?.author;
+	const { authorDetails, canAssignAuthor, supportsAuthor } = useSelect(
+		( select ) => {
+			const { getEditedEntityRecord, getUser, getPostType } =
+				select( coreStore );
+			const currentPost = getEditedEntityRecord(
+				'postType',
+				postType,
+				postId
+			);
+			const authorId = currentPost?.author;
 
-				return {
-					authorId: _authorId,
-					authorDetails: _authorId
-						? getUser( _authorId, { context: 'view' } )
-						: null,
-					supportsAuthor:
-						getPostType( postType )?.supports?.author ?? false,
-					canAssignAuthor: currentPost?._links?.[
-						'wp:action-assign-author'
-					]
-						? true
-						: false,
-				};
-			},
-			[ postType, postId ]
-		);
+			return {
+				authorDetails: authorId
+					? getUser( authorId, { context: 'view' } )
+					: null,
+				supportsAuthor:
+					getPostType( postType )?.supports?.author ?? false,
+				canAssignAuthor: currentPost?._links?.[
+					'wp:action-assign-author'
+				]
+					? true
+					: false,
+			};
+		},
+		[ postType, postId ]
+	);
 
 	const { editEntityRecord } = useDispatch( coreStore );
 
@@ -187,7 +210,7 @@ function PostAuthorEdit( {
 					{ showAuthorControl && (
 						<div style={ { gridColumn: '1 / -1' } }>
 							<AuthorCombobox
-								value={ authorId }
+								value={ authorDetails }
 								onChange={ handleSelect }
 							/>
 						</div>

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -20,6 +20,8 @@ import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
+import { debounce } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
@@ -29,12 +31,56 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
-const minimumUsersForCombobox = 25;
-
 const AUTHORS_QUERY = {
 	who: 'authors',
 	per_page: 100,
+	_fields: 'id,name',
+	context: 'view',
 };
+
+function AuthorCombobox( { value, onChange } ) {
+	const [ filterValue, setFilterValue ] = useState( '' );
+	const { authors, isLoading } = useSelect(
+		( select ) => {
+			const { getUsers, isResolving } = select( coreStore );
+
+			const query = { ...AUTHORS_QUERY };
+			if ( filterValue ) {
+				query.search = filterValue;
+				query.search_columns = [ 'name' ];
+			}
+
+			return {
+				authors: getUsers( query ),
+				isLoading: isResolving( 'getUsers', [ query ] ),
+			};
+		},
+		[ filterValue ]
+	);
+
+	const authorOptions = authors?.length
+		? authors.map( ( { id, name } ) => {
+				return {
+					value: id,
+					label: name,
+				};
+		  } )
+		: [];
+
+	return (
+		<ComboboxControl
+			__next40pxDefaultSize
+			__nextHasNoMarginBottom
+			label={ __( 'Author' ) }
+			options={ authorOptions }
+			value={ value }
+			onFilterValueChange={ debounce( setFilterValue, 300 ) }
+			onChange={ onChange }
+			allowReset={ false }
+			isLoading={ isLoading }
+		/>
+	);
+}
 
 function PostAuthorEdit( {
 	isSelected,
@@ -45,9 +91,9 @@ function PostAuthorEdit( {
 	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
-	const { authorId, authorDetails, authors, supportsAuthor } = useSelect(
+	const { authorId, authorDetails, supportsAuthor } = useSelect(
 		( select ) => {
-			const { getEditedEntityRecord, getUser, getUsers, getPostType } =
+			const { getEditedEntityRecord, getUser, getPostType } =
 				select( coreStore );
 			const _authorId = getEditedEntityRecord(
 				'postType',
@@ -58,7 +104,6 @@ function PostAuthorEdit( {
 			return {
 				authorId: _authorId,
 				authorDetails: _authorId ? getUser( _authorId ) : null,
-				authors: getUsers( AUTHORS_QUERY ),
 				supportsAuthor:
 					getPostType( postType )?.supports?.author ?? false,
 			};
@@ -94,24 +139,13 @@ function PostAuthorEdit( {
 		} ),
 	} );
 
-	const authorOptions = authors?.length
-		? authors.map( ( { id, name } ) => {
-				return {
-					value: id,
-					label: name,
-				};
-		  } )
-		: [];
-
 	const handleSelect = ( nextAuthorId ) => {
 		editEntityRecord( 'postType', postType, postId, {
 			author: nextAuthorId,
 		} );
 	};
 
-	const showCombobox = authorOptions.length >= minimumUsersForCombobox;
-	const showAuthorControl =
-		!! postId && ! isDescendentOfQueryLoop && authorOptions.length > 0;
+	const showAuthorControl = !! postId && ! isDescendentOfQueryLoop;
 
 	if ( ! supportsAuthor && postType !== undefined ) {
 		return (
@@ -142,26 +176,10 @@ function PostAuthorEdit( {
 				>
 					{ showAuthorControl && (
 						<div style={ { gridColumn: '1 / -1' } }>
-							{ ( showCombobox && (
-								<ComboboxControl
-									__next40pxDefaultSize
-									__nextHasNoMarginBottom
-									label={ __( 'Author' ) }
-									options={ authorOptions }
-									value={ authorId }
-									onChange={ handleSelect }
-									allowReset={ false }
-								/>
-							) ) || (
-								<SelectControl
-									__next40pxDefaultSize
-									__nextHasNoMarginBottom
-									label={ __( 'Author' ) }
-									value={ authorId }
-									options={ authorOptions }
-									onChange={ handleSelect }
-								/>
-							) }
+							<AuthorCombobox
+								value={ authorId }
+								onChange={ handleSelect }
+							/>
 						</div>
 					) }
 					<ToolsPanelItem


### PR DESCRIPTION
## What?
Part of #45668.

PR makes the following improvements to the Post Author block:

* Fetch data on demand. Avoid HTTP requests when control isn't rendered.
* Allow searching for more than 100 users, without regressing performance.
* Display data for all users with the right capabilities. Previously, it was only working for admin users.
* Ensure the current author is included in the list.
* Removes the condition for switching between Select and Combobox.  I think the latter has better UX for similar settings.

## Why?
The general plan is to consolidate similar author selection controls across the blocks. I'm avoiding early abstraction of `AuthorCombobox` as suggested in the issue, and here's why:

* The `@wordpress/block-editor` can't depend on the `core-data` package.
* The `@wordpress/editor` is a high-level package and can only be used by `edit-post/edit-site` packages.
* Best option is to have this as a shared component in the `block-library` package, which I'll handle as the last step of #45668.

## How?
The refactoring closely mimics the `PostAuthor` component logic from the `editor` package.

## Testing Instructions
1. Open a post or page.
2. Insert the Post Author block.
3. Confirm that author selection continues to work as before for admin users.
4. Repeat the same step with the `editor` user role.
5. Confirm that the author selection settings are now visible for this role.
6. Repeat the test for the `author` user role.
7. The author selection should be hidden for this role.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2025-06-24 at 14 52 34](https://github.com/user-attachments/assets/c7eaa14d-2eb9-461d-acf9-149d1dc6b425)

