### PR TITLE
DataViews: Avoid unselecting items that are not rendered

### DIFF
--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -13,7 +13,7 @@ import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { drawerRight } from '@wordpress/icons';
-import { useEvent, usePrevious } from '@wordpress/compose';
+import { useEvent } from '@wordpress/compose';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
@@ -327,21 +327,6 @@ export default function PostList( { postType } ) {
 
 		return records;
 	}, [ records, fields, isLoadingFields, view?.sort ] );
-
-	const ids = data?.map( ( record ) => getItemId( record ) ) ?? [];
-	const prevIds = usePrevious( ids ) ?? [];
-	const deletedIds = prevIds.filter( ( id ) => ! ids.includes( id ) );
-	const postIdWasDeleted = deletedIds.includes( postId );
-
-	useEffect( () => {
-		if ( postIdWasDeleted ) {
-			history.navigate(
-				addQueryArgs( location.path, {
-					postId: undefined,
-				} )
-			);
-		}
-	}, [ history, postIdWasDeleted, location.path ] );
 
 	const paginationInfo = useMemo(
 		() => ( {


### PR DESCRIPTION
## What?

In the pages dataviews, when you select an item and then search for something unrelated, the preview changes back to the front page. For me is this the wrong behavior and the previous selection should be kept unless the user changes it explicitly.

## Testing Instructions

- Open "pages" in the site editor
- Select "sample page"
- It renders in the preview
- search for something random "balboa"
- The sample page should remain rendered in the preview. 