### PR TITLE
Update Icon component to support bundled dataviews package

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,7 +12,7 @@
 -   `SelectControl`: Fix font-size for medium screens to ensure consistency with other inputs ([#70619](https://github.com/WordPress/gutenberg/pull/70619)).
 -   `SelectControl`: Move classnames to the root ([#70643](https://github.com/WordPress/gutenberg/pull/70643)).
 -   `Autocomplete`: Prevent text cursor position loss when clicking to insert an item ([#70660](https://github.com/WordPress/gutenberg/pull/70660)).
--   Fix the rendering of icons from bundled `DataViews` packages ([#70756](https://github.com/WordPress/gutenberg/pull/70756)).
+-   `Icon`: Pass `size` prop value as `width`/`height` attributes when `icon` is a JSX element that doesn't exactly match type `svg` or `SVG` ([#70756](https://github.com/WordPress/gutenberg/pull/70756)).
 
 
 ### Internal

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,8 @@
 -   `SelectControl`: Fix font-size for medium screens to ensure consistency with other inputs ([#70619](https://github.com/WordPress/gutenberg/pull/70619)).
 -   `SelectControl`: Move classnames to the root ([#70643](https://github.com/WordPress/gutenberg/pull/70643)).
 -   `Autocomplete`: Prevent text cursor position loss when clicking to insert an item ([#70660](https://github.com/WordPress/gutenberg/pull/70660)).
+-   Fix the rendering of icons from bundled `DataViews` packages ([#70756](https://github.com/WordPress/gutenberg/pull/70756)).
+
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   `Icon`: Pass `size` prop value as `width`/`height` attributes when `icon` is a component that doesn't exactly match `SVG` ([#70756](https://github.com/WordPress/gutenberg/pull/70756)).
+
 ### Internal
 
 -   Add new validated form controls (work in progress, not exported): `ValidatedCheckboxControl`, `ValidatedInputControl`, `ValidatedNumberControl`, `ValidatedRadioControl`, `ValidatedRangeControl`, `ValidatedSelectControl`, `ValidatedTextControl`, `ValidatedTextareaControl`, `ValidatedToggleControl`, `ValidatedCustomSelectControl`, `ValidatedComboboxControl`, `ValidatedToggleGroupControl`, and `ControlWithError` for enhanced form validation capabilities ([#70620](https://github.com/WordPress/gutenberg/pull/70620)).
@@ -12,7 +16,6 @@
 -   `SelectControl`: Fix font-size for medium screens to ensure consistency with other inputs ([#70619](https://github.com/WordPress/gutenberg/pull/70619)).
 -   `SelectControl`: Move classnames to the root ([#70643](https://github.com/WordPress/gutenberg/pull/70643)).
 -   `Autocomplete`: Prevent text cursor position loss when clicking to insert an item ([#70660](https://github.com/WordPress/gutenberg/pull/70660)).
--   `Icon`: Pass `size` prop value as `width`/`height` attributes when `icon` is a JSX element that doesn't exactly match type `svg` or `SVG` ([#70756](https://github.com/WordPress/gutenberg/pull/70756)).
 
 
 ### Internal

--- a/packages/components/src/icon/index.tsx
+++ b/packages/components/src/icon/index.tsx
@@ -107,6 +107,8 @@ function Icon( {
 		return cloneElement( icon, {
 			// @ts-ignore Just forwarding the size prop along
 			size,
+			width: size,
+			height: size,
 			...additionalProps,
 		} );
 	}


### PR DESCRIPTION
## What?

When using the DataViews component from `dataviews/wp` in a WordPress plugin, you can end up with icons not rendering properly. The reason is that the package bundles its own version of `components` and `primitives` packages which means that the test to check whether `SVG` component is used fails (two different instances of SVG).

I think that check is fragile to be honest and shouldn't have existed in the first place. We could in theory just pass "height"/"width" too all components (instead of "size") but to avoid disruptions and potential small breaking changes, I kept the "size" passing for now but just added the height/width props that way the rendering is not broken at least..

## Testing instructions

There should be no impact here, but DataViews actions would look properly if used in a plugin.