### PR TITLE
Headings support for Word Online while pasting.

### DIFF
--- a/packages/blocks/src/api/raw-handling/heading-transformer.js
+++ b/packages/blocks/src/api/raw-handling/heading-transformer.js
@@ -1,0 +1,43 @@
+/**
+ * Transforms paragraphs with heading semantics into proper heading tags.
+ *
+ * This handles cases where content (like from Microsoft Word Online) comes in as
+ * <p> tags with role="heading" and aria-level attributes, and converts them to
+ * proper <h1>, <h2>, etc. tags.
+ *
+ * @param {Node} node The node to check and potentially transform.
+ */
+export default function headingTransformer( node ) {
+	if ( node.nodeType !== node.ELEMENT_NODE ) {
+		return;
+	}
+
+	// Check if this is a paragraph with heading semantics.
+	if (
+		node.tagName === 'P' &&
+		node.getAttribute( 'role' ) === 'heading' &&
+		node.hasAttribute( 'aria-level' )
+	) {
+		const level = parseInt( node.getAttribute( 'aria-level' ), 10 );
+
+		// To ensure valid heading level (1-6).
+		if ( level >= 1 && level <= 6 ) {
+			const headingTag = `H${ level }`;
+			const newHeading = node.ownerDocument.createElement( headingTag );
+
+			// Copying all attributes except role and aria-level.
+			Array.from( node.attributes ).forEach( ( attr ) => {
+				if ( attr.name !== 'role' && attr.name !== 'aria-level' ) {
+					newHeading.setAttribute( attr.name, attr.value );
+				}
+			} );
+
+			while ( node.firstChild ) {
+				newHeading.appendChild( node.firstChild );
+			}
+
+			// Replacing the paragraph with the heading.
+			node.parentNode.replaceChild( newHeading, node );
+		}
+	}
+}

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -34,6 +34,7 @@ import emptyParagraphRemover from './empty-paragraph-remover';
 import slackParagraphCorrector from './slack-paragraph-corrector';
 import isLatexMathMode from './latex-to-math';
 import { createBlock } from '../factory';
+import headingTransformer from './heading-transformer';
 
 const log = ( ...args ) => window?.console?.log?.( ...args );
 
@@ -204,6 +205,7 @@ export function pasteHandler( {
 				figureContentReducer,
 				blockquoteNormaliser(),
 				divNormaliser,
+				headingTransformer,
 			];
 
 			const schema = {

--- a/packages/blocks/src/api/raw-handling/readme.md
+++ b/packages/blocks/src/api/raw-handling/readme.md
@@ -9,19 +9,18 @@ This folder contains all paste specific logic (filters, converters, normalisers.
 | Google Docs      | ✓          | ✓        | ✓     | ✓     | ✓         | ✓     | ✘ [1]               |
 | Apple Pages      | ✓          | ✘ [2]    | ✓     | ✘ [2] | n/a       | ✓     | ✘ [1]               |
 | MS Word          | ✓          | ✓        | ✓     | ✓     | n/a       | ✓     | ✓                   |
-| MS Word Online   | ✓          | ✘ [4]    | ✓     | ✓     | n/a       | ✓     | ✘ [1]               |
+| MS Word Online   | ✓          | ✓        | ✓     | ✓     | n/a       | ✓     | ✘ [1]               |
 | LibreOffice      | ✓          | ✓        | ✓     | ✘ [3] | ✓         | ✓     | ✓                   |
-| Evernote         | ✓          | ✘ [5]    | ✓     | ✓     | ✓         | ✓     | n/a                 |
+| Evernote         | ✓          | ✘ [4]    | ✓     | ✓     | ✓         | ✓     | n/a                 |
 | Markdown         | ✓          | ✓        | ✓     | ✓     | ✓         | ✓     | n/a                 |
-| Legacy WordPress | ✓          | ✓        | ✓     | … [6] | ✓         | ✓     | n/a                 |
+| Legacy WordPress | ✓          | ✓        | ✓     | … [5] | ✓         | ✓     | n/a                 |
 | Web              | ✓          | ✓        | ✓     | ✓     | ✓         | ✓     | n/a                 |
 
 1. Google Docs, Apple Pages and MS Word online don't pass footnote nor endnote information.
 2. Apple Pages does not pass heading and image information.
 3. LibreOffice only provide a local file path, which cannot be accessed in JavaScript for security reasons. Image placeholders will be provided instead. Single images, however, _can_ be copied and pasted without any problem.
-4. Still to do for MS Word Online.
-5. Evernote does not have headings.
-6. For caption and gallery shortcodes, see #2874.
+4. Evernote does not have headings.
+5. For caption and gallery shortcodes, see #2874.
 
 ## Other notable capabilities
 

--- a/test/integration/fixtures/documents/ms-word-online-out.html
+++ b/test/integration/fixtures/documents/ms-word-online-out.html
@@ -1,6 +1,6 @@
-<!-- wp:paragraph -->
-<p>This is a <em>heading</em>&nbsp;</p>
-<!-- /wp:paragraph -->
+<!-- wp:heading {"level":1} -->
+<h1 class="wp-block-heading">This is a <em>heading</em>&nbsp;</h1>
+<!-- /wp:heading -->
 
 <!-- wp:paragraph -->
 <p>This is a <strong>paragraph </strong>with a <a href="https://w.org/" target="_blank" rel="noreferrer noopener">link</a>.&nbsp;</p>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #63824 
This PR adds a paste transformer that correctly maps heading tags from Microsoft Word Online to Gutenberg Heading blocks, instead of defaulting to Paragraph blocks.


<!-- In a few words, what is the PR actually doing? -->

## Why?
Currently, when users copy-paste content from Word Online, all headings are flattened into Paragraph (`<p>`) blocks, resulting in loss of semantic structure. This makes it tedious for users to manually reapply correct heading levels and poses accessibility and SEO issues. This PR improves that flow by preserving the correct heading levels during paste.



## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The transformer scans pasted content for `<p>` tags with role="heading" and aria-level (used by Word Online to represent headings). It replaces them with semantic heading tags based on the aria-level, preserving content and relevant attributes. This ensures correct Heading blocks are generated instead of Paragraph blocks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Create Headings in Word Online using Heading tag at the top.
<img width="420" height="456" alt="image" src="https://github.com/user-attachments/assets/de2475fa-094d-4ba6-abd5-5161705fe5ce" />

2. Use keyboard shortcuts to copy those headings and paste in Block Editor (Ctrl+V or Cmd+V).

2. Use arrow keys to navigate the pasted blocks and ensure that heading blocks are correctly rendered and accessible via keyboard navigation.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

#### Before

https://github.com/user-attachments/assets/341f2ff7-4b1b-408f-9220-322b9eab926f


#### After

https://github.com/user-attachments/assets/88a03548-d434-4fe8-af44-44dd19ffc871


