### PR TITLE
Block Editor: Fix link interception in the iframed editor

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -131,6 +131,20 @@ function Iframe( {
 		function preventFileDropDefault( event ) {
 			event.preventDefault();
 		}
+		function interceptLinkClicks( event ) {
+			if (
+				event.target.tagName === 'A' &&
+				event.target.getAttribute( 'href' )?.startsWith( '#' )
+			) {
+				event.preventDefault();
+
+				// Appending a hash to the current URL will not reload the
+				// page. This is useful for e.g. footnotes.
+				iFrameDocument.defaultView.location.hash = event.target
+					.getAttribute( 'href' )
+					.slice( 1 );
+			}
+		}
 
 		const { ownerDocument } = node;
 
@@ -185,22 +199,10 @@ function Iframe( {
 				preventFileDropDefault,
 				false
 			);
-			// Prevent clicks on links from navigating away. Note that links
+			// Prevent clicks on link fragments from navigating away. Note that links
 			// inside `contenteditable` are already disabled by the browser, so
 			// this is for links in blocks outside of `contenteditable`.
-			iFrameDocument.addEventListener( 'click', ( event ) => {
-				if ( event.target.tagName === 'A' ) {
-					event.preventDefault();
-
-					// Appending a hash to the current URL will not reload the
-					// page. This is useful for e.g. footnotes.
-					const href = event.target.getAttribute( 'href' );
-					if ( href?.startsWith( '#' ) ) {
-						iFrameDocument.defaultView.location.hash =
-							href.slice( 1 );
-					}
-				}
-			} );
+			iFrameDocument.addEventListener( 'click', interceptLinkClicks );
 		}
 
 		node.addEventListener( 'load', onLoad );
@@ -216,6 +218,7 @@ function Iframe( {
 				'drop',
 				preventFileDropDefault
 			);
+			iFrameDocument?.removeEventListener( 'click', interceptLinkClicks );
 		};
 	}, [] );
 

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -131,15 +131,17 @@ function Iframe( {
 		function preventFileDropDefault( event ) {
 			event.preventDefault();
 		}
+		// Prevent clicks on link fragments from navigating away. Note that links
+		// inside `contenteditable` are already disabled by the browser, so
+		// this is for links in blocks outside of `contenteditable`.
 		function interceptLinkClicks( event ) {
 			if (
 				event.target.tagName === 'A' &&
 				event.target.getAttribute( 'href' )?.startsWith( '#' )
 			) {
 				event.preventDefault();
-
-				// Appending a hash to the current URL will not reload the
-				// page. This is useful for e.g. footnotes.
+				// Manually handle link fragment navigation within the iframe to prevent page reloads.
+				// This ensures smooth scrolling to anchor links (e.g., footnotes) despite the iframe's different base URL.
 				iFrameDocument.defaultView.location.hash = event.target
 					.getAttribute( 'href' )
 					.slice( 1 );
@@ -199,9 +201,6 @@ function Iframe( {
 				preventFileDropDefault,
 				false
 			);
-			// Prevent clicks on link fragments from navigating away. Note that links
-			// inside `contenteditable` are already disabled by the browser, so
-			// this is for links in blocks outside of `contenteditable`.
 			iFrameDocument.addEventListener( 'click', interceptLinkClicks );
 		}
 


### PR DESCRIPTION
## What?
This is a follow-up to #66751.

PR updates link interception logic in the iframed editor to only affect hash links.

## Why?
See https://github.com/WordPress/gutenberg/pull/66751#issuecomment-3113005901.

## Testing Instructions
1. Open a post.
2. Add text blocks.
3. Add footnotes.
4. Confirm that clicking on footnote fragment links doesn't reload the editor or navigate away.

### Testing Instructions for Keyboard
Same.