### PR TITLE
Experiment only: add attachment link relation to REST API responses

### DIFF
--- a/lib/compat/wordpress-6.9/rest-api.php
+++ b/lib/compat/wordpress-6.9/rest-api.php
@@ -29,3 +29,39 @@ function gutenberg_rest_theme_export_link_rel( $response, $theme ) {
 	return $response;
 }
 add_filter( 'rest_prepare_theme', 'gutenberg_rest_theme_export_link_rel', 10, 2 );
+
+
+/**
+ * Adds export `attachedTo` link relation to the attachment post responses.
+ * Backport instructions:
+ * To be added to WP_REST_Attachments_Controller::prepare_links()
+ *
+ * @param WP_REST_Response $response The response object.
+ * @param WP_Post          $post     Post object.
+ * @param WP_REST_Request  $request  Request object.
+ * @return WP_REST_Response Modified response object.
+ */
+function gutenberg_rest_attachment_post_export_link_rel( $response, $post, $request ) {
+	if ( ! empty( $response->get_links() ) && $post->post_type === 'attachment' && ! empty( $post->post_parent ) ) {
+		$attached_to_post = get_post( $post->post_parent );
+		$current_links    = $response->get_links();
+
+		if ( $attached_to_post && ! isset( $current_links['attachedTo'] ) ) {
+			$response->add_link(
+				'attachedTo',
+				rest_url( rest_get_route_for_post( $attached_to_post ) ),
+				array(
+					'embeddable' => true,
+					'title'      => $attached_to_post->post_title,
+					'id'         => $attached_to_post->ID,
+					'post_type'  => $attached_to_post->post_type,
+				),
+			);
+		}
+		
+	}
+
+	return $response;
+}
+
+add_filter( 'rest_prepare_attachment', 'gutenberg_rest_attachment_post_export_link_rel', 10, 3 );

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -301,19 +301,28 @@ export default function Image( {
 		setOffsetTop( imageElement?.offsetTop ?? 0 );
 	}, [ imageElement ] );
 	const setRefs = useMergeRefs( [ setImageElement, setResizeObserved ] );
-	const { allowResize = true } = context;
+	const { allowResize = true, postType, postId, queryId } = context;
 
 	const image = useSelect(
 		( select ) =>
 			id && isSingleSelected
-				? select( coreStore ).getEntityRecord(
+				? select( coreStore ).getEditedEntityRecord(
 						'postType',
 						'attachment',
-						id,
-						{ context: 'view' }
+						id
 				  )
 				: null,
 		[ id, isSingleSelected ]
+	);
+
+	const currentPost = useSelect(
+		( select ) =>
+			select( coreStore ).getEditedEntityRecord(
+				'postType',
+				postType,
+				postId
+			),
+		[ postId, postType ]
 	);
 
 	const { canInsertCover, imageEditing, imageSizes, maxWidth } = useSelect(
@@ -897,8 +906,6 @@ export default function Image( {
 	const borderProps = useBorderProps( attributes );
 	const shadowProps = getShadowClassesAndStyles( attributes );
 	const isRounded = attributes.className?.includes( 'is-style-rounded' );
-
-	const { postType, postId, queryId } = context;
 	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 
 	let img =
@@ -1114,6 +1121,52 @@ export default function Image( {
 		} );
 	};
 
+	/**
+	 * Sets or removes the post's attached post with the current image.
+	 */
+	const setAttachedPost = () => {
+		if ( ! currentPost || ! image ) {
+			return;
+		}
+
+		const edits =
+			currentPost?.id === image?.post
+				? {
+						post: 0,
+						_links: {
+							...image?._links,
+							attachedTo: undefined,
+						},
+				  }
+				: {
+						post: currentPost?.id,
+						_links: {
+							...image?._links,
+							attachedTo: [
+								{
+									href: currentPost?._links?.self?.[ 0 ]
+										?.href,
+									embeddable: true,
+									title:
+										currentPost?.title ||
+										currentPost?.title?.raw,
+									id: currentPost?.id,
+									post_type: currentPost?.type,
+								},
+							],
+						},
+				  };
+		editEntityRecord( 'postType', image?.type, image?.id, edits );
+		createSuccessNotice(
+			currentPost?.id === image?.post
+				? __( 'Image removed from post.' )
+				: __( 'Image attached to post.' ),
+			{
+				type: 'snackbar',
+			}
+		);
+	};
+
 	const featuredImageControl = (
 		<BlockSettingsMenuControls>
 			{ ( { selectedClientIds } ) =>
@@ -1130,11 +1183,30 @@ export default function Image( {
 		</BlockSettingsMenuControls>
 	);
 
+	const attachedPostControl = (
+		<BlockSettingsMenuControls>
+			{ ( { selectedClientIds } ) =>
+				selectedClientIds.length === 1 &&
+				! isDescendentOfQueryLoop &&
+				postId &&
+				id &&
+				clientId === selectedClientIds[ 0 ] && (
+					<MenuItem onClick={ () => setAttachedPost() }>
+						{ currentPost?.id === image?.post
+							? __( 'Remove attached post' )
+							: __( 'Set as attached post' ) }
+					</MenuItem>
+				)
+			}
+		</BlockSettingsMenuControls>
+	);
+
 	return (
 		<>
 			{ mediaReplaceFlow }
 			{ controls }
 			{ featuredImageControl }
+			{ attachedPostControl }
 			{ img }
 			{ resizableBox }
 

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -309,16 +309,20 @@ async function loadPostTypeEntities() {
 			name
 		);
 		const namespace = postType?.rest_namespace ?? 'wp/v2';
+		const transientEdits = {
+			blocks: true,
+			selection: true,
+		};
+		if ( name === 'attachment' ) {
+			transientEdits._links = true;
+		}
 		return {
 			kind: 'postType',
 			baseURL: `/${ namespace }/${ postType.rest_base }`,
 			baseURLParams: { context: 'edit' },
 			name,
 			label: postType.name,
-			transientEdits: {
-				blocks: true,
-				selection: true,
-			},
+			transientEdits,
 			mergedEdits: { meta: true },
 			rawAttributes: POST_RAW_ATTRIBUTES,
 			getTitle: ( record ) =>


### PR DESCRIPTION
## 🚧 This is an experiment and for demonstration purposes only. 🚧



https://github.com/user-attachments/assets/fbe75c4f-8cb6-41c5-b764-dc054bf8a2b1




- Introduced a new filter to add an `attachedTo` link relation in the REST API responses for attachment posts, allowing better linkage to parent posts.
- Enhanced the image block to manage attached posts, including UI controls for setting or removing the attachment.
- Updated entity loading to include transient edits for attachments, improving data handling in the core data module.

Confirmed that the `_links` object isn't sent to the REST API when saving the entity:

<img width="494" height="244" alt="Screenshot 2025-08-11 at 12 53 19 pm" src="https://github.com/user-attachments/assets/6452d7f2-6a00-4aa8-8e0a-ddf1d972795b" />


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
