### PR TITLE
Remove the extra font-size override for the select control on medium layouts

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Bug Fixes
 
 -   `FormTokenField`: Fix focus lost on tab when `__experimentalExpandOnFocus` is set ([#70591](https://github.com/WordPress/gutenberg/pull/70591)).
+-   `SelectControl`: Fix font-size for medium screens to ensure consistency with other inputs ([#70619](https://github.com/WordPress/gutenberg/pull/70619)).
+
 
 ## 29.12.0 (2025-06-25)
 

--- a/packages/components/src/select-control/style.scss
+++ b/packages/components/src/select-control/style.scss
@@ -2,9 +2,3 @@
 	outline: 0;
 	-webkit-tap-highlight-color: rgba(0, 0, 0, 0) !important;
 }
-
-@media (max-width: #{ ($break-medium) }) {
-	.components-base-control .components-base-control__field .components-select-control__input {
-		font-size: 16px;
-	}
-}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/70617 <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

The input control changes the font-size when the viewport is lower than 600px but the SelectControl changes before, at 782px. I think this is an error and this PR fixes it and makes the SelectControl consistent to the regular input.

Change introduced at https://github.com/WordPress/gutenberg/pull/10957.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's weird to see the select control change the font-size when the rest of the compnents stay the same.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Run `npm run storybook:dev`
- Access http://localhost:50240/?path=/docs/components-selectcontrol--docs
- Reduce the width of the window to 1082
- Observe nothing changes
- Reduce the width of the window to 900
- Observe the select control font-size changes. It behaves the same as the title and the other input components.


https://github.com/user-attachments/assets/a8f6904c-5240-46cf-b006-283496e34149



### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| ![Screenshot 2025-07-04 at 11 39 36](https://github.com/user-attachments/assets/e9c76227-77d3-484b-9047-cf160e6d41b5) | ![Screenshot 2025-07-04 at 11 55 29](https://github.com/user-attachments/assets/f0adf2af-90b2-40e3-8539-2f635e6cecb6) |



