### PR TITLE
Site Logo: Refactor the media panel to use ToolsPanel

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -23,7 +23,6 @@ import {
 	Button,
 	DropZone,
 	FlexItem,
-	PanelBody,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalItemGroup as ItemGroup,
@@ -476,6 +475,7 @@ export default function LogoEdit( {
 	}, [] );
 	const { getSettings } = useSelect( blockEditorStore );
 	const [ temporaryURL, setTemporaryURL ] = useState();
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	const { editEntityRecord } = useDispatch( coreStore );
 
@@ -633,19 +633,32 @@ export default function LogoEdit( {
 
 	const mediaInspectorPanel = ( canUserEdit || logoUrl ) && (
 		<InspectorControls>
-			<PanelBody title={ __( 'Media' ) }>
-				<div className="block-library-site-logo__inspector-media-replace-container">
-					{ ! canUserEdit ? (
-						<InspectorLogoPreview
-							media={ mediaItemData }
-							itemGroupProps={ {
-								isBordered: true,
-								className:
-									'block-library-site-logo__inspector-readonly-logo-preview',
-							} }
-						/>
-					) : (
-						<>
+			<ToolsPanel
+				label={ __( 'Media' ) }
+				dropdownMenuProps={ dropdownMenuProps }
+			>
+				{ ! canUserEdit ? (
+					<ToolsPanelItem
+						hasValue={ () => false }
+						label={ __( 'Logo preview' ) }
+					>
+						<div className="block-library-site-logo__inspector-media-replace-container">
+							<InspectorLogoPreview
+								media={ mediaItemData }
+								itemGroupProps={ {
+									isBordered: true,
+									className:
+										'block-library-site-logo__inspector-readonly-logo-preview',
+								} }
+							/>
+						</div>
+					</ToolsPanelItem>
+				) : (
+					<ToolsPanelItem
+						hasValue={ () => false }
+						label={ __( 'Logo' ) }
+					>
+						<div className="block-library-site-logo__inspector-media-replace-container">
 							<SiteLogoReplaceFlow
 								{ ...mediaReplaceFlowProps }
 								name={
@@ -668,10 +681,10 @@ export default function LogoEdit( {
 								) }
 							/>
 							<DropZone onFilesDrop={ onFilesDrop } />
-						</>
-					) }
-				</div>
-			</PanelBody>
+						</div>
+					</ToolsPanelItem>
+				) }
+			</ToolsPanel>
 		</InspectorControls>
 	);
 

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -639,7 +639,7 @@ export default function LogoEdit( {
 			>
 				{ ! canUserEdit ? (
 					<ToolsPanelItem
-						hasValue={ () => false }
+						hasValue={ () => !! logoUrl }
 						label={ __( 'Logo preview' ) }
 					>
 						<div className="block-library-site-logo__inspector-media-replace-container">
@@ -655,7 +655,7 @@ export default function LogoEdit( {
 					</ToolsPanelItem>
 				) : (
 					<ToolsPanelItem
-						hasValue={ () => false }
+						hasValue={ () => !! logoUrl }
 						label={ __( 'Logo' ) }
 					>
 						<div className="block-library-site-logo__inspector-media-replace-container">

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -638,21 +638,19 @@ export default function LogoEdit( {
 				dropdownMenuProps={ dropdownMenuProps }
 			>
 				{ ! canUserEdit ? (
-					<ToolsPanelItem
-						hasValue={ () => !! logoUrl }
-						label={ __( 'Logo preview' ) }
+					<div
+						className="block-library-site-logo__inspector-media-replace-container"
+						style={ { gridColumn: '1 / -1' } }
 					>
-						<div className="block-library-site-logo__inspector-media-replace-container">
-							<InspectorLogoPreview
-								media={ mediaItemData }
-								itemGroupProps={ {
-									isBordered: true,
-									className:
-										'block-library-site-logo__inspector-readonly-logo-preview',
-								} }
-							/>
-						</div>
-					</ToolsPanelItem>
+						<InspectorLogoPreview
+							media={ mediaItemData }
+							itemGroupProps={ {
+								isBordered: true,
+								className:
+									'block-library-site-logo__inspector-readonly-logo-preview',
+							} }
+						/>
+					</div>
 				) : (
 					<ToolsPanelItem
 						hasValue={ () => !! logoUrl }

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -657,6 +657,7 @@ export default function LogoEdit( {
 					<ToolsPanelItem
 						hasValue={ () => !! logoUrl }
 						label={ __( 'Logo' ) }
+						isShownByDefault
 					>
 						<div className="block-library-site-logo__inspector-media-replace-container">
 							<SiteLogoReplaceFlow


### PR DESCRIPTION
## What?


Closes https://github.com/WordPress/gutenberg/issues/67936
Comment: https://github.com/WordPress/gutenberg/issues/67936#issuecomment-3022877528

Refactors the "Media" panel of the Site Logo block to use ToolsPanel instead of PanelBody.

## Why?

Part of #67813 - This change ensures consistency with other inspector panels throughout the editor.

## Testing Instructions

- Create a new post or page
- Add a Site Logo block
- Set a site logo image
- Open the block inspector and verify that the "Media" panel appears with ToolsPanel styling
- Test the reset functionality and verify if it works like before 
- Verify that the panel behaves correctly 


## Screenshots


<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
        <img src="https://github.com/user-attachments/assets/b7176379-abc1-4527-bf98-74887c783e55" height="300" style="display:block; margin:auto;">
      </td>
      <td>
        <img src="https://github.com/user-attachments/assets/57622769-e2c0-4934-9c62-df4980e1d602" height="300" style="display:block; margin:auto;">
      </td>
    </tr>
    <tr>
      <td>
        <img src="https://github.com/user-attachments/assets/0e3cae6b-e7fd-4a1d-a82d-e02d02d33c47" height="300" style="display:block; margin:auto;">
      </td>
      <td>
        <img src="https://github.com/user-attachments/assets/c955acc9-595b-4283-9468-bebf4b6f1b80" height="300" style="display:block; margin:auto;">
      </td>
    </tr>
  </tbody>
</table>


