### PR TITLE
Global Styles: Respect global border radius opt-out for button block

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -610,8 +610,10 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			_deprecated_argument( __FUNCTION__, '5.9.0' );
 		}
 
-		$result = new WP_Theme_JSON_Gutenberg();
-		$result->merge( static::get_core_data() );
+		$result    = new WP_Theme_JSON_Gutenberg();
+		$core_data = static::resolve_core_block_default_conflicts( static::get_core_data(), static::get_theme_data() );
+
+		$result->merge( $core_data );
 		if ( 'default' === $origin ) {
 			return $result;
 		}
@@ -1008,5 +1010,35 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Resolves conflicts between core block default settings and the active theme settings.
+	 *
+	 * @param WP_Theme_JSON_Gutenberg $core_data  Core theme data object.
+	 * @param WP_Theme_JSON_Gutenberg $theme_data Active theme data object.
+	 *
+	 * @return WP_Theme_JSON_Gutenberg Potentially adjusted core data object.
+	 */
+	private static function resolve_core_block_default_conflicts( $core_data, $theme_data ) {
+		$core_raw  = $core_data->get_raw_data();
+		$theme_raw = $theme_data->get_raw_data();
+
+		$global_border_radius = isset( $theme_raw['settings']['border']['radius'] )
+			? $theme_raw['settings']['border']['radius']
+			: null;
+
+		// If theme disables global border radius and doesn't override the block, remove it from core.
+		if (
+			false === $global_border_radius &&
+			isset( $core_raw['settings']['blocks']['core/button']['border']['radius'] ) &&
+			true === $core_raw['settings']['blocks']['core/button']['border']['radius'] &&
+			! isset( $theme_raw['settings']['blocks']['core/button']['border']['radius'] )
+		) {
+			unset( $core_raw['settings']['blocks']['core/button']['border']['radius'] );
+			return new WP_Theme_JSON_Gutenberg( $core_raw );
+		}
+
+		return $core_data;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #56626

<!-- In a few words, what is the PR actually doing? -->
This PR ensures that `core/button` block default settings of `border.radius` do not override a theme's explicit intent when global support for `border` is disabled.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, if a theme sets `settings.border.radius` to false, the `core/button` block still shows the border radius UI because core provides a default of true for that block. This leads to confusing behavior where the global opt-out isn't fully respected unless the theme also disables the block level setting manually.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Introduces a helper function `resolve_core_block_default_conflicts()` called in `get_merged_data()`
- This helper checks:
    - If the global border radius is explicitly disabled by the theme.
    - If the block level `core/button` setting comes only from core (not overridden by theme).
    - If both are true, the core provided `core/button.border.radius` is unset.

## Testing Instructions
1. Use a theme with the following `theme.json`:
```json
{
	"version": 2,
	"settings": {
		"border": {
			"color": false,
			"radius": false,
			"style": false,
			"width": false
		}
	}
}
```
2. Open the site editor or post editor and select a button block.
3. Confirm that the Border Radius control does not appear in the block settings panel.

<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Using the above provided config for `theme.json`
|Before|After|
|-|-|
|<img width="262" height="202" alt="Screenshot 2025-07-30 at 7 23 05 PM" src="https://github.com/user-attachments/assets/d482cec2-2f0a-4473-9f0e-ece8ae1858ab" />|<img width="271" height="99" alt="Screenshot 2025-07-30 at 7 22 48 PM" src="https://github.com/user-attachments/assets/51b80c6c-e10b-46f6-b7a9-63c85d9b5017" />|
