### PR TITLE
Block API: Add attribute role-based filtering to 'isUnmodifiedBlock'

### DIFF
--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -395,7 +395,8 @@ Determines whether the block's attributes are equal to the default attributes wh
 
 _Parameters_
 
--   _block_ `WPBlock`: Block Object
+-   _block_ `WPBlock`: Block Object.
+-   _role_ `?string`: Optional role to filter attributes for modification check.
 
 _Returns_
 
@@ -408,6 +409,7 @@ Determines whether the block is a default block and its attributes are equal to 
 _Parameters_
 
 -   _block_ `WPBlock`: Block Object
+-   _role_ `?string`: Optional role to filter attributes for modification check.
 
 _Returns_
 

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -9,6 +9,7 @@ import {
 	setDefaultBlockName,
 } from '../registration';
 import {
+	isUnmodifiedBlock,
 	isUnmodifiedDefaultBlock,
 	getAccessibleBlockLabel,
 	getBlockLabel,
@@ -433,5 +434,61 @@ describe( 'isContentBlock', () => {
 			title: 'test non-content block',
 		} );
 		expect( isContentBlock( 'core/test-non-content-block' ) ).toBe( false );
+	} );
+} );
+
+describe( 'isUnmodifiedBlock', () => {
+	beforeAll( () => {
+		registerBlockType( 'core/test-block', {
+			attributes: {
+				align: {
+					type: 'string',
+				},
+				includesDefault: {
+					type: 'boolean',
+					default: true,
+				},
+				content: {
+					type: 'string',
+					role: 'content',
+				},
+			},
+			save: noop,
+			category: 'text',
+			title: 'test block',
+		} );
+	} );
+
+	afterAll( () => {
+		unregisterBlockType( 'core/test-block' );
+	} );
+
+	it( 'should return true if all attributes match their defaults', () => {
+		const block = createBlock( 'core/test-block' );
+		expect( isUnmodifiedBlock( block ) ).toBe( true );
+	} );
+
+	it( 'should return false if any attribute does not match its default', () => {
+		const block = createBlock( 'core/test-block', {
+			includesDefault: false,
+		} );
+		expect( isUnmodifiedBlock( block ) ).toBe( false );
+	} );
+
+	it( 'should return true if attributes with a specific role match their defaults', () => {
+		const block = createBlock( 'core/test-block' );
+		expect( isUnmodifiedBlock( block, 'content' ) ).toBe( true );
+	} );
+
+	it( 'should return false if attributes with a specific role do not match their defaults', () => {
+		const block = createBlock( 'core/test-block', {
+			content: 'Updated content',
+		} );
+		expect( isUnmodifiedBlock( block, 'content' ) ).toBe( false );
+	} );
+
+	it( 'should return true if no attributes exist for the specified role', () => {
+		const block = createBlock( 'core/test-block' );
+		expect( isUnmodifiedBlock( block, 'non-existent-role' ) ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
## What?
Related https://github.com/WordPress/gutenberg/pull/70741#discussion_r2210678323.

PR introduces a new optional `role` parameter to the `isUnmodifiedBlock` and `isUnmodifiedDefaultBlock` functions, allowing for more granular checks of block attributes based on their roles.

## Why?
Currently, the block is considered unmodified when all of its attributes are equal to the defaults. While this is a reasonable assumption, there are instances when the block editor must determine whether the block's actual content has been changed.

See: https://github.com/WordPress/gutenberg/pull/70741#discussion_r2210623941.

## Testing Instructions
PR has unit test coverage.

### Testing Instructions for Keyboard
Same.