### PR TITLE
Docs: Prevent class name mismatch in deprecated blocks by defining apiVersion

### DIFF
--- a/docs/reference-guides/block-api/block-deprecation.md
+++ b/docs/reference-guides/block-api/block-deprecation.md
@@ -202,4 +202,28 @@ registerBlockType( 'gutenberg/block-with-deprecated-version', {
 
 In the example above we updated the block to use an inner Paragraph block with a title instead of a title attribute.
 
+## Handling Class Name Mismatches with `apiVersion`
+
+When defining deprecated versions of a block, it is important to explicitly set `apiVersion` in each deprecation entry.
+
+If `apiVersion` is missing or less than 1, Gutenberg applies the `blocks.getSaveContent.extraProps` filter, which can add class names like `wp-block-{block-name}` or `is-loading` to the saved HTML. Since these are usually not present in the original content, the block validation may fail to recognize the deprecated version, preventing migration and block recovery from working as expected.
+
+**Example**
+
+```js
+deprecated: [
+  {
+    attributes: {
+      content: { type: 'string' }
+    },
+    save: ({ attributes }) => {
+      return <div className="is-loading">{ attributes.content }</div>;
+    },
+    apiVersion: 2 // Explicitly provide an apiVersion
+  }
+]
+```
+
+In the example above, we explicitly defined `apiVersion` in the deprecated block to prevent unwanted class names from affecting block validation.
+
 _Above are example cases of block deprecation. For more, real-world examples, check for deprecations in the [core block library](https://github.com/WordPress/gutenberg/tree/HEAD/packages/block-library/src). Core blocks have been updated across releases and contain simple and complex deprecations._


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

See #70123

This PR updates the block deprecation documentation to clarify that deprecated block entries should explicitly define `apiVersion` to avoid unexpected behavior.

## Why?

If `apiVersion` is not defined or is less than 1 in a deprecated block, Gutenberg applies the `blocks.getSaveContent.extraProps` filter, which may add extra class names (e.g., `wp-block-{block-name}` or `is-loading`) during serialization. These are often not present in the original saved content, leading to mismatches that prevent the deprecation logic from triggering correctly.

## How?

The documentation now includes a new section explaining this behavior and recommending that `apiVersion` be explicitly set in each `deprecated` entry. An example is provided to illustrate how this prevents mismatches and ensures proper block validation and migration.
