### PR TITLE
Template editor: wrong REST API permissions check

### DIFF
--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -66,6 +66,14 @@ export default function BlockThemeControl( { id } ) {
 		[]
 	);
 
+	const canEditTemplate = useSelect(
+		( select ) =>
+			!! select( coreStore ).canUser( 'update', {
+				kind: 'postType',
+				name: 'wp_template',
+			} )
+	);
+
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
 	// Memoize popoverProps to avoid returning a new object every time.
 	const popoverProps = useMemo(
@@ -124,7 +132,7 @@ export default function BlockThemeControl( { id } ) {
 				{ ( { onClose } ) => (
 					<>
 						<MenuGroup>
-							{ canCreateTemplate && (
+							{ canEditTemplate && (
 								<MenuItem
 									onClick={ () => {
 										onNavigateToEntityRecord( {


### PR DESCRIPTION
## What?
Closes #51886

This PR is designed to showcase one of the solutions[ provided in this post. ](https://github.com/WordPress/gutenberg/issues/51886#issuecomment-3124828349)

## Why?
The idea here is to showcase the use of an `UPDATABLE` REST API point, that targets the `PUT` method and transitively, the `canUser` `update` to show or hide Create and Edit Templates depending on the user permissions.

## Testing Instructions
1. It's important to implement this patch [and the one provided in Core](https://github.com/WordPress/wordpress-develop/pull/9331)

2. Add the code [in the ticket](https://github.com/WordPress/gutenberg/issues/51886#issue-1773772390) to a place where it can be executed (a plugin, the theme `functons.php`, etc.) to manually control the permissions (`true` or `false` in each function `update_item_permissions_check` and `create_item_permissions_check` will control the visibility of the Create and Edit selector for the Template section here:
<img width="610" height="495" alt="image" src="https://github.com/user-attachments/assets/201d26f1-ab28-4d10-a00d-d3e0e780b1e8" />

3. You can confirm that everything is working right, if: 
- `create_item_permissions_check`  returns `true` you might be able to see the Create Template in the selector, and with `false` you won't be able to see it.
- `update_item_permissions_check` returns `true` you might be able to see the Edit Template in the selctor and with `false` you won't be able to see it.