### PR TITLE
Fix: Use color-mix for rich text boundary style

### DIFF
--- a/packages/rich-text/src/component/use-boundary-style.js
+++ b/packages/rich-text/src/component/use-boundary-style.js
@@ -31,11 +31,15 @@ export function useBoundaryStyle( { record } ) {
 		const { ownerDocument } = element;
 		const { defaultView } = ownerDocument;
 		const computedStyle = defaultView.getComputedStyle( element );
-		const newColor = computedStyle.color
-			.replace( ')', ', 0.2)' )
-			.replace( 'rgb', 'rgba' );
+
+		// START --- THIS IS THE FIX ---
+		// The old .replace() logic is removed and replaced with color-mix(),
+		// which works correctly with all CSS color formats.
+		const newBackgroundColor = `color-mix(in oklab, ${ computedStyle.color } 20%, transparent)`;
 		const selector = `.rich-text:focus ${ boundarySelector }`;
-		const rule = `background-color: ${ newColor }`;
+		const rule = `background-color: ${ newBackgroundColor }`;
+		// END --- THIS IS THE FIX ---
+
 		const style = `${ selector } {${ rule }}`;
 		const globalStyleId = 'rich-text-boundary-style';
 


### PR DESCRIPTION
## What?

Closes #70909

This PR fixes a bug where the background highlight on focused rich text formats (like bold text) disappears when using modern CSS color functions, such as `oklch`.

## Why?

The previous implementation used a simple string replacement method to add opacity. This method only worked for `rgb()` color values and failed for modern formats like `oklch`, resulting in an invalid CSS `background-color` value.

## How?

This change updates the code in `use-boundary-style.js` to use the modern CSS `color-mix()` function. This correctly and robustly adds 20% opacity to any valid computed text color, resolving the issue for all supported color formats.

## Testing Instructions

1. Go to the Site Editor.
2. Select a block with text, like a Paragraph block.
3. From the "Styles" sidebar, go to "Colors" -> "Text".
4. Set the text color to a modern CSS color format, for example: `oklch(62% 0.2577 2_9.23)`.
5. In the block, select some text and make it **Bold**.
6. Click on the bolded text to give it focus.
7. **Verify** that a semi-transparent background highlight now correctly appears on the focused bolded text.

### Testing Instructions for Keyboard

The test is primarily visual but can be performed with a keyboard. Use standard keyboard navigation (arrow keys, Shift+arrow keys) to select text, apply the bold format (`Ctrl+B`), and move the cursor back onto the bolded text to verify the background highlight appears.

