### PR TITLE
iAPI: Skip directive execution for "lazy" derived state props

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/render.php
@@ -14,17 +14,12 @@ wp_interactivity_state(
 );
 
 wp_interactivity_state(
-	'test/deferred-store/bind',
+	'test/deferred-store/derived-state',
 	array(
-		'value' => function () {
+		'value'   => function () {
 			$context = wp_interactivity_get_context( 'test/deferred-store/bind' );
 			return $context['counter'] * 2;
 		},
-	)
-);
-wp_interactivity_state(
-	'test/deferred-store/class',
-	array(
 		'below10' => function () {
 			$context = wp_interactivity_get_context( 'test/deferred-store/class' );
 			return $context['counter'] < 10;
@@ -39,8 +34,10 @@ add_filter(
 			$data = array();
 		}
 		$data['derivedStatePropsAccessed'] = array(
-			'test/deferred-store/bind'  => array( 'state.value' ),
-			'test/deferred-store/class' => array( 'state.below10' ),
+			'test/deferred-store/derived-state' => array(
+				'state.value',
+				'state.below10',
+			),
 		);
 		return $data;
 	}
@@ -59,7 +56,13 @@ add_filter(
 	<span data-wp-text="state.double" data-testid="state-double"></span>
 </div>
 
-<div data-wp-interactive="test/deferred-store/bind" data-wp-context='{"counter": 42}'>
+<div data-wp-interactive="test/deferred-store/derived-state">
+	<button data-wp-on--click="actions.load" data-testid="derived-state-load">load</button>
+	<span hidden data-wp-bind--hidden="!state.hydrated" data-testid="derived-state-hydrated">hydrated</span>
+	<span hidden data-wp-bind--hidden="!state.loaded" data-testid="derived-state-loaded">loaded</span>
+</div>
+
+<div data-wp-interactive="test/deferred-store/derived-state" data-wp-context='{"counter": 42}'>
 	<input
 		name="derived-bind"
 		type="text"
@@ -69,12 +72,9 @@ add_filter(
 		data-testid="derived-bind-value"
 	>
 	<button data-wp-on--click="actions.increment" data-testid="derived-bind-increment">+</button>
-	<button data-wp-on--click="actions.load" data-testid="derived-bind-load">load</button>
-	<span hidden data-wp-bind--hidden="!state.hydrated" data-testid="derived-bind-hydrated">hydrated</span>
-	<span hidden data-wp-bind--hidden="!state.loaded" data-testid="derived-bind-loaded">loaded</span>
 </div>
 
-<div data-wp-interactive="test/deferred-store/class" data-wp-context='{"counter": 9}'>
+<div data-wp-interactive="test/deferred-store/derived-state" data-wp-context='{"counter": 9}'>
 	<output
 		class="below-10"
 		data-wp-class--below-10="state.below10"
@@ -82,7 +82,4 @@ add_filter(
 		data-testid="derived-class-element"
 	>NaN</output>
 	<button data-wp-on--click="actions.increment" data-testid="derived-class-increment">+</button>
-	<button data-wp-on--click="actions.load" data-testid="derived-class-load">load</button>
-	<span hidden data-wp-bind--hidden="!state.hydrated" data-testid="derived-class-hydrated">hydrated</span>
-	<span hidden data-wp-bind--hidden="!state.loaded" data-testid="derived-class-loaded">loaded</span>
 </div>

--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/render.php
@@ -113,6 +113,9 @@ add_filter(
 		<template data-wp-each="state.radiotelephonicAlphabet">
 			<li data-wp-text="context.item"></li>
 		</template>
+		<li data-wp-each-child="test/deferred-store/derived-state::state.radiotelephonicAlphabet" data-wp-text="context.item">alpha</li>
+		<li data-wp-each-child="test/deferred-store/derived-state::state.radiotelephonicAlphabet" data-wp-text="context.item">bravo</li>
+		<li data-wp-each-child="test/deferred-store/derived-state::state.radiotelephonicAlphabet" data-wp-text="context.item">charlie</li>
 	</ol>
 	<button data-wp-on--click="actions.addItem" data-testid="derived-each-additem">+</button>
 </div>

--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/render.php
@@ -13,6 +13,39 @@ wp_interactivity_state(
 	)
 );
 
+wp_interactivity_state(
+	'test/deferred-store/bind',
+	array(
+		'value' => function () {
+			$context = wp_interactivity_get_context( 'test/deferred-store/bind' );
+			return $context['counter'] * 2;
+		},
+	)
+);
+wp_interactivity_state(
+	'test/deferred-store/class',
+	array(
+		'below10' => function () {
+			$context = wp_interactivity_get_context( 'test/deferred-store/class' );
+			return $context['counter'] < 10;
+		},
+	)
+);
+
+add_filter(
+	'script_module_data_@wordpress/interactivity',
+	function ( $data ) {
+		if ( ! isset( $data ) ) {
+			$data = array();
+		}
+		$data['derivedStatePropsAccessed'] = array(
+			'test/deferred-store/bind'  => array( 'state.value' ),
+			'test/deferred-store/class' => array( 'state.below10' ),
+		);
+		return $data;
+	}
+);
+
 ?>
 
 <div
@@ -24,4 +57,32 @@ wp_interactivity_state(
 
 	<span data-wp-text="state.number" data-testid="state-number"></span>
 	<span data-wp-text="state.double" data-testid="state-double"></span>
+</div>
+
+<div data-wp-interactive="test/deferred-store/bind" data-wp-context='{"counter": 42}'>
+	<input
+		name="derived-bind"
+		type="text"
+		value="bind-42"
+		readonly
+		data-wp-bind--value="state.value"
+		data-testid="derived-bind-value"
+	>
+	<button data-wp-on--click="actions.increment" data-testid="derived-bind-increment">+</button>
+	<button data-wp-on--click="actions.load" data-testid="derived-bind-load">load</button>
+	<span hidden data-wp-bind--hidden="!state.hydrated" data-testid="derived-bind-hydrated">hydrated</span>
+	<span hidden data-wp-bind--hidden="!state.loaded" data-testid="derived-bind-loaded">loaded</span>
+</div>
+
+<div data-wp-interactive="test/deferred-store/class" data-wp-context='{"counter": 9}'>
+	<output
+		class="below-10"
+		data-wp-class--below-10="state.below10"
+		data-wp-text="context.counter"
+		data-testid="derived-class-element"
+	>NaN</output>
+	<button data-wp-on--click="actions.increment" data-testid="derived-class-increment">+</button>
+	<button data-wp-on--click="actions.load" data-testid="derived-class-load">load</button>
+	<span hidden data-wp-bind--hidden="!state.hydrated" data-testid="derived-class-hydrated">hydrated</span>
+	<span hidden data-wp-bind--hidden="!state.loaded" data-testid="derived-class-loaded">loaded</span>
 </div>

--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/render.php
@@ -87,6 +87,14 @@ add_filter(
 		data-wp-bind--value="state.value"
 		data-testid="derived-bind-value"
 	>
+	<input
+		name="derived-bind-2"
+		type="text"
+		value="bind-42"
+		readonly
+		data-wp-bind--value="state.existingValue"
+		data-testid="derived-bind-value-2"
+	>
 	<button data-wp-on--click="actions.increment" data-testid="derived-bind-increment">+</button>
 </div>
 

--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/render.php
@@ -17,11 +17,11 @@ wp_interactivity_state(
 	'test/deferred-store/derived-state',
 	array(
 		'value'   => function () {
-			$context = wp_interactivity_get_context( 'test/deferred-store/bind' );
-			return $context['counter'] * 2;
+			$context = wp_interactivity_get_context( 'test/deferred-store/derived-state' );
+			return 'bind-' . $context['counter'];
 		},
 		'below10' => function () {
-			$context = wp_interactivity_get_context( 'test/deferred-store/class' );
+			$context = wp_interactivity_get_context( 'test/deferred-store/derived-state' );
 			return $context['counter'] < 10;
 		},
 	)

--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/render.php
@@ -16,13 +16,21 @@ wp_interactivity_state(
 wp_interactivity_state(
 	'test/deferred-store/derived-state',
 	array(
-		'value'   => function () {
+		'value'                   => function () {
 			$context = wp_interactivity_get_context( 'test/deferred-store/derived-state' );
 			return 'bind-' . $context['counter'];
 		},
-		'below10' => function () {
+		'below10'                 => function () {
 			$context = wp_interactivity_get_context( 'test/deferred-store/derived-state' );
 			return $context['counter'] < 10;
+		},
+		'redOrGreen'              => function () {
+			$context = wp_interactivity_get_context( 'test/deferred-store/derived-state' );
+			return $context['isReady'] ? 'rgb(0, 255, 0)' : 'rgb(255, 0, 0)';
+		},
+		'derivedText'             => function () {
+			$context = wp_interactivity_get_context( 'test/deferred-store/derived-state' );
+			return $context['isReady'] ? 'client-updated text' : 'server-rendered text';
 		},
 		'radiotelephonicAlphabet' => function () {
 			$context = wp_interactivity_get_context( 'test/deferred-store/derived-state' );
@@ -52,6 +60,8 @@ add_filter(
 			'test/deferred-store/derived-state' => array(
 				'state.value',
 				'state.below10',
+				'state.redOrGreen',
+				'state.derivedText',
 				'state.radiotelephonicAlphabet',
 			),
 		);
@@ -106,6 +116,23 @@ add_filter(
 		data-testid="derived-class-element"
 	>NaN</output>
 	<button data-wp-on--click="actions.increment" data-testid="derived-class-increment">+</button>
+</div>
+
+<div data-wp-interactive="test/deferred-store/derived-state" data-wp-context='{"isReady": false}'>
+	<output
+		style="color:red;"
+		data-wp-style--color="state.redOrGreen"
+		data-testid="derived-style-element"
+	>Style</output>
+	<button data-wp-on--click="actions.setReady" data-testid="derived-style-ready">Set ready</button>
+</div>
+
+<div data-wp-interactive="test/deferred-store/derived-state" data-wp-context='{"isReady": false}'>
+	<output
+		data-wp-text="state.derivedText"
+		data-testid="derived-text-element"
+	>server-rendered text</output>
+	<button data-wp-on--click="actions.setReady" data-testid="derived-text-update">Update</button>
 </div>
 
 <div data-wp-interactive="test/deferred-store/derived-state" data-wp-context='{"list": ["a", "b", "c"]}'>

--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/render.php
@@ -24,6 +24,21 @@ wp_interactivity_state(
 			$context = wp_interactivity_get_context( 'test/deferred-store/derived-state' );
 			return $context['counter'] < 10;
 		},
+		'radiotelephonicAlphabet' => function () {
+			$context = wp_interactivity_get_context( 'test/deferred-store/derived-state' );
+			$dictionary = array(
+				'a' => 'alpha',
+				'b' => 'bravo',
+				'c' => 'charlie',
+				'd' => 'delta',
+			);
+			return array_map(
+				function ( $item ) use ( $dictionary ) {
+					return $dictionary[ $item ];
+				},
+				$context['list']
+			);
+		},
 	)
 );
 
@@ -37,6 +52,7 @@ add_filter(
 			'test/deferred-store/derived-state' => array(
 				'state.value',
 				'state.below10',
+				'state.radiotelephonicAlphabet',
 			),
 		);
 		return $data;
@@ -82,4 +98,13 @@ add_filter(
 		data-testid="derived-class-element"
 	>NaN</output>
 	<button data-wp-on--click="actions.increment" data-testid="derived-class-increment">+</button>
+</div>
+
+<div data-wp-interactive="test/deferred-store/derived-state" data-wp-context='{"list": ["a", "b", "c"]}'>
+	<ol data-testid="derived-each-list">
+		<template data-wp-each="state.radiotelephonicAlphabet">
+			<li data-wp-text="context.item"></li>
+		</template>
+	</ol>
+	<button data-wp-on--click="actions.addItem" data-testid="derived-each-additem">+</button>
 </div>

--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/render.php
@@ -56,7 +56,7 @@ add_filter(
 		if ( ! isset( $data ) ) {
 			$data = array();
 		}
-		$data['derivedStatePropsAccessed'] = array(
+		$data['derivedStateClosures'] = array(
 			'test/deferred-store/derived-state' => array(
 				'state.value',
 				'state.below10',

--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.js
@@ -37,9 +37,12 @@ window.addEventListener(
 	{ once: true }
 );
 
-store( 'test/deferred-store/derived-state', {
+const { state } = store( 'test/deferred-store/derived-state', {
 	state: {
 		hydrated: true,
+		get existingValue() {
+			return state.value;
+		},
 	},
 	actions: {
 		load() {

--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.js
@@ -37,39 +37,19 @@ window.addEventListener(
 	{ once: true }
 );
 
-store( 'test/deferred-store/bind', {
+store( 'test/deferred-store/derived-state', {
 	state: {
 		hydrated: true,
 	},
 	actions: {
 		load() {
-			store( 'test/deferred-store/bind', {
+			store( 'test/deferred-store/derived-state', {
 				state: {
 					loaded: true,
 					get value() {
 						const { counter } = getContext();
 						return `bind-${ counter }`;
 					},
-				},
-				actions: {
-					increment() {
-						getContext().counter += 1;
-					},
-				},
-			} );
-		},
-	},
-} );
-
-store( 'test/deferred-store/class', {
-	state: {
-		hydrated: true,
-	},
-	actions: {
-		load() {
-			store( 'test/deferred-store/class', {
-				state: {
-					loaded: true,
 					get below10() {
 						const { counter } = getContext();
 						return counter < 10;

--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.js
@@ -57,6 +57,16 @@ const { state } = store( 'test/deferred-store/derived-state', {
 						const { counter } = getContext();
 						return counter < 10;
 					},
+					get redOrGreen() {
+						const { isReady } = getContext();
+						return isReady ? 'rgb(0, 255, 0)' : 'rgb(255, 0, 0)';
+					},
+					get derivedText() {
+						const { isReady } = getContext();
+						return isReady
+							? 'client-updated text'
+							: 'server-rendered text';
+					},
 					get radiotelephonicAlphabet() {
 						const { list } = getContext();
 						const dictionary = {
@@ -71,6 +81,9 @@ const { state } = store( 'test/deferred-store/derived-state', {
 				actions: {
 					increment() {
 						getContext().counter += 1;
+					},
+					setReady() {
+						getContext().isReady = true;
 					},
 					addItem() {
 						const { list } = getContext();

--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.js
@@ -36,3 +36,51 @@ window.addEventListener(
 	},
 	{ once: true }
 );
+
+store( 'test/deferred-store/bind', {
+	state: {
+		hydrated: true,
+	},
+	actions: {
+		load() {
+			store( 'test/deferred-store/bind', {
+				state: {
+					loaded: true,
+					get value() {
+						const { counter } = getContext();
+						return `bind-${ counter }`;
+					},
+				},
+				actions: {
+					increment() {
+						getContext().counter += 1;
+					},
+				},
+			} );
+		},
+	},
+} );
+
+store( 'test/deferred-store/class', {
+	state: {
+		hydrated: true,
+	},
+	actions: {
+		load() {
+			store( 'test/deferred-store/class', {
+				state: {
+					loaded: true,
+					get below10() {
+						const { counter } = getContext();
+						return counter < 10;
+					},
+				},
+				actions: {
+					increment() {
+						getContext().counter += 1;
+					},
+				},
+			} );
+		},
+	},
+} );

--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/view.js
@@ -54,10 +54,26 @@ store( 'test/deferred-store/derived-state', {
 						const { counter } = getContext();
 						return counter < 10;
 					},
+					get radiotelephonicAlphabet() {
+						const { list } = getContext();
+						const dictionary = {
+							a: 'alpha',
+							b: 'bravo',
+							c: 'charlie',
+							d: 'delta',
+						};
+						return list.map( ( item ) => dictionary[ item ] );
+					},
 				},
 				actions: {
 					increment() {
 						getContext().counter += 1;
+					},
+					addItem() {
+						const { list } = getContext();
+						if ( list.length === 3 ) {
+							list.push( 'd' );
+						}
 					},
 				},
 			} );

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -928,7 +928,20 @@ export default () => {
 	);
 
 	// data-wp-each-child (internal use only)
-	directive( 'each-child', () => null, { priority: 1 } );
+	directive(
+		'each-child',
+		( { directives: { 'each-child': eachChild }, element, evaluate } ) => {
+			const entry = eachChild.find( isDefaultDirectiveSuffix );
+
+			if ( ! entry ) {
+				return;
+			}
+
+			const iterable = evaluate( entry );
+			return iterable === PENDING_GETTER ? element : null;
+		},
+		{ priority: 1 }
+	);
 
 	// data-wp-router-region
 	directive(

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -30,6 +30,7 @@ import {
 	getEvaluate,
 	isDefaultDirectiveSuffix,
 	isNonDefaultDirectiveSuffix,
+	NOT_RESOLVED,
 	type DirectiveCallback,
 	type DirectiveEntry,
 } from './hooks';
@@ -205,6 +206,9 @@ const getGlobalEventDirective = (
 				useInit( () => {
 					const cb = ( event: Event ) => {
 						const result = evaluate( entry );
+						if ( result === NOT_RESOLVED ) {
+							return;
+						}
 						if ( typeof result === 'function' ) {
 							if ( ! result?.sync ) {
 								event = wrapEventAsync( event );
@@ -241,6 +245,9 @@ const getGlobalAsyncEventDirective = (
 					const cb = async ( event: Event ) => {
 						await splitTask();
 						const result = evaluate( entry );
+						if ( result === NOT_RESOLVED ) {
+							return;
+						}
 						if ( typeof result === 'function' ) {
 							result( event );
 						}
@@ -371,6 +378,9 @@ export default () => {
 					}
 				}
 				let result = evaluate( entry );
+				if ( result === NOT_RESOLVED ) {
+					return;
+				}
 				if ( typeof result === 'function' ) {
 					result = result();
 				}
@@ -412,6 +422,9 @@ export default () => {
 					}
 				}
 				let result = evaluate( entry );
+				if ( result === NOT_RESOLVED ) {
+					return;
+				}
 				if ( typeof result === 'function' ) {
 					result = result();
 				}
@@ -471,6 +484,9 @@ export default () => {
 						}
 					}
 					const result = evaluate( entry );
+					if ( result === NOT_RESOLVED ) {
+						return;
+					}
 					if ( typeof result === 'function' ) {
 						if ( ! result?.sync ) {
 							event = wrapEventAsync( event );
@@ -526,6 +542,9 @@ export default () => {
 					entries.forEach( async ( entry ) => {
 						await splitTask();
 						const result = evaluate( entry );
+						if ( result === NOT_RESOLVED ) {
+							return;
+						}
 						if ( typeof result === 'function' ) {
 							result( event );
 						}
@@ -559,6 +578,9 @@ export default () => {
 						? `${ entry.suffix }---${ entry.uniqueId }`
 						: entry.suffix;
 					let result = evaluate( entry );
+					if ( result === NOT_RESOLVED ) {
+						return;
+					}
 					if ( typeof result === 'function' ) {
 						result = result();
 					}
@@ -608,6 +630,9 @@ export default () => {
 			}
 			const styleProp = entry.suffix;
 			let result = evaluate( entry );
+			if ( result === NOT_RESOLVED ) {
+				return;
+			}
 			if ( typeof result === 'function' ) {
 				result = result();
 			}
@@ -651,6 +676,9 @@ export default () => {
 			}
 			const attribute = entry.suffix;
 			let result = evaluate( entry );
+			if ( result === NOT_RESOLVED ) {
+				return;
+			}
 			if ( typeof result === 'function' ) {
 				result = result();
 			}
@@ -772,6 +800,9 @@ export default () => {
 			}
 			try {
 				let result = evaluate( entry );
+				if ( result === NOT_RESOLVED ) {
+					return;
+				}
 				if ( typeof result === 'function' ) {
 					result = result();
 				}
@@ -792,6 +823,9 @@ export default () => {
 				}
 			}
 			let result = evaluate( entry );
+			if ( result === NOT_RESOLVED ) {
+				return;
+			}
 			if ( typeof result === 'function' ) {
 				result = result();
 			}
@@ -840,6 +874,9 @@ export default () => {
 			}
 
 			let iterable = evaluate( entry );
+			if ( iterable === NOT_RESOLVED ) {
+				return;
+			}
 			if ( typeof iterable === 'function' ) {
 				iterable = iterable();
 			}

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -30,7 +30,7 @@ import {
 	getEvaluate,
 	isDefaultDirectiveSuffix,
 	isNonDefaultDirectiveSuffix,
-	NOT_RESOLVED,
+	PENDING_GETTER,
 	type DirectiveCallback,
 	type DirectiveEntry,
 } from './hooks';
@@ -206,7 +206,7 @@ const getGlobalEventDirective = (
 				useInit( () => {
 					const cb = ( event: Event ) => {
 						const result = evaluate( entry );
-						if ( result === NOT_RESOLVED ) {
+						if ( result === PENDING_GETTER ) {
 							return;
 						}
 						if ( typeof result === 'function' ) {
@@ -245,7 +245,7 @@ const getGlobalAsyncEventDirective = (
 					const cb = async ( event: Event ) => {
 						await splitTask();
 						const result = evaluate( entry );
-						if ( result === NOT_RESOLVED ) {
+						if ( result === PENDING_GETTER ) {
 							return;
 						}
 						if ( typeof result === 'function' ) {
@@ -378,7 +378,7 @@ export default () => {
 					}
 				}
 				let result = evaluate( entry );
-				if ( result === NOT_RESOLVED ) {
+				if ( result === PENDING_GETTER ) {
 					return;
 				}
 				if ( typeof result === 'function' ) {
@@ -422,7 +422,7 @@ export default () => {
 					}
 				}
 				let result = evaluate( entry );
-				if ( result === NOT_RESOLVED ) {
+				if ( result === PENDING_GETTER ) {
 					return;
 				}
 				if ( typeof result === 'function' ) {
@@ -484,7 +484,7 @@ export default () => {
 						}
 					}
 					const result = evaluate( entry );
-					if ( result === NOT_RESOLVED ) {
+					if ( result === PENDING_GETTER ) {
 						return;
 					}
 					if ( typeof result === 'function' ) {
@@ -542,7 +542,7 @@ export default () => {
 					entries.forEach( async ( entry ) => {
 						await splitTask();
 						const result = evaluate( entry );
-						if ( result === NOT_RESOLVED ) {
+						if ( result === PENDING_GETTER ) {
 							return;
 						}
 						if ( typeof result === 'function' ) {
@@ -578,7 +578,7 @@ export default () => {
 						? `${ entry.suffix }---${ entry.uniqueId }`
 						: entry.suffix;
 					let result = evaluate( entry );
-					if ( result === NOT_RESOLVED ) {
+					if ( result === PENDING_GETTER ) {
 						return;
 					}
 					if ( typeof result === 'function' ) {
@@ -630,7 +630,7 @@ export default () => {
 			}
 			const styleProp = entry.suffix;
 			let result = evaluate( entry );
-			if ( result === NOT_RESOLVED ) {
+			if ( result === PENDING_GETTER ) {
 				return;
 			}
 			if ( typeof result === 'function' ) {
@@ -676,7 +676,7 @@ export default () => {
 			}
 			const attribute = entry.suffix;
 			let result = evaluate( entry );
-			if ( result === NOT_RESOLVED ) {
+			if ( result === PENDING_GETTER ) {
 				return;
 			}
 			if ( typeof result === 'function' ) {
@@ -800,7 +800,7 @@ export default () => {
 			}
 			try {
 				let result = evaluate( entry );
-				if ( result === NOT_RESOLVED ) {
+				if ( result === PENDING_GETTER ) {
 					return;
 				}
 				if ( typeof result === 'function' ) {
@@ -823,7 +823,7 @@ export default () => {
 				}
 			}
 			let result = evaluate( entry );
-			if ( result === NOT_RESOLVED ) {
+			if ( result === PENDING_GETTER ) {
 				return;
 			}
 			if ( typeof result === 'function' ) {
@@ -874,7 +874,7 @@ export default () => {
 			}
 
 			let iterable = evaluate( entry );
-			if ( iterable === NOT_RESOLVED ) {
+			if ( iterable === PENDING_GETTER ) {
 				return;
 			}
 			if ( typeof iterable === 'function' ) {

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -30,12 +30,12 @@ import {
 	getEvaluate,
 	isDefaultDirectiveSuffix,
 	isNonDefaultDirectiveSuffix,
-	PENDING_GETTER,
 	type DirectiveCallback,
 	type DirectiveEntry,
 } from './hooks';
 import { getScope } from './scopes';
 import { proxifyState, proxifyContext, deepMerge } from './proxies';
+import { PENDING_GETTER } from './proxies/state';
 
 const warnUniqueIdWithTwoHyphens = (
 	prefix: string,

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -206,9 +206,6 @@ const getGlobalEventDirective = (
 				useInit( () => {
 					const cb = ( event: Event ) => {
 						const result = evaluate( entry );
-						if ( result === PENDING_GETTER ) {
-							return;
-						}
 						if ( typeof result === 'function' ) {
 							if ( ! result?.sync ) {
 								event = wrapEventAsync( event );
@@ -245,9 +242,6 @@ const getGlobalAsyncEventDirective = (
 					const cb = async ( event: Event ) => {
 						await splitTask();
 						const result = evaluate( entry );
-						if ( result === PENDING_GETTER ) {
-							return;
-						}
 						if ( typeof result === 'function' ) {
 							result( event );
 						}
@@ -378,9 +372,6 @@ export default () => {
 					}
 				}
 				let result = evaluate( entry );
-				if ( result === PENDING_GETTER ) {
-					return;
-				}
 				if ( typeof result === 'function' ) {
 					result = result();
 				}
@@ -422,9 +413,6 @@ export default () => {
 					}
 				}
 				let result = evaluate( entry );
-				if ( result === PENDING_GETTER ) {
-					return;
-				}
 				if ( typeof result === 'function' ) {
 					result = result();
 				}
@@ -484,9 +472,6 @@ export default () => {
 						}
 					}
 					const result = evaluate( entry );
-					if ( result === PENDING_GETTER ) {
-						return;
-					}
 					if ( typeof result === 'function' ) {
 						if ( ! result?.sync ) {
 							event = wrapEventAsync( event );
@@ -542,9 +527,6 @@ export default () => {
 					entries.forEach( async ( entry ) => {
 						await splitTask();
 						const result = evaluate( entry );
-						if ( result === PENDING_GETTER ) {
-							return;
-						}
 						if ( typeof result === 'function' ) {
 							result( event );
 						}
@@ -823,9 +805,6 @@ export default () => {
 				}
 			}
 			let result = evaluate( entry );
-			if ( result === PENDING_GETTER ) {
-				return;
-			}
 			if ( typeof result === 'function' ) {
 				result = result();
 			}

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -23,7 +23,7 @@ import {
 	universalUnlock,
 	derivedStatePropsAccessed,
 } from './store';
-import { warn, type SyncAwareFunction } from './utils';
+import { warn, isPlainObject, type SyncAwareFunction } from './utils';
 import { getScope, setScope, resetScope, type Scope } from './scopes';
 export interface DirectiveEntry {
 	value: string | object;
@@ -208,6 +208,11 @@ export const directive = (
 
 export const PENDING_GETTER = Symbol( 'PENDING_GETTER' );
 
+const isAnInvokedGetter = ( namespace: string, path: string ) =>
+	( derivedStatePropsAccessed[ namespace ] as string[] )?.some(
+		( getterPath ) => path === getterPath
+	);
+
 // Resolve the path to some property of the store object.
 const resolve = ( path: string, namespace: string ) => {
 	if ( ! namespace ) {
@@ -230,21 +235,26 @@ const resolve = ( path: string, namespace: string ) => {
 		...resolvedStore,
 		context: getScope().context[ namespace ],
 	};
-	const isAnInvokedGetter = (
-		derivedStatePropsAccessed[ namespace ] as string[]
-	 )?.find( ( getterPath ) => path.startsWith( getterPath ) );
 
 	try {
-		return path.split( '.' ).reduce( ( acc, key ) => {
+		const pathParts = path.split( '.' );
+		return pathParts.reduce( ( acc, key, index ) => {
 			// Subscribe to the prop, even when it doesn't exist yet.
 			const value = acc[ key ];
-			if ( ! ( key in acc ) ) {
-				throw new Error( 'Property not resolved' );
+			if (
+				// Getters are serialized as plain objects from PHP.
+				isPlainObject( value ) &&
+				isAnInvokedGetter(
+					namespace,
+					pathParts.slice( 0, index + 1 ).join( '.' )
+				)
+			) {
+				throw PENDING_GETTER;
 			}
 			return value;
 		}, current );
 	} catch ( e ) {
-		if ( isAnInvokedGetter ) {
+		if ( e === PENDING_GETTER ) {
 			return PENDING_GETTER;
 		}
 	}

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -17,7 +17,12 @@ import type { VNode, Context } from 'preact';
 /**
  * Internal dependencies
  */
-import { store, stores, universalUnlock } from './store';
+import {
+	store,
+	stores,
+	universalUnlock,
+	derivedStatePropsAccessed,
+} from './store';
 import { warn, type SyncAwareFunction } from './utils';
 import { getScope, setScope, resetScope, type Scope } from './scopes';
 export interface DirectiveEntry {
@@ -201,7 +206,7 @@ export const directive = (
 	directivePriorities[ name ] = priority;
 };
 
-export const NOT_RESOLVED = Symbol( 'NOT_RESOLVED' );
+export const PENDING_GETTER = Symbol( 'PENDING_GETTER' );
 
 // Resolve the path to some property of the store object.
 const resolve = ( path: string, namespace: string ) => {
@@ -225,15 +230,24 @@ const resolve = ( path: string, namespace: string ) => {
 		...resolvedStore,
 		context: getScope().context[ namespace ],
 	};
+	const isAnInvokedGetter = (
+		derivedStatePropsAccessed[ namespace ] as string[]
+	 )?.find( ( getterPath ) => path.startsWith( getterPath ) );
+
 	try {
-		return path
-			.split( '.' )
-			.reduce(
-				( acc, key ) =>
-					key in acc ? acc[ key ] : acc[ key ] || NOT_RESOLVED,
-				current
-			);
-	} catch ( e ) {}
+		return path.split( '.' ).reduce( ( acc, key ) => {
+			// Subscribe to the prop, even when it doesn't exist yet.
+			const value = acc[ key ];
+			if ( ! ( key in acc ) ) {
+				throw new Error( 'Property not resolved' );
+			}
+			return value;
+		}, current );
+	} catch ( e ) {
+		if ( isAnInvokedGetter ) {
+			return PENDING_GETTER;
+		}
+	}
 };
 
 // Generate the evaluate function.
@@ -280,7 +294,7 @@ export const getEvaluate: GetEvaluate =
 		}
 		const result = value;
 		resetScope();
-		return hasNegationOperator && value !== NOT_RESOLVED
+		return hasNegationOperator && value !== PENDING_GETTER
 			? ! result
 			: result;
 	};

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -201,6 +201,8 @@ export const directive = (
 	directivePriorities[ name ] = priority;
 };
 
+export const NOT_RESOLVED = Symbol( 'NOT_RESOLVED' );
+
 // Resolve the path to some property of the store object.
 const resolve = ( path: string, namespace: string ) => {
 	if ( ! namespace ) {
@@ -224,8 +226,13 @@ const resolve = ( path: string, namespace: string ) => {
 		context: getScope().context[ namespace ],
 	};
 	try {
-		// TODO: Support lazy/dynamically initialized stores
-		return path.split( '.' ).reduce( ( acc, key ) => acc[ key ], current );
+		return path
+			.split( '.' )
+			.reduce(
+				( acc, key ) =>
+					key in acc ? acc[ key ] : acc[ key ] || NOT_RESOLVED,
+				current
+			);
 	} catch ( e ) {}
 };
 
@@ -273,7 +280,9 @@ export const getEvaluate: GetEvaluate =
 		}
 		const result = value;
 		resetScope();
-		return hasNegationOperator ? ! result : result;
+		return hasNegationOperator && value !== NOT_RESOLVED
+			? ! result
+			: result;
 	};
 
 // Separate directives by priority. The resulting array contains objects

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -17,14 +17,10 @@ import type { VNode, Context } from 'preact';
 /**
  * Internal dependencies
  */
-import {
-	store,
-	stores,
-	universalUnlock,
-	derivedStatePropsAccessed,
-} from './store';
-import { warn, isPlainObject, type SyncAwareFunction } from './utils';
+import { store, stores, universalUnlock } from './store';
+import { warn, type SyncAwareFunction } from './utils';
 import { getScope, setScope, resetScope, type Scope } from './scopes';
+import { PENDING_GETTER } from './proxies/state';
 export interface DirectiveEntry {
 	value: string | object;
 	namespace: string;
@@ -206,13 +202,6 @@ export const directive = (
 	directivePriorities[ name ] = priority;
 };
 
-export const PENDING_GETTER = Symbol( 'PENDING_GETTER' );
-
-const isAnInvokedGetter = ( namespace: string, path: string ) =>
-	( derivedStatePropsAccessed[ namespace ] as string[] )?.some(
-		( getterPath ) => path === getterPath
-	);
-
 // Resolve the path to some property of the store object.
 const resolve = ( path: string, namespace: string ) => {
 	if ( ! namespace ) {
@@ -238,21 +227,7 @@ const resolve = ( path: string, namespace: string ) => {
 
 	try {
 		const pathParts = path.split( '.' );
-		return pathParts.reduce( ( acc, key, index ) => {
-			// Subscribe to the prop, even when it doesn't exist yet.
-			const value = acc[ key ];
-			if (
-				// Getters are serialized as plain objects from PHP.
-				isPlainObject( value ) &&
-				isAnInvokedGetter(
-					namespace,
-					pathParts.slice( 0, index + 1 ).join( '.' )
-				)
-			) {
-				throw PENDING_GETTER;
-			}
-			return value;
-		}, current );
+		return pathParts.reduce( ( acc, key ) => acc[ key ], current );
 	} catch ( e ) {
 		if ( e === PENDING_GETTER ) {
 			return PENDING_GETTER;

--- a/packages/interactivity/src/proxies/state.ts
+++ b/packages/interactivity/src/proxies/state.ts
@@ -98,6 +98,8 @@ const objToIterable = new WeakMap< object, Signal< number > >();
  */
 let peeking = false;
 
+export const PENDING_GETTER = Symbol( 'PENDING_GETTER' );
+
 /**
  * Handlers for reactive objects and arrays in the state.
  */
@@ -121,6 +123,10 @@ const stateHandlers: ProxyHandler< object > = {
 		const desc = Object.getOwnPropertyDescriptor( target, key );
 		const prop = getPropSignal( receiver, key, desc );
 		const result = prop.getComputed().value;
+
+		if ( result === PENDING_GETTER ) {
+			throw PENDING_GETTER;
+		}
 
 		/*
 		 * Check if the property is a synchronous function. If it is, set the

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -285,7 +285,7 @@ export const parseServerData = ( dom = document ) => {
 export const populateServerData = ( data?: {
 	state?: Record< string, unknown >;
 	config?: Record< string, unknown >;
-	derivedStatePropsAccessed?: Record< string, string[] >;
+	derivedStateClosures?: Record< string, string[] >;
 } ) => {
 	// Resets all the previous server states and configs.
 	serverStates.clear();
@@ -303,8 +303,8 @@ export const populateServerData = ( data?: {
 			storeConfigs.set( namespace, config );
 		} );
 	}
-	if ( isPlainObject( data?.derivedStatePropsAccessed ) ) {
-		Object.entries( data!.derivedStatePropsAccessed ).forEach(
+	if ( isPlainObject( data?.derivedStateClosures ) ) {
+		Object.entries( data!.derivedStateClosures ).forEach(
 			( [ namespace, paths ] ) => {
 				const st = store< any >(
 					namespace,

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { proxifyState, proxifyStore, deepMerge } from './proxies';
+import { PENDING_GETTER } from './proxies/state';
 import { getNamespace } from './namespaces';
 import { isPlainObject, deepReadOnly, navigationSignal } from './utils';
 import type { DeepReadonly } from './utils';
@@ -284,6 +285,7 @@ export const parseServerData = ( dom = document ) => {
 export const populateServerData = ( data?: {
 	state?: Record< string, unknown >;
 	config?: Record< string, unknown >;
+	derivedStatePropsAccessed?: Record< string, string[] >;
 } ) => {
 	// Resets all the previous server states and configs.
 	serverStates.clear();
@@ -301,12 +303,31 @@ export const populateServerData = ( data?: {
 			storeConfigs.set( namespace, config );
 		} );
 	}
+	if ( isPlainObject( data?.derivedStatePropsAccessed ) ) {
+		Object.entries( data!.derivedStatePropsAccessed ).forEach(
+			( [ namespace, paths ] ) => {
+				const st = store< any >(
+					namespace,
+					{},
+					{ lock: universalUnlock }
+				);
+				paths.forEach( ( path ) => {
+					const pathParts = path.split( '.' );
+					const prop = pathParts.splice( -1, 1 )[ 0 ];
+					const parent = pathParts.reduce(
+						( prev, key ) => prev[ key ],
+						st
+					);
+					if ( isPlainObject( parent[ prop ] ) ) {
+						parent[ prop ] = PENDING_GETTER;
+					}
+				} );
+			}
+		);
+	}
 	navigationSignal.value += 1; // Triggers invalidations.
 };
 
 // Parse and populate the initial state and config.
 const data = parseServerData();
 populateServerData( data );
-
-// TODO: move this to another file once the iAPI initialization is refactored.
-export const derivedStatePropsAccessed = data?.derivedStatePropsAccessed || {};

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -309,4 +309,4 @@ const data = parseServerData();
 populateServerData( data );
 
 // TODO: move this to another file once the iAPI initialization is refactored.
-export const derivedStatePropsAccessed = data.derivedStatePropsAccessed || {};
+export const derivedStatePropsAccessed = data?.derivedStatePropsAccessed || {};

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -307,3 +307,6 @@ export const populateServerData = ( data?: {
 // Parse and populate the initial state and config.
 const data = parseServerData();
 populateServerData( data );
+
+// TODO: move this to another file once the iAPI initialization is refactored.
+export const derivedStatePropsAccessed = data.derivedStatePropsAccessed || {};

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -217,7 +217,11 @@ export function toVdom( root: Node ): ComponentChild {
 			}
 		}
 
-		if ( localName === 'template' ) {
+		if ( props.__directives?.[ 'each-child' ] ) {
+			props.dangerouslySetInnerHTML = {
+				__html: elementNode.innerHTML,
+			};
+		} else if ( localName === 'template' ) {
 			props.content = [
 				...( elementNode as HTMLTemplateElement ).content.childNodes,
 			].map( ( childNode ) => toVdom( childNode ) );

--- a/test/e2e/specs/interactivity/deferred-store.spec.ts
+++ b/test/e2e/specs/interactivity/deferred-store.spec.ts
@@ -52,7 +52,7 @@ test.describe( 'deferred store', () => {
 		await expect( stateDouble ).toHaveText( '6' );
 	} );
 
-	test( 'Ensure bind keeps the value of a derived state props from deferred store', async ( {
+	test( 'Ensure wp-bind keeps the value of a derived state props from deferred store', async ( {
 		page,
 	} ) => {
 		const load = page.getByTestId( 'derived-state-load' );
@@ -86,7 +86,7 @@ test.describe( 'deferred store', () => {
 		await expect( value2 ).toHaveValue( 'bind-43' );
 	} );
 
-	test( 'Ensure class keeps the value of a derived state props from deferred store', async ( {
+	test( 'Ensure wp-class keeps the value of a derived state props from deferred store', async ( {
 		page,
 	} ) => {
 		const load = page.getByTestId( 'derived-state-load' );
@@ -113,6 +113,64 @@ test.describe( 'deferred store', () => {
 		await increment.click();
 		await expect( loaded ).toBeVisible();
 		await expect( element ).not.toHaveClass( 'below-10' );
+	} );
+
+	test( 'Ensure wp-style keeps the value of a derived state props from deferred store', async ( {
+		page,
+	} ) => {
+		const load = page.getByTestId( 'derived-state-load' );
+		const loaded = page.getByTestId( 'derived-state-loaded' );
+		const hydrated = page.getByTestId( 'derived-state-hydrated' );
+		const setReady = page.getByTestId( 'derived-style-ready' );
+		const element = page.getByTestId( 'derived-style-element' );
+
+		await expect( hydrated ).toBeVisible();
+		await expect( loaded ).toBeHidden();
+		await expect( element ).toHaveCSS( 'color', 'rgb(255, 0, 0)' );
+
+		// The `setReady` button doesn't work yet; nothing changes.
+		await setReady.click();
+		await expect( loaded ).toBeHidden();
+		await expect( element ).toHaveCSS( 'color', 'rgb(255, 0, 0)' );
+
+		// The element color is maintained according to the computed getter.
+		await load.click();
+		await expect( loaded ).toBeVisible();
+		await expect( element ).toHaveCSS( 'color', 'rgb(255, 0, 0)' );
+
+		// The button works, and the color updated.
+		await setReady.click();
+		await expect( loaded ).toBeVisible();
+		await expect( element ).toHaveCSS( 'color', 'rgb(0, 255, 0)' );
+	} );
+
+	test( 'Ensure wp-text keeps the value of a derived state props from deferred store', async ( {
+		page,
+	} ) => {
+		const load = page.getByTestId( 'derived-state-load' );
+		const loaded = page.getByTestId( 'derived-state-loaded' );
+		const hydrated = page.getByTestId( 'derived-state-hydrated' );
+		const update = page.getByTestId( 'derived-text-update' );
+		const element = page.getByTestId( 'derived-text-element' );
+
+		await expect( hydrated ).toBeVisible();
+		await expect( loaded ).toBeHidden();
+		await expect( element ).toHaveText( 'server-rendered text' );
+
+		// The `update` button doesn't work yet; nothing changes.
+		await update.click();
+		await expect( loaded ).toBeHidden();
+		await expect( element ).toHaveText( 'server-rendered text' );
+
+		// The element text is maintained according to the computed getter.
+		await load.click();
+		await expect( loaded ).toBeVisible();
+		await expect( element ).toHaveText( 'server-rendered text' );
+
+		// The button works, and the text updated.
+		await update.click();
+		await expect( loaded ).toBeVisible();
+		await expect( element ).toHaveText( 'client-updated text' );
 	} );
 
 	test( 'Ensure wp-each keeps server-rendered children until the list is ready', async ( {

--- a/test/e2e/specs/interactivity/deferred-store.spec.ts
+++ b/test/e2e/specs/interactivity/deferred-store.spec.ts
@@ -114,4 +114,39 @@ test.describe( 'deferred store', () => {
 		await expect( loaded ).toBeVisible();
 		await expect( element ).not.toHaveClass( 'below-10' );
 	} );
+
+	test( 'Ensure wp-each keeps server-rendered children until the list is ready', async ( {
+		page,
+	} ) => {
+		const load = page.getByTestId( 'derived-state-load' );
+		const loaded = page.getByTestId( 'derived-state-loaded' );
+		const hydrated = page.getByTestId( 'derived-state-hydrated' );
+		const addItem = page.getByTestId( 'derived-each-additem' );
+		const element = page.getByTestId( 'derived-each-list' );
+		const items = element.getByRole( 'listitem' );
+
+		await expect( hydrated ).toBeVisible();
+		await expect( loaded ).toBeHidden();
+		await expect( items ).toHaveText( [ 'alpha', 'bravo', 'charlie' ] );
+
+		// The `addItem` button doesn't work yet; nothing changes.
+		await addItem.click();
+		await expect( loaded ).toBeHidden();
+		await expect( items ).toHaveText( [ 'alpha', 'bravo', 'charlie' ] );
+
+		// The list items are recreated according to the computed getter.
+		await load.click();
+		await expect( loaded ).toBeVisible();
+		await expect( items ).toHaveText( [ 'alpha', 'bravo', 'charlie' ] );
+
+		// The button works, and a new item is added.
+		await addItem.click();
+		await expect( loaded ).toBeVisible();
+		await expect( items ).toHaveText( [
+			'alpha',
+			'bravo',
+			'charlie',
+			'delta',
+		] );
+	} );
 } );

--- a/test/e2e/specs/interactivity/deferred-store.spec.ts
+++ b/test/e2e/specs/interactivity/deferred-store.spec.ts
@@ -60,25 +60,30 @@ test.describe( 'deferred store', () => {
 		const hydrated = page.getByTestId( 'derived-state-hydrated' );
 		const increment = page.getByTestId( 'derived-bind-increment' );
 		const value = page.getByTestId( 'derived-bind-value' );
+		const value2 = page.getByTestId( 'derived-bind-value-2' );
 
 		await expect( hydrated ).toBeVisible();
 		await expect( loaded ).toBeHidden();
 		await expect( value ).toHaveValue( 'bind-42' );
+		await expect( value2 ).toHaveValue( 'bind-42' );
 
 		// The `+` button doesn't work yet; nothing changes.
 		await increment.click();
 		await expect( loaded ).toBeHidden();
 		await expect( value ).toHaveValue( 'bind-42' );
+		await expect( value2 ).toHaveValue( 'bind-42' );
 
 		// The element displays the derived state prop's value from the getter.
 		await load.click();
 		await expect( loaded ).toBeVisible();
 		await expect( value ).toHaveValue( 'bind-42' );
+		await expect( value2 ).toHaveValue( 'bind-42' );
 
 		// The button works, and the value updated.
 		await increment.click();
 		await expect( loaded ).toBeVisible();
 		await expect( value ).toHaveValue( 'bind-43' );
+		await expect( value2 ).toHaveValue( 'bind-43' );
 	} );
 
 	test( 'Ensure class keeps the value of a derived state props from deferred store', async ( {

--- a/test/e2e/specs/interactivity/deferred-store.spec.ts
+++ b/test/e2e/specs/interactivity/deferred-store.spec.ts
@@ -55,9 +55,9 @@ test.describe( 'deferred store', () => {
 	test( 'Ensure bind keeps the value of a derived state props from deferred store', async ( {
 		page,
 	} ) => {
-		const load = page.getByTestId( 'derived-bind-load' );
-		const loaded = page.getByTestId( 'derived-bind-loaded' );
-		const hydrated = page.getByTestId( 'derived-bind-hydrated' );
+		const load = page.getByTestId( 'derived-state-load' );
+		const loaded = page.getByTestId( 'derived-state-loaded' );
+		const hydrated = page.getByTestId( 'derived-state-hydrated' );
 		const increment = page.getByTestId( 'derived-bind-increment' );
 		const value = page.getByTestId( 'derived-bind-value' );
 
@@ -84,9 +84,9 @@ test.describe( 'deferred store', () => {
 	test( 'Ensure class keeps the value of a derived state props from deferred store', async ( {
 		page,
 	} ) => {
-		const load = page.getByTestId( 'derived-class-load' );
-		const loaded = page.getByTestId( 'derived-class-loaded' );
-		const hydrated = page.getByTestId( 'derived-class-hydrated' );
+		const load = page.getByTestId( 'derived-state-load' );
+		const loaded = page.getByTestId( 'derived-state-loaded' );
+		const hydrated = page.getByTestId( 'derived-state-hydrated' );
 		const increment = page.getByTestId( 'derived-class-increment' );
 		const element = page.getByTestId( 'derived-class-element' );
 

--- a/test/e2e/specs/interactivity/deferred-store.spec.ts
+++ b/test/e2e/specs/interactivity/deferred-store.spec.ts
@@ -51,4 +51,62 @@ test.describe( 'deferred store', () => {
 		await expect( stateNumber ).toHaveText( '3' );
 		await expect( stateDouble ).toHaveText( '6' );
 	} );
+
+	test( 'Ensure bind keeps the value of a derived state props from deferred store', async ( {
+		page,
+	} ) => {
+		const load = page.getByTestId( 'derived-bind-load' );
+		const loaded = page.getByTestId( 'derived-bind-loaded' );
+		const hydrated = page.getByTestId( 'derived-bind-hydrated' );
+		const increment = page.getByTestId( 'derived-bind-increment' );
+		const value = page.getByTestId( 'derived-bind-value' );
+
+		await expect( hydrated ).toBeVisible();
+		await expect( loaded ).toBeHidden();
+		await expect( value ).toHaveValue( 'bind-42' );
+
+		// The `+` button doesn't work yet; nothing changes.
+		await increment.click();
+		await expect( loaded ).toBeHidden();
+		await expect( value ).toHaveValue( 'bind-42' );
+
+		// The element displays the derived state prop's value from the getter.
+		await load.click();
+		await expect( loaded ).toBeVisible();
+		await expect( value ).toHaveValue( 'bind-42' );
+
+		// The button works, and the value updated.
+		await increment.click();
+		await expect( loaded ).toBeVisible();
+		await expect( value ).toHaveValue( 'bind-43' );
+	} );
+
+	test( 'Ensure class keeps the value of a derived state props from deferred store', async ( {
+		page,
+	} ) => {
+		const load = page.getByTestId( 'derived-class-load' );
+		const loaded = page.getByTestId( 'derived-class-loaded' );
+		const hydrated = page.getByTestId( 'derived-class-hydrated' );
+		const increment = page.getByTestId( 'derived-class-increment' );
+		const element = page.getByTestId( 'derived-class-element' );
+
+		await expect( hydrated ).toBeVisible();
+		await expect( loaded ).toBeHidden();
+		await expect( element ).toHaveClass( 'below-10' );
+
+		// The `increment` button doesn't work yet; nothing changes.
+		await increment.click();
+		await expect( loaded ).toBeHidden();
+		await expect( element ).toHaveClass( 'below-10' );
+
+		// The element class disappears according to the computed getter.
+		await load.click();
+		await expect( loaded ).toBeVisible();
+		await expect( element ).toHaveClass( 'below-10' );
+
+		// The button works, and the class updated.
+		await increment.click();
+		await expect( loaded ).toBeVisible();
+		await expect( element ).not.toHaveClass( 'below-10' );
+	} );
 } );


### PR DESCRIPTION
## What?

Closes #70872

Makes directives to return without any change if their paths point to a pending getter ("lazy" derived state props).

Directives that support pending getters with these changes:
- `data-wp-bind`
- `data-wp-class`
- `data-wp-style`
- `data-wp-text`
- `data-wp-each` (partially)

Requires the changes of https://github.com/WordPress/wordpress-develop/pull/9673.

## Why?

See #70872.

Derived state (getters) cannot be serialized at this moment. When directives use a getter, the initial values in the HTML are correctly rendered thanks to server-side rendering, but as soon as they are hydrated, their values disappear. This happens because the value they get when they try to read the getter is undefined.

It is not until the getter is added with store() that the directives get the expected value.

## How?

The logic that marks state props as pending getters lives inside `populateServerData`. Pending getters are listed in the `derivedStatePropsAccessed`, in the initial server data, and are serialized as empty objects from PHP. These properties are assigned the `Symbol('PENDING_GETTER')` value.

Properties that are pending getters (i.e., have the value `Symbol('PENDING_GETTER')`) throw when accessed. The thrown value is the same symbol that identifies them as pending getters.

The `evaluate` function, when the evaluated property throws with `Symbol('PENDING_GETTER')`, either because the referenced value is a pending getter or it depends on a pending getter, captures the error, and returns the same symbol. Directive functions then handle that value and skip the directive execution while subscribing to the pending getter.

**data-wp-each**

This case is complex to solve, and required a compromise solution.

When server-rendered, a `data-wp-each` template could depend on multiple pending getters accessed by other directives inside. That would require capturing any `PENDING_GETTER` error and handling that situation for the whole rendered vDOM tree inside `data-wp-each`.

In addition, the server-side rendered `data-wp-each-child` elements are independent from the related `data-wp-each` element, which causes issues if they hydrate the HTML elements instead of `data-wp-each`. To properly fix this, it would require capturing these elements inside `toVdom` and passing them to the corresponding `data-wp-each` element as children, taking into account the potential text nodes surrounding the HTML elements and such, which is not trivial.

For now, a `data-wp-each` directive will only support the case where the list property is a pending getter or depends on a pending getter. This decision assumes that,  if a `data-wp-each` element depends on a pending getter, and so other elements inside it, all pending getters will be defined in the same module, which will make all getters available at the same time.

## Testing Instructions

This PR requires the changes in WordPress/wordpress-develop#9673 to be tested properly.

1. Create a custom interactive block using `npx @wordpress/create-block@latest test-derived-state --template @wordpress/create-block-interactive-template`.
2. Use the following code for `render.php` and `view.js`:
   <details>
   <summary>render.php</summary>

   ```php
   <?php
   wp_interactivity_state(
       'test-derived-state',
       array(
           'value'                   => function () {
               $context = wp_interactivity_get_context( 'test-derived-state' );
               return 'bind-' . $context['counter'];
           },
           'dependsOnStateValue'     => function () {
               $state = wp_interactivity_state( 'test-derived-state' );
               return $state['value']();
           },
           'below10'                 => function () {
               $context = wp_interactivity_get_context( 'test-derived-state' );
               return $context['counter'] < 10;
           },
           'redOrGreen'              => function () {
               $context = wp_interactivity_get_context( 'test-derived-state' );
               return $context['isReady'] ? 'rgb(0, 255, 0)' : 'rgb(255, 0, 0)';
           },
           'derivedText'             => function () {
               $context = wp_interactivity_get_context( 'test-derived-state' );
               return $context['isReady'] ? 'client-updated text' : 'server-rendered text';
           },
           'radiotelephonicAlphabet' => function () {
               $context = wp_interactivity_get_context( 'test-derived-state' );
               $dictionary = array(
                   'a' => 'alpha',
                   'b' => 'bravo',
                   'c' => 'charlie',
                   'd' => 'delta',
               );
               return array_map(
                   function ( $item ) use ( $dictionary ) {
                       return $dictionary[ $item ];
                   },
                   $context['list']
               );
           },
       )
   );
   ?>
   
   <div
       <?php echo get_block_wrapper_attributes(); ?>
       data-wp-interactive="test-derived-state"
   >
       <div>
           <button data-wp-on--click="actions.load">load</button>
           <span hidden data-wp-bind--hidden="!state.hydrated">hydrated</span>
           <span hidden data-wp-bind--hidden="!state.loaded">loaded</span>
       </div>
   
       <div data-wp-context='{"counter": 42}'>
           <input
               name="derived-bind"
               type="text"
               value="bind-42"
               readonly
               data-wp-bind--value="state.value"
           >
           <input
               name="derived-bind-2"
               type="text"
               value="bind-42"
               readonly
               data-wp-bind--value="state.dependsOnStateValue"
           >
           <button data-wp-on--click="actions.increment">+</button>
       </div>
   
       <div data-wp-context='{"counter": 9}'>
           <output
               class="below-10"
               data-wp-class--below-10="state.below10"
               data-wp-text="context.counter"
           >NaN</output>
           <button data-wp-on--click="actions.increment">+</button>
       </div>
   
       <div data-wp-context='{"isReady": false}'>
           <output
               style="color:red;"
               data-wp-style--color="state.redOrGreen"
           >Style</output>
           <button data-wp-on--click="actions.setReady">Set ready</button>
       </div>
   
       <div data-wp-context='{"isReady": false}'>
           <output
               data-wp-text="state.derivedText"
           >server-rendered text</output>
           <button data-wp-on--click="actions.setReady">Update</button>
       </div>
   
       <div data-wp-context='{"list": ["a", "b", "c"]}'>
           <ol>
               <template data-wp-each="state.radiotelephonicAlphabet">
                   <li data-wp-text="context.item"></li>
               </template>
               <li data-wp-each-child="test-derived-state::state.radiotelephonicAlphabet" data-wp-text="context.item">alpha</li>
               <li data-wp-each-child="test-derived-state::state.radiotelephonicAlphabet" data-wp-text="context.item">bravo</li>
               <li data-wp-each-child="test-derived-state::state.radiotelephonicAlphabet" data-wp-text="context.item">charlie</li>
           </ol>
           <button data-wp-on--click="actions.addItem">+</button>
       </div>
   </div>
   ```

   </details>
   <details>
   <summary>view.js</summary>

   ```js
   /**
    * WordPress dependencies
    */
   import { store, getContext } from "@wordpress/interactivity";
   
   const { state } = store("test-derived-state", {
     state: {
       hydrated: true,
       get dependsOnStateValue() {
         return state.value;
       },
     },
     actions: {
       load() {
         store("test-derived-state", {
           state: {
             loaded: true,
             get value() {
               const { counter } = getContext();
               return `bind-${counter}`;
             },
             get below10() {
               const { counter } = getContext();
               return counter < 10;
             },
             get redOrGreen() {
               const { isReady } = getContext();
               return isReady ? "rgb(0, 255, 0)" : "rgb(255, 0, 0)";
             },
             get derivedText() {
               const { isReady } = getContext();
               return isReady ? "client-updated text" : "server-rendered text";
             },
             get radiotelephonicAlphabet() {
               const { list } = getContext();
               const dictionary = {
                 a: "alpha",
                 b: "bravo",
                 c: "charlie",
                 d: "delta",
               };
               return list.map((item) => dictionary[item]);
             },
           },
           actions: {
             increment() {
               getContext().counter += 1;
             },
             setReady() {
               getContext().isReady = true;
             },
             addItem() {
               const { list } = getContext();
               if (list.length === 3) {
                 list.push("d");
               }
             },
           },
         });
       },
     },
   });
   ```
   
   </details>
3. Compile the block and add it to a post.
4. Visit the post.
5. Ensure the server-rendered content is visible, although the JavaScript state has not loaded yet and the elements are not interactive.
6. Click on the `load` button.
7. Ensure the HTML remains the same.
8. Interact with the elements.
9. Ensure the elements are interactive now.