### PR TITLE
wordcount: fix count function signature to make `userSettings` parameter optional

### DIFF
--- a/packages/wordcount/src/index.ts
+++ b/packages/wordcount/src/index.ts
@@ -117,7 +117,7 @@ function countCharacters(
 export function count(
 	text: string,
 	type: Strategy,
-	userSettings: UserSettings
+	userSettings?: UserSettings
 ): number {
 	const settings = loadSettings( type, userSettings );
 	let matchRegExp: RegExp;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of #67691 
Makes the `userSettings` parameter optional in the `count` function to maintain backward compatibility after TypeScript migration.

## Why?
After the TypeScript migration in #70501 , the `userSettings` parameter was incorrectly marked as required, breaking backward compatibility. This parameter was historically optional and should remain so.

## How?
Made `userSettings` parameter optional
