### PR TITLE
Widget Area Block: apply API version 3

### DIFF
--- a/packages/edit-widgets/src/blocks/widget-area/block.json
+++ b/packages/edit-widgets/src/blocks/widget-area/block.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
 	"name": "core/widget-area",
 	"title": "Widget Area",
 	"category": "widgets",

--- a/packages/edit-widgets/src/blocks/widget-area/edit/index.js
+++ b/packages/edit-widgets/src/blocks/widget-area/edit/index.js
@@ -9,6 +9,7 @@ import {
 	Panel,
 	PanelBody,
 } from '@wordpress/components';
+import { useBlockProps } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -21,7 +22,6 @@ import useIsDraggingWithin from './use-is-dragging-within';
 
 export default function WidgetAreaEdit( {
 	clientId,
-	className,
 	attributes: { id, name },
 } ) {
 	const isOpen = useSelect(
@@ -54,36 +54,40 @@ export default function WidgetAreaEdit( {
 		}
 	}, [ isOpen, isDragging, isDraggingWithin, openedWhileDragging ] );
 
+	const blockProps = useBlockProps();
+
 	return (
-		<Panel className={ className } ref={ wrapper }>
-			<PanelBody
-				title={ name }
-				opened={ isOpen }
-				onToggle={ () => {
-					setIsWidgetAreaOpen( clientId, ! isOpen );
-				} }
-				scrollAfterOpen={ ! isDragging }
-			>
-				{ ( { opened } ) => (
-					// This is required to ensure LegacyWidget blocks are not
-					// unmounted when the panel is collapsed. Unmounting legacy
-					// widgets may have unintended consequences (e.g.  TinyMCE
-					// not being properly reinitialized)
-					<DisclosureContent
-						className="wp-block-widget-area__panel-body-content"
-						visible={ opened }
-					>
-						<EntityProvider
-							kind="root"
-							type="postType"
-							id={ `widget-area-${ id }` }
+		<div { ...blockProps }>
+			<Panel ref={ wrapper }>
+				<PanelBody
+					title={ name }
+					opened={ isOpen }
+					onToggle={ () => {
+						setIsWidgetAreaOpen( clientId, ! isOpen );
+					} }
+					scrollAfterOpen={ ! isDragging }
+				>
+					{ ( { opened } ) => (
+						// This is required to ensure LegacyWidget blocks are not
+						// unmounted when the panel is collapsed. Unmounting legacy
+						// widgets may have unintended consequences (e.g.  TinyMCE
+						// not being properly reinitialized)
+						<DisclosureContent
+							className="wp-block-widget-area__panel-body-content"
+							visible={ opened }
 						>
-							<WidgetAreaInnerBlocks id={ id } />
-						</EntityProvider>
-					</DisclosureContent>
-				) }
-			</PanelBody>
-		</Panel>
+							<EntityProvider
+								kind="root"
+								type="postType"
+								id={ `widget-area-${ id }` }
+							>
+								<WidgetAreaInnerBlocks id={ id } />
+							</EntityProvider>
+						</DisclosureContent>
+					) }
+				</PanelBody>
+			</Panel>
+		</div>
 	);
 }
 


### PR DESCRIPTION
Follow-up #70783

## What?

Make the Widget Area block work with the `apiVersion: 3` to avoid the browser console warning.

## Why?

To encourage block developers to use Block API Version 3 and test in the iframe editor, we added a browser console warning. However, I noticed that the Widget Area block was running with an undefined API version (version 1).

## How?

Adds `apiVersion: 3` to the block.json and uses the `useBlockProps` hook. There should be no visual changes or functionality issues.

## Testing Instructions

- Activate Twenty Twenty-One.
- Appearance > Widget
- Many functionalities have been verified through e2E testing, but make sure they continue to work correctly.