### PR TITLE
Block Editor: Deprecate block hovered global state

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -562,18 +562,6 @@ _Returns_
 
 -   `number`: Number of blocks in the post, or number of blocks with name equal to blockName.
 
-### getHoveredBlockClientId
-
-Returns the currently hovered block.
-
-_Parameters_
-
--   _state_ `Object`: Global application state.
-
-_Returns_
-
--   `Object`: Client Id of the hovered block.
-
 ### getInserterItems
 
 Determines the items that appear in the inserter. Includes both static items (e.g. a regular block type) and dynamic items (e.g. a reusable block).
@@ -1295,18 +1283,6 @@ _Parameters_
 ### hideInsertionPoint
 
 Action that hides the insertion point.
-
-### hoverBlock
-
-Returns an action object used in signalling that the block with the specified client ID has been hovered.
-
-_Parameters_
-
--   _clientId_ `string`: Block client ID.
-
-_Returns_
-
--   `Object`: Action object.
 
 ### insertAfterBlock
 

--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -562,6 +562,12 @@ _Returns_
 
 -   `number`: Number of blocks in the post, or number of blocks with name equal to blockName.
 
+### getHoveredBlockClientId
+
+> **Deprecated**
+
+Returns the currently hovered block.
+
 ### getInserterItems
 
 Determines the items that appear in the inserter. Includes both static items (e.g. a regular block type) and dynamic items (e.g. a reusable block).
@@ -1283,6 +1289,12 @@ _Parameters_
 ### hideInsertionPoint
 
 Action that hides the insertion point.
+
+### hoverBlock
+
+> **Deprecated**
+
+Returns an action object used in signalling that the block with the specified client ID has been hovered.
 
 ### insertAfterBlock
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Store: Remove the block hovered global state and related action/selector ([#70731](https://github.com/WordPress/gutenberg/pull/70731))
+
 ## 14.21.0 (2025-06-25)
 
 ## 14.20.0 (2025-06-04)

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
--   Store: Remove the block hovered global state and related action/selector ([#70731](https://github.com/WordPress/gutenberg/pull/70731))
+-   Store: Deprecate the block hovered global state and related action/selector ([#70731](https://github.com/WordPress/gutenberg/pull/70731))
 
 ## 14.21.0 (2025-06-25)
 

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -114,7 +114,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		useBlockRefProvider( clientId ),
 		useFocusHandler( clientId ),
 		useEventHandlers( { clientId, isSelected } ),
-		useIsHovered( { clientId } ),
+		useIsHovered(),
 		useIntersectionObserver(),
 		useMovingAnimation( { triggerAnimationOnChange: index, clientId } ),
 		useDisabled( { isDisabled: ! hasOverlay } ),

--- a/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
@@ -2,37 +2,23 @@
  * WordPress dependencies
  */
 import { useRefEffect } from '@wordpress/compose';
-import { useDispatch } from '@wordpress/data';
 
-/**
- * Internal dependencies
- */
-import { store as blockEditorStore } from '../../../store';
+function listener( event ) {
+	if ( event.defaultPrevented ) {
+		return;
+	}
+
+	const action = event.type === 'mouseover' ? 'add' : 'remove';
+
+	event.preventDefault();
+	event.currentTarget.classList[ action ]( 'is-hovered' );
+}
 
 /*
  * Adds `is-hovered` class when the block is hovered and in navigation or
  * outline mode.
  */
-export function useIsHovered( { clientId } ) {
-	const { hoverBlock } = useDispatch( blockEditorStore );
-
-	function listener( event ) {
-		if ( event.defaultPrevented ) {
-			return;
-		}
-
-		const action = event.type === 'mouseover' ? 'add' : 'remove';
-
-		event.preventDefault();
-		event.currentTarget.classList[ action ]( 'is-hovered' );
-
-		if ( action === 'add' ) {
-			hoverBlock( clientId );
-		} else {
-			hoverBlock( null );
-		}
-	}
-
+export function useIsHovered() {
 	return useRefEffect( ( node ) => {
 		node.addEventListener( 'mouseout', listener );
 		node.addEventListener( 'mouseover', listener );
@@ -43,7 +29,6 @@ export function useIsHovered( { clientId } ) {
 
 			// Remove class in case it lingers.
 			node.classList.remove( 'is-hovered' );
-			hoverBlock( null );
 		};
 	}, [] );
 }

--- a/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
@@ -8,10 +8,11 @@ function listener( event ) {
 		return;
 	}
 
-	const action = event.type === 'mouseover' ? 'add' : 'remove';
-
 	event.preventDefault();
-	event.currentTarget.classList[ action ]( 'is-hovered' );
+	event.currentTarget.classList.toggle(
+		'is-hovered',
+		event.type === 'mouseover'
+	);
 }
 
 /*

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -213,21 +213,6 @@ export function selectBlock( clientId, initialPosition = 0 ) {
 }
 
 /**
- * Returns an action object used in signalling that the block with the
- * specified client ID has been hovered.
- *
- * @param {string} clientId Block client ID.
- *
- * @return {Object} Action object.
- */
-export function hoverBlock( clientId ) {
-	return {
-		type: 'HOVER_BLOCK',
-		clientId,
-	};
-}
-
-/**
  * Yields action objects used in signalling that the block preceding the given
  * clientId (or optionally, its first parent from bottom to top)
  * should be selected.

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -213,6 +213,22 @@ export function selectBlock( clientId, initialPosition = 0 ) {
 }
 
 /**
+ * Returns an action object used in signalling that the block with the
+ * specified client ID has been hovered.
+ *
+ * @deprecated
+ */
+export function hoverBlock() {
+	deprecated( 'wp.data.dispatch( "core/block-editor" ).hoverBlock', {
+		since: '6.9',
+		version: '7.1',
+	} );
+	return {
+		type: 'DO_NOTHING',
+	};
+}
+
+/**
  * Yields action objects used in signalling that the block preceding the given
  * clientId (or optionally, its first parent from bottom to top)
  * should be selected.

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2056,23 +2056,6 @@ export function lastFocus( state = false, action ) {
 }
 
 /**
- * Reducer setting currently hovered block.
- *
- * @param {boolean} state  Current state.
- * @param {Object}  action Dispatched action.
- *
- * @return {boolean} Updated state.
- */
-export function hoveredBlockClientId( state = false, action ) {
-	switch ( action.type ) {
-		case 'HOVER_BLOCK':
-			return action.clientId;
-	}
-
-	return state;
-}
-
-/**
  * Reducer setting zoom out state.
  *
  * @param {boolean} state  Current state.
@@ -2141,7 +2124,6 @@ const combinedReducers = combineReducers( {
 	blockRemovalRules,
 	openedBlockSettingsMenu,
 	registeredInserterMediaCategories,
-	hoveredBlockClientId,
 	zoomLevel,
 } );
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2910,6 +2910,22 @@ export function isBlockVisible( state, clientId ) {
 }
 
 /**
+ * Returns the currently hovered block.
+ *
+ * @deprecated
+ */
+export function getHoveredBlockClientId() {
+	deprecated(
+		"wp.data.select( 'core/block-editor' ).getHoveredBlockClientId",
+		{
+			since: '6.9',
+			version: '7.1',
+		}
+	);
+	return undefined;
+}
+
+/**
  * Returns the list of all hidden blocks.
  *
  * @param {Object} state Global application state.

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2910,16 +2910,6 @@ export function isBlockVisible( state, clientId ) {
 }
 
 /**
- * Returns the currently hovered block.
- *
- * @param {Object} state Global application state.
- * @return {Object} Client Id of the hovered block.
- */
-export function getHoveredBlockClientId( state ) {
-	return state.hoveredBlockClientId;
-}
-
-/**
  * Returns the list of all hidden blocks.
  *
  * @param {Object} state Global application state.


### PR DESCRIPTION
## What?
PR reverts block hovered global state from the block editor package, introduced in #63668.

## Why?
* This state is no longer used in core. See: #65759.
* The block editor should avoid calling actions synchronously when moving the mouse. Related: #44325.
* The new action and selector should never have been made public.

## Testing Instructions
1. Open a post or page.
2. Insert blocks.
3. Confirm that the `is-hovered` style is correctly applied to the block wrapper. This can be checked via DevTools.

### Testing Instructions for Keyboard
Same.
