### PR TITLE
Media & Text: Retain 'useFeaturedImage' value during transformations

### DIFF
--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -200,6 +200,7 @@ function MediaContainer( props, ref ) {
 					}
 					mediaId={ mediaId }
 					toggleUseFeaturedImage={ toggleUseFeaturedImage }
+					useFeaturedImage={ useFeaturedImage }
 				/>
 				{ ( mediaTypeRenderers[ mediaType ] || noop )() }
 				{ isTemporaryMedia && <Spinner /> }

--- a/packages/block-library/src/media-text/transforms.js
+++ b/packages/block-library/src/media-text/transforms.js
@@ -45,6 +45,7 @@ const transforms = {
 					style,
 					textColor,
 					url,
+					useFeaturedImage,
 				},
 				innerBlocks
 			) => {
@@ -90,6 +91,7 @@ const transforms = {
 						mediaType: backgroundType,
 						mediaUrl: url,
 						textColor,
+						useFeaturedImage,
 						...additionalAttributes,
 					},
 					innerBlocks
@@ -143,6 +145,7 @@ const transforms = {
 					mediaUrl,
 					style,
 					textColor,
+					useFeaturedImage,
 				},
 				innerBlocks
 			) => {
@@ -169,13 +172,14 @@ const transforms = {
 					alt: mediaAlt,
 					anchor,
 					backgroundType: mediaType,
-					dimRatio: !! mediaUrl ? 50 : 100,
+					dimRatio: !! mediaUrl || useFeaturedImage ? 50 : 100,
 					focalPoint,
 					gradient,
 					id: mediaId,
 					overlayColor: backgroundColor,
 					textColor,
 					url: mediaUrl,
+					useFeaturedImage,
 					...additionalAttributes,
 				};
 


### PR DESCRIPTION
## What?

PR fixes Media & Text transformations to and from the Cover block. Ensures that `useFeaturedImage` value is retained during this process.

## Why?
Avoids content loss between transformations.

## Testing Instructions
1. Create a post.
2. Set featured image.
3. Add Media & Text block.
4. Select "Use featured image".
5. Transform to the block Cover.
6. Confirm that the Cover also displays the featured image.
7. Transform it back and test the same.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/1f829db1-35ac-4a73-87bf-41f9048dc9d2


