### PR TITLE
Image: Fix return type annotation for lightbox settings function

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -100,7 +100,7 @@ function render_block_core_image( $attributes, $content, $block ) {
  *
  * @param array $block Block data.
  *
- * @return array Filtered block data.
+ * @return array|null Filtered block data.
  */
 function block_core_image_get_lightbox_settings( $block ) {
 	// Gets the lightbox setting from the block attributes.


### PR DESCRIPTION
## What?

Updates the `@return` annotation for `block_core_image_get_lightbox_settings()` to accurately reflect that the function can return `null`.


## Why?

The function's DocBlock incorrectly documented the return type as only `array`, but the actual implementation can return `null` when lightbox settings are not found. 

----

Originally opened on Trac as Core-63790