### PR TITLE
Block Bindings: Try using `__default` for generic bindings

### DIFF
--- a/lib/compat/wordpress-6.9/post-data-block-bindings.php
+++ b/lib/compat/wordpress-6.9/post-data-block-bindings.php
@@ -34,23 +34,18 @@ function gutenberg_block_bindings_post_data_get_value( array $source_args, $bloc
 		return null;
 	}
 
-	if ( 'date' === $source_args['key'] ) {
-		return esc_attr( get_the_date( 'c', $post_id ) );
-	}
-
-	if ( str_starts_with( $source_args['key'], 'featuredMedia' ) ) {
-		if ( $source_args['key'] === 'featuredMedia.source_url' ) {
+	switch ( $source_args['key'] ) {
+		case 'date':
+			return esc_attr( get_the_date( 'c', $post_id ) );
+		case 'modified':
+			// Only return the modified date if it is later than the publishing date.
+			if ( get_the_modified_date( 'U', $post_id ) > get_the_date( 'U', $post_id ) ) {
+				return esc_attr( get_the_modified_date( 'c', $post_id ) );
+			} else {
+				return '';
+			}
+		case 'featuredMedia.source_url':
 			return get_the_post_thumbnail_url( $post_id, $source_args['size'] ?? null );
-		}
-	}
-
-	if ( 'modified' === $source_args['key'] ) {
-		// Only return the modified date if it is later than the publishing date.
-		if ( get_the_modified_date( 'U', $post_id ) > get_the_date( 'U', $post_id ) ) {
-			return esc_attr( get_the_modified_date( 'c', $post_id ) );
-		} else {
-			return '';
-		}
 	}
 }
 

--- a/lib/compat/wordpress-6.9/post-data-block-bindings.php
+++ b/lib/compat/wordpress-6.9/post-data-block-bindings.php
@@ -38,6 +38,12 @@ function gutenberg_block_bindings_post_data_get_value( array $source_args, $bloc
 		return esc_attr( get_the_date( 'c', $post_id ) );
 	}
 
+	if ( str_starts_with( $source_args['key'], 'featuredMedia' ) ) {
+		if ( $source_args['key'] === 'featuredMedia.source_url' ) {
+			return get_the_post_thumbnail_url( $post_id, $source_args['size'] ?? null );
+		}
+	}
+
 	if ( 'modified' === $source_args['key'] ) {
 		// Only return the modified date if it is later than the publishing date.
 		if ( get_the_modified_date( 'U', $post_id ) > get_the_date( 'U', $post_id ) ) {

--- a/lib/compat/wordpress-6.9/post-data-block-bindings.php
+++ b/lib/compat/wordpress-6.9/post-data-block-bindings.php
@@ -44,6 +44,8 @@ function gutenberg_block_bindings_post_data_get_value( array $source_args, $bloc
 			} else {
 				return '';
 			}
+		case 'featuredMedia.id':
+			return get_post_thumbnail_id( $post_id );
 		case 'featuredMedia.source_url':
 			return get_the_post_thumbnail_url( $post_id, $source_args['size'] ?? null );
 	}

--- a/packages/block-editor/src/utils/block-bindings.js
+++ b/packages/block-editor/src/utils/block-bindings.js
@@ -91,22 +91,25 @@ export function hasPatternOverridesDefaultBinding( bindings ) {
  * @return {Object} The bindings with default replaced for pattern overrides.
  */
 export function replacePatternOverridesDefaultBinding( blockName, bindings ) {
-	// The `__default` binding currently only works for pattern overrides.
-	if ( hasPatternOverridesDefaultBinding( bindings ) ) {
-		const supportedAttributes = BLOCK_BINDINGS_ALLOWED_BLOCKS[ blockName ];
-		const bindingsWithDefaults = {};
-		for ( const attributeName of supportedAttributes ) {
-			// If the block has mixed binding sources, retain any non pattern override bindings.
-			const bindingSource = bindings[ attributeName ]
-				? bindings[ attributeName ]
-				: { source: PATTERN_OVERRIDES_SOURCE };
-			bindingsWithDefaults[ attributeName ] = bindingSource;
-		}
+	const supportedAttributes = BLOCK_BINDINGS_ALLOWED_BLOCKS[ blockName ];
 
-		return bindingsWithDefaults;
+	if ( ! bindings ) {
+		return bindings;
 	}
 
-	return bindings;
+	const { __default: defaultBindings, ...otherBindings } = bindings;
+
+	if ( ! defaultBindings ) {
+		return bindings;
+	}
+
+	for ( const attributeName of supportedAttributes ) {
+		if ( ! otherBindings?.[ attributeName ] ) {
+			otherBindings[ attributeName ] = defaultBindings;
+		}
+	}
+
+	return otherBindings;
 }
 
 /**

--- a/packages/block-editor/src/utils/block-bindings.js
+++ b/packages/block-editor/src/utils/block-bindings.js
@@ -79,8 +79,8 @@ export function hasPatternOverridesDefaultBinding( bindings ) {
 }
 
 /**
- * Returns the bindings with the `__default` binding for pattern overrides
- * replaced with the full-set of supported attributes. e.g.:
+ * Returns bindings with the `__default` binding replaced with the
+ * full set of supported attributes. e.g.:
  *
  * - bindings passed in: `{ __default: { source: 'core/pattern-overrides' } }`
  * - bindings returned: `{ content: { source: 'core/pattern-overrides' } }`
@@ -88,7 +88,7 @@ export function hasPatternOverridesDefaultBinding( bindings ) {
  * @param {string}                  blockName The block name (e.g. 'core/paragraph').
  * @param {?Record<string, object>} bindings  A block's bindings from the metadata attribute.
  *
- * @return {Object} The bindings with default replaced for pattern overrides.
+ * @return {Object} The bindings with default replaced by full set of supported attributes.
  */
 export function replacePatternOverridesDefaultBinding( blockName, bindings ) {
 	const supportedAttributes = BLOCK_BINDINGS_ALLOWED_BLOCKS[ blockName ];


### PR DESCRIPTION
## What?
Experiment, based on some internal discussions with @cbravobernal and @gziolo.

Extend the mechanism that currently maps the `__default` block binding for pattern overrides to _any_ kind of block binding. In other words, if an image block ([whose supported attributes are `id`, `url`, `title`, and `alt`](https://github.com/WordPress/gutenberg/blob/b769889959180f57afdef169ce587b16a434fb25/packages/block-editor/src/utils/block-bindings.js#L17)) has block bindings as follows:

```json
{
	"__default":{"src":"core/post-data","args":{"key":"featuredMedia"}}
}
```

they are expanded into

```json
{
	"alt":{"src":"core/post-data","args":{"key":"featuredMedia"}},
	"id":{"src":"core/post-data","args":{"key":"featuredMedia"}},
	"title":{"src":"core/post-data","args":{"key":"featuredMedia"}},
	"url":{"src":"core/post-data","args":{"key":"featuredMedia"}}
}
```

## Why?
To explore a straightforward way and syntax of binding a block to a non-primitive source object (e.g. an image).

## How?
TBD

## Testing Instructions
TBD
