### PR TITLE
Updated support for MS Word Images

### DIFF
--- a/packages/blocks/src/api/raw-handling/readme.md
+++ b/packages/blocks/src/api/raw-handling/readme.md
@@ -8,7 +8,7 @@ This folder contains all paste specific logic (filters, converters, normalisers.
 | ---------------- | ---------- | -------- | ----- | ----- | --------- | ----- | ------------------- |
 | Google Docs      | ✓          | ✓        | ✓     | ✓     | ✓         | ✓     | ✘ [1]               |
 | Apple Pages      | ✓          | ✘ [2]    | ✓     | ✘ [2] | n/a       | ✓     | ✘ [1]               |
-| MS Word          | ✓          | ✓        | ✓     | ✘ [3] | n/a       | ✓     | ✓                   |
+| MS Word          | ✓          | ✓        | ✓     | ✓     | n/a       | ✓     | ✓                   |
 | MS Word Online   | ✓          | ✘ [4]    | ✓     | ✓     | n/a       | ✓     | ✘ [1]               |
 | LibreOffice      | ✓          | ✓        | ✓     | ✘ [3] | ✓         | ✓     | ✓                   |
 | Evernote         | ✓          | ✘ [5]    | ✓     | ✓     | ✓         | ✓     | n/a                 |
@@ -18,7 +18,7 @@ This folder contains all paste specific logic (filters, converters, normalisers.
 
 1. Google Docs, Apple Pages and MS Word online don't pass footnote nor endnote information.
 2. Apple Pages does not pass heading and image information.
-3. MS Word and LibreOffice only provide a local file path, which cannot be accessed in JavaScript for security reasons. Image placeholders will be provided instead. Single images, however, _can_ be copied and pasted without any problem.
+3. LibreOffice only provide a local file path, which cannot be accessed in JavaScript for security reasons. Image placeholders will be provided instead. Single images, however, _can_ be copied and pasted without any problem.
 4. Still to do for MS Word Online.
 5. Evernote does not have headings.
 6. For caption and gallery shortcodes, see #2874.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #70563 <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Recent testing shows that Gutenberg supports pasting images from MS Word alongside text without any issues. The current README incorrectly marks this feature as unsupported (`✘ [3]`). Updating the table ensures the documentation reflects actual behavior and avoids confusion for contributors and users referencing supported sources.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Modified the README in the `raw-handling` folder.
- Updated the support table row for MS Word, changing the "Image" column from ✘ to ✓.
- Updated footnote [3] to remove mention of MS Word and limit the scope to LibreOffice.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a Word document that contains both text and images.
2. Select and copy the content.
3. Paste it into the Gutenberg editor.
4. Confirm that the pasted content includes both the text and the images without issues.
5. Review the updated support table and confirm the change aligns with current behavior.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. Use keyboard navigation to focus the editor.
2. Use clipboard keyboard shortcuts (e.g., Ctrl+V or Cmd+V) to paste Word content with images.
3. Confirm that the content is inserted correctly and that no accessibility regressions occur.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before
<!-- Before screenshot here -->
<img width="979" alt="image" src="https://github.com/user-attachments/assets/3619ff8d-574d-48a6-9291-d8ffe291b214" />

After
<!-- After screenshot here -->
<img width="1022" alt="image" src="https://github.com/user-attachments/assets/6f3681de-6c95-4698-9d4a-2d9bd3cb8353" />



