### PR TITLE
Fix/70391 block bindings receive custom block context

### DIFF
--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -74,17 +74,34 @@ function render_block_core_block( $attributes, $content, $block_instance ) {
 	}
 
 	/**
-	 * We set the `pattern/overrides` context through the `render_block_context`
-	 * filter so that it is available when a pattern's inner blocks are
-	 * rendering via do_blocks given it only receives the inner content.
+	 * We make the available_context property available so we can add and filter all the context
+	 * that comes from the block parent, including pattern overrides and custom context.
 	 */
-	$synced_context = $block_instance->block_type->provides_context
-		?? array();
 
-	$filter_block_context = static function ( $context ) use ( $attributes, $synced_context ) {
-		foreach ( $synced_context as $key => $value ) {
-			$context[ $key ] = $attributes[ $value ];
+	try {
+		$reflection                 = new ReflectionClass( $block_instance );
+		$available_context_property = $reflection->getProperty( 'available_context' );
+		$available_context_property->setAccessible( true );
+		$available_context = $available_context_property->getValue( $block_instance ) ?? array();
+	} catch ( Exception $e ) {
+		// Fallback to empty array if reflection fails
+		$available_context = array();
+	}
+
+	// Get the pattern overrides context
+	$provides_context = $block_instance->block_type->provides_context ?? array();
+
+	$filter_block_context = static function ( $context ) use ( $attributes, $available_context, $provides_context ) {
+		// First, merge in all the available context from the parent
+		$context = array_merge( $context, $available_context );
+
+		// Then, add pattern overrides context (only for keys that are actually attributes)
+		foreach ( $provides_context as $context_key => $attribute_name ) {
+			if ( isset( $attributes[ $attribute_name ] ) ) {
+				$context[ $context_key ] = $attributes[ $attribute_name ];
+			}
 		}
+
 		return $context;
 	};
 	add_filter( 'render_block_context', $filter_block_context, 1 );

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -16,7 +16,7 @@
  *
  * @return string Rendered HTML of the referenced block.
  */
-function render_block_core_block( $attributes ) {
+function render_block_core_block( $attributes, $content, $block_instance ) {
 	static $seen_refs = array();
 
 	if ( empty( $attributes['ref'] ) ) {
@@ -78,24 +78,27 @@ function render_block_core_block( $attributes ) {
 	 * filter so that it is available when a pattern's inner blocks are
 	 * rendering via do_blocks given it only receives the inner content.
 	 */
-	$has_pattern_overrides = isset( $attributes['content'] ) && null !== get_block_bindings_source( 'core/pattern-overrides' );
-	if ( $has_pattern_overrides ) {
-		$filter_block_context = static function ( $context ) use ( $attributes ) {
+	$synced_context = $block_instance->block_type->provides_context
+		?? array();
+
+	$filter_block_context = static function ( $context ) use ( $attributes, $synced_context ) {
+		$has_pattern_overrides = isset( $attributes['content'] ) && null !== get_block_bindings_source( 'core/pattern-overrides' );
+		if ( $has_pattern_overrides ) {
 			$context['pattern/overrides'] = $attributes['content'];
-			return $context;
-		};
-		add_filter( 'render_block_context', $filter_block_context, 1 );
-	}
+		}
+		foreach ( $synced_context as $key => $value ) {
+			$context[ $key ] = $attributes[ $value ];
+		}
+		return $context;
+	};
+	add_filter( 'render_block_context', $filter_block_context, 1 );
 
 	// Apply Block Hooks.
 	$content = apply_block_hooks_to_content_from_post_object( $content, $reusable_block );
 
 	$content = do_blocks( $content );
 	unset( $seen_refs[ $attributes['ref'] ] );
-
-	if ( $has_pattern_overrides ) {
-		remove_filter( 'render_block_context', $filter_block_context, 1 );
-	}
+	remove_filter( 'render_block_context', $filter_block_context, 1 );
 
 	return $content;
 }

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -82,10 +82,6 @@ function render_block_core_block( $attributes, $content, $block_instance ) {
 		?? array();
 
 	$filter_block_context = static function ( $context ) use ( $attributes, $synced_context ) {
-		$has_pattern_overrides = isset( $attributes['content'] ) && null !== get_block_bindings_source( 'core/pattern-overrides' );
-		if ( $has_pattern_overrides ) {
-			$context['pattern/overrides'] = $attributes['content'];
-		}
 		foreach ( $synced_context as $key => $value ) {
 			$context[ $key ] = $attributes[ $value ];
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #70391

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Still a draft, but I couldn't reproduce the error with the example shown (it works on playground, but here, just adding a group before the bound paragraph it reads its context, out and inside a synced pattern, with or without overrides).

Furthermore, we apply in this PR a global way to include the pattern overrides, without needing the hardcoded conditional.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Needs testing steps yet, working on that.
