### PR TITLE
Cover: fixed resetAll to return image resolution to default value

### DIFF
--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -198,8 +198,8 @@ export default function CoverInspectorControls( {
 								focalPoint: undefined,
 								isRepeated: false,
 								alt: '',
-								sizeSlug: undefined,
 							} );
+							updateImage( DEFAULT_MEDIA_SIZE_SLUG );
 						} }
 						dropdownMenuProps={ dropdownMenuProps }
 					>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Similar #70398 #70514

<!-- In a few words, what is the PR actually doing? -->

## Why?
Clicking Reset all doesn't reset the resolution to default.
Fixed it to go back to full resolution like in #70398 #70514

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open a post or page.
2. Insert Cover block and select a media file.
3. Change its resolution.
4. Confirm that it doesn't reset to the first available option.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before


https://github.com/user-attachments/assets/92ecf498-ec85-4451-bdfe-b6a80b065de0

### After

https://github.com/user-attachments/assets/82dbe62d-b743-4c26-9b4a-1c28b663a212



