### PR TITLE
Update @tannin/sprintf to resolve CommonJS error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13207,9 +13207,9 @@
 			"integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw=="
 		},
 		"node_modules/@tannin/sprintf": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@tannin/sprintf/-/sprintf-1.3.0.tgz",
-			"integrity": "sha512-TTJf+2phgKE9ixjLGuYy5+OD5mo11S628dNd01q05esk43iaHU3c22UjF4HzGl8e8/1uRFOXpOxQiqxKJAEDow==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@tannin/sprintf/-/sprintf-1.3.1.tgz",
+			"integrity": "sha512-3auu6Wqm4TR6gvOh1Dgh1d2k9+arNmu3T0JLiUJoJMgayeHr450OuWeZIMTE4CUuq51rwn/NI9S5InT0JuTxQw==",
 			"license": "MIT"
 		},
 		"node_modules/@testing-library/dom": {
@@ -50944,7 +50944,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
-				"@tannin/sprintf": "^1.3.0",
+				"@tannin/sprintf": "^1.3.1",
 				"@wordpress/hooks": "file:../hooks",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -32,7 +32,7 @@
 	},
 	"dependencies": {
 		"@babel/runtime": "7.25.7",
-		"@tannin/sprintf": "^1.3.0",
+		"@tannin/sprintf": "^1.3.1",
 		"@wordpress/hooks": "file:../hooks",
 		"gettext-parser": "^1.3.1",
 		"memize": "^2.1.0",

--- a/packages/i18n/src/sprintf.ts
+++ b/packages/i18n/src/sprintf.ts
@@ -1,6 +1,8 @@
 /**
  * External dependencies
  */
+// Disable reason: `eslint-plugin-import` doesn't support `exports` (https://github.com/import-js/eslint-plugin-import/issues/1810)
+// eslint-disable-next-line import/no-unresolved
 import _sprintf from '@tannin/sprintf';
 import type { SprintfArgs } from '@tannin/sprintf/types';
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Updates `@tannin/sprintf` dependency from v1.3.0 to v1.3.1 to incorporate a bug fix which causes errors when importing the module in CommonJS contexts in the current version.

See: https://github.com/aduth/tannin/issues/20

Changelog: https://github.com/aduth/tannin/blob/master/packages/sprintf/CHANGELOG.md#131-2025-07-19

Full diff: https://my.diffend.io/npm/@tannin/sprintf/1.3.0/1.3.1

Follow-up to #70434

## Why?

Fixes an error when importing any Gutenberg package that depends on `@tannin/sprintf`, if imported in a CommonJS project. 

Example: https://github.com/Automattic/jetpack/pull/44376#issuecomment-3090522662
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?

See changes in https://github.com/aduth/tannin/commit/ee0b6ff1406f20176a981d3a333f791710284d4a

The root of the issue is that because the package is marked as ESM (`"type": "module"`) and the CommonJS build uses the `.js` file, it is interpreted as ESM, rather than as CommonJS. This is addressed by renaming the built output as `.cjs` instead of `.js`.
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Repeat Testing Instructions from #70434
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
