### PR TITLE
Allow add before/after on block toolbar menu dropdown when in write mode

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -88,6 +88,7 @@ export function BlockSettingsDropdown( {
 		selectedBlockClientIds,
 		openedBlockSettingsMenu,
 		isContentOnly,
+		isZoomOut,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -98,6 +99,7 @@ export function BlockSettingsDropdown( {
 				getBlockAttributes,
 				getOpenedBlockSettingsMenu,
 				getBlockEditingMode,
+				isZoomOut: _isZoomOut,
 			} = unlock( select( blockEditorStore ) );
 
 			const { getActiveBlockVariation } = select( blocksStore );
@@ -122,6 +124,7 @@ export function BlockSettingsDropdown( {
 				openedBlockSettingsMenu: getOpenedBlockSettingsMenu(),
 				isContentOnly:
 					getBlockEditingMode( firstBlockClientId ) === 'contentOnly',
+				isZoomOut: _isZoomOut(),
 			};
 		},
 		[ firstBlockClientId ]
@@ -301,7 +304,7 @@ export function BlockSettingsDropdown( {
 											{ __( 'Duplicate' ) }
 										</MenuItem>
 									) }
-									{ canInsertBlock && ! isContentOnly && (
+									{ canInsertBlock && ! isZoomOut && (
 										<>
 											<MenuItem
 												onClick={ pipe(

--- a/test/e2e/specs/editor/various/write-design-mode.spec.js
+++ b/test/e2e/specs/editor/various/write-design-mode.spec.js
@@ -108,8 +108,8 @@ test.describe( 'Write/Design mode', () => {
 			.getByRole( 'menu', { name: 'Options' } )
 			.getByRole( 'menuitem' );
 
-		// we expect 4 items in the options menu
-		await expect( optionsMenu ).toHaveCount( 4 );
+		// we expect 6 items in the options menu
+		await expect( optionsMenu ).toHaveCount( 6 );
 
 		// We should be able to select the paragraph block and write in it.
 		await paragraph.click();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->



## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->
Allow the add before/after from the block settings dropdown in write mode. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
You can press Enter on a block to access this behavior, so we may as well leave it in the block settings dropdown too.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replace the `! isContentOnly` with an `! isZoomOut` check, as we still don't want this behavior in zoom out. Ideally we would, but if we use it right now it places you in a paragraph block in zoom out mode, which shouldn't be allowed. We'll need an alternate behavior for this, such as opening the zoom out block inserter before/after and moving focus to it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. In Gutenberg Experiments, enable write mode
2. Switch to write mode (icon to the right of the blue + in the header bar of the editor)
3. Click a block to see its toolbar
4. Click the block settings (three dots at end of toolbar)
5. Select Add Before
6. Cursor should be within a new paragraph block before the block
7. Enter zoom out mode
8. Click the block settings (three dots at end of toolbar)
9. Add Before/After should not be available

Check that the content position and full height buttons are NOT available

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
<img width="452" height="396" alt="Screenshot 2025-07-21 at 3 21 20 PM" src="https://github.com/user-attachments/assets/74dd92a5-9010-415d-8d7a-58fba794e722" />
