### PR TITLE
Media Upload: Correct wrapper reference in docstring

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -489,7 +489,7 @@ The module also checks for sessionStorage support and conditionally exports the 
 
 ### mediaUpload
 
-Upload a media file when the file upload button is activated. Wrapper around mediaUpload() that injects the current post ID.
+Upload a media file when the file upload button is activated. Wrapper around uploadMedia() that injects the current post ID.
 
 _Parameters_
 

--- a/packages/editor/src/utils/media-upload/index.js
+++ b/packages/editor/src/utils/media-upload/index.js
@@ -19,7 +19,7 @@ const noop = () => {};
 
 /**
  * Upload a media file when the file upload button is activated.
- * Wrapper around mediaUpload() that injects the current post ID.
+ * Wrapper around uploadMedia() that injects the current post ID.
  *
  * @param {Object}   $0                   Parameters object passed to the function.
  * @param {?Object}  $0.additionalData    Additional data to include in the request.


### PR DESCRIPTION
## What, Why, and How?

This PR corrects a minor typo in the `mediaUpload` function's docstring 😅.

Here, `mediaUpload` is a wrapper around `uploadMedia` (and not `mediaUpload` itself) that injects the current Post ID.

See:
https://github.com/WordPress/gutenberg/blob/fbb342afb885ea1fe55445941a81aaa6a67e76c1/packages/editor/src/utils/media-upload/index.js#L77