### PR TITLE
LinkControl: Automatically highlight first suggestion by default

### DIFF
--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -205,9 +205,6 @@ describe( 'Basic rendering', () => {
 			fauxEntitySuggestions.length
 		);
 
-		// Step down into the search results, highlighting the first result item.
-		triggerArrowDown( searchInput );
-
 		const firstSearchSuggestion = searchResultElements[ 0 ];
 		const secondSearchSuggestion = searchResultElements[ 1 ];
 
@@ -215,7 +212,7 @@ describe( 'Basic rendering', () => {
 			selected: true,
 		} );
 
-		// We should have highlighted the first item using the keyboard.
+		// The first item should be highlighted by default.
 		expect( selectedSearchResultElement ).toEqual( firstSearchSuggestion );
 
 		// Check the aria-selected attribute is set only on the highlighted item.
@@ -233,7 +230,7 @@ describe( 'Basic rendering', () => {
 			selected: true,
 		} );
 
-		// We should have highlighted the first item using the keyboard.
+		// We should have highlighted the second item using the keyboard.
 		expect( selectedSearchResultElement ).toEqual( secondSearchSuggestion );
 
 		// Check the aria-selected attribute is omitted on non-highlighted items.
@@ -1702,9 +1699,6 @@ describe( 'Selecting links', () => {
 					name: /Search results for.*/,
 				} );
 
-				// Step down into the search results, highlighting the first result item.
-				triggerArrowDown( searchInput );
-
 				const searchResultElements =
 					within( searchResults ).getAllByRole( 'option' );
 
@@ -1715,7 +1709,7 @@ describe( 'Selecting links', () => {
 					selected: true,
 				} );
 
-				// We should have highlighted the first item using the keyboard.
+				// The first item should be highlighted by default.
 				expect( selectedSearchResultElement ).toBe(
 					firstSearchSuggestion
 				);
@@ -1729,7 +1723,7 @@ describe( 'Selecting links', () => {
 						selected: true,
 					} );
 
-					// We should have highlighted the first item using the keyboard
+					// We should have highlighted the second item using the keyboard
 					// eslint-disable-next-line jest/no-conditional-expect
 					expect( selectedSearchResultElement ).toBe(
 						secondSearchSuggestion
@@ -1786,9 +1780,6 @@ describe( 'Selecting links', () => {
 				name: 'Search or type URL',
 			} );
 
-			// Step down into the search results, highlighting the first result item.
-			triggerArrowDown( searchInput );
-
 			const searchResultElements = within(
 				screen.getByRole( 'listbox', {
 					name: 'Suggestions',
@@ -1802,7 +1793,7 @@ describe( 'Selecting links', () => {
 				selected: true,
 			} );
 
-			// We should have highlighted the first item using the keyboard.
+			// The first item should be highlighted by default.
 			expect( selectedSearchResultElement ).toEqual(
 				firstSearchSuggestion
 			);
@@ -1814,7 +1805,7 @@ describe( 'Selecting links', () => {
 				selected: true,
 			} );
 
-			// We should have highlighted the first item using the keyboard.
+			// We should have highlighted the second item using the keyboard.
 			expect( selectedSearchResultElement ).toEqual(
 				secondSearchSuggestion
 			);

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -191,6 +191,11 @@ class URLInput extends Component {
 					suggestionsValue: value,
 					loading: false,
 					showSuggestions: !! suggestions.length,
+					selectedSuggestion:
+						this.state.selectedSuggestion === null &&
+						suggestions.length > 0
+							? 0
+							: this.state.selectedSuggestion,
 				} );
 
 				if ( !! suggestions.length ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #56161 

<!-- In a few words, what is the PR actually doing? -->
This PR ensures the first search suggestion is highlighted providing a clear feedback to the user that the first suggestion is selected by default.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently when a user searches for a link, no suggestion is initially highlighted, even though pressing Enter would select the first suggestion. This made it unclear which item was going to be selected by default. By highlighting the first suggestion, it gives a feedback to the user of the selected suggestion.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The state of `selectedSuggestion` is updated in `URLInput` based on the previous state. If no suggestion is highlighted and the list is not empty, the first item (index 0) is selected by default.

## Testing Instructions
1. Add a text to a paragraph block.
2. Select the text and add link to it (opens the LinkControl UI)
3. If the list is not empty, ensure the first item is highlighted by default.
4. Search for a term in the input box
5. Observe the first item stays highlighted.
6. Use arrow keys to navigate between suggestions.
7. Ensure the highlighted item changes on keyboard action (up/down)

<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="595" height="303" alt="Screenshot 2025-08-08 at 1 19 55 PM" src="https://github.com/user-attachments/assets/8b43468f-67f2-4c50-b642-302c77fc46ea" />|<img width="609" height="320" alt="Screenshot 2025-08-08 at 1 22 36 PM" src="https://github.com/user-attachments/assets/6995e62d-6791-4c1d-a495-c1b4e65867a3" />|
