### PR TITLE
Storybook: Add story for `DefaultBlockAppender` component

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/stories/index.story.js
+++ b/packages/block-editor/src/components/default-block-appender/stories/index.story.js
@@ -1,0 +1,54 @@
+/**
+ * Internal dependencies
+ */
+import DefaultBlockAppender from '../';
+import { ExperimentalBlockEditorProvider } from '../../provider';
+
+const meta = {
+	title: 'BlockEditor/DefaultBlockAppender',
+	component: DefaultBlockAppender,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'DefaultBlockAppender provides a user interface for adding blocks to empty containers. Shows placeholder text and an inserter button.',
+			},
+		},
+	},
+	decorators: [
+		( Story ) => (
+			<ExperimentalBlockEditorProvider
+				value={ [] }
+				settings={ {
+					bodyPlaceholder:
+						'Start writing or type / to choose a block',
+				} }
+			>
+				<Story />
+			</ExperimentalBlockEditorProvider>
+		),
+	],
+	argTypes: {
+		rootClientId: {
+			control: false,
+			description:
+				'The root client ID where new blocks will be inserted.',
+			table: {
+				type: { summary: 'string' },
+				defaultValue: { summary: '""' },
+			},
+		},
+	},
+	args: {
+		rootClientId: '',
+	},
+};
+
+export default meta;
+
+export const Default = {
+	render: function Template( args ) {
+		return <DefaultBlockAppender { ...args } />;
+	},
+};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of #67165 
This pull request introduces a Storybook story for the `DefaultBlockAppender` component.

## Why?
As part of the ongoing effort to improve component documentation and testing (#22891), we need comprehensive stories for all Block Editor components.


## Testing Instructions
1. Run Storybook using `npm run storybook:dev`.
2. Open Storybook at http://localhost:50240/
3. Navigate to **BlockEditor > DefaultBlockAppender** in the Storybook sidebar.
4. Confirm that a "+" inserter button is visible. Click the "+" button and verify that the block inserter popover appears.


## Screenshot

<img alt="Screenshot 2025-07-03 at 2 49 31 PM" src="https://github.com/user-attachments/assets/2a8f700c-23ce-478a-98f3-a6bea5ebd914" />

