### PR TITLE
DataForm: bootstrap validation (required and typechecks)

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Internal
 
 -	`RangeControl`: Add placement prop to replace position ([#70326](https://github.com/WordPress/gutenberg/pull/70326)).
+- Expose `ValidatedNumberControl`, `ValidatedTextControl`, and `ValidatedToggleControl` via privateAPIs. ([#70901](https://github.com/WordPress/gutenberg/pull/70901)).
 
 ## 30.0.0 (2025-07-23)
 

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -12,6 +12,11 @@ import { lock } from './lock-unlock';
 import Badge from './badge';
 
 import { DateCalendar, DateRangeCalendar, TZDate } from './calendar';
+import {
+	ValidatedNumberControl,
+	ValidatedTextControl,
+	ValidatedToggleControl,
+} from './validated-form-controls';
 
 export const privateApis = {};
 lock( privateApis, {
@@ -27,4 +32,7 @@ lock( privateApis, {
 	DateCalendar,
 	DateRangeCalendar,
 	TZDate,
+	ValidatedNumberControl,
+	ValidatedTextControl,
+	ValidatedToggleControl,
 } );

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- Field API: `isValid` is now an object that contains `required` and `custom` validation rules.
+
 ### Bug Fixes
 
 - Fix `filterSortAndPaginate` to handle searching fields that have a type of `array` ([#70785](https://github.com/WordPress/gutenberg/pull/70785)).

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking changes
 
-- Field API: `isValid` is now an object that contains `required` and `custom` validation rules.
+- Field API: `isValid` is now an object that contains `required` and `custom` validation rules. Additionally, fields should now opt-in into being a "required" field by setting `isValid.required` to `true` (all fields of type `email` and `integer` were required by default). [#70901](https://github.com/WordPress/gutenberg/pull/70901)
 
 ### Bug Fixes
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -1055,41 +1055,55 @@ Example:
 
 ### `isValid`
 
-Function to validate a field's value.
+Object that contains the validation rules for the field. If a rule is not met, the control will be marked as invalid and a message will be displayed.
 
--   Type: function.
--   Optional.
--   Args
-    -   `item`: the data to validate
-    -   `context`: an object containing the following props:
-        -   `elements`: the elements defined by the field
--   Returns a boolean, indicating if the field is valid or not.
+- `required`: boolean indicating whether the field is required or not.
+- `custom`: a function that validates a field's value. If the value is invalid, the function should return a string explaining why the value is invalid. Otherwise, the function must return null.
 
 Example:
 
 ```js
-// Custom isValid function.
 {
-	isValid: ( item, context ) => {
-		return !! item;
-	};
+	isValid: {
+		custom: ( item: Item, field: NormalizedField<Item> ) => {
+			if ( /* item value is invalid */) {
+				return 'Reason why item value is invalid';
+			}
+
+			return null;
+		}
+	}
 }
 ```
 
+Note that fields that define a type (e.g., `integer`) come with default validation for the type. For example, the `integer` type if the value is a valid integer:
+
 ```js
-// If the field defines a type,
-// it'll get a default isValid function for the type.
 {
-	type: 'number',
+	type: 'integer',
 }
 ```
 
+However, this can be overriden by the field author:
+
 ```js
-// Even if the field provides a type,
-// the field can override the default isValid function.
 {
-	type: 'number',
-	isValid: ( item, context ) => { /* Custom function. */ }
+	type: 'integer',
+	isValid: {
+		custom: ( item: Item, field: NormalizedField<Item> ) => {
+			/* Your custom validation logic. */
+		}
+	}
+}
+```
+
+Fields that define their own Edit component have access to the validation rules via the `field.isValid` object:
+
+```js
+{
+  Edit: ( { field }) => {
+	  return <input required={ !! field.isValid.required } />
+  }
 }
 ```
 

--- a/packages/dataviews/src/dataform-controls/boolean.tsx
+++ b/packages/dataviews/src/dataform-controls/boolean.tsx
@@ -1,12 +1,15 @@
 /**
  * WordPress dependencies
  */
-import { ToggleControl } from '@wordpress/components';
+import { privateApis } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import type { DataFormControlProps } from '../types';
+import { unlock } from '../lock-unlock';
+
+const { ValidatedToggleControl } = unlock( privateApis );
 
 export default function Boolean< Item >( {
 	field,
@@ -17,7 +20,21 @@ export default function Boolean< Item >( {
 	const { id, getValue, label } = field;
 
 	return (
-		<ToggleControl
+		<ValidatedToggleControl
+			required={ !! field.isValid.required }
+			customValidator={ ( newValue: any ) => {
+				if ( field.isValid?.custom ) {
+					return field.isValid.custom(
+						{
+							...data,
+							[ id ]: newValue,
+						},
+						field
+					);
+				}
+
+				return null;
+			} }
 			hidden={ hideLabelFromVision }
 			__nextHasNoMarginBottom
 			label={ label }

--- a/packages/dataviews/src/dataform-controls/email.tsx
+++ b/packages/dataviews/src/dataform-controls/email.tsx
@@ -1,13 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { TextControl } from '@wordpress/components';
+import { privateApis } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import type { DataFormControlProps } from '../types';
+import { unlock } from '../lock-unlock';
+
+const { ValidatedTextControl } = unlock( privateApis );
 
 export default function Email< Item >( {
 	data,
@@ -27,7 +30,21 @@ export default function Email< Item >( {
 	);
 
 	return (
-		<TextControl
+		<ValidatedTextControl
+			required={ !! field.isValid?.required }
+			customValidator={ ( newValue: any ) => {
+				if ( field.isValid?.custom ) {
+					return field.isValid.custom(
+						{
+							...data,
+							[ id ]: newValue,
+						},
+						field
+					);
+				}
+
+				return null;
+			} }
 			type="email"
 			label={ label }
 			placeholder={ placeholder }

--- a/packages/dataviews/src/dataform-controls/text.tsx
+++ b/packages/dataviews/src/dataform-controls/text.tsx
@@ -1,13 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { TextControl } from '@wordpress/components';
+import { privateApis } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import type { DataFormControlProps } from '../types';
+import { unlock } from '../lock-unlock';
+
+const { ValidatedTextControl } = unlock( privateApis );
 
 export default function Text< Item >( {
 	data,
@@ -27,7 +30,21 @@ export default function Text< Item >( {
 	);
 
 	return (
-		<TextControl
+		<ValidatedTextControl
+			required={ !! field.isValid?.required }
+			customValidator={ ( newValue: any ) => {
+				if ( field.isValid?.custom ) {
+					return field.isValid.custom(
+						{
+							...data,
+							[ id ]: newValue,
+						},
+						field
+					);
+				}
+
+				return null;
+			} }
 			label={ label }
 			placeholder={ placeholder }
 			value={ value ?? '' }

--- a/packages/dataviews/src/field-types/boolean.tsx
+++ b/packages/dataviews/src/field-types/boolean.tsx
@@ -10,6 +10,7 @@ import type {
 	DataViewRenderFieldProps,
 	SortDirection,
 	FieldTypeDefinition,
+	NormalizedField,
 } from '../types';
 import { renderFromElements } from '../utils';
 import { OPERATOR_IS, OPERATOR_IS_NOT } from '../constants';
@@ -31,17 +32,22 @@ function sort( a: any, b: any, direction: SortDirection ) {
 	return boolA ? -1 : 1;
 }
 
-function isValid( value: any ) {
-	if ( ! [ true, false, undefined ].includes( value ) ) {
-		return false;
-	}
-
-	return true;
-}
-
 export default {
 	sort,
-	isValid,
+	isValid: {
+		custom: ( item: any, field: NormalizedField< any > ) => {
+			const value = field.getValue( { item } );
+
+			if (
+				! [ undefined, '', null ].includes( value ) &&
+				! [ true, false ].includes( value )
+			) {
+				return __( 'Value must be true, false, or undefined' );
+			}
+
+			return null;
+		},
+	},
 	Edit: 'boolean',
 	render: ( { item, field }: DataViewRenderFieldProps< any > ) => {
 		if ( field.elements ) {

--- a/packages/dataviews/src/field-types/date.ts
+++ b/packages/dataviews/src/field-types/date.ts
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { dateI18n, getDate, getSettings } from '@wordpress/date';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -9,7 +10,7 @@ import { dateI18n, getDate, getSettings } from '@wordpress/date';
 import type {
 	DataViewRenderFieldProps,
 	SortDirection,
-	ValidationContext,
+	NormalizedField,
 	FieldTypeDefinition,
 } from '../types';
 import { renderFromElements } from '../utils';
@@ -24,20 +25,21 @@ function sort( a: any, b: any, direction: SortDirection ) {
 	return direction === 'asc' ? timeA - timeB : timeB - timeA;
 }
 
-function isValid( value: any, context?: ValidationContext ) {
-	if ( context?.elements ) {
-		const validValues = context?.elements.map( ( f ) => f.value );
-		if ( ! validValues.includes( value ) ) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
 export default {
 	sort,
-	isValid,
+	isValid: {
+		custom: ( item: any, field: NormalizedField< any > ) => {
+			const value = field.getValue( { item } );
+			if ( field?.elements ) {
+				const validValues = field.elements.map( ( f ) => f.value );
+				if ( ! validValues.includes( value ) ) {
+					return __( 'Value must be one of the elements.' );
+				}
+			}
+
+			return null;
+		},
+	},
 	Edit: null,
 	render: ( { item, field }: DataViewRenderFieldProps< any > ) => {
 		if ( field.elements ) {

--- a/packages/dataviews/src/field-types/datetime.tsx
+++ b/packages/dataviews/src/field-types/datetime.tsx
@@ -1,10 +1,15 @@
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import type {
 	DataViewRenderFieldProps,
 	SortDirection,
-	ValidationContext,
+	NormalizedField,
 	FieldTypeDefinition,
 } from '../types';
 import { renderFromElements } from '../utils';
@@ -26,20 +31,21 @@ function sort( a: any, b: any, direction: SortDirection ) {
 	return direction === 'asc' ? timeA - timeB : timeB - timeA;
 }
 
-function isValid( value: any, context?: ValidationContext ) {
-	if ( context?.elements ) {
-		const validValues = context?.elements.map( ( f ) => f.value );
-		if ( ! validValues.includes( value ) ) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
 export default {
 	sort,
-	isValid,
+	isValid: {
+		custom: ( item: any, field: NormalizedField< any > ) => {
+			const value = field.getValue( { item } );
+			if ( field?.elements ) {
+				const validValues = field.elements.map( ( f ) => f.value );
+				if ( ! validValues.includes( value ) ) {
+					return __( 'Value must be one of the elements.' );
+				}
+			}
+
+			return null;
+		},
+	},
 	Edit: 'datetime',
 	render: ( { item, field }: DataViewRenderFieldProps< any > ) => {
 		return field.elements

--- a/packages/dataviews/src/field-types/email.tsx
+++ b/packages/dataviews/src/field-types/email.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { isEmail } from '@wordpress/url';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -9,7 +9,7 @@ import { isEmail } from '@wordpress/url';
 import type {
 	DataViewRenderFieldProps,
 	SortDirection,
-	ValidationContext,
+	NormalizedField,
 	FieldTypeDefinition,
 } from '../types';
 import { renderFromElements } from '../utils';
@@ -31,29 +31,34 @@ function sort( valueA: any, valueB: any, direction: SortDirection ) {
 		: valueB.localeCompare( valueA );
 }
 
-function isValid( value: any, context?: ValidationContext ) {
-	// TODO: this implicitly means the value is required.
-	if ( value === '' ) {
-		return false;
-	}
-
-	if ( ! isEmail( value ) ) {
-		return false;
-	}
-
-	if ( context?.elements ) {
-		const validValues = context?.elements?.map( ( f ) => f.value );
-		if ( ! validValues.includes( value ) ) {
-			return false;
-		}
-	}
-
-	return true;
-}
+// Email validation regex based on HTML5 spec
+// https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
+const emailRegex =
+	/^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
 
 export default {
 	sort,
-	isValid,
+	isValid: {
+		custom: ( item: any, field: NormalizedField< any > ) => {
+			const value = field.getValue( { item } );
+
+			if (
+				! [ undefined, '', null ].includes( value ) &&
+				! emailRegex.test( value )
+			) {
+				return __( 'Value must be a valid email address.' );
+			}
+
+			if ( field.elements ) {
+				const validValues = field.elements.map( ( f ) => f.value );
+				if ( ! validValues.includes( value ) ) {
+					return __( 'Value must be one of the elements.' );
+				}
+			}
+
+			return null;
+		},
+	},
 	Edit: 'email',
 	render: ( { item, field }: DataViewRenderFieldProps< any > ) => {
 		return field.elements

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -1,12 +1,17 @@
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import type {
 	DataViewRenderFieldProps,
+	NormalizedField,
 	FieldType,
 	FieldTypeDefinition,
 	SortDirection,
-	ValidationContext,
 } from '../types';
 import { default as email } from './email';
 import { default as integer } from './integer';
@@ -72,15 +77,20 @@ export default function getFieldTypeDefinition< Item >(
 				? a.localeCompare( b )
 				: b.localeCompare( a );
 		},
-		isValid: ( value: any, context?: ValidationContext ) => {
-			if ( context?.elements ) {
-				const validValues = context?.elements?.map( ( f ) => f.value );
-				if ( ! validValues.includes( value ) ) {
-					return false;
+		isValid: {
+			custom: ( item: any, field: NormalizedField< any > ) => {
+				if ( field?.elements ) {
+					const value = field.getValue( { item } );
+					const validValues = field?.elements?.map(
+						( f ) => f.value
+					);
+					if ( ! validValues.includes( value ) ) {
+						return __( 'Value must be one of the elements.' );
+					}
 				}
-			}
 
-			return true;
+				return null;
+			},
 		},
 		Edit: null,
 		render: ( { item, field }: DataViewRenderFieldProps< Item > ) => {

--- a/packages/dataviews/src/field-types/integer.tsx
+++ b/packages/dataviews/src/field-types/integer.tsx
@@ -1,10 +1,15 @@
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import type {
 	DataViewRenderFieldProps,
 	SortDirection,
-	ValidationContext,
+	NormalizedField,
 	FieldTypeDefinition,
 } from '../types';
 import { renderFromElements } from '../utils';
@@ -26,29 +31,28 @@ function sort( a: any, b: any, direction: SortDirection ) {
 	return direction === 'asc' ? a - b : b - a;
 }
 
-function isValid( value: any, context?: ValidationContext ) {
-	// TODO: this implicitly means the value is required.
-	if ( value === '' ) {
-		return false;
-	}
-
-	if ( ! Number.isInteger( Number( value ) ) ) {
-		return false;
-	}
-
-	if ( context?.elements ) {
-		const validValues = context?.elements.map( ( f ) => f.value );
-		if ( ! validValues.includes( Number( value ) ) ) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
 export default {
 	sort,
-	isValid,
+	isValid: {
+		custom: ( item: any, field: NormalizedField< any > ) => {
+			const value = field.getValue( { item } );
+			if (
+				! [ undefined, '', null ].includes( value ) &&
+				! Number.isInteger( value )
+			) {
+				return __( 'Value must be an integer.' );
+			}
+
+			if ( field?.elements ) {
+				const validValues = field.elements.map( ( f ) => f.value );
+				if ( ! validValues.includes( Number( value ) ) ) {
+					return __( 'Value must be one of the elements.' );
+				}
+			}
+
+			return null;
+		},
+	},
 	Edit: 'integer',
 	render: ( { item, field }: DataViewRenderFieldProps< any > ) => {
 		return field.elements

--- a/packages/dataviews/src/field-types/media.tsx
+++ b/packages/dataviews/src/field-types/media.tsx
@@ -1,26 +1,32 @@
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
-import type { ValidationContext, FieldTypeDefinition } from '../types';
+import type { NormalizedField, FieldTypeDefinition } from '../types';
 
 function sort() {
 	return 0;
 }
 
-function isValid( value: any, context?: ValidationContext ) {
-	if ( context?.elements ) {
-		const validValues = context?.elements.map( ( f ) => f.value );
-		if ( ! validValues.includes( value ) ) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
 export default {
 	sort,
-	isValid,
+	isValid: {
+		custom: ( item: any, field: NormalizedField< any > ) => {
+			const value = field.getValue( { item } );
+			if ( field?.elements ) {
+				const validValues = field.elements.map( ( f ) => f.value );
+				if ( ! validValues.includes( value ) ) {
+					return __( 'Value must be one of the elements.' );
+				}
+			}
+
+			return null;
+		},
+	},
 	Edit: null,
 	render: () => null,
 	enableSorting: false,

--- a/packages/dataviews/src/field-types/text.tsx
+++ b/packages/dataviews/src/field-types/text.tsx
@@ -1,10 +1,15 @@
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import type {
 	DataViewRenderFieldProps,
 	SortDirection,
-	ValidationContext,
+	NormalizedField,
 	FieldTypeDefinition,
 } from '../types';
 import { renderFromElements } from '../utils';
@@ -26,20 +31,21 @@ function sort( valueA: any, valueB: any, direction: SortDirection ) {
 		: valueB.localeCompare( valueA );
 }
 
-function isValid( value: any, context?: ValidationContext ) {
-	if ( context?.elements ) {
-		const validValues = context?.elements?.map( ( f ) => f.value );
-		if ( ! validValues.includes( value ) ) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
 export default {
 	sort,
-	isValid,
+	isValid: {
+		custom: ( item: any, field: NormalizedField< any > ) => {
+			const value = field.getValue( { item } );
+			if ( field?.elements ) {
+				const validValues = field.elements.map( ( f ) => f.value );
+				if ( ! validValues.includes( value ) ) {
+					return __( 'Value must be one of the elements.' );
+				}
+			}
+
+			return null;
+		},
+	},
 	Edit: 'text',
 	render: ( { item, field }: DataViewRenderFieldProps< any > ) => {
 		return field.elements

--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -139,14 +139,10 @@ export function normalizeFields< Item >(
 				);
 			};
 
-		const isValid =
-			field.isValid ??
-			function isValid( item, context ) {
-				return fieldTypeDefinition.isValid(
-					getValue( { item } ),
-					context
-				);
-			};
+		const isValid = {
+			...fieldTypeDefinition.isValid,
+			...field.isValid,
+		};
 
 		const Edit = getControl( field, fieldTypeDefinition );
 

--- a/packages/dataviews/src/test/validation.ts
+++ b/packages/dataviews/src/test/validation.ts
@@ -35,21 +35,8 @@ describe( 'validation', () => {
 		expect( result ).toBe( true );
 	} );
 
-	it( 'integer field is invalid if value is not integer', () => {
+	it( 'integer field is invalid if value is not integer when not empty', () => {
 		const item = { id: 1, order: 'd' };
-		const fields: Field< {} >[] = [
-			{
-				id: 'order',
-				type: 'integer',
-			},
-		];
-		const form = { fields: [ 'order' ] };
-		const result = isItemValid( item, fields, form );
-		expect( result ).toBe( false );
-	} );
-
-	it( 'integer field is invalid if value is empty', () => {
-		const item = { id: 1, order: '' };
 		const fields: Field< {} >[] = [
 			{
 				id: 'order',
@@ -121,7 +108,9 @@ describe( 'validation', () => {
 					{ value: 'a', label: 'A' },
 					{ value: 'b', label: 'B' },
 				],
-				isValid: () => true, // Overrides the validation provided for integer types.
+				isValid: {
+					custom: () => null, // Overrides the validation provided for integer types.
+				},
 			},
 		];
 		const form = { fields: [ 'order' ] };

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -100,10 +100,6 @@ export type FieldType =
 	| 'email'
 	| 'array';
 
-export type ValidationContext = {
-	elements?: Option[];
-};
-
 /**
  * An abstract interface for Field based on the field type.
  */
@@ -116,7 +112,7 @@ export type FieldTypeDefinition< Item > = {
 	/**
 	 * Callback used to validate the field.
 	 */
-	isValid: ( item: Item, context?: ValidationContext ) => boolean;
+	isValid: Rules< Item >;
 
 	/**
 	 * Callback used to render an edit control for the field or control name.
@@ -143,6 +139,11 @@ export type FieldTypeDefinition< Item > = {
 	 * Whether the field is sortable.
 	 */
 	enableSorting: boolean;
+};
+
+export type Rules< Item > = {
+	required?: boolean;
+	custom?: ( item: Item, field: NormalizedField< Item > ) => null | string;
 };
 
 /**
@@ -198,7 +199,7 @@ export type Field< Item > = {
 	/**
 	 * Callback used to validate the field.
 	 */
-	isValid?: ( item: Item, context?: ValidationContext ) => boolean;
+	isValid?: Rules< Item >;
 
 	/**
 	 * Callback used to decide if a field should be displayed.
@@ -250,7 +251,7 @@ export type NormalizedField< Item > = Omit< Field< Item >, 'Edit' > & {
 	render: ComponentType< DataViewRenderFieldProps< Item > >;
 	Edit: ComponentType< DataFormControlProps< Item > > | null;
 	sort: ( a: Item, b: Item, direction: SortDirection ) => number;
-	isValid: ( item: Item, context?: ValidationContext ) => boolean;
+	isValid: Rules< Item >;
 	enableHiding: boolean;
 	enableSorting: boolean;
 	filterBy: NormalizedFilterByConfig | false;

--- a/packages/dataviews/src/validation.ts
+++ b/packages/dataviews/src/validation.ts
@@ -21,7 +21,36 @@ export function isItemValid< Item >(
 	const _fields = normalizeFields(
 		fields.filter( ( { id } ) => !! form.fields?.includes( id ) )
 	);
+
+	const isEmptyNullOrUndefined = ( value: any ) =>
+		[ undefined, '', null ].includes( value );
+
 	return _fields.every( ( field ) => {
-		return field.isValid( item, { elements: field.elements } );
+		const value = field.getValue( { item } );
+
+		if ( field.isValid.required ) {
+			if (
+				( field.type === 'text' && isEmptyNullOrUndefined( value ) ) ||
+				( field.type === 'email' && isEmptyNullOrUndefined( value ) ) ||
+				( field.type === 'integer' &&
+					isEmptyNullOrUndefined( value ) ) ||
+				( field.type === undefined && isEmptyNullOrUndefined( value ) )
+			) {
+				return false;
+			}
+
+			if ( field.type === 'boolean' && value !== true ) {
+				return false;
+			}
+		}
+
+		if (
+			typeof field.isValid.custom === 'function' &&
+			field.isValid.custom( item, field ) !== null
+		) {
+			return false;
+		}
+
+		return true;
 	} );
 }

--- a/packages/fields/src/fields/order/index.ts
+++ b/packages/fields/src/fields/order/index.ts
@@ -15,6 +15,9 @@ const orderField: Field< BasePost > = {
 	label: __( 'Order' ),
 	description: __( 'Determines the order of pages.' ),
 	filterBy: false,
+	isValid: {
+		required: true,
+	},
 };
 
 /**


### PR DESCRIPTION
## What

This PR bootstraps basic validation (required, typechecks) for text, email, integer, and boolean field types in DataForm.

https://github.com/user-attachments/assets/6a2a9243-8a3f-4757-9bb8-b1b17b5459be

## Why

We want to introduce validation.

## How

Validation is declared in the Field API via the `isValid` object, and fields opt-in into the existing rules. Only the `required` validation rule has been implemented in this PR:

```js
{
  isValid: {
    required: true
  }
}
```

Fields that declare a type (`email`, `integer`, and `boolean`) have automatic type checks, if they require so. For example, the following requires the field value not to be empty and to conform to the email standard:

```js
{
  type: 'email',
  isValid: {
    required: true
  }
}
```

Fields that define their own `Edit` component have access to the validation rules:

```js
{
  id: 'customField',
  Edit: ( { field }) => {
	  return <input required={ !! field.isValid.required } />
  }
}
```

When a field wants to define its own validation mechanism, it can use the `custom` rule. If the field value doesn't conform to the custom rule, it must return a string which will be used by the UI control to display the error message:

```js
{
  isValid: {
    required: true,
    custom: ( item: Item, field: Field<Item> ) => {

      /* If the field is invalid, return an error message as string. */ 
      if ( /* field value is invalid */ ) {
        returns 'Field must conform to the rule';
      }
      
      /* Otherwise, return null. */
      return null;
    }
  }
}
```

Code changes:

- Field API: the existing `isValid` function is replaced by an object with rules that consumers can enable/disable. There's also a `custom` rule for fields to implement their own validation logic.
- The existing `isValid` functions in the Field Type Definitions are moved to `isValid.custom`.
- `@wordpress/components` exposes via privateApis the following components: `ValidatedTextControl`, `ValidatedNumberControl`, and `ValidatedToggleControl` in the `@wordpress/components` package. The existing DataForm controls are updated to use them, and they all support `require` and `custom` validation messages.
- Introduces a new story for validation (check DataForm > Validation) and it allows users to test all controls in a required and not required status.
- Updates the `isItemValid` function to consider the new `require` rule.

## How to test

```sh
npm install && npm run storybook:dev
```

Wait for the storybook to open and visit "DataForm > Validation".