### PR TITLE
Verse block: add background image overlay and filter option

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -958,7 +958,7 @@ Insert poetry. Use special spacing formats. Or quote song lyrics. ([Source](http
 -	**Name:** core/verse
 -	**Category:** text
 -	**Supports:** anchor, background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
--	**Attributes:** content, textAlign
+-	**Attributes:** content, customOverlayColor, dimRatio, overlayColor, textAlign
 
 ## Video
 

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -17,6 +17,16 @@
 		},
 		"textAlign": {
 			"type": "string"
+		},
+		"dimRatio": {
+			"type": "number",
+			"default": 50
+		},
+		"overlayColor": {
+			"type": "string"
+		},
+		"customOverlayColor": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -12,56 +12,139 @@ import {
 	BlockControls,
 	AlignmentToolbar,
 	useBlockProps,
+	InspectorControls,
+	withColors,
+	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
+	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
 } from '@wordpress/block-editor';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+import { compose } from '@wordpress/compose';
+import {
+	RangeControl,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
 
-export default function VerseEdit( {
+function VerseEdit( {
 	attributes,
 	setAttributes,
 	mergeBlocks,
 	onRemove,
 	insertBlocksAfter,
-	style,
+	overlayColor,
+	setOverlayColor,
+	clientId,
 } ) {
-	const { textAlign, content } = attributes;
+	const { textAlign, content, style, dimRatio = 50 } = attributes;
+
+	const hasBackgroundImage = style?.background?.backgroundImage;
+	const overlayOpacity = dimRatio / 100;
+
 	const blockProps = useBlockProps( {
 		className: clsx( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
+			'has-background-dim': hasBackgroundImage && overlayColor.color,
+			[ `has-background-dim-${ dimRatio }` ]:
+				hasBackgroundImage && overlayColor.color && dimRatio !== 50,
+			[ overlayColor.class ]: hasBackgroundImage && overlayColor.class,
 		} ),
-		style,
+		style: {
+			...style,
+		},
 	} );
+
+	const colorGradientSettings = useMultipleOriginColorsAndGradients();
 
 	return (
 		<>
+			{ hasBackgroundImage && (
+				<InspectorControls group="color">
+					<ColorGradientSettingsDropdown
+						__experimentalIsRenderedInSidebar
+						settings={ [
+							{
+								colorValue: overlayColor.color,
+								label: __( 'Overlay' ),
+								onColorChange: setOverlayColor,
+								isShownByDefault: true,
+								resetAllFilter: () => ( {
+									overlayColor: undefined,
+									customOverlayColor: undefined,
+								} ),
+								clearable: true,
+							},
+						] }
+						panelId={ clientId }
+						{ ...colorGradientSettings }
+					/>
+
+					<ToolsPanelItem
+						label={ __( 'Overlay opacity' ) }
+						hasValue={ () => dimRatio !== 50 }
+						onDeselect={ () => setAttributes( { dimRatio: 50 } ) }
+						isShownByDefault
+						panelId={ clientId }
+					>
+						<RangeControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={ __( 'Overlay opacity' ) }
+							value={ dimRatio }
+							onChange={ ( value ) =>
+								setAttributes( { dimRatio: value } )
+							}
+							min={ 0 }
+							max={ 100 }
+							step={ 10 }
+						/>
+					</ToolsPanelItem>
+				</InspectorControls>
+			) }
+
 			<BlockControls>
 				<AlignmentToolbar
 					value={ textAlign }
-					onChange={ ( nextAlign ) => {
-						setAttributes( { textAlign: nextAlign } );
-					} }
+					onChange={ ( nextAlign ) =>
+						setAttributes( { textAlign: nextAlign } )
+					}
 				/>
 			</BlockControls>
-			<RichText
-				tagName="pre"
-				identifier="content"
-				preserveWhiteSpace
-				value={ content }
-				onChange={ ( nextContent ) => {
-					setAttributes( {
-						content: nextContent,
-					} );
-				} }
-				aria-label={ __( 'Verse text' ) }
-				placeholder={ __( 'Write verse…' ) }
-				onRemove={ onRemove }
-				onMerge={ mergeBlocks }
-				textAlign={ textAlign }
-				{ ...blockProps }
-				__unstablePastePlainText
-				__unstableOnSplitAtDoubleLineEnd={ () =>
-					insertBlocksAfter( createBlock( getDefaultBlockName() ) )
-				}
-			/>
+
+			<div { ...blockProps }>
+				<RichText
+					tagName="pre"
+					identifier="content"
+					preserveWhiteSpace
+					value={ content }
+					onChange={ ( nextContent ) =>
+						setAttributes( { content: nextContent } )
+					}
+					aria-label={ __( 'Verse text' ) }
+					placeholder={ __( 'Write verse…' ) }
+					onRemove={ onRemove }
+					onMerge={ mergeBlocks }
+					textAlign={ textAlign }
+					__unstablePastePlainText
+					__unstableOnSplitAtDoubleLineEnd={ () =>
+						insertBlocksAfter(
+							createBlock( getDefaultBlockName() )
+						)
+					}
+				/>
+				{ hasBackgroundImage && overlayColor.color && (
+					<span
+						className="wp-block-verse__overlay-layer"
+						aria-hidden="true"
+						style={ {
+							backgroundColor: overlayColor.color,
+							opacity: overlayOpacity,
+						} }
+					/>
+				) }
+			</div>
 		</>
 	);
 }
+
+export default compose( [
+	withColors( { overlayColor: 'background-color' } ),
+] )( VerseEdit );

--- a/packages/block-library/src/verse/save.js
+++ b/packages/block-library/src/verse/save.js
@@ -6,17 +6,55 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { RichText, useBlockProps } from '@wordpress/block-editor';
+import {
+	RichText,
+	useBlockProps,
+	getColorClassName,
+} from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { textAlign, content } = attributes;
+	const {
+		textAlign,
+		content,
+		style,
+		dimRatio = 50,
+		overlayColor,
+		customOverlayColor,
+	} = attributes;
+
+	const hasBackgroundImage = style?.background?.backgroundImage;
+	const overlayColorClass = getColorClassName(
+		'background-color',
+		overlayColor
+	);
 
 	const className = clsx( {
 		[ `has-text-align-${ textAlign }` ]: textAlign,
+		'has-background-dim':
+			hasBackgroundImage && ( overlayColor || customOverlayColor ),
+		[ `has-background-dim-${ dimRatio }` ]:
+			hasBackgroundImage && ( overlayColor || customOverlayColor ),
+		[ overlayColorClass ]: hasBackgroundImage && overlayColorClass,
 	} );
 
+	const overlayStyle =
+		hasBackgroundImage && ( overlayColor || customOverlayColor )
+			? {
+					'--wp-verse-overlay-color':
+						customOverlayColor ||
+						`var(--wp--preset--color--${ overlayColor })`,
+			  }
+			: {};
+
 	return (
-		<pre { ...useBlockProps.save( { className } ) }>
+		<pre
+			{ ...useBlockProps.save( {
+				className,
+				style: {
+					...overlayStyle,
+				},
+			} ) }
+		>
 			<RichText.Content value={ content } />
 		</pre>
 	);

--- a/packages/block-library/src/verse/style.scss
+++ b/packages/block-library/src/verse/style.scss
@@ -1,6 +1,86 @@
 pre.wp-block-verse {
 	overflow: auto;
 	white-space: pre-wrap;
+	position: relative;
+
+	// When block has background image and overlay
+	&.has-background-dim {
+
+		&::before {
+			content: "";
+			position: absolute;
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			z-index: 0;
+			pointer-events: none;
+			background-color: var(--wp-verse-overlay-color, rgba(0, 0, 0, 0.5));
+		}
+
+		// Content should be above overlay
+		* {
+			position: relative;
+			z-index: 1;
+		}
+	}
+
+	// Opacity variations
+	&.has-background-dim-0::before {
+		opacity: 0;
+	}
+
+	&.has-background-dim-10::before {
+		opacity: 0.1;
+	}
+
+	&.has-background-dim-20::before {
+		opacity: 0.2;
+	}
+
+	&.has-background-dim-30::before {
+		opacity: 0.3;
+	}
+
+	&.has-background-dim-40::before {
+		opacity: 0.4;
+	}
+
+	&.has-background-dim-50::before {
+		opacity: 0.5;
+	}
+
+	&.has-background-dim-60::before {
+		opacity: 0.6;
+	}
+
+	&.has-background-dim-70::before {
+		opacity: 0.7;
+	}
+
+	&.has-background-dim-80::before {
+		opacity: 0.8;
+	}
+
+	&.has-background-dim-90::before {
+		opacity: 0.9;
+	}
+
+	&.has-background-dim-100::before {
+		opacity: 1;
+	}
+
+}
+
+.wp-block-verse__overlay-layer {
+	content: "";
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	z-index: 1;
+	pointer-events: none;
 }
 
 :where(pre.wp-block-verse) {

--- a/test/integration/fixtures/blocks/core__verse.json
+++ b/test/integration/fixtures/blocks/core__verse.json
@@ -3,7 +3,8 @@
 		"name": "core/verse",
 		"isValid": true,
 		"attributes": {
-			"content": "A <em>verse</em>…<br>And more!"
+			"content": "A <em>verse</em>…<br>And more!",
+			"dimRatio": 50
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
Closes: https://github.com/WordPress/gutenberg/issues/66019

## What?
Enhances the Verse block to support a background overlay color with adjustable opacity. This includes new color controls in the block inspector using ToolsPanel for a cleaner UI, and updated styles to ensure overlay color is contained within the `<pre>` element.

## Why?
The Verse block previously supported only plain backgrounds without any overlay control. This limited design flexibility, especially when combining background images with readable text. By adding overlay color and dim ratio controls, authors can improve text legibility while preserving background visuals.

## Testing Instructions
1. Open the block editor and insert a Verse block.
2. Add a background image.
3. In the block inspector:
- Adjust the overlay color.
- Change the overlay opacity (dim ratio).
4. Verify:
- The overlay is contained within the `<pre>` area.
- Text remains readable with default white text unless overridden by a user-selected text color.
5. Save and preview — settings should persist on the front end.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/33a12f87-1296-4a3e-a5f7-242fa0e183d1


