### PR TITLE
Post Terms: Removing `wp_kses_post` causing issue 

### DIFF
--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -49,9 +49,9 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 	$post_terms = get_the_term_list(
 		$block->context['postId'],
 		$attributes['term'],
-		wp_kses_post( $prefix ),
+		$prefix,
 		'<span class="wp-block-post-terms__separator">' . esc_html( $separator ) . '</span>',
-		wp_kses_post( $suffix )
+		$suffix
 	);
 
 	if ( is_wp_error( $post_terms ) || empty( $post_terms ) ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Fixes: #68742
Follow up: #68810

#68810 has not seen any activity for several months, so I will follow up and resolve the issues.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The bg color of the prefix and suffix format is different from the normal display.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removing `wp_kses_post` which causing the issue.

As mentioned in this #40803

> This probably isn't really necessary, but for consistency with the other blocks that have RichText fields and server-render those fields, I thought we could add it in. (Happy to close this out if folks think it doesn't need it).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open a post or page.
2. Insert a Post Terms block.
3. Set the Prefix to a Color from the toolbar.
4. When you look at the front you can see that the Background is not being rendered.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="1936" height="314" alt="before" src="https://github.com/user-attachments/assets/249f8ca2-aa3b-45f7-ae20-865eec0b89b7" />|<img width="1934" height="352" alt="after" src="https://github.com/user-attachments/assets/40c9a0eb-a930-4fb0-889c-76b3389382c7" />|
