### PR TITLE
Post Date block: Address feedback

### DIFF
--- a/backport-changelog/6.9/9299.md
+++ b/backport-changelog/6.9/9299.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/9299
 
 * https://github.com/WordPress/gutenberg/pull/70585
+* https://github.com/WordPress/gutenberg/pull/70982

--- a/lib/compat/wordpress-6.9/post-data-block-bindings.php
+++ b/lib/compat/wordpress-6.9/post-data-block-bindings.php
@@ -40,7 +40,7 @@ function gutenberg_block_bindings_post_data_get_value( array $source_args, $bloc
 
 	if ( 'modified' === $source_args['key'] ) {
 		// Only return the modified date if it is later than the publishing date.
-		if ( get_the_modified_date( 'Ymdhi', $post_id ) > get_the_date( 'Ymdhi', $post_id ) ) {
+		if ( get_the_modified_date( 'U', $post_id ) > get_the_date( 'U', $post_id ) ) {
 			return esc_attr( get_the_modified_date( 'c', $post_id ) );
 		} else {
 			return '';

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { store as coreDataStore } from '@wordpress/core-data';
 
 /**
@@ -41,12 +42,12 @@ function getPostDataFields( select, context ) {
 		);
 		dataFields = {
 			date: {
-				label: 'Post Date',
+				label: __( 'Post Date' ),
 				value: entityDataValues?.date,
 				type: 'string',
 			},
 			modified: {
-				label: 'Post Modified Date',
+				label: __( 'Post Modified Date' ),
 				value: entityDataValues?.modified,
 				type: 'string',
 			},


### PR DESCRIPTION
## What?
Address some feedback received post-merge of https://github.com/WordPress/gutenberg/pull/70585.

- https://github.com/WordPress/gutenberg/pull/70585#discussion_r2238968411: Translate two labels that are part of the Post Data source (Block Bindings).
- https://github.com/WordPress/gutenberg/pull/70585#discussion_r2240206129: Use epoch format to compare the last modified date to the publish date.

## Why?
Translation of the labels is needed for i18n; using epoch format is the preferable way to compare two timestamps.

## How?
See PR.

## Testing Instructions
The i18n change is trivial. The date format change is covered by unit tests (we verify that the last modified date isn't rendered if it's before the publish date).
