### PR TITLE
Prevent images from appearing squished when only one dimension is set

### DIFF
--- a/packages/block-library/src/image/deprecated.js
+++ b/packages/block-library/src/image/deprecated.js
@@ -860,11 +860,12 @@ const v7 = {
 			},
 		},
 	},
-	migrate( { width, height, ...attributes } ) {
+	migrate( attributes ) {
+		const { width, height } = attributes;
 		return {
 			...attributes,
-			width: `${ width }px`,
-			height: `${ height }px`,
+			width: typeof width === 'number' ? `${ width }px` : width,
+			height: typeof height === 'number' ? `${ height }px` : height,
 		};
 	},
 	save( { attributes } ) {
@@ -1297,13 +1298,6 @@ const v9 = {
 		shadow: {
 			__experimentalSkipSerialization: true,
 		},
-	},
-	isEligible( attributes ) {
-		return (
-			attributes.width !== undefined &&
-			attributes.width !== null &&
-			( attributes.height === undefined || attributes.height === null )
-		);
 	},
 	save( { attributes } ) {
 		const {

--- a/packages/block-library/src/image/deprecated.js
+++ b/packages/block-library/src/image/deprecated.js
@@ -11,7 +11,13 @@ import {
 	useBlockProps,
 	__experimentalGetElementClassName,
 	__experimentalGetBorderClassesAndStyles as getBorderClassesAndStyles,
+	__experimentalGetShadowClassesAndStyles as getShadowClassesAndStyles,
 } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { mediaPosition } from './utils';
 
 /**
  * Deprecation for adding the `wp-image-${id}` class to the image block for
@@ -1166,4 +1172,236 @@ const v8 = {
 	},
 };
 
-export default [ v8, v7, v6, v5, v4, v3, v2, v1 ];
+/**
+ * Deprecation for adding height: auto when only one dimension is explicitly
+ * set, to prevent theme CSS from squishing images.
+ *
+ * @see https://github.com/WordPress/gutenberg/pull/70575
+ */
+const v9 = {
+	attributes: {
+		blob: {
+			type: 'string',
+			role: 'local',
+		},
+		url: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'img',
+			attribute: 'src',
+			role: 'content',
+		},
+		alt: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'img',
+			attribute: 'alt',
+			default: '',
+			role: 'content',
+		},
+		caption: {
+			type: 'rich-text',
+			source: 'rich-text',
+			selector: 'figcaption',
+			role: 'content',
+		},
+		lightbox: {
+			type: 'object',
+			enabled: {
+				type: 'boolean',
+			},
+		},
+		title: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'img',
+			attribute: 'title',
+			role: 'content',
+		},
+		href: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'figure > a',
+			attribute: 'href',
+			role: 'content',
+		},
+		rel: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'figure > a',
+			attribute: 'rel',
+		},
+		linkClass: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'figure > a',
+			attribute: 'class',
+		},
+		id: {
+			type: 'number',
+			role: 'content',
+		},
+		width: {
+			type: 'string',
+		},
+		height: {
+			type: 'string',
+		},
+		aspectRatio: {
+			type: 'string',
+		},
+		scale: {
+			type: 'string',
+		},
+		focalPoint: {
+			type: 'object',
+		},
+		sizeSlug: {
+			type: 'string',
+		},
+		linkDestination: {
+			type: 'string',
+		},
+		linkTarget: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'figure > a',
+			attribute: 'target',
+		},
+	},
+	supports: {
+		interactivity: true,
+		align: [ 'left', 'center', 'right', 'wide', 'full' ],
+		anchor: true,
+		color: {
+			text: false,
+			background: false,
+		},
+		filter: {
+			duotone: true,
+		},
+		spacing: {
+			margin: true,
+		},
+		__experimentalBorder: {
+			color: true,
+			radius: true,
+			width: true,
+			__experimentalSkipSerialization: true,
+			__experimentalDefaultControls: {
+				color: true,
+				radius: true,
+				width: true,
+			},
+		},
+		shadow: {
+			__experimentalSkipSerialization: true,
+		},
+	},
+	isEligible( attributes ) {
+		return (
+			attributes.width !== undefined &&
+			attributes.width !== null &&
+			( attributes.height === undefined || attributes.height === null )
+		);
+	},
+	save( { attributes } ) {
+		const {
+			url,
+			alt,
+			caption,
+			align,
+			href,
+			rel,
+			linkClass,
+			width,
+			height,
+			aspectRatio,
+			scale,
+			focalPoint,
+			id,
+			linkTarget,
+			sizeSlug,
+			title,
+			metadata: { bindings = {} } = {},
+		} = attributes;
+
+		const newRel = ! rel ? undefined : rel;
+		const borderProps = getBorderClassesAndStyles( attributes );
+		const shadowProps = getShadowClassesAndStyles( attributes );
+
+		const classes = clsx( {
+			alignnone: 'none' === align,
+			[ `size-${ sizeSlug }` ]: sizeSlug,
+			'is-resized': width || height,
+			'has-custom-border':
+				!! borderProps.className ||
+				( borderProps.style &&
+					Object.keys( borderProps.style ).length > 0 ),
+		} );
+
+		const imageClasses = clsx( borderProps.className, {
+			[ `wp-image-${ id }` ]: !! id,
+		} );
+
+		const image = (
+			<img
+				src={ url }
+				alt={ alt }
+				className={ imageClasses || undefined }
+				style={ {
+					...borderProps.style,
+					...shadowProps.style,
+					aspectRatio,
+					objectFit: scale,
+					objectPosition:
+						focalPoint && scale
+							? mediaPosition( focalPoint )
+							: undefined,
+					width,
+					height,
+				} }
+				title={ title }
+			/>
+		);
+
+		const displayCaption =
+			! RichText.isEmpty( caption ) ||
+			bindings.caption ||
+			bindings?.__default?.source === 'core/pattern-overrides';
+
+		const figure = (
+			<>
+				{ href ? (
+					<a
+						className={ linkClass }
+						href={ href }
+						target={ linkTarget }
+						rel={ newRel }
+					>
+						{ image }
+					</a>
+				) : (
+					image
+				) }
+				{ displayCaption && (
+					<RichText.Content
+						className={ __experimentalGetElementClassName(
+							'caption'
+						) }
+						tagName="figcaption"
+						value={ caption }
+					/>
+				) }
+			</>
+		);
+
+		return (
+			<figure { ...useBlockProps.save( { className: classes } ) }>
+				{ figure }
+			</figure>
+		);
+	},
+};
+
+export default [ v9, v8, v7, v6, v5, v4, v3, v2, v1 ];

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -1102,7 +1102,33 @@ export default function Image( {
 									height:
 										pixelSize.height + resizeDelta.height,
 							  }
-							: { width, height } ),
+							: ( () => {
+									const style = {};
+									if ( width === 'auto' ) {
+										style.width = 'auto';
+									} else if (
+										width !== undefined &&
+										width !== null
+									) {
+										style.width =
+											typeof width === 'number'
+												? `${ width }px`
+												: width;
+									}
+									if (
+										height === 'auto' ||
+										height === undefined ||
+										height === null
+									) {
+										style.height = 'auto';
+									} else {
+										style.height =
+											typeof height === 'number'
+												? `${ height }px`
+												: height;
+									}
+									return style;
+							  } )() ),
 						objectFit: scale,
 						objectPosition:
 							focalPoint && scale

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -1053,7 +1053,33 @@ export default function Image( {
 									height:
 										pixelSize.height + resizeDelta.height,
 							  }
-							: { width, height } ),
+							: ( () => {
+									const style = {};
+									if ( width === 'auto' ) {
+										style.width = 'auto';
+									} else if (
+										width !== undefined &&
+										width !== null
+									) {
+										style.width =
+											typeof width === 'number'
+												? `${ width }px`
+												: width;
+									}
+									if (
+										height === 'auto' ||
+										height === undefined ||
+										height === null
+									) {
+										style.height = 'auto';
+									} else {
+										style.height =
+											typeof height === 'number'
+												? `${ height }px`
+												: height;
+									}
+									return style;
+							  } )() ),
 						objectFit: scale,
 						objectPosition:
 							focalPoint && scale

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -65,18 +65,43 @@ export default function save( { attributes } ) {
 			src={ url }
 			alt={ alt }
 			className={ imageClasses || undefined }
-			style={ {
-				...borderProps.style,
-				...shadowProps.style,
-				aspectRatio,
-				objectFit: scale,
-				objectPosition:
-					focalPoint && scale
-						? mediaPosition( focalPoint )
-						: undefined,
-				width,
-				height,
-			} }
+			style={ ( () => {
+				const style = {
+					...borderProps.style,
+					...shadowProps.style,
+					aspectRatio,
+					objectFit: scale,
+					objectPosition:
+						focalPoint && scale
+							? mediaPosition( focalPoint )
+							: undefined,
+				};
+				// Only apply dimension styles when a width or height is provided.
+				if ( width !== undefined || height !== undefined ) {
+					// Only apply width when explicitly provided.
+					if ( width === 'auto' ) {
+						style.width = 'auto';
+					} else if ( width !== undefined && width !== null ) {
+						style.width =
+							typeof width === 'number' ? `${ width }px` : width;
+					}
+					// Force height to auto when unspecified to prevent
+					// theme CSS from squishing the image.
+					if (
+						height === 'auto' ||
+						height === undefined ||
+						height === null
+					) {
+						style.height = 'auto';
+					} else {
+						style.height =
+							typeof height === 'number'
+								? `${ height }px`
+								: height;
+					}
+				}
+				return style;
+			} )() }
 			title={ title }
 		/>
 	);

--- a/test/integration/fixtures/blocks/core__image__deprecated-v9-add-height-auto.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v9-add-height-auto.html
@@ -1,0 +1,3 @@
+<!-- wp:image {"width":"200px","sizeSlug":"large"} -->
+<figure class="wp-block-image size-large is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" style="width:200px"/></figure>
+<!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__deprecated-v9-add-height-auto.json
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v9-add-height-auto.json
@@ -1,0 +1,14 @@
+[
+	{
+		"name": "core/image",
+		"isValid": true,
+		"attributes": {
+			"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
+			"alt": "",
+			"caption": "",
+			"sizeSlug": "large",
+			"width": "200px"
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__image__deprecated-v9-add-height-auto.parsed.json
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v9-add-height-auto.parsed.json
@@ -1,0 +1,14 @@
+[
+	{
+		"blockName": "core/image",
+		"attrs": {
+			"width": "200px",
+			"sizeSlug": "large"
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<figure class=\"wp-block-image size-large is-resized\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" style=\"width:200px\"/></figure>\n",
+		"innerContent": [
+			"\n<figure class=\"wp-block-image size-large is-resized\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" style=\"width:200px\"/></figure>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__image__deprecated-v9-add-height-auto.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v9-add-height-auto.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:image {"width":"200px","sizeSlug":"large"} -->
+<figure class="wp-block-image size-large is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" style="width:200px;height:auto"/></figure>
+<!-- /wp:image -->


### PR DESCRIPTION
This PR addresses the issue of images in the editor appearing squashed when only one dimension is set.

## Problem

When you set only one of the image block's dimensions (width or height) in the editor and leave the other blank (auto), Gutenberg serializes just that single value as an inline style, like this:

```
<img 
  src="…blue-shape.png" 
  alt="blue-shape.png" 
  style="width: 64px;" 
  width="228" 
  height="228" 
/>
```

In this example, the blue-shape.png image was uploaded at 228 x 228. In the block editor UI, the width was set to 64px, and the height was left as auto. 

Because many themes (like the one we were using when we discovered this) still define a fixed CSS height (in our case, 76px), the browser will render the image at 64 x 76, making it appear distorted.

In this example, this was the existing CSS:

```
.is-style-features-page-three-column-block_img img {
  width:  76px;
  height: 76px;
}
```

## This Fix

This PR adds similar logic in two places to ensure that whenever only one dimension is set by the user, the other dimension is explicitly set to auto, to preserve the aspect ratio.

This logic is added in two places:
1.	Editor rendering (packages/block-library/src/image/image.js)
2.	Front-end save output (packages/block-library/src/image/save.js)

In each file, a small style object is built that:

- Emits width: XXpx only if the user explicitly provided a width.
- Emits height: auto when height is unset or explicitly set to "auto", blocking any theme CSS height.
- Emits height: XXpx only when the user set a numeric height.

By guaranteeing `height: auto` whenever height isn't defined, this prevents themes' CSS heights from squashing the image. A theme's default width remains in effect when the user hasn't adjusted the width in the editor.

## Handling Existing Content

A new deprecation (v9) is added to handle image blocks that were saved before this fix with only `width` set and no `height` in the inline style. When one of those blocks is next saved, it will be migrated so the inline style includes `height: auto`. Integration test fixtures are included covering parse and serialisation of this migration path.

## Testing Instructions

1. Before you put this PR in place, go to Appearance -> Editor -> Design -> Styles -> CSS and add a new style definition for the image you are about to add:

```
.image-test img {
	width: 76px;
	height: 76px;
}
```

2. Create a new page.
3. Insert an image block (select any image from your Media Library) and set the width to a number (example `64`) and leave the height blank.
4. While that image is still selected, expand "Advanced" and add the `image-test` class.
5. Notice the image dimensions. Save the page and view it (outside of the editor). Right click and select "Inspect" to see the inline style. The image will appear compressed.
6. Put this PR in place and try resetting the dimensions in the editor UI again for this image by setting the width to 50 and leaving the height unset (or set to auto). 
7. Repeat step 5. This time, the image won't appear compressed.

## Screenshots (inside the Editor)

Before the fix (64 x 76):
<img width="634" alt="Screenshot 2025-06-30 at 9 44 24 PM" src="https://github.com/user-attachments/assets/c45d672e-69a5-4315-b06b-619f07653325" />

After the fix (64 x 64):
<img width="634" alt="Screenshot 2025-06-30 at 9 45 15 PM" src="https://github.com/user-attachments/assets/3b456b5d-76df-45b4-9c82-c801e052d83a" />
