### PR TITLE
Improving SQL container Health Checks for Env

### DIFF
--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -186,6 +186,16 @@ module.exports = function buildDockerComposeConfig( config ) {
 			mysql: {
 				image: 'mariadb:lts',
 				ports: [ developmentMysqlPorts ],
+				healthcheck: {
+					test: [
+						'CMD',
+						'healthcheck.sh',
+						'--connect',
+						'--innodb_initialized',
+					],
+					timeout: '20s',
+					retries: 10,
+				},
 				environment: {
 					MYSQL_ROOT_HOST: '%',
 					MYSQL_ROOT_PASSWORD:
@@ -197,6 +207,16 @@ module.exports = function buildDockerComposeConfig( config ) {
 			'tests-mysql': {
 				image: 'mariadb:lts',
 				ports: [ testsMysqlPorts ],
+				healthcheck: {
+					test: [
+						'CMD',
+						'healthcheck.sh',
+						'--connect',
+						'--innodb_initialized',
+					],
+					timeout: '20s',
+					retries: 10,
+				},
 				environment: {
 					MYSQL_ROOT_HOST: '%',
 					MYSQL_ROOT_PASSWORD:
@@ -206,7 +226,11 @@ module.exports = function buildDockerComposeConfig( config ) {
 				volumes: [ 'mysql-test:/var/lib/mysql' ],
 			},
 			wordpress: {
-				depends_on: [ 'mysql' ],
+				depends_on: {
+					mysql: {
+						condition: 'service_healthy',
+					},
+				},
 				build: {
 					context: '.',
 					dockerfile: 'WordPress.Dockerfile',
@@ -224,7 +248,11 @@ module.exports = function buildDockerComposeConfig( config ) {
 				extra_hosts: [ 'host.docker.internal:host-gateway' ],
 			},
 			'tests-wordpress': {
-				depends_on: [ 'tests-mysql' ],
+				depends_on: {
+					'tests-mysql': {
+						condition: 'service_healthy',
+					},
+				},
 				build: {
 					context: '.',
 					dockerfile: 'Tests-WordPress.Dockerfile',

--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -181,21 +181,18 @@ module.exports = function buildDockerComposeConfig( config ) {
 		config.env.tests.phpmyadminPort ?? ''
 	}}:80`;
 
+	const mysqlHealthcheck = {
+		test: [ 'CMD', 'healthcheck.sh', '--connect', '--innodb_initialized' ],
+		timeout: '10s',
+		retries: 10,
+	};
+
 	return {
 		services: {
 			mysql: {
 				image: 'mariadb:lts',
 				ports: [ developmentMysqlPorts ],
-				healthcheck: {
-					test: [
-						'CMD',
-						'healthcheck.sh',
-						'--connect',
-						'--innodb_initialized',
-					],
-					timeout: '20s',
-					retries: 10,
-				},
+				healthcheck: mysqlHealthcheck,
 				environment: {
 					MYSQL_ROOT_HOST: '%',
 					MYSQL_ROOT_PASSWORD:
@@ -207,16 +204,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 			'tests-mysql': {
 				image: 'mariadb:lts',
 				ports: [ testsMysqlPorts ],
-				healthcheck: {
-					test: [
-						'CMD',
-						'healthcheck.sh',
-						'--connect',
-						'--innodb_initialized',
-					],
-					timeout: '20s',
-					retries: 10,
-				},
+				healthcheck: mysqlHealthcheck,
 				environment: {
 					MYSQL_ROOT_HOST: '%',
 					MYSQL_ROOT_PASSWORD:


### PR DESCRIPTION
## What?
It appears that there have been several errors when running Docker containers for CI,[ as reported here](https://wordpress.slack.com/archives/C02QB2JS7/p1753858635236229) like
https://github.com/WordPress/gutenberg/actions/runs/16615410203/job/47007147722?pr=70970

As @talldan has commented, maybe better logging could be implemented to see where is the issue.

## Why?
One of the issues I've personally encountered with docker configurations with the WP images is the fact that mariadb takes a variable amount of time to load, and it can load a little later than the PHP server under certain conditions. 

## How?
To ensure that the DB is loading 100% before the PHP container, a healthcheck could do the trick

I'm taking Official docs for implementing a valid healtcheck for the maridb docker images:
https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/installing-mariadb/binary-packages/automated-mariadb-deployment-and-administration/docker-and-mariadb/using-healthcheck-sh

## Testing Instructions
1. Just run `npx wp-env start`

I want to see how well this patch goes with current GHA.