### PR TITLE
DataViews: Wrap data view action modals in `<Suspense>`

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -31,7 +31,8 @@
 ### Breaking Changes
 
 - Fields with `Edit` defined or `type` will automatically be considered as filters unless `filterBy` is set to `false`.
-- Add `renderItemLink` prop support in the `DataViews` component. It replaces `onClickItem`prop and allows integration with router libraries.
+- Add `renderItemLink` prop support in the `DataViews` component. It replaces `onClickItem` prop and allows integration with router libraries.
+- All action modals are wrapped in a `<Suspense>` component with an empty fallback.
 
 ### Internal
 

--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -13,7 +13,7 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useMemo, useState } from '@wordpress/element';
+import { useMemo, useState, Suspense } from '@wordpress/element';
 import { moreVertical } from '@wordpress/icons';
 import { useRegistry } from '@wordpress/data';
 
@@ -106,18 +106,20 @@ export function ActionModal< Item >( {
 	const label =
 		typeof action.label === 'string' ? action.label : action.label( items );
 	return (
-		<Modal
-			title={ action.modalHeader || label }
-			__experimentalHideHeader={ !! action.hideModalHeader }
-			onRequestClose={ closeModal }
-			focusOnMount={ action.modalFocusOnMount ?? true }
-			size={ action.modalSize || 'medium' }
-			overlayClassName={ `dataviews-action-modal dataviews-action-modal__${ kebabCase(
-				action.id
-			) }` }
-		>
-			<action.RenderModal items={ items } closeModal={ closeModal } />
-		</Modal>
+		<Suspense fallback={ null }>
+			<Modal
+				title={ action.modalHeader || label }
+				__experimentalHideHeader={ !! action.hideModalHeader }
+				onRequestClose={ closeModal }
+				focusOnMount={ action.modalFocusOnMount ?? true }
+				size={ action.modalSize || 'medium' }
+				overlayClassName={ `dataviews-action-modal dataviews-action-modal__${ kebabCase(
+					action.id
+				) }` }
+			>
+				<action.RenderModal items={ items } closeModal={ closeModal } />
+			</Modal>
+		</Suspense>
 	);
 }
 

--- a/packages/dataviews/src/test/dataviews.tsx
+++ b/packages/dataviews/src/test/dataviews.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -145,6 +145,28 @@ function DataViewWrapper( {
 	return <DataViews { ...dataViewProps } />;
 }
 
+function createSuspender< T = number >() {
+	let resolve: ( value: T ) => void;
+	let resolvedValue = undefined as T | undefined;
+	const promise = new Promise( ( res ) => {
+		resolve = res;
+	} );
+
+	return {
+		read: () => {
+			if ( resolvedValue === undefined ) {
+				throw promise;
+			}
+			return resolvedValue;
+		},
+		resolve( value: T ) {
+			resolvedValue = value;
+			resolve( value );
+		},
+		promise,
+	};
+}
+
 // jest.useFakeTimers();
 
 describe( 'DataViews component', () => {
@@ -254,6 +276,50 @@ describe( 'DataViews component', () => {
 		it( 'should render actions column if actions are supported and passed in', () => {
 			render( <DataViewWrapper actions={ actions } /> );
 			expect( screen.getByText( 'Actions' ) ).toBeInTheDocument();
+		} );
+
+		it( 'hides action modal during loading', async () => {
+			const suspender = createSuspender();
+
+			render(
+				<DataViewWrapper
+					actions={ [
+						{
+							id: 'lazy-action',
+							label: 'Lazy action',
+							RenderModal: () => {
+								const value = suspender.read();
+								return <div>Resolved: { value }</div>;
+							},
+							modalHeader: 'Modal header',
+						},
+					] }
+				/>
+			);
+
+			const user = userEvent.setup();
+			await user.click(
+				screen.getAllByRole( 'button', {
+					name: 'Actions',
+				} )[ 0 ] // Clicks the first action button in the table
+			);
+			await user.click(
+				screen.getByRole( 'menuitem', {
+					name: 'Lazy action',
+				} )
+			);
+
+			expect(
+				screen.queryByText( 'Modal header' )
+			).not.toBeInTheDocument();
+
+			await act( async () => {
+				suspender.resolve( 113 );
+				await suspender.promise;
+			} );
+
+			expect( screen.getByText( 'Modal header' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Resolved: 113' ) ).toBeInTheDocument();
 		} );
 
 		it( 'should trigger the onClickItem callback if isItemClickable returns true and title field is clicked', async () => {

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -543,6 +543,8 @@ export interface RenderModalProps< Item > {
 export interface ActionModal< Item > extends ActionBase< Item > {
 	/**
 	 * Modal to render when the action is triggered.
+	 * The modal will be wrapped in a <Suspense> and the default fallback
+	 * behavior is to render nothing until the modal is ready.
 	 */
 	RenderModal: ( {
 		items,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

When action modals in a data view are using React suspense, their default loading behaviour should be for the modal to be hidden while the loading occurs (at least that is a good default for fast loading modals). However, currently when modals are loading they will cause the entire dataview to flash during loading.

Afaict there are no uses of suspense within Gutenberg's own uses of dataview. This is an issue for consumers of the dataview package.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The main issue here is that without a Suspense boundary somewhere, modal contents that use suspense will cause the entire data view to disappear while loading. That isn't an appropriate loading behaviour for modals.

Another approach is we could require all actions that need it, to implement their own Suspense boundary within the modal body. This would fix the flashing content during loading. However it is not a great loading experience when the loading might happen quickly.

An example of a short loading time when a spinner wouldn't be appropriate would be lazy loading the modal contents using `React.lazy()`.

When loading can take longer&mdash;like if a modal is fetching a lot of data&mdash;the modal contents can still implement its own Suspense boundary to show a loading spinner within the modal body.

Perhaps what would be even better would be if the design system had a designed loading state for slow modals. That way `React.lazy`'s internal logic would make sure it wouldn't appear unless a few too many milliseconds had passed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This adds a `<Suspense>` component to wrap the action modal. This means that while a modal is loading the modal will not appear. When the loading only takes a few milliseconds then this is a better experience than showing a spinner.

Technically I believe this is a breaking change. Theoretically someone could have been relying on a loading behaviour where opening a modal would replace the data view with a loading interface. But I'm not sure this is very likely.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

First test that there has been no change to modals that do not use suspense

1. Run storybook with `npm run storybook:dev` and open DataViews -> Default story
2. Click the delete action in one of the rows
  - The modal appears instantly

Now test for modals that use suspense

4. Make the edits from this diff to your own storybook https://github.com/WordPress/gutenberg/compare/update/datavews-action-modal-suspense-boundary...add/lazy-modal-to-dataviews-storybook
  - The relevant change is the delete modal is now loaded with `React.lazy`
5. Click the delete action for one of the rows
  - The modal appears basically instantly

Perhaps a video to demonstrate. If the `<Suspense>` is placed outside the dataview then if you watch carefully you can see the dataview flicker when the modal is opened.

https://github.com/user-attachments/assets/7728e601-f6c8-4e1a-9e19-d27c9b126120

But with the `<Suspense>` wrapping just the modal it looks like this (after I throttled the network)


https://github.com/user-attachments/assets/ddcbcd99-c811-41cf-a02b-478b3f9bc003





### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

The modal action dialog will work with keyboard just as before. Try tabbing to the delete action in the storybook table. Click enter, and the modal will appear as before.