### PR TITLE
Format Library: Improve inline image replacement workflow

### DIFF
--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -145,10 +145,20 @@ function Edit( {
 	activeObjectAttributes,
 	contentRef,
 } ) {
+	let currentImageId;
+	if ( isObjectActive && activeObjectAttributes.className ) {
+		const wpImageMatch =
+			activeObjectAttributes.className.match( /wp-image-(\d+)/ );
+		if ( wpImageMatch && wpImageMatch[ 1 ] ) {
+			currentImageId = parseInt( wpImageMatch[ 1 ], 10 );
+		}
+	}
+
 	return (
 		<MediaUploadCheck>
 			<MediaUpload
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
+				value={ currentImageId }
 				onSelect={ ( { id, url, alt, width: imgWidth } ) => {
 					onChange(
 						insertObject( value, {
@@ -176,7 +186,7 @@ function Edit( {
 								<Path d="M4 18.5h16V17H4v1.5zM16 13v1.5h4V13h-4zM5.1 15h7.8c.6 0 1.1-.5 1.1-1.1V6.1c0-.6-.5-1.1-1.1-1.1H5.1C4.5 5 4 5.5 4 6.1v7.8c0 .6.5 1.1 1.1 1.1zm.4-8.5h7V10l-1-1c-.3-.3-.8-.3-1 0l-1.6 1.5-1.2-.7c-.3-.2-.6-.2-.9 0l-1.3 1V6.5zm0 6.1l1.8-1.3 1.3.8c.3.2.7.2.9-.1l1.5-1.4 1.5 1.4v1.5h-7v-.9z" />
 							</SVG>
 						}
-						title={ title }
+						title={ isObjectActive ? __( 'Replace image' ) : title }
 						onClick={ open }
 						isActive={ isObjectActive }
 					/>

--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -26,6 +26,23 @@ const ALLOWED_MEDIA_TYPES = [ 'image' ];
 const name = 'core/image';
 const title = __( 'Inline image' );
 
+/**
+ * Extracts the image ID from the className attribute.
+ *
+ * @param {Object} activeObjectAttributes The attributes of the active object.
+ * @return {number|undefined} The extracted image ID or undefined if not found.
+ */
+function getCurrentImageId( activeObjectAttributes ) {
+	if ( ! activeObjectAttributes?.className ) {
+		return undefined;
+	}
+
+	const [ , id ] =
+		activeObjectAttributes.className.match( /wp-image-(\d+)/ ) ?? [];
+
+	return id ? parseInt( id, 10 ) : undefined;
+}
+
 export const image = {
 	name,
 	title,
@@ -145,20 +162,11 @@ function Edit( {
 	activeObjectAttributes,
 	contentRef,
 } ) {
-	let currentImageId;
-	if ( isObjectActive && activeObjectAttributes.className ) {
-		const wpImageMatch =
-			activeObjectAttributes.className.match( /wp-image-(\d+)/ );
-		if ( wpImageMatch && wpImageMatch[ 1 ] ) {
-			currentImageId = parseInt( wpImageMatch[ 1 ], 10 );
-		}
-	}
-
 	return (
 		<MediaUploadCheck>
 			<MediaUpload
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
-				value={ currentImageId }
+				value={ getCurrentImageId( activeObjectAttributes ) }
 				onSelect={ ( { id, url, alt, width: imgWidth } ) => {
 					onChange(
 						insertObject( value, {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Closes: https://github.com/WordPress/gutenberg/issues/25909

This PR improves the user experience when working with inline images by addressing issue #25909, where users couldn't easily replace an existing inline image.

## Changes:
1. **Dynamic Button Label**: Changes the toolbar button title to "Replace image" when an inline image is selected.
2. **Image Preselection**: Preselects the current image in the media library when replacing an inline image, providing better context for users.

## Testing Instructions
1. Open the block editor and create a new post
2. Add a paragraph block and type some text
3. Place your cursor in the paragraph and open the format dropdown (+ icon)
4. Select "Inline image" from the dropdown menu
5. Upload or select an image from the media library
6. After the image is inserted, click on it to select it
7. Verify that the toolbar button now shows "Replace image" instead of "Inline image"
8. Click the "Replace image" button
9. Verify that the media library opens with the current image already selected/highlighted
10. Select a different image and confirm it replaces the existing inline image

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/c211f3dc-af8e-4217-821a-809e0decd45f



