### PR TITLE
Block Editor: Update conditions for displaying the empty block inserter

### DIFF
--- a/packages/block-editor/src/components/block-tools/use-show-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/use-show-block-tools.js
@@ -36,7 +36,7 @@ export function useShowBlockTools() {
 		const hasSelectedBlock = !! clientId && !! block;
 		const isEmptyDefaultBlock =
 			hasSelectedBlock &&
-			isUnmodifiedDefaultBlock( block ) &&
+			isUnmodifiedDefaultBlock( block, 'content' ) &&
 			getBlockMode( clientId ) !== 'html';
 		const _showEmptyBlockSideInserter =
 			clientId &&

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -151,7 +151,7 @@ function useInsertionPoint( {
 			if (
 				! isAppender &&
 				selectedBlock &&
-				isUnmodifiedDefaultBlock( selectedBlock )
+				isUnmodifiedDefaultBlock( selectedBlock, 'content' )
 			) {
 				replaceBlocks(
 					selectedBlock.clientId,

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -51,11 +51,7 @@ async function createAndSelectBlock() {
 			name: 'Black',
 		} )
 	);
-	await userEvent.click(
-		screen.getByRole( 'button', {
-			name: 'Select parent block: Cover',
-		} )
-	);
+	await selectBlock( 'Block: Cover' );
 }
 
 describe( 'Cover block', () => {

--- a/test/e2e/specs/editor/plugins/post-type-locking.spec.js
+++ b/test/e2e/specs/editor/plugins/post-type-locking.spec.js
@@ -50,7 +50,8 @@ test.describe( 'Post-type locking', () => {
 					name: 'Empty block',
 				} )
 				.first()
-				.click();
+				.fill( 'p1' );
+			await editor.showBlockToolbar();
 
 			await expect(
 				page
@@ -166,18 +167,15 @@ test.describe( 'Post-type locking', () => {
 			).toBeHidden();
 		} );
 
-		test( 'should allow blocks to be moved', async ( { editor, page } ) => {
+		test( 'should allow blocks to be moved', async ( { editor } ) => {
 			await editor.canvas
 				.getByRole( 'document', {
 					name: 'Empty block',
 				} )
 				.first()
-				.click();
+				.fill( 'p1' );
 
-			await page
-				.getByRole( 'toolbar', { name: 'Block tools' } )
-				.getByRole( 'button', { name: 'Move up' } )
-				.click();
+			await editor.clickBlockToolbarButton( 'Move up' );
 
 			await expect.poll( editor.getBlocks ).toMatchObject( [
 				{
@@ -248,18 +246,15 @@ test.describe( 'Post-type locking', () => {
 			] );
 		} );
 
-		test( 'should allow blocks to be moved', async ( { editor, page } ) => {
+		test( 'should allow blocks to be moved', async ( { editor } ) => {
 			await editor.canvas
 				.getByRole( 'document', {
 					name: 'Empty block',
 				} )
 				.first()
-				.click();
+				.fill( 'p1' );
 
-			await page
-				.getByRole( 'toolbar', { name: 'Block tools' } )
-				.getByRole( 'button', { name: 'Move up' } )
-				.click();
+			await editor.clickBlockToolbarButton( 'Move up' );
 
 			await expect.poll( editor.getBlocks ).toMatchObject( [
 				{
@@ -304,18 +299,15 @@ test.describe( 'Post-type locking', () => {
 			] );
 		} );
 
-		test( 'should allow blocks to be moved', async ( { editor, page } ) => {
+		test( 'should allow blocks to be moved', async ( { editor } ) => {
 			await editor.canvas
 				.getByRole( 'document', {
 					name: 'Empty block',
 				} )
 				.last()
-				.click();
+				.fill( 'p1' );
 
-			await page
-				.getByRole( 'toolbar', { name: 'Block tools' } )
-				.getByRole( 'button', { name: 'Move up' } )
-				.click();
+			await editor.clickBlockToolbarButton( 'Move up' );
 
 			await expect.poll( editor.getBlocks ).toMatchObject( [
 				{
@@ -409,7 +401,8 @@ test.describe( 'Post-type locking', () => {
 					name: 'Empty block',
 				} )
 				.last()
-				.click();
+				.fill( 'p1' );
+			await editor.showBlockToolbar();
 
 			await expect(
 				page
@@ -453,7 +446,8 @@ test.describe( 'Post-type locking', () => {
 					name: 'Empty block',
 				} )
 				.last()
-				.click();
+				.fill( 'p1' );
+			await editor.showBlockToolbar();
 
 			await expect(
 				page


### PR DESCRIPTION
## What?
Closes #33143.
Closes #48806.
Related #70764, #70903.

PR relaxes conditions for displaying an [`EmptyBlockInserter` inserter](https://github.com/WordPress/gutenberg/blob/7a1faf1969e7e70847626982da78a3bba4080dc0/packages/block-editor/src/components/block-tools/index.js#L218-L223). The user should be able to replace the empty default block if it doesn't cause a content loss.

Only changes to attributes with `role: content` or block bindings are considered block modifications, rather than any attribute changes like block styling.

> [!NOTE]
> This introduces a small behavior change for the default block (Paragraph), where the toolbar isn't visible until you add the content. Previously, it would become visible after changing the styling. Hence, the testing changes in this PR.

## Testing Instructions
1. Open a post or page.
2. Style the empty paragraph block.
3. Confirm that the empty block inserter is still displayed.
4. Add content to the block.
5. Confirm that the inserter is now hidden.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="689" height="481" alt="CleanShot 2025-07-29 at 12 38 28" src="https://github.com/user-attachments/assets/c4da77bc-21e5-437f-82e5-05a320df7c44" />
