### PR TITLE
Core Data: Extend PostStatus type to support all WordPress statuses

### DIFF
--- a/packages/core-data/src/entity-types/helpers.ts
+++ b/packages/core-data/src/entity-types/helpers.ts
@@ -21,7 +21,16 @@ export interface AvatarUrls {
 export type MediaType = 'image' | 'file';
 export type CommentingStatus = 'open' | 'closed';
 export type PingStatus = 'open' | 'closed';
-export type PostStatus = 'publish' | 'future' | 'draft' | 'pending' | 'private';
+export type PostStatus =
+	| 'publish'
+	| 'future'
+	| 'draft'
+	| 'pending'
+	| 'private'
+	| 'trash'
+	| 'auto-draft'
+	| 'inherit'
+	| ( string & {} );
 export type PostFormat =
 	| 'standard'
 	| 'aside'


### PR DESCRIPTION
## What?
Fixes #71144
Extends the PostStatus TypeScript type definition in the core-data package to include all default WordPress post statuses and support for custom statuses.

## How?
Modified the PostStatus type in `/packages/core-data/src/entity-types/helpers.ts`to:
- Add missing default statuses: `trash`, `auto-draft`, `inherit`
- Support custom statuses using the (string & {}) pattern