### PR TITLE
Add shuffle style to write mode toolbar

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -91,6 +91,7 @@ export function PrivateBlockToolbar( {
 			getParentSectionBlock,
 			isZoomOut,
 			isNavigationMode: _isNavigationMode,
+			isSectionBlock,
 		} = unlock( select( blockEditorStore ) );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const selectedBlockClientId = selectedBlockClientIds[ 0 ];
@@ -154,7 +155,9 @@ export function PrivateBlockToolbar( {
 			showLockButtons: ! _isZoomOut,
 			showSwitchSectionStyleButton:
 				_isZoomOut ||
-				( isNavigationModeEnabled && editingMode === 'contentOnly' ), // Zoom out or Write Mode
+				( isNavigationModeEnabled &&
+					editingMode === 'contentOnly' &&
+					isSectionBlock( selectedBlockClientId ) ), // Zoom out or Write Mode Section Blocks
 			hasFixedToolbar: getSettings().hasFixedToolbar,
 			isNavigationMode: isNavigationModeEnabled,
 		};

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -100,7 +100,7 @@ export function PrivateBlockToolbar( {
 		const parentBlockName = getBlockName( parentClientId );
 		const parentBlockType = getBlockType( parentBlockName );
 		const editingMode = getBlockEditingMode( selectedBlockClientId );
-		const isContentOnly = editingMode === 'contentOnly';
+		const isNavigationModeEnabled = _isNavigationMode();
 		const _isDefaultEditingMode = editingMode === 'default';
 		const _blockName = getBlockName( selectedBlockClientId );
 		const isValid = selectedBlockClientIds.every( ( id ) =>
@@ -152,9 +152,11 @@ export function PrivateBlockToolbar( {
 			showSlots: ! _isZoomOut,
 			showGroupButtons: ! _isZoomOut,
 			showLockButtons: ! _isZoomOut,
-			showSwitchSectionStyleButton: _isZoomOut || isContentOnly,
+			showSwitchSectionStyleButton:
+				_isZoomOut ||
+				( isNavigationModeEnabled && editingMode === 'contentOnly' ), // Zoom out or Write Mode
 			hasFixedToolbar: getSettings().hasFixedToolbar,
-			isNavigationMode: _isNavigationMode(),
+			isNavigationMode: isNavigationModeEnabled,
 		};
 	}, [] );
 

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -100,6 +100,7 @@ export function PrivateBlockToolbar( {
 		const parentBlockName = getBlockName( parentClientId );
 		const parentBlockType = getBlockType( parentBlockName );
 		const editingMode = getBlockEditingMode( selectedBlockClientId );
+		const isContentOnly = editingMode === 'contentOnly';
 		const _isDefaultEditingMode = editingMode === 'default';
 		const _blockName = getBlockName( selectedBlockClientId );
 		const isValid = selectedBlockClientIds.every( ( id ) =>
@@ -151,7 +152,7 @@ export function PrivateBlockToolbar( {
 			showSlots: ! _isZoomOut,
 			showGroupButtons: ! _isZoomOut,
 			showLockButtons: ! _isZoomOut,
-			showSwitchSectionStyleButton: _isZoomOut,
+			showSwitchSectionStyleButton: _isZoomOut || isContentOnly,
 			hasFixedToolbar: getSettings().hasFixedToolbar,
 			isNavigationMode: _isNavigationMode(),
 		};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Allow style shuffling from the block toolbar while in write mode for section blocks.
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Bring simple editing functionality to write mode.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Checks for `contentOnly` editing mode within the block toolbar, and shows the `SwitchSectionStyle` component if so. The `SwitchSectionStyle` component will only render the toolbar button if the block has an available section style and is a section block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Add this content to your page:
```
<!-- wp:group {"align":"full","className":"is-style-section-2","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group alignfull is-style-section-2" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:heading -->
<h2 class="wp-block-heading">Show Shuffle Icon In Block Toolbar at Group Block Level</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>Testing</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```
- Check in Edit mode that the shuffle style toolbar button is not available for any of the blocks, even if template locked.
- Switch to Write mode
- Check that the toolbar offers a shuffle style button on the group level section block(s)
- Use it :) 
- Check that it does not render on any non-section block in write mode.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/12a76b60-3524-4d47-a065-3e1da7fcdc8b



<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
