### PR TITLE
Updated Small Typo in block-styles.md file

### DIFF
--- a/docs/reference-guides/block-api/block-styles.md
+++ b/docs/reference-guides/block-api/block-styles.md
@@ -70,7 +70,7 @@ Besides the two mandatory properties, the styles properties array should also in
 -   `style_handle`: Contains the handle to an already registered style that should be enqueued in places where block styles are needed.
 -   `style_data`: Contains a theme.json-like notation in an array of style properties.
 
-It is also possible to set the `is_default` property to `true` to mark one of the block styles as the default one, should one be mising.
+It is also possible to set the `is_default` property to `true` to mark one of the block styles as the default one, should one be missing.
 
 The following code sample registers a style for the quote block named "Blue Quote", and provides an inline style that makes quote blocks with the "Blue Quote" style have blue color:
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? Why?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Small Typo in block-styles.md file. (`mising` it should be `missing`)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Updated Small Typo in block-styles.md file. Added `missing` instead of `mising`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open `docs/reference-guides/block-api/block-styles.md` file
2. Go to Line no 73


