### PR TITLE
Editor: Fix incorrect title when multiple post selected

### DIFF
--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -88,9 +88,9 @@ export default function PostCardPanel( {
 	let title = __( 'No title' );
 	if ( labels?.name && postIds.length > 1 ) {
 		title = sprintf(
-			// translators: %i number of selected items %s: Name of the plural post type e.g: "Posts".
-			__( '%i %s' ),
-			postId.length,
+			// translators: %1$d number of selected items %2$s: Name of the plural post type e.g: "Posts".
+			__( '%1$d %2$s' ),
+			postIds.length,
 			labels?.name
 		);
 	} else if ( postTitle ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

I noticed that when selecting multiple posts, the titles were not translated correctly.

## Why?

- The placeholder `%i` is incorrect.
- The parameter is incorrect.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard

- Open the Gutenberg > Experiments settings page.
- Check the "Data Views: add Quick Edit" setting.
- Appearance > Editor > Pages > Table View
- Toggle the Details button
- Select multiple posts
- Confirm the title of the Details panel  is shown correctly

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="773" height="358" alt="image" src="https://github.com/user-attachments/assets/cea89667-1c16-4940-9063-ee16f34417a7" />

### After

<img width="785" height="354" alt="image" src="https://github.com/user-attachments/assets/ef596a64-dcd3-4751-8661-8658206362bc" />
