### PR TITLE
Automated Testing: Re-enable storybook smoke test

### DIFF
--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -34,14 +34,14 @@ jobs:
             - name: Build Storybook
               run: npm run storybook:build
 
-            # - name: Install Playwright dependencies
-            #   run: npx playwright install --with-deps
+            - name: Install Playwright dependencies
+              run: npx --no-install playwright install --with-deps
 
-            # - name: Serve Storybook and run tests
-            #   run: |
-            #       npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
-            #       "npx http-server ./storybook/build --port 50240 --silent" \
-            #       "npx wait-on tcp:127.0.0.1:50240 && \
-            #       NODE_PATH=./node_modules \
-            #       npx --package=@storybook/test-runner -- \
-            #       test-storybook --url http://localhost:50240 --config-dir ./storybook"
+            - name: Serve Storybook and run tests
+              run: |
+                  npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
+                  "npx http-server ./storybook/build --port 50240 --silent" \
+                  "npx wait-on tcp:127.0.0.1:50240 && \
+                  NODE_PATH=./node_modules \
+                  npx --package=@storybook/test-runner@0.22.1 -- \
+                  test-storybook --url http://localhost:50240 --config-dir ./storybook"

--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -35,7 +35,7 @@ jobs:
               run: npm run storybook:build
 
             - name: Install Playwright dependencies
-              run: npx --no-install playwright install --with-deps
+              run: npx --no playwright install --with-deps
 
             - name: Serve Storybook and run tests
               run: |


### PR DESCRIPTION
## What?

This PR re-enables the storybook smoke test and makes some enhancements to prevent CI failures in the feature.

## Why?

To prevent Storybook stories from breaking, #69679 added a smoke test. However, it was subsequently skipped by #69943 due to CI failures caused by a new release of Playwright.

We need to re-enable this CI to ensure that storybook stories don't break.

## How?

I used the `--no-install` flag to avoid any impact from future Playwright upgrades. This should install the local installation of Playwright. This change should not be necessary as #70503 has updated the local playwright to the latest version, but it is a precaution for the future.

Additionally, I have pinned the test runner version to `0.22.1`, as the latest version of the test runner causes CI to fail with the following error:

```
[TEST] Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './internal/csf' is not defined by "exports" in /home/runner/work/gutenberg/gutenberg/node_modules/storybook/package.json
```

Example: https://github.com/WordPress/gutenberg/actions/runs/16819117756/job/47642444066

My guess is that the following change made in the test runner version `0.23.0` is the cause:

https://github.com/storybookjs/test-runner/pull/556

In the future, if we update Storybook to the latest version, we will be able to remove this pinned version.

## Testing Instructions

Check the CI and make sure it's properly smoke tested.

https://github.com/WordPress/gutenberg/actions/runs/16819975585/job/47644834408?pr=71126

<img width="390" height="138" alt="image" src="https://github.com/user-attachments/assets/8fc48359-cbc1-49a6-b2e4-fe53814ab1b5" />