### PR TITLE
Docs: Update RichTextToolbarButton link in docs

### DIFF
--- a/docs/how-to-guides/format-api.md
+++ b/docs/how-to-guides/format-api.md
@@ -225,7 +225,7 @@ If you run into errors:
 Reference documentation used in this guide:
 
 -   RichText: [`registerFormatType`](/packages/rich-text/README.md#registerformattype)
--   Components: [`RichTextToolbarButton`](/packages/editor/README.md#richtexttoolbarbutton)
+-   Components: [`RichTextToolbarButton`](/packages/block-editor/README.md#richtexttoolbarbutton)
 -   RichText: [`applyFormat`](/packages/rich-text/README.md#applyformat)
 -   RichText: [`removeFormat`](/packages/rich-text/README.md#removeformat)
 -   RichText: [`toggleFormat`](/packages/rich-text/README.md#toggleformat)

--- a/docs/how-to-guides/format-api.md
+++ b/docs/how-to-guides/format-api.md
@@ -225,7 +225,7 @@ If you run into errors:
 Reference documentation used in this guide:
 
 -   RichText: [`registerFormatType`](/packages/rich-text/README.md#registerformattype)
--   Components: [`RichTextToolbarButton`](/packages/block-editor/src/components/rich-text#richtexttoolbarbutton)
+-   Components: [`RichTextToolbarButton`](/packages/editor/README.md#richtexttoolbarbutton)
 -   RichText: [`applyFormat`](/packages/rich-text/README.md#applyformat)
 -   RichText: [`removeFormat`](/packages/rich-text/README.md#removeformat)
 -   RichText: [`toggleFormat`](/packages/rich-text/README.md#toggleformat)


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #70802

<!-- In a few words, what is the PR actually doing? -->
Fix broken RichTextToolbarButton documentation link in Format API guide.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The Format API guide contains a broken link to RichTextToolbarButton documentation that returns a 404 error, leaving developers without proper reference material. The current link points to `/packages/block-editor/src/components/rich-text#richtexttoolbarbutton` which doesn't exist, causing confusion for developers trying to follow the guide.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- **Fixed broken documentation link**: Updated the RichTextToolbarButton reference in the "Additional resources" section from the non-existent `/packages/block-editor/src/components/rich-text#richtexttoolbarbutton` to the correct working documentation URL `/packages/editor/README.md#richtexttoolbarbutton`