### PR TITLE
Video: Fix missing trailing periods

### DIFF
--- a/packages/block-library/src/video/poster-image.js
+++ b/packages/block-library/src/video/poster-image.js
@@ -66,11 +66,11 @@ function PosterImage( { poster, setAttributes } ) {
 						{ poster
 							? sprintf(
 									/* translators: %s: poster image URL. */
-									__( 'The current poster image url is %s' ),
+									__( 'The current poster image url is %s.' ),
 									poster
 							  )
 							: __(
-									'There is no poster image currently selected'
+									'There is no poster image currently selected.'
 							  ) }
 					</p>
 					{ !! poster && (


### PR DESCRIPTION
## What, Why, and How?

See https://github.com/WordPress/gutenberg/pull/70816#discussion_r2222315209

Adds missing trailing periods.
