### PR TITLE
Slack Notifications for Testing Team

### DIFF
--- a/.github/workflows/notify-slack-on-label.yml
+++ b/.github/workflows/notify-slack-on-label.yml
@@ -1,0 +1,22 @@
+name: Notify Slack on Needs Testing Label
+
+on:
+    issues:
+        types: [labeled]
+    pull_request:
+        types: [labeled]
+
+jobs:
+    notify:
+        if: ${{ github.event.label.name == 'Needs Testing' }}
+        runs-on: ubuntu-latest
+        steps:
+            - name: Send Slack Notification
+              uses: slackapi/slack-github-action@v2.1.1
+              with:
+                  webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+                  webhook-type: incoming-webhook
+                  payload: |
+                      {
+                        "text": "*Needs Testing*: ${{ github.event_name == 'issues' && github.event.issue.title || github.event.pull_request.title }} in ${{ github.repository }}.\n*Link*: ${{ github.event_name == 'issues' && github.event.issue.html_url || github.event.pull_request.html_url }}"
+                      }

--- a/.github/workflows/notify-slack-on-label.yml
+++ b/.github/workflows/notify-slack-on-label.yml
@@ -10,13 +10,18 @@ jobs:
     notify:
         if: ${{ github.event.label.name == 'Needs Testing' }}
         runs-on: ubuntu-latest
+        permissions: {}
         steps:
             - name: Send Slack Notification
-              uses: slackapi/slack-github-action@v2.1.1
+              uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
+              env:
+                  REPORT_HEADING: "*Gutenberg ${{ github.event_name == 'issues' && 'Issue' || 'Pull Request' }} Needs Testing*"
+                  REPORT_TITLE: ${{ toJSON(github.event_name == 'issues' && github.event.issue.title || github.event.pull_request.title) }}
+                  REPORT_URL: ${{ github.event_name == 'issues' && github.event.issue.html_url || github.event.pull_request.html_url }}
               with:
-                  webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+                  webhook: ${{ secrets.SLACK_NEEDS_TESTING_LABEL_ADDED_WEBHOOK_URL }}
                   webhook-type: incoming-webhook
                   payload: |
                       {
-                        "text": "*Needs Testing*: ${{ github.event_name == 'issues' && github.event.issue.title || github.event.pull_request.title }} in ${{ github.repository }}.\n*Link*: ${{ github.event_name == 'issues' && github.event.issue.html_url || github.event.pull_request.html_url }}"
+                        "text": "${{ env.REPORT_HEADING }}: ${{ fromJSON(env.REPORT_TITLE) }} in ${{ github.repository }}.\n*Link*: ${{ env.REPORT_URL }}"
                       }


### PR DESCRIPTION
As per Slack conversation: https://wordpress.slack.com/archives/C03B0H5J0/p1754065327774839

This PR figures out the integration with Slack for sending messages for the Testing Team in Slack @ #core-test 
https://tools.slack.dev/slack-github-action/sending-techniques/sending-data-webhook-slack-workflow/format-generated-files#github-actions-workflow

After this PR has been merged, here are the instructions to set this up

1. Create the app: https://api.slack.com/apps ⇾ From Scratch

2. Features > Incoming Webhooks > Activate Incoming Webhooks
3. Select the #core-test channel 
4. Pick the webhook URL.
5. Back to GitHub in this repository, add a Secret with the URL:
https://github.com/WordPress/gutenberg/settings/secrets/actions/new

Add: 
Name: SLACK_NEEDS_TESTING_LABEL_ADDED_WEBHOOK_URL
Secret: The Slack webhook URL

And hook, it's done. Every time a new `Needs Testing` tag is added to the repo, it will send a message to the #core-test channel. 

This is how it looks (tested on my own Slack and Repo)

<img width="837" height="103" alt="image" src="https://github.com/user-attachments/assets/a6ce8d5e-86c9-49e2-b361-627de1ebe53c" />