### PR TITLE
Core-Data: Avoid duplicate attachment entity

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -292,7 +292,7 @@ async function loadPostTypeEntities() {
 		path: '/wp/v2/types?context=view',
 	} );
 	return Object.entries( postTypes ?? {} )
-		.filter( ( [ name ] ) => name !== 'attachment' )
+		.filter( ( [ name ] ) => name !== 'attachment' ) // Prevent attachment post type from registering as it is handled by root/media.
 		.map( ( [ name, postType ] ) => {
 			const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
 				name

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -291,75 +291,88 @@ async function loadPostTypeEntities() {
 	const postTypes = await apiFetch( {
 		path: '/wp/v2/types?context=view',
 	} );
-	return Object.entries( postTypes ?? {} ).map( ( [ name, postType ] ) => {
-		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
-			name
-		);
-		const namespace = postType?.rest_namespace ?? 'wp/v2';
-		return {
-			kind: 'postType',
-			baseURL: `/${ namespace }/${ postType.rest_base }`,
-			baseURLParams: { context: 'edit' },
-			name,
-			label: postType.name,
-			transientEdits: {
-				blocks: true,
-				selection: true,
-			},
-			mergedEdits: { meta: true },
-			rawAttributes: POST_RAW_ATTRIBUTES,
-			getTitle: ( record ) =>
-				record?.title?.rendered ||
-				record?.title ||
-				( isTemplate
-					? capitalCase( record.slug ?? '' )
-					: String( record.id ) ),
-			__unstablePrePersist: isTemplate ? undefined : prePersistPostType,
-			__unstable_rest_base: postType.rest_base,
-			syncConfig: {
-				fetch: async ( id ) => {
-					return apiFetch( {
-						path: `/${ namespace }/${ postType.rest_base }/${ id }?context=edit`,
-					} );
+	return Object.entries( postTypes ?? {} )
+		.filter( ( [ name ] ) => name !== 'attachment' )
+		.map( ( [ name, postType ] ) => {
+			const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
+				name
+			);
+			const namespace = postType?.rest_namespace ?? 'wp/v2';
+			return {
+				kind: 'postType',
+				baseURL: `/${ namespace }/${ postType.rest_base }`,
+				baseURLParams: { context: 'edit' },
+				name,
+				label: postType.name,
+				transientEdits: {
+					blocks: true,
+					selection: true,
 				},
-				applyChangesToDoc: ( doc, changes ) => {
-					const document = doc.getMap( 'document' );
+				mergedEdits: { meta: true },
+				rawAttributes: POST_RAW_ATTRIBUTES,
+				getTitle: ( record ) =>
+					record?.title?.rendered ||
+					record?.title ||
+					( isTemplate
+						? capitalCase( record.slug ?? '' )
+						: String( record.id ) ),
+				__unstablePrePersist: isTemplate
+					? undefined
+					: prePersistPostType,
+				__unstable_rest_base: postType.rest_base,
+				syncConfig: {
+					fetch: async ( id ) => {
+						return apiFetch( {
+							path: `/${ namespace }/${ postType.rest_base }/${ id }?context=edit`,
+						} );
+					},
+					applyChangesToDoc: ( doc, changes ) => {
+						const document = doc.getMap( 'document' );
 
-					Object.entries( changes ).forEach( ( [ key, value ] ) => {
-						if ( typeof value !== 'function' ) {
-							if ( key === 'blocks' ) {
-								if ( ! serialisableBlocksCache.has( value ) ) {
-									serialisableBlocksCache.set(
-										value,
-										makeBlocksSerializable( value )
-									);
+						Object.entries( changes ).forEach(
+							( [ key, value ] ) => {
+								if ( typeof value !== 'function' ) {
+									if ( key === 'blocks' ) {
+										if (
+											! serialisableBlocksCache.has(
+												value
+											)
+										) {
+											serialisableBlocksCache.set(
+												value,
+												makeBlocksSerializable( value )
+											);
+										}
+
+										value =
+											serialisableBlocksCache.get(
+												value
+											);
+									}
+
+									if ( document.get( key ) !== value ) {
+										document.set( key, value );
+									}
 								}
-
-								value = serialisableBlocksCache.get( value );
 							}
-
-							if ( document.get( key ) !== value ) {
-								document.set( key, value );
-							}
-						}
-					} );
+						);
+					},
+					fromCRDTDoc: ( doc ) => {
+						return doc.getMap( 'document' ).toJSON();
+					},
 				},
-				fromCRDTDoc: ( doc ) => {
-					return doc.getMap( 'document' ).toJSON();
-				},
-			},
-			syncObjectType: 'postType/' + postType.name,
-			getSyncObjectId: ( id ) => id,
-			supportsPagination: true,
-			getRevisionsUrl: ( parentId, revisionId ) =>
-				`/${ namespace }/${
-					postType.rest_base
-				}/${ parentId }/revisions${
-					revisionId ? '/' + revisionId : ''
-				}`,
-			revisionKey: isTemplate ? 'wp_id' : DEFAULT_ENTITY_KEY,
-		};
-	} );
+				syncObjectType: 'postType/' + postType.name,
+				getSyncObjectId: ( id ) => id,
+				supportsPagination: true,
+				getRevisionsUrl: ( parentId, revisionId ) =>
+					`/${ namespace }/${
+						postType.rest_base
+					}/${ parentId }/revisions${
+						revisionId ? '/' + revisionId : ''
+					}`,
+				revisionKey: isTemplate ? 'wp_id' : DEFAULT_ENTITY_KEY,
+			};
+		} );
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #70815 

Removes the dynamic registration of the `postType/attachment` entity to avoid duplicate caching issues with `root/media`.

## Why?
This PR addresses an issue where the same REST endpoint (`wp/v2/media`) is registered under two separate entity keys: `postType/attachment` and `root/media`. This causes duplicate network requests and results in separate, unsynchronized caches. 

## How?
The loadPostTypeEntities() function now filters out the attachment post type from being dynamically registered. The root/media entity continues to represent the wp/v2/media endpoint, serving as the single source of truth for media records.

## Testing Instructions
- Open the block editor, using the browser console, run 
    `wp.data.select( 'core' ).getEntityRecords( 'postType', 'attachment' );`
    - Expected Result:
        - No network request is made to `wp/v2/media`.
- Now run 
    `wp.data.select( 'core' ).getEntityRecords( 'root', 'media' );`
    - Expected Result:
        - A network request is made to `wp/v2/media`.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before:
<img width="745" height="445" alt="image" src="https://github.com/user-attachments/assets/da176287-fa34-49c1-b8e3-33db14b17804" />

<img width="748" height="496" alt="image" src="https://github.com/user-attachments/assets/147c587f-f2a8-4570-a6c4-105d21c53d4e" />


<img width="745" height="460" alt="image" src="https://github.com/user-attachments/assets/ef98f56f-9a67-4354-ace7-d2f16050012f" />



### After:
<img width="747" height="386" alt="image" src="https://github.com/user-attachments/assets/b84dd3d4-617e-4564-a76d-8d8dda92eb2f" />

<img width="746" height="494" alt="image" src="https://github.com/user-attachments/assets/6cb7e934-e43a-4558-98ca-59c80f164d96" />
