### PR TITLE
registerFormatType: Document 'object' setting

### DIFF
--- a/packages/rich-text/src/register-format-type.js
+++ b/packages/rich-text/src/register-format-type.js
@@ -14,6 +14,8 @@ import { store as richTextStore } from './store';
  * @property {string}        tagName     The HTML tag this format will wrap the
  *                                       selection with.
  * @property {boolean}       interactive Whether format makes content interactive or not.
+ * @property {boolean}       object      Whether the format represents an object (e.g., `img`, `br`),
+ *                                       an object cannot contain other format types.
  * @property {string | null} [className] A class to match the format.
  * @property {string}        title       Name of the format.
  * @property {Function}      edit        Should return a component for the user to


### PR DESCRIPTION
## What?
Closes #40051.

PR adds documentation for `registerFormatType` boolean `object` setting, which I mostly pieced together from "git history".

Here's a full summary that I trimmed down for JSDocs:

> Represents objects (e.g., images, videos) that are stored separately in the `replacements` array. Objects cannot contain formatting and are excluded from normal text formatting operations to simplify logic.

## Testing Instructions
None. It's just an inline docs update.
