### PR TITLE
Install latest NPM for CI static checks

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -40,6 +40,9 @@ jobs:
                   check-latest: true
                   cache: npm
 
+            - name: Install latest npm
+              run: npm install -g npm@latest
+
             - name: Npm install
               # A "full" install is executed, since `npm ci` does not always exit
               # with an error status code if the lock file is inaccurate. This also


### PR DESCRIPTION
## What?

Ensures CI static checks are run using the latest version of NPM.

Follow-up to https://github.com/WordPress/gutenberg/pull/70839#pullrequestreview-3042648383

## Why?

Some of the static checks may behave differently in newer or older versions of NPM. Specifically, "local changes" checks for changes to `package-lock.json` after `npm install`, but changes may only be present on specific versions of NPM. We should default to running the latest version.

## How?

Ideally, this could be configurable through the `actions/setup-node` action. Based on https://github.com/actions/setup-node/issues/324, this does not appear to be possible, and must be a separate step.

## Testing Instructions

Hopefully CI on this branch fails as a demonstration of the check, since I branched from 16302bd04e, intentionally one commit prior to #70839.