### PR TITLE
Fix horizontal overflow caused by long parent page names in Post Panel

### DIFF
--- a/packages/editor/src/components/post-url/style.scss
+++ b/packages/editor/src/components/post-url/style.scss
@@ -45,7 +45,8 @@
 	padding-inline-start: 0 !important;
 }
 
-.editor-post-url__panel-toggle {
+.editor-post-url__panel-toggle,
+.editor-post-parent__panel-toggle {
 	word-break: break-word;
 }
 


### PR DESCRIPTION
## What?
Closes #71113 

This PR applies `word-break: break-word;` CSS styling to the `.editor-post-parent__panel-toggle` class, ensuring long parent page names wrap correctly within the Post Panel and do not cause horizontal overflow.

## Why?
Long parent page names currently create a horizontal overflow within the Post Panel UI, affecting usability and layout. This issue was reported in #71113. Since long slugs already use word wrapping (`word-break: break-word;`), applying the same style to parent page names resolves the problem and maintains consistent UI behavior.

## How?
To prevent the parent page name from overflowing horizontally, you can add the following CSS rule:

```css
.editor-post-parent__panel-toggle {
    word-break: break-word;
}
```

This ensures that long parent page names will break to a new line as needed, improving readability.
It also aligns the styling of parent page names with the existing styles applied to slugs.

## Testing Instructions
1. Create a page with a very long page name.
2. Create another page and set the long-named page as its parent.
3. Open the Post Panel for the child page.
4. Observe that the long parent page name text wraps and does not overflow horizontally.
5. Verify that the slug in the Post Panel still wraps correctly.

## Screenshots or screencast 

|Before|After|
|-|-|
|<img width="1470" height="794" alt="Screenshot 2025-08-07 at 7 11 29 PM" src="https://github.com/user-attachments/assets/a018f16a-f1e3-4f60-bcd5-da944e844e4d" />| <img width="1470" height="796" alt="Screenshot 2025-08-07 at 7 20 42 PM" src="https://github.com/user-attachments/assets/33e7a587-5745-415c-99f7-7b31495f7601" />|
