### PR TITLE
usePostActions: avoid theme fetch for non template part types

### DIFF
--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -133,6 +133,7 @@ export const registerPostTypeSchema =
 
 		let hasDuplicateTemplatePartAction = false;
 		if ( postTypeConfig.slug === 'wp_template_part' && canCreate ) {
+			// Avoid a blocking network request if we can.
 			hasDuplicateTemplatePartAction = (
 				await registry.resolveSelect( coreStore ).getCurrentTheme()
 			)?.is_block_theme;

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -131,6 +131,13 @@ export const registerPostTypeSchema =
 			.resolveSelect( coreStore )
 			.getCurrentTheme();
 
+		let hasDuplicateTemplatePartAction = false;
+		if ( postTypeConfig.slug === 'wp_template_part' && canCreate ) {
+			hasDuplicateTemplatePartAction = (
+				await registry.resolveSelect( coreStore ).getCurrentTheme()
+			)?.is_block_theme;
+		}
+
 		const actions = [
 			postTypeConfig.viewable ? viewPost : undefined,
 			!! postTypeConfig.supports?.revisions
@@ -144,11 +151,7 @@ export const registerPostTypeSchema =
 				  canCreate &&
 				  duplicatePost
 				: undefined,
-			postTypeConfig.slug === 'wp_template_part' &&
-			canCreate &&
-			currentTheme?.is_block_theme
-				? duplicateTemplatePart
-				: undefined,
+			hasDuplicateTemplatePartAction ? duplicateTemplatePart : undefined,
 			canCreate && postTypeConfig.slug === 'wp_block'
 				? duplicatePattern
 				: undefined,

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -127,9 +127,6 @@ export const registerPostTypeSchema =
 				kind: 'postType',
 				name: postType,
 			} );
-		const currentTheme = await registry
-			.resolveSelect( coreStore )
-			.getCurrentTheme();
 
 		let hasDuplicateTemplatePartAction = false;
 		if ( postTypeConfig.slug === 'wp_template_part' && canCreate ) {
@@ -137,6 +134,13 @@ export const registerPostTypeSchema =
 			hasDuplicateTemplatePartAction = (
 				await registry.resolveSelect( coreStore ).getCurrentTheme()
 			)?.is_block_theme;
+		}
+
+		let hasFeaturedImageField = false;
+		if ( postTypeConfig.supports?.thumbnail ) {
+			hasFeaturedImageField = (
+				await registry.resolveSelect( coreStore ).getCurrentTheme()
+			)?.theme_supports?.[ 'post-thumbnails' ];
 		}
 
 		const actions = [
@@ -169,9 +173,7 @@ export const registerPostTypeSchema =
 		].filter( Boolean );
 
 		const fields = [
-			postTypeConfig.supports?.thumbnail &&
-				currentTheme?.theme_supports?.[ 'post-thumbnails' ] &&
-				featuredImageField,
+			hasFeaturedImageField ? featuredImageField : undefined,
 			postTypeConfig.supports?.author && authorField,
 			statusField,
 			dateField,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

A bit related to #70535, this one avoids a request for the current theme if it's not needed. It's only needed for template parts.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Go to Site Editor > Patterns > Template Parts, and check that duplication is still available.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
