### PR TITLE
Add Node.js compatibility tests to prevent SSR crashes

### DIFF
--- a/test/integration/node-packages-compatibility.test.js
+++ b/test/integration/node-packages-compatibility.test.js
@@ -1,0 +1,199 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * These tests ensure that WordPress packages can be imported and used in a
+ * Node.js environment without browser APIs like `window`, `document`, etc.
+ * This is important for server-side rendering (SSR) contexts where these
+ * globals don't exist.
+ * 
+ * The tests prevent regressions where browser-specific code (like direct
+ * access to `window` or `document`) is added to packages that should work
+ * in both browser and Node.js environments.
+ * 
+ * @see https://github.com/WordPress/gutenberg/issues/17273
+ * @see https://github.com/WordPress/gutenberg/pull/17165
+ */
+
+describe( 'WordPress packages in Node.js environment', () => {
+	test( 'should import @wordpress/compose without errors', () => {
+		expect( () => {
+			require( '@wordpress/compose' );
+		} ).not.toThrow();
+	} );
+
+	test( 'should import @wordpress/components without errors', () => {
+		expect( () => {
+			require( '@wordpress/components' );
+		} ).not.toThrow();
+	} );
+
+	test( 'should import @wordpress/element without errors', () => {
+		expect( () => {
+			require( '@wordpress/element' );
+		} ).not.toThrow();
+	} );
+
+	test( 'should import @wordpress/data without errors', () => {
+		expect( () => {
+			require( '@wordpress/data' );
+		} ).not.toThrow();
+	} );
+
+	test( 'should import @wordpress/blocks without errors', () => {
+		expect( () => {
+			require( '@wordpress/blocks' );
+		} ).not.toThrow();
+	} );
+
+	test( 'should import @wordpress/block-editor without errors', () => {
+		expect( () => {
+			require( '@wordpress/block-editor' );
+		} ).not.toThrow();
+	} );
+
+	test( 'should import @wordpress/core-data without errors', () => {
+		expect( () => {
+			require( '@wordpress/core-data' );
+		} ).not.toThrow();
+	} );
+
+	test( 'should import @wordpress/editor without errors', () => {
+		expect( () => {
+			require( '@wordpress/editor' );
+		} ).not.toThrow();
+	} );
+
+	test( 'should import @wordpress/hooks without errors', () => {
+		expect( () => {
+			require( '@wordpress/hooks' );
+		} ).not.toThrow();
+	} );
+
+	test( 'should import @wordpress/i18n without errors', () => {
+		expect( () => {
+			require( '@wordpress/i18n' );
+		} ).not.toThrow();
+	} );
+
+	test( 'should import @wordpress/rich-text without errors', () => {
+		expect( () => {
+			require( '@wordpress/rich-text' );
+		} ).not.toThrow();
+	} );
+
+	test( 'should import @wordpress/url without errors', () => {
+		expect( () => {
+			require( '@wordpress/url' );
+		} ).not.toThrow();
+	} );
+
+	test( 'should import @wordpress/dom-ready without errors', () => {
+		expect( () => {
+			require( '@wordpress/dom-ready' );
+		} ).not.toThrow();
+	} );
+
+	test( 'should import @wordpress/viewport without errors', () => {
+		expect( () => {
+			require( '@wordpress/viewport' );
+		} ).not.toThrow();
+	} );
+} );
+
+describe( 'WordPress packages functionality in Node.js environment', () => {
+	test( 'should be able to use compose utilities', () => {
+		const { compose } = require( '@wordpress/compose' );
+		
+		const addOne = ( x ) => x + 1;
+		const multiplyByTwo = ( x ) => x * 2;
+		const composed = compose( multiplyByTwo, addOne );
+		
+		expect( composed( 5 ) ).toBe( 12 ); // (5 + 1) * 2 = 12
+	} );
+
+	test( 'should be able to use data utilities', () => {
+		const { createRegistry } = require( '@wordpress/data' );
+		
+		expect( () => {
+			const registry = createRegistry();
+			expect( registry ).toBeDefined();
+		} ).not.toThrow();
+	} );
+
+	test( 'should be able to use element utilities', () => {
+		const { createElement } = require( '@wordpress/element' );
+		
+		expect( () => {
+			const element = createElement( 'div', null, 'Hello World' );
+			expect( element ).toBeDefined();
+		} ).not.toThrow();
+	} );
+
+	test( 'should be able to use hooks utilities', () => {
+		const { createHooks } = require( '@wordpress/hooks' );
+		
+		expect( () => {
+			const hooks = createHooks();
+			expect( hooks ).toBeDefined();
+		} ).not.toThrow();
+	} );
+
+	test( 'should be able to use i18n utilities', () => {
+		const { __ } = require( '@wordpress/i18n' );
+		
+		expect( () => {
+			const translated = __( 'Hello World' );
+			expect( translated ).toBe( 'Hello World' );
+		} ).not.toThrow();
+	} );
+
+	test( 'should be able to use url utilities', () => {
+		const { addQueryArgs } = require( '@wordpress/url' );
+		
+		expect( () => {
+			const url = addQueryArgs( 'https://example.com', { foo: 'bar' } );
+			expect( url ).toBe( 'https://example.com?foo=bar' );
+		} ).not.toThrow();
+	} );
+
+	test( 'should be able to use blocks utilities', () => {
+		const { createBlock } = require( '@wordpress/blocks' );
+		
+		expect( () => {
+			// This should not throw even without registering blocks
+			const block = createBlock( 'core/paragraph', { content: 'Hello' } );
+			expect( block ).toBeDefined();
+			expect( block.name ).toBe( 'core/paragraph' );
+		} ).not.toThrow();
+	} );
+} );
+
+describe( 'WordPress packages with browser-dependent features', () => {
+	test( 'should handle dom-ready gracefully in Node.js environment', () => {
+		const domReady = require( '@wordpress/dom-ready' );
+		
+		expect( () => {
+			// dom-ready should handle the lack of document gracefully
+			domReady( () => {} );
+		} ).not.toThrow();
+	} );
+
+	test( 'should handle viewport utilities gracefully in Node.js environment', () => {
+		expect( () => {
+			// This might contain browser-specific code but should not crash on import
+			require( '@wordpress/viewport' );
+		} ).not.toThrow();
+	} );
+
+	test( 'should handle compose hooks gracefully in Node.js environment', () => {
+		const { useReducedMotion, useMediaQuery } = require( '@wordpress/compose' );
+		
+		expect( () => {
+			// These hooks should be importable even if they can't be used without React context
+			expect( typeof useReducedMotion ).toBe( 'function' );
+			expect( typeof useMediaQuery ).toBe( 'function' );
+		} ).not.toThrow();
+	} );
+} );


### PR DESCRIPTION
Hey there! 👋

I noticed issue #17273 has been open for a while and thought I'd take a crack at it. This adds some integration tests to make sure our WordPress packages play nicely with Node.js environments.

## The Problem

Sometimes our packages break when used in server-side rendering because they try to access browser globals like `window` or `document` that don't exist in Node.js. The original issue mentioned `@wordpress/compose` crashing due to naked `window` references, and while that's been fixed, we want to prevent similar issues in the future.

## What I Did

I created a comprehensive test suite that:

- Imports all the major WordPress packages in a pure Node.js environment (no DOM)
- Makes sure they don't crash on import
- Tests basic functionality to ensure they work as expected
- Covers packages like `@wordpress/compose`, `@wordpress/components`, `@wordpress/element`, and many others

The tests are split into three sections:
1. **Import tests** - Just making sure we can require() packages without explosions
2. **Basic functionality** - Testing that core features actually work
3. **Browser-dependent features** - Making sure packages gracefully handle missing browser APIs

## Why This Matters

This will catch regressions early and help maintain compatibility for folks doing SSR with WordPress blocks. It's especially important as the block editor ecosystem grows and more people want to render blocks on the server.

## Testing

Run `npm run test:unit -- test/integration/node-packages-compatibility.test.js` and watch the magic happen! All tests should pass, proving our packages are Node.js friendly.

Let me know if you'd like me to adjust anything or add more test cases. Happy to iterate on this!

Fixes #17273