### PR TITLE
Query Loop Block: Add support for matching all taxonomy terms in block filter

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -714,7 +714,7 @@ An advanced block that allows displaying post types based on different query par
 -	**Name:** core/query
 -	**Category:** theme
 -	**Supports:** align (full, wide), interactivity, layout, ~~html~~
--	**Attributes:** enhancedPagination, namespace, query, queryId, tagName
+-	**Attributes:** enhancedPagination, matchAllTaxonomies, namespace, query, queryId, tagName
 
 ## No Results
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -714,7 +714,7 @@ An advanced block that allows displaying post types based on different query par
 -	**Name:** core/query
 -	**Category:** theme
 -	**Supports:** align (full, wide), interactivity, layout, ~~html~~
--	**Attributes:** enhancedPagination, matchAllTaxonomies, namespace, query, queryId, tagName
+-	**Attributes:** enhancedPagination, matchAllTerms, namespace, query, queryId, tagName
 
 ## No Results
 

--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -14,7 +14,7 @@
 		"templateSlug",
 		"previewPostType",
 		"enhancedPagination",
-		"matchAllTaxonomies",
+		"matchAllTerms",
 		"postType"
 	],
 	"supports": {

--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -14,6 +14,7 @@
 		"templateSlug",
 		"previewPostType",
 		"enhancedPagination",
+		"matchAllTaxonomies",
 		"postType"
 	],
 	"supports": {

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -100,13 +100,14 @@ export default function PostTemplateEdit( {
 		} = {},
 		templateSlug,
 		previewPostType,
+		matchAllTaxonomies,
 	},
 	attributes: { layout },
 	__unstableLayoutClassNames,
 } ) {
 	const { type: layoutType, columnCount = 3 } = layout || {};
 	const [ activeBlockContextId, setActiveBlockContextId ] = useState();
-	const { posts, blocks } = useSelect(
+	const { fetchedPosts, blocks } = useSelect(
 		( select ) => {
 			const { getEntityRecords, getTaxonomies } = select( coreStore );
 			const { getBlocks } = select( blockEditorStore );
@@ -217,7 +218,7 @@ export default function PostTemplateEdit( {
 			// block's postType, which is passed through block context.
 			const usedPostType = previewPostType || currentPostType;
 			return {
-				posts: getEntityRecords( 'postType', usedPostType, {
+				fetchedPosts: getEntityRecords( 'postType', usedPostType, {
 					...query,
 					...restQueryArgs,
 				} ),
@@ -244,6 +245,41 @@ export default function PostTemplateEdit( {
 			previewPostType,
 		]
 	);
+
+	// Filtered list of posts that match all selected taxonomy terms,
+	// applied only when matchAllTaxonomies is enabled.
+	const posts = useMemo( () => {
+		if (
+			! matchAllTaxonomies ||
+			! Array.isArray( fetchedPosts ) ||
+			fetchedPosts.length === 0 ||
+			! taxQuery ||
+			Object.keys( taxQuery ).length === 0
+		) {
+			return fetchedPosts;
+		}
+
+		// Map taxonomy slugs to post field names.
+		// Needed for core taxonomies (categories/tags).
+		const taxonomyToPostKey = {
+			category: 'categories',
+			post_tag: 'tags',
+		};
+
+		return fetchedPosts.filter( ( post ) => {
+			return Object.entries( taxQuery ).every(
+				( [ taxonomySlug, requiredTermIds ] ) => {
+					const postKey =
+						taxonomyToPostKey[ taxonomySlug ] || taxonomySlug;
+					const postTerms = post[ postKey ] || [];
+					return requiredTermIds.every( ( termId ) =>
+						postTerms.includes( termId )
+					);
+				}
+			);
+		} );
+	}, [ fetchedPosts, matchAllTaxonomies, taxQuery ] );
+
 	const blockContexts = useMemo(
 		() =>
 			posts?.map( ( post ) => ( {

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -100,7 +100,7 @@ export default function PostTemplateEdit( {
 		} = {},
 		templateSlug,
 		previewPostType,
-		matchAllTaxonomies,
+		matchAllTerms,
 	},
 	attributes: { layout },
 	__unstableLayoutClassNames,
@@ -247,10 +247,10 @@ export default function PostTemplateEdit( {
 	);
 
 	// Filtered list of posts that match all selected taxonomy terms,
-	// applied only when matchAllTaxonomies is enabled.
+	// applied only when matchAllTerms is enabled.
 	const posts = useMemo( () => {
 		if (
-			! matchAllTaxonomies ||
+			! matchAllTerms ||
 			! Array.isArray( fetchedPosts ) ||
 			fetchedPosts.length === 0 ||
 			! taxQuery ||
@@ -278,7 +278,7 @@ export default function PostTemplateEdit( {
 				}
 			);
 		} );
-	}, [ fetchedPosts, matchAllTaxonomies, taxQuery ] );
+	}, [ fetchedPosts, matchAllTerms, taxQuery ] );
 
 	const blockContexts = useMemo(
 		() =>

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -78,8 +78,6 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 				}
 			}
 			unset( $tax_query_part );
-
-			$query_args['tax_query']['relation'] = 'AND';
 		}
 
 		$query = new WP_Query( $query_args );

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -68,10 +68,10 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 			$query = $wp_query;
 		}
 	} else {
-		$query_args           = build_query_vars_from_query_block( $block, $page );
-		$match_all_taxonomies = ! empty( $block->context['matchAllTaxonomies'] );
+		$query_args      = build_query_vars_from_query_block( $block, $page );
+		$match_all_terms = ! empty( $block->context['matchAllTerms'] );
 
-		if ( $match_all_taxonomies && ! empty( $query_args['tax_query'] ) && is_array( $query_args['tax_query'] ) ) {
+		if ( $match_all_terms && ! empty( $query_args['tax_query'] ) && is_array( $query_args['tax_query'] ) ) {
 			foreach ( $query_args['tax_query'] as &$tax_query_part ) {
 				if ( isset( $tax_query_part['taxonomy'] ) ) {
 					$tax_query_part['operator'] = 'AND';

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -68,8 +68,21 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 			$query = $wp_query;
 		}
 	} else {
-		$query_args = build_query_vars_from_query_block( $block, $page );
-		$query      = new WP_Query( $query_args );
+		$query_args           = build_query_vars_from_query_block( $block, $page );
+		$match_all_taxonomies = ! empty( $block->context['matchAllTaxonomies'] );
+
+		if ( $match_all_taxonomies && ! empty( $query_args['tax_query'] ) && is_array( $query_args['tax_query'] ) ) {
+			foreach ( $query_args['tax_query'] as &$tax_query_part ) {
+				if ( isset( $tax_query_part['taxonomy'] ) ) {
+					$tax_query_part['operator'] = 'AND';
+				}
+			}
+			unset( $tax_query_part );
+
+			$query_args['tax_query']['relation'] = 'AND';
+		}
+
+		$query = new WP_Query( $query_args );
 	}
 
 	if ( ! $query->have_posts() ) {

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -41,7 +41,7 @@
 			"type": "boolean",
 			"default": false
 		},
-		"matchAllTaxonomies": {
+		"matchAllTerms": {
 			"type": "boolean",
 			"default": false
 		}
@@ -52,7 +52,7 @@
 		"query": "query",
 		"displayLayout": "displayLayout",
 		"enhancedPagination": "enhancedPagination",
-		"matchAllTaxonomies": "matchAllTaxonomies"
+		"matchAllTerms": "matchAllTerms"
 	},
 	"supports": {
 		"align": [ "wide", "full" ],

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -40,6 +40,10 @@
 		"enhancedPagination": {
 			"type": "boolean",
 			"default": false
+		},
+		"matchAllTaxonomies": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"usesContext": [ "templateSlug" ],

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -51,7 +51,8 @@
 		"queryId": "queryId",
 		"query": "query",
 		"displayLayout": "displayLayout",
-		"enhancedPagination": "enhancedPagination"
+		"enhancedPagination": "enhancedPagination",
+		"matchAllTaxonomies": "matchAllTaxonomies"
 	},
 	"supports": {
 		"align": [ "wide", "full" ],

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -376,6 +376,9 @@ export default function QueryInspectorControls( props ) {
 							taxQuery: null,
 							format: [],
 						} );
+						setAttributes( {
+							matchAllTerms: false,
+						} );
 						setQuerySearch( '' );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -40,7 +40,7 @@ import {
 import { useToolsPanelDropdownMenuProps } from '../../../utils/hooks';
 
 export default function QueryInspectorControls( props ) {
-	const { attributes, setQuery, isSingular } = props;
+	const { attributes, setAttributes, setQuery, isSingular } = props;
 	const { query } = attributes;
 	const {
 		order,
@@ -392,7 +392,8 @@ export default function QueryInspectorControls( props ) {
 						>
 							<TaxonomyControls
 								onChange={ setQuery }
-								query={ query }
+								attributes={ attributes }
+								setAttributes={ setAttributes }
 							/>
 						</ToolsPanelItem>
 					) }

--- a/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
@@ -3,6 +3,7 @@
  */
 import {
 	FormTokenField,
+	ToggleControl,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -10,6 +11,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useState, useEffect } from '@wordpress/element';
 import { useDebounce } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -47,7 +49,8 @@ const getTermIdByTermValue = ( terms, termValue ) => {
 	)?.id;
 };
 
-export function TaxonomyControls( { onChange, query } ) {
+export function TaxonomyControls( { onChange, attributes, setAttributes } ) {
+	const { query, matchAllTaxonomies } = attributes;
 	const { postType, taxQuery } = query;
 
 	const taxonomies = useTaxonomies( postType );
@@ -76,6 +79,17 @@ export function TaxonomyControls( { onChange, query } ) {
 					/>
 				);
 			} ) }
+			<ToggleControl
+				__nextHasNoMarginBottom
+				label={ __( 'Match all taxonomies' ) }
+				help={ __( 'Help message' ) }
+				checked={ matchAllTaxonomies }
+				onChange={ ( value ) => {
+					setAttributes( {
+						matchAllTaxonomies: value,
+					} );
+				} }
+			/>
 		</VStack>
 	);
 }

--- a/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
@@ -81,8 +81,10 @@ export function TaxonomyControls( { onChange, attributes, setAttributes } ) {
 			} ) }
 			<ToggleControl
 				__nextHasNoMarginBottom
-				label={ __( 'Match all taxonomies terms' ) }
-				help={ __( 'Help message' ) }
+				label={ __( 'Require all selected terms' ) }
+				help={ __(
+					'Only show posts that match all selected terms across all taxonomies.'
+				) }
 				checked={ matchAllTerms }
 				onChange={ ( value ) => {
 					setAttributes( {

--- a/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
@@ -50,7 +50,7 @@ const getTermIdByTermValue = ( terms, termValue ) => {
 };
 
 export function TaxonomyControls( { onChange, attributes, setAttributes } ) {
-	const { query, matchAllTaxonomies } = attributes;
+	const { query, matchAllTerms } = attributes;
 	const { postType, taxQuery } = query;
 
 	const taxonomies = useTaxonomies( postType );
@@ -81,12 +81,12 @@ export function TaxonomyControls( { onChange, attributes, setAttributes } ) {
 			} ) }
 			<ToggleControl
 				__nextHasNoMarginBottom
-				label={ __( 'Match all taxonomies' ) }
+				label={ __( 'Match all taxonomies terms' ) }
 				help={ __( 'Help message' ) }
-				checked={ matchAllTaxonomies }
+				checked={ matchAllTerms }
 				onChange={ ( value ) => {
 					setAttributes( {
-						matchAllTaxonomies: value,
+						matchAllTerms: value,
 					} );
 				} }
 			/>

--- a/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
@@ -50,8 +50,10 @@ const getTermIdByTermValue = ( terms, termValue ) => {
 };
 
 export function TaxonomyControls( { onChange, attributes, setAttributes } ) {
-	const { query, matchAllTerms } = attributes;
-	const { postType, taxQuery } = query;
+	const {
+		query: { postType, taxQuery },
+		matchAllTerms,
+	} = attributes;
 
 	const taxonomies = useTaxonomies( postType );
 	if ( ! taxonomies || taxonomies.length === 0 ) {

--- a/test/integration/fixtures/blocks/core__query.json
+++ b/test/integration/fixtures/blocks/core__query.json
@@ -20,7 +20,8 @@
 				"format": []
 			},
 			"tagName": "div",
-			"enhancedPagination": false
+			"enhancedPagination": false,
+			"matchAllTerms": false
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #58714 

<!-- In a few words, what is the PR actually doing? -->
This PR adds a new toggle option to the Query block settings to allow matching all selected taxonomy terms (AND relation) instead of the default any (OR relation).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, the Query block uses an OR relation for filtering posts by multiple taxonomy terms, which returns posts matching any of the selected terms. Some use cases require a stricter filter that only returns posts matching all selected terms across one or more taxonomies. This PR introduces that capability with a UI toggle and ensures consistency between editor and frontend behavior.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Added a `matchAllTerms` attribute to the Query block.
- Rendered a `ToggleControl` in the block settings panel to toggle `AND` vs `OR` logic.
- In the editor:
    - Applied client-side filtering on fetched posts when `matchAllTerms` is true.
- On the frontend:
    - Modified `tax_query` parts to use `operator: AND` when `matchAllTerms` is enabled.
- Updated default handling and ensured consistent fallback for core and custom taxonomies.

## Testing Instructions
1. Insert a Query Loop block and apply taxonomy filters.
2. Select multiple terms for any taxonomy (e.g. categories)
3. Toggle "Require all selected terms" in the block settings (Filters -> Taxonomies).
4. Confirm the following:
    - When off (default): shows posts matching any selected terms.
    - When on: shows posts only if they match all selected terms.
5. Verify the behavior in both the editor and on the frontend.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/c773bf8d-0823-4056-b4ef-b37f73f30d8a
