### PR TITLE
Video: Fix 'MediaUploadCheck' wrapper for Poster control

### DIFF
--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -23,7 +23,6 @@ import {
 } from '@wordpress/block-editor';
 import { useRef, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useInstanceId } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
 import { video as icon } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
@@ -52,7 +51,6 @@ function VideoEdit( {
 	insertBlocksAfter,
 	onReplace,
 } ) {
-	const instanceId = useInstanceId( VideoEdit );
 	const videoPlayer = useRef();
 	const { id, controls, poster, src, tracks } = attributes;
 	const [ temporaryURL, setTemporaryURL ] = useState( attributes.blob );
@@ -222,7 +220,6 @@ function VideoEdit( {
 					<PosterImage
 						poster={ poster }
 						setAttributes={ setAttributes }
-						instanceId={ instanceId }
 					/>
 				</ToolsPanel>
 			</InspectorControls>

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -208,7 +208,7 @@ function VideoEdit( {
 							muted: false,
 							playsInline: false,
 							preload: 'metadata',
-							poster: '',
+							poster: undefined,
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }

--- a/packages/block-library/src/video/editor.scss
+++ b/packages/block-library/src/video/editor.scss
@@ -19,12 +19,6 @@
 	}
 }
 
-.editor-video-poster-control {
-	.components-button {
-		margin-right: $grid-unit-10;
-	}
-}
-
 .block-library-video-tracks-editor {
 	z-index: z-index("{core/video track editor popover}");
 }

--- a/packages/block-library/src/video/poster-image.js
+++ b/packages/block-library/src/video/poster-image.js
@@ -5,6 +5,7 @@ import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
 import {
 	Button,
 	BaseControl,
+	__experimentalHStack as HStack,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
@@ -41,10 +42,10 @@ function PosterImage( { poster, setAttributes } ) {
 					setAttributes( { poster: undefined } );
 				} }
 			>
-				<div className="editor-video-poster-control">
-					<BaseControl.VisualLabel>
-						{ __( 'Poster image' ) }
-					</BaseControl.VisualLabel>
+				<BaseControl.VisualLabel>
+					{ __( 'Poster image' ) }
+				</BaseControl.VisualLabel>
+				<HStack justify="flex-start">
 					<MediaUpload
 						title={ __( 'Select poster image' ) }
 						onSelect={ onSelectPoster }
@@ -81,7 +82,7 @@ function PosterImage( { poster, setAttributes } ) {
 							{ __( 'Remove' ) }
 						</Button>
 					) }
-				</div>
+				</HStack>
 			</ToolsPanelItem>
 		</MediaUploadCheck>
 	);

--- a/packages/block-library/src/video/poster-image.js
+++ b/packages/block-library/src/video/poster-image.js
@@ -38,7 +38,7 @@ function PosterImage( { poster, setAttributes } ) {
 				isShownByDefault
 				hasValue={ () => !! poster }
 				onDeselect={ () => {
-					setAttributes( { poster: '' } );
+					setAttributes( { poster: undefined } );
 				} }
 			>
 				<div className="editor-video-poster-control">

--- a/packages/block-library/src/video/poster-image.js
+++ b/packages/block-library/src/video/poster-image.js
@@ -9,12 +9,16 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useRef } from '@wordpress/element';
+import { useInstanceId } from '@wordpress/compose';
 
-function PosterImage( { poster, setAttributes, instanceId } ) {
-	const posterImageButton = useRef();
-	const VIDEO_POSTER_ALLOWED_MEDIA_TYPES = [ 'image' ];
+const VIDEO_POSTER_ALLOWED_MEDIA_TYPES = [ 'image' ];
 
-	const videoPosterDescription = `video-block__poster-image-description-${ instanceId }`;
+function PosterImage( { poster, setAttributes } ) {
+	const posterButtonRef = useRef();
+	const descriptionId = useInstanceId(
+		PosterImage,
+		'video-block__poster-image-description'
+	);
 
 	function onSelectPoster( image ) {
 		setAttributes( { poster: image.url } );
@@ -24,7 +28,7 @@ function PosterImage( { poster, setAttributes, instanceId } ) {
 		setAttributes( { poster: undefined } );
 
 		// Move focus back to the Media Upload button.
-		posterImageButton.current.focus();
+		posterButtonRef.current.focus();
 	}
 
 	return (
@@ -50,14 +54,14 @@ function PosterImage( { poster, setAttributes, instanceId } ) {
 								__next40pxDefaultSize
 								variant="primary"
 								onClick={ open }
-								ref={ posterImageButton }
-								aria-describedby={ videoPosterDescription }
+								ref={ posterButtonRef }
+								aria-describedby={ descriptionId }
 							>
 								{ ! poster ? __( 'Select' ) : __( 'Replace' ) }
 							</Button>
 						) }
 					/>
-					<p id={ videoPosterDescription } hidden>
+					<p id={ descriptionId } hidden>
 						{ poster
 							? sprintf(
 									/* translators: %s: poster image URL. */

--- a/packages/block-library/src/video/poster-image.js
+++ b/packages/block-library/src/video/poster-image.js
@@ -28,15 +28,15 @@ function PosterImage( { poster, setAttributes, instanceId } ) {
 	}
 
 	return (
-		<ToolsPanelItem
-			label={ __( 'Poster image' ) }
-			isShownByDefault
-			hasValue={ () => !! poster }
-			onDeselect={ () => {
-				setAttributes( { poster: '' } );
-			} }
-		>
-			<MediaUploadCheck>
+		<MediaUploadCheck>
+			<ToolsPanelItem
+				label={ __( 'Poster image' ) }
+				isShownByDefault
+				hasValue={ () => !! poster }
+				onDeselect={ () => {
+					setAttributes( { poster: '' } );
+				} }
+			>
 				<div className="editor-video-poster-control">
 					<BaseControl.VisualLabel>
 						{ __( 'Poster image' ) }
@@ -78,8 +78,8 @@ function PosterImage( { poster, setAttributes, instanceId } ) {
 						</Button>
 					) }
 				</div>
-			</MediaUploadCheck>
-		</ToolsPanelItem>
+			</ToolsPanelItem>
+		</MediaUploadCheck>
 	);
 }
 


### PR DESCRIPTION
## What?
PR moves `MediaUploadCheck` wrapper up a level and avoids rendering the whole `ToolsPanelItem` when the user can't upload media.

I've also made some minor code quality changes to the component.

## Why?
Prevents the display of the unreachable "Poster image" option in the dropdown and removes extra spacing.

## Testing Instructions
1. Log in as a user with the contributor role.
2. Create a post.
3. Insert a video via URL.
4. Confirm that the "Poster image" option isn't rendered.
5. Switch to admin account.
6. Confirm that the "Poster image" works as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<img width="554" height="450" alt="CleanShot 2025-07-22 at 09 17 29" src="https://github.com/user-attachments/assets/f247ff29-ef73-40ce-baa0-6120747dfffb" />|<img width="560" height="436" alt="CleanShot 2025-07-22 at 09 18 07" src="https://github.com/user-attachments/assets/a8143333-a65c-4f31-b187-01e9aea8a745" />|
