### PR TITLE
ServerSideRender: Use data hooks instead of HoC

### DIFF
--- a/packages/server-side-render/src/index.js
+++ b/packages/server-side-render/src/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useMemo } from '@wordpress/element';
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -14,25 +14,23 @@ import ServerSideRender from './server-side-render';
  */
 const EMPTY_OBJECT = {};
 
-const ExportedServerSideRender = withSelect( ( select ) => {
-	// FIXME: @wordpress/server-side-render should not depend on @wordpress/editor.
-	// It is used by blocks that can be loaded into a *non-post* block editor.
-	// eslint-disable-next-line @wordpress/data-no-store-string-literals
-	const coreEditorSelect = select( 'core/editor' );
-	if ( coreEditorSelect ) {
-		const currentPostId = coreEditorSelect.getCurrentPostId();
+export default function ExportedServerSideRender( {
+	urlQueryArgs = EMPTY_OBJECT,
+	...props
+} ) {
+	const currentPostId = useSelect( ( select ) => {
+		// FIXME: @wordpress/server-side-render should not depend on @wordpress/editor.
+		// It is used by blocks that can be loaded into a *non-post* block editor.
+		// eslint-disable-next-line @wordpress/data-no-store-string-literals
+		const postId = select( 'core/editor' )?.getCurrentPostId();
+
 		// For templates and template parts we use a custom ID format.
 		// Since they aren't real posts, we don't want to use their ID
 		// for server-side rendering. Since they use a string based ID,
 		// we can assume real post IDs are numbers.
-		if ( currentPostId && typeof currentPostId === 'number' ) {
-			return {
-				currentPostId,
-			};
-		}
-	}
-	return EMPTY_OBJECT;
-} )( ( { urlQueryArgs = EMPTY_OBJECT, currentPostId, ...props } ) => {
+		return postId && typeof postId === 'number' ? postId : null;
+	}, [] );
+
 	const newUrlQueryArgs = useMemo( () => {
 		if ( ! currentPostId ) {
 			return urlQueryArgs;
@@ -44,6 +42,4 @@ const ExportedServerSideRender = withSelect( ( select ) => {
 	}, [ currentPostId, urlQueryArgs ] );
 
 	return <ServerSideRender urlQueryArgs={ newUrlQueryArgs } { ...props } />;
-} );
-
-export default ExportedServerSideRender;
+}


### PR DESCRIPTION
## What?
PR refactors `ExportedServerSideRender` component to use data hooks instead of HoCs.

## Why?
A micro-optimization reduces the size of the rendered component tree.

## Testing Instructions
1. Open a post or page.
2. Test any server-side rendered block, such as Archives.
3. Confirm they work as before.