### PR TITLE
Update gutenberg release docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/New_release.md
+++ b/.github/ISSUE_TEMPLATE/New_release.md
@@ -51,3 +51,4 @@ This issue is to provide visibility on the progress of the release process of Gu
 -   [ ] Announce in `#core-editor` channel that the plugin has been released
 -   [ ] Reach out to other contributors to help get the post reviewed
 -   [ ] Publish Release post on Make Core blog
+-   [ ] Post in the `#core-editor` channel [requesting a volunteer for the next Gutenberg release](https://developer.wordpress.org/block-editor/contributors/code/release/#call-for-volunteer-for-the-next-release).

--- a/.github/ISSUE_TEMPLATE/New_release.md
+++ b/.github/ISSUE_TEMPLATE/New_release.md
@@ -38,7 +38,7 @@ This issue is to provide visibility on the progress of the release process of Gu
 -   [ ] Post a reminder in #core-editor for backporting PRs to RC (~Label Backport to Gutenberg RC)
 -   [ ] If there are any PRs marked as [Backport to RC](https://github.com/WordPress/gutenberg/pulls?q=is%3Apr+label%3A%22Backport+to+Gutenberg+RC%22+is%3Aclosed), run the [cherry-pick command to apply them](https://developer.wordpress.org/block-editor/contributors/code/release/auto-cherry-picking/#how-can-i-use-it-for-a-gutenberg-plugin-release) to the release branch. **This needs to be run locally**
 -   [ ] [Draft Release Post Highlights and Change Log](https://docs.google.com/document/d/1D-MTOCmL9eMlP9TDTXqlzuKVOg_ghCPm9_whHFViqMk/edit)
--   [ ] Get assets from [Design Team](https://make.wordpress.org/design/) for the post
+-   [ ] Get assets from [Design Team](https://make.wordpress.org/design/) for the post if required
 -   [ ] Reach out to Highlight Authors to draft sections (if necessary)
 
 ### Release Day - {Weekday, Month, Date}

--- a/docs/contributors/code/release.md
+++ b/docs/contributors/code/release.md
@@ -279,9 +279,13 @@ Once the changelog is cleaned up, the next step is to choose a few changes to hi
 
 Given the big scope of Gutenberg and the high number of PRs merged in each milestone, it is not uncommon to overlook impactful changes worth highlighting; because of this, this step is a collaborative effort between the release manager and other Gutenberg development team members. If you don’t know what to pick, reach out to others on the team for assistance.
 
-#### Requesting release assets
+#### Release assets
 
-After identifying the highlights of a new WordPress release, the release manager requests visual assets from the Design team. The request is made in the [#design](https://wordpress.slack.com/archives/C02S78ZAL) Slack channel, and an example post for 15.8 can be found [here](https://wordpress.slack.com/archives/C02S78ZAL/p1684161811926279). The assets will be provided in a [Google Drive folder](https://drive.google.com/drive/folders/1U8bVbjOc0MekWjpMjNaVFVhHFEzQkYLB) assigned to the specific release.
+The release post has a few visual assets that need to be organized. For the post's featured image, use the same image as the previous release used. It should already be in the media library called 'gb-featured'.
+
+There's also a banner in the post body, which can be added via a synced pattern called 'Gutenberg What's New Banner'. Insert this pattern and update the text to the correct version number.
+
+The highlighted features also require visual assets. For a high profile feature you can request visual assets from the Design team. For other features you can create the assets yourself if you're comfortable. To request assets from design, reach out in the [#design](https://wordpress.slack.com/archives/C02S78ZAL) Slack channel, and an example post for 15.8 can be found [here](https://wordpress.slack.com/archives/C02S78ZAL/p1684161811926279). The assets will be provided in a [Google Drive folder](https://drive.google.com/drive/folders/1U8bVbjOc0MekWjpMjNaVFVhHFEzQkYLB) assigned to the specific release.
 
 When creating visual assets for a WordPress release, use animations (video or GIF) or static images to showcase the highlights. Use [previous release posts](https://make.wordpress.org/core/tag/gutenberg-new/) as a guide, and keep in mind that animations are better for demonstrating workflows, while more direct highlights can be shown with an image. When creating assets, avoid using copyrighted material and disable browser plugins that can be seen in the browser canvas.
 

--- a/docs/contributors/code/release.md
+++ b/docs/contributors/code/release.md
@@ -306,6 +306,12 @@ The author should then enable public preview on the post and ask for a final pee
 
 Finally, the post should be published after the stable version is released and is available on WordPress.org. This will help external media to echo and amplify the release.
 
+### Call for volunteer for the next release
+
+After you've completed the release, post in #core-editor slack channel asking for volunteers to handle the next Gutenberg release.
+
+See an example of that here - https://wordpress.slack.com/archives/C02QB2JS7/p1751595983193709.
+
 ### Creating minor releases
 
 Occasionally it's necessary to create a minor release (i.e. X.Y.**Z**) of the Plugin. This is usually done to expedite fixes for bad regressions or bugs. The `Backport to Gutenberg Minor Release` is usually used to identify PRs that need to be included in a minor release, but as release coordinator you may also be notified more informally through slack. Even so, it's good to ensure all relevant PRs have the correct label.


### PR DESCRIPTION
## What?
See - https://wordpress.slack.com/archives/C02QB2JS7/p1751597024760749

Makes a few changes to the gutenberg release docs and issue:

- Clarifies how to request visual assets - the idea being to reduce the need to involve a designer:
    - Use the existing image in the media library for the featured image
    - Use the 'Gutenberg What's New' synced pattern for the main banner
    - Only request assets from design for high profile features (e.g. not sure if we need to clarify what a high profile feature is)
- Adds a section about requesting a volunteer for the next release at the end of the process - the idea being to make the release process more self-managing rather than needing someone to have oversight of find volunteers.