### PR TITLE
Fix wp-env run command handling of special characters

### DIFF
--- a/packages/env/lib/commands/run.js
+++ b/packages/env/lib/commands/run.js
@@ -94,7 +94,22 @@ function spawnCommandDirectly( config, container, command, envCwd, spinner ) {
 		composeCommand.push( '-T' );
 	}
 
-	composeCommand.push( container, ...command );
+	composeCommand.push( container, 'sh', '-c' );
+
+	// Join the command into a single string and escape special characters.
+	let joinedCmd;
+	if ( command.length > 0 ) {
+		// Properly escape the command to ensure it works with sh -c
+		joinedCmd = command
+			.map( ( part ) => {
+				return part.replace( /(["\\$`])/g, '\\$1' );
+			} )
+			.join( ' ' );
+	} else {
+		joinedCmd = '';
+	}
+
+	composeCommand.push( joinedCmd );
 
 	return new Promise( ( resolve, reject ) => {
 		// Note: since the npm docker-compose package uses the -T option, we


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/58253

This PR fixes issue #58253 where `wp-env run` commands containing special characters (like brackets, quotes, etc.) were failing with exit code 126.

The solution properly escapes special characters and uses `sh -c` within the Docker container to ensure commands are correctly interpreted, while maintaining the performance improvements introduced in PR #50007 that changed from using `docker-compose run` to `docker-compose exec`.