### PR TITLE
DataViews: Clarify filtering behavior in DataViews configuration in README.md

### DIFF
--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -1164,7 +1164,7 @@ Example:
 
 ### `elements`
 
-List of valid values for a field. If provided, it creates a DataViews' filter for the field. DataForm's edit control will also use these values. (See `Edit` field property.)
+List of valid values for a field. If provided, the field's filter will use these as predefined options instead of using the field's `Edit` function for user input (unless `filterBy` is set to `false`, see below).
 
 -   Type: `array` of objects.
 -   Optional.
@@ -1188,11 +1188,12 @@ Example:
 
 ### `filterBy`
 
-Configuration of the filters.
+Configuration of the filters. By default, fields have filtering enabled using the field's `Edit` function for user input. When `elements` are provided, the filter will use those as predefined options instead. Set to `false` to opt the field out of filtering entirely.
 
--   Type: `object`.
+-   Type: `object` | `boolean`.
 -   Optional.
--   Properties:
+-   If `false`, the field will not be available for filtering.
+-   If an object, it can have the following properties:
     -   `operators`: the list of operators supported by the field. See "operators" below. A filter will support the `isAny` and `isNone` multi-selection operators by default.
     -   `isPrimary`: boolean, optional. Indicates if the filter is primary. A primary filter is always visible and is not listed in the "Add filter" component, except for the list layout where it behaves like a secondary filter.
 
@@ -1251,6 +1252,13 @@ Example:
 	filterBy: {
 		operators: [ `isAny`, `isNone`, `isAll`, `isNotAll` ];
 	}
+}
+```
+
+```js
+// Opt out of filtering entirely.
+{
+	filterBy: false;
 }
 ```
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->


Updates the DataViews README documentation to clarify the filterBy configuration behavior and the relationship between elements and filtering.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The previous documentation was inaccurate and incomplete regarding how DataViews' fields currently handle filtering. 

- It didn't explain that filtering is enabled by default for all fields
- It lacked documentation for the filterBy: false opt-out option

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->


 Updated the README.md documentation

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Review the updated documentation in packages/dataviews/README.md
