### PR TITLE
iAPI Router: Preserve media attribute on initial style sheets after client-side navigation

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/render.php
@@ -15,6 +15,13 @@ add_action(
 			plugin_dir_url( __FILE__ ) . 'style-from-link.css',
 			array()
 		);
+		wp_enqueue_style(
+			'wrapper-styles-media-print',
+			plugin_dir_url( __FILE__ ) . 'style-media-print.css',
+			array(),
+			false,
+			'print'
+		);
 	}
 );
 
@@ -91,4 +98,10 @@ $wrapper_attributes = get_block_wrapper_attributes();
 	<div data-wp-interactive="test/router-styles" >
 		Prefetching: <span data-testid="prefetching" data-wp-text="state.prefetching"></span>
 	</div>
+
+	<!-- Text hidden when media=print applies. -->
+	<div class="hide-on-print" data-testid="hide-on-print">This should be visible when media is not "print".</div>
 </div>
+
+
+

--- a/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/style-media-print.css
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/style-media-print.css
@@ -1,0 +1,3 @@
+.wp-block-test-router-styles-wrapper .hide-on-print {
+    display: none;
+}

--- a/packages/interactivity-router/CHANGELOG.md
+++ b/packages/interactivity-router/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Preserve `media` attribute on intial style sheets after client-side navigation. ([70668](https://github.com/WordPress/gutenberg/pull/70668))
+
 ## 2.26.0 (2025-06-25)
 
 ### New Features

--- a/packages/interactivity-router/src/assets/styles.ts
+++ b/packages/interactivity-router/src/assets/styles.ts
@@ -261,8 +261,11 @@ export const applyStyles = ( styles: StyleElement[] ) => {
 		.forEach( ( el: HTMLLinkElement | HTMLStyleElement ) => {
 			if ( el.sheet ) {
 				if ( styles.includes( el ) ) {
-					const { originalMedia = 'all' } = el.dataset;
-					el.sheet.media.mediaText = originalMedia;
+					// Only update mediaText when necessary.
+					if ( el.sheet.media.mediaText === 'preload' ) {
+						const { originalMedia = 'all' } = el.dataset;
+						el.sheet.media.mediaText = originalMedia;
+					}
 					el.sheet.disabled = false;
 				} else {
 					el.sheet.disabled = true;

--- a/packages/interactivity-router/src/assets/test/styles.test.ts
+++ b/packages/interactivity-router/src/assets/test/styles.test.ts
@@ -631,6 +631,24 @@ describe( 'Router styles management', () => {
 			expect( link.sheet!.media.mediaText ).toBe( 'all' );
 			expect( style.sheet!.media.mediaText ).toBe( 'all' );
 		} );
+
+		it( 'should preserve media if it was initially set', () => {
+			// Create link elements with originalMedia.
+			const link = createLinkElement( 'link' );
+			link.setAttribute( 'media', 'print' );
+
+			// Add to document.
+			document.head.appendChild( link );
+
+			// Init `sheet` property.
+			mockSheet( link, { disabled: false, mediaText: 'print' } );
+
+			// Apply styles.
+			applyStyles( [ link ] );
+
+			// Check that media was preserved correctly.
+			expect( link.sheet!.media.mediaText ).toBe( 'print' );
+		} );
 	} );
 
 	describe( 'normalizeMedia', () => {

--- a/test/e2e/specs/interactivity/router-styles.spec.ts
+++ b/test/e2e/specs/interactivity/router-styles.spec.ts
@@ -411,4 +411,23 @@ test.describe( 'Router styles', () => {
 		await expect( blue ).toHaveCSS( 'color', COLOR_WRAPPER );
 		await expect( all ).toHaveCSS( 'color', COLOR_GREEN );
 	} );
+
+	test( 'should respect the original media attribute on initial style sheets', async ( {
+		page,
+	} ) => {
+		const csn = page.getByTestId( 'client-side navigation' );
+		const hideOnPrint = page.getByTestId( 'hide-on-print' );
+
+		await expect( hideOnPrint ).toBeVisible();
+
+		await page.getByTestId( 'link red' ).click();
+
+		// This element disappears when a navigation starts.
+		// It should be visible again after a successful navigation.
+		await expect( csn ).toBeHidden();
+		await expect( csn ).toBeVisible();
+
+		// The "hide-on-print" element should remain visible.
+		await expect( hideOnPrint ).toBeVisible();
+	} );
 } );


### PR DESCRIPTION
## What?

Fixes a bug with style sheets present on the initial page that have a specific `media` attribute, e.g., `media="print"`. The `media` attribute in this case was overridden and unexpectedly set to `all`.

## How?

These changes make the style management logic update the `element.sheet.media.mediaText` property only when its value is `preload`. For elements with any other value, the algorithm considers that the correct media value is already set.

## Testing Instructions

There are unit tests and e2e tests for this case.

It can also be tested by adding a `<style>` element with a `media="print"` attribute to the initial page and ensuring that those styles are not applied on the page after client-side navigation.