### PR TITLE
Elements: Support unitless value in CSS custom properties

### DIFF
--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -526,6 +526,7 @@ function getNormalStylePropertyValue( property, value ) {
 	if (
 		typeof value === 'number' &&
 		0 !== value &&
+		! hasPrefix( property, [ '--' ] ) &&
 		! CSS_PROPERTIES_SUPPORTS_UNITLESS.has( property )
 	) {
 		return value + 'px';

--- a/packages/element/src/test/serialize.js
+++ b/packages/element/src/test/serialize.js
@@ -715,6 +715,14 @@ describe( 'renderStyle()', () => {
 
 			expect( result ).toBe( 'order:10' );
 		} );
+
+		it( 'should not render numeric units for CSS custom properties', () => {
+			const result = renderStyle( {
+				'--myOrder': 10,
+			} );
+
+			expect( result ).toBe( '--myOrder:10' );
+		} );
 	} );
 } );
 


### PR DESCRIPTION
## What?

When a React element is serialized to a string, the `px` unit may be forcibly assigned via [the `getNormalStylePropertyValue()` function](https://github.com/WordPress/gutenberg/blob/064069fef109cc292db4eac5e369f2834a284517/packages/element/src/serialize.js#L525-L535).

CSS custom properties can have no units as their values, but because they are not defined in [CSS_PROPERTIES_SUPPORTS_UNITLESS](https://github.com/WordPress/gutenberg/blob/064069fef109cc292db4eac5e369f2834a284517/packages/element/src/serialize.js#L196-L235), they will always be serialized as values with px units:

```
// React Component
<div style={{'--col':2}}></div>

// Expected
<div style="--col:2"></div>
// Actual
<div style="--col:2px"></div>
```

To avoid this unintended behavior, consumers should explicitly stringify the value:

```
// React Component
<div style={{'--col':'2'}}></div>
```

However, ideally, unintended serialization should be fixed in the serializer itself.

## How?

When rendering a style object as a string, check if the property starts with `--` and if so, render the value as is. However, **if the content already contains blocks that have been serialized with `px`, applying this PR will break those blocks**.

Example:

```
Block validation: Block validation failed for `test/test` ({name: 'test/test', icon: {…}, keywords: Array(0), attributes: {…}, providesContext: {…}, …}).

Content generated by `save` function:

<p style="--col:1" class="wp-block-test-test">Test</p>

Content retrieved from post body:

<p style="--one:1px" class="wp-block-test-test">Test</p>
```

I've tried various approaches, but so far I haven't been able to find a way to prevent the blocks from breaking. If anyone knows a way to prevent the blocks from breaking, please let me know.

## Testing Instructions

I prepared a plugin for testing this PR. This plugin contains a custom block with [some inline styles](https://github.com/t-hamano/css-custom-property-block/blob/73e571c44c92d681a67b36e2a6bdc9080732ca5c/src/index.js#L20-L24).

Download the zip file from the following repo and install it: https://github.com/t-hamano/css-custom-property-block

- Open a post and insert the CSS Custom Property Block
- Save the content. The content should be like this:
  ```html
  <!-- wp:test/css-custom-property -->
  <p style="--one:1px;--two:2;--three:3px;opacity:1;font-size:32px" class="wp-block-test-css-custom-property">CSS Custom Property Test</p>
  <!-- /wp:test/css-custom-property -->
  ```
- Check out this PR and reload the browser. You should see the following browser console error and the block should break:
  ```
  Block validation: Block validation failed for `test/css-custom-property`
  
  Content generated by `save` function:
  <p style="--one:1;--two:2;--three:3px;opacity:1;font-size:32px" class="wp-block-test-css-custom-property">CSS Custom Property Test</p>
  
  Content retrieved from post body:
  <p style="--one:1px;--two:2;--three:3px;opacity:1;font-size:32px" class="wp-block-test-css-custom-property">CSS Custom Property Test</p>
  ```html
- Click the Attempt recovery button. The HTML should be updated like this. Note that `--one:1px` has been changed to the correct `--one:1`:
  ```html
  <!-- wp:test/css-custom-property -->
  <p style="--one:1;--two:2;--three:3px;opacity:1;font-size:32px" class="wp-block-test-css-custom-property">CSS Custom Property Test</p>
  <!-- /wp:test/css-custom-property -->
  ```