### PR TITLE
Adds an examples of post comments count and link blocks

### DIFF
--- a/packages/block-library/src/post-comments-count/index.js
+++ b/packages/block-library/src/post-comments-count/index.js
@@ -18,6 +18,7 @@ export const settings = {
 	icon,
 	edit,
 	transforms,
+	example: {},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/post-comments-link/index.js
+++ b/packages/block-library/src/post-comments-link/index.js
@@ -18,6 +18,7 @@ export const settings = {
 	edit,
 	icon,
 	transforms,
+	example: {},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/64707

## What?
This PR adds an example attribute to the `post-comments-count` and `post-comments-link` to provide a block preview in the inserter.

## Testing Instructions
1. Open a post or page in the WordPress block editor.
2. Open the block inserter by clicking the "+" button.
3. Search for `post-comments-count` and `post-comments-link` in the block inserter.
4. Hover over the both blocks in the inserter to see the preview.

## Screenshots or screencast <!-- if applicable -->

## `post-comments-count`

|Before|After|
|-|-|
|<img width="1006" height="424" alt="Screenshot 2025-08-04 at 3 30 58 PM" src="https://github.com/user-attachments/assets/36f99cff-ddac-43c9-bd71-57c00724068a" />|<img width="1038" height="487" alt="Screenshot 2025-08-04 at 3 31 41 PM" src="https://github.com/user-attachments/assets/9c6f952a-7f9b-4142-8d46-737eb647b4fd" />|

## `post-comments-link`

|Before|After|
|-|-|
|<img width="1116" height="461" alt="Screenshot 2025-08-04 at 3 31 09 PM" src="https://github.com/user-attachments/assets/cd4740c4-9486-457b-bcf1-4c845256d494" />|<img width="1013" height="456" alt="Screenshot 2025-08-04 at 3 31 50 PM" src="https://github.com/user-attachments/assets/3e96df88-018d-4471-8188-c90387460f31" />|



