### PR TITLE
Fix Cover block rendering black overlay when no background is set

### DIFF
--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -104,6 +104,13 @@ export default function save( { attributes } ) {
 
 	const gradientValue = gradient || customGradient;
 
+	const shouldShowBackgroundOverlay = !! (
+		customOverlayColor ||
+		overlayColor ||
+		gradientValue ||
+		( url && dimRatio !== undefined )
+	);
+
 	return (
 		<Tag { ...useBlockProps.save( { className: classes, style } ) }>
 			{ ! useFeaturedImage &&
@@ -149,25 +156,27 @@ export default function save( { attributes } ) {
 			works properly. If it needs to be changed in the future, the
 			selector for the backward compatibility for v14 deprecation also
 			needs change. */ }
-			<span
-				aria-hidden="true"
-				className={ clsx(
-					'wp-block-cover__background',
-					overlayColorClass,
-					dimRatioToClass( dimRatio ),
-					{
-						'has-background-dim': dimRatio !== undefined,
-						// For backwards compatibility. Former versions of the Cover Block applied
-						// `.wp-block-cover__gradient-background` in the presence of
-						// media, a gradient and a dim.
-						'wp-block-cover__gradient-background':
-							url && gradientValue && dimRatio !== 0,
-						'has-background-gradient': gradientValue,
-						[ gradientClass ]: gradientClass,
-					}
-				) }
-				style={ bgStyle }
-			/>
+			{ shouldShowBackgroundOverlay && (
+				<span
+					aria-hidden="true"
+					className={ clsx(
+						'wp-block-cover__background',
+						overlayColorClass,
+						dimRatioToClass( dimRatio ),
+						{
+							'has-background-dim': dimRatio !== undefined,
+							// For backwards compatibility. Former versions of the Cover Block applied
+							// `.wp-block-cover__gradient-background` in the presence of
+							// media, a gradient and a dim.
+							'wp-block-cover__gradient-background':
+								url && gradientValue && dimRatio !== 0,
+							'has-background-gradient': gradientValue,
+							[ gradientClass ]: gradientClass,
+						}
+					) }
+					style={ bgStyle }
+				/>
+			) }
 
 			<div
 				{ ...useInnerBlocksProps.save( {


### PR DESCRIPTION
## What?
Closes #10854 

Prevents the Cover block from rendering a black background overlay when no background color, image, video or gradient is defined.

## Why?
When a Cover block is inserted without setting any background (image, color, gradient, or video), it still renders a `.has-background-dim` overlay span, which appears as a solid black block on the front-end. This creates an inconsistent experience and confuses users who expect the block to remain visually empty unless content is explicitly added.

This update aligns the Cover block’s behavior with that of the Image block — where, if no image is selected, nothing is rendered on the front-end. This provides a more intuitive and predictable editing experience.

## How?
- Introduced a conditional `shouldShowBackgroundOverlay` that evaluates to `true` only when a `customOverlayColor`, `overlayColor`, `gradientValue`, or a combination of `url` and `dimRatio` is present.
- Rendered the background overlay `<span>` only when this condition is met.

## Testing Instructions
1. Open a post or page.
2. Insert a Cover block.
3. Do **not** set a background image, video, color, or gradient.
4. Observe that the Cover block renders **without** a black overlay.
5. Now add a background color or image, confirm that the overlay reappears appropriately.

## Screenshots or screencast 
### Cover Block behaviour after the Patch
https://github.com/user-attachments/assets/8d466719-03a3-43b1-9b7f-bf61ee42d8a5

