### PR TITLE
PaletteEdit: Fill available space with input field

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   `TextareaControl`: Add missing component CSS classname ([#70930](https://github.com/WordPress/gutenberg/pull/70930)).
+-   `PaletteEdit`: Fill available space with input field ([#70935](https://github.com/WordPress/gutenberg/pull/70935)).
 
 ## 30.0.0 (2025-07-23)
 

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -22,7 +22,7 @@ import { useDebounce } from '@wordpress/compose';
  */
 import Button from '../button';
 import { ColorPicker } from '../color-picker';
-import { FlexItem } from '../flex';
+import { FlexBlock, FlexItem } from '../flex';
 import { HStack } from '../h-stack';
 import { Item, ItemGroup } from '../item-group';
 import { VStack } from '../v-stack';
@@ -229,7 +229,7 @@ function Option< T extends PaletteElement >( {
 				>
 					<IndicatorStyled colorValue={ value } />
 				</Button>
-				<FlexItem>
+				<FlexBlock>
 					{ ! canOnlyChangeValues ? (
 						<NameInput
 							label={
@@ -256,7 +256,7 @@ function Option< T extends PaletteElement >( {
 								  '\u00A0' }
 						</NameContainer>
 					) }
-				</FlexItem>
+				</FlexBlock>
 				{ ! canOnlyChangeValues && (
 					<FlexItem>
 						<RemoveButton


### PR DESCRIPTION
## What?

A small improvement to correctly layout elements when editing palettes.

## Why?

My guess is that the natural behavior is for the input field width to fill all available horizontal space.

## Testing Instructions

### Site Editor

- Appearance > Editor > Styles > Colors > Edit Palette > Custom Section
- Click the Add color button

| Before | After |
|--------|--------|
|  <img width="387" height="559" alt="image" src="https://github.com/user-attachments/assets/443a31f6-8f58-4652-a8de-435844927237" /> | <img width="396" height="558" alt="image" src="https://github.com/user-attachments/assets/2b277774-f0fe-429d-9f36-82b91b9702ff" /> | 

### Storybook

http://localhost:50240/?path=/docs/components-paletteedit--docs

| Before | After |
|--------|--------|
|  <img width="573" height="226" alt="image" src="https://github.com/user-attachments/assets/5e86971f-7d8d-4ffa-b3fd-a01b1a3ac82d" /> | <img width="572" height="209" alt="image" src="https://github.com/user-attachments/assets/47b25a71-e94a-40a4-8a85-a5888dc5f8ae" /> |