### PR TITLE
DO NOT MERGE: testcase should fail

### DIFF
--- a/packages/dataviews/src/utils.ts
+++ b/packages/dataviews/src/utils.ts
@@ -13,3 +13,5 @@ export function renderFromElements< Item >( {
 			?.label || field.getValue( { item } )
 	);
 }
+
+// Modification to test the changelog entry.


### PR DESCRIPTION
**NOT TO MERGE**

Test case for https://github.com/WordPress/gutenberg/pull/71023

The expected result is that the `check-dataviews-changelog` workflow fails.