### PR TITLE
CodeVitals: Use a different SHA for the base branch

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -76,14 +76,14 @@ jobs:
             - name: Compare performance with base branch
               if: github.event_name == 'push'
               # The base hash used here need to be a commit that is compatible with the current WP version
-              # The current one is 7f6a627a028f6c5013dc97df316e04e8fc39a4ef and it needs to be updated every WP major release.
+              # The current one is 1b8efa77d39f68fb3d963ea02ce6ea6a8201d521 and it needs to be updated every WP major release.
               # It is used as a base comparison point to avoid fluctuation in the performance metrics.
               # See: https://developer.wordpress.org/block-editor/explanations/architecture/performance/#update-the-reference-commit.
               run: |
                   WP_VERSION="$(awk -F ': ' '/^Tested up to/{print $2}' readme.txt)"
                   IFS=. read -ra WP_VERSION_ARRAY <<< "$WP_VERSION"
                   WP_MAJOR="${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"
-                  ./bin/plugin/cli.js perf "$GITHUB_SHA" 7f6a627a028f6c5013dc97df316e04e8fc39a4ef --tests-branch "$GITHUB_SHA" --wp-version "$WP_MAJOR"
+                  ./bin/plugin/cli.js perf "$GITHUB_SHA" 1b8efa77d39f68fb3d963ea02ce6ea6a8201d521 --tests-branch "$GITHUB_SHA" --wp-version "$WP_MAJOR"
 
             - name: Compare performance with custom branches
               if: github.event_name == 'workflow_dispatch'
@@ -109,7 +109,7 @@ jobs:
                   CODEHEALTH_PROJECT_TOKEN: ${{ secrets.CODEHEALTH_PROJECT_TOKEN }}
               run: |
                   COMMITTED_AT="$(git show -s "$GITHUB_SHA" --format="%cI")"
-                  ./bin/log-performance-results.js "$CODEHEALTH_PROJECT_TOKEN" trunk "$GITHUB_SHA" 7f6a627a028f6c5013dc97df316e04e8fc39a4ef "$COMMITTED_AT"
+                  ./bin/log-performance-results.js "$CODEHEALTH_PROJECT_TOKEN" trunk "$GITHUB_SHA" 1b8efa77d39f68fb3d963ea02ce6ea6a8201d521 "$COMMITTED_AT"
 
             - name: Archive debug artifacts (screenshots, HTML snapshots)
               uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3


### PR DESCRIPTION
Follow-up #70553

## What?

This PR updates the commit hash of the base branch used by [Code Vitals](https://www.codevitals.run/project/gutenberg/firstBlock), which should resolve the failing performance tests in the trunk branch.

## Why?

#70553 fixed the npm library inconsistency, `npm ci` now works properly, and some performance tests now work properly.

Meanwhile, on the trunk branch, we have [performance tests that run when the event is "push"](https://github.com/WordPress/gutenberg/blob/8b0a1f3c2c7201db46f3e731f4dd9a624f168022/.github/workflows/performance.yml#L77), i.e. when a PR is merged. Those performance tests use the 7f6a627a028f6c5013dc97df316e04e8fc39a4ef commit hash, but that commit doesn't yet contain #70553, so `npm ci` fails. As a result, CodeVitals also doesn't update correctly. 

## How?

Update the commit hash with #70553 (1b8efa77d39f68fb3d963ea02ce6ea6a8201d521).

This should allow `npm ci` to succeed on the base branch. However, this commit hash is usually only updated when we update the minimum WordPress version that the Gutenberg plugin supports. Therefore, I am concerned that updating the commit hash now will affect some metrics.

## Testing Instructions

This PR is unfortunately not testable as it tries to resolve performance tests that run only on trunk. Hopefully, the performance tests will pass on the trunk branch, and CodeVitals will be updated.

