### PR TITLE
Core Data: Allow entity overrides

### DIFF
--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -361,28 +361,27 @@ function entity( entityConfig ) {
 export function entitiesConfig( state = rootEntitiesConfig, action ) {
 	switch ( action.type ) {
 		case 'ADD_ENTITIES': {
-			const existingEntitiesMap = new Map();
-
+			const existingEntitiesByKey = new Map();
 			state.forEach( ( currentEntity ) => {
-				if ( currentEntity.baseURL ) {
-					existingEntitiesMap.set(
-						currentEntity.baseURL,
-						currentEntity
-					);
-				}
+				const entityKey = `${ currentEntity.kind }:${ currentEntity.name }`;
+				existingEntitiesByKey.set( entityKey, currentEntity );
 			} );
 
+			const newEntitiesToAdd = [];
 			action.entities.forEach( ( newEntity ) => {
-				if (
-					newEntity.baseURL &&
-					existingEntitiesMap.has( newEntity.baseURL )
-				) {
-					existingEntitiesMap.delete( newEntity.baseURL );
+				const entityKey = `${ newEntity.kind }:${ newEntity.name }`;
+
+				if ( existingEntitiesByKey.has( entityKey ) ) {
+					existingEntitiesByKey.set( entityKey, newEntity );
+				} else {
+					newEntitiesToAdd.push( newEntity );
 				}
 			} );
 
-			const existingEntities = Array.from( existingEntitiesMap.values() );
-			return [ ...existingEntities, ...action.entities ];
+			const existingEntities = Array.from(
+				existingEntitiesByKey.values()
+			);
+			return [ ...existingEntities, ...newEntitiesToAdd ];
 		}
 	}
 

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -361,27 +361,15 @@ function entity( entityConfig ) {
 export function entitiesConfig( state = rootEntitiesConfig, action ) {
 	switch ( action.type ) {
 		case 'ADD_ENTITIES': {
-			const existingEntitiesByKey = new Map();
-			state.forEach( ( currentEntity ) => {
-				const entityKey = `${ currentEntity.kind }:${ currentEntity.name }`;
-				existingEntitiesByKey.set( entityKey, currentEntity );
-			} );
-
-			const newEntitiesToAdd = [];
-			action.entities.forEach( ( newEntity ) => {
-				const entityKey = `${ newEntity.kind }:${ newEntity.name }`;
-
-				if ( existingEntitiesByKey.has( entityKey ) ) {
-					existingEntitiesByKey.set( entityKey, newEntity );
-				} else {
-					newEntitiesToAdd.push( newEntity );
-				}
-			} );
-
-			const existingEntities = Array.from(
-				existingEntitiesByKey.values()
+			const filteredState = state.filter(
+				( currentEntity ) =>
+					! action.entities.some(
+						( newEntity ) =>
+							currentEntity.kind === newEntity.kind &&
+							currentEntity.name === newEntity.name
+					)
 			);
-			return [ ...existingEntities, ...newEntitiesToAdd ];
+			return [ ...filteredState, ...action.entities ];
 		}
 	}
 

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -360,8 +360,30 @@ function entity( entityConfig ) {
  */
 export function entitiesConfig( state = rootEntitiesConfig, action ) {
 	switch ( action.type ) {
-		case 'ADD_ENTITIES':
-			return [ ...state, ...action.entities ];
+		case 'ADD_ENTITIES': {
+			const existingEntitiesMap = new Map();
+
+			state.forEach( ( currentEntity ) => {
+				if ( currentEntity.baseURL ) {
+					existingEntitiesMap.set(
+						currentEntity.baseURL,
+						currentEntity
+					);
+				}
+			} );
+
+			action.entities.forEach( ( newEntity ) => {
+				if (
+					newEntity.baseURL &&
+					existingEntitiesMap.has( newEntity.baseURL )
+				) {
+					existingEntitiesMap.delete( newEntity.baseURL );
+				}
+			} );
+
+			const existingEntities = Array.from( existingEntitiesMap.values() );
+			return [ ...existingEntities, ...action.entities ];
+		}
 	}
 
 	return state;

--- a/packages/core-data/src/test/reducer.js
+++ b/packages/core-data/src/test/reducer.js
@@ -12,7 +12,9 @@ import {
 	userPermissions,
 	autosaves,
 	currentUser,
+	entitiesConfig,
 } from '../reducer';
+import { rootEntitiesConfig } from '../entities';
 
 describe( 'entities', () => {
 	// See also unit tests at `queried-data/test/reducer.js`, which are more
@@ -529,5 +531,95 @@ describe( 'currentUser', () => {
 		);
 
 		expect( state ).toEqual( currentUserData );
+	} );
+} );
+
+describe( 'entitiesConfig', () => {
+	it( 'returns the default state by default', () => {
+		const state = entitiesConfig( undefined, {} );
+		expect( state ).toEqual( rootEntitiesConfig );
+	} );
+
+	it( 'adds new entities', () => {
+		const initialState = [
+			{
+				kind: 'root',
+				name: 'postType',
+				baseURL: '/wp/v2/types',
+				label: 'Post Type',
+			},
+		];
+
+		const newEntities = [
+			{
+				kind: 'root',
+				name: 'media',
+				baseURL: '/wp/v2/media',
+				label: 'Media',
+			},
+		];
+
+		const state = entitiesConfig( initialState, {
+			type: 'ADD_ENTITIES',
+			entities: newEntities,
+		} );
+
+		expect( state ).toHaveLength( 2 );
+		expect( state[ 0 ].name ).toBe( 'postType' );
+		expect( state[ 1 ].name ).toBe( 'media' );
+	} );
+
+	it( 'overwrites existing entities with the same baseURL', () => {
+		const initialState = [
+			{
+				kind: 'root',
+				name: 'postType',
+				baseURL: '/wp/v2/types',
+				label: 'Original Post Type',
+			},
+			{
+				kind: 'root',
+				name: 'media',
+				baseURL: '/wp/v2/media',
+				label: 'Media',
+			},
+		];
+
+		const newEntities = [
+			{
+				kind: 'root',
+				name: 'postType',
+				baseURL: '/wp/v2/types',
+				label: 'Updated Post Type',
+			},
+			{
+				kind: 'root',
+				name: 'user',
+				baseURL: '/wp/v2/users',
+				label: 'Users',
+			},
+		];
+
+		const state = entitiesConfig( initialState, {
+			type: 'ADD_ENTITIES',
+			entities: newEntities,
+		} );
+
+		expect( state ).toHaveLength( 3 );
+
+		const updatedPostType = state.find(
+			( entity ) => entity.baseURL === '/wp/v2/types'
+		);
+		expect( updatedPostType.label ).toBe( 'Updated Post Type' );
+
+		const media = state.find(
+			( entity ) => entity.baseURL === '/wp/v2/media'
+		);
+		expect( media.label ).toBe( 'Media' );
+
+		const user = state.find(
+			( entity ) => entity.baseURL === '/wp/v2/users'
+		);
+		expect( user.label ).toBe( 'Users' );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->
[](https://developer.wordpress.org/block-editor/reference-guides/data/data-core/#addentities)
<!-- In a few words, what is the PR actually doing? -->
Modifies the entitiesConfig reducer to override existing entities when addEntities is called with entities that have the same baseURL as previously registered entities, instead of simply adding duplicates.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Consumers of the api might want to extend or override exiting entities.
Currently, calling addEntities with entities that have the same baseURL results in duplicate entries in the entities configuration. This change ensures that newer entity configurations properly replace older ones with the same baseURL.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Iterates through existing entities to build lookup map
- Removes conflicting entities from map when new entities have same baseURL
- Combines remaining existing entities with new entities

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Checkout this PR and run `npm run dev`
- Open gutenberg demo
- Get the current entity config by executing `wp.data.select(wp.coreData.store).getEntitiesByKind('root')`
- Add an modified entity as a test:
```
wp.data.dispatch(wp.coreData.store).addEntities([{
		label: 'Updated User',
		name: 'user',
		kind: 'root',
		baseURL: '/wp/v2/users',
		baseURLParams: { context: 'edit' },
		plural: 'users',
}])
```
- Execute again `wp.data.select(wp.coreData.store).getEntitiesByKind('root')`
- The updated user entity should be there with the different label, instead of having one more element in the array.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
