### PR TITLE
Autocomplete: Prevent text cursor position loss when clicking to insert an item

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   `FormTokenField`: Fix focus lost on tab when `__experimentalExpandOnFocus` is set ([#70591](https://github.com/WordPress/gutenberg/pull/70591)).
 -   `SelectControl`: Fix font-size for medium screens to ensure consistency with other inputs ([#70619](https://github.com/WordPress/gutenberg/pull/70619)).
 -   `SelectControl`: Move classnames to the root ([#70643](https://github.com/WordPress/gutenberg/pull/70643)).
+-   `Autocomplete`: Prevent text cursor position loss when clicking to insert an item ([#70660](https://github.com/WordPress/gutenberg/pull/70660)).
 
 ### Internal
 

--- a/packages/components/src/autocomplete/autocompleter-ui.tsx
+++ b/packages/components/src/autocomplete/autocompleter-ui.tsx
@@ -70,12 +70,6 @@ function ListBox( {
 						}
 					) }
 					variant={ index === selectedIndex ? 'primary' : undefined }
-					onMouseDown={ (
-						event: React.MouseEvent< HTMLButtonElement >
-					) => {
-						// Prevents button from stealing focus and losing the text cursor position.
-						event.preventDefault();
-					} }
 					onClick={ () => onSelect( option ) }
 				>
 					{ option.label }

--- a/packages/components/src/autocomplete/autocompleter-ui.tsx
+++ b/packages/components/src/autocomplete/autocompleter-ui.tsx
@@ -70,6 +70,12 @@ function ListBox( {
 						}
 					) }
 					variant={ index === selectedIndex ? 'primary' : undefined }
+					onMouseDown={ (
+						event: React.MouseEvent< HTMLButtonElement >
+					) => {
+						// Prevents button from stealing focus and losing the text cursor position.
+						event.preventDefault();
+					} }
 					onClick={ () => onSelect( option ) }
 				>
 					{ option.label }

--- a/packages/components/src/autocomplete/index.tsx
+++ b/packages/components/src/autocomplete/index.tsx
@@ -126,6 +126,10 @@ export function useAutocomplete( {
 		// Reset autocomplete state after insertion rather than before
 		// so insertion events don't cause the completion menu to redisplay.
 		reset();
+
+		// Make sure that the content remains focused after making a selection
+		// and that the text cursor position is not lost.
+		contentRef.current?.focus();
 	}
 
 	function reset() {


### PR DESCRIPTION
## What?
Fixes #50168.

PR fixes text cursor position loss when clicking the autocomplete suggestion item and allows users to continue typing after selection.

## Why?
The behavior works correctly when using the keyboard; it should function similarly after a click interaction.

## How?
~~Prevent the button from "stealing" focus during the click event and let RichText restore the text cursor position.~~

Ensure that the content receives focus back after selection.

## Testing Instructions
1. Create a post.
2. Add a paragraph block.
3. Type the `@` symbol.
4. Select a user by clicking on the suggested item.
5. Confirm that you can continue typing after inserting the item.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/7cfa77ce-6163-4a2a-869d-c431dde297cd

