### PR TITLE
Add space-around and space-evenly justification options

### DIFF
--- a/packages/block-editor/src/components/justify-content-control/style.scss
+++ b/packages/block-editor/src/components/justify-content-control/style.scss
@@ -14,3 +14,11 @@
 .items-justified-space-between {
 	justify-content: space-between;
 }
+
+.items-justified-space-around {
+	justify-content: space-around;
+}
+
+.items-justified-space-evenly {
+	justify-content: space-evenly;
+}

--- a/packages/block-editor/src/components/justify-content-control/ui.js
+++ b/packages/block-editor/src/components/justify-content-control/ui.js
@@ -7,6 +7,8 @@ import {
 	justifyCenter,
 	justifyRight,
 	justifySpaceBetween,
+	justifySpaceAround,
+	justifySpaceEvenly,
 	justifyStretch,
 } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
@@ -16,6 +18,8 @@ const icons = {
 	center: justifyCenter,
 	right: justifyRight,
 	'space-between': justifySpaceBetween,
+	'space-around': justifySpaceAround,
+	'space-evenly': justifySpaceEvenly,
 	stretch: justifyStretch,
 };
 
@@ -67,6 +71,20 @@ function JustifyContentUI( {
 			title: __( 'Space between items' ),
 			isActive: 'space-between' === value,
 			onClick: () => handleClick( 'space-between' ),
+		},
+		{
+			name: 'space-around',
+			icon: justifySpaceAround,
+			title: __( 'Space around items' ),
+			isActive: 'space-around' === value,
+			onClick: () => handleClick( 'space-around' ),
+		},
+		{
+			name: 'space-evenly',
+			icon: justifySpaceEvenly,
+			title: __( 'Space evenly between items' ),
+			isActive: 'space-evenly' === value,
+			onClick: () => handleClick( 'space-evenly' ),
 		},
 		{
 			name: 'stretch',

--- a/packages/block-editor/src/hooks/layout.scss
+++ b/packages/block-editor/src/hooks/layout.scss
@@ -18,6 +18,17 @@
 	}
 }
 
+.block-editor-hooks__flex-layout-justification-controls {
+	display: inline-flex;
+	flex-wrap: wrap;
+	max-width: 100%;
+
+	.components-toggle-group-control {
+		flex-wrap: wrap;
+		max-width: 100%;
+	}
+}
+
 .block-editor-hooks__grid-layout-columns-and-rows-controls,
 .block-editor-hooks__grid-layout-minimum-width-control {
 	// Reset `fieldset` browser defaults.

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -7,6 +7,8 @@ import {
 	justifyCenter,
 	justifyRight,
 	justifySpaceBetween,
+	justifySpaceAround,
+	justifySpaceEvenly,
 	justifyStretch,
 	arrowRight,
 	arrowDown,
@@ -38,6 +40,8 @@ const justifyContentMap = {
 	right: 'flex-end',
 	center: 'center',
 	'space-between': 'space-between',
+	'space-around': 'space-around',
+	'space-evenly': 'space-evenly',
 };
 
 // Used with the vertical (column) flex orientation.
@@ -249,7 +253,7 @@ function FlexLayoutJustifyContentControl( {
 	};
 	const allowedControls = [ 'left', 'center', 'right' ];
 	if ( orientation === 'horizontal' ) {
-		allowedControls.push( 'space-between' );
+		allowedControls.push( 'space-between', 'space-around', 'space-evenly' );
 	} else {
 		allowedControls.push( 'stretch' );
 	}
@@ -282,11 +286,23 @@ function FlexLayoutJustifyContentControl( {
 		},
 	];
 	if ( orientation === 'horizontal' ) {
-		justificationOptions.push( {
-			value: 'space-between',
-			icon: justifySpaceBetween,
-			label: __( 'Space between items' ),
-		} );
+		justificationOptions.push(
+			{
+				value: 'space-between',
+				icon: justifySpaceBetween,
+				label: __( 'Space between items' ),
+			},
+			{
+				value: 'space-around',
+				icon: justifySpaceAround,
+				label: __( 'Space around items' ),
+			},
+			{
+				value: 'space-evenly',
+				icon: justifySpaceEvenly,
+				label: __( 'Space evenly between items' ),
+			}
+		);
 	} else {
 		justificationOptions.push( {
 			value: 'stretch',
@@ -363,7 +379,11 @@ function OrientationControl( { layout, onChange } ) {
 					if ( verticalAlignment === 'stretch' ) {
 						newVerticalAlignment = 'top';
 					}
-					if ( justifyContent === 'space-between' ) {
+					if (
+						justifyContent === 'space-between' ||
+						justifyContent === 'space-around' ||
+						justifyContent === 'space-evenly'
+					) {
 						newJustification = 'left';
 					}
 				}

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -145,6 +145,8 @@ export { default as justifyCenterVertical } from './library/justify-center-verti
 export { default as justifyRight } from './library/justify-right';
 export { default as justifySpaceBetween } from './library/justify-space-between';
 export { default as justifySpaceBetweenVertical } from './library/justify-space-between-vertical';
+export { default as justifySpaceAround } from './library/justify-space-around';
+export { default as justifySpaceEvenly } from './library/justify-space-evenly';
 export { default as justifyStretch } from './library/justify-stretch';
 export { default as justifyStretchVertical } from './library/justify-stretch-vertical';
 export { default as justifyTop } from './library/justify-top';

--- a/packages/icons/src/library/justify-space-around.tsx
+++ b/packages/icons/src/library/justify-space-around.tsx
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const justifySpaceAround = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M5 4v16h1.5V4H5zm6.5 5h1v6h-1V9zm6 0v16h1.5V4H17.5v5zM9 15h6V9H9v6z" />
+	</SVG>
+);
+
+export default justifySpaceAround;

--- a/packages/icons/src/library/justify-space-evenly.tsx
+++ b/packages/icons/src/library/justify-space-evenly.tsx
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const justifySpaceEvenly = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M4 4v16h1.5V4H4zm7.25 5h1.5v6h-1.5V9zm7.25 0v16H20V4h-1.5v5zM9 15h6V9H9v6z" />
+	</SVG>
+);
+
+export default justifySpaceEvenly;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/42536

This PR adds support for `space-around` and `space-evenly` CSS flexbox justify-content values to the Buttons block.

## Why?
Currently, the Buttons block only supports basic justification options (left, center, right, space-between). Adding `space-around` and `space-evenly` gives users more precise control over button spacing and alignment, especially useful for creating balanced layouts with multiple buttons.

## Testing Instructions
1. Insert a Buttons block
2. Add multiple button items
3. Switch to horizontal orientation
4. Test all 6 justification options:
   - Left, Center, Right (existing)
   - Space Between (existing)
   - **Space Around** (new)
   - **Space Evenly** (new)
5. Verify proper spacing behavior for each option

## Screenshots or screencast <!-- if applicable -->

<img width="1918" height="875" alt="Screenshot 2025-08-08 at 2 57 21 PM" src="https://github.com/user-attachments/assets/f1e3a007-dfc7-4a47-8da4-5dee1a3fbe2d" />

