### PR TITLE
Query Pagination: Fix blockGap specificity override in editor styles

### DIFF
--- a/packages/block-library/src/query-pagination/editor.scss
+++ b/packages/block-library/src/query-pagination/editor.scss
@@ -3,7 +3,11 @@
 	justify-content: center;
 }
 
-:where(.editor-styles-wrapper .wp-block-query-pagination.block-editor-block-list__layout) {
-	margin: 0;
+:where(.editor-styles-wrapper) {
+	.wp-block-query-pagination {
+		max-width: 100%;
+		&:where(.block-editor-block-list__layout) {
+			margin: 0;
+		}
+	}
 }
-

--- a/packages/block-library/src/query-pagination/editor.scss
+++ b/packages/block-library/src/query-pagination/editor.scss
@@ -3,12 +3,7 @@
 	justify-content: center;
 }
 
-:where(.editor-styles-wrapper) {
-	.wp-block-query-pagination {
-		max-width: 100%;
-		&.block-editor-block-list__layout {
-			margin: 0;
-		}
-	}
+:where(.editor-styles-wrapper .wp-block-query-pagination.block-editor-block-list__layout) {
+	margin: 0;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #70859
Fixes CSS specificity issue where Query Pagination block editor styles override theme blockGap spacing settings.

<!-- In a few words, what is the PR actually doing? -->

## Why?
The Query Pagination block's editor styles use a selector with higher specificity than theme-generated blockGap container styles, causing the spacing between Query blocks and Pagination to be reset to 0 instead of respecting the theme's blockGap configuration.


## Testing Instructions
1. Open Site Editor or create a new page
2. Add a Query Loop block
3. In Query Loop settings, enable Pagination
4. Add some sample content or ensure there are enough posts to trigger pagination
5. `Before fix:` Notice minimal/no spacing between query content and pagination
6. `After fix:` Verify proper spacing appears between query content and pagination that matches your blockGap setting
7. Test with WooCommerce Product Collection block if available

## Screenshots or screencast

https://github.com/user-attachments/assets/115b1c83-b10f-40ee-9af3-1d9bd968cae3


