### PR TITLE
ServerSideRender: Allow skipping block shadow support value

### DIFF
--- a/packages/server-side-render/src/hook.js
+++ b/packages/server-side-render/src/hook.js
@@ -27,8 +27,15 @@ export function removeBlockSupportAttributes( attributes ) {
 		...restAttributes
 	} = attributes;
 
-	const { border, color, elements, spacing, typography, ...restStyles } =
-		attributes?.style || {};
+	const {
+		border,
+		color,
+		elements,
+		shadow,
+		spacing,
+		typography,
+		...restStyles
+	} = attributes?.style || {};
 
 	return {
 		...restAttributes,

--- a/packages/server-side-render/src/test/index.js
+++ b/packages/server-side-render/src/test/index.js
@@ -104,6 +104,7 @@ describe( 'rendererPath', () => {
 							},
 						},
 					},
+					shadow: 'var:preset|shadow|crisp',
 					spacing: {
 						margin: {
 							top: '10px',


### PR DESCRIPTION
## What?
Closes  #65882.
Based on #65883.

PR fixes `skipBlockSupportAttributes` flag logic to include `shadow` in removed styles.

## Why?
The `shadow` is just another block support feature and should be skipped alongside others when specified.

## Testing Instructions
 1. Enabled `supports.shadow` for Archive block. Any core SSR block could work.
 2. Open a post or page.
 3. Insert the Archive block.
 4. Set the block shadow.
 5. Confirm that the content returned from the server doesn't include box shadow style.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
|Before|After|
|-|-|
|<img width="1046" height="233" alt="CleanShot 2025-07-30 at 10 33 25" src="https://github.com/user-attachments/assets/7f646159-f3f1-4018-b289-e24795d2059a" />|<img width="1049" height="228" alt="CleanShot 2025-07-30 at 10 38 26" src="https://github.com/user-attachments/assets/4f31e493-52c6-4d0e-944b-937f790d6851" />|
