### PR TITLE
Post Featured Image: Ensure block respects placeholder minimum size in editor

### DIFF
--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -88,6 +88,13 @@
 		}
 	}
 
+	// Prevent the block from shrinking below the minimum
+	// placholder dimensions when no featured image is present.
+	&[style*="height"]:has(.components-placeholder) {
+		min-height: $grid-unit-60;
+		min-width: $grid-unit-60;
+	}
+
 	// Provide a minimum size for the placeholder when resized.
 	// Note, this should be as small as we can afford it, and exists only
 	// to ensure there's room for the upload button.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Related #56656 

<!-- In a few words, what is the PR actually doing? -->
This PR ensures that the 'Post Featured Image' block respects the placeholder's minimum size in the editor when no image is present.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
As mentioned in the [original issue discussion](https://github.com/WordPress/gutenberg/issues/56656#issuecomment-3078289034), if the block’s dimensions are set smaller than the placeholder’s minimum size, the block itself shrinks, causing the placeholder to overflow and overlap adjacent elements. This leads to inconsistent layout behaviour in the editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Added a CSS rule to enforce `min-width` and `min-height` on the block only when the placeholder is present. This prevents the block from shrinking below the placeholder's intended minimum dimensions.

## Testing Instructions
1. Insert a Query Loop block with a Featured Image block.
2. Set the featured image block’s size to something smaller than 48px (e.g., 38x38) via block settings.
3. Confirm:
    - When no featured image is selected, the block remains at least 48x48 (or the minimum set dimension for image placeholder).
    - The placeholder does not overlap adjacent elements.
4. Add a featured image for the post in the query.
5. Confirm:
    - The image block respects the user-defined small size (e.g., 38x38).
    - There are no overlaps.
6. Layout is consistent between placeholder and image states.

<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="380" height="154" alt="Screenshot 2025-07-16 at 5 35 43 PM" src="https://github.com/user-attachments/assets/8370acc2-c746-47a5-a384-90cd14beca27" />|<img width="386" height="162" alt="Screenshot 2025-07-16 at 5 42 14 PM" src="https://github.com/user-attachments/assets/4815382d-9ddb-4e21-83be-fea9abf6d1a2" />|
