### PR TITLE
Allow Editing Post Template when no Posts are present

### DIFF
--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -32,6 +32,7 @@ function PostTemplateInnerBlocks( { classList } ) {
 		{ className: clsx( 'wp-block-post', classList ) },
 		{ template: TEMPLATE, __unstableDisableLayoutClassNames: true }
 	);
+
 	return <li { ...innerBlocksProps } />;
 }
 
@@ -269,9 +270,10 @@ export default function PostTemplateEdit( {
 		);
 	}
 
-	if ( ! posts.length ) {
-		return <p { ...blockProps }> { __( 'No results found.' ) }</p>;
-	}
+	// REMOVED THE PROBLEMATIC EARLY RETURN!
+	// if ( ! posts.length ) {
+	//     return <p { ...blockProps }> { __( 'No results found.' ) }</p>;
+	// }
 
 	const setDisplayLayout = ( newDisplayLayout ) =>
 		setAttributes( {
@@ -297,30 +299,48 @@ export default function PostTemplateEdit( {
 		},
 	];
 
-	// To avoid flicker when switching active block contexts, a preview is rendered
-	// for each block context, but the preview for the active block context is hidden.
-	// This ensures that when it is displayed again, the cached rendering of the
-	// block preview is used, instead of having to re-render the preview from scratch.
+	// Create fallback context when no posts exist
+	const effectiveBlockContexts =
+		blockContexts && blockContexts.length > 0
+			? blockContexts
+			: [
+					{
+						postType: postType || 'post',
+						postId: 'template-placeholder',
+						classList: '',
+					},
+			  ];
+
 	return (
 		<>
+			{ /* Show message when no posts exist */ }
+			{ posts.length === 0 && (
+				<p>
+					{ __(
+						'No posts found but you can still design your post template below.'
+					) }
+				</p>
+			) }
+
 			<BlockControls>
 				<ToolbarGroup controls={ displayLayoutControls } />
 			</BlockControls>
 
 			<ul { ...blockProps }>
-				{ blockContexts &&
-					blockContexts.map( ( blockContext ) => (
-						<BlockContextProvider
-							key={ blockContext.postId }
-							value={ blockContext }
-						>
-							{ blockContext.postId ===
-							( activeBlockContextId ||
-								blockContexts[ 0 ]?.postId ) ? (
-								<PostTemplateInnerBlocks
-									classList={ blockContext.classList }
-								/>
-							) : null }
+				{ effectiveBlockContexts.map( ( blockContext ) => (
+					<BlockContextProvider
+						key={ blockContext.postId }
+						value={ blockContext }
+					>
+						{ blockContext.postId ===
+						( activeBlockContextId ||
+							effectiveBlockContexts[ 0 ]?.postId ) ? (
+							<PostTemplateInnerBlocks
+								classList={ blockContext.classList }
+							/>
+						) : null }
+						{ /* Only show preview for real posts, not placeholder */ }
+						{ blockContext.postId !== 'template-placeholder' && (
 							<MemoizedPostTemplateBlockPreview
 								blocks={ blocks }
 								blockContextId={ blockContext.postId }
@@ -331,11 +351,12 @@ export default function PostTemplateEdit( {
 								isHidden={
 									blockContext.postId ===
 									( activeBlockContextId ||
-										blockContexts[ 0 ]?.postId )
+										effectiveBlockContexts[ 0 ]?.postId )
 								}
 							/>
-						</BlockContextProvider>
-					) ) }
+						) }
+					</BlockContextProvider>
+				) ) }
 			</ul>
 		</>
 	);

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -270,11 +270,6 @@ export default function PostTemplateEdit( {
 		);
 	}
 
-	// REMOVED THE PROBLEMATIC EARLY RETURN!
-	// if ( ! posts.length ) {
-	//     return <p { ...blockProps }> { __( 'No results found.' ) }</p>;
-	// }
-
 	const setDisplayLayout = ( newDisplayLayout ) =>
 		setAttributes( {
 			layout: { ...layout, ...newDisplayLayout },
@@ -299,7 +294,7 @@ export default function PostTemplateEdit( {
 		},
 	];
 
-	// Create fallback context when no posts exist
+	// Create fallback context when no posts exist.
 	const effectiveBlockContexts =
 		blockContexts && blockContexts.length > 0
 			? blockContexts
@@ -313,7 +308,7 @@ export default function PostTemplateEdit( {
 
 	return (
 		<>
-			{ /* Show message when no posts exist */ }
+			{ /* Show message when no posts exist. */ }
 			{ posts.length === 0 && (
 				<p>
 					{ __(
@@ -339,7 +334,7 @@ export default function PostTemplateEdit( {
 								classList={ blockContext.classList }
 							/>
 						) : null }
-						{ /* Only show preview for real posts, not placeholder */ }
+						{ /* Only show preview for real posts, not placeholder. */ }
 						{ blockContext.postId !== 'template-placeholder' && (
 							<MemoizedPostTemplateBlockPreview
 								blocks={ blocks }


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/50696

## Why?
In the block editor when no Posts are present we are unable to edit the Post Template.

## How?
If no Posts are present we are early returning the Post not found message causing the inner blocks to be not rendered.

## Testing Instructions
1. Open a new Page/Post.
2. Ensure that no Posts are published.
3. Add a query block.
4. Select blank option and choose your desired template.
5. Try adding a custom block inside the Post Template.

## Screenshots or screencast 
https://github.com/user-attachments/assets/53ac784c-cadd-4c60-90c0-03daedf9dc1d
