### PR TITLE
DataViews: Allow searching over array fieldtypes

### DIFF
--- a/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
@@ -759,5 +759,6 @@ export const fields: Field< SpaceObject >[] = [
 			{ value: 'Gas giant', label: 'Gas giant' },
 		],
 		type: 'array',
+		enableGlobalSearch: true,
 	},
 ];

--- a/packages/dataviews/src/filter-and-sort-data-view.ts
+++ b/packages/dataviews/src/filter-and-sort-data-view.ts
@@ -98,10 +98,17 @@ export function filterSortAndPaginate< Item >(
 		filteredData = filteredData.filter( ( item ) => {
 			return _fields
 				.filter( ( field ) => field.enableGlobalSearch )
-				.map( ( field ) => {
-					return normalizeSearchInput( field.getValue( { item } ) );
-				} )
-				.some( ( field ) => field.includes( normalizedSearch ) );
+				.some( ( field ) => {
+					const fieldValue = field.getValue( { item } );
+					const values = Array.isArray( fieldValue )
+						? fieldValue
+						: [ fieldValue ];
+					return values.some( ( value ) =>
+						normalizeSearchInput( String( value ) ).includes(
+							normalizedSearch
+						)
+					);
+				} );
 		} );
 	}
 

--- a/packages/dataviews/src/test/filter-and-sort-data-view.js
+++ b/packages/dataviews/src/test/filter-and-sort-data-view.js
@@ -81,17 +81,18 @@ describe( 'filters', () => {
 		const { data: result } = filterSortAndPaginate(
 			data,
 			{
-				search: 'NASA',
+				search: 'Moon',
 				filters: [],
 			},
 			fieldsWithArraySearch
 		);
 
-		// Should find both items: one with title "NASA" and one with "NASA" in categories
-		expect( result ).toHaveLength( 2 );
+		// Should find items with "Moon" in categories plus the item with title "Moon"
+		expect( result ).toHaveLength( 3 );
 		expect( result.map( ( r ) => r.title ).sort() ).toEqual( [
-			'Apollo',
-			'NASA',
+			'Europa',
+			'Io',
+			'Moon',
 		] );
 	} );
 
@@ -105,18 +106,17 @@ describe( 'filters', () => {
 		const { data: result } = filterSortAndPaginate(
 			data,
 			{
-				search: 'space',
+				search: 'planet',
 				filters: [],
 			},
 			fieldsWithArraySearch
 		);
 
-		// Should find items with "Space" in categories (case-insensitive)
-		// Plus the item with title "Space" (from title search which is already enabled)
-		expect( result ).toHaveLength( 10 );
-		expect( result.map( ( r ) => r.title ) ).toContain( 'Apollo' );
+		// Should find items with "Planet" in categories (case-insensitive)
+		expect( result ).toHaveLength( 8 );
 		expect( result.map( ( r ) => r.title ) ).toContain( 'Neptune' );
-		expect( result.map( ( r ) => r.title ) ).toContain( 'Space' );
+		expect( result.map( ( r ) => r.title ) ).toContain( 'Mercury' );
+		expect( result.map( ( r ) => r.title ) ).toContain( 'Earth' );
 	} );
 
 	it( 'should search using IS filter', () => {

--- a/packages/dataviews/src/test/filter-and-sort-data-view.js
+++ b/packages/dataviews/src/test/filter-and-sort-data-view.js
@@ -71,6 +71,54 @@ describe( 'filters', () => {
 		expect( result[ 0 ].description ).toBe( 'La planète Vénus' );
 	} );
 
+	it( 'should search over array fields when enableGlobalSearch is true', () => {
+		const fieldsWithArraySearch = fields.map( ( field ) =>
+			field.id === 'categories'
+				? { ...field, enableGlobalSearch: true }
+				: field
+		);
+
+		const { data: result } = filterSortAndPaginate(
+			data,
+			{
+				search: 'NASA',
+				filters: [],
+			},
+			fieldsWithArraySearch
+		);
+
+		// Should find both items: one with title "NASA" and one with "NASA" in categories
+		expect( result ).toHaveLength( 2 );
+		expect( result.map( ( r ) => r.title ).sort() ).toEqual( [
+			'Apollo',
+			'NASA',
+		] );
+	} );
+
+	it( 'should search over array fields case-insensitively', () => {
+		const fieldsWithArraySearch = fields.map( ( field ) =>
+			field.id === 'categories'
+				? { ...field, enableGlobalSearch: true }
+				: field
+		);
+
+		const { data: result } = filterSortAndPaginate(
+			data,
+			{
+				search: 'space',
+				filters: [],
+			},
+			fieldsWithArraySearch
+		);
+
+		// Should find items with "Space" in categories (case-insensitive)
+		// Plus the item with title "Space" (from title search which is already enabled)
+		expect( result ).toHaveLength( 10 );
+		expect( result.map( ( r ) => r.title ) ).toContain( 'Apollo' );
+		expect( result.map( ( r ) => r.title ) ).toContain( 'Neptune' );
+		expect( result.map( ( r ) => r.title ) ).toContain( 'Space' );
+	} );
+
 	it( 'should search using IS filter', () => {
 		const { data: result } = filterSortAndPaginate(
 			data,

--- a/packages/dataviews/src/test/filter-and-sort-data-view.js
+++ b/packages/dataviews/src/test/filter-and-sort-data-view.js
@@ -87,7 +87,7 @@ describe( 'filters', () => {
 			fieldsWithArraySearch
 		);
 
-		// Should find items with "Moon" in categories plus the item with title "Moon"
+		// Should find items with "satellite" in categories
 		expect( result ).toHaveLength( 3 );
 		expect( result.map( ( r ) => r.title ).sort() ).toEqual( [
 			'Europa',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #70782

<!-- In a few words, what is the PR actually doing? -->

Fixing a bug with searching over DataView fields that have the array field types.

Also updating the DataViews storybook to demonstrate that it works.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This fixes a bug with searching over DataView fields that have the array fieldtype. Previously they would crash with _TypeError: input.trim is not a function_

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Treats every value as an array before normalising and searching over every value in that array.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

I've added some tests, to test manually:

1. Open the story book
2. Go to DataViews
3. Search for "planet"
4. Note that it now returns rows that have "planet" as a category, not just in the description

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
