### PR TITLE
BorderControl: Fix border controls rendering when only color or width is enabled

### DIFF
--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -256,6 +256,8 @@ export default function BorderPanel( {
 						colors={ colors }
 						enableAlpha
 						enableStyle={ showBorderStyle }
+						showWidthControl={ showBorderWidth }
+						showColorControl={ showBorderColor }
 						onChange={ onBorderChange }
 						popoverOffset={ 40 }
 						popoverPlacement="left-start"

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -16,6 +16,7 @@
 -   `SelectControl`: Fix font-size for medium screens to ensure consistency with other inputs ([#70619](https://github.com/WordPress/gutenberg/pull/70619)).
 -   `SelectControl`: Move classnames to the root ([#70643](https://github.com/WordPress/gutenberg/pull/70643)).
 -   `Autocomplete`: Prevent text cursor position loss when clicking to insert an item ([#70660](https://github.com/WordPress/gutenberg/pull/70660)).
+-   `BorderControl`: Fix border controls rendering when only color or width is enabled ([#70869](https://github.com/WordPress/gutenberg/pull/70869)).
 
 
 ### Internal

--- a/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
@@ -35,6 +35,8 @@ const BorderBoxControlSplitControls = (
 		size = 'default',
 		value,
 		__experimentalIsRenderedInSidebar,
+		showWidthControl,
+		showColorControl,
 		...otherProps
 	} = useBorderBoxControlSplitControls( props );
 
@@ -77,6 +79,8 @@ const BorderBoxControlSplitControls = (
 			<BorderBoxControlVisualizer value={ value } size={ size } />
 			<BorderControl
 				className={ centeredClassName }
+				showWidthControl={ showWidthControl }
+				showColorControl={ showColorControl }
 				hideLabelFromVision
 				label={ __( 'Top border' ) }
 				onChange={ ( newBorder ) => onChange( newBorder, 'top' ) }
@@ -85,6 +89,8 @@ const BorderBoxControlSplitControls = (
 				{ ...sharedBorderControlProps }
 			/>
 			<BorderControl
+				showWidthControl={ showWidthControl }
+				showColorControl={ showColorControl }
 				hideLabelFromVision
 				label={ __( 'Left border' ) }
 				onChange={ ( newBorder ) => onChange( newBorder, 'left' ) }
@@ -93,6 +99,8 @@ const BorderBoxControlSplitControls = (
 				{ ...sharedBorderControlProps }
 			/>
 			<BorderControl
+				showWidthControl={ showWidthControl }
+				showColorControl={ showColorControl }
 				className={ rightAlignedClassName }
 				hideLabelFromVision
 				label={ __( 'Right border' ) }
@@ -102,6 +110,8 @@ const BorderBoxControlSplitControls = (
 				{ ...sharedBorderControlProps }
 			/>
 			<BorderControl
+				showWidthControl={ showWidthControl }
+				showColorControl={ showColorControl }
 				className={ centeredClassName }
 				hideLabelFromVision
 				label={ __( 'Bottom border' ) }

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -64,6 +64,8 @@ const UnconnectedBorderBoxControl = (
 		toggleLinked,
 		wrapperClassName,
 		__experimentalIsRenderedInSidebar,
+		showWidthControl,
+		showColorControl,
 		...otherProps
 	} = useBorderBoxControl( props );
 
@@ -99,6 +101,8 @@ const UnconnectedBorderBoxControl = (
 				{ isLinked ? (
 					<BorderControl
 						className={ linkedControlClassName }
+						showWidthControl={ showWidthControl }
+						showColorControl={ showColorControl }
 						colors={ colors }
 						disableUnits={ disableUnits }
 						disableCustomColors={ disableCustomColors }
@@ -123,6 +127,8 @@ const UnconnectedBorderBoxControl = (
 					/>
 				) : (
 					<BorderBoxControlSplitControls
+						showWidthControl={ showWidthControl }
+						showColorControl={ showColorControl }
 						colors={ colors }
 						disableCustomColors={ disableCustomColors }
 						enableAlpha={ enableAlpha }

--- a/packages/components/src/border-box-control/styles.ts
+++ b/packages/components/src/border-box-control/styles.ts
@@ -66,6 +66,7 @@ export const borderBoxControlVisualizer = (
 		${ rtl( {
 			borderRight: borderBoxStyleWithFallback( borders?.right ),
 		} )() }
+		z-index: -1;
 	`;
 };
 

--- a/packages/components/src/border-box-control/test/index.tsx
+++ b/packages/components/src/border-box-control/test/index.tsx
@@ -45,6 +45,8 @@ const props = {
 	} ),
 	value: undefined,
 	__next40pxDefaultSize: true,
+	showWidthControl: true,
+	showColorControl: true,
 };
 
 const toggleLabelRegex = /Border color( and style)* picker/;

--- a/packages/components/src/border-box-control/types.ts
+++ b/packages/components/src/border-box-control/types.ts
@@ -51,6 +51,14 @@ export type BorderBoxControlProps = ColorProps &
 		 * @default false
 		 */
 		__next40pxDefaultSize?: boolean;
+		/**
+		 * Whether to show the width control.
+		 */
+		showWidthControl?: boolean;
+		/**
+		 * Whether to show the color control.
+		 */
+		showColorControl?: boolean;
 	};
 
 export type LinkedButtonProps = Pick< BorderBoxControlProps, 'size' > & {
@@ -98,4 +106,12 @@ export type SplitControlsProps = ColorProps &
 		 * color, style, and width.
 		 */
 		value?: Borders;
+		/**
+		 * Whether to show the width control.
+		 */
+		showWidthControl?: boolean;
+		/**
+		 * Whether to show the color control.
+		 */
+		showColorControl?: boolean;
 	};

--- a/packages/components/src/border-control/border-control/component.tsx
+++ b/packages/components/src/border-control/border-control/component.tsx
@@ -77,23 +77,22 @@ const UnconnectedBorderControl = (
 			/>
 			<HStack spacing={ 4 } className={ innerWrapperClassName }>
 				{ showColorControl && ! showWidthControl && (
-					<Spacer marginRight={ 1 } marginBottom={ 0 }>
-						<BorderControlDropdown
-							border={ border }
-							colors={ colors }
-							__unstablePopoverProps={ __unstablePopoverProps }
-							disableCustomColors={ disableCustomColors }
-							enableAlpha={ enableAlpha }
-							enableStyle={ enableStyle }
-							isStyleSettable={ isStyleSettable }
-							onChange={ onBorderChange }
-							previousStyleSelection={ previousStyleSelection }
-							__experimentalIsRenderedInSidebar={
-								__experimentalIsRenderedInSidebar
-							}
-							size={ size }
-						/>
-					</Spacer>
+					<BorderControlDropdown
+						border={ border }
+						colors={ colors }
+						__unstablePopoverProps={ __unstablePopoverProps }
+						disableCustomColors={ disableCustomColors }
+						enableAlpha={ enableAlpha }
+						enableStyle={ enableStyle }
+						isStyleSettable={ isStyleSettable }
+						onChange={ onBorderChange }
+						previousStyleSelection={ previousStyleSelection }
+						__experimentalIsRenderedInSidebar={
+							__experimentalIsRenderedInSidebar
+						}
+						size={ size }
+						className={ withSlider ? 'full-width' : '' }
+					/>
 				) }
 				{ showWidthControl && (
 					<UnitControl

--- a/packages/components/src/border-control/border-control/component.tsx
+++ b/packages/components/src/border-control/border-control/component.tsx
@@ -64,6 +64,8 @@ const UnconnectedBorderControl = (
 		widthValue,
 		withSlider,
 		__experimentalIsRenderedInSidebar,
+		showWidthControl,
+		showColorControl,
 		...otherProps
 	} = useBorderControl( props );
 
@@ -74,43 +76,69 @@ const UnconnectedBorderControl = (
 				hideLabelFromVision={ hideLabelFromVision }
 			/>
 			<HStack spacing={ 4 } className={ innerWrapperClassName }>
-				<UnitControl
-					__next40pxDefaultSize={ __next40pxDefaultSize }
-					__shouldNotWarnDeprecated36pxSize
-					prefix={
-						<Spacer marginRight={ 1 } marginBottom={ 0 }>
-							<BorderControlDropdown
-								border={ border }
-								colors={ colors }
-								__unstablePopoverProps={
-									__unstablePopoverProps
-								}
-								disableCustomColors={ disableCustomColors }
-								enableAlpha={ enableAlpha }
-								enableStyle={ enableStyle }
-								isStyleSettable={ isStyleSettable }
-								onChange={ onBorderChange }
-								previousStyleSelection={
-									previousStyleSelection
-								}
-								__experimentalIsRenderedInSidebar={
-									__experimentalIsRenderedInSidebar
-								}
-								size={ size }
-							/>
-						</Spacer>
-					}
-					label={ __( 'Border width' ) }
-					hideLabelFromVision
-					min={ 0 }
-					onChange={ onWidthChange }
-					value={ border?.width || '' }
-					placeholder={ placeholder }
-					disableUnits={ disableUnits }
-					__unstableInputWidth={ inputWidth }
-					size={ size }
-				/>
-				{ withSlider && (
+				{ showColorControl && ! showWidthControl && (
+					<Spacer marginRight={ 1 } marginBottom={ 0 }>
+						<BorderControlDropdown
+							border={ border }
+							colors={ colors }
+							__unstablePopoverProps={ __unstablePopoverProps }
+							disableCustomColors={ disableCustomColors }
+							enableAlpha={ enableAlpha }
+							enableStyle={ enableStyle }
+							isStyleSettable={ isStyleSettable }
+							onChange={ onBorderChange }
+							previousStyleSelection={ previousStyleSelection }
+							__experimentalIsRenderedInSidebar={
+								__experimentalIsRenderedInSidebar
+							}
+							size={ size }
+						/>
+					</Spacer>
+				) }
+				{ showWidthControl && (
+					<UnitControl
+						__next40pxDefaultSize={ __next40pxDefaultSize }
+						__shouldNotWarnDeprecated36pxSize
+						prefix={
+							showColorControl && (
+								<Spacer marginRight={ 1 } marginBottom={ 0 }>
+									<BorderControlDropdown
+										border={ border }
+										colors={ colors }
+										__unstablePopoverProps={
+											__unstablePopoverProps
+										}
+										disableCustomColors={
+											disableCustomColors
+										}
+										enableAlpha={ enableAlpha }
+										enableStyle={ enableStyle }
+										isStyleSettable={ isStyleSettable }
+										onChange={ onBorderChange }
+										previousStyleSelection={
+											previousStyleSelection
+										}
+										__experimentalIsRenderedInSidebar={
+											__experimentalIsRenderedInSidebar
+										}
+										size={ size }
+									/>
+								</Spacer>
+							)
+						}
+						label={ __( 'Border width' ) }
+						hideLabelFromVision
+						min={ 0 }
+						onChange={ onWidthChange }
+						value={ border?.width || '' }
+						placeholder={ placeholder }
+						disableUnits={ disableUnits }
+						className="some-input-control"
+						__unstableInputWidth={ inputWidth }
+						size={ size }
+					/>
+				) }
+				{ showWidthControl && withSlider && (
 					<RangeControl
 						__nextHasNoMarginBottom
 						label={ __( 'Border width' ) }

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -58,6 +58,15 @@ export const wrapperHeight = ( size?: 'default' | '__unstable-large' ) => {
 export const borderControlDropdown = css`
 	background: #fff;
 
+	&.full-width {
+		flex: 1;
+		${ rtl( { marginRight: space( 3 ) } )() }
+
+		> button {
+			width: 100%;
+		}
+	}
+
 	&& > button {
 		aspect-ratio: 1;
 		padding: 0;

--- a/packages/components/src/border-control/test/index.js
+++ b/packages/components/src/border-control/test/index.js
@@ -38,6 +38,8 @@ function createProps( customProps ) {
 		} ),
 		value: defaultBorder,
 		__next40pxDefaultSize: true,
+		showWidthControl: true,
+		showColorControl: true,
 		...customProps,
 	};
 	return props;
@@ -98,6 +100,38 @@ describe( 'BorderControl', () => {
 			expect( widthInput ).toBeInTheDocument();
 			expect( unitSelect ).toBeInTheDocument();
 			expect( slider ).not.toBeInTheDocument();
+		} );
+
+		it( 'should render only color control when showWidthControl is false', () => {
+			const props = createProps( { showWidthControl: false } );
+			render( <BorderControl { ...props } /> );
+
+			const colorButton = screen.getByLabelText( toggleLabelRegex );
+			const widthInput = screen.queryByRole( 'spinbutton', {
+				name: 'Border width',
+			} );
+			const unitSelect = screen.queryByRole( 'combobox', {
+				name: 'Select unit',
+			} );
+
+			expect( colorButton ).toBeInTheDocument();
+			expect( widthInput ).not.toBeInTheDocument();
+			expect( unitSelect ).not.toBeInTheDocument();
+		} );
+
+		it( 'should render only width control when showColorControl is false', () => {
+			const props = createProps( { showColorControl: false } );
+			render( <BorderControl { ...props } /> );
+
+			const colorButton = screen.queryByLabelText( toggleLabelRegex );
+			const widthInput = getWidthInput();
+			const unitSelect = screen.getByRole( 'combobox', {
+				name: 'Select unit',
+			} );
+
+			expect( colorButton ).not.toBeInTheDocument();
+			expect( widthInput ).toBeInTheDocument();
+			expect( unitSelect ).toBeInTheDocument();
 		} );
 
 		it( 'should hide label', () => {

--- a/packages/components/src/border-control/types.ts
+++ b/packages/components/src/border-control/types.ts
@@ -123,6 +123,14 @@ export type BorderControlProps = ColorProps &
 		 * @ignore
 		 */
 		__shouldNotWarnDeprecated36pxSize?: boolean;
+		/**
+		 * Whether to show the width input (UnitControl and RangeControl)
+		 */
+		showWidthControl?: boolean;
+		/**
+		 * Whether to show the color picker dropdown
+		 */
+		showColorControl?: boolean;
 	};
 
 export type DropdownProps = ColorProps &


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #56402 

<!-- In a few words, what is the PR actually doing? -->
This PR ensures that the rendering of border color and border width controls in the `BorderControl` component correctly reflects their respective `settings.border.color` and `settings.border.width` values.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, the border UI in the editor shows both the color and width controls if either `settings.border.color` or `settings.border.width` is set to true in `theme.json`. This makes it impossible to:

- Show only the color picker while keeping width fixed via default.
- Show only the width input while disabling color control.

This behavior does not respect individual border settings and limits theme authors to control over the UI.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Introduced new attributes `showColorControl` and `showWidthControl` in `BorderControl` and `BorderBoxControl`.
- Updated the `BorderPanel` logic to pass these attributes based on the setting in `theme.json`.
- Conditionally render the border controls based on these attributes.

## Testing Instructions
1. Create a theme or modify your theme.json:
```json
{
  "settings": {
    "border": {
      "color": true,
      "width": false
    }
  }
}
```

2. Open the block editor, insert a block that supports borders (e.g., Group).
3. Go to the block settings and scroll down to the border settings.
3. ✅ You should now only see the color picker (not the width input).
4. Change theme.json to:
```json
{
  "settings": {
    "border": {
      "color": false,
      "width": true
    }
  }
}
```
5. ✅ Reload the editor, now only the width input should appear.
6. If both color and width are true, both controls should appear as before.

<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Setting/View|Linked|Unlinked|
|-|-|-|
|Default|<img width="276" height="125" alt="Screenshot 2025-07-23 at 1 58 31 PM" src="https://github.com/user-attachments/assets/7181af6b-d5f7-4075-87d7-c0673d0a94b3" />|<img width="275" height="224" alt="Screenshot 2025-07-23 at 1 58 41 PM" src="https://github.com/user-attachments/assets/09019daf-be85-4566-8cb0-2aa9a1965a7c" />|
|Only Color|<img width="279" height="125" alt="Screenshot 2025-07-23 at 1 57 17 PM" src="https://github.com/user-attachments/assets/d4d74589-b8c2-448c-9166-c5e6117eaa9a" />|<img width="279" height="231" alt="Screenshot 2025-07-23 at 1 57 28 PM" src="https://github.com/user-attachments/assets/568be351-2d60-47be-90ca-f66aba4bcce9" />|
|Only Width|<img width="274" height="124" alt="Screenshot 2025-07-23 at 1 57 56 PM" src="https://github.com/user-attachments/assets/c762436c-5817-4cc7-9383-b0675df1ccb4" />|<img width="276" height="229" alt="Screenshot 2025-07-23 at 1 58 06 PM" src="https://github.com/user-attachments/assets/a0368915-430c-4d02-aa26-fd45a5a09e72" />|