### PR TITLE
Extend support to add video in Gallery block.

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -340,7 +340,7 @@ Display multiple images in a rich gallery. ([Source](https://github.com/WordPres
 
 -	**Name:** core/gallery
 -	**Category:** media
--	**Allowed Blocks:** core/image
+-	**Allowed Blocks:** core/image, core/video
 -	**Supports:** align, anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), spacing (blockGap, margin, padding), units (em, px, rem, vh, vw), ~~html~~
 -	**Attributes:** allowResize, caption, columns, fixedHeight, ids, imageCrop, images, linkTarget, linkTo, randomOrder, shortCodeTransforms, sizeSlug
 

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -4,7 +4,7 @@
 	"name": "core/gallery",
 	"title": "Gallery",
 	"category": "media",
-	"allowedBlocks": [ "core/image" ],
+	"allowedBlocks": [ "core/image", "core/video" ],
 	"description": "Display multiple images in a rich gallery.",
 	"keywords": [ "images", "photos" ],
 	"textdomain": "default",

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -94,7 +94,7 @@ const LINK_OPTIONS = [
 		noticeText: __( 'None' ),
 	},
 ];
-const ALLOWED_MEDIA_TYPES = [ 'image' ];
+const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
 
 const PLACEHOLDER_TEXT = Platform.isNative
 	? __( 'Add media' )
@@ -104,7 +104,6 @@ const MOBILE_CONTROL_PROPS_RANGE_CONTROL = Platform.isNative
 	? { type: 'stepper' }
 	: {};
 
-const DEFAULT_BLOCK = { name: 'core/image' };
 const EMPTY_ARRAY = [];
 
 export default function GalleryEdit( props ) {
@@ -336,20 +335,24 @@ export default function GalleryEdit( props ) {
 			  )
 			: innerBlockImages;
 
-		const newImageList = processedImages.filter(
+		const newMediaList = processedImages.filter(
 			( img ) =>
 				! existingImageBlocks.find(
 					( existingImg ) => img.id === existingImg.attributes.id
 				)
 		);
 
-		const newBlocks = newImageList.map( ( image ) => {
-			return createBlock( 'core/image', {
-				id: image.id,
-				blob: image.blob,
-				url: image.url,
-				caption: image.caption,
-				alt: image.alt,
+		const newBlocks = newMediaList.map( ( media ) => {
+			const isVideo =
+				media.mime_type?.startsWith( 'video/' ) ||
+				media.type?.startsWith( 'video' );
+			const blockName = isVideo ? 'core/video' : 'core/image';
+			return createBlock( blockName, {
+				id: media.id,
+				url: media.url,
+				src: media.url,
+				caption: media.caption,
+				...( isVideo ? {} : { alt: media.alt } ),
 			} );
 		} );
 
@@ -541,7 +544,7 @@ export default function GalleryEdit( props ) {
 	};
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		defaultBlock: DEFAULT_BLOCK,
+		allowedBlocks: [ 'core/image', 'core/video' ],
 		directInsert: true,
 		orientation: 'horizontal',
 		renderAppender: false,

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -95,6 +95,7 @@ const LINK_OPTIONS = [
 	},
 ];
 const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
+const ALLOWED_BLOCKS = [ 'core/image', 'core/video' ];
 
 const PLACEHOLDER_TEXT = Platform.isNative
 	? __( 'Add media' )
@@ -544,8 +545,7 @@ export default function GalleryEdit( props ) {
 	};
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		allowedBlocks: [ 'core/image', 'core/video' ],
-		directInsert: true,
+		allowedBlocks: ALLOWED_BLOCKS,
 		orientation: 'horizontal',
 		renderAppender: false,
 		...nativeInnerBlockProps,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
- Enables users to add video files inside the core/gallery block.

<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL --> https://github.com/WordPress/gutenberg/issues/59572

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Previously, selecting a video in the Gallery block was not possible.
- This broke the user experience, who wanted to include videos alongside the photos.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Adds Video to be supported in Gallery block.
- When a video is detected, creates a core/video block with the correct id, src, and caption.
- Ensures seamless embedding of videos in the Gallery block, just like images.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Gallery block.
2. Click Add Media and select both an image and a video file. 
3. Observe: 
  - Images render directly. 
  - Videos now render as playable video blocks inside the gallery.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

- Focus on the Gallery block using Tab.
- Use Enter/Return to open the media library or upload panel.
- Navigate via Tab/Arrow keys to select video files and press Enter.
- Once inserted, use Tab to navigate between inner blocks.
- Confirm that the video player is focusable and accessible.

## Screenshots or screencast <!-- if applicable -->



<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://www.loom.com/share/c27db19969b14e66abe8c470e5016765?sid=83dcbb4c-567b-401d-8808-f1fa20d6cae8

