### PR TITLE
iAPI: Fix and refactor runtime initialization logic

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/hydration-timing-async/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/hydration-timing-async/block.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "test/hydration-timing-async",
+	"title": "E2E Interactivity tests - hydration timing async import",
+	"category": "text",
+	"icon": "heart",
+	"description": "",
+	"supports": {
+		"interactivity": true
+	},
+	"textdomain": "e2e-interactivity",
+	"viewScriptModule": "file:./view.js",
+	"render": "file:./render.php"
+}

--- a/packages/e2e-tests/plugins/interactive-blocks/hydration-timing-async/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/hydration-timing-async/render.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * HTML for testing hydration timing - async import block.
+ *
+ * This block's view module dynamically imports @wordpress/interactivity
+ * on DOMContentLoaded, simulating a lazy-loading scenario. The test verifies
+ * that hydration still occurs even when the library is loaded after
+ * DOMContentLoaded has fired.
+ *
+ * @package gutenberg-test-interactive-blocks
+ *
+ * @phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+ */
+?>
+
+<div
+	data-wp-interactive="test/hydration-timing-async"
+	<?php echo wp_interactivity_data_wp_context( array( 'hydrated' => false ) ); ?>
+>
+	<p
+		data-wp-text="state.asyncModuleLoaded"
+		data-testid="async-module-loaded"
+	>no</p>
+
+	<p
+		data-wp-text="context.hydrated"
+		data-testid="async-hydrated"
+	>no</p>
+
+	<div
+		data-wp-init="callbacks.init"
+		data-testid="async-hydration-status"
+	>
+		Async import hydration test block
+	</div>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/hydration-timing-async/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/hydration-timing-async/view.asset.php
@@ -1,0 +1,8 @@
+<?php return array(
+	'dependencies' => array(
+		array(
+			'id'     => '@wordpress/interactivity',
+			'import' => 'dynamic',
+		),
+	),
+);

--- a/packages/e2e-tests/plugins/interactive-blocks/hydration-timing-async/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/hydration-timing-async/view.js
@@ -1,0 +1,29 @@
+/**
+ * This module dynamically imports @wordpress/interactivity on DOMContentLoaded.
+ *
+ * This simulates a lazy-loading scenario where the Interactivity API is not
+ * statically imported. The test verifies that hydration still occurs even
+ * when the library is loaded after DOMContentLoaded has already fired.
+ */
+
+const initStore = async () => {
+	const { store, getContext } = await import( '@wordpress/interactivity' );
+
+	store( 'test/hydration-timing-async', {
+		state: {
+			asyncModuleLoaded: 'yes',
+		},
+		callbacks: {
+			// TODO: this could be unavailable during hydration. Fix
+			// `data-wp-init` to support that case.
+			init() {
+				const context = getContext();
+				context.hydrated = true;
+			},
+		},
+	} );
+};
+
+document.addEventListener( 'DOMContentLoaded', () =>
+	setTimeout( initStore, 1 )
+);

--- a/packages/e2e-tests/plugins/interactive-blocks/hydration-timing-slow/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/hydration-timing-slow/block.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "test/hydration-timing-slow",
+	"title": "E2E Interactivity tests - hydration timing slow module",
+	"category": "text",
+	"icon": "heart",
+	"description": "",
+	"supports": {
+		"interactivity": true
+	},
+	"textdomain": "e2e-interactivity",
+	"viewScriptModule": "file:./view.js",
+	"render": "file:./render.php"
+}

--- a/packages/e2e-tests/plugins/interactive-blocks/hydration-timing-slow/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/hydration-timing-slow/render.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * HTML for testing hydration timing - slow module block.
+ *
+ * This block's view module will be artificially delayed in the test
+ * to simulate a slow network connection. The test verifies that
+ * hydration waits for this module to load even when other modules
+ * that import @wordpress/interactivity have already been evaluated.
+ *
+ * @package gutenberg-test-interactive-blocks
+ *
+ * @phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+ */
+?>
+
+<div
+	data-wp-interactive="test/hydration-timing"
+	<?php echo wp_interactivity_data_wp_context( array( 'slowInitialized' => false ) ); ?>
+>
+	<p
+		data-wp-text="state.slowModuleLoaded"
+		data-testid="slow-module-loaded"
+	>no</p>
+
+	<p
+		data-wp-text="context.slowInitialized"
+		data-testid="slow-context-initialized"
+	>no</p>
+
+	<div
+		data-wp-init="callbacks.slowInit"
+		data-testid="slow-hydration-status"
+	>
+		Slow module hydration test block
+	</div>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/hydration-timing-slow/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/hydration-timing-slow/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/hydration-timing-slow/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/hydration-timing-slow/view.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { store, getContext } from '@wordpress/interactivity';
+
+// This module will be artificially delayed in the test.
+// It also imports @wordpress/interactivity, so when it's evaluated,
+// the interactivity runtime will have already been initialized by
+// the fast module. The test verifies that hydration waits for this
+// module to finish loading before running.
+
+store( 'test/hydration-timing', {
+	state: {
+		slowModuleLoaded: 'yes',
+	},
+	callbacks: {
+		slowInit() {
+			const context = getContext();
+			context.slowInitialized = true;
+		},
+	},
+} );

--- a/packages/e2e-tests/plugins/interactive-blocks/hydration-timing/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/hydration-timing/block.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "test/hydration-timing",
+	"title": "E2E Interactivity tests - hydration timing",
+	"category": "text",
+	"icon": "heart",
+	"description": "",
+	"supports": {
+		"interactivity": true
+	},
+	"textdomain": "e2e-interactivity",
+	"viewScriptModule": "file:./view.js",
+	"render": "file:./render.php"
+}

--- a/packages/e2e-tests/plugins/interactive-blocks/hydration-timing/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/hydration-timing/render.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * HTML for testing hydration timing with delayed module loading.
+ *
+ * @package gutenberg-test-interactive-blocks
+ *
+ * @phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+ */
+?>
+
+<div
+	data-wp-interactive="test/hydration-timing"
+	<?php echo wp_interactivity_data_wp_context( array( 'initialized' => false ) ); ?>
+>
+	<p
+		data-wp-text="state.moduleLoaded"
+		data-testid="module-loaded"
+	>no</p>
+
+	<p
+		data-wp-text="context.initialized"
+		data-testid="context-initialized"
+	>no</p>
+
+	<div
+		data-wp-init="callbacks.init"
+		data-testid="hydration-status"
+	>
+		Hydration test block
+	</div>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/hydration-timing/view.asset.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/hydration-timing/view.asset.php
@@ -1,0 +1,1 @@
+<?php return array( 'dependencies' => array( '@wordpress/interactivity' ) );

--- a/packages/e2e-tests/plugins/interactive-blocks/hydration-timing/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/hydration-timing/view.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import { store, getContext } from '@wordpress/interactivity';
+
+// This is the "fast" module that loads immediately. It imports
+// @wordpress/interactivity, which initializes the runtime.
+//
+// The test pairs this with a "slow" module (hydration-timing-slow) that is
+// artificially delayed. The race condition occurs when this fast module
+// triggers hydration before the slow module has finished loading.
+
+store( 'test/hydration-timing', {
+	state: {
+		moduleLoaded: 'yes',
+	},
+	callbacks: {
+		init() {
+			const context = getContext();
+			context.initialized = true;
+		},
+	},
+} );

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   Preserve boolean HTML attributes during client-side navigation. ([#74446](https://github.com/WordPress/gutenberg/pull/74446))
+-   Fix and refactor runtime initialization logic. ([#71123](https://github.com/WordPress/gutenberg/pull/71123))
 
 ## 6.36.0 (2025-11-26)
 

--- a/packages/interactivity/src/hydration.ts
+++ b/packages/interactivity/src/hydration.ts
@@ -30,19 +30,8 @@ export const getRegionRootFragment = (
 export const initialVdom = new WeakMap< Element, ComponentChild >();
 
 // Initialize the router with the initial DOM.
-export const init = async () => {
+export const hydrateRegions = async () => {
 	const nodes = document.querySelectorAll( `[data-wp-interactive]` );
-
-	/*
-	 * This `await` with setTimeout is required to apparently ensure that the interactive blocks have their stores
-	 * fully initialized prior to hydrating the blocks. If this is not present, then an error occurs, for example:
-	 * > view.js:46 Uncaught (in promise) ReferenceError: Cannot access 'state' before initialization
-	 * This occurs when splitTask() is implemented with scheduler.yield() as opposed to setTimeout(), as with the former
-	 * split tasks are added to the front of the task queue whereas with the latter they are added to the end of the queue.
-	 */
-	await new Promise( ( resolve ) => {
-		setTimeout( resolve, 0 );
-	} );
 
 	for ( const node of nodes ) {
 		if ( ! hydratedIslands.has( node ) ) {

--- a/packages/interactivity/src/index.ts
+++ b/packages/interactivity/src/index.ts
@@ -22,7 +22,7 @@ import { directive } from './hooks';
 import { getNamespace } from './namespaces';
 import { parseServerData, populateServerData } from './store';
 import { proxifyState } from './proxies';
-import { deepReadOnly, navigationSignal, postTask } from './utils';
+import { deepReadOnly, navigationSignal, onDOMReady } from './utils';
 
 export {
 	store,
@@ -75,10 +75,15 @@ export const privateApis = (
 	throw new Error( 'Forbidden access.' );
 };
 
-// Parse and populate the initial state and config.
-// All the core directives are registered at this point as well.
+// Parses and populates the initial state and config. All the core directives
+// are registered at this point as well.
 populateServerData( parseServerData() );
 registerDirectives();
 
-// Defer hydration to the end of the task queue.
-postTask( hydrateRegions );
+// Hydrates all interactive regions when `DOMContentLoaded` is dispatched, or as
+// soon as the `@wordpress/interactivity` module is evaluated in the case that
+// the event was already dispatched. This ensures synchronous modules had the
+// opportunity to register their stores before hydration takes place. For
+// asynchronous modules, or modules importing this module asynchronously, this
+// cannot be guaranteed.
+onDOMReady( hydrateRegions );

--- a/packages/interactivity/src/index.ts
+++ b/packages/interactivity/src/index.ts
@@ -12,13 +12,17 @@ import { batch } from '@preact/signals';
  * Internal dependencies
  */
 import registerDirectives, { routerRegions } from './directives';
-import { init, getRegionRootFragment, initialVdom } from './init';
+import {
+	initialVdom,
+	hydrateRegions,
+	getRegionRootFragment,
+} from './hydration';
 import { toVdom } from './vdom';
 import { directive } from './hooks';
 import { getNamespace } from './namespaces';
 import { parseServerData, populateServerData } from './store';
 import { proxifyState } from './proxies';
-import { deepReadOnly, navigationSignal } from './utils';
+import { deepReadOnly, navigationSignal, postTask } from './utils';
 
 export {
 	store,
@@ -71,5 +75,10 @@ export const privateApis = (
 	throw new Error( 'Forbidden access.' );
 };
 
+// Parse and populate the initial state and config.
+// All the core directives are registered at this point as well.
+populateServerData( parseServerData() );
 registerDirectives();
-init();
+
+// Defer hydration to the end of the task queue.
+postTask( hydrateRegions );

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -329,7 +329,3 @@ export const populateServerData = ( data?: {
 		);
 	}
 };
-
-// Parse and populate the initial state and config.
-const data = parseServerData();
-populateServerData( data );

--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -22,11 +22,25 @@ interface Flusher {
 	readonly dispose: () => void;
 }
 
+type TaskPriority = 'user-blocking' | 'user-visible' | 'background';
+
 declare global {
 	interface Window {
 		scheduler?: {
 			readonly yield?: () => Promise< void >;
+			readonly postTask: < R extends unknown >(
+				callback: () => R,
+				options?: {
+					priority?: TaskPriority;
+					signal?: TaskSignal | AbortSignal;
+					delay?: number;
+				}
+			) => Promise< R >;
 		};
+	}
+
+	interface TaskSignal extends AbortSignal {
+		priority: TaskPriority;
 	}
 }
 
@@ -55,6 +69,14 @@ const afterNextFrame = ( callback: () => void ) => {
 	} );
 };
 
+// TODO: consider initializing this only if required.
+const taskQueue: ( () => any )[] = [];
+const taskChannel = new MessageChannel();
+// Drain one task per message
+taskChannel.port1.onmessage = () => {
+	taskQueue.shift()?.();
+};
+
 /**
  * Returns a promise that resolves after yielding to main.
  *
@@ -64,10 +86,21 @@ export const splitTask =
 	typeof window.scheduler?.yield === 'function'
 		? window.scheduler.yield.bind( window.scheduler )
 		: () => {
-				return new Promise( ( resolve ) => {
-					setTimeout( resolve, 0 );
+				return new Promise< void >( ( resolve ) => {
+					taskQueue.push( resolve );
+					taskChannel.port2.postMessage( null );
 				} );
 		  };
+
+export const postTask = < T extends unknown >( task: () => T ): Promise< T > =>
+	typeof window.scheduler?.postTask === 'function'
+		? window.scheduler.postTask( () => task() )
+		: new Promise( ( resolve ) => {
+				taskQueue.push( () => {
+					resolve( task() );
+				} );
+				taskChannel.port2.postMessage( null );
+		  } );
 
 /**
  * Creates a Flusher object that can be used to flush computed values and notify listeners.

--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -91,16 +91,27 @@ export const splitTask =
 					taskChannel.port2.postMessage( null );
 				} );
 		  };
-
-export const postTask = < T extends unknown >( task: () => T ): Promise< T > =>
-	typeof window.scheduler?.postTask === 'function'
-		? window.scheduler.postTask( () => task() )
-		: new Promise( ( resolve ) => {
-				taskQueue.push( () => {
-					resolve( task() );
-				} );
-				taskChannel.port2.postMessage( null );
-		  } );
+/**
+ * Executes the passed callback on `DOMContentLoaded`, or immediately if that
+ * event has already been triggered.
+ *
+ * This function depends on `PerformanceNavigationTiming` (see
+ * https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming) to
+ * detect whether the event has been dispatched.
+ *
+ * @param callback Function to execute on `DOMContentLoaded`.
+ */
+export const onDOMReady = ( callback: () => void ) => {
+	const [ navigation ] = performance.getEntriesByType( 'navigation' );
+	if (
+		( navigation as PerformanceNavigationTiming )
+			.domContentLoadedEventStart > 0
+	) {
+		callback();
+	} else {
+		document.addEventListener( 'DOMContentLoaded', callback );
+	}
+};
 
 /**
  * Creates a Flusher object that can be used to flush computed values and notify listeners.

--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -22,25 +22,11 @@ interface Flusher {
 	readonly dispose: () => void;
 }
 
-type TaskPriority = 'user-blocking' | 'user-visible' | 'background';
-
 declare global {
 	interface Window {
 		scheduler?: {
 			readonly yield?: () => Promise< void >;
-			readonly postTask: < R extends unknown >(
-				callback: () => R,
-				options?: {
-					priority?: TaskPriority;
-					signal?: TaskSignal | AbortSignal;
-					delay?: number;
-				}
-			) => Promise< R >;
 		};
-	}
-
-	interface TaskSignal extends AbortSignal {
-		priority: TaskPriority;
 	}
 }
 
@@ -69,14 +55,6 @@ const afterNextFrame = ( callback: () => void ) => {
 	} );
 };
 
-// TODO: consider initializing this only if required.
-const taskQueue: ( () => any )[] = [];
-const taskChannel = new MessageChannel();
-// Drain one task per message
-taskChannel.port1.onmessage = () => {
-	taskQueue.shift()?.();
-};
-
 /**
  * Returns a promise that resolves after yielding to main.
  *
@@ -86,9 +64,8 @@ export const splitTask =
 	typeof window.scheduler?.yield === 'function'
 		? window.scheduler.yield.bind( window.scheduler )
 		: () => {
-				return new Promise< void >( ( resolve ) => {
-					taskQueue.push( resolve );
-					taskChannel.port2.postMessage( null );
+				return new Promise( ( resolve ) => {
+					setTimeout( resolve, 0 );
 				} );
 		  };
 /**

--- a/test/e2e/specs/interactivity/hydration-timing.spec.ts
+++ b/test/e2e/specs/interactivity/hydration-timing.spec.ts
@@ -17,6 +17,13 @@ test.describe( 'hydration timing', () => {
 				[ 'test/hydration-timing-slow' ],
 			],
 		} );
+
+		// Create a separate post with only the async block.
+		// This block dynamically imports @wordpress/interactivity on
+		// DOMContentLoaded, so there are no static imports of the library.
+		await utils.addPostWithBlock( 'test/hydration-timing-async', {
+			alias: 'hydration-timing-async',
+		} );
 	} );
 
 	test.afterAll( async ( { interactivityUtils: utils } ) => {
@@ -62,5 +69,32 @@ test.describe( 'hydration timing', () => {
 		);
 		await expect( contextInitialized ).toHaveText( 'true' );
 		await expect( slowContextInitialized ).toHaveText( 'true' );
+	} );
+
+	test( 'should hydrate when the Interactivity API is loaded asynchronously after DOMContentLoaded', async ( {
+		interactivityUtils: utils,
+		page,
+	} ) => {
+		// This test uses a block that dynamically imports @wordpress/interactivity
+		// on DOMContentLoaded. Since there are no static imports of the library
+		// on this page, the library will be loaded after DOMContentLoaded fires.
+		// This verifies that hydration is not skipped when the library is loaded
+		// after that event.
+		await page.goto( utils.getLink( 'hydration-timing-async' ) );
+
+		// Wait for the async hydration status element to be present.
+		const asyncHydrationStatus = page.getByTestId(
+			'async-hydration-status'
+		);
+		await expect( asyncHydrationStatus ).toBeVisible();
+
+		// The async module should have loaded after DOMContentLoaded.
+		const asyncModuleLoaded = page.getByTestId( 'async-module-loaded' );
+		await expect( asyncModuleLoaded ).toHaveText( 'yes' );
+
+		// Hydration should have occurred even though the library was loaded
+		// after DOMContentLoaded.
+		const asyncHydrated = page.getByTestId( 'async-hydrated' );
+		await expect( asyncHydrated ).toHaveText( 'true' );
 	} );
 } );

--- a/test/e2e/specs/interactivity/hydration-timing.spec.ts
+++ b/test/e2e/specs/interactivity/hydration-timing.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * Internal dependencies
+ */
+import { test, expect } from './fixtures';
+
+test.describe( 'hydration timing', () => {
+	test.beforeAll( async ( { interactivityUtils: utils } ) => {
+		await utils.activatePlugins();
+		// Create a post with both blocks using a core/group wrapper.
+		// The "fast" block's module loads immediately, while the "slow"
+		// block's module will be delayed in the test to simulate slow
+		// network conditions.
+		await utils.addPostWithBlock( 'core/group', {
+			alias: 'hydration-timing',
+			innerBlocks: [
+				[ 'test/hydration-timing' ],
+				[ 'test/hydration-timing-slow' ],
+			],
+		} );
+	} );
+
+	test.afterAll( async ( { interactivityUtils: utils } ) => {
+		await utils.deactivatePlugins();
+		await utils.deleteAllPosts();
+	} );
+
+	test( 'should wait for all static imports before hydrating even with delayed module loading', async ( {
+		interactivityUtils: utils,
+		page,
+	} ) => {
+		// Delay only the "slow" module to simulate slow network conditions.
+		// The "fast" module loads immediately and imports @wordpress/interactivity,
+		// which could trigger hydration before the slow module finishes loading.
+		await page.route(
+			/hydration-timing-slow\/view\.js/,
+			async ( route ) => {
+				// Add a 500ms delay to simulate slow module loading.
+				await new Promise( ( resolve ) => setTimeout( resolve, 500 ) );
+				await route.continue();
+			}
+		);
+
+		await page.goto( utils.getLink( 'hydration-timing' ) );
+
+		// Wait for the hydration status elements to be present.
+		const fastHydrationStatus = page.getByTestId( 'hydration-status' );
+		await expect( fastHydrationStatus ).toBeVisible();
+
+		const slowHydrationStatus = page.getByTestId( 'slow-hydration-status' );
+		await expect( slowHydrationStatus ).toBeVisible();
+
+		// Ensure both modules have loaded.
+		const moduleLoaded = page.getByTestId( 'module-loaded' );
+		const slowModuleLoaded = page.getByTestId( 'slow-module-loaded' );
+		await expect( moduleLoaded ).toHaveText( 'yes' );
+		await expect( slowModuleLoaded ).toHaveText( 'yes' );
+
+		// Both init callbacks should have run during hydration.
+		const contextInitialized = page.getByTestId( 'context-initialized' );
+		const slowContextInitialized = page.getByTestId(
+			'slow-context-initialized'
+		);
+		await expect( contextInitialized ).toHaveText( 'true' );
+		await expect( slowContextInitialized ).toHaveText( 'true' );
+	} );
+} );

--- a/test/e2e/specs/interactivity/hydration-timing.spec.ts
+++ b/test/e2e/specs/interactivity/hydration-timing.spec.ts
@@ -41,8 +41,8 @@ test.describe( 'hydration timing', () => {
 		await page.route(
 			/hydration-timing-slow\/view\.js/,
 			async ( route ) => {
-				// Add a 500ms delay to simulate slow module loading.
-				await new Promise( ( resolve ) => setTimeout( resolve, 500 ) );
+				// Add a noticeable delay to simulate slow module loading.
+				await new Promise( ( resolve ) => setTimeout( resolve, 3000 ) );
 				await route.continue();
 			}
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #70870 and #74184.

<!-- In a few words, what is the PR actually doing? -->
Revisits the initialization logic to clarify all steps and when they run. Also, fixes a race condition during the iAPI initialization, causing a bug in the Image block.

For now, this PR serves more as an exploration to discuss possible implementations.

## Why?

See #70870 for the initial motivation.
See #74184 for the Image block bug.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Basically, the code changes are as follows:
1. All initialization has been moved to `index.ts`. There is no longer any initialization of isolated parts in internal modules, as was the case with the initial state and config.
2. The `init.ts` file has been renamed `hydration.ts`, as it only involves the hydration part. The `init()` function is now called `hydrateRegions()`.
3. To delay hydration right after all sync modules have been executed, a util named `isDOMReady` has been implemented. This function relies on [domContentLoadedEventStart](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming/domContentLoadedEventStart) to detect whether the `DOMContentLoaded` event has been dispatched. If not, it registers an event listener for that event, ensuring that all sync modules statically importing `@wordpress/interactivity` have been evaluated before hydration, preventing errors from missing state, actions, or callbacks. If dispatched, hydration is guaranteed; however, missing properties at hydration time may cause directives such as `data-wp-init` to fail.

## Testing Instructions

1. Follow the steps described in #74184, with network throttling enabled (3G should work).
2. Ensure no error appears now in the console after closing the image lightbox.
3. Ensure scrolling works after closing the image lightbox.
