### PR TITLE
FormTokenField: Improve use case stories

### DIFF
--- a/packages/components/src/form-token-field/stories/index.story.tsx
+++ b/packages/components/src/form-token-field/stories/index.story.tsx
@@ -115,28 +115,36 @@ DropdownSelector.args = {
 };
 
 /**
- * The rendered output of each suggestion can be customized by passing a
- * render function to the `__experimentalRenderItem` prop. (This is still an experimental feature
- * and is subject to change.)
+ * The rendered content of each token can be customized by passing a
+ * render function to the `displayTransform` prop.
+ *
+ * Similarly, each suggestion can be customized by passing a
+ * render function to the `__experimentalRenderItem` prop. (This is still an
+ * experimental feature and is subject to change.)
  */
-export const WithCustomRenderItem: StoryFn< typeof FormTokenField > =
+export const WithCustomRenderedItems: StoryFn< typeof FormTokenField > =
 	DefaultTemplate.bind( {} );
-WithCustomRenderItem.args = {
+WithCustomRenderedItems.args = {
 	...Default.args,
+	displayTransform: ( token ) => `📍 ${ token }`,
 	__experimentalRenderItem: ( { item } ) => (
 		<div>{ `${ item } — a nice place to visit` }</div>
 	),
+	__experimentalExpandOnFocus: true,
 };
 
 /**
  * Only values for which the `__experimentalValidateInput` function returns
  * `true` will be tokenized. (This is still an experimental feature and is
  * subject to change.)
+ *
+ * In this example, the user can only add tokens that are already in the list.
  */
-export const WithValidatedInput: StoryFn< typeof FormTokenField > =
+export const ValidateNewTokens: StoryFn< typeof FormTokenField > =
 	DefaultTemplate.bind( {} );
-WithValidatedInput.args = {
+ValidateNewTokens.args = {
 	...Default.args,
 	__experimentalValidateInput: ( input: string ) =>
 		continents.includes( input ),
+	__experimentalExpandOnFocus: true,
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Improves the stories for `FormTokenField` so the solutions to common use cases are easier to discover.

## Why?

- The `displayTransform` prop was not covered in the custom render story.
- It was slightly unclear that the `With Validated Input` story was demonstrating how you can disallow a user from adding new tokens.

## Testing Instructions

`npm run storybook:dev` and see the stories for FormTokenField.

