### PR TITLE
Navigation Link: Fix URL deletion in Inspector Controls

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -175,8 +175,9 @@ function getMissingText( type ) {
  * packages/block-library/src/navigation-submenu/edit.js
  * Consider reusing this components for both blocks.
  */
-function Controls( { attributes, setAttributes, setIsLabelFieldFocused } ) {
+function Controls( { attributes, setAttributes, setIsEditingControl } ) {
 	const { label, url, description, rel, opensInNewTab } = attributes;
+	const lastURLRef = useRef( url );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	return (
 		<ToolsPanel
@@ -207,8 +208,8 @@ function Controls( { attributes, setAttributes, setIsLabelFieldFocused } ) {
 						setAttributes( { label: labelValue } );
 					} }
 					autoComplete="off"
-					onFocus={ () => setIsLabelFieldFocused( true ) }
-					onBlur={ () => setIsLabelFieldFocused( false ) }
+					onFocus={ () => setIsEditingControl( true ) }
+					onBlur={ () => setIsEditingControl( false ) }
 				/>
 			</ToolsPanelItem>
 
@@ -232,6 +233,20 @@ function Controls( { attributes, setAttributes, setIsLabelFieldFocused } ) {
 					} }
 					autoComplete="off"
 					type="url"
+					onFocus={ () => {
+						lastURLRef.current = url;
+						setIsEditingControl( true );
+					} }
+					onBlur={ () => {
+						if ( ! url && lastURLRef.current ) {
+							updateAttributes(
+								{ url: lastURLRef.current },
+								setAttributes,
+								attributes
+							);
+						}
+						setIsEditingControl( false );
+					} }
 				/>
 			</ToolsPanelItem>
 
@@ -327,9 +342,10 @@ export default function NavigationLinkEdit( {
 	const linkUIref = useRef();
 	const prevUrl = usePrevious( url );
 
-	// Change the label using inspector causes rich text to change focus on firefox.
-	// This is a workaround to keep the focus on the label field when label filed is focused we don't render the rich text.
-	const [ isLabelFieldFocused, setIsLabelFieldFocused ] = useState( false );
+	// Change the `label` and `url` using inspector causes RichText to change focus.
+	// This is a workaround to keep the focus on the field when it's focused we don't render the RichText.
+	// See: https://github.com/WordPress/gutenberg/pull/61374.
+	const [ isEditingControl, setIsEditingControl ] = useState( false );
 
 	const {
 		isAtMaxNesting,
@@ -564,14 +580,14 @@ export default function NavigationLinkEdit( {
 				<Controls
 					attributes={ attributes }
 					setAttributes={ setAttributes }
-					setIsLabelFieldFocused={ setIsLabelFieldFocused }
+					setIsEditingControl={ setIsEditingControl }
 				/>
 			</InspectorControls>
 			<div { ...blockProps }>
 				{ /* eslint-disable jsx-a11y/anchor-is-valid */ }
 				<a className={ classes }>
 					{ /* eslint-enable */ }
-					{ ! url ? (
+					{ ! url && ! isEditingControl ? (
 						<div className="wp-block-navigation-link__placeholder-text">
 							<span>{ missingText }</span>
 						</div>
@@ -579,7 +595,7 @@ export default function NavigationLinkEdit( {
 						<>
 							{ ! isInvalid &&
 								! isDraft &&
-								! isLabelFieldFocused && (
+								! isEditingControl && (
 									<>
 										<RichText
 											ref={ ref }
@@ -613,9 +629,7 @@ export default function NavigationLinkEdit( {
 										) }
 									</>
 								) }
-							{ ( isInvalid ||
-								isDraft ||
-								isLabelFieldFocused ) && (
+							{ ( isInvalid || isDraft || isEditingControl ) && (
 								<div
 									className={ clsx(
 										'wp-block-navigation-link__placeholder-text',

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -225,11 +225,9 @@ function Controls( { attributes, setAttributes, setIsEditingControl } ) {
 					label={ __( 'Link' ) }
 					value={ url ? safeDecodeURI( url ) : '' }
 					onChange={ ( urlValue ) => {
-						updateAttributes(
-							{ url: urlValue },
-							setAttributes,
-							attributes
-						);
+						setAttributes( {
+							url: encodeURI( safeDecodeURI( urlValue ) ),
+						} );
 					} }
 					autoComplete="off"
 					type="url"
@@ -238,13 +236,12 @@ function Controls( { attributes, setAttributes, setIsEditingControl } ) {
 						setIsEditingControl( true );
 					} }
 					onBlur={ () => {
-						if ( ! url && lastURLRef.current ) {
-							updateAttributes(
-								{ url: lastURLRef.current },
-								setAttributes,
-								attributes
-							);
-						}
+						// Defer the updateAttributes call to ensure entity connection isn't severed by accident.
+						updateAttributes(
+							{ url: ! url ? lastURLRef.current : url },
+							setAttributes,
+							{ ...attributes, url: lastURLRef.current }
+						);
 						setIsEditingControl( false );
 					} }
 				/>

--- a/packages/block-library/src/navigation-link/update-attributes.js
+++ b/packages/block-library/src/navigation-link/update-attributes.js
@@ -125,7 +125,7 @@ export const updateAttributes = (
 	const {
 		title: newLabel = '', // the title of any provided Post.
 		label: newLabelFromLabel = '', // alternative to title
-		url: newUrl = '',
+		url: newUrl,
 		opensInNewTab,
 		id: newID,
 		kind: newKind = originalKind,
@@ -136,7 +136,7 @@ export const updateAttributes = (
 	const finalNewLabel = newLabel || newLabelFromLabel;
 
 	const newLabelWithoutHttp = finalNewLabel.replace( /http(s?):\/\//gi, '' );
-	const newUrlWithoutHttp = newUrl.replace( /http(s?):\/\//gi, '' );
+	const newUrlWithoutHttp = newUrl?.replace( /http(s?):\/\//gi, '' ) ?? '';
 
 	const useNewLabel =
 		finalNewLabel &&
@@ -174,7 +174,9 @@ export const updateAttributes = (
 
 	const attributes = {
 		// Passed `url` may already be encoded. To prevent double encoding, decodeURI is executed to revert to the original string.
-		...{ url: newUrl ? encodeURI( safeDecodeURI( newUrl ) ) : newUrl },
+		...( newUrl !== undefined
+			? { url: newUrl ? encodeURI( safeDecodeURI( newUrl ) ) : newUrl }
+			: {} ),
 		...( label && { label } ),
 		...( undefined !== opensInNewTab && { opensInNewTab } ),
 		...( kind && { kind } ),

--- a/packages/block-library/src/navigation-link/update-attributes.js
+++ b/packages/block-library/src/navigation-link/update-attributes.js
@@ -174,7 +174,7 @@ export const updateAttributes = (
 
 	const attributes = {
 		// Passed `url` may already be encoded. To prevent double encoding, decodeURI is executed to revert to the original string.
-		...( newUrl && { url: encodeURI( safeDecodeURI( newUrl ) ) } ),
+		...{ url: newUrl ? encodeURI( safeDecodeURI( newUrl ) ) : newUrl },
 		...( label && { label } ),
 		...( undefined !== opensInNewTab && { opensInNewTab } ),
 		...( kind && { kind } ),


### PR DESCRIPTION
## What?
Closes #60758.

PR  fixes a bug for the Navigation Link control and allows deleting the last character in the URL control.

## Why?
The user should be able to modify the URL entirely via the inspector controls.

## How?
Reuse workaround for `label` controls.

## Testing Instructions
1. Open a post or page.
2. Insert a Navigation block.
3. Add a new custom link menu item.
4. Open the settings sidebar.
5. Try to remove the URL via the text field in the sidebar.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/e839f9ea-830c-4841-b68f-b51d03c601f5


