### PR TITLE
Add loading text for legacy widget preview

### DIFF
--- a/packages/widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/index.js
@@ -159,6 +159,9 @@ function NotEmpty( {
 					{ hasPreview === null && mode === 'preview' && (
 						<Placeholder>
 							<Spinner />
+							<span className="wp-block-legacy-widget__preview-loading-text">
+								{ __( 'Loading preview…' ) }
+							</span>
 						</Placeholder>
 					) }
 					{ hasPreview === true && (

--- a/packages/widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/index.js
@@ -12,7 +12,13 @@ import {
 	InspectorControls,
 	BlockIcon,
 } from '@wordpress/block-editor';
-import { Flex, FlexBlock, Spinner, Placeholder } from '@wordpress/components';
+import {
+	Flex,
+	FlexBlock,
+	Spinner,
+	Placeholder,
+	__experimentalText as Text,
+} from '@wordpress/components';
 import { brush as brushIcon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { useState, useCallback } from '@wordpress/element';
@@ -159,9 +165,12 @@ function NotEmpty( {
 					{ hasPreview === null && mode === 'preview' && (
 						<Placeholder>
 							<Spinner />
-							<span className="wp-block-legacy-widget__preview-loading-text">
+							<Text
+								variant="muted"
+								className="wp-block-legacy-widget__preview-loading"
+							>
 								{ __( 'Loading preview…' ) }
-							</span>
+							</Text>
 						</Placeholder>
 					) }
 					{ hasPreview === true && (

--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -163,6 +163,6 @@
 	min-width: 400px;
 }
 
-.wp-block-legacy-widget__preview-loading-text {
+.wp-block-legacy-widget__preview-loading {
 	align-self: center;
 }

--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -163,3 +163,6 @@
 	min-width: 400px;
 }
 
+.wp-block-legacy-widget__preview-loading-text {
+	align-self: center;
+}


### PR DESCRIPTION
## What?
Closes #33667 

Adds a "Loading preview…" label next to the spinner for legacy widget on the block-based Widgets screen.

## Why?
When a site has many widgets and sidebars, the block-based Widgets screen can take a long time to load.
Previously, users only saw a spinner during this time, which created confusion and doubt about whether the interface was working.

This PR improves user feedback during loading, making it clearer that content is actively being loaded.

## How?
Adds a "Loading preview…" text label next to the spinner during the block preview loading phase.

## Testing Instructions
1. Go to **Appearance > Widgets** in a site and add some legacy widgets.
2. Observe the loading phase on reload.
3. Confirm that the spinner now displays the "Loading preview…" label next to it.

## Screenshots or screencast 
|Before|After|
|-|-|
|<img width="1416" alt="Before" src="https://github.com/user-attachments/assets/dc3664b6-204f-4413-b1f8-0cecb8dc8fd3" />|<img width="1414" alt="After" src="https://github.com/user-attachments/assets/3a9d72bf-cfc5-4450-bb96-92af537d8643" />|
