### PR TITLE
Resolve invalid CSS output for multiple nested selectors.

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1452,10 +1452,18 @@ class WP_Theme_JSON_Gutenberg {
 
 		// Split CSS nested rules.
 		$parts = explode( '&', $css );
+		$unprocessed_nested_selectors = [];
 		foreach ( $parts as $part ) {
 			if ( empty( $part ) ) {
 				continue;
 			}
+
+			if ( trim($part)[-1] === ',' ) {
+				// If the part ends with a comma, it is a selector list.
+				$unprocessed_nested_selectors[] = rtrim( $part, "\n\r\t\v\0\," );
+				continue;
+			}
+
 			$is_root_css = ( ! str_contains( $part, '{' ) );
 			if ( $is_root_css ) {
 				// If the part doesn't contain braces, it applies to the root level.
@@ -1466,26 +1474,32 @@ class WP_Theme_JSON_Gutenberg {
 				if ( count( $part ) !== 2 ) {
 					continue;
 				}
-				$nested_selector = $part[0];
+				$nested_selectors = array_merge( $unprocessed_nested_selectors, array($part[0]) );
 				$css_value       = $part[1];
 
-				/*
-				 * Handle pseudo elements such as ::before, ::after etc. Regex will also
-				 * capture any leading combinator such as >, +, or ~, as well as spaces.
-				 * This allows pseudo elements as descendants e.g. `.parent ::before`.
-				 */
-				$matches            = array();
-				$has_pseudo_element = preg_match( '/([>+~\s]*::[a-zA-Z-]+)/', $nested_selector, $matches );
-				$pseudo_part        = $has_pseudo_element ? $matches[1] : '';
-				$nested_selector    = $has_pseudo_element ? str_replace( $pseudo_part, '', $nested_selector ) : $nested_selector;
+				foreach ( $nested_selectors as $nested_selector ) {
+					/*
+					 * Handle pseudo elements such as ::before, ::after etc. Regex will also
+					 * capture any leading combinator such as >, +, or ~, as well as spaces.
+					 * This allows pseudo elements as descendants e.g. `.parent ::before`.
+					 */
+					$matches            = array();
+					$has_pseudo_element = preg_match( '/([>+~\s]*::[a-zA-Z-]+)/', $nested_selector, $matches );
+					$pseudo_part        = $has_pseudo_element ? $matches[1] : '';
+					$nested_selector    = $has_pseudo_element ? str_replace( $pseudo_part, '', $nested_selector ) : $nested_selector;
 
-				// Finalize selector and re-append pseudo element if required.
-				$part_selector  = str_starts_with( $nested_selector, ' ' )
-					? static::scope_selector( $selector, $nested_selector )
-					: static::append_to_selector( $selector, $nested_selector );
-				$final_selector = ":root :where($part_selector)$pseudo_part";
+					// Finalize selector and re-append pseudo element if required.
+					$part_selector  = str_starts_with( $nested_selector, ' ' )
+						? static::scope_selector( $selector, $nested_selector )
+						: static::append_to_selector( $selector, $nested_selector );
+					$final_selector = ":root :where($part_selector)$pseudo_part";
 
-				$processed_css .= $final_selector . '{' . trim( $css_value ) . '}';
+					$processed_css .= $final_selector . '{' . trim( $css_value ) . '}';
+				}
+
+				$unprocessed_nested_selectors = array(); // Reset nested selectors for the next iteration.
+
+
 			}
 		}
 		return $processed_css;

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1460,7 +1460,7 @@ class WP_Theme_JSON_Gutenberg {
 
 			if ( ',' === trim( $part )[-1] ) {
 				// If the part ends with a comma, it is a selector list.
-				$unprocessed_nested_selectors[] = rtrim( $part, "\n\r\t\v\0\," );
+				$unprocessed_nested_selectors[] = rtrim(rtrim( $part ), ',');
 				continue;
 			}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1460,7 +1460,7 @@ class WP_Theme_JSON_Gutenberg {
 
 			if ( ',' === trim( $part )[-1] ) {
 				// If the part ends with a comma, it is a selector list.
-				$unprocessed_nested_selectors[] = rtrim(rtrim( $part ), ',');
+				$unprocessed_nested_selectors[] = rtrim( rtrim( $part ), ',' );
 				continue;
 			}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1451,14 +1451,14 @@ class WP_Theme_JSON_Gutenberg {
 		}
 
 		// Split CSS nested rules.
-		$parts = explode( '&', $css );
-		$unprocessed_nested_selectors = [];
+		$parts                        = explode( '&', $css );
+		$unprocessed_nested_selectors = array();
 		foreach ( $parts as $part ) {
 			if ( empty( $part ) ) {
 				continue;
 			}
 
-			if ( trim($part)[-1] === ',' ) {
+			if ( ',' === trim( $part )[-1] ) {
 				// If the part ends with a comma, it is a selector list.
 				$unprocessed_nested_selectors[] = rtrim( $part, "\n\r\t\v\0\," );
 				continue;
@@ -1474,9 +1474,10 @@ class WP_Theme_JSON_Gutenberg {
 				if ( count( $part ) !== 2 ) {
 					continue;
 				}
-				$nested_selectors = array_merge( $unprocessed_nested_selectors, array($part[0]) );
-				$css_value       = $part[1];
+				$nested_selectors = array_merge( $unprocessed_nested_selectors, array( $part[0] ) );
+				$css_value        = $part[1];
 
+				$final_selectors = array();
 				foreach ( $nested_selectors as $nested_selector ) {
 					/*
 					 * Handle pseudo elements such as ::before, ::after etc. Regex will also
@@ -1489,16 +1490,16 @@ class WP_Theme_JSON_Gutenberg {
 					$nested_selector    = $has_pseudo_element ? str_replace( $pseudo_part, '', $nested_selector ) : $nested_selector;
 
 					// Finalize selector and re-append pseudo element if required.
-					$part_selector  = str_starts_with( $nested_selector, ' ' )
+					$part_selector     = str_starts_with( $nested_selector, ' ' )
 						? static::scope_selector( $selector, $nested_selector )
 						: static::append_to_selector( $selector, $nested_selector );
-					$final_selector = ":root :where($part_selector)$pseudo_part";
+					$final_selectors[] = ":root :where($part_selector)$pseudo_part";
 
-					$processed_css .= $final_selector . '{' . trim( $css_value ) . '}';
 				}
 
-				$unprocessed_nested_selectors = array(); // Reset nested selectors for the next iteration.
+				$processed_css .= join( ',', $final_selectors ) . '{' . trim( $css_value ) . '}';
 
+				$unprocessed_nested_selectors = array(); // Reset nested selectors for the next iteration.
 
 			}
 		}

--- a/packages/block-editor/src/components/global-styles/test/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/test/use-global-styles-output.js
@@ -1130,7 +1130,9 @@ describe( 'global styles renderer', () => {
 		it( 'should return processed CSS with multiple nesetd selectors', () => {
 			expect(
 				processCSSNesting( '&.one, & .two {color: red;}', '.foo' )
-			).toEqual( ':root :where(.foo.one, .foo .two){color: red;}' );
+			).toEqual(
+				':root :where(.foo.one),:root :where(.foo .two){color: red;}'
+			);
 		} );
 	} );
 } );

--- a/packages/block-editor/src/components/global-styles/test/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/test/use-global-styles-output.js
@@ -1127,5 +1127,10 @@ describe( 'global styles renderer', () => {
 				':root :where(.foo, .bar){color: red; margin: auto;}:root :where(.foo.one, .bar.one){color: blue;}:root :where(.foo .two, .bar .two){color: green;}:root :where(.foo, .bar)::before{color: yellow;}:root :where(.foo, .bar) ::before{color: purple;}:root :where(.foo.three, .bar.three)::before{color: orange;}:root :where(.foo .four, .bar .four)::before{color: skyblue;}:root :where(.foo, .bar) > ::before{color: darkseagreen;}'
 			);
 		} );
+		it( 'should return processed CSS with multiple nesetd selectors', () => {
+			expect(
+				processCSSNesting( '&.one, & .two {color: red;}', '.foo' )
+			).toEqual( ':root :where(.foo.one, .foo .two){color: red;}' );
+		} );
 	} );
 } );

--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -1326,8 +1326,14 @@ export function processCSSNesting( css, blockSelector ) {
 
 	// Split CSS nested rules.
 	const parts = css.split( '&' );
+	let unprocessedNestedSelectors = [];
 	parts.forEach( ( part ) => {
 		if ( ! part || part.trim() === '' ) {
+			return;
+		}
+
+		if ( part.trim().endsWith( ',' ) ) {
+			unprocessedNestedSelectors.push( part.trimEnd() );
 			return;
 		}
 
@@ -1342,33 +1348,51 @@ export function processCSSNesting( css, blockSelector ) {
 				return;
 			}
 
-			const [ nestedSelector, cssValue ] = splitPart;
+			const [ unprocessedNestedSelector, cssValue ] = splitPart;
+			const nestedSelectors = [
+				...unprocessedNestedSelectors,
+				unprocessedNestedSelector,
+			];
 
-			// Handle pseudo elements such as ::before, ::after, etc. Regex will also
-			// capture any leading combinator such as >, +, or ~, as well as spaces.
-			// This allows pseudo elements as descendants e.g. `.parent ::before`.
-			const matches = nestedSelector.match( /([>+~\s]*::[a-zA-Z-]+)/ );
-			const pseudoPart = matches ? matches[ 1 ] : '';
-			const withoutPseudoElement = matches
-				? nestedSelector.replace( pseudoPart, '' ).trim()
-				: nestedSelector.trim();
+			const finalSelectors = [];
+			nestedSelectors.forEach( ( nestedSelector ) => {
+				// Handle pseudo elements such as ::before, ::after, etc. Regex will also
+				// capture any leading combinator such as >, +, or ~, as well as spaces.
+				// This allows pseudo elements as descendants e.g. `.parent ::before`.
+				const matches = nestedSelector.match(
+					/([>+~\s]*::[a-zA-Z-]+)/
+				);
+				const pseudoPart = matches ? matches[ 1 ] : '';
+				const withoutPseudoElement = matches
+					? nestedSelector.replace( pseudoPart, '' ).trim()
+					: nestedSelector.trim();
 
-			let combinedSelector;
-			if ( withoutPseudoElement === '' ) {
-				// Only contained a pseudo element to use the block selector to form
-				// the final `:root :where()` selector.
-				combinedSelector = blockSelector;
-			} else {
-				// If the nested selector is a descendant of the block scope it with the
-				// block selector. Otherwise append it to the block selector.
-				combinedSelector = nestedSelector.startsWith( ' ' )
-					? scopeSelector( blockSelector, withoutPseudoElement )
-					: appendToSelector( blockSelector, withoutPseudoElement );
-			}
+				let combinedSelector;
+				if ( withoutPseudoElement === '' ) {
+					// Only contained a pseudo element to use the block selector to form
+					// the final `:root :where()` selector.
+					combinedSelector = blockSelector;
+				} else {
+					// If the nested selector is a descendant of the block scope it with the
+					// block selector. Otherwise append it to the block selector.
+					combinedSelector = nestedSelector.startsWith( ' ' )
+						? scopeSelector( blockSelector, withoutPseudoElement )
+						: appendToSelector(
+								blockSelector,
+								withoutPseudoElement
+						  );
+				}
+				finalSelectors.push(
+					`:root :where(${ combinedSelector })${ pseudoPart }`
+				);
+			} );
 
 			// Build final rule, re-adding any pseudo element outside the `:where()`
 			// to maintain valid CSS selector.
-			processedCSS += `:root :where(${ combinedSelector })${ pseudoPart }{${ cssValue.trim() }}`;
+			processedCSS += `${ finalSelectors.join(
+				','
+			) }{${ cssValue.trim() }}`;
+			unprocessedNestedSelectors = [];
 		}
 	} );
 	return processedCSS;

--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -1333,7 +1333,7 @@ export function processCSSNesting( css, blockSelector ) {
 		}
 
 		if ( part.trim().endsWith( ',' ) ) {
-			unprocessedNestedSelectors.push( part.trimEnd() );
+			unprocessedNestedSelectors.push( part.trimEnd().slice( 0, -1 ) );
 			return;
 		}
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -5515,7 +5515,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'selector' => '.foo',
 					'css'      => '&.one, & .two {color: red;}',
 				),
-				'expected' => ':root :where(.foo.one, .foo .two){color: red;}',
+				'expected' => ':root :where(.foo.one),:root :where(.foo .two){color: red;}',
 			)
 		);
 	}

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -5510,13 +5510,13 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				),
 				'expected' => ':root :where(.foo, .bar){color: red; margin: auto;}:root :where(.foo.one, .bar.one){color: blue;}:root :where(.foo .two, .bar .two){color: green;}:root :where(.foo, .bar)::before{color: yellow;}:root :where(.foo, .bar) ::before{color: purple;}:root :where(.foo.three, .bar.three)::before{color: orange;}:root :where(.foo .four, .bar .four)::before{color: skyblue;}',
 			),
-			'with nested selector list' => array(
-				'input'   => array(
+			'with nested selector list'    => array(
+				'input'    => array(
 					'selector' => '.foo',
 					'css'      => '&.one, & .two {color: red;}',
 				),
 				'expected' => ':root :where(.foo.one),:root :where(.foo .two){color: red;}',
-			)
+			),
 		);
 	}
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -5510,6 +5510,13 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				),
 				'expected' => ':root :where(.foo, .bar){color: red; margin: auto;}:root :where(.foo.one, .bar.one){color: blue;}:root :where(.foo .two, .bar .two){color: green;}:root :where(.foo, .bar)::before{color: yellow;}:root :where(.foo, .bar) ::before{color: purple;}:root :where(.foo.three, .bar.three)::before{color: orange;}:root :where(.foo .four, .bar .four)::before{color: skyblue;}',
 			),
+			'with nested selector list' => array(
+				'input'   => array(
+					'selector' => '.foo',
+					'css'      => '&.one, & .two {color: red;}',
+				),
+				'expected' => ':root :where(.foo.one, .foo .two){color: red;}',
+			)
 		);
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #50575

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Solves the problem of incorrect conversion of CSS per block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Introduced a new variable `$unprocessed_nested_selectors` to temporarily store selector lists that end with a comma, ensuring they are processed correctly in subsequent iterations.
* Modified the logic to merge `$unprocessed_nested_selectors` with the current selector, allowing for accurate handling of multiple nested selectors.
* Updated the code to generate an array of `final_selectors` for each nested selector and concatenate them into the processed CSS, improving the handling of complex selector structures.
* A similar process was added to `processCSSNesting`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Go to site editor
2. Add per block css. example. `& th, & td { background: red;}`
3. Check css output `:root :where(.wp-block-table > table th),:root :where(.wp-block-table > table td){background: red;}`

