### PR TITLE
Embed block: Add example preview

### DIFF
--- a/packages/block-library/src/embed/index.js
+++ b/packages/block-library/src/embed/index.js
@@ -20,6 +20,7 @@ export const settings = {
 	transforms,
 	variations,
 	deprecated,
+	example: {},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );


### PR DESCRIPTION
Part of #64707

## What?
This PR adds an example attribute to the `Embed block` to provide a block preview in the inserter.

## Testing Instructions
1. Open a post or page in the WordPress block editor.
2. Open the block inserter by clicking the "+" button.
3. Search for "embed" in the block inserter.
4. Hover over the Embed block in the inserter to see the preview.

## Screenshots
|Before|After|
|-|-|
|<img width="748" height="388" alt="Screenshot 2025-08-01 at 2 24 44 PM" src="https://github.com/user-attachments/assets/31cd6cfd-b7ed-4b6a-a9a3-db53db165028" />|<img width="737" height="414" alt="Screenshot 2025-08-01 at 2 23 42 PM" src="https://github.com/user-attachments/assets/e7ccd172-d02b-48e1-8b9f-829d6189b564" />|