### PR TITLE
RawHTML: Clarify the wrapper 'div' element behavior

### DIFF
--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -270,7 +270,9 @@ _Related_
 
 ### RawHTML
 
-Component used as equivalent of Fragment with unescaped HTML, in cases where it is desirable to render dangerous HTML without needing a wrapper element. To preserve additional props, a `div` wrapper _will_ be created if any props aside from `children` are passed.
+Component used to render unescaped HTML.
+
+Note: The `renderElement` serializer will remove the `div` wrapper unless non-children props are present; typically when preparing a block for saving.
 
 _Parameters_
 

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -274,6 +274,20 @@ Component used to render unescaped HTML.
 
 Note: The `renderElement` serializer will remove the `div` wrapper unless non-children props are present; typically when preparing a block for saving.
 
+_Usage_
+
+```jsx
+import { RawHTML } from '@wordpress/element';
+
+const Component = () => (
+	<RawHTML>
+		<h3>Hello world</h3>
+	</RawHTML>
+);
+// Edit: <div><h3>Hello world</h3></div>
+// save: <h3>Hello world</h3>
+```
+
 _Parameters_
 
 -   _props_ `RawHTMLProps`: Children should be a string of HTML or an array of strings. Other props will be passed through to the div wrapper.

--- a/packages/element/src/raw-html.js
+++ b/packages/element/src/raw-html.js
@@ -6,10 +6,10 @@ import { Children, createElement } from './react';
 /** @typedef {{children: string} & import('react').ComponentPropsWithoutRef<'div'>} RawHTMLProps */
 
 /**
- * Component used as equivalent of Fragment with unescaped HTML, in cases where
- * it is desirable to render dangerous HTML without needing a wrapper element.
- * To preserve additional props, a `div` wrapper _will_ be created if any props
- * aside from `children` are passed.
+ * Component used to render unescaped HTML.
+ *
+ * Note: The `renderElement` serializer will remove the `div` wrapper
+ * unless non-children props are present; typically when preparing a block for saving.
  *
  * @param {RawHTMLProps} props Children should be a string of HTML or an array
  *                             of strings. Other props will be passed through

--- a/packages/element/src/raw-html.js
+++ b/packages/element/src/raw-html.js
@@ -11,6 +11,15 @@ import { Children, createElement } from './react';
  * Note: The `renderElement` serializer will remove the `div` wrapper
  * unless non-children props are present; typically when preparing a block for saving.
  *
+ * @example
+ * ```jsx
+ * import { RawHTML } from '@wordpress/element';
+ *
+ * const Component = () => <RawHTML><h3>Hello world</h3></RawHTML>;
+ * // Edit: <div><h3>Hello world</h3></div>
+ * // save: <h3>Hello world</h3>
+ * ```
+ *
  * @param {RawHTMLProps} props Children should be a string of HTML or an array
  *                             of strings. Other props will be passed through
  *                             to the div wrapper.


### PR DESCRIPTION
## What?
Closes #70349

PR clarifies the wrapper `div` behavior in `RawHTML` component.

## Testing Instructions
None. It's just a documentation update.
