### PR TITLE
Lower `PostPanelRow` style specifity

### DIFF
--- a/packages/editor/src/components/post-panel-row/index.js
+++ b/packages/editor/src/components/post-panel-row/index.js
@@ -14,6 +14,7 @@ const PostPanelRow = forwardRef( ( { className, label, children }, ref ) => {
 		<HStack
 			className={ clsx( 'editor-post-panel__row', className ) }
 			ref={ ref }
+			align="flex-start"
 		>
 			{ label && (
 				<div className="editor-post-panel__row-label">{ label }</div>

--- a/packages/editor/src/components/post-panel-row/style.scss
+++ b/packages/editor/src/components/post-panel-row/style.scss
@@ -1,8 +1,6 @@
 .editor-post-panel__row {
 	width: 100%;
 	min-height: $grid-unit-40;
-	justify-content: flex-start;
-	align-items: flex-start;
 }
 
 .editor-post-panel__row-label {
@@ -10,7 +8,7 @@
 	flex-shrink: 0;
 	min-height: $grid-unit-40;
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	padding: 6px 0; // Matches button to ensure alignment
 	line-height: $grid-unit-05 * 5;
 	hyphens: auto;
@@ -20,7 +18,7 @@
 	flex-grow: 1;
 	min-height: $grid-unit-40;
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 
 	.components-button {
 		max-width: 100%;

--- a/packages/editor/src/components/post-panel-row/style.scss
+++ b/packages/editor/src/components/post-panel-row/style.scss
@@ -1,8 +1,8 @@
 .editor-post-panel__row {
 	width: 100%;
 	min-height: $grid-unit-40;
-	justify-content: flex-start !important;
-	align-items: flex-start !important;
+	justify-content: flex-start;
+	align-items: flex-start;
 }
 
 .editor-post-panel__row-label {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This removes the overpowering `!important` from alignment and justification values of `.editor-post-panel__row`. They were added in https://github.com/WordPress/gutenberg/pull/56319 but I couldn't decipher why. And frankly I'm not 100% sure what are the wider implications of removing them. I do know removing them resolves the issue in my editor instance (consumed from `packages/editor`) as shown in the screenshot below.

## Why?
To align the grid better.

## How?
Reverting part of https://github.com/WordPress/gutenberg/pull/56319

## Testing Instructions
TBD

### Testing Instructions for Keyboard
Doesn't apply.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="265" height="614" alt="image" src="https://github.com/user-attachments/assets/7c9fe706-9de1-468c-81b4-37211afb1780" /> | <img width="271" height="613" alt="Screenshot 2025-07-30 at 14 41 25" src="https://github.com/user-attachments/assets/5c1f8dbe-90a6-4df0-bcd7-47f0ad370399" />  |
