### PR TITLE
Sync package-lock.json on latest NPM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22541,6 +22541,30 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/docker-compose": {
+			"version": "0.24.8",
+			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.8.tgz",
+			"integrity": "sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==",
+			"license": "MIT",
+			"dependencies": {
+				"yaml": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/docker-compose/node_modules/yaml": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+			"integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			}
+		},
 		"node_modules/doctrine": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -29745,17 +29769,6 @@
 			"dependencies": {
 				"htmlparser2-without-node-native": "^3.9.2",
 				"querystring": "^0.2.0"
-			}
-		},
-		"node_modules/jsdom/node_modules/agent-base": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-			"integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-			"dependencies": {
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
 			}
 		},
 		"node_modules/jsdom/node_modules/https-proxy-agent": {
@@ -48714,14 +48727,6 @@
 				"react": "^18.0.0"
 			}
 		},
-		"packages/annotations/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
-		},
 		"packages/api-fetch": {
 			"name": "@wordpress/api-fetch",
 			"version": "7.26.0",
@@ -48799,19 +48804,6 @@
 				"npm": ">=8.19.2"
 			}
 		},
-		"packages/babel-preset-default/node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.25.7.tgz",
-			"integrity": "sha512-12xfNeKNH7jubQNm7PAkzlLwEmCs1tfuX3UjIw6vP6QXi+leKh6+LyC/+Ed4EIQermwd58wsyh070yjDHFlNGg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/traverse": "^7.25.7",
-				"@babel/types": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"packages/babel-preset-default/node_modules/@babel/helper-create-class-features-plugin": {
 			"version": "7.25.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.7.tgz",
@@ -48886,84 +48878,6 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.25.7.tgz",
-			"integrity": "sha512-wxyWg2RYaSUYgmd9MR0FyRGyeOMQE/Uzr1wzd/g5cf5bwi9A4v6HFdDm7y1MgDtod/fLOSTZY6jDgV0xU9d5bA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.25.7.tgz",
-			"integrity": "sha512-Xwg6tZpLxc4iQjorYsyGMyfJE7nP5MV8t/Ka58BgiA7Jw0fRqQNcANlLfdJ/yvBt9z9LD2We+BEkT7vLqZRWng==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.7",
-				"@babel/plugin-transform-optional-chaining": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.13.0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.25.7.tgz",
-			"integrity": "sha512-UVATLMidXrnH+GMUIuxq55nejlj02HP7F5ETyBONzP6G87fPBogG4CH6kxrSrdIuAjdwNO9VzyaYsrZPscWUrw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/traverse": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-syntax-import-assertions": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.25.7.tgz",
-			"integrity": "sha512-ZvZQRmME0zfJnDQnVBKYzHxXT7lYBB3Revz1GuS7oLXWMgqUPX4G+DDbT30ICClht9WKV34QVrZhSw6WdklwZQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-syntax-import-attributes": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.25.7.tgz",
-			"integrity": "sha512-AqVo+dguCgmpi/3mYBdu9lkngOBlQ2w2vnNpa6gfiCxQZLzV4ZbhsXitJ2Yblkoe1VQwtHSaNmIaGll/26YWRw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
 			}
 		},
 		"packages/babel-preset-default/node_modules/@babel/plugin-syntax-typescript": {
@@ -49043,39 +48957,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-class-properties": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.7.tgz",
-			"integrity": "sha512-mhyfEW4gufjIqYFo9krXHJ3ElbFLIze5IDp+wQTxoPd+mwFb1NxatNAwmv8Q8Iuxv7Zc+q8EkiMQwc9IhyGf4g==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.25.7",
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-class-static-block": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.25.7.tgz",
-			"integrity": "sha512-rvUUtoVlkDWtDWxGAiiQj0aNktTPn3eFynBcMC2IhsXweehwgdI9ODe+XjWw515kEmv22sSOTp/rxIRuTiB7zg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.25.7",
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/plugin-syntax-class-static-block": "^7.14.5"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.12.0"
-			}
-		},
 		"packages/babel-preset-default/node_modules/@babel/plugin-transform-classes": {
 			"version": "7.25.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.7.tgz",
@@ -49127,69 +49008,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-dotall-regex": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.25.7.tgz",
-			"integrity": "sha512-kXzXMMRzAtJdDEgQBLF4oaiT6ZCU3oWHgpARnTKDAqPkDJ+bs3NrZb310YYevR5QlRo3Kn7dzzIdHbZm1VzJdQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.25.7",
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-duplicate-keys": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.25.7.tgz",
-			"integrity": "sha512-by+v2CjoL3aMnWDOyCIg+yxU9KXSRa9tN6MbqggH5xvymmr9p4AMjYkNlQy4brMceBnUyHZ9G8RnpvT8wP7Cfg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-dynamic-import": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.25.7.tgz",
-			"integrity": "sha512-UvcLuual4h7/GfylKm2IAA3aph9rwvAM2XBA0uPKU3lca+Maai4jBjjEVUS568ld6kJcgbouuumCBhMd/Yz17w==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/plugin-syntax-dynamic-import": "^7.8.3"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.25.7.tgz",
-			"integrity": "sha512-yjqtpstPfZ0h/y40fAXRv2snciYr0OAoMXY/0ClC7tm4C/nG5NJKmIItlaYlLbIVAWNfrYuy9dq1bE0SbX0PEg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.25.7",
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
 		"packages/babel-preset-default/node_modules/@babel/plugin-transform-for-of": {
 			"version": "7.25.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.25.7.tgz",
@@ -49223,22 +49041,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-json-strings": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.25.7.tgz",
-			"integrity": "sha512-Ot43PrL9TEAiCe8C/2erAjXMeVSnE/BLEx6eyrKLNFCCw5jvhTHKyHxdI1pA0kz5njZRYAnMO2KObGqOCRDYSA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/plugin-syntax-json-strings": "^7.8.3"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
 		"packages/babel-preset-default/node_modules/@babel/plugin-transform-literals": {
 			"version": "7.25.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.7.tgz",
@@ -49254,44 +49056,12 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-logical-assignment-operators": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.25.7.tgz",
-			"integrity": "sha512-iImzbA55BjiovLyG2bggWS+V+OLkaBorNvc/yJoeeDQGztknRnDdYfp2d/UPmunZYEnZi6Lg8QcTmNMHOB0lGA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
 		"packages/babel-preset-default/node_modules/@babel/plugin-transform-member-expression-literals": {
 			"version": "7.25.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.25.7.tgz",
 			"integrity": "sha512-Std3kXwpXfRV0QtQy5JJcRpkqP8/wG4XL7hSKZmGlxPlDqmpXtEPRmhF7ztnlTCtUN3eXRUJp+sBEZjaIBVYaw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-modules-amd": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.25.7.tgz",
-			"integrity": "sha512-CgselSGCGzjQvKzghCvDTxKHP3iooenLpJDO842ehn5D2G5fJB222ptnDwQho0WjEvg7zyoxb9P+wiYxiJX5yA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-module-transforms": "^7.25.7",
 				"@babel/helper-plugin-utils": "^7.25.7"
 			},
 			"engines": {
@@ -49318,40 +49088,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-modules-systemjs": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.7.tgz",
-			"integrity": "sha512-t9jZIvBmOXJsiuyOwhrIGs8dVcD6jDyg2icw1VL4A/g+FnWyJKwUfSSU2nwJuMV2Zqui856El9u+ElB+j9fV1g==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-module-transforms": "^7.25.7",
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/helper-validator-identifier": "^7.25.7",
-				"@babel/traverse": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-modules-umd": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.25.7.tgz",
-			"integrity": "sha512-p88Jg6QqsaPh+EB7I9GJrIqi1Zt4ZBHUQtjw3z1bzEXcLh6GfPqzZJ6G+G1HBGKUNukT58MnKG7EN7zXQBCODw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-module-transforms": "^7.25.7",
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
 		"packages/babel-preset-default/node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
 			"version": "7.25.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.25.7.tgz",
@@ -49368,71 +49104,6 @@
 				"@babel/core": "^7.0.0"
 			}
 		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-new-target": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.25.7.tgz",
-			"integrity": "sha512-CfCS2jDsbcZaVYxRFo2qtavW8SpdzmBXC2LOI4oO0rP+JSRDxxF3inF4GcPsLgfb5FjkhXG5/yR/lxuRs2pySA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.25.7.tgz",
-			"integrity": "sha512-FbuJ63/4LEL32mIxrxwYaqjJxpbzxPVQj5a+Ebrc8JICV6YX8nE53jY+K0RZT3um56GoNWgkS2BQ/uLGTjtwfw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-numeric-separator": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.25.7.tgz",
-			"integrity": "sha512-8CbutzSSh4hmD+jJHIA8vdTNk15kAzOnFLVVgBSMGr28rt85ouT01/rezMecks9pkU939wDInImwCKv4ahU4IA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/plugin-syntax-numeric-separator": "^7.10.4"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-object-rest-spread": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.25.7.tgz",
-			"integrity": "sha512-1JdVKPhD7Y5PvgfFy0Mv2brdrolzpzSoUq2pr6xsR+m+3viGGeHEokFKsCgOkbeFOQxfB1Vt2F0cPJLRpFI4Zg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.25.7",
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-				"@babel/plugin-transform-parameters": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
 		"packages/babel-preset-default/node_modules/@babel/plugin-transform-object-super": {
 			"version": "7.25.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.25.7.tgz",
@@ -49441,39 +49112,6 @@
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.25.7",
 				"@babel/helper-replace-supers": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-optional-catch-binding": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.25.7.tgz",
-			"integrity": "sha512-m9obYBA39mDPN7lJzD5WkGGb0GO54PPLXsbcnj1Hyeu8mSRz7Gb4b1A6zxNX32ZuUySDK4G6it8SDFWD1nCnqg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-optional-chaining": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.25.7.tgz",
-			"integrity": "sha512-h39agClImgPWg4H8mYVAbD1qP9vClFbEjqoJmt87Zen8pjqK8FTPUwrOXAvqu5soytwxrLMd2fx2KSCp2CHcNg==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.7",
-				"@babel/plugin-syntax-optional-chaining": "^7.8.3"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -49565,37 +49203,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-regenerator": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.25.7.tgz",
-			"integrity": "sha512-mgDoQCRjrY3XK95UuV60tZlFCQGXEtMg8H+IsW72ldw1ih1jZhzYXbJvghmAEpg5UVhhnCeia1CkGttUvCkiMQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"regenerator-transform": "^0.15.2"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-reserved-words": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.25.7.tgz",
-			"integrity": "sha512-3OfyfRRqiGeOvIWSagcwUTVk2hXBsr/ww7bLn6TRTuXnexA+Udov2icFOxFX9abaj4l96ooYkcNN1qi2Zvqwng==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
 		"packages/babel-preset-default/node_modules/@babel/plugin-transform-runtime": {
 			"version": "7.25.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.25.7.tgz",
@@ -49677,21 +49284,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-typeof-symbol": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.25.7.tgz",
-			"integrity": "sha512-OmWmQtTHnO8RSUbL0NTdtpbZHeNTnm68Gj5pA4Y2blFNh+V4iZR68V1qL9cI37J21ZN7AaCnkfdHtLExQPf2uA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
 		"packages/babel-preset-default/node_modules/@babel/plugin-transform-typescript": {
 			"version": "7.25.7",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.25.7.tgz",
@@ -49703,37 +49295,6 @@
 				"@babel/helper-plugin-utils": "^7.25.7",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.7",
 				"@babel/plugin-syntax-typescript": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-unicode-escapes": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.25.7.tgz",
-			"integrity": "sha512-BN87D7KpbdiABA+t3HbVqHzKWUDN3dymLaTnPFAMyc8lV+KN3+YzNhVRNdinaCPA4AUqx7ubXbQ9shRjYBl3SQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-unicode-property-regex": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.25.7.tgz",
-			"integrity": "sha512-IWfR89zcEPQGB/iB408uGtSPlQd3Jpq11Im86vUgcmSTcoWAiQMCTOa2K2yNNqFJEBVICKhayctee65Ka8OB0w==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.25.7",
-				"@babel/helper-plugin-utils": "^7.25.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -49756,22 +49317,6 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"packages/babel-preset-default/node_modules/@babel/plugin-transform-unicode-sets-regex": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.7.tgz",
-			"integrity": "sha512-YRW8o9vzImwmh4Q3Rffd09bH5/hvY0pxg+1H1i0f7APoUeg12G7+HhLj9ZFNIrYkgBXhIijPJ+IXypN0hLTIbw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.25.7",
-				"@babel/helper-plugin-utils": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
 			}
 		},
 		"packages/babel-preset-default/node_modules/@babel/preset-env": {
@@ -50124,14 +49669,6 @@
 				"react-dom": "^18.0.0"
 			}
 		},
-		"packages/block-library/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
-		},
 		"packages/block-serialization-default-parser": {
 			"name": "@wordpress/block-serialization-default-parser",
 			"version": "5.26.0",
@@ -50202,14 +49739,6 @@
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
 			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
-		},
-		"packages/blocks/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
 		},
 		"packages/browserslist-config": {
 			"name": "@wordpress/browserslist-config",
@@ -50531,14 +50060,6 @@
 			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
 			"license": "MIT"
 		},
-		"packages/components/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
-		},
 		"packages/compose": {
 			"name": "@wordpress/compose",
 			"version": "7.26.0",
@@ -50640,14 +50161,6 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
-			}
-		},
-		"packages/core-data/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"bin": {
-				"uuid": "dist/bin/uuid"
 			}
 		},
 		"packages/create-block": {
@@ -50990,14 +50503,6 @@
 				"react-dom": "^18.0.0"
 			}
 		},
-		"packages/e2e-tests/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
-		},
 		"packages/edit-post": {
 			"name": "@wordpress/edit-post",
 			"version": "8.26.0",
@@ -51256,29 +50761,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			}
-		},
-		"packages/env/node_modules/docker-compose": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.2.tgz",
-			"integrity": "sha512-2/WLvA7UZ6A2LDLQrYW0idKipmNBWhtfvrn2yzjC5PnHDzuFVj1zAZN6MJxVMKP0zZH8uzAK6OwVZYHGuyCmTw==",
-			"dependencies": {
-				"yaml": "^2.2.2"
-			},
-			"engines": {
-				"node": ">= 6.0.0"
-			}
-		},
-		"packages/env/node_modules/yaml": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
-			"integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
-			"license": "ISC",
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14"
 			}
 		},
 		"packages/escape-html": {


### PR DESCRIPTION
## What?

Updates `package-lock.json` to commit changes caused on `trunk` when running `npm install` with the latest version of npm (v11.4.2 at time of writing).

Split from #70799

## Why?

- Running `npm install` should not cause local changes
- `package-lock.json` should be kept in sync with the result of `npm install`

## Testing Instructions

You can manually verify these changes are correct on trunk:

1. `git checkout trunk`
2. `npm install -g npm@latest`
3. `npm install`
4. `git diff update/sync-package-lock`
5. Observe that nothing is shown