### PR TITLE
Consolidate `getBlockEditingMode` to return 'contentOnly' or 'disabled' while in NavMode

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -61,6 +61,7 @@ export function PrivateBlockToolbar( {
 	const {
 		blockClientId,
 		blockClientIds,
+		isContentOnlyMode,
 		isDefaultEditingMode,
 		blockType,
 		toolbarKey,
@@ -75,7 +76,6 @@ export function PrivateBlockToolbar( {
 		showLockButtons,
 		showSwitchSectionStyleButton,
 		hasFixedToolbar,
-		isNavigationMode,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockName,
@@ -90,7 +90,6 @@ export function PrivateBlockToolbar( {
 			getSettings,
 			getParentSectionBlock,
 			isZoomOut,
-			isNavigationMode: _isNavigationMode,
 			isSectionBlock,
 		} = unlock( select( blockEditorStore ) );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
@@ -101,8 +100,8 @@ export function PrivateBlockToolbar( {
 		const parentBlockName = getBlockName( parentClientId );
 		const parentBlockType = getBlockType( parentBlockName );
 		const editingMode = getBlockEditingMode( selectedBlockClientId );
-		const isNavigationModeEnabled = _isNavigationMode();
 		const _isDefaultEditingMode = editingMode === 'default';
+		const _isContentOnlyMode = editingMode === 'contentOnly';
 		const _blockName = getBlockName( selectedBlockClientId );
 		const isValid = selectedBlockClientIds.every( ( id ) =>
 			isBlockValid( id )
@@ -138,7 +137,7 @@ export function PrivateBlockToolbar( {
 			showParentSelector:
 				! _isZoomOut &&
 				parentBlockType &&
-				editingMode !== 'contentOnly' &&
+				! _isContentOnlyMode &&
 				getBlockEditingMode( parentClientId ) !== 'disabled' &&
 				hasBlockSupport(
 					parentBlockType,
@@ -153,13 +152,12 @@ export function PrivateBlockToolbar( {
 			showSlots: ! _isZoomOut,
 			showGroupButtons: ! _isZoomOut,
 			showLockButtons: ! _isZoomOut,
+			isContentOnlyMode: _isContentOnlyMode,
 			showSwitchSectionStyleButton:
 				_isZoomOut ||
-				( isNavigationModeEnabled &&
-					editingMode === 'contentOnly' &&
+				( _isContentOnlyMode &&
 					isSectionBlock( selectedBlockClientId ) ), // Zoom out or Write Mode Section Blocks
 			hasFixedToolbar: getSettings().hasFixedToolbar,
-			isNavigationMode: isNavigationModeEnabled,
 		};
 	}, [] );
 
@@ -186,7 +184,7 @@ export function PrivateBlockToolbar( {
 	// Shifts the toolbar to make room for the parent block selector.
 	const classes = clsx( 'block-editor-block-contextual-toolbar', {
 		'has-parent': showParentSelector,
-		'is-inverted-toolbar': isNavigationMode && ! hasFixedToolbar,
+		'is-inverted-toolbar': isContentOnlyMode && ! hasFixedToolbar,
 	} );
 
 	const innerClasses = clsx( 'block-editor-block-toolbar', {

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2309,6 +2309,8 @@ function getDerivedBlockEditingModesForTree(
 			}
 		}
 
+		// If the editor is zoomed out or in navigation mode, all blocks will be set to either contentOnly or disabled.
+		// The fallback is to set the block editing mode to disabled.
 		if ( isZoomedOut || isNavMode ) {
 			// If the root block is the section root set its editing mode to contentOnly.
 			if ( clientId === sectionRootClientId ) {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -3040,56 +3040,22 @@ export function __unstableIsWithinBlockOverlay( state, clientId ) {
  * @return {BlockEditingMode} The block editing mode. One of `'disabled'`,
  *                            `'contentOnly'`, or `'default'`.
  */
-export const getBlockEditingMode = createRegistrySelector(
-	( select ) =>
-		( state, clientId = '' ) => {
-			// Some selectors that call this provide `null` as the default
-			// rootClientId, but the default rootClientId is actually `''`.
-			if ( clientId === null ) {
-				clientId = '';
-			}
+export const getBlockEditingMode = ( state, clientId = '' ) => {
+	// Some selectors that call this provide `null` as the default
+	// rootClientId, but the default rootClientId is actually `''`.
+	if ( clientId === null ) {
+		clientId = '';
+	}
 
-			const isNavMode = isNavigationMode( state );
+	const isNavMode = isNavigationMode( state );
 
-			if ( isNavMode ) {
-				// If the editor *is* in navigation mode, the block editing mode states
-				// are stored in the derivedNavModeBlockEditingModes map.
-				return state.derivedNavModeBlockEditingModes.get( clientId );
-			}
-
-			// If the editor is currently not in navigation mode, check if the clientId
-			// has an editing mode set in the regular derived map.
-			// There may be an editing mode set here for synced patterns or in zoomed out
-			// mode.
-			if ( state.derivedBlockEditingModes?.has( clientId ) ) {
-				return state.derivedBlockEditingModes.get( clientId );
-			}
-
-			// In normal mode, consider that an explicitly set editing mode takes over.
-			const blockEditingMode = state.blockEditingModes.get( clientId );
-			if ( blockEditingMode ) {
-				return blockEditingMode;
-			}
-
-			// In normal mode, top level is default mode.
-			if ( clientId === '' ) {
-				return 'default';
-			}
-
-			const rootClientId = getBlockRootClientId( state, clientId );
-			const templateLock = getTemplateLock( state, rootClientId );
-			// If the parent of the block is contentOnly locked, check whether it's a content block.
-			if ( templateLock === 'contentOnly' ) {
-				const name = getBlockName( state, clientId );
-				const { hasContentRoleAttribute } = unlock(
-					select( blocksStore )
-				);
-				const isContent = hasContentRoleAttribute( name );
-				return isContent ? 'contentOnly' : 'disabled';
-			}
-			return 'default';
-		}
-);
+	if ( isNavMode ) {
+		// If the editor *is* in navigation mode, the block editing mode states
+		// are stored in the derivedNavModeBlockEditingModes map.
+		return state.derivedNavModeBlockEditingModes.get( clientId );
+	}
+	return state.derivedBlockEditingModes.get( clientId );
+};
 
 /**
  * Indicates if a block is ungroupable.

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -3051,24 +3051,20 @@ export const getBlockEditingMode = createRegistrySelector(
 
 			const isNavMode = isNavigationMode( state );
 
+			if ( isNavMode ) {
+				// If the editor *is* in navigation mode, the block editing mode states
+				// are stored in the derivedNavModeBlockEditingModes map.
+				return state.derivedNavModeBlockEditingModes?.has( clientId )
+					? state.derivedNavModeBlockEditingModes.get( clientId )
+					: 'contentOnly';
+			}
+
 			// If the editor is currently not in navigation mode, check if the clientId
 			// has an editing mode set in the regular derived map.
 			// There may be an editing mode set here for synced patterns or in zoomed out
 			// mode.
-			if (
-				! isNavMode &&
-				state.derivedBlockEditingModes?.has( clientId )
-			) {
+			if ( state.derivedBlockEditingModes?.has( clientId ) ) {
 				return state.derivedBlockEditingModes.get( clientId );
-			}
-
-			// If the editor *is* in navigation mode, the block editing mode states
-			// are stored in the derivedNavModeBlockEditingModes map.
-			if (
-				isNavMode &&
-				state.derivedNavModeBlockEditingModes?.has( clientId )
-			) {
-				return state.derivedNavModeBlockEditingModes.get( clientId );
 			}
 
 			// In normal mode, consider that an explicitly set editing mode takes over.

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -3054,9 +3054,7 @@ export const getBlockEditingMode = createRegistrySelector(
 			if ( isNavMode ) {
 				// If the editor *is* in navigation mode, the block editing mode states
 				// are stored in the derivedNavModeBlockEditingModes map.
-				return state.derivedNavModeBlockEditingModes?.has( clientId )
-					? state.derivedNavModeBlockEditingModes.get( clientId )
-					: 'contentOnly';
+				return state.derivedNavModeBlockEditingModes.get( clientId );
 			}
 
 			// If the editor is currently not in navigation mode, check if the clientId

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -13,7 +13,6 @@ import {
 	InspectorControls,
 	URLPopover,
 	URLInput,
-	useBlockEditingMode,
 	useBlockProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
@@ -138,16 +137,18 @@ const SocialLinkEdit = ( {
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
-	const isContentOnlyMode = useBlockEditingMode() === 'contentOnly';
 
-	const { activeVariation } = useSelect(
+	const { activeVariation, isContentOnlyMode } = useSelect(
 		( select ) => {
-			const { getActiveBlockVariation } = select( blocksStore );
+			const { getActiveBlockVariation, getBlockEditingMode } =
+				select( blocksStore );
 			return {
 				activeVariation: getActiveBlockVariation( name, attributes ),
+				isContentOnlyMode:
+					getBlockEditingMode( clientId ) === 'contentOnly',
 			};
 		},
-		[ name, attributes ]
+		[ name, attributes, clientId ]
 	);
 
 	const { icon, label: socialLinkName } = getSocialService( activeVariation );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

<!-- In a few words, what is the PR actually doing? -->
Rearranges the logic to return `contentOnly` or `disabled` for all blocks while in Navigation Mode (Write Mode)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We have a lot of logic spread throughout the codebase to determine if we're in `contentOnly` mode for a block. We're coupling it with `isNavigationMode` within the components consuming the `getBlockEditingMode` checks.  

We already have a check within `useBlockEditingMode` for `isNavMode`, so it should consolidate the logic by moving the `isNavMode` check up so if we're in Write Mode (isNavMode), we always return `contentOnly` or `disabled`.  This is assuming my understanding of how Write Mode is supposed to work is correct, which I'm not confident of yet :)

This should result in a more performant and simplified codebase and give us a better foundation for implementing WriteMode.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Move `isNavMode` logic return first in `getBlockEditingMode`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
