### PR TITLE
Update README.md

### DIFF
--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -778,28 +778,31 @@ Should there be any situation where you want to provide your own webpack config,
 
 To extend the provided webpack config, or replace subsections within the provided webpack config, you can provide your own `webpack.config.js` file, `require` the provided `webpack.config.js` file, and use the [`spread` operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) to import all of or part of the provided configuration.
 
-In the example below, a `webpack.config.js` file is added to the root folder extending the provided webpack config to include custom logic to parse module’s source and convert it to a JavaScript object using [`toml`](https://www.npmjs.com/package/toml). It may be useful to import toml or other non-JSON files as JSON, without specific loaders:
+In the example below, a `webpack.config.js` file is added to the root folder to extend the default WordPress webpack configuration and support importing `.mp3` files as bundled assets. It also ensures compatibility with the `--experimental-modules` flag, which causes the base config to return an array of configurations.
 
 ```javascript
-const toml = require( 'toml' );
-const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
+const wpConfig = require("@wordpress/scripts/config/webpack.config");
 
-module.exports = {
-	...defaultConfig,
-	module: {
-		...defaultConfig.module,
-		rules: [
-			...defaultConfig.module.rules,
-			{
-				test: /.toml/,
-				type: 'json',
-				parser: {
-					parse: toml.parse,
-				},
-			},
-		],
-	},
-};
+// Normalize to array
+const configs = Array.isArray(wpConfig) ? wpConfig : [wpConfig];
+
+// Modify each config (if needed)
+const updatedConfigs = configs.map((config) => ({
+  ...config,
+  module: {
+    ...config.module,
+    rules: [
+      ...(config.module?.rules || []),
+      {
+        test: /\.mp3$/,
+        type: "asset/resource",
+      },
+    ],
+  },
+}));
+
+// Export back in original format
+module.exports = Array.isArray(wpConfig) ? updatedConfigs : updatedConfigs[0];
 ```
 
 If you follow this approach, please, be aware that:


### PR DESCRIPTION
In projects using the `--experimental-modules` flag, the default `@wordpress/scripts` webpack configuration returns an array of configs instead of a single object.

This change normalizes the imported config to an array, applies custom rule modifications (e.g., support for `.mp3` files), and exports it back in its original format. This ensures that custom webpack overrides are compatible with both single and multi-config setups, avoiding unexpected build errors.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Update webpack config override example to support both single and multiple configurations returned by `@wordpress/scripts/config/webpack.config`.

## Why?
The current example assumes a single configuration object. However, when the `WP_EXPERIMENTAL_MODULES` flag is enabled, the config returns an array. Without handling this, any custom override using the `--experimental-modules` flag would throw an error.

This change ensures compatibility in both scenarios.

## How?

- Normalizes the imported wpConfig to an array.
- Maps over each config to inject a rule.
- Exports the modified configs, returning a single object if the original wasn't an array.

## Testing Instructions
Not applicable. This change updates a documentation example. No functional testing required.

### Testing Instructions for Keyboard
Not applicable. This change updates a documentation example. No functional testing required.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/b6cfdcf3-0f74-4964-b4ab-bbf66f9520e2




