### PR TITLE
Add smaller preview size to dataviews grid layout

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ### Enhancements
 
+- Add a smaller size to the grid layout ([#71077](https://github.com/WordPress/gutenberg/pull/71077)).
 - Make the media item clickable along the title ([#70985](https://github.com/WordPress/gutenberg/pull/70985)).
 
 ## 5.0.0 (2025-07-23)

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add `enableMoving` option to the `table` layout to allow or disallow column moving left and right. [#71120](https://github.com/WordPress/gutenberg/pull/71120)
 
+### Enhancements
+
+- Add two smaller sizs to the grid layout ([#71077](https://github.com/WordPress/gutenberg/pull/71077)).
+
 ## 6.0.0 (2025-08-07)
 
 ### Breaking changes
@@ -33,7 +37,6 @@
 
 ### Enhancements
 
-- Add a smaller size to the grid layout ([#71077](https://github.com/WordPress/gutenberg/pull/71077)).
 - Make the media item clickable along the title ([#70985](https://github.com/WordPress/gutenberg/pull/70985)).
 
 ## 5.0.0 (2025-07-23)

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -228,8 +228,7 @@ function GridItem< Item >( {
 									direction="row"
 								>
 									<>
-										{ /* @ts-ignore */ }
-										<Tooltip text={ field.header }>
+										<Tooltip text={ field.label }>
 											<FlexItem className="dataviews-view-grid__field-name">
 												{ field.header }
 											</FlexItem>

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -13,6 +13,7 @@ import {
 	Spinner,
 	Flex,
 	FlexItem,
+	Tooltip,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
@@ -227,9 +228,12 @@ function GridItem< Item >( {
 									direction="row"
 								>
 									<>
-										<FlexItem className="dataviews-view-grid__field-name">
-											{ field.header }
-										</FlexItem>
+										{ /* @ts-ignore */ }
+										<Tooltip text={ field.header }>
+											<FlexItem className="dataviews-view-grid__field-name">
+												{ field.header }
+											</FlexItem>
+										</Tooltip>
 										<FlexItem
 											className="dataviews-view-grid__field-value"
 											style={ { maxHeight: 'none' } }

--- a/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
@@ -38,10 +38,6 @@ export default function PreviewSizePicker() {
 	const context = useContext( DataViewsContext );
 	const view = context.view as ViewGrid;
 
-	if ( context.containerWidth < 588 ) {
-		return null;
-	}
-
 	const breakValues = imageSizes.filter( ( size ) => {
 		return context.containerWidth >= size.breakpoint;
 	} );

--- a/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
@@ -17,6 +17,10 @@ const imageSizes = [
 		breakpoint: 1,
 	},
 	{
+		value: 170,
+		breakpoint: 1,
+	},
+	{
 		value: 230,
 		breakpoint: 1,
 	},
@@ -48,10 +52,10 @@ export default function PreviewSizePicker() {
 		? breakValues
 				.map( ( size, index ) => ( { ...size, index } ) )
 				.filter(
-					( size ) => size.value <= ( view.layout?.previewSize ?? 1 ) // We know the view.layout?.previewSize exists at this point but the linter doesn't seem to.
+					( size ) => size.value <= ( view.layout?.previewSize ?? 2 ) // We know the view.layout?.previewSize exists at this point but the linter doesn't seem to.
 				)
 				.sort( ( a, b ) => b.value - a.value )[ 0 ].index
-		: 1; //Default to the second smallest size if no preview size is set.
+		: 2; // Default to the third smallest size if no preview size is set.
 
 	const marks = breakValues.map( ( size, index ) => {
 		return {

--- a/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
@@ -13,6 +13,10 @@ import type { ViewGrid } from '../../types';
 
 const imageSizes = [
 	{
+		value: 120,
+		breakpoint: 1,
+	},
+	{
 		value: 230,
 		breakpoint: 1,
 	},
@@ -48,10 +52,10 @@ export default function PreviewSizePicker() {
 		? breakValues
 				.map( ( size, index ) => ( { ...size, index } ) )
 				.filter(
-					( size ) => size.value <= ( view.layout?.previewSize ?? 0 ) // We know the view.layout?.previewSize exists at this point but the linter doesn't seem to.
+					( size ) => size.value <= ( view.layout?.previewSize ?? 1 ) // We know the view.layout?.previewSize exists at this point but the linter doesn't seem to.
 				)
 				.sort( ( a, b ) => b.value - a.value )[ 0 ].index
-		: 0;
+		: 1; //Default to the second smallest size if no preview size is set.
 
 	const marks = breakValues.map( ( size, index ) => {
 		return {

--- a/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
@@ -46,16 +46,13 @@ export default function PreviewSizePicker() {
 		return context.containerWidth >= size.breakpoint;
 	} );
 
+	const layoutPreviewSize = view.layout?.previewSize ?? 230; // Default to the third smallest size if no preview size is set.
 	// If the container has resized and the set preview size is no longer available,
 	// we reset it to the next smallest size.
-	const previewSizeToUse = view.layout?.previewSize
-		? breakValues
-				.map( ( size, index ) => ( { ...size, index } ) )
-				.filter(
-					( size ) => size.value <= ( view.layout?.previewSize ?? 2 ) // We know the view.layout?.previewSize exists at this point but the linter doesn't seem to.
-				)
-				.sort( ( a, b ) => b.value - a.value )[ 0 ].index
-		: 2; // Default to the third smallest size if no preview size is set.
+	const previewSizeToUse = breakValues
+		.map( ( size, index ) => ( { ...size, index } ) )
+		.filter( ( size ) => size.value <= layoutPreviewSize )
+		.sort( ( a, b ) => b.value - a.value )[ 0 ].index;
 
 	const marks = breakValues.map( ( size, index ) => {
 		return {

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -58,7 +58,6 @@
 
 	.dataviews-view-grid__media {
 		width: 100%;
-		min-height: 200px;
 		aspect-ratio: 1/1;
 		background-color: $white;
 		border-radius: $radius-medium;

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -104,6 +104,9 @@
 			.dataviews-view-grid__field-name {
 				width: 35%;
 				color: $gray-700;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
 			}
 
 			.dataviews-view-grid__field-value {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Adds a smaller preview size to the dataviews grid layout, to make it easier to preview more items on smaller screens. The current default size is still default.

Also removes the minimum breakpoint for displaying the preview size picker, because this new size is handy for small screens.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Go to Site editor > Templates;
2. In the view config, drag preview size slider to the smallest size and check that items resize accordingly.


https://github.com/user-attachments/assets/925b0e03-c252-4bd1-8ab9-bb80cb0a9e56

