### PR TITLE
Dataviews: Add ctrl/cmd + click multiselection support to table layout when clicking rows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50308,6 +50308,7 @@
 				"@wordpress/element": "file:../element",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
+				"@wordpress/keycodes": "file:../keycodes",
 				"@wordpress/primitives": "file:../primitives",
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/url": "file:../url",

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -54,6 +54,7 @@
 		"@wordpress/element": "file:../element",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
+		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/primitives": "file:../primitives",
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/url": "file:../url",

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -18,6 +18,7 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
+import { isAppleOS } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -117,7 +118,7 @@ function GridItem< Item >( {
 				'is-selected': hasBulkAction && isSelected,
 			} ) }
 			onClickCapture={ ( event ) => {
-				if ( event.ctrlKey || event.metaKey ) {
+				if ( isAppleOS() ? event.metaKey : event.ctrlKey ) {
 					event.stopPropagation();
 					event.preventDefault();
 					if ( ! hasBulkAction ) {

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -16,6 +16,7 @@ import {
 	useRef,
 	useState,
 } from '@wordpress/element';
+import { isAppleOS } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -147,19 +148,34 @@ function TableRow< Item >( {
 			onTouchStart={ () => {
 				isTouchDeviceRef.current = true;
 			} }
-			onClick={ () => {
+			onClick={ ( event ) => {
 				if ( ! hasPossibleBulkAction ) {
 					return;
 				}
+
 				if (
 					! isTouchDeviceRef.current &&
 					document.getSelection()?.type !== 'Range'
 				) {
-					onChangeSelection(
-						selection.includes( id )
-							? selection.filter( ( itemId ) => id !== itemId )
-							: [ id ]
-					);
+					if ( isAppleOS() ? event.metaKey : event.ctrlKey ) {
+						// Handle non-consecutive selection.
+						onChangeSelection(
+							selection.includes( id )
+								? selection.filter(
+										( itemId ) => id !== itemId
+								  )
+								: [ ...selection, id ]
+						);
+					} else {
+						// Handle single selection
+						onChangeSelection(
+							selection.includes( id )
+								? selection.filter(
+										( itemId ) => id !== itemId
+								  )
+								: [ id ]
+						);
+					}
 				}
 			} }
 		>

--- a/packages/dataviews/src/test/dataviews.tsx
+++ b/packages/dataviews/src/test/dataviews.tsx
@@ -285,6 +285,71 @@ describe( 'DataViews component', () => {
 			await user.click( titleField );
 			expect( onClickItemCallback ).toHaveBeenCalledWith( data[ 0 ] );
 		} );
+
+		it( 'accepts click for single selection', async () => {
+			render(
+				<DataViewWrapper
+					view={ {
+						...DEFAULT_VIEW,
+						fields: [ 'author' ],
+						titleField: 'title',
+					} }
+					// A bulk action is required for the dataview to be multi-selectable.
+					actions={ actions }
+				/>
+			);
+			const firstItemElement = screen.getByText( data[ 0 ].title );
+			const thirdItemElement = screen.getByText( data[ 2 ].title );
+			const user = userEvent.setup();
+			await user.click( firstItemElement );
+
+			// First item should be selected.
+			expect(
+				screen.getByRole( 'checkbox', { name: data[ 0 ].title } )
+			).toBeChecked();
+			await user.click( thirdItemElement );
+
+			// Third item should be selected. First item was deselected.
+			expect(
+				screen.getByRole( 'checkbox', { name: data[ 2 ].title } )
+			).toBeChecked();
+		} );
+
+		it( 'accepts ctrl/cmd key and click for non-consecutive multi-selection', async () => {
+			render(
+				<DataViewWrapper
+					view={ {
+						...DEFAULT_VIEW,
+						fields: [ 'author' ],
+						titleField: 'title',
+					} }
+					// A bulk action is required for the dataview to be multi-selectable.
+					actions={ actions }
+				/>
+			);
+			const firstItemElement = screen.getByText( data[ 0 ].title );
+			const thirdItemElement = screen.getByText( data[ 2 ].title );
+			const user = userEvent.setup();
+			await user.click( firstItemElement );
+
+			// First item should be selected.
+			expect(
+				screen.getByRole( 'checkbox', { name: data[ 0 ].title } )
+			).toBeChecked();
+			await user.keyboard( '{Control>}' );
+			await user.click( thirdItemElement );
+
+			// Both items should be selected.
+			expect(
+				screen.getByRole( 'checkbox', { name: data[ 0 ].title } )
+			).toBeChecked();
+			expect(
+				screen.getByRole( 'checkbox', { name: data[ 2 ].title } )
+			).toBeChecked();
+
+			// Don't keep the modifier pressed down, that's just mean.
+			await user.keyboard( '{/Control}' );
+		} );
 	} );
 
 	describe( 'in grid view', () => {
@@ -362,6 +427,70 @@ describe( 'DataViews component', () => {
 			const user = userEvent.setup();
 			await user.click( imageField );
 			expect( mediaClickItemCallback ).toHaveBeenCalledWith( data[ 0 ] );
+		} );
+
+		it( 'accepts click for single selection', async () => {
+			render(
+				<DataViewWrapper
+					view={ {
+						...DEFAULT_VIEW,
+						fields: [ 'author' ],
+						titleField: 'title',
+					} }
+					// A bulk action is required for the dataview to be multi-selectable.
+					actions={ actions }
+				/>
+			);
+			const firstItemElement = screen.getByText( data[ 0 ].title );
+			const thirdItemElement = screen.getByText( data[ 2 ].title );
+			const user = userEvent.setup();
+			await user.click( firstItemElement );
+
+			// First item should be selected.
+			expect(
+				screen.getByRole( 'checkbox', { name: data[ 0 ].title } )
+			).toBeChecked();
+			await user.click( thirdItemElement );
+
+			// Third item should be selected. First item was deselected.
+			expect(
+				screen.getByRole( 'checkbox', { name: data[ 2 ].title } )
+			).toBeChecked();
+		} );
+
+		it( 'accepts ctrl/cmd key and click for non-consecutive multi-selection', async () => {
+			render(
+				<DataViewWrapper
+					view={ {
+						...DEFAULT_VIEW,
+						fields: [ 'author' ],
+						titleField: 'title',
+					} }
+					// A bulk action is required for the dataview to be multi-selectable.
+					actions={ actions }
+				/>
+			);
+			const firstItemElement = screen.getByText( data[ 0 ].title );
+			const thirdItemElement = screen.getByText( data[ 2 ].title );
+			const user = userEvent.setup();
+			await user.click( firstItemElement );
+
+			// First item should be selected.
+			expect(
+				screen.getByRole( 'checkbox', { name: data[ 0 ].title } )
+			).toBeChecked();
+			await user.keyboard( '{Control>}' );
+			await user.click( thirdItemElement );
+
+			// Both items should be selected.
+			expect(
+				screen.getByRole( 'checkbox', { name: data[ 0 ].title } )
+			).toBeChecked();
+			expect(
+				screen.getByRole( 'checkbox', { name: data[ 2 ].title } )
+			).toBeChecked();
+
+			await user.keyboard( '{/Control}' );
 		} );
 	} );
 

--- a/packages/dataviews/tsconfig.json
+++ b/packages/dataviews/tsconfig.json
@@ -17,6 +17,7 @@
 		{ "path": "../element" },
 		{ "path": "../i18n" },
 		{ "path": "../icons" },
+		{ "path": "../keycodes" },
 		{ "path": "../primitives" },
 		{ "path": "../private-apis" },
 		{ "path": "../url" },


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #70721

I noticed that in the table layout there's no way to multi-select when clicking the row, users can only select a single item.

Grid does however support this, so it's an inconsistency.

A note on consecutive multi-selection (e.g. using shift key) - I did consider trying to tackle it, but it's quite a bit more complex. The selection code needs to be aware of the range of items, which currently it isn't, it only knows about the clicked item. I'm also not sure if it should work across pagination. It might require moving a bit more code around.

## How?
- Adds a very similar implementation to the grid view.
- Adjusts the modifier keys for both grid and table to be platform appropriate (not sure how we feel about adding keycodes as a dep, but it should be a small package). This is to fix an issue where users could use 'Windows' key + click to multiselect on Windows, which is unexpected, ctrl + click is the convention.
- Adds tests.

## Testing Instructions
1. Test either in the [site editor](http://localhost:8888/wp-admin/site-editor.php?p=%2Fpage&layout=table) or [storybook](http://localhost:50240/?path=/story/dataviews-dataviews--default)
2. Switch to table view
3. Cmd + Click rows (on a mac) or Ctrl + Click several rows (on a windows)
4. See that multi-selection occurs

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/bbdc0d55-d95f-411d-a5de-65b4049fd9e6


