### PR TITLE
Fix: Use lowercase capitalization for Featured Image 'Link to...' con…

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -259,7 +259,7 @@ export default function PostFeaturedImageEdit( {
 									? sprintf(
 											// translators: %s: Name of the post type e.g: "post".
 											__( 'Link to %s' ),
-											postType.labels.singular_name
+											postType.labels.singular_name.toLowerCase()
 									  )
 									: __( 'Link to post' )
 							}
@@ -278,7 +278,7 @@ export default function PostFeaturedImageEdit( {
 										? sprintf(
 												// translators: %s: Name of the post type e.g: "post".
 												__( 'Link to %s' ),
-												postType.labels.singular_name
+												postType.labels.singular_name.toLowerCase()
 										  )
 										: __( 'Link to post' )
 								}


### PR DESCRIPTION
…trol

The post type value should be lowercased (e.g., 'Link to page' instead of 'Link to Page'). This change applies .toLowerCase() to postType.labels.singular_name in both the ToolsPanelItem label and ToggleControl label, matching the pattern already used in the Post Date block.

Fixes #55057

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Changes the post type capitalization to lowercase in Featured Image block "Link to..." controls.
Closes <!-- #55057 -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
The Featured Image block was displaying "Link to Page" and "Link to Post" with uppercase post type names, which is inconsistent with UI conventions and other blocks like Post Date that use lowercase. This improves consistency across the WordPress block editor interface.


## How?
Applied .toLowerCase()  in both the ToolsPanelItem label and ToggleControl label on lines 258 and 275. This follows the same pattern already used in the Post Date block for identical functionality.

## Testing Instructions
Create or edit a post or page
Add a Post Featured Image block
Select an image for the featured image
Open the block settings panel (Inspector Controls)
Look for the "Link to..." toggle control
Verify it shows "Link to page" (lowercase) instead of "Link to Page"
Test with different post types (posts, pages, custom post types) to ensure they all show lowercase


### Testing Instructions for Keyboard
Navigate to the Post Featured Image block using Tab key
Use Tab to reach the block settings panel
Use Arrow keys to navigate to the "Link to..." control
Verify the label reads correctly with lowercase post type name
Ensure all keyboard interactions work as expected

 