### PR TITLE
Fix broken css nesting when scoping with .editor-styles-wrapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4284,6 +4284,28 @@
 				"@csstools/css-tokenizer": "^3.0.1"
 			}
 		},
+		"node_modules/@csstools/selector-resolve-nested": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-3.1.0.tgz",
+			"integrity": "sha512-mf1LEW0tJLKfWyvn5KdDrhpxHyuxpbNwTIwOYLIvsTffeyOf85j5oIzfG0yosxDgx/sswlqBnESYUcQH0vgZ0g==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"postcss-selector-parser": "^7.0.0"
+			}
+		},
 		"node_modules/@csstools/selector-specificity": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-4.0.0.tgz",
@@ -38300,6 +38322,68 @@
 				"postcss": "^8.1.0"
 			}
 		},
+		"node_modules/postcss-nesting": {
+			"version": "13.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-13.0.2.tgz",
+			"integrity": "sha512-1YCI290TX+VP0U/K/aFxzHzQWHWURL+CtHMSbex1lCdpXD1SoR2sYuxDu5aNI9lPoXpKTCggFZiDJbwylU0LEQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"dependencies": {
+				"@csstools/selector-resolve-nested": "^3.1.0",
+				"@csstools/selector-specificity": "^5.0.0",
+				"postcss-selector-parser": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4"
+			}
+		},
+		"node_modules/postcss-nesting/node_modules/@csstools/selector-specificity": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
+			"integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"postcss-selector-parser": "^7.0.0"
+			}
+		},
+		"node_modules/postcss-nesting/node_modules/postcss-selector-parser": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/postcss-normalize-charset": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-6.0.0.tgz",
@@ -49561,6 +49645,7 @@
 				"memize": "^2.1.0",
 				"parsel-js": "^1.1.2",
 				"postcss": "^8.4.21",
+				"postcss-nesting": "13.0.2",
 				"postcss-prefix-selector": "^1.16.0",
 				"postcss-urlrebase": "^1.4.0",
 				"react-autosize-textarea": "^7.1.0",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -78,6 +78,7 @@
 		"memize": "^2.1.0",
 		"parsel-js": "^1.1.2",
 		"postcss": "^8.4.21",
+		"postcss-nesting": "13.0.2",
 		"postcss-prefix-selector": "^1.16.0",
 		"postcss-urlrebase": "^1.4.0",
 		"react-autosize-textarea": "^7.1.0",

--- a/packages/block-editor/src/utils/transform-styles/index.js
+++ b/packages/block-editor/src/utils/transform-styles/index.js
@@ -4,6 +4,7 @@
 import * as parsel from 'parsel-js';
 import Processor from 'postcss/lib/processor';
 import CssSyntaxError from 'postcss/lib/css-syntax-error';
+import postcssNesting from 'postcss-nesting';
 import prefixSelector from 'postcss-prefix-selector';
 import rebaseUrl from 'postcss-urlrebase';
 
@@ -103,6 +104,7 @@ function transformStyle(
 
 		return new Processor(
 			[
+				postcssNesting,
 				wrapperSelector &&
 					prefixSelector( {
 						prefix: wrapperSelector,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #65172

<!-- In a few words, what is the PR actually doing? -->
This PR fixes the issue where when nested css is being transformed, It converts the nested css into a broken style.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
As the nested CSS is not being scoped properly it produces broken style which is not valid according to W3C CSS spec.

### Example
```css
/* Test nested rules */
.some-parent {
	.some-child {
		color: purple;
	}
}

/* Test root + nested */
body {
	.nested-in-body {
		color: red;
	}
}
```

gets converted into 

```css
/* Test nested rules */
:where(.editor-styles-wrapper) .some-parent {
	:where(.editor-styles-wrapper) .some-child {
		color: purple;
	}
}

/* Test root + nested */
body :where(.editor-styles-wrapper) {
	:where(.editor-styles-wrapper) .nested-in-body {
		color: red;
	}
}
```
which is not valid css 
<img width="1470" height="483" alt="image" src="https://github.com/user-attachments/assets/68d4c307-d77d-4093-a5b4-dd56a07247c3" />


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR addresses this issue by using the `postcss-nesting` package which transforms nested css into flattened css via postcss Processor, resulting in a correct scoping of css.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. create a `css-nesting.css` file in any classic theme.
2. add 
   ```css
   /* Test nested rules */
   .some-parent {
	   .some-child {
		   color: purple;
	   }
   }
   
   /* Test root + nested */
   body {
	   .nested-in-body {
		   color: red;
	    }
   }
   ```
3. In your theme’s functions.php, add: ( I used T11 for testing as it is a classic theme )
   ```php
   add_action( 'after_setup_theme', function() {
     add_theme_support( 'editor-styles' );
     add_editor_style( '/css-nesting.css' );
   } );
   ```
4. Apply the theme and open Editor.
5. Inspect and find .some-parent
6. See the correct style being applied.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![](https://github.com/user-attachments/assets/c146ef48-459e-4cb9-8444-fd0fb70359c1) ![](https://github.com/user-attachments/assets/51ffa2b5-6660-4067-8921-1780582875dc)|![](https://github.com/user-attachments/assets/89b0dc6d-8b9e-4514-9db6-ae929ac815e4) ![](https://github.com/user-attachments/assets/cfe682de-dd3a-471f-bfc7-12fa3c0aa9f4)|
