### PR TITLE
Fix: Default option of Font Appearance in Typography Panel

### DIFF
--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -8,7 +8,7 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useCallback, useMemo, useEffect } from '@wordpress/element';
+import { useCallback, useMemo, useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -263,21 +263,46 @@ export default function TypographyPanel( {
 	}, [ setFontAppearance ] );
 
 	// Check if previous font style and weight values are available in the new font family.
+	const previousFontFamilyRef = useRef();
+
 	useEffect( () => {
-		if ( nearestFontStyle && nearestFontWeight ) {
+		const currentFontFamily = value?.typography?.fontFamily;
+		const previousFontFamily = previousFontFamilyRef.current;
+
+		const fontFamilyChanged = previousFontFamily !== currentFontFamily;
+
+		const userHasExplicitAppearance =
+			undefined !== value?.typography?.fontStyle ||
+			undefined !== value?.typography?.fontWeight;
+
+		if (
+			fontFamilyChanged &&
+			! userHasExplicitAppearance &&
+			nearestFontStyle &&
+			nearestFontWeight
+		) {
 			setFontAppearance( {
 				fontStyle: nearestFontStyle,
 				fontWeight: nearestFontWeight,
 			} );
-		} else {
+		} else if (
+			fontFamilyChanged &&
+			( ! nearestFontStyle || ! nearestFontWeight )
+		) {
 			// Reset font appearance if there are no available styles or weights.
 			resetFontAppearance();
 		}
+
+		// Track the current font family for next render
+		previousFontFamilyRef.current = currentFontFamily;
 	}, [
+		value?.typography?.fontFamily,
+		value?.typography?.fontStyle,
+		value?.typography?.fontWeight,
 		nearestFontStyle,
 		nearestFontWeight,
-		resetFontAppearance,
 		setFontAppearance,
+		resetFontAppearance,
 	] );
 
 	// Line Height


### PR DESCRIPTION
## What?

Closes #70938 

Fixes the issue where resetting typography and selecting **Default** from the Font Appearance dropdown in the Site Editor was not possible.

## Why?

The previous solution used a `useEffect` that ran on changes to `nearestFontStyle` and `nearestFontWeight` only. It updated or reset font appearance regardless of whether the font family changed or if the user had explicitly set font style or weight. This caused:

- Unwanted resets or overwrites of user choices.
- Incorrect behaviour when selecting **Default**, as the default value (`undefined`) was not handled properly.
- Font appearance being stuck or falling back unexpectedly.

## How?

- Introduced a `useRef` to track the previous font family, allowing the effect to only run when the font family actually changes.
- Added logic to check if the user has explicitly set font style or weight, preventing unintended overrides.
- When the font family changes and there is no explicit font appearance set, the nearest valid font style and weight are applied.
- If no valid styles or weights are available for the new font family, the font appearance is reset cleanly.