### PR TITLE
Date block: Allow connecting to Block Bindings

### DIFF
--- a/backport-changelog/6.9/9299.md
+++ b/backport-changelog/6.9/9299.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/9299
+
+* https://github.com/WordPress/gutenberg/pull/70585

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -624,7 +624,7 @@ Display the publish date for an entry such as a post or page. ([Source](https://
 -	**Name:** core/post-date
 -	**Category:** theme
 -	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** date, displayType, format, isLink, textAlign
+-	**Attributes:** date, format, isLink, textAlign
 
 ## Excerpt
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -624,7 +624,7 @@ Display the publish date for an entry such as a post or page. ([Source](https://
 -	**Name:** core/post-date
 -	**Category:** theme
 -	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** date, format, isLink, textAlign
+-	**Attributes:** datetime, format, isLink, textAlign
 
 ## Excerpt
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -624,7 +624,7 @@ Display the publish date for an entry such as a post or page. ([Source](https://
 -	**Name:** core/post-date
 -	**Category:** theme
 -	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** displayType, format, isLink, textAlign
+-	**Attributes:** date, displayType, format, isLink, textAlign
 
 ## Excerpt
 

--- a/lib/compat/wordpress-6.9/post-data-block-bindings.php
+++ b/lib/compat/wordpress-6.9/post-data-block-bindings.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Post Data source for the block bindings.
+ *
+ * @since 6.9.0
+ * @package gutenberg
+ * @subpackage Block Bindings
+ */
+
+/**
+ * Gets value for Post Data source.
+ *
+ * @since 6.9.0
+ * @access private
+ *
+ * @param array    $source_args    Array containing source arguments used to look up the override value.
+ *                                 Example: array( "key" => "foo" ).
+ * @param WP_Block $block_instance The block instance.
+ * @return mixed The value computed for the source.
+ */
+function _block_bindings_post_data_get_value( array $source_args, $block_instance ) {
+	if ( empty( $source_args['key'] ) ) {
+		return null;
+	}
+
+	if ( empty( $block_instance->context['postId'] ) ) {
+		return null;
+	}
+	$post_id = $block_instance->context['postId'];
+
+	// If a post isn't public, we need to prevent unauthorized users from accessing the post data.
+	$post = get_post( $post_id );
+	if ( ( ! is_post_publicly_viewable( $post ) && ! current_user_can( 'read_post', $post_id ) ) || post_password_required( $post ) ) {
+		return null;
+	}
+
+	if ( 'date' === $source_args['key'] ) {
+		return esc_attr( get_the_date( 'c', $post_id ) );
+	}
+
+	if ( 'modified' === $source_args['key'] ) {
+		if ( get_the_modified_date( 'Ymdhi', $post_id ) > get_the_date( 'Ymdhi', $post_id ) ) {
+			return esc_attr( get_the_modified_date( 'c', $post_id ) );
+		} else {
+			return '';
+		}
+	}
+}
+
+/**
+ * Registers Post Data source in the block bindings registry.
+ *
+ * @since 6.9.0
+ * @access private
+ */
+function _register_block_bindings_post_data_source() {
+	register_block_bindings_source(
+		'core/post-date',
+		array(
+			'label'              => _x( 'Post Data', 'block bindings source' ),
+			'get_value_callback' => '_block_bindings_post_data_get_value',
+			'uses_context'       => array( 'postId', 'postType' ),
+		)
+	);
+}
+
+add_action( 'init', '_register_block_bindings_post_data_source' );

--- a/lib/compat/wordpress-6.9/post-data-block-bindings.php
+++ b/lib/compat/wordpress-6.9/post-data-block-bindings.php
@@ -34,11 +34,11 @@ function _block_bindings_post_data_get_value( array $source_args, $block_instanc
 		return null;
 	}
 
-	if ( 'date' === $source_args['key'] ) {
+	if ( 'post_date' === $source_args['key'] ) {
 		return esc_attr( get_the_date( 'c', $post_id ) );
 	}
 
-	if ( 'modified' === $source_args['key'] ) {
+	if ( 'post_modified' === $source_args['key'] ) {
 		if ( get_the_modified_date( 'Ymdhi', $post_id ) > get_the_date( 'Ymdhi', $post_id ) ) {
 			return esc_attr( get_the_modified_date( 'c', $post_id ) );
 		} else {

--- a/lib/compat/wordpress-6.9/post-data-block-bindings.php
+++ b/lib/compat/wordpress-6.9/post-data-block-bindings.php
@@ -18,7 +18,7 @@
  * @param WP_Block $block_instance The block instance.
  * @return mixed The value computed for the source.
  */
-function _block_bindings_post_data_get_value( array $source_args, $block_instance ) {
+function gutenberg_block_bindings_post_data_get_value( array $source_args, $block_instance ) {
 	if ( empty( $source_args['key'] ) ) {
 		return null;
 	}
@@ -56,15 +56,15 @@ function _block_bindings_post_data_get_value( array $source_args, $block_instanc
  * @since 6.9.0
  * @access private
  */
-function _register_block_bindings_post_data_source() {
+function gutenberg_register_block_bindings_post_data_source() {
 	register_block_bindings_source(
 		'core/post-data',
 		array(
 			'label'              => _x( 'Post Data', 'block bindings source' ),
-			'get_value_callback' => '_block_bindings_post_data_get_value',
+			'get_value_callback' => 'gutenberg_block_bindings_post_data_get_value',
 			'uses_context'       => array( 'postId', 'postType' ),
 		)
 	);
 }
 
-add_action( 'init', '_register_block_bindings_post_data_source' );
+add_action( 'init', 'gutenberg_register_block_bindings_post_data_source' );

--- a/lib/compat/wordpress-6.9/post-data-block-bindings.php
+++ b/lib/compat/wordpress-6.9/post-data-block-bindings.php
@@ -34,11 +34,11 @@ function _block_bindings_post_data_get_value( array $source_args, $block_instanc
 		return null;
 	}
 
-	if ( 'post_date' === $source_args['key'] ) {
+	if ( 'date' === $source_args['key'] ) {
 		return esc_attr( get_the_date( 'c', $post_id ) );
 	}
 
-	if ( 'post_modified' === $source_args['key'] ) {
+	if ( 'modified' === $source_args['key'] ) {
 		if ( get_the_modified_date( 'Ymdhi', $post_id ) > get_the_date( 'Ymdhi', $post_id ) ) {
 			return esc_attr( get_the_modified_date( 'c', $post_id ) );
 		} else {

--- a/lib/compat/wordpress-6.9/post-data-block-bindings.php
+++ b/lib/compat/wordpress-6.9/post-data-block-bindings.php
@@ -55,7 +55,7 @@ function _block_bindings_post_data_get_value( array $source_args, $block_instanc
  */
 function _register_block_bindings_post_data_source() {
 	register_block_bindings_source(
-		'core/post-date',
+		'core/post-data',
 		array(
 			'label'              => _x( 'Post Data', 'block bindings source' ),
 			'get_value_callback' => '_block_bindings_post_data_get_value',

--- a/lib/compat/wordpress-6.9/post-data-block-bindings.php
+++ b/lib/compat/wordpress-6.9/post-data-block-bindings.php
@@ -39,6 +39,9 @@ function _block_bindings_post_data_get_value( array $source_args, $block_instanc
 	}
 
 	if ( 'modified' === $source_args['key'] ) {
+		/*
+		 * Only return the modified date if it is later than the publishing date.
+		 */
 		if ( get_the_modified_date( 'Ymdhi', $post_id ) > get_the_date( 'Ymdhi', $post_id ) ) {
 			return esc_attr( get_the_modified_date( 'c', $post_id ) );
 		} else {

--- a/lib/compat/wordpress-6.9/post-data-block-bindings.php
+++ b/lib/compat/wordpress-6.9/post-data-block-bindings.php
@@ -39,9 +39,7 @@ function gutenberg_block_bindings_post_data_get_value( array $source_args, $bloc
 	}
 
 	if ( 'modified' === $source_args['key'] ) {
-		/*
-		 * Only return the modified date if it is later than the publishing date.
-		 */
+		// Only return the modified date if it is later than the publishing date.
 		if ( get_the_modified_date( 'Ymdhi', $post_id ) > get_the_date( 'Ymdhi', $post_id ) ) {
 			return esc_attr( get_the_modified_date( 'c', $post_id ) );
 		} else {

--- a/lib/compat/wordpress-6.9/post-data-block-bindings.php
+++ b/lib/compat/wordpress-6.9/post-data-block-bindings.php
@@ -57,6 +57,11 @@ function gutenberg_block_bindings_post_data_get_value( array $source_args, $bloc
  * @access private
  */
 function gutenberg_register_block_bindings_post_data_source() {
+	if ( get_block_bindings_source( 'core/post-data' ) ) {
+		// The source is already registered.
+		return;
+	}
+
 	register_block_bindings_source(
 		'core/post-data',
 		array(

--- a/lib/compat/wordpress-6.9/post-data-block-bindings.php
+++ b/lib/compat/wordpress-6.9/post-data-block-bindings.php
@@ -67,7 +67,7 @@ function gutenberg_register_block_bindings_post_data_source() {
 		array(
 			'label'              => _x( 'Post Data', 'block bindings source' ),
 			'get_value_callback' => 'gutenberg_block_bindings_post_data_get_value',
-			'uses_context'       => array( 'postId', 'postType' ),
+			'uses_context'       => array( 'postId' ),
 		)
 	);
 }

--- a/lib/load.php
+++ b/lib/load.php
@@ -39,6 +39,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-6.8/rest-api.php';
 
 	// WordPress 6.9 compat.
+	require __DIR__ . '/compat/wordpress-6.9/post-data-block-bindings.php';
 	require __DIR__ . '/compat/wordpress-6.9/rest-api.php';
 	require __DIR__ . '/compat/wordpress-6.9/class-gutenberg-hierarchical-sort.php';
 

--- a/packages/block-editor/src/components/publish-date-time-picker/README.md
+++ b/packages/block-editor/src/components/publish-date-time-picker/README.md
@@ -32,6 +32,7 @@ const MyDateTimePicker = () => {
 					currentDate={ date }
 					onChange={ ( newDate ) => setDate( newDate ) }
 					onClose={ onClose }
+					title={ __( 'Select post date' ) }
 				/>
 			) }
 		/>
@@ -43,6 +44,14 @@ const MyDateTimePicker = () => {
 
 `PublishDateTimePicker` supports all of the props that
 [`DateTimePicker`](/packages/components/src/date-time#Props) supports, plus:
+
+### title
+
+The title displayed in the header of the popover that contains the `DateTimePicker`.
+
+- Type: `String`
+- Required: No
+- Default: `Publish`
 
 ### onClose
 

--- a/packages/block-editor/src/components/publish-date-time-picker/index.js
+++ b/packages/block-editor/src/components/publish-date-time-picker/index.js
@@ -18,6 +18,7 @@ export function PublishDateTimePicker(
 		showPopoverHeaderActions,
 		isCompact,
 		currentDate,
+		title,
 		...additionalProps
 	},
 	ref
@@ -33,7 +34,7 @@ export function PublishDateTimePicker(
 	return (
 		<div ref={ ref } className="block-editor-publish-date-time-picker">
 			<InspectorPopoverHeader
-				title={ __( 'Publish' ) }
+				title={ title || __( 'Publish' ) }
 				actions={
 					showPopoverHeaderActions
 						? [

--- a/packages/block-editor/src/utils/block-bindings.js
+++ b/packages/block-editor/src/utils/block-bindings.js
@@ -16,6 +16,7 @@ const BLOCK_BINDINGS_ALLOWED_BLOCKS = {
 	'core/heading': [ 'content' ],
 	'core/image': [ 'id', 'url', 'title', 'alt' ],
 	'core/button': [ 'url', 'text', 'linkTarget', 'rel' ],
+	'core/post-date': [ 'date' ],
 };
 
 /**

--- a/packages/block-editor/src/utils/block-bindings.js
+++ b/packages/block-editor/src/utils/block-bindings.js
@@ -16,7 +16,7 @@ const BLOCK_BINDINGS_ALLOWED_BLOCKS = {
 	'core/heading': [ 'content' ],
 	'core/image': [ 'id', 'url', 'title', 'alt' ],
 	'core/button': [ 'url', 'text', 'linkTarget', 'rel' ],
-	'core/post-date': [ 'date' ],
+	'core/post-date': [ 'datetime' ],
 };
 
 /**

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -7,6 +7,9 @@
 	"description": "Display the publish date for an entry such as a post or page.",
 	"textdomain": "default",
 	"attributes": {
+		"date": {
+			"type": "string"
+		},
 		"textAlign": {
 			"type": "string"
 		},

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -7,7 +7,7 @@
 	"description": "Display the publish date for an entry such as a post or page.",
 	"textdomain": "default",
 	"attributes": {
-		"date": {
+		"datetime": {
 			"type": "string"
 		},
 		"textAlign": {

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -20,10 +20,6 @@
 			"type": "boolean",
 			"default": false,
 			"role": "content"
-		},
-		"displayType": {
-			"type": "string",
-			"default": "date"
 		}
 	},
 	"usesContext": [ "postId", "postType", "queryId" ],

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -8,7 +8,8 @@
 	"textdomain": "default",
 	"attributes": {
 		"datetime": {
-			"type": "string"
+			"type": "string",
+			"role": "content"
 		},
 		"textAlign": {
 			"type": "string"

--- a/packages/block-library/src/post-date/deprecated.js
+++ b/packages/block-library/src/post-date/deprecated.js
@@ -98,7 +98,7 @@ const v2 = {
 		}
 	},
 	isEligible( attributes ) {
-		// If there's neither an explicit `date` attribute nor a block binding for that attriubte,
+		// If there's neither an explicit `date` attribute nor a block binding for that attribute,
 		// then we're dealing with an old version of the block.
 		return ! attributes.date && ! attributes?.metadata?.bindings?.date;
 	},

--- a/packages/block-library/src/post-date/deprecated.js
+++ b/packages/block-library/src/post-date/deprecated.js
@@ -3,6 +3,93 @@
  */
 import migrateFontFamily from '../utils/migrate-font-family';
 
+const v2 = {
+	attributes: {
+		textAlign: {
+			type: 'string',
+		},
+		format: {
+			type: 'string',
+		},
+		isLink: {
+			type: 'boolean',
+			default: false,
+			role: 'content',
+		},
+		displayType: {
+			type: 'string',
+			default: 'date',
+		},
+	},
+	supports: {
+		html: false,
+		color: {
+			gradients: true,
+			link: true,
+			__experimentalDefaultControls: {
+				background: true,
+				text: true,
+				link: true,
+			},
+		},
+		spacing: {
+			margin: true,
+			padding: true,
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalFontWeight: true,
+			__experimentalFontStyle: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalLetterSpacing: true,
+			__experimentalDefaultControls: {
+				fontSize: true,
+			},
+		},
+		interactivity: {
+			clientNavigation: true,
+		},
+		__experimentalBorder: {
+			radius: true,
+			color: true,
+			width: true,
+			style: true,
+			__experimentalDefaultControls: {
+				radius: true,
+				color: true,
+				width: true,
+				style: true,
+			},
+		},
+	},
+	save() {
+		return null;
+	},
+	migrate( { displayType, ...otherAttributes } ) {
+		if ( displayType === 'date' || displayType === 'modified' ) {
+			return {
+				...otherAttributes,
+				metadata: {
+					bindings: {
+						date: {
+							source: 'core/post-data',
+							args: { key: displayType },
+						},
+					},
+				},
+			};
+		}
+	},
+	isEligible( attributes ) {
+		// If there's neither an explicit `date` attribute nor a block binding for that attriubte,
+		// then we're dealing with an old version of the block.
+		return ! attributes.date && ! attributes?.metadata?.bindings?.date;
+	},
+};
+
 const v1 = {
 	attributes: {
 		textAlign: {
@@ -49,4 +136,4 @@ const v1 = {
  *
  * See block-deprecation.md
  */
-export default [ v1 ];
+export default [ v2, v1 ];

--- a/packages/block-library/src/post-date/deprecated.js
+++ b/packages/block-library/src/post-date/deprecated.js
@@ -88,7 +88,7 @@ const v2 = {
 				metadata: {
 					...metadata,
 					bindings: {
-						date: {
+						datetime: {
 							source: 'core/post-data',
 							args: { key: displayType },
 						},
@@ -98,9 +98,11 @@ const v2 = {
 		}
 	},
 	isEligible( attributes ) {
-		// If there's neither an explicit `date` attribute nor a block binding for that attribute,
+		// If there's neither an explicit `datetime` attribute nor a block binding for that attribute,
 		// then we're dealing with an old version of the block.
-		return ! attributes.date && ! attributes?.metadata?.bindings?.date;
+		return (
+			! attributes.datetime && ! attributes?.metadata?.bindings?.datetime
+		);
 	},
 };
 

--- a/packages/block-library/src/post-date/deprecated.js
+++ b/packages/block-library/src/post-date/deprecated.js
@@ -68,11 +68,12 @@ const v2 = {
 	save() {
 		return null;
 	},
-	migrate( { displayType, ...otherAttributes } ) {
+	migrate( { displayType, metadata, ...otherAttributes } ) {
 		if ( displayType === 'date' || displayType === 'modified' ) {
 			return {
 				...otherAttributes,
 				metadata: {
+					...metadata,
 					bindings: {
 						date: {
 							source: 'core/post-data',

--- a/packages/block-library/src/post-date/deprecated.js
+++ b/packages/block-library/src/post-date/deprecated.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * Internal dependencies
  */
 import migrateFontFamily from '../utils/migrate-font-family';
@@ -68,10 +73,18 @@ const v2 = {
 	save() {
 		return null;
 	},
-	migrate( { displayType, metadata, ...otherAttributes } ) {
+	migrate( { className, displayType, metadata, ...otherAttributes } ) {
 		if ( displayType === 'date' || displayType === 'modified' ) {
+			if ( displayType === 'modified' ) {
+				className = clsx(
+					className,
+					'wp-block-post-date__modified-date'
+				);
+			}
+
 			return {
 				...otherAttributes,
+				className,
 				metadata: {
 					...metadata,
 					bindings: {

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -86,17 +86,12 @@ export default function PostDateEdit( {
 		[ postTypeSlug ]
 	);
 
-	const dateLabel =
-		displayType === 'date' ? __( 'Post Date' ) : __( 'Post Modified Date' );
-
-	let postDate = ! displayType ? (
+	let postDate = (
 		<time dateTime={ dateI18n( 'c', date ) } ref={ setPopoverAnchor }>
 			{ format === 'human-diff'
 				? humanTimeDiff( date )
 				: dateI18n( format || siteFormat, date ) }
 		</time>
-	) : (
-		dateLabel
 	);
 
 	if ( isLink && date ) {

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -40,8 +40,8 @@ import { useSelect } from '@wordpress/data';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 export default function PostDateEdit( {
-	attributes: { textAlign, format, isLink, displayType },
-	context: { postId, postType: postTypeSlug, queryId },
+	attributes: { date, textAlign, format, isLink, displayType },
+	context: { postType: postTypeSlug, queryId },
 	setAttributes,
 } ) {
 	const blockProps = useBlockProps( {
@@ -72,12 +72,6 @@ export default function PostDateEdit( {
 		'root',
 		'site',
 		'time_format'
-	);
-	const [ date, setDate ] = useEntityProp(
-		'postType',
-		postTypeSlug,
-		displayType,
-		postId
 	);
 
 	const postType = useSelect(
@@ -121,49 +115,46 @@ export default function PostDateEdit( {
 						setAttributes( { textAlign: nextAlign } );
 					} }
 				/>
-				{ date &&
-					displayType === 'date' &&
-					! isDescendentOfQueryLoop && (
-						<ToolbarGroup>
-							<Dropdown
-								popoverProps={ popoverProps }
-								renderContent={ ( { onClose } ) => (
-									<PublishDateTimePicker
-										currentDate={ date }
-										onChange={ setDate }
-										is12Hour={ is12HourFormat(
-											siteTimeFormat
-										) }
-										onClose={ onClose }
-										dateOrder={
-											/* translators: Order of day, month, and year. Available formats are 'dmy', 'mdy', and 'ymd'. */
-											_x( 'dmy', 'date order' )
-										}
+				{ displayType === 'date' && ! isDescendentOfQueryLoop && (
+					<ToolbarGroup>
+						<Dropdown
+							popoverProps={ popoverProps }
+							renderContent={ ( { onClose } ) => (
+								<PublishDateTimePicker
+									currentDate={ date }
+									onChange={ ( newDate ) =>
+										setAttributes( { date: newDate } )
+									}
+									is12Hour={ is12HourFormat(
+										siteTimeFormat
+									) }
+									onClose={ onClose }
+									dateOrder={
+										/* translators: Order of day, month, and year. Available formats are 'dmy', 'mdy', and 'ymd'. */
+										_x( 'dmy', 'date order' )
+									}
+								/>
+							) }
+							renderToggle={ ( { isOpen, onToggle } ) => {
+								const openOnArrowDown = ( event ) => {
+									if ( ! isOpen && event.keyCode === DOWN ) {
+										event.preventDefault();
+										onToggle();
+									}
+								};
+								return (
+									<ToolbarButton
+										aria-expanded={ isOpen }
+										icon={ edit }
+										title={ __( 'Change Date' ) }
+										onClick={ onToggle }
+										onKeyDown={ openOnArrowDown }
 									/>
-								) }
-								renderToggle={ ( { isOpen, onToggle } ) => {
-									const openOnArrowDown = ( event ) => {
-										if (
-											! isOpen &&
-											event.keyCode === DOWN
-										) {
-											event.preventDefault();
-											onToggle();
-										}
-									};
-									return (
-										<ToolbarButton
-											aria-expanded={ isOpen }
-											icon={ edit }
-											title={ __( 'Change Date' ) }
-											onClick={ onToggle }
-											onKeyDown={ openOnArrowDown }
-										/>
-									);
-								} }
-							/>
-						</ToolbarGroup>
-					) }
+								);
+							} }
+						/>
+					</ToolbarGroup>
+				) }
 			</BlockControls>
 
 			<InspectorControls>
@@ -171,6 +162,7 @@ export default function PostDateEdit( {
 					label={ __( 'Settings' ) }
 					resetAll={ () => {
 						setAttributes( {
+							date: undefined,
 							format: undefined,
 							isLink: false,
 							displayType: 'date',

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -51,7 +51,6 @@ export default function PostDateEdit( {
 	const blockProps = useBlockProps( {
 		className: clsx( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
-			[ `wp-block-post-date__modified-date` ]: displayType === 'modified',
 		} ),
 	} );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -40,10 +40,14 @@ import { useSelect } from '@wordpress/data';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 export default function PostDateEdit( {
-	attributes: { date, textAlign, format, isLink, displayType },
+	attributes: { date, textAlign, format, isLink, metadata },
 	context: { postType: postTypeSlug, queryId },
 	setAttributes,
 } ) {
+	const displayType =
+		metadata?.bindings?.date?.source === 'core/post-data' &&
+		metadata?.bindings?.date?.args?.key;
+
 	const blockProps = useBlockProps( {
 		className: clsx( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
@@ -85,7 +89,7 @@ export default function PostDateEdit( {
 	const dateLabel =
 		displayType === 'date' ? __( 'Post Date' ) : __( 'Post Modified Date' );
 
-	let postDate = date ? (
+	let postDate = ! displayType ? (
 		<time dateTime={ dateI18n( 'c', date ) } ref={ setPopoverAnchor }>
 			{ format === 'human-diff'
 				? humanTimeDiff( date )
@@ -115,7 +119,7 @@ export default function PostDateEdit( {
 						setAttributes( { textAlign: nextAlign } );
 					} }
 				/>
-				{ displayType === 'date' && ! isDescendentOfQueryLoop && (
+				{ displayType !== 'modified' && ! isDescendentOfQueryLoop && (
 					<ToolbarGroup>
 						<Dropdown
 							popoverProps={ popoverProps }
@@ -165,7 +169,6 @@ export default function PostDateEdit( {
 							date: undefined,
 							format: undefined,
 							isLink: false,
-							displayType: 'date',
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
@@ -215,28 +218,6 @@ export default function PostDateEdit( {
 								setAttributes( { isLink: ! isLink } )
 							}
 							checked={ isLink }
-						/>
-					</ToolsPanelItem>
-					<ToolsPanelItem
-						hasValue={ () => displayType !== 'date' }
-						label={ __( 'Display last modified date' ) }
-						onDeselect={ () =>
-							setAttributes( { displayType: 'date' } )
-						}
-						isShownByDefault
-					>
-						<ToggleControl
-							__nextHasNoMarginBottom
-							label={ __( 'Display last modified date' ) }
-							onChange={ ( value ) =>
-								setAttributes( {
-									displayType: value ? 'modified' : 'date',
-								} )
-							}
-							checked={ displayType === 'modified' }
-							help={ __(
-								'Only shows if the post has been modified'
-							) }
 						/>
 					</ToolsPanelItem>
 				</ToolsPanel>

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -41,13 +41,13 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 export default function PostDateEdit( {
-	attributes: { date, textAlign, format, isLink, metadata },
+	attributes: { datetime, textAlign, format, isLink, metadata },
 	context: { postType: postTypeSlug, queryId },
 	setAttributes,
 } ) {
 	const displayType =
-		metadata?.bindings?.date?.source === 'core/post-data' &&
-		metadata?.bindings?.date?.args?.key;
+		metadata?.bindings?.datetime?.source === 'core/post-data' &&
+		metadata?.bindings?.datetime?.args?.key;
 
 	const blockProps = useBlockProps( {
 		className: clsx( {
@@ -68,15 +68,15 @@ export default function PostDateEdit( {
 	const { __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
 
-	// We need to set the date to a default value upon first loading
+	// We need to set the datetime to a default value upon first loading
 	// to discern the block from its legacy version (which would default
 	// to the containing post's publish date).
 	useEffect( () => {
-		if ( date === undefined ) {
+		if ( datetime === undefined ) {
 			__unstableMarkNextChangeAsNotPersistent();
-			setAttributes( { date: new Date() } );
+			setAttributes( { datetime: new Date() } );
 		}
-	}, [ date ] );
+	}, [ datetime ] );
 
 	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 	const dateSettings = getDateSettings();
@@ -100,14 +100,14 @@ export default function PostDateEdit( {
 	);
 
 	let postDate = (
-		<time dateTime={ dateI18n( 'c', date ) } ref={ setPopoverAnchor }>
+		<time dateTime={ dateI18n( 'c', datetime ) } ref={ setPopoverAnchor }>
 			{ format === 'human-diff'
-				? humanTimeDiff( date )
-				: dateI18n( format || siteFormat, date ) }
+				? humanTimeDiff( datetime )
+				: dateI18n( format || siteFormat, datetime ) }
 		</time>
 	);
 
-	if ( isLink && date ) {
+	if ( isLink && datetime ) {
 		postDate = (
 			<a
 				href="#post-date-pseudo-link"
@@ -138,9 +138,11 @@ export default function PostDateEdit( {
 											? __( 'Publish Date' )
 											: __( 'Date' )
 									}
-									currentDate={ date }
-									onChange={ ( newDate ) =>
-										setAttributes( { date: newDate } )
+									currentDate={ datetime }
+									onChange={ ( newDatetime ) =>
+										setAttributes( {
+											datetime: newDatetime,
+										} )
 									}
 									is12Hour={ is12HourFormat(
 										siteTimeFormat
@@ -179,7 +181,7 @@ export default function PostDateEdit( {
 					label={ __( 'Settings' ) }
 					resetAll={ () => {
 						setAttributes( {
-							date: undefined,
+							datetime: undefined,
 							format: undefined,
 							isLink: false,
 						} );

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -133,6 +133,11 @@ export default function PostDateEdit( {
 							popoverProps={ popoverProps }
 							renderContent={ ( { onClose } ) => (
 								<PublishDateTimePicker
+									title={
+										displayType === 'date'
+											? __( 'Publish Date' )
+											: __( 'Date' )
+									}
 									currentDate={ date }
 									onChange={ ( newDate ) =>
 										setAttributes( { date: newDate } )

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -7,7 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
-import { useMemo, useState } from '@wordpress/element';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 import {
 	dateI18n,
 	humanTimeDiff,
@@ -17,6 +17,7 @@ import {
 	AlignmentControl,
 	BlockControls,
 	InspectorControls,
+	store as blockEditorStore,
 	useBlockProps,
 	__experimentalDateFormatPicker as DateFormatPicker,
 	__experimentalPublishDateTimePicker as PublishDateTimePicker,
@@ -32,7 +33,7 @@ import {
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { edit } from '@wordpress/icons';
 import { DOWN } from '@wordpress/keycodes';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -63,6 +64,19 @@ export default function PostDateEdit( {
 		() => ( { anchor: popoverAnchor } ),
 		[ popoverAnchor ]
 	);
+
+	const { __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( blockEditorStore );
+
+	// We need to set the date to a default value upon first loading
+	// to discern the block from its legacy version (which would default
+	// to the containing post's publish date).
+	useEffect( () => {
+		if ( date === undefined ) {
+			__unstableMarkNextChangeAsNotPersistent();
+			setAttributes( { date: new Date() } );
+		}
+	}, [ date ] );
 
 	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 	const dateSettings = getDateSettings();

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -20,7 +20,7 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 
 	if ( ! isset( $attributes['date'] ) ) {
 		// This must be the legacy version of the block.
-		// In this case, we manually run block bindings for the
+		// In this case, we manually apply block bindings for the
 		// `core/post-data` source to set the `date` attribute.
 
 		$source = get_block_bindings_source( 'core/post-data' );

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -19,10 +19,9 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 	$classes = array();
 
 	if ( ! isset( $attributes['date'] ) ) {
-		// This must be the legacy version of the block.
+		// This is the legacy version of the block.
 		// In this case, we manually apply block bindings for the
 		// `core/post-data` source to set the `date` attribute.
-
 		$source = get_block_bindings_source( 'core/post-data' );
 
 		if ( isset( $attributes['displayType'] ) && 'modified' === $attributes['displayType'] ) {

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -30,15 +30,16 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 		 */
 		if (
 			isset( $attributes['metadata']['bindings']['date']['source'] ) &&
-			'core/post-data' === $attributes['metadata']['bindings']['date']['source'] &&
 			isset( $attributes['metadata']['bindings']['date']['args'] )
 		) {
 			// We're using a version of WordPress that doesn't support the `core/post-data` source for block bindings.
 			// This branch can be removed once the minimum required WordPress version supports the `core/post-data` source.
+			$source      = get_block_bindings_source( $attributes['metadata']['bindings']['date']['source'] );
 			$source_args = $attributes['metadata']['bindings']['date']['args'];
 		} else {
 			// This is the legacy version of the block that didn't have the `date` attribute.
 			// This branch needs to be kept for backward compatibility.
+			$source = get_block_bindings_source( 'core/post-data' );
 			if ( isset( $attributes['displayType'] ) && 'modified' === $attributes['displayType'] ) {
 				$source_args = array(
 					'key' => 'modified',
@@ -50,7 +51,6 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 			}
 		}
 
-		$source             = get_block_bindings_source( 'core/post-data' );
 		$attributes['date'] = $source->get_value( $source_args, $block, 'date' );
 
 		if ( isset( $source_args['key'] ) && 'modified' === $source_args['key'] ) {

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -35,6 +35,13 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 			);
 		}
 		$attributes['date'] = $source->get_value( $source_args, $block, 'date' );
+	} elseif ( empty( $attributes['date'] ) ) {
+		// If the `date` attribute is set but empty, it's because the block is bound to the
+		// post's last modified date, and the latter lies before the publish date.
+		// In this case, we return an empty string.
+		// See https://github.com/WordPress/gutenberg/pull/46839 where this logic was originally
+		// implemented.
+		return '';
 	}
 
 	$unformatted_date = $attributes['date'];

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -29,7 +29,7 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 			$source_args = array(
 				'key' => 'modified',
 			);
-			$classes[] = 'wp-block-post-date__modified-date';
+			$classes[]   = 'wp-block-post-date__modified-date';
 		} else {
 			$source_args = array(
 				'key' => 'date',

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -18,26 +18,26 @@
 function render_block_core_post_date( $attributes, $content, $block ) {
 	$classes = array();
 
-	if ( ! isset( $attributes['date'] ) ) {
+	if ( ! isset( $attributes['datetime'] ) ) {
 		/*
 		 * This can mean two things:
 		 *
-		 * 1. We're dealing with the legacy version of the block that didn't have the `date` attribute.
-		 * 2. The `date` attribute is bound to a Block Bindings source, but we're on a version of WordPress
-		 *    that doesn't support the `core/post-data` source.
+		 * 1. We're dealing with the legacy version of the block that didn't have the `datetime` attribute.
+		 * 2. The `datetime` attribute is bound to a Block Bindings source, but we're on a version of WordPress
+		 *    that doesn't support binding that attribute to a Block Bindings source.
 		 *
-		 * In both cases, we set the `date` attribute to its correct value by applying Block Bindings manually.
+		 * In both cases, we set the `datetime` attribute to its correct value by applying Block Bindings manually.
 		 */
 		if (
-			isset( $attributes['metadata']['bindings']['date']['source'] ) &&
-			isset( $attributes['metadata']['bindings']['date']['args'] )
+			isset( $attributes['metadata']['bindings']['datetime']['source'] ) &&
+			isset( $attributes['metadata']['bindings']['datetime']['args'] )
 		) {
 			// We're using a version of WordPress that doesn't support the `core/post-data` source for block bindings.
 			// This branch can be removed once the minimum required WordPress version supports the `core/post-data` source.
-			$source      = get_block_bindings_source( $attributes['metadata']['bindings']['date']['source'] );
-			$source_args = $attributes['metadata']['bindings']['date']['args'];
+			$source      = get_block_bindings_source( $attributes['metadata']['bindings']['datetime']['source'] );
+			$source_args = $attributes['metadata']['bindings']['datetime']['args'];
 		} else {
-			// This is the legacy version of the block that didn't have the `date` attribute.
+			// This is the legacy version of the block that didn't have the `datetime` attribute.
 			// This branch needs to be kept for backward compatibility.
 			$source = get_block_bindings_source( 'core/post-data' );
 			if ( isset( $attributes['displayType'] ) && 'modified' === $attributes['displayType'] ) {
@@ -51,24 +51,24 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 			}
 		}
 
-		$attributes['date'] = $source->get_value( $source_args, $block, 'date' );
+		$attributes['datetime'] = $source->get_value( $source_args, $block, 'datetime' );
 
 		if ( isset( $source_args['key'] ) && 'modified' === $source_args['key'] ) {
 			$classes[] = 'wp-block-post-date__modified-date';
 		}
 	}
 
-	if ( empty( $attributes['date'] ) ) {
-		// If the `date` attribute is set but empty, it could be because Block Bindings
+	if ( empty( $attributes['datetime'] ) ) {
+		// If the `datetime` attribute is set but empty, it could be because Block Bindings
 		// set it that way. This can happen e.g. if the block is bound to the
 		// post's last modified date, and the latter lies before the publish date.
 		// (See https://github.com/WordPress/gutenberg/pull/46839 where this logic was originally
 		// implemented.)
 		// In this case, we have to respect and return the empty value.
-		return $attributes['date'];
+		return $attributes['datetime'];
 	}
 
-	$unformatted_date = $attributes['date'];
+	$unformatted_date = $attributes['datetime'];
 	$post_timestamp   = strtotime( $unformatted_date );
 
 	if ( isset( $attributes['format'] ) && 'human-diff' === $attributes['format'] ) {

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -59,12 +59,13 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 	}
 
 	if ( empty( $attributes['date'] ) ) {
-		// If the `date` attribute is set but empty, it's because the block is bound to the
+		// If the `date` attribute is set but empty, it could be because Block Bindings
+		// set it that way. This can happen e.g. if the block is bound to the
 		// post's last modified date, and the latter lies before the publish date.
-		// In this case, we return an empty string.
-		// See https://github.com/WordPress/gutenberg/pull/46839 where this logic was originally
-		// implemented.
-		return '';
+		// (See https://github.com/WordPress/gutenberg/pull/46839 where this logic was originally
+		// implemented.)
+		// In this case, we have to respect and return the empty value.
+		return $attributes['date'];
 	}
 
 	$unformatted_date = $attributes['date'];

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -46,8 +46,8 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
 
-	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
-		$formatted_date = sprintf( '<a href="%1s">%2s</a>', get_the_permalink( $post_ID ), $formatted_date );
+	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] && isset( $block->context['postId'] ) ) {
+		$formatted_date = sprintf( '<a href="%1s">%2s</a>', get_the_permalink( $block->context['postId'] ), $formatted_date );
 	}
 
 	return sprintf(

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -19,23 +19,46 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 	$classes = array();
 
 	if ( ! isset( $attributes['date'] ) ) {
-		// This is the legacy version of the block.
-		// In this case, we manually apply block bindings for the
-		// `core/post-data` source to set the `date` attribute.
-		$source = get_block_bindings_source( 'core/post-data' );
-
-		if ( isset( $attributes['displayType'] ) && 'modified' === $attributes['displayType'] ) {
-			$source_args = array(
-				'key' => 'modified',
-			);
-			$classes[]   = 'wp-block-post-date__modified-date';
+		/*
+		 * This can mean two things:
+		 *
+		 * 1. We're dealing with the legacy version of the block that didn't have the `date` attribute.
+		 * 2. The `date` attribute is bound to a Block Bindings source, but we're on a version of WordPress
+		 *    that doesn't support the `core/post-data` source.
+		 *
+		 * In both cases, we set the `date` attribute to its correct value by applying Block Bindings manually.
+		 */
+		if (
+			isset( $attributes['metadata']['bindings']['date']['source'] ) &&
+			'core/post-data' === $attributes['metadata']['bindings']['date']['source'] &&
+			isset( $attributes['metadata']['bindings']['date']['args'] )
+		) {
+			// We're using a version of WordPress that doesn't support the `core/post-data` source for block bindings.
+			// This branch can be removed once the minimum required WordPress version supports the `core/post-data` source.
+			$source_args = $attributes['metadata']['bindings']['date']['args'];
 		} else {
-			$source_args = array(
-				'key' => 'date',
-			);
+			// This is the legacy version of the block that didn't have the `date` attribute.
+			// This branch needs to be kept for backward compatibility.
+			if ( isset( $attributes['displayType'] ) && 'modified' === $attributes['displayType'] ) {
+				$source_args = array(
+					'key' => 'modified',
+				);
+			} else {
+				$source_args = array(
+					'key' => 'date',
+				);
+			}
 		}
+
+		$source             = get_block_bindings_source( 'core/post-data' );
 		$attributes['date'] = $source->get_value( $source_args, $block, 'date' );
-	} elseif ( empty( $attributes['date'] ) ) {
+
+		if ( isset( $source_args['key'] ) && 'modified' === $source_args['key'] ) {
+			$classes[] = 'wp-block-post-date__modified-date';
+		}
+	}
+
+	if ( empty( $attributes['date'] ) ) {
 		// If the `date` attribute is set but empty, it's because the block is bound to the
 		// post's last modified date, and the latter lies before the publish date.
 		// In this case, we return an empty string.

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -16,14 +16,14 @@
  * @return string Returns the filtered post date for the current post wrapped inside "time" tags.
  */
 function render_block_core_post_date( $attributes, $content, $block ) {
-	if ( ! isset( $block->context['postId'] ) ) {
+	if ( ! isset( $attributes['date'] ) ) {
 		return '';
 	}
 
-	$post_ID = $block->context['postId'];
+	$unformatted_date = $attributes['date'];
+	$post_timestamp   = strtotime( $unformatted_date );
 
 	if ( isset( $attributes['format'] ) && 'human-diff' === $attributes['format'] ) {
-		$post_timestamp = get_post_timestamp( $post_ID );
 		if ( $post_timestamp > time() ) {
 			// translators: %s: human-readable time difference.
 			$formatted_date = sprintf( __( '%s from now' ), human_time_diff( $post_timestamp ) );
@@ -32,10 +32,10 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 			$formatted_date = sprintf( __( '%s ago' ), human_time_diff( $post_timestamp ) );
 		}
 	} else {
-		$formatted_date = get_the_date( empty( $attributes['format'] ) ? '' : $attributes['format'], $post_ID );
+		$formatted_date = date( empty( $attributes['format'] ) ? get_option( 'date_format' ) : $attributes['format'], $post_timestamp );
 	}
-	$unformatted_date = esc_attr( get_the_date( 'c', $post_ID ) );
-	$classes          = array();
+
+	$classes = array();
 
 	if ( isset( $attributes['textAlign'] ) ) {
 		$classes[] = 'has-text-align-' . $attributes['textAlign'];

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -32,7 +32,7 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 			isset( $attributes['metadata']['bindings']['datetime']['source'] ) &&
 			isset( $attributes['metadata']['bindings']['datetime']['args'] )
 		) {
-			// We're using a version of WordPress that doesn't support the `core/post-data` source for block bindings.
+			// We're using a version of WordPress that doesn't support binding the block's `datetime` attribute to a Block Bindings source.
 			// This branch can be removed once the minimum required WordPress version supports the `core/post-data` source.
 			$source      = get_block_bindings_source( $attributes['metadata']['bindings']['datetime']['source'] );
 			$source_args = $attributes['metadata']['bindings']['datetime']['args'];

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -16,8 +16,26 @@
  * @return string Returns the filtered post date for the current post wrapped inside "time" tags.
  */
 function render_block_core_post_date( $attributes, $content, $block ) {
+	$classes = array();
+
 	if ( ! isset( $attributes['date'] ) ) {
-		return '';
+		// This must be the legacy version of the block.
+		// In this case, we manually run block bindings for the
+		// `core/post-data` source to set the `date` attribute.
+
+		$source = get_block_bindings_source( 'core/post-data' );
+
+		if ( isset( $attributes['displayType'] ) && 'modified' === $attributes['displayType'] ) {
+			$source_args = array(
+				'key' => 'modified',
+			);
+			$classes[] = 'wp-block-post-date__modified-date';
+		} else {
+			$source_args = array(
+				'key' => 'date',
+			);
+		}
+		$attributes['date'] = $source->get_value( $source_args, $block, 'date' );
 	}
 
 	$unformatted_date = $attributes['date'];
@@ -34,8 +52,6 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 	} else {
 		$formatted_date = date( empty( $attributes['format'] ) ? get_option( 'date_format' ) : $attributes['format'], $post_timestamp );
 	}
-
-	$classes = array();
 
 	if ( isset( $attributes['textAlign'] ) ) {
 		$classes[] = 'has-text-align-' . $attributes['textAlign'];

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -44,25 +44,6 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 		$classes[] = 'has-link-color';
 	}
 
-	/*
-	 * If the "Display last modified date" setting is enabled,
-	 * only display the modified date if it is later than the publishing date.
-	 */
-	if ( isset( $attributes['displayType'] ) && 'modified' === $attributes['displayType'] ) {
-		if ( get_the_modified_date( 'Ymdhi', $post_ID ) > get_the_date( 'Ymdhi', $post_ID ) ) {
-			if ( isset( $attributes['format'] ) && 'human-diff' === $attributes['format'] ) {
-				// translators: %s: human-readable time difference.
-				$formatted_date = sprintf( __( '%s ago' ), human_time_diff( get_post_timestamp( $post_ID, 'modified' ) ) );
-			} else {
-				$formatted_date = get_the_modified_date( empty( $attributes['format'] ) ? '' : $attributes['format'], $post_ID );
-			}
-			$unformatted_date = esc_attr( get_the_modified_date( 'c', $post_ID ) );
-			$classes[]        = 'wp-block-post-date__modified-date';
-		} else {
-			return '';
-		}
-	}
-
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
 
 	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -50,7 +50,7 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 			$formatted_date = sprintf( __( '%s ago' ), human_time_diff( $post_timestamp ) );
 		}
 	} else {
-		$formatted_date = date( empty( $attributes['format'] ) ? get_option( 'date_format' ) : $attributes['format'], $post_timestamp );
+		$formatted_date = gmdate( empty( $attributes['format'] ) ? get_option( 'date_format' ) : $attributes['format'], $post_timestamp );
 	}
 
 	if ( isset( $attributes['textAlign'] ) ) {

--- a/packages/block-library/src/post-date/variations.js
+++ b/packages/block-library/src/post-date/variations.js
@@ -12,7 +12,7 @@ const variations = [
 		attributes: {
 			metadata: {
 				bindings: {
-					date: {
+					datetime: {
 						source: 'core/post-data',
 						args: { key: 'date' },
 					},
@@ -21,9 +21,9 @@ const variations = [
 		},
 		scope: [ 'block', 'inserter' ],
 		isActive: ( blockAttributes ) =>
-			blockAttributes?.metadata?.bindings?.date?.source ===
+			blockAttributes?.metadata?.bindings?.datetime?.source ===
 				'core/post-data' &&
-			blockAttributes?.metadata?.bindings?.date?.args?.key === 'date',
+			blockAttributes?.metadata?.bindings?.datetime?.args?.key === 'date',
 		icon: postDate,
 	},
 	{
@@ -33,7 +33,7 @@ const variations = [
 		attributes: {
 			metadata: {
 				bindings: {
-					date: {
+					datetime: {
 						source: 'core/post-data',
 						args: { key: 'modified' },
 					},
@@ -43,9 +43,10 @@ const variations = [
 		},
 		scope: [ 'block', 'inserter' ],
 		isActive: ( blockAttributes ) =>
-			blockAttributes?.metadata?.bindings?.date?.source ===
+			blockAttributes?.metadata?.bindings?.datetime?.source ===
 				'core/post-data' &&
-			blockAttributes?.metadata?.bindings?.date?.args?.key === 'modified',
+			blockAttributes?.metadata?.bindings?.datetime?.args?.key ===
+				'modified',
 		icon: postDate,
 	},
 ];

--- a/packages/block-library/src/post-date/variations.js
+++ b/packages/block-library/src/post-date/variations.js
@@ -9,10 +9,21 @@ const variations = [
 		name: 'post-date-modified',
 		title: __( 'Modified Date' ),
 		description: __( "Display a post's last updated date." ),
-		attributes: { displayType: 'modified' },
+		attributes: {
+			metadata: {
+				bindings: {
+					date: {
+						source: 'core/post-data',
+						args: { key: 'modified' },
+					},
+				},
+			},
+		},
 		scope: [ 'block', 'inserter' ],
 		isActive: ( blockAttributes ) =>
-			blockAttributes.displayType === 'modified',
+			blockAttributes?.metadata?.bindings?.date?.source ===
+				'core/post-data' &&
+			blockAttributes?.metadata?.bindings?.date?.args?.key === 'modified',
 		icon: postDate,
 	},
 ];

--- a/packages/block-library/src/post-date/variations.js
+++ b/packages/block-library/src/post-date/variations.js
@@ -6,6 +6,27 @@ import { postDate } from '@wordpress/icons';
 
 const variations = [
 	{
+		name: 'post-date',
+		title: __( 'Post Date' ),
+		description: __( "Display a post's publish date." ),
+		attributes: {
+			metadata: {
+				bindings: {
+					date: {
+						source: 'core/post-data',
+						args: { key: 'date' },
+					},
+				},
+			},
+		},
+		scope: [ 'block', 'inserter' ],
+		isActive: ( blockAttributes ) =>
+			blockAttributes?.metadata?.bindings?.date?.source ===
+				'core/post-data' &&
+			blockAttributes?.metadata?.bindings?.date?.args?.key === 'date',
+		icon: postDate,
+	},
+	{
 		name: 'post-date-modified',
 		title: __( 'Modified Date' ),
 		description: __( "Display a post's last updated date." ),

--- a/packages/block-library/src/post-date/variations.js
+++ b/packages/block-library/src/post-date/variations.js
@@ -19,7 +19,7 @@ const variations = [
 				},
 			},
 		},
-		scope: [ 'block', 'inserter' ],
+		scope: [ 'block', 'inserter', 'transform' ],
 		isActive: ( blockAttributes ) =>
 			blockAttributes?.metadata?.bindings?.datetime?.source ===
 				'core/post-data' &&
@@ -41,7 +41,7 @@ const variations = [
 			},
 			className: 'wp-block-post-date__modified-date',
 		},
-		scope: [ 'block', 'inserter' ],
+		scope: [ 'block', 'inserter', 'transform' ],
 		isActive: ( blockAttributes ) =>
 			blockAttributes?.metadata?.bindings?.datetime?.source ===
 				'core/post-data' &&

--- a/packages/block-library/src/post-date/variations.js
+++ b/packages/block-library/src/post-date/variations.js
@@ -39,6 +39,7 @@ const variations = [
 					},
 				},
 			},
+			className: 'wp-block-post-date__modified-date',
 		},
 		scope: [ 'block', 'inserter' ],
 		isActive: ( blockAttributes ) =>

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -544,13 +544,7 @@ registerBlockBindingsSource( {
 
 _Parameters_
 
--   _source_ `Object`: Properties of the source to be registered.
--   _source.name_ `string`: The unique and machine-readable name.
--   _source.label_ `[string]`: Human-readable label. Optional when it is defined in the server.
--   _source.usesContext_ `[Array]`: Optional array of context needed by the source only in the editor.
--   _source.getValues_ `[Function]`: Optional function to get the values from the source.
--   _source.setValues_ `[Function]`: Optional function to update multiple values connected to the source.
--   _source.canUserEditValue_ `[Function]`: Optional function to determine if the user can edit the value.
+-   _source_ `WPBlockBindingsSource`: Object describing a block bindings source.
 
 _Changelog_
 

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -123,6 +123,19 @@ import { unlock } from '../lock-unlock';
  *                                              then no preview is shown.
  */
 
+/**
+ * An object describing a Block Bindings source.
+ *
+ * @typedef {Object} WPBlockBindingsSource
+ *
+ * @property {string}   name               The unique and machine-readable name.
+ * @property {string}   [label]            Human-readable label. Optional when it is defined in the server.
+ * @property {Array}    [usesContext]      Optional array of context needed by the source only in the editor.
+ * @property {Function} [getValues]        Optional function to get the values from the source.
+ * @property {Function} [setValues]        Optional function to update multiple values connected to the source.
+ * @property {Function} [canUserEditValue] Optional function to determine if the user can edit the value.
+ */
+
 function isObject( object ) {
 	return object !== null && typeof object === 'object';
 }
@@ -769,13 +782,7 @@ export const unregisterBlockVariation = ( blockName, variationName ) => {
  *
  * @since 6.7.0 Introduced in WordPress core.
  *
- * @param {Object}   source                    Properties of the source to be registered.
- * @param {string}   source.name               The unique and machine-readable name.
- * @param {string}   [source.label]            Human-readable label. Optional when it is defined in the server.
- * @param {Array}    [source.usesContext]      Optional array of context needed by the source only in the editor.
- * @param {Function} [source.getValues]        Optional function to get the values from the source.
- * @param {Function} [source.setValues]        Optional function to update multiple values connected to the source.
- * @param {Function} [source.canUserEditValue] Optional function to determine if the user can edit the value.
+ * @param {WPBlockBindingsSource} source Object describing a block bindings source.
  *
  * @example
  * ```js

--- a/packages/editor/src/bindings/api.js
+++ b/packages/editor/src/bindings/api.js
@@ -7,6 +7,7 @@ import { registerBlockBindingsSource } from '@wordpress/blocks';
  * Internal dependencies
  */
 import patternOverrides from './pattern-overrides';
+import postData from './post-data';
 import postMeta from './post-meta';
 
 /**
@@ -21,5 +22,6 @@ import postMeta from './post-meta';
  */
 export function registerCoreBlockBindingsSources() {
 	registerBlockBindingsSource( patternOverrides );
+	registerBlockBindingsSource( postData );
 	registerBlockBindingsSource( postMeta );
 }

--- a/packages/editor/src/bindings/pattern-overrides.js
+++ b/packages/editor/src/bindings/pattern-overrides.js
@@ -5,6 +5,9 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 
 const CONTENT = 'content';
 
+/**
+ * @type {WPBlockBindingsSource}
+ */
 export default {
 	name: 'core/pattern-overrides',
 	getValues( { select, clientId, context, bindings } ) {

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -1,0 +1,135 @@
+/**
+ * WordPress dependencies
+ */
+import { store as coreDataStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../store';
+
+/**
+ * Gets a list of post data fields with their values and labels
+ * to be consumed in the needed callbacks.
+ * If the value is not available based on context, like in templates,
+ * it falls back to the default value, label, or key.
+ *
+ * @param {Object} select  The select function from the data store.
+ * @param {Object} context The context provided.
+ * @return {Object} List of post data fields with their value and label.
+ *
+ * @example
+ * ```js
+ * {
+ *     field_1_key: {
+ *         label: 'Field 1 Label',
+ *         value: 'Field 1 Value',
+ *     },
+ *     field_2_key: {
+ *         label: 'Field 2 Label',
+ *         value: 'Field 2 Value',
+ *     },
+ *     ...
+ * }
+ * ```
+ */
+function getPostDataFields( select, context ) {
+	const { getEditedEntityRecord } = select( coreDataStore );
+
+	let entityDataValues, dataFields;
+	// Try to get the current entity data values.
+	if ( context?.postType && context?.postId ) {
+		entityDataValues = getEditedEntityRecord(
+			'postType',
+			context?.postType,
+			context?.postId
+		);
+		dataFields = {
+			date: {
+				label: 'Post Date',
+				value: entityDataValues?.date,
+				type: 'string',
+			},
+			modified: {
+				label: 'Post Modified Date',
+				value: entityDataValues?.modified,
+				type: 'string',
+			},
+		};
+	}
+
+	if ( ! Object.keys( dataFields || {} ).length ) {
+		return null;
+	}
+
+	return dataFields;
+}
+
+export default {
+	name: 'core/post-data',
+	getValues( { select, context, bindings } ) {
+		const dataFields = getPostDataFields( select, context );
+
+		const newValues = {};
+		for ( const [ attributeName, source ] of Object.entries( bindings ) ) {
+			// Use the value, the field label, or the field key.
+			const fieldKey = source.args.key;
+			const { value: fieldValue, label: fieldLabel } =
+				dataFields?.[ fieldKey ] || {};
+			newValues[ attributeName ] = fieldValue ?? fieldLabel ?? fieldKey;
+		}
+		return newValues;
+	},
+	setValues( { dispatch, context, bindings } ) {
+		const newData = {};
+		Object.values( bindings ).forEach( ( { args, newValue } ) => {
+			newData[ args.key ] = newValue;
+		} );
+
+		dispatch( coreDataStore ).editEntityRecord(
+			'postType',
+			context?.postType,
+			context?.postId,
+			newData
+		);
+	},
+	canUserEditValue( { select, context, args } ) {
+		// Lock editing in query loop.
+		if ( context?.query || context?.queryId ) {
+			return false;
+		}
+
+		// Lock editing when `postType` is not defined.
+		if ( ! context?.postType ) {
+			return false;
+		}
+
+		const fieldValue = getPostDataFields( select, context )?.[ args.key ]
+			?.value;
+		// Empty string or `false` could be a valid value, so we need to check if the field value is undefined.
+		if ( fieldValue === undefined ) {
+			return false;
+		}
+		// Check that custom fields metabox is not enabled.
+		const areCustomFieldsEnabled =
+			select( editorStore ).getEditorSettings().enableCustomFields;
+		if ( areCustomFieldsEnabled ) {
+			return false;
+		}
+
+		// Check that the user has the capability to edit post meta.
+		const canUserEdit = select( coreDataStore ).canUser( 'update', {
+			kind: 'postType',
+			name: context?.postType,
+			id: context?.postId,
+		} );
+		if ( ! canUserEdit ) {
+			return false;
+		}
+
+		return true;
+	},
+	getFieldsList( { select, context } ) {
+		return getPostDataFields( select, context );
+	},
+};

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -4,11 +4,6 @@
 import { store as coreDataStore } from '@wordpress/core-data';
 
 /**
- * Internal dependencies
- */
-import { store as editorStore } from '../store';
-
-/**
  * Gets a list of post data fields with their values and labels
  * to be consumed in the needed callbacks.
  * If the value is not available based on context, like in templates,
@@ -110,14 +105,8 @@ export default {
 		if ( fieldValue === undefined ) {
 			return false;
 		}
-		// Check that custom fields metabox is not enabled.
-		const areCustomFieldsEnabled =
-			select( editorStore ).getEditorSettings().enableCustomFields;
-		if ( areCustomFieldsEnabled ) {
-			return false;
-		}
 
-		// Check that the user has the capability to edit post meta.
+		// Check that the user has the capability to edit post data.
 		const canUserEdit = select( coreDataStore ).canUser( 'update', {
 			kind: 'postType',
 			name: context?.postType,

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -45,12 +45,12 @@ function getPostDataFields( select, context ) {
 			context?.postId
 		);
 		dataFields = {
-			post_date: {
+			date: {
 				label: 'Post Date',
 				value: entityDataValues?.date,
 				type: 'string',
 			},
-			post_modified: {
+			modified: {
 				label: 'Post Modified Date',
 				value: entityDataValues?.modified,
 				type: 'string',

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -45,12 +45,12 @@ function getPostDataFields( select, context ) {
 			context?.postId
 		);
 		dataFields = {
-			date: {
+			post_date: {
 				label: 'Post Date',
 				value: entityDataValues?.date,
 				type: 'string',
 			},
-			modified: {
+			post_modified: {
 				label: 'Post Modified Date',
 				value: entityDataValues?.modified,
 				type: 'string',

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -60,6 +60,9 @@ function getPostDataFields( select, context ) {
 	return dataFields;
 }
 
+/**
+ * @type {WPBlockBindingsSource}
+ */
 export default {
 	name: 'core/post-data',
 	getValues( { select, context, bindings } ) {

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -72,6 +72,9 @@ function getPostMetaFields( select, context ) {
 	return metaFields;
 }
 
+/**
+ * @type {WPBlockBindingsSource}
+ */
 export default {
 	name: 'core/post-meta',
 	getValues( { select, context, bindings } ) {

--- a/packages/eslint-plugin/configs/jsdoc.js
+++ b/packages/eslint-plugin/configs/jsdoc.js
@@ -16,6 +16,7 @@ const temporaryWordPressInternalTypes = [
 	'WPBlockSelection',
 	'WPBlockSerializationOptions',
 	'WPBlock',
+	'WPBlockBindingsSource',
 	'WPBlockPattern',
 	'WPBlockType',
 	'WPBlockTypeIcon',

--- a/phpunit/blocks/render-block-core-post-date.php
+++ b/phpunit/blocks/render-block-core-post-date.php
@@ -13,14 +13,16 @@ class Test_Render_Block_Core_Post_Date extends WP_UnitTestCase {
 	protected static $post_id;
 
 	public static function wpSetUpBeforeClass( $factory ) {
-		self::$post_id = $factory->post->create( array(
-			'post_type'     => 'post',
-			'post_status'   => 'publish',
-			'post_name'     => 'tabby',
-			'post_title'    => 'Tabby cats',
-			'post_content'  => 'Tabby cat content',
-			'post_date'     => '2025-07-05 00:00:00',
-		 ) );
+		self::$post_id = $factory->post->create(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_name'    => 'tabby',
+				'post_title'   => 'Tabby cats',
+				'post_content' => 'Tabby cat content',
+				'post_date'    => '2025-07-05 00:00:00',
+			)
+		);
 	}
 
 	public function set_up() {
@@ -29,7 +31,7 @@ class Test_Render_Block_Core_Post_Date extends WP_UnitTestCase {
 		$this->update_post_modified( self::$post_id, '2025-07-10 00:00:00' );
 	}
 
-	function data_render_with_date_attribute_binding() {
+	public function data_render_with_date_attribute_binding() {
 		return array(
 			'Publish date'  => array( 'date', 'get_the_date' ),
 			'Modified date' => array( 'modified', 'get_the_modified_date' ),
@@ -59,7 +61,7 @@ class Test_Render_Block_Core_Post_Date extends WP_UnitTestCase {
 				'attrs'     => $attributes,
 			),
 			array(
-				'postId' => self::$post_id
+				'postId' => self::$post_id,
 			)
 		);
 
@@ -85,7 +87,7 @@ class Test_Render_Block_Core_Post_Date extends WP_UnitTestCase {
 				'attrs'     => $attributes,
 			),
 			array(
-				'postId' => self::$post_id
+				'postId' => self::$post_id,
 			)
 		);
 
@@ -113,7 +115,7 @@ class Test_Render_Block_Core_Post_Date extends WP_UnitTestCase {
 				'attrs'     => $attributes,
 			),
 			array(
-				'postId' => self::$post_id
+				'postId' => self::$post_id,
 			)
 		);
 

--- a/phpunit/blocks/render-block-core-post-date.php
+++ b/phpunit/blocks/render-block-core-post-date.php
@@ -92,4 +92,32 @@ class Test_Render_Block_Core_Post_Date extends WP_UnitTestCase {
         $output = $block->render();
         $this->assertStringContainsString( $expected_date, $output );
     }
+
+    public function test_render_modified_date_before_publish_date() {
+        $this->update_post_modified( self::$post_id, '2025-07-01 00:00:00' );
+
+        $attributes = array(
+            'metadata' => array(
+                'bindings' => array(
+                    'date' => array(
+                        'source' => 'core/post-data',
+                        'args'   => array( 'key' => 'modified' ),
+                    ),
+                ),
+            ),
+        );
+
+        $block = new WP_Block(
+            array(
+                'blockName' => 'core/post-date',
+                'attrs'     => $attributes,
+            ),
+            array(
+                'postId' => self::$post_id
+            )
+        );
+
+        $output = $block->render();
+        $this->assertSame( '', $output );
+    }
 }

--- a/phpunit/blocks/render-block-core-post-date.php
+++ b/phpunit/blocks/render-block-core-post-date.php
@@ -10,114 +10,114 @@
  */
 class Test_Render_Block_Core_Post_Date extends WP_UnitTestCase {
 
-    protected static $post_id;
+	protected static $post_id;
 
-    public static function wpSetUpBeforeClass( $factory ) {
-        self::$post_id = $factory->post->create( array(
-            'post_type'     => 'post',
-            'post_status'   => 'publish',
-            'post_name'     => 'tabby',
-            'post_title'    => 'Tabby cats',
-            'post_content'  => 'Tabby cat content',
-            'post_date'     => '2025-07-05 00:00:00',
-         ) );
-    }
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$post_id = $factory->post->create( array(
+			'post_type'     => 'post',
+			'post_status'   => 'publish',
+			'post_name'     => 'tabby',
+			'post_title'    => 'Tabby cats',
+			'post_content'  => 'Tabby cat content',
+			'post_date'     => '2025-07-05 00:00:00',
+		 ) );
+	}
 
-    public function set_up() {
-        parent::set_up();
+	public function set_up() {
+		parent::set_up();
 
-        $this->update_post_modified( self::$post_id, '2025-07-10 00:00:00' );
-    }
+		$this->update_post_modified( self::$post_id, '2025-07-10 00:00:00' );
+	}
 
-    function data_render_with_date_attribute_binding() {
-        return array(
-            'Publish date'  => array( 'date', 'get_the_date' ),
-            'Modified date' => array( 'modified', 'get_the_modified_date' ),
-        );
-    }
+	function data_render_with_date_attribute_binding() {
+		return array(
+			'Publish date'  => array( 'date', 'get_the_date' ),
+			'Modified date' => array( 'modified', 'get_the_modified_date' ),
+		);
+	}
 
-    /**
-     * @dataProvider data_render_with_date_attribute_binding
-     */
-    public function test_render_with_date_attribute_binding( $field, $expected_date_function ) {
-        $expected_date = call_user_func( $expected_date_function, 'c', self::$post_id );
+	/**
+	 * @dataProvider data_render_with_date_attribute_binding
+	 */
+	public function test_render_with_date_attribute_binding( $field, $expected_date_function ) {
+		$expected_date = call_user_func( $expected_date_function, 'c', self::$post_id );
 
-        $attributes = array(
-            'metadata' => array(
-                'bindings' => array(
-                    'date' => array(
-                        'source' => 'core/post-data',
-                        'args'   => array( 'key' => $field ),
-                    ),
-                ),
-            ),
-        );
+		$attributes = array(
+			'metadata' => array(
+				'bindings' => array(
+					'date' => array(
+						'source' => 'core/post-data',
+						'args'   => array( 'key' => $field ),
+					),
+				),
+			),
+		);
 
-        $block = new WP_Block(
-            array(
-                'blockName' => 'core/post-date',
-                'attrs'     => $attributes,
-            ),
-            array(
-                'postId' => self::$post_id
-            )
-        );
+		$block = new WP_Block(
+			array(
+				'blockName' => 'core/post-date',
+				'attrs'     => $attributes,
+			),
+			array(
+				'postId' => self::$post_id
+			)
+		);
 
-        $output = $block->render();
-        $this->assertStringContainsString( $expected_date, $output );
-    }
+		$output = $block->render();
+		$this->assertStringContainsString( $expected_date, $output );
+	}
 
-    /**
-     * @dataProvider data_render_with_date_attribute_binding
-     */
-    public function test_render_legacy_block( $field, $expected_date_function ) {
-        $expected_date = call_user_func( $expected_date_function, 'c', self::$post_id );
+	/**
+	 * @dataProvider data_render_with_date_attribute_binding
+	 */
+	public function test_render_legacy_block( $field, $expected_date_function ) {
+		$expected_date = call_user_func( $expected_date_function, 'c', self::$post_id );
 
-        $attributes = array();
+		$attributes = array();
 
-        if ( 'modified' === $field ) {
-            $attributes['displayType'] = 'modified';
-        }
+		if ( 'modified' === $field ) {
+			$attributes['displayType'] = 'modified';
+		}
 
-        $block = new WP_Block(
-            array(
-                'blockName' => 'core/post-date',
-                'attrs'     => $attributes,
-            ),
-            array(
-                'postId' => self::$post_id
-            )
-        );
+		$block = new WP_Block(
+			array(
+				'blockName' => 'core/post-date',
+				'attrs'     => $attributes,
+			),
+			array(
+				'postId' => self::$post_id
+			)
+		);
 
-        $output = $block->render();
-        $this->assertStringContainsString( $expected_date, $output );
-    }
+		$output = $block->render();
+		$this->assertStringContainsString( $expected_date, $output );
+	}
 
-    public function test_render_modified_date_before_publish_date() {
-        $this->update_post_modified( self::$post_id, '2025-07-01 00:00:00' );
+	public function test_render_modified_date_before_publish_date() {
+		$this->update_post_modified( self::$post_id, '2025-07-01 00:00:00' );
 
-        $attributes = array(
-            'metadata' => array(
-                'bindings' => array(
-                    'date' => array(
-                        'source' => 'core/post-data',
-                        'args'   => array( 'key' => 'modified' ),
-                    ),
-                ),
-            ),
-        );
+		$attributes = array(
+			'metadata' => array(
+				'bindings' => array(
+					'date' => array(
+						'source' => 'core/post-data',
+						'args'   => array( 'key' => 'modified' ),
+					),
+				),
+			),
+		);
 
-        $block = new WP_Block(
-            array(
-                'blockName' => 'core/post-date',
-                'attrs'     => $attributes,
-            ),
-            array(
-                'postId' => self::$post_id
-            )
-        );
+		$block = new WP_Block(
+			array(
+				'blockName' => 'core/post-date',
+				'attrs'     => $attributes,
+			),
+			array(
+				'postId' => self::$post_id
+			)
+		);
 
-        $output = $block->render();
-        $this->assertSame( '', $output );
-    }
+		$output = $block->render();
+		$this->assertSame( '', $output );
+	}
 }

--- a/phpunit/blocks/render-block-core-post-date.php
+++ b/phpunit/blocks/render-block-core-post-date.php
@@ -35,7 +35,7 @@ class Test_Render_Block_Core_Post_Date extends WP_UnitTestCase {
 		$expected_date = '2025-03-02 00:00:00';
 
 		$attributes = array(
-			'date' => $expected_date,
+			'datetime' => $expected_date,
 		);
 
 		$block = new WP_Block(
@@ -68,7 +68,7 @@ class Test_Render_Block_Core_Post_Date extends WP_UnitTestCase {
 		$attributes = array(
 			'metadata' => array(
 				'bindings' => array(
-					'date' => array(
+					'datetime' => array(
 						'source' => 'core/post-data',
 						'args'   => array( 'key' => $field ),
 					),
@@ -122,7 +122,7 @@ class Test_Render_Block_Core_Post_Date extends WP_UnitTestCase {
 		$attributes = array(
 			'metadata' => array(
 				'bindings' => array(
-					'date' => array(
+					'datetime' => array(
 						'source' => 'core/post-data',
 						'args'   => array( 'key' => 'modified' ),
 					),

--- a/phpunit/blocks/render-block-core-post-date.php
+++ b/phpunit/blocks/render-block-core-post-date.php
@@ -66,4 +66,30 @@ class Test_Render_Block_Core_Post_Date extends WP_UnitTestCase {
         $output = $block->render();
         $this->assertStringContainsString( $expected_date, $output );
     }
+
+    /**
+     * @dataProvider data_render_with_date_attribute_binding
+     */
+    public function test_render_legacy_block( $field, $expected_date_function ) {
+        $expected_date = call_user_func( $expected_date_function, 'c', self::$post_id );
+
+        $attributes = array();
+
+        if ( 'modified' === $field ) {
+            $attributes['displayType'] = 'modified';
+        }
+
+        $block = new WP_Block(
+            array(
+                'blockName' => 'core/post-date',
+                'attrs'     => $attributes,
+            ),
+            array(
+                'postId' => self::$post_id
+            )
+        );
+
+        $output = $block->render();
+        $this->assertStringContainsString( $expected_date, $output );
+    }
 }

--- a/phpunit/blocks/render-block-core-post-date.php
+++ b/phpunit/blocks/render-block-core-post-date.php
@@ -31,6 +31,27 @@ class Test_Render_Block_Core_Post_Date extends WP_UnitTestCase {
 		$this->update_post_modified( self::$post_id, '2025-07-10 00:00:00' );
 	}
 
+	public function test_render_with_explicit_date_attribute() {
+		$expected_date = '2025-03-02 00:00:00';
+
+		$attributes = array(
+			'date' => $expected_date,
+		);
+
+		$block = new WP_Block(
+			array(
+				'blockName' => 'core/post-date',
+				'attrs'     => $attributes,
+			),
+			array(
+				'postId' => self::$post_id,
+			)
+		);
+
+		$output = $block->render();
+		$this->assertStringContainsString( $expected_date, $output );
+	}
+
 	public function data_render_with_date_attribute_binding() {
 		return array(
 			'Publish date'  => array( 'date', 'get_the_date' ),

--- a/phpunit/blocks/render-block-core-post-date.php
+++ b/phpunit/blocks/render-block-core-post-date.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Tests for the gutenberg_render_block_core_post_date() function.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @covers ::gutenberg_render_block_core_post_date
+ * @group blocks
+ */
+class Test_Render_Block_Core_Post_Date extends WP_UnitTestCase {
+
+    protected static $post_id;
+
+    public static function wpSetUpBeforeClass( $factory ) {
+        self::$post_id = $factory->post->create( array(
+            'post_type'     => 'post',
+            'post_status'   => 'publish',
+            'post_name'     => 'tabby',
+            'post_title'    => 'Tabby cats',
+            'post_content'  => 'Tabby cat content',
+            'post_date'     => '2025-07-05 00:00:00',
+         ) );
+    }
+
+    public function set_up() {
+        parent::set_up();
+
+        $this->update_post_modified( self::$post_id, '2025-07-10 00:00:00' );
+    }
+
+    function data_render_with_date_attribute_binding() {
+        return array(
+            'Publish date'  => array( 'date', 'get_the_date' ),
+            'Modified date' => array( 'modified', 'get_the_modified_date' ),
+        );
+    }
+
+    /**
+     * @dataProvider data_render_with_date_attribute_binding
+     */
+    public function test_render_with_date_attribute_binding( $field, $expected_date_function ) {
+        $expected_date = call_user_func( $expected_date_function, 'c', self::$post_id );
+
+        $attributes = array(
+            'metadata' => array(
+                'bindings' => array(
+                    'date' => array(
+                        'source' => 'core/post-data',
+                        'args'   => array( 'key' => $field ),
+                    ),
+                ),
+            ),
+        );
+
+        $block = new WP_Block(
+            array(
+                'blockName' => 'core/post-date',
+                'attrs'     => $attributes,
+            ),
+            array(
+                'postId' => self::$post_id
+            )
+        );
+
+        $output = $block->render();
+        $this->assertStringContainsString( $expected_date, $output );
+    }
+}

--- a/test/e2e/specs/editor/various/__snapshots__/Inserting-blocks-firefox-webkit-inserts-p-59603-ragging-and-dropping-from-the-global-inserter-1-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Inserting-blocks-firefox-webkit-inserts-p-59603-ragging-and-dropping-from-the-global-inserter-1-chromium.txt
@@ -14,6 +14,6 @@
 <hr class="wp-block-separator has-css-opacity"/>
 <!-- /wp:separator -->
 
-<!-- wp:post-date /-->
+<!-- wp:post-date {"metadata":{"bindings":{"date":{"source":"core/post-data","args":{"key":"date"}}}}} /-->
 <!-- /wp:post-template --></div>
 <!-- /wp:query -->

--- a/test/e2e/specs/editor/various/__snapshots__/Inserting-blocks-firefox-webkit-inserts-p-59603-ragging-and-dropping-from-the-global-inserter-1-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Inserting-blocks-firefox-webkit-inserts-p-59603-ragging-and-dropping-from-the-global-inserter-1-chromium.txt
@@ -14,6 +14,6 @@
 <hr class="wp-block-separator has-css-opacity"/>
 <!-- /wp:separator -->
 
-<!-- wp:post-date {"metadata":{"bindings":{"date":{"source":"core/post-data","args":{"key":"date"}}}}} /-->
+<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"key":"date"}}}}} /-->
 <!-- /wp:post-template --></div>
 <!-- /wp:query -->

--- a/test/e2e/specs/editor/various/__snapshots__/Inserting-blocks-firefox-webkit-inserts-p-59603-ragging-and-dropping-from-the-global-inserter-1-webkit.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Inserting-blocks-firefox-webkit-inserts-p-59603-ragging-and-dropping-from-the-global-inserter-1-webkit.txt
@@ -14,6 +14,6 @@
 <hr class="wp-block-separator has-css-opacity"/>
 <!-- /wp:separator -->
 
-<!-- wp:post-date /-->
+<!-- wp:post-date {"metadata":{"bindings":{"date":{"source":"core/post-data","args":{"key":"date"}}}}} /-->
 <!-- /wp:post-template --></div>
 <!-- /wp:query -->

--- a/test/e2e/specs/editor/various/__snapshots__/Inserting-blocks-firefox-webkit-inserts-p-59603-ragging-and-dropping-from-the-global-inserter-1-webkit.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Inserting-blocks-firefox-webkit-inserts-p-59603-ragging-and-dropping-from-the-global-inserter-1-webkit.txt
@@ -14,6 +14,6 @@
 <hr class="wp-block-separator has-css-opacity"/>
 <!-- /wp:separator -->
 
-<!-- wp:post-date {"metadata":{"bindings":{"date":{"source":"core/post-data","args":{"key":"date"}}}}} /-->
+<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"key":"date"}}}}} /-->
 <!-- /wp:post-template --></div>
 <!-- /wp:query -->

--- a/test/integration/fixtures/blocks/core__post-date.json
+++ b/test/integration/fixtures/blocks/core__post-date.json
@@ -6,7 +6,7 @@
 			"isLink": false,
 			"metadata": {
 				"bindings": {
-					"date": {
+					"datetime": {
 						"source": "core/post-data",
 						"args": {
 							"key": "date"

--- a/test/integration/fixtures/blocks/core__post-date.serialized.html
+++ b/test/integration/fixtures/blocks/core__post-date.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:post-date {"metadata":{"bindings":{"date":{"source":"core/post-data","args":{"key":"date"}}}}} /-->
+<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"key":"date"}}}}} /-->

--- a/test/integration/fixtures/blocks/core__post-date.serialized.html
+++ b/test/integration/fixtures/blocks/core__post-date.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:post-date /-->
+<!-- wp:post-date {"metadata":{"bindings":{"date":{"source":"core/post-data","args":{"key":"date"}}}}} /-->

--- a/test/integration/fixtures/blocks/core__post-date__deprecated-v2.html
+++ b/test/integration/fixtures/blocks/core__post-date__deprecated-v2.html
@@ -1,0 +1,1 @@
+<!-- wp:post-date {"displayType":"modified"} /-->

--- a/test/integration/fixtures/blocks/core__post-date__deprecated-v2.json
+++ b/test/integration/fixtures/blocks/core__post-date__deprecated-v2.json
@@ -7,7 +7,7 @@
 			"className": "wp-block-post-date__modified-date",
 			"metadata": {
 				"bindings": {
-					"date": {
+					"datetime": {
 						"source": "core/post-data",
 						"args": {
 							"key": "modified"

--- a/test/integration/fixtures/blocks/core__post-date__deprecated-v2.json
+++ b/test/integration/fixtures/blocks/core__post-date__deprecated-v2.json
@@ -9,7 +9,7 @@
 					"date": {
 						"source": "core/post-data",
 						"args": {
-							"key": "date"
+							"key": "modified"
 						}
 					}
 				}

--- a/test/integration/fixtures/blocks/core__post-date__deprecated-v2.json
+++ b/test/integration/fixtures/blocks/core__post-date__deprecated-v2.json
@@ -4,6 +4,7 @@
 		"isValid": true,
 		"attributes": {
 			"isLink": false,
+			"className": "wp-block-post-date__modified-date",
 			"metadata": {
 				"bindings": {
 					"date": {

--- a/test/integration/fixtures/blocks/core__post-date__deprecated-v2.parsed.json
+++ b/test/integration/fixtures/blocks/core__post-date__deprecated-v2.parsed.json
@@ -1,0 +1,11 @@
+[
+	{
+		"blockName": "core/post-date",
+		"attrs": {
+			"displayType": "modified"
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__post-date__deprecated-v2.serialized.html
+++ b/test/integration/fixtures/blocks/core__post-date__deprecated-v2.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:post-date {"metadata":{"bindings":{"date":{"source":"core/post-data","args":{"key":"modified"}}}}} /-->
+<!-- wp:post-date {"className":"wp-block-post-date__modified-date","metadata":{"bindings":{"date":{"source":"core/post-data","args":{"key":"modified"}}}}} /-->

--- a/test/integration/fixtures/blocks/core__post-date__deprecated-v2.serialized.html
+++ b/test/integration/fixtures/blocks/core__post-date__deprecated-v2.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:post-date {"className":"wp-block-post-date__modified-date","metadata":{"bindings":{"date":{"source":"core/post-data","args":{"key":"modified"}}}}} /-->
+<!-- wp:post-date {"className":"wp-block-post-date__modified-date","metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"key":"modified"}}}}} /-->

--- a/test/integration/fixtures/blocks/core__post-date__deprecated-v2.serialized.html
+++ b/test/integration/fixtures/blocks/core__post-date__deprecated-v2.serialized.html
@@ -1,0 +1,1 @@
+<!-- wp:post-date {"metadata":{"bindings":{"date":{"source":"core/post-data","args":{"key":"modified"}}}}} /-->

--- a/test/integration/fixtures/blocks/core__query__deprecated-3.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-3.json
@@ -68,7 +68,16 @@
 								"isValid": true,
 								"attributes": {
 									"isLink": false,
-									"displayType": "date"
+									"metadata": {
+										"bindings": {
+											"date": {
+												"source": "core/post-data",
+												"args": {
+													"key": "date"
+												}
+											}
+										}
+									}
 								},
 								"innerBlocks": []
 							},

--- a/test/integration/fixtures/blocks/core__query__deprecated-3.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-3.json
@@ -70,7 +70,7 @@
 									"isLink": false,
 									"metadata": {
 										"bindings": {
-											"date": {
+											"datetime": {
 												"source": "core/post-data",
 												"args": {
 													"key": "date"

--- a/test/integration/fixtures/blocks/core__query__deprecated-3.serialized.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-3.serialized.html
@@ -3,7 +3,7 @@
 <div class="wp-block-group has-pale-cyan-blue-color has-text-color has-background has-link-color" style="background-color:#284d5f"><!-- wp:post-template {"fontSize":"large","layout":{"type":"grid","columnCount":3}} -->
 <!-- wp:post-title /-->
 
-<!-- wp:post-date {"metadata":{"bindings":{"date":{"source":"core/post-data","args":{"key":"date"}}}}} /-->
+<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"key":"date"}}}}} /-->
 
 <!-- wp:post-excerpt /-->
 <!-- /wp:post-template -->

--- a/test/integration/fixtures/blocks/core__query__deprecated-3.serialized.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-3.serialized.html
@@ -3,7 +3,7 @@
 <div class="wp-block-group has-pale-cyan-blue-color has-text-color has-background has-link-color" style="background-color:#284d5f"><!-- wp:post-template {"fontSize":"large","layout":{"type":"grid","columnCount":3}} -->
 <!-- wp:post-title /-->
 
-<!-- wp:post-date /-->
+<!-- wp:post-date {"metadata":{"bindings":{"date":{"source":"core/post-data","args":{"key":"date"}}}}} /-->
 
 <!-- wp:post-excerpt /-->
 <!-- /wp:post-template -->


### PR DESCRIPTION
## What?
Make the Date block accept a manually set date, i.e. independent of the current post's publish or last modified date. Retain the latter two options by introducing a new Block Bindings source called `core/post-data` that exposes those two dates.

Update existing block variations of the Date block to continue to allow easy insertion of the "Post Date" and "Last Modified Date" variations of the block.

Include code for back-compat in the block's PHP, and a block deprecation to update existing Date blocks to use the new Block Bindings-based approach.

## Why?
Various reasons: The block already supports the publish date of the post, and the "last modified" date. It's a natural extension to connect it to other data sources. One real-world example that inspired this PR was e.g. a director's website with a `film` CPT that had the movie's release as one meta field.

## How?
In order to connect the block to Block Bindings, we need an explicit date attribute for Block Bindings to connect to.

## Problem(s) to solve

Prior to this PR, the block used the `__experimentalPublishDateTimePicker` to set the post (publish) date _and time_, as that date picker also allows setting the time. For back-compat, it might be easiest to continue storing date and time in all cases; for that, we should probably rename the newly introduced attribute to `datetime`.

## Testing Instructions

Start by testing backwards compatibility:

On the `trunk` branch, create a new post, and insert the "Date" block, and "Modified Date" blocks.

<img width="280" height="268" alt="image" src="https://github.com/user-attachments/assets/51c8bbe7-cd7f-4f10-adf0-698e2ee016eb" />

Check the code editor; the markup should look like this:

```html
<!-- wp:post-date /-->

<!-- wp:post-date {"displayType":"modified"} /-->
```

Go back to the visual editor. Set the post's publish date to an earlier date (e.g. yesterday).

Publish the post and view it on the frontend. It should look something like this:

<img width="279" height="231" alt="image" src="https://github.com/user-attachments/assets/081e09b8-88fe-44a6-9551-78be7b6ea761" />

Now switch to this PR's branch, rebuild Gutenberg, and reload the page on the frontend. Verify that the blocks still look the same as before.

Go back to the editor and reload it. Make a small change (e.g. add a new paragraph with a few characters), and switch to the Code Editor. Verify that the blocks have been updated by a block migration. They are now using Block Bindings:

```html
<!-- wp:post-date {"metadata":{"bindings":{"date":{"source":"core/post-data","args":{"key":"date"}}}}} /-->

<!-- wp:post-date {"metadata":{"bindings":{"date":{"source":"core/post-data","args":{"key":"modified"}}}},"className":"wp-block-post-date__modified-date"} /-->
```

Go back to the Visual Editor. Observe that the first block is now called "Post Date". Save the post again. Once again, view it on the frontend, and verify that it still looks the same as before.

---

Go back to the editor once more. Insert a "Date" block. In the block's toolbar, use the pencil icon to set an arbitrary date. Save the block, view the post on the frontend, and verify that all three blocks render as expected.

---

Finally, open a template in the Site Editor that contains a query loop with Post Date blocks. Verify that the block instances work fine there as well.

## Screenshots or screencast

### Before

Date (i.e. post publish date) and Modified Date blocks:

![date-block-old](https://github.com/user-attachments/assets/34a0e4ec-925e-455f-9a10-418855af6455)

### After

Post Date (i.e. post publish date), Modified Date, and "generic" Date block (that can be used to format a manually entered date):

![date-block-new](https://github.com/user-attachments/assets/c67afb1d-8338-45a1-a75b-3a848758e4ce)

Note that the Post Date block changes upon publish -- this is because the post wasn't previously published, so clicking "Publish" sets the post publish date, and the block reflects it.