### PR TITLE
Dynamically set `node-version-file` input

### DIFF
--- a/.github/setup-node/action.yml
+++ b/.github/setup-node/action.yml
@@ -12,7 +12,7 @@ runs:
         - name: Use desired version of Node.js
           uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
           with:
-              node-version-file: '.nvmrc'
+              node-version-file: ${{ inputs.node-version == '' && '.nvmrc' || '' }}
               node-version: ${{ inputs.node-version }}
               check-latest: true
               cache: npm


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
When both `node-version-file` and `node-version` are passed to `actions/setup-node`, a warning is output.

When inputs are empty, they are ignored. This will silence the error while keeping the same functionality.

<!-- In a few words, what is the PR actually doing? -->

## Why?
Avoiding warnings for expected outcomes helps to avoid distractions.

