### PR TITLE
DataViews: Add action `isTextButton` and `hideItemAction` options

### DIFF
--- a/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
@@ -173,7 +173,9 @@ function ActionTrigger< Item >( {
 			children={
 				action.isTextButton ? ( label as ReactNode ) : undefined
 			}
-			variant={ action.isPrimary ? 'primary' : undefined }
+			variant={
+				action.isPrimary && action.isTextButton ? 'primary' : undefined
+			}
 			icon={ action.icon }
 			isDestructive={ action.isDestructive }
 			size="compact"

--- a/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
@@ -83,6 +83,7 @@ export function useSomeItemHasAPossibleBulkAction< Item >(
 			return actions.some( ( action ) => {
 				return (
 					action.supportsBulk &&
+					! action.hideItemAction &&
 					( ! action.isEligible || action.isEligible( item ) )
 				);
 			} );

--- a/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { ReactElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 /**
  * WordPress dependencies
@@ -169,7 +169,11 @@ function ActionTrigger< Item >( {
 		<Button
 			disabled={ isBusy }
 			accessibleWhenDisabled
-			label={ label }
+			label={ action.isTextButton ? undefined : label }
+			children={
+				action.isTextButton ? ( label as ReactNode ) : undefined
+			}
+			variant={ action.isPrimary ? 'primary' : undefined }
 			icon={ action.icon }
 			isDestructive={ action.isDestructive }
 			size="compact"
@@ -336,7 +340,7 @@ function FooterContent< Item >( {
 			actions.filter( ( action ) => {
 				return (
 					action.supportsBulk &&
-					action.icon &&
+					( action.icon || action.isTextButton ) &&
 					selectedItems.some(
 						( item ) =>
 							! action.isEligible || action.isEligible( item )

--- a/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
@@ -83,7 +83,6 @@ export function useSomeItemHasAPossibleBulkAction< Item >(
 			return actions.some( ( action ) => {
 				return (
 					action.supportsBulk &&
-					! action.hideItemAction &&
 					( ! action.isEligible || action.isEligible( item ) )
 				);
 			} );

--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -157,7 +157,9 @@ export default function ItemActions< Item >( {
 		// If an action is eligible for all items, doesn't need
 		// to provide the `isEligible` function.
 		const _eligibleActions = actions.filter(
-			( action ) => ! action.isEligible || action.isEligible( item )
+			( action ) =>
+				! action.hideItemAction &&
+				( ! action.isEligible || action.isEligible( item ) )
 		);
 		const _primaryActions = _eligibleActions.filter(
 			( action ) => action.isPrimary && !! action.icon

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -9,6 +9,7 @@ import type { Meta } from '@storybook/react';
 import {
 	useState,
 	useMemo,
+	useCallback,
 	createInterpolateElement,
 } from '@wordpress/element';
 import {
@@ -323,6 +324,113 @@ export const CustomPerPageSizes = () => {
 			actions={ actions.filter( ( action ) => ! action.supportsBulk ) }
 			defaultLayouts={ defaultLayouts }
 			perPageSizes={ [ 3, 6, 12, 24 ] }
+		/>
+	);
+};
+
+const Selection = ( {
+	multiple,
+	onSelectionComplete,
+}: {
+	multiple?: boolean;
+	onSelectionComplete: ( items: SpaceObject[] ) => void;
+} ) => {
+	const [ selection, setSelection ] = useState< string[] >( [] );
+	const [ view, setView ] = useState< View >( {
+		...DEFAULT_VIEW,
+		fields: [ 'categories' ],
+		titleField: 'title',
+		descriptionField: 'description',
+		mediaField: 'image',
+	} );
+
+	const { data: shownData, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( data, view, fields );
+	}, [ view ] );
+
+	const selectionActions = useMemo(
+		() =>
+			multiple
+				? [
+						{
+							id: 'select',
+							label: __( 'Select' ),
+							isPrimary: true,
+							isEligible() {
+								return Boolean( multiple );
+							},
+							callback( items: SpaceObject[] ) {
+								onSelectionComplete( items );
+							},
+							supportsBulk: Boolean( multiple ),
+						},
+				  ]
+				: [],
+		[ multiple, onSelectionComplete ]
+	);
+
+	const onClickItem = useCallback(
+		( item: SpaceObject ) => {
+			if ( multiple ) {
+				if ( selection.includes( item.id.toString() ) ) {
+					setSelection(
+						selection.filter( ( id ) => id !== item.id.toString() )
+					);
+				} else {
+					setSelection( [ item.id.toString(), ...selection ] );
+				}
+			} else {
+				onSelectionComplete( [ item ] );
+			}
+		},
+		[ multiple, selection, onSelectionComplete ]
+	);
+
+	return (
+		<DataViews
+			getItemId={ ( item ) => item.id.toString() }
+			paginationInfo={ paginationInfo }
+			data={ shownData }
+			view={ view }
+			fields={ fields }
+			onChangeView={ setView }
+			actions={ selectionActions }
+			selection={ selection }
+			onChangeSelection={ setSelection }
+			onClickItem={ onClickItem }
+			isItemClickable={ () => true }
+			defaultLayouts={ defaultLayouts }
+		/>
+	);
+};
+
+export const SingleSelection = () => {
+	return (
+		<Selection
+			onSelectionComplete={ ( items: SpaceObject[] ) => {
+				// eslint-disable-next-line no-alert
+				alert(
+					`Selected: ${ items
+						.map( ( item ) => item.title )
+						.join( ', ' ) }`
+				);
+			} }
+		/>
+	);
+};
+
+export const MultiSelection = () => {
+	return (
+		<Selection
+			multiple
+			onSelectionComplete={ ( items: SpaceObject[] ) => {
+				// eslint-disable-next-line no-alert
+				alert(
+					`Selected: ${ items
+						.map( ( item ) => item.title )
+						.join( ', ' ) }`
+				);
+			} }
 		/>
 	);
 };

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -356,6 +356,7 @@ const Selection = ( {
 							id: 'select',
 							label: __( 'Select' ),
 							isPrimary: true,
+							isTextButton: true,
 							isEligible() {
 								return Boolean( multiple );
 							},

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -357,6 +357,7 @@ const Selection = ( {
 							label: __( 'Select' ),
 							isPrimary: true,
 							isTextButton: true,
+							hideItemAction: true,
 							isEligible() {
 								return Boolean( multiple );
 							},

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -183,7 +183,9 @@ function ListItem< Item >( {
 		// If an action is eligible for all items, doesn't need
 		// to provide the `isEligible` function.
 		const _eligibleActions = actions.filter(
-			( action ) => ! action.isEligible || action.isEligible( item )
+			( action ) =>
+				! action.hideItemAction &&
+				( ! action.isEligible || action.isEligible( item ) )
 		);
 		const _primaryActions = _eligibleActions.filter(
 			( action ) => action.isPrimary && !! action.icon

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -12,6 +12,7 @@ import { Spinner } from '@wordpress/components';
 import {
 	useContext,
 	useEffect,
+	useMemo,
 	useId,
 	useRef,
 	useState,
@@ -95,6 +96,14 @@ function TableColumnField< Item >( {
 	);
 }
 
+function getHasActionsColumn< Item >( actions: Action< Item >[], item: Item ) {
+	return actions.some(
+		( action ) =>
+			! action.hideItemAction &&
+			( ! action.isEligible || action.isEligible( item ) )
+	);
+}
+
 function TableRow< Item >( {
 	hasBulkActions,
 	item,
@@ -134,6 +143,11 @@ function TableRow< Item >( {
 		( titleField && showTitle ) ||
 		( mediaField && showMedia ) ||
 		( descriptionField && showDescription );
+
+	const hasActionsColumn = useMemo(
+		() => getHasActionsColumn( actions, item ),
+		[ actions, item ]
+	);
 
 	return (
 		<tr
@@ -216,7 +230,7 @@ function TableRow< Item >( {
 					</td>
 				);
 			} ) }
-			{ !! actions?.length && (
+			{ hasActionsColumn && (
 				// Disable reason: we are not making the element interactive,
 				// but preventing any click events from bubbling up to the
 				// table row. This allows us to add a click handler to the row
@@ -265,6 +279,10 @@ function ViewTable< Item >( {
 	const [ nextHeaderMenuToFocus, setNextHeaderMenuToFocus ] =
 		useState< HTMLButtonElement >();
 	const hasBulkActions = useSomeItemHasAPossibleBulkAction( actions, data );
+	const hasActionsColumns = useMemo(
+		() => data.some( ( item ) => getHasActionsColumn( actions, item ) ),
+		[ actions, data ]
+	);
 
 	useEffect( () => {
 		if ( headerMenuToFocusRef.current ) {
@@ -404,7 +422,7 @@ function ViewTable< Item >( {
 								</th>
 							);
 						} ) }
-						{ !! actions?.length && (
+						{ hasActionsColumns && (
 							<th
 								className={ clsx(
 									'dataviews-view-table__actions-column',

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -533,6 +533,11 @@ interface ActionBase< Item > {
 	supportsBulk?: boolean;
 
 	/**
+	 * Whether the action is hidden on the item.
+	 */
+	hideItemAction?: boolean;
+
+	/**
 	 * The context in which the action is visible.
 	 * This is only a "meta" information for now.
 	 */

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -518,6 +518,11 @@ interface ActionBase< Item > {
 	isPrimary?: boolean;
 
 	/**
+	 * Whether to show a text button instead of an icon button in the bulk actions footer.
+	 */
+	isTextButton?: boolean;
+
+	/**
 	 * Whether the item passed as an argument supports the current action.
 	 */
 	isEligible?: ( item: Item ) => boolean;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds two options to dataviews actions:
- `hideItemAction` - makes an action not appear in an individual item's action dropdown.

- `isTextButton` - when an action appears in the footer, this makes it show as a text button.
<img width="292" height="54" alt="Screenshot 2025-07-15 at 11 28 18 am" src="https://github.com/user-attachments/assets/15150506-067e-42c7-8da8-a10cff43d578" />

## Why?
The goal of these changes is to support experiences where dataviews can be used as a 'picker'. For example, a UI for choosing a parent post or choosing a featured image.

Before this PR, you could kind of implement this behavior, but with two issues:
- The action for confirming a selection doesn't make sense for individual items (hence `hideItemAction`)
- The bulk action in the footer for confirming a selection only appeared as an icon button, not prominent enough for a main CTA.

I've added two new stories 'Single selection' and 'Multi selection' to demonstrate how it might work.

## How?
- Adds the two options
- Adds to the logic for hiding the row actions when there are no eligible action, taking `hideItemAction` into account.
- Makes text buttons use `primary` styling when the `isPrimary` option is used on an action (but this change doesn't affect icon buttons).

## Testing Instructions
1. Check out this branch locally
2. Run `npm run storybook:dev` to start the story book
3. Navigate to the DataViews stories, and try the Single Selection and Multi Selection stories.
4. Note that it's best to use the checkbox for multiselection. I've reported a possible bug around clicking the row - [DataViews: Multi-selection works inconsistently in table layout](https://github.com/WordPress/gutenberg/issues/70721#top)

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/aa1421c9-4d6d-4dd1-a2f7-4c2b770b6cb3


