### PR TITLE
DataForm: Fix Edit for `array` field type

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 - Do not render an empty `&nbsp;` when the title field has level 0. [#71021](https://github.com/WordPress/gutenberg/pull/71021)
+- When a field type is `array` and it has elements, the select control should allow multi-selection. [#71000](https://github.com/WordPress/gutenberg/pull/71000)
 - Set minimum and maximum number of items in `pePageSizes`, so that the UI control is disabled when the list exceeds those limits. [#71004](https://github.com/WordPress/gutenberg/pull/71004)
 - Fix `filterSortAndPaginate` to handle searching fields that have a type of `array` ([#70785](https://github.com/WordPress/gutenberg/pull/70785)).
 - Fix user-input filters: empty value for text and integer filters means there's no value to search for (so it returns all items). It also fixes a type conversion where empty strings for integer were converted to 0 [#70956](https://github.com/WordPress/gutenberg/pull/70956/).

--- a/packages/dataviews/src/dataform-controls/select.tsx
+++ b/packages/dataviews/src/dataform-controls/select.tsx
@@ -16,8 +16,9 @@ export default function Select< Item >( {
 	onChange,
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
-	const { id, label } = field;
-	const value = field.getValue( { item: data } ) ?? '';
+	const { id, label, type } = field;
+	const isMultiple = type === 'array';
+	const value = field.getValue( { item: data } ) ?? ( isMultiple ? [] : '' );
 	const onChangeControl = useCallback(
 		( newValue: any ) =>
 			onChange( {
@@ -31,19 +32,20 @@ export default function Select< Item >( {
 		( { value: elementValue } ) => elementValue === ''
 	);
 
-	const elements = hasEmptyValue
-		? fieldElements
-		: [
-				/*
-				 * Value can be undefined when:
-				 *
-				 * - the field is not required
-				 * - in bulk editing
-				 *
-				 */
-				{ label: __( 'Select item' ), value: '' },
-				...fieldElements,
-		  ];
+	const elements =
+		hasEmptyValue || isMultiple
+			? fieldElements
+			: [
+					/*
+					 * Value can be undefined when:
+					 *
+					 * - the field is not required
+					 * - in bulk editing
+					 *
+					 */
+					{ label: __( 'Select item' ), value: '' },
+					...fieldElements,
+			  ];
 
 	return (
 		<SelectControl
@@ -55,7 +57,7 @@ export default function Select< Item >( {
 			__next40pxDefaultSize
 			__nextHasNoMarginBottom
 			hideLabelFromVision={ hideLabelFromVision }
-			multiple={ field.type === 'array' }
+			multiple={ isMultiple }
 		/>
 	);
 }

--- a/packages/dataviews/src/dataform-controls/select.tsx
+++ b/packages/dataviews/src/dataform-controls/select.tsx
@@ -55,6 +55,7 @@ export default function Select< Item >( {
 			__next40pxDefaultSize
 			__nextHasNoMarginBottom
 			hideLabelFromVision={ hideLabelFromVision }
+			multiple={ field.type === 'array' }
 		/>
 	);
 }


### PR DESCRIPTION
## What?

When the `array` field type has `elements`, render a multi-selection select control.

https://github.com/user-attachments/assets/8459022e-354d-443f-9b0e-526bc9825803

## Why?

It's returning an error because there's a mismatch between the control displayed for editing (`select` with single-selection) and the array nature of the field (multiple elements).

## How?

By making the `select` control use multi-selection when the field type is an array.

## Testing Instructions

- Start the local storybook (`npm install && npm run storybook:dev`, and visit the "DataViews > FieldTypes > Array" story.
- Select an item in the table.
- Verify the right sidebar displays a select control with multi-selection and that changing data updates the table.

