### PR TITLE
Fix submenu border visibility in Navigation block

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -46,6 +46,7 @@ $navigation-icon-size: 24px;
 	// but still allow them to be overridden by user-set colors.
 	.wp-block-navigation-item__content {
 		display: block;
+		z-index: 1;
 	}
 
 	// This rule needs extra specificity so that it inherits the correct color from its parent.
@@ -159,7 +160,7 @@ $navigation-icon-size: 24px;
 		background-color: inherit;
 		color: inherit;
 		position: absolute;
-		z-index: 2;
+		z-index: 2000;
 		display: flex;
 		flex-direction: column;
 		align-items: normal;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -160,7 +160,7 @@ $navigation-icon-size: 24px;
 		background-color: inherit;
 		color: inherit;
 		position: absolute;
-		z-index: 2000;
+		z-index: 2;
 		display: flex;
 		flex-direction: column;
 		align-items: normal;


### PR DESCRIPTION
## What?
Closes #70516 

Fixes the visual clipping of submenus in the Navigation block when a menu item is focused via keyboard. Specifically, it resolves an issue where the bottom part of nested submenus was hidden.

## Why?
When using the keyboard to navigate a nested menu (e.g., via the `Tab` key), the browser displays a focus outline on the menu item. In many default themes (including Emptytheme), the bottom portion of the focused submenu was being clipped, making it inaccessible or visually broken.

## How?
Added `z-index: 1` to the `.wp-block-navigation-item__content` class to ensure that submenu containers are correctly layered above surrounding elements, preventing clipping and making the keyboard focus outline fully visible.

## Testing Instructions
1. Open a post or page editor.
2. Insert a Navigation block.
3. Add a nested menu structure (at least two levels deep).
4. Save and preview the page on the front end.
5. Use the `Tab` key to navigate into the menu and focus a submenu item.

### Testing Instructions for Keyboard
1. Use `Tab` key to focus into the top-level menu.
2. Continue tabbing into the submenu.
3. Observe that:

   * Focus ring appears correctly.
   * Entire submenu content (including bottom items) remains visible.
   * No parts are visually cut off.

## Screenshots or screencast 
#### Emptytheme
<img width="565" alt="Emptytheme" src="https://github.com/user-attachments/assets/3785c861-bfeb-4d6a-ba86-84d3fd206092" />

#### Twenty Twenty-Two
<img width="562" alt="Twenty Twenty-Two" src="https://github.com/user-attachments/assets/653bd860-7010-4e9d-bdd9-38be87f7b9c8" />

#### Twenty Twenty-Three
<img width="551" alt="Twenty Twenty-Five" src="https://github.com/user-attachments/assets/d690ace1-f9bd-4dce-b4f6-c0adc2f39be2" />

#### Twenty Twenty-Four
<img width="562" alt="Twenty Twenty-Two" src="https://github.com/user-attachments/assets/4b33290a-8101-4952-a5dc-44a4d0eac149" />

#### Twenty Twenty-Five
<img width="551" alt="Twenty Twenty-Five" src="https://github.com/user-attachments/assets/f6e8d38e-e039-4b1b-ba49-8c5a73e94f51" />
