### PR TITLE
Add clear delete label for inner block

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -10,7 +10,7 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { moreVertical } from '@wordpress/icons';
 import { Children, cloneElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { pipe, useCopyToClipboard } from '@wordpress/compose';
 
@@ -88,6 +88,8 @@ export function BlockSettingsDropdown( {
 		selectedBlockClientIds,
 		openedBlockSettingsMenu,
 		isContentOnly,
+		blockType,
+		variation,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -107,6 +109,9 @@ export function BlockSettingsDropdown( {
 			const parentBlockName =
 				_firstParentClientId && getBlockName( _firstParentClientId );
 
+			const blockName = getBlockName( firstBlockClientId );
+			const blockAttributes = getBlockAttributes( firstBlockClientId );
+
 			return {
 				firstParentClientId: _firstParentClientId,
 				parentBlockType:
@@ -122,6 +127,11 @@ export function BlockSettingsDropdown( {
 				openedBlockSettingsMenu: getOpenedBlockSettingsMenu(),
 				isContentOnly:
 					getBlockEditingMode( firstBlockClientId ) === 'contentOnly',
+				blockType: getBlockType( blockName ),
+				variation: getActiveBlockVariation(
+					blockName,
+					blockAttributes
+				),
 			};
 		},
 		[ firstBlockClientId ]
@@ -213,6 +223,19 @@ export function BlockSettingsDropdown( {
 
 	const shouldShowBlockParentMenuItem =
 		! parentBlockIsSelected && !! firstParentClientId;
+
+	// Generate specific delete label for inner blocks
+	let deleteLabel = __( 'Delete' );
+	if ( count > 1 ) {
+		/* translators: %d: number of blocks */
+		deleteLabel = sprintf( __( 'Delete %d blocks' ), count );
+	} else if ( firstParentClientId ) {
+		deleteLabel = sprintf(
+			/* translators: %s: block name */
+			__( 'Delete %s' ),
+			variation?.title || blockType?.title || __( 'block' )
+		);
+	}
 
 	return (
 		<BlockActions
@@ -369,7 +392,7 @@ export function BlockSettingsDropdown( {
 											) }
 											shortcut={ shortcuts.remove }
 										>
-											{ __( 'Delete' ) }
+											{ deleteLabel }
 										</MenuItem>
 									</MenuGroup>
 								) }


### PR DESCRIPTION
Closes [#56370](https://github.com/WordPress/gutenberg/issues/56370)

## What?
Adds specific block names to the delete action in the block settings menu for inner blocks to clarify what will be deleted.

## Why?
Currently, when users interact with inner blocks (like individual social icons within a Social Icons block), the delete action simply shows "Delete" without specifying what will be deleted. This creates confusion about whether the action will delete:
- Just the specific inner block (e.g., the Instagram icon)
- The entire parent block (e.g., the whole Social Icons block)

## How?
The solution adds the delete label based on the inner block's name and variation

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
- Add Social Icons block
- Add social inside Social Icons block eg. Instagram, Facebook etc
- Select any on social icon and click on three dots in Toolbar of block
- Check the Delete label is now Delete Instagram or Delete Facebook

## Screenshots or screencast <!-- if applicable -->
<img width="453" height="399" alt="Screenshot 2025-07-18 at 7 00 27 PM" src="https://github.com/user-attachments/assets/c809e9bf-8e34-40f6-bbd4-bacdee404f2c" />
<img width="401" height="410" alt="Screenshot 2025-07-18 at 7 00 41 PM" src="https://github.com/user-attachments/assets/36e05084-0d79-4098-bece-af65351f72b6" />

