### PR TITLE
Site Editor: Sort post types alphabetically within the `Add Template` modal

### DIFF
--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -80,10 +80,12 @@ const usePublicPostTypes = () => {
 	);
 	return useMemo( () => {
 		const excludedPostTypes = [ 'attachment' ];
-		return postTypes?.filter(
-			( { viewable, slug } ) =>
-				viewable && ! excludedPostTypes.includes( slug )
-		);
+		return postTypes
+			?.filter(
+				( { viewable, slug } ) =>
+					viewable && ! excludedPostTypes.includes( slug )
+			)
+			.sort( ( a, b ) => a.name.localeCompare( b.name ) );
 	}, [ postTypes ] );
 };
 

--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -86,6 +86,8 @@ const usePublicPostTypes = () => {
 					viewable && ! excludedPostTypes.includes( slug )
 			)
 			.sort( ( a, b ) => {
+				// Sort post types alphabetically by name,
+				// but exclude the built-in 'post' type from sorting.
 				if ( a.slug === 'post' || b.slug === 'post' ) {
 					return 0;
 				}

--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -85,7 +85,13 @@ const usePublicPostTypes = () => {
 				( { viewable, slug } ) =>
 					viewable && ! excludedPostTypes.includes( slug )
 			)
-			.sort( ( a, b ) => a.name.localeCompare( b.name ) );
+			.sort( ( a, b ) => {
+				if ( a.slug === 'post' || b.slug === 'post' ) {
+					return 0;
+				}
+
+				return a.name.localeCompare( b.name );
+			} );
 	}, [ postTypes ] );
 };
 


### PR DESCRIPTION
## What, Why, and How?
Closes #70558

This PR adds the logic to order `Post Types` using locale-aware string comparison, making it easier for users to find specific post types in the list.

## Testing Instructions

1. Make sure to register some custom post types.
<details>
<summary>Example</summary>

```php
function register_book_type() {
	$labels = array(
		'name'                  => _x( 'Book', 'Post type general name', 'book' ),
		'singular_name'         => _x( 'Book', 'Post type singular name', 'book' ),
		'menu_name'             => _x( 'Books', 'Admin Menu text', 'book' ),
		'name_admin_bar'        => _x( 'Book', 'Add New on Toolbar', 'book' ),
		'add_new'               => __( 'Add New', 'book' ),
		'add_new_item'          => __( 'Add New Book', 'book' ),
		'new_item'              => __( 'New Book', 'book' ),
		'edit_item'             => __( 'Edit Book', 'book' ),
		'view_item'             => __( 'View Book', 'book' ),
		'all_items'             => __( 'All Books', 'book' ),
		'search_items'          => __( 'Search Books', 'book' ),
		'parent_item_colon'     => __( 'Parent Books:', 'book' ),
		'not_found'             => __( 'No Books found.', 'book' ),
	);
	$args   = array(
		'labels'             => $labels,
		'description'        => 'Book custom post type.',
		'public'             => true,
		'publicly_queryable' => true,
		'show_ui'            => true,
		'show_in_menu'       => true,
		'query_var'          => true,
		'rewrite'            => array( 'slug' => 'book' ),
		'capability_type'    => 'post',
		'has_archive'        => true,
		'hierarchical'       => false,
		'menu_position'      => 20,
		'supports'           => array( 'title', 'editor', 'author', 'thumbnail' ),
		'taxonomies'         => array( 'category', 'post_tag' ),
		'show_in_rest'       => true,
	);

	register_post_type( 'Book', $args );
}

add_action( 'init', 'register_book_type' );
```

</details>

2. Navigate to `Appearance -> Editor -> Templates` and click on the `Add Template` button.
3. Confirm that the `Archive:` and `Single item:` values are all alphabetically ordered.

### Testing Instructions for Keyboard

Same.

## Screenshots

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/391c325e-a227-4b8f-a955-f4fc598d486b)|![after](https://github.com/user-attachments/assets/e6c694c4-b8ef-45e5-8427-db31e82ab5d6)|