### PR TITLE
env: Add support for dynamic URLs and allow setting `WP_HOME` and `WP_SITEURL` via env variables

### DIFF
--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -240,8 +240,10 @@ module.exports = async function start( {
 		await executeLifecycleScript( 'afterStart', config, spinner );
 	}
 
-	const siteUrl = config.env.development.config.WP_SITEURL;
-	const testsSiteUrl = config.env.tests.config.WP_SITEURL;
+	const siteUrl =
+		process.env.WP_ENV_SITEURL || config.env.development.config.WP_SITEURL;
+	const testsSiteUrl =
+		process.env.WP_ENV_TESTS_SITEURL || config.env.tests.config.WP_SITEURL;
 
 	const mySQLPort = await getPublicDockerPort(
 		'mysql',

--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -96,8 +96,29 @@ async function configureWordPress( environment, config, spinner ) {
 
 	const isMultisite = config.env[ environment ].multisite;
 
+	const isDynamicUrlsEnabled =
+		process.env.WP_ENV_DYNAMIC_URLS_ENABLED !== 'false';
+
+	const hasCustomEnvUrls = !! (
+		process.env.WP_ENV_HOME ||
+		process.env.WP_ENV_SITEURL ||
+		process.env.WP_ENV_TESTS_HOME ||
+		process.env.WP_ENV_TESTS_SITEURL
+	);
+
+	let siteUrl;
+	if ( environment === 'development' ) {
+		siteUrl =
+			process.env.WP_ENV_SITEURL ||
+			config.env[ environment ].config.WP_SITEURL;
+	} else {
+		siteUrl =
+			process.env.WP_ENV_TESTS_SITEURL ||
+			config.env[ environment ].config.WP_SITEURL;
+	}
+
 	const installMethod = isMultisite ? 'multisite-install' : 'install';
-	const installCommand = `wp core ${ installMethod } --url="${ config.env[ environment ].config.WP_SITEURL }" --title="${ config.name }" --admin_user=admin --admin_password=password --admin_email=wordpress@example.com --skip-email`;
+	const installCommand = `wp core ${ installMethod } --url="${ siteUrl }" --title="${ config.name }" --admin_user=admin --admin_password=password --admin_email=wordpress@example.com --skip-email`;
 
 	// -eo pipefail exits the command as soon as anything fails in bash.
 	const setupCommands = [
@@ -147,6 +168,36 @@ echo 'RewriteRule . index.php [L]'
 			continue;
 		}
 
+		// Skip setting WP_HOME and WP_SITEURL when dynamic urls is enabled and custom urls are not set.
+		if (
+			isDynamicUrlsEnabled &&
+			! hasCustomEnvUrls &&
+			key === 'WP_HOME' &&
+			key === 'WP_SITEURL'
+		) {
+			continue;
+		}
+
+		if ( key === 'WP_HOME' ) {
+			const envVar =
+				environment === 'development'
+					? 'WP_ENV_HOME'
+					: 'WP_ENV_TESTS_HOME';
+			if ( process.env[ envVar ] ) {
+				value = process.env[ envVar ];
+			}
+		}
+
+		if ( key === 'WP_SITEURL' ) {
+			const envVar =
+				environment === 'development'
+					? 'WP_ENV_SITEURL'
+					: 'WP_ENV_TESTS_SITEURL';
+			if ( process.env[ envVar ] ) {
+				value = process.env[ envVar ];
+			}
+		}
+
 		// Add quotes around string values to work with multi-word strings better.
 		value = typeof value === 'string' ? `"${ value }"` : value;
 		setupCommands.push(
@@ -179,6 +230,40 @@ echo 'RewriteRule . index.php [L]'
 			log: config.debug,
 		}
 	);
+
+	if ( isDynamicUrlsEnabled && ! hasCustomEnvUrls ) {
+		await dockerCompose.exec(
+			environment === 'development' ? 'wordpress' : 'tests-wordpress',
+			[
+				'sh',
+				'-c',
+				`grep -q "define('DOCKER_REQUEST_URL'" /var/www/html/wp-config.php || sed -i "/\\/\\/ a helper function to lookup \\"env_FILE\\", \\"env\\", then fallback/i \\
+if (isset(\\$_SERVER['HTTP_X_FORWARDED_PROTO']) \\&\\& \\$_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {\\n\\
+\\t\\$_SERVER['HTTPS'] = 'on';\\n\\
+\\tdefine('DOCKER_REQUEST_URL', 'https://' . (!empty(\\$_SERVER['HTTP_HOST']) ? \\$_SERVER['HTTP_HOST'] : 'localhost'));\\n\\
+\\tdefine('WP_HOME', DOCKER_REQUEST_URL);\\n\\
+\\tdefine('WP_SITEURL', DOCKER_REQUEST_URL);\\n\\
+}\\n" /var/www/html/wp-config.php`,
+			],
+			{
+				config: config.dockerComposeConfigPath,
+				log: config.debug,
+			}
+		);
+	} else {
+		await dockerCompose.exec(
+			environment === 'development' ? 'wordpress' : 'tests-wordpress',
+			[
+				'sh',
+				'-c',
+				`sed -i '/if (isset(\\$_SERVER\\['HTTP_X_FORWARDED_PROTO'\\]) \\&\\& \\$_SERVER\\['HTTP_X_FORWARDED_PROTO'\\'] === '\\''https'\\'') {/,/define('WP_SITEURL', DOCKER_REQUEST_URL);/d' /var/www/html/wp-config.php`,
+			],
+			{
+				config: config.dockerComposeConfigPath,
+				log: config.debug,
+			}
+		);
+	}
 
 	// WordPress versions below 5.1 didn't use proper spacing in wp-config.
 	// Additionally, WordPress versions below 5.4 used `dirname( __FILE__ )` instead of `__DIR__`.
@@ -313,7 +398,7 @@ async function copyCoreFiles( fromPath, toPath ) {
  * @param {WPSource} coreSource The WordPress source.
  * @param {Object}   spinner    A CLI spinner which indicates progress.
  * @param {boolean}  debug      Indicates whether or not the CLI is in debug mode.
- * @return {string} The version of WordPress the source is for.
+ * @return {Promise<string>} The version of WordPress the source is for.
  */
 async function readWordPressVersion( coreSource, spinner, debug ) {
 	const versionFilePath = path.join(

--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -100,9 +100,9 @@ async function configureWordPress( environment, config, spinner ) {
 		process.env.WP_ENV_DYNAMIC_URLS_ENABLED !== 'false';
 
 	const hasCustomEnvUrls = !! (
-		process.env.WP_ENV_HOME ||
+		process.env.WP_ENV_HOMEURL ||
 		process.env.WP_ENV_SITEURL ||
-		process.env.WP_ENV_TESTS_HOME ||
+		process.env.WP_ENV_TESTS_HOMEURL ||
 		process.env.WP_ENV_TESTS_SITEURL
 	);
 
@@ -172,8 +172,7 @@ echo 'RewriteRule . index.php [L]'
 		if (
 			isDynamicUrlsEnabled &&
 			! hasCustomEnvUrls &&
-			key === 'WP_HOME' &&
-			key === 'WP_SITEURL'
+			( key === 'WP_HOME' || key === 'WP_SITEURL' )
 		) {
 			continue;
 		}
@@ -181,8 +180,8 @@ echo 'RewriteRule . index.php [L]'
 		if ( key === 'WP_HOME' ) {
 			const envVar =
 				environment === 'development'
-					? 'WP_ENV_HOME'
-					: 'WP_ENV_TESTS_HOME';
+					? 'WP_ENV_HOMEURL'
+					: 'WP_ENV_TESTS_HOMEURL';
 			if ( process.env[ envVar ] ) {
 				value = process.env[ envVar ];
 			}
@@ -195,6 +194,18 @@ echo 'RewriteRule . index.php [L]'
 					: 'WP_ENV_TESTS_SITEURL';
 			if ( process.env[ envVar ] ) {
 				value = process.env[ envVar ];
+			}
+		}
+
+		if ( key === 'WP_TESTS_DOMAIN' ) {
+			const envVar =
+				environment === 'development'
+					? 'WP_ENV_SITEURL'
+					: 'WP_ENV_TESTS_SITEURL';
+			if ( process.env[ envVar ] ) {
+				value = process.env[ envVar ]
+					.replace( 'https://', '' )
+					.replace( 'http://', '' );
 			}
 		}
 

--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -238,7 +238,7 @@ echo 'RewriteRule . index.php [L]'
 				'sh',
 				'-c',
 				`grep -q "define('DOCKER_REQUEST_URL'" /var/www/html/wp-config.php || sed -i "/\\/\\/ a helper function to lookup \\"env_FILE\\", \\"env\\", then fallback/i \\
-if (isset(\\$_SERVER['HTTP_X_FORWARDED_PROTO']) \\&\\& \\$_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {\\n\\
+if (isset(\\$_SERVER['HTTP_X_FORWARDED_PROTO']) \\&\\& strpos(\\$_SERVER['HTTP_X_FORWARDED_PROTO'], 'https') !== false) {\\n\\
 \\t\\$_SERVER['HTTPS'] = 'on';\\n\\
 \\tdefine('DOCKER_REQUEST_URL', 'https://' . (!empty(\\$_SERVER['HTTP_HOST']) ? \\$_SERVER['HTTP_HOST'] : 'localhost'));\\n\\
 \\tdefine('WP_HOME', DOCKER_REQUEST_URL);\\n\\
@@ -256,7 +256,7 @@ if (isset(\\$_SERVER['HTTP_X_FORWARDED_PROTO']) \\&\\& \\$_SERVER['HTTP_X_FORWAR
 			[
 				'sh',
 				'-c',
-				`sed -i '/if (isset(\\$_SERVER\\['HTTP_X_FORWARDED_PROTO'\\]) \\&\\& \\$_SERVER\\['HTTP_X_FORWARDED_PROTO'\\'] === '\\''https'\\'') {/,/define('WP_SITEURL', DOCKER_REQUEST_URL);/d' /var/www/html/wp-config.php`,
+				`sed -i '/if (isset(\\$_SERVER\\['HTTP_X_FORWARDED_PROTO'\\]) \\&\\& strpos(\\$_SERVER\\['HTTP_X_FORWARDED_PROTO'\\], '\\''https'\\'') !== false) {/,/define('WP_SITEURL', DOCKER_REQUEST_URL);/d' /var/www/html/wp-config.php`,
 			],
 			{
 				config: config.dockerComposeConfigPath,

--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -237,13 +237,15 @@ echo 'RewriteRule . index.php [L]'
 			[
 				'sh',
 				'-c',
-				`grep -q "define('DOCKER_REQUEST_URL'" /var/www/html/wp-config.php || sed -i "/\\/\\/ a helper function to lookup \\"env_FILE\\", \\"env\\", then fallback/i \\
-if (isset(\\$_SERVER['HTTP_X_FORWARDED_PROTO']) \\&\\& strpos(\\$_SERVER['HTTP_X_FORWARDED_PROTO'], 'https') !== false) {\\n\\
-\\t\\$_SERVER['HTTPS'] = 'on';\\n\\
-\\tdefine('DOCKER_REQUEST_URL', 'https://' . (!empty(\\$_SERVER['HTTP_HOST']) ? \\$_SERVER['HTTP_HOST'] : 'localhost'));\\n\\
-\\tdefine('WP_HOME', DOCKER_REQUEST_URL);\\n\\
-\\tdefine('WP_SITEURL', DOCKER_REQUEST_URL);\\n\\
-}\\n" /var/www/html/wp-config.php`,
+				`grep -q "// BEGIN DYNAMIC_URLS" /var/www/html/wp-config.php || sed -i "/\\/\\/ a helper function to lookup \\"env_FILE\\", \\"env\\", then fallback/i \\
+\\/\\/ BEGIN DYNAMIC_URLS\\n\
+if (isset(\\$_SERVER['HTTP_X_FORWARDED_PROTO']) \\&\\& strpos(\\$_SERVER['HTTP_X_FORWARDED_PROTO'], 'https') !== false) {\\n\
+\\t\\$_SERVER['HTTPS'] = 'on';\\n\
+\\tdefine('DOCKER_REQUEST_URL', 'https://' . (!empty(\\$_SERVER['HTTP_HOST']) ? \\$_SERVER['HTTP_HOST'] : 'localhost'));\\n\
+\\tdefine('WP_HOME', DOCKER_REQUEST_URL);\\n\
+\\tdefine('WP_SITEURL', DOCKER_REQUEST_URL);\\n\
+}\\n\
+\\/\\/ END DYNAMIC_URLS" /var/www/html/wp-config.php`,
 			],
 			{
 				config: config.dockerComposeConfigPath,
@@ -256,7 +258,7 @@ if (isset(\\$_SERVER['HTTP_X_FORWARDED_PROTO']) \\&\\& strpos(\\$_SERVER['HTTP_X
 			[
 				'sh',
 				'-c',
-				`sed -i '/if (isset(\\$_SERVER\\['HTTP_X_FORWARDED_PROTO'\\]) \\&\\& strpos(\\$_SERVER\\['HTTP_X_FORWARDED_PROTO'\\], '\\''https'\\'') !== false) {/,/define('WP_SITEURL', DOCKER_REQUEST_URL);/d' /var/www/html/wp-config.php`,
+				`sed -i '/\\/\\/ BEGIN DYNAMIC_URLS/,/\\/\\/ END DYNAMIC_URLS/d' /var/www/html/wp-config.php`,
 			],
 			{
 				config: config.dockerComposeConfigPath,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #23947, #65008

<!-- In a few words, what is the PR actually doing? -->
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently the wp-env site is set to localhost address, so trying to map the site to the likes of an ngrok external domain just results in a redirect back to localhost.(#23947)

This PR adds support for that by dynamically defining the `WP_HOME` and `WP_SITEURL` via the snippet sent by @glendaviesnz.

Alongside this PR also adds support for setting `WP_HOME` and `WP_SITEURL` via env variables to allow for cases where the url is generated dynamically like gitpod.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR solves this by adding `WP_ENV_DYNAMIC_URLS_ENABLED` env var ( default to true ) which enables dynamically defining WP_HOME and WP_SITEURL constants.
This PR also adds `WP_ENV_HOMEURL` , `WP_ENV_SITEURL` for development environment and `WP_ENV_TESTS_HOMEURL` , `WP_ENV_TESTS_SITEURL` for tests environment.

to disable dynamically defining , pass `WP_ENV_DYNAMIC_URLS_ENABLED=false` when running wp-env start.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->_
<!-- 3. etc. -->
1. run `npm run wp-env start -- --update`
2. run a tunnel ( npx localtunnel -p 8888 )
3. open the tunnel domain
4. see the site working as normal.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
### npm run wp-env start -- --update
<img width="637" height="189" alt="image" src="https://github.com/user-attachments/assets/b17e8ab7-4e1f-4181-81d6-52788fc20bae" />

<img width="1466" height="876" alt="image" src="https://github.com/user-attachments/assets/3a8d03bd-506b-4c62-b64e-7e7950dfdd6b" />

### WP_ENV_DYNAMIC_URLS_ENABLED=false npm run wp-env start -- --update

<img width="1225" height="570" alt="image" src="https://github.com/user-attachments/assets/cf718671-e321-44be-9405-b76f4bb56757" />

### WP_ENV_SITEURL & WP_ENV_HOMEURL support
<img width="884" height="385" alt="image" src="https://github.com/user-attachments/assets/454df0d1-d167-495b-8b67-f6b7417dd6c0" />

> `cmd: WP_ENV_HOMEURL="https://tricky-boats-post.loca.lt" WP_ENV_SITEURL="https://tricky-boats-post.loca.lt" npm run wp-env start -- --debug --update`

> Note: --update is required because it needs to write to wp-config.php.