### PR TITLE
Dimensions support: Fix duplicate output of styling rules

### DIFF
--- a/lib/block-supports/dimensions.php
+++ b/lib/block-supports/dimensions.php
@@ -149,9 +149,7 @@ function gutenberg_render_dimensions_support( $block_content, $block ) {
 	return $block_content;
 }
 
-if ( function_exists( 'wp_render_dimensions_support' ) ) {
-	remove_filter( 'render_block', 'wp_render_dimensions_support' );
-}
+remove_filter( 'render_block', 'wp_render_dimensions_support', 10 );
 add_filter( 'render_block', 'gutenberg_render_dimensions_support', 10, 2 );
 
 // Register the block support.

--- a/lib/block-supports/dimensions.php
+++ b/lib/block-supports/dimensions.php
@@ -149,6 +149,9 @@ function gutenberg_render_dimensions_support( $block_content, $block ) {
 	return $block_content;
 }
 
+if ( function_exists( 'wp_render_dimensions_support' ) ) {
+	remove_filter( 'render_block', 'wp_render_dimensions_support' );
+}
 add_filter( 'render_block', 'gutenberg_render_dimensions_support', 10, 2 );
 
 // Register the block support.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Similar #56997

<!-- In a few words, what is the PR actually doing? -->
Fix duplicate output of Dimensions styling rules for the Cover block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add a remove_filter line to disable core's callback for the dimensions support if present

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a Cover block.
3. Set Aspect radio 
4. You will see the styles being rendered twice on the frontend.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="582" height="295" alt="before" src="https://github.com/user-attachments/assets/513ea5a2-80d7-4332-955d-7f73c2b7bdfe" />|<img width="590" height="238" alt="after" src="https://github.com/user-attachments/assets/6f52b433-2726-485c-876e-8c808453e8b5" /> |
