### PR TITLE
iAPI: Make state getters to be updated asynchronously with `store()`

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/render.php
@@ -4,6 +4,15 @@
  *
  * @package gutenberg-test-interactive-blocks
  */
+
+wp_interactivity_state(
+	'test/deferred-store',
+	array(
+		'number' => 2,
+		'double' => 4,
+	)
+);
+
 ?>
 
 <div
@@ -12,4 +21,7 @@
 >
 	<span data-wp-text="state.reversedText" data-testid="result"></span>
 	<span data-wp-text="state.reversedTextGetter" data-testid="result-getter"></span>
+
+	<span data-wp-text="state.number" data-testid="state-number"></span>
+	<span data-wp-text="state.double" data-testid="state-double"></span>
 </div>

--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.js
@@ -20,3 +20,19 @@ window.addEventListener(
 	},
 	{ once: true }
 );
+
+window.addEventListener(
+	'_test_proceed_',
+	() => {
+		const { state } = store( 'test/deferred-store', {
+			state: {
+				number: 3,
+
+				get double() {
+					return state.number * 2;
+				},
+			},
+		} );
+	},
+	{ once: true }
+);

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -7,6 +7,10 @@
 -   Deprecated the `"data-wp-ignore"` directive of the Interactivity API.([#70945](https://github.com/WordPress/gutenberg/pull/70945))  
     It is deprecated as of WordPress 6.9 and will be removed in version 7.0.
 
+### Bug Fixes
+
+-   Make state getters to be updated asynchronously with `store()`. ([#70974](https://github.com/WordPress/gutenberg/pull/70974))
+
 ## 6.27.0 (2025-07-23)
 
 ## 6.26.0 (2025-06-25)

--- a/packages/interactivity/src/proxies/signals.ts
+++ b/packages/interactivity/src/proxies/signals.ts
@@ -97,7 +97,7 @@ export class PropSignal {
 	 */
 	public setPendingGetter( getter: () => any ) {
 		this.pendingGetter = getter;
-		Promise.resolve().then( () => this.consolidateGetter() );
+		queueMicrotask( () => this.consolidateGetter() );
 	}
 
 	/**

--- a/packages/interactivity/src/proxies/signals.ts
+++ b/packages/interactivity/src/proxies/signals.ts
@@ -95,7 +95,7 @@ export class PropSignal {
 	 *
 	 * @param getter New getter.
 	 */
-	public setGetterAsync( getter: () => any ) {
+	public setPendingGetter( getter: () => any ) {
 		this.pendingGetter = getter;
 		Promise.resolve().then( () => this.consolidateGetter() );
 	}

--- a/packages/interactivity/src/proxies/signals.ts
+++ b/packages/interactivity/src/proxies/signals.ts
@@ -51,11 +51,6 @@ export class PropSignal {
 	private getterSignal?: Signal< ( () => any ) | undefined >;
 
 	/**
-	 * Pending getter to be consolidated.
-	 */
-	private pendingGetter?: () => any;
-
-	/**
 	 * Structure that manages reactivity for a property in a state object, using
 	 * signals to keep track of property value or getter modifications.
 	 *
@@ -81,26 +76,10 @@ export class PropSignal {
 	 * Changes the internal getter. If a value was set before, it is set to
 	 * `undefined`.
 	 *
-	 * The update is made asynchronously in a microtask, which prevents issues
-	 * with getters accessing the state, and ensures the update occurs before
-	 * any render.
-	 *
 	 * @param getter New getter.
 	 */
 	public setGetter( getter: () => any ) {
-		this.pendingGetter = getter;
-		Promise.resolve().then( () => this.consolidateGetter() );
-	}
-
-	/**
-	 * Consolidate the pending value of the getter.
-	 */
-	private consolidateGetter() {
-		const getter = this.pendingGetter;
-		if ( getter ) {
-			this.pendingGetter = undefined;
-			this.update( { get: getter } );
-		}
+		this.update( { get: getter } );
 	}
 
 	/**
@@ -122,15 +101,6 @@ export class PropSignal {
 
 		if ( ! this.computedsByScope.has( scope ) ) {
 			const callback = () => {
-				/*
-				 * If there is any pending getter, consolidate it first. This
-				 * could happen if a getter is accessed synchronously after
-				 * being set with `store()`.
-				 */
-				if ( this.pendingGetter ) {
-					this.consolidateGetter();
-				}
-
 				const getter = this.getterSignal?.value;
 				return getter
 					? getter.call( this.owner )

--- a/packages/interactivity/src/proxies/signals.ts
+++ b/packages/interactivity/src/proxies/signals.ts
@@ -51,6 +51,11 @@ export class PropSignal {
 	private getterSignal?: Signal< ( () => any ) | undefined >;
 
 	/**
+	 * Pending getter to be consolidated.
+	 */
+	private pendingGetter?: () => any;
+
+	/**
 	 * Structure that manages reactivity for a property in a state object, using
 	 * signals to keep track of property value or getter modifications.
 	 *
@@ -76,10 +81,26 @@ export class PropSignal {
 	 * Changes the internal getter. If a value was set before, it is set to
 	 * `undefined`.
 	 *
+	 * The update is made asynchronously in a microtask, which prevents issues
+	 * with getters accessing the state, and ensures the update occurs before
+	 * any render.
+	 *
 	 * @param getter New getter.
 	 */
 	public setGetter( getter: () => any ) {
-		this.update( { get: getter } );
+		this.pendingGetter = getter;
+		Promise.resolve().then( () => this.consolidateGetter() );
+	}
+
+	/**
+	 * Consolidate the pending value of the getter.
+	 */
+	private consolidateGetter() {
+		const getter = this.pendingGetter;
+		if ( getter ) {
+			this.pendingGetter = undefined;
+			this.update( { get: getter } );
+		}
 	}
 
 	/**
@@ -101,6 +122,15 @@ export class PropSignal {
 
 		if ( ! this.computedsByScope.has( scope ) ) {
 			const callback = () => {
+				/*
+				 * If there is any pending getter, consolidate it first. This
+				 * could happen if a getter is accessed synchronously after
+				 * being set with `store()`.
+				 */
+				if ( this.pendingGetter ) {
+					this.consolidateGetter();
+				}
+
 				const getter = this.getterSignal?.value;
 				return getter
 					? getter.call( this.owner )

--- a/packages/interactivity/src/proxies/signals.ts
+++ b/packages/interactivity/src/proxies/signals.ts
@@ -51,6 +51,11 @@ export class PropSignal {
 	private getterSignal?: Signal< ( () => any ) | undefined >;
 
 	/**
+	 * Pending getter to be consolidated.
+	 */
+	private pendingGetter?: () => any;
+
+	/**
 	 * Structure that manages reactivity for a property in a state object, using
 	 * signals to keep track of property value or getter modifications.
 	 *
@@ -83,6 +88,30 @@ export class PropSignal {
 	}
 
 	/**
+	 * Changes the internal getter asynchronously.
+	 *
+	 * The update is made in a microtask, which prevents issues with getters
+	 * accessing the state, and ensures the update occurs before any render.
+	 *
+	 * @param getter New getter.
+	 */
+	public setGetterAsync( getter: () => any ) {
+		this.pendingGetter = getter;
+		Promise.resolve().then( () => this.consolidateGetter() );
+	}
+
+	/**
+	 * Consolidate the pending value of the getter.
+	 */
+	private consolidateGetter() {
+		const getter = this.pendingGetter;
+		if ( getter ) {
+			this.pendingGetter = undefined;
+			this.update( { get: getter } );
+		}
+	}
+
+	/**
 	 * Returns the computed that holds the result of evaluating the prop in the
 	 * current scope.
 	 *
@@ -97,6 +126,15 @@ export class PropSignal {
 
 		if ( ! this.valueSignal && ! this.getterSignal ) {
 			this.update( {} );
+		}
+
+		/*
+		 * If there is any pending getter, consolidate it first. This
+		 * could happen if a getter is accessed synchronously after
+		 * being set with `store()`.
+		 */
+		if ( this.pendingGetter ) {
+			this.consolidateGetter();
 		}
 
 		if ( ! this.computedsByScope.has( scope ) ) {

--- a/packages/interactivity/src/proxies/state.ts
+++ b/packages/interactivity/src/proxies/state.ts
@@ -334,7 +334,7 @@ const deepMergeRecursive = (
 				} );
 				// Update the getter in the property signal if it exists
 				if ( desc.get && propSignal ) {
-					propSignal.setGetterAsync( desc.get );
+					propSignal.setPendingGetter( desc.get );
 				}
 			}
 

--- a/packages/interactivity/src/proxies/state.ts
+++ b/packages/interactivity/src/proxies/state.ts
@@ -49,43 +49,6 @@ export const hasPropSignal = ( proxy: object, key: string ) =>
 const readOnlyProxies = new WeakSet();
 
 /**
- * Map of those PropSignal instances that have a pending getter update.
- *
- * Getter updates are made asyncronously inside {@link deepMergeRecursive} to
- * avoid issues with getters referencing `state`. These getters can run
- * synchronously during `store()` execution and fail silently if `state` is
- * being destructured from the `store()` returned value.
- */
-const pendingGetterUpdates = new WeakMap< WeakKey, () => void >();
-
-/**
- * Updates the internal signal getter of the given PropSignal asynchronously.
- *
- * The update is made asynchronously in a microtask, which prevents issues with
- * getters accessing the state, and ensures the update occurs before any render.
- *
- * @param propSignal The PropSignal instance to update.
- * @param getter     The getter function to assign.
- */
-const setGetterAsync = ( propSignal: PropSignal, getter: () => any ) => {
-	const updater = () => {
-		/*
-		 * The pending update could have changed or have been processed already.
-		 * Do nothing in this case.
-		 */
-		if ( pendingGetterUpdates.get( propSignal ) === updater ) {
-			pendingGetterUpdates.delete( propSignal );
-			propSignal.setGetter( getter );
-		}
-	};
-
-	pendingGetterUpdates.set( propSignal, updater );
-
-	// Delay the updater execution to a microtask.
-	Promise.resolve().then( () => updater() );
-};
-
-/**
  * Returns the {@link PropSignal | `PropSignal`} instance associated with the
  * specified prop in the passed proxy.
  *
@@ -125,12 +88,7 @@ const getPropSignal = (
 			}
 		}
 	}
-	const propSignal = props.get( key )!;
-
-	// If there is a pending getter update, resolve it synchronously.
-	pendingGetterUpdates.get( propSignal )?.();
-
-	return propSignal;
+	return props.get( key )!;
 };
 
 /**
@@ -376,8 +334,7 @@ const deepMergeRecursive = (
 				} );
 				// Update the getter in the property signal if it exists
 				if ( desc.get && propSignal ) {
-					// This update is made asynchronously!
-					setGetterAsync( propSignal, desc.get );
+					propSignal.setGetter( desc.get );
 				}
 			}
 

--- a/packages/interactivity/src/proxies/state.ts
+++ b/packages/interactivity/src/proxies/state.ts
@@ -49,6 +49,43 @@ export const hasPropSignal = ( proxy: object, key: string ) =>
 const readOnlyProxies = new WeakSet();
 
 /**
+ * Map of those PropSignal instances that have a pending getter update.
+ *
+ * Getter updates are made asyncronously inside {@link deepMergeRecursive} to
+ * avoid issues with getters referencing `state`. These getters can run
+ * synchronously during `store()` execution and fail silently if `state` is
+ * being destructured from the `store()` returned value.
+ */
+const pendingGetterUpdates = new WeakMap< WeakKey, () => void >();
+
+/**
+ * Updates the internal signal getter of the given PropSignal asynchronously.
+ *
+ * The update is made asynchronously in a microtask, which prevents issues with
+ * getters accessing the state, and ensures the update occurs before any render.
+ *
+ * @param propSignal The PropSignal instance to update.
+ * @param getter     The getter function to assign.
+ */
+const setGetterAsync = ( propSignal: PropSignal, getter: () => any ) => {
+	const updater = () => {
+		/*
+		 * The pending update could have changed or have been processed already.
+		 * Do nothing in this case.
+		 */
+		if ( pendingGetterUpdates.get( propSignal ) === updater ) {
+			pendingGetterUpdates.delete( propSignal );
+			propSignal.setGetter( getter );
+		}
+	};
+
+	pendingGetterUpdates.set( propSignal, updater );
+
+	// Delay the updater execution to a microtask.
+	Promise.resolve().then( () => updater() );
+};
+
+/**
  * Returns the {@link PropSignal | `PropSignal`} instance associated with the
  * specified prop in the passed proxy.
  *
@@ -88,7 +125,12 @@ const getPropSignal = (
 			}
 		}
 	}
-	return props.get( key )!;
+	const propSignal = props.get( key )!;
+
+	// If there is a pending getter update, resolve it synchronously.
+	pendingGetterUpdates.get( propSignal )?.();
+
+	return propSignal;
 };
 
 /**
@@ -334,7 +376,8 @@ const deepMergeRecursive = (
 				} );
 				// Update the getter in the property signal if it exists
 				if ( desc.get && propSignal ) {
-					propSignal.setGetter( desc.get );
+					// This update is made asynchronously!
+					setGetterAsync( propSignal, desc.get );
 				}
 			}
 

--- a/packages/interactivity/src/proxies/state.ts
+++ b/packages/interactivity/src/proxies/state.ts
@@ -334,7 +334,7 @@ const deepMergeRecursive = (
 				} );
 				// Update the getter in the property signal if it exists
 				if ( desc.get && propSignal ) {
-					propSignal.setGetter( desc.get );
+					propSignal.setGetterAsync( desc.get );
 				}
 			}
 

--- a/packages/interactivity/src/proxies/test/deep-merge.ts
+++ b/packages/interactivity/src/proxies/test/deep-merge.ts
@@ -515,6 +515,73 @@ describe( 'Interactivity API', () => {
 			expect( deepValue ).toBe( 'value 2' );
 		} );
 
+		it( 'should overwrite the getters of existing signals asynchronously', async () => {
+			const target: any = proxifyState( 'test', {
+				number: 2,
+				double: 4,
+			} );
+
+			let double: any;
+			const spy = jest.fn( () => ( double = target.double ) );
+			effect( spy );
+
+			expect( spy ).toHaveBeenCalledTimes( 1 );
+			expect( double ).toBe( 4 );
+
+			deepMerge(
+				target,
+				{
+					number: 3,
+					get double() {
+						return this.number * 2;
+					},
+				},
+				true
+			);
+
+			expect( spy ).toHaveBeenCalledTimes( 1 );
+			expect( double ).toBe( 4 );
+
+			// After this await, the `double` getter should have been updated.
+			await Promise.resolve();
+
+			expect( spy ).toHaveBeenCalledTimes( 2 );
+			expect( double ).toBe( 6 );
+		} );
+
+		it( 'should overwrite the getters of existing signals synchronously when accessed immediately after', async () => {
+			const target: any = proxifyState( 'test', {
+				number: 2,
+				double: 4,
+			} );
+
+			let double: any;
+			const spy = jest.fn( () => ( double = target.double ) );
+			effect( spy );
+
+			expect( spy ).toHaveBeenCalledTimes( 1 );
+			expect( double ).toBe( 4 );
+
+			deepMerge(
+				target,
+				{
+					number: 3,
+					get double() {
+						return this.number * 2;
+					},
+				},
+				true
+			);
+
+			expect( spy ).toHaveBeenCalledTimes( 1 );
+			expect( double ).toBe( 4 );
+
+			// Access the getter synchronously.
+			expect( target.double ).toBe( 6 );
+			expect( spy ).toHaveBeenCalledTimes( 2 );
+			expect( double ).toBe( 6 );
+		} );
+
 		describe( 'arrays', () => {
 			it( 'should handle arrays', () => {
 				const target = { a: [ 1, 2 ] };

--- a/packages/interactivity/src/proxies/test/deep-merge.ts
+++ b/packages/interactivity/src/proxies/test/deep-merge.ts
@@ -582,6 +582,50 @@ describe( 'Interactivity API', () => {
 			expect( double ).toBe( 6 );
 		} );
 
+		it( 'should set the last value for multiple-overwritten getters', async () => {
+			const target: any = proxifyState( 'test', {
+				number: 2,
+				double: 4,
+			} );
+
+			let double: any;
+			const spy = jest.fn( () => ( double = target.double ) );
+			effect( spy );
+
+			expect( spy ).toHaveBeenCalledTimes( 1 );
+			expect( double ).toBe( 4 );
+
+			deepMerge(
+				target,
+				{
+					number: 3,
+					get double() {
+						return this.number * 2;
+					},
+				},
+				true
+			);
+
+			deepMerge(
+				target,
+				{
+					number: 3,
+					get double() {
+						return `${ this.number * 2 }!`;
+					},
+				},
+				true
+			);
+
+			expect( spy ).toHaveBeenCalledTimes( 1 );
+			expect( double ).toBe( 4 );
+
+			// Access the getter synchronously.
+			expect( target.double ).toBe( '6!' );
+			expect( spy ).toHaveBeenCalledTimes( 2 );
+			expect( double ).toBe( '6!' );
+		} );
+
 		describe( 'arrays', () => {
 			it( 'should handle arrays', () => {
 				const target = { a: [ 1, 2 ] };

--- a/test/e2e/specs/interactivity/deferred-store.spec.ts
+++ b/test/e2e/specs/interactivity/deferred-store.spec.ts
@@ -37,4 +37,18 @@ test.describe( 'deferred store', () => {
 		} );
 		await expect( resultInput ).toHaveText( 'Hello, world!' );
 	} );
+
+	test( 'Ensure that a state getter can access the returned state even when directives already subscribed to it', async ( {
+		page,
+	} ) => {
+		const stateNumber = page.getByTestId( 'state-number' );
+		const stateDouble = page.getByTestId( 'state-double' );
+		await expect( stateNumber ).toHaveText( '2' );
+		await expect( stateDouble ).toHaveText( '4' );
+		await page.evaluate( () => {
+			window.dispatchEvent( new Event( '_test_proceed_' ) );
+		} );
+		await expect( stateNumber ).toHaveText( '3' );
+		await expect( stateDouble ).toHaveText( '6' );
+	} );
 } );


### PR DESCRIPTION
## What?

Closes #70874

Changes the way getters are updated when `store()` is called. Instead of synchronously, which can cause problems with stores that are loaded after hydration, they are now updated asynchronously in a [microtask](https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide/In_depth#tasks_vs._microtasks), ensuring the updates happen before Preact renders.

In the case that a getter is accessed synchronously right after being updated, the pending update is consolidated at that moment to reflect the correct value.

## Why?

See #70874.

The `store()` function of the interactivity API is intended to allow the following syntax:

```js
import { store } from '@wordpress/interactivity';

const { state } = store( 'myPlugin', {
  state: {
    number: 2,
    get double () {
      return state.number * 2;
    },
  },
} );
```

See how the returned `state` is used inside the `state.double` getter. When the `store()` function runs before hydration, it works just fine. But if it happens after hydration, and the `state.double` was already accessed, meaning that a computed was already created for that prop, the getter is evaluated before `store()` returns, and the execution fails with the following error:

```
ReferenceError: Cannot access 'state'  before initialization
```

This happens because of the Preact's `computed()` implementation, which updates all computeds synchronously when any of their sources change.

## How?

Instead of creating a custom `computed()` implementation, this PR adds a `setGetterAsync` method to `PropSignal` (the internal class that handles prop updates). That method makes `PropSignal` getters to be updated in a microtask. As microtasks run right at the end of the current task, the update is ensured to happen before the next Preact render ([scheduled for the next task](https://preactjs.com/guide/v10/options/#:~:text=By%20default%2C%20Preact%20uses%20a%20zero%20duration%20setTimeout.)).

In addition, if the `getComputed()` function of the `PropSignal` class is called and a pending getter update exists, the update is performed synchronously at that moment.

## Testing Instructions

Apart from the added unit tests and e2e tests, you can test the fix manually following these steps:

1. In a page or template with interactive blocks, add a Custom HTML block with this content:
   <details>
   <summary>Custom HTML</summary>

   ```html
   <div data-wp-interactive="myPlugin">
     <button data-wp-on--click="actions.inc">+</button>
     <p>Count: <span data-wp-text="state.count"></span></p>
     <p>Double: <span data-wp-text="state.double"></span></p>
   </div>
   <script type=module>
   /**
    * WordPress dependencies
    */
   import { store } from '@wordpress/interactivity';
   
   // Simulate state serialized from the server.
   store('myPlugin', {
     state: {
       count: 1,
       double: 2,
     },
   });
   
   // Simulate lazy loaded store.
   setTimeout(() => {
     const { state } = store('myPlugin', {
       state: {
         get double() {
           return state.count * 2;
         },
       },
       actions: {
         inc: () => {
           state.count++;
         },
       },
     });
   });
   </script>
   ```
   </details>
2. Save and visit the page with the Custom HTML block.
3. A button with the symbol `+` should be rendered, along with the words "Count" and "Double", each with its corresponding value.
4. Press the button `+` a couple of times.
5. Ensure the value of "Double" is consistent with the value of "Count".

