### PR TITLE
Cache redundant function call for is_user_logged_in() function

### DIFF
--- a/packages/block-library/src/form-input/index.php
+++ b/packages/block-library/src/form-input/index.php
@@ -19,10 +19,12 @@ function render_block_core_form_input( $attributes, $content ) {
 		$visibility_permissions = $attributes['visibilityPermissions'];
 	}
 
-	if ( 'logged-in' === $visibility_permissions && ! is_user_logged_in() ) {
+	$user_logged_in = is_user_logged_in();
+
+	if ( 'logged-in' === $visibility_permissions && ! $user_logged_in ) {
 		return '';
 	}
-	if ( 'logged-out' === $visibility_permissions && is_user_logged_in() ) {
+	if ( 'logged-out' === $visibility_permissions && $user_logged_in ) {
 		return '';
 	}
 	return $content;

--- a/packages/block-library/src/loginout/index.php
+++ b/packages/block-library/src/loginout/index.php
@@ -23,14 +23,16 @@ function render_block_core_loginout( $attributes ) {
 	 */
 	$current_url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 
-	$classes  = is_user_logged_in() ? 'logged-in' : 'logged-out';
+	$user_logged_in = is_user_logged_in();
+
+	$classes  = $user_logged_in ? 'logged-in' : 'logged-out';
 	$contents = wp_loginout(
 		isset( $attributes['redirectToCurrent'] ) && $attributes['redirectToCurrent'] ? $current_url : '',
 		false
 	);
 
 	// If logged-out and displayLoginAsForm is true, show the login form.
-	if ( ! is_user_logged_in() && ! empty( $attributes['displayLoginAsForm'] ) ) {
+	if ( ! $user_logged_in && ! empty( $attributes['displayLoginAsForm'] ) ) {
 		// Add a class.
 		$classes .= ' has-login-form';
 


### PR DESCRIPTION
Closes [#70998](https://github.com/WordPress/gutenberg/issues/70998)

## What?
Optimizes Form Input and LoginOut blocks by caching `is_user_logged_in()` function.

## Why?
Currently, both blocks make repeated function calls that don't change during a single request:

## How?
Saved result of `is_user_logged_in()` in variable

