### PR TITLE
Clarify block name immutability and namespace best practices [docs]

### DIFF
--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -29,6 +29,29 @@ _Note:_ A block name can only contain lowercase alphanumeric characters and dash
 
 _Note:_ This name is used on the comment delimiters as `<!-- wp:my-plugin/book -->`. Those blocks provided by core don't include a namespace when serialized.
 
+#### Important: Choose Your Namespace Carefully
+
+Block names cannot be changed later without consequences. The block name is stored in the post content of every post using that block, so changing it requires editing all affected posts or running database scripts.
+
+#### Namespace Best Practices
+
+-   Use your actual plugin/theme name: `my-awesome-plugin/block-name`
+-   Avoid generic names like `editorial/`, `block/`, or `create-block/`
+-   Use the same namespace for all blocks in your plugin/theme
+-   Make it unique to prevent conflicts with other plugins
+
+```js
+// Good examples
+registerBlockType( 'my-company-blocks/hero', {} );
+registerBlockType( 'awesome-gallery-plugin/slideshow', {} );
+
+// Avoid these
+registerBlockType( 'create-block/example', {} ); // Too generic
+registerBlockType( 'block/content', {} ); // Too generic
+```
+
+_Note:_ `registerBlockCollection()` only works with blocks from a single namespace.
+
 ### Block configuration
 
 -   **Type:** `Object` [ `{ key: value }` ]


### PR DESCRIPTION
Closes [#71022](https://github.com/WordPress/gutenberg/issues/71022)

## What?
Updates the Block Name documentation to clarify that block names are immutable and provides improved guidance on namespace selection.

## Why?
The current documentation doesn't emphasize that block names cannot be changed after deployment, which can lead to serious issues for developers who need to rename blocks later. Block names are stored in post content as HTML comments, making changes require manual post editing or database scripts. Additionally, many developers use generic namespaces like `create-block/*` without understanding the long-term implications.

## How?
- Added a prominent warning that block names cannot be changed later
- Explained the technical reason (stored in post content) and consequences
- Provided clear examples of good vs bad namespace choices
- Added guidance to avoid generic namespaces and use plugin/theme-specific names
- Noted the `registerBlockCollection()` limitation to single namespaces

