### PR TITLE
Editor: Fix 'isEditedPostAutosaveable' selector return value

### DIFF
--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -610,9 +610,14 @@ export const isEditedPostAutosaveable = createRegistrySelector(
 		}
 
 		const postType = getCurrentPostType( state );
+		const postTypeObject = select( coreStore ).getPostType( postType );
 
 		// Currently template autosaving is not supported.
-		if ( postType === 'wp_template' ) {
+		// @todo: Remove hardcode check for template after bumping required WP version to 6.8.
+		if (
+			postType === 'wp_template' ||
+			! postTypeObject?.supports?.autosave
+		) {
 			return false;
 		}
 

--- a/packages/editor/src/store/test/selectors.js
+++ b/packages/editor/src/store/test/selectors.js
@@ -124,6 +124,9 @@ selectorNames.forEach( ( name ) => {
 					labels: {
 						singular_name: postTypeLabel,
 					},
+					supports: {
+						autosave: state.postType !== 'without-autosave',
+					},
 				};
 			},
 
@@ -1586,6 +1589,33 @@ describe( 'selectors', () => {
 				currentPost: {},
 				saving: {},
 				postAutosavingLock: { example: true },
+			};
+
+			expect( isEditedPostAutosaveable( state ) ).toBe( false );
+		} );
+
+		it( 'should return false if post type does not support autosave', () => {
+			const state = {
+				editor: {
+					present: {
+						blocks: {
+							value: [],
+						},
+						edits: {},
+					},
+				},
+				initialEdits: {},
+				currentPost: {
+					title: 'sassel',
+				},
+				saving: {},
+				getCurrentUser() {},
+				hasFetchedAutosaves() {
+					return true;
+				},
+				getAutosave() {},
+				postAutosavingLock: {},
+				postType: 'without-autosave',
 			};
 
 			expect( isEditedPostAutosaveable( state ) ).toBe( false );


### PR DESCRIPTION
## What?
Related #68680.

PR fixes the return value of `isEditedPostAutosaveable` selector when a post type doesn't support `autosave`.

## Why?
The selector is used by `AutosaveMonitor` and was providing it with a false value.

## Testing Instructions
1. Disable autosaves for posts.
2. Create a post and add some content.
3. Using DevTools, check if the edited post is autosavable - `wp.data.select( 'core/editor' ).isEditedPostAutosaveable()`
4. Selector should return a value based on the post type support flag.

```php
// Disable autosave for posts.
add_action( 'init', function() {
	remove_post_type_support( 'post', 'autosave' );
} );
```

### Testing Instructions for Keyboard
Same.