### PR TITLE
File Block: Follow HTML API best practices

### DIFF
--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -28,12 +28,8 @@ function render_block_core_file( $attributes, $content ) {
 		$processor->set_attribute( 'data-wp-interactive', 'core/file' );
 	}
 
-	while ( 'OBJECT' !== $processor->get_tag() && $processor->next_tag( 'object' ) ) {
-		continue;
-	}
-
-	// If this occurs, there is likely no block content or a plugin has modified the block.
-	if ( 'OBJECT' !== $processor->get_tag() ) {
+	// If there are no OBJECT elements, something might have already modified the block.
+	if ( ! $processor->next_tag( 'OBJECT' ) ) {
 		return $content;
 	}
 
@@ -41,7 +37,7 @@ function render_block_core_file( $attributes, $content ) {
 	$processor->set_attribute( 'hidden', true );
 
 	$filename     = $processor->get_attribute( 'aria-label' );
-	$has_filename = ! empty( $filename ) && 'PDF embed' !== $filename;
+	$has_filename = is_string( $filename ) && ! empty( $filename ) && 'PDF embed' !== $filename;
 	$label        = $has_filename ? sprintf(
 		/* translators: %s: filename. */
 		__( 'Embed of %s.' ),

--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -16,33 +16,43 @@
  * @return string Returns the block content.
  */
 function render_block_core_file( $attributes, $content ) {
-	// If it's interactive, enqueue the script module and add the directives.
-	if ( ! empty( $attributes['displayPreview'] ) ) {
-		wp_enqueue_script_module( '@wordpress/block-library/file/view' );
-
-		$processor = new WP_HTML_Tag_Processor( $content );
-		$processor->next_tag();
-		$processor->set_attribute( 'data-wp-interactive', 'core/file' );
-		$processor->next_tag( 'object' );
-		$processor->set_attribute( 'data-wp-bind--hidden', '!state.hasPdfPreview' );
-		$processor->set_attribute( 'hidden', true );
-
-		$filename     = $processor->get_attribute( 'aria-label' );
-		$has_filename = ! empty( $filename ) && 'PDF embed' !== $filename;
-		$label        = $has_filename ? sprintf(
-			/* translators: %s: filename. */
-			__( 'Embed of %s.' ),
-			$filename
-		) : __( 'PDF embed' );
-
-		// Update object's aria-label attribute if present in block HTML.
-		// Match an aria-label attribute from an object tag.
-		$processor->set_attribute( 'aria-label', $label );
-
-		return $processor->get_updated_html();
+	if ( empty( $attributes['displayPreview'] ) ) {
+		return $content;
 	}
 
-	return $content;
+	// If it's interactive, enqueue the script module and add the directives.
+	wp_enqueue_script_module( '@wordpress/block-library/file/view' );
+
+	$processor = new WP_HTML_Tag_Processor( $content );
+	if ( $processor->next_tag() ) {
+		$processor->set_attribute( 'data-wp-interactive', 'core/file' );
+	}
+
+	while ( 'OBJECT' !== $processor->get_tag() && $processor->next_tag( 'object' ) ) {
+		continue;
+	}
+
+	// If this occurs, there is likely no block content or a plugin has modified the block.
+	if ( 'OBJECT' !== $processor->get_tag() ) {
+		return $content;
+	}
+
+	$processor->set_attribute( 'data-wp-bind--hidden', '!state.hasPdfPreview' );
+	$processor->set_attribute( 'hidden', true );
+
+	$filename     = $processor->get_attribute( 'aria-label' );
+	$has_filename = ! empty( $filename ) && 'PDF embed' !== $filename;
+	$label        = $has_filename ? sprintf(
+		/* translators: %s: filename. */
+		__( 'Embed of %s.' ),
+		$filename
+	) : __( 'PDF embed' );
+
+	// Update object's aria-label attribute if present in block HTML.
+	// Match an aria-label attribute from an object tag.
+	$processor->set_attribute( 'aria-label', $label );
+
+	return $processor->get_updated_html();
 }
 
 /**


### PR DESCRIPTION
## What?
This is a follow-up https://github.com/WordPress/gutenberg/pull/60494#discussion_r1556338570.

PR updates `render_block_core_file` render callback to follow HTML API best practices.

## Why?
See: https://github.com/WordPress/gutenberg/pull/60494#discussion_r1556338570

## Testing Instructions
1. Create a post.
2. Add a file block and upload a PDF file.
3. Save the post and preview it.
4. Confirm that the inline preview is rendered correctly.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="1280" height="969" alt="CleanShot 2025-08-03 at 13 47 28" src="https://github.com/user-attachments/assets/df45a924-20d4-4f59-a7dd-d6d04ee99c03" />

