### PR TITLE
potFilesCommand: fix shell command built arbitary code injection from environment values childProcess

### DIFF
--- a/bin/plugin/lib/utils.js
+++ b/bin/plugin/lib/utils.js
@@ -23,30 +23,31 @@ const { log, formats } = require( './logger' );
  * @param {string=} cwd    Working directory.
  * @param {Env=}    env    Additional environment variables to pass to the script.
  */
-function runShellScript( script, cwd, env = {} ) {
+function runShellScript( command, args = [], cwd, env = {} ) {
 	return new Promise( ( resolve, reject ) => {
-		childProcess.exec(
-			script,
-			{
-				cwd,
-				env: {
-					NO_CHECKS: 'true',
-					PATH: process.env.PATH,
-					HOME: process.env.HOME,
-					USER: process.env.USER,
-					...env,
-				},
-			},
-			function ( error, stdout, stderr ) {
-				if ( error ) {
-					console.log( stdout ); // Sometimes the error message is thrown via stdout.
-					console.log( stderr );
-					reject( error );
-				} else {
-					resolve( true );
-				}
-			}
-		);
+	    childProcess.execFile(
+	        command,
+	        args,
+	        {
+	            cwd,
+	            env: {
+	                NO_CHECKS: 'true',
+	                PATH: process.env.PATH,
+	                HOME: process.env.HOME,
+	                USER: process.env.USER,
+	                ...env,
+	            },
+	        },
+	        function ( error, stdout, stderr ) {
+	            if ( error ) {
+	                console.log( stdout ); // Sometimes the error message is thrown via stdout.
+	                console.log( stderr );
+	                reject( error );
+	            } else {
+	                resolve( true );
+	            }
+	        }
+	    );
 	} );
 }
 

--- a/packages/react-native-editor/bin/extract-used-strings.js
+++ b/packages/react-native-editor/bin/extract-used-strings.js
@@ -131,12 +131,14 @@ const getUsedStrings = ( potFilesDir, domains ) => {
 
 const generatePotFiles = ( plugins, potFilesDir ) => {
 	const potFilesCommand = path.join( __dirname, 'generate-pot-files.sh' );
-	const potFilesArgs = plugins
-		.map( ( { name, sourcePath } ) => `${ name } ${ sourcePath }` )
-		.join( ' ' );
+	const potFilesArgs = [
+		'--path', potFilesDir,
+		...plugins.flatMap( ( { name, sourcePath } ) => [ name, sourcePath ] ),
+	];
 	try {
-		childProcess.execSync(
-			`${ potFilesCommand } --path ${ potFilesDir } ${ potFilesArgs } `,
+		childProcess.execFileSync(
+			potFilesCommand,
+			potFilesArgs,
 			{
 				stdio: 'inherit',
 				env: { ...process.env },


### PR DESCRIPTION
https://github.com/WordPress/gutenberg/blob/5d2f86a1e0db8708d875b1ca04f9e25541a822b0/packages/react-native-editor/bin/extract-used-strings.js#L139-L139

https://github.com/WordPress/gutenberg/blob/1df817efa8db189ed332ac3b22ef3b63395ac039/bin/plugin/lib/utils.js#L26-L49

Dynamically constructing a shell command with values from the local environment, such as file paths, may inadvertently change the meaning of the shell command. Such changes can occur when an environment value contains characters that the shell interprets in a special way, for instance quotes and spaces. This can result in the shell command misbehaving, or even allowing a malicious user to execute arbitrary commands on the system.



To resolve the issue, the code should replace `childProcess.execSync` with `childProcess.execFileSync`, which allows passing arguments separately rather than interpolating them into a single shell command string. This approach ensures that special characters in file paths or arguments are passed correctly and avoids shell interpretation.

Specific fixes:
1. Extract the `potFilesCommand` as the command to invoke (`generate-pot-files.sh`).
2. Construct an array of arguments (`potFilesArgs`) and pass them explicitly to `execFileSync`.
3. Ensure that the arguments are sanitized or validated before use.

This change ensures that the command execution is safer and avoids vulnerabilities associated with shell command injection.