### PR TITLE
Navigation Block: Fix justification (space between) layout when overlay menu is off

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -5,6 +5,11 @@
 // Undo default editor styles.
 // These need extra specificity.
 .editor-styles-wrapper .wp-block-navigation {
+	// Ensure navigation container takes full width in editor.
+	.wp-block-navigation__container {
+		width: 100%;
+	}
+
 	// Extra specificity is applied to do two things in classic themes:
 	// 1. Override the auto margin from alignment styles. This is needed as the `ul` element
 	//    has a `wp-block` class applied to it, even though it's not a block.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #57517 

<!-- In a few words, what is the PR actually doing? -->
This PR ensures that the navigation container spans the full width in the block editor when the overlay menu is disabled and 'Space between items' is selected for justification layout.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When the overlay menu is turned off in the Navigation block, layout justification options for space between have no visible effect in the editor because the container doesn't expand to the full width of the navigation block. This creates a mismatch between the editor and frontend

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
A `width: 100%` style was added to `.wp-block-navigation__container` in `editor.scss` to ensure it stretches fully in non-overlay mode, matching frontend behavior.

## Testing Instructions
1. Add a Navigation block in the editor.
2. Turn off the Overlay Menu setting in block settings.
3. Under Layout settings, set Justify items to Space between.
4. Add at least 3 navigation items.
5. Confirm that the navigation items are now correctly spaced apart across the full width (as they are on the frontend).

<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="716" alt="Screenshot 2025-07-08 at 9 38 44 PM" src="https://github.com/user-attachments/assets/56abf66d-1be5-4f50-aed0-8ae7da4a84da" />|<img width="706" alt="Screenshot 2025-07-08 at 9 39 23 PM" src="https://github.com/user-attachments/assets/1a27638f-c6d7-4afb-8e48-1c5417592f17" />|
