### PR TITLE
Paragraph Block: Fix 'Drop cap' control reset value

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -81,8 +81,8 @@ function DropCapControl( { clientId, attributes, setAttributes, name } ) {
 				hasValue={ () => !! dropCap }
 				label={ __( 'Drop cap' ) }
 				isShownByDefault={ isDropCapControlEnabledByDefault }
-				onDeselect={ () => setAttributes( { dropCap: undefined } ) }
-				resetAllFilter={ () => ( { dropCap: undefined } ) }
+				onDeselect={ () => setAttributes( { dropCap: false } ) }
+				resetAllFilter={ () => ( { dropCap: false } ) }
 				panelId={ clientId }
 			>
 				<ToggleControl


### PR DESCRIPTION
## What?
PR fixes reset value for the Paragraph block's "Drop cap" typography control. The attribute's default value is set to `false` in the schema.

## Why?
Resetting the value to `undefined` instead of the default `false` value marked the block as modified.

## Testing Instructions
1. Open a post or page.
2. Add a paragraph block.
3. Enable "Drop cap".
4. Confirm that the empty block inserter isn't displayed.
5. Reset the setting.
6. Confirm that the empty block inserter is displayed.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/5d8cc3f0-5806-4249-80c9-493e4d4de9ab

