### PR TITLE
Core Data: Allow useEntityProp setter to accept an updater function

### DIFF
--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -1006,6 +1006,35 @@ _Parameters_
 
 Hook that returns the value and a setter for the specified property of the nearest provided entity of the specified type.
 
+_Usage_
+
+```js
+import { useEntityProp } from '@wordpress/core-data';
+
+function MetaUpdater( { postType, postId } ) {
+	const [ meta, setMeta ] = useEntityProp(
+		'postType',
+		postType,
+		'meta',
+		postId
+	);
+
+	const handleSyncUpdate = () => {
+		const result = syncTask();
+
+		// Use setter with a static value:
+		setMeta( { ...meta, taskKey: result } );
+	};
+
+	const handleAsyncUpdate = async () => {
+		const result = await asyncTask();
+
+		// Use setter with an updater function:
+		setMeta( ( currentMeta ) => ( { ...currentMeta, taskKey: result } ) );
+	};
+}
+```
+
 _Parameters_
 
 -   _kind_ `string`: The entity kind.

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -1015,7 +1015,7 @@ _Parameters_
 
 _Returns_
 
--   `[*, Function, *]`: An array where the first item is the property value, the second is the setter and the third is the full value object from REST API containing more information like `raw`, `rendered` and `protected` props.
+-   `[*, Function, *]`: An array where the first item is the property value, the second is the setter (which accepts either a value or an updater function) and the third is the full value object from REST API containing more information like `raw`, `rendered` and `protected` props.
 
 ### useEntityRecord
 

--- a/packages/core-data/src/hooks/use-entity-prop.js
+++ b/packages/core-data/src/hooks/use-entity-prop.js
@@ -15,6 +15,29 @@ import useEntityId from './use-entity-id';
  * specified property of the nearest provided
  * entity of the specified type.
  *
+ * @example
+ * ```js
+ * import { useEntityProp } from '@wordpress/core-data';
+ *
+ * function MetaUpdater( { postType, postId } ) {
+ * 	const [ meta, setMeta ] = useEntityProp( 'postType', postType, 'meta', postId );
+ *
+ * 	const handleSyncUpdate = () => {
+ * 		const result = syncTask();
+ *
+ * 		// Use setter with a static value:
+ * 		setMeta( { ...meta, taskKey: result } );
+ * 	};
+ *
+ * 	const handleAsyncUpdate = async () => {
+ * 		const result = await asyncTask();
+ *
+ * 		// Use setter with an updater function:
+ * 		setMeta( ( currentMeta ) => ( { ...currentMeta, taskKey: result } ) );
+ * 	};
+ * }
+ * ```
+ *
  * @param {string}        kind  The entity kind.
  * @param {string}        name  The entity name.
  * @param {string}        prop  The property name.

--- a/packages/core-data/src/hooks/use-entity-prop.js
+++ b/packages/core-data/src/hooks/use-entity-prop.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useCallback } from '@wordpress/element';
-import { useRegistry, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -22,7 +22,8 @@ import useEntityId from './use-entity-id';
  *
  * @return {[*, Function, *]} An array where the first item is the
  *                            property value, the second is the
- *                            setter and the third is the full value
+ *                            setter (which accepts either a value or an updater function)
+ *                            and the third is the full value
  * 							  object from REST API containing more
  * 							  information like `raw`, `rendered` and
  * 							  `protected` props.
@@ -30,8 +31,6 @@ import useEntityId from './use-entity-id';
 export default function useEntityProp( kind, name, prop, _id ) {
 	const providerId = useEntityId( kind, name );
 	const id = _id ?? providerId;
-
-	const registry = useRegistry();
 
 	const { value, fullValue } = useSelect(
 		( select ) => {
@@ -48,21 +47,26 @@ export default function useEntityProp( kind, name, prop, _id ) {
 		},
 		[ kind, name, id, prop ]
 	);
+	const { editEntityRecord } = useDispatch( STORE_NAME );
+	const { getEditedEntityRecord } = useSelect(
+		( select ) => select( STORE_NAME ),
+		[]
+	);
 
 	const setValue = useCallback(
 		( newValue ) => {
-			let updatedValue = newValue;
 			if ( typeof newValue === 'function' ) {
-				const currentValue = registry
-					.select( STORE_NAME )
-					.getEditedEntityRecord( kind, name, id )?.[ prop ];
-				updatedValue = newValue( currentValue );
+				const currentRecord = getEditedEntityRecord( kind, name, id );
+				const currentValue = currentRecord
+					? currentRecord[ prop ]
+					: undefined;
+				newValue = newValue( currentValue );
 			}
-			registry.dispatch( STORE_NAME ).editEntityRecord( kind, name, id, {
-				[ prop ]: updatedValue,
+			editEntityRecord( kind, name, id, {
+				[ prop ]: newValue,
 			} );
 		},
-		[ registry, kind, name, id, prop ]
+		[ editEntityRecord, getEditedEntityRecord, kind, name, id, prop ]
 	);
 
 	return [ value, setValue, fullValue ];

--- a/packages/core-data/src/hooks/use-entity-prop.js
+++ b/packages/core-data/src/hooks/use-entity-prop.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useCallback } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useRegistry, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -31,6 +31,8 @@ export default function useEntityProp( kind, name, prop, _id ) {
 	const providerId = useEntityId( kind, name );
 	const id = _id ?? providerId;
 
+	const registry = useRegistry();
+
 	const { value, fullValue } = useSelect(
 		( select ) => {
 			const { getEntityRecord, getEditedEntityRecord } =
@@ -46,14 +48,21 @@ export default function useEntityProp( kind, name, prop, _id ) {
 		},
 		[ kind, name, id, prop ]
 	);
-	const { editEntityRecord } = useDispatch( STORE_NAME );
+
 	const setValue = useCallback(
 		( newValue ) => {
-			editEntityRecord( kind, name, id, {
-				[ prop ]: newValue,
+			let updatedValue = newValue;
+			if ( typeof newValue === 'function' ) {
+				const currentValue = registry
+					.select( STORE_NAME )
+					.getEditedEntityRecord( kind, name, id )?.[ prop ];
+				updatedValue = newValue( currentValue );
+			}
+			registry.dispatch( STORE_NAME ).editEntityRecord( kind, name, id, {
+				[ prop ]: updatedValue,
 			} );
 		},
-		[ editEntityRecord, kind, name, id, prop ]
+		[ registry, kind, name, id, prop ]
 	);
 
 	return [ value, setValue, fullValue ];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR implements updater function support for the `useEntityProp` hook, addressing the stale closure issue.

Closes #70748 

## Why?

When using `useEntityProp` in async functions, stale closures can lead to data loss. The existing setter requires a static value, which can become outdated during async operations.

## How?
Updated Hook Logic: Modified the setValue function to accept updater functions. If newValue is a function, it will receive the current state. This prevents stale data issues by ensuring the setter captures the most recent state when invoked.

## Testing Instructions

1. Create a test component that uses useEntityProp:
```js
   const [meta, setMeta] = useEntityProp('postType', 'post', 'meta', postId);
```

2. Test backward compatibility - verify static values still work:
```js
   setMeta({ key: 'static value' }); 
```

3. Test new updater function - verify the new functionality:
```js
   setMeta((currentMeta) => ({ ...currentMeta, newKey: 'value' }));
```
