### PR TITLE
Social Icon: Retire the Skype social service

### DIFF
--- a/packages/block-library/src/social-link/variations.js
+++ b/packages/block-library/src/social-link/variations.js
@@ -258,6 +258,7 @@ const variations = [
 		attributes: { service: 'skype' },
 		title: __( 'Skype' ),
 		icon: SkypeIcon,
+		// Deprecated: Skype service is no longer available.
 		scope: [],
 	},
 	{

--- a/packages/block-library/src/social-link/variations.js
+++ b/packages/block-library/src/social-link/variations.js
@@ -258,6 +258,7 @@ const variations = [
 		attributes: { service: 'skype' },
 		title: __( 'Skype' ),
 		icon: SkypeIcon,
+		scope: [],
 	},
 	{
 		name: 'snapchat',


### PR DESCRIPTION
## What?
Closes #28991.

PR retires the Skype social service as a variation for the Social Icon block by disabling insertion scopes.

Microsoft officially retired Skype early this year, and the service has been unavailable since May. See: https://www.microsoft.com/en-us/microsoft-365/blog/2025/02/28/the-next-chapter-moving-from-skype-to-microsoft-teams/

## Testing Instructions
1. Open a post or page.
2. Insert Social Icons block.
3. Confirm that Skype is no longer available as a Social Icon variation.
4. Confirm that the Skype icon still renders for the previously inserted block.

### Example block

```html
<!-- wp:social-links -->
<ul class="wp-block-social-links"><!-- wp:social-link {"url":"#","service":"wordpress"} /-->
<!-- wp:social-link {"url":"#","service":"bluesky"} /-->
<!-- wp:social-link {"url":"#","service":"skype"} /--></ul>
<!-- /wp:social-links -->
```

### Testing Instructions for Keyboard
Same.

## Screenshot
<img width="850" height="449" alt="CleanShot 2025-07-29 at 11 42 41" src="https://github.com/user-attachments/assets/38aec6ea-42c7-43b2-8c8e-133265c4fca9" />
