### PR TITLE
core-data: Try using cached permissions even when `_fields` is present in the query

### DIFF
--- a/packages/core-data/src/hooks/test/use-entity-records.js
+++ b/packages/core-data/src/hooks/test/use-entity-records.js
@@ -15,7 +15,9 @@ import { render, waitFor } from '@testing-library/react';
  * Internal dependencies
  */
 import { store as coreDataStore } from '../../index';
-import useEntityRecords from '../use-entity-records';
+import useEntityRecords, {
+	useEntityRecordsWithPermissions,
+} from '../use-entity-records';
 
 describe( 'useEntityRecords', () => {
 	let registry;
@@ -72,5 +74,106 @@ describe( 'useEntityRecords', () => {
 			totalItems: 3,
 			totalPages: 1,
 		} );
+	} );
+} );
+
+describe( 'useEntityRecordsWithPermissions', () => {
+	let registry;
+
+	beforeEach( () => {
+		registry = createRegistry();
+		registry.register( coreDataStore );
+
+		// Mock the post entity configuration
+		registry.dispatch( coreDataStore ).addEntities( [
+			{
+				name: 'post',
+				kind: 'postType',
+				baseURL: '/wp/v2/posts',
+				baseURLParams: { context: 'edit' },
+			},
+		] );
+	} );
+
+	const TEST_RECORDS = [
+		{ id: 1, title: 'Post 1', slug: 'post-1' },
+		{ id: 2, title: 'Post 2', slug: 'post-2' },
+	];
+
+	const fieldsFromMock = Object.keys( TEST_RECORDS[ 0 ] ).join( ',' );
+
+	it( 'injects _links when _fields is provided', async () => {
+		// Mock the API response
+		triggerFetch.mockImplementation( () => TEST_RECORDS );
+
+		const TestComponent = () => {
+			useEntityRecordsWithPermissions( 'postType', 'post', {
+				_fields: fieldsFromMock,
+			} );
+			return <div />;
+		};
+		render(
+			<RegistryProvider value={ registry }>
+				<TestComponent />
+			</RegistryProvider>
+		);
+
+		// Should inject _links into the _fields parameter
+		await waitFor( () =>
+			expect( triggerFetch ).toHaveBeenCalledWith( {
+				path: `/wp/v2/posts?context=edit&_fields=${ encodeURIComponent(
+					fieldsFromMock + ',_links'
+				) }`,
+			} )
+		);
+	} );
+
+	it( 'does not modify query when _fields is not provided', async () => {
+		// Mock the API response
+		triggerFetch.mockImplementation( () => TEST_RECORDS );
+
+		const TestComponent = () => {
+			useEntityRecordsWithPermissions( 'postType', 'post', {} );
+			return <div />;
+		};
+		render(
+			<RegistryProvider value={ registry }>
+				<TestComponent />
+			</RegistryProvider>
+		);
+
+		// Should not add _fields when not originally provided
+		await waitFor( () =>
+			expect( triggerFetch ).toHaveBeenCalledWith( {
+				path: '/wp/v2/posts?context=edit',
+			} )
+		);
+	} );
+
+	it( 'avoids duplicate _links when already present in _fields', async () => {
+		// Mock the API response
+		triggerFetch.mockImplementation( () => TEST_RECORDS );
+
+		const fieldsWithLinks = fieldsFromMock + ',_links';
+		const TestComponent = () => {
+			useEntityRecordsWithPermissions( 'postType', 'post', {
+				_fields: fieldsWithLinks,
+			} );
+			return <div />;
+		};
+		render(
+			<RegistryProvider value={ registry }>
+				<TestComponent />
+			</RegistryProvider>
+		);
+
+		// Should not duplicate _links (deduplication working correctly)
+		await waitFor( () =>
+			expect( triggerFetch ).toHaveBeenCalledWith( {
+				path: `/wp/v2/posts?context=edit&_fields=${ encodeURIComponent(
+					fieldsWithLinks
+				) }`,
+			} )
+		);
 	} );
 } );

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -168,7 +168,15 @@ export function useEntityRecordsWithPermissions< RecordType >(
 	const { records: data, ...ret } = useEntityRecords(
 		kind,
 		name,
-		queryArgs,
+		{
+			...queryArgs,
+			// If _fields is provided, we need to include _links in the request for permission caching to work.
+			...( queryArgs._fields
+				? {
+						_fields: `${ queryArgs._fields },_links`,
+				  }
+				: {} ),
+		},
 		options
 	);
 	const ids = useMemo(

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -14,6 +14,7 @@ import { store as coreStore } from '../';
 import type { Options } from './use-entity-record';
 import type { Status } from './constants';
 import { unlock } from '../lock-unlock';
+import { getNormalizedCommaSeparable } from '../utils';
 
 interface EntityRecordsResolution< RecordType > {
 	/** The requested entity record */
@@ -173,7 +174,14 @@ export function useEntityRecordsWithPermissions< RecordType >(
 			// If _fields is provided, we need to include _links in the request for permission caching to work.
 			...( queryArgs._fields
 				? {
-						_fields: `${ queryArgs._fields },_links`,
+						_fields: [
+							...new Set( [
+								...( getNormalizedCommaSeparable(
+									queryArgs._fields
+								) || [] ),
+								'_links',
+							] ),
+						].join(),
 				  }
 				: {} ),
 		},

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -368,11 +368,16 @@ export const getEntityRecords =
 				// See https://github.com/WordPress/gutenberg/pull/70738
 				if ( ! query.context ) {
 					const targetHints = records
-						.filter( ( record ) => record?.[ key ] )
+						.filter(
+							( record ) =>
+								!! record?.[ key ] &&
+								!! record?._links?.self?.[ 0 ]?.targetHints
+									?.allow
+						)
 						.map( ( record ) => ( {
 							id: record[ key ],
 							permissions: getUserPermissionsFromAllowHeader(
-								record?._links?.self?.[ 0 ]?.targetHints?.allow
+								record._links.self[ 0 ].targetHints.allow
 							),
 						} ) );
 

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -400,13 +400,15 @@ export const getEntityRecords =
 						}
 					}
 
-					dispatch.receiveUserPermissions(
-						receiveUserPermissionArgs
-					);
-					dispatch.finishResolutions(
-						'canUser',
-						canUserResolutionsArgs
-					);
+					if ( targetHints.length > 0 ) {
+						dispatch.receiveUserPermissions(
+							receiveUserPermissionArgs
+						);
+						dispatch.finishResolutions(
+							'canUser',
+							canUserResolutionsArgs
+						);
+					}
 
 					if ( ! query?._fields ) {
 						dispatch.finishResolutions(

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -365,6 +365,7 @@ export const getEntityRecords =
 				// the `getEntityRecord` and `canUser` selectors in addition to `getEntityRecords`.
 				// See https://github.com/WordPress/gutenberg/pull/26575
 				// See https://github.com/WordPress/gutenberg/pull/64504
+				// See https://github.com/WordPress/gutenberg/pull/70738
 				if ( ! query.context ) {
 					const targetHints = records
 						.filter( ( record ) => record?.[ key ] )

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -365,13 +365,13 @@ export const getEntityRecords =
 				// the `getEntityRecord` and `canUser` selectors in addition to `getEntityRecords`.
 				// See https://github.com/WordPress/gutenberg/pull/26575
 				// See https://github.com/WordPress/gutenberg/pull/64504
-				if ( ! query?._fields && ! query.context ) {
+				if ( ! query.context ) {
 					const targetHints = records
 						.filter( ( record ) => record?.[ key ] )
 						.map( ( record ) => ( {
 							id: record[ key ],
 							permissions: getUserPermissionsFromAllowHeader(
-								record?._links?.self?.[ 0 ].targetHints.allow
+								record?._links?.self?.[ 0 ]?.targetHints?.allow
 							),
 						} ) );
 
@@ -398,13 +398,16 @@ export const getEntityRecords =
 						receiveUserPermissionArgs
 					);
 					dispatch.finishResolutions(
-						'getEntityRecord',
-						getResolutionsArgs( records )
-					);
-					dispatch.finishResolutions(
 						'canUser',
 						canUserResolutionsArgs
 					);
+
+					if ( ! query?._fields ) {
+						dispatch.finishResolutions(
+							'getEntityRecord',
+							getResolutionsArgs( records )
+						);
+					}
 				}
 
 				dispatch.__unstableReleaseStoreLock( lock );

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -135,6 +135,12 @@ describe( 'getEntityRecords', () => {
 			baseURL: '/wp/v2/types',
 			baseURLParams: { context: 'edit' },
 		},
+		{
+			name: 'post',
+			kind: 'postType',
+			baseURL: '/wp/v2/posts',
+			baseURLParams: { context: 'edit' },
+		},
 	];
 	const registry = { batch: ( callback ) => callback() };
 	const resolveSelect = { getEntitiesConfig: jest.fn( () => ENTITIES ) };
@@ -246,9 +252,11 @@ describe( 'getEntityRecords', () => {
 		} );
 
 		// Provide response with _links structure
-		const postTypesWithLinks = {
-			post: {
-				slug: 'post',
+		const postsWithLinks = [
+			{
+				id: 1,
+				title: 'Hello World',
+				slug: 'hello-world',
 				_links: {
 					self: [
 						{
@@ -259,10 +267,13 @@ describe( 'getEntityRecords', () => {
 					],
 				},
 			},
-		};
-		triggerFetch.mockImplementation( () => postTypesWithLinks );
+		];
 
-		await getEntityRecords( 'postType', 'post', { _fields: 'slug,_links' } )( {
+		triggerFetch.mockImplementation( () => postsWithLinks );
+
+		await getEntityRecords( 'postType', 'post', {
+			_fields: Object.keys( postsWithLinks[ 0 ] ).join( ',' ),
+		} )( {
 			dispatch,
 			registry,
 			resolveSelect,
@@ -276,6 +287,49 @@ describe( 'getEntityRecords', () => {
 		);
 
 		// But individual entity records should NOT be marked as resolved
+		expect( finishResolutions ).not.toHaveBeenCalledWith(
+			'getEntityRecord',
+			expect.any( Array )
+		);
+	} );
+
+	it( 'does not cache permissions when _links field is missing from response', async () => {
+		const finishResolutions = jest.fn();
+		const dispatch = Object.assign( jest.fn(), {
+			receiveEntityRecords: jest.fn(),
+			receiveUserPermissions: jest.fn(),
+			__unstableAcquireStoreLock: jest.fn(),
+			__unstableReleaseStoreLock: jest.fn(),
+			finishResolutions,
+		} );
+
+		// Provide response without _links structure
+		const postsWithoutLinks = [
+			{
+				id: 1,
+				title: 'Hello World',
+				slug: 'hello-world',
+			},
+		];
+
+		triggerFetch.mockImplementation( () => postsWithoutLinks );
+
+		await getEntityRecords( 'postType', 'post', {
+			_fields: Object.keys( postsWithoutLinks[ 0 ] ).join( ',' ),
+		} )( {
+			dispatch,
+			registry,
+			resolveSelect,
+		} );
+
+		// Permissions should NOT have been cached
+		expect( dispatch.receiveUserPermissions ).not.toHaveBeenCalled();
+		expect( finishResolutions ).not.toHaveBeenCalledWith(
+			'canUser',
+			expect.any( Array )
+		);
+
+		// Individual entity records should NOT be marked as resolved
 		expect( finishResolutions ).not.toHaveBeenCalledWith(
 			'getEntityRecord',
 			expect.any( Array )

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -262,7 +262,7 @@ describe( 'getEntityRecords', () => {
 		};
 		triggerFetch.mockImplementation( () => postTypesWithLinks );
 
-		await getEntityRecords( 'root', 'postType', { _fields: 'slug' } )( {
+		await getEntityRecords( 'postType', 'post', { _fields: 'slug,_links' } )( {
 			dispatch,
 			registry,
 			resolveSelect,

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -234,6 +234,53 @@ describe( 'getEntityRecords', () => {
 			[ ENTITIES[ 1 ].kind, ENTITIES[ 1 ].name, 2 ],
 		] );
 	} );
+
+	it( 'caches permissions but does not mark entity records as resolved when using _fields', async () => {
+		const finishResolutions = jest.fn();
+		const dispatch = Object.assign( jest.fn(), {
+			receiveEntityRecords: jest.fn(),
+			receiveUserPermissions: jest.fn(),
+			__unstableAcquireStoreLock: jest.fn(),
+			__unstableReleaseStoreLock: jest.fn(),
+			finishResolutions,
+		} );
+
+		// Provide response with _links structure
+		const postTypesWithLinks = {
+			post: {
+				slug: 'post',
+				_links: {
+					self: [
+						{
+							targetHints: {
+								allow: [ 'GET', 'POST', 'PUT', 'DELETE' ],
+							},
+						},
+					],
+				},
+			},
+		};
+		triggerFetch.mockImplementation( () => postTypesWithLinks );
+
+		await getEntityRecords( 'root', 'postType', { _fields: 'slug' } )( {
+			dispatch,
+			registry,
+			resolveSelect,
+		} );
+
+		// Permissions should have been cached
+		expect( dispatch.receiveUserPermissions ).toHaveBeenCalled();
+		expect( finishResolutions ).toHaveBeenCalledWith(
+			'canUser',
+			expect.any( Array )
+		);
+
+		// But individual entity records should NOT be marked as resolved
+		expect( finishResolutions ).not.toHaveBeenCalledWith(
+			'getEntityRecord',
+			expect.any( Array )
+		);
+	} );
 } );
 
 describe( 'getEmbedPreview', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Enhances `core-data`'s resolver to allow caching entity permissions if the data is available, even if the entity is not complete.

<!-- In a few words, what is the PR actually doing? -->

## Why?
Currently, when useEntityRecordsWithPermissions is called with a _fields parameter, permission caching is disabled. For example, if we optimize the post list experiment to only include the fields that are present in the view, this results in individual OPTIONS requests being made for each entity record to check permissions.



## How?
By caching permissions from the `_links.targetHints.allow` data already present in the response, eliminating the need for separate OPTIONS requests when using `_fields`.

## Testing Instructions
1. Test #70744 and verify in the network console that it's firing one OPTIONS request per post in the table
2. Combine both PRs and verify that the OPTIONS requests are not happening anymore 

## Screenshots or screencast <!-- if applicable -->
Post list experiment currently:
<img width="892" height="90" alt="image" src="https://github.com/user-attachments/assets/faf1c3fd-9722-4bdd-831b-e054261de309" />

When we optimize the post list experiment as in #70744, the size of the request with the posts query is much smaller, as it doesn't contain unnecessary data like all the posts' content, but we see an OPTIONS request per post:

<img width="886" height="491" alt="image" src="https://github.com/user-attachments/assets/4dc12677-f6ac-4863-a1d0-1924e20aa43c" />

Once we apply the changes to the resolver in this PR, we only see the original two requests plus a third one that fetches the selected post to preview it, without the options requests:
<img width="892" height="103" alt="image" src="https://github.com/user-attachments/assets/719f5828-ac82-4a4f-9a2b-88ca5e23a7ee" />
