### PR TITLE
Fields: Add label to Password field

### DIFF
--- a/packages/fields/src/fields/password/index.tsx
+++ b/packages/fields/src/fields/password/index.tsx
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import type { Field } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -12,6 +13,7 @@ import PasswordEdit from './edit';
 const passwordField: Field< BasePost > = {
 	id: 'password',
 	type: 'text',
+	label: __( 'Password' ),
 	Edit: PasswordEdit,
 	enableSorting: false,
 	enableHiding: false,


### PR DESCRIPTION
## What?

I noticed that the password field doesn't have a label and can't be translated.

## Testing Instructions

- Dashboard > Gutenberg > Experiments > Check the "Data Views: enable for Posts" setting
- Access http://localhost:8888/wp-admin/admin.php?p=%2F&page=gutenberg-posts-dashboard&layout=table
- Open the View Options dropdown and check the hidden fields

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| <img width="438" height="300" alt="image" src="https://github.com/user-attachments/assets/467b8014-fff4-46cd-b3ee-88aabecfa73a" /> | <img width="522" height="310" alt="image" src="https://github.com/user-attachments/assets/c941b026-7b7d-401e-8f6a-b9178008431c" /> |