### PR TITLE
Synced Pattern block: Pass block context to pattern content

### DIFF
--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -73,20 +73,6 @@ function render_block_core_block( $attributes, $content, $block_instance ) {
 		$attributes['content'] = $attributes['overrides'];
 	}
 
-	/**
-	 * We set the `pattern/overrides` context through the `render_block_context`
-	 * filter so that it is available when a pattern's inner blocks are
-	 * rendering via do_blocks given it only receives the inner content.
-	 */
-	$has_pattern_overrides = isset( $attributes['content'] ) && null !== get_block_bindings_source( 'core/pattern-overrides' );
-	if ( $has_pattern_overrides ) {
-		$filter_block_context = static function ( $context ) use ( $attributes ) {
-			$context['pattern/overrides'] = $attributes['content'];
-			return $context;
-		};
-		add_filter( 'render_block_context', $filter_block_context, 1 );
-	}
-
 	// Apply Block Hooks.
 	$content = apply_block_hooks_to_content_from_post_object( $content, $reusable_block );
 
@@ -95,10 +81,6 @@ function render_block_core_block( $attributes, $content, $block_instance ) {
 	$block_instance->refresh_context_dependents();
 	$content = $block_instance->render( array( 'dynamic' => false ) );
 	unset( $seen_refs[ $attributes['ref'] ] );
-
-	if ( $has_pattern_overrides ) {
-		remove_filter( 'render_block_context', $filter_block_context, 1 );
-	}
 
 	return $content;
 }

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName // Needed for WP_Block_Cloner helper class.
 /**
  * Server-side rendering of the `core/block` block.
  *
@@ -88,10 +88,12 @@ function render_block_core_block( $attributes, $content, $block_instance ) {
 		$block_instance->refresh_context_dependents();
 	} else {
 		// This branch can be removed once Gutenberg requires WordPress 6.8 or later.
+		// phpcs:ignore Gutenberg.Commenting.SinceTag.MissingClassSinceTag
 		class WP_Block_Cloner extends WP_Block {
 			// Static methods of subclasses have access to protected properties
 			// of instances of the parent class.
 			// In this case, this gives us access to `available_context` and `registry`.
+			// phpcs:ignore Gutenberg.Commenting.SinceTag.MissingMethodSinceTag
 			public static function clone_instance( $instance ) {
 				return new WP_Block(
 					$instance->parsed_block,
@@ -100,7 +102,7 @@ function render_block_core_block( $attributes, $content, $block_instance ) {
 				);
 			}
 		}
-		$block_instance = WP_Block_Cloner::clone_instance( $block_instance);
+		$block_instance = WP_Block_Cloner::clone_instance( $block_instance );
 	}
 
 	$content = $block_instance->render( array( 'dynamic' => false ) );

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -16,7 +16,7 @@
  *
  * @return string Rendered HTML of the referenced block.
  */
-function render_block_core_block( $attributes ) {
+function render_block_core_block( $attributes, $content, $block_instance ) {
 	static $seen_refs = array();
 
 	if ( empty( $attributes['ref'] ) ) {
@@ -90,7 +90,10 @@ function render_block_core_block( $attributes ) {
 	// Apply Block Hooks.
 	$content = apply_block_hooks_to_content_from_post_object( $content, $reusable_block );
 
-	$content = do_blocks( $content );
+	$block_instance->parsed_block['innerBlocks'] = parse_blocks( $content );
+	$block_instance->parsed_block['innerContent'] = array_fill( 0, count( $block_instance->parsed_block['innerBlocks'] ), null );
+	$block_instance->refresh_context_dependents();
+	$content = $block_instance->render( array( 'dynamic' => false ) );
 	unset( $seen_refs[ $attributes['ref'] ] );
 
 	if ( $has_pattern_overrides ) {

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -100,8 +100,8 @@ function render_block_core_block( $attributes, $content, $block_instance ) {
 				);
 			}
 		}
+		$block_instance = WP_Block_Cloner::clone_instance( $block_instance);
 	}
-	$block_instance = WP_Block_Cloner::clone_instance( $block_instance);
 
 	$content = $block_instance->render( array( 'dynamic' => false ) );
 	unset( $seen_refs[ $attributes['ref'] ] );

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -76,6 +76,11 @@ function render_block_core_block( $attributes, $content, $block_instance ) {
 	// Apply Block Hooks.
 	$content = apply_block_hooks_to_content_from_post_object( $content, $reusable_block );
 
+	/**
+	 * We attach the blocks from $content as inner blocks to the Synced Pattern block instance.
+	 * This ensures that block context available to the Synced Pattern block instance is provided to
+	 * those blocks.
+	 */
 	$block_instance->parsed_block['innerBlocks']  = parse_blocks( $content );
 	$block_instance->parsed_block['innerContent'] = array_fill( 0, count( $block_instance->parsed_block['innerBlocks'] ), null );
 	$block_instance->refresh_context_dependents();

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -83,7 +83,26 @@ function render_block_core_block( $attributes, $content, $block_instance ) {
 	 */
 	$block_instance->parsed_block['innerBlocks']  = parse_blocks( $content );
 	$block_instance->parsed_block['innerContent'] = array_fill( 0, count( $block_instance->parsed_block['innerBlocks'] ), null );
-	$block_instance->refresh_context_dependents();
+	if ( method_exists( $block_instance, 'refresh_context_dependents' ) ) {
+		// WP_Block::refresh_context_dependents() was introduced in WordPress 6.8.
+		$block_instance->refresh_context_dependents();
+	} else {
+		// This branch can be removed once Gutenberg requires WordPress 6.8 or later.
+		class WP_Block_Cloner extends WP_Block {
+			// Static methods of subclasses have access to protected properties
+			// of instances of the parent class.
+			// In this case, this gives us access to `available_context` and `registry`.
+			public static function clone_instance( $instance ) {
+				return new WP_Block(
+					$instance->parsed_block,
+					$instance->available_context,
+					$instance->registry
+				);
+			}
+		}
+	}
+	$block_instance = WP_Block_Cloner::clone_instance( $block_instance);
+
 	$content = $block_instance->render( array( 'dynamic' => false ) );
 	unset( $seen_refs[ $attributes['ref'] ] );
 

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -90,9 +90,11 @@ function render_block_core_block( $attributes, $content, $block_instance ) {
 		// This branch can be removed once Gutenberg requires WordPress 6.8 or later.
 		// phpcs:ignore Gutenberg.Commenting.SinceTag.MissingClassSinceTag
 		class WP_Block_Cloner extends WP_Block {
-			// Static methods of subclasses have access to protected properties
-			// of instances of the parent class.
-			// In this case, this gives us access to `available_context` and `registry`.
+			/**
+			 * Static methods of subclasses have access to protected properties
+			 * of instances of the parent class.
+			 * In this case, this gives us access to `available_context` and `registry`.
+			 */
 			// phpcs:ignore Gutenberg.Commenting.SinceTag.MissingMethodSinceTag
 			public static function clone_instance( $instance ) {
 				return new WP_Block(

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -90,7 +90,7 @@ function render_block_core_block( $attributes, $content, $block_instance ) {
 	// Apply Block Hooks.
 	$content = apply_block_hooks_to_content_from_post_object( $content, $reusable_block );
 
-	$block_instance->parsed_block['innerBlocks'] = parse_blocks( $content );
+	$block_instance->parsed_block['innerBlocks']  = parse_blocks( $content );
 	$block_instance->parsed_block['innerContent'] = array_fill( 0, count( $block_instance->parsed_block['innerBlocks'] ), null );
 	$block_instance->refresh_context_dependents();
 	$content = $block_instance->render( array( 'dynamic' => false ) );

--- a/phpunit/blocks/renderReusable.php
+++ b/phpunit/blocks/renderReusable.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Tests for synced pattern rendering.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @todo This should be eventually merged into Core's renderReusable.php test file.
+ * 
+ * @covers ::gutenberg_render_block_core_block
+ * @group blocks
+ */
+class Test_Blocks_RenderReusable extends WP_UnitTestCase {
+
+	/**
+	 * Test block ID.
+	 *
+	 * @var int
+	 */
+	protected static $block_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		register_block_bindings_source(
+			'test/block-binding',
+			array(
+				'label' => 'My Block Binding',
+				'get_value_callback' => function ( $source_args, $block ) {
+					return $block->context[ 'my-custom/context' ] ?? 'Fallback value provided by block bindings source';
+				},
+				'uses_context' => array( 'my-custom/context' ),
+			),
+		);
+
+		self::$block_id = $factory->post->create(
+			array(
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+				'post_title'   => 'Test Block',
+				'post_content' => '<!-- wp:core/paragraph {"metadata":{"bindings":{"content":{"source":"test/block-binding","args":{"key":"ignored"}}}}} --><p>Hello world!</p><!-- /wp:core/paragraph -->',
+			)
+		);
+	}
+
+	public static function wpTearDownAfterClass() {
+		wp_delete_post( self::$block_id, true );
+		unregister_block_bindings_source( 'test/block-binding' );
+	}
+
+	/**
+	 * @see https://github.com/WordPress/gutenberg/issues/70391
+	 */
+	public function test_render_respects_custom_context() {
+		$synced_pattern_block_instance = new WP_Block(
+			array(
+				'blockName' => 'core/block',
+				'attrs'     => array(
+					'ref' => self::$block_id,
+				),
+			),
+			array(
+				'my-custom/context' => 'Custom content set from block context',
+			)
+		);
+
+		$output = $synced_pattern_block_instance->render();
+		$this->assertSame( '<p>Custom content set from block context</p>', $output );
+	}
+}

--- a/phpunit/blocks/renderReusable.php
+++ b/phpunit/blocks/renderReusable.php
@@ -6,7 +6,7 @@
  * @subpackage Blocks
  *
  * @todo This should be eventually merged into Core's renderReusable.php test file.
- * 
+ *
  * @covers ::gutenberg_render_block_core_block
  * @group blocks
  */
@@ -23,12 +23,12 @@ class Test_Blocks_RenderReusable extends WP_UnitTestCase {
 		register_block_bindings_source(
 			'test/block-binding',
 			array(
-				'label' => 'My Block Binding',
+				'label'              => 'My Block Binding',
 				'get_value_callback' => function ( $source_args, $block ) {
-					return $block->context[ 'my-custom/context' ] ?? 'Fallback value provided by block bindings source';
+					return $block->context['my-custom/context'] ?? 'Fallback value provided by block bindings source';
 				},
-				'uses_context' => array( 'my-custom/context' ),
-			),
+				'uses_context'       => array( 'my-custom/context' ),
+			)
 		);
 
 		self::$block_id = $factory->post->create(


### PR DESCRIPTION
## What?
Closes #70391

## Why?
Blocks like Synced Pattern do not contain inner blocks but reference block markup that is obtained from another source. On the other hand, some mechanisms -- such as passing block context from "ancestor" blocks to "descendants" -- only work if the descendants are _actual_ inner blocks (of inner blocks) of the ancestor.

## How?
By parsing the referenced block markup into blocks, and attaching them to the Synced Pattern block's `innerBlocks` property, and running `refresh_context_dependents()`, which passes the context provided to them. This then allows  invoking the Synced Pattern block instance's `render()` method (with the `dynamic` option set to `false`), which will correctly respect block context when producing the rendered block markup.

## Testing Instructions
Refer to https://github.com/WordPress/gutenberg/issues/70391, and verify that the issue described there is fixed by this PR.

To verify that this fix is required, you can cherry-pick the unit test file added by https://github.com/WordPress/gutenberg/pull/70943/commits/536a623c44a67b9e64acc752411cddb9d9fdfac6 to `trunk` and `npm run test:unit:php` there; it will fail.

## Screenshots or screencast

TBD

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
