### PR TITLE
Add left margin to prevent line number overlap in legacy custom HTML block

### DIFF
--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -75,6 +75,10 @@
 		select {
 			padding-left: $grid-unit-05;
 		}
+
+		.CodeMirror pre {
+			margin-left: 64px;
+		}
 	}
 
 	// Reset z-index set on https://github.com/WordPress/wordpress-develop/commit/f26d4d37351a55fd1fc5dad0f5fef8f0f964908c.


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #35499 

This PR fixes a visual issue in the Custom HTML block within the legacy widgets screen, where the line numbers overlap the editable HTML content, and the left edge of the content is not visible.

## Why?
When editing a Legacy custom HTML widget under Appearance → Widgets, the line numbers currently overlap the code, making it difficult to read and edit. This is due to insufficient left margin in the editor.

## How?
This PR adjusts the margin of the `pre` tag to add enough space between the line numbers and the code, improving visibility and usability.

## Testing Instructions
1. Install and activate the Classic Widgets plugin.
2. Go to **Appearance → Widgets** in the WordPress admin.
3. Add a **Custom HTML** widget and enter multiline HTML.
4. Deactivate the Classic Widgets plugin.
5. Verify that:
   - Line numbers no longer overlap the HTML content.
   - Left edge of the HTML is clearly visible.

## Screenshots or screencast 

|Before|After|
|-|-|
|<img width="1470" alt="Before_Fix" src="https://github.com/user-attachments/assets/25322872-cec5-4d72-8098-89273f539af7" />|<img width="1470" alt="After_Fix" src="https://github.com/user-attachments/assets/51b53ea9-86db-4128-be53-33cd39be86d7" />|
