### PR TITLE
Editor: Move editor-sidebar CSS reset closer to its target

### DIFF
--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -19,7 +19,6 @@ body.js.block-editor-page {
 //  and custom fields areas.
 .editor-header,
 .editor-text-editor,
-.editor-sidebar,
 .editor-post-publish-panel,
 .edit-post-visual-editor.is-iframed {
 	@include reset;

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -15,11 +15,6 @@ body.js.block-editor-page {
 	}
 }
 
-// Target the editor UI excluding the non-iframed visual editor contents, metaboxes
-//  and custom fields areas.
-.editor-header,
-.editor-text-editor,
-.editor-post-publish-panel,
 .edit-post-visual-editor.is-iframed {
 	@include reset;
 }

--- a/packages/edit-site/src/components/global-styles-sidebar/style.scss
+++ b/packages/edit-site/src/components/global-styles-sidebar/style.scss
@@ -1,22 +1,3 @@
-.editor-sidebar {
-	width: $sidebar-width;
-
-	> .components-panel {
-		border-left: 0;
-		border-right: 0;
-		margin-bottom: -1px;
-		margin-top: -1px;
-
-		> .components-panel__header {
-			background: $gray-100;
-		}
-	}
-
-	.block-editor-block-inspector__card {
-		margin: 0;
-	}
-}
-
 .edit-site-global-styles-sidebar {
 	display: flex;
 	flex-direction: column;

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -1,4 +1,5 @@
 .editor-header {
+	@include reset;
 	height: $header-height;
 	background: $white;
 	display: grid;

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -198,6 +198,7 @@
 }
 
 .editor-post-publish-panel {
+	@include reset;
 	position: fixed;
 	z-index: z-index(".editor-post-publish-panel");
 	background: $white;

--- a/packages/editor/src/components/sidebar/style.scss
+++ b/packages/editor/src/components/sidebar/style.scss
@@ -14,3 +14,7 @@
 .editor-post-summary .components-v-stack:empty {
 	display: none;
 }
+
+.editor-sidebar {
+	@include reset;
+}

--- a/packages/editor/src/components/text-editor/style.scss
+++ b/packages/editor/src/components/text-editor/style.scss
@@ -1,4 +1,5 @@
 .editor-text-editor {
+	@include reset;
 	position: relative;
 	width: 100%;
 	background-color: $white;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The editor-sidebar children (such as `editor-post-panel__row-label`) need `box-sizing: inherit (border-box)` to look visually aligned. In most environments they get this CSS from the [CSS reset](https://github.com/WordPress/gutenberg/blob/74c71e23c8b974d0b3ece0d22ff4b6b86df45b4f/packages/edit-post/src/style.scss#L22-L25) of the `edit-post` package which is often used to render the editor, and all seems fine. But when the editor is rendered directly from `@wordpress/editor`, i.e without `edit-post` package, this reset is missing, and the sidebar items look misaligned as pictured.

<img width="284" height="676" alt="image" src="https://github.com/user-attachments/assets/effe1a43-2982-4401-a498-f985df024d86" />

## Why?
This moves the CSS reset to where it actually applies. Removing the need for the assumption that the editor will always run inside the `@wordpress/edit-post` package.

## How?
But moving the reset from `edit-post` to the editor itself.

## Testing Instructions
1. Go to [this playground URL](https://playground.wordpress.net/?gutenberg-pr=71096#%7B%22landingPage%22:%22/wp-admin/post-new.php%22,%22features%22:%7B%22networking%22:true%7D,%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D%5D%7D).
3. Inspect the a sidebar label such as `Status`, try to find `editor-post-panel__row-label`.
4. It should have `box-sizing: inherit;`.
5. The CSS should come from `wp-content/plugins/gutenberg/build/editor/style.css?ver=21.3.0`.
6. Now to compare, you can check [this URL](https://playground.wordpress.net/#%7B%22landingPage%22:%22/wp-admin/post-new.php%22,%22features%22:%7B%22networking%22:true%7D,%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D%5D%7D) that uses `trunk`, 
7. Inspect the same element, you'll see the CSS comes from `gutenberg/build/edit-post/style.css?ver=21.3.0`.

### Testing Instructions for Keyboard
Unrelated

## Screenshots or screencast <!-- if applicable -->
N/A
