### PR TITLE
DataViews: support groupBy in table layout

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Features
 
+- Add "groupBy" support to the table layout. [#71055](https://github.com/WordPress/gutenberg/pull/71055)
 - Elements in the Field API can now provide an empty value that will be used instead of the default. [#70894](https://github.com/WordPress/gutenberg/pull/70894)
 - Support Ctrl + Click / Cmd + Click for multiselecting rows in the Table layout ([#70891](https://github.com/WordPress/gutenberg/pull/70891)).
 - Add support for the `Edit` control on the date field type ([#70836](https://github.com/WordPress/gutenberg/pull/70836)).

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -207,7 +207,7 @@ Properties:
 -   `showMedia`: Whether the media should be shown in the UI. `true` by default.
 -   `showDescription`: Whether the description should be shown in the UI. `true` by default.
 -   `showLevels`: Whether to display the hierarchical levels for the data. `false` by default. See related `getItemLevel` DataView prop.
--   `groupByField`: The id of the field used for grouping the dataset. So far, only the `grid` layout supports grouping.
+-   `groupByField`: The id of the field used for grouping the dataset. Supported by the `grid` and `table` layouts.
 -   `fields`: a list of remaining field `id` that are visible in the UI and the specific order in which they are displayed.
 -   `layout`: config that is specific to a particular layout type.
 

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -347,7 +347,7 @@ export const WithCard = () => {
 	);
 };
 
-export const GroupedGridLayout = () => {
+export const GroupByLayout = () => {
 	const [ view, setView ] = useState< View >( {
 		type: LAYOUT_GRID,
 		search: '',

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -155,8 +155,8 @@
 }
 
 .dataviews-view-grid__group-header {
-	font-size: 16px;
-	font-weight: 600;
+	font-size: $font-size-large;
+	font-weight: $font-weight-medium;
 	color: $gray-900;
 	margin: 0 0 $grid-unit-10 0;
 	padding: 0 $grid-unit-60;

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -297,3 +297,14 @@
 		max-width: 80ch;
 	}
 }
+
+// Group header styling
+.dataviews-view-table__group-header-row {
+	background-color: $gray-100;
+
+	.dataviews-view-table__group-header-cell {
+		font-weight: 600;
+		padding: $grid-unit-15 $grid-unit-60;
+		color: $gray-900;
+	}
+}

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -298,10 +298,7 @@
 	}
 }
 
-// Group header styling
 .dataviews-view-table__group-header-row {
-	background-color: $gray-100;
-
 	.dataviews-view-table__group-header-cell {
 		font-weight: $font-weight-medium;
 		padding: $grid-unit-15 $grid-unit-60;

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -303,7 +303,7 @@
 	background-color: $gray-100;
 
 	.dataviews-view-table__group-header-cell {
-		font-weight: 600;
+		font-weight: $font-weight-medium;
 		padding: $grid-unit-15 $grid-unit-60;
 		color: $gray-900;
 	}


### PR DESCRIPTION
## What?

Adds support to group the table layout by a field.

https://github.com/user-attachments/assets/9f4dd768-121e-4ea9-812d-f1432a3edd21

## Why?

Part of https://github.com/WordPress/gutenberg/issues/57967

## How?

- Each group in the table in divided into its own tbody – which is [valid HTML as per the spec](https://html.spec.whatwg.org/multipage/tables.html#the-table-element).
- The header of each group is a TR element with a single TD element expanded to all columns.

## Testing Instructions

- Visit storybook (`npm install && npm run storybook:dev`) and interact with the "group by layout" story.
