### PR TITLE
DO NOT MERGE: testcase should pass

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+Modify the changelog entry.
+
 ### Breaking changes
 
 - Field API: `isValid` is now an object that contains `required` and `custom` validation rules. Additionally, fields should now opt-in into being a "required" field by setting `isValid.required` to `true` (all fields of type `email` and `integer` were required by default). [#70901](https://github.com/WordPress/gutenberg/pull/70901)

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-Modify the changelog entry.
+Modify the changelog entry. [#71025](https://github.com/WordPress/gutenberg/pull/71025)
 
 ### Breaking changes
 

--- a/packages/dataviews/src/utils.ts
+++ b/packages/dataviews/src/utils.ts
@@ -13,3 +13,5 @@ export function renderFromElements< Item >( {
 			?.label || field.getValue( { item } )
 	);
 }
+
+// Modification to test the changelog entry.


### PR DESCRIPTION
**NOT TO MERGE**

Test case for https://github.com/WordPress/gutenberg/pull/71023

The expected result is that the `check-dataviews-changelog` workflow passes.