### PR TITLE
Inserter: Fix focus style for disabled items

### DIFF
--- a/packages/block-editor/src/components/inserter-list-item/style.scss
+++ b/packages/block-editor/src/components/inserter-list-item/style.scss
@@ -81,10 +81,6 @@
 			}
 		}
 
-		&:focus {
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-		}
-
 		&.is-active {
 			color: $white;
 			background: $gray-900;
@@ -92,6 +88,12 @@
 			// Windows High Contrast mode will show this outline, but not the box-shadow.
 			outline: 2px solid transparent;
 			outline-offset: -2px;
+		}
+	}
+
+	&:not(:disabled) {
+		&:focus {
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 	}
 }


### PR DESCRIPTION
## What?
Related #70663.

PR fixes focus styling for disabled items in the Inserter.

## Why?
Items are still focusable when disabled; the focus styles should be applied correctly.

## Testing Instructions
1. Open a post or page.
2. Open the inserter and insert the "More" block.
3. Move focus to the disabled "More" block.
4. Confirm that the focus outline is correctly displayed.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
| before | after |
|--------|--------|
| <img width="355" height="503" alt="CleanShot 2025-07-11 at 14 56 34" src="https://github.com/user-attachments/assets/7fbd8e78-9523-4c0d-9d41-6816bc086ebc" /> | <img width="351" height="506" alt="CleanShot 2025-07-11 at 15 01 58" src="https://github.com/user-attachments/assets/1127ca9b-cd46-4396-9fa8-5fdf1b717f77" /> |
