### PR TITLE
Social: Document guidelines and extensibility

### DIFF
--- a/packages/block-library/src/social-link/README.md
+++ b/packages/block-library/src/social-link/README.md
@@ -5,17 +5,17 @@ The Social Icon is a foundational block that displays various icons linking to d
 
 ## Adding new social icons
 
-The core maintains certain standards for social icons. To add a new one to the existing variations, it must be a well-established, popular, and mainstream service.
+The core maintains certain standards for adding new social icons. To add a new variation to WordPress, it must be well-established and popular.
 
-When considering establishment and popularity, several factors should be evaluated, such as:
+To evaluate if a social service should be added, contributors will consider the following factors:
 
 * Is the service popular enough for core developers to have heard of it before? Is it "mainstream?"
-* How old is the service?
-* Does it have a well-established Wikipedia article? (Seriously.)
-* Has anyone written a WordPress plugin that already adds it as a block variation? Do these plugins have any noticeable adoption or traction that would indicate usage and demand?
+* How long has the service been online?
+* Does it have a Wikipedia article?
+* Is there a plugin adding social icons in the repository that includes the services in question and has a considerable number of active installations?
 * Is this social service frequently requested?
 
 
 ## Adding custom social icons
 
-Starting from WordPress 6.9, it's possible to add custom social icons to your site. Here's an example plugin: https://github.com/wptrainingteam/devblog-custom-social-icons.
+Starting from WordPress 6.9, it's possible to add custom social icons to your site. See: [#70261](https://github.com/WordPress/gutenberg/pull/70261).

--- a/packages/block-library/src/social-link/README.md
+++ b/packages/block-library/src/social-link/README.md
@@ -1,0 +1,21 @@
+# Social Icon block
+
+The Social Icon is a foundational block that displays various icons linking to different social profiles or sites. Each social service is registered as a variation of this block.
+
+
+## Adding new social icons
+
+The core maintains certain standards for social icons. To add a new one to the existing variations, it must be a well-established, popular, and mainstream service.
+
+When considering establishment and popularity, several factors should be evaluated, such as:
+
+* Is the service popular enough for core developers to have heard of it before? Is it "mainstream?"
+* How old is the service?
+* Does it have a well-established Wikipedia article? (Seriously.)
+* Has anyone written a WordPress plugin that already adds it as a block variation? Do these plugins have any noticeable adoption or traction that would indicate usage and demand?
+* Is this social service frequently requested?
+
+
+## Adding custom social icons
+
+Starting from WordPress 6.9, it's possible to add custom social icons to your site. Here's an example plugin: https://github.com/wptrainingteam/devblog-custom-social-icons.


### PR DESCRIPTION
## What?
Closes #70774.

PR adds guidelines for including new social services in the core and a section about extensibility.

The guideline borrows from the core oEmbed provider "rules" - https://make.wordpress.org/core/handbook/contribute/design-decisions/#adding-new-oembed-providers.

## Testing Instructions
Review the proposed documentation.
