### PR TITLE
Block Bindings: Add support to image caption attribute in block bindings

### DIFF
--- a/lib/compat/wordpress-6.9/blocks.php
+++ b/lib/compat/wordpress-6.9/blocks.php
@@ -139,31 +139,33 @@ function gutenberg_process_image_caption_binding( $block_content, $parsed_block,
 			$processor->maybe_remove_figcaption();
 			return $processor->get_updated_html();
 		}
-	}
+	} else {
+		$caption_binding = $parsed_block['attrs']['metadata']['bindings']['caption'];
 
-	$caption_binding = $parsed_block['attrs']['metadata']['bindings']['caption'];
+		$caption_binding_source = get_block_bindings_source( $caption_binding['source'] );
+		$source_args            = ! empty( $caption_binding['args'] ) && is_array( $caption_binding['args'] ) ? $caption_binding['args'] : array();
+		$source_value           = $caption_binding_source->get_value( $source_args, $block_instance, 'caption' );
 
-	$caption_binding_source = get_block_bindings_source( $caption_binding['source'] );
-	$source_args            = ! empty( $caption_binding['args'] ) && is_array( $caption_binding['args'] ) ? $caption_binding['args'] : array();
-	$source_value           = $caption_binding_source->get_value( $source_args, $block_instance, 'caption' );
-
-	if ( is_null( $source_value ) ) {
-		return $block_content;
-	}
-
-	$processor = new $block_reader( $block_content );
-
-	if ( $processor->next_tag( 'FIGCAPTION' ) ) {
-		$maybe_remove = $processor->get_attribute( 'data-wp-maybe-remove' );
-
-		if ( 'true' === $maybe_remove ) {
-			$processor->maybe_remove_figcaption();
-		} else {
-			$processor->set_figcaption_content( wp_kses_post( $source_value ) );
+		if ( is_null( $source_value ) ) {
+			return $block_content;
 		}
+
+		$processor = new $block_reader( $block_content );
+
+		if ( $processor->next_tag( 'FIGCAPTION' ) ) {
+			$maybe_remove = $processor->get_attribute( 'data-wp-maybe-remove' );
+
+			if ( 'true' === $maybe_remove ) {
+				$processor->maybe_remove_figcaption();
+			} else {
+				$processor->set_figcaption_content( wp_kses_post( $source_value ) );
+			}
+		}
+
+		return $processor->get_updated_html();
 	}
 
-	return $processor->get_updated_html();
+
 }
 
 add_filter( 'render_block_core/image', 'gutenberg_process_image_caption_binding', 20, 3 );

--- a/lib/compat/wordpress-6.9/blocks.php
+++ b/lib/compat/wordpress-6.9/blocks.php
@@ -56,7 +56,7 @@ function gutenberg_process_image_caption_binding( $block_content, $parsed_block,
 	}
 
 	$block_reader = new class($block_content) extends WP_HTML_Tag_Processor {
-		public function set_figcaption_content( $new_content ) {
+		public function gutenberg_do_not_copy_set_figcaption_content( $new_content ) {
 			if ( $this->is_tag_closer() || 'FIGCAPTION' !== $this->get_tag() ) {
 				return false;
 			}
@@ -72,11 +72,11 @@ function gutenberg_process_image_caption_binding( $block_content, $parsed_block,
 			$this->set_bookmark( 'closer_tag' );
 			$opener_tag_bookmark = $this->bookmarks['opener_tag'];
 			$closer_tag_bookmark = $this->bookmarks['closer_tag'];
-			$after_opener_tag = $opener_tag_bookmark->start + $opener_tag_bookmark->length;
+			$after_opener_tag    = $opener_tag_bookmark->start + $opener_tag_bookmark->length;
 			if ( '>' === $this->html[ $after_opener_tag ] ) {
 				++$after_opener_tag;
 			}
-			$inner_content_length = $closer_tag_bookmark->start - $after_opener_tag;
+			$inner_content_length    = $closer_tag_bookmark->start - $after_opener_tag;
 			$this->lexical_updates[] = new WP_HTML_Text_Replacement(
 				$after_opener_tag,
 				$inner_content_length,
@@ -84,7 +84,7 @@ function gutenberg_process_image_caption_binding( $block_content, $parsed_block,
 			);
 			return true;
 		}
-		public function maybe_remove_figcaption() {
+		public function gutenberg_do_not_copy_maybe_remove_figcaption() {
 			if ( $this->is_tag_closer() || 'FIGCAPTION' !== $this->get_tag() ) {
 				return false;
 			}
@@ -98,9 +98,9 @@ function gutenberg_process_image_caption_binding( $block_content, $parsed_block,
 				return false;
 			}
 			$this->set_bookmark( 'closer_tag' );
-			$opener_tag_bookmark = $this->bookmarks['opener_tag'];
-			$closer_tag_bookmark = $this->bookmarks['closer_tag'];
-			$total_element_length = $closer_tag_bookmark->start + $closer_tag_bookmark->length - $opener_tag_bookmark->start;
+			$opener_tag_bookmark     = $this->bookmarks['opener_tag'];
+			$closer_tag_bookmark     = $this->bookmarks['closer_tag'];
+			$total_element_length    = $closer_tag_bookmark->start + $closer_tag_bookmark->length - $opener_tag_bookmark->start;
 			$this->lexical_updates[] = new WP_HTML_Text_Replacement(
 				$opener_tag_bookmark->start,
 				$total_element_length,
@@ -109,28 +109,28 @@ function gutenberg_process_image_caption_binding( $block_content, $parsed_block,
 			return true;
 		}
 	};
-	$processor = new $block_reader( $block_content );
+	$processor    = new $block_reader( $block_content );
 	$processor->next_tag( 'FIGCAPTION' );
 	$maybe_remove = $processor->get_attribute( 'data-wp-maybe-remove' );
 
 	if ( $has_binding ) {
-		$caption_binding = $parsed_block['attrs']['metadata']['bindings']['caption'];
+		$caption_binding        = $parsed_block['attrs']['metadata']['bindings']['caption'];
 		$caption_binding_source = get_block_bindings_source( $caption_binding['source'] );
-		$source_args = ! empty( $caption_binding['args'] ) && is_array( $caption_binding['args'] ) ? $caption_binding['args'] : array();
-		$source_value = $caption_binding_source->get_value( $source_args, $block_instance, 'caption' );
+		$source_args            = ! empty( $caption_binding['args'] ) && is_array( $caption_binding['args'] ) ? $caption_binding['args'] : array();
+		$source_value           = $caption_binding_source->get_value( $source_args, $block_instance, 'caption' );
 
 		if ( is_null( $source_value ) ) {
 			return $block_content;
 		}
 
 		if ( 'true' === $maybe_remove ) {
-			$processor->maybe_remove_figcaption();
+			$processor->gutenberg_do_not_copy_maybe_remove_figcaption();
 		} else {
-			$processor->set_figcaption_content( wp_kses_post( $source_value ) );
+			$processor->gutenberg_do_not_copy_set_figcaption_content( wp_kses_post( $source_value ) );
 		}
 	} else {
 		if ( 'true' === $maybe_remove ) {
-			$processor->maybe_remove_figcaption();
+			$processor->gutenberg_do_not_copy_maybe_remove_figcaption();
 		}
 	}
 

--- a/lib/compat/wordpress-6.9/blocks.php
+++ b/lib/compat/wordpress-6.9/blocks.php
@@ -5,63 +5,6 @@
  * @package gutenberg
  */
 
-
-class Bindings_Unsecure_HTML_Processor extends WP_HTML_Tag_Processor {
-
-    /**
-     * Replace the inner content of a figcaption element with the passed content.
-     *
-     * @param string $new_content New content to insert in the figcaption element.
-     * @return bool Whether the inner content was properly replaced.
-     */
-    public function set_figcaption_content( $new_content ) {
-        // Check that the processor is paused on a figcaption opener tag
-        if ( $this->is_tag_closer() || 'FIGCAPTION' !== $this->get_tag() ) {
-            return false;
-        }
-
-        // Set position of the opener tag
-        $this->set_bookmark( 'opener_tag' );
-
-        // Find the closing figcaption tag
-        if ( ! $this->next_tag(
-            array(
-                'tag_name'    => 'FIGCAPTION',
-                'tag_closers' => 'visit',
-            )
-        ) || ! $this->is_tag_closer() ) {
-            return false;
-        }
-
-        // Set position of the closer tag
-        $this->set_bookmark( 'closer_tag' );
-
-        // Get opener and closer tag bookmarks
-        $opener_tag_bookmark = $this->bookmarks['opener_tag'];
-        $closer_tag_bookmark = $this->bookmarks['closer_tag'];
-
-        // Calculate the position after the opening tag
-        $after_opener_tag = $opener_tag_bookmark->start + $opener_tag_bookmark->length;
-
-        // Handle the '>' character after the tag
-        if ( '>' === $this->html[ $after_opener_tag ] ) {
-            ++$after_opener_tag;
-        }
-
-        // Calculate the length of content between tags
-        $inner_content_length = $closer_tag_bookmark->start - $after_opener_tag;
-
-        // Replace the content between the tags
-        $this->lexical_updates[] = new WP_HTML_Text_Replacement(
-            $after_opener_tag,
-            $inner_content_length,
-            $new_content
-        );
-
-        return true;
-    }
-}
-
 /**
  * Replace the `__default` block bindings attribute with the full list of supported
  * attribute names for pattern overrides.
@@ -125,7 +68,64 @@ function gutenberg_process_image_caption_binding( $block_content, $parsed_block,
 	if ( is_null( $source_value ) ) {
 		return $block_content;
 	}
-	$processor = new Bindings_Unsecure_HTML_Processor( $block_content );
+
+	// Creating an internal class to process the HTML until we have set_inner_html() available in the block API.
+	$block_reader = new class($block_content) extends WP_HTML_Tag_Processor {
+		/**
+		 * Replace the inner content of a figcaption element with the passed content.
+		 *
+		 * @param string $new_content New content to insert in the figcaption element.
+		 * @return bool Whether the inner content was properly replaced.
+		 */
+		public function set_figcaption_content( $new_content ) {
+			// Check that the processor is paused on a figcaption opener tag
+			if ( $this->is_tag_closer() || 'FIGCAPTION' !== $this->get_tag() ) {
+				return false;
+			}
+
+			// Set position of the opener tag
+			$this->set_bookmark( 'opener_tag' );
+
+			// Find the closing figcaption tag
+			if ( ! $this->next_tag(
+				array(
+					'tag_name'    => 'FIGCAPTION',
+					'tag_closers' => 'visit',
+				)
+			) || ! $this->is_tag_closer() ) {
+				return false;
+			}
+
+			// Set position of the closer tag
+			$this->set_bookmark( 'closer_tag' );
+
+			// Get opener and closer tag bookmarks
+			$opener_tag_bookmark = $this->bookmarks['opener_tag'];
+			$closer_tag_bookmark = $this->bookmarks['closer_tag'];
+
+			// Calculate the position after the opening tag
+			$after_opener_tag = $opener_tag_bookmark->start + $opener_tag_bookmark->length;
+
+			// Handle the '>' character after the tag
+			if ( '>' === $this->html[ $after_opener_tag ] ) {
+				++$after_opener_tag;
+			}
+
+			// Calculate the length of content between tags
+			$inner_content_length = $closer_tag_bookmark->start - $after_opener_tag;
+
+			// Replace the content between the tags
+			$this->lexical_updates[] = new WP_HTML_Text_Replacement(
+				$after_opener_tag,
+				$inner_content_length,
+				$new_content
+			);
+
+			return true;
+		}
+	};
+
+	$processor = new $block_reader( $block_content );
 
 	// Find and update the figcaption
 	if ( $processor->next_tag( 'FIGCAPTION' ) ) {

--- a/lib/compat/wordpress-6.9/blocks.php
+++ b/lib/compat/wordpress-6.9/blocks.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Temporary compatibility shims for block APIs present in Gutenberg.
+ *
+ * @package gutenberg
+ */
+
+
+class Bindings_Unsecure_HTML_Processor extends WP_HTML_Tag_Processor {
+
+    /**
+     * Replace the inner content of a figcaption element with the passed content.
+     *
+     * @param string $new_content New content to insert in the figcaption element.
+     * @return bool Whether the inner content was properly replaced.
+     */
+    public function set_figcaption_content( $new_content ) {
+        // Check that the processor is paused on a figcaption opener tag
+        if ( $this->is_tag_closer() || 'FIGCAPTION' !== $this->get_tag() ) {
+            return false;
+        }
+
+        // Set position of the opener tag
+        $this->set_bookmark( 'opener_tag' );
+
+        // Find the closing figcaption tag
+        if ( ! $this->next_tag(
+            array(
+                'tag_name'    => 'FIGCAPTION',
+                'tag_closers' => 'visit',
+            )
+        ) || ! $this->is_tag_closer() ) {
+            return false;
+        }
+
+        // Set position of the closer tag
+        $this->set_bookmark( 'closer_tag' );
+
+        // Get opener and closer tag bookmarks
+        $opener_tag_bookmark = $this->bookmarks['opener_tag'];
+        $closer_tag_bookmark = $this->bookmarks['closer_tag'];
+
+        // Calculate the position after the opening tag
+        $after_opener_tag = $opener_tag_bookmark->start + $opener_tag_bookmark->length;
+
+        // Handle the '>' character after the tag
+        if ( '>' === $this->html[ $after_opener_tag ] ) {
+            ++$after_opener_tag;
+        }
+
+        // Calculate the length of content between tags
+        $inner_content_length = $closer_tag_bookmark->start - $after_opener_tag;
+
+        // Replace the content between the tags
+        $this->lexical_updates[] = new WP_HTML_Text_Replacement(
+            $after_opener_tag,
+            $inner_content_length,
+            $new_content
+        );
+
+        return true;
+    }
+}
+
+/**
+ * Replace the `__default` block bindings attribute with the full list of supported
+ * attribute names for pattern overrides.
+ *
+ * @param array $parsed_block The full block, including name and attributes.
+ *
+ * @return string The parsed block with default binding replace.
+ */
+function gutenberg_replace_pattern_override_default_binding( $parsed_block ) {
+	$supported_block_attrs = array(
+		'core/paragraph' => array( 'content' ),
+		'core/heading'   => array( 'content' ),
+		'core/image'     => array( 'id', 'url', 'title', 'alt', 'caption' ),
+		'core/button'    => array( 'url', 'text', 'linkTarget', 'rel' ),
+	);
+
+	$bindings = $parsed_block['attrs']['metadata']['bindings'] ?? array();
+	if (
+		isset( $bindings['__default']['source'] ) &&
+		'core/pattern-overrides' === $bindings['__default']['source']
+	) {
+		$updated_bindings = array();
+
+		// Build an binding array of all supported attributes.
+		// Note that this also omits the `__default` attribute from the
+		// resulting array.
+		foreach ( $supported_block_attrs[ $parsed_block['blockName'] ] as $attribute_name ) {
+			// Retain any non-pattern override bindings that might be present.
+			$updated_bindings[ $attribute_name ] = isset( $bindings[ $attribute_name ] )
+				? $bindings[ $attribute_name ]
+				: array( 'source' => 'core/pattern-overrides' );
+		}
+		$parsed_block['attrs']['metadata']['bindings'] = $updated_bindings;
+	}
+
+	return $parsed_block;
+}
+
+add_filter( 'render_block_data', 'gutenberg_replace_pattern_override_default_binding', 10, 1 );
+
+/**
+ * Process the block bindings attribute.
+ *
+ * @param string   $block_content Block Content.
+ * @param array    $parsed_block  The full block, including name and attributes.
+ * @param WP_Block $block_instance The block instance.
+ * @return string  Block content with the bind applied.
+ */
+function gutenberg_process_image_caption_binding( $block_content, $parsed_block, $block_instance ) {
+	if ( ! isset( $parsed_block['attrs']['metadata']['bindings']['caption'] ) ) {
+		return $block_content;
+	}
+
+	$caption_binding = $parsed_block['attrs']['metadata']['bindings']['caption'];
+
+	$caption_binding_source = get_block_bindings_source( $caption_binding['source'] );
+	$source_args            = ! empty( $caption_binding['args'] ) && is_array( $caption_binding['args'] ) ? $caption_binding['args'] : array();
+	$source_value           = $caption_binding_source->get_value( $source_args, $block_instance, 'caption' );
+
+	// If the value is not null, process the HTML based on the block and the attribute.
+	if ( is_null( $source_value ) ) {
+		return $block_content;
+	}
+	$processor = new Bindings_Unsecure_HTML_Processor( $block_content );
+
+	// Find and update the figcaption
+	if ( $processor->next_tag( 'FIGCAPTION' ) ) {
+		$processor->set_figcaption_content( wp_kses_post( $source_value ) );
+	}
+
+	return $processor->get_updated_html();
+}
+
+add_filter( 'render_block_core/image', 'gutenberg_process_image_caption_binding', 20, 3 );

--- a/lib/compat/wordpress-6.9/blocks.php
+++ b/lib/compat/wordpress-6.9/blocks.php
@@ -123,7 +123,8 @@ function gutenberg_process_image_caption_binding( $block_content, $parsed_block,
 			return $block_content;
 		}
 
-		if ( 'true' === $maybe_remove ) {
+		$should_remove = ( 'true' === $maybe_remove ) || empty( trim( (string) $source_value ) );
+		if ( $should_remove ) {
 			$processor->gutenberg_do_not_copy_maybe_remove_figcaption();
 		} else {
 			$processor->gutenberg_do_not_copy_set_figcaption_content( wp_kses_post( $source_value ) );

--- a/lib/compat/wordpress-6.9/blocks.php
+++ b/lib/compat/wordpress-6.9/blocks.php
@@ -50,20 +50,17 @@ add_filter( 'render_block_data', 'gutenberg_replace_pattern_override_default_bin
  * @return string  Block content with the bind applied.
  */
 function gutenberg_process_image_caption_binding( $block_content, $parsed_block, $block_instance ) {
+	$has_binding = isset( $parsed_block['attrs']['metadata']['bindings']['caption'] );
+	if ( strpos( $block_content, '<figcaption' ) === false ) {
+		return $block_content;
+	}
+
 	$block_reader = new class($block_content) extends WP_HTML_Tag_Processor {
-		/**
-		 * Replace the inner content of a figcaption element with the passed content.
-		 *
-		 * @param string $new_content New content to insert in the figcaption element.
-		 * @return bool Whether the inner content was properly replaced.
-		 */
 		public function set_figcaption_content( $new_content ) {
 			if ( $this->is_tag_closer() || 'FIGCAPTION' !== $this->get_tag() ) {
 				return false;
 			}
-
 			$this->set_bookmark( 'opener_tag' );
-
 			if ( ! $this->next_tag(
 				array(
 					'tag_name'    => 'FIGCAPTION',
@@ -72,41 +69,26 @@ function gutenberg_process_image_caption_binding( $block_content, $parsed_block,
 			) || ! $this->is_tag_closer() ) {
 				return false;
 			}
-
 			$this->set_bookmark( 'closer_tag' );
-
 			$opener_tag_bookmark = $this->bookmarks['opener_tag'];
 			$closer_tag_bookmark = $this->bookmarks['closer_tag'];
-
 			$after_opener_tag = $opener_tag_bookmark->start + $opener_tag_bookmark->length;
-
 			if ( '>' === $this->html[ $after_opener_tag ] ) {
 				++$after_opener_tag;
 			}
-
 			$inner_content_length = $closer_tag_bookmark->start - $after_opener_tag;
-
 			$this->lexical_updates[] = new WP_HTML_Text_Replacement(
 				$after_opener_tag,
 				$inner_content_length,
 				$new_content
 			);
-
 			return true;
 		}
-
-		/**
-		 * Remove the entire figcaption element if it has data-wp-maybe-remove="true".
-		 *
-		 * @return bool Whether the figcaption element was properly removed.
-		 */
 		public function maybe_remove_figcaption() {
 			if ( $this->is_tag_closer() || 'FIGCAPTION' !== $this->get_tag() ) {
 				return false;
 			}
-
 			$this->set_bookmark( 'opener_tag' );
-
 			if ( ! $this->next_tag(
 				array(
 					'tag_name'    => 'FIGCAPTION',
@@ -115,57 +97,44 @@ function gutenberg_process_image_caption_binding( $block_content, $parsed_block,
 			) || ! $this->is_tag_closer() ) {
 				return false;
 			}
-
 			$this->set_bookmark( 'closer_tag' );
-
 			$opener_tag_bookmark = $this->bookmarks['opener_tag'];
 			$closer_tag_bookmark = $this->bookmarks['closer_tag'];
-
 			$total_element_length = $closer_tag_bookmark->start + $closer_tag_bookmark->length - $opener_tag_bookmark->start;
-
 			$this->lexical_updates[] = new WP_HTML_Text_Replacement(
 				$opener_tag_bookmark->start,
 				$total_element_length,
 				''
 			);
-
 			return true;
 		}
 	};
-	if ( ! isset( $parsed_block['attrs']['metadata']['bindings']['caption'] ) ) {
-		if ( strpos( $block_content, '<figcaption' ) !== false ) {
-			$processor = new $block_reader( $block_content );
-			$processor->next_tag( 'FIGCAPTION' );
-			$processor->maybe_remove_figcaption();
-			return $processor->get_updated_html();
-		}
-	} else {
-		$caption_binding = $parsed_block['attrs']['metadata']['bindings']['caption'];
+	$processor = new $block_reader( $block_content );
+	$processor->next_tag( 'FIGCAPTION' );
+	$maybe_remove = $processor->get_attribute( 'data-wp-maybe-remove' );
 
+	if ( $has_binding ) {
+		$caption_binding = $parsed_block['attrs']['metadata']['bindings']['caption'];
 		$caption_binding_source = get_block_bindings_source( $caption_binding['source'] );
-		$source_args            = ! empty( $caption_binding['args'] ) && is_array( $caption_binding['args'] ) ? $caption_binding['args'] : array();
-		$source_value           = $caption_binding_source->get_value( $source_args, $block_instance, 'caption' );
+		$source_args = ! empty( $caption_binding['args'] ) && is_array( $caption_binding['args'] ) ? $caption_binding['args'] : array();
+		$source_value = $caption_binding_source->get_value( $source_args, $block_instance, 'caption' );
 
 		if ( is_null( $source_value ) ) {
 			return $block_content;
 		}
 
-		$processor = new $block_reader( $block_content );
-
-		if ( $processor->next_tag( 'FIGCAPTION' ) ) {
-			$maybe_remove = $processor->get_attribute( 'data-wp-maybe-remove' );
-
-			if ( 'true' === $maybe_remove ) {
-				$processor->maybe_remove_figcaption();
-			} else {
-				$processor->set_figcaption_content( wp_kses_post( $source_value ) );
-			}
+		if ( 'true' === $maybe_remove ) {
+			$processor->maybe_remove_figcaption();
+		} else {
+			$processor->set_figcaption_content( wp_kses_post( $source_value ) );
 		}
-
-		return $processor->get_updated_html();
+	} else {
+		if ( 'true' === $maybe_remove ) {
+			$processor->maybe_remove_figcaption();
+		}
 	}
 
-
+	return $processor->get_updated_html();
 }
 
 add_filter( 'render_block_core/image', 'gutenberg_process_image_caption_binding', 20, 3 );

--- a/lib/compat/wordpress-6.9/blocks.php
+++ b/lib/compat/wordpress-6.9/blocks.php
@@ -28,11 +28,7 @@ function gutenberg_replace_pattern_override_default_binding( $parsed_block ) {
 	) {
 		$updated_bindings = array();
 
-		// Build an binding array of all supported attributes.
-		// Note that this also omits the `__default` attribute from the
-		// resulting array.
 		foreach ( $supported_block_attrs[ $parsed_block['blockName'] ] as $attribute_name ) {
-			// Retain any non-pattern override bindings that might be present.
 			$updated_bindings[ $attribute_name ] = isset( $bindings[ $attribute_name ] )
 				? $bindings[ $attribute_name ]
 				: array( 'source' => 'core/pattern-overrides' );
@@ -54,22 +50,6 @@ add_filter( 'render_block_data', 'gutenberg_replace_pattern_override_default_bin
  * @return string  Block content with the bind applied.
  */
 function gutenberg_process_image_caption_binding( $block_content, $parsed_block, $block_instance ) {
-	if ( ! isset( $parsed_block['attrs']['metadata']['bindings']['caption'] ) ) {
-		return $block_content;
-	}
-
-	$caption_binding = $parsed_block['attrs']['metadata']['bindings']['caption'];
-
-	$caption_binding_source = get_block_bindings_source( $caption_binding['source'] );
-	$source_args            = ! empty( $caption_binding['args'] ) && is_array( $caption_binding['args'] ) ? $caption_binding['args'] : array();
-	$source_value           = $caption_binding_source->get_value( $source_args, $block_instance, 'caption' );
-
-	// If the value is not null, process the HTML based on the block and the attribute.
-	if ( is_null( $source_value ) ) {
-		return $block_content;
-	}
-
-	// Creating an internal class to process the HTML until we have set_inner_html() available in the block API.
 	$block_reader = new class($block_content) extends WP_HTML_Tag_Processor {
 		/**
 		 * Replace the inner content of a figcaption element with the passed content.
@@ -78,15 +58,12 @@ function gutenberg_process_image_caption_binding( $block_content, $parsed_block,
 		 * @return bool Whether the inner content was properly replaced.
 		 */
 		public function set_figcaption_content( $new_content ) {
-			// Check that the processor is paused on a figcaption opener tag
 			if ( $this->is_tag_closer() || 'FIGCAPTION' !== $this->get_tag() ) {
 				return false;
 			}
 
-			// Set position of the opener tag
 			$this->set_bookmark( 'opener_tag' );
 
-			// Find the closing figcaption tag
 			if ( ! $this->next_tag(
 				array(
 					'tag_name'    => 'FIGCAPTION',
@@ -96,25 +73,19 @@ function gutenberg_process_image_caption_binding( $block_content, $parsed_block,
 				return false;
 			}
 
-			// Set position of the closer tag
 			$this->set_bookmark( 'closer_tag' );
 
-			// Get opener and closer tag bookmarks
 			$opener_tag_bookmark = $this->bookmarks['opener_tag'];
 			$closer_tag_bookmark = $this->bookmarks['closer_tag'];
 
-			// Calculate the position after the opening tag
 			$after_opener_tag = $opener_tag_bookmark->start + $opener_tag_bookmark->length;
 
-			// Handle the '>' character after the tag
 			if ( '>' === $this->html[ $after_opener_tag ] ) {
 				++$after_opener_tag;
 			}
 
-			// Calculate the length of content between tags
 			$inner_content_length = $closer_tag_bookmark->start - $after_opener_tag;
 
-			// Replace the content between the tags
 			$this->lexical_updates[] = new WP_HTML_Text_Replacement(
 				$after_opener_tag,
 				$inner_content_length,
@@ -123,13 +94,73 @@ function gutenberg_process_image_caption_binding( $block_content, $parsed_block,
 
 			return true;
 		}
+
+		/**
+		 * Remove the entire figcaption element if it has data-wp-maybe-remove="true".
+		 *
+		 * @return bool Whether the figcaption element was properly removed.
+		 */
+		public function maybe_remove_figcaption() {
+			if ( $this->is_tag_closer() || 'FIGCAPTION' !== $this->get_tag() ) {
+				return false;
+			}
+
+			$this->set_bookmark( 'opener_tag' );
+
+			if ( ! $this->next_tag(
+				array(
+					'tag_name'    => 'FIGCAPTION',
+					'tag_closers' => 'visit',
+				)
+			) || ! $this->is_tag_closer() ) {
+				return false;
+			}
+
+			$this->set_bookmark( 'closer_tag' );
+
+			$opener_tag_bookmark = $this->bookmarks['opener_tag'];
+			$closer_tag_bookmark = $this->bookmarks['closer_tag'];
+
+			$total_element_length = $closer_tag_bookmark->start + $closer_tag_bookmark->length - $opener_tag_bookmark->start;
+
+			$this->lexical_updates[] = new WP_HTML_Text_Replacement(
+				$opener_tag_bookmark->start,
+				$total_element_length,
+				''
+			);
+
+			return true;
+		}
 	};
+	if ( ! isset( $parsed_block['attrs']['metadata']['bindings']['caption'] ) ) {
+		if ( strpos( $block_content, '<figcaption' ) !== false ) {
+			$processor = new $block_reader( $block_content );
+			$processor->next_tag( 'FIGCAPTION' );
+			$processor->maybe_remove_figcaption();
+			return $processor->get_updated_html();
+		}
+	}
+
+	$caption_binding = $parsed_block['attrs']['metadata']['bindings']['caption'];
+
+	$caption_binding_source = get_block_bindings_source( $caption_binding['source'] );
+	$source_args            = ! empty( $caption_binding['args'] ) && is_array( $caption_binding['args'] ) ? $caption_binding['args'] : array();
+	$source_value           = $caption_binding_source->get_value( $source_args, $block_instance, 'caption' );
+
+	if ( is_null( $source_value ) ) {
+		return $block_content;
+	}
 
 	$processor = new $block_reader( $block_content );
 
-	// Find and update the figcaption
 	if ( $processor->next_tag( 'FIGCAPTION' ) ) {
-		$processor->set_figcaption_content( wp_kses_post( $source_value ) );
+		$maybe_remove = $processor->get_attribute( 'data-wp-maybe-remove' );
+
+		if ( 'true' === $maybe_remove ) {
+			$processor->maybe_remove_figcaption();
+		} else {
+			$processor->set_figcaption_content( wp_kses_post( $source_value ) );
+		}
 	}
 
 	return $processor->get_updated_html();

--- a/lib/load.php
+++ b/lib/load.php
@@ -39,6 +39,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-6.8/rest-api.php';
 
 	// WordPress 6.9 compat.
+	require __DIR__ . '/compat/wordpress-6.9/blocks.php';
 	require __DIR__ . '/compat/wordpress-6.9/post-data-block-bindings.php';
 	require __DIR__ . '/compat/wordpress-6.9/rest-api.php';
 	require __DIR__ . '/compat/wordpress-6.9/class-gutenberg-hierarchical-sort.php';

--- a/packages/block-editor/src/components/block-draggable/test/__snapshots__/index.native.js.snap
+++ b/packages/block-editor/src/components/block-draggable/test/__snapshots__/index.native.js.snap
@@ -6,7 +6,7 @@ exports[`BlockDraggable moves blocks: Initial order 1`] = `
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"sizeSlug":"large"} -->
-<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
+<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:spacer -->
@@ -15,18 +15,18 @@ exports[`BlockDraggable moves blocks: Initial order 1`] = `
 
 <!-- wp:gallery {"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
+<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
+<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
 
 exports[`BlockDraggable moves blocks: Paragraph block moved from first to second position 1`] = `
 "<!-- wp:image {"sizeSlug":"large"} -->
-<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
+<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph -->
@@ -39,11 +39,11 @@ exports[`BlockDraggable moves blocks: Paragraph block moved from first to second
 
 <!-- wp:gallery {"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
+<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
+<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
@@ -54,7 +54,7 @@ exports[`BlockDraggable moves blocks: Spacer block moved from third to first pos
 <!-- /wp:spacer -->
 
 <!-- wp:image {"sizeSlug":"large"} -->
-<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
+<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph -->
@@ -63,11 +63,11 @@ exports[`BlockDraggable moves blocks: Spacer block moved from third to first pos
 
 <!-- wp:gallery {"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
+<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
+<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;

--- a/packages/block-editor/src/components/block-draggable/test/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/test/index.native.js
@@ -54,7 +54,7 @@ const BLOCKS = [
 		name: 'Image',
 		html: `
 		<!-- wp:image {"sizeSlug":"large"} -->
-		<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
+		<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 		<!-- /wp:image -->`,
 		layout: { x: 0, y: 100, width: 100, height: 100 },
 	},
@@ -71,11 +71,11 @@ const BLOCKS = [
 		html: `
 		<!-- wp:gallery {"linkTo":"none"} -->
 		<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-		<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
+		<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 		<!-- /wp:image -->
 
 		<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-		<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/></figure>
+		<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 		<!-- /wp:image --></figure>
 		<!-- /wp:gallery -->`,
 		layout: { x: 0, y: 300, width: 100, height: 100 },

--- a/packages/block-editor/src/hooks/test/__snapshots__/align.native.js.snap
+++ b/packages/block-editor/src/hooks/test/__snapshots__/align.native.js.snap
@@ -20,37 +20,37 @@ exports[`Align options for group block sets Wide width option 1`] = `
 
 exports[`Align options for media block sets Align center option 1`] = `
 "<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"none","align":"center"} -->
-<figure class="wp-block-image aligncenter size-large"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-1"/></figure>
+<figure class="wp-block-image aligncenter size-large"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-1"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->"
 `;
 
 exports[`Align options for media block sets Align left option 1`] = `
 "<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"none","align":"left"} -->
-<figure class="wp-block-image alignleft size-large"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-1"/></figure>
+<figure class="wp-block-image alignleft size-large"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-1"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->"
 `;
 
 exports[`Align options for media block sets Align right option 1`] = `
 "<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"none","align":"right"} -->
-<figure class="wp-block-image alignright size-large"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-1"/></figure>
+<figure class="wp-block-image alignright size-large"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-1"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->"
 `;
 
 exports[`Align options for media block sets Full width option 1`] = `
 "<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"none","align":"full"} -->
-<figure class="wp-block-image alignfull size-large"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-1"/></figure>
+<figure class="wp-block-image alignfull size-large"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-1"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->"
 `;
 
 exports[`Align options for media block sets None option 1`] = `
 "<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-1"/></figure>
+<figure class="wp-block-image size-large"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-1"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->"
 `;
 
 exports[`Align options for media block sets Wide width option 1`] = `
 "<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"none","align":"wide"} -->
-<figure class="wp-block-image alignwide size-large"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-1"/></figure>
+<figure class="wp-block-image alignwide size-large"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-1"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->"
 `;
 

--- a/packages/block-editor/src/hooks/test/align.native.js
+++ b/packages/block-editor/src/hooks/test/align.native.js
@@ -17,7 +17,7 @@ import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
 import { registerCoreBlocks } from '@wordpress/block-library';
 
 const imageHTML = `<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-1"/></figure>
+<figure class="wp-block-image size-large"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-1"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->`;
 
 beforeAll( () => {

--- a/packages/block-editor/src/utils/block-bindings.js
+++ b/packages/block-editor/src/utils/block-bindings.js
@@ -14,7 +14,7 @@ const PATTERN_OVERRIDES_SOURCE = 'core/pattern-overrides';
 const BLOCK_BINDINGS_ALLOWED_BLOCKS = {
 	'core/paragraph': [ 'content' ],
 	'core/heading': [ 'content' ],
-	'core/image': [ 'id', 'url', 'title', 'alt' ],
+	'core/image': [ 'id', 'url', 'title', 'alt', 'caption' ],
 	'core/button': [ 'url', 'text', 'linkTarget', 'rel' ],
 	'core/post-date': [ 'datetime' ],
 };

--- a/packages/block-library/src/block/test/edit.native.js
+++ b/packages/block-library/src/block/test/edit.native.js
@@ -229,7 +229,7 @@ describe( 'Synced patterns', () => {
 			// with an URL that includes the width query parameter:
 			// https://cldup.com/cXyG__fTLN.jpg => https://cldup.com/cXyG__fTLN.jpg?w=500
 			response.content.raw = `<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/></figure>
+<figure class="wp-block-image size-large"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->`;
 			return Promise.resolve( {
 				json: () => Promise.resolve( response ),

--- a/packages/block-library/src/cover/test/__snapshots__/transforms.native.js.snap
+++ b/packages/block-library/src/cover/test/__snapshots__/transforms.native.js.snap
@@ -24,7 +24,7 @@ exports[`Cover block transformations with Image to Group block 1`] = `
 
 exports[`Cover block transformations with Image to Image block 1`] = `
 "<!-- wp:image {"id":890,"style":{"color":{}}} -->
-<figure class="wp-block-image"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-890"/></figure>
+<figure class="wp-block-image"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-890"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->"
 `;
 

--- a/packages/block-library/src/gallery/test/__snapshots__/index.native.js.snap
+++ b/packages/block-library/src/gallery/test/__snapshots__/index.native.js.snap
@@ -3,15 +3,15 @@
 exports[`Gallery block Columns setting decrements columns 1`] = `
 "<!-- wp:gallery {"columns":2,"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-2 is-cropped"><!-- wp:image {"id":2000} -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":2001} -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-2.jpeg" alt="" class="wp-image-2001"/></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-2.jpeg" alt="" class="wp-image-2001"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":2002} -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-3.jpeg" alt="" class="wp-image-2002"/></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-3.jpeg" alt="" class="wp-image-2002"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
@@ -19,15 +19,15 @@ exports[`Gallery block Columns setting decrements columns 1`] = `
 exports[`Gallery block Columns setting does not increment due to maximum value 1`] = `
 "<!-- wp:gallery {"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":2000} -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":2001} -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-2.jpeg" alt="" class="wp-image-2001"/></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-2.jpeg" alt="" class="wp-image-2001"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":2002} -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-3.jpeg" alt="" class="wp-image-2002"/></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-3.jpeg" alt="" class="wp-image-2002"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
@@ -35,11 +35,11 @@ exports[`Gallery block Columns setting does not increment due to maximum value 1
 exports[`Gallery block cancels uploads 1`] = `
 "<!-- wp:gallery {"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":null} -->
-<figure class="wp-block-image"><img alt=""/></figure>
+<figure class="wp-block-image"><img alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":null} -->
-<figure class="wp-block-image"><img alt=""/></figure>
+<figure class="wp-block-image"><img alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
@@ -47,7 +47,7 @@ exports[`Gallery block cancels uploads 1`] = `
 exports[`Gallery block disables crop images setting 1`] = `
 "<!-- wp:gallery {"imageCrop":false,"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-default"><!-- wp:image {"id":2000} -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
@@ -55,11 +55,11 @@ exports[`Gallery block disables crop images setting 1`] = `
 exports[`Gallery block finishes pending uploads upon opening the editor 1`] = `
 "<!-- wp:gallery {"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":2000} -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":2001} -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-2.jpeg" alt="" class="wp-image-2001"/></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-2.jpeg" alt="" class="wp-image-2001"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
@@ -67,11 +67,11 @@ exports[`Gallery block finishes pending uploads upon opening the editor 1`] = `
 exports[`Gallery block handles failed uploads 1`] = `
 "<!-- wp:gallery {"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":1} -->
-<figure class="wp-block-image"><img src="file:///local-image-1.jpeg" alt="" class="wp-image-1"/></figure>
+<figure class="wp-block-image"><img src="file:///local-image-1.jpeg" alt="" class="wp-image-1"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":2} -->
-<figure class="wp-block-image"><img src="file:///local-image-2.jpeg" alt="" class="wp-image-2"/></figure>
+<figure class="wp-block-image"><img src="file:///local-image-2.jpeg" alt="" class="wp-image-2"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
@@ -85,11 +85,11 @@ exports[`Gallery block inserts block 1`] = `
 exports[`Gallery block overrides "Link" setting of gallery items 1`] = `
 "<!-- wp:gallery {"linkTo":"media"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":1,"linkDestination":"media"} -->
-<figure class="wp-block-image"><img src="file:///local-image-1.jpeg" alt="" class="wp-image-1"/></figure>
+<figure class="wp-block-image"><img src="file:///local-image-1.jpeg" alt="" class="wp-image-1"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":2,"linkDestination":"media"} -->
-<figure class="wp-block-image"><img src="file:///local-image-2.jpeg" alt="" class="wp-image-2"/></figure>
+<figure class="wp-block-image"><img src="file:///local-image-2.jpeg" alt="" class="wp-image-2"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
@@ -97,15 +97,15 @@ exports[`Gallery block overrides "Link" setting of gallery items 1`] = `
 exports[`Gallery block rearranges gallery items 1`] = `
 "<!-- wp:gallery {"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":2002} -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-3.jpeg" alt="" class="wp-image-2002"/></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-3.jpeg" alt="" class="wp-image-2002"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":2000} -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":2001} -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-2.jpeg" alt="" class="wp-image-2001"/></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-2.jpeg" alt="" class="wp-image-2001"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
@@ -119,7 +119,7 @@ exports[`Gallery block renders gallery block placeholder correctly if the block 
 exports[`Gallery block sets caption to gallery 1`] = `
 "<!-- wp:gallery {"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":2000} -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --><figcaption class="blocks-gallery-caption wp-element-caption"><strong>Bold</strong> <em>italic</em> <s>strikethrough</s> gallery caption</figcaption></figure>
 <!-- /wp:gallery -->"
 `;
@@ -127,7 +127,7 @@ exports[`Gallery block sets caption to gallery 1`] = `
 exports[`Gallery block sets caption to gallery items 1`] = `
 "<!-- wp:gallery {"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":2000} -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/><figcaption class="wp-element-caption"><strong>Bold</strong> <em>italic</em> <s>strikethrough</s> image caption</figcaption></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/><figcaption class="wp-element-caption" data-wp-maybe-remove="false"><strong>Bold</strong> <em>italic</em> <s>strikethrough</s> image caption</figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
@@ -135,11 +135,11 @@ exports[`Gallery block sets caption to gallery items 1`] = `
 exports[`Gallery block successfully uploads items 1`] = `
 "<!-- wp:gallery {"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":2000} -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":2001} -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-2.jpeg" alt="" class="wp-image-2001"/></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-2.jpeg" alt="" class="wp-image-2001"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
@@ -147,7 +147,7 @@ exports[`Gallery block successfully uploads items 1`] = `
 exports[`Gallery block takes a photo 1`] = `
 "<!-- wp:gallery {"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":2000} -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
@@ -155,11 +155,11 @@ exports[`Gallery block takes a photo 1`] = `
 exports[`Gallery block uploads from free photo library 1`] = `
 "<!-- wp:gallery {"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":2000} -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":2001} -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-2.jpeg" alt="" class="wp-image-2001"/></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-2.jpeg" alt="" class="wp-image-2001"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
@@ -167,11 +167,11 @@ exports[`Gallery block uploads from free photo library 1`] = `
 exports[`Gallery block uploads from other apps 1`] = `
 "<!-- wp:gallery {"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":2000} -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt="" class="wp-image-2000"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":2001} -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-2.jpeg" alt="" class="wp-image-2001"/></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-2.jpeg" alt="" class="wp-image-2001"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;

--- a/packages/block-library/src/gallery/test/__snapshots__/transforms.native.js.snap
+++ b/packages/block-library/src/gallery/test/__snapshots__/transforms.native.js.snap
@@ -5,15 +5,15 @@ exports[`Gallery block transformations to Columns block 1`] = `
 <div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
 <div class="wp-block-column" style="flex-basis:100%"><!-- wp:gallery {"columns":8,"linkTo":"none","className":"alignfull"} -->
 <figure class="wp-block-gallery has-nested-images columns-8 is-cropped alignfull"><!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon.png" alt=""/><figcaption class="wp-element-caption">Paragraph</figcaption></figure>
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon.png" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Paragraph</figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon-Heading.png" alt=""/><figcaption class="wp-element-caption">Heading</figcaption></figure>
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon-Heading.png" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Heading</figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon-Subheading.png" alt=""/><figcaption class="wp-element-caption">Subheading</figcaption></figure>
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon-Subheading.png" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Subheading</figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery --></div>
 <!-- /wp:column --></div>
@@ -24,15 +24,15 @@ exports[`Gallery block transformations to Group block 1`] = `
 "<!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:gallery {"columns":8,"linkTo":"none","className":"alignfull"} -->
 <figure class="wp-block-gallery has-nested-images columns-8 is-cropped alignfull"><!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon.png" alt=""/><figcaption class="wp-element-caption">Paragraph</figcaption></figure>
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon.png" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Paragraph</figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon-Heading.png" alt=""/><figcaption class="wp-element-caption">Heading</figcaption></figure>
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon-Heading.png" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Heading</figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon-Subheading.png" alt=""/><figcaption class="wp-element-caption">Subheading</figcaption></figure>
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon-Subheading.png" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Subheading</figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery --></div>
 <!-- /wp:group -->"
@@ -40,14 +40,14 @@ exports[`Gallery block transformations to Group block 1`] = `
 
 exports[`Gallery block transformations to Image block 1`] = `
 "<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon.png" alt=""/><figcaption class="wp-element-caption">Paragraph</figcaption></figure>
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon.png" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Paragraph</figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon-Heading.png" alt=""/><figcaption class="wp-element-caption">Heading</figcaption></figure>
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon-Heading.png" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Heading</figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon-Subheading.png" alt=""/><figcaption class="wp-element-caption">Subheading</figcaption></figure>
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon-Subheading.png" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Subheading</figcaption></figure>
 <!-- /wp:image -->"
 `;

--- a/packages/block-library/src/gallery/test/helpers.native.js
+++ b/packages/block-library/src/gallery/test/helpers.native.js
@@ -95,7 +95,7 @@ export const generateGalleryBlock = (
 				? media[ index ].localUrl
 				: media[ index ].serverUrl;
 			return `<!-- wp:image {"id":${ id }} -->
-            <figure class="wp-block-image"><img src="${ url }" alt="" class="wp-image-${ id }"/></figure>
+            <figure class="wp-block-image"><img src="${ url }" alt="" class="wp-image-${ id }"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
             <!-- /wp:image -->`;
 		} )
 		.join( '\n\n' );

--- a/packages/block-library/src/gallery/test/index.native.js
+++ b/packages/block-library/src/gallery/test/index.native.js
@@ -601,11 +601,11 @@ describe( 'Gallery block', () => {
 		const screen = await initializeWithGalleryBlock( {
 			html: `<!-- wp:gallery {"linkTo":"none"} -->
 		<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":${ media[ 0 ].localId }} -->
-		<figure class="wp-block-image"><img src="${ media[ 0 ].localUrl }" alt="" class="wp-image-${ media[ 0 ].localId }"/></figure>
+		<figure class="wp-block-image"><img src="${ media[ 0 ].localUrl }" alt="" class="wp-image-${ media[ 0 ].localId }"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 		<!-- /wp:image -->
 
 		<!-- wp:image {"id":${ media[ 1 ].localId },"linkDestination":"attachment"} -->
-		<figure class="wp-block-image"><img src="${ media[ 1 ].localUrl }" alt="" class="wp-image-${ media[ 1 ].localId }"/></figure>
+		<figure class="wp-block-image"><img src="${ media[ 1 ].localUrl }" alt="" class="wp-image-${ media[ 1 ].localId }"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 		<!-- /wp:image --></figure>
 		<!-- /wp:gallery -->`,
 			numberOfItems: 2,

--- a/packages/block-library/src/gallery/test/transforms.native.js
+++ b/packages/block-library/src/gallery/test/transforms.native.js
@@ -13,15 +13,15 @@ const block = 'Gallery';
 const initialHtml = `
 <!-- wp:gallery {"columns":8,"linkTo":"none","className":"alignfull"} -->
 <figure class="wp-block-gallery has-nested-images columns-8 is-cropped alignfull"><!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon.png" alt=""/><figcaption class="wp-element-caption">Paragraph</figcaption></figure>
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon.png" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Paragraph</figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon-Heading.png" alt=""/><figcaption class="wp-element-caption">Heading</figcaption></figure>
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon-Heading.png" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Heading</figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon-Subheading.png" alt=""/><figcaption class="wp-element-caption">Subheading</figcaption></figure>
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2018/07/Block-Icon-Subheading.png" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Subheading</figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->`;
 

--- a/packages/block-library/src/group/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/group/test/__snapshots__/edit.native.js.snap
@@ -10,7 +10,7 @@ exports[`Group block inserts block and adds a Heading block as an inner block 1`
 
 exports[`Group block ungroups inner blocks 1`] = `
 "<!-- wp:image -->
-<figure class="wp-block-image"><img alt=""/></figure>
+<figure class="wp-block-image"><img alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:spacer -->

--- a/packages/block-library/src/group/test/edit.native.js
+++ b/packages/block-library/src/group/test/edit.native.js
@@ -18,7 +18,7 @@ import { registerCoreBlocks } from '@wordpress/block-library';
 
 const NESTED_GROUP_BLOCK = `<!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:image -->
-<figure class="wp-block-image"><img alt=""/></figure>
+<figure class="wp-block-image"><img alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:spacer -->

--- a/packages/block-library/src/image/deprecated.js
+++ b/packages/block-library/src/image/deprecated.js
@@ -11,6 +11,7 @@ import {
 	useBlockProps,
 	__experimentalGetElementClassName,
 	__experimentalGetBorderClassesAndStyles as getBorderClassesAndStyles,
+	__experimentalGetShadowClassesAndStyles as getShadowClassesAndStyles,
 } from '@wordpress/block-editor';
 
 /**
@@ -1166,4 +1167,211 @@ const v8 = {
 	},
 };
 
-export default [ v8, v7, v6, v5, v4, v3, v2, v1 ];
+const v9 = {
+	attributes: {
+		blob: {
+			type: 'string',
+			role: 'local',
+		},
+		url: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'img',
+			attribute: 'src',
+			role: 'content',
+		},
+		alt: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'img',
+			attribute: 'alt',
+			default: '',
+			role: 'content',
+		},
+		caption: {
+			type: 'rich-text',
+			source: 'rich-text',
+			selector: 'figcaption',
+			role: 'content',
+		},
+		lightbox: {
+			type: 'object',
+			enabled: {
+				type: 'boolean',
+			},
+		},
+		title: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'img',
+			attribute: 'title',
+			role: 'content',
+		},
+		href: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'figure > a',
+			attribute: 'href',
+			role: 'content',
+		},
+		rel: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'figure > a',
+			attribute: 'rel',
+		},
+		linkClass: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'figure > a',
+			attribute: 'class',
+		},
+		id: {
+			type: 'number',
+			role: 'content',
+		},
+		width: {
+			type: 'string',
+		},
+		height: {
+			type: 'string',
+		},
+		aspectRatio: {
+			type: 'string',
+		},
+		scale: {
+			type: 'string',
+		},
+		sizeSlug: {
+			type: 'string',
+		},
+		linkDestination: {
+			type: 'string',
+		},
+		linkTarget: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'figure > a',
+			attribute: 'target',
+		},
+	},
+	supports: {
+		interactivity: true,
+		align: [ 'left', 'center', 'right', 'wide', 'full' ],
+		anchor: true,
+		color: {
+			text: false,
+			background: false,
+		},
+		filter: {
+			duotone: true,
+		},
+		spacing: {
+			margin: true,
+		},
+		__experimentalBorder: {
+			color: true,
+			radius: true,
+			width: true,
+			__experimentalSkipSerialization: true,
+			__experimentalDefaultControls: {
+				color: true,
+				radius: true,
+				width: true,
+			},
+		},
+		shadow: {
+			__experimentalSkipSerialization: true,
+		},
+	},
+	save( { attributes } ) {
+		const {
+			url,
+			alt,
+			caption,
+			align,
+			href,
+			rel,
+			linkClass,
+			width,
+			height,
+			aspectRatio,
+			scale,
+			id,
+			linkTarget,
+			sizeSlug,
+			title,
+		} = attributes;
+
+		const newRel = ! rel ? undefined : rel;
+		const borderProps = getBorderClassesAndStyles( attributes );
+		const shadowProps = getShadowClassesAndStyles( attributes );
+
+		const classes = clsx( {
+			// All other align classes are handled by block supports.
+			// `{ align: 'none' }` is unique to transforms for the image block.
+			alignnone: 'none' === align,
+			[ `size-${ sizeSlug }` ]: sizeSlug,
+			'is-resized': width || height,
+			'has-custom-border':
+				!! borderProps.className ||
+				( borderProps.style &&
+					Object.keys( borderProps.style ).length > 0 ),
+		} );
+
+		const imageClasses = clsx( borderProps.className, {
+			[ `wp-image-${ id }` ]: !! id,
+		} );
+
+		const image = (
+			<img
+				src={ url }
+				alt={ alt }
+				className={ imageClasses || undefined }
+				style={ {
+					...borderProps.style,
+					...shadowProps.style,
+					aspectRatio,
+					objectFit: scale,
+					width,
+					height,
+				} }
+				title={ title }
+			/>
+		);
+
+		const figure = (
+			<>
+				{ href ? (
+					<a
+						className={ linkClass }
+						href={ href }
+						target={ linkTarget }
+						rel={ newRel }
+					>
+						{ image }
+					</a>
+				) : (
+					image
+				) }
+				{ ! RichText.isEmpty( caption ) && (
+					<RichText.Content
+						className={ __experimentalGetElementClassName(
+							'caption'
+						) }
+						tagName="figcaption"
+						value={ caption }
+					/>
+				) }
+			</>
+		);
+
+		return (
+			<figure { ...useBlockProps.save( { className: classes } ) }>
+				{ figure }
+			</figure>
+		);
+	},
+};
+
+export default [ v9, v8, v7, v6, v5, v4, v3, v2, v1 ];

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -625,7 +625,7 @@ export default function Image( {
 		lockAltControlsMessage,
 		lockTitleControls = false,
 		lockTitleControlsMessage,
-		lockCaption = false,
+		hideCaptionControls = false,
 	} = useSelect(
 		( select ) => {
 			if ( ! isSingleSelected ) {
@@ -635,6 +635,7 @@ export default function Image( {
 				url: urlBinding,
 				alt: altBinding,
 				title: titleBinding,
+				caption: captionBinding,
 			} = metadata?.bindings || {};
 			const hasParentPattern = !! context[ 'pattern/overrides' ];
 			const urlBindingSource = getBlockBindingsSource(
@@ -658,10 +659,6 @@ export default function Image( {
 					// Disable editing the link of the URL if the image is inside a pattern instance.
 					// This is a temporary solution until we support overriding the link on the frontend.
 					hasParentPattern || arePatternOverridesEnabled,
-				lockCaption:
-					// Disable editing the caption if the image is inside a pattern instance.
-					// This is a temporary solution until we support overriding the caption on the frontend.
-					hasParentPattern,
 				lockAltControls:
 					!! altBinding &&
 					! altBindingSource?.canUserEditValue?.( {
@@ -690,6 +687,7 @@ export default function Image( {
 							titleBindingSource.label
 					  )
 					: __( 'Connected to dynamic data' ),
+				hideCaptionControls: !! captionBinding,
 			};
 		},
 		[
@@ -1146,10 +1144,9 @@ export default function Image( {
 				label={ __( 'Image caption text' ) }
 				showToolbarButton={
 					isSingleSelected &&
-					hasNonContentControls &&
-					! arePatternOverridesEnabled
+					( hasNonContentControls || isContentOnlyMode ) &&
+					! hideCaptionControls
 				}
-				readOnly={ lockCaption }
 			/>
 		</>
 	);

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -71,8 +71,13 @@ export default function save( { attributes } ) {
 		/>
 	);
 
+	const arePatternOverridesEnabled =
+		bindings?.__default?.source === 'core/pattern-overrides';
+
 	const shouldRemoveCaption =
-		! bindings.caption && RichText.isEmpty( caption );
+		! bindings.caption &&
+		RichText.isEmpty( caption ) &&
+		! arePatternOverridesEnabled;
 
 	const figure = (
 		<>

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -84,13 +84,12 @@ export default function save( { attributes } ) {
 			) : (
 				image
 			) }
-			{ ! RichText.isEmpty( caption ) && (
-				<RichText.Content
-					className={ __experimentalGetElementClassName( 'caption' ) }
-					tagName="figcaption"
-					value={ caption }
-				/>
-			) }
+			<RichText.Content
+				className={ __experimentalGetElementClassName( 'caption' ) }
+				tagName="figcaption"
+				value={ caption }
+				data-wp-maybe-remove={ ! RichText.isEmpty( caption ) }
+			/>
 		</>
 	);
 

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -31,6 +31,7 @@ export default function save( { attributes } ) {
 		linkTarget,
 		sizeSlug,
 		title,
+		metadata: { bindings = {} } = {},
 	} = attributes;
 
 	const newRel = ! rel ? undefined : rel;
@@ -70,6 +71,9 @@ export default function save( { attributes } ) {
 		/>
 	);
 
+	const shouldRemoveCaption =
+		! bindings.caption && RichText.isEmpty( caption );
+
 	const figure = (
 		<>
 			{ href ? (
@@ -88,7 +92,7 @@ export default function save( { attributes } ) {
 				className={ __experimentalGetElementClassName( 'caption' ) }
 				tagName="figcaption"
 				value={ caption }
-				data-wp-maybe-remove={ RichText.isEmpty( caption ) }
+				data-wp-maybe-remove={ shouldRemoveCaption }
 			/>
 		</>
 	);

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -88,7 +88,7 @@ export default function save( { attributes } ) {
 				className={ __experimentalGetElementClassName( 'caption' ) }
 				tagName="figcaption"
 				value={ caption }
-				data-wp-maybe-remove={ ! RichText.isEmpty( caption ) }
+				data-wp-maybe-remove={ RichText.isEmpty( caption ) }
 			/>
 		</>
 	);

--- a/packages/block-library/src/image/test/__snapshots__/transforms.native.js.snap
+++ b/packages/block-library/src/image/test/__snapshots__/transforms.native.js.snap
@@ -4,7 +4,7 @@ exports[`Image block transformations to Columns block 1`] = `
 "<!-- wp:columns -->
 <div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
 <div class="wp-block-column" style="flex-basis:100%"><!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"media","className":"is-style-default"} -->
-<figure class="wp-block-image size-large is-style-default"><a href="https://cldup.com/cXyG__fTLN.jpg"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/></a><figcaption class="wp-element-caption">Mountain</figcaption></figure>
+<figure class="wp-block-image size-large is-style-default"><a href="https://cldup.com/cXyG__fTLN.jpg"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Mountain</figcaption></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->"
@@ -27,7 +27,7 @@ exports[`Image block transformations to File block 1`] = `
 exports[`Image block transformations to Gallery block 1`] = `
 "<!-- wp:gallery {"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"media","className":"is-style-default"} -->
-<figure class="wp-block-image size-large is-style-default"><a href="https://cldup.com/cXyG__fTLN.jpg"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/></a><figcaption class="wp-element-caption">Mountain</figcaption></figure>
+<figure class="wp-block-image size-large is-style-default"><a href="https://cldup.com/cXyG__fTLN.jpg"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Mountain</figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->"
 `;
@@ -35,7 +35,7 @@ exports[`Image block transformations to Gallery block 1`] = `
 exports[`Image block transformations to Group block 1`] = `
 "<!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"media","className":"is-style-default"} -->
-<figure class="wp-block-image size-large is-style-default"><a href="https://cldup.com/cXyG__fTLN.jpg"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/></a><figcaption class="wp-element-caption">Mountain</figcaption></figure>
+<figure class="wp-block-image size-large is-style-default"><a href="https://cldup.com/cXyG__fTLN.jpg"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Mountain</figcaption></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->"
 `;

--- a/packages/block-library/src/image/test/edit.native.js
+++ b/packages/block-library/src/image/test/edit.native.js
@@ -102,7 +102,7 @@ describe( 'Image Block', () => {
 			<a href="https://cldup.com/cXyG__fTLN.jpg">
 				<img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/>
 			</a>
-		<figcaption class="wp-element-caption">Mountain</figcaption></figure>
+		<figcaption class="wp-element-caption" data-wp-maybe-remove="false">Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
 		const screen = await initializeEditor( { initialHtml } );
 		// Check that image is fetched via `getEntityRecord`
@@ -119,7 +119,7 @@ describe( 'Image Block', () => {
 		fireEvent.press( screen.getByText( 'None' ) );
 
 		const expectedHtml = `<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"none","className":"is-style-default"} -->
-<figure class="wp-block-image size-large is-style-default"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/><figcaption class="wp-element-caption">Mountain</figcaption></figure>
+<figure class="wp-block-image size-large is-style-default"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Mountain</figcaption></figure>
 <!-- /wp:image -->`;
 		expect( getEditorHtml() ).toBe( expectedHtml );
 	} );
@@ -129,7 +129,7 @@ describe( 'Image Block', () => {
 		<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"none","className":"is-style-default"} -->
 		<figure class="wp-block-image size-large is-style-default">
 			<img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/>
-		<figcaption class="wp-element-caption">Mountain</figcaption></figure>
+		<figcaption class="wp-element-caption" data-wp-maybe-remove="false">Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
 		const screen = await initializeEditor( { initialHtml } );
 		// Check that image is fetched via `getEntityRecord`
@@ -146,7 +146,7 @@ describe( 'Image Block', () => {
 		fireEvent.press( screen.getByText( 'Media File' ) );
 
 		const expectedHtml = `<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"media","className":"is-style-default"} -->
-<figure class="wp-block-image size-large is-style-default"><a href="https://cldup.com/cXyG__fTLN.jpg"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/></a><figcaption class="wp-element-caption">Mountain</figcaption></figure>
+<figure class="wp-block-image size-large is-style-default"><a href="https://cldup.com/cXyG__fTLN.jpg"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Mountain</figcaption></figure>
 <!-- /wp:image -->`;
 		expect( getEditorHtml() ).toBe( expectedHtml );
 	} );
@@ -156,7 +156,7 @@ describe( 'Image Block', () => {
 		<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"none","className":"is-style-default"} -->
 		<figure class="wp-block-image size-large is-style-default">
 			<img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/>
-		<figcaption class="wp-element-caption">Mountain</figcaption></figure>
+		<figcaption class="wp-element-caption" data-wp-maybe-remove="false">Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
 		const screen = await initializeEditor( { initialHtml } );
 		// Check that image is fetched via `getEntityRecord`
@@ -183,7 +183,7 @@ describe( 'Image Block', () => {
 		);
 
 		const expectedHtml = `<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"custom","className":"is-style-default"} -->
-<figure class="wp-block-image size-large is-style-default"><a href="http://wordpress.org"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/></a><figcaption class="wp-element-caption">Mountain</figcaption></figure>
+<figure class="wp-block-image size-large is-style-default"><a href="http://wordpress.org"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Mountain</figcaption></figure>
 <!-- /wp:image -->`;
 		expect( getEditorHtml() ).toBe( expectedHtml );
 	} );
@@ -193,7 +193,7 @@ describe( 'Image Block', () => {
 		<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"none","className":"is-style-default"} -->
 		<figure class="wp-block-image size-large is-style-default">
 			<img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/>
-		<figcaption class="wp-element-caption">Mountain</figcaption></figure>
+		<figcaption class="wp-element-caption" data-wp-maybe-remove="false">Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
 		const screen = await initializeEditor( { initialHtml } );
 		// Check that image is fetched via `getEntityRecord`
@@ -214,7 +214,7 @@ describe( 'Image Block', () => {
 		fireEvent.press( screen.getByText( 'Media File' ) );
 
 		const expectedHtml = `<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"media","className":"is-style-default"} -->
-<figure class="wp-block-image size-large is-style-default"><a href="https://cldup.com/cXyG__fTLN.jpg"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/></a><figcaption class="wp-element-caption">Mountain</figcaption></figure>
+<figure class="wp-block-image size-large is-style-default"><a href="https://cldup.com/cXyG__fTLN.jpg"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Mountain</figcaption></figure>
 <!-- /wp:image -->`;
 		expect( getEditorHtml() ).toBe( expectedHtml );
 	} );
@@ -226,7 +226,7 @@ describe( 'Image Block', () => {
 			<a href="https://cldup.com/cXyG__fTLN.jpg">
 				<img src="https://cldup.com/cXyG__fTLN.jpg?w=683" alt="" class="wp-image-1"/>
 			</a>
-		<figcaption class="wp-element-caption">Mountain</figcaption></figure>
+		<figcaption class="wp-element-caption" data-wp-maybe-remove="false">Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
 		const screen = await initializeEditor( { initialHtml } );
 		// Check that image is not fetched via `getEntityRecord` due to the presence of query parameters in the URL.
@@ -251,7 +251,7 @@ describe( 'Image Block', () => {
 			<a href="https://wordpress.org">
 				<img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/>
 			</a>
-		<figcaption class="wp-element-caption">Mountain</figcaption></figure>
+		<figcaption class="wp-element-caption" data-wp-maybe-remove="false">Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
 		const screen = await initializeEditor( { initialHtml } );
 		// Check that image is fetched via `getEntityRecord`
@@ -269,7 +269,7 @@ describe( 'Image Block', () => {
 		fireEvent.press( linkTargetButton );
 
 		const expectedHtml = `<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"custom","className":"is-style-default"} -->
-<figure class="wp-block-image size-large is-style-default"><a href="https://wordpress.org" target="_blank" rel="noreferrer noopener"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/></a><figcaption class="wp-element-caption">Mountain</figcaption></figure>
+<figure class="wp-block-image size-large is-style-default"><a href="https://wordpress.org" target="_blank" rel="noreferrer noopener"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Mountain</figcaption></figure>
 <!-- /wp:image -->`;
 		expect( getEditorHtml() ).toBe( expectedHtml );
 	} );
@@ -281,7 +281,7 @@ describe( 'Image Block', () => {
 			<a href="https://wordpress.org" target="_blank" rel="noreferrer noopener">
 				<img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/>
 			</a>
-			<figcaption class="wp-element-caption">Mountain</figcaption>
+			<figcaption class="wp-element-caption" data-wp-maybe-remove="false">Mountain</figcaption>
 		</figure>
 		<!-- /wp:image -->`;
 		const screen = await initializeEditor( { initialHtml } );
@@ -300,7 +300,7 @@ describe( 'Image Block', () => {
 		fireEvent.press( linkTargetButton );
 
 		const expectedHtml = `<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"custom","className":"is-style-default"} -->
-<figure class="wp-block-image size-large is-style-default"><a href="https://wordpress.org"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/></a><figcaption class="wp-element-caption">Mountain</figcaption></figure>
+<figure class="wp-block-image size-large is-style-default"><a href="https://wordpress.org"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Mountain</figcaption></figure>
 <!-- /wp:image -->`;
 		expect( getEditorHtml() ).toBe( expectedHtml );
 	} );
@@ -443,7 +443,7 @@ describe( 'Image Block', () => {
 		const initialHtml = `
 		<!-- wp:image -->
 		<figure class="wp-block-image">
-				<img alt="" />
+				<img alt="" /><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption>
 		</figure>
 		<!-- /wp:image -->`;
 		const screen = await initializeEditor( { initialHtml } );
@@ -452,7 +452,7 @@ describe( 'Image Block', () => {
 		fireEvent.press( screen.getByText( 'WordPress Media Library' ) );
 
 		const expectedHtml = `<!-- wp:image {"id":${ IMAGE.id },"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="${ IMAGE.url }" alt="${ IMAGE.alt }" class="wp-image-${ IMAGE.id }"/></figure>
+<figure class="wp-block-image size-large"><img src="${ IMAGE.url }" alt="${ IMAGE.alt }" class="wp-image-${ IMAGE.id }"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->`;
 		expect( getEditorHtml() ).toBe( expectedHtml );
 	} );

--- a/packages/block-library/src/image/test/transforms.native.js
+++ b/packages/block-library/src/image/test/transforms.native.js
@@ -12,7 +12,7 @@ import {
 const block = 'Image';
 const initialHtml = `
 <!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"media","className":"is-style-default"} -->
-<figure class="wp-block-image size-large is-style-default"><a href="https://cldup.com/cXyG__fTLN.jpg"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/></a><figcaption class="wp-element-caption">Mountain</figcaption></figure>
+<figure class="wp-block-image size-large is-style-default"><a href="https://cldup.com/cXyG__fTLN.jpg"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Mountain</figcaption></figure>
 <!-- /wp:image -->`;
 
 const transformsWithInnerBlocks = [ 'Gallery', 'Columns', 'Group' ];

--- a/packages/block-library/src/media-text/test/__snapshots__/transforms.native.js.snap
+++ b/packages/block-library/src/media-text/test/__snapshots__/transforms.native.js.snap
@@ -32,7 +32,7 @@ exports[`Media & Text block transformations with Image to Group block 1`] = `
 
 exports[`Media & Text block transformations with Image to Image block 1`] = `
 "<!-- wp:image {"id":4674} -->
-<figure class="wp-block-image"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-4674"/></figure>
+<figure class="wp-block-image"><img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-4674"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->"
 `;
 

--- a/packages/components/src/mobile/link-settings/test/edit.native.js
+++ b/packages/components/src/mobile/link-settings/test/edit.native.js
@@ -63,7 +63,7 @@ describe.each( [
 			initialHtml: `
 				<!-- wp:image {"id":20,"sizeSlug":"large","linkDestination":"custom"} -->
 				<figure class="wp-block-image size-large">
-					<img class="wp-image-20" src="https://tonytahmouchtest.files.wordpress.com/2021/10/img_0111-2.jpg?w=1024" alt="" />
+					<img class="wp-image-20" src="https://tonytahmouchtest.files.wordpress.com/2021/10/img_0111-2.jpg?w=1024" alt="" /><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption>
 				</figure>
 				<!-- /wp:image -->
 			`,

--- a/packages/edit-post/src/test/__snapshots__/editor.native.js.snap
+++ b/packages/edit-post/src/test/__snapshots__/editor.native.js.snap
@@ -2,29 +2,29 @@
 
 exports[`Editor adds empty image block when pasting unsupported HTML local image path 1`] = `
 "<!-- wp:image -->
-<figure class="wp-block-image"><img src="" alt=""/></figure>
+<figure class="wp-block-image"><img src="" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->"
 `;
 
 exports[`Editor adds image block when pasting HTML local image path 1`] = `
 "<!-- wp:image -->
-<figure class="wp-block-image"><img src="file:///path/to/file.png" alt=""/></figure>
+<figure class="wp-block-image"><img src="file:///path/to/file.png" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->"
 `;
 
 exports[`Editor appends media correctly for allowed types 1`] = `
 "<!-- wp:image -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt=""/></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-3.jpeg" alt=""/></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-3.jpeg" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->"
 `;
 
 exports[`Editor appends media correctly for allowed types and skips unsupported ones 1`] = `
 "<!-- wp:image -->
-<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt=""/></figure>
+<figure class="wp-block-image"><img src="https://test-site.files.wordpress.com/local-image-1.jpeg" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:video -->

--- a/packages/patterns/src/components/pattern-overrides-controls.js
+++ b/packages/patterns/src/components/pattern-overrides-controls.js
@@ -61,13 +61,12 @@ function PatternOverridesControls( {
 	}
 
 	const hasUnsupportedImageAttributes =
-		blockName === 'core/image' &&
-		( !! attributes.caption?.length || !! attributes.href?.length );
+		blockName === 'core/image' && !! attributes.href?.length;
 
 	const helpText =
 		! hasOverrides && hasUnsupportedImageAttributes
 			? __(
-					`Overrides currently don't support image captions or links. Remove the caption or link first before enabling overrides.`
+					`Overrides currently don't support links. Remove the caption or link first before enabling overrides.`
 			  )
 			: __(
 					'Allow changes to this block throughout instances of this pattern.'

--- a/packages/react-native-editor/__device-tests__/helpers/test-data.js
+++ b/packages/react-native-editor/__device-tests__/helpers/test-data.js
@@ -6,7 +6,7 @@ exports.mediumText = `The finer continuum interprets the polynomial rabbit. When
 
 exports.slashInserter = '/';
 
-exports.longText = `Beneath the busy continuum blinks the ineffective husband. Why a metric now outside the official subway? How can the prompt crop exhaust his tree 
+exports.longText = `Beneath the busy continuum blinks the ineffective husband. Why a metric now outside the official subway? How can the prompt crop exhaust his tree
 Does this chord crowd my emptied search? A theory bubbles under the cartoon. The discontinued speaker cracks every thick epic. extraordinary twin shifts behind
 The finer continuum interprets the polynomial rabbit. When can the geology runs? An astronomer runs. Should a communist consent?`;
 
@@ -153,7 +153,7 @@ exports.listBlockEmpty = `<!-- wp:list -->
 <!-- /wp:list -->`;
 
 exports.imageBlockEmpty = `<!-- wp:image -->
-<figure class="wp-block-image"><img alt=""/></figure>
+<figure class="wp-block-image"><img alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->`;
 
 exports.moreBlockEmpty = `<!-- wp:more -->

--- a/packages/react-native-editor/src/initial-html.js
+++ b/packages/react-native-editor/src/initial-html.js
@@ -55,11 +55,11 @@ else:
 <!-- /wp:verse -->`;
 
 export const mediaBlocks = `<!-- wp:image -->
-<figure class="wp-block-image"><img alt=""/></figure>
+<figure class="wp-block-image"><img alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image -->
-<figure class="wp-block-image"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/><figcaption class="wp-element-caption">Mountain</figcaption></figure>
+<figure class="wp-block-image"><img src="https://cldup.com/cXyG__fTLN.jpg" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Mountain</figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:video {"id":683} -->

--- a/test/e2e/specs/editor/blocks/gallery.spec.js
+++ b/test/e2e/specs/editor/blocks/gallery.spec.js
@@ -67,7 +67,7 @@ test.describe( 'Gallery', () => {
 		expect( editedPostContent )
 			.toBe( `<!-- wp:gallery {"columns":3,"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-3 is-cropped"><!-- wp:image {"id":${ uploadedMedia.id },"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="${ uploadedMedia.source_url }" alt="${ uploadedMedia.alt_text }" class="wp-image-${ uploadedMedia.id }"/></figure>
+<figure class="wp-block-image size-large"><img src="${ uploadedMedia.source_url }" alt="${ uploadedMedia.alt_text }" class="wp-image-${ uploadedMedia.id }"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->` );
 
@@ -107,7 +107,7 @@ test.describe( 'Gallery', () => {
 		await expect( image ).toHaveAttribute( 'src', new RegExp( fileName ) );
 
 		const regex = new RegExp(
-			`<!-- wp:gallery {\\"linkTo\\":\\"none\\"} -->\\s*<figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"><!-- wp:image {\\"id\\":\\d+,\\"sizeSlug\\":\\"(?:full|large)\\",\\"linkDestination\\":\\"none\\"} -->\\s*<figure class=\\"wp-block-image (?:size-full|size-large)\\"><img src=\\"[^"]+\/${ fileName }\.png\\" alt=\\"\\" class=\\"wp-image-\\d+\\"\/><\/figure>\\s*<!-- \/wp:image --><\/figure>\\s*<!-- \/wp:gallery -->`
+			`<!-- wp:gallery {\\"linkTo\\":\\"none\\"} -->\\s*<figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"><!-- wp:image {\\"id\\":\\d+,\\"sizeSlug\\":\\"(?:full|large)\\",\\"linkDestination\\":\\"none\\"} -->\\s*<figure class=\\"wp-block-image (?:size-full|size-large)\\"><img src=\\"[^"]+\/${ fileName }\.png\\" alt=\\"\\" class=\\"wp-image-\\d+\\"\/><figcaption class=\\"wp-element-caption\\" data-wp-maybe-remove=\\"true\\"></figcaption><\/figure>\\s*<!-- \/wp:image --><\/figure>\\s*<!-- \/wp:gallery -->`
 		);
 		await expect.poll( editor.getEditedPostContent ).toMatch( regex );
 	} );

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -55,7 +55,7 @@ test.describe( 'Image', () => {
 
 		const regex = new RegExp(
 			`<!-- wp:image {"id":(\\d+),"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="[^"]+\\/${ fileName }\\.png" alt="" class="wp-image-\\1"/></figure>
+<figure class="wp-block-image size-full"><img src="[^"]+\\/${ fileName }\\.png" alt="" class="wp-image-\\1"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- \\/wp:image -->`
 		);
 		expect( await editor.getEditedPostContent() ).toMatch( regex );
@@ -951,7 +951,7 @@ test.describe( 'Image - lightbox', () => {
 				page,
 			} ) => {
 				await editor.setContent( `<!-- wp:image {"id":${ uploadedMedia.id },"sizeSlug":"full","linkDestination":"none"} -->
-				<figure class="wp-block-image size-full"><img src="${ uploadedMedia.source_url }" alt="" class="wp-image-${ uploadedMedia.id }"/></figure>
+				<figure class="wp-block-image size-full"><img src="${ uploadedMedia.source_url }" alt="" class="wp-image-${ uploadedMedia.id }"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 				<!-- /wp:image --> ` );
 
 				const imageBlock = editor.canvas.locator(
@@ -1082,7 +1082,7 @@ test.describe( 'Image - Site editor', () => {
 
 		const regex = new RegExp(
 			`<!-- wp:image {"id":(\\d+),"sizeSlug":"full","linkDestination":"none"} -->
-<figure class="wp-block-image size-full"><img src="[^"]+\\/${ fileName }\\.png" alt="" class="wp-image-\\1"/></figure>
+<figure class="wp-block-image size-full"><img src="[^"]+\\/${ fileName }\\.png" alt="" class="wp-image-\\1"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- \\/wp:image -->`
 		);
 		expect( await editor.getEditedPostContent() ).toMatch( regex );

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -416,7 +416,7 @@ test.describe( 'Image', () => {
 		// Expect an empty image block (placeholder) rather than one with a
 		// broken temporary URL.
 		expect( await editor.getEditedPostContent() ).toBe( `<!-- wp:image -->
-<figure class="wp-block-image"><img alt=""/></figure>
+<figure class="wp-block-image"><img alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->` );
 	} );
 

--- a/test/e2e/specs/editor/plugins/__snapshots__/Post-type-templates-Using-a-CPT-with-a-predefi-fffe1--custom-post-types-with-a-predefined-template-1-chromium.txt
+++ b/test/e2e/specs/editor/plugins/__snapshots__/Post-type-templates-Using-a-CPT-with-a-predefi-fffe1--custom-post-types-with-a-predefined-template-1-chromium.txt
@@ -1,5 +1,5 @@
 <!-- wp:image -->
-<figure class="wp-block-image"><img alt=""/></figure>
+<figure class="wp-block-image"><img alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph {"placeholder":"Add a book description"} -->
@@ -15,7 +15,7 @@
 <!-- wp:columns -->
 <div class="wp-block-columns"><!-- wp:column -->
 <div class="wp-block-column"><!-- wp:image -->
-<figure class="wp-block-image"><img alt=""/></figure>
+<figure class="wp-block-image"><img alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column -->
 

--- a/test/e2e/specs/editor/plugins/post-type-templates.spec.js
+++ b/test/e2e/specs/editor/plugins/post-type-templates.spec.js
@@ -103,7 +103,7 @@ test.describe( 'Post type templates', () => {
 
 			await expect.poll( editor.getEditedPostContent )
 				.toBe( `<!-- wp:image -->
-<figure class="wp-block-image"><img alt=""/></figure>
+<figure class="wp-block-image"><img alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->` );
 		} );
 

--- a/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
@@ -159,6 +159,10 @@ test.describe( 'Registered sources', () => {
 								source: 'testing/complete-source',
 								args: { key: 'text_field' },
 							},
+							caption: {
+								source: 'testing/complete-source',
+								args: { key: 'text_field' },
+							},
 						},
 					},
 				},
@@ -185,6 +189,11 @@ test.describe( 'Registered sources', () => {
 				.getByLabel( 'Alternative text' )
 				.inputValue();
 			expect( altValue ).toBe( 'Text Field Value' );
+
+			const captionValue = editor.canvas.getByRole( 'textbox', {
+				name: 'Image caption text',
+			} );
+			await expect( captionValue ).toHaveText( 'Text Field Value' );
 
 			// Title input should have the original value.
 			const advancedButton = page
@@ -894,6 +903,10 @@ test.describe( 'Registered sources', () => {
 				name: 'Show linkClass',
 			} );
 			await expect( linkClassAttribute ).toBeHidden();
+			const captionAttribute = page.getByRole( 'menuitemcheckbox', {
+				name: 'Show caption',
+			} );
+			await expect( captionAttribute ).toBeVisible();
 		} );
 		test( 'should show all the available fields in the dropdown UI', async ( {
 			editor,

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -737,7 +737,7 @@ test.describe( 'insert media from inserter', () => {
 		await page.getByLabel( uploadedMedia.title.raw ).click();
 		await expect.poll( editor.getEditedPostContent ).toBe(
 			`<!-- wp:image {"id":${ uploadedMedia.id }} -->
-<figure class="wp-block-image"><img src="${ uploadedMedia.source_url }" alt="${ uploadedMedia.alt_text }" class="wp-image-${ uploadedMedia.id }"/></figure>
+<figure class="wp-block-image"><img src="${ uploadedMedia.source_url }" alt="${ uploadedMedia.alt_text }" class="wp-image-${ uploadedMedia.id }"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->`
 		);
 	} );

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -955,7 +955,7 @@ test.describe( 'Pattern Overrides', () => {
 		const { id } = await requestUtils.createBlock( {
 			title: 'Pattern',
 			content: `<!-- wp:image {"metadata":{"name":"${ imageName }","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
-<figure class="wp-block-image"><img alt=""/></figure>
+<figure class="wp-block-image"><img alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->`,
 			status: 'publish',
 		} );
@@ -1015,7 +1015,7 @@ test.describe( 'Pattern Overrides', () => {
 		const { id } = await requestUtils.createBlock( {
 			title: 'Pattern',
 			content: `<!-- wp:image {"metadata":{"name":"${ imageName }","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
-<figure class="wp-block-image"><img alt=""/></figure>
+<figure class="wp-block-image"><img alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->`,
 			status: 'publish',
 		} );
@@ -1344,7 +1344,7 @@ test.describe( 'Pattern Overrides', () => {
 		const { id } = await requestUtils.createBlock( {
 			title: 'Pattern',
 			content: `<!-- wp:image {"metadata":{"name":"${ imageName }","bindings":{"id":{"source":"core/pattern-overrides"},"url":{"source":"core/pattern-overrides"},"title":{"source":"core/pattern-overrides"},"alt":{"source":"core/pattern-overrides"}}}} -->
-<figure class="wp-block-image"><img alt=""/></figure>
+<figure class="wp-block-image"><img alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->`,
 			status: 'publish',
 		} );

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -955,7 +955,7 @@ test.describe( 'Pattern Overrides', () => {
 		const { id } = await requestUtils.createBlock( {
 			title: 'Pattern',
 			content: `<!-- wp:image {"metadata":{"name":"${ imageName }","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
-<figure class="wp-block-image"><img alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
+<figure class="wp-block-image"><img alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="false"></figcaption></figure>
 <!-- /wp:image -->`,
 			status: 'publish',
 		} );
@@ -1015,7 +1015,7 @@ test.describe( 'Pattern Overrides', () => {
 		const { id } = await requestUtils.createBlock( {
 			title: 'Pattern',
 			content: `<!-- wp:image {"metadata":{"name":"${ imageName }","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
-<figure class="wp-block-image"><img alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
+<figure class="wp-block-image"><img alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="false"></figcaption></figure>
 <!-- /wp:image -->`,
 			status: 'publish',
 		} );
@@ -1344,7 +1344,7 @@ test.describe( 'Pattern Overrides', () => {
 		const { id } = await requestUtils.createBlock( {
 			title: 'Pattern',
 			content: `<!-- wp:image {"metadata":{"name":"${ imageName }","bindings":{"id":{"source":"core/pattern-overrides"},"url":{"source":"core/pattern-overrides"},"title":{"source":"core/pattern-overrides"},"alt":{"source":"core/pattern-overrides"}}}} -->
-<figure class="wp-block-image"><img alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
+<figure class="wp-block-image"><img alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="false"></figcaption></figure>
 <!-- /wp:image -->`,
 			status: 'publish',
 		} );

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -860,7 +860,7 @@ test.describe( 'Writing Flow (@firefox, @webkit)', () => {
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"align":"wide"} -->
-<figure class="wp-block-image alignwide"><img alt=""/></figure>
+<figure class="wp-block-image alignwide"><img alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->` );
 
 		const paragraphBlock = editor.canvas.locator(

--- a/test/integration/__snapshots__/blocks-raw-handling.test.js.snap
+++ b/test/integration/__snapshots__/blocks-raw-handling.test.js.snap
@@ -98,7 +98,7 @@ exports[`rawHandler should convert HTML post to blocks with minimal content chan
 <!-- /wp:heading -->
 
 <!-- wp:image -->
-<figure class="wp-block-image"><img src="https://w.org" alt=""/></figure>
+<figure class="wp-block-image"><img src="https://w.org" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph -->
@@ -123,7 +123,7 @@ exports[`rawHandler should convert HTML post to blocks with minimal content chan
 
 <!-- wp:gallery {"columns":3,"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-3 is-cropped"><!-- wp:image {"id":1} -->
-<figure class="wp-block-image"><img alt="" class="wp-image-1"/></figure>
+<figure class="wp-block-image"><img alt="" class="wp-image-1"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->
 
@@ -161,19 +161,19 @@ exports[`rawHandler should convert HTML post to blocks with minimal content chan
 
 exports[`rawHandler should convert a caption shortcode 1`] = `
 "<!-- wp:image {"id":122,"align":"none","className":"size-medium wp-image-122"} -->
-<figure class="wp-block-image alignnone size-medium wp-image-122"><img src="image.png" alt="" class="wp-image-122"/><figcaption class="wp-element-caption">test</figcaption></figure>
+<figure class="wp-block-image alignnone size-medium wp-image-122"><img src="image.png" alt="" class="wp-image-122"/><figcaption class="wp-element-caption" data-wp-maybe-remove="false">test</figcaption></figure>
 <!-- /wp:image -->"
 `;
 
 exports[`rawHandler should convert a caption shortcode with caption 1`] = `
 "<!-- wp:image {"id":122,"align":"none","className":"size-medium wp-image-122"} -->
-<figure class="wp-block-image alignnone size-medium wp-image-122"><img src="image.png" alt="" class="wp-image-122"/><figcaption class="wp-element-caption"><a href="https://w.org">test</a></figcaption></figure>
+<figure class="wp-block-image alignnone size-medium wp-image-122"><img src="image.png" alt="" class="wp-image-122"/><figcaption class="wp-element-caption" data-wp-maybe-remove="false"><a href="https://w.org">test</a></figcaption></figure>
 <!-- /wp:image -->"
 `;
 
 exports[`rawHandler should convert a caption shortcode with link 1`] = `
 "<!-- wp:image {"id":754,"align":"none"} -->
-<figure class="wp-block-image alignnone"><a href="http://build.wordpress-develop.test/wp-content/uploads/2011/07/100_5478.jpg"><img src="http://build.wordpress-develop.test/wp-content/uploads/2011/07/100_5478.jpg?w=604" alt="Bell on Wharf" class="wp-image-754"/></a><figcaption class="wp-element-caption">Bell on wharf in San Francisco</figcaption></figure>
+<figure class="wp-block-image alignnone"><a href="http://build.wordpress-develop.test/wp-content/uploads/2011/07/100_5478.jpg"><img src="http://build.wordpress-develop.test/wp-content/uploads/2011/07/100_5478.jpg?w=604" alt="Bell on Wharf" class="wp-image-754"/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Bell on wharf in San Francisco</figcaption></figure>
 <!-- /wp:image -->"
 `;
 

--- a/test/integration/fixtures/blocks/core__gallery-with-caption.html
+++ b/test/integration/fixtures/blocks/core__gallery-with-caption.html
@@ -9,6 +9,7 @@
 			alt="Image gallery image"
 			class="wp-image-1421"
 		/>
+		<figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption>
 	</figure>
 	<!-- /wp:image -->
 
@@ -19,6 +20,7 @@
 			alt="Image gallery image"
 			class="wp-image-1440"
 		/>
+		<figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption>
 	</figure>
 	<!-- /wp:image -->
 	<figcaption class="blocks-gallery-caption wp-element-caption">Gallery Caption</figcaption>

--- a/test/integration/fixtures/blocks/core__gallery-with-caption.parsed.json
+++ b/test/integration/fixtures/blocks/core__gallery-with-caption.parsed.json
@@ -18,9 +18,9 @@
 					}
 				},
 				"innerBlocks": [],
-				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1421\"\n\t\t/>\n\t</figure>\n\t",
+				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1421\"\n\t\t/>\n\t\t<figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption>\n\t</figure>\n\t",
 				"innerContent": [
-					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1421\"\n\t\t/>\n\t</figure>\n\t"
+					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1421\"\n\t\t/>\n\t\t<figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption>\n\t</figure>\n\t"
 				]
 			},
 			{
@@ -36,9 +36,9 @@
 					}
 				},
 				"innerBlocks": [],
-				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1440\"\n\t\t/>\n\t</figure>\n\t",
+				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1440\"\n\t\t/>\n\t\t<figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption>\n\t</figure>\n\t",
 				"innerContent": [
-					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1440\"\n\t\t/>\n\t</figure>\n\t"
+					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1440\"\n\t\t/>\n\t\t<figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption>\n\t</figure>\n\t"
 				]
 			}
 		],

--- a/test/integration/fixtures/blocks/core__gallery-with-caption.serialized.html
+++ b/test/integration/fixtures/blocks/core__gallery-with-caption.serialized.html
@@ -1,9 +1,9 @@
 <!-- wp:gallery {"linkTo":"none","className":"columns-2"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped columns-2"><!-- wp:image {"id":1421,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190" alt="Image gallery image" class="wp-image-1421"/></figure>
+<figure class="wp-block-image size-large"><img src="https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190" alt="Image gallery image" class="wp-image-1421"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":1440,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580" alt="Image gallery image" class="wp-image-1440"/></figure>
+<figure class="wp-block-image size-large"><img src="https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580" alt="Image gallery image" class="wp-image-1440"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --><figcaption class="blocks-gallery-caption wp-element-caption">Gallery Caption</figcaption></figure>
 <!-- /wp:gallery -->

--- a/test/integration/fixtures/blocks/core__gallery.html
+++ b/test/integration/fixtures/blocks/core__gallery.html
@@ -9,6 +9,7 @@
 			alt="Image gallery image"
 			class="wp-image-1421"
 		/>
+		<figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption>
 	</figure>
 	<!-- /wp:image -->
 
@@ -19,6 +20,7 @@
 			alt="Image gallery image"
 			class="wp-image-1440"
 		/>
+		<figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption>
 	</figure>
 	<!-- /wp:image -->
 </figure>

--- a/test/integration/fixtures/blocks/core__gallery.parsed.json
+++ b/test/integration/fixtures/blocks/core__gallery.parsed.json
@@ -14,9 +14,9 @@
 					"linkDestination": "none"
 				},
 				"innerBlocks": [],
-				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1421\"\n\t\t/>\n\t</figure>\n\t",
+				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1421\"\n\t\t/>\n\t\t<figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption>\n\t</figure>\n\t",
 				"innerContent": [
-					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1421\"\n\t\t/>\n\t</figure>\n\t"
+					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1421\"\n\t\t/>\n\t\t<figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption>\n\t</figure>\n\t"
 				]
 			},
 			{
@@ -27,9 +27,9 @@
 					"linkDestination": "none"
 				},
 				"innerBlocks": [],
-				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1440\"\n\t\t/>\n\t</figure>\n\t",
+				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1440\"\n\t\t/>\n\t\t<figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption>\n\t</figure>\n\t",
 				"innerContent": [
-					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1440\"\n\t\t/>\n\t</figure>\n\t"
+					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1440\"\n\t\t/>\n\t\t<figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption>\n\t</figure>\n\t"
 				]
 			}
 		],

--- a/test/integration/fixtures/blocks/core__gallery.serialized.html
+++ b/test/integration/fixtures/blocks/core__gallery.serialized.html
@@ -1,9 +1,9 @@
 <!-- wp:gallery {"linkTo":"none","className":"columns-2"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped columns-2"><!-- wp:image {"id":1421,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190" alt="Image gallery image" class="wp-image-1421"/></figure>
+<figure class="wp-block-image size-large"><img src="https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190" alt="Image gallery image" class="wp-image-1421"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":1440,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580" alt="Image gallery image" class="wp-image-1440"/></figure>
+<figure class="wp-block-image size-large"><img src="https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580" alt="Image gallery image" class="wp-image-1440"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->

--- a/test/integration/fixtures/blocks/core__gallery__columns.html
+++ b/test/integration/fixtures/blocks/core__gallery__columns.html
@@ -7,6 +7,7 @@
 			alt="Image gallery image"
 			class="wp-image-1421"
 		/>
+		<figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption>
 	</figure>
 	<!-- /wp:image -->
 
@@ -17,6 +18,7 @@
 			alt="Image gallery image"
 			class="wp-image-1440"
 		/>
+		<figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption>
 	</figure>
 	<!-- /wp:image -->
 </figure>

--- a/test/integration/fixtures/blocks/core__gallery__columns.parsed.json
+++ b/test/integration/fixtures/blocks/core__gallery__columns.parsed.json
@@ -19,9 +19,9 @@
 					}
 				},
 				"innerBlocks": [],
-				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1421\"\n\t\t/>\n\t</figure>\n\t",
+				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1421\"\n\t\t/>\n\t\t<figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption>\n\t</figure>\n\t",
 				"innerContent": [
-					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1421\"\n\t\t/>\n\t</figure>\n\t"
+					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1421\"\n\t\t/>\n\t\t<figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption>\n\t</figure>\n\t"
 				]
 			},
 			{
@@ -37,9 +37,9 @@
 					}
 				},
 				"innerBlocks": [],
-				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1440\"\n\t\t/>\n\t</figure>\n\t",
+				"innerHTML": "\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1440\"\n\t\t/>\n\t\t<figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption>\n\t</figure>\n\t",
 				"innerContent": [
-					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1440\"\n\t\t/>\n\t</figure>\n\t"
+					"\n\t<figure class=\"wp-block-image size-large\">\n\t\t<img\n\t\t\tsrc=\"https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580\"\n\t\t\talt=\"Image gallery image\"\n\t\t\tclass=\"wp-image-1440\"\n\t\t/>\n\t\t<figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption>\n\t</figure>\n\t"
 				]
 			}
 		],

--- a/test/integration/fixtures/blocks/core__gallery__columns.serialized.html
+++ b/test/integration/fixtures/blocks/core__gallery__columns.serialized.html
@@ -1,9 +1,9 @@
 <!-- wp:gallery {"columns":1,"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-1 is-cropped"><!-- wp:image {"id":1421,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190" alt="Image gallery image" class="wp-image-1421"/></figure>
+<figure class="wp-block-image size-large"><img src="https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190" alt="Image gallery image" class="wp-image-1421"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":1440,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580" alt="Image gallery image" class="wp-image-1440"/></figure>
+<figure class="wp-block-image size-large"><img src="https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580" alt="Image gallery image" class="wp-image-1440"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-1.serialized.html
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-1.serialized.html
@@ -1,9 +1,9 @@
 <!-- wp:gallery {"columns":2,"linkTo":"none","align":"wide"} -->
 <figure class="wp-block-gallery alignwide has-nested-images columns-2 is-cropped"><!-- wp:image {"linkDestination":"none"} -->
-<figure class="wp-block-image"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="title"/></figure>
+<figure class="wp-block-image"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="title"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"linkDestination":"none"} -->
-<figure class="wp-block-image"><img src="data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=" alt="title"/></figure>
+<figure class="wp-block-image"><img src="data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=" alt="title"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-2.serialized.html
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-2.serialized.html
@@ -1,9 +1,9 @@
 <!-- wp:gallery {"columns":2,"linkTo":"none","align":"wide"} -->
 <figure class="wp-block-gallery alignwide has-nested-images columns-2 is-cropped"><!-- wp:image {"id":1,"linkDestination":"none"} -->
-<figure class="wp-block-image"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="title" class="wp-image-1"/></figure>
+<figure class="wp-block-image"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="title" class="wp-image-1"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":2,"linkDestination":"none"} -->
-<figure class="wp-block-image"><img src="data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=" alt="title" class="wp-image-2"/></figure>
+<figure class="wp-block-image"><img src="data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=" alt="title" class="wp-image-2"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-3.serialized.html
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-3.serialized.html
@@ -1,9 +1,9 @@
 <!-- wp:gallery {"linkTo":"none","align":"wide"} -->
 <figure class="wp-block-gallery alignwide has-nested-images columns-default is-cropped"><!-- wp:image {"linkDestination":"none"} -->
-<figure class="wp-block-image"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="title"/></figure>
+<figure class="wp-block-image"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="title"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"linkDestination":"none"} -->
-<figure class="wp-block-image"><img src="data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=" alt="title"/></figure>
+<figure class="wp-block-image"><img src="data:image/jpeg;base64,/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=" alt="title"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-4.serialized.html
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-4.serialized.html
@@ -1,13 +1,13 @@
 <!-- wp:gallery {"linkTo":"none","align":"wide"} -->
 <figure class="wp-block-gallery alignwide has-nested-images columns-default is-cropped"><!-- wp:image {"id":1421,"linkDestination":"none"} -->
-<figure class="wp-block-image"><img src="https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190" alt="" class="wp-image-1421"/></figure>
+<figure class="wp-block-image"><img src="https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190" alt="" class="wp-image-1421"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":1440,"linkDestination":"none"} -->
-<figure class="wp-block-image"><img src="https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580" alt="" class="wp-image-1440"/></figure>
+<figure class="wp-block-image"><img src="https://sergioestevaofolio.files.wordpress.com/2017/09/cropped-l1001498-1.jpg?w=580" alt="" class="wp-image-1440"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":1362,"linkDestination":"none"} -->
-<figure class="wp-block-image"><img src="https://sergioestevaofolio.files.wordpress.com/2017/05/cropped-l1005945-2-2.jpg?w=580" alt="" class="wp-image-1362"/></figure>
+<figure class="wp-block-image"><img src="https://sergioestevaofolio.files.wordpress.com/2017/05/cropped-l1005945-2-2.jpg?w=580" alt="" class="wp-image-1362"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-5.serialized.html
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-5.serialized.html
@@ -1,13 +1,13 @@
 <!-- wp:gallery {"linkTo":"media"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":705,"sizeSlug":"large","linkDestination":"media"} -->
-<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg" alt="" class="wp-image-705"/></a></figure>
+<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg" alt="" class="wp-image-705"/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":704,"sizeSlug":"large","linkDestination":"media"} -->
-<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg" alt="" class="wp-image-704"/></a></figure>
+<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg" alt="" class="wp-image-704"/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":703,"sizeSlug":"large","linkDestination":"media"} -->
-<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg"><img src="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg" alt="" class="wp-image-703"/></a></figure>
+<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg"><img src="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg" alt="" class="wp-image-703"/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-6.serialized.html
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-6.serialized.html
@@ -1,13 +1,13 @@
 <!-- wp:gallery {"linkTo":"media"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":705,"sizeSlug":"large","linkDestination":"media"} -->
-<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg" alt="" class="wp-image-705"/></a></figure>
+<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg" alt="" class="wp-image-705"/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":704,"sizeSlug":"large","linkDestination":"media"} -->
-<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg" alt="" class="wp-image-704"/></a></figure>
+<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg" alt="" class="wp-image-704"/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":703,"sizeSlug":"large","linkDestination":"media"} -->
-<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg"><img src="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg" alt="" class="wp-image-703"/></a></figure>
+<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg"><img src="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg" alt="" class="wp-image-703"/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-7.serialized.html
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-7.serialized.html
@@ -1,27 +1,27 @@
 <!-- wp:gallery {"linkTo":"media"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":705,"sizeSlug":"large","linkDestination":"media"} -->
-<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg" alt="" class="wp-image-705"/></a></figure>
+<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg" alt="" class="wp-image-705"/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":704,"sizeSlug":"large","linkDestination":"media"} -->
-<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg" alt="" class="wp-image-704"/></a></figure>
+<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg" alt="" class="wp-image-704"/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":703,"sizeSlug":"large","linkDestination":"media"} -->
-<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg"><img src="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg" alt="" class="wp-image-703"/></a></figure>
+<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg"><img src="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg" alt="" class="wp-image-703"/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->
 
 <!-- wp:gallery {"linkTo":"media"} -->
 <figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":705,"sizeSlug":"large","linkDestination":"media"} -->
-<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg" alt="" class="wp-image-705"/></a></figure>
+<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1-682x1024.jpg" alt="" class="wp-image-705"/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":704,"sizeSlug":"large","linkDestination":"media"} -->
-<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg" alt="" class="wp-image-704"/></a></figure>
+<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg"><img src="http://wptest.local/wp-content/uploads/2020/09/test-image-edited-1024x682.jpg" alt="" class="wp-image-704"/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":703,"sizeSlug":"large","linkDestination":"media"} -->
-<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg"><img src="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg" alt="" class="wp-image-703"/></a></figure>
+<figure class="wp-block-image size-large"><a href="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg"><img src="http://wptest.local/wp-content/uploads/2020/04/test-image-1024x683.jpg" alt="" class="wp-image-703"/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --><figcaption class="blocks-gallery-caption wp-element-caption">This gallery has a caption</figcaption></figure>
 <!-- /wp:gallery -->

--- a/test/integration/fixtures/blocks/core__image.html
+++ b/test/integration/fixtures/blocks/core__image.html
@@ -1,3 +1,3 @@
 <!-- wp:core/image -->
-<figure class="wp-block-image"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" /></figure>
+<figure class="wp-block-image"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" /><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:core/image -->

--- a/test/integration/fixtures/blocks/core__image.parsed.json
+++ b/test/integration/fixtures/blocks/core__image.parsed.json
@@ -3,9 +3,9 @@
 		"blockName": "core/image",
 		"attrs": {},
 		"innerBlocks": [],
-		"innerHTML": "\n<figure class=\"wp-block-image\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /></figure>\n",
+		"innerHTML": "\n<figure class=\"wp-block-image\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /><figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption></figure>\n",
 		"innerContent": [
-			"\n<figure class=\"wp-block-image\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /></figure>\n"
+			"\n<figure class=\"wp-block-image\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /><figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption></figure>\n"
 		]
 	}
 ]

--- a/test/integration/fixtures/blocks/core__image.serialized.html
+++ b/test/integration/fixtures/blocks/core__image.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image -->
-<figure class="wp-block-image"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt=""/></figure>
+<figure class="wp-block-image"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__attachment-link.html
+++ b/test/integration/fixtures/blocks/core__image__attachment-link.html
@@ -1,3 +1,3 @@
 <!-- wp:core/image {"linkDestination":"attachment"}  -->
-<figure class="wp-block-image"><a href="http://localhost:8888/?attachment_id=7"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" /></a></figure>
+<figure class="wp-block-image"><a href="http://localhost:8888/?attachment_id=7"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" /></a><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:core/image -->

--- a/test/integration/fixtures/blocks/core__image__attachment-link.parsed.json
+++ b/test/integration/fixtures/blocks/core__image__attachment-link.parsed.json
@@ -5,9 +5,9 @@
 			"linkDestination": "attachment"
 		},
 		"innerBlocks": [],
-		"innerHTML": "\n<figure class=\"wp-block-image\"><a href=\"http://localhost:8888/?attachment_id=7\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /></a></figure>\n",
+		"innerHTML": "\n<figure class=\"wp-block-image\"><a href=\"http://localhost:8888/?attachment_id=7\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /></a><figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption></figure>\n",
 		"innerContent": [
-			"\n<figure class=\"wp-block-image\"><a href=\"http://localhost:8888/?attachment_id=7\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /></a></figure>\n"
+			"\n<figure class=\"wp-block-image\"><a href=\"http://localhost:8888/?attachment_id=7\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /></a><figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption></figure>\n"
 		]
 	}
 ]

--- a/test/integration/fixtures/blocks/core__image__attachment-link.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__attachment-link.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image {"linkDestination":"attachment"} -->
-<figure class="wp-block-image"><a href="http://localhost:8888/?attachment_id=7"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt=""/></a></figure>
+<figure class="wp-block-image"><a href="http://localhost:8888/?attachment_id=7"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt=""/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__center-caption.html
+++ b/test/integration/fixtures/blocks/core__image__center-caption.html
@@ -1,3 +1,3 @@
 <!-- wp:core/image {"align":"center"} -->
-<figure class="wp-block-image aligncenter"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" /><figcaption class="wp-element-caption">Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>
+<figure class="wp-block-image aligncenter"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" /><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>
 <!-- /wp:core/image -->

--- a/test/integration/fixtures/blocks/core__image__center-caption.parsed.json
+++ b/test/integration/fixtures/blocks/core__image__center-caption.parsed.json
@@ -5,9 +5,9 @@
 			"align": "center"
 		},
 		"innerBlocks": [],
-		"innerHTML": "\n<figure class=\"wp-block-image aligncenter\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /><figcaption class=\"wp-element-caption\">Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>\n",
+		"innerHTML": "\n<figure class=\"wp-block-image aligncenter\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /><figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"false\">Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>\n",
 		"innerContent": [
-			"\n<figure class=\"wp-block-image aligncenter\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /><figcaption class=\"wp-element-caption\">Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>\n"
+			"\n<figure class=\"wp-block-image aligncenter\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /><figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"false\">Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>\n"
 		]
 	}
 ]

--- a/test/integration/fixtures/blocks/core__image__center-caption.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__center-caption.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image {"align":"center"} -->
-<figure class="wp-block-image aligncenter"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt=""/><figcaption class="wp-element-caption">Give it a try. Press the "really wide" button on the image toolbar.</figcaption></figure>
+<figure class="wp-block-image aligncenter"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="false">Give it a try. Press the "really wide" button on the image toolbar.</figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__custom-link-class.html
+++ b/test/integration/fixtures/blocks/core__image__custom-link-class.html
@@ -1,3 +1,3 @@
 <!-- wp:core/image {"linkDestination":"custom"}  -->
-<figure class="wp-block-image"><a class="custom-link" href="https://wordpress.org/"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" /></a></figure>
+<figure class="wp-block-image"><a class="custom-link" href="https://wordpress.org/"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" /></a><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:core/image -->

--- a/test/integration/fixtures/blocks/core__image__custom-link-class.parsed.json
+++ b/test/integration/fixtures/blocks/core__image__custom-link-class.parsed.json
@@ -5,9 +5,9 @@
 			"linkDestination": "custom"
 		},
 		"innerBlocks": [],
-		"innerHTML": "\n<figure class=\"wp-block-image\"><a class=\"custom-link\" href=\"https://wordpress.org/\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /></a></figure>\n",
+		"innerHTML": "\n<figure class=\"wp-block-image\"><a class=\"custom-link\" href=\"https://wordpress.org/\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /></a><figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption></figure>\n",
 		"innerContent": [
-			"\n<figure class=\"wp-block-image\"><a class=\"custom-link\" href=\"https://wordpress.org/\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /></a></figure>\n"
+			"\n<figure class=\"wp-block-image\"><a class=\"custom-link\" href=\"https://wordpress.org/\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /></a><figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption></figure>\n"
 		]
 	}
 ]

--- a/test/integration/fixtures/blocks/core__image__custom-link-class.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__custom-link-class.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image {"linkDestination":"custom"} -->
-<figure class="wp-block-image"><a class="custom-link" href="https://wordpress.org/"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt=""/></a></figure>
+<figure class="wp-block-image"><a class="custom-link" href="https://wordpress.org/"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt=""/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__custom-link-rel.html
+++ b/test/integration/fixtures/blocks/core__image__custom-link-rel.html
@@ -1,3 +1,3 @@
 <!-- wp:core/image {"linkDestination":"custom"}  -->
-<figure class="wp-block-image"><a href="https://wordpress.org/" rel="external"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" /></a></figure>
+<figure class="wp-block-image"><a href="https://wordpress.org/" rel="external"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" /></a><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:core/image -->

--- a/test/integration/fixtures/blocks/core__image__custom-link-rel.parsed.json
+++ b/test/integration/fixtures/blocks/core__image__custom-link-rel.parsed.json
@@ -5,9 +5,9 @@
 			"linkDestination": "custom"
 		},
 		"innerBlocks": [],
-		"innerHTML": "\n<figure class=\"wp-block-image\"><a href=\"https://wordpress.org/\" rel=\"external\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /></a></figure>\n",
+		"innerHTML": "\n<figure class=\"wp-block-image\"><a href=\"https://wordpress.org/\" rel=\"external\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /></a><figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption></figure>\n",
 		"innerContent": [
-			"\n<figure class=\"wp-block-image\"><a href=\"https://wordpress.org/\" rel=\"external\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /></a></figure>\n"
+			"\n<figure class=\"wp-block-image\"><a href=\"https://wordpress.org/\" rel=\"external\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /></a><figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption></figure>\n"
 		]
 	}
 ]

--- a/test/integration/fixtures/blocks/core__image__custom-link-rel.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__custom-link-rel.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image {"linkDestination":"custom"} -->
-<figure class="wp-block-image"><a href="https://wordpress.org/" rel="external"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt=""/></a></figure>
+<figure class="wp-block-image"><a href="https://wordpress.org/" rel="external"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt=""/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__custom-link.html
+++ b/test/integration/fixtures/blocks/core__image__custom-link.html
@@ -1,3 +1,3 @@
 <!-- wp:core/image {"linkDestination":"custom"}  -->
-<figure class="wp-block-image"><a href="https://wordpress.org/"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" /></a></figure>
+<figure class="wp-block-image"><a href="https://wordpress.org/"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" /></a><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:core/image -->

--- a/test/integration/fixtures/blocks/core__image__custom-link.parsed.json
+++ b/test/integration/fixtures/blocks/core__image__custom-link.parsed.json
@@ -5,9 +5,9 @@
 			"linkDestination": "custom"
 		},
 		"innerBlocks": [],
-		"innerHTML": "\n<figure class=\"wp-block-image\"><a href=\"https://wordpress.org/\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /></a></figure>\n",
+		"innerHTML": "\n<figure class=\"wp-block-image\"><a href=\"https://wordpress.org/\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /></a><figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption></figure>\n",
 		"innerContent": [
-			"\n<figure class=\"wp-block-image\"><a href=\"https://wordpress.org/\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /></a></figure>\n"
+			"\n<figure class=\"wp-block-image\"><a href=\"https://wordpress.org/\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /></a><figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption></figure>\n"
 		]
 	}
 ]

--- a/test/integration/fixtures/blocks/core__image__custom-link.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__custom-link.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image {"linkDestination":"custom"} -->
-<figure class="wp-block-image"><a href="https://wordpress.org/"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt=""/></a></figure>
+<figure class="wp-block-image"><a href="https://wordpress.org/"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt=""/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__deprecated-v1-add-responsive-class.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v1-add-responsive-class.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image {"align":"left"} -->
-<figure class="wp-block-image alignleft"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt=""/></figure>
+<figure class="wp-block-image alignleft"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__deprecated-v2-add-is-resized-class.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v2-add-is-resized-class.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image {"width":100,"height":100,"align":"left"} -->
-<figure class="wp-block-image alignleft is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" style="width:100px;height:100px"/></figure>
+<figure class="wp-block-image alignleft is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" style="width:100px;height:100px"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__deprecated-v3-add-align-wrapper.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v3-add-align-wrapper.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image {"width":"100px","height":"100px","align":"left"} -->
-<figure class="wp-block-image alignleft is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" style="width:100px;height:100px"/></figure>
+<figure class="wp-block-image alignleft is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" style="width:100px;height:100px"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__deprecated-v4-remove-align-wrapper.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v4-remove-align-wrapper.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image {"id":13,"width":358,"height":164,"sizeSlug":"large","linkDestination":"none","align":"left"} -->
-<figure class="wp-block-image alignleft size-large is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" class="wp-image-13" style="width:358px;height:164px"/></figure>
+<figure class="wp-block-image alignleft size-large is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" class="wp-image-13" style="width:358px;height:164px"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__deprecated-v5-move-border-radius-style.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v5-move-border-radius-style.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image {"id":246,"sizeSlug":"large","linkDestination":"none","style":{"border":{"radius":"50px"}}} -->
-<figure class="wp-block-image size-large has-custom-border"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" class="wp-image-246" style="border-radius:50px"/></figure>
+<figure class="wp-block-image size-large has-custom-border"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" class="wp-image-246" style="border-radius:50px"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__deprecated-v6-add-style-width-height.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v6-add-style-width-height.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image {"width":"164px","height":"164px","sizeSlug":"large","align":"left","className":"is-style-rounded","style":{"border":{"radius":"100%"}}} -->
-<figure class="wp-block-image alignleft size-large is-resized has-custom-border is-style-rounded"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" style="border-radius:100%;width:164px;height:164px"/></figure>
+<figure class="wp-block-image alignleft size-large is-resized has-custom-border is-style-rounded"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" style="border-radius:100%;width:164px;height:164px"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__deprecated-v7-string-width-height-attributes.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v7-string-width-height-attributes.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image {"width":"164px","height":"164px","sizeSlug":"large"} -->
-<figure class="wp-block-image size-large is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" style="width:164px;height:164px"/></figure>
+<figure class="wp-block-image size-large is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" style="width:164px;height:164px"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__deprecated-v8-deprecate-behaviors-lightbox.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-v8-deprecate-behaviors-lightbox.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image {"lightbox":{"enabled":true},"id":8,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" class="wp-image-8"/></figure>
+<figure class="wp-block-image size-large"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" class="wp-image-8"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__media-link.html
+++ b/test/integration/fixtures/blocks/core__image__media-link.html
@@ -1,3 +1,3 @@
 <!-- wp:core/image {"linkDestination":"media"}  -->
-<figure class="wp-block-image"><a href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" /></a></figure>
+<figure class="wp-block-image"><a href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" /></a><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:core/image -->

--- a/test/integration/fixtures/blocks/core__image__media-link.parsed.json
+++ b/test/integration/fixtures/blocks/core__image__media-link.parsed.json
@@ -5,9 +5,9 @@
 			"linkDestination": "media"
 		},
 		"innerBlocks": [],
-		"innerHTML": "\n<figure class=\"wp-block-image\"><a href=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /></a></figure>\n",
+		"innerHTML": "\n<figure class=\"wp-block-image\"><a href=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /></a><figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption></figure>\n",
 		"innerContent": [
-			"\n<figure class=\"wp-block-image\"><a href=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /></a></figure>\n"
+			"\n<figure class=\"wp-block-image\"><a href=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /></a><figcaption class=\"wp-element-caption\" data-wp-maybe-remove=\"true\"></figcaption></figure>\n"
 		]
 	}
 ]

--- a/test/integration/fixtures/blocks/core__image__media-link.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__media-link.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image {"linkDestination":"media"} -->
-<figure class="wp-block-image"><a href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt=""/></a></figure>
+<figure class="wp-block-image"><a href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt=""/></a><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/documents/evernote-out.html
+++ b/test/integration/fixtures/documents/evernote-out.html
@@ -51,5 +51,5 @@
 <!-- /wp:table -->
 
 <!-- wp:image -->
-<figure class="wp-block-image"><img src="" alt=""/></figure>
+<figure class="wp-block-image"><img src="" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/documents/google-docs-out.html
+++ b/test/integration/fixtures/documents/google-docs-out.html
@@ -55,5 +55,5 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:image -->
-<figure class="wp-block-image"><img src="https://lh4.googleusercontent.com/ID" alt=""/></figure>
+<figure class="wp-block-image"><img src="https://lh4.googleusercontent.com/ID" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/documents/google-docs-with-comments-out.html
+++ b/test/integration/fixtures/documents/google-docs-with-comments-out.html
@@ -55,5 +55,5 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:image -->
-<figure class="wp-block-image"><img src="https://lh4.googleusercontent.com/ID" alt=""/></figure>
+<figure class="wp-block-image"><img src="https://lh4.googleusercontent.com/ID" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/documents/ms-word-online-out.html
+++ b/test/integration/fixtures/documents/ms-word-online-out.html
@@ -47,5 +47,5 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:image -->
-<figure class="wp-block-image"><img src="" alt=""/></figure>
+<figure class="wp-block-image"><img src="" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/documents/ms-word-out.html
+++ b/test/integration/fixtures/documents/ms-word-out.html
@@ -59,7 +59,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:image -->
-<figure class="wp-block-image"><img src="" alt=""/></figure>
+<figure class="wp-block-image"><img src="" alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph -->

--- a/test/integration/fixtures/documents/one-image-out.html
+++ b/test/integration/fixtures/documents/one-image-out.html
@@ -1,3 +1,3 @@
 <!-- wp:image {"id":5114} -->
-<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" class="wp-image-5114"/></figure>
+<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" class="wp-image-5114"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/documents/shortcode-matching-out.html
+++ b/test/integration/fixtures/documents/shortcode-matching-out.html
@@ -2,7 +2,7 @@
 
 <!-- wp:gallery {"columns":3,"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-3 is-cropped"><!-- wp:image {"id":1000} -->
-<figure class="wp-block-image"><img alt="" class="wp-image-1000"/></figure>
+<figure class="wp-block-image"><img alt="" class="wp-image-1000"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->
 

--- a/test/integration/fixtures/documents/two-images-out.html
+++ b/test/integration/fixtures/documents/two-images-out.html
@@ -1,7 +1,7 @@
 <!-- wp:image {"id":5114} -->
-<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" class="wp-image-5114"/></figure>
+<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-08-2017-15-12-24-17-300x137.gif" alt="" class="wp-image-5114"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":5109} -->
-<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-05-2017-17-52-09-9-300x248.gif" alt="" class="wp-image-5109"/></figure>
+<figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2018/01/Dec-05-2017-17-52-09-9-300x248.gif" alt="" class="wp-image-5109"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/documents/wordpress-out.html
+++ b/test/integration/fixtures/documents/wordpress-out.html
@@ -20,16 +20,16 @@
 
 <!-- wp:gallery {"columns":3,"linkTo":"none"} -->
 <figure class="wp-block-gallery has-nested-images columns-3 is-cropped"><!-- wp:image {"id":1} -->
-<figure class="wp-block-image"><img alt="" class="wp-image-1"/></figure>
+<figure class="wp-block-image"><img alt="" class="wp-image-1"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image --></figure>
 <!-- /wp:gallery -->
 
 <!-- wp:image {"id":5114} -->
-<figure class="wp-block-image"><img src="block.png" alt="" class="wp-image-5114"/></figure>
+<figure class="wp-block-image"><img src="block.png" alt="" class="wp-image-5114"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:image {"id":5114,"align":"right"} -->
-<figure class="wp-block-image alignright"><img src="aligned.png" alt="" class="wp-image-5114"/></figure>
+<figure class="wp-block-image alignright"><img src="aligned.png" alt="" class="wp-image-5114"/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph -->

--- a/test/native/integration/editor-history.native.js
+++ b/test/native/integration/editor-history.native.js
@@ -62,7 +62,7 @@ describe( 'Editor History', () => {
 		<!-- /wp:verse -->
 
 		<!-- wp:image -->
-		<figure class="wp-block-image"><img alt=""/></figure>
+		<figure class="wp-block-image"><img alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 		<!-- /wp:image -->
 
 		<!-- wp:paragraph -->
@@ -90,7 +90,7 @@ describe( 'Editor History', () => {
 		<!-- /wp:verse -->
 
 		<!-- wp:image -->
-		<figure class="wp-block-image"><img alt=""/></figure>
+		<figure class="wp-block-image"><img alt=""/><figcaption class="wp-element-caption" data-wp-maybe-remove="true"></figcaption></figure>
 		<!-- /wp:image -->
 
 		<!-- wp:paragraph -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Supersedes https://github.com/WordPress/gutenberg/pull/61255 with a slight different approach.
Instead of using the HTML to determine the markup of the image content to land the `figcaption` in the correct place. It removes those conditionals by always adding the caption, and deleting it later if there is no caption.

Pros: simplicity, scalability with future role `content`, bits or data-wp-bind.
Cons: Markup added by default on the `save.js` file. Which means a deprecation and updating tons of tests.

## How to test

As I copied some part of @SantosGuillamot 's original PR. I will copy also the testing process :-)

Go to a page and add a row with three images: One with a figcaption that will be replaced, another one without figcaption, and other with a caption that will be removed. You can use this snippet:

```
<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
<div class="wp-block-group"><!-- wp:image {"width":"126px","height":"auto","sizeSlug":"large","metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"Bulbasur Override"}} -->
<figure class="wp-block-image size-large is-resized"><img src="https://img.pokemondb.net/artwork/large/bulbasaur.jpg" alt="" style="width:126px;height:auto"/><figcaption class="wp-element-caption">Replace</figcaption></figure>
<!-- /wp:image -->

<!-- wp:image {"width":"107px","height":"auto","sizeSlug":"large","metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"Charmander Override"}} -->
<figure class="wp-block-image size-large is-resized"><img src="https://img.pokemondb.net/artwork/large/charmander.jpg" alt="" style="width:107px;height:auto"/></figure>
<!-- /wp:image -->

<!-- wp:image {"width":"118px","height":"auto","sizeSlug":"large","metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"Squirtle Override"}} -->
<figure class="wp-block-image size-large is-resized"><img src="https://img.pokemondb.net/artwork/large/squirtle.jpg" alt="" style="width:118px;height:auto"/><figcaption class="wp-element-caption">Remove</figcaption></figure>
<!-- /wp:image --></div>
<!-- /wp:group -->
```

1) Click on the options and select create pattern, and give it a name.
2) Change the name of the first caption to whatever you want. "Bulbasur", for example.
3) Add a caption to the second image. "Charmander", for example.
4) Remove the caption of the third image.
5) Save and check the frontend shows the expected results.

<img width="535" height="261" alt="Screenshot 2025-07-22 at 10 40 58" src="https://github.com/user-attachments/assets/4280bc17-4b84-4a14-b103-f31d7421a34c" />


## Backport to Core missing

I intentionally left this part until we discuss the final approach for this PR. Once the PR is approved on the PHP part, I'll create and link the Core backport.