### PR TITLE
Editor: Allow replacing the 'PostLockedModal' component

### DIFF
--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -7,6 +7,7 @@ import {
 	Button,
 	ExternalLink,
 	__experimentalHStack as HStack,
+	withFilters,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
@@ -20,13 +21,7 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import { store as editorStore } from '../../store';
 
-/**
- * A modal component that is displayed when a post is locked for editing by another user.
- * The modal provides information about the lock status and options to take over or exit the editor.
- *
- * @return {React.ReactNode} The rendered PostLockedModal component.
- */
-export default function PostLockedModal() {
+function PostLockedModal() {
 	const instanceId = useInstanceId( PostLockedModal );
 	const hookName = 'core/editor/post-locked-modal-' + instanceId;
 	const { autosave, updatePostLock } = useDispatch( editorStore );
@@ -277,3 +272,13 @@ export default function PostLockedModal() {
 		</Modal>
 	);
 }
+
+/**
+ * A modal component that is displayed when a post is locked for editing by another user.
+ * The modal provides information about the lock status and options to take over or exit the editor.
+ *
+ * @return {React.ReactNode} The rendered PostLockedModal component.
+ */
+export default globalThis.IS_GUTENBERG_PLUGIN
+	? withFilters( 'editor.PostLockedModal' )( PostLockedModal )
+	: PostLockedModal;


### PR DESCRIPTION
## What?
Closes #70537.

PR introduces a new `editor.PostLockedModal` filter, allowing replacement of the `PostLockedModal` core component in editors.

> [!NOTE]
> The new filter is limited to the Gutenberg plugin and won't ship in WordPress core, at least for now.

## Why?
Prepares for the upcoming collaborating editing work in the block editor, which will be developed as a separate plugin.

## Testing Instructions
1. Open a post or page.
2. Filter snippet in DevTools console.
3. Confirm that the component can be replaced.

<details><summary>Test Snippet</summary>
<p>

```javascript
function replacePostLockedModal() {
	return function () {
        console.log( 'The replacement contents or components.' );
        return React.createElement(
			'div',
			{},
			'The replacement contents or components.'
		);
	};
}

wp.hooks.addFilter(
	'editor.PostLockedModal',
	'mamaduka/replace-post-locked-modal',
	replacePostLockedModal
);
``` 

</p>
</details> 

### Testing Instructions for Keyboard
Same.