### PR TITLE
Fix: Hide heading level and alignment controls in site-title block when in contentOnly mode

### DIFF
--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -17,6 +17,7 @@ import {
 	useBlockProps,
 	HeadingLevelDropdown,
 	useBlockEditingMode,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
 	ToggleControl,
@@ -37,9 +38,11 @@ export default function SiteTitleEdit( {
 	insertBlocksAfter,
 } ) {
 	const { level, levelOptions, textAlign, isLink, linkTarget } = attributes;
-	const { canUserEdit, title } = useSelect( ( select ) => {
+	const { canUserEdit, title, isNavigationMode } = useSelect( ( select ) => {
 		const { canUser, getEntityRecord, getEditedEntityRecord } =
 			select( coreStore );
+		const { isNavigationMode: _isNavigationMode } =
+			select( blockEditorStore );
 		const canEdit = canUser( 'update', {
 			kind: 'root',
 			name: 'site',
@@ -50,6 +53,7 @@ export default function SiteTitleEdit( {
 		return {
 			canUserEdit: canEdit,
 			title: canEdit ? settings?.title : readOnlySettings?.name,
+			isNavigationMode: _isNavigationMode(),
 		};
 	}, [] );
 	const { editEntityRecord } = useDispatch( coreStore );
@@ -105,23 +109,26 @@ export default function SiteTitleEdit( {
 	);
 	return (
 		<>
-			{ blockEditingMode === 'default' && (
-				<BlockControls group="block">
-					<HeadingLevelDropdown
-						value={ level }
-						options={ levelOptions }
-						onChange={ ( newLevel ) =>
-							setAttributes( { level: newLevel } )
-						}
-					/>
-					<AlignmentControl
-						value={ textAlign }
-						onChange={ ( nextAlign ) => {
-							setAttributes( { textAlign: nextAlign } );
-						} }
-					/>
-				</BlockControls>
-			) }
+			{ blockEditingMode === 'default' &&
+				! (
+					isNavigationMode && blockEditingMode === 'contentOnly'
+				) && (
+					<BlockControls group="block">
+						<HeadingLevelDropdown
+							value={ level }
+							options={ levelOptions }
+							onChange={ ( newLevel ) =>
+								setAttributes( { level: newLevel } )
+							}
+						/>
+						<AlignmentControl
+							value={ textAlign }
+							onChange={ ( nextAlign ) => {
+								setAttributes( { textAlign: nextAlign } );
+							} }
+						/>
+					</BlockControls>
+				) }
 			<InspectorControls>
 				<ToolsPanel
 					label={ __( 'Settings' ) }

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -109,26 +109,23 @@ export default function SiteTitleEdit( {
 	);
 	return (
 		<>
-			{ blockEditingMode === 'default' &&
-				! (
-					isNavigationMode && blockEditingMode === 'contentOnly'
-				) && (
-					<BlockControls group="block">
-						<HeadingLevelDropdown
-							value={ level }
-							options={ levelOptions }
-							onChange={ ( newLevel ) =>
-								setAttributes( { level: newLevel } )
-							}
-						/>
-						<AlignmentControl
-							value={ textAlign }
-							onChange={ ( nextAlign ) => {
-								setAttributes( { textAlign: nextAlign } );
-							} }
-						/>
-					</BlockControls>
-				) }
+			{ ! isNavigationMode && blockEditingMode === 'default' && (
+				<BlockControls group="block">
+					<HeadingLevelDropdown
+						value={ level }
+						options={ levelOptions }
+						onChange={ ( newLevel ) =>
+							setAttributes( { level: newLevel } )
+						}
+					/>
+					<AlignmentControl
+						value={ textAlign }
+						onChange={ ( nextAlign ) => {
+							setAttributes( { textAlign: nextAlign } );
+						} }
+					/>
+				</BlockControls>
+			) }
 			<InspectorControls>
 				<ToolsPanel
 					label={ __( 'Settings' ) }

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -16,6 +16,7 @@ import {
 	BlockControls,
 	useBlockProps,
 	HeadingLevelDropdown,
+	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import {
 	ToggleControl,
@@ -53,6 +54,7 @@ export default function SiteTitleEdit( {
 	}, [] );
 	const { editEntityRecord } = useDispatch( coreStore );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+	const blockEditingMode = useBlockEditingMode();
 
 	function setTitle( newTitle ) {
 		editEntityRecord( 'root', 'site', undefined, {
@@ -103,21 +105,23 @@ export default function SiteTitleEdit( {
 	);
 	return (
 		<>
-			<BlockControls group="block">
-				<HeadingLevelDropdown
-					value={ level }
-					options={ levelOptions }
-					onChange={ ( newLevel ) =>
-						setAttributes( { level: newLevel } )
-					}
-				/>
-				<AlignmentControl
-					value={ textAlign }
-					onChange={ ( nextAlign ) => {
-						setAttributes( { textAlign: nextAlign } );
-					} }
-				/>
-			</BlockControls>
+			{ blockEditingMode === 'default' && (
+				<BlockControls group="block">
+					<HeadingLevelDropdown
+						value={ level }
+						options={ levelOptions }
+						onChange={ ( newLevel ) =>
+							setAttributes( { level: newLevel } )
+						}
+					/>
+					<AlignmentControl
+						value={ textAlign }
+						onChange={ ( nextAlign ) => {
+							setAttributes( { textAlign: nextAlign } );
+						} }
+					/>
+				</BlockControls>
+			) }
 			<InspectorControls>
 				<ToolsPanel
 					label={ __( 'Settings' ) }


### PR DESCRIPTION
## What

Fixes an issue where the `core/site-title` block was showing heading level and alignment controls in the block toolbar when in contentOnly mode, which should not happen.

This PR means that when the block is in Write Mode these controls won't show up which is what is required.

## Why

When blocks are in contentOnly mode (like in navigation block editing), non-content UI controls should be hidden to allow users to focus on editing content only. The site-title block was not following this pattern and was showing heading level and alignment controls that should be hidden.

## How

- Added hook import to detect the current editing mode
- Wrapped the  section with a conditional check  
- This follows the same pattern used by other blocks like post-title and image blocks

## Testing

1. Switch to Write mode (requires enabling the experiment in Gutenberg menu in WPAdmin).
2. Select Site title block. Verify that heading level and alignment controls are hidden in the toolbar
3. Verify that the site title text can still be edited
4. Verify that controls are still visible when editing the site-title block outside of Write mode

## Screenshots

<img width="1678" height="1048" alt="Screen Shot 2025-08-05 at 10 28 51 (1)" src="https://github.com/user-attachments/assets/f16f8e3d-1203-456b-ae01-7b14cddd9436" />
