### PR TITLE
Enhancement: Add serif & sans-serif default font options

### DIFF
--- a/lib/theme.json
+++ b/lib/theme.json
@@ -279,6 +279,18 @@
 			"customFontSize": true,
 			"defaultFontSizes": true,
 			"dropCap": true,
+			"fontFamilies": [
+				{
+					"name": "Sans Serif",
+					"slug": "sans-serif",
+					"fontFamily": "sans-serif"
+				},
+				{
+					"name": "Serif",
+					"slug": "serif",
+					"fontFamily": "serif"
+				}
+			],
 			"fontSizes": [
 				{
 					"name": "Small",

--- a/packages/block-editor/src/components/font-family/index.js
+++ b/packages/block-editor/src/components/font-family/index.js
@@ -31,6 +31,17 @@ export default function FontFamilyControl( {
 		fontFamilies = blockLevelFontFamilies;
 	}
 
+	// Flatten fontFamilies if it's in the object format with default/theme/custom
+	if (
+		fontFamilies &&
+		typeof fontFamilies === 'object' &&
+		! Array.isArray( fontFamilies )
+	) {
+		fontFamilies = [ 'default', 'theme', 'custom' ].flatMap(
+			( key ) => fontFamilies?.[ key ] ?? []
+		);
+	}
+
 	if ( ! fontFamilies || fontFamilies.length === 0 ) {
 		return null;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #54186

<!-- In a few words, what is the PR actually doing? -->

## Why?
It is currently difficult to simply select "sans-serif" or "serif" for a font selection in the editor. Sometimes you don't want to use or load an external font.

## How?
This PR adds the ability to select sans-serif or serif font in font selection dropdowns. After the theme default.

> TODO: Update description after ready for review

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
