### PR TITLE
Block Variation Transforms: Add box-sizing rule

### DIFF
--- a/packages/block-editor/src/components/block-variation-transforms/style.scss
+++ b/packages/block-editor/src/components/block-variation-transforms/style.scss
@@ -6,6 +6,7 @@
 }
 
 .block-editor-block-variation-transforms {
+	box-sizing: border-box;
 	padding: 0 $grid-unit-20 $grid-unit-20 52px;
 	width: 100%;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Semi-related to: #70684

This is a similar kind of PR to a couple of my earlier ones at trying to ensure that block editor components are responsible for their own dependencies. After fixing `fieldset`s in #70685, I noticed that the block variation transforms components (i.e. the switcher in the right hand sidebar for the Group block) expects a global `box-sizing` rule in order to prevent a horizontal scrollbar from happening.

This tiny PR seeks to make sure that the block variation transforms component is responsible for its own sizing.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To ensure that (similar to the components library) block editor components are taking care of their own resets / aren't so dependent on global rules.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add a `box-sizing: border-box` rule to the block variation transforms component.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

This is a little artificial, but open up the post editor, add a Group block, and inspect element on the switcher in the sidebar where you switch to Row, Stack, Grid, etc.

Toggle the box-sizing rule for the post editor off, and on `trunk` you'll end up with a horizontal scrollbar.
With this PR applied, no scrollbar should be present.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

<img width="1270" height="730" alt="image" src="https://github.com/user-attachments/assets/e13965e8-efbe-4cbb-b012-d72d941370bc" />

### After

<img width="1261" height="716" alt="image" src="https://github.com/user-attachments/assets/bb4bfe12-31ea-424e-b250-29f317ca700b" />

