### PR TITLE
DataViews: Align media styles in table view with list view for consistency

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -29,7 +29,8 @@
 - Add `label-position-side` classes to labels in the form field layouts. Ensure that labels in the panel view do not align center, and that all side labels are center aligned.
 - Allow readonly fields in DataForm when `readOnly` is set to `true`.
 - Adjust the padding when the component is placed inside a `Card`.
-- Introduce `perPageSizes` to control the available sizes of the items per page
+- Introduce `perPageSizes` to control the available sizes of the items per page.
+- Align media styles in table view with list view for consistency.
 
 ### Breaking Changes
 

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -49,8 +49,8 @@
 		width: 100%;
 		min-height: 200px;
 		aspect-ratio: 1/1;
-		background-color: $gray-100;
-		border-radius: $grid-unit-05;
+		background-color: $white;
+		border-radius: $radius-medium;
 		position: relative;
 
 		img {

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -136,8 +136,8 @@ div.dataviews-view-list {
 		overflow: hidden;
 		position: relative;
 		flex-shrink: 0;
-		background-color: $gray-100;
-		border-radius: $grid-unit-05;
+		background-color: $white;
+		border-radius: $radius-medium;
 
 		img {
 			width: 100%;
@@ -153,7 +153,7 @@ div.dataviews-view-list {
 			width: 100%;
 			height: 100%;
 			box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.1);
-			border-radius: $grid-unit-05;
+			border-radius: $radius-medium;
 		}
 	}
 

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -260,4 +260,26 @@
 
 .dataviews-column-primary__media {
 	max-width: 60px;
+	overflow: hidden;
+	position: relative;
+	flex-shrink: 0;
+	background-color: $gray-100;
+	border-radius: $grid-unit-05;
+
+	img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+
+	&::after {
+		content: "";
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.1);
+		border-radius: $grid-unit-05;
+	}
 }

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -263,8 +263,8 @@
 	overflow: hidden;
 	position: relative;
 	flex-shrink: 0;
-	background-color: $gray-100;
-	border-radius: $grid-unit-05;
+	background-color: $white;
+	border-radius: $radius-medium;
 
 	img {
 		width: 100%;
@@ -280,6 +280,6 @@
 		width: 100%;
 		height: 100%;
 		box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.1);
-		border-radius: $grid-unit-05;
+		border-radius: $radius-medium;
 	}
 }

--- a/packages/edit-site/src/components/page-templates/style.scss
+++ b/packages/edit-site/src/components/page-templates/style.scss
@@ -25,17 +25,6 @@
 		max-height: 160px;
 		text-wrap: balance; // Fallback for Safari.
 		text-wrap: pretty;
-
-		&::after {
-			content: "";
-			position: absolute;
-			top: 0;
-			left: 0;
-			width: 100%;
-			height: 100%;
-			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
-			border-radius: $radius-medium;
-		}
 	}
 }
 

--- a/packages/fields/src/fields/featured-image/style.scss
+++ b/packages/fields/src/fields/featured-image/style.scss
@@ -90,3 +90,12 @@ fieldset.fields-controls__featured-image {
 		display: block;
 	}
 }
+
+.dataviews-view-list__media-wrapper {
+	.fields-controls__featured-image-image,
+	.fields-controls__featured-image-placeholder {
+		width: 100%;
+		height: 100%;
+		display: block;
+	}
+}

--- a/packages/fields/src/fields/featured-image/style.scss
+++ b/packages/fields/src/fields/featured-image/style.scss
@@ -82,16 +82,8 @@ fieldset.fields-controls__featured-image {
 	}
 }
 
-.dataviews-view-table__cell-content-wrapper {
-	.fields-controls__featured-image-image,
-	.fields-controls__featured-image-placeholder {
-		width: 32px;
-		height: 32px;
-		display: block;
-		border-radius: $radius-medium;
-	}
-}
-
+.dataviews-view-grid__media,
+.dataviews-view-table__cell-content-wrapper.dataviews-column-primary__media,
 .dataviews-view-list__media-wrapper {
 	.fields-controls__featured-image-image,
 	.fields-controls__featured-image-placeholder {
@@ -99,5 +91,18 @@ fieldset.fields-controls__featured-image {
 		height: 100%;
 		display: block;
 		border-radius: $radius-medium;
+	}
+
+	.fields-controls__featured-image-placeholder {
+		box-shadow: none;
+		background: $gray-100;
+	}
+}
+
+.dataviews-view-table__cell-content-wrapper.dataviews-column-primary__media {
+	.fields-controls__featured-image-image,
+	.fields-controls__featured-image-placeholder {
+		width: 32px;
+		height: 32px;
 	}
 }

--- a/packages/fields/src/fields/featured-image/style.scss
+++ b/packages/fields/src/fields/featured-image/style.scss
@@ -88,6 +88,7 @@ fieldset.fields-controls__featured-image {
 		width: 32px;
 		height: 32px;
 		display: block;
+		border-radius: $radius-medium;
 	}
 }
 
@@ -97,5 +98,6 @@ fieldset.fields-controls__featured-image {
 		width: 100%;
 		height: 100%;
 		display: block;
+		border-radius: $radius-medium;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->


<!-- In a few words, what is the PR actually doing? -->

Align media styles in table view with list view for consistency

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, the media item displayed in the table view and list view differs slightly. It would be better to make them consistent for a more cohesive user experience.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Apply following styles to the media item in the table view
  * `background-color: $gray-100;`
  * `border-radius: $grid-unit-05;`
  * `box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.1);`
  * `flex-shrink: 0` to prevent it from shrinking

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Run `npm run storybook:dev` to open the storybook
2. Navigate to DataViews > Default, and switch to the table view
3. Ensure the media has following styles
  * `background-color: $gray-100;`
  * `border-radius: $grid-unit-05;`
  * `box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.1);`
  * `flex-shrink: 0` to prevent it from shrinking

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="491" alt="image" src="https://github.com/user-attachments/assets/900a25be-ebcd-4170-96b8-ef919d10b9a6" /> | <img width="574" alt="image" src="https://github.com/user-attachments/assets/afd168e5-9229-46a5-9a2d-86cb30823bab" /> |
