### PR TITLE
Classic block: Prevent event from bubbling on paste

### DIFF
--- a/packages/block-library/src/freeform/edit.js
+++ b/packages/block-library/src/freeform/edit.js
@@ -191,6 +191,16 @@ function ClassicEdit( {
 			editor.on( 'init', () => {
 				const rootNode = editor.getBody();
 
+				// TinyMCE selection isn’t synced with the block editor selection store.
+				// This event handler prevents paste from bubbling so the useClipboardHandler
+				// won’t replace the block.
+				const onPaste = ( event ) => event.stopPropagation();
+				rootNode.addEventListener( 'paste', onPaste );
+
+				editor.on( 'remove', () => {
+					rootNode.removeEventListener( 'paste', onPaste );
+				} );
+
 				// Create the toolbar by refocussing the editor.
 				if ( rootNode.ownerDocument.activeElement === rootNode ) {
 					rootNode.blur();

--- a/packages/block-library/src/freeform/edit.js
+++ b/packages/block-library/src/freeform/edit.js
@@ -188,18 +188,15 @@ function ClassicEdit( {
 				}
 			} );
 
-			editor.on( 'init', () => {
-				const rootNode = editor.getBody();
-
+			editor.on( 'paste', ( event ) => {
 				// TinyMCE selection isn’t synced with the block editor selection store.
 				// This event handler prevents paste from bubbling so the useClipboardHandler
 				// won’t replace the block.
-				const onPaste = ( event ) => event.stopPropagation();
-				rootNode.addEventListener( 'paste', onPaste );
+				event.stopPropagation();
+			} );
 
-				editor.on( 'remove', () => {
-					rootNode.removeEventListener( 'paste', onPaste );
-				} );
+			editor.on( 'init', () => {
+				const rootNode = editor.getBody();
 
 				// Create the toolbar by refocussing the editor.
 				if ( rootNode.ownerDocument.activeElement === rootNode ) {


### PR DESCRIPTION
## What?

Closes #64771

## Why?

When text is pasted into the block editor from an external resource, the `useClipboardHandler` hook replaces the target block itself if the selection is not partial.

In most cases, this logic works fine, but TinyMCE isn't synced with the block editor selection store. As a result, when text is pasted into the TinyMCE content area, the `usePasteHandler` hook determines that the selection is a block, not partial, and replaces the Classic block itself with a Paragraph block, which is not what we intended.

## How?

Add a paste event handler to prevent the paste event from bubbling to the `useClipboardHandler` hook. There may be other events that we want to prevent from bubbling, but for now, I will only prevent bubbling of paste events.


## Testing Instructions

This bug only occurs when the Classic block works in inline mode. Therefore, to make the post editor work as a non-iframe editor, follow these two steps:

- Activate Twenty Twenty-One.
- Temporarily register v2 block by executing the following code in your browser console:
  ```javascript
  wp.blocks.registerBlockType( 'test/v2', {
  	apiVersion: '2',
  	title: 'test',
  } );
  ```

- Run the code above to make the post editor work as a non-iframe editor.
- Insert a Classic block.
- Paste some text from your text editing app into the Classic block.
- Confirm that the Classic block isn't transformed into a Paragraph block and that the test is pasted correctly.

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/af55efe5-23f2-4f5d-bd84-2673b8130d9d

### After

https://github.com/user-attachments/assets/f4ae3b64-78dd-4e35-b6ec-015d9581b822