### PR TITLE
Block Library: Clarify More block description about theme dependency

### DIFF
--- a/packages/block-library/src/more/block.json
+++ b/packages/block-library/src/more/block.json
@@ -4,7 +4,7 @@
 	"name": "core/more",
 	"title": "More",
 	"category": "design",
-	"description": "Content before this block will be shown in the excerpt on your archives page.",
+	"description": "Hide the remaining content behind a link on your archives page. Only works when your theme displays full post content, not excerpts.",
 	"keywords": [ "read more" ],
 	"textdomain": "default",
 	"attributes": {


### PR DESCRIPTION
## What?
Updates the More block description to clarify that it only works when themes display full post content, not excerpts.

## Why?
The current description "Content before this block will be shown in the excerpt on your archives page" is misleading and doesn't explain the theme dependency. As reported in #41854, users are confused when the More block doesn't work as expected because their theme displays excerpts instead of full content.

## How?
Updated the description in `block.json` to: "Hide the remaining content behind a link on your archives page. Only works when your theme displays full post content, not excerpts."

This new description:
- Explains what the block does
- Clearly states when it works
- Sets proper user expectations
- Prevents confusion about theme requirements

## Testing Instructions
1. Activate Twenty Twenty-One theme with default settings (shows excerpts)
2. Create a post with content before and after a More block
3. View the front page - confirm the new description accurately describes the behavior
4. Switch theme to show full content and verify the More block works as described

## Related
- Addresses user confusion mentioned in Trac ticket 52361
- Improves block discoverability and user understanding

Fixes #41854