### PR TITLE
Primary button: Update disabled state to be less prominent.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   `Button`: Update the disabled state for the Primary button to be less emphasized, to avoid confusing it for enabled. ([#70674](https://github.com/WordPress/gutenberg/pull/70674)).
+
 ### Enhancement
 
 -   `ColorPicker`: Improve color picker slider focus styles for better keyboard navigation accessibility ([#70146](https://github.com/WordPress/gutenberg/pull/70146)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,11 +2,10 @@
 
 ## Unreleased
 
--   `Button`: Update the disabled state for the Primary button to be less emphasized, to avoid confusing it for enabled. ([#70674](https://github.com/WordPress/gutenberg/pull/70674)).
-
 ### Enhancement
 
 -   `ColorPicker`: Improve color picker slider focus styles for better keyboard navigation accessibility ([#70146](https://github.com/WordPress/gutenberg/pull/70146)).
+-   `Button`: Update the disabled state for the Primary button to be less emphasized, to avoid confusing it for enabled. ([#70674](https://github.com/WordPress/gutenberg/pull/70674)).
 
 ### Bug Fixes
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -80,7 +80,7 @@
 		&[aria-disabled="true"]:enabled, // This catches a situation where a Button is aria-disabled, but not disabled.
 		&[aria-disabled="true"]:active:enabled {
 			// TODO: Prepare for theming (https://github.com/WordPress/gutenberg/pull/45466/files#r1030872724)
-			color: $white;
+			color: $components-color-foreground-inverted;
 			background: $components-color-gray-300;
 			border-color: $components-color-gray-300;
 			outline: none;

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -81,8 +81,8 @@
 		&[aria-disabled="true"]:active:enabled {
 			// TODO: Prepare for theming (https://github.com/WordPress/gutenberg/pull/45466/files#r1030872724)
 			color: $white;
-			background: $gray-300;
-			border-color: $gray-300;
+			background: $components-color-gray-300;
+			border-color: $components-color-gray-300;
 			outline: none;
 
 			&:focus:enabled {

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -80,9 +80,9 @@
 		&[aria-disabled="true"]:enabled, // This catches a situation where a Button is aria-disabled, but not disabled.
 		&[aria-disabled="true"]:active:enabled {
 			// TODO: Prepare for theming (https://github.com/WordPress/gutenberg/pull/45466/files#r1030872724)
-			color: rgba($white, 0.4);
-			background: $components-color-accent;
-			border-color: $components-color-accent;
+			color: $white;
+			background: $gray-300;
+			border-color: $gray-300;
 			outline: none;
 
 			&:focus:enabled {


### PR DESCRIPTION
## What?

Related to #63856 ("Disabled states of the primary variant are very prominent, and draw a lot of attention given their un-interactivity.")

Changes the color of a disabled primary button to gray.

## Why?

This makes it less prominent, and reduces confusion around the button being interactive.

## Testing Instructions

Add a new post and observe the disabled "Publish" button. In this PR it shoudl be gray.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="311" alt="image" src="https://github.com/user-attachments/assets/444b8888-1ceb-4d89-9445-35d64a59c442" /> | ![Screenshot 2025-07-10 at 10 56 53](https://github.com/user-attachments/assets/80aba974-0285-4169-838d-e959ebcdecd5) |
