### PR TITLE
TypeScript: migrate with-select component in data package to TS

### DIFF
--- a/packages/data/src/components/with-select/index.tsx
+++ b/packages/data/src/components/with-select/index.tsx
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+import type { ComponentType } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { createHigherOrderComponent, pure } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import useSelect from '../use-select';
+import type { SelectFunction, DataRegistry } from '../../types';
+
+/**
+ * Higher-order component used to inject state-derived props using registered
+ * selectors.
+ *
+ * @param mapSelectToProps Function called on every state change,
+ *                         expected to return object of props to
+ *                         merge with the component's own props.
+ *
+ * @example
+ * ```ts
+ * import { withSelect } from '@wordpress/data';
+ * import { store as myCustomStore } from 'my-custom-store';
+ *
+ * interface PriceDisplayProps {
+ * 	price: number;
+ * 	currency: string;
+ * }
+ *
+ * function PriceDisplay( { price, currency }: PriceDisplayProps ) {
+ * 	return new Intl.NumberFormat( 'en-US', {
+ * 		style: 'currency',
+ * 		currency,
+ * 	} ).format( price );
+ * }
+ *
+ * interface HammerPriceDisplayProps {
+ * 	currency: string;
+ * }
+ *
+ * const HammerPriceDisplay = withSelect( ( select, ownProps: HammerPriceDisplayProps ) => {
+ * 	const { getPrice } = select( myCustomStore );
+ * 	const { currency } = ownProps;
+ *
+ * 	return {
+ * 		price: getPrice( 'hammer', currency ),
+ * 	};
+ * } )( PriceDisplay );
+ *
+ * // Rendered in the application:
+ * //
+ * //  <HammerPriceDisplay currency="USD" />
+ * ```
+ * In the above example, when `HammerPriceDisplay` is rendered into an
+ * application, it will pass the price into the underlying `PriceDisplay`
+ * component and update automatically if the price of a hammer ever changes in
+ * the store.
+ *
+ * @return Enhanced component with merged state data props.
+ */
+const withSelect = < P extends Record< string, unknown > >(
+	mapSelectToProps: (
+		select: SelectFunction,
+		ownProps: P,
+		registry: DataRegistry
+	) => Record< string, unknown >
+) =>
+	createHigherOrderComponent(
+		( WrappedComponent: ComponentType< P & Record< string, unknown > > ) =>
+			pure( ( ownProps: P ) => {
+				const mapSelect = (
+					select: SelectFunction,
+					registry: DataRegistry
+				) => mapSelectToProps( select, ownProps, registry );
+				const mergeProps = useSelect( mapSelect, [ ownProps ] );
+				return <WrappedComponent { ...ownProps } { ...mergeProps } />;
+			} ),
+		'withSelect'
+	);
+
+export default withSelect;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of https://github.com/WordPress/gutenberg/issues/67691

<!-- In a few words, what is the PR actually doing? -->
Migrating the with-select component in data package to TypeScript.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To enhance DX and add type safety.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By porting the code and tests to TypeScript.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
Typecheck and unit tests.