### PR TITLE
TypeScript: Convert data controls to TS

### DIFF
--- a/packages/data/src/controls.ts
+++ b/packages/data/src/controls.ts
@@ -2,14 +2,13 @@
  * Internal dependencies
  */
 import { createRegistryControl } from './factory';
-
-/** @typedef {import('./types').StoreDescriptor} StoreDescriptor */
+import type { StoreDescriptor } from './types';
 
 const SELECT = '@@data/SELECT';
 const RESOLVE_SELECT = '@@data/RESOLVE_SELECT';
 const DISPATCH = '@@data/DISPATCH';
 
-function isObject( object ) {
+function isObject( object: unknown ): object is Record< string, unknown > {
 	return object !== null && typeof object === 'object';
 }
 
@@ -19,9 +18,9 @@ function isObject( object ) {
  * Note: This control synchronously returns the current selector value, triggering the
  * resolution, but not waiting for it.
  *
- * @param {string|StoreDescriptor} storeNameOrDescriptor Unique namespace identifier for the store
- * @param {string}                 selectorName          The name of the selector.
- * @param {Array}                  args                  Arguments for the selector.
+ * @param storeNameOrDescriptor Unique namespace identifier for the store
+ * @param selectorName          The name of the selector.
+ * @param args                  Arguments for the selector.
  *
  * @example
  * ```js
@@ -34,9 +33,13 @@ function isObject( object ) {
  * }
  * ```
  *
- * @return {Object} The control descriptor.
+ * @return The control descriptor.
  */
-function select( storeNameOrDescriptor, selectorName, ...args ) {
+function select(
+	storeNameOrDescriptor: string | StoreDescriptor,
+	selectorName: string,
+	...args: unknown[]
+) {
 	return {
 		type: SELECT,
 		storeKey: isObject( storeNameOrDescriptor )
@@ -54,9 +57,9 @@ function select( storeNameOrDescriptor, selectorName, ...args ) {
  * selectors that may have a resolver. In such case, it will return a `Promise` that resolves
  * after the selector finishes resolving, with the final result value.
  *
- * @param {string|StoreDescriptor} storeNameOrDescriptor Unique namespace identifier for the store
- * @param {string}                 selectorName          The name of the selector
- * @param {Array}                  args                  Arguments for the selector.
+ * @param storeNameOrDescriptor Unique namespace identifier for the store
+ * @param selectorName          The name of the selector
+ * @param args                  Arguments for the selector.
  *
  * @example
  * ```js
@@ -69,9 +72,13 @@ function select( storeNameOrDescriptor, selectorName, ...args ) {
  * }
  * ```
  *
- * @return {Object} The control descriptor.
+ * @return The control descriptor.
  */
-function resolveSelect( storeNameOrDescriptor, selectorName, ...args ) {
+function resolveSelect(
+	storeNameOrDescriptor: string | StoreDescriptor< any >,
+	selectorName: string,
+	...args: any[]
+) {
 	return {
 		type: RESOLVE_SELECT,
 		storeKey: isObject( storeNameOrDescriptor )
@@ -85,9 +92,9 @@ function resolveSelect( storeNameOrDescriptor, selectorName, ...args ) {
 /**
  * Dispatches a control action for triggering a registry dispatch.
  *
- * @param {string|StoreDescriptor} storeNameOrDescriptor Unique namespace identifier for the store
- * @param {string}                 actionName            The name of the action to dispatch
- * @param {Array}                  args                  Arguments for the dispatch action.
+ * @param storeNameOrDescriptor Unique namespace identifier for the store
+ * @param actionName            The name of the action to dispatch
+ * @param args                  Arguments for the dispatch action.
  *
  * @example
  * ```js
@@ -100,9 +107,13 @@ function resolveSelect( storeNameOrDescriptor, selectorName, ...args ) {
  * }
  * ```
  *
- * @return {Object}  The control descriptor.
+ * @return   The control descriptor.
  */
-function dispatch( storeNameOrDescriptor, actionName, ...args ) {
+function dispatch(
+	storeNameOrDescriptor: string | StoreDescriptor,
+	actionName: string,
+	...args: unknown[]
+) {
 	return {
 		type: DISPATCH,
 		storeKey: isObject( storeNameOrDescriptor )
@@ -115,15 +126,27 @@ function dispatch( storeNameOrDescriptor, actionName, ...args ) {
 
 export const controls = { select, resolveSelect, dispatch };
 
+type SelectorControlArgs = {
+	storeKey: string;
+	selectorName: string;
+	args: unknown[];
+};
+
+type ActionControlArgs = {
+	storeKey: string;
+	actionName: string;
+	args: unknown[];
+};
+
 export const builtinControls = {
 	[ SELECT ]: createRegistryControl(
 		( registry ) =>
-			( { storeKey, selectorName, args } ) =>
+			( { storeKey, selectorName, args }: SelectorControlArgs ) =>
 				registry.select( storeKey )[ selectorName ]( ...args )
 	),
 	[ RESOLVE_SELECT ]: createRegistryControl(
 		( registry ) =>
-			( { storeKey, selectorName, args } ) => {
+			( { storeKey, selectorName, args }: SelectorControlArgs ) => {
 				const method = registry.select( storeKey )[ selectorName ]
 					.hasResolver
 					? 'resolveSelect'
@@ -135,7 +158,7 @@ export const builtinControls = {
 	),
 	[ DISPATCH ]: createRegistryControl(
 		( registry ) =>
-			( { storeKey, actionName, args } ) =>
+			( { storeKey, actionName, args }: ActionControlArgs ) =>
 				registry.dispatch( storeKey )[ actionName ]( ...args )
 	),
 };

--- a/packages/data/src/promise-middleware.ts
+++ b/packages/data/src/promise-middleware.ts
@@ -2,18 +2,19 @@
  * External dependencies
  */
 import isPromise from 'is-promise';
+import type { Middleware } from 'redux';
 
 /**
  * Simplest possible promise redux middleware.
- *
- * @type {import('redux').Middleware}
  */
-const promiseMiddleware = () => ( next ) => ( action ) => {
+const promiseMiddleware: Middleware = () => ( next ) => ( action ) => {
 	if ( isPromise( action ) ) {
 		return action.then( ( resolvedAction ) => {
 			if ( resolvedAction ) {
 				return next( resolvedAction );
 			}
+
+			return undefined;
 		} );
 	}
 

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -31,6 +31,7 @@ import { lock, unlock } from './lock-unlock';
  * @property {Function} dispatch             Given a namespace key, returns an
  *                                           object of the store's registered
  *                                           action dispatchers.
+ * @property {any}      stores               An object of registered stores.
  */
 
 /**

--- a/packages/data/src/resolvers-cache-middleware.ts
+++ b/packages/data/src/resolvers-cache-middleware.ts
@@ -1,17 +1,30 @@
-/** @typedef {import('./registry').WPDataRegistry} WPDataRegistry */
+/**
+ * External dependencies
+ */
+import type { Middleware } from 'redux';
+/**
+ * Internal dependencies
+ */
+import type { WPDataRegistry } from './registry';
 
 /**
  * Creates a middleware handling resolvers cache invalidation.
  *
- * @param {WPDataRegistry} registry  Registry for which to create the middleware.
- * @param {string}         storeName Name of the store for which to create the middleware.
+ * @param registry  Registry for which to create the middleware.
+ * @param storeName Name of the store for which to create the middleware.
  *
- * @return {Function} Middleware function.
+ * @return Middleware function.
  */
 const createResolversCacheMiddleware =
-	( registry, storeName ) => () => ( next ) => ( action ) => {
+	( registry: WPDataRegistry, storeName: string ): Middleware =>
+	() =>
+	( next ) =>
+	( action ) => {
 		const resolvers = registry.select( storeName ).getCachedResolvers();
-		const resolverEntries = Object.entries( resolvers );
+		const resolverEntries =
+			Object.entries< Map< string, { status: 'finished' | 'error' } > >(
+				resolvers
+			);
 		resolverEntries.forEach( ( [ selectorName, resolversByArgs ] ) => {
 			const resolver =
 				registry.stores[ storeName ]?.resolvers?.[ selectorName ];


### PR DESCRIPTION
## What?

Converts several JavaScript files in the `@wordpress/data` package to TypeScript.

## Why?

This is part of the ongoing effort (via #67691) to improve type safety and developer experience in the Gutenberg codebase by migrating JavaScript files to TypeScript.

## How?

Converted the following files from JavaScript to TypeScript:

-   `controls.js` → `controls.ts`: Added types for the `select`, `resolveSelect`, and `dispatch` control functions, including proper typing for `StoreDescriptor` parameters and control arguments (`SelectorControlArgs`, `ActionControlArgs`).

-   `promise-middleware.js` → `promise-middleware.ts`: Added the Redux `Middleware` type annotation.

-   `resolvers-cache-middleware.js` → `resolvers-cache-middleware.ts`: Added types for the registry parameter (`WPDataRegistry`), store name, and the resolver entries map.


## Testing Instructions

1. Run `npm run clean:package-types && npm run build` to verify the build succeeds.

### Testing Instructions for Keyboard

N/A - No UI changes.

## Screenshots or screencast

N/A - Internal code changes only.
