### PR TITLE
Categories: Disable links in the editor

### DIFF
--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -25,6 +25,8 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { pin } from '@wordpress/icons';
 import { useEntityRecords } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { store as noticeStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -44,6 +46,7 @@ export default function CategoriesEdit( {
 	},
 	setAttributes,
 	className,
+	clientId,
 } ) {
 	const selectId = useInstanceId( CategoriesEdit, 'blocks-category-select' );
 
@@ -69,6 +72,15 @@ export default function CategoriesEdit( {
 		taxonomySlug,
 		query
 	);
+
+	const { createWarningNotice } = useDispatch( noticeStore );
+	const showRedirectionPreventedNotice = ( event ) => {
+		event.preventDefault();
+		createWarningNotice( __( 'Links are disabled in the editor.' ), {
+			id: `block-library/core/categories/redirection-prevented/${ clientId }`,
+			type: 'snackbar',
+		} );
+	};
 
 	const getCategoriesList = ( parentId ) => {
 		if ( ! categories?.length ) {
@@ -99,7 +111,11 @@ export default function CategoriesEdit( {
 		const { id, link, count, name } = category;
 		return (
 			<li key={ id } className={ `cat-item cat-item-${ id }` }>
-				<a href={ link } target="_blank" rel="noreferrer noopener">
+				<a
+					href={ link }
+					rel="noreferrer noopener"
+					onClick={ showRedirectionPreventedNotice }
+				>
 					{ renderCategoryName( name ) }
 				</a>
 				{ showPostCounts && ` (${ count })` }

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -111,11 +111,7 @@ export default function CategoriesEdit( {
 		const { id, link, count, name } = category;
 		return (
 			<li key={ id } className={ `cat-item cat-item-${ id }` }>
-				<a
-					href={ link }
-					rel="noreferrer noopener"
-					onClick={ showRedirectionPreventedNotice }
-				>
+				<a href={ link } onClick={ showRedirectionPreventedNotice }>
 					{ renderCategoryName( name ) }
 				</a>
 				{ showPostCounts && ` (${ count })` }

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -774,7 +774,6 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 									{ addLinkToFeaturedImage ? (
 										<a
 											href={ post.link }
-											rel="noreferrer noopener"
 											onClick={
 												showRedirectionPreventedNotice
 											}
@@ -789,7 +788,6 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 							<a
 								className="wp-block-latest-posts__post-title"
 								href={ post.link }
-								rel="noreferrer noopener"
 								dangerouslySetInnerHTML={
 									!! titleTrimmed
 										? {


### PR DESCRIPTION
## What?
Closes #48432.
This is similar to #40593.

PR prevents default link behavior for category links and displays a snackbar notice instead.

## Why?

> There is no need to open the links in the editor, and especially in the site editor, where the content is loaded in an iframe, it might cause an inception effect.

## Testing Instructions
1. Open a post.
2. Insert the Categories List block.
3. Confirm that clicking on a category link doesn't open it.
4. A snackbar notice should be displayed instead.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
<img width="1276" height="583" alt="CleanShot 2025-07-24 at 15 27 50" src="https://github.com/user-attachments/assets/a7e0b846-7737-467d-b273-9399f42fd127" />
