### PR TITLE
Inserter: Restore styling for disabled blocks

### DIFF
--- a/packages/block-editor/src/components/inserter-list-item/style.scss
+++ b/packages/block-editor/src/components/inserter-list-item/style.scss
@@ -49,12 +49,13 @@
 	position: relative;
 	height: auto;
 
-	&:disabled {
+	&:disabled,
+	&[aria-disabled="true"] {
 		opacity: 0.6;
 		cursor: default;
 	}
 
-	&:not(:disabled) {
+	&:not(:disabled, [aria-disabled="true"]) {
 		&:hover {
 			.block-editor-block-types-list__item-title {
 				color: var(--wp-admin-theme-color) !important;


### PR DESCRIPTION
## What?
PR restores styling for disabled blocks in the inserter.

## Why?
I believe this was an unintentional regression due to #62480. It switched the Button component to use `color` instead of `opacity` for disabled styling, which was overridden by the styles of list items.

## How?
Update CSS selector targeting disabled list items and account for both `disabled` and `[aria-disabled="true"]`.


## Testing Instructions
1. Open a post or page.
2. Open the inserter and insert the "More" block.
3. Confirm disabled styling is correctly applied after block insertion.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|![CleanShot 2025-07-09 at 15 37 33](https://github.com/user-attachments/assets/8afab5a8-b92d-4eed-93a8-e871844c5d2c)|![CleanShot 2025-07-09 at 15 37 00](https://github.com/user-attachments/assets/bcd9d77e-598d-4839-8a60-91848964f76e)|