### PR TITLE
Background panel: Remove unused style

### DIFF
--- a/packages/block-editor/src/components/background-image-control/style.scss
+++ b/packages/block-editor/src/components/background-image-control/style.scss
@@ -76,17 +76,13 @@
 	}
 }
 
-.block-editor-global-styles-background-panel__image-preview-content,
-.block-editor-global-styles-background-panel__dropdown-toggle {
-	height: 100%;
-	width: 100%;
-	padding-left: $grid-unit-15;
-}
-
 .block-editor-global-styles-background-panel__dropdown-toggle {
 	cursor: pointer;
 	background: transparent;
 	border: none;
+	height: 100%;
+	width: 100%;
+	padding-left: $grid-unit-15;
 }
 
 .block-editor-global-styles-background-panel__inspector-media-replace-title {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The element with the CSS class name `.block-editor-global-styles-background-panel__image-preview-content` has not been used. This style is no longer used anywhere.

<!-- In a few words, what is the PR actually doing? -->
This style was added in #60151, but there are no elements with the class `.block-editor-global-styles-background-panel__image-preview-content` since then.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Confirmed the background controls such as group blocks work as they did before.
