### PR TITLE
feat: added class to children of modal & fill

### DIFF
--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -359,6 +359,13 @@ function UnforwardedModal(
 						) }
 
 						<div
+							className={ clsx(
+								'components-modal__children-container',
+								{
+									'is-fill-size':
+										size === 'fill' || isFullScreen,
+								}
+							) }
 							ref={ useMergeRefs( [
 								childrenContainerRef,
 								focusOnMount === 'firstContentElement'

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -208,3 +208,11 @@
 		outline-offset: -2px;
 	}
 }
+
+// Children container for modal content.
+.components-modal__children-container {
+	// When the modal has fill size, make the children container take up the full available height
+	&.is-fill-size {
+		height: 100%;
+	}
+}

--- a/packages/components/src/modal/test/index.tsx
+++ b/packages/components/src/modal/test/index.tsx
@@ -486,4 +486,52 @@ describe( 'Modal', () => {
 			expect( baseElement ).not.toHaveClass( 'is-A-open' );
 		} );
 	} );
+
+	it( 'should apply fill size class to children container when size is fill', () => {
+		render(
+			<Modal size="fill" onRequestClose={ noop }>
+				<p>Modal content</p>
+			</Modal>
+		);
+
+		const dialog = screen.getByRole( 'dialog' );
+		// Disable reason: No semantic query can reach the children container class.
+		// eslint-disable-next-line testing-library/no-node-access
+		const childrenContainer = dialog.querySelector(
+			'.components-modal__children-container'
+		);
+		expect( childrenContainer ).toHaveClass( 'is-fill-size' );
+	} );
+
+	it( 'should apply fill size class to children container when isFullScreen is true', () => {
+		render(
+			<Modal isFullScreen onRequestClose={ noop }>
+				<p>Modal content</p>
+			</Modal>
+		);
+
+		const dialog = screen.getByRole( 'dialog' );
+		// Disable reason: No semantic query can reach the children container class.
+		// eslint-disable-next-line testing-library/no-node-access
+		const childrenContainer = dialog.querySelector(
+			'.components-modal__children-container'
+		);
+		expect( childrenContainer ).toHaveClass( 'is-fill-size' );
+	} );
+
+	it( 'should not apply fill size class to children container when size is not fill', () => {
+		render(
+			<Modal size="medium" onRequestClose={ noop }>
+				<p>Modal content</p>
+			</Modal>
+		);
+
+		const dialog = screen.getByRole( 'dialog' );
+		// Disable reason: No semantic query can reach the children container class.
+		// eslint-disable-next-line testing-library/no-node-access
+		const childrenContainer = dialog.querySelector(
+			'.components-modal__children-container'
+		);
+		expect( childrenContainer ).not.toHaveClass( 'is-fill-size' );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #70611

<!-- In a few words, what is the PR actually doing? -->
Adds CSS class support to modal children container when using fill size or fullscreen mode to enable proper height styling.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, when using the Modal component with `size="fill"` or `isFullScreen={true}`, the children container div doesn't have proper height styling. This makes it difficult for developers to create content that takes up the full height of the modal, as the container collapses to its content height rather than expanding to fill the available space.

The issue affects developers who want to create modals with content that needs to utilize the full available height, such as forms with bottom-positioned buttons or scrollable content areas.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Added conditional CSS class `is-fill-size` to the modal's children container when `size="fill"` or `isFullScreen={true}`
- This class can be targeted by developers to apply `min-height: 100%` or similar styles to make content fill the available modal height
- Only applying the class when fill sizing is explicitly requested
- Added comprehensive tests to verify the class is applied correctly in all scenarios

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Open the Modal component storybook: https://wordpress.github.io/gutenberg/?path=/story/components-modal--default
2. Set the modal size to "fill" using the storybook controls
3. Verify that the modal's children container now has the `is-fill-size` CSS class
4. Test with `isFullScreen={true}` to ensure the class is also applied in fullscreen mode
5. Verify that regular modal sizes (small, medium, large) do not have the `is-fill-size` class
6. Test the new functionality by adding content with `height: 100%` to see it now properly fills the modal height

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. Navigate to the Modal storybook using Tab key
2. Use arrow keys to change the size control to "fill"
3. Verify the modal opens and closes properly with Escape key
4. Test focus management within the modal using Tab key
5. Ensure the new CSS class doesn't interfere with existing keyboard navigation

## Screenshots  

![image](https://github.com/user-attachments/assets/26255bee-09a9-48ed-95b7-9f4285d7bf6e)