### PR TITLE
MediaReplaceFlow: Correctly truncate long URL

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -34,12 +34,6 @@
 			margin: 0; // Reset default LinkControl margins.
 		}
 
-		.block-editor-link-control__search-item-title,
-		.block-editor-link-control__search-item-info {
-			max-width: 200px;
-			white-space: nowrap;
-		}
-
 		.block-editor-link-control__tools {
 			justify-content: flex-end;
 			padding: $grid-unit-20 var(--wp-admin-border-width-focus) var(--wp-admin-border-width-focus);


### PR DESCRIPTION
Fixes #59807
Follow-up #57775

## What?

Truncates a long media URL in the `MediaReplaceFlow` component.

## Why?

This URL is expected to be truncated by the `Truncate` component, but I noticed that the three dots were not displayed, and the buttons were pushed slightly to the right.

## How?

It seems that the `white-space: nowrap` style of the parent element was affecting it, so I removed it. Furthermore, `max-width` should also be unnecessary. The inner `Truncate` component should properly process text for both elements by default:

https://github.com/WordPress/gutenberg/blob/8470c8b4d59df3007827b942e6958c88b3a356de/packages/block-editor/src/components/link-control/link-preview.js#L132-L146

These two CSS elements should probably have been removed when the `Truncate` component was added in #57775.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Use the following HTML to check the URL without an extension to be truncated correctly:

```html
<!-- wp:image {"sizeSlug":"large"} -->
<figure class="wp-block-image size-large"><img src="https://picsum.photos/id/870/200/300?grayscale&amp;blur=2" alt=""/></figure>
<!-- /wp:image -->
```

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="722" height="300" alt="image" src="https://github.com/user-attachments/assets/40ac392d-8f67-4ead-8246-eaad91e2a0ee" />

### After

<img width="709" height="331" alt="image" src="https://github.com/user-attachments/assets/1ec52b14-2f5c-4dd4-8620-9cb8918cd8e1" />

