### PR TITLE
List View: Remove public APIs for getting images

### DIFF
--- a/packages/block-editor/src/components/list-view/use-list-view-images.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-images.js
@@ -39,40 +39,42 @@ const IMAGE_GETTERS = {
 			};
 		}
 	},
+	'core/gallery': ( { innerBlocks } ) => {
+		const images = [];
+		const getValues = !! innerBlocks?.length
+			? IMAGE_GETTERS[ innerBlocks[ 0 ].name ]
+			: undefined;
+		if ( ! getValues ) {
+			return images;
+		}
+
+		for ( const innerBlock of innerBlocks ) {
+			const img = getValues( innerBlock );
+			if ( img ) {
+				images.push( img );
+			}
+			if ( images.length >= MAX_IMAGES ) {
+				return images;
+			}
+		}
+
+		return images;
+	},
 };
 
-function getImage( block ) {
-	const getValues = IMAGE_GETTERS[ block.name ];
+function getImagesFromBlock( block, isExpanded ) {
+	const getImages = IMAGE_GETTERS[ block.name ];
+	const images = !! getImages ? getImages( block ) : undefined;
 
-	return getValues ? getValues( block ) : undefined;
-}
-
-function getImagesFromGallery( block ) {
-	if ( block.name !== 'core/gallery' || ! block.innerBlocks ) {
+	if ( ! images ) {
 		return [];
 	}
 
-	const images = [];
-
-	for ( const innerBlock of block.innerBlocks ) {
-		const img = getImage( innerBlock );
-		if ( img ) {
-			images.push( img );
-		}
-		if ( images.length >= MAX_IMAGES ) {
-			return images;
-		}
+	if ( ! Array.isArray( images ) ) {
+		return [ images ];
 	}
 
-	return images;
-}
-
-function getImagesFromBlock( block, isExpanded ) {
-	const img = getImage( block );
-	if ( img ) {
-		return [ img ];
-	}
-	return isExpanded ? [] : getImagesFromGallery( block );
+	return isExpanded ? [] : images;
 }
 
 /**

--- a/packages/block-editor/src/components/list-view/use-list-view-images.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-images.js
@@ -3,7 +3,6 @@
  */
 import { useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { __experimentalGetBlockImage as getBlockImage } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -12,19 +11,40 @@ import { store as blockEditorStore } from '../../store';
 
 // Maximum number of images to display in a list view row.
 const MAX_IMAGES = 3;
+const IMAGE_GETTERS = {
+	'core/image': ( { clientId, attributes } ) => {
+		if ( attributes.url ) {
+			return {
+				url: attributes.url,
+				alt: attributes.alt || '',
+				clientId,
+			};
+		}
+	},
+	'core/cover': ( { clientId, attributes } ) => {
+		if ( attributes.backgroundType === 'image' && attributes.url ) {
+			return {
+				url: attributes.url,
+				alt: attributes.alt || '',
+				clientId,
+			};
+		}
+	},
+	'core/media-text': ( { clientId, attributes } ) => {
+		if ( attributes.mediaType === 'image' && attributes.mediaUrl ) {
+			return {
+				url: attributes.mediaUrl,
+				alt: attributes.mediaAlt || '',
+				clientId,
+			};
+		}
+	},
+};
 
 function getImage( block ) {
-	if ( block.name !== 'core/image' ) {
-		return;
-	}
+	const getValues = IMAGE_GETTERS[ block.name ];
 
-	if ( block.attributes?.url ) {
-		return {
-			url: block.attributes.url,
-			alt: block.attributes.alt,
-			clientId: block.clientId,
-		};
-	}
+	return getValues ? getValues( block ) : undefined;
 }
 
 function getImagesFromGallery( block ) {
@@ -70,31 +90,11 @@ function getImagesFromBlock( block, isExpanded ) {
 export default function useListViewImages( { clientId, isExpanded } ) {
 	const { block } = useSelect(
 		( select ) => {
-			const _block = select( blockEditorStore ).getBlock( clientId );
-			return { block: _block };
+			return { block: select( blockEditorStore ).getBlock( clientId ) };
 		},
 		[ clientId ]
 	);
 	const images = useMemo( () => {
-		const blockImageURL = getBlockImage(
-			block.name,
-			block.attributes,
-			'list-view'
-		);
-		if ( blockImageURL ) {
-			return [
-				{
-					url: blockImageURL,
-					alt:
-						block.attributes?.alt ||
-						block.attributes?.mediaAlt ||
-						'',
-					clientId: block.clientId,
-				},
-			];
-		}
-
-		// Fallback to custom logic for core/image or core/gallery.
 		return getImagesFromBlock( block, isExpanded );
 	}, [ block, isExpanded ] );
 

--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -45,15 +45,6 @@ export const settings = {
 			},
 		],
 	},
-	__experimentalImage( attributes, { context } ) {
-		if (
-			attributes.backgroundType === 'image' &&
-			context === 'list-view' &&
-			attributes?.url
-		) {
-			return attributes?.url;
-		}
-	},
 	transforms,
 	save,
 	edit,

--- a/packages/block-library/src/media-text/index.js
+++ b/packages/block-library/src/media-text/index.js
@@ -44,15 +44,6 @@ export const settings = {
 			},
 		],
 	},
-	__experimentalImage( attributes, { context } ) {
-		if (
-			attributes.mediaType === 'image' &&
-			context === 'list-view' &&
-			attributes?.mediaUrl
-		) {
-			return attributes?.mediaUrl;
-		}
-	},
 	transforms,
 	edit,
 	save,

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -156,7 +156,6 @@ export {
 	__experimentalSanitizeBlockAttributes,
 	getBlockAttributesNamesByRole,
 	__experimentalGetBlockAttributesNamesByRole,
-	getBlockImage as __experimentalGetBlockImage,
 } from './utils';
 
 // Templates are, in a general sense, a basic collection of block nodes with any

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -418,22 +418,3 @@ export function omit( object, keys ) {
 		Object.entries( object ).filter( ( [ key ] ) => ! keys.includes( key ) )
 	);
 }
-
-/**
- * Return the block image URL.
- *
- * @param {string|Object} blockTypeOrName The block type or name.
- * @param {Object}        attributes      The block's attributes.
- * @param {string}        context         The context in which the block is being displayed.
- *
- * @return {string|null} The block image URL or null.
- */
-export function getBlockImage( blockTypeOrName, attributes, context ) {
-	const blockType = normalizeBlockType( blockTypeOrName );
-	const { __experimentalImage: getImage } = blockType;
-	const url = getImage && getImage( attributes, { context } );
-	if ( url ) {
-		return url;
-	}
-	return null;
-}


### PR DESCRIPTION
## What?
Closes #70690.

PR partially reverts #68910. Removes new experimental public APIs and colocates image getter logic for the List View.

## Why?
* Project no longer makes experimental APIs public.
* The new block API method name is too generic. Let's create a new issue to discuss this method.

## Testing Instructions
1. Create a post.
2. Inserter Image, Gallery, Media & Text and Cover blocks with various configurations.
3. Confirm that images are displayed in the List View when they're available.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="356" height="532" alt="CleanShot 2025-07-14 at 12 05 47" src="https://github.com/user-attachments/assets/6a7cccc4-f0e0-4081-a014-202aec5ee37f" />

