### PR TITLE
Fix: Font Library Modal: Focus outline not displaying correctly

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
@@ -90,6 +90,11 @@ $footer-height: 70px;
 
 .font-library-modal__fonts-list-item {
 	margin-bottom: 0;
+	.components-button {
+		&:focus {
+			position: relative;
+		}
+	}
 }
 
 .font-library-modal__font-card {

--- a/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
@@ -90,11 +90,6 @@ $footer-height: 70px;
 
 .font-library-modal__fonts-list-item {
 	margin-bottom: 0;
-	.components-button {
-		&:focus {
-			position: relative;
-		}
-	}
 }
 
 .font-library-modal__font-card {
@@ -110,6 +105,10 @@ $footer-height: 70px;
 
 	&:hover {
 		background-color: $gray-100;
+	}
+
+	&:focus {
+		position: relative;
 	}
 
 	.font-library-modal__font-card__name {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/wordpress/gutenberg/issues/70656

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes Font Library Modal: Focus outline not displaying correctly

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add the position property as relative for the font list item to make its outline visible.

|Before|After|
|-|-|
|<img width="1280" alt="Screenshot 2025-07-09 at 9 16 15 PM" src="https://github.com/user-attachments/assets/233f1d0a-4f28-4318-a1df-94cf049b88e7" />|<img width="1280" alt="Screenshot 2025-07-09 at 9 13 51 PM" src="https://github.com/user-attachments/assets/9d8bab0f-d3da-4314-9455-ef37f101de6a" />|
