### PR TITLE
ServerSideRender: Add missing changelog entry

### DIFF
--- a/packages/server-side-render/CHANGELOG.md
+++ b/packages/server-side-render/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Introduce a new `useServerSideRender` hook ([70543](https://github.com/WordPress/gutenberg/pull/70543)).
+
 ## 6.3.0 (2025-07-23)
 
 ## 6.2.0 (2025-06-25)


### PR DESCRIPTION
## What?
Related #70543.

PR adds missing changelog entry for the new `useServerSideRender` hook. I forgot this in the main PR 😓

## Testing Instructions
None.