### PR TITLE
File Block: Fix PDF preview on URLs containing query parameters

### DIFF
--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -29,6 +29,7 @@ import { __, _x } from '@wordpress/i18n';
 import { file as icon } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
+import { getFilename } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -127,8 +128,9 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 			return;
 		}
 
-		const parsedUrl = new URL( newMedia.url, window.location.origin );
-		const isPdf = parsedUrl.pathname.toLowerCase().endsWith( '.pdf' );
+		const isPdf = getFilename( newMedia.url )
+			.toLowerCase()
+			.endsWith( '.pdf' );
 		const pdfAttributes = {
 			displayPreview: isPdf
 				? attributes.displayPreview ?? true

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -127,7 +127,8 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 			return;
 		}
 
-		const isPdf = newMedia.url.endsWith( '.pdf' );
+		const parsedUrl = new URL( newMedia.url, window.location.origin );
+		const isPdf = parsedUrl.pathname.toLowerCase().endsWith( '.pdf' );
 		const pdfAttributes = {
 			displayPreview: isPdf
 				? attributes.displayPreview ?? true


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #70908 

<!-- In a few words, what is the PR actually doing? -->
This PR fixes the issue in the File block where PDF files with query parameters  are not recognised as PDFs, resulting in the embedded preview not rendering.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Some media storage plugins or CDN setups generate signed PDF URLs with query parameters for access control. These still point to valid PDFs, but the current logic fails to detect them as such, disabling the embedded preview.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Updated the PDF detection logic to use `URL` API. This safely extracts the pathname from the media URL, ignoring query parameters and hash fragments.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Follow the instructions from the [original issue](https://github.com/WordPress/gutenberg/issues/70908) to set up and offload media to cloud storage.
2. Use a File block in the block editor and select an offloaded PDF file
3. Confirm that the embedded PDF preview appears correctly, even if the media URL has query parameters.

### Manual Testing with Code Injection
If not able to set up cloud storage, test manually with:
1. Go to the [PDF check in FileEdit component](https://github.com/WordPress/gutenberg/blob/a2cb1b07ac94daa5e93902bc778b6717c25f013b/packages/block-library/src/file/edit.js#L130)
2. Modify the code just before the PDF check:
```js
newMedia.url = newMedia.url + '?foo=bar';
```
3. Open the editor, insert a File block, and select any locally uploaded PDF.
4. Confirm that:
    - The PDF source includes the query params.
    - The preview still renders correctly.

<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="740" height="272" alt="Screenshot 2025-07-25 at 10 47 33 PM" src="https://github.com/user-attachments/assets/64e7abcd-6ec6-4bb5-8a61-d784fdc70454" />|<img width="755" height="813" alt="Screenshot 2025-07-25 at 11 36 05 PM" src="https://github.com/user-attachments/assets/64b21ebd-0ab2-4fe4-b01b-46aba4431a4c" />|
