### PR TITLE
`DateCalendar`, `DateRangeCalendar`: move to private APIs

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 ## Unreleased
 
-### New Features
-
--   Add new `DateCalendar` and `DateRangeCalendar` components ([#70578](https://github.com/WordPress/gutenberg/pull/70578)).
-
 ### Bug Fixes
 
 -   `FormTokenField`: Fix focus lost on tab when `__experimentalExpandOnFocus` is set ([#70591](https://github.com/WordPress/gutenberg/pull/70591)).
 -   `SelectControl`: Fix font-size for medium screens to ensure consistency with other inputs ([#70619](https://github.com/WordPress/gutenberg/pull/70619)).
 -   `SelectControl`: Move classnames to the root ([#70643](https://github.com/WordPress/gutenberg/pull/70643)).
+
+### Internal
+
+-   Add new private `DateCalendar` and `DateRangeCalendar` components ([#70578](https://github.com/WordPress/gutenberg/pull/70578), [#70681](https://github.com/WordPress/gutenberg/pull/70681)).
 
 ## 29.12.0 (2025-06-25)
 

--- a/packages/components/src/calendar/date-calendar/README.md
+++ b/packages/components/src/calendar/date-calendar/README.md
@@ -24,95 +24,95 @@ These props are shared between both single date and date range calendar modes.
 
 ### `required`
 
-- Type: `boolean`
-- Required: No
-- Default: `false`
+-   Type: `boolean`
+-   Required: No
+-   Default: `false`
 
 Whether the selection is required. When `true`, there always needs to be a date selected.
 
 ### `selected`
 
-- Type: `Date | undefined | null`
-- Required: No
+-   Type: `Date | undefined | null`
+-   Required: No
 
 The selected date.
 
 ### `onSelect`
 
-- Type: `(selected: Date | undefined, triggerDate: Date, modifiers: Modifiers, e: React.MouseEvent | React.KeyboardEvent) => void`
-- Required: No
+-   Type: `(selected: Date | undefined, triggerDate: Date, modifiers: Modifiers, e: React.MouseEvent | React.KeyboardEvent) => void`
+-   Required: No
 
 Event handler when a day is selected.
 
 ### `defaultSelected`
 
-- Type: `Date`
-- Required: No
+-   Type: `Date`
+-   Required: No
 
 The default selected date (for uncontrolled usage).
 
 ### `defaultMonth`
 
-- Type: `Date`
-- Required: No
-- Default: Current month
+-   Type: `Date`
+-   Required: No
+-   Default: Current month
 
 The initial month to show in the calendar view (uncontrolled).
 
 ### `month`
 
-- Type: `Date`
-- Required: No
+-   Type: `Date`
+-   Required: No
 
 The month displayed in the calendar view (controlled). Use together with `onMonthChange` to change the month programmatically.
 
 ### `numberOfMonths`
 
-- Type: `number`
-- Required: No
-- Default: `1`
+-   Type: `number`
+-   Required: No
+-   Default: `1`
 
 The number of months displayed at once.
 
 ### `startMonth`
 
-- Type: `Date`
-- Required: No
+-   Type: `Date`
+-   Required: No
 
 The earliest month to start the month navigation.
 
 ### `endMonth`
 
-- Type: `Date`
-- Required: No
+-   Type: `Date`
+-   Required: No
 
 The latest month to end the month navigation.
 
 ### `autoFocus`
 
-- Type: `boolean`
-- Required: No
+-   Type: `boolean`
+-   Required: No
 
 Focus the first selected day (if set) or today's date (if not disabled). Use this prop when you need to focus the calendar after a user action (e.g. opening the dialog with the calendar).
 
 ### `disabled`
 
-- Type: `Matcher | Matcher[] | undefined`
-- Required: No
+-   Type: `Matcher | Matcher[] | undefined`
+-   Required: No
 
 Specify which days are disabled. Using `true` will disable all dates. See the [Matcher Types](#matcher-types) section for more details.
 
 ### `disableNavigation`
 
-- Type: `boolean`
-- Required: No
+-   Type: `boolean`
+-   Required: No
 
 Disable the navigation buttons.
 
 ### `labels`
 
-- Type: `object`
-- Required: No
+-   Type: `object`
+-   Required: No
 
 Use custom labels for internationalization. All labels are optional and have sensible defaults:
 
@@ -132,9 +132,9 @@ Use custom labels for internationalization. All labels are optional and have sen
 
 ### `locale`
 
-- Type: `Locale`
-- Required: No
-- Default: `enUS` from `@date-fns/locale`
+-   Type: `Locale`
+-   Required: No
+-   Default: `enUS` from `@date-fns/locale`
 
 The locale object used to localize dates. Pass a locale from `@date-fns/locale` to localize the calendar.
 
@@ -142,23 +142,23 @@ The locale object used to localize dates. Pass a locale from `@date-fns/locale` 
 
 ### `weekStartsOn`
 
-- Type: `0 | 1 | 2 | 3 | 4 | 5 | 6 | undefined`
-- Required: No
-- Default: Based on the `locale` prop
+-   Type: `0 | 1 | 2 | 3 | 4 | 5 | 6 | undefined`
+-   Required: No
+-   Default: Based on the `locale` prop
 
 The index of the first day of the week (0 - Sunday). Overrides the locale's setting.
 
 ### `onMonthChange`
 
-- Type: `(month: Date) => void`
-- Required: No
+-   Type: `(month: Date) => void`
+-   Required: No
 
 Event fired when the user navigates between months.
 
 ### `timeZone`
 
-- Type: `string`
-- Required: No
+-   Type: `string`
+-   Required: No
 
 The time zone (IANA or UTC offset) to use in the calendar. See [Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for possible values.
 
@@ -172,15 +172,21 @@ export function WithTimeZone() {
 	const [ selected, setSelected ] = useState< Date | undefined >(
 		new TZDate( 2024, 12, 10, timeZone ) // Use `TZDate` instead of `Date`
 	);
-	return <DateCalendar timeZone={ timeZone } selected={ selected } onSelect={ setSelected } />;
+	return (
+		<DateCalendar
+			timeZone={ timeZone }
+			selected={ selected }
+			onSelect={ setSelected }
+		/>
+	);
 }
 ```
 
 ### `role`
 
-- Type: `'application' | 'dialog' | undefined`
-- Required: No
-- Default: `'application'`
+-   Type: `'application' | 'dialog' | undefined`
+-   Required: No
+-   Default: `'application'`
 
 The role attribute to add to the container element.
 
@@ -203,7 +209,10 @@ const dateMatcher: Matcher = new Date(); // Will match today's date
 ### Array Matcher
 
 ```typescript
-const arrayMatcher: Matcher = [ new Date( 2019, 1, 2 ), new Date( 2019, 1, 4 ) ]; // Will match the days in the array
+const arrayMatcher: Matcher = [
+	new Date( 2019, 1, 2 ),
+	new Date( 2019, 1, 4 ),
+]; // Will match the days in the array
 ```
 
 ### Date After Matcher

--- a/packages/components/src/calendar/date-calendar/README.md
+++ b/packages/components/src/calendar/date-calendar/README.md
@@ -1,5 +1,7 @@
 # `DateCalendar`
 
+🔒 This component is locked as a [private API](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-private-apis/). We do not yet recommend using this outside of the Gutenberg project.
+
 `DateCalendar` is a React component that provides a customizable calendar interface for **single date** selection.
 
 The component is built with accessibility in mind and follows ARIA best practices for calendar widgets. It provides keyboard navigation, screen reader support, and customizable labels for internationalization.
@@ -7,7 +9,7 @@ The component is built with accessibility in mind and follows ARIA best practice
 ## Usage example
 
 ```tsx
-import { DateCalendar } from '@automattic/components';
+import { DateCalendar } from '@wordpress/components';
 
 function MyComponent() {
 	const [ selected, setSelected ] = useState< Date >( new Date() );
@@ -163,7 +165,7 @@ The time zone (IANA or UTC offset) to use in the calendar. See [Wikipedia](https
 When working with time zones, use the `TZDate` object exported by this package instead of the native `Date` object.
 
 ```tsx
-import { DateCalendar, TZDate } from '@automattic/components';
+import { DateCalendar, TZDate } from '@wordpress/components';
 
 export function WithTimeZone() {
 	const timeZone = 'America/New_York';

--- a/packages/components/src/calendar/date-range-calendar/README.md
+++ b/packages/components/src/calendar/date-range-calendar/README.md
@@ -1,5 +1,7 @@
 # `DateRangeCalendar`
 
+🔒 This component is locked as a [private API](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-private-apis/). We do not yet recommend using this outside of the Gutenberg project.
+
 `DateRangeCalendar` is a React component that provides a customizable calendar interface for **date range** selection.
 
 The component is built with accessibility in mind and follows ARIA best practices for calendar widgets. It provides keyboard navigation, screen reader support, and customizable labels for internationalization.
@@ -7,7 +9,7 @@ The component is built with accessibility in mind and follows ARIA best practice
 ## Usage example
 
 ```tsx
-import { DateRangeCalendar } from '@automattic/components';
+import { DateRangeCalendar } from '@wordpress/components';
 
 type DateRange = {
 	from: Date | undefined;
@@ -199,7 +201,7 @@ The time zone (IANA or UTC offset) to use in the calendar. See [Wikipedia](https
 When working with time zones, use the `TZDate` object exported by this package instead of the native `Date` object.
 
 ```tsx
-import { DateRangeCalendar, TZDate } from '@automattic/components';
+import { DateRangeCalendar, TZDate } from '@wordpress/components';
 
 export function WithTimeZone() {
 	const timeZone = 'America/New_York';

--- a/packages/components/src/calendar/date-range-calendar/README.md
+++ b/packages/components/src/calendar/date-range-calendar/README.md
@@ -32,16 +32,16 @@ These props are shared between both single date and date range calendar modes.
 
 ### `required`
 
-- Type: `boolean`
-- Required: No
-- Default: `false`
+-   Type: `boolean`
+-   Required: No
+-   Default: `false`
 
 Whether the selection is required. When `true`, there always needs to be a date selected.
 
 ### `selected`
 
-- Type: `DateRange | undefined | null`
-- Required: No
+-   Type: `DateRange | undefined | null`
+-   Required: No
 
 The selected date range. A `DateRange` object has the following shape:
 
@@ -54,101 +54,101 @@ The selected date range. A `DateRange` object has the following shape:
 
 ### `onSelect`
 
-- Type: `(selected: DateRange | undefined, triggerDate: Date, modifiers: Modifiers, e: React.MouseEvent | React.KeyboardEvent) => void`
-- Required: No
+-   Type: `(selected: DateRange | undefined, triggerDate: Date, modifiers: Modifiers, e: React.MouseEvent | React.KeyboardEvent) => void`
+-   Required: No
 
 Event handler when the selection changes. The `selected` parameter will contain the new date range.
 
 ### `defaultSelected`
 
-- Type: `DateRange`
-- Required: No
+-   Type: `DateRange`
+-   Required: No
 
 The default selected range (for uncontrolled usage).
 
 ### `excludeDisabled`
 
-- Type: `boolean`
-- Required: No
+-   Type: `boolean`
+-   Required: No
 
 When `true`, the range will reset when including a disabled day. This is useful to prevent users from selecting ranges that include unavailable dates.
 
 ### `min`
 
-- Type: `number`
-- Required: No
+-   Type: `number`
+-   Required: No
 
 The minimum number of days to include in the range. If a user tries to select a range shorter than this, the selection will be adjusted to meet the minimum requirement.
 
 ### `max`
 
-- Type: `number`
-- Required: No
+-   Type: `number`
+-   Required: No
 
 The maximum number of days to include in the range. If a user tries to select a range longer than this, the selection will be adjusted to meet the maximum requirement.
 
 ### `defaultMonth`
 
-- Type: `Date`
-- Required: No
-- Default: Current month
+-   Type: `Date`
+-   Required: No
+-   Default: Current month
 
 The initial month to show in the calendar view (uncontrolled).
 
 ### `month`
 
-- Type: `Date`
-- Required: No
+-   Type: `Date`
+-   Required: No
 
 The month displayed in the calendar view (controlled). Use together with `onMonthChange` to change the month programmatically.
 
 ### `numberOfMonths`
 
-- Type: `number`
-- Required: No
-- Default: `1`
+-   Type: `number`
+-   Required: No
+-   Default: `1`
 
 The number of months displayed at once.
 
 ### `startMonth`
 
-- Type: `Date`
-- Required: No
+-   Type: `Date`
+-   Required: No
 
 The earliest month to start the month navigation.
 
 ### `endMonth`
 
-- Type: `Date`
-- Required: No
+-   Type: `Date`
+-   Required: No
 
 The latest month to end the month navigation.
 
 ### `autoFocus`
 
-- Type: `boolean`
-- Required: No
+-   Type: `boolean`
+-   Required: No
 
 Focus the first selected day (if set) or today's date (if not disabled). Use this prop when you need to focus the calendar after a user action (e.g. opening the dialog with the calendar).
 
 ### `disabled`
 
-- Type: `Matcher | Matcher[] | undefined`
-- Required: No
+-   Type: `Matcher | Matcher[] | undefined`
+-   Required: No
 
 Specify which days are disabled. Using `true` will disable all dates. See the [Matcher Types](#matcher-types) section for more details.
 
 ### `disableNavigation`
 
-- Type: `boolean`
-- Required: No
+-   Type: `boolean`
+-   Required: No
 
 Disable the navigation buttons.
 
 ### `labels`
 
-- Type: `object`
-- Required: No
+-   Type: `object`
+-   Required: No
 
 Use custom labels for internationalization. All labels are optional and have sensible defaults:
 
@@ -168,9 +168,9 @@ Use custom labels for internationalization. All labels are optional and have sen
 
 ### `locale`
 
-- Type: `Locale`
-- Required: No
-- Default: `enUS` from `@date-fns/locale`
+-   Type: `Locale`
+-   Required: No
+-   Default: `enUS` from `@date-fns/locale`
 
 The locale object used to localize dates. Pass a locale from `@date-fns/locale` to localize the calendar.
 
@@ -178,23 +178,23 @@ The locale object used to localize dates. Pass a locale from `@date-fns/locale` 
 
 ### `weekStartsOn`
 
-- Type: `0 | 1 | 2 | 3 | 4 | 5 | 6 | undefined`
-- Required: No
-- Default: Based on the `locale` prop
+-   Type: `0 | 1 | 2 | 3 | 4 | 5 | 6 | undefined`
+-   Required: No
+-   Default: Based on the `locale` prop
 
 The index of the first day of the week (0 - Sunday). Overrides the locale's setting.
 
 ### `onMonthChange`
 
-- Type: `(month: Date) => void`
-- Required: No
+-   Type: `(month: Date) => void`
+-   Required: No
 
 Event fired when the user navigates between months.
 
 ### `timeZone`
 
-- Type: `string`
-- Required: No
+-   Type: `string`
+-   Required: No
 
 The time zone (IANA or UTC offset) to use in the calendar. See [Wikipedia](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for possible values.
 
@@ -209,15 +209,21 @@ export function WithTimeZone() {
 		from: new TZDate( 2024, 12, 10, timeZone ), // Use `TZDate` instead of `Date`
 		to: new TZDate( 2024, 12, 8, timeZone ), // Use `TZDate` instead of `Date`
 	} );
-	return <DateRangeCalendar timeZone={ timeZone } selected={ selected } onSelect={ setSelected } />;
+	return (
+		<DateRangeCalendar
+			timeZone={ timeZone }
+			selected={ selected }
+			onSelect={ setSelected }
+		/>
+	);
 }
 ```
 
 ### `role`
 
-- Type: `'application' | 'dialog' | undefined`
-- Required: No
-- Default: `'application'`
+-   Type: `'application' | 'dialog' | undefined`
+-   Required: No
+-   Default: `'application'`
 
 The role attribute to add to the container element.
 
@@ -240,7 +246,10 @@ const dateMatcher: Matcher = new Date(); // Will match today's date
 ### Array Matcher
 
 ```typescript
-const arrayMatcher: Matcher = [ new Date( 2019, 1, 2 ), new Date( 2019, 1, 4 ) ]; // Will match the days in the array
+const arrayMatcher: Matcher = [
+	new Date( 2019, 1, 2 ),
+	new Date( 2019, 1, 4 ),
+]; // Will match the days in the array
 ```
 
 ### Date After Matcher

--- a/packages/components/src/calendar/types.ts
+++ b/packages/components/src/calendar/types.ts
@@ -284,7 +284,7 @@ export interface BaseProps
 	 * When working with time zones, use the `TZDate` object exported by this
 	 * package instead of the native `Date` object.
 	 * @example
-	 *   import { DateCalendar, TZDate } from "@automattic/components";
+	 *   import { DateCalendar, TZDate } from "@wordpress/components";
 	 *
 	 *   export function WithTimeZone() {
 	 *     const timeZone = "America/New_York";

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -57,7 +57,6 @@ export {
 	CardHeader,
 	CardMedia,
 } from './card';
-export { DateCalendar, DateRangeCalendar, TZDate } from './calendar';
 export { default as CheckboxControl } from './checkbox-control';
 export { default as ClipboardButton } from './clipboard-button';
 export { default as __experimentalPaletteEdit } from './palette-edit';

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -10,7 +10,7 @@ import { kebabCase, normalizeTextString } from './utils/strings';
 import { withIgnoreIMEEvents } from './utils/with-ignore-ime-events';
 import { lock } from './lock-unlock';
 import Badge from './badge';
-export { DateCalendar, DateRangeCalendar, TZDate } from './calendar';
+import { DateCalendar, DateRangeCalendar, TZDate } from './calendar';
 
 export const privateApis = {};
 lock( privateApis, {

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -10,6 +10,7 @@ import { kebabCase, normalizeTextString } from './utils/strings';
 import { withIgnoreIMEEvents } from './utils/with-ignore-ime-events';
 import { lock } from './lock-unlock';
 import Badge from './badge';
+export { DateCalendar, DateRangeCalendar, TZDate } from './calendar';
 
 export const privateApis = {};
 lock( privateApis, {
@@ -22,4 +23,7 @@ lock( privateApis, {
 	withIgnoreIMEEvents,
 	Badge,
 	normalizeTextString,
+	DateCalendar,
+	DateRangeCalendar,
+	TZDate,
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

<!-- In a few words, what is the PR actually doing? -->

Mark the `DateCalendar` and `DateRangeCalendar` components recently added in #70578 as private APIs of the `@wordpress/components` package, instead of being public.

cc @chihsuan

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The components are initially needed by the `@wordpress/dataviews` package, which will serve as a testing ground for the components before eventually marking them as public.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Tweaked how the components are exported — from the public `index.ts` file to the `private-apis.ts` file (exported behing `lock` call).

I also tweaked the relevant README and JSDocs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Make sure that `DateCalendar`, `DateRangeCalendar` (and the `TZDate` utility) can't be imported directly from `@wordpress/components`
- Make sure that they can be imported as private APIs by using the `unlock` function