### PR TITLE
Fix: Clipboard Google Docs codeblocks support

### DIFF
--- a/packages/blocks/src/api/raw-handling/google-docs-paste-convertor.js
+++ b/packages/blocks/src/api/raw-handling/google-docs-paste-convertor.js
@@ -81,5 +81,55 @@ export default function googleDocsHtmlMarkdownProcessor( htmlString ) {
 		}
 	} );
 
+	// For Multiline code blocks (```) we need to look for back-ticks at the beginning/end of paragraph nodes.
+	const paragraphs = Array.from( body.querySelectorAll( 'p' ) );
+	let inCodeBlock = false;
+	let codeBlockLines = [];
+	let nodesToRemove = [];
+	let firstCodeBlockNode = null;
+
+	paragraphs.forEach( ( p ) => {
+		const pText = p.textContent.trim();
+
+		if ( pText === '```' ) {
+			nodesToRemove.push( p );
+
+			if ( ! inCodeBlock ) {
+				inCodeBlock = true;
+				firstCodeBlockNode = p;
+			} else {
+				inCodeBlock = false;
+
+				// Replace the collected nodes with a single <pre><code> block
+				if ( firstCodeBlockNode && codeBlockLines.length > 0 ) {
+					const pre = doc.createElement( 'pre' );
+					const code = doc.createElement( 'code' );
+					code.textContent = codeBlockLines.join( '\n' );
+					pre.appendChild( code );
+
+					// Replace the first node of the block with the <pre> tag.
+					// Then remove all subsequent nodes in the block.
+					firstCodeBlockNode.parentNode.replaceChild(
+						pre,
+						firstCodeBlockNode
+					);
+
+					nodesToRemove.forEach( ( node ) => {
+						if ( node !== firstCodeBlockNode && node.parentNode ) {
+							node.parentNode.removeChild( node );
+						}
+					} );
+				}
+
+				codeBlockLines = [];
+				nodesToRemove = [];
+				firstCodeBlockNode = null;
+			}
+		} else if ( inCodeBlock ) {
+			codeBlockLines.push( pText );
+			nodesToRemove.push( p );
+		}
+	} );
+
 	return body.innerHTML;
 }

--- a/packages/blocks/src/api/raw-handling/google-docs-paste-convertor.js
+++ b/packages/blocks/src/api/raw-handling/google-docs-paste-convertor.js
@@ -1,0 +1,85 @@
+/* global DOMParser, NodeFilter */
+
+const parser = new DOMParser();
+
+/**
+ * Custom filter function to process Google Docs HTML, converting Markdown patterns
+ * into semantic HTML (`<code>`, `<pre>`) while preserving other formatting.
+ *
+ * @param {string} htmlString The HTML content from the clipboard (from GDocs).
+ * @return {string} The processed HTML string with Markdown converted.
+ */
+export default function googleDocsHtmlMarkdownProcessor( htmlString ) {
+	// Detect if it's a Google Docs paste from the HTML string.
+	const isGoogleDocsHtml = htmlString.includes( 'docs-internal-guid-' );
+	if ( ! isGoogleDocsHtml ) {
+		return htmlString;
+	}
+
+	const doc = parser.parseFromString( htmlString, 'text/html' );
+	const body = doc.body;
+
+	const allTextNodes = [];
+	const treeWalker = doc.createTreeWalker(
+		body,
+		NodeFilter.SHOW_TEXT,
+		null,
+		false
+	);
+	let currentNode;
+	while ( ( currentNode = treeWalker.nextNode() ) ) {
+		allTextNodes.push( currentNode );
+	}
+
+	allTextNodes.forEach( ( node ) => {
+		const textContent = node.nodeValue;
+		const inlineCodeRegex = /`([^`]+)`/g;
+
+		if ( ! inlineCodeRegex.test( textContent ) ) {
+			return; // No inline code found in this node.
+		}
+
+		inlineCodeRegex.lastIndex = 0;
+
+		const fragment = doc.createDocumentFragment();
+		let lastIndex = 0;
+		let match;
+		let changed = false;
+
+		while ( ( match = inlineCodeRegex.exec( textContent ) ) !== null ) {
+			const codeContent = match[ 1 ];
+			const startIndex = match.index;
+			const endIndex = inlineCodeRegex.lastIndex;
+
+			if ( startIndex > lastIndex ) {
+				fragment.appendChild(
+					doc.createTextNode(
+						textContent.substring( lastIndex, startIndex )
+					)
+				);
+			}
+
+			const codeElement = doc.createElement( 'code' );
+			codeElement.textContent = codeContent;
+			fragment.appendChild( codeElement );
+			changed = true;
+
+			lastIndex = endIndex;
+		}
+
+		if ( lastIndex < textContent.length ) {
+			fragment.appendChild(
+				doc.createTextNode( textContent.substring( lastIndex ) )
+			);
+		}
+
+		if ( changed ) {
+			const parent = node.parentNode;
+			if ( parent ) {
+				parent.replaceChild( fragment, node );
+			}
+		}
+	} );
+
+	return body.innerHTML;
+}

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -32,6 +32,7 @@ import brRemover from './br-remover';
 import { deepFilterHTML, isPlain, getBlockContentSchema } from './utils';
 import emptyParagraphRemover from './empty-paragraph-remover';
 import slackParagraphCorrector from './slack-paragraph-corrector';
+import googleDocsPasteConverter from './google-docs-paste-convertor';
 
 const log = ( ...args ) => window?.console?.log?.( ...args );
 
@@ -119,6 +120,8 @@ export function pasteHandler( {
 	if ( String.prototype.normalize ) {
 		HTML = HTML.normalize();
 	}
+
+	HTML = googleDocsPasteConverter( HTML, plainText );
 
 	// Must be run before checking if it's inline content.
 	HTML = deepFilterHTML( HTML, [ slackParagraphCorrector ] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #32917 

This PR ensures that Markdown formatting, such as inline code (`` `code` ``) and code blocks (```), is correctly recognized when pasted from a Google Document into the Gutenberg editor.

## Why?
Previously, Markdown formatting copied from a Google Document wasn't recognized by the Gutenberg editor. For example, inline code and code blocks would appear as plain text, and the formatting cues (like backticks) were not interpreted correctly. 

## How?
This PR adjusts the clipboard input handling to normalize pasted content from Google Docs. It identifies and parses the content from Google Docs paste and converts them to format which can be used by Gutenberg directly.

## Testing Instructions
1. Copy the following Markdown-formatted text:
```
    Inline code like this `code goes here` is not recognized.

    ```
    Code is not recognized
    ```
```
2. Open a Google Document and paste the text into it (without formatting to preserve GDocs formatting).
3. Copy the text from Google Docs and paste it back into the Editor.
4. Confirm that the inline code and multiline code block are rendered correctly and recognized as code elements.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before:

https://github.com/user-attachments/assets/bf0ef2f7-24a0-4eaa-905c-0ec31305181f

### After:

https://github.com/user-attachments/assets/fc0dfc14-4f9e-4340-b526-2aec94571f3b

