### PR TITLE
Slack Notifications for Testing Team, Workflow Edition

### DIFF
--- a/.github/workflows/notify-slack-on-label.yml
+++ b/.github/workflows/notify-slack-on-label.yml
@@ -1,0 +1,23 @@
+name: Notify Slack on Needs Testing Label
+
+on:
+    issues:
+        types: [labeled]
+    pull_request:
+        types: [labeled]
+
+jobs:
+    notify:
+        if: ${{ github.event.label.name == 'Needs Testing' }}
+        runs-on: ubuntu-latest
+        permissions: {}
+        steps:
+            - name: Send custom HTTP request with testing data
+              run: |
+                  curl -X POST -H "Content-Type: application/json" -d '
+                  {
+                    "url": "${{ github.event_name == 'issues' && github.event.issue.html_url || github.event.pull_request.html_url }}",
+                    "type": "${{ github.event_name }}",
+                    "title": ${{ toJSON(github.event_name == 'issues' && github.event.issue.title || github.event.pull_request.title) }}
+                  }
+                  ' ${{ secrets.SLACK_NEEDS_TESTING_LABEL_ADDED_WEBHOOK_URL }}

--- a/.github/workflows/notify-slack-on-label.yml
+++ b/.github/workflows/notify-slack-on-label.yml
@@ -11,13 +11,16 @@ jobs:
         if: ${{ github.event.label.name == 'Needs Testing' }}
         runs-on: ubuntu-latest
         permissions: {}
+        env:
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NEEDS_TESTING_LABEL_ADDED_WEBHOOK_URL }}
         steps:
+            - name: Skip when webhook is unavailable
+              if: ${{ env.SLACK_WEBHOOK_URL == '' }}
+              run: echo "SLACK_NEEDS_TESTING_LABEL_ADDED_WEBHOOK_URL is not available; skipping notification."
+
             - name: Send custom HTTP request with testing data
+              if: ${{ env.SLACK_WEBHOOK_URL != '' }}
               run: |
-                  curl -X POST -H "Content-Type: application/json" -d '
-                  {
-                    "url": "${{ github.event_name == 'issues' && github.event.issue.html_url || github.event.pull_request.html_url }}",
-                    "type": "${{ github.event_name }}",
-                    "title": ${{ toJSON(github.event_name == 'issues' && github.event.issue.title || github.event.pull_request.title) }}
-                  }
-                  ' ${{ secrets.SLACK_NEEDS_TESTING_LABEL_ADDED_WEBHOOK_URL }}
+                  payload='{"url":"${{ github.event_name == 'issues' && github.event.issue.html_url || github.event.pull_request.html_url }}","type":"${{ github.event_name }}","title":${{ toJSON(github.event_name == 'issues' && github.event.issue.title || github.event.pull_request.title) }}}'
+
+                  curl -X POST -H "Content-Type: application/json" -d "$payload" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/notify-slack-on-label.yml
+++ b/.github/workflows/notify-slack-on-label.yml
@@ -20,7 +20,11 @@ jobs:
 
             - name: Send custom HTTP request with testing data
               if: ${{ env.SLACK_WEBHOOK_URL != '' }}
+              env:
+                  TARGET_URL: ${{ github.event_name == 'issues' && github.event.issue.html_url || github.event.pull_request.html_url }}
+                  TARGET_TYPE: ${{ github.event_name }}
+                  TARGET_TITLE: ${{ github.event_name == 'issues' && github.event.issue.title || github.event.pull_request.title }}
               run: |
-                  payload='{"url":"${{ github.event_name == 'issues' && github.event.issue.html_url || github.event.pull_request.html_url }}","type":"${{ github.event_name }}","title":${{ toJSON(github.event_name == 'issues' && github.event.issue.title || github.event.pull_request.title) }}}'
+                  payload=$(jq -n --arg url "$TARGET_URL" --arg type "$TARGET_TYPE" --arg title "$TARGET_TITLE" '{url:$url,type:$type,title:$title}')
 
                   curl -X POST -H "Content-Type: application/json" -d "$payload" "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
After additional conversation with @dd32 here https://wordpress.slack.com/archives/C03B0H5J0/p1754065327774839
It appears that he preferfs us to switch into workflow mode.

Checking docs, it appears that it simply requires a simple `application/json` delivery, and the message is mostly formatted in the Slack Worflow itself

**NOTE:** I already have the workflow ready. Please PM in Slack and I will send you the webhook URL so it can be added to the secrets (check GitHub Part below)

### Slack Part

I attach some screenshots:

The workflow
<img width="720" height="492" alt="image" src="https://github.com/user-attachments/assets/8ed7dfb9-b592-4311-ac1c-16750622e6b8" />

<img width="510" height="824" alt="image" src="https://github.com/user-attachments/assets/4f0ba902-d4f6-41f0-8d2b-83efed0e398f" />

The message, takes 3 items:
type: text
title: text
url: text

<img width="511" height="669" alt="image" src="https://github.com/user-attachments/assets/ef24d6c3-9aad-4bff-b5d9-540021666279" />

The message: **Gutenberg {} type Needs Testing**: {} title in WordPress/gutenberg
The button: Link to {}url

<img width="507" height="559" alt="image" src="https://github.com/user-attachments/assets/0abaf6dd-30f2-46d9-9331-91718bf8bd3c" />

### GitHub Part

In GitHub in this repository, we need to add a **secret** with the URL:
https://github.com/WordPress/gutenberg/settings/secrets/actions/new

Add:
Name: SLACK_NEEDS_TESTING_LABEL_ADDED_WEBHOOK_URL
Secret: The Slack webhook URL 

### Final result
<img width="780" height="116" alt="image" src="https://github.com/user-attachments/assets/b9990f7e-7534-44b3-ae1f-98446e6689f9" />