### PR TITLE
Documentation: Add `isPostAutosavingLocked` example to doc block 

### DIFF
--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -1006,6 +1006,27 @@ _Returns_
 
 Returns whether post autosaving is locked.
 
+_Usage_
+
+```jsx
+import { __ } from '@wordpress/i18n';
+import { store as editorStore } from '@wordpress/editor';
+import { useSelect } from '@wordpress/data';
+
+const ExampleComponent = () => {
+	const isAutoSavingLocked = useSelect(
+		( select ) => select( editorStore ).isPostAutosavingLocked(),
+		[]
+	);
+
+	return isAutoSavingLocked ? (
+		<p>{ __( 'Post auto saving is locked' ) }</p>
+	) : (
+		<p>{ __( 'Post auto saving is not locked' ) }</p>
+	);
+};
+```
+
 _Parameters_
 
 -   _state_ `Object`: Global application state.

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1084,6 +1084,26 @@ export function isPostSavingLocked( state ) {
  *
  * @param {Object} state Global application state.
  *
+ * @example
+ * ```jsx
+ * import { __ } from '@wordpress/i18n';
+ * import { store as editorStore } from '@wordpress/editor';
+ * import { useSelect } from '@wordpress/data';
+ *
+ * const ExampleComponent = () => {
+ * 	const isAutoSavingLocked = useSelect(
+ * 		( select ) => select( editorStore ).isPostAutosavingLocked(),
+ * 		[]
+ * 	);
+ *
+ * 	return isAutoSavingLocked ? (
+ * 		<p>{ __( 'Post auto saving is locked' ) }</p>
+ * 	) : (
+ * 		<p>{ __( 'Post auto saving is not locked' ) }</p>
+ * 	);
+ * };
+ * ```
+ *
  * @return {boolean} Is locked.
  */
 export function isPostAutosavingLocked( state ) {


### PR DESCRIPTION
## What?
Related to: https://github.com/WordPress/gutenberg/issues/42125
PR: https://github.com/WordPress/gutenberg/pull/16249

This PR adds a JSDoc @example comment to the `isPostAutosavingLocked` selector.

## Why?
The `isPostAutosavingLocked` API was introduced in PR #16249, and this selector was missing its example documentation.

## How?
Added a JSDoc @example block to the `isPostAutosavingLocked` selector that demonstrates:
- How to use the selector with the `useSelect` hook in a React component
- An example showing conditional rendering based on the selector's return value