### PR TITLE
Docs: Fixes #61207 - Rename 'API Reference' to 'Directives and Store …

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -540,9 +540,9 @@
 		"parent": "interactivity-api"
 	},
 	{
-		"title": "API Reference",
-		"slug": "api-reference",
-		"markdown_source": "../docs/reference-guides/interactivity-api/api-reference.md",
+		"title": "Directives and Store API Reference",
+		"slug": "directives-store-api-reference",
+		"markdown_source": "../docs/reference-guides/interactivity-api/directives-store-api-reference.md",
 		"parent": "interactivity-api"
 	},
 	{

--- a/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md
@@ -739,13 +739,13 @@ By using derived state, you create a more maintainable and less error-prone code
 
 Interactivity API offers a region-based navigation feature that dynamically replaces a part of the page without a full page reload. The [Query block](/docs/reference-guides/core-blocks.md#query-loop) natively supports this feature when the `Force page reload` toggle is disabled. Developers can use the same functionality in custom blocks by calling [`actions.navigate()`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-interactivity-router/#actions) from the [`@wordpress/interactivity-router`](https://github.com/WordPress/gutenberg/tree/trunk/packages/interactivity-router) script module.
 
-When using region-based navigation, it's crucial to ensure that your interactive blocks stay in sync with the server-provided global state and local context. By default, the Interactivity API will never overwrite the global state or local context with the server-provided values. The Interactivity API provides two functions to help manage this synchronization: [`getServerState()`](/docs/reference-guides/interactivity-api/api-reference.md#getserverstate) and [`getServerContext()`](/docs/reference-guides/interactivity-api/api-reference.md#getservercontext).
+When using region-based navigation, it's crucial to ensure that your interactive blocks stay in sync with the server-provided global state and local context. By default, the Interactivity API will never overwrite the global state or local context with the server-provided values. The Interactivity API provides two functions to help manage this synchronization: [`getServerState()`](/docs/reference-guides/interactivity-api/directives-store-api-reference.md#getserverstate) and [`getServerContext()`](/docs/reference-guides/interactivity-api/directives-store-api-reference.md#getservercontext).
 
 ### `getServerState()`
 
 `getServerState()` allows you to subscribe to changes in the **global state** that occur during client-side navigation. This function is analogous to `getServerContext()`, but it works with the global state instead of the local context.
 
-The `getServerState()` function returns a read-only reactive object. This means that any [callbacks](/docs/reference-guides/interactivity-api/api-reference.md#accessing-data-in-callbacks) you have defined that watch the returned object will only trigger when the value returned by the function changes. If the value remains the same, the callback will not re-trigger.
+The `getServerState()` function returns a read-only reactive object. This means that any [callbacks](/docs/reference-guides/interactivity-api/directives-store-api-reference.md#accessing-data-in-callbacks) you have defined that watch the returned object will only trigger when the value returned by the function changes. If the value remains the same, the callback will not re-trigger.
 
 Let's consider a quiz that has multiple questions. Each question is a separate page. When the user navigates to a new question, the server provides the new question and the time left to answer all the questions.
 
@@ -789,7 +789,7 @@ store( 'myPlugin', {
 
 `getServerContext()` allows you to subscribe to changes in the **local context** that occur during client-side navigation. This function is analogous to `getServerState()`, but it works with the local context instead of the global state.
 
-The `getServerContext()` function returns a read-only reactive object. This means that any [callbacks](/docs/reference-guides/interactivity-api/api-reference.md#accessing-data-in-callbacks) you have defined that watch the returned object will only trigger when the value returned by the function changes. If the value remains the same, the callback will not re-trigger.
+The `getServerContext()` function returns a read-only reactive object. This means that any [callbacks](/docs/reference-guides/interactivity-api/directives-store-api-reference.md#accessing-data-in-callbacks) you have defined that watch the returned object will only trigger when the value returned by the function changes. If the value remains the same, the callback will not re-trigger.
 
 Consider a quiz that has multiple questions. Each question is a separate page. When the user navigates to a new question, the server provides the new question and the time left to answer all the questions.
 
@@ -835,7 +835,7 @@ Whenever you have interactive blocks that rely on global state or local context 
 ### Best Practices for using `getServerState()` and `getServerContext()`
 
 -   **Read-Only References:** Both `getServerState()` and `getServerContext()` return read-only objects. You can use those objects to update the global state or local context.
--   **Callback Integration:** Incorporate these functions within your store [callbacks](/docs/reference-guides/interactivity-api/api-reference.md#accessing-data-in-callbacks) to react to state and context changes. Both `getServerState()` and `getServerContext()` return reactive objects. This means that their watch callbacks will only trigger when the value of a property changes. If the value remains the same, the callback will not re-trigger.
+-   **Callback Integration:** Incorporate these functions within your store [callbacks](/docs/reference-guides/interactivity-api/directives-store-api-reference.md#accessing-data-in-callbacks) to react to state and context changes. Both `getServerState()` and `getServerContext()` return reactive objects. This means that their watch callbacks will only trigger when the value of a property changes. If the value remains the same, the callback will not re-trigger.
 
 ## Conclusion
 

--- a/docs/reference-guides/interactivity-api/directives-store-api-reference.md
+++ b/docs/reference-guides/interactivity-api/directives-store-api-reference.md
@@ -1,4 +1,4 @@
-# API Reference
+# Directives and Store API Reference
 
 <div class="callout callout-alert">
 Interactivity API is only available for WordPress 6.5 and above.

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -227,7 +227,7 @@
 						"docs/reference-guides/interactivity-api/iapi-quick-start-guide.md": []
 					},
 					{
-						"docs/reference-guides/interactivity-api/api-reference.md": []
+						"docs/reference-guides/interactivity-api/directives-store-api-reference.md": []
 					},
 					{
 						"docs/reference-guides/interactivity-api/iapi-about.md": []

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -126,7 +126,7 @@
 
 ### Enhancements
 
--   Export `splitTask` function from `@wordpress/interactivity` package to facilitate yielding to the main thread. See example in [async actions](https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/interactivity-api/api-reference.md#async-actions) documentation. ([#62665](https://github.com/WordPress/gutenberg/pull/62665))
+-   Export `splitTask` function from `@wordpress/interactivity` package to facilitate yielding to the main thread. See example in [async actions](https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/interactivity-api/directives-store-api-reference.md#async-actions) documentation. ([#62665](https://github.com/WordPress/gutenberg/pull/62665))
 
 ## 6.1.0 (2024-06-15)
 


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR addresses issue #61207 by renaming the "API Reference" page within the Interactivity API documentation to "Directives and Store API Reference". It also updates all internal references to this file to prevent broken links and improve clarity.

Closes #61207

## Why?
As pointed out in the issue, having both "Interactivity API Reference" and a sub-page named "API Reference" was confusing. Renaming the file and its title to be more specific ("Directives and Store API Reference") improves the documentation's structure and understandability. This also proactively avoids potential filename conflicts with other `api-reference.md` files in the project.

## How?
1.  **File Rename:** The file `docs/reference-guides/interactivity-api/api-reference.md` was renamed to `docs/reference-guides/interactivity-api/directives-store-api-reference.md`.
2.  **Title Update:** The title inside the renamed markdown file was changed from `# API Reference` to `# Directives and Store API Reference`.
3.  **Reference Updates:** All occurrences of the old filename and path were updated across the project to point to the new file. This included modifications in:
    *   `docs/toc.json`
    *   `docs/manifest.json`
    *   `docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md`

## Testing Instructions
1.  Review the file changes in this pull request.
2.  Confirm that `docs/reference-guides/interactivity-api/api-reference.md` is deleted.
3.  Confirm that `docs/reference-guides/interactivity-api/directives-store-api-reference.md` has been created and its title is updated.
4.  Check the `docs/toc.json`, `docs/manifest.json`, and `docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md` files to ensure all links now point to the new `directives-store-api-reference.md` file.
5.  If you build the documentation locally, navigate to the "Block Editor Handbook" -> "Reference Guides" -> "Interactivity API Reference" section.
6.  Verify that the link previously labeled "API Reference" is now "Directives and Store API Reference" and that it navigates to the correct page.

### Testing Instructions for Keyboard
This pull request only involves changes to documentation files and does not affect the user interface. Therefore, no specific keyboard navigation testing is required.
