### PR TITLE
Fix focus visibility for video elements in Cover block on Firefox

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -178,6 +178,11 @@
 		border: none;
 		box-shadow: none;
 	}
+
+	video.wp-block-cover__video-background:focus {
+		outline: 2px solid currentColor;
+		outline-offset: -2px;
+	}
 }
 
 .wp-block-cover-image,


### PR DESCRIPTION
## What?
Closes #41989 

Restores visible focus outlines for `<video>` elements used as background in the Cover block when viewed in Firefox.

## Why?
Firefox includes `<video>` elements in the tab focus order even when controls are not visible. However, the Cover block previously removed outlines from these elements, making it unclear when they are focused during keyboard navigation. This created an accessibility issue for keyboard users in Firefox.

This PR ensures a visible focus style is applied, improving accessibility and aligning behavior with other browsers.

## How?
A new CSS rule is added to `video.wp-block-cover__video-background:focus` that:
- Restores the focus outline using `outline: 2px solid currentColor`
- Uses `outline-offset: -2px` to keep the outline from being clipped or hidden

This fix only affects focused video elements and does not interfere with visual layout or behavior in other browsers.

## Testing Instructions
1. Open a published page or post with a Cover block using a video background.
2. Use Firefox to visit the page.
3. Press `Tab` repeatedly to move through focusable elements.
4. When the video receives focus, a visible outline should now appear around it.

### Testing Instructions for Keyboard
1. Use Firefox on desktop.
2. Navigate to the page with the Cover block containing a video background.
3. Use `Tab` key to navigate from one focusable element to the next.
4. Confirm that when the video receives focus, an outline is visible (where it was previously missing).

## Screenshots or screencast 
### Chrome Browser

> **Note:** In Chrome, the `<video>` element is not included in the tab focus order unless controls are enabled.  
> Therefore, the before and after visuals remain unchanged.

#### Before Patch
https://github.com/user-attachments/assets/7b2cdb4f-ae19-4e14-b649-7e7226ab283b 

#### After Patch
https://github.com/user-attachments/assets/8bb306ec-b200-413b-b04d-969bd9d3e150

#### Mozilla Firefox Browser
#### Before Patch
https://github.com/user-attachments/assets/721114e5-7a48-465c-bbde-fba0637c15dc

#### After Patch
https://github.com/user-attachments/assets/a7d12ded-159e-4bdb-abf0-907765c3c6cb


