### PR TITLE
Added Missing Global Documentation

### DIFF
--- a/lib/experimental/block-comments.php
+++ b/lib/experimental/block-comments.php
@@ -45,6 +45,8 @@ if ( ! function_exists( 'update_get_avatar_comment_type' ) ) {
  * This function modifies the comments query to exclude comments of type 'block_comment'
  * when the query is for comments in the WordPress admin.
  *
+ * @global wpdb $wpdb WordPress database abstraction object.
+ *
  * @param WP_Comment_Query $query The current comments query.
  *
  * @return void


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? Why?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
- `@global` documentation is missing in  `lib/experimental/block-comments.php` file

## How?
- Added Missing `@global` documentation in `lib/experimental/block-comments.php` file

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open `lib/experimental/block-comments.php` file
2. See Global documentation in this file

