### PR TITLE
Block API: Add special case for metadata attribute in 'isUnmodifiedBlock'

### DIFF
--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -452,6 +452,9 @@ describe( 'isUnmodifiedBlock', () => {
 					type: 'string',
 					role: 'content',
 				},
+				metadata: {
+					type: 'object',
+				},
 			},
 			save: noop,
 			category: 'text',
@@ -490,5 +493,24 @@ describe( 'isUnmodifiedBlock', () => {
 	it( 'should return true if no attributes exist for the specified role', () => {
 		const block = createBlock( 'core/test-block' );
 		expect( isUnmodifiedBlock( block, 'non-existent-role' ) ).toBe( true );
+	} );
+
+	it( 'should return true if metadata attributes is not modified for role content', () => {
+		const block = createBlock( 'core/test-block' );
+		expect( isUnmodifiedBlock( block, 'content' ) ).toBe( true );
+	} );
+
+	it( 'should return false if metadata attributes is modified for role content', () => {
+		const block = createBlock( 'core/test-block', {
+			metadata: {
+				bindings: {
+					content: {
+						source: 'core/post-meta',
+						args: { key: 'genre' },
+					},
+				},
+			},
+		} );
+		expect( isUnmodifiedBlock( block, 'content' ) ).toBe( false );
 	} );
 } );

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -44,11 +44,19 @@ export function isUnmodifiedBlock( block, role ) {
 
 	// Filter attributes by role if a role is provided.
 	const attributesToCheck = role
-		? Object.entries( blockAttributes ).filter(
-				( [ , definition ] ) =>
+		? Object.entries( blockAttributes ).filter( ( [ key, definition ] ) => {
+				// A special case for the metadata attribute.
+				// It can include block bindings that serve as a source of content,
+				// without directly modifying content attributes.
+				if ( role === 'content' && key === 'metadata' ) {
+					return true;
+				}
+
+				return (
 					definition.role === role ||
 					definition.__experimentalRole === role
-		  )
+				);
+		  } )
 		: Object.entries( blockAttributes );
 
 	return attributesToCheck.every( ( [ key, definition ] ) => {


### PR DESCRIPTION
## What?
This is a follow-up to #70764.
Related #70897.

PR adds a special case for the `metadata` attribute, making sure block modification is correctly checked when attributes are bound to external sources.

## Why?
While the `metadata` attribute can't have a role itself, it can contain data that could serve as content. Counting any metadata modifications as a change will prevent accidental "content" loss.

## Testing Instructions
1. Open a post or page.
2. Add an image block followed by a paragraph.
3. Bind the paragraph's content attribute to a meta source.
4. Place the caret at the start of the text in the paragraph.
5. Confirm that pressing Backspace selects the image block and doesn't remove the paragraph.


<details><summary>Test meta source</summary>
<p>

```php
add_action( 'init', function() {
	register_meta(
		'post',
		'text_short',
		array(
			'label'             => __( 'Genre' ),
			'show_in_rest'      => true,
			'single'            => true,
			'type'              => 'string',
			'sanitize_callback' => 'wp_strip_all_tags',
			'default'           => 'Some text for a Paragraph',
		)
	);
} );
``` 

</p>
</details> 

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/74ca7a9a-a467-443b-91d6-7a63730c091e



