### PR TITLE
Editor: Hide 'sticky' option for password-protected posts

### DIFF
--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -137,6 +137,8 @@ export default function PostStatus() {
 			status: newStatus,
 			date: newDate,
 			password: newPassword,
+			// A pasword protected post cannot be sticky.
+			...( newPassword ? { sticky: false } : {} ),
 		} );
 	};
 
@@ -267,7 +269,7 @@ export default function PostStatus() {
 											) }
 										</VStack>
 									) }
-									<PostSticky />
+									{ ! showPassword && <PostSticky /> }
 								</VStack>
 							</form>
 						</>


### PR DESCRIPTION
## What?
Closes #30373.

PR updates `PostStatus` component to hide the sticky post option when a password is set, preventing a saving error.

> [!NOTE]
> The issue suggests making this option only available for public posts, but as far as post saving is concerned, all options are valid except password-protected.

## Why?
Currently, if you try to make a password-protected post sticky, saving will fail with an error.

## Testing Instructions
1. Create a post.
2. Make it sticky.
3. Set a password and save.
4. Confirm saving is successful and the post isn't sticky.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/a177d407-6c9c-4a6b-89c0-b06c36b77f5f

<img width="1056" height="617" alt="CleanShot 2025-07-24 at 09 37 19" src="https://github.com/user-attachments/assets/64c260dc-798c-4c7c-ae29-32166044db34" />
