### PR TITLE
Background panel: Remove unused props

### DIFF
--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -115,7 +115,6 @@ function InspectorImagePreviewItem( {
 	toggleProps = {},
 	filename,
 	label,
-	className,
 	onToggleCallback = noop,
 } ) {
 	const { isOpen, ...restToggleProps } = toggleProps;
@@ -168,12 +167,7 @@ function InspectorImagePreviewItem( {
 	};
 
 	return as === 'button' ? (
-		<Button
-			__next40pxDefaultSize
-			className={ className }
-			{ ...restToggleProps }
-			aria-expanded={ isOpen }
-		>
+		<Button __next40pxDefaultSize { ...restToggleProps }>
 			{ renderPreviewContent() }
 		</Button>
 	) : (
@@ -386,7 +380,6 @@ function BackgroundImageControls( {
 				} }
 				name={
 					<InspectorImagePreviewItem
-						className="block-editor-global-styles-background-panel__image-preview"
 						imgUrl={ url }
 						filename={ title }
 						label={ imgLabel }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Background panel: Remove unused props

`toggleProps` has properties `className` and `aria-expanded`.

https://github.com/WordPress/gutenberg/blob/95e8e91a3d2c0d274336ebf8342a98419728c4cd/packages/block-editor/src/components/background-image-control/index.js#L203-L212

Therefore, `className` will be overwritten. `block-editor-global-styles-background-panel__image-preview` will not be rendered.

`aria-expanded` is a redundant property and does not need to be present.

https://github.com/WordPress/gutenberg/blob/95e8e91a3d2c0d274336ebf8342a98419728c4cd/packages/block-editor/src/components/background-image-control/index.js#L171-L178

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This eliminates duplicate props and makes the code cleaner.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Confirmed the background controls such as group blocks work as they did before.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
There is no difference in the rendered code.

|Before|After|
|-|-|
| ![before](https://github.com/user-attachments/assets/2d67e26b-dcf2-4b12-9504-229b3ab90be3) | ![after](https://github.com/user-attachments/assets/c0af51d8-f6cc-4c34-aa69-4a788b7d4fa6) |
