### PR TITLE
[WIP] DataViews and Fields: Try a hidden title in the Grid layout

### DIFF
--- a/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
@@ -681,7 +681,7 @@ export const fields: Field< SpaceObject >[] = [
 		label: 'Title',
 		id: 'title',
 		type: 'text',
-		enableHiding: false,
+		enableHiding: true,
 		enableGlobalSearch: true,
 		filterBy: {
 			operators: [ 'contains', 'notContains', 'startsWith' ],

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -383,3 +383,43 @@ export const GroupedGridLayout = () => {
 		/>
 	);
 };
+
+export const GridLayoutHiddenTitle = () => {
+	const [ view, setView ] = useState< View >( {
+		type: LAYOUT_GRID,
+		search: '',
+		page: 1,
+		perPage: 20,
+		filters: [],
+		fields: [],
+		titleField: 'title',
+		mediaField: 'image',
+		layout: {},
+		showTitle: false,
+	} );
+	const { data: shownData, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( data, view, fields );
+	}, [ view ] );
+	return (
+		<DataViews
+			getItemId={ ( item ) => item.id.toString() }
+			paginationInfo={ paginationInfo }
+			data={ shownData }
+			view={ view }
+			fields={ fields }
+			onChangeView={ setView }
+			actions={ actions }
+			defaultLayouts={ {
+				[ LAYOUT_GRID ]: {
+					showTitle: false, // Only hide in the grid layout.
+				},
+				[ LAYOUT_LIST ]: {
+					showTitle: true, // Show title in the list layout.
+				},
+				[ LAYOUT_TABLE ]: {
+					showTitle: true, // Show title in the table layout.
+				},
+			} }
+		/>
+	);
+};

--- a/packages/fields/src/fields/title/index.ts
+++ b/packages/fields/src/fields/title/index.ts
@@ -18,7 +18,7 @@ const titleField: Field< CommonPost > = {
 	placeholder: __( 'No title' ),
 	getValue: ( { item } ) => getItemTitle( item ),
 	render: TitleView,
-	enableHiding: false,
+	enableHiding: true,
 	enableGlobalSearch: true,
 	filterBy: false,
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71078

WIP: not yet ready for review

* Enable the title field to be toggled
* Add a DataViews Grid story that includes a hidden title

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
