### PR TITLE
Fix incorrect block icon size on widgets page

### DIFF
--- a/packages/block-editor/src/components/block-icon/content.scss
+++ b/packages/block-editor/src/components/block-icon/content.scss
@@ -5,6 +5,12 @@
 	width: 24px;
 	height: 24px;
 
+	// Prevents the icon image from overflowing the container.
+	img {
+		max-width: 100%;
+		height: auto;
+	}
+
 	&.has-colors {
 		svg {
 			fill: currentColor;

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -309,6 +309,13 @@ $block-inserter-tabs-height: 44px;
 	// see https://github.com/WordPress/gutenberg/issues/24529.
 	max-width: 100%;
 
+	// Avoids large icons for custom block icons.
+	// Needs this rule for fixing size on block widget editor.
+	img {
+		max-width: 100%;
+		height: auto;
+	}
+
 	@include break-medium {
 		width: $block-quick-inserter-width;
 	}

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -309,15 +309,19 @@ $block-inserter-tabs-height: 44px;
 	// see https://github.com/WordPress/gutenberg/issues/24529.
 	max-width: 100%;
 
+	@include break-medium {
+		width: $block-quick-inserter-width;
+	}
+}
+
+.block-editor-inserter__quick-inserter,
+.block-editor-inserter__panel-content,
+.block-editor-inserter__preview-container {
 	// Avoids large icons for custom block icons.
 	// Needs this rule for fixing size on block widget editor.
 	img {
 		max-width: 100%;
 		height: auto;
-	}
-
-	@include break-medium {
-		width: $block-quick-inserter-width;
 	}
 }
 

--- a/packages/edit-widgets/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-widgets/src/components/secondary-sidebar/style.scss
@@ -12,6 +12,12 @@
 	height: calc(100% - #{$button-size} - #{$grid-unit-10});
 	overflow-y: auto;
 	padding: $grid-unit-10;
+
+	// Prevents the icon image from overflowing the container.
+	img {
+		max-width: 100%;
+		height: auto;
+	}
 }
 
 .edit-widgets-editor__list-view-panel-header {


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #70762

This PR prevents overflow of custom block icon in various places on Block Widget editor page.

Currently this behavior is handled by a style on post editor page so the issue isn't visible there

```css
.block-editor__container img {
    max-width: 100%;
    height: auto;
}
```

But when this class isn't present on another page, eg. in widgets editor, the block icons overflow into nearby components

## Why?
As the widgets editor page doesn't have `block-editor__container` class, the block image icons break in block widget editor page 

Ideally, components shouldn't depend on page styles to prevent overflow cases & they need to be handled on component level instead

## How?
This PR adds CSS rules to prevent icon image overflow on component level so they are not dependent on parent style for that edge case

As a result of this, icon overflow is prevented on block widget editor page

## Testing Instructions
1. Register a custom block with custom image icon [my icon was 100x100]
2. Enable a classic theme
3. Go to Appearance -> Widgets ( `/wp-admin/widgets.php` )
4. Open quick inserter & search for your block. Observe that icon looks of correct size
5. Open block inserter using the `+` icon & observe the icon
6. Hover on the icon & look at the block preview, observe icon size there too

## Screenshots or screencast

|Before|After|
|-|-|
Quick inserter
|<img width="492" height="263" alt="image" src="https://github.com/user-attachments/assets/7a11f430-b88b-4cdc-8427-0413cf9499bc" />|<img width="546" height="270" alt="image" src="https://github.com/user-attachments/assets/0a091745-8aa2-4902-a571-cc0cba974520" />|
Inserter from side panel
|<img width="573" height="350" alt="image" src="https://github.com/user-attachments/assets/bafbf6b2-ea5a-4621-9cac-da260ee4d9fc" />|<img width="575" height="351" alt="image" src="https://github.com/user-attachments/assets/dd89b28b-4809-4e20-9011-3012824ca4b9" />|
In list view
|<img width="445" height="278" alt="image" src="https://github.com/user-attachments/assets/b70fb4cd-5a8b-488a-8c6a-a3e481184277" />|<img width="449" height="267" alt="image" src="https://github.com/user-attachments/assets/8ae3abe0-ec3b-4273-a265-a328048f65e9" />|
In block toolbar
|<img width="382" height="140" alt="image" src="https://github.com/user-attachments/assets/4352b562-3454-4878-8e90-559b86c25005" />|<img width="320" height="115" alt="image" src="https://github.com/user-attachments/assets/871f4a82-5fe7-42b4-a18a-aa89e8e65b73" />|