### PR TITLE
DataViews: clear user-input filters properly

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - Fix `filterSortAndPaginate` to handle searching fields that have a type of `array` ([#70785](https://github.com/WordPress/gutenberg/pull/70785)).
+- Fix user-input filters: empty value for text and integer filters means there's no value to search for (so it returns all items). It also fixes a type conversion where empty strings for integer were converted to 0 [#70956](https://github.com/WordPress/gutenberg/pull/70956/).
 
 ### Features
 

--- a/packages/dataviews/src/components/dataviews-filters/input-widget.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/input-widget.tsx
@@ -62,7 +62,9 @@ export default function InputWidget( {
 							..._filter,
 							operator:
 								currentFilter.operator || filter.operators[ 0 ],
-							value: nextValue,
+							value: [ '', undefined, null ].includes( nextValue )
+								? undefined
+								: nextValue,
 					  }
 					: _filter
 			),

--- a/packages/dataviews/src/components/dataviews-filters/input-widget.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/input-widget.tsx
@@ -62,9 +62,13 @@ export default function InputWidget( {
 							..._filter,
 							operator:
 								currentFilter.operator || filter.operators[ 0 ],
-							value: [ '', undefined, null ].includes( nextValue )
-								? undefined
-								: nextValue,
+							// Consider empty strings as undefined:
+							//
+							// - undefined as value means the filter is unset: the filter widget displays no value and the search returns all records
+							// - empty string as value means "search empty string": returns only the records that have an empty string as value
+							//
+							// In practice, this means the filter will not be able to find an empty string as the value.
+							value: nextValue === '' ? undefined : nextValue,
 					  }
 					: _filter
 			),

--- a/packages/dataviews/src/dataform-controls/integer.tsx
+++ b/packages/dataviews/src/dataform-controls/integer.tsx
@@ -83,7 +83,10 @@ export default function Integer< Item >( {
 	const onChangeControl = useCallback(
 		( newValue: string | undefined ) =>
 			onChange( {
-				[ id ]: [ '', undefined, null ].includes( newValue )
+				// Do not convert an empty string or undefined to a number,
+				// otherwise there's a mismatch between the UI control (empty)
+				// and the data relied by onChange (0).
+				[ id ]: [ '', undefined ].includes( newValue )
 					? undefined
 					: Number( newValue ),
 			} ),

--- a/packages/dataviews/src/dataform-controls/integer.tsx
+++ b/packages/dataviews/src/dataform-controls/integer.tsx
@@ -83,7 +83,9 @@ export default function Integer< Item >( {
 	const onChangeControl = useCallback(
 		( newValue: string | undefined ) =>
 			onChange( {
-				[ id ]: Number( newValue ),
+				[ id ]: [ '', undefined, null ].includes( newValue )
+					? undefined
+					: Number( newValue ),
 			} ),
 		[ id, onChange ]
 	);


### PR DESCRIPTION
## What?

Fixes a bug that prevented the user-input filters (text, integer) to be cleared.

Before:

https://github.com/user-attachments/assets/d61e32fc-0a32-4a18-a7de-99bc49e10932

After:

https://github.com/user-attachments/assets/e02761a4-8a15-4858-a38a-6bb68049e937


## How?

- Text: empty string is considered undefined.
- Integer: do not convert empty string or undefined to number.

## Testing Instructions

- Open the storybook and find the "DataViews > Field Types > All" story.
- Use the filters for text and integer and verify they are cleared properly.
