### PR TITLE
Media Utils: Add support for passing an `onSuccess` callback within `uploadMedia`

### DIFF
--- a/packages/media-utils/README.md
+++ b/packages/media-utils/README.md
@@ -54,6 +54,7 @@ _Parameters_
 -   _$0.maxUploadFileSize_ `UploadMediaArgs[ 'maxUploadFileSize' ]`: Maximum upload size in bytes allowed for the site.
 -   _$0.onError_ `UploadMediaArgs[ 'onError' ]`: Function called when an error happens.
 -   _$0.onFileChange_ `UploadMediaArgs[ 'onFileChange' ]`: Function called each time a file or a temporary representation of the file is available.
+-   _$0.onSuccess_ `UploadMediaArgs[ 'onSuccess' ]`: Function called after the final representation of the file is available.
 -   _$0.wpAllowedMimeTypes_ `UploadMediaArgs[ 'wpAllowedMimeTypes' ]`: List of allowed mime types and file extensions.
 -   _$0.signal_ `UploadMediaArgs[ 'signal' ]`: Abort signal.
 -   _$0.multiple_ `UploadMediaArgs[ 'multiple' ]`: Whether to allow multiple files to be uploaded.

--- a/packages/media-utils/src/utils/types.ts
+++ b/packages/media-utils/src/utils/types.ts
@@ -199,6 +199,7 @@ export type Attachment = BetterOmit<
 };
 
 export type OnChangeHandler = ( attachments: Partial< Attachment >[] ) => void;
+export type OnSuccessHandler = ( attachments: Partial< Attachment >[] ) => void;
 export type OnErrorHandler = ( error: Error ) => void;
 
 export type CreateRestAttachment = Partial< RestAttachment >;

--- a/packages/media-utils/src/utils/upload-media.ts
+++ b/packages/media-utils/src/utils/upload-media.ts
@@ -12,6 +12,7 @@ import type {
 	Attachment,
 	OnChangeHandler,
 	OnErrorHandler,
+	OnSuccessHandler,
 } from './types';
 import { uploadToServer } from './upload-to-server';
 import { validateMimeType } from './validate-mime-type';
@@ -38,6 +39,8 @@ interface UploadMediaArgs {
 	onError?: OnErrorHandler;
 	// Function called each time a file or a temporary representation of the file is available.
 	onFileChange?: OnChangeHandler;
+	// Function called after the final representation of the file is available.
+	onSuccess?: OnSuccessHandler;
 	// List of allowed mime types and file extensions.
 	wpAllowedMimeTypes?: Record< string, string > | null;
 	// Abort signal.
@@ -57,6 +60,7 @@ interface UploadMediaArgs {
  * @param $0.maxUploadFileSize  Maximum upload size in bytes allowed for the site.
  * @param $0.onError            Function called when an error happens.
  * @param $0.onFileChange       Function called each time a file or a temporary representation of the file is available.
+ * @param $0.onSuccess          Function called after the final representation of the file is available.
  * @param $0.wpAllowedMimeTypes List of allowed mime types and file extensions.
  * @param $0.signal             Abort signal.
  * @param $0.multiple           Whether to allow multiple files to be uploaded.
@@ -69,6 +73,7 @@ export function uploadMedia( {
 	maxUploadFileSize,
 	onError,
 	onFileChange,
+	onSuccess,
 	signal,
 	multiple = true,
 }: UploadMediaArgs ) {
@@ -131,45 +136,60 @@ export function uploadMedia( {
 		}
 	}
 
-	validFiles.map( async ( file, index ) => {
-		try {
-			const attachment = await uploadToServer(
-				file,
-				additionalData,
-				signal
-			);
-			setAndUpdateFiles( index, attachment );
-		} catch ( error ) {
-			// Reset to empty on failure.
-			setAndUpdateFiles( index, null );
-
-			// @wordpress/api-fetch throws any response that isn't in the 200 range as-is.
-			let message: string;
-			if (
-				typeof error === 'object' &&
-				error !== null &&
-				'message' in error
-			) {
-				message =
-					typeof error.message === 'string'
-						? error.message
-						: String( error.message );
-			} else {
-				message = sprintf(
-					// translators: %s: file name
-					__( 'Error while uploading file %s to the media library.' ),
-					file.name
-				);
-			}
-
-			onError?.(
-				new UploadError( {
-					code: 'GENERAL',
-					message,
+	Promise.all(
+		validFiles.map( async ( file, index ) => {
+			try {
+				const attachment = await uploadToServer(
 					file,
-					cause: error instanceof Error ? error : undefined,
-				} )
-			);
+					additionalData,
+					signal
+				);
+				setAndUpdateFiles( index, attachment );
+				return attachment;
+			} catch ( error ) {
+				// Reset to empty on failure.
+				setAndUpdateFiles( index, null );
+
+				// @wordpress/api-fetch throws any response that isn't in the 200 range as-is.
+				let message: string;
+				if (
+					typeof error === 'object' &&
+					error !== null &&
+					'message' in error
+				) {
+					message =
+						typeof error.message === 'string'
+							? error.message
+							: String( error.message );
+				} else {
+					message = sprintf(
+						// translators: %s: file name
+						__(
+							'Error while uploading file %s to the media library.'
+						),
+						file.name
+					);
+				}
+
+				onError?.(
+					new UploadError( {
+						code: 'GENERAL',
+						message,
+						file,
+						cause: error instanceof Error ? error : undefined,
+					} )
+				);
+
+				return null;
+			}
+		} )
+	).then( ( results ) => {
+		const attachments = results.filter(
+			( attachment ) => attachment !== null
+		);
+
+		if ( attachments.length > 0 ) {
+			onSuccess?.( attachments );
 		}
 	} );
 }


### PR DESCRIPTION
## What?
Closes #70639 

This PR introduces support for an `onSuccess` callback in the `uploadMedia` function. The callback is intended to execute after the upload process completes successfully and all related promises are resolved, allowing for post-upload handling or additional operations.

## Why?

- This enables execution of custom logic after the upload process completes successfully, with the callback receiving the full file context for further handling.
- `onSuccess` is already being passed by `mediaUpload`, which is a wrapper over `uploadMedia`.
Ref.
https://github.com/WordPress/gutenberg/blob/7a4876482f8a64cc7baa684d49757a036732ce82/packages/editor/src/utils/media-upload/index.js#L77

## How?

By simply wrapping the upload calls within a `Promise.all` and executing `onSuccess` post resolution.

## Testing Instructions

N/A

### Testing Instructions for Keyboard

N/A
