### PR TITLE
Fix: Global Styles: Font Appearance doesn't work well with theme.json default value

### DIFF
--- a/packages/block-editor/src/components/global-styles/typography-utils.js
+++ b/packages/block-editor/src/components/global-styles/typography-utils.js
@@ -37,6 +37,26 @@ import { getFontStylesAndWeights } from '../../utils/get-font-styles-and-weights
  */
 
 /**
+ * Font weight mapping from the theme.json font weight values to numeric values.
+ */
+const fontWeightMapping = {
+	thin: 100,
+	'extra light': 200,
+	'extra-light': 200,
+	light: 300,
+	regular: 400,
+	medium: 500,
+	'semi bold': 600,
+	'semi-bold': 600,
+	bold: 700,
+	'extra bold': 800,
+	'extra-bold': 800,
+	black: 900,
+	'extra black': 1000,
+	'extra-black': 1000,
+};
+
+/**
  * Returns a font-size value based on a given font-size preset.
  * Takes into account fluid typography parameters and attempts to return a css formula depending on available, valid values.
  *
@@ -180,6 +200,13 @@ export function findNearestFontWeight(
 			: newFontWeightValue;
 	if ( ! newFontWeightValue || typeof newFontWeightValue !== 'string' ) {
 		return '';
+	}
+
+	newFontWeightValue = newFontWeightValue.toLowerCase().trim();
+
+	// Check if newFontWeightValue is not a numeric number, but it is a valid string.
+	if ( isNaN( parseInt( newFontWeightValue ) ) ) {
+		newFontWeightValue = fontWeightMapping[ newFontWeightValue ] ?? '100';
 	}
 
 	if ( ! availableFontWeights || availableFontWeights.length === 0 ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #70937 

<!-- In a few words, what is the PR actually doing? -->

## Why?
- PR adds the fontWeight text mapping to number to get accurate results.
- See - https://github.com/WordPress/gutenberg/issues/70937#issuecomment-3135687934

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- PR adds the mapping object to check for the fontWeight text and use it's corresponding number.

## Testing Instructions
1. Add theme.json as per - https://github.com/WordPress/gutenberg/issues/70937#issuecomment-3135687934
2. Open global styles --> Typography.
3. Add the patch, and check, Now `Bold` fontWeight would be selected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- NIL

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/9dc0bab8-88eb-4eed-8df2-98a916631c6f

