### PR TITLE
Fix footnotes's subscript numbering on para delete and undone

### DIFF
--- a/packages/core-data/src/footnotes/index.js
+++ b/packages/core-data/src/footnotes/index.js
@@ -10,6 +10,18 @@ import getFootnotesOrder from './get-footnotes-order';
 
 let oldFootnotes = {};
 
+/**
+ * @typedef {Object} UpdateFootnotesFromMetaResult
+ * @property {Record<string, unknown>} meta   - The updated meta information.
+ * @property {Array}                   blocks - The updated blocks with footnotes processed.
+ */
+
+/**
+ * Updates footnotes in blocks based on meta information.
+ * @param {Array}                   blocks - The blocks to update.
+ * @param {Record<string, unknown>} meta   - The meta information to use for updates.
+ * @return {UpdateFootnotesFromMetaResult} - The updated blocks and meta information.
+ */
 export function updateFootnotesFromMeta( blocks, meta ) {
 	const output = { blocks };
 	if ( ! meta ) {
@@ -140,4 +152,30 @@ export function updateFootnotesFromMeta( blocks, meta ) {
 		},
 		blocks: newBlocks,
 	};
+}
+
+/**
+ * Checks if the block list contains a subscript attribute
+ *
+ * @param {Array} blockList - The list of blocks to check.
+ *
+ * @return {boolean} - Returns true if a core/footnotes block is found, otherwise false.
+ */
+export function hasFootnotesSubscriptBlock( blockList ) {
+	for ( const block of blockList ) {
+		if (
+			block.attributes &&
+			block.attributes[ 'data-fn' ] &&
+			block.tagName === 'sup'
+		) {
+			return true;
+		}
+
+		if ( block.innerBlocks && block.innerBlocks.length > 0 ) {
+			if ( hasFootnotesSubscriptBlock( block.innerBlocks ) ) {
+				return true;
+			}
+		}
+	}
+	return false;
 }

--- a/packages/core-data/src/hooks/use-entity-block-editor.js
+++ b/packages/core-data/src/hooks/use-entity-block-editor.js
@@ -10,7 +10,10 @@ import { parse, __unstableSerializeAndClean } from '@wordpress/blocks';
  */
 import { STORE_NAME } from '../name';
 import useEntityId from './use-entity-id';
-import { updateFootnotesFromMeta } from '../footnotes';
+import {
+	hasFootnotesSubscriptBlock,
+	updateFootnotesFromMeta,
+} from '../footnotes';
 
 const EMPTY_ARRAY = [];
 const parsedBlocksCache = new WeakMap();
@@ -72,23 +75,31 @@ export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 		// If not, cache by the original entity record.
 		const edits = getEntityRecordEdits( kind, name, id );
 		const isUnedited = ! edits || ! Object.keys( edits ).length;
-		const cackeKey = isUnedited ? getEntityRecord( kind, name, id ) : edits;
-		let _blocks = parsedBlocksCache.get( cackeKey );
+		const cacheKey = isUnedited ? getEntityRecord( kind, name, id ) : edits;
+		let _blocks = parsedBlocksCache.get( cacheKey );
 
 		if ( ! _blocks ) {
 			_blocks = parse( content );
-			parsedBlocksCache.set( cackeKey, _blocks );
+			parsedBlocksCache.set( cacheKey, _blocks );
+		}
+
+		if ( hasFootnotesSubscriptBlock( _blocks ) ) {
+			// If the blocks contain footnotes, we need to process them.
+			// This is done to ensure that footnotes are always up-to-date
+			_blocks = updateFootnotesFromMeta( _blocks, meta ).blocks;
+			parsedBlocksCache.set( cacheKey, _blocks );
 		}
 
 		return _blocks;
 	}, [
+		id,
 		kind,
 		name,
-		id,
 		editedBlocks,
 		content,
-		getEntityRecord,
 		getEntityRecordEdits,
+		getEntityRecord,
+		meta,
 	] );
 
 	const onChange = useCallback(
@@ -115,13 +126,13 @@ export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 			} );
 		},
 		[
+			blocks,
+			meta,
+			editEntityRecord,
 			kind,
 			name,
 			id,
-			blocks,
-			meta,
 			__unstableCreateUndoLevel,
-			editEntityRecord,
 		]
 	);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL --> #60050

<!-- In a few words, what is the PR actually doing? -->
This PR fixes the footnote numbers being incorrect when paragraphs are deleted and undone.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently when we delete paragraph containing the footnote and undo it the numbering on subscript gets broken 

### Example
```
Para1: Hello World[^1]
Para2: Ok Bye[^2]
```

> delete Para1 and undo it

```
Para1: Hello World[^1]
Para2: Ok Bye[^1]
```

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR fixes this by updating useEntityBlockEditor to check if blocks contain footnotes and if it does then update the blocks to match current footnotes.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Set footnotes for each of several paragraphs.
2. Delete the first paragraph.
3. Undo.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/e0735fa4-3af8-4f20-a57d-d53bb2dc418b


