### PR TITLE
Page List: Fix Notice component background gets incorrectly inherited

### DIFF
--- a/packages/block-library/src/page-list/editor.scss
+++ b/packages/block-library/src/page-list/editor.scss
@@ -1,10 +1,4 @@
 .wp-block-navigation {
-	// Block wrapper gets the classes in the editor, and there's an extra div wrapper for now, so background styles need to be inherited.
-	.wp-block-page-list > div,
-	.wp-block-page-list {
-		background-color: inherit;
-	}
-
 	// space-between justification.
 	&.items-justified-space-between {
 		.wp-block-page-list > div,


### PR DESCRIPTION
## What?
Closes #70929

This PR fixes the issue where the notice component's background is incorrectly inherited, causing it to become invisible.

## Why?

The `.wp-block-page-list > div` rule overrides the `background-color` defined within `.components-notice`. 

## How?

The following styles were removed.

https://github.com/WordPress/gutenberg/blob/d07eb03adda0ee905b14ca78b90d359e601c05f2/packages/block-library/src/page-list/editor.scss#L2-L6

I can confirm that there's no extra `div` as the `ServerSideRender` component was removed, therefore making `.wp-block-page-list > div` rule unnecessary.

Ref.
|With ServerSideRender|Without ServerSideRender (Trunk)|
|-|-|
|<img width="368" height="128" alt="with-ssr" src="https://github.com/user-attachments/assets/587a5459-6e65-404e-a322-8057d8a926fd" />|<img width="366" height="68" alt="without-ssr" src="https://github.com/user-attachments/assets/b53acc06-9831-4602-9acd-660599264ccc" />|

I've tested this across various scenarios, including custom colors, backgrounds, and submenu overlays applied to the parent Navigation block, and it appears to be working as expected. However, I recommend thorough testing to help identify any potential edge cases.

## Testing Instructions

1. Select a style with a dark background. For Twenty Twenty-Five, for example, "Evening".
2. Ensure that there are no published pages.
3. Create a new post and insert the `Page List` block.
4. Ensure that the `Notice` is properly displayed and has a proper background.

### Testing Instructions for Keyboard

Same.

## Screenshots

|Before|After|
|-|-|
|<img width="281" height="101" alt="before" src="https://github.com/user-attachments/assets/31bbbfc8-905a-43fa-aebf-db1c3db74483" />|<img width="281" height="101" alt="after" src="https://github.com/user-attachments/assets/59084b9a-1a25-4506-80d8-9f4ce15e954f" />|
