### PR TITLE
Add customization for the "Menu" label.

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -473,7 +473,7 @@ A collection of blocks that allow visitors to get around your site. ([Source](ht
 -	**Category:** theme
 -	**Allowed Blocks:** core/navigation-link, core/search, core/social-links, core/page-list, core/spacer, core/home-link, core/site-title, core/site-logo, core/navigation-submenu, core/loginout, core/buttons
 -	**Supports:** align (full, wide), ariaLabel, inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~
--	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, templateLock, textColor
+-	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, menuCloseLabel, menuOpenLabel, openSubmenusOnClick, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, templateLock, textColor
 
 ## Custom Link
 

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -62,6 +62,12 @@
 			"type": "boolean",
 			"default": true
 		},
+		"menuOpenLabel": {
+			"type": "string"
+		},
+		"menuCloseLabel": {
+			"type": "string"
+		},
 		"__unstableLocation": {
 			"type": "string"
 		},

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -40,6 +40,7 @@ import {
 	Button,
 	Spinner,
 	Notice,
+	TextControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
@@ -227,6 +228,8 @@ function Navigation( {
 		} = {},
 		hasIcon,
 		icon = 'handle',
+		menuOpenLabel = __( 'Menu' ),
+		menuCloseLabel = __( 'Close' ),
 	} = attributes;
 
 	const ref = attributes.ref;
@@ -635,8 +638,8 @@ function Navigation( {
 									) }
 									{ ! hasIcon && (
 										<>
-											<span>{ __( 'Menu' ) }</span>
-											<span>{ __( 'Close' ) }</span>
+											<span>{ menuOpenLabel }</span>
+											<span>{ menuCloseLabel }</span>
 										</>
 									) }
 								</Button>
@@ -657,6 +660,38 @@ function Navigation( {
 									</VStack>
 								) }
 							</>
+						) }
+
+						{ ! hasIcon && (
+							<VStack
+								style={ {
+									gridColumn: 'span 2',
+									gap: 0,
+								} }
+							>
+								<TextControl
+									__nextHasNoMarginBottom
+									__next40pxDefaultSize
+									label={ __( 'Menu open label' ) }
+									value={ menuOpenLabel }
+									onChange={ ( value ) =>
+										setAttributes( {
+											menuOpenLabel: value,
+										} )
+									}
+								/>
+								<TextControl
+									__nextHasNoMarginBottom
+									__next40pxDefaultSize
+									label={ __( 'Menu close label' ) }
+									value={ menuCloseLabel }
+									onChange={ ( value ) =>
+										setAttributes( {
+											menuCloseLabel: value,
+										} )
+									}
+								/>
+							</VStack>
 						) }
 
 						<ToolsPanelItem
@@ -835,6 +870,8 @@ function Navigation( {
 					isHiddenByDefault={ isHiddenByDefault }
 					overlayBackgroundColor={ overlayBackgroundColor }
 					overlayTextColor={ overlayTextColor }
+					menuOpenLabel={ menuOpenLabel }
+					menuCloseLabel={ menuCloseLabel }
 				>
 					<UnsavedInnerBlocks
 						createNavigationMenu={ createNavigationMenu }
@@ -994,6 +1031,8 @@ function Navigation( {
 									overlayBackgroundColor
 								}
 								overlayTextColor={ overlayTextColor }
+								menuOpenLabel={ menuOpenLabel }
+								menuCloseLabel={ menuCloseLabel }
 							>
 								{ isEntityAvailable && (
 									<NavigationInnerBlocks

--- a/packages/block-library/src/navigation/edit/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/responsive-wrapper.js
@@ -27,6 +27,8 @@ export default function ResponsiveWrapper( {
 	overlayTextColor,
 	hasIcon,
 	icon,
+	menuOpenLabel,
+	menuCloseLabel,
 } ) {
 	if ( ! isResponsive ) {
 		return children;
@@ -86,7 +88,7 @@ export default function ResponsiveWrapper( {
 					onClick={ () => onToggle( true ) }
 				>
 					{ hasIcon && <OverlayMenuIcon icon={ icon } /> }
-					{ ! hasIcon && __( 'Menu' ) }
+					{ ! hasIcon && menuOpenLabel }
 				</Button>
 			) }
 
@@ -107,7 +109,7 @@ export default function ResponsiveWrapper( {
 							onClick={ () => onToggle( false ) }
 						>
 							{ hasIcon && <Icon icon={ close } /> }
-							{ ! hasIcon && __( 'Close' ) }
+							{ ! hasIcon && menuCloseLabel }
 						</Button>
 						<div
 							className="wp-block-navigation__responsive-container-content"

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -478,15 +478,17 @@ class WP_Navigation_Block_Renderer {
 		);
 
 		$should_display_icon_label = isset( $attributes['hasIcon'] ) && true === $attributes['hasIcon'];
+		$menu_open_label = isset( $attributes['menuOpenLabel'] ) ? $attributes['menuOpenLabel'] : __( 'Menu' );
+		$menu_close_label = isset( $attributes['menuCloseLabel'] ) ? $attributes['menuCloseLabel'] : __( 'Close' );
 		$toggle_button_icon        = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5" /><rect x="4" y="15" width="16" height="1.5" /></svg>';
 		if ( isset( $attributes['icon'] ) ) {
 			if ( 'menu' === $attributes['icon'] ) {
 				$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5 5v1.5h14V5H5zm0 7.8h14v-1.5H5v1.5zM5 19h14v-1.5H5V19z" /></svg>';
 			}
 		}
-		$toggle_button_content       = $should_display_icon_label ? $toggle_button_icon : __( 'Menu' );
+		$toggle_button_content       = $should_display_icon_label ? $toggle_button_icon : $menu_open_label;
 		$toggle_close_button_icon    = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path d="m13.06 12 6.47-6.47-1.06-1.06L12 10.94 5.53 4.47 4.47 5.53 10.94 12l-6.47 6.47 1.06 1.06L12 13.06l6.47 6.47 1.06-1.06L13.06 12Z"></path></svg>';
-		$toggle_close_button_content = $should_display_icon_label ? $toggle_close_button_icon : __( 'Close' );
+		$toggle_close_button_content = $should_display_icon_label ? $toggle_close_button_icon : $menu_close_label;
 		$toggle_aria_label_open      = $should_display_icon_label ? 'aria-label="' . __( 'Open menu' ) . '"' : ''; // Open button label.
 		$toggle_aria_label_close     = $should_display_icon_label ? 'aria-label="' . __( 'Close menu' ) . '"' : ''; // Close button label.
 


### PR DESCRIPTION
Closes [#56040](https://github.com/WordPress/gutenberg/issues/56040)

## What?
Adds two new feature to the Navigation block for customizing menu label.

<!-- In a few words, what is the PR actually doing? -->

## Why?
This PR improves accessibility and flexibility by allowing the open/close button labels to be customized instead of using hardcoded text

## How?
- Adds two new attributes to the Navigation block: `menuOpenLabel` and `menuCloseLabel`.
- Update edit function and frontend rendering of menu label.

## Testing Instructions
- Insert or select the Navigation block.
- In Inspector Controls head to `Display` and click on the Display icon button
- Toggle off the `Show icon button`
- Enter `Menu open label` and `Menu close label` value
- See the changes in editor
- Save the page/post and see changes on frontend

## Screenshots or screencast <!-- if applicable -->
[screen-capture.webm](https://github.com/user-attachments/assets/c11fab06-11aa-43e2-9bcb-5a7e2664fc81)

