### PR TITLE
Pages: filters should not be visible if they are present in the bundled view

### DIFF
--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -238,9 +238,9 @@ export default function PostList( { postType } ) {
 		).map( ( { field } ) => field );
 		return _fields.map( ( field ) => ( {
 			...field,
-			elements: activeViewFilters.includes( field.id )
-				? []
-				: field.elements,
+			...( activeViewFilters.includes( field.id )
+				? { filterBy: false }
+				: {} ),
 		} ) );
 	}, [ _fields, defaultViews, activeView ] );
 


### PR DESCRIPTION
## What?

Fixes a bug in the Site Editor's Pages screen: when you select a bundled view the "status" filter should not visible. It was visible but without elements.

Before

https://github.com/user-attachments/assets/2e06026f-2ceb-4c9a-817d-d33deb563838

After

https://github.com/user-attachments/assets/a86b80ce-2f9d-40d1-ab05-5d033f0d311f

## How?

By using `filterBy` to hide it. This is probably a side-effect of changing how filters how at https://github.com/WordPress/gutenberg/pull/70567

## Testing Instructions

- Visit the Site Editor's Pages screen.
- Verify the status filter is available for the "All pages" bundled view.
- Verify the status filter is not available for any other bundled view (published, drafts, etc.).
