### PR TITLE
Add roles to root entity

### DIFF
--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -89,6 +89,7 @@ function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 				'page_for_posts',
 				'page_on_front',
 				'show_on_front',
+				'roles',
 			)
 		);
 	}

--- a/lib/compat/wordpress-6.8/rest-api.php
+++ b/lib/compat/wordpress-6.8/rest-api.php
@@ -178,3 +178,30 @@ function gutenberg_register_rest_theme_fields() {
 	);
 }
 add_action( 'rest_api_init', 'gutenberg_register_rest_theme_fields' );
+
+/**
+ * Adds the site roles to the REST API index.
+ *
+ * @param WP_REST_Response $response REST API response.
+ * @return WP_REST_Response Modified REST API response.
+ */
+function gutenberg_add_rest_index_roles( WP_REST_Response $response ) {
+	if ( ! current_user_can( 'list_users' ) ) {
+		return $response;
+	}
+	
+	$wp_roles = wp_roles();
+	$roles_array = array();
+	
+	foreach ( $wp_roles->get_names() as $role_id => $role_name ) {
+		$roles_array[] = array(
+			'id'   => $role_id,
+			'name' => $role_name,
+		);
+	}
+
+	$response->data['roles'] = $roles_array;
+
+	return $response;
+}
+add_filter( 'rest_index', 'gutenberg_add_rest_index_roles' );

--- a/lib/compat/wordpress-6.8/rest-api.php
+++ b/lib/compat/wordpress-6.8/rest-api.php
@@ -189,10 +189,10 @@ function gutenberg_add_rest_index_roles( WP_REST_Response $response ) {
 	if ( ! current_user_can( 'list_users' ) ) {
 		return $response;
 	}
-	
-	$wp_roles = wp_roles();
+
+	$wp_roles    = wp_roles();
 	$roles_array = array();
-	
+
 	foreach ( $wp_roles->get_names() as $role_id => $role_name ) {
 		$roles_array[] = array(
 			'id'   => $role_id,

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -35,6 +35,7 @@ export const rootEntitiesConfig = [
 				'page_for_posts',
 				'page_on_front',
 				'show_on_front',
+				'roles',
 			].join( ',' ),
 		},
 		// The entity doesn't support selecting multiple records.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->
The PR adds the available roles to the response of the root entity for users with list_users permission.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Roles can be added dynamically by plugins, and there is no reliable way to fetch the available roles on the frontend.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Use `rest_index` to add the roles array in the format { id, name }

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Checkout this PR
- Run `npm run dev`
- Navigate to http://localhost:8888/wp-admin/post-new.php?gutenberg-demo
- Run `wp.data.select(wp.coreData.store).getEntityRecord( 'root', '__unstableBase' )` in the console
- The result should contain the available roles

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="928" height="312" alt="Screenshot 2025-08-01 at 16 18 42" src="https://github.com/user-attachments/assets/851e7686-717f-4ac7-8110-37d1a12b0252" /> | <img width="879" height="433" alt="Screenshot 2025-08-01 at 16 17 16" src="https://github.com/user-attachments/assets/6b61eb27-e21f-418c-bf90-b23b8ae5cf53" /> |
