### PR TITLE
Fix: Use lowercase for "link to page" label in Featured Image block

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -258,10 +258,10 @@ export default function PostFeaturedImageEdit( {
 								postType?.labels.singular_name
 									? sprintf(
 											// translators: %s: Name of the post type e.g: "post".
-											__( 'Link to %s' ),
+											__( 'link to %s' ),
 											postType.labels.singular_name
 									  )
-									: __( 'Link to post' )
+									: __( 'link to post' )
 							}
 							isShownByDefault
 							hasValue={ () => !! isLink }
@@ -277,10 +277,10 @@ export default function PostFeaturedImageEdit( {
 									postType?.labels.singular_name
 										? sprintf(
 												// translators: %s: Name of the post type e.g: "post".
-												__( 'Link to %s' ),
+												__( 'link to %s' ),
 												postType.labels.singular_name
 										  )
-										: __( 'Link to post' )
+										: __( 'link to post' )
 								}
 								onChange={ () =>
 									setAttributes( { isLink: ! isLink } )


### PR DESCRIPTION
### Description

This PR updates the label text in the `Post Featured Image` block from **"Link to page"** to **"link to page"**, as per [issue #55057](https://github.com/WordPress/gutenberg/issues/55057).

### What changed

- Updated both instances of the translation string from `__('Link to %s')` to `__('link to %s')`
- Also updated the fallback text `__('Link to post')` → `__('link to post')`

### Testing Instructions

1. Add the Post Featured Image block in the editor.
2. Under Settings, toggle the **"link to page"** switch.
3. Confirm that the label now begins with a lowercase **l**.

### Screenshots

*Before:*
> Link to page

*After:*
> link to page

---

Fixes #55057
