### PR TITLE
Post Navigation Link: Add toggle to hide label text when arrow or chevron is selected

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -650,7 +650,7 @@ Displays the next or previous post link that is adjacent to the current post. ([
 -	**Name:** core/post-navigation-link
 -	**Category:** theme
 -	**Supports:** color (background, link, text), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** arrow, label, linkLabel, showTitle, taxonomy, textAlign, type
+-	**Attributes:** arrow, label, linkLabel, showLabel, showTitle, taxonomy, textAlign, type
 
 ## Post Template
 

--- a/packages/block-library/src/post-navigation-link/block.json
+++ b/packages/block-library/src/post-navigation-link/block.json
@@ -30,6 +30,10 @@
 			"type": "string",
 			"default": "none"
 		},
+		"showLabel": {
+			"type": "boolean",
+			"default": true
+		},
 		"taxonomy": {
 			"type": "string",
 			"default": ""

--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -207,7 +207,7 @@ export default function PostNavigationLinkEdit( {
 							/>
 						</ToggleGroupControl>
 					</ToolsPanelItem>
-					{ arrow !== 'none' && (
+					{ arrow !== 'none' && ! showTitle && (
 						<ToolsPanelItem
 							hasValue={ () => ! showLabel }
 							label={ __( 'Show label' ) }
@@ -220,7 +220,7 @@ export default function PostNavigationLinkEdit( {
 								__nextHasNoMarginBottom
 								label={ __( 'Show label text' ) }
 								help={ __(
-									'Make label text visible, e.g. "Next".'
+									'Make Next/Previous label text visible'
 								) }
 								onChange={ ( value ) => {
 									setAttributes( { showLabel: value } );
@@ -271,7 +271,7 @@ export default function PostNavigationLinkEdit( {
 						{ displayArrow }
 					</span>
 				) }
-				{ showLabel && (
+				{ ( ! displayArrow || showLabel ) && (
 					<RichText
 						tagName="a"
 						identifier="label"

--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -262,16 +262,16 @@ export default function PostNavigationLinkEdit( {
 				{ ! isNext && displayArrow && (
 					<span
 						className={ `wp-block-post-navigation-link__arrow-previous is-arrow-${ arrow } ${
-							! showLabel ? 'no-label' : ''
+							! showLabel && ! showTitle ? 'no-label' : ''
 						}` }
-						{ ...( ! showLabel
+						{ ...( ! showLabel && ! showTitle
 							? { 'aria-label': ariaLabel }
 							: { 'aria-hidden': true } ) }
 					>
 						{ displayArrow }
 					</span>
 				) }
-				{ ( ! displayArrow || showLabel ) && (
+				{ ( ! displayArrow || showLabel || showTitle ) && (
 					<RichText
 						tagName="a"
 						identifier="label"
@@ -295,9 +295,9 @@ export default function PostNavigationLinkEdit( {
 				{ isNext && displayArrow && (
 					<span
 						className={ `wp-block-post-navigation-link__arrow-next is-arrow-${ arrow } ${
-							! showLabel ? 'no-label' : ''
+							! showLabel && ! showTitle ? 'no-label' : ''
 						}` }
-						{ ...( ! showLabel
+						{ ...( ! showLabel && ! showTitle
 							? { 'aria-label': ariaLabel }
 							: { 'aria-hidden': true } ) }
 					>

--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -40,6 +40,7 @@ export default function PostNavigationLinkEdit( {
 		textAlign,
 		linkLabel,
 		arrow,
+		showLabel,
 		taxonomy,
 	},
 	setAttributes,
@@ -109,6 +110,7 @@ export default function PostNavigationLinkEdit( {
 					label={ __( 'Settings' ) }
 					resetAll={ () => {
 						setAttributes( {
+							showLabel: true,
 							showTitle: false,
 							linkLabel: false,
 							arrow: 'none',
@@ -205,6 +207,28 @@ export default function PostNavigationLinkEdit( {
 							/>
 						</ToggleGroupControl>
 					</ToolsPanelItem>
+					{ arrow !== 'none' && (
+						<ToolsPanelItem
+							hasValue={ () => ! showLabel }
+							label={ __( 'Show label' ) }
+							onDeselect={ () =>
+								setAttributes( { showLabel: true } )
+							}
+							isShownByDefault
+						>
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={ __( 'Show label text' ) }
+								help={ __(
+									'Make label text visible, e.g. "Next".'
+								) }
+								onChange={ ( value ) => {
+									setAttributes( { showLabel: value } );
+								} }
+								checked={ showLabel === true }
+							/>
+						</ToolsPanelItem>
+					) }
 				</ToolsPanel>
 			</InspectorControls>
 			<InspectorControls group="advanced">
@@ -237,22 +261,29 @@ export default function PostNavigationLinkEdit( {
 			<div { ...blockProps }>
 				{ ! isNext && displayArrow && (
 					<span
-						className={ `wp-block-post-navigation-link__arrow-previous is-arrow-${ arrow }` }
+						className={ `wp-block-post-navigation-link__arrow-previous is-arrow-${ arrow } ${
+							! showLabel ? 'no-label' : ''
+						}` }
+						{ ...( ! showLabel
+							? { 'aria-label': ariaLabel }
+							: { 'aria-hidden': true } ) }
 					>
 						{ displayArrow }
 					</span>
 				) }
-				<RichText
-					tagName="a"
-					identifier="label"
-					aria-label={ ariaLabel }
-					placeholder={ placeholder }
-					value={ label }
-					withoutInteractiveFormatting
-					onChange={ ( newLabel ) =>
-						setAttributes( { label: newLabel } )
-					}
-				/>
+				{ showLabel && (
+					<RichText
+						tagName="a"
+						identifier="label"
+						aria-label={ ariaLabel }
+						placeholder={ placeholder }
+						value={ label }
+						withoutInteractiveFormatting
+						onChange={ ( newLabel ) =>
+							setAttributes( { label: newLabel } )
+						}
+					/>
+				) }
 				{ showTitle && (
 					<a
 						href="#post-navigation-pseudo-link"
@@ -263,8 +294,12 @@ export default function PostNavigationLinkEdit( {
 				) }
 				{ isNext && displayArrow && (
 					<span
-						className={ `wp-block-post-navigation-link__arrow-next is-arrow-${ arrow }` }
-						aria-hidden
+						className={ `wp-block-post-navigation-link__arrow-next is-arrow-${ arrow } ${
+							! showLabel ? 'no-label' : ''
+						}` }
+						{ ...( ! showLabel
+							? { 'aria-label': ariaLabel }
+							: { 'aria-hidden': true } ) }
 					>
 						{ displayArrow }
 					</span>

--- a/packages/block-library/src/post-navigation-link/index.php
+++ b/packages/block-library/src/post-navigation-link/index.php
@@ -37,8 +37,14 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 	);
 	// Set default values.
 	$format = '%link';
-	$link   = 'next' === $navigation_type ? _x( 'Next', 'label for next post link' ) : _x( 'Previous', 'label for previous post link' );
+	$link   = '';
 	$label  = '';
+
+	$show_label = ! isset( $attributes['showLabel'] ) || $attributes['showLabel'];
+
+	if ( $show_label ) {
+		$link = 'next' === $navigation_type ? _x( 'Next', 'label for next post link' ) : _x( 'Previous', 'label for previous post link' );
+	}
 
 	// Only use hardcoded values here, otherwise we need to add escaping where these values are used.
 	$arrow_map = array(
@@ -90,14 +96,31 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 		}
 	}
 
+
 	// Display arrows.
 	if ( isset( $attributes['arrow'] ) && 'none' !== $attributes['arrow'] && isset( $arrow_map[ $attributes['arrow'] ] ) ) {
 		$arrow = $arrow_map[ $attributes['arrow'] ][ $navigation_type ];
 
-		if ( 'next' === $navigation_type ) {
-			$format = '%link<span class="wp-block-post-navigation-link__arrow-next is-arrow-' . $attributes['arrow'] . '" aria-hidden="true">' . $arrow . '</span>';
+		if ( $show_label ) {
+			if ( 'next' === $navigation_type ) {
+				$format = '%link<span class="wp-block-post-navigation-link__arrow-next is-arrow-' . $attributes['arrow'] . '" aria-hidden="true">' . $arrow . '</span>';
+			} else {
+				$format = '<span class="wp-block-post-navigation-link__arrow-previous is-arrow-' . $attributes['arrow'] . '" aria-hidden="true">' . $arrow . '</span>%link';
+			}
 		} else {
-			$format = '<span class="wp-block-post-navigation-link__arrow-previous is-arrow-' . $attributes['arrow'] . '" aria-hidden="true">' . $arrow . '</span>%link';
+			$aria_label = 'next' === $navigation_type
+				? _x( 'Next Post', 'aria label for next post link' )
+				: _x( 'Previous Post', 'aria label for previous post link' );
+
+			$format = '%link';
+			$link = sprintf(
+				'<span class="wp-block-post-navigation-link__arrow-%1$s is-arrow-%2$s no-label" aria-label="%3$s">%4$s</span>',
+				esc_attr( $navigation_type ),
+				esc_attr( $attributes['arrow'] ),
+				esc_attr( $aria_label ),
+				$arrow
+			);
+
 		}
 	}
 

--- a/packages/block-library/src/post-navigation-link/index.php
+++ b/packages/block-library/src/post-navigation-link/index.php
@@ -40,7 +40,7 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 	$link   = '';
 	$label  = '';
 
-	$show_label = ! isset( $attributes['showLabel'] ) || $attributes['showLabel'];
+	$show_label = ! isset( $attributes['showLabel'] ) || $attributes['showLabel'] || 'none' === $attributes['arrow'];
 
 	if ( $show_label ) {
 		$link = 'next' === $navigation_type ? _x( 'Next', 'label for next post link' ) : _x( 'Previous', 'label for previous post link' );

--- a/packages/block-library/src/post-navigation-link/index.php
+++ b/packages/block-library/src/post-navigation-link/index.php
@@ -96,7 +96,6 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 		}
 	}
 
-
 	// Display arrows.
 	if ( isset( $attributes['arrow'] ) && 'none' !== $attributes['arrow'] && isset( $arrow_map[ $attributes['arrow'] ] ) ) {
 		$arrow = $arrow_map[ $attributes['arrow'] ][ $navigation_type ];
@@ -113,7 +112,7 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 				: _x( 'Previous Post', 'aria label for previous post link' );
 
 			$format = '%link';
-			$link = sprintf(
+			$link   = sprintf(
 				'<span class="wp-block-post-navigation-link__arrow-%1$s is-arrow-%2$s no-label" aria-label="%3$s">%4$s</span>',
 				esc_attr( $navigation_type ),
 				esc_attr( $attributes['arrow'] ),

--- a/packages/block-library/src/post-navigation-link/index.php
+++ b/packages/block-library/src/post-navigation-link/index.php
@@ -40,7 +40,7 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 	$link   = '';
 	$label  = '';
 
-	$show_label = ! isset( $attributes['showLabel'] ) || $attributes['showLabel'] || 'none' === $attributes['arrow'];
+	$show_label = ! isset( $attributes['showLabel'] ) || $attributes['showLabel'] || 'none' === $attributes['arrow'] || $attributes['showTitle'];
 
 	if ( $show_label ) {
 		$link = 'next' === $navigation_type ? _x( 'Next', 'label for next post link' ) : _x( 'Previous', 'label for previous post link' );

--- a/packages/block-library/src/post-navigation-link/style.scss
+++ b/packages/block-library/src/post-navigation-link/style.scss
@@ -20,6 +20,11 @@
 		}
 	}
 
+	.wp-block-post-navigation-link__arrow-previous.no-label,
+	.wp-block-post-navigation-link__arrow-next.no-label {
+		margin: 0;
+	}
+
 	&.has-text-align-right[style*="writing-mode: vertical-rl"],
 	&.has-text-align-left[style*="writing-mode: vertical-lr"] {
 		rotate: 180deg;

--- a/test/integration/fixtures/blocks/core__post-navigation-link.json
+++ b/test/integration/fixtures/blocks/core__post-navigation-link.json
@@ -7,6 +7,7 @@
 			"showTitle": false,
 			"linkLabel": false,
 			"arrow": "none",
+			"showLabel": true,
 			"taxonomy": ""
 		},
 		"innerBlocks": []


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #57433 

<!-- In a few words, what is the PR actually doing? -->
This PR adds a `showLabel` toggle option to the Post Navigation Link block, allowing users to hide the text label (Next/Previous) when an arrow or chevron is selected. This mirrors the behavior of the Query Pagination block, providing consistent design flexibility.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, the Query Pagination block allows users to hide the label when using arrows or chevrons — creating a minimalist design with arrow-only navigation. However, the Post Navigation Link block does not support this. This change closes that gap and ensures both blocks offer the same level of control

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Adds `showLabel` block attribute.
- Updates editor UI to conditionally show the toggle when arrow/chevron is selected.
- Adjusts frontend and editor output to render arrow only markup.
- Shows controls only when `showTitle` toggle isn't selected

## Testing Instructions
1. Add a Post Navigation Link block in the editor.
2. Select an arrow or chevron from the block settings.
3. Toggle off "Show label text" (only the arrow should remain)
4. Toggle it back on (the label should return)
5. Confirm the frontend matches editor output

<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/71b87645-80c6-46dd-a97d-c954e73b6b40

