### PR TITLE
[Block] Form: add `dialog` method

### DIFF
--- a/packages/block-library/src/form/edit.js
+++ b/packages/block-library/src/form/edit.js
@@ -182,6 +182,7 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 						options={ [
 							{ label: 'Get', value: 'get' },
 							{ label: 'Post', value: 'post' },
+							{ label: 'Dialog', value: 'dialog' },
 						] }
 						value={ method }
 						onChange={ ( value ) =>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR adds "dialog" option for the "Method" select in the editor.

## Why?

`<form>` element supports a "dialog" method that can be used when it is inside a `<dialog>`. Its purpose is to let submit button inside close the dialog.

While there is not a direct way to add a `<dialog>` in Gutenberg, custom blocks can do so. It would be nice to be able to nest the Form block as InnerBlock.

## How?
The PR simply adds another option for the `SelectControl` of "Method". Its `onChange` already sets the selected value, and the front-end already renders the `method` attribute accordingly.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert an `Experimental Comment form` block.
3. Select the new form block and open "Settings".
4. Under "Submissions method", select "- Custom -".
5. Expand "Advanced" panel.
6. Under "Method", choose "Dialog".
7. Save the post or page.
8. Inspect the `<form>` element on front-end.
9. Verify that the `<form>` element has `method` attribute with value "dialog".