### PR TITLE
File Block: Use mime type to determine if file is PDF

### DIFF
--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -128,9 +128,10 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 			return;
 		}
 
-		const isPdf = getFilename( newMedia.url )
-			.toLowerCase()
-			.endsWith( '.pdf' );
+		const isPdf =
+			// Media Library and REST API use different properties for mime type.
+			( newMedia.mime || newMedia.mime_type ) === 'application/pdf' ||
+			getFilename( newMedia.url ).toLowerCase().endsWith( '.pdf' );
 		const pdfAttributes = {
 			displayPreview: isPdf
 				? attributes.displayPreview ?? true


### PR DESCRIPTION
## What?
Related #70915.

PR updates the File block to use the mime type to determine if the file is PDF and the filename in the URL as a fallback.

## Why?
The mime type should be a better source of the truth.

## Testing Instructions
1. Comment out the fallback condition.
2. Open a post.
3. Add the file block.
4. Upload a PDF file.
5. Confirm that the preview is displayed.
6. Replace the PDF file via Media Library.
7. Confirm that the preview is displayed.

### Testing Instructions for Keyboard
Same.
