### PR TITLE
Improving Gitignore for files related to applying patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ test/gutenberg-test-themes/twentytwentyone
 test/gutenberg-test-themes/twentytwentythree
 test/gutenberg-test-themes/twentytwentyfour
 packages/react-native-editor/src/setup-local.js
+
+# Files related to applying patches
+*.rej
+*.orig


### PR DESCRIPTION
[Similarly to Core](https://github.com/SirLouen/wordpress-develop/blob/8900f0a1c397c0dfab1c098308eb22ba6a1669f3/.gitignore#L97-L99), when applying patches with something like:

```
gh pr diff $1 --repo=WordPress/gutenberg | patch -p1
```

`orig`and `rej` files could appear (depending on whether the patch applies or not) 

It would be great to remove them with `.gitignore`

Closes #70742 