### PR TITLE
wp-env: don't overwrite wp-cli.yml if it already exists

### DIFF
--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -87,7 +87,8 @@ async function configureWordPress( environment, config, spinner ) {
 	}
 
 	// Create a project-specific wp-cli configuration, important for the `rewrite` command.
-	const cliConfigCommand = `(
+	// Don't overwrite existing configuration.
+	const cliConfigCommand = `[ -f /var/www/html/wp-cli.yml ] || (
 		exec > /var/www/html/wp-cli.yml
 		echo "apache_modules:"
 		echo "  - mod_rewrite"


### PR DESCRIPTION
Follow-up to #70661 where @westonruter [points out](https://github.com/WordPress/gutenberg/pull/70661#issuecomment-3056020780) that we don't want to overwrite an existing `wp-cli.yml`. That's relevant especially when running `wp-env start --update`.

The simplest solution is to not amend the existing config file. The idea is that it's the user's responsibility to have the custom config file in order. It's not hard to add `apache_modules` manually, after all, we just want to provide a default that works well.