### PR TITLE
Post Template: Implement `Stack on mobile` toggle within the Grid View

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -661,6 +661,7 @@ Contains the block elements used to render a post, like the title, date, feature
 -	**Category:** theme
 -	**Ancestor:** core/query
 -	**Supports:** align (full, wide), color (background, gradients, link, text), interactivity (clientNavigation), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Attributes:** isStackedOnMobile
 
 ## Post Terms
 

--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -16,6 +16,12 @@
 		"enhancedPagination",
 		"postType"
 	],
+	"attributes": {
+		"isStackedOnMobile": {
+			"type": "boolean",
+			"default": true
+		}
+	},
 	"supports": {
 		"reusable": false,
 		"html": false,

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -16,10 +16,22 @@ import {
 	useBlockProps,
 	useInnerBlocksProps,
 	store as blockEditorStore,
+	InspectorControls,
 } from '@wordpress/block-editor';
-import { Spinner, ToolbarGroup } from '@wordpress/components';
+import {
+	Spinner,
+	ToolbarGroup,
+	ToggleControl,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { list, grid } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const TEMPLATE = [
 	[ 'core/post-title' ],
@@ -101,7 +113,7 @@ export default function PostTemplateEdit( {
 		templateSlug,
 		previewPostType,
 	},
-	attributes: { layout },
+	attributes: { layout, isStackedOnMobile },
 	__unstableLayoutClassNames,
 } ) {
 	const { type: layoutType, columnCount = 3 } = layout || {};
@@ -258,8 +270,11 @@ export default function PostTemplateEdit( {
 		className: clsx( __unstableLayoutClassNames, {
 			[ `columns-${ columnCount }` ]:
 				layoutType === 'grid' && columnCount, // Ensure column count is flagged via classname for backwards compatibility.
+			'is-not-stacked-on-mobile': ! isStackedOnMobile,
 		} ),
 	} );
+
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	if ( ! posts ) {
 		return (
@@ -306,6 +321,42 @@ export default function PostTemplateEdit( {
 			<BlockControls>
 				<ToolbarGroup controls={ displayLayoutControls } />
 			</BlockControls>
+
+			{ layoutType === 'grid' && (
+				<InspectorControls>
+					<ToolsPanel
+						label={ __( 'Settings' ) }
+						resetAll={ () => {
+							setAttributes( {
+								isStackedOnMobile: true,
+							} );
+						} }
+						dropdownMenuProps={ dropdownMenuProps }
+					>
+						<ToolsPanelItem
+							label={ __( 'Stack on mobile' ) }
+							isShownByDefault
+							hasValue={ () => isStackedOnMobile !== true }
+							onDeselect={ () =>
+								setAttributes( {
+									isStackedOnMobile: true,
+								} )
+							}
+						>
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={ __( 'Stack on mobile' ) }
+								checked={ isStackedOnMobile }
+								onChange={ () =>
+									setAttributes( {
+										isStackedOnMobile: ! isStackedOnMobile,
+									} )
+								}
+							/>
+						</ToolsPanelItem>
+					</ToolsPanel>
+				</InspectorControls>
+			) }
 
 			<ul { ...blockProps }>
 				{ blockContexts &&

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -336,7 +336,7 @@ export default function PostTemplateEdit( {
 						<ToolsPanelItem
 							label={ __( 'Stack on mobile' ) }
 							isShownByDefault
-							hasValue={ () => isStackedOnMobile !== true }
+							hasValue={ () => ! isStackedOnMobile }
 							onDeselect={ () =>
 								setAttributes( {
 									isStackedOnMobile: true,

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -90,9 +90,15 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 		$classnames .= ' has-link-color';
 	}
 
-	// Ensure backwards compatibility by flagging the number of columns via classname when using grid layout.
-	if ( isset( $attributes['layout']['type'] ) && 'grid' === $attributes['layout']['type'] && ! empty( $attributes['layout']['columnCount'] ) ) {
-		$classnames .= ' ' . sanitize_title( 'columns-' . $attributes['layout']['columnCount'] );
+	if ( isset( $attributes['layout']['type'] ) && 'grid' === $attributes['layout']['type'] ) {
+		// Ensure backwards compatibility by flagging the number of columns via classname when using grid layout.
+		if ( ! empty( $attributes['layout']['columnCount'] ) ) {
+			$classnames .= ' ' . sanitize_title( 'columns-' . $attributes['layout']['columnCount'] );
+		}
+
+		if ( isset( $attributes['isStackedOnMobile'] ) && ! $attributes['isStackedOnMobile'] ) {
+			$classnames .= ' is-not-stacked-on-mobile';
+		}
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => trim( $classnames ) ) );

--- a/packages/block-library/src/post-template/style.scss
+++ b/packages/block-library/src/post-template/style.scss
@@ -31,7 +31,7 @@
 
 @media ( max-width: $break-small ) {
 	// Temporary specificity bump until "wp-container" layout specificity is revisited.
-	.wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid {
+	.wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid:not(.is-not-stacked-on-mobile) {
 		grid-template-columns: 1fr;
 	}
 }

--- a/test/integration/fixtures/blocks/core__post-template.json
+++ b/test/integration/fixtures/blocks/core__post-template.json
@@ -2,7 +2,9 @@
 	{
 		"name": "core/post-template",
 		"isValid": true,
-		"attributes": {},
+		"attributes": {
+			"isStackedOnMobile": true
+		},
 		"innerBlocks": []
 	}
 ]

--- a/test/integration/fixtures/blocks/core__query__deprecated-2-with-colors.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-2-with-colors.json
@@ -48,6 +48,7 @@
 						"name": "core/post-template",
 						"isValid": true,
 						"attributes": {
+							"isStackedOnMobile": true,
 							"layout": {
 								"type": "default"
 							}

--- a/test/integration/fixtures/blocks/core__query__deprecated-2.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-2.json
@@ -28,6 +28,7 @@
 				"name": "core/post-template",
 				"isValid": true,
 				"attributes": {
+					"isStackedOnMobile": true,
 					"layout": {
 						"type": "default"
 					}

--- a/test/integration/fixtures/blocks/core__query__deprecated-3.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-3.json
@@ -45,6 +45,7 @@
 						"name": "core/post-template",
 						"isValid": true,
 						"attributes": {
+							"isStackedOnMobile": true,
 							"fontSize": "large",
 							"layout": {
 								"type": "grid",

--- a/test/integration/fixtures/blocks/core__query__deprecated-4.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-4.json
@@ -28,6 +28,7 @@
 				"name": "core/post-template",
 				"isValid": true,
 				"attributes": {
+					"isStackedOnMobile": true,
 					"layout": {
 						"type": "default"
 					}

--- a/test/integration/fixtures/blocks/core__query__deprecated-5.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-5.json
@@ -27,6 +27,7 @@
 				"name": "core/post-template",
 				"isValid": true,
 				"attributes": {
+					"isStackedOnMobile": true,
 					"layout": {
 						"type": "default"
 					}


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/34145
Part of https://github.com/WordPress/gutenberg/issues/41405

This PR adds a "Stack on mobile" toggle to Grid View, allowing users to display the specified number of columns on mobile devices, instead of defaulting to a single-column layout.

## Why?

Currently, items are always stacked on mobile devices, which limits design flexibility and layout options on mobile devices.

## How?

A corresponding control has been introduced, and the `grid-template-columns: 1fr;` rule is now conditionally applied based on the corresponding attribute.

## Testing Instructions

1. Create a new post.
2. Add a Query Loop block with `Photo blog posts` (available in TT5) pattern.
3. Select the `Post Template` block and ensure that it's in `Grid View`.
4. Choose the `Grid Item Position` as `Manual` and choose `3` columns.
5. Disable  `Stack on mobile`.
6. On mobile layout, confirm that the individual elements are displayed in a column of 3.

### Testing Instructions for Keyboard
Same.

## Screencast

https://github.com/user-attachments/assets/08a8a6bb-8c34-4e9a-a56a-dad9260b4651