### PR TITLE
Block Editor: Use consistent sizing for the block locking modal

### DIFF
--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -84,6 +84,7 @@ export default function BlockLockModal( { clientId, onClose } ) {
 			) }
 			overlayClassName="block-editor-block-lock-modal"
 			onRequestClose={ onClose }
+			size="small"
 		>
 			<form
 				onSubmit={ ( event ) => {

--- a/packages/block-editor/src/components/block-lock/style.scss
+++ b/packages/block-editor/src/components/block-lock/style.scss
@@ -1,11 +1,5 @@
 .block-editor-block-lock-modal {
 	z-index: z-index(".block-editor-block-lock-modal");
-
-	.components-modal__frame {
-		@include break-small() {
-			max-width: $break-mobile;
-		}
-	}
 }
 
 .block-editor-block-lock-modal__options legend {


### PR DESCRIPTION
## What?
PR updates `BlockLockModal` component to use `size` prop for dimensions instead of custom CSS. This makes it more consistent with other modals opened from the block options dropdown.

## Testing Instructions
1. Open a post or page.
2. Insert a heading block.
3. Open the block locking modal.
4. Confirm new size.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![CleanShot 2025-07-02 at 16 32 17](https://github.com/user-attachments/assets/51baa9b0-4b83-4cf7-bc52-34e9d88ee1c0)|![CleanShot 2025-07-02 at 16 29 54](https://github.com/user-attachments/assets/6b916630-27ec-40b6-b6dc-89b7617ade90)|
