### PR TITLE
Media & Text: fixed resetAll to return image resolution to default value

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -317,8 +317,8 @@ function MediaTextEdit( {
 					mediaAlt: '',
 					focalPoint: undefined,
 					mediaWidth: 50,
-					mediaSizeSlug: undefined,
 				} );
+				updateImage( DEFAULT_MEDIA_SIZE_SLUG );
 			} }
 			dropdownMenuProps={ dropdownMenuProps }
 		>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Similar #70398 #70514 #70608

<!-- In a few words, what is the PR actually doing? -->

## Why?
Clicking Reset all doesn't reset the resolution to default.
Fixed it to go back to full resolution like in #70398 #70514 #70608

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open a post or page.
2. Insert Media & Text block and select a media file.
3. Change its resolution.
4. Confirm that it doesn't reset to the first available option.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

https://github.com/user-attachments/assets/cc3c73af-f844-4955-adee-9445950e23b5


### After

https://github.com/user-attachments/assets/1dc2b467-e992-4877-94ef-8f31344a27fd

