### PR TITLE
TextareaControl: Add missing component CSS classname

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `TextareaControl`: Add missing component CSS classname ([#70930](https://github.com/WordPress/gutenberg/pull/70930)).
+
 ## 30.0.0 (2025-07-23)
 
 ### Breaking Changes

--- a/packages/components/src/textarea-control/index.tsx
+++ b/packages/components/src/textarea-control/index.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
@@ -32,6 +37,8 @@ function UnforwardedTextareaControl(
 	const onChangeValue = ( event: React.ChangeEvent< HTMLTextAreaElement > ) =>
 		onChange( event.target.value );
 
+	const classes = clsx( 'components-textarea-control', className );
+
 	return (
 		<BaseControl
 			__nextHasNoMarginBottom={ __nextHasNoMarginBottom }
@@ -40,7 +47,7 @@ function UnforwardedTextareaControl(
 			hideLabelFromVision={ hideLabelFromVision }
 			id={ id }
 			help={ help }
-			className={ className }
+			className={ classes }
 		>
 			<StyledTextarea
 				className="components-textarea-control__input"


### PR DESCRIPTION
## What?

I noticed that even though the TextareaControl component has a CSS class like `.components-textarea-control__{element}` applied internally, the root element does not have the `.components-textarea-control` CSS class.

```html
<!-- Before: -->
<div class="components-base-control my-custom-class">
  <div class="components-base-control__field">
    <label class="components-base-control__label">Text</label>
    <textarea class="components-textarea-control__input">
    </textarea>
  </div>
  <p class="components-base-control__help">Enter some text</p>
</div>

<!-- After -->
<div class="components-base-control components-textarea-control my-custom-class">
  <div class="components-base-control__field">
    <label class="components-base-control__label">Text</label>
    <textarea class="components-textarea-control__input" >
    </textarea>
  </div>
  <p class="components-base-control__help">Enter some text</p>
</div>
```

## Why?

To improve consistency in CSS design and naming of components

## Testing Instructions

Beforehand, add a custom class name to the default story.

```diff
diff --git a/packages/components/src/textarea-control/stories/index.story.tsx b/packages/components/src/textarea-control/stories/index.story.tsx
index 3160e0bfe6..1d0d19dc9d 100644
--- a/packages/components/src/textarea-control/stories/index.story.tsx
+++ b/packages/components/src/textarea-control/stories/index.story.tsx
@@ -56,4 +56,5 @@ Default.args = {
        label: 'Text',
        help: 'Enter some text',
        placeholder: 'Placeholder',
+       className: 'my-custom-class',
 };
```

- Run `storybook:dev`
- Open `localhost:50240/?path=/docs/components-textareacontrol--docs`
- Check Ensure that the component's root element has two CSS classes: `.components-textarea-control` and `my-custom-class`.