### PR TITLE
Add option to edit the featured image of post in Query loop

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -460,7 +460,7 @@ export default function PostFeaturedImageEdit( {
 	return (
 		<>
 			{ ! temporaryURL && controls }
-			{ !! media && ! isDescendentOfQueryLoop && (
+			{ !! media && (
 				<BlockControls group="other">
 					<MediaReplaceFlow
 						mediaId={ featuredImage }
@@ -470,6 +470,11 @@ export default function PostFeaturedImageEdit( {
 						onSelect={ onSelectImage }
 						onError={ onUploadError }
 						onReset={ onResetImage }
+						name={
+							! mediaUrl
+								? __( 'Add featured image' )
+								: __( 'Replace featured image' )
+						}
 					/>
 				</BlockControls>
 			) }


### PR DESCRIPTION
Closes [#56367](https://github.com/WordPress/gutenberg/issues/56367)

## What?
Enables MediaReplaceFlow component for Post Featured Image blocks within Query Loop contexts, allowing users to replace featured images directly from homepage layouts without navigating to individual posts.

## Why?
Currently, Post Featured Image blocks placed within Query Loops have no editing options available, forcing users to navigate to individual posts to change featured images. This creates significant workflow friction for users building homepage layouts where featured images are key visual elements.

## How?
The implementation makes a targeted change to enable MediaReplaceFlow in Query Loop contexts.

## Testing Instructions
- Create a new page and insert a Query Loop block
- Configure the Query Loop to show posts (use default settings)
- Within the Query Loop pattern, add a Post Featured Image block
- Verify the MediaReplaceFlow controls appear in the block toolbar when the image is selected
- Click the "Replace featured image" button and test:
  - Upload a new image from computer
  - Select from Media Library
  - Insert from URL
- Verify the featured image updates correctly in both the editor and frontend
- Check that only the specific post's featured image changed (not other posts in the loop)

## Screenshots or screencast <!-- if applicable -->
[screen-capture (10).webm](https://github.com/user-attachments/assets/9e07b946-e1f0-4218-9cb5-b813f941f38b)
