### PR TITLE
List Block: Add support for `core/image` and `core/gallery` inner blocks to List Item Block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -425,7 +425,7 @@ An individual item within a list. ([Source](https://github.com/WordPress/gutenbe
 -	**Name:** core/list-item
 -	**Category:** text
 -	**Parent:** core/list
--	**Allowed Blocks:** core/list
+-	**Allowed Blocks:** core/list, core/image, core/gallery
 -	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fontSize, lineHeight), ~~className~~
 -	**Attributes:** content, placeholder
 

--- a/packages/block-library/src/list-item/block.json
+++ b/packages/block-library/src/list-item/block.json
@@ -5,7 +5,7 @@
 	"title": "List Item",
 	"category": "text",
 	"parent": [ "core/list" ],
-	"allowedBlocks": [ "core/list" ],
+	"allowedBlocks": [ "core/list", "core/image", "core/gallery" ],
 	"description": "An individual item within a list.",
 	"textdomain": "default",
 	"attributes": {

--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -7,6 +7,7 @@ import {
 	useInnerBlocksProps,
 	BlockControls,
 	store as blockEditorStore,
+	InnerBlocks,
 } from '@wordpress/block-editor';
 import { isRTL, __ } from '@wordpress/i18n';
 import { ToolbarButton } from '@wordpress/components';
@@ -77,7 +78,7 @@ export default function ListItemEdit( {
 	const { placeholder, content } = attributes;
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		renderAppender: false,
+		renderAppender: InnerBlocks.DefaultBlockAppender,
 		__unstableDisableDropZone: true,
 	} );
 	const useEnterRef = useEnter( { content, clientId } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes https://github.com/WordPress/gutenberg/issues/17999
Related issue: https://github.com/WordPress/gutenberg/issues/38251

Extends the List block to allow Image and Gallery blocks inside List Items by updating the innerBlocks configuration. See suggestion [here](https://github.com/WordPress/gutenberg/issues/38251#issuecomment-1682003017) 

> A better solution might be allowing other blocks to be added to the list? https://github.com/WordPress/gutenberg/issues/17999

## Why?

Users frequently need to add visual content within list items but currently lack this functionality. This enhancement provides the flexibility to create richer, more engaging list content by embedding images and galleries directly within list items.

## How?

- Modified the List Item block's innerBlocks allowedBlocks to include core/image and core/gallery
- Updated block configuration to support nested media blocks within list structure
- Maintains proper semantic HTML structure (ol/ul with li elements) for accessibility and SEO

## Screencast 

https://github.com/user-attachments/assets/942c8615-21c6-4f33-bc74-0c45f19fa1c8


