### PR TITLE
DataViews can render custom empty states with an `empty` prop

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Allow readonly fields in DataForm when `readOnly` is set to `true`.
 - Adjust the padding when the component is placed inside a `Card`.
 - Introduce `perPageSizes` to control the available sizes of the items per page
+- Add an `empty` prop to `DataViews` to support rendering custom empty states.
 
 ### Breaking Changes
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -410,9 +410,13 @@ The component receives the following props:
 />
 ```
 
+#### `empty`: React component
+
+React element to be rendered in place of the data view's default empty state.
+
 #### `header`: React component
 
-React component to be rendered next to the view config button.
+React element to be rendered next to the view config button.
 
 #### `perPageSizes`: `[ number, number, number, number ]`
 

--- a/packages/dataviews/src/components/dataviews-layout/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layout/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { ComponentType } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 
 /**
  * WordPress dependencies
@@ -17,9 +17,13 @@ import type { ViewBaseProps } from '../../types';
 
 type DataViewsLayoutProps = {
 	className?: string;
+	empty?: ReactNode;
 };
 
-export default function DataViewsLayout( { className }: DataViewsLayoutProps ) {
+export default function DataViewsLayout( {
+	className,
+	empty,
+}: DataViewsLayoutProps ) {
 	const {
 		actions = [],
 		data,
@@ -43,6 +47,7 @@ export default function DataViewsLayout( { className }: DataViewsLayoutProps ) {
 	return (
 		<ViewComponent
 			className={ className }
+			empty={ empty }
 			actions={ actions }
 			data={ data }
 			fields={ fields }

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -56,6 +56,7 @@ type DataViewsProps< Item > = {
 		} & ComponentProps< 'a' >
 	) => ReactElement;
 	isItemClickable?: ( item: Item ) => boolean;
+	empty?: ReactNode;
 	header?: ReactNode;
 	getItemLevel?: ( item: Item ) => number;
 	children?: ReactNode;
@@ -70,10 +71,11 @@ const EMPTY_ARRAY: any[] = [];
 
 type DefaultUIProps = Pick<
 	DataViewsProps< any >,
-	'header' | 'search' | 'searchLabel'
+	'empty' | 'header' | 'search' | 'searchLabel'
 >;
 
 function DefaultUI( {
+	empty,
 	header,
 	search = true,
 	searchLabel = undefined,
@@ -107,7 +109,7 @@ function DefaultUI( {
 			{ isShowingFilter && (
 				<DataViewsFilters className="dataviews-filters__container" />
 			) }
-			<DataViewsLayout />
+			<DataViewsLayout empty={ empty } />
 			<DataViewsFooter />
 		</>
 	);
@@ -131,6 +133,7 @@ function DataViews< Item >( {
 	onClickItem,
 	renderItemLink,
 	isItemClickable = defaultIsItemClickable,
+	empty,
 	header,
 	children,
 	perPageSizes,
@@ -206,6 +209,7 @@ function DataViews< Item >( {
 			>
 				{ children ?? (
 					<DefaultUI
+						empty={ empty }
 						header={ header }
 						search={ search }
 						searchLabel={ searchLabel }

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -326,3 +326,23 @@ export const CustomPerPageSizes = () => {
 		/>
 	);
 };
+
+export const CustomEmptyState = () => {
+	const [ view, setView ] = useState< View >( {
+		...DEFAULT_VIEW,
+		fields: [ 'title', 'description', 'categories' ],
+	} );
+	return (
+		<DataViews
+			getItemId={ ( item ) => item.id.toString() }
+			paginationInfo={ { totalItems: 0, totalPages: 0 } }
+			data={ [] }
+			view={ view }
+			fields={ fields }
+			onChangeView={ setView }
+			actions={ actions }
+			defaultLayouts={ defaultLayouts }
+			empty={ <p>Nothing found, add some data to your dataview.</p> }
+		/>
+	);
+};

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -254,6 +254,7 @@ function ViewGrid< Item >( {
 	selection,
 	view,
 	className,
+	empty,
 }: ViewGridProps< Item > ) {
 	const titleField = fields.find(
 		( field ) => field.id === view?.titleField
@@ -335,7 +336,13 @@ function ViewGrid< Item >( {
 						'dataviews-no-results': ! isLoading,
 					} ) }
 				>
-					<p>{ isLoading ? <Spinner /> : __( 'No results' ) }</p>
+					{ isLoading ? (
+						<p>
+							<Spinner />
+						</p>
+					) : (
+						empty || <p>{ __( 'No results' ) }</p>
+					) }
 				</div>
 			) }
 		</>

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -354,6 +354,7 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 		selection,
 		view,
 		className,
+		empty,
 	} = props;
 	const baseId = useInstanceId( ViewList, 'view-list' );
 
@@ -487,8 +488,12 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 					'dataviews-no-results': ! hasData && ! isLoading,
 				} ) }
 			>
-				{ ! hasData && (
-					<p>{ isLoading ? <Spinner /> : __( 'No results' ) }</p>
+				{ isLoading ? (
+					<p>
+						<Spinner />
+					</p>
+				) : (
+					empty || <p>{ __( 'No results' ) }</p>
 				) }
 			</div>
 		);

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -256,6 +256,7 @@ function ViewTable< Item >( {
 	renderItemLink,
 	view,
 	className,
+	empty,
 }: ViewTableProps< Item > ) {
 	const { containerRef } = useContext( DataViewsContext );
 	const headerMenuRefs = useRef<
@@ -463,9 +464,14 @@ function ViewTable< Item >( {
 				} ) }
 				id={ tableNoticeId }
 			>
-				{ ! hasData && (
-					<p>{ isLoading ? <Spinner /> : __( 'No results' ) }</p>
-				) }
+				{ ! hasData &&
+					( isLoading ? (
+						<p>
+							<Spinner />
+						</p>
+					) : (
+						empty || <p>{ __( 'No results' ) }</p>
+					) ) }
 			</div>
 		</>
 	);

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import type { ReactElement, ComponentType, ComponentProps } from 'react';
+import type {
+	ReactElement,
+	ReactNode,
+	ComponentType,
+	ComponentProps,
+} from 'react';
 
 /**
  * Internal dependencies
@@ -592,6 +597,7 @@ export type Action< Item > = ActionModal< Item > | ActionButton< Item >;
 
 export interface ViewBaseProps< Item > {
 	className?: string;
+	empty?: ReactNode;
 	actions: Action< Item >[];
 	data: Item[];
 	fields: NormalizedField< Item >[];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Related to #61442

Adds an `empty` prop to the `DataViews` component. It allows data views to render a custom empty state.

This doesn't fully resolve #61442 because IMO that issue is proposing changes to the design system. This PR is a way of facilitating that, but it doesn't actually do the work of designing a new empty state.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As is noted in #61442, sometimes it is useful to have more context in the empty state. [Here is an example from outside of Gutenberg which is using `<DataViews>` as a component](https://github.com/WordPress/gutenberg/issues/61442#issuecomment-2139395539). In general, providing buttons with "next steps" would be useful. However

1. we have not settled on a standard design for this, and
2. we need the ability to pass in context.

By allowing the user of `<DataViews>` to provide an arbitrary empty state they can use as much context as they like when creating their element. They can also have whatever logic they want to determine whether the view empty because their is no data, or empty because of the filtering.

It also doesn't rule out using a standard design in the future. If we settle on a design then the `empty` prop would be used like `empty={ <DataViews.EmptyState { ... } /> }`

An alternative for package users would be to use the `<DataView>` in "free composition" mode—replacing the inner parts of the data view when there is no data there.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR allows the user of a `<DataViews>` to pass in an arbitrary custom empty state.

I considered using a slot for providing the empty state, but the idea here is that the empty state would be customised on a per-dataview basis. This isn't a way to allow plugins to modify every dataview's empty state. It also matches how the `header` prop works, which also doesn't use a slot.

I didn't add the `empty` prop to the `DataViewsContext` because it doesn't feel like it needs to be drilled down that far. The leaf-most components aren't going to need access to it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

In storybook
- Open the `DataViews > Empty` story
  - There are no changes, it works as before
- Open the `DataViews > Custom Empty State` story
  - See the custom copy

In the site editor
- Open up your dev Gutenberg environment
- Add a custom empty message to the post list in the site editor: https://github.com/WordPress/gutenberg/blob/7db8f3805f01f36a5952465048529a5dc8dd12e2/packages/edit-site/src/components/post-list/index.js#L412
- In the site editor search for a non-existent page and see your custom message

<img width="1556" height="1182" alt="CleanShot 2025-07-11 at 17 17 43@2x" src="https://github.com/user-attachments/assets/a1a931c7-5a73-43f9-b9ef-1956aff23495" />


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

No changes to the UI, however custom empty states will need to be accessible.
