### PR TITLE
Fix: Pagination misalignment on first and last pages in Query Pagination Block

### DIFF
--- a/packages/block-library/src/query-pagination-numbers/style.scss
+++ b/packages/block-library/src/query-pagination-numbers/style.scss
@@ -1,0 +1,7 @@
+.wp-block-query-pagination.is-content-justification-space-between > .wp-block-query-pagination-numbers:first-child:nth-last-child(2) {
+	margin-inline-start: auto;
+}
+
+.wp-block-query-pagination.is-content-justification-space-between > .wp-block-query-pagination-numbers:nth-child(2):nth-last-child(1) {
+	margin-inline-end: auto;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #69580 

<!-- In a few words, what is the PR actually doing? -->
> When pagination is set to “space between,” it displays correctly on middle pages with three elements: page numbers centered, and navigation controls on either side. However, on the first and last category pages, the third element (either the previous or next control) is missing. This causes the page numbers to shift to the edge instead of remaining centered, disrupting the consistent layout. 

This PR fixes that issue by keeping the page numbers centered even on first and last pages.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This ensures consistent and expected UX for users as the sudden drastic shift in position of the page numbers while on first and last pages can be quite confusing to the users.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
A few approaches were discussed in the linked issue but each had their gotchas.  Initially I was going to solve it using one of the approaches (rendering empty element) but that would have caused problem in future if border styling is introduced. Somehow while inspecting the styles of the elements, I came up with this solution to conditionally apply margin to the page numbers using only CSS.

So basically, I wrote the CSS selectors for when there will be no previous/next buttons and accordingly applied `auto` inline-margin in the corresponding directions.

## Testing Instructions
1. Go to Pages > Add New.
2. Add a Query Loop block.
3. Configure it to display a list of posts.
4. Ensure that the Pagination block is present.
5. Set the justification of the Pagination block to Space between items.
6. Add Enough Posts for Multiple Pages: Ensure the post count exceeds the Posts per Page value to trigger pagination.
7. Check First and Last Pages: - Navigate to the first and last pages of the query loop.
8. Observe that page numbers do not shift to the edges due to the missing previous or next control.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/b34283e8-7c60-4a13-bd11-e67c994a34d0

| Page |Before|After|
|-|-|-|
| First Page |<img width="1455" alt="Screenshot 2025-07-03 at 8 30 06 PM" src="https://github.com/user-attachments/assets/0b860145-7d84-4a4f-85e5-399c1953ee5a" />|<img width="1472" alt="Screenshot 2025-07-03 at 8 30 22 PM" src="https://github.com/user-attachments/assets/046a5a38-73ce-4137-8c4c-fec9bead70e2" />|
| Last Page |<img width="1442" alt="Screenshot 2025-07-03 at 8 30 42 PM" src="https://github.com/user-attachments/assets/32f2e0b0-a673-41a2-ab69-237ca49372ec" />|<img width="1450" alt="Screenshot 2025-07-03 at 8 31 04 PM" src="https://github.com/user-attachments/assets/8c5fe5c3-1da6-4c6b-a9c2-5742f752873c" />|
