### PR TITLE
Fix/add redirect url

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -292,7 +292,7 @@ A form. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/blo
 -	**Category:** common
 -	**Allowed Blocks:** core/paragraph, core/heading, core/form-input, core/form-submit-button, core/form-submission-notification, core/group, core/columns
 -	**Supports:** anchor, color (background, gradients, link, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~className~~
--	**Attributes:** action, email, method, submissionMethod
+-	**Attributes:** action, email, method, redirectUrl, submissionMethod
 
 ## Input Field
 

--- a/packages/block-library/src/form/block.json
+++ b/packages/block-library/src/form/block.json
@@ -32,6 +32,10 @@
 		},
 		"email": {
 			"type": "string"
+		},
+		"redirectUrl": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/form/edit.js
+++ b/packages/block-library/src/form/edit.js
@@ -65,10 +65,17 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 			email: undefined,
 			action: undefined,
 			method: 'post',
+			redirectUrl: '',
 		} );
 	};
 
-	const { action, method, email, submissionMethod } = attributes;
+	const {
+		action,
+		method,
+		email,
+		submissionMethod,
+		redirectUrl = '',
+	} = attributes;
 	const blockProps = useBlockProps();
 
 	const { hasInnerBlocks } = useSelect(
@@ -171,6 +178,32 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 							/>
 						</ToolsPanelItem>
 					) }
+					<ToolsPanelItem
+						hasValue={ () => !! redirectUrl }
+						label={ __( 'Redirect URL' ) }
+						onDeselect={ () =>
+							setAttributes( {
+								redirectUrl: '',
+							} )
+						}
+						isShownByDefault
+					>
+						<TextControl
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+							autoComplete="off"
+							label={ __( 'Redirect URL' ) }
+							value={ redirectUrl || '' }
+							required
+							onChange={ ( value ) =>
+								setAttributes( { redirectUrl: value } )
+							}
+							help={ __(
+								'The URL to redirect to after form submission.'
+							) }
+							type="url"
+						/>
+					</ToolsPanelItem>
 				</ToolsPanel>
 			</InspectorControls>
 			{ submissionMethod !== 'email' && (

--- a/packages/block-library/src/form/save.js
+++ b/packages/block-library/src/form/save.js
@@ -5,13 +5,14 @@ import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const blockProps = useBlockProps.save();
-	const { submissionMethod } = attributes;
+	const { submissionMethod, redirectUrl } = attributes;
 
 	return (
 		<form
 			{ ...blockProps }
 			className="wp-block-form"
 			encType={ submissionMethod === 'email' ? 'text/plain' : null }
+			data-redirect-url={ redirectUrl }
 		>
 			<InnerBlocks.Content />
 		</form>

--- a/packages/block-library/src/form/view.js
+++ b/packages/block-library/src/form/view.js
@@ -36,6 +36,10 @@ document.querySelectorAll( 'form.wp-block-form' ).forEach( function ( form ) {
 		formData._wp_http_referer = window.location.href;
 		formData.formAction = form.action;
 
+		// Add redirect URL to form data
+		const redirectUrl = form.getAttribute( 'data-redirect-url' ) || '';
+		formData.redirectUrl = redirectUrl;
+
 		try {
 			const response = await fetch( formSettings.ajaxUrl, {
 				method: 'POST',
@@ -45,7 +49,11 @@ document.querySelectorAll( 'form.wp-block-form' ).forEach( function ( form ) {
 				body: new URLSearchParams( formData ).toString(),
 			} );
 			if ( response.ok ) {
-				redirectNotification( 'success' );
+				if ( redirectUrl ) {
+					window.location.href = redirectUrl;
+				} else {
+					redirectNotification( 'success' );
+				}
 			} else {
 				redirectNotification( 'error' );
 			}


### PR DESCRIPTION
Issues [#58096](https://github.com/WordPress/gutenberg/issues/58096)

## What?
Adds a redirect URL option to the experimental form block, allowing users to specify where visitors should be redirected after successful form submission.

## Why?
Currently, the form block don't supports custom URL after form submission. User need to redirect visitors to custom thank-you pages, confirmation pages, or external URLs after form submission for better user experience and conversion tracking.

## How?
The implementation adds a new `redirectUrl` attribute to the form block with the following components:

## Testing Instructions
- Open a post or page in the block editor
- Insert a Form block from the block inserter
- In the Inspector Controls sidebar, locate the "Redirect URL" field
- Enter a redirect URL (e.g., /thank-you or https://example.com/success)
- Configure form submission method (email) and add a recipient email
- Save the post and view it on the frontend
- Fill out the form and submit it
- Verify that you are redirected to the specified URL after successful submission

## Screenshots or screencast <!-- if applicable -->
<img width="315" height="469" alt="Screenshot 2025-07-17 at 5 25 12 PM" src="https://github.com/user-attachments/assets/92a6c40e-ee05-4a9c-b6d6-735744284c75" />
<img width="293" height="89" alt="Screenshot 2025-07-17 at 5 25 26 PM" src="https://github.com/user-attachments/assets/d75022d3-00d2-4b96-ac46-472fe7429ff5" />
