### PR TITLE
Register Custom CPT's "Add New" Command in Command Pallete 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50584,6 +50584,7 @@
 				"@babel/runtime": "7.25.7",
 				"@wordpress/block-editor": "file:../block-editor",
 				"@wordpress/commands": "file:../commands",
+				"@wordpress/components": "29.12.0",
 				"@wordpress/compose": "file:../compose",
 				"@wordpress/core-data": "file:../core-data",
 				"@wordpress/data": "file:../data",

--- a/packages/core-commands/package.json
+++ b/packages/core-commands/package.json
@@ -31,6 +31,7 @@
 		"@babel/runtime": "7.25.7",
 		"@wordpress/block-editor": "file:../block-editor",
 		"@wordpress/commands": "file:../commands",
+		"@wordpress/components": "29.12.0",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",

--- a/packages/core-commands/src/admin-navigation-commands.js
+++ b/packages/core-commands/src/admin-navigation-commands.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useCommand, useCommandLoader } from '@wordpress/commands';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { getPath } from '@wordpress/url';
 import { store as coreStore } from '@wordpress/core-data';
@@ -10,6 +10,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback, useMemo } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { Dashicon } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -17,6 +18,20 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { unlock } from './lock-unlock';
 
 const { useHistory } = unlock( routerPrivateApis );
+
+const GLOBAL_SYSTEM_POST_TYPES = [
+	'post',
+	'page',
+	'attachment',
+	'nav_menu_item',
+	'wp_block',
+	'wp_template',
+	'wp_template_part',
+	'wp_global_styles',
+	'wp_navigation',
+	'wp_font_family',
+	'wp_font_face',
+];
 
 const getAddNewPageCommand = () =>
 	function useAddNewPageCommand() {
@@ -87,6 +102,74 @@ const getAddNewPageCommand = () =>
 		};
 	};
 
+const getAddNewCustomPostTypeCommands = () =>
+	function useAddNewCustomPostTypeCommands() {
+		const customPostTypes = useSelect( ( select ) => {
+			const { getPostTypes } = select( coreStore );
+			const postTypes = getPostTypes( { per_page: -1 } );
+
+			if ( ! postTypes ) {
+				return [];
+			}
+
+			// Filter to only include user-created custom post types
+			// Exclude system post types and core WordPress post types
+			const systemPostTypes = GLOBAL_SYSTEM_POST_TYPES;
+
+			return postTypes
+				?.filter(
+					( { viewable, slug } ) =>
+						viewable && ! systemPostTypes.includes( slug )
+				)
+				.sort( ( a, b ) => a.name.localeCompare( b.name ) );
+		}, [] );
+
+		const commands = useMemo( () => {
+			return customPostTypes.map( ( postType ) => {
+				const { slug, labels, icon } = postType;
+				const singularName =
+					labels?.singular_name || labels?.name || slug;
+				const commandLabel = sprintf(
+					// translators: %s: Post type name
+					__( 'Add new %s' ),
+					singularName
+				);
+
+				// Handle icon - convert dashicon strings to proper components
+				let iconComponent = plus;
+				if ( icon && typeof icon === 'string' ) {
+					// If it's a dashicon string (starts with 'dashicons-'), convert to Dashicon component
+					if ( icon.startsWith( 'dashicons-' ) ) {
+						const dashiconName = icon.replace( 'dashicons-', '' );
+						iconComponent = <Dashicon icon={ dashiconName } />;
+					} else {
+						// For other string icons, use plus as fallback
+						iconComponent = plus;
+					}
+				} else if ( icon && typeof icon === 'function' ) {
+					// If it's already a component, use it
+					iconComponent = icon;
+				}
+
+				return {
+					name: `core/add-new-${ slug }`,
+					label: commandLabel,
+					icon: iconComponent,
+					callback: () => {
+						document.location.assign(
+							`post-new.php?post_type=${ slug }`
+						);
+					},
+				};
+			} );
+		}, [ customPostTypes ] );
+
+		return {
+			isLoading: false,
+			commands,
+		};
+	};
+
 export function useAdminNavigationCommands() {
 	useCommand( {
 		name: 'core/add-new-post',
@@ -100,5 +183,10 @@ export function useAdminNavigationCommands() {
 	useCommandLoader( {
 		name: 'core/add-new-page',
 		hook: getAddNewPageCommand(),
+	} );
+
+	useCommandLoader( {
+		name: 'core/add-new-custom-post-types',
+		hook: getAddNewCustomPostTypeCommands(),
 	} );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #70559

This PR enhances the WordPress Block Editor's Command Palette by adding dynamic "Add New" commands for custom post types (CPTs). Users can now quickly create new custom post types directly from the Command Palette, similar to how they can add new posts and pages.


<!-- In a few words, what is the PR actually doing? -->

## Why?
Currently, the Command Palette only provides "Add new post" and "Add new page" commands. Users with custom post types need to navigate through the admin menu to create new content, which is inefficient. This enhancement improves the user experience by providing quick access to create any custom post type directly from the Command Palette.

## How?
The implementation:

-  Uses getPostTypes() to fetch all available post types and dynamically generates commands for user-created custom post types
-  Excludes system post types (post, page, attachment, etc.) and only includes viewable custom post types
- Converts dashicon strings (e.g., dashicons-book) to proper React components using the Dashicon component
-  Follows the same patterns as existing "Add new post/page" commands


## Testing Instructions

### Custom Post Type Testing:
- Create a custom post type (e.g., "Books") with a custom icon
- Open the Command Palette
- Search for "Add new Book"
- Verify the command appears with the correct icon and label
- Test the command to ensure it navigates to post-new.php?post_type=books

### Edge Cases:

- Test with custom post types that have no icon set
- Test with custom post types that use non-dashicon icons
- Verify system post types (post, page, attachment, etc.) do not appear in the list

### Testing Instructions for Keyboard

- Open the Command Palette using Ctrl/Cmd + K
- Use arrow keys to navigate through the command list
- Type "Add new" to filter commands
- Use Tab/Shift+Tab to navigate between commands
- Press Enter to execute a command
- Verify that the selected command properly navigates to the new post page
- Test with screen readers to ensure proper accessibility

## Screenshots 

### Before
<img width="3404" height="1196" alt="image" src="https://github.com/user-attachments/assets/effe0702-f448-4af6-ab53-cd878e2fcc32" />


### After
<img width="3420" height="1306" alt="image" src="https://github.com/user-attachments/assets/6526e37f-7044-484c-b50a-2d0b6a5dadf5" />

 
