### PR TITLE
[WIP] Block Editor: Add contextual label for block inserter button

### DIFF
--- a/packages/block-editor/src/components/button-block-appender/index.js
+++ b/packages/block-editor/src/components/button-block-appender/index.js
@@ -36,6 +36,7 @@ function ButtonBlockAppender(
 				disabled,
 				isOpen,
 				blockTitle,
+				parentBlockTitle,
 				hasSingleBlockType,
 			} ) => {
 				const isToggleButton = ! hasSingleBlockType;
@@ -48,9 +49,13 @@ function ButtonBlockAppender(
 							),
 							blockTitle
 					  )
-					: _x(
-							'Add block',
-							'Generic label for block inserter button'
+					: sprintf(
+							// translators: %s: the name of the block
+							_x(
+								'Add New %s Item',
+								'Generic label for block inserter button'
+							),
+							parentBlockTitle
 					  );
 
 				return (

--- a/packages/block-editor/src/components/button-block-appender/index.js
+++ b/packages/block-editor/src/components/button-block-appender/index.js
@@ -52,8 +52,8 @@ function ButtonBlockAppender(
 					: sprintf(
 							// translators: %s: the name of the block
 							_x(
-								'Add New %s Item',
-								'Generic label for block inserter button'
+								'Add block to %s',
+								'Label for block inserter button'
 							),
 							parentBlockTitle
 					  );

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -12,7 +12,11 @@ import { Dropdown, Button } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose, ifCondition } from '@wordpress/compose';
-import { createBlock, store as blocksStore } from '@wordpress/blocks';
+import {
+	createBlock,
+	store as blocksStore,
+	getBlockType,
+} from '@wordpress/blocks';
 import { plus } from '@wordpress/icons';
 
 /**
@@ -111,6 +115,7 @@ class Inserter extends Component {
 			toggleProps,
 			hasItems,
 			renderToggle = defaultRenderToggle,
+			parentBlockTitle,
 		} = this.props;
 
 		return renderToggle( {
@@ -121,6 +126,7 @@ class Inserter extends Component {
 			hasSingleBlockType,
 			directInsertBlock,
 			toggleProps,
+			parentBlockTitle,
 		} );
 	}
 
@@ -224,6 +230,7 @@ export default compose( [
 				hasInserterItems,
 				getAllowedBlocks,
 				getDirectInsertBlock,
+				getBlock,
 			} = select( blockEditorStore );
 
 			const { getBlockVariations } = select( blocksStore );
@@ -246,6 +253,13 @@ export default compose( [
 				allowedBlockType = allowedBlocks[ 0 ];
 			}
 
+			const parentBlock = rootClientId ? getBlock( rootClientId ) : null;
+			const parentBlockType = parentBlock?.name
+				? getBlockType( parentBlock.name )
+				: null;
+			const parentBlockTitle =
+				parentBlockType?.title || parentBlock?.name || '';
+
 			return {
 				hasItems: hasInserterItems( rootClientId ),
 				hasSingleBlockType,
@@ -253,6 +267,7 @@ export default compose( [
 				allowedBlockType,
 				directInsertBlock,
 				rootClientId,
+				parentBlockTitle,
 			};
 		}
 	),

--- a/test/e2e/specs/editor/blocks/group.spec.js
+++ b/test/e2e/specs/editor/blocks/group.spec.js
@@ -68,7 +68,9 @@ test.describe( 'Group', () => {
 				'button[aria-label="Group: Gather blocks in a container."]'
 			)
 			.click();
-		await editor.canvas.locator( 'role=button[name="Add block"i]' ).click();
+		await editor.canvas
+			.locator( 'role=button[name="Add block to Group"i]' )
+			.click();
 		await page.click(
 			'role=listbox[name="Blocks"i] >> role=option[name="Paragraph"i]'
 		);

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -215,7 +215,7 @@ test.describe( 'Navigation block', () => {
 			await editor.insertBlock( { name: 'core/navigation' } );
 
 			const navBlockInserter = editor.canvas.getByRole( 'button', {
-				name: 'Add block',
+				name: 'Add block to Navigation',
 			} );
 			await navBlockInserter.click();
 
@@ -455,7 +455,7 @@ test.describe( 'Navigation block', () => {
 			// Move focus to the submenu navigation appender
 			await page.keyboard.press( 'End' );
 			await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
-			await navigation.useBlockInserter();
+			await navigation.useBlockInserter( 'Submenu' );
 			await navigation.addLinkClose();
 			/**
 			 * TODO: This is not desired behavior. Ideally the
@@ -554,7 +554,7 @@ test.describe( 'Navigation block', () => {
 			await navigation.addPage( 'Dog' );
 			await page.keyboard.press( 'End' );
 			await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
-			await navigation.useBlockInserter();
+			await navigation.useBlockInserter( 'Submenu' );
 			await navigation.addCustomURL( 'https://wordpress.org' );
 			await navigation.expectToHaveTextSelected( 'wordpress.org' );
 
@@ -570,7 +570,7 @@ test.describe( 'Navigation block', () => {
 			// Add a link back so we can delete the first submenu link.
 			await page.keyboard.press( 'End' );
 			await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
-			await navigation.useBlockInserter();
+			await navigation.useBlockInserter( 'Submenu' );
 			await navigation.addCustomURL( 'https://wordpress.org' );
 			await navigation.expectToHaveTextSelected( 'wordpress.org' );
 
@@ -644,7 +644,9 @@ test.describe( 'Navigation block', () => {
 
 		await editor.selectBlocks( navBlock );
 
-		await navBlock.getByRole( 'button', { name: 'Add block' } ).click();
+		await navBlock
+			.getByRole( 'button', { name: 'Add block to Navigation' } )
+			.click();
 
 		// This relies on network so allow additional time for
 		// the request to complete.
@@ -685,8 +687,10 @@ class Navigation {
 		} );
 	}
 
-	getNavBlockInserter() {
-		return this.getNavBlock().getByLabel( 'Add block' );
+	getNavBlockInserter( parentBlockLabel = 'Navigation' ) {
+		return this.getNavBlock().getByLabel(
+			`Add block to ${ parentBlockLabel }`
+		);
 	}
 
 	getLinkControlSearch() {
@@ -702,8 +706,8 @@ class Navigation {
 		} );
 	}
 
-	async useBlockInserter() {
-		const navBlockInserter = this.getNavBlockInserter();
+	async useBlockInserter( parentBlockLabel = 'Navigation' ) {
+		const navBlockInserter = this.getNavBlockInserter( parentBlockLabel );
 
 		// Wait until the nav block inserter is visible before we move on to using it
 		await expect( navBlockInserter ).toBeVisible();

--- a/test/e2e/specs/editor/blocks/search.spec.js
+++ b/test/e2e/specs/editor/blocks/search.spec.js
@@ -40,7 +40,7 @@ test.describe( 'Search', () => {
 		} );
 
 		const navBlockInserter = editor.canvas.getByRole( 'button', {
-			name: 'Add block',
+			name: 'Add block to Navigation',
 		} );
 		await navBlockInserter.click();
 

--- a/test/e2e/specs/editor/various/block-deletion.spec.js
+++ b/test/e2e/specs/editor/various/block-deletion.spec.js
@@ -381,7 +381,7 @@ test.describe( 'Block deletion', () => {
 
 		// Ensure that the block appender button is visible.
 		await expect(
-			editor.canvas.getByRole( 'button', { name: 'Add block' } )
+			editor.canvas.getByRole( 'button', { name: 'Add block to' } )
 		).toBeVisible();
 
 		// TODO: There should be expectations around where focus is placed in

--- a/test/e2e/specs/editor/various/draggable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/draggable-blocks.spec.js
@@ -386,7 +386,7 @@ test.describe( 'Draggable block', () => {
 				name: 'Block: Row',
 			} );
 			const rowAppender = rowBlock.getByRole( 'button', {
-				name: 'Add block to Row',
+				name: 'Add block',
 			} );
 
 			await dragOver( rowAppender );

--- a/test/e2e/specs/editor/various/draggable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/draggable-blocks.spec.js
@@ -386,7 +386,7 @@ test.describe( 'Draggable block', () => {
 				name: 'Block: Row',
 			} );
 			const rowAppender = rowBlock.getByRole( 'button', {
-				name: 'Add block',
+				name: 'Add block to Row',
 			} );
 
 			await dragOver( rowAppender );
@@ -426,7 +426,7 @@ test.describe( 'Draggable block', () => {
 					name: 'Block: Column',
 				} )
 				.getByRole( 'button', {
-					name: 'Add block',
+					name: 'Add block to Column',
 					includeHidden: true,
 				} );
 

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -547,7 +547,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			.click();
 		await editor.canvas
 			.getByRole( 'button', {
-				name: 'Add block',
+				name: 'Add block to Group',
 			} )
 			.click();
 		await page.getByRole( 'button', { name: 'Browse All' } ).click();
@@ -595,7 +595,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			.click();
 		await editor.canvas
 			.getByRole( 'button', {
-				name: 'Add block',
+				name: 'Add block to Group',
 			} )
 			.click();
 

--- a/test/e2e/specs/editor/various/writing-flow.spec.js
+++ b/test/e2e/specs/editor/various/writing-flow.spec.js
@@ -1159,7 +1159,9 @@ class WritingFlowUtils {
 			.locator( 'role=button[name="Two columns; equal split"i]' )
 			.click();
 		await this.editor.canvas
-			.locator( '.is-selected >> role=button[name="Add block"i]' )
+			.locator(
+				'.is-selected >> role=button[name="Add block to Column"i]'
+			)
 			.click();
 		await this.page.click(
 			'role=listbox[name="Blocks"i] >> role=option[name="Paragraph"i]'
@@ -1170,7 +1172,7 @@ class WritingFlowUtils {
 			.locator( 'role=document[name="Block: Column (2 of 2)"i]' )
 			.focus();
 		await this.editor.canvas
-			.locator( 'role=button[name="Add block"i]' )
+			.locator( 'role=button[name="Add block to Column"i]' )
 			.click();
 		await this.page.click(
 			'role=listbox[name="Blocks"i] >> role=option[name="Paragraph"i]'

--- a/test/e2e/specs/site-editor/block-style-variations.spec.js
+++ b/test/e2e/specs/site-editor/block-style-variations.spec.js
@@ -319,7 +319,9 @@ async function addPageContent( editor, page ) {
 	await editor.canvas
 		.locator( 'role=button[name="Group: Gather blocks in a container."i]' )
 		.click();
-	await editor.canvas.locator( 'role=button[name="Add block"i]' ).click();
+	await editor.canvas
+		.locator( 'role=button[name="Add block to Group"i]' )
+		.click();
 	await page.click(
 		'role=listbox[name="Blocks"i] >> role=option[name="Paragraph"i]'
 	);
@@ -333,7 +335,9 @@ async function addPageContent( editor, page ) {
 	await editor.canvas
 		.locator( 'role=button[name="Group: Gather blocks in a container."i]' )
 		.click();
-	await editor.canvas.locator( 'role=button[name="Add block"i]' ).click();
+	await editor.canvas
+		.locator( 'role=button[name="Add block to Group"i]' )
+		.click();
 	await page.click(
 		'role=listbox[name="Blocks"i] >> role=option[name="Paragraph"i]'
 	);
@@ -347,7 +351,9 @@ async function addPageContent( editor, page ) {
 	await editor.canvas
 		.locator( 'role=button[name="Group: Gather blocks in a container."i]' )
 		.click();
-	await editor.canvas.locator( 'role=button[name="Add block"i]' ).click();
+	await editor.canvas
+		.locator( 'role=button[name="Add block to Group"i]' )
+		.click();
 	await page.click(
 		'role=listbox[name="Blocks"i] >> role=option[name="Paragraph"i]'
 	);

--- a/test/e2e/specs/site-editor/template-part.spec.js
+++ b/test/e2e/specs/site-editor/template-part.spec.js
@@ -45,7 +45,7 @@ test.describe( 'Template Part', () => {
 			'[data-type="core/template-part"]'
 		);
 		const addBlockButton = templatePart.locator(
-			'role=button[name="Add block"i]'
+			'role=button[name="Add block to Template Part"i]'
 		);
 		await expect( templatePart ).toBeVisible();
 		await expect( addBlockButton ).toBeVisible();

--- a/test/e2e/specs/widgets/customizing-widgets.spec.js
+++ b/test/e2e/specs/widgets/customizing-widgets.spec.js
@@ -75,7 +75,7 @@ test.describe( 'Widgets Customizer', () => {
 
 		// Click on the inline appender.
 		await page.click(
-			'css=.editor-styles-wrapper >> role=button[name="Add block"i]'
+			'css=.editor-styles-wrapper >> role=button[name="Add block to"i]'
 		);
 
 		const inlineInserterSearchBox = page.locator(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/71162


<!-- In a few words, what is the PR actually doing? -->

This PR updates the block inserter button label to show a contextual and clearer message when adding new blocks inside a parent block. Instead of the generic "Add block" tooltip, it shows "Add block to [Parent Block Title]" where applicable (e.g., for navigation menu items).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The generic "Add block" tooltip can be confusing when adding items inside blocks like the Navigation block, where users expect to add a new menu item rather than just a generic block. This change improves clarity by specifying the type of item being added based on the parent block's title.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- The `ButtonBlockAppender` component now receives a `parentBlockTitle` prop and uses it to customize the button label.
- The label changes from a generic "Add block" to a contextual string, e.g., "Add block to Navigation" for navigation blocks.
- The `Inserter` component obtains the parent block title by retrieving the parent block's block type title or name and passes it down as a prop.
- The label text uses WordPress translation functions (`_x` and `sprintf`) with translator comments for internationalization support.

Reference taken from here: https://github.com/WordPress/gutenberg/pull/45238#discussion_r1003290784

## Testing Instructions
1. Open the editor and add a Navigation block (or any block with nested child blocks).
2. Hover over or focus the block inserter button inside the parent block.
3. Confirm that the tooltip/button label reads "Add block to [Parent Block Title]" (e.g., "Add block to Navigation") instead of the generic "Add block."
4. Verify that the label is properly translated and appears correctly for other block types as well.

## Screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/dcce8add-e91c-472d-a7cc-6e16dc6ab916


### After

https://github.com/user-attachments/assets/61c15d30-4dfe-41df-a126-7551e079976b

