### PR TITLE
Add aspect ratio control for gallery block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -342,7 +342,7 @@ Display multiple images in a rich gallery. ([Source](https://github.com/WordPres
 -	**Category:** media
 -	**Allowed Blocks:** core/image
 -	**Supports:** align, anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), spacing (blockGap, margin, padding), units (em, px, rem, vh, vw), ~~html~~
--	**Attributes:** allowResize, caption, columns, fixedHeight, ids, imageCrop, images, linkTarget, linkTo, randomOrder, shortCodeTransforms, sizeSlug
+-	**Attributes:** allowResize, aspectRatio, caption, columns, fixedHeight, ids, imageCrop, images, linkTarget, linkTo, randomOrder, shortCodeTransforms, sizeSlug
 
 ## Group
 

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -102,12 +102,17 @@
 		"allowResize": {
 			"type": "boolean",
 			"default": false
+		},
+		"aspectRatio": {
+			"type": "string",
+			"default": "auto"
 		}
 	},
 	"providesContext": {
 		"allowResize": "allowResize",
 		"imageCrop": "imageCrop",
-		"fixedHeight": "fixedHeight"
+		"fixedHeight": "fixedHeight",
+		"aspectRatio": "aspectRatio"
 	},
 	"supports": {
 		"anchor": true,

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -111,8 +111,7 @@
 	"providesContext": {
 		"allowResize": "allowResize",
 		"imageCrop": "imageCrop",
-		"fixedHeight": "fixedHeight",
-		"aspectRatio": "aspectRatio"
+		"fixedHeight": "fixedHeight"
 	},
 	"supports": {
 		"anchor": true,

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -119,7 +119,13 @@ export default function GalleryEdit( props ) {
 		onFocus,
 	} = props;
 
-	const [ lightboxSetting ] = useSettings( 'blocks.core/image.lightbox' );
+	const [ lightboxSetting, defaultRatios, themeRatios, showDefaultRatios ] =
+		useSettings(
+			'blocks.core/image.lightbox',
+			'dimensions.aspectRatios.default',
+			'dimensions.aspectRatios.theme',
+			'dimensions.defaultAspectRatios'
+		);
 
 	const linkOptions = ! lightboxSetting?.allowEditing
 		? LINK_OPTIONS.filter(
@@ -127,8 +133,15 @@ export default function GalleryEdit( props ) {
 		  )
 		: LINK_OPTIONS;
 
-	const { columns, imageCrop, randomOrder, linkTarget, linkTo, sizeSlug } =
-		attributes;
+	const {
+		columns,
+		imageCrop,
+		randomOrder,
+		linkTarget,
+		linkTo,
+		sizeSlug,
+		aspectRatio = 'auto',
+	} = attributes;
 
 	const {
 		__unstableMarkNextChangeAsNotPersistent,
@@ -191,6 +204,23 @@ export default function GalleryEdit( props ) {
 	const imageData = useGetMedia( innerBlockImages );
 
 	const newImages = useGetNewImages( images, imageData );
+
+	const themeOptions = themeRatios?.map( ( { name, ratio } ) => ( {
+		label: name,
+		value: ratio,
+	} ) );
+	const defaultOptions = defaultRatios?.map( ( { name, ratio } ) => ( {
+		label: name,
+		value: ratio,
+	} ) );
+	const aspectRatioOptions = [
+		{
+			label: _x( 'Original', 'Aspect ratio option for Gallery images' ),
+			value: 'auto',
+		},
+		...( showDefaultRatios ? defaultOptions || [] : [] ),
+		...( themeOptions || [] ),
+	];
 
 	useEffect( () => {
 		newImages?.forEach( ( newImage ) => {
@@ -259,6 +289,7 @@ export default function GalleryEdit( props ) {
 			sizeSlug,
 			caption: imageAttributes.caption || image.caption?.raw,
 			alt: imageAttributes.alt || image.alt_text,
+			aspectRatio: aspectRatio === 'auto' ? undefined : aspectRatio,
 		};
 	}
 
@@ -476,6 +507,39 @@ export default function GalleryEdit( props ) {
 		);
 	}
 
+	function setAspectRatio( value ) {
+		setAttributes( { aspectRatio: value } );
+
+		// Update all inner image blocks with the new aspect ratio
+		const changedAttributes = {};
+		const blocks = [];
+
+		getBlock( clientId ).innerBlocks.forEach( ( block ) => {
+			blocks.push( block.clientId );
+			changedAttributes[ block.clientId ] = {
+				aspectRatio: value === 'auto' ? undefined : value,
+			};
+		} );
+
+		updateBlockAttributes( blocks, changedAttributes, true );
+
+		const aspectRatioText = aspectRatioOptions.find(
+			( option ) => option.value === value
+		);
+
+		createSuccessNotice(
+			sprintf(
+				/* translators: %s: aspect ratio setting */
+				__( 'All gallery images updated to aspect ratio: %s' ),
+				aspectRatioText?.label || value
+			),
+			{
+				id: 'gallery-attributes-aspectRatio',
+				type: 'snackbar',
+			}
+		);
+	}
+
 	useEffect( () => {
 		// linkTo attribute must be saved so blocks don't break when changing image_default_link_type in options.php.
 		if ( ! linkTo ) {
@@ -572,6 +636,7 @@ export default function GalleryEdit( props ) {
 								columns: undefined,
 								imageCrop: true,
 								randomOrder: false,
+								aspectRatio: 'auto',
 							} );
 
 							if ( sizeSlug !== DEFAULT_MEDIA_SIZE_SLUG ) {
@@ -686,6 +751,32 @@ export default function GalleryEdit( props ) {
 								/>
 							</ToolsPanelItem>
 						) }
+						{ aspectRatioOptions.length > 1 && (
+							<ToolsPanelItem
+								hasValue={ () =>
+									!! aspectRatio && aspectRatio !== 'auto'
+								}
+								label={ __( 'Aspect ratio' ) }
+								onDeselect={ () => setAspectRatio( 'auto' ) }
+								resetAllFilter={ () => ( {
+									aspectRatio: 'auto',
+								} ) }
+								isShownByDefault
+								panelId={ clientId }
+							>
+								<SelectControl
+									__next40pxDefaultSize
+									__nextHasNoMarginBottom
+									label={ __( 'Aspect ratio' ) }
+									help={ __(
+										'Set a consistent aspect ratio for all images in the gallery.'
+									) }
+									value={ aspectRatio }
+									options={ aspectRatioOptions }
+									onChange={ setAspectRatio }
+								/>
+							</ToolsPanelItem>
+						) }
 					</ToolsPanel>
 				) }
 				{ Platform.isNative && (
@@ -748,6 +839,20 @@ export default function GalleryEdit( props ) {
 								label={ __( 'Open images in new tab' ) }
 								checked={ linkTarget === '_blank' }
 								onChange={ toggleOpenInNewTab }
+							/>
+						) }
+						{ aspectRatioOptions.length > 1 && (
+							<SelectControl
+								__nextHasNoMarginBottom
+								label={ __( 'Aspect Ratio' ) }
+								help={ __(
+									'Set a consistent aspect ratio for all images in the gallery.'
+								) }
+								value={ aspectRatio }
+								options={ aspectRatioOptions }
+								onChange={ setAspectRatio }
+								hideCancelButton
+								size="__unstable-large"
 							/>
 						) }
 					</PanelBody>

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -636,7 +636,6 @@ export default function GalleryEdit( props ) {
 								columns: undefined,
 								imageCrop: true,
 								randomOrder: false,
-								aspectRatio: 'auto',
 							} );
 
 setAspectRatio( 'auto' );

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -758,9 +758,6 @@ export default function GalleryEdit( props ) {
 								}
 								label={ __( 'Aspect ratio' ) }
 								onDeselect={ () => setAspectRatio( 'auto' ) }
-								resetAllFilter={ () => ( {
-									aspectRatio: 'auto',
-								} ) }
 								isShownByDefault
 							>
 								<SelectControl

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -639,6 +639,7 @@ export default function GalleryEdit( props ) {
 								aspectRatio: 'auto',
 							} );
 
+setAspectRatio( 'auto' );
 							if ( sizeSlug !== DEFAULT_MEDIA_SIZE_SLUG ) {
 								updateImagesSize( DEFAULT_MEDIA_SIZE_SLUG );
 							}

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -140,7 +140,7 @@ export default function GalleryEdit( props ) {
 		linkTarget,
 		linkTo,
 		sizeSlug,
-		aspectRatio = 'auto',
+		aspectRatio,
 	} = attributes;
 
 	const {

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -638,7 +638,8 @@ export default function GalleryEdit( props ) {
 								randomOrder: false,
 							} );
 
-setAspectRatio( 'auto' );
+							setAspectRatio( 'auto' );
+
 							if ( sizeSlug !== DEFAULT_MEDIA_SIZE_SLUG ) {
 								updateImagesSize( DEFAULT_MEDIA_SIZE_SLUG );
 							}

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -762,7 +762,6 @@ export default function GalleryEdit( props ) {
 									aspectRatio: 'auto',
 								} ) }
 								isShownByDefault
-								panelId={ clientId }
 							>
 								<SelectControl
 									__next40pxDefaultSize


### PR DESCRIPTION
Closes [#66760](https://github.com/WordPress/gutenberg/issues/66760)

## What?
Adds aspect ratio control to the Gallery block, allowing users to force all image blocks within the gallery to use the same aspect ratio for consistent visual presentation.

## Why?
Currently the Gallery block displays images in their original aspect ratios, there is no way to control their aspect ratio.

## How?
Add Aspect Ration control for gallery block.

## Testing Instructions
- Open a post or page in the block editor
- Insert a Gallery block
- Add multiple images with different aspect ratios (e.g., portrait, landscape, square)
- In the Gallery block settings sidebar, locate the new "Aspect ratio" control
- Select a different aspect ratio (e.g., "Square (1:1)" or "16:9")
- Verify all images in the gallery now display with the selected aspect ratio
- Save the post and verify aspect ratios are maintained on the frontend

## Screenshots or screencast <!-- if applicable -->
<img width="307" height="353" alt="Screenshot 2025-08-07 at 7 03 40 PM" src="https://github.com/user-attachments/assets/e619b807-cc60-4350-9fa7-524cb4d1ad0f" />

<img width="2854" height="3350" alt="screencapture-localhost-8888-2025-08-07-18_51_42" src="https://github.com/user-attachments/assets/abd301dd-bda3-44be-8971-5c69e3ddde55" />

