### PR TITLE
Block Editor: Fix single block selection when holding 'Shift' key

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-click-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-click-selection.js
@@ -27,7 +27,9 @@ export default function useClickSelection() {
 				const clickedClientId = getBlockClientId( event.target );
 
 				if ( event.shiftKey ) {
-					if ( startClientId !== clickedClientId ) {
+					// When selecting a single block in a document by holding the shift key,
+					// don't mark this action as multiselection.
+					if ( startClientId && startClientId !== clickedClientId ) {
 						node.contentEditable = true;
 						// Firefox doesn't automatically move focus.
 						node.focus();

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -291,9 +291,6 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		editor,
 		pageUtils,
 	} ) => {
-		// To do: run with iframe.
-		await editor.switchToLegacyCanvas();
-
 		await editor.insertBlock( {
 			name: 'core/paragraph',
 			attributes: { content: 'test' },
@@ -301,10 +298,8 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 
 		await editor.saveDraft();
 		await page.reload();
-		// To do: run with iframe.
-		await editor.switchToLegacyCanvas();
 
-		await page
+		await editor.canvas
 			.getByRole( 'document', { name: 'Block: Paragraph' } )
 			.click( { modifiers: [ 'Shift' ] } );
 		await pageUtils.pressKeys( 'primary+a' );


### PR DESCRIPTION
## What?
Fixes a regression of #34137.

PR fixes a regression in the `useClickSelection` hook when the `shiftKey` modifier is used.

It looks like this regressed a while ago, but only started failing with the recent Playwright upgrade (#70503). The bug is easy to reproduce consistently when testing manually.

## Why?
Allows for easy editing of a single selected block without needing to clear multi-selection.

## How?
Same as #34137. Confirm that the start client ID exists before triggering multi-selection.

## Testing Instructions
1. Create a post.
2. Add a paragraph block with content.
3. Save and reload.
4. Click on the paragraph block while holding the <kbd>Shift</kbd> key.
5. Confirm that focus moves to paragraph blocks.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/c7acdf46-d642-4f17-bb3d-3fba754873c2

**After**

https://github.com/user-attachments/assets/b675f489-5957-4ff6-9dd8-b826f6010a5d

