### PR TITLE
DataViews: do not render an empty level span if level is 0

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+- Do not render an empty `&nbsp;` when the title field has level 0. [#71021](https://github.com/WordPress/gutenberg/pull/71021)
 - Set minimum and maximum number of items in `pePageSizes`, so that the UI control is disabled when the list exceeds those limits. [#71004](https://github.com/WordPress/gutenberg/pull/71004)
 - Fix `filterSortAndPaginate` to handle searching fields that have a type of `array` ([#70785](https://github.com/WordPress/gutenberg/pull/70785)).
 - Fix user-input filters: empty value for text and integer filters means there's no value to search for (so it returns all items). It also fixes a type conversion where empty strings for integer were converted to 0 [#70956](https://github.com/WordPress/gutenberg/pull/70956/).

--- a/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
@@ -76,7 +76,7 @@ function ColumnPrimary< Item >( {
 						renderItemLink={ renderItemLink }
 						className="dataviews-view-table__cell-content-wrapper dataviews-title-field"
 					>
-						{ level !== undefined && (
+						{ level !== undefined && level > 0 && (
 							<span className="dataviews-view-table__level">
 								{ '—'.repeat( level ) }&nbsp;
 							</span>


### PR DESCRIPTION
## What?

Removes an unnecessary `span` in the title field when level is 0.

## How?

Check that level is greater than 0 to add the span.

## Testing Instructions

- Go to the Site Editor's pages page.
- Open the table view.
- Inspect the title field and verify there's no span element with class `dataviews-view-table__level` if the item doesn't have parents.
