### PR TITLE
Eslint/no order css property: Add stylelint rule to prevent usage of the order CSS property #61241

### DIFF
--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -89,6 +89,7 @@ The granular rulesets will not define any environment globals. As such, if they 
 | [react-no-unsafe-timeout](https://github.com/WordPress/gutenberg/tree/HEAD/packages/eslint-plugin/docs/rules/react-no-unsafe-timeout.md)                             | Disallow unsafe `setTimeout` in component.                                                      |             |
 | [valid-sprintf](https://github.com/WordPress/gutenberg/tree/HEAD/packages/eslint-plugin/docs/rules/valid-sprintf.md)                                                 | Enforce valid sprintf usage.                                                                    | ✓           |
 | [wp-global-usage](https://github.com/WordPress/gutenberg/tree/HEAD/packages/eslint-plugin/docs/rules/wp-global-usage.md)                                             | Enforce correct usage of WordPress globals like `globalThis.SCRIPT_DEBUG`.                      |             |
+| [no-order-css-property](https://github.com/WordPress/gutenberg/tree/HEAD/packages/eslint-plugin/docs/rules/no-order-css-property.md)                                 | Disallow usage of the `order` CSS property in JS (CSS-in-JS, object styles).                    |             |
 
 ### Legacy
 

--- a/packages/eslint-plugin/configs/custom.js
+++ b/packages/eslint-plugin/configs/custom.js
@@ -8,6 +8,7 @@ module.exports = {
 		'@wordpress/no-global-get-selection': 'error',
 		'@wordpress/no-unsafe-wp-apis': 'error',
 		'@wordpress/no-wp-process-env': 'error',
+		'@wordpress/no-order-css-property': 'error',
 	},
 	overrides: [
 		{

--- a/packages/eslint-plugin/docs/rules/no-order-css-property.md
+++ b/packages/eslint-plugin/docs/rules/no-order-css-property.md
@@ -1,0 +1,42 @@
+# Disallow usage of the 'order' CSS property in JS (no-order-css-property)
+
+The `order` CSS property can have a significant impact on accessibility. For accessibility reasons, visual, reading, and DOM order must match. Only use the `order` property when it does not affect reading order, meaning, and interaction.
+
+This rule disallows the use of the `order` property in CSS-in-JS (such as styled-components, emotion, or object style definitions in JS/TS files).
+
+## Rule details
+
+Examples of **incorrect** code for this rule:
+
+```js
+const style = { order: 1 };
+const Styled = styled.div`
+	order: 1;
+`;
+const Styled = styled.div`
+	display: flex;
+	order: 2;
+`;
+```
+
+Examples of **correct** code for this rule:
+
+```js
+const style = { display: 'flex' };
+const Styled = styled.div`
+	display: flex;
+`;
+```
+
+## When not to use it
+
+If you have a rare case where the `order` property is appropriate and does not affect accessibility, you may disable this rule for that line (with a comment and reason).
+
+## Further reading
+
+-   [Why avoid the order property?](https://github.com/WordPress/gutenberg/issues/61241)
+-   [Stylelint rule for order](https://github.com/WordPress/gutenberg/pull/61243)
+
+## Run the test for this rule alone
+
+`npm run test:unit -- packages/eslint-plugin/rules/__tests__/no-order-css-property.js`

--- a/packages/eslint-plugin/docs/rules/no-order-css-property.md
+++ b/packages/eslint-plugin/docs/rules/no-order-css-property.md
@@ -17,6 +17,9 @@ const Styled = styled.div`
 	display: flex;
 	order: 2;
 `;
+const theS = myDiv.style;
+theS.order = '123';
+myOtherDiv.style = { ...theS };
 ```
 
 Examples of **correct** code for this rule:
@@ -40,3 +43,18 @@ If you have a rare case where the `order` property is appropriate and does not a
 ## Run the test for this rule alone
 
 `npm run test:unit -- packages/eslint-plugin/rules/__tests__/no-order-css-property.js`
+
+or test it by adding the error in a random file (e.g. edit `/packages/myTempTestFileToDelete.ts`) and create illegal code to test, like
+
+```
+	const div = document.createElement( 'div' );
+	div.style.order = '123';
+```
+
+And run eslint, expecting to receive the 'noOrder' eslint error:
+
+```
+	npm run lint:js -- /packages/myTempTestFileToDelete.ts
+```
+
+Don't forget to delete the test file afterwards!

--- a/packages/eslint-plugin/rules/__tests__/no-order-css-property.js
+++ b/packages/eslint-plugin/rules/__tests__/no-order-css-property.js
@@ -30,6 +30,10 @@ ruleTester.run( 'no-order-css-property', rule, {
 		{ code: 'const style = { border: 0 };' },
 		// 'order' as a variable, not a property
 		{ code: 'const order = 1;' },
+		// String literal with 'border', not 'order'
+		{
+			code: "container.setAttribute('style', 'position: absolute; border: 0;' );",
+		},
 	],
 	invalid: [
 		// Object style
@@ -82,19 +86,14 @@ ruleTester.run( 'no-order-css-property', rule, {
 			code: "const style = {\n    order: '123'\n};",
 			errors: [ { messageId: 'noOrder' } ],
 		},
-		// String containing 'order: 123;'
-		{
-			code: "'order: 123;'",
-			errors: [ { messageId: 'noOrder' } ],
-		},
-		// String containing '    order: 123;'
-		{
-			code: "'    order: 123;'",
-			errors: [ { messageId: 'noOrder' } ],
-		},
 		// Assigning to prop like 'style.order =  '123';'
 		{
 			code: "div.style.order = '123';",
+			errors: [ { messageId: 'noOrder' } ],
+		},
+		// Assigning as an attribute.
+		{
+			code: "orderedDiv.setAttribute( 'style', 'order: 0;' );",
 			errors: [ { messageId: 'noOrder' } ],
 		},
 	],

--- a/packages/eslint-plugin/rules/__tests__/no-order-css-property.js
+++ b/packages/eslint-plugin/rules/__tests__/no-order-css-property.js
@@ -19,6 +19,7 @@ const ruleTester = new RuleTester( {
 // We need to disable the eslint rule because, ironically, eslint triggers the
 // errors when linting the staged js.
 /* eslint-disable @wordpress/no-order-css-property */
+
 ruleTester.run( 'no-order-css-property', rule, {
 	valid: [
 		// Object style, not using 'order'
@@ -89,6 +90,11 @@ ruleTester.run( 'no-order-css-property', rule, {
 		// String containing '    order: 123;'
 		{
 			code: "'    order: 123;'",
+			errors: [ { messageId: 'noOrder' } ],
+		},
+		// Assigning to prop like 'style.order =  '123';'
+		{
+			code: "div.style.order = '123';",
 			errors: [ { messageId: 'noOrder' } ],
 		},
 	],

--- a/packages/eslint-plugin/rules/__tests__/no-order-css-property.js
+++ b/packages/eslint-plugin/rules/__tests__/no-order-css-property.js
@@ -96,6 +96,16 @@ ruleTester.run( 'no-order-css-property', rule, {
 			code: "orderedDiv.setAttribute( 'style', 'order: 0;' );",
 			errors: [ { messageId: 'noOrder' } ],
 		},
+		// Assigning as a property.
+		{
+			code: "div2.style.setProperty( 'order', '1' );",
+			errors: [ { messageId: 'noOrder' } ],
+		},
+		// creating CSS inline
+		{
+			code: "const style = document.createElement( 'style' ); style.textContent = `.order-one { order: 1; }`;",
+			errors: [ { messageId: 'noOrder' } ],
+		},
 	],
 	/* eslint-enable @wordpress/no-order-css-property */
 } );

--- a/packages/eslint-plugin/rules/__tests__/no-order-css-property.js
+++ b/packages/eslint-plugin/rules/__tests__/no-order-css-property.js
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import { RuleTester } from 'eslint';
+
+/**
+ * Internal dependencies
+ */
+import rule from '../no-order-css-property';
+
+const ruleTester = new RuleTester( {
+	parserOptions: {
+		ecmaVersion: 2020,
+		sourceType: 'module',
+		ecmaFeatures: { jsx: true },
+	},
+} );
+
+// We need to disable the eslint rule because, ironically, eslint triggers the
+// errors when linting the staged js.
+/* eslint-disable @wordpress/no-order-css-property */
+ruleTester.run( 'no-order-css-property', rule, {
+	valid: [
+		// Object style, not using 'order'
+		{ code: 'const style = { display: "flex" };' },
+		// Template literal, not using 'order'
+		{ code: 'const Styled = styled.div`display: flex;`;' },
+		// Irrelevant property
+		{ code: 'const style = { border: 0 };' },
+		// 'order' as a variable, not a property
+		{ code: 'const order = 1;' },
+	],
+	invalid: [
+		// Object style
+		{
+			code: 'const style = { order: 1 };',
+			errors: [ { messageId: 'noOrder' } ],
+		},
+		// Object style with string key
+		{
+			code: 'const style = { "order": 2 };',
+			errors: [ { messageId: 'noOrder' } ],
+		},
+		// Template literal (styled-components, emotion, etc.)
+		{
+			code: 'const Styled = styled.div`order: 1;`;',
+			errors: [ { messageId: 'noOrder' } ],
+		},
+		// Template literal with whitespace
+		{
+			code: 'const Styled = styled.div`\n  display: flex;\n  order: 2;\n`;',
+			errors: [ { messageId: 'noOrder' } ],
+		},
+		// Object style: order: 123;
+		{
+			code: 'const style = { order: 123 };',
+			errors: [ { messageId: 'noOrder' } ],
+		},
+		// Object style:     order: 123;
+		{
+			code: 'const style = {\n    order: 123\n};',
+			errors: [ { messageId: 'noOrder' } ],
+		},
+		// Object style: order: 123,
+		{
+			code: 'const style = { order: 123, };',
+			errors: [ { messageId: 'noOrder' } ],
+		},
+		// Object style:     order: 123,
+		{
+			code: 'const style = {\n    order: 123,\n};',
+			errors: [ { messageId: 'noOrder' } ],
+		},
+		// Object style: order: '123',
+		{
+			code: "const style = { order: '123' };",
+			errors: [ { messageId: 'noOrder' } ],
+		},
+		// Object style:     order: '123',
+		{
+			code: "const style = {\n    order: '123'\n};",
+			errors: [ { messageId: 'noOrder' } ],
+		},
+		// String containing 'order: 123;'
+		{
+			code: "'order: 123;'",
+			errors: [ { messageId: 'noOrder' } ],
+		},
+		// String containing '    order: 123;'
+		{
+			code: "'    order: 123;'",
+			errors: [ { messageId: 'noOrder' } ],
+		},
+	],
+	/* eslint-enable @wordpress/no-order-css-property */
+} );

--- a/packages/eslint-plugin/rules/no-order-css-property.js
+++ b/packages/eslint-plugin/rules/no-order-css-property.js
@@ -48,6 +48,45 @@ module.exports = {
 					report( node );
 				}
 			},
+			// Detect assignments like myDiv.style.order = XXX (complex but effective)
+			AssignmentExpression( node ) {
+				const left = node.left;
+
+				// Helper to check if a MemberExpression is .order
+				function isOrderProperty( memberExpr ) {
+					return (
+						memberExpr.type === 'MemberExpression' &&
+						! memberExpr.computed &&
+						memberExpr.property.type === 'Identifier' &&
+						memberExpr.property.name === 'order'
+					);
+				}
+
+				// Helper to check if a MemberExpression is .style
+				function isStyleProperty( memberExpr ) {
+					return (
+						memberExpr.type === 'MemberExpression' &&
+						! memberExpr.computed &&
+						memberExpr.property.type === 'Identifier' &&
+						memberExpr.property.name === 'style'
+					);
+				}
+
+				// Case 1: div.style.order = '123';
+				if (
+					isOrderProperty( left ) &&
+					isStyleProperty( left.object )
+				) {
+					report( left.property );
+				}
+
+				// Case 2: theS.order = '123'; where theS is later assigned to div.style
+				// We want to catch any assignment to .order, regardless of the object,
+				// as long as it's a direct property (not computed).
+				else if ( isOrderProperty( left ) ) {
+					report( left.property );
+				}
+			},
 		};
 	},
 };

--- a/packages/eslint-plugin/rules/no-order-css-property.js
+++ b/packages/eslint-plugin/rules/no-order-css-property.js
@@ -81,16 +81,17 @@ module.exports = {
 
 				// Check if any sibling properties are CSS properties
 				for ( const prop of objectProps ) {
-					let keyName;
-					if ( prop.key.type === 'Identifier' ) {
-						keyName = prop.key.name;
-					} else if ( prop.key.type === 'Literal' ) {
-						keyName = prop.key.value;
-					} else {
-						keyName = null;
-					}
-					if ( keyName && cssProperties.has( keyName ) ) {
-						return true;
+					if ( prop.type === 'Property' && prop.key ) {
+						let keyName = null;
+						if ( prop.key.type === 'Identifier' ) {
+							keyName = prop.key.name;
+						} else if ( prop.key.type === 'Literal' ) {
+							keyName = prop.key.value;
+						}
+
+						if ( keyName && cssProperties.has( keyName ) ) {
+							return true;
+						}
 					}
 				}
 			}
@@ -116,14 +117,13 @@ module.exports = {
 
 				// Check if we're in a Property assignment (for object properties)
 				if ( current.type === 'Property' && current.key ) {
-					let keyName;
+					let keyName = null;
 					if ( current.key.type === 'Identifier' ) {
 						keyName = current.key.name;
 					} else if ( current.key.type === 'Literal' ) {
 						keyName = current.key.value;
-					} else {
-						keyName = null;
 					}
+
 					if ( keyName && isCSSRelatedName( keyName ) ) {
 						return true;
 					}
@@ -205,26 +205,68 @@ module.exports = {
 			return false;
 		}
 
+		// Track variable declarations to better detect DOM elements
+		// Maps variable name to its created element type (e.g., 'style', 'div')
+		const domElementVariables = new Map();
+
 		return {
+			// Track variable declarations to identify DOM elements
+			VariableDeclarator( node ) {
+				if (
+					node.id &&
+					node.id.type === 'Identifier' &&
+					node.init &&
+					node.init.type === 'CallExpression'
+				) {
+					const init = node.init;
+					// Track document.createElement calls
+					if (
+						init.callee &&
+						init.callee.type === 'MemberExpression' &&
+						init.callee.object &&
+						init.callee.object.name === 'document' &&
+						init.callee.property &&
+						init.callee.property.name === 'createElement' &&
+						init.arguments &&
+						init.arguments[ 0 ] &&
+						init.arguments[ 0 ].type === 'Literal'
+					) {
+						domElementVariables.set(
+							node.id.name,
+							init.arguments[ 0 ].value
+						);
+					}
+				}
+			},
 			// Detect order in object styles: { order: ... }
 			Property( node ) {
-				if (
-					node.key &&
-					( ( node.key.type === 'Identifier' &&
-						node.key.name === 'order' ) ||
-						( node.key.type === 'Literal' &&
-							node.key.value === 'order' ) )
-				) {
-					// Check multiple contexts:
-					// 1. Object contains other CSS properties
-					// 2. Object is assigned to a CSS-related variable
-					// 3. We're in a CSS-in-JS context
+				if ( node.key ) {
+					let isOrderProperty = false;
+
 					if (
-						isLikelyCSSContext( node.key ) ||
-						isInCSSObjectDeclaration( node ) ||
-						isInCSSInJSContext( node )
+						node.key.type === 'Identifier' &&
+						node.key.name === 'order'
 					) {
-						report( node.key );
+						isOrderProperty = true;
+					} else if (
+						node.key.type === 'Literal' &&
+						node.key.value === 'order'
+					) {
+						isOrderProperty = true;
+					}
+
+					if ( isOrderProperty ) {
+						// Check multiple contexts:
+						// 1. Object contains other CSS properties
+						// 2. Object is assigned to a CSS-related variable
+						// 3. We're in a CSS-in-JS context
+						if (
+							isLikelyCSSContext( node.key ) ||
+							isInCSSObjectDeclaration( node ) ||
+							isInCSSInJSContext( node )
+						) {
+							report( node.key );
+						}
 					}
 				}
 			},
@@ -244,15 +286,16 @@ module.exports = {
 					typeof node.value === 'string' &&
 					/(^|\s|;)order\s*:/i.test( node.value )
 				) {
-					// Be more conservative with string literals
+					// Be more conservative with string literals, only report if in a clear CSS-in-JS context
 					if ( isInCSSInJSContext( node ) ) {
 						report( node );
 					}
 				}
 			},
-			// Detect assignments like myDiv.style.order = XXX (complex but effective)
+			// Detect assignments like myDiv.style.order = XXX or styleElement.textContent = '...'
 			AssignmentExpression( node ) {
 				const left = node.left;
+				const right = node.right;
 
 				// Helper to check if a MemberExpression is .order
 				function isOrderProperty( memberExpr ) {
@@ -281,21 +324,55 @@ module.exports = {
 				) {
 					report( left.property );
 				}
-
 				// Case 2: theS.order = '123'; where theS might be assigned to div.style
-				// Be more careful here - only report if the object name suggests CSS context
 				else if ( isOrderProperty( left ) ) {
-					const objectName =
-						left.object.type === 'Identifier'
-							? left.object.name
-							: null;
+					let objectName = null;
+					if ( left.object.type === 'Identifier' ) {
+						objectName = left.object.name;
+					}
+
 					if ( objectName && isCSSRelatedName( objectName ) ) {
 						report( left.property );
+					}
+				}
+				// NEW Case 3: styleElement.textContent = `.order-one { order: 1; }`;
+				else if (
+					left.type === 'MemberExpression' &&
+					! left.computed &&
+					left.property.type === 'Identifier' &&
+					left.property.name === 'textContent' &&
+					left.object.type === 'Identifier' // e.g., 'style' in 'style.textContent'
+				) {
+					const varName = left.object.name;
+					// Check if the variable refers to a '<style>' element
+					if ( domElementVariables.get( varName ) === 'style' ) {
+						let cssContent = null;
+						if (
+							right.type === 'Literal' &&
+							typeof right.value === 'string'
+						) {
+							cssContent = right.value;
+						} else if ( right.type === 'TemplateLiteral' ) {
+							// Concatenate all parts of the template literal
+							cssContent = right.quasis
+								.map( ( q ) => q.value.cooked )
+								.join( '' );
+							// Note: This won't evaluate expressions inside template literals.
+							// For full accuracy, you'd need a more complex AST traversal or type checker.
+						}
+
+						if (
+							cssContent &&
+							/(^|\s|;)order\s*:/i.test( cssContent )
+						) {
+							report( right ); // Report the right-hand side (the content)
+						}
 					}
 				}
 			},
 
 			// Detect setAttribute with style attribute containing order
+			// NEW: Also detect setProperty for CSSStyleDeclaration
 			CallExpression( node ) {
 				// Check for setAttribute calls
 				if (
@@ -320,6 +397,35 @@ module.exports = {
 						// Check if the style string contains 'order:'
 						if ( /(^|\s|;)order\s*:/i.test( secondArg.value ) ) {
 							report( secondArg );
+						}
+					}
+				}
+				// NEW Case: Detect .style.setProperty('order', 'value')
+				else if (
+					node.callee &&
+					node.callee.type === 'MemberExpression' &&
+					node.callee.property &&
+					node.callee.property.type === 'Identifier' &&
+					node.callee.property.name === 'setProperty' &&
+					node.arguments &&
+					node.arguments.length >= 1
+				) {
+					const firstArg = node.arguments[ 0 ]; // The property name, e.g., 'order'
+					const styleObject = node.callee.object; // The object before .setProperty, e.g., 'div2.style'
+
+					// Ensure the first argument is 'order'
+					if (
+						firstArg.type === 'Literal' &&
+						firstArg.value === 'order'
+					) {
+						// Ensure it's being called on a '.style' property
+						if (
+							styleObject.type === 'MemberExpression' &&
+							! styleObject.computed &&
+							styleObject.property.type === 'Identifier' &&
+							styleObject.property.name === 'style'
+						) {
+							report( firstArg ); // Report the 'order' literal
 						}
 					}
 				}

--- a/packages/eslint-plugin/rules/no-order-css-property.js
+++ b/packages/eslint-plugin/rules/no-order-css-property.js
@@ -1,0 +1,53 @@
+/**
+ * @file Disallow usage of the 'order' CSS property in CSS-in-JS for accessibility reasons.
+ */
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+	meta: {
+		type: 'problem',
+		messages: {
+			noOrder:
+				"Avoid the 'order' CSS property. For accessibility reasons, visual, reading, and DOM order must match. Only use the order property when it does not affect reading order, meaning, and interaction.",
+		},
+		schema: [],
+	},
+	create( context ) {
+		function report( node ) {
+			context.report( {
+				node,
+				messageId: 'noOrder',
+			} );
+		}
+
+		return {
+			// Detect order in object styles: { order: ... }
+			Property( node ) {
+				if (
+					node.key &&
+					( ( node.key.type === 'Identifier' &&
+						node.key.name === 'order' ) ||
+						( node.key.type === 'Literal' &&
+							node.key.value === 'order' ) )
+				) {
+					report( node.key );
+				}
+			},
+			// Detect order in template literals (CSS-in-JS)
+			TemplateElement( node ) {
+				if ( /order\s*:/i.test( node.value.raw ) ) {
+					report( node );
+				}
+			},
+			// Detect order in string literals
+			Literal( node ) {
+				if (
+					typeof node.value === 'string' &&
+					/order\s*:/i.test( node.value )
+				) {
+					report( node );
+				}
+			},
+		};
+	},
+};

--- a/packages/eslint-plugin/rules/no-order-css-property.js
+++ b/packages/eslint-plugin/rules/no-order-css-property.js
@@ -20,6 +20,191 @@ module.exports = {
 			} );
 		}
 
+		// Helper to check if a property is likely CSS-related
+		function isLikelyCSSContext( node ) {
+			// Check if the property is part of an object that contains other CSS properties
+			if (
+				node.parent &&
+				node.parent.type === 'Property' &&
+				node.parent.parent &&
+				node.parent.parent.type === 'ObjectExpression'
+			) {
+				const objectProps = node.parent.parent.properties;
+				const cssProperties = new Set( [
+					'display',
+					'position',
+					'top',
+					'right',
+					'bottom',
+					'left',
+					'width',
+					'height',
+					'margin',
+					'padding',
+					'border',
+					'background',
+					'color',
+					'font',
+					'fontSize',
+					'fontFamily',
+					'fontWeight',
+					'textAlign',
+					'textDecoration',
+					'lineHeight',
+					'overflow',
+					'opacity',
+					'visibility',
+					'zIndex',
+					'cursor',
+					'transition',
+					'transform',
+					'animation',
+					'boxShadow',
+					'borderRadius',
+					'flexDirection',
+					'justifyContent',
+					'alignItems',
+					'flexWrap',
+					'flex',
+					'flexGrow',
+					'flexShrink',
+					'flexBasis',
+					'alignSelf',
+					'gridTemplateColumns',
+					'gridTemplateRows',
+					'gridColumn',
+					'gridRow',
+					'gap',
+					'rowGap',
+					'columnGap',
+				] );
+
+				// Check if any sibling properties are CSS properties
+				for ( const prop of objectProps ) {
+					let keyName;
+					if ( prop.key.type === 'Identifier' ) {
+						keyName = prop.key.name;
+					} else if ( prop.key.type === 'Literal' ) {
+						keyName = prop.key.value;
+					} else {
+						keyName = null;
+					}
+					if ( keyName && cssProperties.has( keyName ) ) {
+						return true;
+					}
+				}
+			}
+
+			return false;
+		}
+
+		// Helper to check if we're in a CSS object based on variable declaration
+		function isInCSSObjectDeclaration( node ) {
+			let current = node;
+			while ( current ) {
+				// Check if we're in a VariableDeclarator
+				if (
+					current.type === 'VariableDeclarator' &&
+					current.id &&
+					current.id.type === 'Identifier'
+				) {
+					const varName = current.id.name;
+					if ( isCSSRelatedName( varName ) ) {
+						return true;
+					}
+				}
+
+				// Check if we're in a Property assignment (for object properties)
+				if ( current.type === 'Property' && current.key ) {
+					let keyName;
+					if ( current.key.type === 'Identifier' ) {
+						keyName = current.key.name;
+					} else if ( current.key.type === 'Literal' ) {
+						keyName = current.key.value;
+					} else {
+						keyName = null;
+					}
+					if ( keyName && isCSSRelatedName( keyName ) ) {
+						return true;
+					}
+				}
+
+				current = current.parent;
+			}
+			return false;
+		}
+
+		// Helper to check if a variable/object name suggests CSS context
+		function isCSSRelatedName( name ) {
+			if ( ! name || typeof name !== 'string' ) {
+				return false;
+			}
+
+			const cssPatterns = [
+				/^style$/i, // Exact match for 'style'
+				/^styles$/i, // Exact match for 'styles'
+				/^css$/i, // Exact match for 'css'
+				/^theme$/i, // Exact match for 'theme'
+				/^sx$/i, // MUI sx prop
+				/^styled/i, // Starts with 'styled'
+				/style$/i, // Ends with 'style'
+				/styles$/i, // Ends with 'styles'
+				/css$/i, // Ends with 'css'
+				/styling/i, // Contains 'styling'
+				/className/i, // Contains 'className'
+				/classes/i, // Contains 'classes'
+			];
+
+			return cssPatterns.some( ( pattern ) => pattern.test( name ) );
+		}
+
+		// Helper to check if we're in a CSS-in-JS context (styled-components, emotion, etc.)
+		function isInCSSInJSContext( node ) {
+			let current = node;
+			while ( current ) {
+				// Check for tagged template literals (styled-components)
+				if ( current.type === 'TaggedTemplateExpression' ) {
+					const tag = current.tag;
+					if (
+						tag.type === 'Identifier' &&
+						/^styled/i.test( tag.name )
+					) {
+						return true;
+					}
+					if (
+						tag.type === 'MemberExpression' &&
+						tag.object &&
+						tag.object.name === 'styled'
+					) {
+						return true;
+					}
+				}
+
+				// Check for css`` template literals
+				if (
+					current.type === 'TaggedTemplateExpression' &&
+					current.tag.type === 'Identifier' &&
+					current.tag.name === 'css'
+				) {
+					return true;
+				}
+
+				// Check for function calls that might be CSS-in-JS
+				if ( current.type === 'CallExpression' ) {
+					const callee = current.callee;
+					if (
+						callee.type === 'Identifier' &&
+						( callee.name === 'css' || callee.name === 'styled' )
+					) {
+						return true;
+					}
+				}
+
+				current = current.parent;
+			}
+			return false;
+		}
+
 		return {
 			// Detect order in object styles: { order: ... }
 			Property( node ) {
@@ -30,22 +215,39 @@ module.exports = {
 						( node.key.type === 'Literal' &&
 							node.key.value === 'order' ) )
 				) {
-					report( node.key );
+					// Check multiple contexts:
+					// 1. Object contains other CSS properties
+					// 2. Object is assigned to a CSS-related variable
+					// 3. We're in a CSS-in-JS context
+					if (
+						isLikelyCSSContext( node.key ) ||
+						isInCSSObjectDeclaration( node ) ||
+						isInCSSInJSContext( node )
+					) {
+						report( node.key );
+					}
 				}
 			},
 			// Detect order in template literals (CSS-in-JS)
 			TemplateElement( node ) {
-				if ( /order\s*:/i.test( node.value.raw ) ) {
-					report( node );
+				// Only match 'order' as a standalone property, not as part of another word (e.g., 'border')
+				if ( /(^|\s|;)order\s*:/i.test( node.value.raw ) ) {
+					// Template literals in CSS-in-JS are usually already in the right context
+					if ( isInCSSInJSContext( node ) ) {
+						report( node );
+					}
 				}
 			},
 			// Detect order in string literals
 			Literal( node ) {
 				if (
 					typeof node.value === 'string' &&
-					/order\s*:/i.test( node.value )
+					/(^|\s|;)order\s*:/i.test( node.value )
 				) {
-					report( node );
+					// Be more conservative with string literals
+					if ( isInCSSInJSContext( node ) ) {
+						report( node );
+					}
 				}
 			},
 			// Detect assignments like myDiv.style.order = XXX (complex but effective)
@@ -72,7 +274,7 @@ module.exports = {
 					);
 				}
 
-				// Case 1: div.style.order = '123';
+				// Case 1: div.style.order = '123'; (this is clearly CSS-related)
 				if (
 					isOrderProperty( left ) &&
 					isStyleProperty( left.object )
@@ -80,11 +282,46 @@ module.exports = {
 					report( left.property );
 				}
 
-				// Case 2: theS.order = '123'; where theS is later assigned to div.style
-				// We want to catch any assignment to .order, regardless of the object,
-				// as long as it's a direct property (not computed).
+				// Case 2: theS.order = '123'; where theS might be assigned to div.style
+				// Be more careful here - only report if the object name suggests CSS context
 				else if ( isOrderProperty( left ) ) {
-					report( left.property );
+					const objectName =
+						left.object.type === 'Identifier'
+							? left.object.name
+							: null;
+					if ( objectName && isCSSRelatedName( objectName ) ) {
+						report( left.property );
+					}
+				}
+			},
+
+			// Detect setAttribute with style attribute containing order
+			CallExpression( node ) {
+				// Check for setAttribute calls
+				if (
+					node.callee &&
+					node.callee.type === 'MemberExpression' &&
+					node.callee.property &&
+					node.callee.property.type === 'Identifier' &&
+					node.callee.property.name === 'setAttribute' &&
+					node.arguments &&
+					node.arguments.length >= 2
+				) {
+					const firstArg = node.arguments[ 0 ];
+					const secondArg = node.arguments[ 1 ];
+
+					// Check if first argument is 'style' (string literal)
+					if (
+						firstArg.type === 'Literal' &&
+						firstArg.value === 'style' &&
+						secondArg.type === 'Literal' &&
+						typeof secondArg.value === 'string'
+					) {
+						// Check if the style string contains 'order:'
+						if ( /(^|\s|;)order\s*:/i.test( secondArg.value ) ) {
+							report( secondArg );
+						}
+					}
 				}
 			},
 		};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #61247

This PR introduces a new ESLint rule to prevent the usage of the `order` CSS property in JavaScript files, particularly in CSS-in-JS patterns such as `style={{ order: … }}` and `css` tagged templates.

## Why?
The `order` CSS property can negatively impact accessibility when visual and DOM order diverge. Previous efforts addressed this via Stylelint (#61241, #61243). This PR complements those by enforcing the same restriction at the JavaScript level, helping contributors avoid unintended accessibility regressions.

## How?
- Adds a new ESLint rule: `no-order-css-property`
- Detects usage of `order` in JSX `style={{}}` objects and in `css` tagged template literals
- Includes documentation and unit tests for the rule
- Registers the rule in the plugin and enables it in the recommended config

Modified files:
- `packages/eslint-plugin/no-order-css-property.js`
- `packages/eslint-plugin/rules/__tests__/no-order-css-property.js`
- `packages/eslint-plugin/configs/custom.js`
- `packages/eslint-plugin/docs/rules/no-order-css-property.md`
- `packages/eslint-plugin/README.md`

## Testing Instructions

### Running unit test
1. Run unit tests with `npm run test:unit -- packages/eslint-plugin/rules/__tests__/no-order-css-property.js` 
2. Verify all tests pass. You should see only green ticks and not red Xs.

### Simulating an eslint error and confirm it triggers.
1. Create a new .ts, or .tsx file or edit an existing one. e.g.  packages/element/src/index.js
3. Create some code that triggers the ESLint error. For example:
```
const div1 = document.createElement( 'div' );
div1.style.order = 1;
```
4. If you work in an IDE like VSCode, confirm that the editor highlights the ESLint error (in this example, underlines the code `div1.style.order` with the error `@wordpress/no-order-css-property`)
5. Trigger eslint into the file or folder where you created the test code. In this case 
`npm run lint:js -- packages/element/src/index.js`
6. Confirm that you receive the error `@wordpress/no-order-css-property`

### Confirming that the new rule doesn't trigger 'false positives'
1. This should be checked with a simple `npm run lint:js -- --quiet`, but probably you'll run out of memory.
2. I have been using `npm run lint:js -- packages/` to avoid that problem.
3. You should not see any error for `@wordpress/no-order-css-property` (NOTE: I did see other 6 errors of type `import/no-unresolved` , but not related or generated by this PR: )

### Testing Instructions for Keyboard
Not applicable — this PR does not modify UI components.

## Screenshots or screencast
Not applicable — this PR affects linting rules only.

|Before|After|
|-|-|
|No lint error for `order` in JS|Lint error is triggered for `order` usage|
