### PR TITLE
iAPI router: Move internal properties to a private store

### DIFF
--- a/packages/interactivity-router/CHANGELOG.md
+++ b/packages/interactivity-router/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Deprecations
+
+-   Move `state.navigation.hasStarted` and `state.navigation.hasFinished` to a private store and deprecate direct access from the public `core/router` store. ([#70882](https://github.com/WordPress/gutenberg/pull/70882))
+
 ### Bug Fixes
 
 -   Update cached styles for re-fetched pages. ([#75097](https://github.com/WordPress/gutenberg/pull/75097))
@@ -41,8 +45,7 @@
 
 -   Preserve `media` attribute on intial style sheets after client-side navigation. ([70668](https://github.com/WordPress/gutenberg/pull/70668))
 
--  Ignores `<noscript>` elements while preparing DOM. ([70905](https://github.com/WordPress/gutenberg/pull/70905))
-
+-   Ignores `<noscript>` elements while preparing DOM. ([70905](https://github.com/WordPress/gutenberg/pull/70905))
 
 ## 2.26.0 (2025-06-25)
 

--- a/packages/interactivity-router/README.md
+++ b/packages/interactivity-router/README.md
@@ -45,15 +45,6 @@ When loaded, this package [adds the following state and actions](https://github.
 const { state, actions } = store( 'core/router', {
 	state: {
 		url: window.location.href,
-		navigation: {
-			hasStarted: false,
-			hasFinished: false,
-			texts: {
-				loading: '',
-				loaded: '',
-			},
-			message: '',
-		},
 	},
 	actions: {
 		*navigate(href, options) {...},
@@ -157,7 +148,6 @@ prefetch( url: string, options: PrefetchOptions = {} )
 ### State
 
 `state.url` is a reactive property synchronized with the current URL.
-Properties under `state.navigation` are meant for loading bar animations.
 
 ## Installation
 

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -394,12 +394,41 @@ interface Store {
 	};
 }
 
-export const { state, actions } = store< Store >( 'core/router', {
+interface PrivateStore {
 	state: {
-		url: window.location.href,
+		navigation: {
+			hasStarted: boolean;
+			hasFinished: boolean;
+		};
+	};
+}
+
+// Create the private store for internal navigation properties
+const { state: privateState } = store< PrivateStore >( 'core/router/private', {
+	state: {
 		navigation: {
 			hasStarted: false,
 			hasFinished: false,
+		},
+	},
+} );
+
+export const { state, actions } = store< Store >( 'core/router', {
+	state: {
+		url: window.location.href,
+		get navigation() {
+			// Deprecation warning for hasStarted and hasFinished properties.
+			// TODO: Remove this in a future version.
+			if (
+				typeof window !== 'undefined' &&
+				window.console &&
+				window.console.warn
+			) {
+				window.console.warn(
+					'core/router store navigation.hasStarted and navigation.hasFinished properties are part of the private API and its usage is discouraged.'
+				);
+			}
+			return privateState.navigation;
 		},
 	},
 	actions: {
@@ -428,7 +457,7 @@ export const { state, actions } = store< Store >( 'core/router', {
 			}
 
 			const pagePath = getPagePath( href );
-			const { navigation } = state;
+			const { navigation } = privateState;
 			const {
 				loadingAnimation = true,
 				screenReaderAnnouncement = true,

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -395,17 +395,7 @@ interface Store {
 	};
 }
 
-interface PrivateStore {
-	state: {
-		navigation: {
-			hasStarted: boolean;
-			hasFinished: boolean;
-		};
-	};
-}
-
-// Create the private store for internal navigation properties
-const { state: privateState } = store< PrivateStore >(
+const { state: privateState } = store(
 	'core/router/private',
 	{
 		state: {
@@ -421,11 +411,9 @@ const { state: privateState } = store< PrivateStore >(
 export const { state, actions } = store< Store >( 'core/router', {
 	state: {
 		get navigation() {
-			// Deprecation warning for hasStarted and hasFinished properties.
-			// TODO: Remove this in a future version.
 			if ( globalThis.SCRIPT_DEBUG ) {
 				warn(
-					'core/router store navigation.hasStarted and navigation.hasFinished properties are part of the private API and its usage is discouraged.'
+					`The usage of state.navigation.{hasStarted|hasFinished} from core/router is deprecated and will stop working in WordPress 7.1.`
 				);
 			}
 			return privateState.navigation;

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -405,14 +405,18 @@ interface PrivateStore {
 }
 
 // Create the private store for internal navigation properties
-const { state: privateState } = store< PrivateStore >( 'core/router/private', {
-	state: {
-		navigation: {
-			hasStarted: false,
-			hasFinished: false,
+const { state: privateState } = store< PrivateStore >(
+	'core/router/private',
+	{
+		state: {
+			navigation: {
+				hasStarted: false,
+				hasFinished: false,
+			},
 		},
 	},
-} );
+	{ lock: true }
+);
 
 export const { state, actions } = store< Store >( 'core/router', {
 	state: {

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -420,7 +420,6 @@ const { state: privateState } = store< PrivateStore >(
 
 export const { state, actions } = store< Store >( 'core/router', {
 	state: {
-		url: window.location.href,
 		get navigation() {
 			// Deprecation warning for hasStarted and hasFinished properties.
 			// TODO: Remove this in a future version.
@@ -575,6 +574,9 @@ export const { state, actions } = store< Store >( 'core/router', {
 		},
 	},
 } );
+
+// Initialize the URL in the state if it hasn't been set yet in the server.
+state.url = state.url || window.location.href;
 
 /**
  * Announces a message to screen readers.

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -25,6 +25,7 @@ const {
 	routerRegions,
 	h: createElement,
 	navigationSignal,
+	warn,
 } = privateApis(
 	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.'
 );
@@ -419,12 +420,8 @@ export const { state, actions } = store< Store >( 'core/router', {
 		get navigation() {
 			// Deprecation warning for hasStarted and hasFinished properties.
 			// TODO: Remove this in a future version.
-			if (
-				typeof window !== 'undefined' &&
-				window.console &&
-				window.console.warn
-			) {
-				window.console.warn(
+			if ( globalThis.SCRIPT_DEBUG ) {
+				warn(
 					'core/router store navigation.hasStarted and navigation.hasFinished properties are part of the private API and its usage is discouraged.'
 				);
 			}

--- a/packages/interactivity/src/index.ts
+++ b/packages/interactivity/src/index.ts
@@ -22,7 +22,7 @@ import { directive } from './hooks';
 import { getNamespace } from './namespaces';
 import { parseServerData, populateServerData } from './store';
 import { proxifyState } from './proxies';
-import { deepReadOnly, navigationSignal, onDOMReady } from './utils';
+import { deepReadOnly, navigationSignal, onDOMReady, warn } from './utils';
 
 export {
 	store,
@@ -69,6 +69,7 @@ export const privateApis = (
 			routerRegions,
 			deepReadOnly,
 			navigationSignal,
+			warn,
 		};
 	}
 


### PR DESCRIPTION
## What?
This PR adds a private `core/router/private` store for storing internal properties of core router

Closes #70879 

## Why?
The Interactivity Router store contains details that are internal and are not part of the public API

These need to be moved to a private store so these are not used as public API

## How?
This PR adds a new `core/router/private` store and moves `navigation` properties there.
Namely, `hasStarted` & `hasFinished` properties
They are still accessible from `core/router` store but it throws a console warning stating deprecation.