### PR TITLE
Block Lock Modal: Add ul browser defaults CSS resets

### DIFF
--- a/packages/block-editor/src/components/block-lock/style.scss
+++ b/packages/block-editor/src/components/block-lock/style.scss
@@ -15,6 +15,9 @@
 }
 
 .block-editor-block-lock-modal__checklist {
+	// Reset `ul` browser defaults.
+	list-style: none;
+	padding: 0;
 	margin: 0;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Related to #70684 and a follow-on to #70685

Adds CSS resets for the `ul` element used in the block lock modal.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To ensure that block editor components provide their own CSS resets, rather than depending on `common.css`. Currently, the other instances of `ul` within the block editor package provide their own resets for `list-style` and `padding`. The block lock modal is the only one in this package that doesn't (yet) do so.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

For the CSS class used within the block lock modal, reset the list-style and padding (margin was already being reset).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Open up the block editor and select a block. Either in the list view or in the block toolbar settings, select to lock the block.
* With the modal open, paste following into your browser console to unload the `common.css` rules: `document.querySelector( 'link#common-css' ).remove()`
* With this PR applied, the lock checkboxes should look like the "After" screenshot below.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="828" height="846" alt="image" src="https://github.com/user-attachments/assets/708e5f6e-6015-495c-85e4-cdbab18b027d" /> | <img width="836" height="846" alt="image" src="https://github.com/user-attachments/assets/e32d9f32-303a-44b1-baf3-0035cb7a72a3" /> |
