### PR TITLE
Fix: preserve hasParallax when switching from video to image in Cover block

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -238,13 +238,21 @@ function CoverEdit( {
 			}
 		}
 
+		const preserveParallax =
+			backgroundType === VIDEO_BACKGROUND_TYPE &&
+			isImage &&
+			hasParallax !== undefined;
+
+		const { hasParallax: _, ...filteredMediaAttributes } = mediaAttributes;
+
 		setAttributes( {
-			...mediaAttributes,
+			...filteredMediaAttributes,
 			focalPoint: undefined,
 			useFeaturedImage: undefined,
 			dimRatio: newDimRatio,
 			isDark: newIsDark,
 			isUserOverlayColor: isUserOverlayColor || false,
+			...( preserveParallax ? { hasParallax } : {} ),
 		} );
 	};
 

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -238,21 +238,13 @@ function CoverEdit( {
 			}
 		}
 
-		const preserveParallax =
-			backgroundType === VIDEO_BACKGROUND_TYPE &&
-			isImage &&
-			hasParallax !== undefined;
-
-		const { hasParallax: _, ...filteredMediaAttributes } = mediaAttributes;
-
 		setAttributes( {
-			...filteredMediaAttributes,
+			...mediaAttributes,
 			focalPoint: undefined,
 			useFeaturedImage: undefined,
 			dimRatio: newDimRatio,
 			isDark: newIsDark,
 			isUserOverlayColor: isUserOverlayColor || false,
-			...( preserveParallax ? { hasParallax } : {} ),
 		} );
 	};
 

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -208,7 +208,7 @@ export default function CoverInspectorControls( {
 								<ToolsPanelItem
 									label={ __( 'Fixed background' ) }
 									isShownByDefault
-									hasValue={ () => hasParallax }
+									hasValue={ () => !! hasParallax }
 									onDeselect={ () =>
 										setAttributes( {
 											hasParallax: false,
@@ -219,7 +219,7 @@ export default function CoverInspectorControls( {
 									<ToggleControl
 										__nextHasNoMarginBottom
 										label={ __( 'Fixed background' ) }
-										checked={ hasParallax }
+										checked={ !! hasParallax }
 										onChange={ toggleParallax }
 									/>
 								</ToolsPanelItem>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Preserves the `hasParallax` attribute when switching a Cover block from video to image.
Closes #70701 

## Why?
Fixed background option disappears when switching from video to image in cover block

## How?
- When switching media, if the previous background was a video and had `hasParallax` set, this attribute is preserved when switching to an image.

## Testing Instructions
1. Add a Cover block.
2. Select an image and confirm "Fixed background" is available.
3. Replace with a video.
4. Replace again with an image.
5. Confirm "Fixed background" remains available.


## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/06fc2415-273e-4b03-b0a5-a964a542fa0c


