### PR TITLE
Calendar component: Adjusts the justification for the first and last days of the week.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   `TextareaControl`: Add missing component CSS classname ([#70930](https://github.com/WordPress/gutenberg/pull/70930)).
 -   `PaletteEdit`: Fill available space with input field ([#70935](https://github.com/WordPress/gutenberg/pull/70935)).
+-   `DatePicker`: Fix day label alignment for start and end of week ([#71005](https://github.com/WordPress/gutenberg/pull/71005)).
 
 ### Enhancement
 
@@ -17,8 +18,8 @@
 
 ### Internal
 
--	`RangeControl`: Add placement prop to replace position ([#70326](https://github.com/WordPress/gutenberg/pull/70326)).
-- Expose `ValidatedNumberControl`, `ValidatedTextControl`, and `ValidatedToggleControl` via privateAPIs. ([#70901](https://github.com/WordPress/gutenberg/pull/70901)).
+-   `RangeControl`: Add placement prop to replace position ([#70326](https://github.com/WordPress/gutenberg/pull/70326)).
+-   Expose `ValidatedNumberControl`, `ValidatedTextControl`, and `ValidatedToggleControl` via privateAPIs. ([#70901](https://github.com/WordPress/gutenberg/pull/70901)).
 
 ## 30.0.0 (2025-07-23)
 
@@ -36,7 +37,6 @@
 -   `SelectControl`: Fix font-size for medium screens to ensure consistency with other inputs ([#70619](https://github.com/WordPress/gutenberg/pull/70619)).
 -   `SelectControl`: Move classnames to the root ([#70643](https://github.com/WordPress/gutenberg/pull/70643)).
 -   `Autocomplete`: Prevent text cursor position loss when clicking to insert an item ([#70660](https://github.com/WordPress/gutenberg/pull/70660)).
-
 
 ### Internal
 

--- a/packages/components/src/date-time/date/index.tsx
+++ b/packages/components/src/date-time/date/index.tsx
@@ -33,13 +33,14 @@ import type { DatePickerProps } from '../types';
 import {
 	Wrapper,
 	Navigator,
+	ViewPreviousMonthButton,
+	ViewNextMonthButton,
 	NavigatorHeading,
 	Calendar,
 	DayOfWeek,
 	DayButton,
 } from './styles';
 import { inputToDate } from '../utils';
-import Button from '../../button';
 import { TIMEZONELESS_FORMAT } from '../constants';
 
 /**
@@ -111,7 +112,7 @@ export function DatePicker( {
 			aria-label={ __( 'Calendar' ) }
 		>
 			<Navigator>
-				<Button
+				<ViewPreviousMonthButton
 					icon={ isRTL() ? arrowRight : arrowLeft }
 					variant="tertiary"
 					aria-label={ __( 'View previous month' ) }
@@ -137,7 +138,7 @@ export function DatePicker( {
 					</strong>{ ' ' }
 					{ dateI18n( 'Y', viewing, -viewing.getTimezoneOffset() ) }
 				</NavigatorHeading>
-				<Button
+				<ViewNextMonthButton
 					icon={ isRTL() ? arrowLeft : arrowRight }
 					variant="tertiary"
 					aria-label={ __( 'View next month' ) }

--- a/packages/components/src/date-time/date/styles.ts
+++ b/packages/components/src/date-time/date/styles.ts
@@ -17,12 +17,24 @@ export const Wrapper = styled.div`
 `;
 
 export const Navigator = styled( HStack )`
+	display: grid;
+	grid-template-columns: 0.5fr repeat( 5, 1fr ) 0.5fr;
+	justify-items: center;
 	margin-bottom: ${ space( 4 ) };
+`;
+
+export const ViewPreviousMonthButton = styled( Button )`
+	grid-column: 1 / 2;
+`;
+
+export const ViewNextMonthButton = styled( Button )`
+	grid-column: 7 / 8;
 `;
 
 export const NavigatorHeading = styled( Heading )`
 	font-size: ${ CONFIG.fontSize };
 	font-weight: ${ CONFIG.fontWeight };
+	grid-column: 2 / 7;
 
 	strong {
 		font-weight: ${ CONFIG.fontWeightHeading };

--- a/packages/components/src/date-time/date/styles.ts
+++ b/packages/components/src/date-time/date/styles.ts
@@ -57,18 +57,6 @@ export const DayButton = styled( Button, {
 	justify-content: center;
 
 	${ ( props ) =>
-		props.column === 1 &&
-		`
-		justify-self: start;
-		` }
-
-	${ ( props ) =>
-		props.column === 7 &&
-		`
-		justify-self: end;
-		` }
-
-	${ ( props ) =>
 		props.disabled &&
 		`
 		pointer-events: none;

--- a/packages/components/src/date-time/date/styles.ts
+++ b/packages/components/src/date-time/date/styles.ts
@@ -17,6 +17,7 @@ export const Wrapper = styled.div`
 `;
 
 export const Navigator = styled( HStack )`
+	column-gap: ${ space( 2 ) };
 	display: grid;
 	grid-template-columns: 0.5fr repeat( 5, 1fr ) 0.5fr;
 	justify-items: center;

--- a/packages/components/src/date-time/date/styles.ts
+++ b/packages/components/src/date-time/date/styles.ts
@@ -41,14 +41,6 @@ export const DayOfWeek = styled.div`
 	color: ${ COLORS.theme.gray[ 700 ] };
 	font-size: ${ CONFIG.fontSize };
 	line-height: ${ CONFIG.fontLineHeightBase };
-
-	&:nth-of-type( 1 ) {
-		justify-self: start;
-	}
-
-	&:nth-of-type( 7 ) {
-		justify-self: end;
-	}
 `;
 
 export const DayButton = styled( Button, {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Calendar component: Adjusts the justification for the first and last days of the week.
https://wordpress.github.io/gutenberg/?path=/docs/components-datetimepicker--docs

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For some reason, Mon and Sun have been misaligned from the beginning.
https://github.com/WordPress/gutenberg/pull/43005/files#diff-31d96f3ca131e0db2cb4139278f183d847e8fc58ead209af6389d8520fffae21
For some reason, Mon and Sun have been misaligned from the beginning since this component was introduced.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This misalignment is particularly noticeable when translated into single characters, such as Japanese. We'll remove this misalignment so that the days are displayed in the same position as the date.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

If you are testing in the Block Editor, opening the Publish panel will display the calendar component, making it easy to understand.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="630" height="506" alt="after-en" src="https://github.com/user-attachments/assets/5fdda5a7-1ea2-44a6-93b7-7adbc6481a0f" />|<img width="618" height="508" alt="before-en" src="https://github.com/user-attachments/assets/141314f1-4c90-47fd-b30a-d7684a614033" />|
| <img width="606" height="486" alt="ja-before" src="https://github.com/user-attachments/assets/a6c27cc1-2cc3-48f2-9d3c-9eb58a1105bc" /> |  <img width="614" height="502" alt="ja-after" src="https://github.com/user-attachments/assets/3fc0f896-2d96-4e29-be99-6357b6996502" /> |


