### PR TITLE
DataViews: introduce locked filters

### DIFF
--- a/packages/dataviews/src/components/dataviews-filters/filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter.tsx
@@ -497,8 +497,9 @@ export default function Filter( {
 	}
 
 	const isPrimary = filter.isPrimary;
-	const hasValues = filterInView?.value !== undefined;
-	const canResetOrRemove = ! isPrimary || hasValues;
+	const isLocked = filterInView?.isLocked;
+	const hasValues = ! isLocked && filterInView?.value !== undefined;
+	const canResetOrRemove = ! isLocked && ( ! isPrimary || hasValues );
 	return (
 		<Dropdown
 			defaultOpen={ openedFilter === filter.field }
@@ -527,13 +528,21 @@ export default function Filter( {
 							) }
 							role="button"
 							tabIndex={ 0 }
-							onClick={ onToggle }
+							onClick={ () => {
+								if ( ! isLocked ) {
+									onToggle();
+								}
+							} }
 							onKeyDown={ ( event ) => {
-								if ( [ ENTER, SPACE ].includes( event.key ) ) {
+								if (
+									! isLocked &&
+									[ ENTER, SPACE ].includes( event.key )
+								) {
 									onToggle();
 									event.preventDefault();
 								}
 							} }
+							aria-disabled={ isLocked }
 							aria-pressed={ isOpen }
 							aria-expanded={ isOpen }
 							ref={ toggleRef }

--- a/packages/dataviews/src/components/dataviews-filters/index.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/index.tsx
@@ -52,6 +52,10 @@ export function useFilters( fields: NormalizedField< any >[], view: View ) {
 							ALL_OPERATORS.includes( f.operator )
 					),
 				isPrimary,
+				isLocked:
+					view.filters?.some(
+						( f ) => f.field === field.id && !! f.isLocked
+					) ?? false,
 			} );
 		} );
 		// Sort filters by primary property. We need the primary filters to be first.

--- a/packages/dataviews/src/components/dataviews-filters/reset-filters.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/reset-filters.tsx
@@ -42,7 +42,8 @@ export default function ResetFilter( {
 					...view,
 					page: 1,
 					search: '',
-					filters: [],
+					filters:
+						view.filters?.filter( ( f ) => !! f.isLocked ) || [],
 				} );
 			} }
 		>

--- a/packages/dataviews/src/components/dataviews-filters/reset-filters.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/reset-filters.tsx
@@ -28,7 +28,8 @@ export default function ResetFilter( {
 		! view.search &&
 		! view.filters?.some(
 			( _filter ) =>
-				_filter.value !== undefined || ! isPrimary( _filter.field )
+				! _filter.isLocked &&
+				( _filter.value !== undefined || ! isPrimary( _filter.field ) )
 		);
 	return (
 		<Button

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -7,7 +7,13 @@ import type { ReactNode, ComponentProps, ReactElement } from 'react';
  * WordPress dependencies
  */
 import { __experimentalHStack as HStack } from '@wordpress/components';
-import { useContext, useMemo, useRef, useState } from '@wordpress/element';
+import {
+	useContext,
+	useMemo,
+	useRef,
+	useState,
+	useEffect,
+} from '@wordpress/element';
 import { useResizeObserver } from '@wordpress/compose';
 
 /**
@@ -171,8 +177,22 @@ function DataViews< Item >( {
 
 	const filters = useFilters( _fields, view );
 	const [ isShowingFilter, setIsShowingFilter ] = useState< boolean >( () =>
-		( filters || [] ).some( ( filter ) => filter.isPrimary )
+		( filters || [] ).some(
+			( filter ) => filter.isPrimary || filter.isLocked
+		)
 	);
+	useEffect( () => {
+		// The fields may be empty when DataViews is mounted,
+		// so any time the filters are recalculated, check if filter visibility has changed.
+		if (
+			( filters || [] ).some(
+				( filter ) => filter.isPrimary || filter.isLocked
+			) &&
+			! isShowingFilter
+		) {
+			setIsShowingFilter( true );
+		}
+	}, [ filters ] );
 
 	return (
 		<DataViewsContext.Provider

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -351,6 +351,11 @@ export interface NormalizedFilter {
 	 * Whether it is a primary filter.
 	 */
 	isPrimary: boolean;
+
+	/**
+	 * Whether the filter can be edited by the user.
+	 */
+	isLocked: boolean;
 }
 
 interface ViewBase {

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -309,6 +309,11 @@ export interface Filter {
 	 * The value to filter by.
 	 */
 	value: any;
+
+	/**
+	 * Whether the filter can be edited by the user.
+	 */
+	isLocked?: boolean;
 }
 
 export interface NormalizedFilter {

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -223,55 +223,14 @@ export default function PostList( { postType } ) {
 		},
 		[ location.path, location.query.isCustom, history ]
 	);
-	const getActiveViewFilters = ( views, match ) => {
-		const found = views.find( ( { slug } ) => slug === match );
-		return found?.filters ?? [];
-	};
 
-	const { isLoading: isLoadingFields, fields: _fields } = usePostFields( {
+	const { isLoading: isLoadingFields, fields: fields } = usePostFields( {
 		postType,
 	} );
-	const fields = useMemo( () => {
-		const activeViewFilters = getActiveViewFilters(
-			defaultViews,
-			activeView
-		).map( ( { field } ) => field );
-		return _fields.map( ( field ) => ( {
-			...field,
-			...( activeViewFilters.includes( field.id )
-				? { filterBy: false }
-				: {} ),
-		} ) );
-	}, [ _fields, defaultViews, activeView ] );
 
 	const queryArgs = useMemo( () => {
 		const filters = {};
 		view.filters?.forEach( ( filter ) => {
-			if (
-				filter.field === 'status' &&
-				filter.operator === OPERATOR_IS_ANY
-			) {
-				filters.status = filter.value;
-			}
-			if (
-				filter.field === 'author' &&
-				filter.operator === OPERATOR_IS_ANY
-			) {
-				filters.author = filter.value;
-			} else if (
-				filter.field === 'author' &&
-				filter.operator === OPERATOR_IS_NONE
-			) {
-				filters.author_exclude = filter.value;
-			}
-		} );
-
-		// The bundled views want data filtered without displaying the filter.
-		const activeViewFilters = getActiveViewFilters(
-			defaultViews,
-			activeView
-		);
-		activeViewFilters.forEach( ( filter ) => {
 			if (
 				filter.field === 'status' &&
 				filter.operator === OPERATOR_IS_ANY

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -69,66 +69,81 @@ export function useDefaultViews( { postType } ) {
 				title: __( 'Published' ),
 				slug: 'published',
 				icon: published,
-				view: DEFAULT_POST_BASE,
-				filters: [
-					{
-						field: 'status',
-						operator: OPERATOR_IS_ANY,
-						value: 'publish',
-					},
-				],
+				view: {
+					...DEFAULT_POST_BASE,
+					filters: [
+						{
+							field: 'status',
+							operator: OPERATOR_IS_ANY,
+							value: 'publish',
+							isLocked: true,
+						},
+					],
+				},
 			},
 			{
 				title: __( 'Scheduled' ),
 				slug: 'future',
 				icon: scheduled,
-				view: DEFAULT_POST_BASE,
-				filters: [
-					{
-						field: 'status',
-						operator: OPERATOR_IS_ANY,
-						value: 'future',
-					},
-				],
+				view: {
+					...DEFAULT_POST_BASE,
+					filters: [
+						{
+							field: 'status',
+							operator: OPERATOR_IS_ANY,
+							value: 'future',
+							isLocked: true,
+						},
+					],
+				},
 			},
 			{
 				title: __( 'Drafts' ),
 				slug: 'drafts',
 				icon: drafts,
-				view: DEFAULT_POST_BASE,
-				filters: [
-					{
-						field: 'status',
-						operator: OPERATOR_IS_ANY,
-						value: 'draft',
-					},
-				],
+				view: {
+					...DEFAULT_POST_BASE,
+					filters: [
+						{
+							field: 'status',
+							operator: OPERATOR_IS_ANY,
+							value: 'draft',
+							isLocked: true,
+						},
+					],
+				},
 			},
 			{
 				title: __( 'Pending' ),
 				slug: 'pending',
 				icon: pending,
-				view: DEFAULT_POST_BASE,
-				filters: [
-					{
-						field: 'status',
-						operator: OPERATOR_IS_ANY,
-						value: 'pending',
-					},
-				],
+				view: {
+					...DEFAULT_POST_BASE,
+					filters: [
+						{
+							field: 'status',
+							operator: OPERATOR_IS_ANY,
+							value: 'pending',
+							isLocked: true,
+						},
+					],
+				},
 			},
 			{
 				title: __( 'Private' ),
 				slug: 'private',
 				icon: notAllowed,
-				view: DEFAULT_POST_BASE,
-				filters: [
-					{
-						field: 'status',
-						operator: OPERATOR_IS_ANY,
-						value: 'private',
-					},
-				],
+				view: {
+					...DEFAULT_POST_BASE,
+					filters: [
+						{
+							field: 'status',
+							operator: OPERATOR_IS_ANY,
+							value: 'private',
+							isLocked: true,
+						},
+					],
+				},
 			},
 			{
 				title: __( 'Trash' ),
@@ -138,14 +153,15 @@ export function useDefaultViews( { postType } ) {
 					...DEFAULT_POST_BASE,
 					type: LAYOUT_TABLE,
 					layout: defaultLayouts[ LAYOUT_TABLE ].layout,
+					filters: [
+						{
+							field: 'status',
+							operator: OPERATOR_IS_ANY,
+							value: 'trash',
+							isLocked: true,
+						},
+					],
 				},
-				filters: [
-					{
-						field: 'status',
-						operator: OPERATOR_IS_ANY,
-						value: 'trash',
-					},
-				],
 			},
 		];
 	}, [ labels ] );


### PR DESCRIPTION
## What?

Introduces "locked filters" and uses them in the Site Editor's Pages screen.

https://github.com/user-attachments/assets/0aeb8e4f-c5a1-45af-89f5-4330765246c6

## Why?

This replaces some custom code we had in the Pages screen that was sub-optimal (filter value wasn't visible).

## Testing Instructions

Visit the Site Editor's Pages screen and navigate through the bundled views (sidebar). Verify "All pages" contains a "status" filter that can be interacted with, and the other pages have a "locked filter" (displays the value but can't be interacted with).
