### PR TITLE
Global Styles: Make Button element inherit all typography styles on the frontend

### DIFF
--- a/backport-changelog/6.9/9268.md
+++ b/backport-changelog/6.9/9268.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/9268
+
+* https://github.com/WordPress/gutenberg/pull/70676

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -384,6 +384,10 @@
 				"typography": {
 					"fontSize": "inherit",
 					"fontFamily": "inherit",
+					"fontStyle": "inherit",
+					"fontWeight": "inherit",
+					"letterSpacing": "inherit",
+					"textTransform": "inherit",
 					"lineHeight": "inherit",
 					"textDecoration": "none"
 				},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #60403

<!-- In a few words, what is the PR actually doing? -->
Button elements in WordPress Gutenberg are missing inherited typography styles, including font-style, text-transform, letter-spacing, and font-weight, which are applied in the editor but not on the frontend.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The issue needs to be fixed because button elements in WordPress Gutenberg are missing some inherited typography styles, including font-style, text-transform, letter-spacing, and font-weight, which are applied in the editor but not on the frontend.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This change is related to an issue where button elements with the `wp-element-button` class were not inheriting certain typography styles, such as font style, text transform, letter spacing, and font weight, when updated via the Global Styles. The issue was observed when updating typography styles at the root level, then inserting a Search block. The expected behavior is for these styles to be applied to the button element on the frontend, but currently, they are not. The provided code change aims to address this issue by adding the missing styles to the typography object.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
- Go to the Site Editor > Global Styles > Typography > Text > Typography panel
- Update all styles.
- Insert a Search block in a post and check if it's style is getting inherited on the front end.

## Screenshots or screencast <!-- if applicable -->

### Before
<!-- Add before image URL if available -->
<img width="689" alt="Screenshot 2025-07-10 at 3 11 07 PM" src="https://github.com/user-attachments/assets/283640ff-e53b-40a3-be0f-127c03bb3fde" />

### After
<!-- Add after image URL if available -->
<img width="701" alt="Screenshot 2025-07-10 at 3 11 20 PM" src="https://github.com/user-attachments/assets/22b52e1e-033c-4f54-b502-c6986be62563" />

---

note: please let me know if this needs to be backported to core, I'll be happy to create a corresponding core ticket for it.