### PR TITLE
Cover/Video Block: Add Drag-and-Drop Support for Poster Uploads

### DIFF
--- a/packages/block-library/src/utils/poster-image.js
+++ b/packages/block-library/src/utils/poster-image.js
@@ -80,7 +80,6 @@ function PosterImage( { poster, onChange } ) {
 				isShownByDefault
 				hasValue={ () => !! poster }
 				onDeselect={ () => onChange( undefined ) }
-				className="tools-panel-poster-image"
 			>
 				<BaseControl.VisualLabel>
 					{ __( 'Poster image' ) }

--- a/packages/block-library/src/utils/poster-image.js
+++ b/packages/block-library/src/utils/poster-image.js
@@ -36,9 +36,13 @@ function PosterImage( { poster, onChange, noticeUI, noticeOperations } ) {
 		'block-library-poster-image-description'
 	);
 
-	const { getSettings } = useSelect( blockEditorStore );
+	const { mediaUpload } = useSelect(
+		( select ) => select( blockEditorStore ).getSettings(),
+		[]
+	);
+
 	const onDropFiles = ( filesList ) => {
-		getSettings().mediaUpload( {
+		mediaUpload( {
 			allowedTypes: POSTER_IMAGE_ALLOWED_MEDIA_TYPES,
 			filesList,
 			onFileChange: ( [ image ] ) => {
@@ -55,6 +59,7 @@ function PosterImage( { poster, onChange, noticeUI, noticeOperations } ) {
 			onError: ( message ) => {
 				noticeOperations.removeAllNotices();
 				noticeOperations.createErrorNotice( message );
+				setIsLoading( false );
 			},
 			multiple: false,
 		} );

--- a/packages/block-library/src/utils/poster-image.js
+++ b/packages/block-library/src/utils/poster-image.js
@@ -65,6 +65,14 @@ function PosterImage( { poster, onChange, noticeUI, noticeOperations } ) {
 		} );
 	};
 
+	const getPosterButtonContent = () => {
+		if ( ! poster && isLoading ) {
+			return <Spinner />;
+		}
+
+		return ! poster ? __( 'Set poster image' ) : __( 'Replace' );
+	};
+
 	return (
 		<MediaUploadCheck>
 			<ToolsPanelItem
@@ -123,10 +131,10 @@ function PosterImage( { poster, onChange, noticeUI, noticeOperations } ) {
 									variant={
 										! poster ? 'secondary' : undefined
 									}
+									disabled={ isLoading }
+									accessibleWhenDisabled
 								>
-									{ ! poster
-										? __( 'Set poster image' )
-										: __( 'Replace' ) }
+									{ getPosterButtonContent() }
 								</Button>
 								<p id={ descriptionId } hidden>
 									{ poster
@@ -151,6 +159,8 @@ function PosterImage( { poster, onChange, noticeUI, noticeOperations } ) {
 											posterButtonRef.current.focus();
 										} }
 										className="block-library-poster-image__action"
+										disabled={ isLoading }
+										accessibleWhenDisabled
 									>
 										{ __( 'Remove' ) }
 									</Button>

--- a/packages/block-library/src/utils/poster-image.js
+++ b/packages/block-library/src/utils/poster-image.js
@@ -11,12 +11,12 @@ import {
 	MediaUploadCheck,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import { store as noticesStore } from '@wordpress/notices';
 import {
 	Button,
 	BaseControl,
 	DropZone,
 	Spinner,
-	withNotices,
 	__experimentalHStack as HStack,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
@@ -24,11 +24,11 @@ import { isBlobURL } from '@wordpress/blob';
 import { __, sprintf } from '@wordpress/i18n';
 import { useRef, useState } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 const POSTER_IMAGE_ALLOWED_MEDIA_TYPES = [ 'image' ];
 
-function PosterImage( { poster, onChange, noticeUI, noticeOperations } ) {
+function PosterImage( { poster, onChange } ) {
 	const posterButtonRef = useRef();
 	const [ isLoading, setIsLoading ] = useState( false );
 	const descriptionId = useInstanceId(
@@ -36,13 +36,11 @@ function PosterImage( { poster, onChange, noticeUI, noticeOperations } ) {
 		'block-library-poster-image-description'
 	);
 
-	const { mediaUpload } = useSelect(
-		( select ) => select( blockEditorStore ).getSettings(),
-		[]
-	);
+	const { getSettings } = useSelect( blockEditorStore );
+	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const onDropFiles = ( filesList ) => {
-		mediaUpload( {
+		getSettings().mediaUpload( {
 			allowedTypes: POSTER_IMAGE_ALLOWED_MEDIA_TYPES,
 			filesList,
 			onFileChange: ( [ image ] ) => {
@@ -57,8 +55,10 @@ function PosterImage( { poster, onChange, noticeUI, noticeOperations } ) {
 				setIsLoading( false );
 			},
 			onError: ( message ) => {
-				noticeOperations.removeAllNotices();
-				noticeOperations.createErrorNotice( message );
+				createErrorNotice( message, {
+					id: 'poster-image-upload-notice',
+					type: 'snackbar',
+				} );
 				setIsLoading( false );
 			},
 			multiple: false,
@@ -85,7 +85,6 @@ function PosterImage( { poster, onChange, noticeUI, noticeOperations } ) {
 				<BaseControl.VisualLabel>
 					{ __( 'Poster image' ) }
 				</BaseControl.VisualLabel>
-				{ noticeUI }
 				<MediaUpload
 					title={ __( 'Select poster image' ) }
 					onSelect={ onChange }
@@ -175,4 +174,4 @@ function PosterImage( { poster, onChange, noticeUI, noticeOperations } ) {
 	);
 }
 
-export default withNotices( PosterImage );
+export default PosterImage;

--- a/packages/block-library/src/utils/poster-image.js
+++ b/packages/block-library/src/utils/poster-image.js
@@ -6,25 +6,59 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
+import {
+	MediaUpload,
+	MediaUploadCheck,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import {
 	Button,
 	BaseControl,
+	DropZone,
+	Spinner,
+	withNotices,
 	__experimentalHStack as HStack,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
+import { isBlobURL } from '@wordpress/blob';
 import { __, sprintf } from '@wordpress/i18n';
-import { useRef } from '@wordpress/element';
+import { useRef, useState } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
 
 const POSTER_IMAGE_ALLOWED_MEDIA_TYPES = [ 'image' ];
 
-function PosterImage( { poster, onChange } ) {
+function PosterImage( { poster, onChange, noticeUI, noticeOperations } ) {
 	const posterButtonRef = useRef();
+	const [ isLoading, setIsLoading ] = useState( false );
 	const descriptionId = useInstanceId(
 		PosterImage,
 		'block-library-poster-image-description'
 	);
+
+	const { getSettings } = useSelect( blockEditorStore );
+	const onDropFiles = ( filesList ) => {
+		getSettings().mediaUpload( {
+			allowedTypes: POSTER_IMAGE_ALLOWED_MEDIA_TYPES,
+			filesList,
+			onFileChange: ( [ image ] ) => {
+				if ( isBlobURL( image?.url ) ) {
+					setIsLoading( true );
+					return;
+				}
+
+				if ( image ) {
+					onChange( image );
+				}
+				setIsLoading( false );
+			},
+			onError: ( message ) => {
+				noticeOperations.removeAllNotices();
+				noticeOperations.createErrorNotice( message );
+			},
+			multiple: false,
+		} );
+	};
 
 	return (
 		<MediaUploadCheck>
@@ -33,10 +67,12 @@ function PosterImage( { poster, onChange } ) {
 				isShownByDefault
 				hasValue={ () => !! poster }
 				onDeselect={ () => onChange( undefined ) }
+				className="tools-panel-poster-image"
 			>
 				<BaseControl.VisualLabel>
 					{ __( 'Poster image' ) }
 				</BaseControl.VisualLabel>
+				{ noticeUI }
 				<MediaUpload
 					title={ __( 'Select poster image' ) }
 					onSelect={ onChange }
@@ -48,24 +84,19 @@ function PosterImage( { poster, onChange } ) {
 									__next40pxDefaultSize
 									onClick={ open }
 									aria-haspopup="dialog"
-									aria-label={
-										! poster
-											? null
-											: __(
-													'Edit or replace the poster image.'
-											  )
-									}
-									className={
-										poster
-											? 'block-library-poster-image__preview'
-											: 'block-library-poster-image__toggle'
-									}
+									aria-label={ __(
+										'Edit or replace the poster image.'
+									) }
+									className="block-library-poster-image__preview"
+									disabled={ isLoading }
+									accessibleWhenDisabled
 								>
 									<img
 										src={ poster }
 										alt={ __( 'Poster image preview' ) }
 										className="block-library-poster-image__preview-image"
 									/>
+									{ isLoading && <Spinner /> }
 								</Button>
 							) }
 							<HStack
@@ -120,6 +151,7 @@ function PosterImage( { poster, onChange } ) {
 									</Button>
 								) }
 							</HStack>
+							<DropZone onFilesDrop={ onDropFiles } />
 						</div>
 					) }
 				/>
@@ -128,4 +160,4 @@ function PosterImage( { poster, onChange } ) {
 	);
 }
 
-export default PosterImage;
+export default withNotices( PosterImage );

--- a/packages/block-library/src/utils/poster-image.scss
+++ b/packages/block-library/src/utils/poster-image.scss
@@ -38,7 +38,6 @@
 	}
 }
 
-.block-library-poster-image__toggle,
 .block-library-poster-image__preview {
 	width: 100%;
 	padding: 0;
@@ -48,9 +47,6 @@
 
 	display: flex;
 	justify-content: center;
-}
-
-.block-library-poster-image__preview {
 	height: auto !important;
 	outline: $border-width solid rgba($black, 0.1);
 
@@ -63,18 +59,6 @@
 		width: 100%;
 		object-position: 50% 50%;
 		aspect-ratio: 2/1;
-	}
-}
-
-.block-library-poster-image__toggle {
-	box-shadow: inset 0 0 0 $border-width $gray-400;
-
-	&:focus:not(:disabled) {
-		// Allow smooth transition between focused and unfocused box-shadow states.
-		box-shadow:
-			0 0 0 currentColor inset,
-			0 0 0 var(--wp-admin-border-width-focus)
-			var(--wp-admin-theme-color);
 	}
 }
 

--- a/packages/block-library/src/utils/poster-image.scss
+++ b/packages/block-library/src/utils/poster-image.scss
@@ -50,10 +50,6 @@
 	height: auto !important;
 	outline: $border-width solid rgba($black, 0.1);
 
-	.tools-panel-poster-image:has(.components-notice) & {
-		margin-top: $grid-unit-10;
-	}
-
 	.block-library-poster-image__preview-image {
 		object-fit: cover;
 		width: 100%;

--- a/packages/block-library/src/utils/poster-image.scss
+++ b/packages/block-library/src/utils/poster-image.scss
@@ -13,6 +13,29 @@
 		opacity: 1;
 		margin-top: $grid-unit-20;
 	}
+
+	.components-drop-zone__content {
+		border-radius: $radius-small;
+	}
+
+	// Align text and icons horizontally to avoid clipping when the poster image is not set.
+	.components-drop-zone .components-drop-zone__content-inner {
+		display: flex;
+		align-items: center;
+		gap: $grid-unit-10;
+
+		.components-drop-zone__content-icon {
+			margin: 0;
+		}
+	}
+
+	.components-spinner {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		margin-top: -9px;
+		margin-left: -9px;
+	}
 }
 
 .block-library-poster-image__toggle,
@@ -30,6 +53,10 @@
 .block-library-poster-image__preview {
 	height: auto !important;
 	outline: $border-width solid rgba($black, 0.1);
+
+	.tools-panel-poster-image:has(.components-notice) & {
+		margin-top: $grid-unit-10;
+	}
 
 	.block-library-poster-image__preview-image {
 		object-fit: cover;


### PR DESCRIPTION
## What?

Follow-up to https://github.com/WordPress/gutenberg/pull/70939

This PR adds drag-and-drop functionality for uploading posters in the Cover/Video block.

## Why?

Previously, uploading an image in the new poster control required a three-step process. This update streamlines the experience by allowing users to upload images directly via drag-and-drop, making the workflow faster and more intuitive.

## How?

The `DropZone` component was integrated directly, accompanied by an `onFilesDrop` callback to handle file uploads.

## Testing Instructions

1. Create a new `Cover` or `Video` block.
2. Attach a video to it.
3. Add a poster image to the block by dragging and dropping it over the corresponding control.
4. Confirm that the image gets properly applied.

### Testing Instructions for Keyboard
Same.

## Screencast

https://github.com/user-attachments/assets/8c48687e-710a-4db9-bd80-a02c9e5b2fd7