### PR TITLE
Video: Fix track editor state saves without explicitly applying the changes

### DIFF
--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -49,6 +49,14 @@ const KIND_OPTIONS = [
 	{ label: __( 'Metadata' ), value: 'metadata' },
 ];
 
+const DEFAULT_TRACK = {
+	src: '',
+	label: '',
+	srcLang: 'en',
+	kind: DEFAULT_KIND,
+	default: false,
+};
+
 function TrackList( { tracks, onEditPress } ) {
 	const content = tracks.map( ( track, index ) => {
 		return (
@@ -93,13 +101,12 @@ function SingleTrackEditor( {
 	onRemove,
 	allowSettingDefault,
 } ) {
-	const {
-		src = '',
-		label = '',
-		srcLang = '',
-		kind = DEFAULT_KIND,
-		default: isDefaultTrack = false,
-	} = track;
+	const [ trackState, setTrackState ] = useState( {
+		...DEFAULT_TRACK,
+		...track,
+	} );
+
+	const { src, label, srcLang, kind, default: isDefaultTrack } = trackState;
 	const fileName = src.startsWith( 'blob:' ) ? '' : getFilename( src ) || '';
 	return (
 		<VStack
@@ -117,10 +124,10 @@ function SingleTrackEditor( {
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom
 					onChange={ ( newLabel ) =>
-						onChange( {
-							...track,
+						setTrackState( ( prevTrackState ) => ( {
+							...prevTrackState,
 							label: newLabel,
-						} )
+						} ) )
 					}
 					label={ __( 'Label' ) }
 					value={ label }
@@ -130,10 +137,10 @@ function SingleTrackEditor( {
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom
 					onChange={ ( newSrcLang ) =>
-						onChange( {
-							...track,
+						setTrackState( ( prevTrackState ) => ( {
+							...prevTrackState,
 							srcLang: newSrcLang,
-						} )
+						} ) )
 					}
 					label={ __( 'Source language' ) }
 					value={ srcLang }
@@ -148,12 +155,12 @@ function SingleTrackEditor( {
 					options={ KIND_OPTIONS }
 					value={ kind }
 					label={ __( 'Kind' ) }
-					onChange={ ( newKind ) => {
-						onChange( {
-							...track,
+					onChange={ ( newKind ) =>
+						setTrackState( ( prevTrackState ) => ( {
+							...prevTrackState,
 							kind: newKind,
-						} );
-					} }
+						} ) )
+					}
 				/>
 				<ToggleControl
 					__next40pxDefaultSize
@@ -161,12 +168,12 @@ function SingleTrackEditor( {
 					label={ __( 'Set as default track' ) }
 					checked={ isDefaultTrack }
 					disabled={ ! allowSettingDefault }
-					onChange={ ( defaultTrack ) => {
-						onChange( {
-							...track,
+					onChange={ ( defaultTrack ) =>
+						setTrackState( ( prevTrackState ) => ( {
+							...prevTrackState,
 							default: defaultTrack,
-						} );
-					} }
+						} ) )
+					}
 				/>
 				<HStack className="block-library-video-tracks-editor__single-track-editor-buttons-container">
 					<Button
@@ -181,26 +188,7 @@ function SingleTrackEditor( {
 						__next40pxDefaultSize
 						variant="primary"
 						onClick={ () => {
-							const changes = {};
-							let hasChanges = false;
-							if ( label === '' ) {
-								changes.label = __( 'English' );
-								hasChanges = true;
-							}
-							if ( srcLang === '' ) {
-								changes.srcLang = 'en';
-								hasChanges = true;
-							}
-							if ( track.kind === undefined ) {
-								changes.kind = DEFAULT_KIND;
-								hasChanges = true;
-							}
-							if ( hasChanges ) {
-								onChange( {
-									...track,
-									...changes,
-								} );
-							}
+							onChange( trackState );
 							onClose();
 						} }
 					>
@@ -230,7 +218,10 @@ export default function TracksEditor( { tracks = [], onChange } ) {
 		}
 
 		const trackIndex = tracks.length;
-		onChange( [ ...tracks, { label: title || '', src: url } ] );
+		onChange( [
+			...tracks,
+			{ ...DEFAULT_TRACK, label: title || '', src: url },
+		] );
 		setTrackBeingEdited( trackIndex );
 	};
 


### PR DESCRIPTION
## What?
Follow-up to https://github.com/WordPress/gutenberg/pull/70227#issuecomment-2915261427

This PR implements an internal editing state for `SingleTrackEditor` and uses the `onChange` to write the state to attributes only when `Apply` is pressed.

## Why?

Previously, for every change in value, the `onChange` would execute, writing the state changes to attributes as they occurred; this rendered the `Apply` button useless.

Removing the `Apply` button itself was previously discussed in the tagged PR, but it was decided to keep it for better Accessibility and UX.

## How?

An internal state is maintained, and the state is synced with attributes when the changes are applied; otherwise, they are discarded.

## Testing Instructions

1. Create a Video block.
2. Attach a Track to it by selecting a subtitle file from the `Media Library`.
3. Fill in the details. Do not click `Apply` and then close the modal.
4. Reopen the single-track editing modal, and confirm that the states are reverted.

### Testing Instructions for Keyboard
Same.

## Screencast

https://github.com/user-attachments/assets/2efa2827-cb50-4147-b22e-24dcbd4e5c6c