### PR TITLE
Video: Enable support for adding multiple tracks

### DIFF
--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -60,7 +60,7 @@ function TrackList( { tracks, onEditPress } ) {
 	const content = tracks.map( ( track, index ) => {
 		return (
 			<HStack
-				key={ track.id }
+				key={ track.id ?? track.src }
 				className="block-library-video-tracks-editor__track-list-track"
 			>
 				<span>{ track.label }</span>
@@ -237,10 +237,18 @@ export default function TracksEditor( { tracks = [], onChange } ) {
 			allowedTypes: ALLOWED_TYPES,
 			filesList: files,
 			onFileChange: ( selectedTracks ) => {
+				if ( ! Array.isArray( selectedTracks ) ) {
+					return;
+				}
+
 				// Wait until the track has been uploaded.
-				const uploadedTracks = selectedTracks?.filter(
+				const uploadedTracks = selectedTracks.filter(
 					( track ) => !! track?.id
 				);
+
+				if ( ! uploadedTracks.length ) {
+					return;
+				}
 				handleTrackSelect( uploadedTracks, true );
 			},
 		} );

--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -24,9 +24,8 @@ import {
 	MediaUploadCheck,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { store as noticesStore } from '@wordpress/notices';
 import { upload, media } from '@wordpress/icons';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { useState, useRef, useEffect } from '@wordpress/element';
 import { getFilename } from '@wordpress/url';
 
@@ -61,7 +60,7 @@ function TrackList( { tracks, onEditPress } ) {
 	const content = tracks.map( ( track, index ) => {
 		return (
 			<HStack
-				key={ track.src }
+				key={ track.id }
 				className="block-library-video-tracks-editor__track-list-track"
 			>
 				<span>{ track.label }</span>
@@ -201,28 +200,35 @@ function SingleTrackEditor( {
 }
 
 export default function TracksEditor( { tracks = [], onChange } ) {
-	const { createNotice } = useDispatch( noticesStore );
 	const mediaUpload = useSelect( ( select ) => {
 		return select( blockEditorStore ).getSettings().mediaUpload;
 	}, [] );
 	const [ trackBeingEdited, setTrackBeingEdited ] = useState( null );
 	const dropdownPopoverRef = useRef();
 
-	const handleTrackSelect = ( { title, url } ) => {
-		if ( tracks.some( ( track ) => track.src === url ) ) {
-			createNotice( 'error', __( 'This track already exists.' ), {
-				isDismissible: true,
-				type: 'snackbar',
-			} );
+	const handleTrackSelect = ( selectedTracks = [], appendTracks = false ) => {
+		const existingTracksMap = new Map(
+			tracks.map( ( track ) => [ track.id, track ] )
+		);
+		const tracksToAdd = selectedTracks.map( ( { id, title, url } ) => {
+			// Reuse existing tracks to preserve user-configured metadata.
+			if ( existingTracksMap.has( id ) ) {
+				return existingTracksMap.get( id );
+			}
+
+			return {
+				...DEFAULT_TRACK,
+				id,
+				label: title || '',
+				src: url,
+			};
+		} );
+
+		if ( tracksToAdd.length === 0 ) {
 			return;
 		}
 
-		const trackIndex = tracks.length;
-		onChange( [
-			...tracks,
-			{ ...DEFAULT_TRACK, label: title || '', src: url },
-		] );
-		setTrackBeingEdited( trackIndex );
+		onChange( [ ...( appendTracks ? tracks : [] ), ...tracksToAdd ] );
 	};
 
 	function uploadFiles( event ) {
@@ -230,13 +236,12 @@ export default function TracksEditor( { tracks = [], onChange } ) {
 		mediaUpload( {
 			allowedTypes: ALLOWED_TYPES,
 			filesList: files,
-			onFileChange: ( [ track ] ) => {
+			onFileChange: ( selectedTracks ) => {
 				// Wait until the track has been uploaded.
-				if ( ! track?.id ) {
-					return;
-				}
-
-				handleTrackSelect( track );
+				const uploadedTracks = selectedTracks?.filter(
+					( track ) => !! track?.id
+				);
+				handleTrackSelect( uploadedTracks, true );
 			},
 		} );
 	}
@@ -332,6 +337,8 @@ export default function TracksEditor( { tracks = [], onChange } ) {
 									<MediaUpload
 										onSelect={ handleTrackSelect }
 										allowedTypes={ ALLOWED_TYPES }
+										value={ tracks.map( ( { id } ) => id ) }
+										multiple
 										render={ ( { open } ) => (
 											<MenuItem
 												icon={ media }
@@ -344,6 +351,7 @@ export default function TracksEditor( { tracks = [], onChange } ) {
 									<FormFileUpload
 										onChange={ uploadFiles }
 										accept=".vtt,text/vtt"
+										multiple
 										render={ ( { openFileDialog } ) => {
 											return (
 												<MenuItem

--- a/packages/block-library/src/video/tracks.js
+++ b/packages/block-library/src/video/tracks.js
@@ -1,5 +1,5 @@
 export default function Tracks( { tracks = [] } ) {
 	return tracks.map( ( track ) => {
-		return <track key={ track.src } { ...track } />;
+		return <track key={ track.id } { ...track } />;
 	} );
 }

--- a/packages/block-library/src/video/tracks.js
+++ b/packages/block-library/src/video/tracks.js
@@ -1,5 +1,6 @@
 export default function Tracks( { tracks = [] } ) {
 	return tracks.map( ( track ) => {
-		return <track key={ track.id } { ...track } />;
+		const { id, ...trackAttrs } = track;
+		return <track key={ id } { ...trackAttrs } />;
 	} );
 }

--- a/packages/block-library/src/video/tracks.js
+++ b/packages/block-library/src/video/tracks.js
@@ -1,6 +1,6 @@
 export default function Tracks( { tracks = [] } ) {
 	return tracks.map( ( track ) => {
 		const { id, ...trackAttrs } = track;
-		return <track key={ id } { ...trackAttrs } />;
+		return <track key={ id ?? trackAttrs.src } { ...trackAttrs } />;
 	} );
 }


### PR DESCRIPTION
## What?
Closes #70688 

This PR implements support for adding multiple tracks to the video block.

## Why?

This would allow users to attach multiple track files at once, eliminating the need to repeat the process for each file.

## How?

Enabled `multiple` option for both `FormFileUpload` and `MediaUpload` components and handled the selection logic appropriately.

## Testing Instructions

1. Create a new post.
2. Insert a video block.
3. Confirm being able to attach multiple tracks to the video block.

### Testing Instructions for Keyboard

Same.

## Screencast

https://github.com/user-attachments/assets/40a7a04d-9d24-479b-885a-86d24b9f5427
