### PR TITLE
DataViews: Introduce `perPageSizes` to control the available sizes of the items per page

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Add `label-position-side` classes to labels in the form field layouts. Ensure that labels in the panel view do not align center, and that all side labels are center aligned.
 - Allow readonly fields in DataForm when `readOnly` is set to `true`.
 - Adjust the padding when the component is placed inside a `Card`.
+- Introduce `perPageSizes` to control the available sizes of the items per page
 
 ### Breaking Changes
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -414,6 +414,12 @@ The component receives the following props:
 
 React component to be rendered next to the view config button.
 
+#### `perPageSizes`: `[ number, number, number, number ]`
+
+A list of numbers used to control the available item counts per page.
+
+It's optional. Defaults to `[10, 20, 50, 100]`.
+
 ### Composition modes
 
 The `DataViews` component supports two composition modes:

--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -51,6 +51,8 @@ type DataViewsContextType< Item > = {
 	filters: NormalizedFilter[];
 	isShowingFilter: boolean;
 	setIsShowingFilter: ( value: boolean ) => void;
+	/** Control the available sizes of the items per page */
+	perPageSizes?: [ number, number, number, number ];
 };
 
 const DataViewsContext = createContext< DataViewsContextType< any > >( {

--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -51,7 +51,6 @@ type DataViewsContextType< Item > = {
 	filters: NormalizedFilter[];
 	isShowingFilter: boolean;
 	setIsShowingFilter: ( value: boolean ) => void;
-	/** Control the available sizes of the items per page */
 	perPageSizes?: [ number, number, number, number ];
 };
 

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -215,8 +215,8 @@ function SortDirectionControl() {
 
 const PAGE_SIZE_VALUES = [ 10, 20, 50, 100 ];
 function ItemsPerPageControl() {
-	const { view, onChangeView } = useContext( DataViewsContext );
-	const pageSizeValues = view.perPageSizes ?? PAGE_SIZE_VALUES;
+	const { view, perPageSizes, onChangeView } = useContext( DataViewsContext );
+	const pageSizeValues = perPageSizes ?? PAGE_SIZE_VALUES;
 	return (
 		<ToggleGroupControl
 			__nextHasNoMarginBottom

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -216,6 +216,7 @@ function SortDirectionControl() {
 const PAGE_SIZE_VALUES = [ 10, 20, 50, 100 ];
 function ItemsPerPageControl() {
 	const { view, onChangeView } = useContext( DataViewsContext );
+	const pageSizeValues = view.perPageSizes ?? PAGE_SIZE_VALUES;
 	return (
 		<ToggleGroupControl
 			__nextHasNoMarginBottom
@@ -237,7 +238,7 @@ function ItemsPerPageControl() {
 				} );
 			} }
 		>
-			{ PAGE_SIZE_VALUES.map( ( value ) => {
+			{ pageSizeValues.map( ( value ) => {
 				return (
 					<ToggleGroupControlOption
 						key={ value }

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -59,6 +59,7 @@ type DataViewsProps< Item > = {
 	header?: ReactNode;
 	getItemLevel?: ( item: Item ) => number;
 	children?: ReactNode;
+	perPageSizes?: [ number, number, number, number ];
 } & ( Item extends ItemWithId
 	? { getItemId?: ( item: Item ) => string }
 	: { getItemId: ( item: Item ) => string } );
@@ -132,6 +133,7 @@ function DataViews< Item >( {
 	isItemClickable = defaultIsItemClickable,
 	header,
 	children,
+	perPageSizes,
 }: DataViewsProps< Item > ) {
 	const containerRef = useRef< HTMLDivElement | null >( null );
 	const [ containerWidth, setContainerWidth ] = useState( 0 );
@@ -195,6 +197,7 @@ function DataViews< Item >( {
 				filters,
 				isShowingFilter,
 				setIsShowingFilter,
+				perPageSizes,
 			} }
 		>
 			<div

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -307,7 +307,6 @@ export const CustomPerPageSizes = () => {
 		titleField: 'title',
 		descriptionField: 'description',
 		mediaField: 'image',
-		perPageSizes: [ 3, 6, 12, 24 ],
 		perPage: 3,
 	} );
 	const { data: shownData, paginationInfo } = useMemo( () => {
@@ -323,6 +322,7 @@ export const CustomPerPageSizes = () => {
 			onChangeView={ setView }
 			actions={ actions.filter( ( action ) => ! action.supportsBulk ) }
 			defaultLayouts={ defaultLayouts }
+			perPageSizes={ [ 3, 6, 12, 24 ] }
 		/>
 	);
 };

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -299,3 +299,30 @@ export const WithCard = () => {
 		</Card>
 	);
 };
+
+export const CustomPerPageSizes = () => {
+	const [ view, setView ] = useState< View >( {
+		...DEFAULT_VIEW,
+		fields: [ 'categories' ],
+		titleField: 'title',
+		descriptionField: 'description',
+		mediaField: 'image',
+		perPageSizes: [ 3, 6, 12, 24 ],
+		perPage: 3,
+	} );
+	const { data: shownData, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( data, view, fields );
+	}, [ view ] );
+	return (
+		<DataViews
+			getItemId={ ( item ) => item.id.toString() }
+			paginationInfo={ paginationInfo }
+			data={ shownData }
+			view={ view }
+			fields={ fields }
+			onChangeView={ setView }
+			actions={ actions.filter( ( action ) => ! action.supportsBulk ) }
+			defaultLayouts={ defaultLayouts }
+		/>
+	);
+};

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -380,11 +380,6 @@ interface ViewBase {
 	perPage?: number;
 
 	/**
-	 * Control the available sizes of the items per page
-	 */
-	perPageSizes?: [ number, number, number, number ];
-
-	/**
 	 * The fields to render
 	 */
 	fields?: string[];

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -380,6 +380,11 @@ interface ViewBase {
 	perPage?: number;
 
 	/**
+	 * Control the available sizes of the items per page
+	 */
+	perPageSizes?: [ number, number, number, number ];
+
+	/**
 	 * The fields to render
 	 */
 	fields?: string[];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->
Introduce `perPageSizes` to control the available sizes of the items per page

![image](https://github.com/user-attachments/assets/1e0a12c7-0495-4a0a-99dd-6bd55a0fe3ee)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The consumer would like to customize the number of items per page based on their layout requirements.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Introduce the `perPageSizes` option to the view config

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
* Run `npm run storybook:dev` to start the storybook
* Navigate to `DataViews > Custom Per Page Sizes`
* Ensure there are only 3 items
* Open the appearance to change item per page
* Ensure it works as expected

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="339" alt="image" src="https://github.com/user-attachments/assets/288bc9a2-dacd-468b-954f-970d805ad700" />|![image](https://github.com/user-attachments/assets/1e0a12c7-0495-4a0a-99dd-6bd55a0fe3ee)|
