### PR TITLE
Cover: Enable support for adding posters over video

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -246,7 +246,7 @@ Add an image or video with a text overlay. ([Source](https://github.com/WordPres
 -	**Name:** core/cover
 -	**Category:** media
 -	**Supports:** align, anchor, color (heading, text, ~~background~~, ~~enableContrastChecker~~), dimensions (aspectRatio), filter (duotone), interactivity (clientNavigation), layout (~~allowJustification~~), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** allowedBlocks, alt, backgroundType, contentPosition, customGradient, customOverlayColor, dimRatio, focalPoint, gradient, hasParallax, id, isDark, isRepeated, isUserOverlayColor, minHeight, minHeightUnit, overlayColor, sizeSlug, tagName, templateLock, url, useFeaturedImage
+-	**Attributes:** allowedBlocks, alt, backgroundType, contentPosition, customGradient, customOverlayColor, dimRatio, focalPoint, gradient, hasParallax, id, isDark, isRepeated, isUserOverlayColor, minHeight, minHeightUnit, overlayColor, poster, sizeSlug, tagName, templateLock, url, useFeaturedImage
 
 ## Details
 

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -81,6 +81,12 @@
 		},
 		"sizeSlug": {
 			"type": "string"
+		},
+		"poster": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "video",
+			"attribute": "poster"
 		}
 	},
 	"usesContext": [ "postId", "postType" ],

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -102,6 +102,7 @@ function CoverEdit( {
 		tagName: TagName = 'div',
 		isUserOverlayColor,
 		sizeSlug,
+		poster,
 	} = attributes;
 
 	const [ featuredImage ] = useEntityProp(
@@ -590,6 +591,7 @@ function CoverEdit( {
 						muted
 						loop
 						src={ url }
+						poster={ poster }
 						style={ mediaStyle }
 					/>
 				) }

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -35,7 +35,7 @@ import { COVER_MIN_HEIGHT, mediaPosition } from '../shared';
 import { unlock } from '../../lock-unlock';
 import { useToolsPanelDropdownMenuProps } from '../../utils/hooks';
 import { DEFAULT_MEDIA_SIZE_SLUG } from '../constants';
-import PosterImage from '../../video/poster-image';
+import PosterImage from './poster-image';
 
 const { cleanEmptyObject, ResolutionTool, HTMLElementControl } = unlock(
 	blockEditorPrivateApis
@@ -121,7 +121,6 @@ export default function CoverInspectorControls( {
 		overlayColor,
 	} = currentSettings;
 
-	const instanceId = useInstanceId( CoverInspectorControls );
 	const sizeSlug = attributes.sizeSlug || DEFAULT_MEDIA_SIZE_SLUG;
 
 	const { gradientValue, setGradient } = __experimentalUseGradient();
@@ -201,7 +200,7 @@ export default function CoverInspectorControls( {
 								focalPoint: undefined,
 								isRepeated: false,
 								alt: '',
-								poster: '',
+								poster: undefined,
 							} );
 							updateImage( DEFAULT_MEDIA_SIZE_SLUG );
 						} }
@@ -251,7 +250,6 @@ export default function CoverInspectorControls( {
 							<PosterImage
 								poster={ poster }
 								setAttributes={ setAttributes }
-								instanceId={ instanceId }
 							/>
 						) }
 						{ showFocalPointPicker && (

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -246,12 +246,6 @@ export default function CoverInspectorControls( {
 								</ToolsPanelItem>
 							</>
 						) }
-						{ isVideoBackground && (
-							<PosterImage
-								poster={ poster }
-								setAttributes={ setAttributes }
-							/>
-						) }
 						{ showFocalPointPicker && (
 							<ToolsPanelItem
 								label={ __( 'Focal point' ) }
@@ -277,6 +271,12 @@ export default function CoverInspectorControls( {
 									}
 								/>
 							</ToolsPanelItem>
+						) }
+						{ isVideoBackground && (
+							<PosterImage
+								poster={ poster }
+								setAttributes={ setAttributes }
+							/>
 						) }
 						{ ! useFeaturedImage && url && ! isVideoBackground && (
 							<ToolsPanelItem

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -35,6 +35,7 @@ import { COVER_MIN_HEIGHT, mediaPosition } from '../shared';
 import { unlock } from '../../lock-unlock';
 import { useToolsPanelDropdownMenuProps } from '../../utils/hooks';
 import { DEFAULT_MEDIA_SIZE_SLUG } from '../constants';
+import PosterImage from '../../video/poster-image';
 
 const { cleanEmptyObject, ResolutionTool, HTMLElementControl } = unlock(
 	blockEditorPrivateApis
@@ -110,6 +111,7 @@ export default function CoverInspectorControls( {
 		minHeightUnit,
 		alt,
 		tagName,
+		poster,
 	} = attributes;
 	const {
 		isVideoBackground,
@@ -119,6 +121,7 @@ export default function CoverInspectorControls( {
 		overlayColor,
 	} = currentSettings;
 
+	const instanceId = useInstanceId( CoverInspectorControls );
 	const sizeSlug = attributes.sizeSlug || DEFAULT_MEDIA_SIZE_SLUG;
 
 	const { gradientValue, setGradient } = __experimentalUseGradient();
@@ -198,6 +201,7 @@ export default function CoverInspectorControls( {
 								focalPoint: undefined,
 								isRepeated: false,
 								alt: '',
+								poster: '',
 							} );
 							updateImage( DEFAULT_MEDIA_SIZE_SLUG );
 						} }
@@ -242,6 +246,13 @@ export default function CoverInspectorControls( {
 									/>
 								</ToolsPanelItem>
 							</>
+						) }
+						{ isVideoBackground && (
+							<PosterImage
+								poster={ poster }
+								setAttributes={ setAttributes }
+								instanceId={ instanceId }
+							/>
 						) }
 						{ showFocalPointPicker && (
 							<ToolsPanelItem

--- a/packages/block-library/src/cover/edit/poster-image.js
+++ b/packages/block-library/src/cover/edit/poster-image.js
@@ -66,11 +66,11 @@ function PosterImage( { poster, setAttributes } ) {
 						{ poster
 							? sprintf(
 									/* translators: %s: poster image URL. */
-									__( 'The current poster image url is %s' ),
+									__( 'The current poster image url is %s.' ),
 									poster
 							  )
 							: __(
-									'There is no poster image currently selected'
+									'There is no poster image currently selected.'
 							  ) }
 					</p>
 					{ !! poster && (

--- a/packages/block-library/src/cover/edit/poster-image.js
+++ b/packages/block-library/src/cover/edit/poster-image.js
@@ -15,9 +15,11 @@ import { useInstanceId } from '@wordpress/compose';
 const COVER_POSTER_ALLOWED_MEDIA_TYPES = [ 'image' ];
 
 function PosterImage( { poster, setAttributes } ) {
-	const posterImageButton = useRef();
-	const instanceId = useInstanceId( PosterImage );
-	const videoPosterDescription = `cover-block__poster-image-description-${ instanceId }`;
+	const posterButtonRef = useRef();
+	const descriptionId = useInstanceId(
+		PosterImage,
+		'cover-block__poster-image-description'
+	);
 
 	function onSelectPoster( image ) {
 		setAttributes( { poster: image.url } );
@@ -27,7 +29,7 @@ function PosterImage( { poster, setAttributes } ) {
 		setAttributes( { poster: undefined } );
 
 		// Move focus back to the Media Upload button.
-		posterImageButton.current.focus();
+		posterButtonRef.current.focus();
 	}
 
 	return (
@@ -53,14 +55,14 @@ function PosterImage( { poster, setAttributes } ) {
 								__next40pxDefaultSize
 								variant="primary"
 								onClick={ open }
-								ref={ posterImageButton }
-								aria-describedby={ videoPosterDescription }
+								ref={ posterButtonRef }
+								aria-describedby={ descriptionId }
 							>
 								{ ! poster ? __( 'Select' ) : __( 'Replace' ) }
 							</Button>
 						) }
 					/>
-					<p id={ videoPosterDescription } hidden>
+					<p id={ descriptionId } hidden>
 						{ poster
 							? sprintf(
 									/* translators: %s: poster image URL. */

--- a/packages/block-library/src/cover/edit/poster-image.js
+++ b/packages/block-library/src/cover/edit/poster-image.js
@@ -1,0 +1,89 @@
+/**
+ * WordPress dependencies
+ */
+import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
+import {
+	Button,
+	BaseControl,
+	__experimentalHStack as HStack,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { useRef } from '@wordpress/element';
+import { useInstanceId } from '@wordpress/compose';
+
+const COVER_POSTER_ALLOWED_MEDIA_TYPES = [ 'image' ];
+
+function PosterImage( { poster, setAttributes } ) {
+	const posterImageButton = useRef();
+	const instanceId = useInstanceId( PosterImage );
+	const videoPosterDescription = `cover-block__poster-image-description-${ instanceId }`;
+
+	function onSelectPoster( image ) {
+		setAttributes( { poster: image.url } );
+	}
+
+	function onRemovePoster() {
+		setAttributes( { poster: undefined } );
+
+		// Move focus back to the Media Upload button.
+		posterImageButton.current.focus();
+	}
+
+	return (
+		<ToolsPanelItem
+			label={ __( 'Poster image' ) }
+			isShownByDefault
+			hasValue={ () => !! poster }
+			onDeselect={ () => {
+				setAttributes( { poster: undefined } );
+			} }
+		>
+			<MediaUploadCheck>
+				<BaseControl.VisualLabel>
+					{ __( 'Poster image' ) }
+				</BaseControl.VisualLabel>
+				<HStack justify="flex-start">
+					<MediaUpload
+						title={ __( 'Select poster image' ) }
+						onSelect={ onSelectPoster }
+						allowedTypes={ COVER_POSTER_ALLOWED_MEDIA_TYPES }
+						render={ ( { open } ) => (
+							<Button
+								__next40pxDefaultSize
+								variant="primary"
+								onClick={ open }
+								ref={ posterImageButton }
+								aria-describedby={ videoPosterDescription }
+							>
+								{ ! poster ? __( 'Select' ) : __( 'Replace' ) }
+							</Button>
+						) }
+					/>
+					<p id={ videoPosterDescription } hidden>
+						{ poster
+							? sprintf(
+									/* translators: %s: poster image URL. */
+									__( 'The current poster image url is %s' ),
+									poster
+							  )
+							: __(
+									'There is no poster image currently selected'
+							  ) }
+					</p>
+					{ !! poster && (
+						<Button
+							__next40pxDefaultSize
+							onClick={ onRemovePoster }
+							variant="tertiary"
+						>
+							{ __( 'Remove' ) }
+						</Button>
+					) }
+				</HStack>
+			</MediaUploadCheck>
+		</ToolsPanelItem>
+	);
+}
+
+export default PosterImage;

--- a/packages/block-library/src/cover/edit/poster-image.js
+++ b/packages/block-library/src/cover/edit/poster-image.js
@@ -33,15 +33,15 @@ function PosterImage( { poster, setAttributes } ) {
 	}
 
 	return (
-		<ToolsPanelItem
-			label={ __( 'Poster image' ) }
-			isShownByDefault
-			hasValue={ () => !! poster }
-			onDeselect={ () => {
-				setAttributes( { poster: undefined } );
-			} }
-		>
-			<MediaUploadCheck>
+		<MediaUploadCheck>
+			<ToolsPanelItem
+				label={ __( 'Poster image' ) }
+				isShownByDefault
+				hasValue={ () => !! poster }
+				onDeselect={ () => {
+					setAttributes( { poster: undefined } );
+				} }
+			>
 				<BaseControl.VisualLabel>
 					{ __( 'Poster image' ) }
 				</BaseControl.VisualLabel>
@@ -83,8 +83,8 @@ function PosterImage( { poster, setAttributes } ) {
 						</Button>
 					) }
 				</HStack>
-			</MediaUploadCheck>
-		</ToolsPanelItem>
+			</ToolsPanelItem>
+		</MediaUploadCheck>
 	);
 }
 

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -46,6 +46,7 @@ export default function save( { attributes } ) {
 		minHeightUnit,
 		tagName: Tag,
 		sizeSlug,
+		poster,
 	} = attributes;
 	const overlayColorClass = getColorClassName(
 		'background-color',
@@ -137,6 +138,7 @@ export default function save( { attributes } ) {
 					loop
 					playsInline
 					src={ url }
+					poster={ poster }
 					style={ { objectPosition } }
 					data-object-fit="cover"
 					data-object-position={ objectPosition }


### PR DESCRIPTION
## What?
Closes #18962

This PR adds support for displaying posters over videos within the `Core/Cover` block.

## Why?

For larger videos and users on slower connections, the inability to set a poster image can result in blocks displaying a blank background, leading to a poor user experience.

## How?

The refactorings made in https://github.com/WordPress/gutenberg/pull/67044 extracted the `poster-image` component, which is reused in this PR to implement a similar functionality within the `core/cover` block.

## Testing Instructions

1. Create a new post and insert a cover block.
2. Attach a large video to it.
3. Also, attach a corresponding poster image to the video.
4. On the front-end, from the developer tools, enable network throttling and set the throttle to "fast 4G".
5. Confirm that the poster gets shown and acts as a placeholder until the video loads up.

### Testing Instructions for Keyboard
Same.

## Screencast

https://github.com/user-attachments/assets/177dc205-674b-4abf-b5e7-ccb1b439bdc5