### PR TITLE
useSaveImage: handle missing editMediaEntity gracefully

### DIFF
--- a/packages/block-editor/src/components/image-editor/use-save-image.js
+++ b/packages/block-editor/src/components/image-editor/use-save-image.js
@@ -46,9 +46,7 @@ export default function useSaveImage( {
 		if ( ! editMediaEntity ) {
 			onFinishEditing();
 			createErrorNotice(
-				__(
-					'Sorry, you are not allowed to edit images on this site.'
-				),
+				__( 'Sorry, you are not allowed to edit images on this site.' ),
 				{
 					id: 'image-editing-error',
 					type: 'snackbar',

--- a/packages/block-editor/src/components/image-editor/use-save-image.js
+++ b/packages/block-editor/src/components/image-editor/use-save-image.js
@@ -47,7 +47,7 @@ export default function useSaveImage( {
 			onFinishEditing();
 			createErrorNotice(
 				__(
-					'Could not edit image. No edit media entity action found.'
+					'Could not edit image. Sorry, you are not allowed to edit media on this site.'
 				),
 				{
 					id: 'image-editing-error',

--- a/packages/block-editor/src/components/image-editor/use-save-image.js
+++ b/packages/block-editor/src/components/image-editor/use-save-image.js
@@ -33,7 +33,7 @@ export default function useSaveImage( {
 	const { editMediaEntity } = useSelect( ( select ) => {
 		const settings = select( blockEditorStore ).getSettings();
 		return {
-			editMediaEntity: settings[ mediaEditKey ],
+			editMediaEntity: settings?.[ mediaEditKey ],
 		};
 	}, [] );
 
@@ -43,6 +43,20 @@ export default function useSaveImage( {
 	}, [ onFinishEditing ] );
 
 	const apply = useCallback( async () => {
+		if ( ! editMediaEntity ) {
+			onFinishEditing();
+			createErrorNotice(
+				__(
+					'Could not edit image. No edit media entity action found.'
+				),
+				{
+					id: 'image-editing-error',
+					type: 'snackbar',
+				}
+			);
+			return;
+		}
+
 		setIsInProgress( true );
 
 		const modifiers = [];

--- a/packages/block-editor/src/components/image-editor/use-save-image.js
+++ b/packages/block-editor/src/components/image-editor/use-save-image.js
@@ -47,7 +47,7 @@ export default function useSaveImage( {
 			onFinishEditing();
 			createErrorNotice(
 				__(
-					'Could not edit image. Sorry, you are not allowed to edit media on this site.'
+					'Sorry, you are not allowed to edit images on this site.'
 				),
 				{
 					id: 'image-editing-error',


### PR DESCRIPTION
## What and how and why?

In https://github.com/WordPress/gutenberg/pull/70814  a new private action `editMediaEntity` was added to Core Data. The action acts as an interface to `WP_REST_Attachments_Controller REST` API's `wp/v2/media/{ id }/edit route`.

`editMediaEntity` is only accessible in block editor settings if the user has upload permissions. This matches the backend's permission settings: https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php#L531

Because some users might not have upload permissions, this PR adds a check to `editMediaEntity` and optional chaining in the selector.

If `editMediaEntity` is not available, an error notification is shown.

Shout out to @Mamaduka for the [nudge](https://github.com/WordPress/gutenberg/pull/70814#discussion_r2238890021)

## Testing Instructions

First, test that you can successfully crop and image as admin or editor. 

Then remove your upload files permissions, e.g., 


```php
function remove_editor_upload_capability() {
    // Get the editor role
    $editor_role = get_role('editor');
    
    // Check if the role exists and remove the upload_files capability
    if ($editor_role) {
        $editor_role->remove_cap('upload_files');
    }
}

// Hook into WordPress initialization
add_action('init', 'remove_editor_upload_capability');
```

Check that the error shows and nothing else borks.



## Screenshots or screencast <!-- if applicable -->

<img width="445" height="241" alt="Screenshot 2025-07-30 at 9 38 07 am" src="https://github.com/user-attachments/assets/729861d9-220e-4561-968b-2f2971a5eda6" />

