### PR TITLE
DataViews: `perPageSizes` tweaks

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+- Set minimum and maximum number of items in `pePageSizes`, so that the UI control is disabled when the list exceeds those limits. [#71004](https://github.com/WordPress/gutenberg/pull/71004)
 - Fix `filterSortAndPaginate` to handle searching fields that have a type of `array` ([#70785](https://github.com/WordPress/gutenberg/pull/70785)).
 - Fix user-input filters: empty value for text and integer filters means there's no value to search for (so it returns all items). It also fixes a type conversion where empty strings for integer were converted to 0 [#70956](https://github.com/WordPress/gutenberg/pull/70956/).
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -415,11 +415,9 @@ The component receives the following props:
 
 React component to be rendered next to the view config button.
 
-#### `perPageSizes`: `[ number, number, number, number ]`
+#### `perPageSizes`: `number[]`
 
-A list of numbers used to control the available item counts per page.
-
-It's optional. Defaults to `[10, 20, 50, 100]`.
+A list of numbers used to control the available item counts per page. It's optional. Defaults to `[10, 20, 50, 100]`. The list needs to have a minimum of 2 items and a maximum of 6, otherwise the UI component won't be displayed.
 
 ### Composition modes
 

--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -54,7 +54,7 @@ type DataViewsContextType< Item > = {
 	filters: NormalizedFilter[];
 	isShowingFilter: boolean;
 	setIsShowingFilter: ( value: boolean ) => void;
-	perPageSizes?: [ number, number, number, number ];
+	perPageSizes: number[];
 };
 
 const DataViewsContext = createContext< DataViewsContextType< any > >( {
@@ -80,6 +80,7 @@ const DataViewsContext = createContext< DataViewsContextType< any > >( {
 	filters: [],
 	isShowingFilter: false,
 	setIsShowingFilter: () => {},
+	perPageSizes: [],
 } );
 
 export default DataViewsContext;

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -215,6 +215,10 @@ function SortDirectionControl() {
 
 function ItemsPerPageControl() {
 	const { view, perPageSizes, onChangeView } = useContext( DataViewsContext );
+	if ( perPageSizes.length === 0 ) {
+		return null;
+	}
+
 	return (
 		<ToggleGroupControl
 			__nextHasNoMarginBottom

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -215,7 +215,7 @@ function SortDirectionControl() {
 
 function ItemsPerPageControl() {
 	const { view, perPageSizes, onChangeView } = useContext( DataViewsContext );
-	if ( perPageSizes.length < 2 ) {
+	if ( perPageSizes.length < 2 || perPageSizes.length > 6 ) {
 		return null;
 	}
 

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -215,7 +215,7 @@ function SortDirectionControl() {
 
 function ItemsPerPageControl() {
 	const { view, perPageSizes, onChangeView } = useContext( DataViewsContext );
-	if ( perPageSizes.length === 0 ) {
+	if ( perPageSizes.length < 2 ) {
 		return null;
 	}
 

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -213,10 +213,8 @@ function SortDirectionControl() {
 	);
 }
 
-const PAGE_SIZE_VALUES = [ 10, 20, 50, 100 ];
 function ItemsPerPageControl() {
 	const { view, perPageSizes, onChangeView } = useContext( DataViewsContext );
-	const pageSizeValues = perPageSizes ?? PAGE_SIZE_VALUES;
 	return (
 		<ToggleGroupControl
 			__nextHasNoMarginBottom
@@ -238,7 +236,7 @@ function ItemsPerPageControl() {
 				} );
 			} }
 		>
-			{ pageSizeValues.map( ( value ) => {
+			{ perPageSizes.map( ( value ) => {
 				return (
 					<ToggleGroupControlOption
 						key={ value }

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -59,7 +59,7 @@ type DataViewsProps< Item > = {
 	header?: ReactNode;
 	getItemLevel?: ( item: Item ) => number;
 	children?: ReactNode;
-	perPageSizes?: [ number, number, number, number ];
+	perPageSizes?: number[];
 } & ( Item extends ItemWithId
 	? { getItemId?: ( item: Item ) => string }
 	: { getItemId: ( item: Item ) => string } );
@@ -133,7 +133,7 @@ function DataViews< Item >( {
 	isItemClickable = defaultIsItemClickable,
 	header,
 	children,
-	perPageSizes,
+	perPageSizes = [ 10, 20, 50, 100 ],
 }: DataViewsProps< Item > ) {
 	const containerRef = useRef< HTMLDivElement | null >( null );
 	const [ containerWidth, setContainerWidth ] = useState( 0 );

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -53,7 +53,7 @@ const defaultLayouts = {
 	[ LAYOUT_LIST ]: {},
 };
 
-export const Default = () => {
+export const Default = ( { perPageSizes = [ 10, 25, 50, 100 ] } ) => {
 	const [ view, setView ] = useState< View >( {
 		...DEFAULT_VIEW,
 		fields: [ 'categories' ],
@@ -86,8 +86,20 @@ export const Default = () => {
 			) }
 			isItemClickable={ () => true }
 			defaultLayouts={ defaultLayouts }
+			perPageSizes={ perPageSizes }
 		/>
 	);
+};
+
+Default.args = {
+	perPageSizes: [ 10, 25, 50, 100 ],
+};
+
+Default.argTypes = {
+	perPageSizes: {
+		control: 'object',
+		description: 'Array of available page sizes',
+	},
 };
 
 export const Empty = () => {
@@ -297,33 +309,6 @@ export const WithCard = () => {
 				/>
 			</CardBody>
 		</Card>
-	);
-};
-
-export const CustomPerPageSizes = () => {
-	const [ view, setView ] = useState< View >( {
-		...DEFAULT_VIEW,
-		fields: [ 'categories' ],
-		titleField: 'title',
-		descriptionField: 'description',
-		mediaField: 'image',
-		perPage: 3,
-	} );
-	const { data: shownData, paginationInfo } = useMemo( () => {
-		return filterSortAndPaginate( data, view, fields );
-	}, [ view ] );
-	return (
-		<DataViews
-			getItemId={ ( item ) => item.id.toString() }
-			paginationInfo={ paginationInfo }
-			data={ shownData }
-			view={ view }
-			fields={ fields }
-			onChangeView={ setView }
-			actions={ actions.filter( ( action ) => ! action.supportsBulk ) }
-			defaultLayouts={ defaultLayouts }
-			perPageSizes={ [ 3, 6, 12, 24 ] }
-		/>
 	);
 };
 


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/70604.

## What?

- Consider the empty case: if an empty array is passed, the page size control is not rendered.
- Do not limit page sizes to 4 exact values.
- Storybook: remove the `CustomPerPageSizes` story and add an argument to the `Default` story

https://github.com/user-attachments/assets/c45da95f-1405-4264-af39-2e3c2b2df9fb

## Testing Instructions

Open the storybook and verify you can modify the sizes and the control respond to the changes. Check the empty case works.

`npm install && npm storybook:dev`
