### PR TITLE
Blocks: Set default 'apiVersion' for client-side registration

### DIFF
--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking changes
+
+-   `registerBlockType`: Set default `apiVersion` when none is provided during client-side block registration ([#70750](https://github.com/WordPress/gutenberg/pull/70750)).
+
 ## 14.15.0 (2025-06-25)
 
 ## 14.14.0 (2025-06-04)

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -141,6 +141,7 @@ describe( 'blocks', () => {
 			);
 			expect( console ).not.toHaveWarned();
 			expect( block ).toEqual( {
+				apiVersion: 1,
 				name: 'my-plugin/fancy-block-4',
 				icon: { src: BLOCK_ICON_DEFAULT },
 				attributes: {},
@@ -287,6 +288,7 @@ describe( 'blocks', () => {
 			} );
 
 			expect( getBlockType( 'core/test-block-with-defaults' ) ).toEqual( {
+				apiVersion: 1,
 				name: 'core/test-block-with-defaults',
 				title: 'block title',
 				category: 'text',
@@ -319,6 +321,7 @@ describe( 'blocks', () => {
 			registerBlockType( 'core/test-block-with-attributes', blockType );
 			expect( getBlockType( 'core/test-block-with-attributes' ) ).toEqual(
 				{
+					apiVersion: 1,
 					name: 'core/test-block-with-attributes',
 					settingName: 'settingValue',
 					save: noop,
@@ -359,6 +362,7 @@ describe( 'blocks', () => {
 			};
 			registerBlockType( blockName, blockType );
 			expect( getBlockType( blockName ) ).toEqual( {
+				apiVersion: 1,
 				name: blockName,
 				save: expect.any( Function ),
 				title: 'block title',
@@ -436,6 +440,7 @@ describe( 'blocks', () => {
 			};
 			registerBlockType( blockName, blockType );
 			expect( getBlockType( blockName ) ).toEqual( {
+				apiVersion: 1,
 				name: blockName,
 				save: expect.any( Function ),
 				title: 'block settings merge',
@@ -484,6 +489,7 @@ describe( 'blocks', () => {
 				blockType
 			);
 			expect( getBlockType( blockName ) ).toEqual( {
+				apiVersion: 1,
 				name: blockName,
 				save: expect.any( Function ),
 				title: 'block title',
@@ -543,6 +549,7 @@ describe( 'blocks', () => {
 			expect(
 				getBlockType( 'core/test-block-icon-normalize-element' )
 			).toEqual( {
+				apiVersion: 1,
 				name: 'core/test-block-icon-normalize-element',
 				save: noop,
 				category: 'text',
@@ -587,6 +594,7 @@ describe( 'blocks', () => {
 			expect(
 				getBlockType( 'core/test-block-icon-normalize-string' )
 			).toEqual( {
+				apiVersion: 1,
 				name: 'core/test-block-icon-normalize-string',
 				save: noop,
 				category: 'text',
@@ -634,6 +642,7 @@ describe( 'blocks', () => {
 			expect(
 				getBlockType( 'core/test-block-icon-normalize-function' )
 			).toEqual( {
+				apiVersion: 1,
 				name: 'core/test-block-icon-normalize-function',
 				save: noop,
 				category: 'text',
@@ -681,6 +690,7 @@ describe( 'blocks', () => {
 			expect(
 				getBlockType( 'core/test-block-icon-normalize-background' )
 			).toEqual( {
+				apiVersion: 1,
 				name: 'core/test-block-icon-normalize-background',
 				save: noop,
 				category: 'text',
@@ -724,6 +734,7 @@ describe( 'blocks', () => {
 			registerBlockType( 'core/test-block-with-settings', blockType );
 			blockType.mutated = true;
 			expect( getBlockType( 'core/test-block-with-settings' ) ).toEqual( {
+				apiVersion: 1,
 				name: 'core/test-block-with-settings',
 				settingName: 'settingValue',
 				save: noop,
@@ -757,6 +768,7 @@ describe( 'blocks', () => {
 				'Parent must be undefined or an array of strings (block types), but it is a string.'
 			);
 			expect( block ).toEqual( {
+				apiVersion: 1,
 				name: 'core/test-block-parent-string',
 				save: noop,
 				category: 'text',
@@ -1013,6 +1025,7 @@ describe( 'blocks', () => {
 				}
 			);
 			expect( block ).toEqual( {
+				apiVersion: 1,
 				name: 'test/block-from-metadata',
 				title: 'Block from metadata',
 				category: 'text',
@@ -1081,6 +1094,7 @@ describe( 'blocks', () => {
 			);
 
 			expect( block ).toEqual( {
+				apiVersion: 1,
 				name: 'test/block-from-metadata-i18n',
 				title: 'I18n title from metadata (translated)',
 				description: 'I18n description from metadata (translated)',
@@ -1149,6 +1163,7 @@ describe( 'blocks', () => {
 			registerBlockType( 'core/test-block', defaultBlockSettings );
 			expect( getBlockTypes() ).toEqual( [
 				{
+					apiVersion: 1,
 					name: 'core/test-block',
 					save: noop,
 					category: 'text',
@@ -1168,6 +1183,7 @@ describe( 'blocks', () => {
 			const oldBlock = unregisterBlockType( 'core/test-block' );
 			expect( console ).not.toHaveWarned();
 			expect( oldBlock ).toEqual( {
+				apiVersion: 1,
 				name: 'core/test-block',
 				save: noop,
 				category: 'text',
@@ -1249,6 +1265,7 @@ describe( 'blocks', () => {
 		it( 'should return { name, save } for blocks with minimum settings', () => {
 			registerBlockType( 'core/test-block', defaultBlockSettings );
 			expect( getBlockType( 'core/test-block' ) ).toEqual( {
+				apiVersion: 1,
 				name: 'core/test-block',
 				save: noop,
 				category: 'text',
@@ -1275,6 +1292,7 @@ describe( 'blocks', () => {
 			};
 			registerBlockType( 'core/test-block-with-settings', blockType );
 			expect( getBlockType( 'core/test-block-with-settings' ) ).toEqual( {
+				apiVersion: 1,
 				name: 'core/test-block-with-settings',
 				settingName: 'settingValue',
 				save: noop,
@@ -1310,6 +1328,7 @@ describe( 'blocks', () => {
 			registerBlockType( 'core/test-block-with-settings', blockType );
 			expect( getBlockTypes() ).toEqual( [
 				{
+					apiVersion: 1,
 					name: 'core/test-block',
 					save: noop,
 					category: 'text',
@@ -1326,6 +1345,7 @@ describe( 'blocks', () => {
 					blockHooks: {},
 				},
 				{
+					apiVersion: 1,
 					name: 'core/test-block-with-settings',
 					settingName: 'settingValue',
 					save: noop,

--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -78,6 +78,7 @@ export const processBlockType =
 		const bootstrappedBlockType = select.getBootstrappedBlockType( name );
 
 		const blockType = {
+			apiVersion: 1,
 			name,
 			icon: BLOCK_ICON_DEFAULT,
 			keywords: [],


### PR DESCRIPTION
## What?
PR updates block type processing helper function and sets the default - `apiVersion: 1`.

## Why?
* Ensures `apiVersion` is always defined during block registration.
* Matches the defaults provided by the server. Sources: [one](https://github.com/WordPress/wordpress-develop/blob/d6b7ae50e532749c7edbe26a6a9ccef94a98ff59/src/wp-includes/class-wp-block-type.php#L20-L26) and [two](https://github.com/WordPress/wordpress-develop/blob/d6b7ae50e532749c7edbe26a6a9ccef94a98ff59/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php#L484-L490).

## Testing Instructions
1. Open a post or page.
2. Do a client-side block registration via the `registerBlockType` function.
3. Confirm that the registered block has the default `apiVersion` set - `wp.blocks.getBlockType( 'test/block-api-version' );`.

### Example Block

```js
const { createElement: el } = wp.element;
const { registerBlockType } = wp.blocks;
const { useBlockProps } = wp.blockEditor;

registerBlockType( 'test/block-api-version', {
	apiVersion: 3,
	title: 'Test Block: apiVersion',
	icon: 'list-view',
	category: 'text',

	edit: function Edit() {
		const blockProps = useBlockProps();

		return el(
			'div',
			{ ...blockProps },
			'hello'
		);
	},
} );
```

### Testing Instructions for Keyboard
Same.
