### PR TITLE
TypeScript: Fix types for core entity meta

### DIFF
--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   Fixed the TS type for meta values for core entities ([#70788](https://github.com/WordPress/gutenberg/pull/70788))
+
 ## 7.26.0 (2025-06-25)
 
 ## 7.25.0 (2025-06-04)

--- a/packages/core-data/src/entity-types/attachment.ts
+++ b/packages/core-data/src/entity-types/attachment.ts
@@ -123,7 +123,7 @@ declare module './base-entity-records' {
 			 * Meta fields.
 			 */
 			meta: ContextualField<
-				Record< string, string >,
+				Record< string, unknown >,
 				'view' | 'edit',
 				C
 			>;

--- a/packages/core-data/src/entity-types/comment.ts
+++ b/packages/core-data/src/entity-types/comment.ts
@@ -83,7 +83,7 @@ declare module './base-entity-records' {
 			 * Meta fields.
 			 */
 			meta: ContextualField<
-				Record< string, string >,
+				Record< string, unknown >,
 				'view' | 'edit',
 				C
 			>;

--- a/packages/core-data/src/entity-types/nav-menu-item.ts
+++ b/packages/core-data/src/entity-types/nav-menu-item.ts
@@ -98,7 +98,7 @@ declare module './base-entity-records' {
 			 * Meta fields.
 			 */
 			meta: ContextualField<
-				Record< string, string >,
+				Record< string, unknown >,
 				'view' | 'edit',
 				C
 			>;

--- a/packages/core-data/src/entity-types/nav-menu.ts
+++ b/packages/core-data/src/entity-types/nav-menu.ts
@@ -28,7 +28,7 @@ declare module './base-entity-records' {
 			 * Meta fields.
 			 */
 			meta: ContextualField<
-				Record< string, string >,
+				Record< string, unknown >,
 				'view' | 'edit',
 				C
 			>;

--- a/packages/core-data/src/entity-types/page.ts
+++ b/packages/core-data/src/entity-types/page.ts
@@ -127,7 +127,7 @@ declare module './base-entity-records' {
 			 * Meta fields.
 			 */
 			meta: ContextualField<
-				Record< string, string >,
+				Record< string, unknown >,
 				'view' | 'edit',
 				C
 			>;

--- a/packages/core-data/src/entity-types/post-revision.ts
+++ b/packages/core-data/src/entity-types/post-revision.ts
@@ -60,7 +60,7 @@ declare module './base-entity-records' {
 			 * Meta fields.
 			 */
 			meta: ContextualField<
-				Record< string, string >,
+				Record< string, unknown >,
 				'view' | 'edit',
 				C
 			>;

--- a/packages/core-data/src/entity-types/post.ts
+++ b/packages/core-data/src/entity-types/post.ts
@@ -124,7 +124,7 @@ declare module './base-entity-records' {
 			 * Meta fields.
 			 */
 			meta: ContextualField<
-				Record< string, string >,
+				Record< string, unknown >,
 				'view' | 'edit',
 				C
 			>;

--- a/packages/core-data/src/entity-types/term.ts
+++ b/packages/core-data/src/entity-types/term.ts
@@ -44,7 +44,7 @@ declare module './base-entity-records' {
 			 * Meta fields.
 			 */
 			meta: ContextualField<
-				Record< string, string >,
+				Record< string, unknown >,
 				'view' | 'edit',
 				C
 			>;

--- a/packages/core-data/src/entity-types/user.ts
+++ b/packages/core-data/src/entity-types/user.ts
@@ -101,7 +101,7 @@ declare module './base-entity-records' {
 			 * Meta fields.
 			 */
 			meta: ContextualField<
-				Record< string, string >,
+				Record< string, unknown >,
 				'view' | 'edit',
 				C
 			>;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes #70786

<!-- In a few words, what is the PR actually doing? -->

## Why?
The meta for the entity types like Post, User, Comment etc can be anything, not just a record of strings. Thus this PR reflects the same in the TS types.

## How?
This PR changes the type of meta to be a record of `unknown` because that is what meta is -  we don't know what type it is.

## Testing Instructions

- Use this snippet in some TS file
```
useSelect( select => {
	const { meta } = select( coreStore ).getEntityRecord< Post >( 'postType', 'post', 123 );

	return meta.some_key;
}, [] );
```
- Confirm that the type of `some_key` is `unknown`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
