### PR TITLE
Improve wp-env Docker status message

### DIFF
--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -92,9 +92,44 @@ module.exports = function cli() {
 		execSync( 'docker info', { stdio: 'ignore' } );
 	} catch {
 		console.error(
-			chalk.red( 'Could not connect to Docker. Is it running?' )
+			chalk.red(
+				'Could not connect to Docker daemon. Is Docker running?'
+			)
+		);
+		console.error(
+			chalk.yellow(
+				'Please ensure Docker is installed and running on your system.'
+			)
 		);
 		process.exit( 1 );
+	}
+
+	// Check Docker Compose availability.
+	try {
+		execSync( 'docker compose version', { stdio: 'ignore' } );
+	} catch {
+		try {
+			execSync( 'docker-compose --version', { stdio: 'ignore' } );
+		} catch {
+			console.error( chalk.red( 'Docker Compose is not available.' ) );
+			console.error(
+				chalk.yellow(
+					'wp-env requires Docker Compose to manage containers.'
+				)
+			);
+			console.error( chalk.yellow( 'Please install Docker Compose:' ) );
+			console.error(
+				chalk.blue(
+					'• For Docker Desktop: Docker Compose is included by default'
+				)
+			);
+			console.error(
+				chalk.blue(
+					'• For Docker Engine: https://docs.docker.com/compose/install/clear'
+				)
+			);
+			process.exit( 1 );
+		}
 	}
 
 	yargs.usage( wpPrimary( '$0 <command>' ) );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/51218

This PR enhances the wp-env Docker status checking to provide more specific error messages


## Testing Instructions
1. Test with Docker running but Docker Compose unavailable - should show specific Docker Compose error message
2. Test with Docker daemon not running - should show Docker daemon error message
3. Test with both Docker and Docker Compose available - should work normally
