### PR TITLE
Icon: Match `SVG` type by displayName

### DIFF
--- a/packages/components/src/icon/index.tsx
+++ b/packages/components/src/icon/index.tsx
@@ -92,7 +92,7 @@ function Icon( {
 		} );
 	}
 
-	if ( icon && ( icon.type === 'svg' || icon.type === SVG ) ) {
+	if ( icon && ( icon.type === 'svg' || icon.type?.displayName === 'SVG' ) ) {
 		const appliedProps = {
 			...icon.props,
 			width: size,
@@ -107,8 +107,6 @@ function Icon( {
 		return cloneElement( icon, {
 			// @ts-ignore Just forwarding the size prop along
 			size,
-			width: size,
-			height: size,
 			...additionalProps,
 		} );
 	}


### PR DESCRIPTION
## What?

Alternative to #70756

Matches the `SVG` type by `displayName` rather than by reference equality, thereby removing the need for a more breaking change to address the DataViews bundling issue.

## Why?

I think this has a lower chance of resulting in broken styles or invalid HTML.

## Testing Instructions

See the Storybook for `Icon` and verify that the `SVG` icon is still being matched as expected.

No visual changes.