### PR TITLE
ServerSideRender: Remove unnecessary props for default loading placeholder

### DIFF
--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -69,21 +69,16 @@ function DefaultErrorResponsePlaceholder( { response, className } ) {
 	return <Placeholder className={ className }>{ errorMessage }</Placeholder>;
 }
 
-function DefaultLoadingResponsePlaceholder( { children, isLoading } ) {
+function DefaultLoadingResponsePlaceholder( { children } ) {
 	const [ showLoader, setShowLoader ] = useState( false );
 
 	useEffect( () => {
-		if ( ! isLoading ) {
-			setShowLoader( false );
-			return;
-		}
-
 		// Schedule showing the Spinner after 1 second.
 		const timeout = setTimeout( () => {
 			setShowLoader( true );
 		}, 1000 );
 		return () => clearTimeout( timeout );
-	}, [ isLoading ] );
+	}, [] );
 
 	return (
 		<div style={ { position: 'relative' } }>

--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -222,7 +222,7 @@ export default function ServerSideRender( props ) {
 
 	if ( isLoading ) {
 		return (
-			<LoadingResponsePlaceholder { ...props } isLoading={ isLoading }>
+			<LoadingResponsePlaceholder { ...props }>
 				{ hasResponse && ! hasError && (
 					<RawHTML className={ className }>{ response }</RawHTML>
 				) }


### PR DESCRIPTION
## What?
This is a follow-up to #70147.
Extracted from #70543.

PR removes the unnecessary `isLoading` prop from the `DefaultLoadingResponsePlaceholder` component.

P.S. I'm omitting the changelog entry; the one from the original issue will cover this.

## Why?
It serves no purpose, and I should've listened to @t-hamano https://github.com/WordPress/gutenberg/pull/70147#discussion_r2093858645.

## Testing Instructions
1. Open a post or page.
2. Insert the Archives block
3. Throttle Network to slow 3G.
4. Toggle any Archives block's controls.
5. Confirm that the loading spinner is displayed after a slight (1-second) delay.

### Testing Instructions for Keyboard
Same.
