### PR TITLE
Hide Cut/Copy commands in Write Mode (contentOnly)

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -158,7 +158,7 @@ export function BlockSettingsDropdown( {
 		};
 	}, [] );
 	const hasSelectedBlocks = selectedBlockClientIds.length > 0;
-	const isWriteMode = isNavigationMode && isContentOnly;
+	const isContentOnlyWriteMode = isNavigationMode && isContentOnly;
 
 	async function updateSelectionAfterDuplicate( clientIdsPromise ) {
 		if ( ! __experimentalSelectBlock ) {
@@ -282,14 +282,14 @@ export function BlockSettingsDropdown( {
 											clientId={ firstBlockClientId }
 										/>
 									) }
-									{ ! isWriteMode && (
+									{ ! isContentOnlyWriteMode && (
 										<CopyMenuItem
 											clientIds={ clientIds }
 											onCopy={ onCopy }
 											shortcut={ shortcuts.copy }
 										/>
 									) }
-									{ ! isWriteMode && (
+									{ ! isContentOnlyWriteMode && (
 										<CopyMenuItem
 											clientIds={ clientIds }
 											label={ __( 'Cut' ) }

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -246,7 +246,7 @@ export function BlockSettingsDropdown( {
 					! canRemove &&
 					! canDuplicate &&
 					! canInsertBlock &&
-					isWriteMode;
+					isContentOnly;
 
 				if ( isEmpty ) {
 					return null;

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -88,6 +88,7 @@ export function BlockSettingsDropdown( {
 		selectedBlockClientIds,
 		openedBlockSettingsMenu,
 		isContentOnly,
+		isNavigationMode,
 		isZoomOut,
 	} = useSelect(
 		( select ) => {
@@ -99,6 +100,7 @@ export function BlockSettingsDropdown( {
 				getBlockAttributes,
 				getOpenedBlockSettingsMenu,
 				getBlockEditingMode,
+				isNavigationMode: _isNavigationMode,
 				isZoomOut: _isZoomOut,
 			} = unlock( select( blockEditorStore ) );
 
@@ -124,6 +126,7 @@ export function BlockSettingsDropdown( {
 				openedBlockSettingsMenu: getOpenedBlockSettingsMenu(),
 				isContentOnly:
 					getBlockEditingMode( firstBlockClientId ) === 'contentOnly',
+				isNavigationMode: _isNavigationMode(),
 				isZoomOut: _isZoomOut(),
 			};
 		},
@@ -155,6 +158,7 @@ export function BlockSettingsDropdown( {
 		};
 	}, [] );
 	const hasSelectedBlocks = selectedBlockClientIds.length > 0;
+	const isWriteMode = isNavigationMode && isContentOnly;
 
 	async function updateSelectionAfterDuplicate( clientIdsPromise ) {
 		if ( ! __experimentalSelectBlock ) {
@@ -242,7 +246,7 @@ export function BlockSettingsDropdown( {
 					! canRemove &&
 					! canDuplicate &&
 					! canInsertBlock &&
-					isContentOnly;
+					isWriteMode;
 
 				if ( isEmpty ) {
 					return null;
@@ -278,14 +282,14 @@ export function BlockSettingsDropdown( {
 											clientId={ firstBlockClientId }
 										/>
 									) }
-									{ ! isContentOnly && (
+									{ ! isWriteMode && (
 										<CopyMenuItem
 											clientIds={ clientIds }
 											onCopy={ onCopy }
 											shortcut={ shortcuts.copy }
 										/>
 									) }
-									{ ! isContentOnly && (
+									{ ! isWriteMode && (
 										<CopyMenuItem
 											clientIds={ clientIds }
 											label={ __( 'Cut' ) }

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -278,20 +278,24 @@ export function BlockSettingsDropdown( {
 											clientId={ firstBlockClientId }
 										/>
 									) }
-									<CopyMenuItem
-										clientIds={ clientIds }
-										onCopy={ onCopy }
-										shortcut={ shortcuts.copy }
-									/>
-									<CopyMenuItem
-										clientIds={ clientIds }
-										label={ __( 'Cut' ) }
-										eventType="cut"
-										shortcut={ shortcuts.cut }
-										__experimentalUpdateSelection={
-											! __experimentalSelectBlock
-										}
-									/>
+									{ ! isContentOnly && (
+										<CopyMenuItem
+											clientIds={ clientIds }
+											onCopy={ onCopy }
+											shortcut={ shortcuts.copy }
+										/>
+									) }
+									{ ! isContentOnly && (
+										<CopyMenuItem
+											clientIds={ clientIds }
+											label={ __( 'Cut' ) }
+											eventType="cut"
+											shortcut={ shortcuts.cut }
+											__experimentalUpdateSelection={
+												! __experimentalSelectBlock
+											}
+										/>
+									) }
 									{ canDuplicate && (
 										<MenuItem
 											onClick={ pipe(

--- a/test/e2e/specs/editor/various/write-design-mode.spec.js
+++ b/test/e2e/specs/editor/various/write-design-mode.spec.js
@@ -108,8 +108,8 @@ test.describe( 'Write/Design mode', () => {
 			.getByRole( 'menu', { name: 'Options' } )
 			.getByRole( 'menuitem' );
 
-		// we expect 6 items in the options menu
-		await expect( optionsMenu ).toHaveCount( 6 );
+		// we expect 4 items in the options menu (Cut and Copy are hidden in Write Mode)
+		await expect( optionsMenu ).toHaveCount( 4 );
 
 		// We should be able to select the paragraph block and write in it.
 		await paragraph.click();


### PR DESCRIPTION
## What

Fixes issue where Cut/Copy/Paste commands were visible in Write Mode when they should be hidden. Write Mode is contentOnly mode where users should only see content-editing capabilities without structural controls.

## Why

When users are in Write Mode (contentOnly mode), they should only see content-editing capabilities without interference from structural/formatting controls. The Cut/Copy/Paste commands are structural controls that should be hidden in this mode to provide a cleaner, more focused editing experience.

## How

- Added isContentOnly condition to CopyMenuItem for Copy command
- Added isContentOnly condition to CopyMenuItem for Cut command
- Maintains existing behavior for other menu items that already check for contentOnly mode

## Testing

1. Enter Write Mode by enabling the experiment.
2. Add a Gallery block with some images.
3. Select an Image within the gallery.
4. Open the block settings menu (three dots)
5. Verify that Cut and Copy commands are _not_ visible
6. Exit Write Mode and verify that Cut and Copy commands are visible again
7. Test with different block types (paragraph, image, gallery, etc.)

## Screenshots
<img width="1290" height="526" alt="Screen Shot 2025-08-05 at 12 58 57" src="https://github.com/user-attachments/assets/b37e1d6d-4566-4b1d-9e5d-3e86dff29cb4" />

