### PR TITLE
Fix: Standardize block descriptions to third-person verb form

### DIFF
--- a/packages/block-library/src/audio/block.json
+++ b/packages/block-library/src/audio/block.json
@@ -4,7 +4,7 @@
 	"name": "core/audio",
 	"title": "Audio",
 	"category": "media",
-	"description": "Embed a simple audio player.",
+	"description": "Embeds a simple audio player.",
 	"keywords": [ "music", "sound", "podcast", "recording" ],
 	"textdomain": "default",
 	"attributes": {

--- a/packages/block-library/src/code/block.json
+++ b/packages/block-library/src/code/block.json
@@ -4,7 +4,7 @@
 	"name": "core/code",
 	"title": "Code",
 	"category": "text",
-	"description": "Display code snippets that respect your spacing and tabs.",
+	"description": "Displays code snippets that respect your spacing and tabs.",
 	"textdomain": "default",
 	"attributes": {
 		"content": {

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -4,7 +4,7 @@
 	"name": "core/cover",
 	"title": "Cover",
 	"category": "media",
-	"description": "Add an image or video with a text overlay.",
+	"description": "Adds an image or video with a text overlay.",
 	"textdomain": "default",
 	"attributes": {
 		"url": {

--- a/packages/block-library/src/file/block.json
+++ b/packages/block-library/src/file/block.json
@@ -4,7 +4,7 @@
 	"name": "core/file",
 	"title": "File",
 	"category": "media",
-	"description": "Add a link to a downloadable file.",
+	"description": "Adds a link to a downloadable file.",
 	"keywords": [ "document", "pdf", "download" ],
 	"textdomain": "default",
 	"attributes": {

--- a/packages/block-library/src/separator/block.json
+++ b/packages/block-library/src/separator/block.json
@@ -4,7 +4,7 @@
 	"name": "core/separator",
 	"title": "Separator",
 	"category": "design",
-	"description": "Create a break between ideas or sections with a horizontal separator.",
+	"description": "Creates a break between ideas or sections with a horizontal separator.",
 	"keywords": [ "horizontal-line", "hr", "divider" ],
 	"textdomain": "default",
 	"attributes": {


### PR DESCRIPTION
Closes #69475

This PR updates the block descriptions for five blocks (`audio`, `code`, `cover`, `file`, `separator`) to follow a consistent third-person verb pattern such as "Embeds...", "Displays...", etc.

### Why?

As discussed in #69475, block descriptions were inconsistent in verb tense. This change improves clarity and standardization in the Gutenberg UI.

### How?

Descriptions were updated in:

- `audio` → "Embed..." → "Embeds..."
- `code` → "Display..." → "Displays..."
- `cover` → "Add..." → "Adds..."
- `file` → "Add..." → "Adds..."
- `separator` → "Create..." → "Creates..."

### Testing

- Open the block inserter in the editor
- Check that these block descriptions display the updated wording
- No UI functionality or logic is affected
