### PR TITLE
[Block] Cover: Fix resize handler gets stuck on undo

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -324,7 +324,7 @@ function CoverEdit( {
 	const [ resizeListener, { height, width } ] = useResizeObserver();
 	const resizableBoxDimensions = useMemo( () => {
 		return {
-			height: minHeightUnit === 'px' ? minHeight : 'auto',
+			height: minHeightUnit === 'px' && minHeight ? minHeight : 'auto',
 			width: 'auto',
 		};
 	}, [ minHeight, minHeightUnit ] );


### PR DESCRIPTION
## What, Why, and How?

Closes #70819

This PR fixes a bug where the resize handler doesn't reset correctly after the first undo following a `Cover` block resize.

This occurs because the following line only checks whether `minHeightUnit` is set to `px`.

Ref:
https://github.com/WordPress/gutenberg/blob/2a278af3c61714a3e6fbfdf97e4a4cf1e5e578dd/packages/block-library/src/cover/edit/index.js#L327

After resizing and undoing, the unit may still be `px`, but `minHeight` becomes `undefined`. In this case, the `resizableBox` height should default to `auto`.

Ref. of a similar condition:
https://github.com/WordPress/gutenberg/blob/2a278af3c61714a3e6fbfdf97e4a4cf1e5e578dd/packages/block-library/src/cover/edit/index.js#L332-L335

## Testing Instructions

1. Create a new post, insert a "Cover" block, and attach an image/video to it.
2. Resize the "Cover" block.
3. After resizing, undo the changes by pressing `CMD/CTRL + Z`.
4. Confirm that the resize handler gets reset properly.

### Testing Instructions for Keyboard

Same.

## Screenshots

|Before|After|
|-|-|
|<img width="670" height="513" alt="before" src="https://github.com/user-attachments/assets/c343cbba-86fa-457a-81d0-065fa95a54a3" />|<img width="670" height="513" alt="after" src="https://github.com/user-attachments/assets/b1c38b15-9415-4020-99c4-6d607345e49a" />|


