### PR TITLE
Correctly document the `blockName` property as being nullable

### DIFF
--- a/packages/block-serialization-default-parser/class-wp-block-parser-block.php
+++ b/packages/block-serialization-default-parser/class-wp-block-parser-block.php
@@ -19,7 +19,7 @@ class WP_Block_Parser_Block {
 	 * @example "core/paragraph"
 	 *
 	 * @since 5.0.0
-	 * @var string
+	 * @var string|null
 	 */
 	public $blockName; // phpcs:ignore WordPress.NamingConventions.ValidVariableName
 
@@ -74,11 +74,11 @@ class WP_Block_Parser_Block {
 	 *
 	 * @since 5.0.0
 	 *
-	 * @param string $name          Name of block.
-	 * @param array  $attrs         Optional set of attributes from block comment delimiters.
-	 * @param array  $inner_blocks  List of inner blocks (of this same class).
-	 * @param string $inner_html    Resultant HTML from inside block comment delimiters after removing inner blocks.
-	 * @param array  $inner_content List of string fragments and null markers where inner blocks were found.
+	 * @param string|null $name          Name of block.
+	 * @param array       $attrs         Optional set of attributes from block comment delimiters.
+	 * @param array       $inner_blocks  List of inner blocks (of this same class).
+	 * @param string      $inner_html    Resultant HTML from inside block comment delimiters after removing inner blocks.
+	 * @param array       $inner_content List of string fragments and null markers where inner blocks were found.
 	 */
 	public function __construct( $name, $attrs, $inner_blocks, $inner_html, $inner_content ) {
 		$this->blockName    = $name;          // phpcs:ignore WordPress.NamingConventions.ValidVariableName

--- a/packages/block-serialization-default-parser/class-wp-block-parser.php
+++ b/packages/block-serialization-default-parser/class-wp-block-parser.php
@@ -35,6 +35,8 @@ class WP_Block_Parser {
 	/**
 	 * List of parsed blocks
 	 *
+	 * See WP_Block_Parser_Block for the structure of each block.
+	 *
 	 * @since 5.0.0
 	 * @var array[]
 	 */
@@ -58,7 +60,21 @@ class WP_Block_Parser {
 	 * @since 5.0.0
 	 *
 	 * @param string $document Input document being parsed.
-	 * @return array[]
+	 * @return array[] {
+	 *     Array of block structures.
+	 *
+	 *     @type array ...$0 {
+	 *         An associative array of a single parsed block object. See WP_Block_Parser_Block.
+	 *
+	 *         @type string|null $blockName    Name of block.
+	 *         @type array       $attrs        Attributes from block comment delimiters.
+	 *         @type array[]     $innerBlocks  List of inner blocks. An array of arrays that
+	 *                                         have the same structure as this one.
+	 *         @type string      $innerHTML    HTML from inside block comment delimiters.
+	 *         @type array       $innerContent List of string fragments and null markers where
+	 *                                         inner blocks were found.
+	 *     }
+	 * }
 	 */
 	public function parse( $document ) {
 		$this->document = $document;


### PR DESCRIPTION
## What?

The `blockName` property is nullable. See:

* https://core.trac.wordpress.org/ticket/63663
* https://github.com/WordPress/wordpress-develop/pull/9187

## Why?

[It gets populated with a null value here](https://github.com/WordPress/gutenberg/blob/b94e18a09b072b67e59005b5424a13081f51d074/packages/block-serialization-default-parser/class-wp-block-parser.php#L312).
