### PR TITLE
wp-env: add wp-cli config when creating environment

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Add config file for WP-CLI when creating an environment. ([#70661](https://github.com/WordPress/gutenberg/pull/70661)).
+
 ## 10.26.0 (2025-06-25)
 
 ## 10.25.0 (2025-06-04)

--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -86,13 +86,24 @@ async function configureWordPress( environment, config, spinner ) {
 		// Ignore error.
 	}
 
+	// Create a project-specific wp-cli configuration, important for the `rewrite` command.
+	const cliConfigCommand = `(
+		exec > /var/www/html/wp-cli.yml
+		echo "apache_modules:"
+		echo "  - mod_rewrite"
+	)`;
+
 	const isMultisite = config.env[ environment ].multisite;
 
 	const installMethod = isMultisite ? 'multisite-install' : 'install';
 	const installCommand = `wp core ${ installMethod } --url="${ config.env[ environment ].config.WP_SITEURL }" --title="${ config.name }" --admin_user=admin --admin_password=password --admin_email=wordpress@example.com --skip-email`;
 
 	// -eo pipefail exits the command as soon as anything fails in bash.
-	const setupCommands = [ 'set -eo pipefail', installCommand ];
+	const setupCommands = [
+		'set -eo pipefail',
+		cliConfigCommand,
+		installCommand,
+	];
 
 	// Bootstrap .htaccess for multisite
 	if ( isMultisite ) {


### PR DESCRIPTION
When configuring WordPress, both in the "normal" and "test" environments, let's add a project-local WP-CLI config for the environment that tells WP-CLI that Apache with mod_rewrite is being used. That is needed by WP-CLI when running commands like:
```
wp rewrite structure /%postname%/ --hard
```
The `--hard` flag tells WP-CLI to flush the `.htaccess` file but it won't do it unless configured. It will print a warning:
```
Warning: Regenerating a .htaccess file requires special configuration. See usage docs.
```
The relevant usage docs are here: https://developer.wordpress.org/cli/commands/rewrite/structure/

I'm adding write of the config file to `setupCommands` in `configureWordPress`. The `setupCommands` array includes several calls to WP-CLI (`wp core`, `wp plugin`, ...) so it makes sense to configure it right at the very beginning.

## Testing instructions:
The bug we're fixing is that the following command will never write `.htaccess` and will print a warning instead:
```
npm run wp-env run cli -- wp rewrite structure /%postname%/ --hard
```
Verify that when you create a new env with this patch, this bug is fixed. No warning, and there's `.htaccess` in `~/.wp-env/{hash}/WordPress`.