### PR TITLE
a11y: Comments Pagination Nav Wrapper

### DIFF
--- a/packages/block-library/src/comments-pagination/index.php
+++ b/packages/block-library/src/comments-pagination/index.php
@@ -27,7 +27,7 @@ function render_block_core_comments_pagination( $attributes, $content ) {
 	$classes            = ( isset( $attributes['style']['elements']['link']['color']['text'] ) ) ? 'has-link-color' : '';
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
-			'aria-label' => __( 'Pagination' ),
+			'aria-label' => __( 'Comments pagination' ),
 			'class'      => $classes,
 		)
 	);

--- a/packages/block-library/src/comments-pagination/index.php
+++ b/packages/block-library/src/comments-pagination/index.php
@@ -25,10 +25,15 @@ function render_block_core_comments_pagination( $attributes, $content ) {
 	}
 
 	$classes            = ( isset( $attributes['style']['elements']['link']['color']['text'] ) ) ? 'has-link-color' : '';
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		array(
+			'aria-label' => __( 'Pagination' ),
+			'class'      => $classes,
+		)
+	);
 
 	return sprintf(
-		'<div %1$s>%2$s</div>',
+		'<nav %1$s>%2$s</nav>',
 		$wrapper_attributes,
 		$content
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #70729 

This PR updates the Comments Pagination block to use a `<nav>` element with `aria-label="Comments pagination"` as its wrapper, instead of a `<div>`

## Why?
- Improves accessibility by providing a navigation landmark
- Aligns the block’s markup with the core `the_comments_pagination()` function and the Query Pagination block.

## How?
- Changes the render function to output <nav> with aria-label="Comments pagination" and the appropriate classes.
- Uses `get_block_wrapper_attributes()` to add the aria-label and class attributes.

## Testing Instructions

1. Add a Comments Pagination block to a post or template.
2. View the front end and inspect the markup.
3. Confirm the pagination is wrapped in a `<nav>` element with `aria-label="Comments pagination"`.
