### PR TITLE
PostAuthorCombobox: Simplify 'onFilterValueChange' debounced callback

### DIFF
--- a/packages/editor/src/components/post-author/combobox.js
+++ b/packages/editor/src/components/post-author/combobox.js
@@ -32,15 +32,6 @@ export default function PostAuthorCombobox() {
 		editPost( { author: postAuthorId } );
 	};
 
-	/**
-	 * Handle user input.
-	 *
-	 * @param {string} inputValue The current value of the input field.
-	 */
-	const handleKeydown = ( inputValue ) => {
-		setFieldValue( inputValue );
-	};
-
 	return (
 		<ComboboxControl
 			__nextHasNoMarginBottom
@@ -48,7 +39,7 @@ export default function PostAuthorCombobox() {
 			label={ __( 'Author' ) }
 			options={ authorOptions }
 			value={ authorId }
-			onFilterValueChange={ debounce( handleKeydown, 300 ) }
+			onFilterValueChange={ debounce( setFieldValue, 300 ) }
 			onChange={ handleSelect }
 			allowReset={ false }
 			hideLabelFromVision


### PR DESCRIPTION
## What?
A minor code quality optimization, pass `fieldValue` state setter directly to the `debounce` method, instead of wrapping it into another function.

## Testing Instructions
1. Open a post or page.
2. Confirm that the search in the post author combobox works as before.

### Testing Instructions for Keyboard
Same.
