### PR TITLE
File Block: Fix Safari PDF preview display issue

### DIFF
--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -275,13 +275,10 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 						onResizeStop={ handleOnResizeStop }
 						showHandle={ isSelected }
 					>
-						<object
+						<iframe
 							className="wp-block-file__preview"
-							data={ href }
-							type="application/pdf"
-							aria-label={ __(
-								'Embed of the selected PDF file.'
-							) }
+							src={ href }
+							title={ __( 'Embed of the selected PDF file.' ) }
 						/>
 						{ ! isSelected && (
 							<div className="wp-block-file__preview-overlay" />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes: #62120

Fixes Safari PDF preview display issue in the File block by replacing the `<object>` element with an `<iframe>` element for PDF embedding.

## Why?
Safari has a known issue with PDF embedding using the `<object>` tag with `type="application/pdf"`. When users toggle the "Show inline embed" option off and back on for a PDF file in the File block, Safari displays a gray box instead of the PDF content. This issue is specific to Safari and doesn't occur in Chrome or Firefox.

The problem occurs because Safari doesn't properly reload PDF content when the `<object>` element is dynamically removed and re-added to the DOM during React re-rendering.

## Testing Instructions
1. Open a post or page in the WordPress editor
2. Insert a File block
3. Upload or select a PDF file from the media library
4. Verify the PDF displays correctly in the editor preview
5. In the block settings sidebar, toggle OFF the "Show inline embed" option
6. Observe that the PDF preview is hidden
7. Toggle ON the "Show inline embed" option
8. Verify that the PDF preview displays correctly (not as a gray box)
9. Test resizing the PDF preview using the resize handle
10. Repeat steps 5-8 multiple times to ensure consistent behavior

**Important**: Test specifically in Safari browser to verify the gray box issue is resolved.

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/94619c12-53d9-41ba-aa4d-8da4be2dd886

### After

https://github.com/user-attachments/assets/f314b3e3-20c5-4651-acb4-3fd03827a32c

