### PR TITLE
Add healthcheck commands for MySQL containers

### DIFF
--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -79,6 +79,18 @@ function getMounts(
 	];
 }
 
+function getDatabaseContainerHealthcheck() {
+	return {
+		test: [
+			'CMD-SHELL',
+			'if [ "$LOCAL_DB_TYPE" = "mariadb" ]; then case "$LOCAL_DB_VERSION" in 5.5|10.0|10.1|10.2|10.3) mysqladmin ping -h localhost || exit $?;; *) mariadb-admin ping -h localhost || exit $?;; esac; fi',
+		],
+		timeout: '5s',
+		interval: '5s',
+		retries: 10,
+	};
+}
+
 /**
  * Creates a docker-compose config object which, when serialized into a
  * docker-compose.yml file, tells docker-compose how to run the environment.
@@ -193,6 +205,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 					MYSQL_DATABASE: dbEnv.development.WORDPRESS_DB_NAME,
 				},
 				volumes: [ 'mysql:/var/lib/mysql' ],
+				healthcheck: getDatabaseContainerHealthcheck(),
 			},
 			'tests-mysql': {
 				image: 'mariadb:lts',
@@ -204,9 +217,14 @@ module.exports = function buildDockerComposeConfig( config ) {
 					MYSQL_DATABASE: dbEnv.tests.WORDPRESS_DB_NAME,
 				},
 				volumes: [ 'mysql-test:/var/lib/mysql' ],
+				healthcheck: getDatabaseContainerHealthcheck(),
 			},
 			wordpress: {
-				depends_on: [ 'mysql' ],
+				depends_on: {
+					mysql: {
+						condition: 'service_healthy',
+					},
+				},
 				build: {
 					context: '.',
 					dockerfile: 'WordPress.Dockerfile',
@@ -224,7 +242,11 @@ module.exports = function buildDockerComposeConfig( config ) {
 				extra_hosts: [ 'host.docker.internal:host-gateway' ],
 			},
 			'tests-wordpress': {
-				depends_on: [ 'tests-mysql' ],
+				depends_on: {
+					'tests-mysql': {
+						condition: 'service_healthy',
+					},
+				},
 				build: {
 					context: '.',
 					dockerfile: 'Tests-WordPress.Dockerfile',

--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -79,18 +79,6 @@ function getMounts(
 	];
 }
 
-function getDatabaseContainerHealthcheck() {
-	return {
-		test: [
-			'CMD-SHELL',
-			'if [ "$LOCAL_DB_TYPE" = "mariadb" ]; then case "$LOCAL_DB_VERSION" in 5.5|10.0|10.1|10.2|10.3) mysqladmin ping -h localhost || exit $?;; *) mariadb-admin ping -h localhost || exit $?;; esac; fi',
-		],
-		timeout: '5s',
-		interval: '5s',
-		retries: 10,
-	};
-}
-
 /**
  * Creates a docker-compose config object which, when serialized into a
  * docker-compose.yml file, tells docker-compose how to run the environment.
@@ -193,6 +181,16 @@ module.exports = function buildDockerComposeConfig( config ) {
 		config.env.tests.phpmyadminPort ?? ''
 	}}:80`;
 
+	const healthcheck = {
+		test: [
+			'CMD-SHELL',
+			'if [ "$LOCAL_DB_TYPE" = "mariadb" ]; then case "$LOCAL_DB_VERSION" in 5.5|10.0|10.1|10.2|10.3) mysqladmin ping -h localhost || exit $?;; *) mariadb-admin ping -h localhost || exit $?;; esac; fi',
+		],
+		timeout: '5s',
+		interval: '5s',
+		retries: 10,
+	};
+
 	return {
 		services: {
 			mysql: {
@@ -204,8 +202,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 						dbEnv.credentials.WORDPRESS_DB_PASSWORD,
 					MYSQL_DATABASE: dbEnv.development.WORDPRESS_DB_NAME,
 				},
-				volumes: [ 'mysql:/var/lib/mysql' ],
-				healthcheck: getDatabaseContainerHealthcheck(),
+				healthcheck,
 			},
 			'tests-mysql': {
 				image: 'mariadb:lts',
@@ -217,7 +214,7 @@ module.exports = function buildDockerComposeConfig( config ) {
 					MYSQL_DATABASE: dbEnv.tests.WORDPRESS_DB_NAME,
 				},
 				volumes: [ 'mysql-test:/var/lib/mysql' ],
-				healthcheck: getDatabaseContainerHealthcheck(),
+				healthcheck,
 			},
 			wordpress: {
 				depends_on: {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
This adds some additional safe guards so that running `wp-env start` does not fail when a database container takes a while to finish starting.

- The `depends_on` setting for containers that rely on a database container has been expanded to expect a `service_healthy` status.
- Defines a `healthcheck` that waits for a successful response to `(mysql|mariadb)-admin ping` command and retries up to 10 times.

<!-- In a few words, what is the PR actually doing? -->

## Why?
The `wp-env start` command has been failing more frequently within GitHub Actions recently.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->