### PR TITLE
More Block: Fix undo/redo history for custom text

### DIFF
--- a/packages/block-library/src/more/edit.js
+++ b/packages/block-library/src/more/edit.js
@@ -7,9 +7,13 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	ToggleControl,
 } from '@wordpress/components';
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { ENTER } from '@wordpress/keycodes';
+import {
+	InspectorControls,
+	PlainText,
+	useBlockProps,
+} from '@wordpress/block-editor';
 import { getDefaultBlockName, createBlock } from '@wordpress/blocks';
+
 /**
  * Internal dependencies
  */
@@ -22,29 +26,6 @@ export default function MoreEdit( {
 	insertBlocksAfter,
 	setAttributes,
 } ) {
-	const onChangeInput = ( event ) => {
-		setAttributes( {
-			customText: event.target.value,
-		} );
-	};
-
-	const onKeyDown = ( { keyCode } ) => {
-		if ( keyCode === ENTER ) {
-			insertBlocksAfter( [ createBlock( getDefaultBlockName() ) ] );
-		}
-	};
-
-	const getHideExcerptHelp = ( checked ) =>
-		checked
-			? __( 'The excerpt is hidden.' )
-			: __( 'The excerpt is visible.' );
-
-	const toggleHideExcerpt = () => setAttributes( { noTeaser: ! noTeaser } );
-
-	const style = {
-		width: `${ ( customText ? customText : DEFAULT_TEXT ).length + 1.2 }em`,
-	};
-
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	return (
@@ -73,21 +54,34 @@ export default function MoreEdit( {
 								'Hide the excerpt on the full content page'
 							) }
 							checked={ !! noTeaser }
-							onChange={ toggleHideExcerpt }
-							help={ getHideExcerptHelp }
+							onChange={ () =>
+								setAttributes( { noTeaser: ! noTeaser } )
+							}
+							help={ ( checked ) =>
+								checked
+									? __( 'The excerpt is hidden.' )
+									: __( 'The excerpt is visible.' )
+							}
 						/>
 					</ToolsPanelItem>
 				</ToolsPanel>
 			</InspectorControls>
 			<div { ...useBlockProps() }>
-				<input
-					aria-label={ __( '“Read more” link text' ) }
-					type="text"
+				<PlainText
+					__experimentalVersion={ 2 }
+					tagName="span"
+					aria-label={ __( '"Read more" text' ) }
 					value={ customText }
 					placeholder={ DEFAULT_TEXT }
-					onChange={ onChangeInput }
-					onKeyDown={ onKeyDown }
-					style={ style }
+					onChange={ ( value ) =>
+						setAttributes( { customText: value } )
+					}
+					disableLineBreaks
+					__unstableOnSplitAtEnd={ () =>
+						insertBlocksAfter(
+							createBlock( getDefaultBlockName() )
+						)
+					}
 				/>
 			</div>
 		</>

--- a/packages/block-library/src/more/editor.scss
+++ b/packages/block-library/src/more/editor.scss
@@ -11,27 +11,18 @@
 	white-space: nowrap;
 
 	// Label
-	input[type="text"] {
+	.rich-text {
 		position: relative;
 		font-size: $default-font-size;
 		text-transform: uppercase;
 		font-weight: 600;
 		font-family: $default-font;
 		color: $gray-700;
-		border: none;
-		box-shadow: none;
+		display: inline-flex;
 		white-space: nowrap;
 		text-align: center;
-		margin: 0;
-		border-radius: 4px;
 		background: $white;
-		padding: 6px 8px;
-		height: $button-size-small;
-		max-width: 100%;
-
-		&:focus {
-			box-shadow: none;
-		}
+		padding: 10px 36px;
 	}
 
 	// Dashed line


### PR DESCRIPTION
## What?
Closes #58875.
Based on the original proposal in #61131 by @carolinan.

PR updates the More block to use `PlainText` for rendering editable custom text. This allows proper integration in edit history, fixing the undo/redo bug.

I tried to keep the current (trunk) styling as much as possible.

## Testing Instructions
1. Create a post.
3. Add some content.
4. Split it using the More block.
5. Confirm that the default is displayed as a placeholder.
6. Slowly type the custom text. Take a couple of seconds break between each word.
7. Now undo/redo changes.
8. Confirm that history works similarly to a paragraph block.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<img width="684" height="393" alt="CleanShot 2025-08-06 at 13 42 58" src="https://github.com/user-attachments/assets/c6b134e0-7bb4-44e3-a734-9500a7da3d9c" />|<img width="697" height="301" alt="CleanShot 2025-08-06 at 13 47 42" src="https://github.com/user-attachments/assets/f1ac7665-7981-4d5a-91b0-e1365f8b7161" />|


https://github.com/user-attachments/assets/592534dc-5457-44ae-977f-8f193ed4d76d