### PR TITLE
Add support for precision type placeholders to translator comments eslint

### DIFF
--- a/packages/eslint-plugin/rules/__tests__/i18n-translator-comments.js
+++ b/packages/eslint-plugin/rules/__tests__/i18n-translator-comments.js
@@ -87,6 +87,23 @@ _x( '"%1$s"/ %2$s', 'caption' );
 _x( '"%1$s"/ %2$s', 'caption' );
 			`,
 		},
+		{
+			code: ` // translators: %s: Hello at 6:00 AM
+		i18n.sprintf( i18n.__( 'Hello at %s' ), '6:00 AM' );`,
+		},
+		// test for precisions now
+		{
+			code: `// translators: %.2f: Percentage
+		i18n.sprintf( i18n.__( 'Percentage: %.2f' ), 1.00 );`,
+		},
+		{
+			code: `// translators: %.*f: Percentage
+		i18n.sprintf( i18n.__( 'Percentage: %.*f' ), 2, 1.00 );`,
+		},
+		{
+			code: `// translators: %(named).2s: truncated name
+		i18n.sprintf( i18n.__( 'Truncated name: %(named).2s' ), { named: 'Long Name' } );`,
+		},
 	],
 	invalid: [
 		{

--- a/packages/eslint-plugin/rules/__tests__/i18n-translator-comments.js
+++ b/packages/eslint-plugin/rules/__tests__/i18n-translator-comments.js
@@ -91,7 +91,6 @@ _x( '"%1$s"/ %2$s', 'caption' );
 			code: ` // translators: %s: Hello at 6:00 AM
 		i18n.sprintf( i18n.__( 'Hello at %s' ), '6:00 AM' );`,
 		},
-		// test for precisions now
 		{
 			code: `// translators: %.2f: Percentage
 		i18n.sprintf( i18n.__( 'Percentage: %.2f' ), 1.00 );`,

--- a/packages/eslint-plugin/rules/i18n-translator-comments.js
+++ b/packages/eslint-plugin/rules/i18n-translator-comments.js
@@ -155,7 +155,6 @@ module.exports = {
 							extractTranslatorKeys( commentText );
 						const placeholdersUsed =
 							candidates.flatMap( extractPlaceholders );
-						// console.log( { keysInComment, placeholdersUsed } );
 
 						const keysInCommentArr = [ ...keysInComment.keys() ];
 
@@ -213,8 +212,6 @@ module.exports = {
 									return isValidType && isUnused;
 							  } )
 							: [];
-
-						// console.log({extra, keysInComment, placeholdersUsed});
 
 						if ( extra.length > 0 ) {
 							context.report( {

--- a/packages/eslint-plugin/rules/i18n-translator-comments.js
+++ b/packages/eslint-plugin/rules/i18n-translator-comments.js
@@ -50,7 +50,9 @@ function extractTranslatorKeys( commentText ) {
 	while (
 		( match = REGEXP_COMMENT_PLACEHOLDER.exec( commentBody ) ) !== null
 	) {
-		keys.set( match[ 1 ], keys.get( match[ 1 ] ) || match[ 2 ] === ':' );
+		const rawKey = match[ 1 ];
+		const hasColon = match.groups?.colon?.trim() === ':';
+		keys.set( rawKey, keys.get( rawKey ) || hasColon );
 	}
 
 	return keys;
@@ -153,6 +155,7 @@ module.exports = {
 							extractTranslatorKeys( commentText );
 						const placeholdersUsed =
 							candidates.flatMap( extractPlaceholders );
+						// console.log( { keysInComment, placeholdersUsed } );
 
 						const keysInCommentArr = [ ...keysInComment.keys() ];
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Addresses: [`comment`](https://github.com/WordPress/gutenberg/pull/70458#issuecomment-3166078885) #70458

<!-- In a few words, what is the PR actually doing? -->
This PR adds support for precision based placeholders to be allowed in translator comments by eslint.

This PR also fixes false positives like 6:00 AM by forcing a placeholder to have space after `:` to be counted as placeholder.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently eslint for translator comments flags cases that are supposed to be valid by counting words like 6:00 AM as placeholder due to `:` placement.

Alongside this, support for precision based placeholder was not available causing translators comments to fail for placeholders like `%.*s`, `1$.2f` etc.

#### Example
```js
  // translators: %s: a formatted time (e.g. 6:00AM).
  const test = __( 'Alarm is set for %s', 'some-pkg' );

  // Lint → Translator comment has extra placeholder(s): 6.
```

This PR adds support for this to prevent these false positive flags and precision placeholder supports. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR supports this by extending the `REGEXP_COMMENT_PLACEHOLDER` Regex to support precisions as well as forcing a space after colon for placeholder.

The Regex now enforces groups for easier accessing values from matches.
Currently named and positional groups aren't being used in extra but it can be used in future depending on the use-case.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
CI Lint Testing should suffice.


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<img width="501" height="110" alt="image" src="https://github.com/user-attachments/assets/7e8b6a84-ba76-4e0c-9f82-3373e28148f6" />
