### PR TITLE
Add `enableMoving` option to the `table` layout to allow or disallow column moving left and right

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add `enableMoving` option to the `table` layout to allow or disallow column moving left and right. [#71120](https://github.com/WordPress/gutenberg/pull/71120)
+
 ## 6.0.0 (2025-08-07)
 
 ### Breaking changes

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -37,7 +37,7 @@ import {
 } from './fixtures';
 import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../../../constants';
 import { filterSortAndPaginate } from '../../../filter-and-sort-data-view';
-import type { View } from '../../../types';
+import type { Field, View } from '../../../types';
 
 import './style.css';
 
@@ -144,37 +144,7 @@ export const CustomEmpty = () => {
 	);
 };
 
-export const FieldsNoSortableNoHidable = () => {
-	const [ view, setView ] = useState< View >( {
-		...DEFAULT_VIEW,
-		fields: [ 'title', 'description', 'categories' ],
-	} );
-	const { data: shownData, paginationInfo } = useMemo( () => {
-		return filterSortAndPaginate( data, view, fields );
-	}, [ view ] );
-
-	const _fields = fields.map( ( field ) => ( {
-		...field,
-		enableSorting: false,
-		enableHiding: false,
-	} ) );
-
-	return (
-		<DataViews
-			getItemId={ ( item ) => item.id.toString() }
-			paginationInfo={ paginationInfo }
-			data={ shownData }
-			view={ view }
-			fields={ _fields }
-			onChangeView={ setView }
-			defaultLayouts={ {
-				table: {},
-			} }
-		/>
-	);
-};
-
-export const FieldsNoSortableNoHidableNoMovable = () => {
+export const NonInteractive = () => {
 	const [ view, setView ] = useState< View >( {
 		...DEFAULT_VIEW,
 		fields: [ 'title', 'description', 'categories' ],
@@ -186,10 +156,11 @@ export const FieldsNoSortableNoHidableNoMovable = () => {
 		return filterSortAndPaginate( data, view, fields );
 	}, [ view ] );
 
-	const _fields = fields.map( ( field ) => ( {
+	const _fields: Field< SpaceObject >[] = fields.map( ( field ) => ( {
 		...field,
 		enableSorting: false,
 		enableHiding: false,
+		filterBy: false,
 	} ) );
 
 	return (
@@ -199,6 +170,8 @@ export const FieldsNoSortableNoHidableNoMovable = () => {
 			data={ shownData }
 			view={ view }
 			fields={ _fields }
+			perPageSizes={ [] }
+			search={ false }
 			onChangeView={ setView }
 			defaultLayouts={ {
 				table: {},

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -174,6 +174,39 @@ export const FieldsNoSortableNoHidable = () => {
 	);
 };
 
+export const FieldsNoSortableNoHidableNoMovable = () => {
+	const [ view, setView ] = useState< View >( {
+		...DEFAULT_VIEW,
+		fields: [ 'title', 'description', 'categories' ],
+		layout: {
+			enableMoving: false,
+		},
+	} );
+	const { data: shownData, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( data, view, fields );
+	}, [ view ] );
+
+	const _fields = fields.map( ( field ) => ( {
+		...field,
+		enableSorting: false,
+		enableHiding: false,
+	} ) );
+
+	return (
+		<DataViews
+			getItemId={ ( item ) => item.id.toString() }
+			paginationInfo={ paginationInfo }
+			data={ shownData }
+			view={ view }
+			fields={ _fields }
+			onChangeView={ setView }
+			defaultLayouts={ {
+				table: {},
+			} }
+		/>
+	);
+};
+
 /**
  * Custom composition example
  */

--- a/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
@@ -94,6 +94,10 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 		field.filterBy !== false &&
 		! field.filterBy?.isPrimary;
 
+	if ( ! isSortable && ! canMove && ! isHidable && ! canAddFilter ) {
+		return header;
+	}
+
 	return (
 		<Menu>
 			<Menu.TriggerButton

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -434,6 +434,9 @@ function ViewTable< Item >( {
 										onChangeView={ onChangeView }
 										onHide={ onHide }
 										setOpenedFilter={ setOpenedFilter }
+										canMove={
+											view.layout?.enableMoving ?? true
+										}
 									/>
 								</th>
 							);

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -482,6 +482,11 @@ export interface ViewTable extends ViewBase {
 		 * The density of the view.
 		 */
 		density?: Density;
+
+		/**
+		 * Whether the view allows column moving.
+		 */
+		enableMoving?: boolean;
 	};
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

The Table Layout allows columns to be moved left and right. To support more static views using DataViews, this allows the option to move columns left and right to be turned off via layout options. 

```
layout: {
	enableMoving: false,
},
```

This defaults to `true` as before. If the column header menu is empty as a result of this, the menu is now not rendered at all.

If the `layout` option is not best suited for this, please help me choose an alternative location. It should not be at field level because having a mixture of movable/not-movable columns could be confusing.

## Why?

I want to be able to turn off filtering, hiding, moving, and sorting on some static data views.

## How?

Layout option specific to tables.

## Testing Instructions

1. Open storybook and go to `?path=/story/dataviews-dataviews--fields-no-sortable-no-hidable-no-movable`. 
2. Click the title header. No moving options are displayed.
3. You cannot click the 'description' header. There is no button rendered.
4. Go to any other dataview and confirm the move left/right options are still visible.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
 
<img width="410" height="132" alt="Screenshot 2025-08-07 at 16 45 16" src="https://github.com/user-attachments/assets/8205b097-601f-4ae9-80b3-6bb56f379556" />

_Note, move left and right is missing._