### PR TITLE
Fix: Prevent overflow in Post Author Biography block for long unbreak…

### DIFF
--- a/packages/block-library/src/post-author-biography/style.scss
+++ b/packages/block-library/src/post-author-biography/style.scss
@@ -1,4 +1,4 @@
 .wp-block-post-author-biography {
-	// This block has customizable padding, border-box makes that more predictable.
-	box-sizing: border-box;
+	word-break: break-word;
+	overflow-wrap: break-word;
 }


### PR DESCRIPTION
### Description

Fixes horizontal overflow in the Post Author Biography block when the biography contains long, unbreakable strings.

### Fix

Added `word-break` and `overflow-wrap` CSS properties to prevent layout break.

### Issue

Fixes: https://github.com/WordPress/gutenberg/issues/70849
