### PR TITLE
Core data: Deprecate the root/media entity

### DIFF
--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -298,11 +298,15 @@ _Usage_
 const getFeaturedMediaUrl = useSelect( ( select ) => {
 	const getFeaturedMediaId =
 		select( 'core/editor' ).getEditedPostAttribute( 'featured_media' );
-	const getMedia = select( 'core' ).getMedia( getFeaturedMediaId );
+	const media = select( 'core' ).getEntityRecord(
+		'postType',
+		'attachment',
+		getFeaturedMediaId
+	);
 
 	return (
-		getMedia?.media_details?.sizes?.large?.source_url ||
-		getMedia?.source_url ||
+		media?.media_details?.sizes?.large?.source_url ||
+		media?.source_url ||
 		''
 	);
 }, [] );
@@ -1226,22 +1230,6 @@ _Usage_
 ```js
 // Update the post title
 wp.data.dispatch( 'core/editor' ).editPost( { title: `${ newTitle }` } );
-```
-
-```js
-// Get specific media size based on the featured media ID
-// Note: change sizes?.large for any registered size
-const getFeaturedMediaUrl = useSelect( ( select ) => {
-	const getFeaturedMediaId =
-		select( 'core/editor' ).getEditedPostAttribute( 'featured_media' );
-	const getMedia = select( 'core' ).getMedia( getFeaturedMediaId );
-
-	return (
-		getMedia?.media_details?.sizes?.large?.source_url ||
-		getMedia?.source_url ||
-		''
-	);
-}, [] );
 ```
 
 _Parameters_

--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -117,7 +117,7 @@ _Parameters_
 
 -   _state_ `State`: Data state.
 -   _action_ `string`: Action to check. One of: 'create', 'read', 'update', 'delete'.
--   _resource_ `string | EntityResource`: Entity resource to check. Accepts entity object `{ kind: 'root', name: 'media', id: 1 }` or REST base as a string - `media`.
+-   _resource_ `string | EntityResource`: Entity resource to check. Accepts entity object `{ kind: 'postType', name: 'attachment', id: 1 }` or REST base as a string - `media`.
 -   _id_ `EntityRecordKey`: Optional ID of the rest resource to check.
 
 _Returns_

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -120,9 +120,14 @@ function CoverEdit( {
 			return {
 				media:
 					featuredImage && useFeaturedImage
-						? select( coreStore ).getMedia( featuredImage, {
-								context: 'view',
-						  } )
+						? select( coreStore ).getEntityRecord(
+								'postType',
+								'attachment',
+								featuredImage,
+								{
+									context: 'view',
+								}
+						  )
 						: undefined,
 			};
 		},

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -131,7 +131,12 @@ export default function CoverInspectorControls( {
 	const image = useSelect(
 		( select ) =>
 			id && isImageBackground
-				? select( coreStore ).getMedia( id, { context: 'view' } )
+				? select( coreStore ).getEntityRecord(
+						'postType',
+						'attachment',
+						id,
+						{ context: 'view' }
+				  )
 				: null,
 		[ id, isImageBackground ]
 	);

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -80,7 +80,11 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 			media:
 				id === undefined
 					? undefined
-					: select( coreStore ).getMedia( id ),
+					: select( coreStore ).getEntityRecord(
+							'postType',
+							'attachment',
+							id
+					  ),
 		} ),
 		[ id ]
 	);

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -583,7 +583,11 @@ export default compose( [
 		const isNotFileHref = id && getProtocol( href ) !== 'file:';
 		return {
 			media: isNotFileHref
-				? select( coreStore ).getMedia( id )
+				? select( coreStore ).getEntityRecord(
+						'postType',
+						'attachment',
+						id
+				  )
 				: undefined,
 			isSidebarOpened: isSelected && isEditorSidebarOpened(),
 			wasBlockJustInserted: select(

--- a/packages/block-library/src/file/transforms.js
+++ b/packages/block-library/src/file/transforms.js
@@ -104,8 +104,8 @@ const transforms = {
 				if ( ! id ) {
 					return false;
 				}
-				const { getMedia } = select( coreStore );
-				const media = getMedia( id );
+				const { getEntityRecord } = select( coreStore );
+				const media = getEntityRecord( 'postType', 'attachment', id );
 				return !! media && media.mime_type.includes( 'audio' );
 			},
 			transform: ( attributes ) => {
@@ -124,8 +124,8 @@ const transforms = {
 				if ( ! id ) {
 					return false;
 				}
-				const { getMedia } = select( coreStore );
-				const media = getMedia( id );
+				const { getEntityRecord } = select( coreStore );
+				const media = getEntityRecord( 'postType', 'attachment', id );
 				return !! media && media.mime_type.includes( 'video' );
 			},
 			transform: ( attributes ) => {
@@ -144,8 +144,8 @@ const transforms = {
 				if ( ! id ) {
 					return false;
 				}
-				const { getMedia } = select( coreStore );
-				const media = getMedia( id );
+				const { getEntityRecord } = select( coreStore );
+				const media = getEntityRecord( 'postType', 'attachment', id );
 				return !! media && media.mime_type.includes( 'image' );
 			},
 			transform: ( attributes ) => {

--- a/packages/block-library/src/gallery/use-get-media.js
+++ b/packages/block-library/src/gallery/use-get-media.js
@@ -26,11 +26,15 @@ export default function useGetMedia( innerBlockImages ) {
 			}
 
 			return (
-				select( coreStore ).getMediaItems( {
-					include: imageIds.join( ',' ),
-					per_page: -1,
-					orderby: 'include',
-				} ) ?? EMPTY_IMAGE_MEDIA
+				select( coreStore ).getEntityRecords(
+					'postType',
+					'attachment',
+					{
+						include: imageIds.join( ',' ),
+						per_page: -1,
+						orderby: 'include',
+					}
+				) ?? EMPTY_IMAGE_MEDIA
 			);
 		},
 		[ innerBlockImages ]

--- a/packages/block-library/src/gallery/use-get-media.native.js
+++ b/packages/block-library/src/gallery/use-get-media.native.js
@@ -32,12 +32,16 @@ export default function useGetMedia( innerBlockImages = [] ) {
 			}
 
 			return (
-				select( coreStore ).getMediaItems( {
-					include: imageIds.join( ',' ),
-					per_page:
-						imageIds.length /* 'hard' limit necessary as unbounded queries aren't supported on native */,
-					orderby: 'include',
-				} ) ?? EMPTY_IMAGE_MEDIA
+				select( coreStore ).getEntityRecords(
+					'postType',
+					'attachment',
+					{
+						include: imageIds.join( ',' ),
+						per_page:
+							imageIds.length /* 'hard' limit necessary as unbounded queries aren't supported on native */,
+						orderby: 'include',
+					}
+				) ?? EMPTY_IMAGE_MEDIA
 			);
 		},
 		[ innerBlockImages ]

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -905,7 +905,7 @@ export class ImageEdit extends Component {
 
 export default compose( [
 	withSelect( ( select, props ) => {
-		const { getMedia } = select( coreStore );
+		const { getEntityRecord } = select( coreStore );
 		const { getSettings, wasBlockJustInserted } =
 			select( blockEditorStore );
 		const { getEditedPostAttribute } = select( 'core/editor' );
@@ -926,7 +926,9 @@ export default compose( [
 				isNotFileUrl &&
 				url &&
 				! hasQueryArg( url, 'w' ) );
-		const image = shouldGetMedia ? getMedia( id ) : null;
+		const image = shouldGetMedia
+			? getEntityRecord( 'postType', 'attachment', id )
+			: null;
 
 		return {
 			image,

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -306,7 +306,12 @@ export default function Image( {
 	const image = useSelect(
 		( select ) =>
 			id && isSingleSelected
-				? select( coreStore ).getMedia( id, { context: 'view' } )
+				? select( coreStore ).getEntityRecord(
+						'postType',
+						'attachment',
+						id,
+						{ context: 'view' }
+				  )
 				: null,
 		[ id, isSingleSelected ]
 	);

--- a/packages/block-library/src/image/test/edit.native.js
+++ b/packages/block-library/src/image/test/edit.native.js
@@ -42,7 +42,9 @@ sendMediaUpload.mockImplementation( ( payload ) => {
 } );
 
 function mockGetMedia( media ) {
-	jest.spyOn( select( coreStore ), 'getMedia' ).mockReturnValue( media );
+	jest.spyOn( select( coreStore ), 'getEntityRecord' ).mockReturnValue(
+		media
+	);
 }
 
 const FETCH_MEDIA = {
@@ -71,8 +73,11 @@ beforeEach( () => {
 	// Mock media fetch requests
 	setupApiFetch( [ FETCH_MEDIA ] );
 
-	// Invalidate `getMedia` resolutions to allow requesting to the API the same media id
-	dispatch( coreStore ).invalidateResolutionForStoreSelector( 'getMedia' );
+	// Invalidate `getEntityRecord` resolutions to allow requesting to the API the same media id
+	dispatch( coreStore ).invalidateResolution( 'getEntityRecord', [
+		'postType',
+		'attachment',
+	] );
 } );
 
 afterEach( () => {
@@ -99,7 +104,7 @@ describe( 'Image Block', () => {
 		<figcaption class="wp-element-caption">Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
 		const screen = await initializeEditor( { initialHtml } );
-		// Check that image is fetched via `getMedia`
+		// Check that image is fetched via `getEntityRecord`
 		expect( apiFetch ).toHaveBeenCalledWith( FETCH_MEDIA.request );
 
 		const [ imageBlock ] = screen.getAllByLabelText( /Image Block/ );
@@ -126,7 +131,7 @@ describe( 'Image Block', () => {
 		<figcaption class="wp-element-caption">Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
 		const screen = await initializeEditor( { initialHtml } );
-		// Check that image is fetched via `getMedia`
+		// Check that image is fetched via `getEntityRecord`
 		expect( apiFetch ).toHaveBeenCalledWith( FETCH_MEDIA.request );
 
 		const [ imageBlock ] = screen.getAllByLabelText( /Image Block/ );
@@ -153,7 +158,7 @@ describe( 'Image Block', () => {
 		<figcaption class="wp-element-caption">Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
 		const screen = await initializeEditor( { initialHtml } );
-		// Check that image is fetched via `getMedia`
+		// Check that image is fetched via `getEntityRecord`
 		expect( apiFetch ).toHaveBeenCalledWith( FETCH_MEDIA.request );
 
 		const [ imageBlock ] = screen.getAllByLabelText( /Image Block/ );
@@ -190,7 +195,7 @@ describe( 'Image Block', () => {
 		<figcaption class="wp-element-caption">Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
 		const screen = await initializeEditor( { initialHtml } );
-		// Check that image is fetched via `getMedia`
+		// Check that image is fetched via `getEntityRecord`
 		expect( apiFetch ).toHaveBeenCalledWith( FETCH_MEDIA.request );
 
 		const [ imageBlock ] = screen.getAllByLabelText( /Image Block/ );
@@ -223,7 +228,7 @@ describe( 'Image Block', () => {
 		<figcaption class="wp-element-caption">Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
 		const screen = await initializeEditor( { initialHtml } );
-		// Check that image is not fetched via `getMedia` due to the presence of query parameters in the URL.
+		// Check that image is not fetched via `getEntityRecord` due to the presence of query parameters in the URL.
 		expect( apiFetch ).not.toHaveBeenCalledWith( FETCH_MEDIA.request );
 
 		const [ imageBlock ] = screen.getAllByLabelText( /Image Block/ );
@@ -248,7 +253,7 @@ describe( 'Image Block', () => {
 		<figcaption class="wp-element-caption">Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
 		const screen = await initializeEditor( { initialHtml } );
-		// Check that image is fetched via `getMedia`
+		// Check that image is fetched via `getEntityRecord`
 		expect( apiFetch ).toHaveBeenCalledWith( FETCH_MEDIA.request );
 
 		const [ imageBlock ] = screen.getAllByLabelText( /Image Block/ );
@@ -279,7 +284,7 @@ describe( 'Image Block', () => {
 		</figure>
 		<!-- /wp:image -->`;
 		const screen = await initializeEditor( { initialHtml } );
-		// Check that image is fetched via `getMedia`
+		// Check that image is fetched via `getEntityRecord`
 		expect( apiFetch ).toHaveBeenCalledWith( FETCH_MEDIA.request );
 
 		const [ imageBlock ] = screen.getAllByLabelText( /Image Block/ );

--- a/packages/block-library/src/image/test/edit.native.js
+++ b/packages/block-library/src/image/test/edit.native.js
@@ -77,6 +77,7 @@ beforeEach( () => {
 	dispatch( coreStore ).invalidateResolution( 'getEntityRecord', [
 		'postType',
 		'attachment',
+		1,
 	] );
 } );
 

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -199,9 +199,14 @@ function MediaTextEdit( {
 			return {
 				featuredImageMedia:
 					featuredImage && useFeaturedImage
-						? select( coreStore ).getMedia( featuredImage, {
-								context: 'view',
-						  } )
+						? select( coreStore ).getEntityRecord(
+								'postType',
+								'attachment',
+								featuredImage,
+								{
+									context: 'view',
+								}
+						  )
 						: undefined,
 			};
 		},
@@ -213,9 +218,14 @@ function MediaTextEdit( {
 			return {
 				image:
 					mediaId && isSelected
-						? select( coreStore ).getMedia( mediaId, {
-								context: 'view',
-						  } )
+						? select( coreStore ).getEntityRecord(
+								'postType',
+								'attachment',
+								mediaId,
+								{
+									context: 'view',
+								}
+						  )
 						: null,
 			};
 		},

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -133,12 +133,12 @@ export default function PostFeaturedImageEdit( {
 
 	const { media, postType, postPermalink } = useSelect(
 		( select ) => {
-			const { getMedia, getPostType, getEditedEntityRecord } =
+			const { getEntityRecord, getPostType, getEditedEntityRecord } =
 				select( coreStore );
 			return {
 				media:
 					featuredImage &&
-					getMedia( featuredImage, {
+					getEntityRecord( 'postType', 'attachment', featuredImage, {
 						context: 'view',
 					} ),
 				postType: postTypeSlug && getPostType( postTypeSlug ),

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -454,12 +454,19 @@ export default function LogoEdit( {
 		const _siteIconId = siteSettings?.site_icon;
 		const mediaItem =
 			_siteLogoId &&
-			select( coreStore ).getMedia( _siteLogoId, {
-				context: 'view',
-			} );
+			select( coreStore ).getEntityRecord(
+				'postType',
+				'attachment',
+				_siteLogoId,
+				{
+					context: 'view',
+				}
+			);
 		const _isRequestingMediaItem =
 			!! _siteLogoId &&
-			! select( coreStore ).hasFinishedResolution( 'getMedia', [
+			! select( coreStore ).hasFinishedResolution( 'getEntityRecord', [
+				'postType',
+				'attachment',
 				_siteLogoId,
 				{ context: 'view' },
 			] );

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -339,7 +339,7 @@ _Parameters_
 
 -   _state_ `State`: Data state.
 -   _action_ `string`: Action to check. One of: 'create', 'read', 'update', 'delete'.
--   _resource_ `string | EntityResource`: Entity resource to check. Accepts entity object `{ kind: 'root', name: 'media', id: 1 }` or REST base as a string - `media`.
+-   _resource_ `string | EntityResource`: Entity resource to check. Accepts entity object `{ kind: 'postType', name: 'attachment', id: 1 }` or REST base as a string - `media`.
 -   _id_ `EntityRecordKey`: Optional ID of the rest resource to check.
 
 _Returns_
@@ -1231,7 +1231,7 @@ the store state using `canUser()`, or resolved if missing.
 
 _Parameters_
 
--   _resource_ `string | EntityResource`: Entity resource to check. Accepts entity object `{ kind: 'root', name: 'media', id: 1 }` or REST base as a string - `media`.
+-   _resource_ `string | EntityResource`: Entity resource to check. Accepts entity object `{ kind: 'postType', name: 'attachment', id: 1 }` or REST base as a string - `media`.
 -   _id_ `IdType`: Optional ID of the resource to check, e.g. 10. Note: This argument is discouraged when using an entity object as a resource to check permissions and will be ignored.
 
 _Returns_

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -93,7 +93,6 @@ export function receiveEntityRecords(
 	edits,
 	meta
 ) {
-	logEntityDeprecation( kind, name, 'receiveEntityRecords' );
 	// Auto drafts should not have titles, but some plugins rely on them so we can't filter this
 	// on the server.
 	if ( kind === 'postType' ) {

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -20,6 +20,7 @@ import { DEFAULT_ENTITY_KEY } from './entities';
 import { createBatch } from './batch';
 import { STORE_NAME } from './name';
 import { getSyncProvider } from './sync';
+import logEntityDeprecation from './utils/log-entity-deprecation';
 
 /**
  * Returns an action object used in signalling that authors have been received.
@@ -92,6 +93,7 @@ export function receiveEntityRecords(
 	edits,
 	meta
 ) {
+	logEntityDeprecation( kind, name, 'receiveEntityRecords' );
 	// Auto drafts should not have titles, but some plugins rely on them so we can't filter this
 	// on the server.
 	if ( kind === 'postType' ) {
@@ -286,6 +288,7 @@ export const deleteEntityRecord =
 		{ __unstableFetch = apiFetch, throwOnError = false } = {}
 	) =>
 	async ( { dispatch, resolveSelect } ) => {
+		logEntityDeprecation( kind, name, 'deleteEntityRecord' );
 		const configs = await resolveSelect.getEntitiesConfig( kind );
 		const entityConfig = configs.find(
 			( config ) => config.kind === kind && config.name === name
@@ -363,6 +366,7 @@ export const deleteEntityRecord =
 export const editEntityRecord =
 	( kind, name, recordId, edits, options = {} ) =>
 	( { select, dispatch } ) => {
+		logEntityDeprecation( kind, name, 'editEntityRecord' );
 		const entityConfig = select.getEntityConfig( kind, name );
 		if ( ! entityConfig ) {
 			throw new Error(
@@ -503,6 +507,7 @@ export const saveEntityRecord =
 		} = {}
 	) =>
 	async ( { select, resolveSelect, dispatch } ) => {
+		logEntityDeprecation( kind, name, 'saveEntityRecord' );
 		const configs = await resolveSelect.getEntitiesConfig( kind );
 		const entityConfig = configs.find(
 			( config ) => config.kind === kind && config.name === name
@@ -781,6 +786,7 @@ export const __experimentalBatch =
 export const saveEditedEntityRecord =
 	( kind, name, recordId, options ) =>
 	async ( { select, dispatch, resolveSelect } ) => {
+		logEntityDeprecation( kind, name, 'saveEditedEntityRecord' );
 		if ( ! select.hasEditsForEntityRecord( kind, name, recordId ) ) {
 			return;
 		}
@@ -814,6 +820,11 @@ export const saveEditedEntityRecord =
 export const __experimentalSaveSpecifiedEntityEdits =
 	( kind, name, recordId, itemsToSave, options ) =>
 	async ( { select, dispatch, resolveSelect } ) => {
+		logEntityDeprecation(
+			kind,
+			name,
+			'__experimentalSaveSpecifiedEntityEdits'
+		);
 		if ( ! select.hasEditsForEntityRecord( kind, name, recordId ) ) {
 			return;
 		}
@@ -974,6 +985,7 @@ export function receiveDefaultTemplateId( query, templateId ) {
 export const receiveRevisions =
 	( kind, name, recordKey, records, query, invalidateCache = false, meta ) =>
 	async ( { dispatch, resolveSelect } ) => {
+		logEntityDeprecation( kind, name, 'receiveRevisions' );
 		const configs = await resolveSelect.getEntitiesConfig( kind );
 		const entityConfig = configs.find(
 			( config ) => config.kind === kind && config.name === name

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -97,6 +97,17 @@ export const rootEntitiesConfig = [
 		label: __( 'Media' ),
 		rawAttributes: [ 'caption', 'title', 'description' ],
 		supportsPagination: true,
+		deprecation: {
+			since: '6.9',
+			alternative: {
+				kind: 'postType',
+				name: 'attachment',
+			},
+			hint: __(
+				'When working with attachment, caption and description are returned as objects with raw and rendered properties.' +
+					'Some code may need to be updated to handle this.'
+			),
+		},
 	},
 	{
 		name: 'taxonomy',

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -97,17 +97,6 @@ export const rootEntitiesConfig = [
 		label: __( 'Media' ),
 		rawAttributes: [ 'caption', 'title', 'description' ],
 		supportsPagination: true,
-		deprecation: {
-			since: '6.9',
-			alternative: {
-				kind: 'postType',
-				name: 'attachment',
-			},
-			hint: __(
-				'When working with attachment, caption and description are returned as objects with raw and rendered properties.' +
-					'Some code may need to be updated to handle this.'
-			),
-		},
 	},
 	{
 		name: 'taxonomy',
@@ -229,6 +218,18 @@ export const rootEntitiesConfig = [
 		key: 'slug',
 	},
 ];
+
+export const deprecatedEntities = {
+	root: {
+		media: {
+			since: '6.9',
+			alternative: {
+				kind: 'postType',
+				name: 'attachment',
+			},
+		},
+	},
+};
 
 export const additionalEntityConfigLoaders = [
 	{ kind: 'postType', loadEntities: loadPostTypeEntities },

--- a/packages/core-data/src/hooks/test/use-resource-permissions.js
+++ b/packages/core-data/src/hooks/test/use-resource-permissions.js
@@ -98,8 +98,8 @@ describe( 'useResourcePermissions', () => {
 		let data;
 		const TestComponent = () => {
 			data = useResourcePermissions( {
-				kind: 'root',
-				name: 'media',
+				kind: 'postType',
+				name: 'attachment',
 			} );
 			return <div />;
 		};
@@ -131,8 +131,8 @@ describe( 'useResourcePermissions', () => {
 		let data;
 		const TestComponent = () => {
 			data = useResourcePermissions( {
-				kind: 'root',
-				name: 'media',
+				kind: 'postType',
+				name: 'attachment',
 				id: 1,
 			} );
 			return <div />;
@@ -169,8 +169,8 @@ describe( 'useResourcePermissions', () => {
 		const TestComponent = () => {
 			useResourcePermissions(
 				{
-					kind: 'root',
-					name: 'media',
+					kind: 'postType',
+					name: 'attachment',
 				},
 				1
 			);

--- a/packages/core-data/src/hooks/test/use-resource-permissions.js
+++ b/packages/core-data/src/hooks/test/use-resource-permissions.js
@@ -98,8 +98,8 @@ describe( 'useResourcePermissions', () => {
 		let data;
 		const TestComponent = () => {
 			data = useResourcePermissions( {
-				kind: 'postType',
-				name: 'attachment',
+				kind: 'root',
+				name: 'user',
 			} );
 			return <div />;
 		};
@@ -131,8 +131,8 @@ describe( 'useResourcePermissions', () => {
 		let data;
 		const TestComponent = () => {
 			data = useResourcePermissions( {
-				kind: 'postType',
-				name: 'attachment',
+				kind: 'root',
+				name: 'user',
 				id: 1,
 			} );
 			return <div />;
@@ -169,8 +169,8 @@ describe( 'useResourcePermissions', () => {
 		const TestComponent = () => {
 			useResourcePermissions(
 				{
-					kind: 'postType',
-					name: 'attachment',
+					kind: 'root',
+					name: 'user',
 				},
 				1
 			);

--- a/packages/core-data/src/hooks/use-resource-permissions.ts
+++ b/packages/core-data/src/hooks/use-resource-permissions.ts
@@ -59,7 +59,7 @@ function useResourcePermissions< IdType = void >(
  *
  * @since 6.1.0 Introduced in WordPress core.
  *
- * @param    resource Entity resource to check. Accepts entity object `{ kind: 'root', name: 'media', id: 1 }`
+ * @param    resource Entity resource to check. Accepts entity object `{ kind: 'postType', name: 'attachment', id: 1 }`
  *                    or REST base as a string - `media`.
  * @param    id       Optional ID of the resource to check, e.g. 10. Note: This argument is discouraged
  *                    when using an entity object as a resource to check permissions and will be ignored.

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -21,6 +21,7 @@ import {
 import { STORE_NAME } from './name';
 import { unlock } from './lock-unlock';
 import { dynamicActions, dynamicSelectors } from './dynamic-entities';
+import logEntityDeprecation from './utils/log-entity-deprecation';
 
 // The entity selectors/resolvers and actions are shortcuts to their generic equivalents
 // (getEntityRecord, getEntityRecords, updateEntityRecord, updateEntityRecords)
@@ -33,26 +34,38 @@ const entitiesConfig = [
 
 const entitySelectors = entitiesConfig.reduce( ( result, entity ) => {
 	const { kind, name, plural } = entity;
-	result[ getMethodName( kind, name ) ] = ( state, key, query ) =>
-		selectors.getEntityRecord( state, kind, name, key, query );
+
+	const getEntityRecordMethodName = getMethodName( kind, name );
+	result[ getEntityRecordMethodName ] = ( state, key, query ) => {
+		logEntityDeprecation( kind, name, getEntityRecordMethodName );
+		return selectors.getEntityRecord( state, kind, name, key, query );
+	};
 
 	if ( plural ) {
-		result[ getMethodName( kind, plural, 'get' ) ] = ( state, query ) =>
-			selectors.getEntityRecords( state, kind, name, query );
+		const getEntityRecordsMethodName = getMethodName( kind, plural, 'get' );
+		result[ getEntityRecordsMethodName ] = ( state, query ) => {
+			logEntityDeprecation( kind, plural, getEntityRecordsMethodName );
+			return selectors.getEntityRecords( state, kind, name, query );
+		};
 	}
 	return result;
 }, {} );
 
 const entityResolvers = entitiesConfig.reduce( ( result, entity ) => {
 	const { kind, name, plural } = entity;
-	result[ getMethodName( kind, name ) ] = ( key, query ) =>
-		resolvers.getEntityRecord( kind, name, key, query );
+	const getEntityRecordMethodName = getMethodName( kind, name );
+	result[ getEntityRecordMethodName ] = ( key, query ) => {
+		logEntityDeprecation( kind, name, getEntityRecordMethodName );
+		return resolvers.getEntityRecord( kind, name, key, query );
+	};
 
 	if ( plural ) {
-		const pluralMethodName = getMethodName( kind, plural, 'get' );
-		result[ pluralMethodName ] = ( ...args ) =>
-			resolvers.getEntityRecords( kind, name, ...args );
-		result[ pluralMethodName ].shouldInvalidate = ( action ) =>
+		const getEntityRecordsMethodName = getMethodName( kind, plural, 'get' );
+		result[ getEntityRecordsMethodName ] = ( ...args ) => {
+			logEntityDeprecation( kind, plural, getEntityRecordsMethodName );
+			return resolvers.getEntityRecords( kind, name, ...args );
+		};
+		result[ getEntityRecordsMethodName ].shouldInvalidate = ( action ) =>
 			resolvers.getEntityRecords.shouldInvalidate( action, kind, name );
 	}
 	return result;
@@ -60,10 +73,19 @@ const entityResolvers = entitiesConfig.reduce( ( result, entity ) => {
 
 const entityActions = entitiesConfig.reduce( ( result, entity ) => {
 	const { kind, name } = entity;
-	result[ getMethodName( kind, name, 'save' ) ] = ( record, options ) =>
-		actions.saveEntityRecord( kind, name, record, options );
-	result[ getMethodName( kind, name, 'delete' ) ] = ( key, query, options ) =>
-		actions.deleteEntityRecord( kind, name, key, query, options );
+
+	const saveEntityRecordMethodName = getMethodName( kind, name, 'save' );
+	result[ saveEntityRecordMethodName ] = ( record, options ) => {
+		logEntityDeprecation( kind, name, saveEntityRecordMethodName );
+		return actions.saveEntityRecord( kind, name, record, options );
+	};
+
+	const deleteEntityRecordMethodName = getMethodName( kind, name, 'delete' );
+	result[ deleteEntityRecordMethodName ] = ( key, query, options ) => {
+		logEntityDeprecation( kind, name, deleteEntityRecordMethodName );
+		return actions.deleteEntityRecord( kind, name, key, query, options );
+	};
+
 	return result;
 }, {} );
 

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -51,7 +51,7 @@ const entitySelectors = entitiesConfig.reduce( ( result, entity ) => {
 		result[ getEntityRecordsMethodName ] = ( state, query ) => {
 			logEntityDeprecation(
 				kind,
-				plural,
+				name,
 				getEntityRecordsMethodName,
 				'getEntityRecords'
 			);

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -37,24 +37,20 @@ const entitySelectors = entitiesConfig.reduce( ( result, entity ) => {
 
 	const getEntityRecordMethodName = getMethodName( kind, name );
 	result[ getEntityRecordMethodName ] = ( state, key, query ) => {
-		logEntityDeprecation(
-			kind,
-			name,
-			getEntityRecordMethodName,
-			'getEntityRecord'
-		);
+		logEntityDeprecation( kind, name, getEntityRecordMethodName, {
+			isShorthandSelector: true,
+			alternativeFunctionName: 'getEntityRecord',
+		} );
 		return selectors.getEntityRecord( state, kind, name, key, query );
 	};
 
 	if ( plural ) {
 		const getEntityRecordsMethodName = getMethodName( kind, plural, 'get' );
 		result[ getEntityRecordsMethodName ] = ( state, query ) => {
-			logEntityDeprecation(
-				kind,
-				name,
-				getEntityRecordsMethodName,
-				'getEntityRecords'
-			);
+			logEntityDeprecation( kind, name, getEntityRecordsMethodName, {
+				isShorthandSelector: true,
+				alternativeFunctionName: 'getEntityRecords',
+			} );
 			return selectors.getEntityRecords( state, kind, name, query );
 		};
 	}
@@ -65,24 +61,20 @@ const entityResolvers = entitiesConfig.reduce( ( result, entity ) => {
 	const { kind, name, plural } = entity;
 	const getEntityRecordMethodName = getMethodName( kind, name );
 	result[ getEntityRecordMethodName ] = ( key, query ) => {
-		logEntityDeprecation(
-			kind,
-			name,
-			getEntityRecordMethodName,
-			'getEntityRecord'
-		);
+		logEntityDeprecation( kind, name, getEntityRecordMethodName, {
+			isShorthandSelector: true,
+			alternativeFunctionName: 'getEntityRecord',
+		} );
 		return resolvers.getEntityRecord( kind, name, key, query );
 	};
 
 	if ( plural ) {
 		const getEntityRecordsMethodName = getMethodName( kind, plural, 'get' );
 		result[ getEntityRecordsMethodName ] = ( ...args ) => {
-			logEntityDeprecation(
-				kind,
-				plural,
-				getEntityRecordsMethodName,
-				'getEntityRecords'
-			);
+			logEntityDeprecation( kind, plural, getEntityRecordsMethodName, {
+				isShorthandSelector: true,
+				alternativeFunctionName: 'getEntityRecords',
+			} );
 			return resolvers.getEntityRecords( kind, name, ...args );
 		};
 		result[ getEntityRecordsMethodName ].shouldInvalidate = ( action ) =>
@@ -96,23 +88,19 @@ const entityActions = entitiesConfig.reduce( ( result, entity ) => {
 
 	const saveEntityRecordMethodName = getMethodName( kind, name, 'save' );
 	result[ saveEntityRecordMethodName ] = ( record, options ) => {
-		logEntityDeprecation(
-			kind,
-			name,
-			saveEntityRecordMethodName,
-			'saveEntityRecord'
-		);
+		logEntityDeprecation( kind, name, saveEntityRecordMethodName, {
+			isShorthandSelector: true,
+			alternativeFunctionName: 'saveEntityRecord',
+		} );
 		return actions.saveEntityRecord( kind, name, record, options );
 	};
 
 	const deleteEntityRecordMethodName = getMethodName( kind, name, 'delete' );
 	result[ deleteEntityRecordMethodName ] = ( key, query, options ) => {
-		logEntityDeprecation(
-			kind,
-			name,
-			deleteEntityRecordMethodName,
-			'deleteEntityRecord'
-		);
+		logEntityDeprecation( kind, name, deleteEntityRecordMethodName, {
+			isShorthandSelector: true,
+			alternativeFunctionName: 'deleteEntityRecord',
+		} );
 		return actions.deleteEntityRecord( kind, name, key, query, options );
 	};
 

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -37,14 +37,24 @@ const entitySelectors = entitiesConfig.reduce( ( result, entity ) => {
 
 	const getEntityRecordMethodName = getMethodName( kind, name );
 	result[ getEntityRecordMethodName ] = ( state, key, query ) => {
-		logEntityDeprecation( kind, name, getEntityRecordMethodName );
+		logEntityDeprecation(
+			kind,
+			name,
+			getEntityRecordMethodName,
+			'getEntityRecord'
+		);
 		return selectors.getEntityRecord( state, kind, name, key, query );
 	};
 
 	if ( plural ) {
 		const getEntityRecordsMethodName = getMethodName( kind, plural, 'get' );
 		result[ getEntityRecordsMethodName ] = ( state, query ) => {
-			logEntityDeprecation( kind, plural, getEntityRecordsMethodName );
+			logEntityDeprecation(
+				kind,
+				plural,
+				getEntityRecordsMethodName,
+				'getEntityRecords'
+			);
 			return selectors.getEntityRecords( state, kind, name, query );
 		};
 	}
@@ -55,14 +65,24 @@ const entityResolvers = entitiesConfig.reduce( ( result, entity ) => {
 	const { kind, name, plural } = entity;
 	const getEntityRecordMethodName = getMethodName( kind, name );
 	result[ getEntityRecordMethodName ] = ( key, query ) => {
-		logEntityDeprecation( kind, name, getEntityRecordMethodName );
+		logEntityDeprecation(
+			kind,
+			name,
+			getEntityRecordMethodName,
+			'getEntityRecord'
+		);
 		return resolvers.getEntityRecord( kind, name, key, query );
 	};
 
 	if ( plural ) {
 		const getEntityRecordsMethodName = getMethodName( kind, plural, 'get' );
 		result[ getEntityRecordsMethodName ] = ( ...args ) => {
-			logEntityDeprecation( kind, plural, getEntityRecordsMethodName );
+			logEntityDeprecation(
+				kind,
+				plural,
+				getEntityRecordsMethodName,
+				'getEntityRecords'
+			);
 			return resolvers.getEntityRecords( kind, name, ...args );
 		};
 		result[ getEntityRecordsMethodName ].shouldInvalidate = ( action ) =>
@@ -76,13 +96,23 @@ const entityActions = entitiesConfig.reduce( ( result, entity ) => {
 
 	const saveEntityRecordMethodName = getMethodName( kind, name, 'save' );
 	result[ saveEntityRecordMethodName ] = ( record, options ) => {
-		logEntityDeprecation( kind, name, saveEntityRecordMethodName );
+		logEntityDeprecation(
+			kind,
+			name,
+			saveEntityRecordMethodName,
+			'saveEntityRecord'
+		);
 		return actions.saveEntityRecord( kind, name, record, options );
 	};
 
 	const deleteEntityRecordMethodName = getMethodName( kind, name, 'delete' );
 	result[ deleteEntityRecordMethodName ] = ( key, query, options ) => {
-		logEntityDeprecation( kind, name, deleteEntityRecordMethodName );
+		logEntityDeprecation(
+			kind,
+			name,
+			deleteEntityRecordMethodName,
+			'deleteEntityRecord'
+		);
 		return actions.deleteEntityRecord( kind, name, key, query, options );
 	};
 

--- a/packages/core-data/src/private-actions.js
+++ b/packages/core-data/src/private-actions.js
@@ -59,8 +59,8 @@ export const editMediaEntity =
 			return;
 		}
 
-		const kind = 'root';
-		const name = 'media';
+		const kind = 'postType';
+		const name = 'attachment';
 
 		const configs = await resolveSelect.getEntitiesConfig( kind );
 		const entityConfig = configs.find(

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -9,6 +9,7 @@ import { createSelector, createRegistrySelector } from '@wordpress/data';
 import { getDefaultTemplateId, getEntityRecord, type State } from './selectors';
 import { STORE_NAME } from './name';
 import { unlock } from './lock-unlock';
+import logEntityDeprecation from './utils/log-entity-deprecation';
 
 type EntityRecordKey = string | number;
 
@@ -97,6 +98,7 @@ export function getEntityRecordPermissions(
 	name: string,
 	id: string
 ) {
+	logEntityDeprecation( kind, name, 'getEntityRecordPermissions' );
 	return getEntityRecordsPermissions( state, kind, name, id )[ 0 ];
 }
 

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -479,7 +479,7 @@ export const getEmbedPreview =
  *
  * @param {string}        requestedAction Action to check. One of: 'create', 'read', 'update',
  *                                        'delete'.
- * @param {string|Object} resource        Entity resource to check. Accepts entity object `{ kind: 'root', name: 'media', id: 1 }`
+ * @param {string|Object} resource        Entity resource to check. Accepts entity object `{ kind: 'postType', name: 'attachment', id: 1 }`
  *                                        or REST base as a string - `media`.
  * @param {?string}       id              ID of the rest resource to check.
  */

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -24,6 +24,7 @@ import {
 } from './utils';
 import type * as ET from './entity-types';
 import type { UndoManager } from '@wordpress/undo-manager';
+import logEntityDeprecation from './utils/log-entity-deprecation';
 
 // This is an incomplete, high-level approximation of the State type.
 // It makes the selectors slightly more safe, but is intended to evolve
@@ -272,6 +273,8 @@ export function getEntityConfig(
 	kind: string,
 	name: string
 ): any {
+	logEntityDeprecation( kind, name, 'getEntityConfig' );
+
 	return state.entities.config?.find(
 		( config ) => config.kind === kind && config.name === name
 	);
@@ -353,6 +356,8 @@ export const getEntityRecord = createSelector(
 		key?: EntityRecordKey,
 		query?: GetRecordsHttpQuery
 	): EntityRecord | undefined => {
+		logEntityDeprecation( kind, name, 'getEntityRecord' );
+
 		const queriedState =
 			state.entities.records?.[ kind ]?.[ name ]?.queriedData;
 		if ( ! queriedState ) {
@@ -450,6 +455,8 @@ export const getRawEntityRecord = createSelector(
 		name: string,
 		key: EntityRecordKey
 	): EntityRecord | undefined => {
+		logEntityDeprecation( kind, name, 'getRawEntityRecord' );
+
 		const record = getEntityRecord< EntityRecord >(
 			state,
 			kind,
@@ -512,6 +519,7 @@ export function hasEntityRecords(
 	name: string,
 	query?: GetRecordsHttpQuery
 ): boolean {
+	logEntityDeprecation( kind, name, 'hasEntityRecords' );
 	return Array.isArray( getEntityRecords( state, kind, name, query ) );
 }
 
@@ -567,6 +575,8 @@ export const getEntityRecords = ( <
 	name: string,
 	query: GetRecordsHttpQuery
 ): EntityRecord[] | null => {
+	logEntityDeprecation( kind, name, 'getEntityRecords' );
+
 	// Queried data state is prepopulated for all known entities. If this is not
 	// assigned for the given parameters, then it is known to not exist.
 	const queriedState =
@@ -594,6 +604,8 @@ export const getEntityRecordsTotalItems = (
 	name: string,
 	query: GetRecordsHttpQuery
 ): number | null => {
+	logEntityDeprecation( kind, name, 'getEntityRecordsTotalItems' );
+
 	// Queried data state is prepopulated for all known entities. If this is not
 	// assigned for the given parameters, then it is known to not exist.
 	const queriedState =
@@ -621,6 +633,8 @@ export const getEntityRecordsTotalPages = (
 	name: string,
 	query: GetRecordsHttpQuery
 ): number | null => {
+	logEntityDeprecation( kind, name, 'getEntityRecordsTotalPages' );
+
 	// Queried data state is prepopulated for all known entities. If this is not
 	// assigned for the given parameters, then it is known to not exist.
 	const queriedState =
@@ -774,6 +788,7 @@ export function getEntityRecordEdits(
 	name: string,
 	recordId: EntityRecordKey
 ): Optional< any > {
+	logEntityDeprecation( kind, name, 'getEntityRecordEdits' );
 	return state.entities.records?.[ kind ]?.[ name ]?.edits?.[
 		recordId as string | number
 	];
@@ -800,6 +815,7 @@ export const getEntityRecordNonTransientEdits = createSelector(
 		name: string,
 		recordId: EntityRecordKey
 	): Optional< any > => {
+		logEntityDeprecation( kind, name, 'getEntityRecordNonTransientEdits' );
 		const { transientEdits } = getEntityConfig( state, kind, name ) || {};
 		const edits = getEntityRecordEdits( state, kind, name, recordId ) || {};
 		if ( ! transientEdits ) {
@@ -835,6 +851,7 @@ export function hasEditsForEntityRecord(
 	name: string,
 	recordId: EntityRecordKey
 ): boolean {
+	logEntityDeprecation( kind, name, 'hasEditsForEntityRecord' );
 	return (
 		isSavingEntityRecord( state, kind, name, recordId ) ||
 		Object.keys(
@@ -860,6 +877,7 @@ export const getEditedEntityRecord = createSelector(
 		name: string,
 		recordId: EntityRecordKey
 	): ET.Updatable< EntityRecord > | false => {
+		logEntityDeprecation( kind, name, 'getEditedEntityRecord' );
 		const raw = getRawEntityRecord( state, kind, name, recordId );
 		const edited = getEntityRecordEdits( state, kind, name, recordId );
 		// Never return a non-falsy empty object. Unfortunately we can't return
@@ -910,6 +928,7 @@ export function isAutosavingEntityRecord(
 	name: string,
 	recordId: EntityRecordKey
 ): boolean {
+	logEntityDeprecation( kind, name, 'isAutosavingEntityRecord' );
 	const { pending, isAutosave } =
 		state.entities.records?.[ kind ]?.[ name ]?.saving?.[ recordId ] ?? {};
 	return Boolean( pending && isAutosave );
@@ -931,6 +950,7 @@ export function isSavingEntityRecord(
 	name: string,
 	recordId: EntityRecordKey
 ): boolean {
+	logEntityDeprecation( kind, name, 'isSavingEntityRecord' );
 	return (
 		state.entities.records?.[ kind ]?.[ name ]?.saving?.[
 			recordId as EntityRecordKey
@@ -954,6 +974,7 @@ export function isDeletingEntityRecord(
 	name: string,
 	recordId: EntityRecordKey
 ): boolean {
+	logEntityDeprecation( kind, name, 'isDeletingEntityRecord' );
 	return (
 		state.entities.records?.[ kind ]?.[ name ]?.deleting?.[
 			recordId as EntityRecordKey
@@ -977,6 +998,7 @@ export function getLastEntitySaveError(
 	name: string,
 	recordId: EntityRecordKey
 ): any {
+	logEntityDeprecation( kind, name, 'getLastEntitySaveError' );
 	return state.entities.records?.[ kind ]?.[ name ]?.saving?.[ recordId ]
 		?.error;
 }
@@ -997,6 +1019,7 @@ export function getLastEntityDeleteError(
 	name: string,
 	recordId: EntityRecordKey
 ): any {
+	logEntityDeprecation( kind, name, 'getLastEntityDeleteError' );
 	return state.entities.records?.[ kind ]?.[ name ]?.deleting?.[ recordId ]
 		?.error;
 }
@@ -1159,6 +1182,9 @@ export function canUser(
 	const isEntity = typeof resource === 'object';
 	if ( isEntity && ( ! resource.kind || ! resource.name ) ) {
 		return false;
+	}
+	if ( isEntity ) {
+		logEntityDeprecation( resource.kind, resource.name, 'canUser' );
 	}
 
 	const key = getUserPermissionCacheKey( action, resource, id );
@@ -1418,6 +1444,7 @@ export const getRevisions = (
 	recordKey: EntityRecordKey,
 	query?: GetRecordsHttpQuery
 ): RevisionRecord[] | null => {
+	logEntityDeprecation( kind, name, 'getRevisions' );
 	const queriedStateRevisions =
 		state.entities.records?.[ kind ]?.[ name ]?.revisions?.[ recordKey ];
 	if ( ! queriedStateRevisions ) {
@@ -1449,6 +1476,7 @@ export const getRevision = createSelector(
 		revisionKey: EntityRecordKey,
 		query?: GetRecordsHttpQuery
 	): RevisionRecord | Record< PropertyKey, never > | undefined => {
+		logEntityDeprecation( kind, name, 'getRevision' );
 		const queriedState =
 			state.entities.records?.[ kind ]?.[ name ]?.revisions?.[
 				recordKey

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -1166,7 +1166,7 @@ export function isPreviewEmbedFallback( state: State, url: string ): boolean {
  *
  * @param state    Data state.
  * @param action   Action to check. One of: 'create', 'read', 'update', 'delete'.
- * @param resource Entity resource to check. Accepts entity object `{ kind: 'root', name: 'media', id: 1 }`
+ * @param resource Entity resource to check. Accepts entity object `{ kind: 'postType', name: 'attachment', id: 1 }`
  *                 or REST base as a string - `media`.
  * @param id       Optional ID of the rest resource to check.
  *

--- a/packages/core-data/src/test/deprecated-entity-logging.js
+++ b/packages/core-data/src/test/deprecated-entity-logging.js
@@ -19,6 +19,12 @@ jest.useFakeTimers();
 /**
  * Creates a test registry with the core-data store and sets up the deprecated media entity.
  *
+ * This approach enables testing generated selections/actions (like `getMedia`), and simplifies
+ * the tests by avoiding an endless amount of mocks.
+ *
+ * It means the tests in this file are integration rather than unit tests, so they're kept
+ * separate from the selector.js/reducer.js tests.
+ *
  * @return {Object} Registry with core-data store registered.
  */
 function createTestRegistry() {

--- a/packages/core-data/src/test/deprecated-entity-logging.js
+++ b/packages/core-data/src/test/deprecated-entity-logging.js
@@ -17,6 +17,39 @@ jest.mock( '@wordpress/deprecated' );
 jest.useFakeTimers();
 
 /**
+ * Returns the expected arguments for the deprecated function call.
+ *
+ * @param {string}  name                - The name of the function.
+ * @param {Array}   args                - The arguments for the function.
+ * @param {boolean} isShorthandSelector - Whether the function is a shorthand selector.
+ * @param {string}  alternativeFunction - The name of the alternative function.
+ * @return {Array} The expected arguments for the deprecated function call.
+ */
+function getExpectedDeprecationArgs(
+	name,
+	args,
+	isShorthandSelector,
+	alternativeFunction
+) {
+	const expectedMessage = isShorthandSelector
+		? name
+		: `The 'root', 'media' entity (used via '${ name }')`;
+
+	let expectedAlternative = "the 'postType', 'attachment' entity";
+	if ( alternativeFunction ) {
+		expectedAlternative += ` via the '${ alternativeFunction }' function`;
+	}
+
+	return [
+		expectedMessage,
+		{
+			alternative: expectedAlternative,
+			since: '6.9',
+		},
+	];
+}
+
+/**
  * Creates a test registry with the core-data store and sets up the deprecated media entity.
  *
  * This approach enables testing generated selections/actions (like `getMedia`), and simplifies
@@ -148,39 +181,44 @@ describe( 'Deprecated entity logging - selectors', () => {
 		{
 			name: 'getMedia',
 			args: [ '123' ],
+			isShorthandSelector: true,
 			alternativeFunction: 'getEntityRecord',
 		},
 		{
 			name: 'getMediaItems',
 			args: [],
+			isShorthandSelector: true,
 			alternativeFunction: 'getEntityRecords',
 		},
-	] )( '$name', ( { name, args, alternativeFunction } ) => {
-		beforeEach( () => {
-			deprecated.mockReset();
-		} );
+	] )(
+		'$name',
+		( { name, args, alternativeFunction, isShorthandSelector } ) => {
+			beforeEach( () => {
+				deprecated.mockReset();
+			} );
 
-		it( 'logs a deprecation warning when used with deprecated entities', () => {
-			// Create a test registry with the actual store
-			const registry = createTestRegistry();
+			it( 'logs a deprecation warning when used with deprecated entities', () => {
+				// Create a test registry with the actual store
+				const registry = createTestRegistry();
 
-			// Dispatch the action.
-			registry.select( coreDataStore )[ name ]( ...args );
+				// Dispatch the action.
+				registry.select( coreDataStore )[ name ]( ...args );
 
-			let expectedAlternative = "the 'postType', 'attachment' entity";
-			if ( alternativeFunction ) {
-				expectedAlternative += ` via the '${ alternativeFunction }' function`;
-			}
+				const [ expectedMessage, expectedOptions ] =
+					getExpectedDeprecationArgs(
+						name,
+						args,
+						isShorthandSelector,
+						alternativeFunction
+					);
 
-			expect( deprecated ).toHaveBeenCalledWith(
-				`The 'root', 'media' entity (used via '${ name }')`,
-				{
-					alternative: expectedAlternative,
-					since: '6.9',
-				}
-			);
-		} );
-	} );
+				expect( deprecated ).toHaveBeenCalledWith(
+					expectedMessage,
+					expectedOptions
+				);
+			} );
+		}
+	);
 } );
 
 describe( 'Deprecated entity logging - actions', () => {
@@ -217,36 +255,41 @@ describe( 'Deprecated entity logging - actions', () => {
 			name: 'saveMedia',
 			args: [ { title: 'Media' } ],
 			alternativeFunction: 'saveEntityRecord',
+			isShorthandSelector: true,
 		},
 		{
 			name: 'deleteMedia',
 			args: [ '123' ],
 			alternativeFunction: 'deleteEntityRecord',
+			isShorthandSelector: true,
 		},
-	] )( '$name', ( { name, args, alternativeFunction } ) => {
-		beforeEach( () => {
-			deprecated.mockReset();
-		} );
+	] )(
+		'$name',
+		( { name, args, alternativeFunction, isShorthandSelector } ) => {
+			beforeEach( () => {
+				deprecated.mockReset();
+			} );
 
-		it( 'logs a deprecation warning when used with deprecated entities', () => {
-			// Create a test registry with the actual store
-			const registry = createTestRegistry();
+			it( 'logs a deprecation warning when used with deprecated entities', () => {
+				// Create a test registry with the actual store
+				const registry = createTestRegistry();
 
-			// Dispatch the action.
-			registry.dispatch( coreDataStore )[ name ]( ...args );
+				// Dispatch the action.
+				registry.dispatch( coreDataStore )[ name ]( ...args );
 
-			let expectedAlternative = "the 'postType', 'attachment' entity";
-			if ( alternativeFunction ) {
-				expectedAlternative += ` via the '${ alternativeFunction }' function`;
-			}
+				const [ expectedMessage, expectedOptions ] =
+					getExpectedDeprecationArgs(
+						name,
+						args,
+						isShorthandSelector,
+						alternativeFunction
+					);
 
-			expect( deprecated ).toHaveBeenCalledWith(
-				`The 'root', 'media' entity (used via '${ name }')`,
-				{
-					alternative: expectedAlternative,
-					since: '6.9',
-				}
-			);
-		} );
-	} );
+				expect( deprecated ).toHaveBeenCalledWith(
+					expectedMessage,
+					expectedOptions
+				);
+			} );
+		}
+	);
 } );

--- a/packages/core-data/src/test/deprecated-entity-logging.js
+++ b/packages/core-data/src/test/deprecated-entity-logging.js
@@ -32,7 +32,7 @@ function getExpectedDeprecationArgs(
 	alternativeFunction
 ) {
 	const expectedMessage = isShorthandSelector
-		? name
+		? `'${ name }'`
 		: `The 'root', 'media' entity (used via '${ name }')`;
 
 	let expectedAlternative = "the 'postType', 'attachment' entity";

--- a/packages/core-data/src/test/deprecated-entity-logging.js
+++ b/packages/core-data/src/test/deprecated-entity-logging.js
@@ -93,175 +93,169 @@ function createTestRegistry() {
 		.dispatch( coreDataStore )
 		.receiveEntityRecords( 'root', 'media', mediaRecord );
 
-	// The call to receiveEntityRecords will log a deprecation warning,
-	// run all timers to flush timeouts and ensure that the warnings from the tests are logged.
 	jest.runAllTimers();
 
 	return registry;
 }
 
-describe( 'Deprecated entity logging - selectors', () => {
+describe( 'Deprecated entity logging', () => {
 	describe.each( [
 		{
+			type: 'selector',
 			name: 'getEntityConfig',
 			args: [ 'root', 'media' ],
 		},
 		{
+			type: 'selector',
 			name: 'getEntityRecord',
 			args: [ 'root', 'media', '123' ],
 		},
 		{
+			type: 'selector',
 			name: 'getRawEntityRecord',
 			args: [ 'root', 'media', '123' ],
 		},
 		{
+			type: 'selector',
 			name: 'hasEntityRecords',
 			args: [ 'root', 'media' ],
 		},
 		{
+			type: 'selector',
 			name: 'getEntityRecords',
 			args: [ 'root', 'media' ],
 		},
 		{
+			type: 'selector',
 			name: 'getEntityRecordsTotalItems',
 			args: [ 'root', 'media', { _fields: 'title' } ],
 		},
 		{
+			type: 'selector',
 			name: 'getEntityRecordsTotalPages',
 			args: [ 'root', 'media', { _fields: 'title' } ],
 		},
 		{
+			type: 'selector',
 			name: 'getEntityRecordEdits',
 			args: [ 'root', 'media', '123' ],
 		},
 		{
+			type: 'selector',
 			name: 'getEntityRecordNonTransientEdits',
 			args: [ 'root', 'media', '123' ],
 		},
 		{
+			type: 'selector',
 			name: 'hasEditsForEntityRecord',
 			args: [ 'root', 'media', '123' ],
 		},
 		{
+			type: 'selector',
 			name: 'getEditedEntityRecord',
 			args: [ 'root', 'media', '123' ],
 		},
 		{
+			type: 'selector',
 			name: 'isAutosavingEntityRecord',
 			args: [ 'root', 'media', '123' ],
 		},
 		{
+			type: 'selector',
 			name: 'isSavingEntityRecord',
 			args: [ 'root', 'media', '123' ],
 		},
 		{
+			type: 'selector',
 			name: 'isDeletingEntityRecord',
 			args: [ 'root', 'media', '123' ],
 		},
 		{
+			type: 'selector',
 			name: 'getLastEntitySaveError',
 			args: [ 'root', 'media', '123' ],
 		},
 		{
+			type: 'selector',
 			name: 'getLastEntityDeleteError',
 			args: [ 'root', 'media', '123' ],
 		},
 		{
+			type: 'selector',
 			name: 'canUser',
 			args: [ 'create', { kind: 'root', name: 'media' }, '123' ],
 		},
 		{
+			type: 'selector',
 			name: 'getRevisions',
 			args: [ 'root', 'media', '123' ],
 		},
 		{
+			type: 'selector',
 			name: 'getRevision',
 			args: [ 'root', 'media', '123', '10' ],
 		},
 		{
+			type: 'selector',
 			name: 'getMedia',
 			args: [ '123' ],
 			isShorthandSelector: true,
 			alternativeFunction: 'getEntityRecord',
 		},
 		{
+			type: 'selector',
 			name: 'getMediaItems',
 			args: [],
 			isShorthandSelector: true,
 			alternativeFunction: 'getEntityRecords',
 		},
-	] )(
-		'$name',
-		( { name, args, alternativeFunction, isShorthandSelector } ) => {
-			beforeEach( () => {
-				deprecated.mockReset();
-			} );
-
-			it( 'logs a deprecation warning when used with deprecated entities', () => {
-				// Create a test registry with the actual store
-				const registry = createTestRegistry();
-
-				// Dispatch the action.
-				registry.select( coreDataStore )[ name ]( ...args );
-
-				const [ expectedMessage, expectedOptions ] =
-					getExpectedDeprecationArgs(
-						name,
-						args,
-						isShorthandSelector,
-						alternativeFunction
-					);
-
-				expect( deprecated ).toHaveBeenCalledWith(
-					expectedMessage,
-					expectedOptions
-				);
-			} );
-		}
-	);
-} );
-
-describe( 'Deprecated entity logging - actions', () => {
-	describe.each( [
 		{
+			type: 'action',
 			name: 'deleteEntityRecord',
 			args: [ 'root', 'media', '123' ],
 		},
 		{
+			type: 'action',
 			name: 'editEntityRecord',
 			args: [ 'root', 'media', '123', { title: 'Media' } ],
 		},
 		{
+			type: 'action',
 			name: 'saveEntityRecord',
 			args: [ 'root', 'media', { title: 'Media' } ],
 		},
 		{
+			type: 'action',
 			name: 'saveEditedEntityRecord',
 			args: [ 'root', 'media', '123' ],
 		},
 		{
+			type: 'action',
 			name: '__experimentalSaveSpecifiedEntityEdits',
 			args: [ 'root', 'media', '123', [ 'title' ] ],
 		},
 		{
+			type: 'action',
 			name: 'receiveRevisions',
 			args: [ 'root', 'media', '123', [ 'title' ] ],
 		},
 		{
+			type: 'action',
 			name: 'saveMedia',
 			args: [ { title: 'Media' } ],
 			alternativeFunction: 'saveEntityRecord',
 			isShorthandSelector: true,
 		},
 		{
+			type: 'action',
 			name: 'deleteMedia',
 			args: [ '123' ],
 			alternativeFunction: 'deleteEntityRecord',
 			isShorthandSelector: true,
 		},
 	] )(
-		'$name',
-		( { name, args, alternativeFunction, isShorthandSelector } ) => {
+		'$name $type',
+		( { type, name, args, alternativeFunction, isShorthandSelector } ) => {
 			beforeEach( () => {
 				deprecated.mockReset();
 			} );
@@ -270,8 +264,13 @@ describe( 'Deprecated entity logging - actions', () => {
 				// Create a test registry with the actual store
 				const registry = createTestRegistry();
 
-				// Dispatch the action.
-				registry.dispatch( coreDataStore )[ name ]( ...args );
+				if ( type === 'selector' ) {
+					// Dispatch the action.
+					registry.select( coreDataStore )[ name ]( ...args );
+				} else {
+					// Dispatch the action.
+					registry.dispatch( coreDataStore )[ name ]( ...args );
+				}
 
 				const [ expectedMessage, expectedOptions ] =
 					getExpectedDeprecationArgs(

--- a/packages/core-data/src/test/deprecated-entity-logging.js
+++ b/packages/core-data/src/test/deprecated-entity-logging.js
@@ -11,6 +11,11 @@ import { store as coreDataStore } from '../index';
 
 jest.mock( '@wordpress/deprecated' );
 
+// Use fake timers within this file.
+// logEntityDeprecation() uses setTimeout() to avoid spurious logging, so fake timers are used to
+// ensure that the deprecation warning is logged correctly.
+jest.useFakeTimers();
+
 /**
  * Creates a test registry with the core-data store and sets up the deprecated media entity.
  *
@@ -48,6 +53,10 @@ function createTestRegistry() {
 	registry
 		.dispatch( coreDataStore )
 		.receiveEntityRecords( 'root', 'media', mediaRecord );
+
+	// The call to receiveEntityRecords will log a deprecation warning,
+	// run all timers to flush timeouts and ensure that the warnings from the tests are logged.
+	jest.runAllTimers();
 
 	return registry;
 }

--- a/packages/core-data/src/test/deprecated-entity-logging.js
+++ b/packages/core-data/src/test/deprecated-entity-logging.js
@@ -224,10 +224,6 @@ describe( 'Deprecated entity logging - selectors', () => {
 describe( 'Deprecated entity logging - actions', () => {
 	describe.each( [
 		{
-			name: 'receiveEntityRecords',
-			args: [ 'root', 'media', { title: 'Media' } ],
-		},
-		{
 			name: 'deleteEntityRecord',
 			args: [ 'root', 'media', '123' ],
 		},

--- a/packages/core-data/src/test/deprecated-entity-logging.js
+++ b/packages/core-data/src/test/deprecated-entity-logging.js
@@ -1,0 +1,237 @@
+/**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+import { createRegistry } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as coreDataStore } from '../index';
+
+jest.mock( '@wordpress/deprecated' );
+
+/**
+ * Creates a test registry with the core-data store and sets up the deprecated media entity.
+ *
+ * @return {Object} Registry with core-data store registered.
+ */
+function createTestRegistry() {
+	const registry = createRegistry();
+
+	// Register the core-data store
+	registry.register( coreDataStore );
+
+	// Set up the deprecated media entity configuration
+	const mediaEntityConfig = {
+		name: 'media',
+		kind: 'root',
+		baseURL: '/wp/v2/media',
+		baseURLParams: { context: 'edit' },
+		plural: 'mediaItems',
+		label: 'Media',
+		rawAttributes: [ 'caption', 'title', 'description' ],
+		supportsPagination: true,
+	};
+
+	// Add the media entity to the store
+	registry.dispatch( coreDataStore ).addEntities( [ mediaEntityConfig ] );
+
+	// Add a sample media record to the store for testing
+	const mediaRecord = {
+		id: '123',
+		title: 'Test Media',
+		content: 'Test content',
+		excerpt: 'Test excerpt',
+	};
+
+	registry
+		.dispatch( coreDataStore )
+		.receiveEntityRecords( 'root', 'media', mediaRecord );
+
+	return registry;
+}
+
+describe( 'Deprecated entity logging - selectors', () => {
+	describe.each( [
+		{
+			name: 'getEntityConfig',
+			args: [ 'root', 'media' ],
+		},
+		{
+			name: 'getEntityRecord',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			name: 'getRawEntityRecord',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			name: 'hasEntityRecords',
+			args: [ 'root', 'media' ],
+		},
+		{
+			name: 'getEntityRecords',
+			args: [ 'root', 'media' ],
+		},
+		{
+			name: 'getEntityRecordsTotalItems',
+			args: [ 'root', 'media', { _fields: 'title' } ],
+		},
+		{
+			name: 'getEntityRecordsTotalPages',
+			args: [ 'root', 'media', { _fields: 'title' } ],
+		},
+		{
+			name: 'getEntityRecordEdits',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			name: 'getEntityRecordNonTransientEdits',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			name: 'hasEditsForEntityRecord',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			name: 'getEditedEntityRecord',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			name: 'isAutosavingEntityRecord',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			name: 'isSavingEntityRecord',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			name: 'isDeletingEntityRecord',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			name: 'getLastEntitySaveError',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			name: 'getLastEntityDeleteError',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			name: 'canUser',
+			args: [ 'create', { kind: 'root', name: 'media' }, '123' ],
+		},
+		{
+			name: 'getRevisions',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			name: 'getRevision',
+			args: [ 'root', 'media', '123', '10' ],
+		},
+		{
+			name: 'getMedia',
+			args: [ '123' ],
+			alternativeFunction: 'getEntityRecord',
+		},
+		{
+			name: 'getMediaItems',
+			args: [],
+			alternativeFunction: 'getEntityRecords',
+		},
+	] )( '$name', ( { name, args, alternativeFunction } ) => {
+		beforeEach( () => {
+			deprecated.mockReset();
+		} );
+
+		it( 'logs a deprecation warning when used with deprecated entities', () => {
+			// Create a test registry with the actual store
+			const registry = createTestRegistry();
+
+			// Dispatch the action.
+			registry.select( coreDataStore )[ name ]( ...args );
+
+			let expectedAlternative = "The 'postType', 'attachment' entity";
+			if ( alternativeFunction ) {
+				expectedAlternative += ` via the '${ alternativeFunction }' function`;
+			}
+
+			expect( deprecated ).toHaveBeenCalledWith(
+				`The 'root', 'media' entity (used via '${ name }')`,
+				{
+					alternative: expectedAlternative,
+					since: '6.9',
+				}
+			);
+		} );
+	} );
+} );
+
+describe( 'Deprecated entity logging - actions', () => {
+	describe.each( [
+		{
+			name: 'receiveEntityRecords',
+			args: [ 'root', 'media', { title: 'Media' } ],
+		},
+		{
+			name: 'deleteEntityRecord',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			name: 'editEntityRecord',
+			args: [ 'root', 'media', '123', { title: 'Media' } ],
+		},
+		{
+			name: 'saveEntityRecord',
+			args: [ 'root', 'media', { title: 'Media' } ],
+		},
+		{
+			name: 'saveEditedEntityRecord',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			name: '__experimentalSaveSpecifiedEntityEdits',
+			args: [ 'root', 'media', '123', [ 'title' ] ],
+		},
+		{
+			name: 'receiveRevisions',
+			args: [ 'root', 'media', '123', [ 'title' ] ],
+		},
+		{
+			name: 'saveMedia',
+			args: [ { title: 'Media' } ],
+			alternativeFunction: 'saveEntityRecord',
+		},
+		{
+			name: 'deleteMedia',
+			args: [ '123' ],
+			alternativeFunction: 'deleteEntityRecord',
+		},
+	] )( '$name', ( { name, args, alternativeFunction } ) => {
+		beforeEach( () => {
+			deprecated.mockReset();
+		} );
+
+		it( 'logs a deprecation warning when used with deprecated entities', () => {
+			// Create a test registry with the actual store
+			const registry = createTestRegistry();
+
+			// Dispatch the action.
+			registry.dispatch( coreDataStore )[ name ]( ...args );
+
+			let expectedAlternative = "The 'postType', 'attachment' entity";
+			if ( alternativeFunction ) {
+				expectedAlternative += ` via the '${ alternativeFunction }' function`;
+			}
+
+			expect( deprecated ).toHaveBeenCalledWith(
+				`The 'root', 'media' entity (used via '${ name }')`,
+				{
+					alternative: expectedAlternative,
+					since: '6.9',
+				}
+			);
+		} );
+	} );
+} );

--- a/packages/core-data/src/test/deprecated-entity-logging.js
+++ b/packages/core-data/src/test/deprecated-entity-logging.js
@@ -10,6 +10,7 @@ import { createRegistry } from '@wordpress/data';
 import { store as coreDataStore } from '../index';
 
 jest.mock( '@wordpress/deprecated' );
+jest.mock( '@wordpress/api-fetch' );
 
 // Use fake timers within this file.
 // logEntityDeprecation() uses setTimeout() to avoid spurious logging, so fake timers are used to

--- a/packages/core-data/src/test/deprecated-entity-logging.js
+++ b/packages/core-data/src/test/deprecated-entity-logging.js
@@ -167,7 +167,7 @@ describe( 'Deprecated entity logging - selectors', () => {
 			// Dispatch the action.
 			registry.select( coreDataStore )[ name ]( ...args );
 
-			let expectedAlternative = "The 'postType', 'attachment' entity";
+			let expectedAlternative = "the 'postType', 'attachment' entity";
 			if ( alternativeFunction ) {
 				expectedAlternative += ` via the '${ alternativeFunction }' function`;
 			}
@@ -235,7 +235,7 @@ describe( 'Deprecated entity logging - actions', () => {
 			// Dispatch the action.
 			registry.dispatch( coreDataStore )[ name ]( ...args );
 
-			let expectedAlternative = "The 'postType', 'attachment' entity";
+			let expectedAlternative = "the 'postType', 'attachment' entity";
 			if ( alternativeFunction ) {
 				expectedAlternative += ` via the '${ alternativeFunction }' function`;
 			}

--- a/packages/core-data/src/test/private-actions.js
+++ b/packages/core-data/src/test/private-actions.js
@@ -24,8 +24,8 @@ describe( 'editMediaEntity', () => {
 		resolveSelect = {
 			getEntitiesConfig: jest.fn( () => [
 				{
-					kind: 'root',
-					name: 'media',
+					kind: 'postType',
+					name: 'attachment',
 					baseURL: '/wp/v2/media',
 				},
 			] ),
@@ -82,14 +82,14 @@ describe( 'editMediaEntity', () => {
 
 		expect( dispatch.__unstableAcquireStoreLock ).toHaveBeenCalledWith(
 			'core',
-			[ 'entities', 'records', 'root', 'media', recordId ],
+			[ 'entities', 'records', 'postType', 'attachment', recordId ],
 			{ exclusive: true }
 		);
 
 		expect( dispatch ).toHaveBeenCalledWith( {
 			type: 'SAVE_ENTITY_RECORD_START',
-			kind: 'root',
-			name: 'media',
+			kind: 'postType',
+			name: 'attachment',
 			recordId,
 		} );
 
@@ -100,8 +100,8 @@ describe( 'editMediaEntity', () => {
 		} );
 
 		expect( dispatch.receiveEntityRecords ).toHaveBeenCalledWith(
-			'root',
-			'media',
+			'postType',
+			'attachment',
 			[ updatedRecord ],
 			undefined,
 			true,
@@ -111,8 +111,8 @@ describe( 'editMediaEntity', () => {
 
 		expect( dispatch ).toHaveBeenCalledWith( {
 			type: 'SAVE_ENTITY_RECORD_FINISH',
-			kind: 'root',
-			name: 'media',
+			kind: 'postType',
+			name: 'attachment',
 			recordId,
 			error: undefined,
 		} );
@@ -137,15 +137,15 @@ describe( 'editMediaEntity', () => {
 
 		expect( dispatch ).toHaveBeenCalledWith( {
 			type: 'SAVE_ENTITY_RECORD_START',
-			kind: 'root',
-			name: 'media',
+			kind: 'postType',
+			name: 'attachment',
 			recordId,
 		} );
 
 		expect( dispatch ).toHaveBeenCalledWith( {
 			type: 'SAVE_ENTITY_RECORD_FINISH',
-			kind: 'root',
-			name: 'media',
+			kind: 'postType',
+			name: 'attachment',
 			recordId,
 			error: apiError,
 		} );

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -379,8 +379,8 @@ describe( 'getEmbedPreview', () => {
 describe( 'canUser', () => {
 	const ENTITIES = [
 		{
-			name: 'media',
-			kind: 'root',
+			name: 'postType',
+			kind: 'attachment',
 			baseURL: '/wp/v2/media',
 			baseURLParams: { context: 'edit' },
 		},
@@ -417,7 +417,7 @@ describe( 'canUser', () => {
 			'create',
 			'media'
 		)( { dispatch, registry, resolveSelect } );
-		await canUser( 'create', { kind: 'root', name: 'media' } )( {
+		await canUser( 'create', { kind: 'postType', name: 'attachment' } )( {
 			dispatch,
 			registry,
 			resolveSelect,
@@ -469,7 +469,7 @@ describe( 'canUser', () => {
 			headers: new Map( [ [ 'allow', 'GET' ] ] ),
 		} ) );
 
-		await canUser( 'create', { kind: 'root', name: 'media' } )( {
+		await canUser( 'create', { kind: 'postType', name: 'attachment' } )( {
 			dispatch,
 			registry,
 			resolveSelect,
@@ -514,7 +514,7 @@ describe( 'canUser', () => {
 			headers: new Map( [ [ 'allow', 'POST, GET, PUT, DELETE' ] ] ),
 		} ) );
 
-		await canUser( 'create', { kind: 'root', name: 'media' } )( {
+		await canUser( 'create', { kind: 'postType', name: 'attachment' } )( {
 			dispatch,
 			registry,
 			resolveSelect,

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -379,8 +379,8 @@ describe( 'getEmbedPreview', () => {
 describe( 'canUser', () => {
 	const ENTITIES = [
 		{
-			name: 'postType',
-			kind: 'attachment',
+			name: 'attachment',
+			kind: 'postType',
 			baseURL: '/wp/v2/media',
 			baseURLParams: { context: 'edit' },
 		},
@@ -482,7 +482,7 @@ describe( 'canUser', () => {
 		} );
 
 		expect( dispatch.receiveUserPermission ).toHaveBeenCalledWith(
-			'create/root/media',
+			'create/postType/attachment',
 			false
 		);
 	} );
@@ -527,7 +527,7 @@ describe( 'canUser', () => {
 		} );
 
 		expect( dispatch.receiveUserPermission ).toHaveBeenCalledWith(
-			'create/root/media',
+			'create/postType/attachment',
 			true
 		);
 	} );

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -732,7 +732,7 @@ describe( 'canUser', () => {
 		} );
 		expect( canUser( state, 'create', 'media' ) ).toBe( undefined );
 		expect(
-			canUser( state, 'create', { kind: 'root', name: 'media' } )
+			canUser( state, 'create', { kind: 'postType', name: 'attachment' } )
 		).toBe( undefined );
 	} );
 
@@ -740,8 +740,12 @@ describe( 'canUser', () => {
 		const state = deepFreeze( {
 			userPermissions: {},
 		} );
-		expect( canUser( state, 'create', { name: 'media' } ) ).toBe( false );
-		expect( canUser( state, 'create', { kind: 'root' } ) ).toBe( false );
+		expect( canUser( state, 'create', { name: 'attachment' } ) ).toBe(
+			false
+		);
+		expect( canUser( state, 'create', { kind: 'postType' } ) ).toBe(
+			false
+		);
 	} );
 
 	it( 'returns whether an action can be performed', () => {
@@ -753,7 +757,7 @@ describe( 'canUser', () => {
 		} );
 		expect( canUser( state, 'create', 'media' ) ).toBe( false );
 		expect(
-			canUser( state, 'create', { kind: 'root', name: 'media' } )
+			canUser( state, 'create', { kind: 'postType', name: 'attachment' } )
 		).toBe( false );
 	} );
 
@@ -766,7 +770,11 @@ describe( 'canUser', () => {
 		} );
 		expect( canUser( state, 'create', 'media', 123 ) ).toBe( false );
 		expect(
-			canUser( state, 'create', { kind: 'root', name: 'media', id: 123 } )
+			canUser( state, 'create', {
+				kind: 'postType',
+				name: 'attachment',
+				id: 123,
+			} )
 		).toBe( false );
 	} );
 } );

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -752,7 +752,7 @@ describe( 'canUser', () => {
 		const state = deepFreeze( {
 			userPermissions: {
 				'create/media': false,
-				'create/root/media': false,
+				'create/postType/attachment': false,
 			},
 		} );
 		expect( canUser( state, 'create', 'media' ) ).toBe( false );
@@ -765,7 +765,7 @@ describe( 'canUser', () => {
 		const state = deepFreeze( {
 			userPermissions: {
 				'create/media/123': false,
-				'create/root/media/123': false,
+				'create/postType/attachment/123': false,
 			},
 		} );
 		expect( canUser( state, 'create', 'media', 123 ) ).toBe( false );

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -4,35 +4,19 @@
 import deepFreeze from 'deep-freeze';
 
 /**
- * WordPress dependencies
- */
-import deprecated from '@wordpress/deprecated';
-
-/**
  * Internal dependencies
  */
 import {
-	getEntityConfig,
 	getEntityRecord,
 	__experimentalGetEntityRecordNoResolver,
 	hasEntityRecords,
 	getEntityRecords,
-	getEntityRecordsTotalItems,
-	getEntityRecordsTotalPages,
 	getRawEntityRecord,
-	getEntityRecordEdits,
-	hasEditsForEntityRecord,
-	getEditedEntityRecord,
-	isAutosavingEntityRecord,
 	__experimentalGetDirtyEntityRecords,
 	__experimentalGetEntitiesBeingSaved,
 	getEntityRecordNonTransientEdits,
 	getEmbedPreview,
 	isPreviewEmbedFallback,
-	isSavingEntityRecord,
-	isDeletingEntityRecord,
-	getLastEntitySaveError,
-	getLastEntityDeleteError,
 	canUser,
 	getAutosave,
 	getAutosaves,
@@ -40,8 +24,6 @@ import {
 	getRevisions,
 	getRevision,
 } from '../selectors';
-
-jest.mock( '@wordpress/deprecated' );
 
 // getEntityRecord and __experimentalGetEntityRecordNoResolver selectors share the same tests.
 describe.each( [
@@ -1023,135 +1005,6 @@ describe( 'getRevision', () => {
 			content: 'chicken',
 			author: 'bob',
 			parent: 1,
-		} );
-	} );
-} );
-
-describe( 'Deprecated entity logging', () => {
-	describe.each( [
-		{
-			selector: getEntityConfig,
-			name: 'getEntityConfig',
-			args: [ 'root', 'media' ],
-		},
-		{
-			selector: getEntityRecord,
-			name: 'getEntityRecord',
-			args: [ 'root', 'media', '123' ],
-		},
-		{
-			selector: getRawEntityRecord,
-			name: 'getRawEntityRecord',
-			args: [ 'root', 'media', '123' ],
-		},
-		{
-			selector: hasEntityRecords,
-			name: 'hasEntityRecords',
-			args: [ 'root', 'media' ],
-		},
-		{
-			selector: getEntityRecords,
-			name: 'getEntityRecords',
-			args: [ 'root', 'media' ],
-		},
-		{
-			selector: getEntityRecordsTotalItems,
-			name: 'getEntityRecordsTotalItems',
-			args: [ 'root', 'media', { _fields: 'title' } ],
-		},
-		{
-			selector: getEntityRecordsTotalPages,
-			name: 'getEntityRecordsTotalPages',
-			args: [ 'root', 'media', { _fields: 'title' } ],
-		},
-		{
-			selector: getEntityRecordEdits,
-			name: 'getEntityRecordEdits',
-			args: [ 'root', 'media', '123' ],
-		},
-		{
-			selector: getEntityRecordNonTransientEdits,
-			name: 'getEntityRecordNonTransientEdits',
-			args: [ 'root', 'media', '123' ],
-		},
-		{
-			selector: hasEditsForEntityRecord,
-			name: 'hasEditsForEntityRecord',
-			args: [ 'root', 'media', '123' ],
-		},
-		{
-			selector: getEditedEntityRecord,
-			name: 'getEditedEntityRecord',
-			args: [ 'root', 'media', '123' ],
-		},
-		{
-			selector: isAutosavingEntityRecord,
-			name: 'isAutosavingEntityRecord',
-			args: [ 'root', 'media', '123' ],
-		},
-		{
-			selector: isSavingEntityRecord,
-			name: 'isSavingEntityRecord',
-			args: [ 'root', 'media', '123' ],
-		},
-		{
-			selector: isDeletingEntityRecord,
-			name: 'isDeletingEntityRecord',
-			args: [ 'root', 'media', '123' ],
-		},
-		{
-			selector: getLastEntitySaveError,
-			name: 'getLastEntitySaveError',
-			args: [ 'root', 'media', '123' ],
-		},
-		{
-			selector: getLastEntityDeleteError,
-			name: 'getLastEntityDeleteError',
-			args: [ 'root', 'media', '123' ],
-		},
-		{
-			selector: canUser,
-			name: 'canUser',
-			args: [ 'create', { kind: 'root', name: 'media' }, '123' ],
-		},
-		{
-			selector: getRevisions,
-			name: 'getRevisions',
-			args: [ 'root', 'media', '123' ],
-		},
-		{
-			selector: getRevision,
-			name: 'getRevision',
-			args: [ 'root', 'media', '123', '10' ],
-		},
-	] )( '$name', ( { selector, name, args } ) => {
-		it( 'logs a deprecation warning when used with deprecated entities', () => {
-			const state = deepFreeze( {
-				entities: {
-					records: {
-						root: {
-							media: {
-								queriedData: {
-									items: {},
-									itemIsComplete: {},
-									queries: {},
-								},
-							},
-						},
-					},
-				},
-				userPermissions: {},
-			} );
-
-			selector( state, ...args );
-
-			expect( deprecated ).toHaveBeenCalledWith(
-				`The 'root', 'media' entity (used via '${ name }')`,
-				{
-					alternative: "The 'postType', 'attachment' entity",
-					since: '6.9',
-				}
-			);
 		} );
 	} );
 } );

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -4,19 +4,35 @@
 import deepFreeze from 'deep-freeze';
 
 /**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
  * Internal dependencies
  */
 import {
+	getEntityConfig,
 	getEntityRecord,
 	__experimentalGetEntityRecordNoResolver,
 	hasEntityRecords,
 	getEntityRecords,
+	getEntityRecordsTotalItems,
+	getEntityRecordsTotalPages,
 	getRawEntityRecord,
+	getEntityRecordEdits,
+	hasEditsForEntityRecord,
+	getEditedEntityRecord,
+	isAutosavingEntityRecord,
 	__experimentalGetDirtyEntityRecords,
 	__experimentalGetEntitiesBeingSaved,
 	getEntityRecordNonTransientEdits,
 	getEmbedPreview,
 	isPreviewEmbedFallback,
+	isSavingEntityRecord,
+	isDeletingEntityRecord,
+	getLastEntitySaveError,
+	getLastEntityDeleteError,
 	canUser,
 	getAutosave,
 	getAutosaves,
@@ -24,6 +40,9 @@ import {
 	getRevisions,
 	getRevision,
 } from '../selectors';
+
+jest.mock( '@wordpress/deprecated' );
+
 // getEntityRecord and __experimentalGetEntityRecordNoResolver selectors share the same tests.
 describe.each( [
 	[ getEntityRecord ],
@@ -52,6 +71,7 @@ describe.each( [
 			] );
 		} );
 	} );
+
 	it( 'should return undefined for unknown entity kind, name', () => {
 		const state = deepFreeze( {
 			entities: {
@@ -290,6 +310,7 @@ describe( 'getRawEntityRecord', () => {
 			},
 		},
 	};
+
 	it( 'should preserve the structure of `raw` field by default', () => {
 		const state = deepFreeze( {
 			entities: {
@@ -1002,6 +1023,135 @@ describe( 'getRevision', () => {
 			content: 'chicken',
 			author: 'bob',
 			parent: 1,
+		} );
+	} );
+} );
+
+describe( 'Deprecated entity logging', () => {
+	describe.each( [
+		{
+			selector: getEntityConfig,
+			name: 'getEntityConfig',
+			args: [ 'root', 'media' ],
+		},
+		{
+			selector: getEntityRecord,
+			name: 'getEntityRecord',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			selector: getRawEntityRecord,
+			name: 'getRawEntityRecord',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			selector: hasEntityRecords,
+			name: 'hasEntityRecords',
+			args: [ 'root', 'media' ],
+		},
+		{
+			selector: getEntityRecords,
+			name: 'getEntityRecords',
+			args: [ 'root', 'media' ],
+		},
+		{
+			selector: getEntityRecordsTotalItems,
+			name: 'getEntityRecordsTotalItems',
+			args: [ 'root', 'media', { _fields: 'title' } ],
+		},
+		{
+			selector: getEntityRecordsTotalPages,
+			name: 'getEntityRecordsTotalPages',
+			args: [ 'root', 'media', { _fields: 'title' } ],
+		},
+		{
+			selector: getEntityRecordEdits,
+			name: 'getEntityRecordEdits',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			selector: getEntityRecordNonTransientEdits,
+			name: 'getEntityRecordNonTransientEdits',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			selector: hasEditsForEntityRecord,
+			name: 'hasEditsForEntityRecord',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			selector: getEditedEntityRecord,
+			name: 'getEditedEntityRecord',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			selector: isAutosavingEntityRecord,
+			name: 'isAutosavingEntityRecord',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			selector: isSavingEntityRecord,
+			name: 'isSavingEntityRecord',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			selector: isDeletingEntityRecord,
+			name: 'isDeletingEntityRecord',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			selector: getLastEntitySaveError,
+			name: 'getLastEntitySaveError',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			selector: getLastEntityDeleteError,
+			name: 'getLastEntityDeleteError',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			selector: canUser,
+			name: 'canUser',
+			args: [ 'create', { kind: 'root', name: 'media' }, '123' ],
+		},
+		{
+			selector: getRevisions,
+			name: 'getRevisions',
+			args: [ 'root', 'media', '123' ],
+		},
+		{
+			selector: getRevision,
+			name: 'getRevision',
+			args: [ 'root', 'media', '123', '10' ],
+		},
+	] )( '$name', ( { selector, name, args } ) => {
+		it( 'logs a deprecation warning when used with deprecated entities', () => {
+			const state = deepFreeze( {
+				entities: {
+					records: {
+						root: {
+							media: {
+								queriedData: {
+									items: {},
+									itemIsComplete: {},
+									queries: {},
+								},
+							},
+						},
+					},
+				},
+				userPermissions: {},
+			} );
+
+			selector( state, ...args );
+
+			expect( deprecated ).toHaveBeenCalledWith(
+				`The 'root', 'media' entity (used via '${ name }')`,
+				{
+					alternative: "The 'postType', 'attachment' entity",
+					since: '6.9',
+				}
+			);
 		} );
 	} );
 } );

--- a/packages/core-data/src/utils/log-entity-deprecation.ts
+++ b/packages/core-data/src/utils/log-entity-deprecation.ts
@@ -23,10 +23,10 @@ export default function logEntityDeprecation( kind, name, functionName ) {
 
 	const { alternative } = deprecation;
 	deprecated(
-		`${ kind }, ${ name } entity (used in a call to ${ functionName })`,
+		`The '${ kind }', '${ name }' entity (used in a call to ${ functionName })`,
 		{
 			...deprecation,
-			alternative: `the ${ alternative.kind }, ${ alternative.name } entity`,
+			alternative: `The '${ alternative.kind }', '${ alternative.name }' entity`,
 		}
 	);
 }

--- a/packages/core-data/src/utils/log-entity-deprecation.ts
+++ b/packages/core-data/src/utils/log-entity-deprecation.ts
@@ -11,22 +11,34 @@ import { deprecatedEntities } from '../entities';
 /**
  * Logs a deprecation warning for an entity, if it's deprecated.
  *
- * @param kind         - The kind of the entity.
- * @param name         - The name of the entity.
- * @param functionName - The name of the function that was called with a deprecated entity.
+ * @param kind                    - The kind of the entity.
+ * @param name                    - The name of the entity.
+ * @param functionName            - The name of the function that was called with a deprecated entity.
+ * @param alternativeFunctionName - The name of the alternative function that should be used instead.
  */
-export default function logEntityDeprecation( kind, name, functionName ) {
+export default function logEntityDeprecation(
+	kind: string,
+	name: string,
+	functionName: string,
+	alternativeFunctionName?: string
+) {
 	const deprecation = deprecatedEntities[ kind ]?.[ name ];
 	if ( ! deprecation ) {
 		return;
 	}
 
 	const { alternative } = deprecation;
+	let alternativeMessage = `The '${ alternative.kind }', '${ alternative.name }' entity`;
+
+	if ( alternativeFunctionName ) {
+		alternativeMessage += ` via the '${ alternativeFunctionName }' function`;
+	}
+
 	deprecated(
-		`The '${ kind }', '${ name }' entity (used in a call to ${ functionName })`,
+		`The '${ kind }', '${ name }' entity (used via '${ functionName }')`,
 		{
 			...deprecation,
-			alternative: `The '${ alternative.kind }', '${ alternative.name }' entity`,
+			alternative: alternativeMessage,
 		}
 	);
 }

--- a/packages/core-data/src/utils/log-entity-deprecation.ts
+++ b/packages/core-data/src/utils/log-entity-deprecation.ts
@@ -48,6 +48,8 @@ export default function logEntityDeprecation(
 
 	// Only log an entity deprecation once per call stack,
 	// else there's spurious logging when selections or actions call through to other selectors or actions.
+	// Note: this won't prevent the deprecation warning being logged if a selector or action makes an async call
+	// to another selector or action, but this is probably the best we can do.
 	loggedAlready = true;
 	// At the end of the call stack, reset the flag.
 	setTimeout( () => {

--- a/packages/core-data/src/utils/log-entity-deprecation.ts
+++ b/packages/core-data/src/utils/log-entity-deprecation.ts
@@ -13,37 +13,46 @@ let loggedAlready = false;
 /**
  * Logs a deprecation warning for an entity, if it's deprecated.
  *
- * @param kind                    - The kind of the entity.
- * @param name                    - The name of the entity.
- * @param functionName            - The name of the function that was called with a deprecated entity.
- * @param alternativeFunctionName - The name of the alternative function that should be used instead.
+ * @param kind                            The kind of the entity.
+ * @param name                            The name of the entity.
+ * @param functionName                    The name of the function that was called with a deprecated entity.
+ * @param options                         The options for the deprecation warning.
+ * @param options.alternativeFunctionName The name of the alternative function that should be used instead.
+ * @param options.isShorthandSelector     Whether the function is a shorthand selector.
  */
 export default function logEntityDeprecation(
 	kind: string,
 	name: string,
 	functionName: string,
-	alternativeFunctionName?: string
+	{
+		alternativeFunctionName,
+		isShorthandSelector = false,
+	}: {
+		alternativeFunctionName?: string;
+		isShorthandSelector?: boolean;
+	} = {}
 ) {
 	const deprecation = deprecatedEntities[ kind ]?.[ name ];
 	if ( ! deprecation ) {
 		return;
 	}
 
-	const { alternative } = deprecation;
-	let alternativeMessage = `the '${ alternative.kind }', '${ alternative.name }' entity`;
-
-	if ( alternativeFunctionName ) {
-		alternativeMessage += ` via the '${ alternativeFunctionName }' function`;
-	}
-
 	if ( ! loggedAlready ) {
-		deprecated(
-			`The '${ kind }', '${ name }' entity (used via '${ functionName }')`,
-			{
-				...deprecation,
-				alternative: alternativeMessage,
-			}
-		);
+		const { alternative } = deprecation;
+
+		const message = isShorthandSelector
+			? functionName
+			: `The '${ kind }', '${ name }' entity (used via '${ functionName }')`;
+
+		let alternativeMessage = `the '${ alternative.kind }', '${ alternative.name }' entity`;
+		if ( alternativeFunctionName ) {
+			alternativeMessage += ` via the '${ alternativeFunctionName }' function`;
+		}
+
+		deprecated( message, {
+			...deprecation,
+			alternative: alternativeMessage,
+		} );
 	}
 
 	// Only log an entity deprecation once per call stack,

--- a/packages/core-data/src/utils/log-entity-deprecation.ts
+++ b/packages/core-data/src/utils/log-entity-deprecation.ts
@@ -41,7 +41,7 @@ export default function logEntityDeprecation(
 		const { alternative } = deprecation;
 
 		const message = isShorthandSelector
-			? functionName
+			? `'${ functionName }'`
 			: `The '${ kind }', '${ name }' entity (used via '${ functionName }')`;
 
 		let alternativeMessage = `the '${ alternative.kind }', '${ alternative.name }' entity`;

--- a/packages/core-data/src/utils/log-entity-deprecation.ts
+++ b/packages/core-data/src/utils/log-entity-deprecation.ts
@@ -30,7 +30,7 @@ export default function logEntityDeprecation(
 	}
 
 	const { alternative } = deprecation;
-	let alternativeMessage = `The '${ alternative.kind }', '${ alternative.name }' entity`;
+	let alternativeMessage = `the '${ alternative.kind }', '${ alternative.name }' entity`;
 
 	if ( alternativeFunctionName ) {
 		alternativeMessage += ` via the '${ alternativeFunctionName }' function`;

--- a/packages/core-data/src/utils/log-entity-deprecation.ts
+++ b/packages/core-data/src/utils/log-entity-deprecation.ts
@@ -8,6 +8,8 @@ import deprecated from '@wordpress/deprecated';
  */
 import { deprecatedEntities } from '../entities';
 
+let loggedAlready = false;
+
 /**
  * Logs a deprecation warning for an entity, if it's deprecated.
  *
@@ -34,11 +36,21 @@ export default function logEntityDeprecation(
 		alternativeMessage += ` via the '${ alternativeFunctionName }' function`;
 	}
 
-	deprecated(
-		`The '${ kind }', '${ name }' entity (used via '${ functionName }')`,
-		{
-			...deprecation,
-			alternative: alternativeMessage,
-		}
-	);
+	if ( ! loggedAlready ) {
+		deprecated(
+			`The '${ kind }', '${ name }' entity (used via '${ functionName }')`,
+			{
+				...deprecation,
+				alternative: alternativeMessage,
+			}
+		);
+	}
+
+	// Only log an entity deprecation once per call stack,
+	// else there's spurious logging when selections or actions call through to other selectors or actions.
+	loggedAlready = true;
+	// At the end of the call stack, reset the flag.
+	setTimeout( () => {
+		loggedAlready = false;
+	}, 0 );
 }

--- a/packages/core-data/src/utils/log-entity-deprecation.ts
+++ b/packages/core-data/src/utils/log-entity-deprecation.ts
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
+ * Internal dependencies
+ */
+import { deprecatedEntities } from '../entities';
+
+/**
+ * Logs a deprecation warning for an entity, if it's deprecated.
+ *
+ * @param kind         - The kind of the entity.
+ * @param name         - The name of the entity.
+ * @param functionName - The name of the function that was called with a deprecated entity.
+ */
+export default function logEntityDeprecation( kind, name, functionName ) {
+	const deprecation = deprecatedEntities[ kind ]?.[ name ];
+	if ( ! deprecation ) {
+		return;
+	}
+
+	const { alternative } = deprecation;
+	deprecated(
+		`${ kind }, ${ name } entity (used in a call to ${ functionName })`,
+		{
+			...deprecation,
+			alternative: `the ${ alternative.kind }, ${ alternative.name } entity`,
+		}
+	);
+}

--- a/packages/core-data/src/utils/test/log-entity-deprecation.js
+++ b/packages/core-data/src/utils/test/log-entity-deprecation.js
@@ -8,6 +8,8 @@ import deprecated from '@wordpress/deprecated';
  */
 import logEntityDeprecation from '../log-entity-deprecation';
 
+jest.useFakeTimers();
+
 // Mock the deprecatedEntities import
 jest.mock( '../../entities', () => ( {
 	deprecatedEntities: {
@@ -29,6 +31,9 @@ jest.mock( '@wordpress/deprecated' );
 describe( 'logEntityDeprecation', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+
+		// Ensure the timeout that prevents spurious logging is cleared.
+		jest.runAllTimers();
 	} );
 
 	it( 'should call deprecated when entity is deprecated', () => {

--- a/packages/core-data/src/utils/test/log-entity-deprecation.js
+++ b/packages/core-data/src/utils/test/log-entity-deprecation.js
@@ -73,12 +73,9 @@ describe( 'logEntityDeprecation', () => {
 	} );
 
 	it( 'should include alternative function name when provided', () => {
-		logEntityDeprecation(
-			'root',
-			'media',
-			'getEntityRecord',
-			'getPostTypeEntity'
-		);
+		logEntityDeprecation( 'root', 'media', 'getEntityRecord', {
+			alternativeFunctionName: 'getPostTypeEntity',
+		} );
 
 		expect( deprecated ).toHaveBeenCalledWith(
 			"The 'root', 'media' entity (used via 'getEntityRecord')",
@@ -88,6 +85,17 @@ describe( 'logEntityDeprecation', () => {
 					"the 'postType', 'attachment' entity via the 'getPostTypeEntity' function",
 			}
 		);
+	} );
+
+	it( 'should handle isShorthandSelector', () => {
+		logEntityDeprecation( 'root', 'media', 'getMedia', {
+			isShorthandSelector: true,
+		} );
+
+		expect( deprecated ).toHaveBeenCalledWith( 'getMedia', {
+			since: '6.9',
+			alternative: "the 'postType', 'attachment' entity",
+		} );
 	} );
 
 	it( 'should handle empty string parameters', () => {
@@ -108,7 +116,7 @@ describe( 'logEntityDeprecation', () => {
 		expect( deprecated ).not.toHaveBeenCalled();
 	} );
 
-	it( 'should handle undefined alternativeFunctionName', () => {
+	it( 'should handle undefined options', () => {
 		logEntityDeprecation( 'root', 'media', 'getEntityRecord', undefined );
 
 		expect( deprecated ).toHaveBeenCalledWith(

--- a/packages/core-data/src/utils/test/log-entity-deprecation.js
+++ b/packages/core-data/src/utils/test/log-entity-deprecation.js
@@ -1,0 +1,117 @@
+/**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
+ * Internal dependencies
+ */
+import logEntityDeprecation from '../log-entity-deprecation';
+
+// Mock the deprecatedEntities import
+jest.mock( '../../entities', () => ( {
+	deprecatedEntities: {
+		root: {
+			media: {
+				since: '6.9',
+				alternative: {
+					kind: 'postType',
+					name: 'attachment',
+				},
+			},
+		},
+	},
+} ) );
+
+// Mock the deprecated function
+jest.mock( '@wordpress/deprecated' );
+
+describe( 'logEntityDeprecation', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should call deprecated when entity is deprecated', () => {
+		logEntityDeprecation( 'root', 'media', 'getEntityRecord' );
+
+		expect( deprecated ).toHaveBeenCalledWith(
+			"The 'root', 'media' entity (used via 'getEntityRecord')",
+			{
+				since: '6.9',
+				alternative: "The 'postType', 'attachment' entity",
+			}
+		);
+	} );
+
+	it( 'should not call deprecated when entity is not deprecated', () => {
+		logEntityDeprecation( 'root', 'nonExistentEntity', 'getEntityRecord' );
+
+		expect( deprecated ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should not call deprecated when kind is not deprecated', () => {
+		logEntityDeprecation( 'nonExistentKind', 'media', 'getEntityRecord' );
+
+		expect( deprecated ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should handle different function names', () => {
+		logEntityDeprecation( 'root', 'media', 'saveEntityRecord' );
+
+		expect( deprecated ).toHaveBeenCalledWith(
+			"The 'root', 'media' entity (used via 'saveEntityRecord')",
+			{
+				since: '6.9',
+				alternative: "The 'postType', 'attachment' entity",
+			}
+		);
+	} );
+
+	it( 'should include alternative function name when provided', () => {
+		logEntityDeprecation(
+			'root',
+			'media',
+			'getEntityRecord',
+			'getPostTypeEntity'
+		);
+
+		expect( deprecated ).toHaveBeenCalledWith(
+			"The 'root', 'media' entity (used via 'getEntityRecord')",
+			{
+				since: '6.9',
+				alternative:
+					"The 'postType', 'attachment' entity via the 'getPostTypeEntity' function",
+			}
+		);
+	} );
+
+	it( 'should handle empty string parameters', () => {
+		logEntityDeprecation( '', '', '' );
+
+		expect( deprecated ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should handle null parameters', () => {
+		logEntityDeprecation( null, null, null );
+
+		expect( deprecated ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should handle undefined parameters', () => {
+		logEntityDeprecation( undefined, undefined, undefined );
+
+		expect( deprecated ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should handle undefined alternativeFunctionName', () => {
+		logEntityDeprecation( 'root', 'media', 'getEntityRecord', undefined );
+
+		expect( deprecated ).toHaveBeenCalledWith(
+			"The 'root', 'media' entity (used via 'getEntityRecord')",
+			{
+				since: '6.9',
+				alternative: "The 'postType', 'attachment' entity",
+			}
+		);
+	} );
+} );

--- a/packages/core-data/src/utils/test/log-entity-deprecation.js
+++ b/packages/core-data/src/utils/test/log-entity-deprecation.js
@@ -43,7 +43,7 @@ describe( 'logEntityDeprecation', () => {
 			"The 'root', 'media' entity (used via 'getEntityRecord')",
 			{
 				since: '6.9',
-				alternative: "The 'postType', 'attachment' entity",
+				alternative: "the 'postType', 'attachment' entity",
 			}
 		);
 	} );
@@ -67,7 +67,7 @@ describe( 'logEntityDeprecation', () => {
 			"The 'root', 'media' entity (used via 'saveEntityRecord')",
 			{
 				since: '6.9',
-				alternative: "The 'postType', 'attachment' entity",
+				alternative: "the 'postType', 'attachment' entity",
 			}
 		);
 	} );
@@ -85,7 +85,7 @@ describe( 'logEntityDeprecation', () => {
 			{
 				since: '6.9',
 				alternative:
-					"The 'postType', 'attachment' entity via the 'getPostTypeEntity' function",
+					"the 'postType', 'attachment' entity via the 'getPostTypeEntity' function",
 			}
 		);
 	} );
@@ -115,7 +115,7 @@ describe( 'logEntityDeprecation', () => {
 			"The 'root', 'media' entity (used via 'getEntityRecord')",
 			{
 				since: '6.9',
-				alternative: "The 'postType', 'attachment' entity",
+				alternative: "the 'postType', 'attachment' entity",
 			}
 		);
 	} );

--- a/packages/core-data/src/utils/test/log-entity-deprecation.js
+++ b/packages/core-data/src/utils/test/log-entity-deprecation.js
@@ -92,7 +92,7 @@ describe( 'logEntityDeprecation', () => {
 			isShorthandSelector: true,
 		} );
 
-		expect( deprecated ).toHaveBeenCalledWith( 'getMedia', {
+		expect( deprecated ).toHaveBeenCalledWith( "'getMedia'", {
 			since: '6.9',
 			alternative: "the 'postType', 'attachment' entity",
 		} );

--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -52,8 +52,8 @@ export default function SidebarBlockEditor( {
 		return {
 			hasUploadPermissions:
 				select( coreStore ).canUser( 'create', {
-					kind: 'root',
-					name: 'media',
+					kind: 'postType',
+					name: 'attachment',
 				} ) ?? true,
 			isFixedToolbarActive: !! get(
 				'core/customize-widgets',

--- a/packages/edit-site/src/components/media/index.js
+++ b/packages/edit-site/src/components/media/index.js
@@ -4,7 +4,7 @@
 import { useEntityRecord } from '@wordpress/core-data';
 
 function Media( { id, size = [ 'large', 'medium', 'thumbnail' ], ...props } ) {
-	const { record: media } = useEntityRecord( 'root', 'media', id );
+	const { record: media } = useEntityRecord( 'postType', 'attachment', id );
 	const currentSize = size.find(
 		( s ) => !! media?.media_details?.sizes?.[ s ]
 	);

--- a/packages/edit-site/src/components/page-templates/hooks.js
+++ b/packages/edit-site/src/components/page-templates/hooks.js
@@ -35,12 +35,8 @@ import { TEMPLATE_ORIGINS } from '../../utils/constants';
 export function useAddedBy( postType, postId ) {
 	return useSelect(
 		( select ) => {
-			const {
-				getEntityRecord,
-				getMedia,
-				getUser,
-				getEditedEntityRecord,
-			} = select( coreStore );
+			const { getEntityRecord, getUser, getEditedEntityRecord } =
+				select( coreStore );
 			const template = getEditedEntityRecord(
 				'postType',
 				postType,
@@ -77,7 +73,11 @@ export function useAddedBy( postType, postId ) {
 						type: originalSource,
 						icon: globeIcon,
 						imageUrl: siteData?.site_logo
-							? getMedia( siteData.site_logo )?.source_url
+							? getEntityRecord(
+									'postType',
+									'attachment',
+									siteData.site_logo
+							  )?.source_url
 							: undefined,
 						text: authorText,
 						isCustomized: false,

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -393,8 +393,8 @@ export const StyleBookPreview = ( { userConfig = {}, isStatic = false } ) => {
 	const canUserUploadMedia = useSelect(
 		( select ) =>
 			select( coreStore ).canUser( 'create', {
-				kind: 'root',
-				name: 'media',
+				kind: 'postType',
+				name: 'attachment',
 			} ),
 		[]
 	);

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -79,7 +79,7 @@ export const getCanUserCreateMedia = createRegistrySelector(
 			`wp.data.select( 'core/edit-site' ).getCanUserCreateMedia()`,
 			{
 				since: '6.7',
-				alternative: `wp.data.select( 'core' ).canUser( 'create', { kind: 'root', type: 'media' } )`,
+				alternative: `wp.data.select( 'core' ).canUser( 'create', { kind: 'postType', type: 'attachment' } )`,
 			}
 		);
 

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -53,8 +53,8 @@ export default function WidgetAreasBlockEditorProvider( {
 		return {
 			hasUploadPermissions:
 				canUser( 'create', {
-					kind: 'root',
-					name: 'media',
+					kind: 'postType',
+					name: 'attachment',
 				} ) ?? true,
 			reusableBlocks: ALLOW_REUSABLE_BLOCKS
 				? getEntityRecords( 'postType', 'wp_block' )

--- a/packages/editor/src/components/media-categories/index.js
+++ b/packages/editor/src/components/media-categories/index.js
@@ -125,10 +125,14 @@ const getOpenverseCaption = ( item ) => {
 };
 
 const coreMediaFetch = async ( query = {} ) => {
-	const mediaItems = await resolveSelect( coreStore ).getMediaItems( {
-		...query,
-		orderBy: !! query?.search ? 'relevance' : 'date',
-	} );
+	const mediaItems = await resolveSelect( coreStore ).getEntityRecords(
+		'postType',
+		'attachment',
+		{
+			...query,
+			orderBy: !! query?.search ? 'relevance' : 'date',
+		}
+	);
 	return mediaItems.map( ( mediaItem ) => ( {
 		...mediaItem,
 		alt: mediaItem.alt_text,

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -305,21 +305,25 @@ function PostFeaturedImage( {
 }
 
 const applyWithSelect = withSelect( ( select ) => {
-	const { getMedia, getPostType, hasFinishedResolution } =
+	const { getEntityRecord, getPostType, hasFinishedResolution } =
 		select( coreStore );
 	const { getCurrentPostId, getEditedPostAttribute } = select( editorStore );
 	const featuredImageId = getEditedPostAttribute( 'featured_media' );
 
 	return {
 		media: featuredImageId
-			? getMedia( featuredImageId, { context: 'view' } )
+			? getEntityRecord( 'postType', 'attachment', featuredImageId, {
+					context: 'view',
+			  } )
 			: null,
 		currentPostId: getCurrentPostId(),
 		postType: getPostType( getEditedPostAttribute( 'type' ) ),
 		featuredImageId,
 		isRequestingFeaturedImageMedia:
 			!! featuredImageId &&
-			! hasFinishedResolution( 'getMedia', [
+			! hasFinishedResolution( 'getEntityRecord', [
+				'postType',
+				'attachment',
 				featuredImageId,
 				{ context: 'view' },
 			] ),

--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -47,7 +47,11 @@ import { __ } from '@wordpress/i18n';
 const postTypeEntities = [
 	{ name: 'post', baseURL: '/wp/v2/posts' },
 	{ name: 'page', baseURL: '/wp/v2/pages' },
-	{ name: 'attachment', baseURL: '/wp/v2/media' },
+	{
+		name: 'attachment',
+		baseURL: '/wp/v2/media',
+		baseURLParams: { context: 'edit' },
+	},
 	{ name: 'wp_block', baseURL: '/wp/v2/blocks' },
 ].map( ( postTypeEntity ) => ( {
 	kind: 'postType',

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -177,8 +177,8 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 				keepCaretInsideBlock: get( 'core', 'keepCaretInsideBlock' ),
 				hasUploadPermissions:
 					canUser( 'create', {
-						kind: 'root',
-						name: 'media',
+						kind: 'postType',
+						name: 'attachment',
 					} ) ?? true,
 				userCanCreatePages: canUser( 'create', {
 					kind: 'postType',

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -165,21 +165,6 @@ export function setEditedPost( postType, postId ) {
  * wp.data.dispatch( 'core/editor' ).editPost( { title: `${ newTitle }` } );
  * ```
  *
- * @example
- *```js
- * 	// Get specific media size based on the featured media ID
- * 	// Note: change sizes?.large for any registered size
- * 	const getFeaturedMediaUrl = useSelect( ( select ) => {
- * 		const getFeaturedMediaId =
- * 			select( 'core/editor' ).getEditedPostAttribute( 'featured_media' );
- * 		const getMedia = select( 'core' ).getMedia( getFeaturedMediaId );
- *
- * 		return (
- * 			getMedia?.media_details?.sizes?.large?.source_url || getMedia?.source_url || ''
- * 		);
- * }, [] );
- * ```
- *
  * @return {Object} Action object
  */
 export const editPost =

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -330,10 +330,14 @@ const getNestedEditedPostProperty = createSelector(
  * 	const getFeaturedMediaUrl = useSelect( ( select ) => {
  * 		const getFeaturedMediaId =
  * 			select( 'core/editor' ).getEditedPostAttribute( 'featured_media' );
- * 		const getMedia = select( 'core' ).getMedia( getFeaturedMediaId );
+ * 		const media = select( 'core' ).getEntityRecord(
+ * 			'postType',
+ * 			'attachment',
+ * 			getFeaturedMediaId
+ * 		);
  *
  * 		return (
- * 			getMedia?.media_details?.sizes?.large?.source_url || getMedia?.source_url || ''
+ * 			media?.media_details?.sizes?.large?.source_url || media?.source_url || ''
  * 		);
  * }, [] );
  *```

--- a/packages/editor/src/utils/media-upload/index.js
+++ b/packages/editor/src/utils/media-upload/index.js
@@ -92,8 +92,8 @@ export default function mediaUpload( {
 			if ( entityFiles?.length ) {
 				const invalidateCache = true;
 				receiveEntityRecords(
-					'root',
-					'media',
+					'postType',
+					'attachment',
 					entityFiles,
 					undefined,
 					invalidateCache

--- a/packages/fields/src/fields/featured-image/featured-image-edit.tsx
+++ b/packages/fields/src/fields/featured-image/featured-image-edit.tsx
@@ -28,7 +28,7 @@ export const FeaturedImageEdit = ( {
 	const media = useSelect(
 		( select ) => {
 			const { getEntityRecord } = select( coreStore );
-			return getEntityRecord( 'root', 'media', value );
+			return getEntityRecord( 'postType', 'attachment', value );
 		},
 		[ value ]
 	);

--- a/packages/fields/src/fields/featured-image/featured-image-view.tsx
+++ b/packages/fields/src/fields/featured-image/featured-image-view.tsx
@@ -19,7 +19,9 @@ export const FeaturedImageView = ( {
 	const media = useSelect(
 		( select ) => {
 			const { getEntityRecord } = select( coreStore );
-			return mediaId ? getEntityRecord( 'root', 'media', mediaId ) : null;
+			return mediaId
+				? getEntityRecord( 'postType', 'attachment', mediaId )
+				: null;
 		},
 		[ mediaId ]
 	);

--- a/test/native/integration-test-helpers/transform-block.js
+++ b/test/native/integration-test-helpers/transform-block.js
@@ -37,7 +37,7 @@ export const transformBlock = async (
 	fireEvent.press( getByText( 'Transform block…' ) );
 	fireEvent.press( getByText( targetBlockName ) );
 
-	// For media blocks, we must wait for the media fetch via `getMedia`.
+	// For media blocks, we must wait for the media fetch via `getEntityRecord`.
 	if ( isMediaBlock ) {
 		await act( () => apiFetchPromise );
 	}


### PR DESCRIPTION
## What?
Fixes #70815
Alternative to the previous attempt: #70833

Removes use of and deprecates (without removal) the root/media entity. Consumers can still use this entity the same as today, but any usage will log a deprecation message, hopefully prompting them to change.

## Why?
As mentioned in the issue, there are two entities in the core data store that represent the `wp/v2/media` REST endpoint:
- `{ kind: 'postType', name: 'attachment' }`
- `{ kind: 'root', name: 'media' }`

These two entities serve the same purpose, but maintain completely separate caches, which can trigger spurious REST API calls and result in problems with lingering stale data.

## How?
- Adds a `deprecatedEntities` configuration to the `entities.js` file.
- Adds a `logEntityDeprecation` utility function that logs .
- Every selector or actions that handles entity kind/name calls `logEntityDeprecation` to optionally output a deprecation message if a deprecated entity is being accessed.
- Adds unit tests.
- Changes every usage in the codebase of the `media` entity to the `attachment` entity.

I think the only drawback I've seen is that we can end up with multiple deprecation messages logged - e.g. if an action or selector calls through to another action or selection both will log deprecation messages. I've added some code to avoid this by using `setTimeout` to ensure a deprecation is only logged once per call stack, but it doesn't work for async code. Not sure if there's a way to solve that. I think it's probably good enough!

## Testing Instructions
### Smoke testing
1. Do some general smoke testing (particularly with media blocks and other media related features)
2. Check that no deprecation messages are logged related to the media entity

### Test the deprecation messages
1. Load a block editor
2. Call a selector or action in your browser console to see deprecation messages. Some examples below:
```js
wp.data.select( 'core' ).getMediaItems();
wp.data.select( 'core' ).getEntityRecord( 'root', 'media', 10 )
wp.data.dispatch( 'core' ).deleteEntityRecord( 'root', 'media', 10 )
wp.data.dispatch( 'core' ).saveMedia( { title: 'hello' } )
```
