### PR TITLE
Cover: Correct gradient inline style properties in editor to match frontend.

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -85,7 +85,6 @@ function CoverEdit( {
 } ) {
 	const {
 		contentPosition,
-		customGradient,
 		id,
 		url: originalUrl,
 		backgroundType: originalBackgroundType,
@@ -348,7 +347,7 @@ function CoverEdit( {
 
 	const bgStyle = {
 		backgroundColor: overlayColor.color,
-		background: customGradient ? customGradient : undefined,
+		background: gradientValue ? gradientValue : undefined,
 	};
 	const mediaStyle = {
 		objectPosition:

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -85,6 +85,7 @@ function CoverEdit( {
 } ) {
 	const {
 		contentPosition,
+		customGradient,
 		id,
 		url: originalUrl,
 		backgroundType: originalBackgroundType,
@@ -345,7 +346,10 @@ function CoverEdit( {
 
 	const backgroundPosition = mediaPosition( focalPoint );
 
-	const bgStyle = { backgroundColor: overlayColor.color };
+	const bgStyle = {
+		backgroundColor: overlayColor.color,
+		background: customGradient ? customGradient : undefined,
+	};
 	const mediaStyle = {
 		objectPosition:
 			focalPoint && isImgElement
@@ -614,7 +618,7 @@ function CoverEdit( {
 								[ gradientClass ]: gradientClass,
 							}
 						) }
-						style={ { backgroundImage: gradientValue, ...bgStyle } }
+						style={ bgStyle }
 					/>
 				) }
 

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -346,8 +346,8 @@ function CoverEdit( {
 	const backgroundPosition = mediaPosition( focalPoint );
 
 	const bgStyle = {
+		background: gradientValue,
 		backgroundColor: overlayColor.color,
-		background: gradientValue ? gradientValue : undefined,
 	};
 	const mediaStyle = {
 		objectPosition:


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Correct gradient inline style properties in editor to match frontend.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Custom gradient properties are rendered with the `background` property on the frontend, not `background-image`.
https://github.com/WordPress/gutenberg/blob/7a1faf1969e7e70847626982da78a3bba4080dc0/packages/block-library/src/cover/save.js#L70-L73

They're rendered with `background-image` in the editor, so this matches the frontend.

Different properties between the frontend and the editor can lead to css mismatches.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page. 
2. Insert a cover block. 
3. You can see that the inline style background is rendered when you set a custom gradient in the editor.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="943" height="657" alt="before-2" src="https://github.com/user-attachments/assets/02fae9ff-5232-4254-9137-1b0ff685a0d8" /> Preset value | <img width="953" height="656" alt="after-1" src="https://github.com/user-attachments/assets/fa4ed54b-1b5f-4688-9470-d78fed220f1c" /> Preset value |
| <img width="952" height="655" alt="before-1" src="https://github.com/user-attachments/assets/cbdf198e-ef2e-411b-b362-b50f3d1d870e" /> Custom value | <img width="964" height="653" alt="after-2" src="https://github.com/user-attachments/assets/ffdcc807-6bfa-4175-8b97-1ae836a96246" /> Custom value | 
