### PR TITLE
Mentioning Playground CLI instead wp-now

### DIFF
--- a/docs/getting-started/devenv/README.md
+++ b/docs/getting-started/devenv/README.md
@@ -4,9 +4,10 @@ This guide will help you set up the right development environment to create bloc
 
 A block development environment includes the tools you need on your computer to successfully develop for the Block Editor. The three essential requirements are:
 
-1.  [Code editor](#code-editor)
-2.  [Node.js development tools](#node-js-development-tools)
-3.  [Local WordPress environment (site)](#local-wordpress-environment)
+- [Block Development Environment](#block-development-environment)
+  - [Code editor](#code-editor)
+  - [Node.js development tools](#nodejs-development-tools)
+  - [Local WordPress environment](#local-wordpress-environment)
 
 <div class="callout callout-info">
     To contribute to the Gutenberg project itself, refer to the additional documentation in the <a href="https://developer.wordpress.org/block-editor/contributors/code/getting-started-with-code-contribution">code contribution guide</a>.
@@ -25,7 +26,7 @@ Node.js (`node`) is an open-source runtime environment that allows you to execut
 Node.js and its accompanying development tools allow you to:
 
 -   Install and run WordPress packages needed for Block Editor development, such as `wp-scripts`
--   Set up local WordPress environments with `wp-env` and `wp-now`
+-   Set up local WordPress environments with `wp-env` and `@wp-playground/cli`
 -   Use the latest ECMAScript features and write code in ESNext
 -   Lint, format, and test JavaScript code
 -   Scaffold custom blocks with the `create-block` package
@@ -48,7 +49,7 @@ In the broader WordPress community, many tools are available for setting up a lo
 Refer to the [Get started with `wp-env`](/docs/getting-started/devenv/get-started-with-wp-env.md) guide for setup instructions.
 
 <div class="callout callout-info">
-    Throughout the Handbook, you may also see references to <code><a href="https://github.com/WordPress/playground-tools/tree/trunk/packages/wp-now">wp-now</a></code>. This is a lightweight tool powered by <a hre="https://developer.wordpress.org/playground/">WordPress Playground</a> that streamlines setting up a simple local WordPress environment. While still experimental, this tool is great for quickly testing WordPress releases, plugins, and themes. 
+    Throughout the Handbook, you may also see references to <code><a href="https://github.com/WordPress/wordpress-playground/tree/trunk/packages/playground/cli">@wp-playground/cli</a></code>. This is a lightweight tool powered by <a href="https://developer.wordpress.org/playground/">WordPress Playground</a> that streamlines setting up a simple local WordPress environment. While still experimental, this tool is great for quickly testing WordPress releases, plugins, and themes. 
 </div>
 
 This list is not exhaustive, but here are several additional options to choose from if you prefer not to use `wp-env`:

--- a/docs/reference-guides/interactivity-api/iapi-quick-start-guide.md
+++ b/docs/reference-guides/interactivity-api/iapi-quick-start-guide.md
@@ -32,10 +32,10 @@ When you are finished making changes, run the `npm run build` command. This opti
 
 ## View the block in action
 
-If you have a local WordPress installation already running, you can launch the commands above inside the `plugins` folder of that installation. If not, you can use [`wp-now`](https://github.com/WordPress/playground-tools/tree/trunk/packages/wp-now) to launch a WordPress site with the plugin installed by executing the following command from the plugin's folder (`my-first-interactive-block`).
+If you have a local WordPress installation already running, you can launch the commands above inside the `plugins` folder of that installation. If not, you can use [`@wp-playground/cli`](https://www.npmjs.com/package/@wp-playground/cli) to launch a WordPress site with the plugin installed by executing the following command from the plugin's folder (`my-first-interactive-block`).
 
 ```
-npx @wp-now/wp-now start
+npx @wp-playground/cli server --auto-mount
 ```
 
 You should be able to insert the "My First Interactive Block" block into any post and see how it behaves in the front end when published.

--- a/docs/reference-guides/interactivity-api/iapi-quick-start-guide.md
+++ b/docs/reference-guides/interactivity-api/iapi-quick-start-guide.md
@@ -32,7 +32,7 @@ When you are finished making changes, run the `npm run build` command. This opti
 
 ## View the block in action
 
-If you have a local WordPress installation already running, you can launch the commands above inside the `plugins` folder of that installation. If not, you can use [`@wp-playground/cli`](https://www.npmjs.com/package/@wp-playground/cli) to launch a WordPress site with the plugin installed by executing the following command from the plugin's folder (`my-first-interactive-block`).
+If you have a local WordPress installation already running, you can launch the commands above inside the `plugins` folder of that installation. If not, you can use [`@wp-playground/cli`](https://github.com/WordPress/wordpress-playground/tree/trunk/packages/playground/cli) to launch a WordPress site with the plugin installed by executing the following command from the plugin's folder (`my-first-interactive-block`).
 
 ```
 npx @wp-playground/cli server --auto-mount


### PR DESCRIPTION
This pull request replaces the reference from `wp-now` to `@wp-playground/cli` in the Block Editor Handbook, `wp-now` will be deprecated soon, and the most recent efforts from the Playground team are included on the Playground CLI.  The two references in the documentation to `wp-now`, namely the Interactive API Quick Start Guide and Dev Environment, are being replaced with the new Playground CLI.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71070

Adding the playground CLI to the documentation, replacing the soon-deprecated `wp-now`. This pull request also fixes a typo at the playground page link on the Block Development Environment page.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Most recent Playground features are being implemented at `@wp-playground/cli`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Run the handbook documentation
2. Navigate to `/block-editor/getting-started/devenv/`.
3. Check the new references from `@wp-playground/cli`.
4. Test the links to the Playground CLI repository.
5. Navigate to `/block-editor/reference-guides/interactivity-api/iapi-quick-start-guide/#view-the-block-in-action`
6. Check the new references from `@wp-playground/cli`.
7. Test the links to the Playground CLI repository.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note that this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
