### PR TITLE
Fix viewbox for table and formatting related icons

### DIFF
--- a/packages/icons/src/library/format-ltr.tsx
+++ b/packages/icons/src/library/format-ltr.tsx
@@ -4,7 +4,7 @@
 import { SVG, Path } from '@wordpress/primitives';
 
 const formatLtr = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 24 24">
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path d="M3 9c0 2.8 2.2 5 5 5v-.2V20h1.5V5.5H12V20h1.5V5.5h3V4H8C5.2 4 3 6.2 3 9Zm15.9-1-1.1 1 2.6 3-2.6 3 1.1 1 3.4-4-3.4-4Z" />
 	</SVG>
 );

--- a/packages/icons/src/library/format-rtl.tsx
+++ b/packages/icons/src/library/format-rtl.tsx
@@ -4,7 +4,7 @@
 import { SVG, Path } from '@wordpress/primitives';
 
 const formatRtl = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 24 24">
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path d="M3 9c0 2.8 2.2 5 5 5v-.2V20h1.5V5.5H12V20h1.5V5.5h3V4H8C5.2 4 3 6.2 3 9Zm19.3 0-1.1-1-3.4 4 3.4 4 1.1-1-2.6-3 2.6-3Z" />
 	</SVG>
 );

--- a/packages/icons/src/library/insert-after.tsx
+++ b/packages/icons/src/library/insert-after.tsx
@@ -4,7 +4,7 @@
 import { SVG, Path } from '@wordpress/primitives';
 
 const insertAfter = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 24 24">
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path d="M9 12h2v-2h2V8h-2V6H9v2H7v2h2v2zm1 4c3.9 0 7-3.1 7-7s-3.1-7-7-7-7 3.1-7 7 3.1 7 7 7zm0-12c2.8 0 5 2.2 5 5s-2.2 5-5 5-5-2.2-5-5 2.2-5 5-5zM3 19h14v-2H3v2z" />
 	</SVG>
 );

--- a/packages/icons/src/library/insert-before.tsx
+++ b/packages/icons/src/library/insert-before.tsx
@@ -4,7 +4,7 @@
 import { SVG, Path } from '@wordpress/primitives';
 
 const insertBefore = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 24 24">
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path d="M11 8H9v2H7v2h2v2h2v-2h2v-2h-2V8zm-1-4c-3.9 0-7 3.1-7 7s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 12c-2.8 0-5-2.2-5-5s2.2-5 5-5 5 2.2 5 5-2.2 5-5 5zM3 1v2h14V1H3z" />
 	</SVG>
 );

--- a/packages/icons/src/library/table-column-after.tsx
+++ b/packages/icons/src/library/table-column-after.tsx
@@ -4,7 +4,7 @@
 import { SVG, Path } from '@wordpress/primitives';
 
 const tableColumnAfter = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 24 24">
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0  24 24">
 		<Path d="M19 3H5c-1.1 0-2 .9-2 2v14.2c.1.9.9 1.7 1.8 1.8H19.2c1-.1 1.8-1 1.8-2V5c0-1.1-.9-2-2-2ZM8.5 19.5H5c-.3 0-.5-.2-.5-.5v-3.5h4v4Zm0-5.5h-4v-4h4v4Zm0-5.5h-4V5c0-.3.2-.5.5-.5h3.5v4Zm11 10.5c0 .3-.2.5-.5.5h-9v-15h9c.3 0 .5.2.5.5v14Zm-4-10.8H14v3h-3v1.5h3v3h1.5v-3h3v-1.5h-3v-3Z" />
 	</SVG>
 );

--- a/packages/icons/src/library/table-column-before.tsx
+++ b/packages/icons/src/library/table-column-before.tsx
@@ -4,7 +4,7 @@
 import { SVG, Path } from '@wordpress/primitives';
 
 const tableColumnBefore = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 24 24">
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1 .8 1.9 1.8 2H19.2c.9-.1 1.7-.9 1.8-1.8V5c0-1.1-.9-2-2-2Zm-5 16.5H5c-.3 0-.5-.2-.5-.5V5c0-.3.2-.5.5-.5h9v15Zm5.5-.5c0 .3-.2.5-.5.5h-3.5v-4h4V19Zm0-5h-4v-4h4v4Zm0-5.5h-4v-4H19c.3 0 .5.2.5.5v3.5Zm-11 7.3H10v-3h3v-1.5h-3v-3H8.5v3h-3v1.5h3v3Z" />
 	</SVG>
 );

--- a/packages/icons/src/library/table-column-delete.tsx
+++ b/packages/icons/src/library/table-column-delete.tsx
@@ -4,7 +4,7 @@
 import { SVG, Path } from '@wordpress/primitives';
 
 const tableColumnDelete = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 24 24">
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path d="M19 3H5c-1.1 0-2 .9-2 2v14.2c.1.9.9 1.7 1.8 1.8H19.2c1-.1 1.8-1 1.8-2V5c0-1.1-.9-2-2-2ZM8.5 19.5H5c-.3 0-.5-.2-.5-.5V5c0-.3.2-.5.5-.5h3.5v15Zm11-.5c0 .3-.2.5-.5.5h-9v-15h9c.3 0 .5.2.5.5v14ZM16.9 8.8l-2.1 2.1-2.1-2.1-1.1 1.1 2.1 2.1-2.1 2.1 1.1 1.1 2.1-2.1 2.1 2.1 1.1-1.1-2.1-2.1L18 9.9l-1.1-1.1Z" />
 	</SVG>
 );

--- a/packages/icons/src/library/table-row-after.tsx
+++ b/packages/icons/src/library/table-row-after.tsx
@@ -4,7 +4,7 @@
 import { SVG, Path } from '@wordpress/primitives';
 
 const tableRowAfter = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 24 24">
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path d="M19 3H4.8c-.9.1-1.7.9-1.8 1.8V19.2c.1 1 1 1.8 2 1.8h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2Zm-9 1.5h4v4h-4v-4ZM4.5 5c0-.3.2-.5.5-.5h3.5v4h-4V5Zm15 14c0 .3-.2.5-.5.5H5c-.3 0-.5-.2-.5-.5v-9h15v9Zm0-10.5h-4v-4H19c.3 0 .5.2.5.5v3.5Zm-8.3 10h1.5v-3h3V14h-3v-3h-1.5v3h-3v1.5h3v3Z" />
 	</SVG>
 );

--- a/packages/icons/src/library/table-row-before.tsx
+++ b/packages/icons/src/library/table-row-before.tsx
@@ -5,8 +5,7 @@ import { SVG, Path } from '@wordpress/primitives';
 
 const tableRowBefore = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M21 5c0-1.1-.9-2-2-2H5c-1 0-1.9.8-2 1.8V19.2c.1.9.9 1.7 1.8 1.8H19c1.1 0 2-.9 2-2V5ZM4.5 14V5c0-.3.2-.5.5-.5h14c.3 0 .5.2.5.5v9h-15Zm4 5.5H5c-.3 0-.5-.2-.5-.5v-3.5h4v4Zm5.5 0h-4v-4h4v4Zm5.5-.5c0 .3-.2.5-.5.5h-3.5v-4h4V19Z" />
-		<path d="M11.2 10h-3V8.5h3v-3h1.5v3h3V10h-3v3h-1.5v-3Z" />
+		<Path d="M21 5c0-1.1-.9-2-2-2H5c-1 0-1.9.8-2 1.8V19.2c.1.9.9 1.7 1.8 1.8H19c1.1 0 2-.9 2-2V5ZM4.5 14V5c0-.3.2-.5.5-.5h14c.3 0 .5.2.5.5v9h-15Zm4 5.5H5c-.3 0-.5-.2-.5-.5v-3.5h4v4Zm5.5 0h-4v-4h4v4Zm5.5-.5c0 .3-.2.5-.5.5h-3.5v-4h4V19ZM11.2 10h-3V8.5h3v-3h1.5v3h3V10h-3v3h-1.5v-3Z" />
 	</SVG>
 );
 

--- a/packages/icons/src/library/table-row-before.tsx
+++ b/packages/icons/src/library/table-row-before.tsx
@@ -4,7 +4,7 @@
 import { SVG, Path } from '@wordpress/primitives';
 
 const tableRowBefore = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 24 24">
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path d="M21 5c0-1.1-.9-2-2-2H5c-1 0-1.9.8-2 1.8V19.2c.1.9.9 1.7 1.8 1.8H19c1.1 0 2-.9 2-2V5ZM4.5 14V5c0-.3.2-.5.5-.5h14c.3 0 .5.2.5.5v9h-15Zm4 5.5H5c-.3 0-.5-.2-.5-.5v-3.5h4v4Zm5.5 0h-4v-4h4v4Zm5.5-.5c0 .3-.2.5-.5.5h-3.5v-4h4V19Z" />
 		<path d="M11.2 10h-3V8.5h3v-3h1.5v3h3V10h-3v3h-1.5v-3Z" />
 	</SVG>

--- a/packages/icons/src/library/table-row-delete.tsx
+++ b/packages/icons/src/library/table-row-delete.tsx
@@ -4,7 +4,7 @@
 import { SVG, Path } from '@wordpress/primitives';
 
 const tableRowDelete = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 24 24">
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path d="M19 3H4.8c-.9.1-1.7.9-1.8 1.8V19.2c.1 1 1 1.8 2 1.8h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2Zm.5 16c0 .3-.2.5-.5.5H5c-.3 0-.5-.2-.5-.5v-9h15v9Zm0-10.5h-15V5c0-.3.2-.5.5-.5h14c.3 0 .5.2.5.5v3.5Zm-9.6 9.4 2.1-2.1 2.1 2.1 1.1-1.1-2.1-2.1 2.1-2.1-1.1-1.1-2.1 2.1-2.1-2.1-1.1 1.1 2.1 2.1-2.1 2.1 1.1 1.1Z" />
 	</SVG>
 );


### PR DESCRIPTION
Related to #71084, #71085

## What?

Fixes several icons that are not center-aligned due to incorrect viewbox values.

<img width="178" height="99" alt="image" src="https://github.com/user-attachments/assets/e23a5245-48a7-4a67-96a2-30198ffe379b" />

## Testing Instructions

Run `storybook:dev` and confirm these icons.

## Screenshots or screencast <!-- if applicable -->

### Table Icons

| Before | After |
|--------|--------|
| <img width="312" height="548" alt="image" src="https://github.com/user-attachments/assets/f5fce4f8-1257-4fa6-b92b-aadad5a624b4" /> | <img width="290" height="529" alt="image" src="https://github.com/user-attachments/assets/34b29a06-c6f4-4ea6-8ad4-8b62b496a1db" /> | 

### Format Icons

| Before | After |
|--------|--------|
| <img width="331" height="318" alt="image" src="https://github.com/user-attachments/assets/6535341c-eabe-4be9-ac8b-52d85a74dd60" /> | <img width="337" height="310" alt="image" src="https://github.com/user-attachments/assets/5f630755-d641-42b0-aec9-1ce7e69a36b9" /> | 

### Table Block Toolbar


| Before | After |
|--------|--------|
| <img width="224" height="338" alt="image" src="https://github.com/user-attachments/assets/7f79c9ad-eaed-4576-96ec-5466aa5e5a1e" />| <img width="229" height="343" alt="image" src="https://github.com/user-attachments/assets/7e814014-5d13-4b7b-a07c-fe21e57cfe0a" /> | 


