### PR TITLE
Add hidden field support to the experimental form block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -292,7 +292,7 @@ A form. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/blo
 -	**Category:** common
 -	**Allowed Blocks:** core/paragraph, core/heading, core/form-input, core/form-submit-button, core/form-submission-notification, core/group, core/columns
 -	**Supports:** anchor, color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~className~~
--	**Attributes:** action, email, method, submissionMethod
+-	**Attributes:** action, email, hiddenFields, method, submissionMethod
 
 ## Input Field
 

--- a/packages/block-library/src/form/block.json
+++ b/packages/block-library/src/form/block.json
@@ -32,6 +32,24 @@
 		},
 		"email": {
 			"type": "string"
+		},
+		"hiddenFields": {
+			"type": "array",
+			"default": [],
+			"items": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "string"
+					},
+					"name": {
+						"type": "string"
+					},
+					"value": {
+						"type": "string"
+					}
+				}
+			}
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/form/deprecated.js
+++ b/packages/block-library/src/form/deprecated.js
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+const deprecated = [
+	{
+		attributes: {
+			submissionMethod: {
+				type: 'string',
+				default: 'email',
+			},
+			method: {
+				type: 'string',
+				default: 'post',
+			},
+			action: {
+				type: 'string',
+			},
+			email: {
+				type: 'string',
+			},
+		},
+		save( { attributes } ) {
+			const blockProps = useBlockProps.save();
+			const { submissionMethod } = attributes;
+
+			return (
+				<form
+					{ ...blockProps }
+					className="wp-block-form"
+					encType={
+						submissionMethod === 'email' ? 'text/plain' : null
+					}
+				>
+					<InnerBlocks.Content />
+				</form>
+			);
+		},
+	},
+];
+
+export default deprecated;

--- a/packages/block-library/src/form/edit.js
+++ b/packages/block-library/src/form/edit.js
@@ -12,10 +12,16 @@ import {
 import {
 	SelectControl,
 	TextControl,
+	Button,
+	BaseControl,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+import { plus, trash } from '@wordpress/icons';
+import { Fragment } from '@wordpress/element';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -65,10 +71,17 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 			email: undefined,
 			action: undefined,
 			method: 'post',
+			hiddenFields: [],
 		} );
 	};
 
-	const { action, method, email, submissionMethod } = attributes;
+	const {
+		action,
+		method,
+		email,
+		submissionMethod,
+		hiddenFields = [],
+	} = attributes;
 	const blockProps = useBlockProps();
 
 	const { hasInnerBlocks } = useSelect(
@@ -88,6 +101,35 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 			? undefined
 			: InnerBlocks.ButtonBlockAppender,
 	} );
+
+	const instanceId = useInstanceId( Edit );
+	const id = `inspector-controls-${ instanceId }`;
+
+	const addHiddenField = () => {
+		const newHiddenField = [
+			...hiddenFields,
+			{
+				id: `hidden_field_${ Date.now() }`,
+				name: '',
+				value: '',
+			},
+		];
+		setAttributes( { hiddenFields: newHiddenField } );
+	};
+
+	const removeHiddenField = ( index ) => {
+		const newHiddenFields = hiddenFields.filter( ( _, i ) => i !== index );
+		setAttributes( { hiddenFields: newHiddenFields } );
+	};
+
+	const updateHiddenField = ( index, field, value ) => {
+		const newHiddenFields = [ ...hiddenFields ];
+		newHiddenFields[ index ] = {
+			...newHiddenFields[ index ],
+			[ field ]: value,
+		};
+		setAttributes( { hiddenFields: newHiddenFields } );
+	};
 
 	return (
 		<>
@@ -171,6 +213,78 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 							/>
 						</ToolsPanelItem>
 					) }
+					<ToolsPanelItem
+						hasValue={ () => hiddenFields.length > 0 }
+						label={ __( 'Hidden fields' ) }
+						onDeselect={ () =>
+							setAttributes( { hiddenFields: [] } )
+						}
+						isShownByDefault
+					>
+						<BaseControl
+							__nextHasNoMarginBottom
+							id={ id }
+							label={ __( 'Hidden fields' ) }
+							help={ __(
+								'Add hidden fields to the form. These fields will not be visible to users but will be included in the form submission.'
+							) }
+						>
+							<VStack spacing={ 2 }>
+								{ hiddenFields.map( ( field, index ) => (
+									<Fragment key={ field.id }>
+										<TextControl
+											__nextHasNoMarginBottom
+											__next40pxDefaultSize
+											label={ __( 'Field Name' ) }
+											value={ field.name }
+											onChange={ ( value ) =>
+												updateHiddenField(
+													index,
+													'name',
+													value
+												)
+											}
+										/>
+										<TextControl
+											__nextHasNoMarginBottom
+											__next40pxDefaultSize
+											label={ __( 'Field Value' ) }
+											value={ field.value }
+											onChange={ ( value ) =>
+												updateHiddenField(
+													index,
+													'value',
+													value
+												)
+											}
+										/>
+										<Button
+											__nextHasNoMarginBottom
+											__next40pxDefaultSize
+											isDestructive
+											variant="secondary"
+											icon={ trash }
+											onClick={ () =>
+												removeHiddenField( index )
+											}
+										>
+											{ __( 'Remove field' ) }
+										</Button>
+									</Fragment>
+								) ) }
+
+								<Button
+									__nextHasNoMarginBottom
+									__next40pxDefaultSize
+									variant="secondary"
+									onClick={ addHiddenField }
+									icon={ plus }
+								>
+									{ __( 'Add hidden field' ) }
+								</Button>
+							</VStack>
+						</BaseControl>
+					</ToolsPanelItem>
 				</ToolsPanel>
 			</InspectorControls>
 			{ submissionMethod !== 'email' && (

--- a/packages/block-library/src/form/index.js
+++ b/packages/block-library/src/form/index.js
@@ -6,6 +6,7 @@ import edit from './edit';
 import metadata from './block.json';
 import save from './save';
 import variations from './variations';
+import deprecated from './deprecated';
 
 /**
  * WordPress dependencies
@@ -21,6 +22,7 @@ export const settings = {
 	save,
 	variations,
 	example: {},
+	deprecated,
 };
 
 export const init = () => {

--- a/packages/block-library/src/form/save.js
+++ b/packages/block-library/src/form/save.js
@@ -5,7 +5,12 @@ import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const blockProps = useBlockProps.save();
-	const { submissionMethod } = attributes;
+	const { submissionMethod, hiddenFields } = attributes;
+
+	const hasHiddenFields =
+		hiddenFields &&
+		Array.isArray( hiddenFields ) &&
+		hiddenFields.length > 0;
 
 	return (
 		<form
@@ -13,6 +18,18 @@ export default function save( { attributes } ) {
 			className="wp-block-form"
 			encType={ submissionMethod === 'email' ? 'text/plain' : null }
 		>
+			{ hasHiddenFields &&
+				hiddenFields.map(
+					( field ) =>
+						field.name && (
+							<input
+								key={ field.id }
+								type="hidden"
+								name={ field.name }
+								value={ field.value }
+							/>
+						)
+				) }
 			<InnerBlocks.Content />
 		</form>
 	);


### PR DESCRIPTION
Closes #57610

## What?
Add hidden field support to the experimental form block, allowing users to include invisible form fields that are submitted with the form data.

## Why?
Hidden fields are a fundamental requirement for modern web forms, especially when integrating with third-party services.

## How?
The implementation adds a complete hidden fields management system:

#### Backend Changes:
- New `hiddenFields` array attribute in block.json schema
- Each field object contains `id`, `name`, and `value` properties
- Block deprecation for backward compatibility with existing forms

### Editor Experience:
- New "Hidden fields" section in Inspector Controls Tools Panel
- Add/remove interface

## Testing Instructions
- Open a post or page in the block editor
- Insert a Form block
- In the Inspector Controls sidebar, scroll to "Hidden fields" section
- Click "Add hidden field" button
- Enter field name: source and value: website
- Add a second field with name: campaign and value: spring2024
- Save the post and view frontend
- Right-click form and "Inspect Element" to verify hidden inputs are present

## Screenshots or screencast <!-- if applicable -->
<img width="572" height="661" alt="Screenshot 2025-07-14 at 4 23 11 PM" src="https://github.com/user-attachments/assets/02f1a434-3f5f-4cd6-9065-695172cea23f" />
<img width="602" height="138" alt="Screenshot 2025-07-14 at 4 23 48 PM" src="https://github.com/user-attachments/assets/85aeeeaf-b480-4a46-9b46-b9334458e909" />

