### PR TITLE
Add Node.js 24 to test strategy

### DIFF
--- a/.github/setup-node/action.yml
+++ b/.github/setup-node/action.yml
@@ -12,7 +12,7 @@ runs:
         - name: Use desired version of Node.js
           uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
           with:
-              node-version-file: '.nvmrc'
+              node-version-file: ${{ inputs.node-version == '' && '.nvmrc' || '' }}
               node-version: ${{ inputs.node-version }}
               check-latest: true
               cache: npm

--- a/.github/setup-node/action.yml
+++ b/.github/setup-node/action.yml
@@ -12,7 +12,7 @@ runs:
         - name: Use desired version of Node.js
           uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
           with:
-              node-version-file: ${{ inputs.node-version == '' && '.nvmrc' || '' }}
+              node-version-file: '.nvmrc'
               node-version: ${{ inputs.node-version }}
               check-latest: true
               cache: npm

--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -26,7 +26,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node: ['20', '22']
+                node: ['20', '22', '24']
                 os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
 
         steps:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -33,7 +33,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node: ['20', '22']
+                node: ['20', '22', '24']
                 shard: ['1/4', '2/4', '3/4', '4/4']
 
         steps:
@@ -78,7 +78,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node: ['20', '22']
+                node: ['20', '22', '24']
 
         steps:
             - name: Checkout repository


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This adds version 24 of Node.js to the testing strategies for workflows that test multiple versions of Node.js.

<!-- In a few words, what is the PR actually doing? -->

## Why?
- Node.js 22 is the Active LTS version.
- Node.js 24 is the Current version and slated to become Active LTS later this year (October). This will push 22.x to Maintenance LTS.

Testing against newer versions than the one currently pinned in the WordPress Core/Gutenberg repositories helps spot potential issues ahead of time making upgrading easier when the time comes.

See related: #70844.

## How?
The GitHub Actions testing strategies have been updated for workflows that currently test multiple versions of Node.js
