### PR TITLE
Navigation Submenu Link: Add `Open in new tab` toggle to navigation block sidebar

### DIFF
--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -8,6 +8,7 @@ import clsx from 'clsx';
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
+	CheckboxControl,
 	TextControl,
 	TextareaControl,
 	ToolbarButton,
@@ -134,7 +135,7 @@ export default function NavigationSubmenuEdit( {
 	context,
 	clientId,
 } ) {
-	const { label, url, description, rel } = attributes;
+	const { label, url, description, rel, opensInNewTab } = attributes;
 
 	const { showSubmenuIcon, maxNestingLevel, openSubmenusOnClick } = context;
 
@@ -430,6 +431,24 @@ export default function NavigationSubmenuEdit( {
 							label={ __( 'Link' ) }
 							autoComplete="off"
 							type="url"
+						/>
+					</ToolsPanelItem>
+
+					<ToolsPanelItem
+						hasValue={ () => !! opensInNewTab }
+						label={ __( 'Open in new tab' ) }
+						onDeselect={ () =>
+							setAttributes( { opensInNewTab: false } )
+						}
+						isShownByDefault
+					>
+						<CheckboxControl
+							__nextHasNoMarginBottom
+							label={ __( 'Open in new tab' ) }
+							checked={ opensInNewTab }
+							onChange={ ( value ) =>
+								setAttributes( { opensInNewTab: value } )
+							}
 						/>
 					</ToolsPanelItem>
 

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -393,6 +393,7 @@ export default function NavigationSubmenuEdit( {
 							url: '',
 							description: '',
 							rel: '',
+							opensInNewTab: false,
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }


### PR DESCRIPTION
Follow up of: #67262 

## What?
Adds the "Open in new tab" toggle option to the Navigation Submenu block's settings sidebar, making it accessible alongside other link settings.

## Why?
Users need the ability to configure submenu links to open in new tabs. This setting was missing from the Navigation Submenu Inspector controls, creating an inconsistency with other navigation blocks.

## Testing Instructions

1. Create a Navigation block with submenus
2. Select a Navigation Submenu block
3. Verify the "Open in new tab" toggle appears in the Inspector control
4. Toggle the setting and confirm it saves correctly
5. Test the link behavior on the frontend

## Screencast:
[Uploading Screen Recording 2025-07-11 at 1.17.33 PM.mov…](https://github.com/user-attachments/assets/c8d3db47-7dbd-4e9e-ba1b-a1b3cf822edc)