### PR TITLE
Navigation Link: Add visibility option for logged-in users

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -484,7 +484,7 @@ Add a page, link, or another item to your navigation. ([Source](https://github.c
 -	**Parent:** core/navigation
 -	**Allowed Blocks:** core/navigation-link, core/navigation-submenu, core/page-list
 -	**Supports:** interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~, ~~reusable~~
--	**Attributes:** description, id, isTopLevelLink, kind, label, opensInNewTab, rel, title, type, url
+-	**Attributes:** description, id, isTopLevelLink, kind, label, opensInNewTab, rel, showForLoggedInOnly, title, type, url
 
 ## Submenu
 

--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -43,6 +43,10 @@
 		},
 		"isTopLevelLink": {
 			"type": "boolean"
+		},
+		"showForLoggedInOnly": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"usesContext": [

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -16,6 +16,7 @@ import {
 	ToolbarButton,
 	Tooltip,
 	ToolbarGroup,
+	CheckboxControl,
 } from '@wordpress/components';
 import { displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
@@ -160,7 +161,8 @@ function getMissingText( type ) {
  * Consider reuseing this components for both blocks.
  */
 function Controls( { attributes, setAttributes, setIsLabelFieldFocused } ) {
-	const { label, url, description, title, rel } = attributes;
+	const { label, url, description, title, rel, showForLoggedInOnly } =
+		attributes;
 	return (
 		<ToolsPanel label={ __( 'Settings' ) }>
 			<ToolsPanelItem
@@ -202,6 +204,25 @@ function Controls( { attributes, setAttributes, setIsLabelFieldFocused } ) {
 						);
 					} }
 					autoComplete="off"
+				/>
+			</ToolsPanelItem>
+
+			<ToolsPanelItem
+				hasValue={ () => !! showForLoggedInOnly }
+				label={ __( 'Visibility' ) }
+				onDeselect={ () =>
+					setAttributes( { showForLoggedInOnly: false } )
+				}
+				isShownByDefault
+			>
+				<CheckboxControl
+					__nextHasNoMarginBottom
+					label="Only show for logged-in users"
+					help="Show navigation link only to logged-in users."
+					checked={ showForLoggedInOnly }
+					onChange={ ( value ) =>
+						setAttributes( { showForLoggedInOnly: value } )
+					}
 				/>
 			</ToolsPanelItem>
 

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -174,6 +174,14 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	$is_post_type           = isset( $attributes['kind'] ) && 'post-type' === $attributes['kind'];
 	$is_post_type           = $is_post_type || isset( $attributes['type'] ) && ( 'post' === $attributes['type'] || 'page' === $attributes['type'] );
 
+	// Check for the `showForLoggedInOnly` attribute.
+	if ( ! empty( $attributes['showForLoggedInOnly'] ) ) {
+		// If the block is set to show only for logged-in users, check if the user is logged in.
+        if ( ! is_user_logged_in() ) {
+            return ''; // Hide for non-logged-in users
+        }
+    }
+
 	// Don't render the block's subtree if it is a draft or if the ID does not exist.
 	if ( $is_post_type && $navigation_link_has_id ) {
 		$post = get_post( $attributes['id'] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/wordpress/gutenberg/issues/70605
<!-- In a few words, what is the PR actually doing? -->
Add a checkbox to show the navigation link to only logged in user.
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, there is no built-in way to add conditions to menus, such as displaying different menu items when a user is logged in or logged out.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Created a checkbox option in navigation-link and set a attribute
- While dynamically rendering menu check attribute and display only if its set and user is logged in
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/e19248fa-ea0d-4c4b-b73f-cd7bdc091a23



<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1280" alt="Screenshot 2025-07-09 at 1 14 37 PM" src="https://github.com/user-attachments/assets/c21360a9-6efe-46d6-b147-6689ff61eab3" />|<img width="1280" alt="Screenshot 2025-07-09 at 1 15 41 PM" src="https://github.com/user-attachments/assets/b9703830-8c61-48ac-a26a-2d7eeebd8f1a" />|
