### PR TITLE
Latest Comments: Prevent shortcode processing

### DIFF
--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -113,7 +113,9 @@ function render_block_core_latest_comments( $attributes ) {
 			}
 			$list_items_markup .= '</footer>';
 			if ( $attributes['displayExcerpt'] ) {
-				$list_items_markup .= '<div class="wp-block-latest-comments__comment-excerpt">' . wpautop( get_comment_excerpt( $comment ) ) . '</div>';
+				$comment_excerpt = get_comment_excerpt( $comment );
+				$comment_excerpt = strip_shortcodes( $comment_excerpt );
+				$list_items_markup .= '<div class="wp-block-latest-comments__comment-excerpt">' . wpautop( $comment_excerpt ) . '</div>';
 			}
 			$list_items_markup .= '</article></li>';
 		}

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -115,7 +115,7 @@ function render_block_core_latest_comments( $attributes ) {
 			if ( $attributes['displayExcerpt'] ) {
 				$comment_excerpt = get_comment_excerpt( $comment );
 				// Escape shortcode syntax to prevent processing while preserving display.
-				$comment_excerpt = str_replace( array( '[', ']' ), array( '&#91;', '&#93;' ), $comment_excerpt );
+				$comment_excerpt    = str_replace( array( '[', ']' ), array( '&#91;', '&#93;' ), $comment_excerpt );
 				$list_items_markup .= '<div class="wp-block-latest-comments__comment-excerpt">' . wpautop( $comment_excerpt ) . '</div>';
 			}
 			$list_items_markup .= '</article></li>';

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -114,7 +114,8 @@ function render_block_core_latest_comments( $attributes ) {
 			$list_items_markup .= '</footer>';
 			if ( $attributes['displayExcerpt'] ) {
 				$comment_excerpt = get_comment_excerpt( $comment );
-				$comment_excerpt = strip_shortcodes( $comment_excerpt );
+				// Escape shortcode syntax to prevent processing while preserving display.
+				$comment_excerpt = str_replace( array( '[', ']' ), array( '&#91;', '&#93;' ), $comment_excerpt );
 				$list_items_markup .= '<div class="wp-block-latest-comments__comment-excerpt">' . wpautop( $comment_excerpt ) . '</div>';
 			}
 			$list_items_markup .= '</article></li>';


### PR DESCRIPTION
## What?
This PR prevents latest comments block from processing shortcodes in comment excerpt, which is used in the Latest Comments block

Closes #33495 

## Why?
Third party shortcodes with security issues can be abused on sites that use that block and don't moderate comments.
We should not process shortcodes in comments content

## How?
The PR converts `[]` into their corresponding entities so that they are not processed as shortcodes but the syntax is still visible in the frontend as it is

## Testing Instructions
1. Create a post
2. Add a comment containing any shortcode syntax
3. Add a `Latest Comments` block to the post
4. Observe the shortcode syntax doesn't get processed

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
| <img width="832" height="568" alt="Screenshot 2025-08-06 at 7 43 15 PM" src="https://github.com/user-attachments/assets/93b1c67a-1e6c-41e2-a3db-be7d235284a3" /> | <img width="832" height="568" alt="Screenshot 2025-08-07 at 3 50 31 PM" src="https://github.com/user-attachments/assets/78e280c6-9423-44c6-b290-6fa2b54b6a25" /> |
