### PR TITLE
Storybook: Replace implicit actions with explicit ones 

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/stories/index.story.js
+++ b/packages/block-editor/src/components/block-patterns-list/stories/index.story.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import blockLibraryStyles from '!!raw-loader!../../../../../block-library/build-style/style.css';
+import { fn } from '@storybook/test';
 
 /**
  * Internal dependencies
@@ -32,6 +33,8 @@ export const Default = {
 		isDraggable: false,
 		label: 'Block patterns story',
 		showTitlesAsTooltip: false,
+		onClickPattern: fn(),
+		onHover: fn(),
 	},
 	argTypes: {
 		blockPatterns: { description: 'The patterns to render.' },
@@ -58,7 +61,6 @@ export const Default = {
 		},
 	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 	},
 };

--- a/packages/components/src/alignment-matrix-control/stories/index.story.tsx
+++ b/packages/components/src/alignment-matrix-control/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 /**
  * WordPress dependencies
@@ -27,8 +28,10 @@ const meta: Meta< typeof AlignmentMatrixControl > = {
 		onChange: { control: false },
 		value: { control: false },
 	},
+	args: {
+		onChange: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},

--- a/packages/components/src/angle-picker-control/stories/index.story.tsx
+++ b/packages/components/src/angle-picker-control/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 /**
  * WordPress dependencies
@@ -20,8 +21,10 @@ const meta: Meta< typeof AnglePickerControl > = {
 		as: { control: false },
 		value: { control: false },
 	},
+	args: {
+		onChange: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: {
 			expanded: true,
 		},

--- a/packages/components/src/box-control/stories/index.story.tsx
+++ b/packages/components/src/box-control/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 /**
  * WordPress dependencies
@@ -19,8 +20,10 @@ const meta: Meta< typeof BoxControl > = {
 	argTypes: {
 		values: { control: false },
 	},
+	args: {
+		onChange: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},

--- a/packages/components/src/circular-option-picker/stories/index.story.tsx
+++ b/packages/components/src/circular-option-picker/stories/index.story.tsx
@@ -37,7 +37,6 @@ const meta: Meta< typeof CircularOptionPicker > = {
 		children: { control: { type: 'text' } },
 	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: {
 			canvas: { sourceState: 'shown' },

--- a/packages/components/src/color-picker/stories/index.story.tsx
+++ b/packages/components/src/color-picker/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 /**
  * Internal dependencies
@@ -16,8 +17,10 @@ const meta: Meta< typeof ColorPicker > = {
 		as: { control: false },
 		color: { control: false },
 	},
+	args: {
+		onChange: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: {
 			expanded: true,
 		},

--- a/packages/components/src/combobox-control/stories/index.story.tsx
+++ b/packages/components/src/combobox-control/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 /**
  * WordPress dependencies
@@ -40,8 +41,11 @@ const meta: Meta< typeof ComboboxControl > = {
 	argTypes: {
 		value: { control: false },
 	},
+	args: {
+		onChange: fn(),
+		onFilterValueChange: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},

--- a/packages/components/src/confirm-dialog/stories/index.story.tsx
+++ b/packages/components/src/confirm-dialog/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 /**
  * WordPress dependencies
@@ -23,8 +24,11 @@ const meta: Meta< typeof ConfirmDialog > = {
 			control: false,
 		},
 	},
+	args: {
+		onCancel: fn(),
+		onConfirm: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: {
 			expanded: true,
 		},

--- a/packages/components/src/custom-gradient-picker/stories/index.story.tsx
+++ b/packages/components/src/custom-gradient-picker/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+import { fn } from '@storybook/test';
 /**
  * WordPress dependencies
  */
@@ -16,8 +17,10 @@ const meta: Meta< typeof CustomGradientPicker > = {
 	title: 'Components/Selection & Input/Color/CustomGradientPicker',
 	id: 'components-customgradientpicker',
 	component: CustomGradientPicker,
+	args: {
+		onChange: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},

--- a/packages/components/src/custom-select-control-v2/stories/index.story.tsx
+++ b/packages/components/src/custom-select-control-v2/stories/index.story.tsx
@@ -28,7 +28,6 @@ const meta: Meta< typeof CustomSelectControlV2 > = {
 	},
 	tags: [ 'status-wip' ],
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: {
 			source: { excludeDecorators: true },

--- a/packages/components/src/custom-select-control/stories/index.story.tsx
+++ b/packages/components/src/custom-select-control/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 /**
  * WordPress dependencies
@@ -21,8 +22,10 @@ const meta: Meta< typeof CustomSelectControl > = {
 		onChange: { control: false },
 		value: { control: false },
 	},
+	args: {
+		onChange: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: {
 			source: { excludeDecorators: true },

--- a/packages/components/src/draggable/stories/index.story.tsx
+++ b/packages/components/src/draggable/stories/index.story.tsx
@@ -3,6 +3,7 @@
  */
 import type { Meta, StoryFn } from '@storybook/react';
 import type { DragEvent } from 'react';
+import { fn } from '@storybook/test';
 
 /**
  * WordPress dependencies
@@ -24,8 +25,12 @@ const meta: Meta< typeof Draggable > = {
 		elementId: { control: false },
 		__experimentalDragComponent: { control: false },
 	},
+	args: {
+		onDragStart: fn(),
+		onDragEnd: fn(),
+		onDragOver: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: { source: { code: '' } },
 	},

--- a/packages/components/src/drop-zone/stories/index.story.tsx
+++ b/packages/components/src/drop-zone/stories/index.story.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryFn } from '@storybook/react';
  * WordPress dependencies
  */
 import { upload, media } from '@wordpress/icons';
+import { fn } from '@storybook/test';
 
 /**
  * Internal dependencies
@@ -26,8 +27,12 @@ const meta: Meta< typeof DropZone > = {
 			mapping: ICONS,
 		},
 	},
+	args: {
+		onFilesDrop: fn(),
+		onHTMLDrop: fn(),
+		onDrop: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},

--- a/packages/components/src/dropdown-menu/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 /**
  * Internal dependencies
@@ -27,9 +28,11 @@ const meta: Meta< typeof DropdownMenu > = {
 	component: DropdownMenu,
 	id: 'components-dropdownmenu',
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
+	},
+	args: {
+		onToggle: fn(),
 	},
 	argTypes: {
 		icon: {

--- a/packages/components/src/dropdown/stories/index.story.tsx
+++ b/packages/components/src/dropdown/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 /**
  * Internal dependencies
@@ -18,6 +19,10 @@ const meta: Meta< typeof Dropdown > = {
 	component: Dropdown,
 	// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 	subcomponents: { DropdownContentWrapper },
+	args: {
+		onClose: fn(),
+		onToggle: fn(),
+	},
 	argTypes: {
 		focusOnMount: {
 			options: [ 'firstElement', true, false ],
@@ -34,7 +39,6 @@ const meta: Meta< typeof Dropdown > = {
 		onClose: { control: false },
 	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: {
 			expanded: true,
 		},

--- a/packages/components/src/focal-point-picker/stories/index.story.tsx
+++ b/packages/components/src/focal-point-picker/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 /**
  * WordPress dependencies
@@ -19,8 +20,13 @@ const meta: Meta< typeof FocalPointPicker > = {
 		help: { control: 'text' },
 		label: { control: 'text' },
 	},
+	args: {
+		onChange: fn(),
+		onDrag: fn(),
+		onDragEnd: fn(),
+		onDragStart: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},

--- a/packages/components/src/font-size-picker/stories/index.story.tsx
+++ b/packages/components/src/font-size-picker/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 /**
  * WordPress dependencies
@@ -23,8 +24,10 @@ const meta: Meta< typeof FontSizePicker > = {
 			options: [ 'px', 'em', 'rem', 'vw', 'vh' ],
 		},
 	},
+	args: {
+		onChange: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},

--- a/packages/components/src/gradient-picker/stories/index.story.tsx
+++ b/packages/components/src/gradient-picker/stories/index.story.tsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+import { fn } from '@storybook/test';
+
 /**
  * WordPress dependencies
  */
@@ -19,7 +21,9 @@ const meta: Meta< typeof GradientPicker > = {
 	parameters: {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
-		actions: { argTypesRegex: '^on.*' },
+	},
+	args: {
+		onChange: fn(),
 	},
 	argTypes: {
 		value: { control: false },

--- a/packages/components/src/input-control/stories/index.story.tsx
+++ b/packages/components/src/input-control/stories/index.story.tsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+import { fn } from '@storybook/test';
+
 /**
  * WordPress dependencies
  */
@@ -30,8 +32,12 @@ const meta: Meta< typeof InputControl > = {
 		type: { control: { type: 'text' } },
 		value: { control: { disable: true } },
 	},
+	args: {
+		onChange: fn(),
+		onValidate: fn(),
+		onKeyDown: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},

--- a/packages/components/src/menu/stories/index.story.tsx
+++ b/packages/components/src/menu/stories/index.story.tsx
@@ -3,6 +3,7 @@
  */
 import type { StoryObj, Meta } from '@storybook/react';
 import { css } from '@emotion/react';
+import { fn } from '@storybook/test';
 
 /**
  * WordPress dependencies
@@ -52,12 +53,14 @@ const meta: Meta< typeof Menu > = {
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 		Popover: Menu.Popover,
 	},
+	args: {
+		onOpenChange: fn(),
+	},
 	argTypes: {
 		children: { control: false },
 	},
 	tags: [ 'status-private' ],
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: {
 			canvas: { sourceState: 'shown' },

--- a/packages/components/src/navigable-container/stories/navigable-menu.story.tsx
+++ b/packages/components/src/navigable-container/stories/navigable-menu.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 /**
  * Internal dependencies
@@ -15,8 +16,11 @@ const meta: Meta< typeof NavigableMenu > = {
 	argTypes: {
 		children: { control: false },
 	},
+	args: {
+		onKeyDown: fn(),
+		onNavigate: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: {
 			expanded: true,
 		},

--- a/packages/components/src/navigable-container/stories/tabbable-container.story.tsx
+++ b/packages/components/src/navigable-container/stories/tabbable-container.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 /**
  * Internal dependencies
@@ -15,8 +16,11 @@ const meta: Meta< typeof TabbableContainer > = {
 	argTypes: {
 		children: { control: false },
 	},
+	args: {
+		onKeyDown: fn(),
+		onNavigate: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: {
 			expanded: true,
 		},

--- a/packages/components/src/notice/stories/index.story.tsx
+++ b/packages/components/src/notice/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 /**
  * WordPress dependencies
@@ -22,8 +23,11 @@ const meta: Meta< typeof Notice > = {
 	component: Notice,
 	// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 	subcomponents: { NoticeList },
+	args: {
+		onDismiss: fn(),
+		onRemove: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},

--- a/packages/components/src/palette-edit/stories/index.story.tsx
+++ b/packages/components/src/palette-edit/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 /**
  * WordPress dependencies
@@ -17,8 +18,10 @@ import type { Color, Gradient } from '../types';
 const meta: Meta< typeof PaletteEdit > = {
 	title: 'Components/PaletteEdit',
 	component: PaletteEdit,
+	args: {
+		onChange: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},

--- a/packages/components/src/query-controls/stories/index.story.tsx
+++ b/packages/components/src/query-controls/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 /**
  * WordPress dependencies
@@ -29,8 +30,14 @@ const meta: Meta< typeof QueryControls > = {
 		selectedCategories: { control: false },
 		selectedCategoryId: { control: false },
 	},
+	args: {
+		onAuthorChange: fn(),
+		onNumberOfItemsChange: fn(),
+		onOrderByChange: fn(),
+		onOrderChange: fn(),
+		onCategoryChange: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},

--- a/packages/components/src/range-control/stories/index.story.tsx
+++ b/packages/components/src/range-control/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 /**
  * WordPress dependencies
@@ -46,8 +47,14 @@ const meta: Meta< typeof RangeControl > = {
 		type: { control: { type: 'check' }, options: [ 'stepper' ] },
 		value: { control: false },
 	},
+	args: {
+		onBlur: fn(),
+		onChange: fn(),
+		onFocus: fn(),
+		onMouseLeave: fn(),
+		onMouseMove: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},

--- a/packages/components/src/sandbox/stories/index.story.tsx
+++ b/packages/components/src/sandbox/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 /**
  * Internal dependencies
@@ -15,8 +16,10 @@ const meta: Meta< typeof SandBox > = {
 	argTypes: {
 		onFocus: { control: false },
 	},
+	args: {
+		onFocus: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},

--- a/packages/components/src/select-control/stories/index.story.tsx
+++ b/packages/components/src/select-control/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 /**
  * WordPress dependencies
@@ -25,8 +26,10 @@ const meta: Meta< typeof SelectControl > = {
 		suffix: { control: { type: 'text' } },
 		value: { control: false },
 	},
+	args: {
+		onChange: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},

--- a/packages/components/src/tab-panel/stories/index.story.tsx
+++ b/packages/components/src/tab-panel/stories/index.story.tsx
@@ -19,7 +19,6 @@ const meta: Meta< typeof TabPanel > = {
 	id: 'components-tabpanel',
 	component: TabPanel,
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},

--- a/packages/components/src/tabs/stories/index.story.tsx
+++ b/packages/components/src/tabs/stories/index.story.tsx
@@ -35,7 +35,6 @@ const meta: Meta< typeof Tabs > = {
 	},
 	tags: [ 'status-private' ],
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},

--- a/packages/components/src/text/stories/index.story.tsx
+++ b/packages/components/src/text/stories/index.story.tsx
@@ -27,7 +27,6 @@ const meta: Meta< typeof Text > = {
 		weight: { control: { type: 'text' } },
 	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},

--- a/packages/components/src/tools-panel/stories/index.story.tsx
+++ b/packages/components/src/tools-panel/stories/index.story.tsx
@@ -3,6 +3,7 @@
  */
 import type { Meta, StoryFn } from '@storybook/react';
 import styled from '@emotion/styled';
+import { fn } from '@storybook/test';
 
 /**
  * WordPress dependencies
@@ -36,8 +37,10 @@ const meta: Meta< typeof ToolsPanel > = {
 		panelId: { control: false },
 		resetAll: { action: 'resetAll' },
 	},
+	args: {
+		resetAll: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: {
 			expanded: true,
 		},

--- a/packages/components/src/tree-grid/stories/index.story.tsx
+++ b/packages/components/src/tree-grid/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 /**
  * WordPress dependencies
@@ -24,8 +25,12 @@ const meta: Meta< typeof TreeGrid > = {
 	argTypes: {
 		children: { control: false },
 	},
+	args: {
+		onExpandRow: fn(),
+		onCollapseRow: fn(),
+		onFocusRow: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: { expanded: true },
 	},
 };

--- a/packages/components/src/unit-control/stories/index.story.tsx
+++ b/packages/components/src/unit-control/stories/index.story.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { Meta, StoryFn } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 /**
  * WordPress dependencies
@@ -26,8 +27,13 @@ const meta: Meta< typeof UnitControl > = {
 		prefix: { control: { type: 'text' } },
 		value: { control: false },
 	},
+	args: {
+		onChange: fn(),
+		onUnitChange: fn(),
+		onFocus: fn(),
+		onBlur: fn(),
+	},
 	parameters: {
-		actions: { argTypesRegex: '^on.*' },
 		controls: {
 			expanded: true,
 		},


### PR DESCRIPTION


## What?
Closes #60660

Replaces implicit action args (matched via `argTypesRegex`) with explicit `fn()` spies from `@storybook/test` in stories. Some components had there stories updated in this [PR](https://github.com/WordPress/gutenberg/pull/67574)


## Why?
Storybook 8 [removes](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#implicit-actions-can-not-be-used-during-rendering-for-example-in-the-play-function:~:text=In%20Storybook%208%20this%20feature%20is%20removed%2C%20and%20spies%20have%20to%20added%20explicitly%3A) support for implicit action args via argTypesRegex. Explicit fn() spies are now the recommended approach for better testing, portability, and future-proofing.



## How?
Updated stories that were relying on argTypesRegex to instead use explicit actions.


## Testing Instructions

1. Run `npm run storybook:dev`.
2. Verify storybook builds
3. Open affected component stories.
4. Test every component or docs page to ensure nothing breaks.
5. Confirm events still show in the actions panel.



