### PR TITLE
wp-env: Fix Docker build errors with Debian Buster repositories

### DIFF
--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -129,6 +129,11 @@ RUN sed -i 's|deb.debian.org/debian stretch|archive.debian.org/debian stretch|g'
 RUN sed -i 's|security.debian.org/debian-security stretch|archive.debian.org/debian-security stretch|g' /etc/apt/sources.list
 RUN sed -i '/stretch-updates/d' /etc/apt/sources.list
 
+# buster (https://lists.debian.org/debian-devel-announce/2025/06/msg00001.html)
+RUN sed -i 's|deb.debian.org/debian buster|archive.debian.org/debian buster|g' /etc/apt/sources.list
+RUN sed -i 's|security.debian.org/debian-security buster/updates|archive.debian.org/debian-security buster/updates|g' /etc/apt/sources.list
+RUN sed -i '/buster-updates/d' /etc/apt/sources.list
+
 # Create the host's user so that we can match ownership in the container.
 ARG HOST_USERNAME
 ARG HOST_UID


### PR DESCRIPTION
## What?

Recently, Docker startup has been failing in unit tests for the following reasons:

Example: https://github.com/WordPress/gutenberg/actions/runs/16267438249/job/45926622123

```
#15 [tests-wordpress  9/20] RUN apt-get -qy update
#15 0.170 Ign:1 http://deb.debian.org/debian buster InRelease
#15 0.172 Ign:2 http://security.debian.org/debian-security buster/updates InRelease
#15 0.172 Ign:3 http://deb.debian.org/debian buster-updates InRelease
#15 0.174 Err:4 http://security.debian.org/debian-security buster/updates Release
#15 0.174   404  Not Found [IP: 151.101.66.132 80]
#15 0.175 Err:5 http://deb.debian.org/debian buster Release
#15 0.175   404  Not Found [IP: 146.75.78.132 80]
#15 0.177 Err:6 http://deb.debian.org/debian buster-updates Release
#15 0.177   404  Not Found [IP: 146.75.78.132 80]
#15 0.181 Reading package lists...
#15 0.189 E: The repository 'http://security.debian.org/debian-security buster/updates Release' does not have a Release file.
#15 0.189 E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
#15 0.189 E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
#15 ERROR: process "/bin/sh -c apt-get -qy update" did not complete successfully: exit code: 100
------
 > [tests-wordpress  9/20] RUN apt-get -qy update:
0.174 Err:4 http://security.debian.org/debian-security buster/updates Release
0.174   404  Not Found [IP: 151.101.66.132 80]
0.175 Err:5 http://deb.debian.org/debian buster Release
0.175   404  Not Found [IP: 146.75.78.132 80]
0.177 Err:6 http://deb.debian.org/debian buster-updates Release
0.177   404  Not Found [IP: 146.75.78.132 80]
0.181 Reading package lists...
0.189 E: The repository 'http://security.debian.org/debian-security buster/updates Release' does not have a Release file.
0.189 E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
0.189 E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
------
Error: Process completed with exit code 1.
```

## Why?

I suspect this is because the `buster` package is archived:

https://lists.debian.org/debian-devel-announce/2025/06/msg00001.html

Let's check the archive site and see if CI is successful.