### PR TITLE
Add "Add New Post/Page" link to Block Editor header for easier navigation.

### DIFF
--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -10,11 +10,13 @@ import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, _x } from '@wordpress/i18n';
 import { NavigableToolbar, ToolSelector } from '@wordpress/block-editor';
-import { ToolbarButton, ToolbarItem } from '@wordpress/components';
+import { ToolbarButton, ToolbarItem, Button } from '@wordpress/components';
 import { listView, plus } from '@wordpress/icons';
 import { useCallback } from '@wordpress/element';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { addQueryArgs } from '@wordpress/url';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -36,6 +38,8 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 		listViewToggleRef,
 		showIconLabels,
 		showTools,
+		post,
+		postType
 	} = useSelect( ( select ) => {
 		const { get } = select( preferencesStore );
 		const {
@@ -45,8 +49,11 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 			getListViewToggleRef,
 			getRenderingMode,
 			getCurrentPostType,
+			getEditedPostAttribute,
+			getCurrentPost,
 		} = unlock( select( editorStore ) );
 		const { getShortcutRepresentation } = select( keyboardShortcutsStore );
+		const { getPostType } = select( coreStore );
 
 		return {
 			isInserterOpened: select( editorStore ).isInserterOpened(),
@@ -63,6 +70,9 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 				!! window?.__experimentalEditorWriteMode &&
 				( getRenderingMode() !== 'post-only' ||
 					getCurrentPostType() === 'wp_template' ),
+			post: getCurrentPost(),
+			postType: getPostType( getEditedPostAttribute( 'type' ) ),
+
 		};
 	}, [] );
 
@@ -101,6 +111,11 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 		'Generic label for block inserter button'
 	);
 	const shortLabel = ! isInserterOpened ? __( 'Add' ) : __( 'Close' );
+
+	const addNewPostLabel = postType?.labels?.add_new_item;
+	const addLink = addQueryArgs( 'post-new.php', {
+		post_type: post.type,
+	} );
 
 	return (
 		// Some plugins expect and use the `edit-post-header-toolbar` CSS class to
@@ -159,7 +174,7 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 						/>
 						{ ! isDistractionFree && (
 							<ToolbarButton
-								className="editor-document-tools__document-overview-toggle"
+								className="editor-document-tools__document-overview-toggle nikunj"
 								icon={ listView }
 								disabled={ disableBlockTools }
 								isPressed={ isListViewOpen }
@@ -175,6 +190,14 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 								ref={ listViewToggleRef }
 							/>
 						) }
+						<Button
+							variant="primary"
+							__next40pxDefaultSize
+							href={ addLink }
+							className="editor-document-tools__add-new-button"
+						>
+							{ addNewPostLabel }
+						</Button>
 					</>
 				) }
 			</div>

--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -174,7 +174,7 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 						/>
 						{ ! isDistractionFree && (
 							<ToolbarButton
-								className="editor-document-tools__document-overview-toggle nikunj"
+								className="editor-document-tools__document-overview-toggle"
 								icon={ listView }
 								disabled={ disableBlockTools }
 								isPressed={ isListViewOpen }

--- a/packages/editor/src/components/document-tools/style.scss
+++ b/packages/editor/src/components/document-tools/style.scss
@@ -61,6 +61,9 @@
 			display: none;
 		}
 	}
+	.editor-document-tools__add-new-button.is-primary {
+		height: $button-size-compact;
+	}
 }
 
 .editor-document-tools__left {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #70559 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
In the Classic Editor, users can quickly add a new Post or Page using the “Add New” link displayed in the Edit screen. However, this convenience is missing in the Block Editor (Gutenberg), creating a minor but noticeable gap in the user workflow.

This issue becomes more relevant for users who frequently create content (e.g., editors, bloggers, content creators) and expect consistent navigation tools across different editor experiences.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR introduces an “Add New” button to the Block Editor header (toolbar), based on the current post type being edited. The button allows users to quickly navigate to the corresponding “Add New” screen:
- For posts: /wp-admin/post-new.php
- For pages: /wp-admin/post-new.php?post_type=page
- For CPTs: /wp-admin/post-new.php?post_type={custom_post_type}

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open the Block Editor for any Post, Page, or Custom Post Type.
2. Look for the "Add {Post Type}" button in the top editor toolbar.
3. Click the button to confirm it navigates to the correct “Add New” screen.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/3359a44d-afe6-498d-b40b-f79dd0abe4d4)|![image](https://github.com/user-attachments/assets/2f04c2fb-699c-4e11-b8e2-18c0f04cb872)|
