### PR TITLE
iAPI Router: Prioritize custom click event handlers when full-page navigation is enabled

### DIFF
--- a/packages/interactivity-router/src/full-page.ts
+++ b/packages/interactivity-router/src/full-page.ts
@@ -21,20 +21,14 @@ const isValidEvent = ( event: MouseEvent ) =>
 	! event.defaultPrevented;
 
 // Navigate on click.
-document.addEventListener(
-	'click',
-	async ( event ) => {
-		const ref = ( event.target as Element ).closest( 'a' );
-		if ( isValidLink( ref ) && isValidEvent( event ) ) {
-			event.preventDefault();
-			const { actions } = await import(
-				'@wordpress/interactivity-router'
-			);
-			actions.navigate( ref.href );
-		}
-	},
-	true
-);
+document.addEventListener( 'click', async ( event ) => {
+	const ref = ( event.target as Element ).closest( 'a' );
+	if ( isValidLink( ref ) && isValidEvent( event ) ) {
+		event.preventDefault();
+		const { actions } = await import( '@wordpress/interactivity-router' );
+		actions.navigate( ref.href );
+	}
+} );
 // Prefetch on hover.
 document.addEventListener(
 	'mouseenter',


### PR DESCRIPTION
## What?

Gives priority to custom click event handlers, typically defined with `data-wp-on--click` directives, over the global click event handler that controls all site links added by the `@wordpress/interactivity-router/full-page` module.

This fixes the click logic of the Query Pagination blocks.

## Why?

Specific behavior defined in blocks should take precedence over the more general full-page behavior. This block-specific behavior, added to a link, would typically handle navigation.

## How?

The `useCapture` value of `true` is removed. That would make any event handler calling `event.preventDefault()` to effectively prevent the event from being captured by the full-page event listener.

## Testing Instructions

1. In a site with the **Interactivity API: Full-page client-side navigation** experiment enabled, visit a page with a Query block with the **Force page reload** setting disabled.
2. Check out `trunk`
3. Click on the Query Pagination links
4. Navigation happens without scrolling to the top of the page.
5. Check out this branch
6. Click on the Query Pagination links
7. Navigation should happen, and the browser scrolls to the top of the page. This is the common behavior when the full-page client-side navigation experiment is disabled.