### PR TITLE
Add preview example for `comments-count` and `comments-link`

### DIFF
--- a/packages/block-library/src/post-comments-count/block.json
+++ b/packages/block-library/src/post-comments-count/block.json
@@ -12,6 +12,9 @@
 		}
 	},
 	"usesContext": [ "postId" ],
+	"example": {
+		"viewportWidth": 350
+	},
 	"supports": {
 		"html": false,
 		"color": {

--- a/packages/block-library/src/post-comments-link/block.json
+++ b/packages/block-library/src/post-comments-link/block.json
@@ -12,6 +12,9 @@
 			"type": "string"
 		}
 	},
+	"example": {
+		"viewportWidth": 350
+	},
 	"supports": {
 		"html": false,
 		"color": {


### PR DESCRIPTION
Part of #64707

## What?
This PR adds example attributes to the Post Comments Count and Post Comments Link blocks to provide block previews in the inserter with optimized viewport width.

## Testing Instructions
1. Open a post or page in the WordPress block editor.
2. Open the block inserter by clicking the "+" button.
3. Search for "Post Comments Count" and "Post Comments Link" blocks in the inserter.
4. Hover over these blocks in the inserter to see the previews with the new viewport width setting.

## Screenshots

|Before|After|
|-|-|
|<img width="687" height="435" alt="Screenshot 2025-08-01 at 4 26 56 PM" src="https://github.com/user-attachments/assets/a68c7644-3558-41ca-b6f9-49fce4ca5bed" /><img width="1362" height="692" alt="image" src="https://github.com/user-attachments/assets/daf58e7b-be98-4bca-b56c-a1375ffdb1a6" />|<img width="1636" height="766" alt="image" src="https://github.com/user-attachments/assets/5d8b0d3c-56ff-4005-bcfc-583ca4e7a146" /><img width="708" height="344" alt="Screenshot 2025-08-01 at 4 25 22 PM" src="https://github.com/user-attachments/assets/46ff6c0f-99aa-46db-b1c4-f9e626177391" />|


While working on this issue, I noticed a minor warning that appears briefly on reload:
`Post Comments Link block: post not found.`

This is not issue for preview example but as per my understanding it is related to the fact that this:
```
const hasPostAndComments = postId && commentsCount !== undefined;
```
takes a moment to load. As a result, the warning gets triggered by the code at the following locations:
https://github.com/WordPress/gutenberg/blob/94af11b45d80ceb0a43cc82de6efed4aa71ccfc0/packages/block-library/src/post-comments-link/edit.js#L104

https://github.com/WordPress/gutenberg/blob/94af11b45d80ceb0a43cc82de6efed4aa71ccfc0/packages/block-library/src/post-comments-count/edit.js#L75

### Screencast:

https://github.com/user-attachments/assets/420505db-377f-4a2b-a53d-01ca7e66bb40
