### PR TITLE
Icons: Fix plusCircleFilled size

### DIFF
--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 -  Update `cancelCircleFilled`, `currencyDollar`, `currencyPound`, `currencyEuro`, `globe`, `helpFilled`, `siteLogo`, `swatch`, to have unified circular size footprints. ([https://github.com/WordPress/gutenberg/pull/70581](#70581)).
 -  Update `help`, `plusCircle`, and `typography` icons to have a unified circular footprint that matches other circle icons. ([#70299](https://github.com/WordPress/gutenberg/pull/70299)).
+-  Update `plusCircleFilled` to have unified circular size footprints. ([https://github.com/WordPress/gutenberg/pull/70650](#70650)).
 
 ## 10.26.0 (2025-06-25)
 

--- a/packages/icons/src/library/plus-circle-filled.js
+++ b/packages/icons/src/library/plus-circle-filled.js
@@ -5,7 +5,7 @@ import { SVG, Path } from '@wordpress/primitives';
 
 const plusCircleFilled = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M2 12C2 6.44444 6.44444 2 12 2C17.5556 2 22 6.44444 22 12C22 17.5556 17.5556 22 12 22C6.44444 22 2 17.5556 2 12ZM13 11V7H11V11H7V13H11V17H13V13H17V11H13Z" />
+		<Path d="M4 12a8 8 0 1 1 16 0 8 8 0 0 1-16 0zm8.8-.8V8h-1.6v3.2H8v1.6h3.2V16h1.6v-3.2H16v-1.6h-3.2z" />
 	</SVG>
 );
 

--- a/packages/icons/src/library/plus-circle-filled.js
+++ b/packages/icons/src/library/plus-circle-filled.js
@@ -5,7 +5,7 @@ import { SVG, Path } from '@wordpress/primitives';
 
 const plusCircleFilled = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M4 12a8 8 0 1 1 16 0 8 8 0 0 1-16 0zm8.8-.8V8h-1.6v3.2H8v1.6h3.2V16h1.6v-3.2H16v-1.6h-3.2z" />
+		<Path d="M12 4c-4.4 0-8 3.6-8 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8Zm3.8 8.8h-3v3h-1.5v-3h-3v-1.5h3v-3h1.5v3h3v1.5Z" />
 	</SVG>
 );
 


### PR DESCRIPTION
## What?

Related to https://github.com/WordPress/gutenberg/pull/70581

By changing the path size of the `plusCircleFilled` icon from 40px to 32px, make it consistent with the other icons.

## Testing Instructions

Launch Storybook and access http://localhost:50240/?path=/story/icons-icon--library

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
| ![before](https://github.com/user-attachments/assets/ab02106c-8277-4f34-ae50-664be3770e7b) | ![after](https://github.com/user-attachments/assets/331dcbfa-00ea-4450-8bb5-4ec38f476f25) |

