### PR TITLE
[WIP] Command Palette: Update cmdk version from 1.0.0 to 1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9014,25 +9014,19 @@
 			}
 		},
 		"node_modules/@radix-ui/primitive": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
-			"integrity": "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10"
-			}
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
+			"integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
+			"license": "MIT"
 		},
 		"node_modules/@radix-ui/react-compose-refs": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
-			"integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+			"integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
 			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10"
-			},
 			"peerDependencies": {
 				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0"
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
@@ -9041,53 +9035,134 @@
 			}
 		},
 		"node_modules/@radix-ui/react-context": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
-			"integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+			"integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
 			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10"
-			},
 			"peerDependencies": {
 				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0"
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dialog": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.14.tgz",
+			"integrity": "sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.2",
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-context": "1.1.2",
+				"@radix-ui/react-dismissable-layer": "1.1.10",
+				"@radix-ui/react-focus-guards": "1.1.2",
+				"@radix-ui/react-focus-scope": "1.1.7",
+				"@radix-ui/react-id": "1.1.1",
+				"@radix-ui/react-portal": "1.1.9",
+				"@radix-ui/react-presence": "1.1.4",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-slot": "1.2.3",
+				"@radix-ui/react-use-controllable-state": "1.2.2",
+				"aria-hidden": "^1.2.4",
+				"react-remove-scroll": "^2.6.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dismissable-layer": {
+			"version": "1.1.10",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.10.tgz",
+			"integrity": "sha512-IM1zzRV4W3HtVgftdQiiOmA0AdJlCtMLe00FXaHwgt3rAnNsIyDqshvkIW3hj/iu5hu8ERP7KIYki6NkqDxAwQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.2",
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-use-callback-ref": "1.1.1",
+				"@radix-ui/react-use-escape-keydown": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
 					"optional": true
 				}
 			}
 		},
 		"node_modules/@radix-ui/react-focus-guards": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.1.tgz",
-			"integrity": "sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.2.tgz",
+			"integrity": "sha512-fyjAACV62oPV925xFCrH8DR5xWhg9KYtJT4s3u54jxp+L/hbpTY2kIeEFFbFe+a/HCE94zGQMZLIpVTPVZDhaA==",
 			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10"
-			},
 			"peerDependencies": {
 				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0"
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-focus-scope": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+			"integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-use-callback-ref": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
 					"optional": true
 				}
 			}
 		},
 		"node_modules/@radix-ui/react-id": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.1.tgz",
-			"integrity": "sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+			"integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-use-layout-effect": "1.0.1"
+				"@radix-ui/react-use-layout-effect": "1.1.1"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0"
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
@@ -9095,20 +9170,67 @@
 				}
 			}
 		},
-		"node_modules/@radix-ui/react-primitive": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
-			"integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
+		"node_modules/@radix-ui/react-portal": {
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+			"integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-slot": "1.0.2"
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-use-layout-effect": "1.1.1"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
 				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0",
-				"react-dom": "^16.8 || ^17.0 || ^18.0"
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-presence": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.4.tgz",
+			"integrity": "sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-use-layout-effect": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-primitive": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+			"integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-slot": "1.2.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
@@ -9120,17 +9242,16 @@
 			}
 		},
 		"node_modules/@radix-ui/react-slot": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
-			"integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+			"integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-compose-refs": "1.0.1"
+				"@radix-ui/react-compose-refs": "1.1.2"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0"
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
@@ -9139,16 +9260,13 @@
 			}
 		},
 		"node_modules/@radix-ui/react-use-callback-ref": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
-			"integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+			"integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
 			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10"
-			},
 			"peerDependencies": {
 				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0"
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
@@ -9157,17 +9275,35 @@
 			}
 		},
 		"node_modules/@radix-ui/react-use-controllable-state": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz",
-			"integrity": "sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+			"integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-use-callback-ref": "1.0.1"
+				"@radix-ui/react-use-effect-event": "0.0.2",
+				"@radix-ui/react-use-layout-effect": "1.1.1"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0"
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-effect-event": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+			"integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
@@ -9176,17 +9312,16 @@
 			}
 		},
 		"node_modules/@radix-ui/react-use-escape-keydown": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz",
-			"integrity": "sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+			"integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-use-callback-ref": "1.0.1"
+				"@radix-ui/react-use-callback-ref": "1.1.1"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0"
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
@@ -9195,16 +9330,13 @@
 			}
 		},
 		"node_modules/@radix-ui/react-use-layout-effect": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
-			"integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+			"integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
 			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10"
-			},
 			"peerDependencies": {
 				"@types/react": "*",
-				"react": "^16.8 || ^17.0 || ^18.0"
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
@@ -17157,9 +17289,10 @@
 			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
 		},
 		"node_modules/aria-hidden": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz",
-			"integrity": "sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+			"integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+			"license": "MIT",
 			"dependencies": {
 				"tslib": "^2.0.0"
 			},
@@ -19679,6 +19812,22 @@
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/cmdk": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+			"integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "^1.1.1",
+				"@radix-ui/react-dialog": "^1.1.6",
+				"@radix-ui/react-id": "^1.1.0",
+				"@radix-ui/react-primitive": "^2.0.2"
+			},
+			"peerDependencies": {
+				"react": "^18 || ^19 || ^19.0.0-rc",
+				"react-dom": "^18 || ^19 || ^19.0.0-rc"
 			}
 		},
 		"node_modules/co": {
@@ -22454,7 +22603,8 @@
 		"node_modules/detect-node-es": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-			"integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+			"integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+			"license": "MIT"
 		},
 		"node_modules/devtools-protocol": {
 			"version": "0.0.1367902",
@@ -26028,6 +26178,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
 			"integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -39957,23 +40108,23 @@
 			}
 		},
 		"node_modules/react-remove-scroll": {
-			"version": "2.5.5",
-			"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
-			"integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
+			"integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
 			"license": "MIT",
 			"dependencies": {
-				"react-remove-scroll-bar": "^2.3.3",
-				"react-style-singleton": "^2.2.1",
+				"react-remove-scroll-bar": "^2.3.7",
+				"react-style-singleton": "^2.2.3",
 				"tslib": "^2.1.0",
-				"use-callback-ref": "^1.3.0",
-				"use-sidecar": "^1.1.2"
+				"use-callback-ref": "^1.3.3",
+				"use-sidecar": "^1.1.3"
 			},
 			"engines": {
 				"node": ">=10"
 			},
 			"peerDependencies": {
-				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
@@ -39982,19 +40133,20 @@
 			}
 		},
 		"node_modules/react-remove-scroll-bar": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.6.tgz",
-			"integrity": "sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==",
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+			"integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+			"license": "MIT",
 			"dependencies": {
-				"react-style-singleton": "^2.2.1",
+				"react-style-singleton": "^2.2.2",
 				"tslib": "^2.0.0"
 			},
 			"engines": {
 				"node": ">=10"
 			},
 			"peerDependencies": {
-				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
@@ -40185,20 +40337,20 @@
 			}
 		},
 		"node_modules/react-style-singleton": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
-			"integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+			"integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+			"license": "MIT",
 			"dependencies": {
 				"get-nonce": "^1.0.0",
-				"invariant": "^2.2.4",
 				"tslib": "^2.0.0"
 			},
 			"engines": {
 				"node": ">=10"
 			},
 			"peerDependencies": {
-				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
@@ -45724,9 +45876,10 @@
 			}
 		},
 		"node_modules/use-callback-ref": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
-			"integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+			"integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+			"license": "MIT",
 			"dependencies": {
 				"tslib": "^2.0.0"
 			},
@@ -45734,8 +45887,8 @@
 				"node": ">=10"
 			},
 			"peerDependencies": {
-				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
@@ -45761,9 +45914,10 @@
 			}
 		},
 		"node_modules/use-sidecar": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
-			"integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+			"integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+			"license": "MIT",
 			"dependencies": {
 				"detect-node-es": "^1.1.0",
 				"tslib": "^2.0.0"
@@ -45772,8 +45926,8 @@
 				"node": ">=10"
 			},
 			"peerDependencies": {
-				"@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
@@ -50195,7 +50349,7 @@
 				"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 				"@wordpress/private-apis": "file:../private-apis",
 				"clsx": "^2.1.1",
-				"cmdk": "^1.0.0"
+				"cmdk": "1.1.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -50205,220 +50359,6 @@
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}
-		},
-		"packages/commands/node_modules/@radix-ui/react-dialog": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.5.tgz",
-			"integrity": "sha512-GjWJX/AUpB703eEBanuBnIWdIXg6NvJFCXcNlSZk4xdszCdhrJgBoUd1cGk67vFO+WdA2pfI/plOpqz/5GUP6Q==",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/primitive": "1.0.1",
-				"@radix-ui/react-compose-refs": "1.0.1",
-				"@radix-ui/react-context": "1.0.1",
-				"@radix-ui/react-dismissable-layer": "1.0.5",
-				"@radix-ui/react-focus-guards": "1.0.1",
-				"@radix-ui/react-focus-scope": "1.0.4",
-				"@radix-ui/react-id": "1.0.1",
-				"@radix-ui/react-portal": "1.0.4",
-				"@radix-ui/react-presence": "1.0.1",
-				"@radix-ui/react-primitive": "1.0.3",
-				"@radix-ui/react-slot": "1.0.2",
-				"@radix-ui/react-use-controllable-state": "1.0.1",
-				"aria-hidden": "^1.1.1",
-				"react-remove-scroll": "2.5.5"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0",
-				"react-dom": "^16.8 || ^17.0 || ^18.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"packages/commands/node_modules/@radix-ui/react-dialog/node_modules/@babel/runtime": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.9.tgz",
-			"integrity": "sha512-4zpTHZ9Cm6L9L+uIqghQX8ZXg8HKFcjYO3qHoO8zTmRm6HQUJ8SSJ+KRvbMBZn0EGVlT4DRYeQ/6hjlyXBh+Kg==",
-			"license": "MIT",
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"packages/commands/node_modules/@radix-ui/react-dismissable-layer": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.5.tgz",
-			"integrity": "sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/primitive": "1.0.1",
-				"@radix-ui/react-compose-refs": "1.0.1",
-				"@radix-ui/react-primitive": "1.0.3",
-				"@radix-ui/react-use-callback-ref": "1.0.1",
-				"@radix-ui/react-use-escape-keydown": "1.0.3"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0",
-				"react-dom": "^16.8 || ^17.0 || ^18.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"packages/commands/node_modules/@radix-ui/react-dismissable-layer/node_modules/@babel/runtime": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.9.tgz",
-			"integrity": "sha512-4zpTHZ9Cm6L9L+uIqghQX8ZXg8HKFcjYO3qHoO8zTmRm6HQUJ8SSJ+KRvbMBZn0EGVlT4DRYeQ/6hjlyXBh+Kg==",
-			"license": "MIT",
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"packages/commands/node_modules/@radix-ui/react-focus-scope": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.4.tgz",
-			"integrity": "sha512-sL04Mgvf+FmyvZeYfNu1EPAaaxD+aw7cYeIB9L9Fvq8+urhltTRaEo5ysKOpHuKPclsZcSUMKlN05x4u+CINpA==",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-compose-refs": "1.0.1",
-				"@radix-ui/react-primitive": "1.0.3",
-				"@radix-ui/react-use-callback-ref": "1.0.1"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0",
-				"react-dom": "^16.8 || ^17.0 || ^18.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"packages/commands/node_modules/@radix-ui/react-focus-scope/node_modules/@babel/runtime": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.9.tgz",
-			"integrity": "sha512-4zpTHZ9Cm6L9L+uIqghQX8ZXg8HKFcjYO3qHoO8zTmRm6HQUJ8SSJ+KRvbMBZn0EGVlT4DRYeQ/6hjlyXBh+Kg==",
-			"license": "MIT",
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"packages/commands/node_modules/@radix-ui/react-portal": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.4.tgz",
-			"integrity": "sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-primitive": "1.0.3"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0",
-				"react-dom": "^16.8 || ^17.0 || ^18.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"packages/commands/node_modules/@radix-ui/react-portal/node_modules/@babel/runtime": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.9.tgz",
-			"integrity": "sha512-4zpTHZ9Cm6L9L+uIqghQX8ZXg8HKFcjYO3qHoO8zTmRm6HQUJ8SSJ+KRvbMBZn0EGVlT4DRYeQ/6hjlyXBh+Kg==",
-			"license": "MIT",
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"packages/commands/node_modules/@radix-ui/react-presence": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz",
-			"integrity": "sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-compose-refs": "1.0.1",
-				"@radix-ui/react-use-layout-effect": "1.0.1"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0",
-				"react-dom": "^16.8 || ^17.0 || ^18.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"packages/commands/node_modules/@radix-ui/react-presence/node_modules/@babel/runtime": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.9.tgz",
-			"integrity": "sha512-4zpTHZ9Cm6L9L+uIqghQX8ZXg8HKFcjYO3qHoO8zTmRm6HQUJ8SSJ+KRvbMBZn0EGVlT4DRYeQ/6hjlyXBh+Kg==",
-			"license": "MIT",
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"packages/commands/node_modules/cmdk": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.0.0.tgz",
-			"integrity": "sha512-gDzVf0a09TvoJ5jnuPvygTB77+XdOSwEmJ88L6XPFPlv7T3RxbP9jgenfylrAMD0+Le1aO0nVjQUzl2g+vjz5Q==",
-			"dependencies": {
-				"@radix-ui/react-dialog": "1.0.5",
-				"@radix-ui/react-primitive": "1.0.3"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"packages/commands/node_modules/regenerator-runtime": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-			"license": "MIT"
 		},
 		"packages/components": {
 			"name": "@wordpress/components",

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -37,7 +37,7 @@
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/private-apis": "file:../private-apis",
 		"clsx": "^2.1.1",
-		"cmdk": "^1.0.0"
+		"cmdk": "1.1.1"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",

--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -1,20 +1,14 @@
 /**
  * External dependencies
  */
-import { Command, useCommandState } from 'cmdk';
+import { Command } from 'cmdk';
 import clsx from 'clsx';
 
 /**
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import {
-	useState,
-	useEffect,
-	useRef,
-	useCallback,
-	useMemo,
-} from '@wordpress/element';
+import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	Modal,
@@ -153,33 +147,6 @@ export function CommandMenuGroup( { isContextual, search, setLoader, close } ) {
 	);
 }
 
-function CommandInput( { isOpen, search, setSearch } ) {
-	const commandMenuInput = useRef();
-	const _value = useCommandState( ( state ) => state.value );
-	const selectedItemId = useMemo( () => {
-		const item = document.querySelector(
-			`[cmdk-item=""][data-value="${ _value }"]`
-		);
-		return item?.getAttribute( 'id' );
-	}, [ _value ] );
-	useEffect( () => {
-		// Focus the command palette input when mounting the modal.
-		if ( isOpen ) {
-			commandMenuInput.current.focus();
-		}
-	}, [ isOpen ] );
-	return (
-		<Command.Input
-			ref={ commandMenuInput }
-			value={ search }
-			onValueChange={ setSearch }
-			placeholder={ inputLabel }
-			aria-activedescendant={ selectedItemId }
-			icon={ search }
-		/>
-	);
-}
-
 /**
  * @ignore
  */
@@ -192,6 +159,7 @@ export function CommandMenu() {
 	);
 	const { open, close } = useDispatch( commandsStore );
 	const [ loaders, setLoaders ] = useState( {} );
+	const commandMenuInput = useRef();
 
 	useEffect( () => {
 		registerShortcut( {
@@ -239,6 +207,13 @@ export function CommandMenu() {
 		close();
 	};
 
+	useEffect( () => {
+		// Focus the command palette input when mounting the modal.
+		if ( isOpen ) {
+			commandMenuInput.current.focus();
+		}
+	}, [ isOpen ] );
+
 	if ( ! isOpen ) {
 		return false;
 	}
@@ -269,10 +244,11 @@ export function CommandMenu() {
 			<div className="commands-command-menu__container">
 				<Command label={ inputLabel } onKeyDown={ onKeyDown }>
 					<div className="commands-command-menu__header">
-						<CommandInput
-							search={ search }
-							setSearch={ setSearch }
-							isOpen={ isOpen }
+						<Command.Input
+							ref={ commandMenuInput }
+							value={ search }
+							onValueChange={ setSearch }
+							placeholder={ __( 'Type a command or search' ) }
 						/>
 						<Icon icon={ inputIcon } />
 					</div>

--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -248,7 +248,7 @@ export function CommandMenu() {
 							ref={ commandMenuInput }
 							value={ search }
 							onValueChange={ setSearch }
-							placeholder={ __( 'Type a command or search' ) }
+							placeholder={ inputLabel }
 						/>
 						<Icon icon={ inputIcon } />
 					</div>


### PR DESCRIPTION
> [!NOTE]
> To move this PR forward, the upstream `cmdk` library needs to be fixed. See https://github.com/WordPress/gutenberg/pull/70627#issuecomment-3052161740 for more details.


Related to #50846

## What?

Update `cmdk` version from `1.0.0` to `1.1.1` to fix a11y issues.

## Why?

- The `cmdk` version `0.2.0` was missing the `aria-activedescendant` property.
- [#52930](https://github.com/WordPress/gutenberg/pull/52930) was submitted to temporarily resolve this issue.
- After that, [#63465](https://github.com/WordPress/gutenberg/pull/63465) updated the `cmdk` version to `1.0.0`, and this property no longer appears to be rendered correctly.

## How?

Updating cmdk to the latest version and removing the temporary fix code seems to resolve the issue.

## Testing Instructions

### Testing Instructions for Keyboard

- Open a post.
- Launch the command palette.
- Enter some text. Make sure that the `aria-activedescendant` attribute is applied to the input element and list.

## Screenshots or screencast <!-- if applicable -->

The screenshots below use browser developer tools to compare the presence and absence of the `aria-activedescendant` attribute.

|Before|After|
|--------|--------|
| ![before](https://github.com/user-attachments/assets/83c84f3d-1d06-4e6b-8d88-59d616baba57) | ![after](https://github.com/user-attachments/assets/680b425a-4447-4c3d-8185-521a246a23a5) |