### PR TITLE
Block Editor Components: Add missing style resets for fieldset elements

### DIFF
--- a/packages/block-editor/src/components/block-lock/style.scss
+++ b/packages/block-editor/src/components/block-lock/style.scss
@@ -2,6 +2,13 @@
 	z-index: z-index(".block-editor-block-lock-modal");
 }
 
+.block-editor-block-lock-modal__options {
+	// Reset `fieldset` browser defaults.
+	border: 0;
+	padding: 0;
+	margin: 0;
+}
+
 .block-editor-block-lock-modal__options legend {
 	margin-bottom: $grid-unit-20;
 	padding: 0;

--- a/packages/block-editor/src/components/block-variation-transforms/style.scss
+++ b/packages/block-editor/src/components/block-variation-transforms/style.scss
@@ -1,3 +1,10 @@
+fieldset.block-editor-block-variation-transforms {
+	// Reset `fieldset` browser defaults.
+	border: 0;
+	padding: 0;
+	margin: 0;
+}
+
 .block-editor-block-variation-transforms {
 	padding: 0 $grid-unit-20 $grid-unit-20 52px;
 	width: 100%;

--- a/packages/block-editor/src/components/block-variation-transforms/style.scss
+++ b/packages/block-editor/src/components/block-variation-transforms/style.scss
@@ -1,4 +1,4 @@
-fieldset.block-editor-block-variation-transforms {
+.block-editor-block-variation-transforms:where(fieldset) {
 	// Reset `fieldset` browser defaults.
 	border: 0;
 	padding: 0;

--- a/packages/block-editor/src/components/border-radius-control/style.scss
+++ b/packages/block-editor/src/components/border-radius-control/style.scss
@@ -1,4 +1,9 @@
 .components-border-radius-control {
+	// Reset `fieldset` browser defaults.
+	border: 0;
+	padding: 0;
+	margin: 0;
+
 	margin-bottom: $grid-unit-15;
 
 	legend {

--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -10,6 +10,11 @@ $swatch-gap: 12px;
 }
 
 .block-editor-color-gradient-control__fieldset {
+	// Reset `fieldset` browser defaults.
+	border: 0;
+	padding: 0;
+	margin: 0;
+
 	// Prevents the `fieldset` from growing beyond its parent's size
 	// in order to fit its content.
 	min-width: 0;

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -345,6 +345,13 @@ $block-editor-link-control-number-of-actions: 1;
 	position: relative;
 }
 
+.block-editor-link-control__settings {
+	// Reset `fieldset` browser defaults.
+	border: 0;
+	padding: 0;
+	margin: 0;
+}
+
 .block-editor-link-control__setting {
 	margin-bottom: 0;
 	flex: 1;

--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -1,4 +1,9 @@
 .spacing-sizes-control {
+	// Reset `fieldset` browser defaults.
+	border: 0;
+	padding: 0;
+	margin: 0;
+
 	.spacing-sizes-control__custom-value-input,
 	.spacing-sizes-control__label {
 		margin-bottom: 0;

--- a/packages/block-editor/src/hooks/layout.scss
+++ b/packages/block-editor/src/hooks/layout.scss
@@ -17,3 +17,11 @@
 		margin-bottom: $grid-unit-10;
 	}
 }
+
+.block-editor-hooks__grid-layout-columns-and-rows-controls,
+.block-editor-hooks__grid-layout-minimum-width-control {
+	// Reset `fieldset` browser defaults.
+	border: 0;
+	padding: 0;
+	margin: 0;
+}

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -243,7 +243,7 @@ function GridLayoutMinimumWidthControl( { layout, onChange } ) {
 	};
 
 	return (
-		<fieldset>
+		<fieldset className="block-editor-hooks__grid-layout-minimum-width-control">
 			<BaseControl.VisualLabel as="legend">
 				{ __( 'Minimum column width' ) }
 			</BaseControl.VisualLabel>
@@ -302,7 +302,7 @@ function GridLayoutColumnsAndRowsControl( {
 
 	return (
 		<>
-			<fieldset>
+			<fieldset className="block-editor-hooks__grid-layout-columns-and-rows-controls">
 				{ ( ! window.__experimentalEnableGridInteractivity ||
 					! isManualPlacement ) && (
 					<BaseControl.VisualLabel as="legend">

--- a/packages/preferences/src/components/preferences-modal-section/style.scss
+++ b/packages/preferences/src/components/preferences-modal-section/style.scss
@@ -1,4 +1,8 @@
 .preferences-modal__section {
+	// Reset `fieldset` browser defaults.
+	border: 0;
+	padding: 0;
+
 	margin: 0 0 2.5rem 0;
 
 	&:last-child {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/70684

<!-- In a few words, what is the PR actually doing? -->

Add `fieldset` resets for a number of the block-editor components (those listed in #70684) that didn't already have them.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Components in the _components_ library appear to already be doing this, but a number in `block-editor` weren't. Currently, the block editor components expect to be displayed within an admin context that includes CSS resets for the `fieldset` element. However, these components should be responsible for their own resets, similar to the components library.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I reviewed components in the `block-editor` package to find `fieldset` elements that didn't have resets, and then added them in. I _think_ I've covered all the fieldsets with current usage in the block editor.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Smoke test the following areas in the editor UI to make sure this doesn't break anything:

* The block lock modal (open up the list view and go to lock a block)
* Add a Group block, and give it some padding and margin and make sure those controls look okay
* Ensure the border radius control looks okay
* Go to add a background color, and ensure the controls within the popover look okay
* Add a paragraph block and add a link to some text. Open up the advanced controls for open in new window, etc, and that section should look okay
* Add a Grid block, and check that the min column width controls look okay, and if you switch to manual "grid item position" it should look okay, too
* Open up the editor preferences modal, and ensure the overall section looks okay

In normal usage, this PR should be identical to trunk. However if you want to test that these rules work, you can run the following in the browser console to remove `common.css`: `document.querySelector( 'link#common-css' ).remove()`.

<!--
could hack this in locally in `gutenberg.php` to skip some of the admin styles resets provided by common.css:

```php
add_action('admin_init', function () {
    ob_start(function ($buffer) {
        return preg_replace(
            '#<link[^>]+common\.css[^>]+>#',
            '',
            $buffer
        );
    });
});
```

I'm sure there's a better way to test that — but I don't think `wp_dequeue_style('common');` really works as the common CSS appears to be loaded pretty early in the process. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

This is a pretty contrived before/after:

|Before|After|
|-|-|
| <img width="1336" height="1234" alt="image" src="https://github.com/user-attachments/assets/fc6fc3d9-8ef3-4bc9-8bc8-89f384bf18a0" /> | <img width="1216" height="1240" alt="image" src="https://github.com/user-attachments/assets/dcb9c774-99ff-4fae-967b-74f703c7ed1f" /> |