### PR TITLE
feat: added keyword support & added basic keywords for post/page

### DIFF
--- a/packages/commands/README.md
+++ b/packages/commands/README.md
@@ -11,6 +11,7 @@ There are two ways to register commands: static or dynamic. Both methods receive
 -   `icon`: An SVG icon
 -   `callback`: A callback function that is called when the command is selected
 -   `context`: (Optional) The context of the command
+-   `keywords`: (Optional) An array of keywords for search matching
 
 ### Static commands
 

--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -50,6 +50,7 @@ function CommandMenuLoader( { name, search, hook, setLoader, close } ) {
 				<Command.Item
 					key={ command.name }
 					value={ command.searchLabel ?? command.label }
+					keywords={ command.keywords }
 					onSelect={ () => command.callback( { close } ) }
 					id={ command.name }
 				>
@@ -121,6 +122,7 @@ export function CommandMenuGroup( { isContextual, search, setLoader, close } ) {
 				<Command.Item
 					key={ command.name }
 					value={ command.searchLabel ?? command.label }
+					keywords={ command.keywords }
 					onSelect={ () => command.callback( { close } ) }
 					id={ command.name }
 				>

--- a/packages/commands/src/hooks/use-command.js
+++ b/packages/commands/src/hooks/use-command.js
@@ -47,6 +47,7 @@ export default function useCommand( command ) {
 			label: command.label,
 			searchLabel: command.searchLabel,
 			icon: command.icon,
+			keywords: command.keywords,
 			callback: ( ...args ) => currentCallbackRef.current( ...args ),
 		} );
 		return () => {
@@ -58,6 +59,7 @@ export default function useCommand( command ) {
 		command.searchLabel,
 		command.icon,
 		command.context,
+		command.keywords,
 		command.disabled,
 		registerCommand,
 		unregisterCommand,

--- a/packages/commands/src/store/actions.js
+++ b/packages/commands/src/store/actions.js
@@ -12,6 +12,7 @@
  * @property {JSX.Element} icon        Command icon.
  * @property {Function}    callback    Command callback.
  * @property {boolean}     disabled    Whether to disable the command.
+ * @property {string[]=}   keywords    Command keywords for search matching.
  */
 
 /**

--- a/packages/commands/src/store/reducer.js
+++ b/packages/commands/src/store/reducer.js
@@ -23,6 +23,7 @@ function commands( state = {}, action ) {
 					context: action.context,
 					callback: action.callback,
 					icon: action.icon,
+					keywords: action.keywords,
 				},
 			};
 		case 'UNREGISTER_COMMAND': {

--- a/packages/core-commands/src/admin-navigation-commands.js
+++ b/packages/core-commands/src/admin-navigation-commands.js
@@ -78,13 +78,10 @@ const getAddNewPageCommand = () =>
 					icon: plus,
 					callback: addNewPage,
 					keywords: [
-						'page',
-						'new',
-						'page new',
-						'add new page',
-						'create page',
-						'create new page',
-						'create',
+						__( 'page' ),
+						__( 'new' ),
+						__( 'add' ),
+						__( 'create' ),
 					],
 				},
 			];
@@ -104,15 +101,7 @@ export function useAdminNavigationCommands() {
 		callback: () => {
 			document.location.assign( 'post-new.php' );
 		},
-		keywords: [
-			'post',
-			'new',
-			'post new',
-			'add new post',
-			'create post',
-			'create new post',
-			'create',
-		],
+		keywords: [ __( 'post' ), __( 'new' ), __( 'add' ), __( 'create' ) ],
 	} );
 
 	useCommandLoader( {

--- a/packages/core-commands/src/admin-navigation-commands.js
+++ b/packages/core-commands/src/admin-navigation-commands.js
@@ -77,6 +77,15 @@ const getAddNewPageCommand = () =>
 					label: __( 'Add new page' ),
 					icon: plus,
 					callback: addNewPage,
+					keywords: [
+						'page',
+						'new',
+						'page new',
+						'add new page',
+						'create page',
+						'create new page',
+						'create',
+					],
 				},
 			];
 		}, [ createPageEntity, isSiteEditor, isBlockBasedTheme ] );
@@ -95,6 +104,15 @@ export function useAdminNavigationCommands() {
 		callback: () => {
 			document.location.assign( 'post-new.php' );
 		},
+		keywords: [
+			'post',
+			'new',
+			'post new',
+			'add new post',
+			'create post',
+			'create new post',
+			'create',
+		],
 	} );
 
 	useCommandLoader( {

--- a/test/e2e/specs/site-editor/command-center.spec.js
+++ b/test/e2e/specs/site-editor/command-center.spec.js
@@ -39,6 +39,37 @@ test.describe( 'Site editor command palette', () => {
 		).toBeVisible();
 	} );
 
+	test( 'Open the command palette and create page using "create" keyword', async ( {
+		page,
+	} ) => {
+		await page
+			.getByRole( 'button', { name: 'Open command palette' } )
+			.focus();
+		await page.keyboard.press( 'Meta+k' );
+		await page.keyboard.type( 'create page' );
+		await page.getByRole( 'option', { name: 'Add new page' } ).click();
+		await expect( page ).toHaveURL(
+			/\/wp-admin\/site-editor.php\?p=%2Fpage%2F(\d+)&canvas=edit/
+		);
+		await expect(
+			page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'No title · Page' } )
+		).toBeVisible();
+	} );
+
+	test( 'Open the command palette and create post using "create" keyword', async ( {
+		page,
+	} ) => {
+		await page
+			.getByRole( 'button', { name: 'Open command palette' } )
+			.focus();
+		await page.keyboard.press( 'Meta+k' );
+		await page.keyboard.type( 'create post' );
+		await page.getByRole( 'option', { name: 'Add new post' } ).click();
+		await expect( page ).toHaveURL( /\/wp-admin\/post-new\.php/ );
+	} );
+
 	test( 'Open the command palette and navigate to a template', async ( {
 		page,
 	} ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #70595

<!-- In a few words, what is the PR actually doing? -->
Adds "create" as a keyword for post/page commands in Command Palette to improve user experience and searchability.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, when users open the Command Palette (⌘ + K) and type "create post" or "create page", no matching commands are shown. However, typing "add post" or "add page" works as expected. Many end users naturally think of "creating" content rather than "adding" it, so it would be more intuitive if "create" were recognized as an alias or keyword for the existing "Add Post" and "Add Page" commands.

This PR addresses the issue described in [#70595](https://github.com/WordPress/gutenberg/issues/70595) by adding comprehensive keywords support to both static and dynamic commands in the Command Palette.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

### Core Implementation
1. **Fixed `useCommand` hook** - Added `keywords: command.keywords` to `registerCommand` call for static commands
2. **Updated `commands` reducer** - Added `keywords: action.keywords` to store keywords in state
3. **Enhanced TypeScript definitions** - Added `@property {string[]=} keywords` to `WPCommandConfig` typedef
4. **Leveraged `cmdk` library's built-in keywords support** - Used proper `keywords` prop on `Command.Item` components

### Command Updates
- **"Add new post" command** - Added keywords: `['post', 'new', 'post new', 'add new post', 'create post', 'create new post', 'create']`
- **"Add new page" command** - Added keywords: `['page', 'new', 'page new', 'add new page', 'create page', 'create new page', 'create']`

### Documentation
- Updated README.md to document keywords support

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open the WordPress site/post editor
2. Press `⌘ + K` (or `Ctrl + K` on Windows/Linux) to open the Command Palette
3. Type "create post" and verify that "Add new post" command appears
4. Type "create page" and verify that "Add new page" command appears
5. Type "add post" and verify that "Add new post" command still appears (existing functionality preserved)
6. Type "add page" and verify that "Add new page" command still appears (existing functionality preserved)
7. Test partial matches like "create", "post", "page" to ensure they all work

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. Navigate to the WordPress admin using keyboard only (Tab, Enter, Arrow keys)
2. Press `⌘ + K` to open Command Palette
3. Type "create post" using keyboard
4. Use Arrow keys to navigate through results
5. Press Enter to select "Add new post" command
6. Verify the command executes correctly
7. Repeat with "create page" and other variations
8. Test with screen reader to ensure proper announcement of command options

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
 

|Before|After|
|-|-|
|![Before: "create post" returns no results](https://github.com/user-attachments/assets/36c14150-e6d9-41cb-bc70-d097e8c03f2e)|![After: "create post" shows "Add new post" command](https://github.com/user-attachments/assets/1f6a756b-1050-4ac5-88d4-cece61b61ade)|
 

**Note:** The implementation ensures backward compatibility - all existing search terms continue to work while adding the new "create" keyword functionality.