### PR TITLE
DataViews: Show tooltip when hovering table header that has `headerTooltipText` property

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Add `label-position-side` classes to labels in the form field layouts. Ensure that labels in the panel view do not align center, and that all side labels are center aligned.
 - Allow readonly fields in DataForm when `readOnly` is set to `true`.
 - Adjust the padding when the component is placed inside a `Card`.
+- Show tooltip when the user hover on a table header that has `description` property set in the field.
 
 ### Breaking Changes
 

--- a/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
@@ -706,7 +706,7 @@ export const fields: Field< SpaceObject >[] = [
 		label: 'Satellites',
 		id: 'satellites',
 		type: 'integer',
-		description: 'The number of satellites orbiting this planet',
+		headerTooltipText: 'The number of satellites orbiting this planet',
 		enableSorting: true,
 	},
 	{

--- a/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
@@ -706,6 +706,7 @@ export const fields: Field< SpaceObject >[] = [
 		label: 'Satellites',
 		id: 'satellites',
 		type: 'integer',
+		description: 'The number of satellites orbiting this planet',
 		enableSorting: true,
 	},
 	{

--- a/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
@@ -79,7 +79,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 
 	isHidable = field.enableHiding !== false;
 	isSortable = field.enableSorting !== false;
-	const header = field.header;
+	const { header, headerTooltipText } = field;
 
 	operators = ( !! field.filterBy && field.filterBy?.operators ) || [];
 
@@ -99,15 +99,14 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 		<Menu>
 			<Menu.TriggerButton
 				render={
-					field.description ? (
+					headerTooltipText ? (
 						( props: any ) => (
-							<Tooltip text={ field.description } placement="top">
+							<Tooltip text={ headerTooltipText } placement="top">
 								<Button
 									size="compact"
 									className="dataviews-view-table-header-button"
 									ref={ ref }
 									variant="tertiary"
-									description={ field.description }
 									{ ...props }
 								/>
 							</Tooltip>

--- a/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
@@ -11,6 +11,7 @@ import { arrowLeft, arrowRight, unseen, funnel } from '@wordpress/icons';
 import {
 	Button,
 	Icon,
+	Tooltip,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { forwardRef, Children, Fragment } from '@wordpress/element';
@@ -98,15 +99,27 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 		<Menu>
 			<Menu.TriggerButton
 				render={
-					<Button
-						size="compact"
-						className="dataviews-view-table-header-button"
-						ref={ ref }
-						variant="tertiary"
-						showTooltip={ !! field.description }
-						tooltipPosition="top"
-						shortcut={ field.description }
-					/>
+					field.description ? (
+						( props: any ) => (
+							<Tooltip text={ field.description } placement="top">
+								<Button
+									size="compact"
+									className="dataviews-view-table-header-button"
+									ref={ ref }
+									variant="tertiary"
+									description={ field.description }
+									{ ...props }
+								/>
+							</Tooltip>
+						)
+					) : (
+						<Button
+							size="compact"
+							className="dataviews-view-table-header-button"
+							ref={ ref }
+							variant="tertiary"
+						/>
+					)
 				}
 			>
 				{ header }

--- a/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
@@ -103,6 +103,9 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 						className="dataviews-view-table-header-button"
 						ref={ ref }
 						variant="tertiary"
+						showTooltip={ !! field.description }
+						tooltipPosition="top"
+						label={ field.description }
 					/>
 				}
 			>

--- a/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
@@ -105,7 +105,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 						variant="tertiary"
 						showTooltip={ !! field.description }
 						tooltipPosition="top"
-						label={ field.description }
+						shortcut={ field.description }
 					/>
 				}
 			>

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -170,6 +170,11 @@ export type Field< Item > = {
 	header?: string | ReactElement;
 
 	/**
+	 * The text of the tooltip to display when hovering the header.
+	 */
+	headerTooltipText?: string;
+
+	/**
 	 * A description of the field.
 	 */
 	description?: string;


### PR DESCRIPTION
## What?

This PR adds a tooltip that displays the column header's `field.headerTooltipText` when hovered over in the table view.


## Why?

Sometimes, it's important to provide additional explanation about a column when the title alone isn't clear enough.

## How?

When the `field` has the `headerTooltipText` property set, we wrap the underlying `<Button>` with a `<Tooltip>`.

## Testing Instructions

1. Run `npm run storybook:dev`
1. Go to DataViews > Default
1. Using the Table view, show the Satellites column
1. Hover over that column header
1. Verify you see the tooltip.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<img width="504" alt="image" src="https://github.com/user-attachments/assets/e72a8efc-896c-4154-9c33-51eb00aad668" />
