### PR TITLE
Fix: Hide crop and dimensions controls in site-logo block when in Write Mode

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -77,7 +77,12 @@ const SiteLogo = ( {
 
 	// Check if we're in contentOnly mode
 	const blockEditingMode = useBlockEditingMode();
+	const isNavigationMode = useSelect(
+		( select ) => select( blockEditorStore ).isNavigationMode(),
+		[]
+	);
 	const isContentOnlyMode = blockEditingMode === 'contentOnly';
+	const isWriteMode = isNavigationMode && isContentOnlyMode;
 
 	const { imageEditing, maxWidth, title } = useSelect( ( select ) => {
 		const settings = select( blockEditorStore ).getSettings();
@@ -211,8 +216,8 @@ const SiteLogo = ( {
 	const canEditImage =
 		logoId && naturalWidth && naturalHeight && imageEditing;
 
-	// Hide crop and dimensions editing in contentOnly mode
-	const shouldShowCropAndDimensions = ! isContentOnlyMode;
+	// Hide crop and dimensions editing in write mode
+	const shouldShowCropAndDimensions = ! isWriteMode;
 
 	let imgEdit;
 	if ( canEditImage && isEditingImage ) {

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -38,6 +38,7 @@ import {
 	useBlockProps,
 	store as blockEditorStore,
 	__experimentalImageEditor as ImageEditor,
+	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -73,6 +74,11 @@ const SiteLogo = ( {
 	const [ isEditingImage, setIsEditingImage ] = useState( false );
 	const { toggleSelection } = useDispatch( blockEditorStore );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+
+	// Check if we're in contentOnly mode
+	const blockEditingMode = useBlockEditingMode();
+	const isContentOnlyMode = blockEditingMode === 'contentOnly';
+
 	const { imageEditing, maxWidth, title } = useSelect( ( select ) => {
 		const settings = select( blockEditorStore ).getSettings();
 		const siteEntities = select( coreStore ).getEntityRecord(
@@ -205,8 +211,12 @@ const SiteLogo = ( {
 	const canEditImage =
 		logoId && naturalWidth && naturalHeight && imageEditing;
 
-	const imgEdit =
-		canEditImage && isEditingImage ? (
+	// Hide crop and dimensions editing in contentOnly mode
+	const shouldShowCropAndDimensions = ! isContentOnlyMode;
+
+	let imgEdit;
+	if ( canEditImage && isEditingImage ) {
+		imgEdit = (
 			<ImageEditor
 				id={ logoId }
 				url={ logoUrl }
@@ -221,7 +231,9 @@ const SiteLogo = ( {
 					setIsEditingImage( false );
 				} }
 			/>
-		) : (
+		);
+	} else if ( shouldShowCropAndDimensions ) {
+		imgEdit = (
 			<ResizableBox
 				size={ {
 					width: currentWidth,
@@ -251,6 +263,9 @@ const SiteLogo = ( {
 				{ imgWrapper }
 			</ResizableBox>
 		);
+	} else {
+		imgEdit = imgWrapper;
+	}
 
 	// Support the previous location for the Site Icon settings. To be removed
 	// when the required WP core version for Gutenberg is >= 6.5.0.
@@ -371,15 +386,17 @@ const SiteLogo = ( {
 					) }
 				</ToolsPanel>
 			</InspectorControls>
-			<BlockControls group="block">
-				{ canEditImage && ! isEditingImage && (
-					<ToolbarButton
-						onClick={ () => setIsEditingImage( true ) }
-						icon={ crop }
-						label={ __( 'Crop' ) }
-					/>
+			{ canEditImage &&
+				! isEditingImage &&
+				shouldShowCropAndDimensions && (
+					<BlockControls group="block">
+						<ToolbarButton
+							onClick={ () => setIsEditingImage( true ) }
+							icon={ crop }
+							label={ __( 'Crop' ) }
+						/>
+					</BlockControls>
 				) }
-			</BlockControls>
 			{ imgEdit }
 		</>
 	);

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -82,7 +82,7 @@ const SiteLogo = ( {
 		[]
 	);
 	const isContentOnlyMode = blockEditingMode === 'contentOnly';
-	const isWriteMode = isNavigationMode && isContentOnlyMode;
+	const isContentOnlyWriteMode = isNavigationMode && isContentOnlyMode;
 
 	const { imageEditing, maxWidth, title } = useSelect( ( select ) => {
 		const settings = select( blockEditorStore ).getSettings();
@@ -217,7 +217,7 @@ const SiteLogo = ( {
 		logoId && naturalWidth && naturalHeight && imageEditing;
 
 	// Hide crop and dimensions editing in write mode
-	const shouldShowCropAndDimensions = ! isWriteMode;
+	const shouldShowCropAndDimensions = ! isContentOnlyWriteMode;
 
 	let imgEdit;
 	if ( canEditImage && isEditingImage ) {

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -264,7 +264,8 @@ const SiteLogo = ( {
 			</ResizableBox>
 		);
 	} else {
-		imgEdit = imgWrapper;
+		// When not showing ResizableBox, still apply size constraints
+		imgEdit = <div style={ { width, height } }>{ imgWrapper }</div>;
 	}
 
 	// Support the previous location for the Site Icon settings. To be removed

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -232,14 +232,15 @@ const SiteLogo = ( {
 				} }
 			/>
 		);
-	} else if ( shouldShowCropAndDimensions ) {
+	} else {
+		// Always render ResizableBox but disable resize functionality in contentOnly mode
 		imgEdit = (
 			<ResizableBox
 				size={ {
 					width: currentWidth,
 					height: currentHeight,
 				} }
-				showHandle={ isSelected }
+				showHandle={ isSelected && shouldShowCropAndDimensions }
 				minWidth={ minWidth }
 				maxWidth={ maxWidthBuffer }
 				minHeight={ minHeight }
@@ -263,9 +264,6 @@ const SiteLogo = ( {
 				{ imgWrapper }
 			</ResizableBox>
 		);
-	} else {
-		// When not showing ResizableBox, still apply size constraints
-		imgEdit = <div style={ { width, height } }>{ imgWrapper }</div>;
 	}
 
 	// Support the previous location for the Site Icon settings. To be removed


### PR DESCRIPTION
## What

Fixes an issue where the  block was showing crop and dimensions editing controls when in contentOnly mode, which should not happen.

This PR means that when the block is in Write Mode these controls won't show up which is what is required.

## Why

When blocks are in contentOnly mode (like in navigation block editing), non-content UI controls should be hidden to allow users to focus on editing content only. The site-logo block was not following this pattern and was showing crop and dimensions editing controls that should be hidden.

## How

* Added  hook to detect the current editing mode
* Wrapped crop button in BlockControls with conditional rendering
* Always render ResizableBox to maintain size constraints but conditionally show resize handles
* This follows the same pattern used by other blocks like site-title and image blocks

## Testing

1. Switch to Write mode (requires enabling the experiment in Gutenberg menu in WPAdmin).
2. Select Site Logo block. Verify that crop and dimensions editing controls are hidden in the toolbar
3. Verify that the logo maintains its correct size (doesn't become huge - try uploading a large logo to test this)
4. Verify that the logo can still be edited/replaced
5. Verify that controls are still visible when editing the site-logo block outside of Write mode

## Screenshots

<img width="1012" height="574" alt="Screen Shot 2025-08-05 at 12 07 51" src="https://github.com/user-attachments/assets/5f9d83b4-d71c-4051-940e-65630757dacc" />

https://github.com/user-attachments/assets/54c63e05-5581-44ef-8eaf-a7e72cc43fac



## Breaking Changes

None - this is a UI improvement that maintains existing functionality.