### PR TITLE
Allow Dataform Select Box to have a custom empty option

### DIFF
--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -62,6 +62,7 @@ const fields = [
 		label: 'Date as options',
 		type: 'datetime' as const,
 		elements: [
+			{ value: '', label: 'Select a date' },
 			{ value: '1970-02-23T12:00:00', label: "Jane's birth date" },
 			{ value: '1950-02-23T12:00:00', label: "John's birth date" },
 		],

--- a/packages/dataviews/src/dataform-controls/select.tsx
+++ b/packages/dataviews/src/dataform-controls/select.tsx
@@ -26,17 +26,24 @@ export default function Select< Item >( {
 		[ id, onChange ]
 	);
 
-	const elements = [
-		/*
-		 * Value can be undefined when:
-		 *
-		 * - the field is not required
-		 * - in bulk editing
-		 *
-		 */
-		{ label: __( 'Select item' ), value: '' },
-		...( field?.elements ?? [] ),
-	];
+	const fieldElements = field?.elements ?? [];
+	const hasEmptyValue = fieldElements.some(
+		( { value: elementValue } ) => elementValue === ''
+	);
+
+	const elements = hasEmptyValue
+		? fieldElements
+		: [
+				/*
+				 * Value can be undefined when:
+				 *
+				 * - the field is not required
+				 * - in bulk editing
+				 *
+				 */
+				{ label: __( 'Select item' ), value: '' },
+				...fieldElements,
+		  ];
 
 	return (
 		<SelectControl


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates the select component under the [dataviews package](https://github.com/WordPress/gutenberg/tree/trunk/packages/dataviews).

Currently a value of "Select Item" is forced before any provided option values. if you attempt to pass your own blank option, for example, with improved wording, you get a duplicate:

<img width="326" height="74" alt="Screenshot 2025-07-24 at 10 59 30" src="https://github.com/user-attachments/assets/515811f7-5b1e-4db2-9de0-3255b4b36553" />

This PR changes this behaviour to first check if a blank option is provided as an element before rendering "select item".

## Why?

Consumers should have control over the "Select X" option.

## How?

Checks if an empty option is already provided by the consumer.

Alternative would have been extra props but this seemed like a more logical approach.

## Testing Instructions

- Open Storybook
- Go to the dataforms entry
- See the "date" select box example. I've updated this with a custom "select a date" option to show it taking precedence over "select item"

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
