### PR TITLE
Add eslint support for semver validation and optional description to `@since`  tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51314,7 +51314,8 @@
 				"eslint-plugin-react": "^7.27.0",
 				"eslint-plugin-react-hooks": "^4.3.0",
 				"globals": "^13.12.0",
-				"requireindex": "^1.2.0"
+				"requireindex": "^1.2.0",
+				"semver": "7.7.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -51353,13 +51354,25 @@
 				"eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
 			}
 		},
-		"packages/eslint-plugin/node_modules/semver": {
+		"packages/eslint-plugin/node_modules/@babel/eslint-parser/node_modules/semver": {
 			"version": "6.3.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
+			}
+		},
+		"packages/eslint-plugin/node_modules/semver": {
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"packages/fields": {

--- a/packages/eslint-plugin/configs/jsdoc.js
+++ b/packages/eslint-plugin/configs/jsdoc.js
@@ -149,5 +149,6 @@ module.exports = {
 		'jsdoc/require-returns-description': 'error',
 		'jsdoc/require-returns-type': 'error',
 		'jsdoc/valid-types': 'error',
+		'@wordpress/require-valid-since': 'error',
 	},
 };

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -47,7 +47,8 @@
 		"eslint-plugin-react": "^7.27.0",
 		"eslint-plugin-react-hooks": "^4.3.0",
 		"globals": "^13.12.0",
-		"requireindex": "^1.2.0"
+		"requireindex": "^1.2.0",
+		"semver": "7.7.2"
 	},
 	"peerDependencies": {
 		"@babel/core": ">=7",

--- a/packages/eslint-plugin/rules/__tests__/require-valid-since.js
+++ b/packages/eslint-plugin/rules/__tests__/require-valid-since.js
@@ -1,0 +1,111 @@
+/**
+ * External dependencies
+ */
+import { RuleTester } from 'eslint';
+
+/**
+ * Internal dependencies
+ */
+import rule from '../require-valid-since.js';
+
+const ruleTester = new RuleTester( {
+	parserOptions: {
+		ecmaVersion: 6,
+	},
+} );
+
+ruleTester.run( 'require-valid-since', rule, {
+	valid: [
+		{
+			code: `
+			/**
+			 * @since 1.2.3
+			 */
+			function test() {}
+			`,
+		},
+		{
+			code: `
+			/**
+			 * @since 2.0.0 Adds support for new feature.
+			 */
+			const foo = () => {};
+			`,
+		},
+		{
+			code: `
+			/**
+			 * Some other comment
+			 * @param {string} name
+			 */
+			function greet(name) {}
+			`,
+		},
+		{
+			code: `
+			/**
+			 * @since 10.5.99 Additional notes here.
+			 */
+			class MyClass {}
+			`,
+		},
+	],
+	invalid: [
+		{
+			code: `
+			/**
+			 * @since 1.2
+			 */
+			function test() {}
+			`,
+			errors: [
+				{
+					message:
+						'@since version "1.2" is invalid. Must be valid semver (e.g., 1.2.3).',
+				},
+			],
+		},
+		{
+			code: `
+			/**
+			 * @since version 3
+			 */
+			function foo() {}
+			`,
+			errors: [
+				{
+					message:
+						'@since version "version" is invalid. Must be valid semver (e.g., 1.2.3).',
+				},
+			],
+		},
+		{
+			code: `
+			/**
+			 * @since 6.7.x
+			 */
+			const bar = () => {};
+			`,
+			errors: [
+				{
+					message:
+						'@since version "6.7.x" is invalid. Must be valid semver (e.g., 1.2.3).',
+				},
+			],
+		},
+		{
+			code: `
+			/**
+			 * @since 3.14
+			 */
+			class MyClass {}
+			`,
+			errors: [
+				{
+					message:
+						'@since version "3.14" is invalid. Must be valid semver (e.g., 1.2.3).',
+				},
+			],
+		},
+	],
+} );

--- a/packages/eslint-plugin/rules/require-valid-since.js
+++ b/packages/eslint-plugin/rules/require-valid-since.js
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+const semver = require( 'semver' );
+
+module.exports = {
+	meta: {
+		type: 'suggestion',
+		docs: {
+			description:
+				'Require @since tags to use strict semver version, followed by optional description',
+		},
+		schema: [],
+	},
+	create( context ) {
+		const sourceCode = context.getSourceCode();
+
+		return {
+			Program() {
+				const comments = sourceCode.getAllComments();
+
+				for ( const comment of comments ) {
+					if (
+						comment.type !== 'Block' ||
+						! comment.value.includes( '@since' )
+					) {
+						continue;
+					}
+
+					/** @type {string[]} */
+					const lines = comment.value.split( '\n' );
+
+					for ( const line of lines ) {
+						const sinceMatch = line.match(
+							/@since\s+([^\s]+)(.*)/
+						);
+
+						if ( ! sinceMatch ) {
+							continue;
+						}
+
+						const version = sinceMatch[ 1 ];
+
+						if ( ! semver.valid( version ) ) {
+							context.report( {
+								loc: comment.loc,
+								message: `@since version "${ version }" is invalid. Must be valid semver (e.g., 1.2.3).`,
+							} );
+						}
+					}
+				}
+			},
+		};
+	},
+};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #20859

This PR adds supports for adding semver validation and optional description for `@since` tag in JSDoc

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While #20427 ( increasing severity of `eslint-plugin-jsdoc` ) was being worked on, It was found that, It flagged description/explanation after the version in `@since` which is a frequently-used pattern in WordPress projects.

Due to this, `jsdoc/check-values` was disabled to prevent errors but this leads to  manually checking versions in `@since`.

This PR adds supports for semver validation on `@since` while also adding support for optional description.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR adds a custom `@wordpress/require-valid-since` ( name can be changed ) which checks for proper semver versions in `@since` tag while also allowing optional description.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Added Unit Tests should suffice for testing


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<img width="755" height="612" alt="image" src="https://github.com/user-attachments/assets/97ed9948-969b-46d6-88df-c54d9941fb17" />

<img width="502" height="647" alt="image" src="https://github.com/user-attachments/assets/7a8f65b1-5677-4e14-aff8-e443ff6c4c86" />
