### PR TITLE
Fix: Focus outline width inconsistency in Site Editor

### DIFF
--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -264,7 +264,7 @@
 			content: "";
 			position: absolute;
 			top: 0;
-			right: -(24px + 5px); // Icon size + padding.
+			right: -(24px + 1px); // Icon size + padding.
 			bottom: 0;
 			left: 0;
 			border-radius: inherit;


### PR DESCRIPTION
## What?
Closes: #70613
Fix focus outline width inconsistency in Site Editor Navigation panel by adjusting padding from 5px to 1px.

## Why?
The focus outline and selected item background in the Site Editor Navigation panel have inconsistent widths, creating visual misalignment. The focus outline doesn't properly align with the highlighted selection background, making the interface appear inconsistent.

## How?
Updated the CSS calculation for the right positioning from -(24px + 5px) to -(24px + 1px), reducing the padding component from 5px to 1px while maintaining the 24px icon size. This ensures the focus outline width matches the selected item background width, creating consistent visual alignment in the navigation panel.

## Testing Instructions
1. Navigate to the WordPress admin dashboard
2. Go to Appearance > Editor
3. Select Navigation from the design options
4. Select any one navigation item from list
5. Observe the focus outline width compared to the selected/highlighted item background

## Screenshots

|Before|After|
|-|-|
|![Image](https://github.com/user-attachments/assets/7388eb65-19dd-4e13-8d05-7c147b8aacdf)|<img width="421" alt="Screenshot 2025-07-04 at 2 21 47 PM" src="https://github.com/user-attachments/assets/bc52db1a-33af-40f0-be5e-2b9b1526e67a" />|
