### PR TITLE
feat: add story for ColorPalette component

### DIFF
--- a/packages/block-editor/src/components/color-palette/stories/color-palette.story.js
+++ b/packages/block-editor/src/components/color-palette/stories/color-palette.story.js
@@ -1,0 +1,63 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { ColorPalette } from '@wordpress/block-editor';
+
+export default {
+	title: 'BlockEditor/ColorPalette',
+	component: ColorPalette,
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The `ColorPalette` component renders a palette of selectable colors for users to apply to block editor components, allowing selection from a predefined set of colors.',
+			},
+		},
+	},
+	argTypes: {
+		onChange: { action: 'Color selected' },
+	},
+};
+
+function ColorPaletteStory( { onChange, ...args } ) {
+	const [ selectedColor, setSelectedColor ] = useState( null );
+
+	return (
+		<div style={ { padding: '20px', background: '#f0f0f0' } }>
+			<ColorPalette
+				{ ...args }
+				value={ selectedColor }
+				onChange={ ( color ) => {
+					setSelectedColor( color );
+					onChange( color );
+				} }
+			/>
+			<div style={ { marginTop: '12px' } }>
+				<strong>Color Selected:</strong> { selectedColor || 'None' }
+			</div>
+		</div>
+	);
+}
+
+export const Default = {
+	render: ColorPaletteStory,
+	args: {
+		colors: [
+			{ name: 'Red', color: '#FF0000' },
+			{ name: 'Orange', color: '#FF7F00' },
+			{ name: 'Yellow', color: '#FFFF00' },
+			{ name: 'Green', color: '#00FF00' },
+			{ name: 'Blue', color: '#0000FF' },
+			{ name: 'Indigo', color: '#4B0082' },
+			{ name: 'Violet', color: '#8B00FF' },
+			{ name: 'Black', color: '#000000' },
+			{ name: 'White', color: '#FFFFFF' },
+		],
+		disableCustomColors: false,
+	},
+};


### PR DESCRIPTION
Part of: #67165

## What?
This PR adds Storybook stories for `ColorPalette` component in `@wordpress/block-editor`.

## Why?
This helps improve visual documentation and makes it easier for contributors and designers to understand and test `ColorPalette` separately. It also supports ongoing efforts to expand Storybook coverage for Block Editor components.

## How?
- Imported and rendered `ColorPalette` with props like `colors`, `value`, and `onChange`.
- Used `useState` to manage internal color selection.
- Displayed the currently selected color below the palette for better clarity.
- Added rainbow palette for easier visual testing.

## Testing Instructions
- Run storybook locally: `npm run storybook:dev`
- Open: http://localhost:50240/
- In the left sidebar, go to: `BlockEditor / ColorPalette`
- Check the following:
  - The component renders without issues.
  - Clicking swatches changes the selected color.
  - The chosen color appears below the palette.

## Screenshots or screencast
https://github.com/user-attachments/assets/a9b07906-453c-4585-9040-16bc6dd6fe7f




