### PR TITLE
`getCurrentPostId()`: Clear post ID on navigation in the Site Editor

### DIFF
--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -1,10 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useCallback, useMemo } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -31,6 +32,7 @@ function AppLayout() {
 
 export default function App() {
 	useRegisterSiteEditorRoutes();
+	const { setEditedPost } = useDispatch( editorStore );
 	const { routes, currentTheme, editorSettings } = useSelect( ( select ) => {
 		return {
 			routes: unlock( select( editSiteStore ) ).getRoutes(),
@@ -40,22 +42,26 @@ export default function App() {
 		};
 	}, [] );
 
-	const beforeNavigate = useCallback( ( { path, query } ) => {
-		if ( ! isPreviewingTheme() ) {
-			return { path, query };
-		}
+	const beforeNavigate = useCallback(
+		( { path, query } ) => {
+			setEditedPost( null, null );
+			if ( ! isPreviewingTheme() ) {
+				return { path, query };
+			}
 
-		return {
-			path,
-			query: {
-				...query,
-				wp_theme_preview:
-					'wp_theme_preview' in query
-						? query.wp_theme_preview
-						: currentlyPreviewingTheme(),
-			},
-		};
-	}, [] );
+			return {
+				path,
+				query: {
+					...query,
+					wp_theme_preview:
+						'wp_theme_preview' in query
+							? query.wp_theme_preview
+							: currentlyPreviewingTheme(),
+				},
+			};
+		},
+		[ setEditedPost ]
+	);
 
 	const matchResolverArgsValue = useMemo(
 		() => ( {


### PR DESCRIPTION
## What?
Closes #70570 

This pull request addresses an issue where `select('core/edit-site').getCurrentPostId()` returns a stale value when navigating within the Site Editor.

## Why?
When navigating away from an editor view (e.g., editing a template) to a list view (e.g., the main templates list), the `postId` was not being cleared from the data store. This caused functions relying on `getCurrentPostId()` to behave incorrectly, as they would continue to receive the ID of the last-edited post instead of a null or undefined value.

## How?
This PR introduces a change in the main App component of the Site Editor. By hooking into the `beforeNavigate` callback of the router, it now dispatches `setEditedPost( null, null )` before every route change. This action clears the current `postId` and `postType` from the core/editor store, ensuring a clean slate for the new route. Routes responsible for editing a post or template will subsequently set the new ID as part of their loading process.

## Testing Instructions
1.  Navigate to _Appearance > Editor_.
2.  Open your browser's developer console.
3.  Check the current post ID by running: `wp.data.select('core/editor').getCurrentPostId()`
4.  You should see the ID for the template being previewed (e.g., the home template).
5.  From the left-hand sidebar, click on _Templates_.
6.  Run `wp.data.select('core/editor').getCurrentPostId()` again in the console.
7.  **Expected Result:** The value should now be `null`. _(Before this fix, it would have incorrectly shown the previous template's ID)_.
8.  Click on any template to open it in the editor (e.g., "Single Posts").
9.  Run `wp.data.select('core/editor').getCurrentPostId()` in the console. It should show the ID for the template you are currently editing.
10. Navigate back to the _Templates_ screen again.
11. Run `wp.data.select('core/editor').getCurrentPostId()` one last time.
12. **Expected Result:** The value should once again be `null`.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/a2c233d5-9d6e-43bb-964a-262058e27f97


