### PR TITLE
RichText: Support more colors for format boundary colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19789,7 +19789,8 @@
 		"node_modules/colord": {
 			"version": "2.9.3",
 			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
-			"integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw=="
+			"integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+			"license": "MIT"
 		},
 		"node_modules/colorette": {
 			"version": "1.4.0",
@@ -51739,6 +51740,7 @@
 				"@wordpress/escape-html": "file:../escape-html",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/keycodes": "file:../keycodes",
+				"colord": "2.9.3",
 				"memize": "^2.1.0"
 			},
 			"engines": {

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -41,6 +41,7 @@
 		"@wordpress/escape-html": "file:../escape-html",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/keycodes": "file:../keycodes",
+		"colord": "2.9.3",
 		"memize": "^2.1.0"
 	},
 	"peerDependencies": {

--- a/packages/rich-text/src/component/use-boundary-style.js
+++ b/packages/rich-text/src/component/use-boundary-style.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { colord } from 'colord';
+
+/**
  * WordPress dependencies
  */
 import { useEffect, useRef } from '@wordpress/element';
@@ -31,9 +36,9 @@ export function useBoundaryStyle( { record } ) {
 		const { ownerDocument } = element;
 		const { defaultView } = ownerDocument;
 		const computedStyle = defaultView.getComputedStyle( element );
-		const newColor = computedStyle.color
-			.replace( ')', ', 0.2)' )
-			.replace( 'rgb', 'rgba' );
+		const newColor = colord( computedStyle.color )
+			.alpha( 0.2 )
+			.toRgbString();
 		const selector = `.rich-text:focus ${ boundarySelector }`;
 		const rule = `background-color: ${ newColor }`;
 		const style = `${ selector } {${ rule }}`;


### PR DESCRIPTION
## What?

Closes #70909

When the rich text has a format and it receives the focus, the background color based on the current text color is applied. This PR supports more color value variations.

## Why?

The current implementation replaces the string dynamically, so the incorrect color may be rendered.

## How?

Use the [colord](https://github.com/omgovich/colord) library, which is already used by some packages. This library supports some alpha color values and system colors. Additionally, the library does not support colors such as `color-mix()` or `oklch()`, but will fall back to black, ensuring that the boundary color will be rendered no matter what color it is.

We may be able to choose other libraries if we want to support more complex color values, but I think it's enough to support major colors for now.

## Testing Instructions

- Apply bold format to some text
- Site Editor > Global Styles > More> Additional CSS
- Define body color by using the  rgba color
- Focus the bolded text and confirm the background color.

## Screenshots or screencast <!-- if applicable -->

| Color | Screenshot |
|--------|--------|
| `body { color: #00ff0080; }` | <img width="100" height="74" alt="image" src="https://github.com/user-attachments/assets/aaa06fe1-9013-4bc6-b096-d135b792f83d" />|
| `body { color: rgba(255, 0, 0, 0.7); }` | <img width="109" height="74" alt="image" src="https://github.com/user-attachments/assets/334bead3-dceb-46b0-bcb2-f5e04a16ad9f" /> |
| `body { color: hsla(120, 40%, 70%, 0.7); }` | <img width="111" height="73" alt="image" src="https://github.com/user-attachments/assets/972c0d0c-edc1-42e8-8dd2-2b01a4a8fb13" /> |

Note that the following colors will not be parsed, and so `background-color: rgba(0, 0, 0, 0.2)` will be applied as a fallback color:

```css
body { color: oklch(62% 0.2577 29.23); }
body { color: color-mix(in srgb, red 50%, blue); }
body { color: color(srgb 1 0 0); }
body { color: rgb(from red r g 128); }
```

<img width="113" height="75" alt="image" src="https://github.com/user-attachments/assets/3ee226f6-03fb-410d-badb-f6e8d26c04bf" />
