### PR TITLE
Navigation Block: Make selectable in Write Mode

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -232,19 +232,24 @@ const BlockInspectorSingleBlock = ( {
 				getClientIdsOfDescendants,
 				getBlockName,
 				getBlockEditingMode,
+				getBlockParents,
 			} = select( blockEditorStore );
 
-			// Don't show content blocks for navigation blocks
-			if ( blockName === 'core/navigation' ) {
-				return [];
-			}
-
 			return getClientIdsOfDescendants( clientId ).filter(
-				( current ) =>
-					getBlockName( current ) !== 'core/list-item' &&
-					getBlockName( current ) !== 'core/navigation-link' &&
-					getBlockName( current ) !== 'core/navigation-submenu' &&
-					getBlockEditingMode( current ) === 'contentOnly'
+				( current ) => {
+					// Check if this block is within a navigation context
+					const parents = getBlockParents( current );
+					const isWithinNavigation = parents.some( ( parentId ) => {
+						const parentName = getBlockName( parentId );
+						return parentName === 'core/navigation';
+					} );
+
+					return (
+						! isWithinNavigation &&
+						getBlockName( current ) !== 'core/list-item' &&
+						getBlockEditingMode( current ) === 'contentOnly'
+					);
+				}
 			);
 		},
 		[ isSectionBlock, clientId ]

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -233,9 +233,17 @@ const BlockInspectorSingleBlock = ( {
 				getBlockName,
 				getBlockEditingMode,
 			} = select( blockEditorStore );
+
+			// Don't show content blocks for navigation blocks
+			if ( blockName === 'core/navigation' ) {
+				return [];
+			}
+
 			return getClientIdsOfDescendants( clientId ).filter(
 				( current ) =>
 					getBlockName( current ) !== 'core/list-item' &&
+					getBlockName( current ) !== 'core/navigation-link' &&
+					getBlockName( current ) !== 'core/navigation-submenu' &&
 					getBlockEditingMode( current ) === 'contentOnly'
 			);
 		},

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2339,7 +2339,6 @@ function getDerivedBlockEditingModesForTree(
 				clientId,
 				sectionClientIds
 			);
-
 			if ( ! isInSection ) {
 				if ( clientId === '' ) {
 					derivedBlockEditingModes.set( clientId, 'disabled' );

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2346,7 +2346,10 @@ function getDerivedBlockEditingModesForTree(
 				}
 
 				// Allow selection of template parts outside of sections.
-				if ( blockName === 'core/template-part' ) {
+				if (
+					blockName === 'core/template-part' ||
+					blockName === 'core/navigation'
+				) {
 					derivedBlockEditingModes.set( clientId, 'contentOnly' );
 					return;
 				}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2339,6 +2339,7 @@ function getDerivedBlockEditingModesForTree(
 				clientId,
 				sectionClientIds
 			);
+
 			if ( ! isInSection ) {
 				if ( clientId === '' ) {
 					derivedBlockEditingModes.set( clientId, 'disabled' );
@@ -2346,10 +2347,7 @@ function getDerivedBlockEditingModesForTree(
 				}
 
 				// Allow selection of template parts outside of sections.
-				if (
-					blockName === 'core/template-part' ||
-					blockName === 'core/navigation'
-				) {
+				if ( blockName === 'core/template-part' ) {
 					derivedBlockEditingModes.set( clientId, 'contentOnly' );
 					return;
 				}

--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -14,7 +14,8 @@
 	"textdomain": "default",
 	"attributes": {
 		"label": {
-			"type": "string"
+			"type": "string",
+			"role": "content"
 		},
 		"type": {
 			"type": "string"

--- a/packages/block-library/src/navigation-submenu/block.json
+++ b/packages/block-library/src/navigation-submenu/block.json
@@ -9,7 +9,8 @@
 	"textdomain": "default",
 	"attributes": {
 		"label": {
-			"type": "string"
+			"type": "string",
+			"role": "content"
 		},
 		"type": {
 			"type": "string"

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -22,7 +22,8 @@
 	"textdomain": "default",
 	"attributes": {
 		"ref": {
-			"type": "number"
+			"type": "number",
+			"role": "content"
 		},
 		"textColor": {
 			"type": "string"


### PR DESCRIPTION
## What

Fixes part of #65699: Make Navigation blocks selectable in Write Mode by adding content role attributes to navigation menu item labels.

This change allows users to edit navigation menu item text/labels directly in the canvas when in Write Mode, while maintaining the content-focused editing experience.

## Why

Currently, Navigation blocks are not selectable in Write Mode because they lack the required  attributes that Write Mode uses to determine which blocks are editable. This prevents users from editing navigation menu content when in Write Mode.

## How

- Added  to the  attribute in both  and  blocks
- Added  to the  attribute in  block
- Optimized inspector logic to exclude navigation blocks from content panel
- Removed custom Navigation block handling from reducer in favor of using the existing content role system

## Testing

1. Enable Write Mode in Gutenberg experiments
2. Add a Navigation block to a template or pattern
3. Verify that navigation menu item labels are editable in the canvas
4. Verify that the Navigation block itself is selectable in Write Mode
5. Verify that navigation blocks don't appear in the content panel of other blocks' inspectors

## Screenshots


https://github.com/user-attachments/assets/1c8e80ed-2c1a-4881-aea9-5a13fb6c2e5f



## Notes

This addresses part of the UX described in #65699 but does not implement the full inspector-based menu editing experience outlined in https://github.com/WordPress/gutenberg/issues/65699#issue-2552416654. The current implementation focuses on making navigation menu items directly editable in the canvas, which aligns with Write Mode's content-focused philosophy.