### PR TITLE
Navigation Link: Add `opensInNewTab` to resetAll

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -187,6 +187,7 @@ function Controls( { attributes, setAttributes, setIsLabelFieldFocused } ) {
 					url: '',
 					description: '',
 					rel: '',
+					opensInNewTab: false,
 				} );
 			} }
 			dropdownMenuProps={ dropdownMenuProps }


### PR DESCRIPTION
## What?
Follow up of: #67262
Add `opensInNewTab: false` to the default attributes when resetting navigation link fields.

## Why?
This PR ensures that when navigation link attributes are reset, the `opensInNewTab` attribute is also properly reset to its default value of `false`.

## How?
Added `opensInNewTab: false` to the object passed to `setAttributes()` in the reset functionality within the Controls component of the navigation-link block. This ensures all navigation link attributes are consistently reset to their default values when the clear action is triggered.

## Testing Instructions
1. Open a post or page in the block editor.
2. Insert a Navigation block.
3. Add a Navigation Link block within the Navigation block.
4. Set the link URL, description, and enable "Open in new tab".
5. Reset the link using the `reset all` functionality.
6. Verify that all fields are back to there default state, including the "Open in new tab" setting.

## Screencast

https://github.com/user-attachments/assets/255a6e78-22ff-40e2-8970-c2e37d24e699
