### PR TITLE
Media library modal: Fix plugin incompatibilities with MediaUpload filter

### DIFF
--- a/packages/editor/src/hooks/media-upload.js
+++ b/packages/editor/src/hooks/media-upload.js
@@ -1,28 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { MediaUpload } from '@wordpress/media-utils';
-import { store as coreStore } from '@wordpress/core-data';
-import { dispatch } from '@wordpress/data';
-
-class MediaUploadWithCacheInvalidation extends Component {
-	render() {
-		const { onClose: originalOnClose, ...rest } = this.props;
-
-		const onClose = ( ...onCloseArgs ) => {
-			dispatch( coreStore ).invalidateResolutionForStoreSelector(
-				'getMediaItems'
-			);
-			originalOnClose?.( ...onCloseArgs );
-		};
-		return <MediaUpload onClose={ onClose } { ...rest } />;
-	}
-}
 
 addFilter(
 	'editor.MediaUpload',
 	'core/editor/components/media-upload',
-	() => MediaUploadWithCacheInvalidation
+	() => MediaUpload
 );

--- a/packages/editor/src/hooks/media-upload.js
+++ b/packages/editor/src/hooks/media-upload.js
@@ -1,20 +1,24 @@
 /**
  * WordPress dependencies
  */
+import { Component } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { MediaUpload } from '@wordpress/media-utils';
 import { store as coreStore } from '@wordpress/core-data';
-import { useDispatch } from '@wordpress/data';
+import { dispatch } from '@wordpress/data';
 
-function MediaUploadWithCacheInvalidation( props ) {
-	const { invalidateResolutionForStoreSelector } = useDispatch( coreStore );
-	const { onClose: originalOnClose, ...rest } = props;
+class MediaUploadWithCacheInvalidation extends Component {
+	render() {
+		const { onClose: originalOnClose, ...rest } = this.props;
 
-	const onClose = ( ...onCloseArgs ) => {
-		invalidateResolutionForStoreSelector( 'getMediaItems' );
-		originalOnClose?.( ...onCloseArgs );
-	};
-	return <MediaUpload onClose={ onClose } { ...rest } />;
+		const onClose = ( ...onCloseArgs ) => {
+			dispatch( coreStore ).invalidateResolutionForStoreSelector(
+				'getMediaItems'
+			);
+			originalOnClose?.( ...onCloseArgs );
+		};
+		return <MediaUpload onClose={ onClose } { ...rest } />;
+	}
 }
 
 addFilter(

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -196,6 +196,7 @@ function installDependencies( service, env, config ) {
 		case 'wordpress': {
 			dockerFileContent += `
 # Make sure we're working with the latest packages.
+RUN apt-get clean
 RUN apt-get -qy update
 
 # Install some basic PHP dependencies.


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/gutenberg/issues/70647

Some users started experiencing errors after Gutenberg 21.1. Example here - https://wordpress.org/support/topic/unexpected-error-after-updating-to-21-1-0/.

From my testing, this seems to be caused by an incompatibility between gutenberg and the AMP plugin (cc @westonruter, @swissspidy). There may also be other plugins that have similar issues.

After #70405 the `MediaUpload` filter instead started receiving a function component instead of a class component.

I think this is the relevant code in AMP - https://github.com/ampproject/amp-wp/blob/7b4ed4c001cdc0fbf9adb518fb0b8e1ddebf4d5a/assets/src/block-editor/components/with-media-library-notice.js.

Notice that it calls `extend` on the `InitialMediaUpload` arg from the filter, so when a function component started being used this failed. This code seems like it has the potential to cause lots of general incompatibilities, for example if other plugins use the filter and modify the return results. 

To temporarily fix this I'm proposing to partially revert #70405 and release a hotfix with that change.

## Testing Instructions
1. Install the AMP plugin
2. Try editing a post
3. Ensure the post editor loads
4. Try inserting and editing a paragraph.
