### PR TITLE
block.json schema: Make the apiVersion field required and only allow 3

### DIFF
--- a/phpunit/fixtures/hooked-block/block.json
+++ b/phpunit/fixtures/hooked-block/block.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
 	"title": "Hooked Block",
 	"name": "tests/hooked-block",
 	"blockHooks": {

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -16,10 +16,9 @@
 			"type": "string"
 		},
 		"apiVersion": {
-			"description": "The version of the Block API used by the block. The most recent version is 3 and it was introduced in WordPress 6.3.\n\n See the API versions documentation at https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/ for more details.",
+			"description": "The version of the Block API used by the block. If the block is registered with API version 2 or lower, the post editor may work as a non-iframe editor. Since all editors are planned to work as iframes in the future, it is recommended to set the `apiVersion` field to 3 and test the block inside the iframe editor. \n\n See the API versions documentation at https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/ for more details.",
 			"type": "integer",
-			"enum": [ 1, 2, 3 ],
-			"default": 1
+			"const": 3
 		},
 		"name": {
 			"description": "The name for a block is a unique string that identifies a block. Names have to be structured as `namespace/block-name`, where namespace is the name of your plugin or theme.",
@@ -996,6 +995,6 @@
 			"type": "string"
 		}
 	},
-	"required": [ "name", "title" ],
+	"required": [ "apiVersion", "name", "title" ],
 	"additionalProperties": false
 }

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -16,7 +16,7 @@
 			"type": "string"
 		},
 		"apiVersion": {
-			"description": "The version of the Block API used by the block. If the block is registered with API version 2 or lower, the post editor may work as a non-iframe editor. Since all editors are planned to work as iframes in the future, it is recommended to set the `apiVersion` field to 3 and test the block inside the iframe editor. \n\n See the API versions documentation at https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/ for more details.",
+			"description": "The version of the Block API used by the block. If the block is registered with API version 2 or lower, the post editor may work as a non-iframe editor. Since all editors are planned to work as iframes in the future, it is recommended to set the `apiVersion` field to 3 and test the block inside the iframe editor.\n\nSee the API versions documentation at https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/ for more details.",
 			"type": "integer",
 			"const": 3
 		},


### PR DESCRIPTION
Part of #70743

## Why?

If the block is registered with API version 2 or lower, the post editor may work as a non-iframe editor. However, we aim to have all editors work as iframes in the future. To encourage more block developers to test their products in the iframe editor, let's only allow the value 3.

## Testing Instructions

- Create the following `block.json` file:
  ```json
  {
  	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/refs/heads/block-json-schema-api-version-3/schemas/json/block.json",
  	"name": "test/test",
  	"title": "Test Block"
  }
  ```
- The code editor should warn you when anything other than 3 is entered.
- Confirm the description text.

## Screenshots or screencast <!-- if applicable -->

<img width="1138" height="525" alt="image" src="https://github.com/user-attachments/assets/ce13df4d-4519-4e56-aaa4-559127986f1f" />

<img width="1074" height="363" alt="image" src="https://github.com/user-attachments/assets/b0480b96-ab09-4ac5-bd08-078a9e9bc43c" />

