### PR TITLE
Explore Navigation Block contentOnly mode UX via Content Panel

### DIFF
--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -73,29 +73,63 @@ function BlockCard( {
 		( { title, icon, description } = blockType );
 	}
 
-	const { parentNavBlockClientId } = useSelect( ( select ) => {
-		const { getSelectedBlockClientId, getBlockParentsByBlockName } =
-			select( blockEditorStore );
+	const { backButtonTarget, showBackButton, buttonLabel } = useSelect(
+		( select ) => {
+			const {
+				getSelectedBlockClientId,
+				getBlockParentsByBlockName,
+				getBlockName,
+				getBlockEditingMode,
+				getParentSectionBlock,
+			} = unlock( select( blockEditorStore ) );
 
-		const _selectedBlockClientId = getSelectedBlockClientId();
+			const _selectedBlockClientId = getSelectedBlockClientId();
+			const selectedBlockName =
+				_selectedBlockClientId &&
+				getBlockName( _selectedBlockClientId );
+			const blockEditingMode =
+				_selectedBlockClientId &&
+				getBlockEditingMode( _selectedBlockClientId );
 
-		return {
-			parentNavBlockClientId: getBlockParentsByBlockName(
+			// If we're in a Navigation block and in contentOnly mode, go to parent section
+			if (
+				selectedBlockName === 'core/navigation' &&
+				blockEditingMode === 'contentOnly'
+			) {
+				const parentSection = getParentSectionBlock(
+					_selectedBlockClientId
+				);
+				return {
+					backButtonTarget: parentSection,
+					showBackButton: !! parentSection,
+					buttonLabel: __( 'Go to parent section' ),
+				};
+			}
+
+			// Otherwise, use the existing logic for parent Navigation block
+			const parentNav = getBlockParentsByBlockName(
 				_selectedBlockClientId,
 				'core/navigation',
 				true
-			)[ 0 ],
-		};
-	}, [] );
+			)[ 0 ];
+
+			return {
+				backButtonTarget: parentNav,
+				showBackButton: !! parentNav,
+				buttonLabel: __( 'Go to parent Navigation block' ),
+			};
+		},
+		[]
+	);
 
 	const { selectBlock } = useDispatch( blockEditorStore );
 
 	return (
 		<div className={ clsx( 'block-editor-block-card', className ) }>
-			{ parentNavBlockClientId && ( // This is only used by the Navigation block for now. It's not ideal having Navigation block specific code here.
+			{ showBackButton && ( // This is only used by the Navigation block for now. It's not ideal having Navigation block specific code here.
 				<Button
-					onClick={ () => selectBlock( parentNavBlockClientId ) }
-					label={ __( 'Go to parent Navigation block' ) }
+					onClick={ () => selectBlock( backButtonTarget ) }
+					label={ buttonLabel }
 					style={
 						// TODO: This style override is also used in ToolsPanelHeader.
 						// It should be supported out-of-the-box by Button.

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -100,11 +100,12 @@ function BlockInspector() {
 			getSelectedBlockCount,
 			getBlockName,
 			getParentSectionBlock,
-			getBlockParentsByBlockName,
 			isSectionBlock: _isSectionBlock,
+			getBlockParentsByBlockName,
 		} = unlock( select( blockEditorStore ) );
 		const { getBlockStyles } = select( blocksStore );
 		const _selectedBlockClientId = getSelectedBlockClientId();
+
 		const currentBlockName =
 			_selectedBlockClientId && getBlockName( _selectedBlockClientId );
 
@@ -145,7 +146,6 @@ function BlockInspector() {
 		};
 	}, [] );
 
-<<<<<<< HEAD
 	// Separate useSelect for contentClientIds with proper dependencies
 	const contentClientIds = useSelect(
 		( select ) => {
@@ -157,16 +157,26 @@ function BlockInspector() {
 				getClientIdsOfDescendants,
 				getBlockName,
 				getBlockEditingMode,
+				getBlockParents,
 			} = unlock( select( blockEditorStore ) );
 
 			const descendants = getClientIdsOfDescendants(
 				selectedBlockClientId
 			);
-			return descendants.filter(
-				( current ) =>
+			return descendants.filter( ( current ) => {
+				// Check if this block is within a navigation context
+				const parents = getBlockParents( current );
+				const isWithinNavigation = parents.some( ( parentId ) => {
+					const parentName = getBlockName( parentId );
+					return parentName === 'core/navigation';
+				} );
+
+				return (
+					! isWithinNavigation &&
 					getBlockName( current ) !== 'core/list-item' &&
 					getBlockEditingMode( current ) === 'contentOnly'
-			);
+				);
+			} );
 		},
 		[ isSectionBlock, selectedBlockClientId ]
 	);
@@ -177,14 +187,11 @@ function BlockInspector() {
 		isSectionBlock,
 		hasBlockStyles
 	);
-	const hasMultipleTabs = availableTabs?.length > 1;
-=======
-	const availableTabs = useInspectorControlsTabs( blockType?.name );
-	const hasMultipleTabs =
-		availableTabs?.length > 1 ||
+
+	const isNavigationLinkBlock =
 		blockType?.name === 'core/navigation-link' ||
 		blockType?.name === 'core/navigation-submenu';
->>>>>>> 846d63aa61d (Add content role to Navigation Link and Submenu label attributes)
+	const hasMultipleTabs = availableTabs?.length > 1 || isNavigationLinkBlock;
 
 	// The block inspector animation settings will be completely
 	// removed in the future to create an API which allows the block
@@ -312,9 +319,6 @@ const BlockInspectorSingleBlock = ( {
 	hasBlockStyles,
 } ) => {
 	const hasMultipleTabs = availableTabs?.length > 1;
-<<<<<<< HEAD
-=======
-
 	const blockEditingMode = useSelect(
 		( select ) =>
 			select( blockEditorStore ).getBlockEditingMode( clientId ),
@@ -323,51 +327,11 @@ const BlockInspectorSingleBlock = ( {
 	const isContentOnlyNavBlock =
 		blockName === 'core/navigation' && blockEditingMode === 'contentOnly';
 
-	const shouldShowTabs =
-		! isSectionBlock && hasMultipleTabs && ! isContentOnlyNavBlock;
->>>>>>> 846d63aa61d (Add content role to Navigation Link and Submenu label attributes)
-
 	const blockInformation = useBlockDisplayInformation( clientId );
-<<<<<<< HEAD
-=======
-	const contentClientIds = useSelect(
-		( select ) => {
-			// Avoid unnecessary subscription.
-			if ( ! isSectionBlock ) {
-				return;
-			}
-
-			const {
-				getClientIdsOfDescendants,
-				getBlockName,
-				getBlockEditingMode,
-				getBlockParents,
-			} = select( blockEditorStore );
-
-			return getClientIdsOfDescendants( clientId ).filter(
-				( current ) => {
-					// Check if this block is within a navigation context
-					const parents = getBlockParents( current );
-					const isWithinNavigation = parents.some( ( parentId ) => {
-						const parentName = getBlockName( parentId );
-						return parentName === 'core/navigation';
-					} );
-
-					return (
-						! isWithinNavigation &&
-						getBlockName( current ) !== 'core/list-item' &&
-						getBlockEditingMode( current ) === 'contentOnly'
-					);
-				}
-			);
-		},
-		[ isSectionBlock, clientId ]
-	);
-
->>>>>>> 846d63aa61d (Add content role to Navigation Link and Submenu label attributes)
 	const isBlockSynced = blockInformation.isSynced;
 
-	const shouldShowTabs = ! isBlockSynced && hasMultipleTabs;
+	const shouldShowTabs =
+		! isBlockSynced && hasMultipleTabs && ! isContentOnlyNavBlock;
 
 	return (
 		<div className="block-editor-block-inspector">
@@ -395,25 +359,7 @@ const BlockInspectorSingleBlock = ( {
 					{ hasBlockStyles && (
 						<BlockStylesPanel clientId={ clientId } />
 					) }
-<<<<<<< HEAD
 					<ContentTab contentClientIds={ contentClientIds } />
-=======
-
-					{ blockName === 'core/navigation' &&
-					blockEditingMode === 'contentOnly' ? (
-						<InspectorControls.Slot group="list" />
-					) : (
-						contentClientIds &&
-						contentClientIds?.length > 0 && (
-							<PanelBody title={ __( 'Content' ) }>
-								<BlockQuickNavigation
-									clientIds={ contentClientIds }
-								/>
-							</PanelBody>
-						)
-					) }
-
->>>>>>> 846d63aa61d (Add content role to Navigation Link and Submenu label attributes)
 					{ ! isSectionBlock && (
 						<StyleInspectorSlots
 							blockName={ blockName }

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -100,13 +100,27 @@ function BlockInspector() {
 			getSelectedBlockCount,
 			getBlockName,
 			getParentSectionBlock,
+			getBlockParentsByBlockName,
 			isSectionBlock: _isSectionBlock,
 		} = unlock( select( blockEditorStore ) );
 		const { getBlockStyles } = select( blocksStore );
 		const _selectedBlockClientId = getSelectedBlockClientId();
+		const currentBlockName =
+			_selectedBlockClientId && getBlockName( _selectedBlockClientId );
+
+		// For Navigation blocks and their children, always show the Navigation block's inspector controls
+		const navigationParents = getBlockParentsByBlockName(
+			_selectedBlockClientId,
+			'core/navigation',
+			true
+		);
+		const isChildOfNavigation = navigationParents.length > 0;
+
 		const renderedBlockClientId =
-			getParentSectionBlock( _selectedBlockClientId ) ||
-			_selectedBlockClientId;
+			currentBlockName === 'core/navigation' || isChildOfNavigation
+				? _selectedBlockClientId
+				: getParentSectionBlock( _selectedBlockClientId ) ||
+				  _selectedBlockClientId;
 		const _selectedBlockName =
 			renderedBlockClientId && getBlockName( renderedBlockClientId );
 		const _blockType =
@@ -131,6 +145,7 @@ function BlockInspector() {
 		};
 	}, [] );
 
+<<<<<<< HEAD
 	// Separate useSelect for contentClientIds with proper dependencies
 	const contentClientIds = useSelect(
 		( select ) => {
@@ -163,6 +178,13 @@ function BlockInspector() {
 		hasBlockStyles
 	);
 	const hasMultipleTabs = availableTabs?.length > 1;
+=======
+	const availableTabs = useInspectorControlsTabs( blockType?.name );
+	const hasMultipleTabs =
+		availableTabs?.length > 1 ||
+		blockType?.name === 'core/navigation-link' ||
+		blockType?.name === 'core/navigation-submenu';
+>>>>>>> 846d63aa61d (Add content role to Navigation Link and Submenu label attributes)
 
 	// The block inspector animation settings will be completely
 	// removed in the future to create an API which allows the block
@@ -290,8 +312,59 @@ const BlockInspectorSingleBlock = ( {
 	hasBlockStyles,
 } ) => {
 	const hasMultipleTabs = availableTabs?.length > 1;
+<<<<<<< HEAD
+=======
+
+	const blockEditingMode = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getBlockEditingMode( clientId ),
+		[ clientId ]
+	);
+	const isContentOnlyNavBlock =
+		blockName === 'core/navigation' && blockEditingMode === 'contentOnly';
+
+	const shouldShowTabs =
+		! isSectionBlock && hasMultipleTabs && ! isContentOnlyNavBlock;
+>>>>>>> 846d63aa61d (Add content role to Navigation Link and Submenu label attributes)
 
 	const blockInformation = useBlockDisplayInformation( clientId );
+<<<<<<< HEAD
+=======
+	const contentClientIds = useSelect(
+		( select ) => {
+			// Avoid unnecessary subscription.
+			if ( ! isSectionBlock ) {
+				return;
+			}
+
+			const {
+				getClientIdsOfDescendants,
+				getBlockName,
+				getBlockEditingMode,
+				getBlockParents,
+			} = select( blockEditorStore );
+
+			return getClientIdsOfDescendants( clientId ).filter(
+				( current ) => {
+					// Check if this block is within a navigation context
+					const parents = getBlockParents( current );
+					const isWithinNavigation = parents.some( ( parentId ) => {
+						const parentName = getBlockName( parentId );
+						return parentName === 'core/navigation';
+					} );
+
+					return (
+						! isWithinNavigation &&
+						getBlockName( current ) !== 'core/list-item' &&
+						getBlockEditingMode( current ) === 'contentOnly'
+					);
+				}
+			);
+		},
+		[ isSectionBlock, clientId ]
+	);
+
+>>>>>>> 846d63aa61d (Add content role to Navigation Link and Submenu label attributes)
 	const isBlockSynced = blockInformation.isSynced;
 
 	const shouldShowTabs = ! isBlockSynced && hasMultipleTabs;
@@ -322,7 +395,25 @@ const BlockInspectorSingleBlock = ( {
 					{ hasBlockStyles && (
 						<BlockStylesPanel clientId={ clientId } />
 					) }
+<<<<<<< HEAD
 					<ContentTab contentClientIds={ contentClientIds } />
+=======
+
+					{ blockName === 'core/navigation' &&
+					blockEditingMode === 'contentOnly' ? (
+						<InspectorControls.Slot group="list" />
+					) : (
+						contentClientIds &&
+						contentClientIds?.length > 0 && (
+							<PanelBody title={ __( 'Content' ) }>
+								<BlockQuickNavigation
+									clientIds={ contentClientIds }
+								/>
+							</PanelBody>
+						)
+					) }
+
+>>>>>>> 846d63aa61d (Add content role to Navigation Link and Submenu label attributes)
 					{ ! isSectionBlock && (
 						<StyleInspectorSlots
 							blockName={ blockName }

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -10,6 +10,7 @@ import {
 	FlexBlock,
 	FlexItem,
 } from '@wordpress/components';
+import { chevronRight } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -42,15 +43,16 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 		clientId,
 		context: 'list-view',
 	} );
-	const { isSelected } = useSelect(
+	const { isSelected, blockName } = useSelect(
 		( select ) => {
-			const { isBlockSelected, hasSelectedInnerBlock } =
+			const { isBlockSelected, hasSelectedInnerBlock, getBlockName } =
 				select( blockEditorStore );
 
 			return {
 				isSelected:
 					isBlockSelected( clientId ) ||
 					hasSelectedInnerBlock( clientId, /* deep: */ true ),
+				blockName: getBlockName( clientId ),
 			};
 		},
 		[ clientId ]
@@ -75,6 +77,11 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 				<FlexBlock style={ { textAlign: 'left' } }>
 					<Truncate>{ blockTitle }</Truncate>
 				</FlexBlock>
+				{ blockName === 'core/navigation' && (
+					<FlexItem>
+						<BlockIcon icon={ chevronRight } />
+					</FlexItem>
+				) }
 			</Flex>
 		</Button>
 	);

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2992,7 +2992,14 @@ export function __unstableHasActiveBlockOverlayActive( state, clientId ) {
 	// 'disabled' then the overlay is redundant since the block can't be
 	// selected. If the mode is 'contentOnly' then the overlay is redundant
 	// since there will be no controls to interact with once selected.
-	if ( getBlockEditingMode( state, clientId ) !== 'default' ) {
+
+	// Exception: Navigation blocks should show overlays in contentOnly mode
+	// to provide visual feedback for the View button functionality.
+	// Todo: consider a supports.__experimentalForceBlockOverlay which blocks
+	// can opt into. We can make this a private API.
+	const blockName = getBlockName( state, clientId );
+	const blockEditingMode = getBlockEditingMode( state, clientId );
+	if ( blockEditingMode !== 'default' && blockName !== 'core/navigation' ) {
 		return false;
 	}
 

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -11,6 +11,8 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	__experimentalVStack as VStack,
+	Button,
 	CheckboxControl,
 	TextControl,
 	TextareaControl,
@@ -30,7 +32,7 @@ import {
 	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP, safeDecodeURI } from '@wordpress/url';
-import { useState, useEffect, useRef } from '@wordpress/element';
+import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { decodeEntities } from '@wordpress/html-entities';
 import { link as linkIcon, addSubmenu } from '@wordpress/icons';
@@ -44,6 +46,7 @@ import { LinkUI } from './link-ui';
 import { updateAttributes } from './update-attributes';
 import { getColors } from '../navigation/edit/utils';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+import { ViewPageSidebarButton } from './shared-view-page-button';
 
 const DEFAULT_BLOCK = { name: 'core/navigation-link' };
 const NESTING_BLOCK_NAMES = [
@@ -193,6 +196,8 @@ function Controls( { attributes, setAttributes, setIsEditingControl } ) {
 			} }
 			dropdownMenuProps={ dropdownMenuProps }
 		>
+			<ViewPageSidebarButton attributes={ attributes } />
+
 			<ToolsPanelItem
 				hasValue={ () => !! label }
 				label={ __( 'Text' ) }

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -139,3 +139,9 @@
 		text-transform: uppercase;
 	}
 }
+
+.components-button.navigation-link-view-page-button {
+	display: block;
+	width: 100%;
+	text-align: center;
+}

--- a/packages/block-library/src/navigation-link/shared-view-page-button.js
+++ b/packages/block-library/src/navigation-link/shared-view-page-button.js
@@ -1,0 +1,103 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
+import { useBlockEditingMode } from '@wordpress/block-editor';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { __experimentalVStack as VStack, Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Shared View Page button component for Navigation blocks
+ *
+ * @param {Object} props - Component props
+ * @param {Object} props.attributes - Block attributes containing kind, id, type
+ * @param {string} props.variant - Button variant (default: 'secondary')
+ * @param {string} props.className - Additional CSS class
+ * @param {Object} props.style - Additional inline styles
+ */
+export function ViewPageButton( {
+	attributes,
+	variant = 'secondary',
+	className = 'navigation-link-view-page-button',
+	style = {},
+} ) {
+	const { kind, id, type } = attributes;
+	const blockEditingMode = useBlockEditingMode();
+	const onNavigateToEntityRecord = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getSettings().onNavigateToEntityRecord,
+		[]
+	);
+
+	const onViewPage = useCallback( () => {
+		if (
+			kind === 'post-type' &&
+			type === 'page' &&
+			id &&
+			onNavigateToEntityRecord
+		) {
+			onNavigateToEntityRecord( {
+				postId: id,
+				postType: type,
+			} );
+		}
+	}, [ kind, id, type, onNavigateToEntityRecord ] );
+
+	// Only show for page-type links, when navigation is available, and when in contentOnly mode.
+	if (
+		kind !== 'post-type' ||
+		type !== 'page' ||
+		! id ||
+		! onNavigateToEntityRecord ||
+		blockEditingMode !== 'contentOnly'
+	) {
+		return null;
+	}
+
+	return (
+		<VStack spacing={ 4 }>
+			<Button
+				__next40pxDefaultSize
+				variant={ variant }
+				onClick={ onViewPage }
+				className={ className }
+				style={ style }
+			>
+				{ __( 'View Page' ) }
+			</Button>
+		</VStack>
+	);
+}
+
+/**
+ * View Page button for toolbar (smaller variant)
+ */
+export function ViewPageToolbarButton( { attributes } ) {
+	return (
+		<ViewPageButton
+			attributes={ attributes }
+			variant="tertiary"
+			className="navigation-view-page-toolbar-button"
+		/>
+	);
+}
+
+/**
+ * View Page button for sidebar (full width variant)
+ */
+export function ViewPageSidebarButton( { attributes } ) {
+	return (
+		<ViewPageButton
+			attributes={ attributes }
+			variant="secondary"
+			className="navigation-link-view-page-button"
+			style={ {
+				display: 'block',
+				width: '100%',
+				textAlign: 'center',
+			} }
+		/>
+	);
+}

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -25,6 +25,7 @@ import {
 	InspectorControls,
 	RichText,
 	useBlockProps,
+	useBlockEditingMode,
 	store as blockEditorStore,
 	getColorClassName,
 } from '@wordpress/block-editor';
@@ -47,6 +48,7 @@ import {
 } from '../navigation/edit/utils';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import { DEFAULT_BLOCK } from '../navigation/constants';
+import { ViewPageSidebarButton } from '../navigation-link/shared-view-page-button';
 
 const ALLOWED_BLOCKS = [
 	'core/navigation-link',
@@ -134,7 +136,16 @@ export default function NavigationSubmenuEdit( {
 } ) {
 	const { label, url, description, rel, opensInNewTab } = attributes;
 
-	const { showSubmenuIcon, maxNestingLevel, openSubmenusOnClick } = context;
+	const {
+		showSubmenuIcon,
+		maxNestingLevel,
+		openSubmenusOnClick: contextOpenSubmenusOnClick,
+	} = context;
+	const blockEditingMode = useBlockEditingMode();
+
+	// Force click-only behavior in contentOnly mode to prevent hover dropdowns
+	const openSubmenusOnClick =
+		blockEditingMode !== 'default' ? true : contextOpenSubmenusOnClick;
 
 	const {
 		__unstableMarkNextChangeAsNotPersistent,
@@ -395,6 +406,7 @@ export default function NavigationSubmenuEdit( {
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
 				>
+					<ViewPageSidebarButton attributes={ attributes } />
 					<ToolsPanelItem
 						label={ __( 'Text' ) }
 						isShownByDefault

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -15,6 +15,7 @@ import {
 } from '@wordpress/element';
 import {
 	InspectorControls,
+	BlockControls,
 	useBlockProps,
 	RecursionProvider,
 	useHasRecursion,
@@ -26,11 +27,12 @@ import {
 	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
 	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
 	useBlockEditingMode,
-	BlockControls,
 } from '@wordpress/block-editor';
 import { EntityProvider, store as coreStore } from '@wordpress/core-data';
 
 import { useDispatch, useSelect } from '@wordpress/data';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { store as interfaceStore } from '@wordpress/interface';
 import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
@@ -39,9 +41,9 @@ import {
 	__experimentalVStack as VStack,
 	ToggleControl,
 	Button,
+	ToolbarButton,
 	Spinner,
 	Notice,
-	ToolbarButton,
 	ToolbarGroup,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -89,10 +91,12 @@ import { DEFAULT_BLOCK } from '../constants';
  * @return {JSX.Element|null} The Add page button component or null if not applicable.
  */
 function NavigationAddPageButton( { clientId } ) {
-	const { insertBlock } = useDispatch( blockEditorStore );
 	const { getBlockCount } = useSelect( blockEditorStore );
+	const { insertBlock } = useDispatch( blockEditorStore );
+	const { enableComplementaryArea } = useDispatch( interfaceStore );
 
 	const onAddPage = useCallback( () => {
+		enableComplementaryArea( 'core', 'edit-post/block' );
 		// Get the current number of blocks to insert at the end
 		const blockCount = getBlockCount( clientId );
 

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -6,6 +6,7 @@ import {
 	useInnerBlocksProps,
 	InnerBlocks,
 	store as blockEditorStore,
+	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
@@ -22,6 +23,7 @@ export default function NavigationInnerBlocks( {
 	orientation,
 	templateLock,
 } ) {
+	const blockEditingMode = useBlockEditingMode();
 	const {
 		isImmediateParentOfSelectedBlock,
 		selectedBlockHasChildren,
@@ -92,14 +94,21 @@ export default function NavigationInnerBlocks( {
 			// This should be a temporary fix, to be replaced by improvements to
 			// the sibling inserter.
 			// See https://github.com/WordPress/gutenberg/issues/37572.
-			renderAppender:
-				isSelected ||
-				( isImmediateParentOfSelectedBlock &&
-					! selectedBlockHasChildren ) ||
-				// Show the appender while dragging to allow inserting element between item and the appender.
-				parentOrChildHasSelection
-					? InnerBlocks.ButtonBlockAppender
-					: false,
+			renderAppender: ( () => {
+				if ( blockEditingMode === 'contentOnly' ) {
+					return false;
+				}
+				if (
+					isSelected ||
+					( isImmediateParentOfSelectedBlock &&
+						! selectedBlockHasChildren ) ||
+					// Show the appender while dragging to allow inserting element between item and the appender.
+					parentOrChildHasSelection
+				) {
+					return InnerBlocks.ButtonBlockAppender;
+				}
+				return false;
+			} )(),
 			placeholder: showPlaceholder ? placeholder : undefined,
 			__experimentalCaptureToolbars: true,
 			__unstableDisableLayoutClassNames: true,

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -6,7 +6,6 @@ import {
 	useInnerBlocksProps,
 	InnerBlocks,
 	store as blockEditorStore,
-	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
@@ -23,7 +22,6 @@ export default function NavigationInnerBlocks( {
 	orientation,
 	templateLock,
 } ) {
-	const blockEditingMode = useBlockEditingMode();
 	const {
 		isImmediateParentOfSelectedBlock,
 		selectedBlockHasChildren,
@@ -95,9 +93,6 @@ export default function NavigationInnerBlocks( {
 			// the sibling inserter.
 			// See https://github.com/WordPress/gutenberg/issues/37572.
 			renderAppender: ( () => {
-				if ( blockEditingMode === 'contentOnly' ) {
-					return false;
-				}
 				if (
 					isSelected ||
 					( isImmediateParentOfSelectedBlock &&

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -25,6 +25,8 @@ import { __, sprintf } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { useState } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { store as interfaceStore } from '@wordpress/interface';
 
 /**
  * Internal dependencies
@@ -108,6 +110,8 @@ export default function TemplatePartEdit( {
 } ) {
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const { editEntityRecord } = useDispatch( coreStore );
+	const { selectBlock } = useDispatch( blockEditorStore );
+	const { enableComplementaryArea } = useDispatch( interfaceStore );
 	const currentTheme = useSelect(
 		( select ) => select( coreStore ).getCurrentTheme()?.stylesheet,
 		[]
@@ -126,11 +130,19 @@ export default function TemplatePartEdit( {
 		onNavigateToEntityRecord,
 		title,
 		canUserEdit,
+		hasNavigationBlocks,
+		firstNavigationBlockId,
+		blockEditingMode,
 	} = useSelect(
 		( select ) => {
 			const { getEditedEntityRecord, hasFinishedResolution } =
 				select( coreStore );
-			const { getBlockCount, getSettings } = select( blockEditorStore );
+			const {
+				getBlockCount,
+				getSettings,
+				getBlocksByName,
+				getBlockParentsByBlockName,
+			} = select( blockEditorStore );
 
 			const getEntityArgs = [
 				'postType',
@@ -156,6 +168,29 @@ export default function TemplatePartEdit( {
 				  } )
 				: false;
 
+			// Check for Navigation blocks within this Template Part
+			const allNavigationBlocks = getBlocksByName( 'core/navigation' );
+			const navigationBlocksInTemplatePart = allNavigationBlocks.filter(
+				( blockId ) => {
+					// Check if this Navigation block is a descendant of the current Template Part
+					const templatePartParents = getBlockParentsByBlockName(
+						blockId,
+						'core/template-part',
+						true
+					);
+					return templatePartParents.includes( clientId );
+				}
+			);
+			const _hasNavigationBlocks =
+				navigationBlocksInTemplatePart.length > 0;
+			const _firstNavigationBlockId = _hasNavigationBlocks
+				? navigationBlocksInTemplatePart[ 0 ]
+				: null;
+
+			// Get block editing mode for the current block
+			const _blockEditingMode =
+				select( blockEditorStore ).getBlockEditingMode( clientId );
+
 			return {
 				hasInnerBlocks: getBlockCount( clientId ) > 0,
 				isResolved: hasResolvedEntity,
@@ -168,6 +203,9 @@ export default function TemplatePartEdit( {
 					getSettings().onNavigateToEntityRecord,
 				title: entityRecord?.title,
 				canUserEdit: !! _canUserEdit,
+				hasNavigationBlocks: _hasNavigationBlocks,
+				firstNavigationBlockId: _firstNavigationBlockId,
+				blockEditingMode: _blockEditingMode,
 			};
 		},
 		[ templatePartId, attributes.area, clientId ]
@@ -232,13 +270,19 @@ export default function TemplatePartEdit( {
 		);
 	}
 
+	/*
+	 * PROTOTYPE HACK: Using different group props to create visual separation
+	 * between toolbar buttons. WordPress automatically adds separators between
+	 * different BlockControls groups. This avoids the need for custom CSS
+	 * while maintaining the standard toolbar appearance.
+	 */
 	return (
 		<>
 			<RecursionProvider uniqueId={ templatePartId }>
 				{ isEntityAvailable &&
 					onNavigateToEntityRecord &&
 					canUserEdit && (
-						<BlockControls group="other">
+						<BlockControls group="block">
 							<ToolbarButton
 								onClick={ () =>
 									onNavigateToEntityRecord( {
@@ -247,10 +291,36 @@ export default function TemplatePartEdit( {
 									} )
 								}
 							>
-								{ __( 'Edit' ) }
+								{ hasNavigationBlocks
+									? sprintf(
+											/* translators: %s: template part title or fallback text */
+											__( 'Edit %s' ),
+											(
+												title || __( 'template part' )
+											).toLowerCase()
+									  )
+									: __( 'Edit' ) }
 							</ToolbarButton>
 						</BlockControls>
 					) }
+				{ hasNavigationBlocks && blockEditingMode === 'contentOnly' && (
+					<BlockControls group="other">
+						<ToolbarButton
+							label={ __( 'Edit navigation' ) }
+							onClick={ () => {
+								// Select the first Navigation block
+								selectBlock( firstNavigationBlockId );
+								// Enable the complementary area (inspector)
+								enableComplementaryArea(
+									'core',
+									'edit-post/block'
+								);
+							} }
+						>
+							{ __( 'Edit navigation' ) }
+						</ToolbarButton>
+					</BlockControls>
+				) }
 				{ canUserEdit && (
 					<InspectorControls group="advanced">
 						<TemplatePartAdvancedControls

--- a/packages/block-library/src/template-part/edit/inner-blocks.js
+++ b/packages/block-library/src/template-part/edit/inner-blocks.js
@@ -100,9 +100,35 @@ function EditableTemplatePartInnerBlocks( {
 	tagName: TagName,
 	blockProps,
 } ) {
-	const onNavigateToEntityRecord = useSelect(
-		( select ) =>
-			select( blockEditorStore ).getSettings().onNavigateToEntityRecord,
+	const { onNavigateToEntityRecord, isNavigationContext } = useSelect(
+		( select ) => {
+			const {
+				getSelectedBlockClientId,
+				getBlockName,
+				getBlockParentsByBlockName,
+			} = select( blockEditorStore );
+			const selectedBlockId = getSelectedBlockClientId();
+			const selectedBlockName =
+				selectedBlockId && getBlockName( selectedBlockId );
+
+			// Check if selected block is a Navigation block or a descendant of one
+			const navigationParents = getBlockParentsByBlockName(
+				selectedBlockId,
+				'core/navigation',
+				true
+			);
+			const isDescendantOfNavigation = navigationParents.length > 0;
+			const isNavigationBlock = selectedBlockName === 'core/navigation';
+			const isInNavigationContext =
+				isNavigationBlock || isDescendantOfNavigation;
+
+			return {
+				onNavigateToEntityRecord:
+					select( blockEditorStore ).getSettings()
+						.onNavigateToEntityRecord,
+				isNavigationContext: isInNavigationContext,
+			};
+		},
 		[]
 	);
 
@@ -123,13 +149,16 @@ function EditableTemplatePartInnerBlocks( {
 	const blockEditingMode = useBlockEditingMode();
 
 	const customProps =
-		blockEditingMode === 'contentOnly' && onNavigateToEntityRecord
+		blockEditingMode === 'contentOnly' &&
+		onNavigateToEntityRecord &&
+		! isNavigationContext
 			? {
-					onDoubleClick: () =>
+					onDoubleClick: () => {
 						onNavigateToEntityRecord( {
 							postId: id,
 							postType: 'wp_template_part',
-						} ),
+						} );
+					},
 			  }
 			: {};
 

--- a/packages/block-library/src/template-part/edit/inner-blocks.js
+++ b/packages/block-library/src/template-part/edit/inner-blocks.js
@@ -100,35 +100,9 @@ function EditableTemplatePartInnerBlocks( {
 	tagName: TagName,
 	blockProps,
 } ) {
-	const { onNavigateToEntityRecord, isNavigationContext } = useSelect(
-		( select ) => {
-			const {
-				getSelectedBlockClientId,
-				getBlockName,
-				getBlockParentsByBlockName,
-			} = select( blockEditorStore );
-			const selectedBlockId = getSelectedBlockClientId();
-			const selectedBlockName =
-				selectedBlockId && getBlockName( selectedBlockId );
-
-			// Check if selected block is a Navigation block or a descendant of one
-			const navigationParents = getBlockParentsByBlockName(
-				selectedBlockId,
-				'core/navigation',
-				true
-			);
-			const isDescendantOfNavigation = navigationParents.length > 0;
-			const isNavigationBlock = selectedBlockName === 'core/navigation';
-			const isInNavigationContext =
-				isNavigationBlock || isDescendantOfNavigation;
-
-			return {
-				onNavigateToEntityRecord:
-					select( blockEditorStore ).getSettings()
-						.onNavigateToEntityRecord,
-				isNavigationContext: isInNavigationContext,
-			};
-		},
+	const onNavigateToEntityRecord = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getSettings().onNavigateToEntityRecord,
 		[]
 	);
 
@@ -149,16 +123,13 @@ function EditableTemplatePartInnerBlocks( {
 	const blockEditingMode = useBlockEditingMode();
 
 	const customProps =
-		blockEditingMode === 'contentOnly' &&
-		onNavigateToEntityRecord &&
-		! isNavigationContext
+		blockEditingMode === 'contentOnly' && onNavigateToEntityRecord
 			? {
-					onDoubleClick: () => {
+					onDoubleClick: () =>
 						onNavigateToEntityRecord( {
 							postId: id,
 							postType: 'wp_template_part',
-						} );
-					},
+						} ),
 			  }
 			: {};
 


### PR DESCRIPTION
## What

This is a **PROTOTYPE** exploring an alternative UX approach for Navigation blocks in Write Mode, different from the approach in #70977.

Instead of making Navigation block children directly editable in the canvas, this prototype explores a **Content Panel → List View** workflow where:

1. Users click on "Header Navigation" in the Content panel of a section block
2. This selects the Navigation block and shows its inspector controls
3. The inspector displays the List View tab for menu editing
4. Child blocks of Navigation blocks are disabled from direct editing

Closes https://github.com/WordPress/gutenberg/issues/65699

## Why

This explores an alternative to the direct canvas editing approach in #70977. The goal is to provide a more structured menu editing experience while maintaining Write Mode's content-focused philosophy.

## How

- Modified block inspector logic to show Navigation block controls when selected from Content panel
- Added chevron icon to Navigation blocks in Content panel to indicate clickable behavior
- Updated back button logic to navigate to parent section when in contentOnly mode
- ~**HACK**: Force disabled editing for child blocks of Navigation blocks~

## Testing

1. Enable Write Mode in Gutenberg experiments
2. Add a Navigation block to a section
3. Click "Header Navigation" in the section's Content panel
4. Verify Navigation block inspector shows with List View tab
6. Verify child blocks are not editable in canvas
7. Test back button navigation

## Screenshots



https://github.com/user-attachments/assets/f7a4393f-e6e1-466c-a61e-ea2a3895ab85





## Prototype Hacks and Limitations

⚠️ **This is a prototype with several hacks that would need proper APIs if pursued:**

### Hacks Implemented:

**Block Inspector Override**: Modified  to show Navigation block inspector instead of Content panel when Navigation block is selected
   - **Proper Solution**: Would need a proper API for blocks to register custom inspector behaviors

**Content Panel Click Behavior**: Added chevron icon and click-through logic in 
   - **Proper Solution**: Would need a proper system for blocks to define custom Content panel interactions

**Back Button Logic**: Modified  to navigate to parent section for Navigation blocks in contentOnly mode
   - **Proper Solution**: Would need a proper API for blocks to define custom navigation behaviors

**UI State Management**: Multiple properties updated to respect the disabled state (, , , etc.)
   - **Proper Solution**: Would need a unified system for managing block editing states

**Overlay ("Click through")**: added nav block specific condition
   - **Proper Solution**: consider a `supports.__experimentalForceBlockOverlay` which blocks can use to opt into overlay even when in `contentOnly`.

### Why These Are Hacks:

- **Hard-coded block names**: Uses  string comparisons
- **UI layer modifications**: Changes inspector behavior at the UI level rather than through proper APIs
- **State overrides**: Forces editing modes without proper block-level configuration
- **Tight coupling**: Creates dependencies between different components that should be loosely coupled

### What Would Be Needed for Production:

1. **Block Configuration API**: Allow blocks to define their Content panel behavior
2. **Inspector Customization API**: Allow blocks to define custom inspector layouts
3. **Child Block Management API**: Allow blocks to define which children are editable vs. managed
4. **Navigation Behavior API**: Allow blocks to define custom back/forward navigation
5. **State Management System**: Unified system for managing block editing states

## Alternative Approach

This prototype explores a different UX than #70977:
- **#70977**: Direct canvas editing of Navigation block children
- **This PR**: Content Panel → List View workflow with disabled child editing

Both approaches have merit and this prototype helps evaluate the trade-offs between direct editing vs. structured menu management.

## Next Steps

This prototype is for feedback and discussion. If this UX direction is pursued, the hacks would need to be replaced with proper APIs and systems.