### PR TITLE
Deprecate data-wp-ignore directive with warning message

### DIFF
--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Deprecations
+
+-   Deprecated the `"data-wp-ignore"` directive of the Interactivity API.([#70945](https://github.com/WordPress/gutenberg/pull/70945))  
+    It is deprecated as of WordPress 6.9 and will be removed in version 7.0.
+
 ## 6.27.0 (2025-07-23)
 
 ## 6.26.0 (2025-06-25)

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -602,7 +602,7 @@ export default () => {
 		} ) => {
 			// Shown deprecation warning
 			warn(
-				'The "data-wp-ignore" directive is deprecated and will be removed in a future WordPress release.'
+				'The "data-wp-ignore" directive of the Interactivity API is deprecated since version 6.9 and will be removed in version 7.0.'
 			);
 
 			// Preserve the initial inner HTML

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -600,7 +600,12 @@ export default () => {
 		}: {
 			element: any;
 		} ) => {
-			// Preserve the initial inner HTML.
+			// Shown deprecation warning
+			warn(
+				'The "data-wp-ignore" directive is deprecated and will be removed in a future WordPress release.'
+			);
+
+			// Preserve the initial inner HTML
 			const cached = useMemo( () => innerHTML, [] );
 			return createElement( Type, {
 				dangerouslySetInnerHTML: { __html: cached },


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #70881 

This PR adds a deprecation warning to the `data-wp-ignore` directive. The directive is being deprecated due to issues with context inheritance and navigation handling, and is likely to be removed in a future release.

## Why?
The `data-wp-ignore` directive breaks context inheritance and complicates client-side navigation. While it's designed to prevent hydration of a specific region, it introduces bugs in the current implementation. The deprecation warning informs developers early.

## How?
Added a `warn()` call inside the directive to log a deprecation message:

```
warn(
  'The "data-wp-ignore" directive is deprecated and will be removed in a future WordPress release.'
);
```

## Testing Instructions
1. Start the Gutenberg development environment.
2. Use or simulate a block/component using data-wp-ignore.
3. Open browser console.
4. You should see the warning message:
    The "data-wp-ignore" directive is deprecated and will be removed in a future WordPress release.

## Screenshots
Before
<img width="1963" height="808" alt="Screenshot 2025-07-28 222211" src="https://github.com/user-attachments/assets/b229af93-ec94-4991-bbb8-bd883e373a69" />

After
<img width="2050" height="1204" alt="code" src="https://github.com/user-attachments/assets/45a506b6-f794-4b05-a17a-2857e9aaf7a8" />

