### PR TITLE
TextControl: Improve theming support

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   `TextControl`: Improve theming support ([#70910](https://github.com/WordPress/gutenberg/pull/70910)).
+
 ## 30.0.0 (2025-07-23)
 
 ### Breaking Changes

--- a/packages/components/src/text-control/stories/index.story.tsx
+++ b/packages/components/src/text-control/stories/index.story.tsx
@@ -56,6 +56,7 @@ export const Default: StoryFn< typeof TextControl > = DefaultTemplate.bind(
 Default.args = {
 	__nextHasNoMarginBottom: true,
 	__next40pxDefaultSize: true,
+	placeholder: 'Placeholder',
 };
 
 export const WithLabelAndHelpText: StoryFn< typeof TextControl > =

--- a/packages/components/src/text-control/style.scss
+++ b/packages/components/src/text-control/style.scss
@@ -18,7 +18,12 @@
 	margin: 0;
 	background: $components-color-background;
 	color: $components-color-foreground;
-	@include input-control( $components-color-accent);
+	@include input-control( $components-color-accent );
+	border-color: $components-color-border;
+
+	&::placeholder {
+		color: $components-color-dark-gray-placeholder;
+	}
 
 	&.is-next-40px-default-size {
 		height: $grid-unit-50;

--- a/packages/components/src/utils/theme-variables.scss
+++ b/packages/components/src/utils/theme-variables.scss
@@ -24,5 +24,8 @@ $components-color-gray-600: var(--wp-components-color-gray-600, $gray-600);
 $components-color-gray-700: var(--wp-components-color-gray-700, $gray-700);
 $components-color-gray-800: var(--wp-components-color-gray-800, $gray-800);
 
+$components-color-dark-gray-placeholder: color-mix(in srgb, $components-color-foreground, transparent 38%);
+$components-color-light-gray-placeholder: color-mix(in srgb, $components-color-background, transparent 35%);
+
 // Semantic aliases (prefer these over raw gray values when applicable).
 $components-color-border: #{ $components-color-gray-600 };


### PR DESCRIPTION
## What?

Makes the border and placeholder colors of `TextControl` themable.

## Why?

To expand themability of our basic components.

## Testing Instructions

`npm run storybook:dev` and go to the story for `TextControl`. Use the theme switcher in the top toolbar to try the dark theme.

<img width="261" height="48" alt="theme switcher" src="https://github.com/user-attachments/assets/2ab6e13c-faca-47b1-a3ae-721dc235f271" />

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img width="1150" height="542" alt="TextControl with placeholder, before" src="https://github.com/user-attachments/assets/eb76ab19-7ba7-4f85-b956-a62503f4b904" />|<img width="1148" height="542" alt="TextControl with placeholder, after" src="https://github.com/user-attachments/assets/2ecb53ba-bd84-4cc6-954d-e5d915914924" />|
