### PR TITLE
Fix: Use displayCaption attribute to persist caption visibility for Image block.

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -388,7 +388,7 @@ Insert an image to make a visual statement. ([Source](https://github.com/WordPre
 -	**Name:** core/image
 -	**Category:** media
 -	**Supports:** align (center, full, left, right, wide), anchor, color (~~background~~, ~~text~~), filter (duotone), interactivity, shadow (), spacing (margin)
--	**Attributes:** alt, aspectRatio, blob, caption, height, href, id, lightbox, linkClass, linkDestination, linkTarget, rel, scale, sizeSlug, title, url, width
+-	**Attributes:** alt, aspectRatio, blob, caption, displayCaption, height, href, id, lightbox, linkClass, linkDestination, linkTarget, rel, scale, sizeSlug, title, url, width
 
 ## Latest Comments
 

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -41,6 +41,10 @@
 			"selector": "figcaption",
 			"role": "content"
 		},
+		"displayCaption": {
+			"type": "boolean",
+			"default": true
+		},
 		"lightbox": {
 			"type": "object",
 			"enabled": {

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -1138,6 +1138,7 @@ export default function Image( {
 				setAttributes={ setAttributes }
 				isSelected={ isSingleSelected }
 				insertBlocksAfter={ insertBlocksAfter }
+				preserveCaptionOnToggle
 				label={ __( 'Image caption text' ) }
 				showToolbarButton={
 					isSingleSelected &&

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -19,6 +19,7 @@ export default function save( { attributes } ) {
 		url,
 		alt,
 		caption,
+		displayCaption,
 		align,
 		href,
 		rel,
@@ -89,6 +90,7 @@ export default function save( { attributes } ) {
 					className={ __experimentalGetElementClassName( 'caption' ) }
 					tagName="figcaption"
 					value={ caption }
+					style={ ! displayCaption ? { display: 'none' } : undefined }
 				/>
 			) }
 		</>

--- a/packages/block-library/src/utils/caption.js
+++ b/packages/block-library/src/utils/caption.js
@@ -39,6 +39,7 @@ export function Caption( {
 	addLabel = __( 'Add caption' ),
 	removeLabel = __( 'Remove caption' ),
 	icon = captionIcon,
+	preserveCaptionOnToggle = false,
 	...props
 } ) {
 	const caption = attributes[ attributeKey ];
@@ -46,7 +47,11 @@ export function Caption( {
 	const { PrivateRichText: RichText } = unlock( blockEditorPrivateApis );
 	const isCaptionEmpty = RichText.isEmpty( caption );
 	const isPrevCaptionEmpty = RichText.isEmpty( prevCaption );
-	const [ showCaption, setShowCaption ] = useState( ! isCaptionEmpty );
+	const [ showCaption, setShowCaption ] = useState(
+		preserveCaptionOnToggle
+			? attributes.displayCaption ?? ! isCaptionEmpty
+			: ! isCaptionEmpty
+	);
 
 	// We need to show the caption when changes come from
 	// history navigation(undo/redo).
@@ -61,6 +66,15 @@ export function Caption( {
 			setShowCaption( false );
 		}
 	}, [ isSelected, isCaptionEmpty ] );
+
+	useEffect( () => {
+		if (
+			preserveCaptionOnToggle &&
+			attributes.displayCaption !== showCaption
+		) {
+			setShowCaption( attributes.displayCaption );
+		}
+	}, [ attributes.displayCaption, preserveCaptionOnToggle, showCaption ] );
 
 	// Focus the caption when we click to add one.
 	const ref = useCallback(
@@ -78,11 +92,17 @@ export function Caption( {
 				<BlockControls group="block">
 					<ToolbarButton
 						onClick={ () => {
-							setShowCaption( ! showCaption );
-							if ( showCaption && caption ) {
-								setAttributes( {
-									[ attributeKey ]: undefined,
-								} );
+							if ( preserveCaptionOnToggle ) {
+								const nextValue = ! showCaption;
+								setShowCaption( nextValue );
+								setAttributes( { displayCaption: nextValue } );
+							} else {
+								setShowCaption( ! showCaption );
+								if ( showCaption && caption ) {
+									setAttributes( {
+										[ attributeKey ]: undefined,
+									} );
+								}
 							}
 						} }
 						icon={ icon }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL --> https://github.com/WordPress/gutenberg/issues/49081

<!-- In a few words, what is the PR actually doing? -->
This PR introduces a new displayCaption attribute to the core/image block, enabling users to toggle the visibility of image captions via the block toolbar. It ensures the toggle state is persisted in block attributes and accurately reflected across both the editor and frontend.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Until now, image captions in the core/image block were always shown if present. There was no way for users to temporarily or permanently hide captions without deleting them. This change:

- Gives users more granular control over whether captions are displayed.
- Avoids accidental data loss by allowing users to toggle captions without deleting the content.
- Ensures consistent behavior between the editor and saved frontend output.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- A new boolean attribute displayCaption (default true) was added to the image block via block.json.
- The Caption component was updated to support preserveCaptionOnToggle, enabling a caption visibility toggle that doesn't delete caption data.
- On clicking the toolbar button:
  - If preserveCaptionOnToggle is true, it updates displayCaption without clearing the caption field.
  - Otherwise, it behaves as before (clearing the caption if hidden).
- The save() function applies inline style={{ display: 'none' }} to <figcaption> when displayCaption is false, ensuring that captions are hidden on the frontend without being removed from markup.
- The editor uses useEffect to correctly sync internal caption visibility (showCaption) with the stored displayCaption value, including across reloads.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add an Image block.
2. Add a caption and ensure it displays below the image.
3. Use the toolbar button to hide/show the caption.
4. Toggle off → Save post → Reload editor → Verify caption remains hidden.
5. Toggle back on → Caption should reappear with the original text intact.
6. Save and view on the frontend → Caption visibility should match the editor.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. Caption toggle button is reachable via Tab.
2. Operable via Enter/Space keys.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://www.loom.com/share/87fec6bdd51440e480b4442145065dc9?sid=3a7d71a3-2c00-4132-993f-73f2d6aec083
