### PR TITLE
Post/Pages List: Add `_fields` to the posts query

### DIFF
--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -297,17 +297,32 @@ export default function PostList( { postType } ) {
 			filters.status = DEFAULT_STATUSES;
 		}
 
+		// We will only request the fields that are needed for the current view.
+		const fieldIds = fields?.map( ( field ) => field.id ) || [];
+		const essentialFields = [
+			'id', // Required by getItemId() and navigation
+			'status', // Required by isItemClickable()
+			'_links', // Required for permission caching (targetHints.allow)
+		];
+
+		if ( view.showLevels ) {
+			essentialFields.push( 'level' );
+		}
+
+		const allFields = [ ...new Set( [ ...essentialFields, ...fieldIds ] ) ];
+
 		return {
 			per_page: view.perPage,
 			page: view.page,
 			_embed: 'author',
+			_fields: allFields.join( ',' ),
 			order: view.sort?.direction,
 			orderby: view.sort?.field,
 			orderby_hierarchy: !! view.showLevels,
 			search: view.search,
 			...filters,
 		};
-	}, [ view, activeView, defaultViews ] );
+	}, [ view, activeView, defaultViews, fields ] );
 	const {
 		records,
 		isResolving: isLoadingData,

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -27,6 +27,8 @@ import {
 import {
 	OPERATOR_IS_ANY,
 	OPERATOR_IS_NONE,
+	OPERATOR_IS,
+	OPERATOR_IS_NOT,
 	LAYOUT_LIST,
 } from '../../utils/constants';
 
@@ -106,11 +108,12 @@ function useView( postType ) {
 		}
 
 		const type = layout ?? initialView.type;
-		return {
+		const result = {
 			...initialView,
 			type,
 			...defaultLayouts[ type ],
 		};
+		return result;
 	} );
 
 	const setViewWithUrlUpdate = useEvent( ( newView ) => {
@@ -264,6 +267,17 @@ export default function PostList( { postType } ) {
 			) {
 				filters.author_exclude = filter.value;
 			}
+			if (
+				filter.field === 'parent' &&
+				filter.operator === OPERATOR_IS
+			) {
+				filters.parent = filter.value;
+			} else if (
+				filter.field === 'parent' &&
+				filter.operator === OPERATOR_IS_NOT
+			) {
+				filters.parent_exclude = filter.value;
+			}
 		} );
 
 		// The bundled views want data filtered without displaying the filter.
@@ -302,7 +316,25 @@ export default function PostList( { postType } ) {
 		const essentialFields = [
 			'id', // Required by getItemId() and navigation
 			'status', // Required by isItemClickable()
-			'_links', // Required for permission caching (targetHints.allow)
+			'type', // Required by post actions and navigation
+			// '_links' is automatically added by useEntityRecordsWithPermissions
+			// 'permissions' is automatically added by useEntityRecordsWithPermissions
+			// Action-specific fields (could be fetched on-demand instead):
+			'link', // Required by post actions (view-post)
+			'is_custom', // Required by post actions (rename-post, delete-post)
+			'has_theme_file', // Required by post actions (delete-post)
+			'content', // Required by post actions (duplicate-post)
+			'excerpt', // Required by post actions (duplicate-post)
+			'title', // Required by post actions (duplicate-post)
+			'comment_status', // Required by post actions (duplicate-post)
+			'meta', // Required by post actions (duplicate-post)
+			'parent', // Required by post actions (duplicate-post)
+			'password', // Required by post actions (duplicate-post)
+			'template', // Required by post actions (duplicate-post)
+			'format', // Required by post actions (duplicate-post)
+			'featured_media', // Required by post actions (duplicate-post)
+			'menu_order', // Required by post actions (duplicate-post)
+			'ping_status', // Required by post actions (duplicate-post)
 		];
 
 		if ( view.showLevels ) {


### PR DESCRIPTION
Depends on #70789 

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Improves the pages/posts list performance by limiting the query to the fields that are needed. 

<!-- In a few words, what is the PR actually doing? -->

## Why?
To improve performance, as we avoid fetching unnecessary fields like the post content.

## How?
Leveraging `_fields` in the posts query, including a minimum set of required fields plus those fields present in the current view.

## Testing Instructions
1. Go to the posts list experiment, or to the pages list in the site editor
2. Test that it's working with no errors
3. In the network tab of the browser, verify that the request that queries the posts is smaller in size and faster.

## Screenshots or screencast <!-- if applicable -->
Before, the posts query fetches the default fields, including the post content, for all posts on the first page of the dataview
<img width="882" height="153" alt="image" src="https://github.com/user-attachments/assets/84321e3e-5034-4f28-b9e0-2848ce9a7a9d" />

After, it will only fetch the required fields, plus an extra request to fetch the whole selected post to preview it:
<img width="890" height="128" alt="image" src="https://github.com/user-attachments/assets/62fcf3df-1bd3-4143-a25a-71721758a7f1" />

Note:
Depends on #70738; until it lands, permissions are not properly cached, and there will be one extra OPTIONS request per post in the dataview to check permissions.