### PR TITLE
Date Block: Ensure that fallback value is overridden if source is not registered

### DIFF
--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -9,6 +9,7 @@
  * Renders the `core/post-date` block on the server.
  *
  * @since 5.8.0
+ * @since 6.9.0 Added `datetime` attribute and Block Bindings support.
  *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -19,44 +19,39 @@
 function render_block_core_post_date( $attributes, $content, $block ) {
 	$classes = array();
 
-	if ( ! isset( $attributes['datetime'] ) ) {
+	if (
+		isset( $attributes['metadata']['bindings']['datetime']['source'] ) &&
+		isset( $attributes['metadata']['bindings']['datetime']['args'] )
+	) {
 		/*
-		 * This can mean two things:
-		 *
-		 * 1. We're dealing with the legacy version of the block that didn't have the `datetime` attribute.
-		 * 2. The `datetime` attribute is bound to a Block Bindings source, but we're on a version of WordPress
-		 *    that doesn't support binding that attribute to a Block Bindings source.
-		 *
-		 * In both cases, we set the `datetime` attribute to its correct value by applying Block Bindings manually.
+		 * We might be running on a version of WordPress that doesn't support binding the block's `datetime` attribute
+		 * to a Block Bindings source. In this case, we need to manually set the `datetime` attribute to its correct value.
+		 * This branch can be removed once the minimum required WordPress version is 6.9 or newer.
 		 */
-		if (
-			isset( $attributes['metadata']['bindings']['datetime']['source'] ) &&
-			isset( $attributes['metadata']['bindings']['datetime']['args'] )
-		) {
-			// We're using a version of WordPress that doesn't support binding the block's `datetime` attribute to a Block Bindings source.
-			// This branch can be removed once the minimum required WordPress version supports the `core/post-data` source.
-			$source      = get_block_bindings_source( $attributes['metadata']['bindings']['datetime']['source'] );
-			$source_args = $attributes['metadata']['bindings']['datetime']['args'];
-		} else {
-			// This is the legacy version of the block that didn't have the `datetime` attribute.
-			// This branch needs to be kept for backward compatibility.
-			$source = get_block_bindings_source( 'core/post-data' );
-			if ( isset( $attributes['displayType'] ) && 'modified' === $attributes['displayType'] ) {
-				$source_args = array(
-					'key' => 'modified',
-				);
-			} else {
-				$source_args = array(
-					'key' => 'date',
-				);
-			}
-		}
+		$source      = get_block_bindings_source( $attributes['metadata']['bindings']['datetime']['source'] );
+		$source_args = $attributes['metadata']['bindings']['datetime']['args'];
 
 		$attributes['datetime'] = $source->get_value( $source_args, $block, 'datetime' );
-
-		if ( isset( $source_args['key'] ) && 'modified' === $source_args['key'] ) {
-			$classes[] = 'wp-block-post-date__modified-date';
+	} elseif ( ! isset( $attributes['datetime'] ) ) {
+		/*
+		 * This is the legacy version of the block that didn't have the `datetime` attribute.
+		 * This branch needs to be kept for backward compatibility.
+		 */
+		$source = get_block_bindings_source( 'core/post-data' );
+		if ( isset( $attributes['displayType'] ) && 'modified' === $attributes['displayType'] ) {
+			$source_args = array(
+				'key' => 'modified',
+			);
+		} else {
+			$source_args = array(
+				'key' => 'date',
+			);
 		}
+		$attributes['datetime'] = $source->get_value( $source_args, $block, 'datetime' );
+	}
+
+	if ( isset( $source_args['key'] ) && 'modified' === $source_args['key'] ) {
+		$classes[] = 'wp-block-post-date__modified-date';
 	}
 
 	if ( empty( $attributes['datetime'] ) ) {

--- a/phpunit/blocks/render-block-core-post-date.php
+++ b/phpunit/blocks/render-block-core-post-date.php
@@ -107,38 +107,6 @@ class Test_Render_Block_Core_Post_Date extends WP_UnitTestCase {
 	/**
 	 * @dataProvider data_render_with_date_attribute_binding
 	 */
-	public function test_render_with_date_attribute_binding_overrides_fallback_value( $field, $expected_date_function ) {
-		$expected_date = call_user_func( $expected_date_function, 'c', self::$post_id );
-
-		$attributes = array(
-			'datetime' => '2025-01-01 00:00:00', // This should be overridden by Block Bindings.
-			'metadata' => array(
-				'bindings' => array(
-					'datetime' => array(
-						'source' => 'core/post-data',
-						'args'   => array( 'key' => $field ),
-					),
-				),
-			),
-		);
-
-		$block = new WP_Block(
-			array(
-				'blockName' => 'core/post-date',
-				'attrs'     => $attributes,
-			),
-			array(
-				'postId' => self::$post_id,
-			)
-		);
-
-		$output = $block->render();
-		$this->assertStringContainsString( $expected_date, $output );
-	}
-
-	/**
-	 * @dataProvider data_render_with_date_attribute_binding
-	 */
 	public function test_render_legacy_block( $field, $expected_date_function ) {
 		$expected_date = call_user_func( $expected_date_function, 'c', self::$post_id );
 

--- a/phpunit/blocks/render-block-core-post-date.php
+++ b/phpunit/blocks/render-block-core-post-date.php
@@ -87,6 +87,52 @@ class Test_Render_Block_Core_Post_Date extends WP_UnitTestCase {
 		);
 
 		$output = $block->render();
+		$this->assertStringContainsString(
+			$expected_date,
+			$output,
+			'The datetime attribute was not set correctly from the Block Bindings source.'
+		);
+
+		// Now verify that a fallback value is overridden by Block Bindings.
+		$block->attributes['datetime'] = '2025-01-01 00:00:00'; // This should be overridden by Block Bindings.
+
+		$output = $block->render();
+		$this->assertStringContainsString(
+			$expected_date,
+			$output,
+			'The datetime attribute fallback value was not overridden by the Block Bindings source.'
+		);
+	}
+
+	/**
+	 * @dataProvider data_render_with_date_attribute_binding
+	 */
+	public function test_render_with_date_attribute_binding_overrides_fallback_value( $field, $expected_date_function ) {
+		$expected_date = call_user_func( $expected_date_function, 'c', self::$post_id );
+
+		$attributes = array(
+			'datetime' => '2025-01-01 00:00:00', // This should be overridden by Block Bindings.
+			'metadata' => array(
+				'bindings' => array(
+					'datetime' => array(
+						'source' => 'core/post-data',
+						'args'   => array( 'key' => $field ),
+					),
+				),
+			),
+		);
+
+		$block = new WP_Block(
+			array(
+				'blockName' => 'core/post-date',
+				'attrs'     => $attributes,
+			),
+			array(
+				'postId' => self::$post_id,
+			)
+		);
+
+		$output = $block->render();
 		$this->assertStringContainsString( $expected_date, $output );
 	}
 

--- a/phpunit/blocks/render-block-core-post-date.php
+++ b/phpunit/blocks/render-block-core-post-date.php
@@ -94,7 +94,7 @@ class Test_Render_Block_Core_Post_Date extends WP_UnitTestCase {
 		);
 
 		// Now verify that a fallback value is overridden by Block Bindings.
-		$block->attributes['datetime'] = '2025-01-01 00:00:00'; // This should be overridden by Block Bindings.
+		$block->attributes['datetime'] = '2025-01-01 00:00:00';
 
 		$output = $block->render();
 		$this->assertStringContainsString(


### PR DESCRIPTION
## What?

If the block's `datetime` attribute is set, and it is bound to a Block Bindings source, ensure that the value received is indeed the one set by Block bindings -- i.e. that the fallback value is correctly overridden.

## Why?
Quoting https://github.com/WordPress/secure-custom-fields/pull/206#issuecomment-3150857180:

> Note that if the Date block is inserted and its `datetime` attribute is bound to a[ Block Bindings source], it will currently show the wrong date on the frontend. The reason is that the `datetime` attribute is set to the current timestamp upon insertion (the reason for this is to distinguish the block from its deprecated version, which didn't have a `datetime` attribute, and would instead automatically "bind" to the containing post's publish date).
>
> However, the Date block's `datetime` attribute isn't listed as bindable [yet](https://github.com/WordPress/wordpress-develop/pull/9299/files#diff-c569b1ecb11a007a563788a481710b51e0cb21cd1d1885490bf9c91777842f23R288). While the Date block itself contains [logic to provide backwards-compatibility](https://github.com/WordPress/gutenberg/blob/dff10d2f731a15446aadae4895e79f3013dcb980/packages/block-library/src/post-date/index.php#L21-L59), that code is currently only invoked if the attribute is not set at all.
> 
> We'll probably need to amend the latter logic to accommodate for cases where the attribute _is_ set, but to the "wrong" (i.e. fallback) value, and needs to be overridden by Block Bindings.

## How?
By fixing the logic, based on an added assertion in the unit test to cover this scenario.

You can verify that the change is indeed needed to make tests pass by reverting it (https://github.com/WordPress/gutenberg/pull/71047/commits/e328014fe3288d19cd5002a0595b632d1415454f) and re-running tests.

## Testing Instructions
Covered by automated tests.
