### PR TITLE
fix: Repair missing Freeform/Classic block render

### DIFF
--- a/bin/packages/build.js
+++ b/bin/packages/build.js
@@ -229,6 +229,8 @@ if ( files.length ) {
 				`**/{__mocks__,__tests__,test}/**`,
 				`**/{storybook,stories}/**`,
 				`**/e2e-test-utils-playwright/**`,
+				// Native stylesheets are irrelevant to web builds, and require configuration not supported by this build script
+				`**/*.native.scss`,
 			],
 			onlyFiles: true,
 		}

--- a/packages/block-freeform/src/style.native.scss
+++ b/packages/block-freeform/src/style.native.scss
@@ -1,0 +1,79 @@
+.helpIconContainer {
+	position: absolute;
+	top: 0;
+	right: 0;
+	height: 48;
+	width: 48;
+	padding-top: 12;
+	padding-right: 12;
+	justify-content: flex-start;
+	align-items: flex-end;
+}
+
+.infoIcon {
+	size: 36;
+	height: 36;
+	padding-top: 8;
+	padding-bottom: 8;
+	color: $light-secondary;
+}
+
+.infoIconDark {
+	color: $dark-tertiary;
+}
+
+.unsupportedBlock {
+	height: 142;
+	background-color: #e0e0e0; // $light-dim
+	padding-top: 24;
+	padding-bottom: 24;
+	padding-left: 8;
+	padding-right: 8;
+	border-top-left-radius: 4;
+	border-top-right-radius: 4;
+	border-bottom-left-radius: 4;
+	border-bottom-right-radius: 4;
+	align-items: center;
+	justify-content: center;
+}
+
+.unsupportedBlockDark {
+	background-color: #1f1f1f; // $dark-dim
+}
+
+.unsupportedBlockHeader {
+	flex-direction: row;
+	align-items: center;
+	margin-top: 4;
+	margin-bottom: 8;
+}
+
+.unsupportedBlockIcon {
+	color: $light-secondary;
+}
+
+.unsupportedBlockIconDark {
+	color: $dark-tertiary;
+}
+
+.unsupportedBlockMessage {
+	text-align: center;
+	color: $light-secondary;
+	font-size: 16;
+	font-weight: 400;
+	margin-left: 6;
+}
+
+.unsupportedBlockMessageDark {
+	color: $dark-tertiary;
+}
+
+.unsupportedBlockSubtitle {
+	text-align: center;
+	color: $gray-darken-20;
+	font-size: 12;
+}
+
+.unsupportedBlockSubtitleDark {
+	color: $gray-20;
+}

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -10,7 +10,6 @@ import {
 	hasBlockSupport,
 	registerBlockType,
 	setDefaultBlockName,
-	setFreeformContentHandlerName,
 	setUnregisteredTypeHandlerName,
 	setGroupingBlockName,
 } from '@wordpress/blocks';
@@ -57,7 +56,6 @@ import * as textColumns from './text-columns';
 import * as verse from './verse';
 import * as video from './video';
 import * as tagCloud from './tag-cloud';
-import * as classic from '../../block-freeform/src/index';
 import * as group from './group';
 import * as buttons from './buttons';
 import * as socialLink from './social-link';
@@ -109,7 +107,6 @@ export const coreBlocks = [
 	textColumns,
 	verse,
 	video,
-	classic,
 	buttons,
 	socialLink,
 	socialLinks,
@@ -225,7 +222,6 @@ export const registerCoreBlocks = () => {
 		columns,
 		column,
 		group,
-		classic,
 		button,
 		spacer,
 		shortcode,
@@ -247,7 +243,6 @@ export const registerCoreBlocks = () => {
 
 	registerBlockVariations( socialLink );
 	setDefaultBlockName( paragraph.name );
-	setFreeformContentHandlerName( classic.name );
 	setUnregisteredTypeHandlerName( missing.name );
 	if ( group ) {
 		setGroupingBlockName( group.name );

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -10,6 +10,7 @@ import {
 	hasBlockSupport,
 	registerBlockType,
 	setDefaultBlockName,
+	setFreeformContentHandlerName,
 	setUnregisteredTypeHandlerName,
 	setGroupingBlockName,
 } from '@wordpress/blocks';
@@ -56,6 +57,7 @@ import * as textColumns from './text-columns';
 import * as verse from './verse';
 import * as video from './video';
 import * as tagCloud from './tag-cloud';
+import * as classic from '../../block-freeform/src/index';
 import * as group from './group';
 import * as buttons from './buttons';
 import * as socialLink from './social-link';
@@ -107,6 +109,7 @@ export const coreBlocks = [
 	textColumns,
 	verse,
 	video,
+	classic,
 	buttons,
 	socialLink,
 	socialLinks,
@@ -149,12 +152,12 @@ const devOnly = ( block ) => ( !! __DEV__ ? block : null );
 const iOSOnly = ( block ) =>
 	Platform.OS === 'ios' ? block : devOnly( block );
 
-// Hide the SocialLink block
+// Hide blocks from the inserter
 addFilter(
 	'blocks.registerBlockType',
 	'core/react-native-editor',
 	( settings, name ) => {
-		const hiddenBlocks = [ 'core/social-link' ];
+		const hiddenBlocks = [ 'core/freeform', 'core/social-link' ];
 		if (
 			hiddenBlocks.includes( name ) &&
 			hasBlockSupport( settings, 'inserter', true )
@@ -222,6 +225,7 @@ export const registerCoreBlocks = () => {
 		columns,
 		column,
 		group,
+		classic,
 		button,
 		spacer,
 		shortcode,
@@ -243,6 +247,7 @@ export const registerCoreBlocks = () => {
 
 	registerBlockVariations( socialLink );
 	setDefaultBlockName( paragraph.name );
+	setFreeformContentHandlerName( classic.name );
 	setUnregisteredTypeHandlerName( missing.name );
 	if ( group ) {
 		setGroupingBlockName( group.name );

--- a/packages/edit-post/src/index.native.js
+++ b/packages/edit-post/src/index.native.js
@@ -5,6 +5,8 @@ import '@wordpress/core-data';
 import '@wordpress/format-library';
 import { dispatch } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
+import { init as initFreeformBlock } from '@wordpress/block-freeform';
+import { setFreeformContentHandlerName } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -36,6 +38,9 @@ export function initializeEditor( id, postType, postId ) {
 		isPublishSidebarEnabled: true,
 		fixedToolbar: false,
 	} );
+
+	initFreeformBlock();
+	setFreeformContentHandlerName( 'core/freeform' );
 
 	return <Editor postId={ postId } postType={ postType } />;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
<!-- In a few words, what is the PR actually doing? -->
Follow up to https://github.com/WordPress/gutenberg/pull/70603. 

Ensure the mobile-specific fallback block is rendered, rather than an
unsupported block UI with an unexpectedly missing title.

This functionality was originally added in https://github.com/WordPress/gutenberg/pull/22609. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The title-less unsupported block UI fails to communicate that the block is
unsupported.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Reinstate necessary block registration for rendering the mobile editor's
custom "unsupported" block UI. Without this registration, the
new `block-freeform` code is never utilized when the relevant block
markup is encountered.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open the mobile editor.
1. Tap the "more" menu in the top-right corner.
1. Switch to HTML mode.
1. Insert some text into the post.
1. Switch to Visual mode.
1. Verify the correct UI is displayed.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no navigation changes.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| ![classic-block-before](https://github.com/user-attachments/assets/ca70fafd-6b52-4ccf-8c61-743f2cf9cb69) | ![classic-block-after](https://github.com/user-attachments/assets/cbe54502-467b-47c1-9b5f-4986bbb072f5) |

