### PR TITLE
Image Block: Prepend HTTP to links when missing protocol

### DIFF
--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -21,6 +21,7 @@ import {
 	fullscreen,
 	linkOff,
 } from '@wordpress/icons';
+import { prependHTTP } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -149,7 +150,7 @@ const ImageURLInputUI = ( {
 					)?.linkDestination || LINK_DESTINATION_CUSTOM;
 
 				onChangeUrl( {
-					href: urlInput,
+					href: prependHTTP( urlInput ),
 					linkDestination: selectedDestination,
 					lightbox: { enabled: false },
 				} );

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -697,6 +697,43 @@ test.describe( 'Image', () => {
 		await expect( linkDom ).toHaveAttribute( 'href', url );
 	} );
 
+	test( 'appends http protocol to links added which are missing a protocol', async ( {
+		editor,
+		page,
+		imageBlockUtils,
+	} ) => {
+		await editor.insertBlock( { name: 'core/image' } );
+		const imageBlock = editor.canvas.locator(
+			'role=document[name="Block: Image"i]'
+		);
+		await expect( imageBlock ).toBeVisible();
+
+		await imageBlockUtils.upload(
+			imageBlock.locator( 'data-testid=form-file-upload-input' )
+		);
+
+		await page.getByLabel( 'Block tools' ).getByLabel( 'Link' ).click();
+
+		// This form lacks distinguishing qualities other than the
+		// class name, so we use page.locator() instead of page.getByRole()
+		const form = page.locator( '.block-editor-url-popover__link-editor' );
+
+		const url = 'example.com';
+
+		await expect( form.getByLabel( 'URL' ) ).toBeFocused();
+		await form.getByLabel( 'URL' ).fill( url );
+		await form.getByRole( 'button', { name: 'Apply' } ).click();
+
+		// Move to "Edit" and switch UI back to edit mode
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Enter' );
+
+		// Check the value of the URL input has had http:// prepended.
+		await expect( form.getByLabel( 'URL' ) ).toHaveValue(
+			'http://example.com'
+		);
+	} );
+
 	test( 'should upload external image to media library', async ( {
 		editor,
 	} ) => {

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -712,26 +712,22 @@ test.describe( 'Image', () => {
 			imageBlock.locator( 'data-testid=form-file-upload-input' )
 		);
 
-		await page.getByLabel( 'Block tools' ).getByLabel( 'Link' ).click();
+		await editor.clickBlockToolbarButton( 'Link' );
 
-		// This form lacks distinguishing qualities other than the
-		// class name, so we use page.locator() instead of page.getByRole()
-		const form = page.locator( '.block-editor-url-popover__link-editor' );
+		const urlPopover = page.locator(
+			'.block-editor-url-popover__link-editor'
+		);
+		const urlInput = urlPopover.getByRole( 'combobox', { name: 'URL' } );
 
-		const url = 'example.com';
-
-		await expect( form.getByLabel( 'URL' ) ).toBeFocused();
-		await form.getByLabel( 'URL' ).fill( url );
-		await form.getByRole( 'button', { name: 'Apply' } ).click();
+		await urlInput.fill( 'example.com' );
+		await urlPopover.getByRole( 'button', { name: 'Apply' } ).click();
 
 		// Move to "Edit" and switch UI back to edit mode
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Enter' );
 
 		// Check the value of the URL input has had http:// prepended.
-		await expect( form.getByLabel( 'URL' ) ).toHaveValue(
-			'http://example.com'
-		);
+		await expect( urlInput ).toHaveValue( 'http://example.com' );
 	} );
 
 	test( 'should upload external image to media library', async ( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #35910

<!-- In a few words, what is the PR actually doing? -->

Prepending `http://` to a link without protocol ( for eg. 'www.example.com' ) added to the image block for correct linking.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When a valid link without protocol ( for eg. 'www.example.com' ) is added to an image in Gutenberg, the WordPress site's base URL is incorrectly appended to the link, resulting in a 404 error. This behavior is inconsistent with links added in paragraph blocks, which link correctly.

Similar to https://github.com/WordPress/gutenberg/pull/47311 which uses this methodology for the button block

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Modifies `image-url-input-ui.js` using `prependHttp()` from `@wordpress/url`.

Additionally, a new test case has been added to `image.spec.js`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

- Create a Page
- Add an Image Block
- Add a link without `http://` or `https://` using the block toolbar
- Publish the Page
- Click the Image on the published Page
