### PR TITLE
Update internationalization.md

### DIFF
--- a/docs/how-to-guides/internationalization.md
+++ b/docs/how-to-guides/internationalization.md
@@ -34,6 +34,7 @@ function myguten_block_init() {
 }
 add_action( 'init', 'myguten_block_init' );
 ```
+You can skip this step if you use [create-block](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-create-block/).
 
 In your code, you can include the i18n functions. The most common function is **\_\_** (a double underscore) which provides translation of a simple string. Here is a basic block example:
 
@@ -211,7 +212,8 @@ The final part is to tell WordPress where it can look to find the translation fi
 ```php
 <?php
 	function myguten_set_script_translations() {
-		wp_set_script_translations( 'myguten-script', 'myguten', plugin_dir_path( __FILE__ ) . 'languages' );
+		$block_handle = generate_block_asset_handle("myguten/simple", "editorScript");
+		wp_set_script_translations( $block_handle, 'myguten', plugin_dir_path( __FILE__ ) . 'languages' );
 	}
 	add_action( 'init', 'myguten_set_script_translations' );
 ```


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Added: skip first step if using create-block
Changed: automatically get block handle to attach translations

## Why?
The first step shows old school block registration in PHP instead of JSON. 

Near the end, it's not clear what to put in the first param of `wp_set_script_translations()`
When using create-block, we don't know the exact name of the block handle because it's automated.

## How?
Using `generate_block_asset_handle()` gives the right handle.
