### PR TITLE
`FormTokenField`: Fix focus lost on tab when `__experimentalExpandOnFocus` is set

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   `FormTokenField`: Fix focus lost on tab when used within modal ([#70591](https://github.com/WordPress/gutenberg/pull/70591)).
+-   `FormTokenField`: Fix focus lost on tab when `__experimentalExpandOnFocus` is set ([#70591](https://github.com/WordPress/gutenberg/pull/70591)).
 
 ## 29.12.0 (2025-06-25)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--	`FormTokenField`: Fix focus lost on tab when used within modal ([#70591](https://github.com/WordPress/gutenberg/pull/70591)).
+-   `FormTokenField`: Fix focus lost on tab when used within modal ([#70591](https://github.com/WordPress/gutenberg/pull/70591)).
 
 ## 29.12.0 (2025-06-25)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-	`FormTokenField`: Fix focus lost on tab when used within modal ([#70591](https://github.com/WordPress/gutenberg/pull/70591)).
+
 ## 29.12.0 (2025-06-25)
 
 ### Bug Fixes

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -241,6 +241,9 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 			case 'Escape':
 				preventDefault = handleEscapeKey( event );
 				break;
+			case 'Tab':
+				preventDefault = handleTabKey( event );
+				break;
 			default:
 				break;
 		}
@@ -381,6 +384,11 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		}
 
 		return true; // PreventDefault.
+	}
+
+	function handleTabKey( event: KeyboardEvent ) {
+		handleEscapeKey( event );
+		return false; // Do not prevent the default behavior.
 	}
 
 	function handleCommaKey() {

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -375,19 +375,22 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 		return true; // PreventDefault.
 	}
 
-	function handleEscapeKey( event: KeyboardEvent ) {
+	function collapseSuggestionsList( event: KeyboardEvent ) {
 		if ( event.target instanceof HTMLInputElement ) {
 			setIncompleteTokenValue( event.target.value );
 			setIsExpanded( false );
 			setSelectedSuggestionIndex( -1 );
 			setSelectedSuggestionScroll( false );
 		}
+	}
 
+	function handleEscapeKey( event: KeyboardEvent ) {
+		collapseSuggestionsList( event );
 		return true; // PreventDefault.
 	}
 
 	function handleTabKey( event: KeyboardEvent ) {
-		handleEscapeKey( event );
+		collapseSuggestionsList( event );
 		return false; // Do not prevent the default behavior.
 	}
 


### PR DESCRIPTION
## What, Why, and How?
Closes #66571

This PR fixes a focus loss issue triggered during `tab` navigation when the `FormTokenField` component is used inside a `Modal`.

The problem arises because, when tabbing, the `SuggestionList` briefly receives focus. This triggers the `onBlur` logic, which collapses the `SuggestionList` prematurely and results in a loss of focus.

To address this, the PR introduces a `keydown` handler for the `Tab` key. This ensures the `SuggestionList` is collapsed before the default `Tab` behaviour is executed, allowing the focus to correctly move to the next focusable element.

## Testing Instructions

1. Create a new post.
2. Insert a paragraph within it.
3. From its Block Toolbar, click on `Options`, then `Create pattern`.
4. Try tabbing through the Modal and confirm that the modal does not close abruptly, and also that the focus is preserved within the modal.

### Testing Instructions for Keyboard
Same.

## Screencast

https://github.com/user-attachments/assets/9dc1f73c-be43-43ef-9436-9ba8cbf1a75a