### PR TITLE
Core Data: Add getTitle for user entity

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -138,6 +138,7 @@ export const rootEntitiesConfig = [
 		name: 'user',
 		kind: 'root',
 		baseURL: '/wp/v2/users',
+		getTitle: ( record ) => record?.username || record?.slug,
 		baseURLParams: { context: 'edit' },
 		plural: 'users',
 	},

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -138,7 +138,7 @@ export const rootEntitiesConfig = [
 		name: 'user',
 		kind: 'root',
 		baseURL: '/wp/v2/users',
-		getTitle: ( record ) => record?.username || record?.slug,
+		getTitle: ( record ) => record?.name || record?.slug,
 		baseURLParams: { context: 'edit' },
 		plural: 'users',
 	},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->
The title for edited users was not resolving correctly.
This lead to changes for user entities showing as untitled in the review changes modal.
This PR adds a mechanism for generating the title for users based on their username.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- To show better changes to users in the review changes modal
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Checkout this PR
- Build everything `npm run build`
- Open the site editor: http://localhost:8888/wp-admin/site-editor.php
- In the console trigger this call:
```
wp.data.dispatch(wp.coreData.store).editEntityRecord( 'root', 'user', 1, {first_name: 'test'} )
```
- In case there is an error trigger it one more time
- This will edit the user record for the admin user with id: 1
- You should see `Review 1 change...` showing at the bottom of the sidebar
- Click on that
- You should see the admin username displayed instead of 'Untitled'

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1024" height="939" alt="Screenshot 2025-07-28 at 15 16 08" src="https://github.com/user-attachments/assets/865658e6-6a05-4a49-b660-e5425f2257ef" />| <img width="1036" height="956" alt="Screenshot 2025-07-28 at 15 12 10" src="https://github.com/user-attachments/assets/f883e8e2-553c-4508-82e4-9f72308e36fc" />|
