### PR TITLE
Fix: Clipboard Google Sheets table markdown links support

### DIFF
--- a/packages/blocks/src/api/raw-handling/google-docs-paste-convertor.js
+++ b/packages/blocks/src/api/raw-handling/google-docs-paste-convertor.js
@@ -1,0 +1,90 @@
+/* global DOMParser, NodeFilter */
+
+const parser = new DOMParser();
+
+/**
+ * Custom filter function to process Google Docs HTML, converting Markdown patterns
+ * into semantic HTML while preserving other formatting.
+ *
+ * @param {string} htmlString The HTML content from the clipboard.
+ * @return {string} The processed HTML string with Markdown converted.
+ */
+export default function googleDocsHtmlMarkdownProcessor( htmlString ) {
+	// Detect if it's a Google Docs paste from the HTML string.
+	const isGoogleDocsHtml = htmlString.includes(
+		'<google-sheets-html-origin>'
+	);
+	if ( ! isGoogleDocsHtml ) {
+		return htmlString;
+	}
+
+	const doc = parser.parseFromString( htmlString, 'text/html' );
+	const body = doc.body;
+
+	const allTextNodes = [];
+	const treeWalker = doc.createTreeWalker(
+		body,
+		NodeFilter.SHOW_TEXT,
+		null,
+		false
+	);
+	let currentNode;
+	while ( ( currentNode = treeWalker.nextNode() ) ) {
+		allTextNodes.push( currentNode );
+	}
+
+	allTextNodes.forEach( ( node ) => {
+		const textContent = node.nodeValue;
+		// Match Markdown links: [text](url)
+		const markdownLinkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
+
+		if ( ! markdownLinkRegex.test( textContent ) ) {
+			return;
+		}
+
+		markdownLinkRegex.lastIndex = 0;
+
+		const fragment = doc.createDocumentFragment();
+		let lastIndex = 0;
+		let match;
+		let changed = false;
+
+		while ( ( match = markdownLinkRegex.exec( textContent ) ) !== null ) {
+			const linkText = match[ 1 ];
+			const linkUrl = match[ 2 ];
+			const startIndex = match.index;
+			const endIndex = markdownLinkRegex.lastIndex;
+
+			if ( startIndex > lastIndex ) {
+				fragment.appendChild(
+					doc.createTextNode(
+						textContent.substring( lastIndex, startIndex )
+					)
+				);
+			}
+
+			const linkElement = doc.createElement( 'a' );
+			linkElement.textContent = linkText;
+			linkElement.href = linkUrl;
+			fragment.appendChild( linkElement );
+			changed = true;
+
+			lastIndex = endIndex;
+		}
+
+		if ( lastIndex < textContent.length ) {
+			fragment.appendChild(
+				doc.createTextNode( textContent.substring( lastIndex ) )
+			);
+		}
+
+		if ( changed ) {
+			const parent = node.parentNode;
+			if ( parent ) {
+				parent.replaceChild( fragment, node );
+			}
+		}
+	} );
+
+	return body.innerHTML;
+}

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -32,6 +32,7 @@ import brRemover from './br-remover';
 import { deepFilterHTML, isPlain, getBlockContentSchema } from './utils';
 import emptyParagraphRemover from './empty-paragraph-remover';
 import slackParagraphCorrector from './slack-paragraph-corrector';
+import googleDocsPasteConverter from './google-docs-paste-convertor';
 
 const log = ( ...args ) => window?.console?.log?.( ...args );
 
@@ -119,6 +120,8 @@ export function pasteHandler( {
 	if ( String.prototype.normalize ) {
 		HTML = HTML.normalize();
 	}
+
+	HTML = googleDocsPasteConverter( HTML, plainText );
 
 	// Must be run before checking if it's inline content.
 	HTML = deepFilterHTML( HTML, [ slackParagraphCorrector ] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #29833 

<!-- In a few words, what is the PR actually doing? -->
This PR ensures that Markdown links inside tables are correctly recognized when pasted from a Google Sheets Document into the Gutenberg editor.

## Why?
Markdown link formatting is currently not recognized by Gutenberg when copied from a Google Sheet Document.

## How?
This PR adjusts the clipboard input handling, it identifies and parses the content from Google Sheets paste and converts them to format which can be used by Gutenberg directly.

## Testing Instructions
1. Open a Google Sheets  and paste the text into it (without formatting to preserve GDocs formatting).
2. Create a table with the following structure:
    <img width="733" height="152" alt="image" src="https://github.com/user-attachments/assets/fabcbc3b-37ca-45a7-a26c-489ae8b2afb4" />

3. Copy the table and paste it in the Editor


## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/ce77e398-326c-473c-be44-40e3a67c64c4

### After

https://github.com/user-attachments/assets/a185876e-f33d-493d-9fc8-de58578c84cb




