### PR TITLE
DataForm: make `isValid.custom` async

### DIFF
--- a/packages/dataviews/src/components/dataform/index.tsx
+++ b/packages/dataviews/src/components/dataform/index.tsx
@@ -1,12 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { useMemo, useCallback } from '@wordpress/element';
+import { useMemo, useCallback, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import type { DataFormProps } from '../../types';
+import type { DataFormProps, ValidationError } from '../../types';
 import { DataFormProvider } from '../dataform-context';
 import { normalizeFields } from '../../normalize-fields';
 import { DataFormLayout } from '../../dataforms-layouts/data-form-layout';
@@ -23,15 +23,59 @@ export default function DataForm< Item >( {
 		[ fields ]
 	);
 
+	const [ isFormValid, setIsFormValid ] = useState< boolean | undefined >();
+	const [ validating, setValidating ] = useState< string[] >( [] );
+	const [ formErrors, setFormErrors ] = useState< ValidationError[] >( [] );
+
 	const onValidateCb = useCallback(
-		( isValid: boolean | undefined, isValidating: boolean ) => {
+		( {
+			id,
+			isValid,
+			isValidating,
+			errors,
+		}: {
+			id: string;
+			isValid: boolean | undefined;
+			isValidating: boolean;
+			errors: string[];
+		} ) => {
 			if ( ! onValidate ) {
 				return;
 			}
 
-			onValidate( isValid, isValidating );
+			// Process errors.
+			const newFormErrors = [
+				...formErrors.filter( ( error ) => error.id !== id ),
+				...errors.map( ( error ) => ( {
+					id,
+					message: error,
+				} ) ),
+			];
+
+			// Process isValidating.
+			const newValidating = isValidating
+				? [ ...validating, id ]
+				: validating.filter( ( v ) => v !== id );
+
+			// Process isValid.
+			let newIsValid = isFormValid;
+			if ( isValid === false ) {
+				newIsValid = false;
+			}
+			if ( newFormErrors.length === 0 && newValidating.length === 0 ) {
+				newIsValid = true;
+			}
+
+			setIsFormValid( newIsValid );
+			setValidating( newValidating );
+			setFormErrors( newFormErrors );
+			onValidate( {
+				isValid: newIsValid,
+				isValidating: newValidating.length > 0,
+				errors: newFormErrors,
+			} );
 		},
-		[ onValidate ]
+		[ onValidate, formErrors, validating, isFormValid ]
 	);
 
 	if ( ! form.fields ) {

--- a/packages/dataviews/src/components/dataform/index.tsx
+++ b/packages/dataviews/src/components/dataform/index.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useMemo } from '@wordpress/element';
+import { useMemo, useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -16,10 +16,22 @@ export default function DataForm< Item >( {
 	form,
 	fields,
 	onChange,
+	onValidate,
 }: DataFormProps< Item > ) {
 	const normalizedFields = useMemo(
 		() => normalizeFields( fields ),
 		[ fields ]
+	);
+
+	const onValidateCb = useCallback(
+		( isValid: boolean | undefined, isValidating: boolean ) => {
+			if ( ! onValidate ) {
+				return;
+			}
+
+			onValidate( isValid, isValidating );
+		},
+		[ onValidate ]
 	);
 
 	if ( ! form.fields ) {
@@ -28,7 +40,12 @@ export default function DataForm< Item >( {
 
 	return (
 		<DataFormProvider fields={ normalizedFields }>
-			<DataFormLayout data={ data } form={ form } onChange={ onChange } />
+			<DataFormLayout
+				data={ data }
+				form={ form }
+				onChange={ onChange }
+				onValidate={ onValidateCb }
+			/>
 		</DataFormProvider>
 	);
 }

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -12,7 +12,6 @@ import {
  * Internal dependencies
  */
 import DataForm from '../index';
-import { isItemValid } from '../../../validation';
 import type {
 	Field,
 	Form,
@@ -398,6 +397,10 @@ const ValidationComponent = ( {
 		customEdit: string;
 	};
 
+	// TODO: what should be the initial state of the form validation?
+	// Do we still need isItemValid for this case?
+	const [ isFormValid, setIsFormValid ] = useState< boolean | undefined >();
+	const [ isFormBusy, setIsFormBusy ] = useState< boolean >( false );
 	const [ post, setPost ] = useState< ValidatedItem >( {
 		text: 'Can have letters and spaces',
 		email: 'hi@example.com',
@@ -508,8 +511,6 @@ const ValidationComponent = ( {
 		fields: [ 'text', 'email', 'integer', 'boolean', 'customEdit' ],
 	};
 
-	const canSave = isItemValid( post, _fields, form );
-
 	return (
 		<form>
 			<VStack alignment="left">
@@ -523,11 +524,16 @@ const ValidationComponent = ( {
 							...edits,
 						} ) )
 					}
+					onValidate={ ( isValid, isValidating ) => {
+						setIsFormValid( isValid );
+						setIsFormBusy( isValidating );
+					} }
 				/>
 				<Button
 					__next40pxDefaultSize
 					accessibleWhenDisabled
-					disabled={ ! canSave }
+					disabled={ isFormBusy || ! isFormValid }
+					isBusy={ isFormBusy }
 					variant="primary"
 				>
 					Submit

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -383,10 +383,12 @@ const ValidationComponent = ( {
 	required,
 	type,
 	custom,
+	isCustomAsync,
 }: {
 	required: boolean;
-	custom: boolean;
 	type: 'regular' | 'panel';
+	custom: boolean;
+	isCustomAsync: boolean;
 } ) => {
 	type ValidatedItem = {
 		text: string;
@@ -426,10 +428,25 @@ const ValidationComponent = ( {
 		return null;
 	};
 
+	const makeAsync = ( rule: ( item: ValidatedItem ) => null | string ) => {
+		return async ( value: ValidatedItem ) => {
+			return await new Promise< string | null >( ( resolve ) => {
+				setTimeout( () => {
+					const validationResult = rule( value );
+					resolve( validationResult );
+				}, 2000 );
+			} );
+		};
+	};
+
 	const maybeCustomRule = (
 		rule: ( item: ValidatedItem ) => null | string
 	) => {
-		return custom ? rule : undefined;
+		if ( custom ) {
+			return isCustomAsync ? makeAsync( rule ) : rule;
+		}
+
+		return undefined;
 	};
 
 	const _fields: Field< ValidatedItem >[] = [
@@ -885,11 +902,16 @@ export const Validation = {
 			control: { type: 'boolean' },
 			description: 'Whether or not the fields have custom validation.',
 		},
+		isCustomAsync: {
+			control: { type: 'boolean' },
+			description: 'Whether or not the custom validation is async.',
+		},
 	},
 	args: {
 		required: true,
 		type: 'regular',
 		custom: true,
+		isCustomAsync: false,
 	},
 };
 

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useMemo, useState } from '@wordpress/element';
+import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
 import {
 	Button,
 	__experimentalVStack as VStack,
@@ -346,14 +346,23 @@ const LayoutPanelComponent = ( {
 	);
 };
 
+// This implements a custom Edit control.
+// It's a copy-over of the text's DataForm control.
 function CustomEditControl< Item >( {
 	data,
 	field,
 	onChange,
+	onValidate,
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
 	const { id, label, placeholder, description } = field;
-	const value = field.getValue( { item: data } );
+	const value = field.getValue( { item: data } ) ?? '';
+	const [ customValidity, setCustomValidity ] =
+		useState<
+			React.ComponentProps<
+				typeof ValidatedTextControl
+			>[ 'customValidity' ]
+		>( undefined );
 
 	const onChangeControl = useCallback(
 		( newValue: string ) =>
@@ -363,9 +372,82 @@ function CustomEditControl< Item >( {
 		[ id, onChange ]
 	);
 
+	// onValidate needs access to the latest value that has been validated
+	// to bail early if it didn't change.
+	//
+	// We can't use the value directly because it is updated by onChange,
+	// and so there may be race conditions between onChange and onValidate.
+	const previousValidatedValueRef = useRef< unknown >( value );
+
 	return (
 		<ValidatedTextControl
 			required={ !! field.isValid?.required }
+			onValidate={ ( newValue: any ) => {
+				// Do not trigger validation if the value is the same as before.
+				if ( newValue === previousValidatedValueRef.current ) {
+					return;
+				}
+				previousValidatedValueRef.current = newValue;
+
+				const message = field?.isValid?.custom?.(
+					{
+						...data,
+						[ id ]: newValue,
+					},
+					field
+				);
+
+				// Async validation:
+				// validity can be validating, invalid, valid.
+				if ( message instanceof Promise ) {
+					setCustomValidity( {
+						type: 'validating',
+						message: 'Validating...',
+					} );
+					onValidate( undefined, true );
+
+					message
+						.then( ( result ) => {
+							if ( result ) {
+								setCustomValidity( {
+									type: 'invalid',
+									message: result,
+								} );
+								onValidate( false, false );
+							} else {
+								setCustomValidity( {
+									type: 'valid',
+									message: 'Validated',
+								} );
+								onValidate( true, false );
+							}
+						} )
+						.catch( ( error ) => {
+							setCustomValidity( {
+								type: 'invalid',
+								message: error.message,
+							} );
+							onValidate( false, false );
+						} );
+
+					return;
+				}
+
+				// Sync validation:
+				// validity is either invalid or undefined (nothing displayed).
+				if ( message ) {
+					setCustomValidity( {
+						type: 'invalid',
+						message,
+					} );
+					onValidate( false, false );
+					return;
+				}
+
+				onValidate( true, false );
+				setCustomValidity( undefined );
+			} }
+			customValidity={ customValidity }
 			label={ label }
 			placeholder={ placeholder }
 			value={ value ?? '' }
@@ -382,12 +464,10 @@ const ValidationComponent = ( {
 	required,
 	type,
 	custom,
-	isCustomAsync,
 }: {
 	required: boolean;
 	type: 'regular' | 'panel';
-	custom: boolean;
-	isCustomAsync: boolean;
+	custom: 'sync' | 'async' | 'none';
 } ) => {
 	type ValidatedItem = {
 		text: string;
@@ -437,6 +517,13 @@ const ValidationComponent = ( {
 
 		return null;
 	};
+	const customEditRule = ( value: ValidatedItem ) => {
+		if ( ! /^[a-zA-Z ]+$/.test( value.customEdit ) ) {
+			return 'Value must only contain letters and spaces.';
+		}
+
+		return null;
+	};
 
 	const makeAsync = ( rule: ( item: ValidatedItem ) => null | string ) => {
 		return async ( value: ValidatedItem ) => {
@@ -452,11 +539,30 @@ const ValidationComponent = ( {
 	const maybeCustomRule = (
 		rule: ( item: ValidatedItem ) => null | string
 	) => {
-		if ( custom ) {
-			return isCustomAsync ? makeAsync( rule ) : rule;
+		if ( custom === 'sync' ) {
+			return rule;
+		}
+
+		if ( custom === 'async' ) {
+			return makeAsync( rule );
 		}
 
 		return undefined;
+	};
+
+	const getDescription = (
+		customStatus: 'sync' | 'async' | 'none',
+		message: string
+	) => {
+		if ( customStatus === 'sync' ) {
+			return 'Custom validation (sync): ' + message;
+		}
+
+		if ( customStatus === 'async' ) {
+			return 'Custom validation (async): ' + message;
+		}
+
+		return 'Custom validation: none';
 	};
 
 	const _fields: Field< ValidatedItem >[] = [
@@ -464,9 +570,10 @@ const ValidationComponent = ( {
 			id: 'text',
 			type: 'text',
 			label: 'Text',
-			description: custom
-				? 'Custom validation: can only have letters and spaces.'
-				: undefined,
+			description: getDescription(
+				custom,
+				'can only have letters and spaces.'
+			),
 			isValid: {
 				required,
 				custom: maybeCustomRule( customTextRule ),
@@ -476,9 +583,10 @@ const ValidationComponent = ( {
 			id: 'email',
 			type: 'email',
 			label: 'e-mail',
-			description: custom
-				? 'Custom validation: can only use @example.com emails.'
-				: undefined,
+			description: getDescription(
+				custom,
+				'can only use @example.com emails.'
+			),
 			isValid: {
 				required,
 				custom: maybeCustomRule( customEmailRule ),
@@ -488,9 +596,7 @@ const ValidationComponent = ( {
 			id: 'integer',
 			type: 'integer',
 			label: 'Integer',
-			description: custom
-				? 'Custom validation: can only use even integers.'
-				: undefined,
+			description: getDescription( custom, 'can only use even numbers.' ),
 			isValid: {
 				required,
 				custom: maybeCustomRule( customIntegerRule ),
@@ -500,9 +606,7 @@ const ValidationComponent = ( {
 			id: 'boolean',
 			type: 'boolean',
 			label: 'Boolean',
-			description: custom
-				? 'Custom validation: can only be true.'
-				: undefined,
+			description: getDescription( custom, 'can only be true.' ),
 			isValid: {
 				required,
 				custom: maybeCustomRule( customBooleanRule ),
@@ -511,9 +615,14 @@ const ValidationComponent = ( {
 		{
 			id: 'customEdit',
 			label: 'Custom Edit',
+			description: getDescription(
+				custom,
+				'can only have letters and spaces.'
+			),
 			Edit: CustomEditControl,
 			isValid: {
 				required,
+				custom: maybeCustomRule( customEditRule ),
 			},
 		},
 	];
@@ -925,19 +1034,15 @@ export const Validation = {
 			options: [ 'regular', 'panel' ],
 		},
 		custom: {
-			control: { type: 'boolean' },
+			control: { type: 'select' },
 			description: 'Whether or not the fields have custom validation.',
-		},
-		isCustomAsync: {
-			control: { type: 'boolean' },
-			description: 'Whether or not the custom validation is async.',
+			options: [ 'sync', 'async', 'none' ],
 		},
 	},
 	args: {
 		required: true,
 		type: 'regular',
-		custom: true,
-		isCustomAsync: false,
+		custom: 'sync',
 	},
 };
 

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -427,6 +427,13 @@ const ValidationComponent = ( {
 
 		return null;
 	};
+	const customBooleanRule = ( value: ValidatedItem ) => {
+		if ( value.boolean !== true ) {
+			return 'Boolean must be true.';
+		}
+
+		return null;
+	};
 
 	const makeAsync = ( rule: ( item: ValidatedItem ) => null | string ) => {
 		return async ( value: ValidatedItem ) => {
@@ -483,11 +490,12 @@ const ValidationComponent = ( {
 			label: 'Boolean',
 			isValid: {
 				required,
+				custom: maybeCustomRule( customBooleanRule ),
 			},
 		},
 		{
 			id: 'customEdit',
-			label: 'Custom Control',
+			label: 'Custom Edit',
 			Edit: CustomEditControl,
 			isValid: {
 				required,

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -404,7 +404,12 @@ function CustomEditControl< Item >( {
 						type: 'validating',
 						message: 'Validating...',
 					} );
-					onValidate( undefined, true );
+					onValidate( {
+						id: field.id,
+						isValid: undefined,
+						isValidating: true,
+						errors: [],
+					} );
 
 					message
 						.then( ( result ) => {
@@ -413,13 +418,23 @@ function CustomEditControl< Item >( {
 									type: 'invalid',
 									message: result,
 								} );
-								onValidate( false, false );
+								onValidate( {
+									id: field.id,
+									isValid: false,
+									isValidating: false,
+									errors: [ result ],
+								} );
 							} else {
 								setCustomValidity( {
 									type: 'valid',
 									message: 'Validated',
 								} );
-								onValidate( true, false );
+								onValidate( {
+									id: field.id,
+									isValid: true,
+									isValidating: false,
+									errors: [],
+								} );
 							}
 						} )
 						.catch( ( error ) => {
@@ -427,7 +442,12 @@ function CustomEditControl< Item >( {
 								type: 'invalid',
 								message: error.message,
 							} );
-							onValidate( false, false );
+							onValidate( {
+								id: field.id,
+								isValid: false,
+								isValidating: false,
+								errors: [ error.message ],
+							} );
 						} );
 
 					return;
@@ -440,11 +460,21 @@ function CustomEditControl< Item >( {
 						type: 'invalid',
 						message,
 					} );
-					onValidate( false, false );
+					onValidate( {
+						id: field.id,
+						isValid: false,
+						isValidating: false,
+						errors: [ message ],
+					} );
 					return;
 				}
 
-				onValidate( true, false );
+				onValidate( {
+					id: field.id,
+					isValid: true,
+					isValidating: false,
+					errors: [],
+				} );
 				setCustomValidity( undefined );
 			} }
 			customValidity={ customValidity }
@@ -645,7 +675,7 @@ const ValidationComponent = ( {
 							...edits,
 						} ) )
 					}
-					onValidate={ ( isValid, isValidating ) => {
+					onValidate={ ( { isValid, isValidating } ) => {
 						setIsFormValid( isValid );
 						setIsFormBusy( isValidating );
 					} }

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -402,7 +402,7 @@ const ValidationComponent = ( {
 	const [ isFormValid, setIsFormValid ] = useState< boolean | undefined >();
 	const [ isFormBusy, setIsFormBusy ] = useState< boolean >( false );
 	const [ post, setPost ] = useState< ValidatedItem >( {
-		text: 'Can have letters and spaces',
+		text: 'Some text',
 		email: 'hi@example.com',
 		integer: 2,
 		boolean: true,
@@ -464,6 +464,9 @@ const ValidationComponent = ( {
 			id: 'text',
 			type: 'text',
 			label: 'Text',
+			description: custom
+				? 'Custom validation: can only have letters and spaces.'
+				: undefined,
 			isValid: {
 				required,
 				custom: maybeCustomRule( customTextRule ),
@@ -473,6 +476,9 @@ const ValidationComponent = ( {
 			id: 'email',
 			type: 'email',
 			label: 'e-mail',
+			description: custom
+				? 'Custom validation: can only use @example.com emails.'
+				: undefined,
 			isValid: {
 				required,
 				custom: maybeCustomRule( customEmailRule ),
@@ -482,6 +488,9 @@ const ValidationComponent = ( {
 			id: 'integer',
 			type: 'integer',
 			label: 'Integer',
+			description: custom
+				? 'Custom validation: can only use even integers.'
+				: undefined,
 			isValid: {
 				required,
 				custom: maybeCustomRule( customIntegerRule ),
@@ -491,6 +500,9 @@ const ValidationComponent = ( {
 			id: 'boolean',
 			type: 'boolean',
 			label: 'Boolean',
+			description: custom
+				? 'Custom validation: can only be true.'
+				: undefined,
 			isValid: {
 				required,
 				custom: maybeCustomRule( customBooleanRule ),

--- a/packages/dataviews/src/components/dataviews-filters/input-widget.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/input-widget.tsx
@@ -91,6 +91,7 @@ export default function InputWidget( {
 				field={ field }
 				operator={ currentFilter.operator }
 				onChange={ handleChange }
+				onValidate={ () => {} } // TODO: decide whether onValidate should be optional
 			/>
 		</Flex>
 	);

--- a/packages/dataviews/src/dataform-controls/boolean.tsx
+++ b/packages/dataviews/src/dataform-controls/boolean.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { privateApis } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { useState, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -19,6 +19,7 @@ export default function Boolean< Item >( {
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
 	const { id, getValue, label } = field;
+	const value = getValue( { item: data } );
 	const [ customValidity, setCustomValidity ] =
 		useState<
 			React.ComponentProps<
@@ -26,10 +27,23 @@ export default function Boolean< Item >( {
 			>[ 'customValidity' ]
 		>( undefined );
 
+	// onValidate needs access to the latest value that has been validated
+	// to bail early if it didn't change.
+	//
+	// We can't use the value directly because it is updated by onChange,
+	// and so there may be race conditions between onChange and onValidate.
+	const previousValidatedValueRef = useRef< unknown >( value );
+
 	return (
 		<ValidatedToggleControl
 			required={ !! field.isValid.required }
 			onValidate={ ( newValue: any ) => {
+				// Do not trigger validation if the value is the same as before.
+				if ( newValue === previousValidatedValueRef.current ) {
+					return;
+				}
+				previousValidatedValueRef.current = newValue;
+
 				const message = field.isValid?.custom?.(
 					{
 						...data,
@@ -38,6 +52,40 @@ export default function Boolean< Item >( {
 					field
 				);
 
+				// Async validation:
+				// validity can be validating, invalid, valid.
+				if ( message instanceof Promise ) {
+					setCustomValidity( {
+						type: 'validating',
+						message: 'Validating...',
+					} );
+
+					message
+						.then( ( result ) => {
+							if ( result ) {
+								setCustomValidity( {
+									type: 'invalid',
+									message: result,
+								} );
+							} else {
+								setCustomValidity( {
+									type: 'valid',
+									message: 'Validated',
+								} );
+							}
+						} )
+						.catch( ( error ) => {
+							setCustomValidity( {
+								type: 'invalid',
+								message: error.message,
+							} );
+						} );
+
+					return;
+				}
+
+				// Sync validation:
+				// validity is either invalid or undefined (nothing displayed).
 				if ( message ) {
 					setCustomValidity( {
 						type: 'invalid',
@@ -52,10 +100,8 @@ export default function Boolean< Item >( {
 			hidden={ hideLabelFromVision }
 			__nextHasNoMarginBottom
 			label={ label }
-			checked={ getValue( { item: data } ) }
-			onChange={ () =>
-				onChange( { [ id ]: ! getValue( { item: data } ) } )
-			}
+			checked={ value }
+			onChange={ () => onChange( { [ id ]: ! value } ) }
 		/>
 	);
 }

--- a/packages/dataviews/src/dataform-controls/boolean.tsx
+++ b/packages/dataviews/src/dataform-controls/boolean.tsx
@@ -60,7 +60,12 @@ export default function Boolean< Item >( {
 						type: 'validating',
 						message: 'Validating...',
 					} );
-					onValidate( undefined, true );
+					onValidate( {
+						id: field.id,
+						isValid: undefined,
+						isValidating: true,
+						errors: [],
+					} );
 
 					message
 						.then( ( result ) => {
@@ -69,13 +74,23 @@ export default function Boolean< Item >( {
 									type: 'invalid',
 									message: result,
 								} );
-								onValidate( false, false );
+								onValidate( {
+									id: field.id,
+									isValid: false,
+									isValidating: false,
+									errors: [ result ],
+								} );
 							} else {
 								setCustomValidity( {
 									type: 'valid',
 									message: 'Validated',
 								} );
-								onValidate( true, false );
+								onValidate( {
+									id: field.id,
+									isValid: true,
+									isValidating: false,
+									errors: [],
+								} );
 							}
 						} )
 						.catch( ( error ) => {
@@ -83,7 +98,12 @@ export default function Boolean< Item >( {
 								type: 'invalid',
 								message: error.message,
 							} );
-							onValidate( false, false );
+							onValidate( {
+								id: field.id,
+								isValid: false,
+								isValidating: false,
+								errors: [ error.message ],
+							} );
 						} );
 
 					return;
@@ -96,11 +116,21 @@ export default function Boolean< Item >( {
 						type: 'invalid',
 						message,
 					} );
-					onValidate( false, false );
+					onValidate( {
+						id: field.id,
+						isValid: false,
+						isValidating: false,
+						errors: [ message ],
+					} );
 					return;
 				}
 
-				onValidate( true, false );
+				onValidate( {
+					id: field.id,
+					isValid: true,
+					isValidating: false,
+					errors: [],
+				} );
 				setCustomValidity( undefined );
 			} }
 			customValidity={ customValidity }

--- a/packages/dataviews/src/dataform-controls/boolean.tsx
+++ b/packages/dataviews/src/dataform-controls/boolean.tsx
@@ -15,6 +15,7 @@ const { ValidatedToggleControl } = unlock( privateApis );
 export default function Boolean< Item >( {
 	field,
 	onChange,
+	onValidate,
 	data,
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
@@ -59,6 +60,7 @@ export default function Boolean< Item >( {
 						type: 'validating',
 						message: 'Validating...',
 					} );
+					onValidate( undefined, true );
 
 					message
 						.then( ( result ) => {
@@ -67,11 +69,13 @@ export default function Boolean< Item >( {
 									type: 'invalid',
 									message: result,
 								} );
+								onValidate( false, false );
 							} else {
 								setCustomValidity( {
 									type: 'valid',
 									message: 'Validated',
 								} );
+								onValidate( true, false );
 							}
 						} )
 						.catch( ( error ) => {
@@ -79,6 +83,7 @@ export default function Boolean< Item >( {
 								type: 'invalid',
 								message: error.message,
 							} );
+							onValidate( false, false );
 						} );
 
 					return;
@@ -91,9 +96,11 @@ export default function Boolean< Item >( {
 						type: 'invalid',
 						message,
 					} );
+					onValidate( false, false );
 					return;
 				}
 
+				onValidate( true, false );
 				setCustomValidity( undefined );
 			} }
 			customValidity={ customValidity }

--- a/packages/dataviews/src/dataform-controls/email.tsx
+++ b/packages/dataviews/src/dataform-controls/email.tsx
@@ -16,6 +16,7 @@ export default function Email< Item >( {
 	data,
 	field,
 	onChange,
+	onValidate,
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
 	const { id, label, placeholder, description } = field;
@@ -67,6 +68,7 @@ export default function Email< Item >( {
 						type: 'validating',
 						message: 'Validating...',
 					} );
+					onValidate( undefined, true );
 
 					message
 						.then( ( result ) => {
@@ -75,11 +77,13 @@ export default function Email< Item >( {
 									type: 'invalid',
 									message: result,
 								} );
+								onValidate( false, false );
 							} else {
 								setCustomValidity( {
 									type: 'valid',
 									message: 'Validated',
 								} );
+								onValidate( true, false );
 							}
 						} )
 						.catch( ( error ) => {
@@ -87,6 +91,7 @@ export default function Email< Item >( {
 								type: 'invalid',
 								message: error.message,
 							} );
+							onValidate( false, false );
 						} );
 
 					return;
@@ -99,9 +104,11 @@ export default function Email< Item >( {
 						type: 'invalid',
 						message,
 					} );
+					onValidate( false, false );
 					return;
 				}
 
+				onValidate( true, false );
 				setCustomValidity( undefined );
 			} }
 			customValidity={ customValidity }

--- a/packages/dataviews/src/dataform-controls/email.tsx
+++ b/packages/dataviews/src/dataform-controls/email.tsx
@@ -68,7 +68,12 @@ export default function Email< Item >( {
 						type: 'validating',
 						message: 'Validating...',
 					} );
-					onValidate( undefined, true );
+					onValidate( {
+						id: field.id,
+						isValid: undefined,
+						isValidating: true,
+						errors: [],
+					} );
 
 					message
 						.then( ( result ) => {
@@ -77,13 +82,23 @@ export default function Email< Item >( {
 									type: 'invalid',
 									message: result,
 								} );
-								onValidate( false, false );
+								onValidate( {
+									id: field.id,
+									isValid: false,
+									isValidating: false,
+									errors: [ result ],
+								} );
 							} else {
 								setCustomValidity( {
 									type: 'valid',
 									message: 'Validated',
 								} );
-								onValidate( true, false );
+								onValidate( {
+									id: field.id,
+									isValid: true,
+									isValidating: false,
+									errors: [],
+								} );
 							}
 						} )
 						.catch( ( error ) => {
@@ -91,7 +106,12 @@ export default function Email< Item >( {
 								type: 'invalid',
 								message: error.message,
 							} );
-							onValidate( false, false );
+							onValidate( {
+								id: field.id,
+								isValid: false,
+								isValidating: false,
+								errors: [ error.message ],
+							} );
 						} );
 
 					return;
@@ -104,11 +124,21 @@ export default function Email< Item >( {
 						type: 'invalid',
 						message,
 					} );
-					onValidate( false, false );
+					onValidate( {
+						id: field.id,
+						isValid: false,
+						isValidating: false,
+						errors: [ message ],
+					} );
 					return;
 				}
 
-				onValidate( true, false );
+				onValidate( {
+					id: field.id,
+					isValid: true,
+					isValidating: false,
+					errors: [],
+				} );
 				setCustomValidity( undefined );
 			} }
 			customValidity={ customValidity }

--- a/packages/dataviews/src/dataform-controls/email.tsx
+++ b/packages/dataviews/src/dataform-controls/email.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { privateApis } from '@wordpress/components';
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useState, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -35,11 +35,24 @@ export default function Email< Item >( {
 		[ id, onChange ]
 	);
 
+	// onValidate needs access to the latest value that has been validated
+	// to bail early if it didn't change.
+	//
+	// We can't use the value directly because it is updated by onChange,
+	// and so there may be race conditions between onChange and onValidate.
+	const previousValidatedValueRef = useRef< unknown >( value );
+
 	return (
 		<ValidatedTextControl
 			required={ !! field.isValid?.required }
 			onValidate={ ( newValue: any ) => {
-				const message = field.isValid?.custom?.(
+				// Do not trigger validation if the value is the same as before.
+				if ( newValue === previousValidatedValueRef.current ) {
+					return;
+				}
+				previousValidatedValueRef.current = newValue;
+
+				const message = field?.isValid?.custom?.(
 					{
 						...data,
 						[ id ]: newValue,
@@ -47,6 +60,40 @@ export default function Email< Item >( {
 					field
 				);
 
+				// Async validation:
+				// validity can be validating, invalid, valid.
+				if ( message instanceof Promise ) {
+					setCustomValidity( {
+						type: 'validating',
+						message: 'Validating...',
+					} );
+
+					message
+						.then( ( result ) => {
+							if ( result ) {
+								setCustomValidity( {
+									type: 'invalid',
+									message: result,
+								} );
+							} else {
+								setCustomValidity( {
+									type: 'valid',
+									message: 'Validated',
+								} );
+							}
+						} )
+						.catch( ( error ) => {
+							setCustomValidity( {
+								type: 'invalid',
+								message: error.message,
+							} );
+						} );
+
+					return;
+				}
+
+				// Sync validation:
+				// validity is either invalid or undefined (nothing displayed).
 				if ( message ) {
 					setCustomValidity( {
 						type: 'invalid',

--- a/packages/dataviews/src/dataform-controls/integer.tsx
+++ b/packages/dataviews/src/dataform-controls/integer.tsx
@@ -79,6 +79,7 @@ export default function Integer< Item >( {
 	data,
 	field,
 	onChange,
+	onValidate,
 	hideLabelFromVision,
 	operator,
 }: DataFormControlProps< Item > ) {
@@ -150,6 +151,7 @@ export default function Integer< Item >( {
 						type: 'validating',
 						message: 'Validating...',
 					} );
+					onValidate( undefined, true );
 
 					message
 						.then( ( result ) => {
@@ -158,11 +160,13 @@ export default function Integer< Item >( {
 									type: 'invalid',
 									message: result,
 								} );
+								onValidate( false, false );
 							} else {
 								setCustomValidity( {
 									type: 'valid',
 									message: 'Validated',
 								} );
+								onValidate( true, false );
 							}
 						} )
 						.catch( ( error ) => {
@@ -170,6 +174,7 @@ export default function Integer< Item >( {
 								type: 'invalid',
 								message: error.message,
 							} );
+							onValidate( false, false );
 						} );
 
 					return;
@@ -182,9 +187,11 @@ export default function Integer< Item >( {
 						type: 'invalid',
 						message,
 					} );
+					onValidate( false, false );
 					return;
 				}
 
+				onValidate( true, false );
 				setCustomValidity( undefined );
 			} }
 			customValidity={ customValidity }

--- a/packages/dataviews/src/dataform-controls/integer.tsx
+++ b/packages/dataviews/src/dataform-controls/integer.tsx
@@ -151,7 +151,12 @@ export default function Integer< Item >( {
 						type: 'validating',
 						message: 'Validating...',
 					} );
-					onValidate( undefined, true );
+					onValidate( {
+						id: field.id,
+						isValid: undefined,
+						isValidating: true,
+						errors: [],
+					} );
 
 					message
 						.then( ( result ) => {
@@ -160,13 +165,23 @@ export default function Integer< Item >( {
 									type: 'invalid',
 									message: result,
 								} );
-								onValidate( false, false );
+								onValidate( {
+									id: field.id,
+									isValid: false,
+									isValidating: false,
+									errors: [ result ],
+								} );
 							} else {
 								setCustomValidity( {
 									type: 'valid',
 									message: 'Validated',
 								} );
-								onValidate( true, false );
+								onValidate( {
+									id: field.id,
+									isValid: true,
+									isValidating: false,
+									errors: [],
+								} );
 							}
 						} )
 						.catch( ( error ) => {
@@ -174,7 +189,12 @@ export default function Integer< Item >( {
 								type: 'invalid',
 								message: error.message,
 							} );
-							onValidate( false, false );
+							onValidate( {
+								id: field.id,
+								isValid: false,
+								isValidating: false,
+								errors: [ error.message ],
+							} );
 						} );
 
 					return;
@@ -187,11 +207,16 @@ export default function Integer< Item >( {
 						type: 'invalid',
 						message,
 					} );
-					onValidate( false, false );
+					onValidate( {
+						id: field.id,
+						isValid: false,
+						isValidating: false,
+						errors: [ message ],
+					} );
 					return;
 				}
 
-				onValidate( true, false );
+				// onValidate( true, false );
 				setCustomValidity( undefined );
 			} }
 			customValidity={ customValidity }

--- a/packages/dataviews/src/dataform-controls/integer.tsx
+++ b/packages/dataviews/src/dataform-controls/integer.tsx
@@ -7,7 +7,7 @@ import {
 	__experimentalNumberControl as NumberControl,
 	privateApis,
 } from '@wordpress/components';
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useState, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -105,6 +105,13 @@ export default function Integer< Item >( {
 		[ id, onChange ]
 	);
 
+	// onValidate needs access to the latest value that has been validated
+	// to bail early if it didn't change.
+	//
+	// We can't use the value directly because it is updated by onChange,
+	// and so there may be race conditions between onChange and onValidate.
+	const previousValidatedValueRef = useRef< unknown >( value );
+
 	if ( operator === OPERATOR_BETWEEN ) {
 		return (
 			<BetweenControls
@@ -120,6 +127,12 @@ export default function Integer< Item >( {
 		<ValidatedNumberControl
 			required={ !! field.isValid?.required }
 			onValidate={ ( newValue: any ) => {
+				// Do not trigger validation if the value is the same as before.
+				if ( newValue === previousValidatedValueRef.current ) {
+					return;
+				}
+				previousValidatedValueRef.current = newValue;
+
 				const message = field.isValid?.custom?.(
 					{
 						...data,
@@ -130,6 +143,40 @@ export default function Integer< Item >( {
 					field
 				);
 
+				// Async validation:
+				// validity can be validating, invalid, valid.
+				if ( message instanceof Promise ) {
+					setCustomValidity( {
+						type: 'validating',
+						message: 'Validating...',
+					} );
+
+					message
+						.then( ( result ) => {
+							if ( result ) {
+								setCustomValidity( {
+									type: 'invalid',
+									message: result,
+								} );
+							} else {
+								setCustomValidity( {
+									type: 'valid',
+									message: 'Validated',
+								} );
+							}
+						} )
+						.catch( ( error ) => {
+							setCustomValidity( {
+								type: 'invalid',
+								message: error.message,
+							} );
+						} );
+
+					return;
+				}
+
+				// Sync validation:
+				// validity is either invalid or undefined (nothing displayed).
 				if ( message ) {
 					setCustomValidity( {
 						type: 'invalid',

--- a/packages/dataviews/src/dataform-controls/text.tsx
+++ b/packages/dataviews/src/dataform-controls/text.tsx
@@ -68,7 +68,12 @@ export default function Text< Item >( {
 						type: 'validating',
 						message: 'Validating...',
 					} );
-					onValidate( undefined, true );
+					onValidate( {
+						id: field.id,
+						isValid: undefined,
+						isValidating: true,
+						errors: [],
+					} );
 
 					message
 						.then( ( result ) => {
@@ -77,13 +82,23 @@ export default function Text< Item >( {
 									type: 'invalid',
 									message: result,
 								} );
-								onValidate( false, false );
+								onValidate( {
+									id: field.id,
+									isValid: false,
+									isValidating: false,
+									errors: [ result ],
+								} );
 							} else {
 								setCustomValidity( {
 									type: 'valid',
 									message: 'Validated',
 								} );
-								onValidate( true, false );
+								onValidate( {
+									id: field.id,
+									isValid: true,
+									isValidating: false,
+									errors: [],
+								} );
 							}
 						} )
 						.catch( ( error ) => {
@@ -91,7 +106,12 @@ export default function Text< Item >( {
 								type: 'invalid',
 								message: error.message,
 							} );
-							onValidate( false, false );
+							onValidate( {
+								id: field.id,
+								isValid: false,
+								isValidating: false,
+								errors: [ error.message ],
+							} );
 						} );
 
 					return;
@@ -104,11 +124,21 @@ export default function Text< Item >( {
 						type: 'invalid',
 						message,
 					} );
-					onValidate( false, false );
+					onValidate( {
+						id: field.id,
+						isValid: false,
+						isValidating: false,
+						errors: [ message ],
+					} );
 					return;
 				}
 
-				onValidate( true, false );
+				onValidate( {
+					id: field.id,
+					isValid: true,
+					isValidating: false,
+					errors: [],
+				} );
 				setCustomValidity( undefined );
 			} }
 			customValidity={ customValidity }

--- a/packages/dataviews/src/dataform-controls/text.tsx
+++ b/packages/dataviews/src/dataform-controls/text.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { privateApis } from '@wordpress/components';
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useState, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -19,7 +19,7 @@ export default function Text< Item >( {
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
 	const { id, label, placeholder, description } = field;
-	const value = field.getValue( { item: data } );
+	const value = field.getValue( { item: data } ) ?? '';
 	const [ customValidity, setCustomValidity ] =
 		useState<
 			React.ComponentProps<
@@ -35,11 +35,24 @@ export default function Text< Item >( {
 		[ id, onChange ]
 	);
 
+	// onValidate needs access to the latest value that has been validated
+	// to bail early if it didn't change.
+	//
+	// We can't use the value directly because it is updated by onChange,
+	// and so there may be race conditions between onChange and onValidate.
+	const previousValidatedValueRef = useRef< unknown >( value );
+
 	return (
 		<ValidatedTextControl
 			required={ !! field.isValid?.required }
 			onValidate={ ( newValue: any ) => {
-				const message = field.isValid?.custom?.(
+				// Do not trigger validation if the value is the same as before.
+				if ( newValue === previousValidatedValueRef.current ) {
+					return;
+				}
+				previousValidatedValueRef.current = newValue;
+
+				const message = field?.isValid?.custom?.(
 					{
 						...data,
 						[ id ]: newValue,
@@ -47,6 +60,40 @@ export default function Text< Item >( {
 					field
 				);
 
+				// Async validation:
+				// validity can be validating, invalid, valid.
+				if ( message instanceof Promise ) {
+					setCustomValidity( {
+						type: 'validating',
+						message: 'Validating...',
+					} );
+
+					message
+						.then( ( result ) => {
+							if ( result ) {
+								setCustomValidity( {
+									type: 'invalid',
+									message: result,
+								} );
+							} else {
+								setCustomValidity( {
+									type: 'valid',
+									message: 'Validated',
+								} );
+							}
+						} )
+						.catch( ( error ) => {
+							setCustomValidity( {
+								type: 'invalid',
+								message: error.message,
+							} );
+						} );
+
+					return;
+				}
+
+				// Sync validation:
+				// validity is either invalid or undefined (nothing displayed).
 				if ( message ) {
 					setCustomValidity( {
 						type: 'invalid',
@@ -60,7 +107,7 @@ export default function Text< Item >( {
 			customValidity={ customValidity }
 			label={ label }
 			placeholder={ placeholder }
-			value={ value ?? '' }
+			value={ value }
 			help={ description }
 			onChange={ onChangeControl }
 			__next40pxDefaultSize

--- a/packages/dataviews/src/dataform-controls/text.tsx
+++ b/packages/dataviews/src/dataform-controls/text.tsx
@@ -16,6 +16,7 @@ export default function Text< Item >( {
 	data,
 	field,
 	onChange,
+	onValidate,
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
 	const { id, label, placeholder, description } = field;
@@ -67,6 +68,7 @@ export default function Text< Item >( {
 						type: 'validating',
 						message: 'Validating...',
 					} );
+					onValidate( undefined, true );
 
 					message
 						.then( ( result ) => {
@@ -75,11 +77,13 @@ export default function Text< Item >( {
 									type: 'invalid',
 									message: result,
 								} );
+								onValidate( false, false );
 							} else {
 								setCustomValidity( {
 									type: 'valid',
 									message: 'Validated',
 								} );
+								onValidate( true, false );
 							}
 						} )
 						.catch( ( error ) => {
@@ -87,6 +91,7 @@ export default function Text< Item >( {
 								type: 'invalid',
 								message: error.message,
 							} );
+							onValidate( false, false );
 						} );
 
 					return;
@@ -99,9 +104,11 @@ export default function Text< Item >( {
 						type: 'invalid',
 						message,
 					} );
+					onValidate( false, false );
 					return;
 				}
 
+				onValidate( true, false );
 				setCustomValidity( undefined );
 			} }
 			customValidity={ customValidity }

--- a/packages/dataviews/src/dataforms-layouts/card/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/card/index.tsx
@@ -71,6 +71,7 @@ export default function FormCardField< Item >( {
 	data,
 	field,
 	onChange,
+	onValidate,
 	hideLabelFromVision,
 }: FieldLayoutProps< Item > ) {
 	const { fields } = useContext( DataFormContext );
@@ -108,6 +109,7 @@ export default function FormCardField< Item >( {
 							data={ data }
 							form={ form }
 							onChange={ onChange }
+							onValidate={ onValidate }
 						/>
 					</CardBody>
 				) }
@@ -143,6 +145,7 @@ export default function FormCardField< Item >( {
 						data={ data }
 						field={ field }
 						onChange={ onChange }
+						onValidate={ onValidate }
 						hideLabelFromVision={
 							hideLabelFromVision || withHeader
 						}

--- a/packages/dataviews/src/dataforms-layouts/data-form-layout.tsx
+++ b/packages/dataviews/src/dataforms-layouts/data-form-layout.tsx
@@ -7,7 +7,7 @@ import { useContext, useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import type { Form, FormField, SimpleFormField } from '../types';
+import type { SimpleFormField, DataFormLayoutProps } from '../types';
 import { getFormFieldLayout } from './index';
 import DataFormContext from '../components/dataform-context';
 import { isCombinedField } from './is-combined-field';
@@ -17,21 +17,9 @@ export function DataFormLayout< Item >( {
 	data,
 	form,
 	onChange,
+	onValidate,
 	children,
-}: {
-	data: Item;
-	form: Form;
-	onChange: ( value: any ) => void;
-	children?: (
-		FieldLayout: ( props: {
-			data: Item;
-			field: FormField;
-			onChange: ( value: any ) => void;
-			hideLabelFromVision?: boolean;
-		} ) => React.JSX.Element | null,
-		field: FormField
-	) => React.JSX.Element;
-} ) {
+}: DataFormLayoutProps< Item > ) {
 	const { fields: fieldDefinitions } = useContext( DataFormContext );
 
 	function getFieldDefinition( field: SimpleFormField | string ) {
@@ -79,6 +67,7 @@ export function DataFormLayout< Item >( {
 						data={ data }
 						field={ formField }
 						onChange={ onChange }
+						onValidate={ onValidate }
 					/>
 				);
 			} ) }

--- a/packages/dataviews/src/dataforms-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/dropdown.tsx
@@ -59,6 +59,7 @@ function PanelDropdown< Item >( {
 	labelPosition = 'side',
 	data,
 	onChange,
+	onValidate,
 	field,
 }: {
 	fieldDefinition: NormalizedField< Item >;
@@ -66,6 +67,7 @@ function PanelDropdown< Item >( {
 	labelPosition: 'side' | 'top' | 'none';
 	data: Item;
 	onChange: ( value: any ) => void;
+	onValidate: ( isValid: boolean | undefined, isValidating: boolean ) => void;
 	field: FormField;
 } ) {
 	const fieldLabel = isCombinedField( field )
@@ -138,6 +140,7 @@ function PanelDropdown< Item >( {
 						data={ data }
 						form={ form }
 						onChange={ onChange }
+						onValidate={ onValidate }
 					>
 						{ ( FieldLayout, nestedField ) => (
 							<FieldLayout
@@ -145,6 +148,7 @@ function PanelDropdown< Item >( {
 								data={ data }
 								field={ nestedField }
 								onChange={ onChange }
+								onValidate={ onValidate }
 								hideLabelFromVision={
 									( form?.fields ?? [] ).length < 2
 								}

--- a/packages/dataviews/src/dataforms-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/dropdown.tsx
@@ -67,7 +67,12 @@ function PanelDropdown< Item >( {
 	labelPosition: 'side' | 'top' | 'none';
 	data: Item;
 	onChange: ( value: any ) => void;
-	onValidate: ( isValid: boolean | undefined, isValidating: boolean ) => void;
+	onValidate: ( arg: {
+		id: string;
+		isValid: boolean | undefined;
+		isValidating: boolean;
+		errors: string[];
+	} ) => void;
 	field: FormField;
 } ) {
 	const fieldLabel = isCombinedField( field )

--- a/packages/dataviews/src/dataforms-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/index.tsx
@@ -30,6 +30,7 @@ export default function FormPanelField< Item >( {
 	data,
 	field,
 	onChange,
+	onValidate,
 }: FieldLayoutProps< Item > ) {
 	const { fields } = useContext( DataFormContext );
 	const fieldDefinition = fields.find( ( _field ) => {
@@ -86,6 +87,7 @@ export default function FormPanelField< Item >( {
 				fieldDefinition={ fieldDefinition }
 				data={ data }
 				onChange={ onChange }
+				onValidate={ onValidate }
 				labelPosition={ labelPosition }
 			/>
 		) : (
@@ -95,6 +97,7 @@ export default function FormPanelField< Item >( {
 				fieldDefinition={ fieldDefinition }
 				data={ data }
 				onChange={ onChange }
+				onValidate={ onValidate }
 				labelPosition={ labelPosition }
 			/>
 		);

--- a/packages/dataviews/src/dataforms-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/modal.tsx
@@ -23,12 +23,14 @@ function ModalContent< Item >( {
 	form,
 	fieldLabel,
 	onChange,
+	onValidate,
 	onClose,
 }: {
 	data: Item;
 	form: Form;
 	fieldLabel: string;
 	onChange: ( data: Partial< Item > ) => void;
+	onValidate: ( isValid: boolean | undefined, isValidating: boolean ) => void;
 	onClose: () => void;
 } ) {
 	const [ changes, setChanges ] = useState< Partial< Item > >( {} );
@@ -57,6 +59,7 @@ function ModalContent< Item >( {
 				data={ displayData }
 				form={ form }
 				onChange={ handleOnChange }
+				onValidate={ onValidate }
 			>
 				{ ( FieldLayout, nestedField ) => (
 					<FieldLayout
@@ -64,6 +67,7 @@ function ModalContent< Item >( {
 						data={ displayData }
 						field={ nestedField }
 						onChange={ handleOnChange }
+						onValidate={ onValidate }
 						hideLabelFromVision={
 							( form?.fields ?? [] ).length < 2
 						}
@@ -99,12 +103,14 @@ function PanelModal< Item >( {
 	labelPosition,
 	data,
 	onChange,
+	onValidate,
 	field,
 }: {
 	fieldDefinition: NormalizedField< Item >;
 	labelPosition: 'side' | 'top' | 'none';
 	data: Item;
 	onChange: ( value: any ) => void;
+	onValidate: ( isValid: boolean | undefined, isValidating: boolean ) => void;
 	field: FormField;
 } ) {
 	const [ isOpen, setIsOpen ] = useState( false );
@@ -155,6 +161,7 @@ function PanelModal< Item >( {
 					form={ form as Form }
 					fieldLabel={ fieldLabel ?? '' }
 					onChange={ onChange }
+					onValidate={ onValidate }
 					onClose={ () => setIsOpen( false ) }
 				/>
 			) }

--- a/packages/dataviews/src/dataforms-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/modal.tsx
@@ -30,7 +30,12 @@ function ModalContent< Item >( {
 	form: Form;
 	fieldLabel: string;
 	onChange: ( data: Partial< Item > ) => void;
-	onValidate: ( isValid: boolean | undefined, isValidating: boolean ) => void;
+	onValidate: ( arg: {
+		id: string;
+		isValid: boolean | undefined;
+		isValidating: boolean;
+		errors: string[];
+	} ) => void;
 	onClose: () => void;
 } ) {
 	const [ changes, setChanges ] = useState< Partial< Item > >( {} );
@@ -110,7 +115,12 @@ function PanelModal< Item >( {
 	labelPosition: 'side' | 'top' | 'none';
 	data: Item;
 	onChange: ( value: any ) => void;
-	onValidate: ( isValid: boolean | undefined, isValidating: boolean ) => void;
+	onValidate: ( arg: {
+		id: string;
+		isValid: boolean | undefined;
+		isValidating: boolean;
+		errors: string[];
+	} ) => void;
 	field: FormField;
 } ) {
 	const [ isOpen, setIsOpen ] = useState( false );

--- a/packages/dataviews/src/dataforms-layouts/regular/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/regular/index.tsx
@@ -44,6 +44,7 @@ export default function FormRegularField< Item >( {
 	data,
 	field,
 	onChange,
+	onValidate,
 	hideLabelFromVision,
 }: FieldLayoutProps< Item > ) {
 	const { fields } = useContext( DataFormContext );
@@ -66,6 +67,7 @@ export default function FormRegularField< Item >( {
 					data={ data }
 					form={ form }
 					onChange={ onChange }
+					onValidate={ onValidate }
 				/>
 			</>
 		);
@@ -107,6 +109,7 @@ export default function FormRegularField< Item >( {
 							data={ data }
 							field={ fieldDefinition }
 							onChange={ onChange }
+							onValidate={ onValidate }
 							hideLabelFromVision
 						/>
 					) }
@@ -136,6 +139,7 @@ export default function FormRegularField< Item >( {
 					data={ data }
 					field={ fieldDefinition }
 					onChange={ onChange }
+					onValidate={ onValidate }
 					hideLabelFromVision={
 						labelPosition === 'none' ? true : hideLabelFromVision
 					}

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -279,7 +279,12 @@ export type DataFormControlProps< Item > = {
 	data: Item;
 	field: NormalizedField< Item >;
 	onChange: ( value: Record< string, any > ) => void;
-	onValidate: ( isValid: boolean | undefined, isValidating: boolean ) => void;
+	onValidate: ( arg: {
+		id: string;
+		isValid: boolean | undefined;
+		isValidating: boolean;
+		errors: string[];
+	} ) => void;
 	hideLabelFromVision?: boolean;
 	/**
 	 * The currently selected filter operator for this field.
@@ -758,22 +763,33 @@ export type Form = {
 	fields?: Array< FormField | string >;
 };
 
+export interface ValidationError {
+	id: string;
+	message: string;
+}
+
 export interface DataFormProps< Item > {
 	data: Item;
 	fields: Field< Item >[];
 	form: Form;
 	onChange: ( value: Record< string, any > ) => void;
-	onValidate?: (
-		isValid: boolean | undefined,
-		isValidating: boolean
-	) => void;
+	onValidate?: ( arg: {
+		isValid: boolean | undefined;
+		isValidating: boolean;
+		errors: ValidationError[];
+	} ) => void;
 }
 
 export interface FieldLayoutProps< Item > {
 	data: Item;
 	field: FormField;
 	onChange: ( value: any ) => void;
-	onValidate: ( isValid: boolean | undefined, isValidating: boolean ) => void;
+	onValidate: ( arg: {
+		id: string;
+		isValid: boolean | undefined;
+		isValidating: boolean;
+		errors: string[];
+	} ) => void;
 	hideLabelFromVision?: boolean;
 }
 
@@ -781,16 +797,23 @@ export interface DataFormLayoutProps< Item > {
 	data: Item;
 	form: Form;
 	onChange: ( value: any ) => void;
-	onValidate: ( isValid: boolean | undefined, isValidating: boolean ) => void;
+	onValidate: ( arg: {
+		id: string;
+		isValid: boolean | undefined;
+		isValidating: boolean;
+		errors: string[];
+	} ) => void;
 	children?: (
 		FieldLayout: ( props: {
 			data: Item;
 			field: FormField;
 			onChange: ( value: any ) => void;
-			onValidate: (
-				isValid: boolean | undefined,
-				isValidating: boolean
-			) => void;
+			onValidate: ( arg: {
+				id: string;
+				isValid: boolean | undefined;
+				isValidating: boolean;
+				errors: string[];
+			} ) => void;
 			hideLabelFromVision?: boolean;
 		} ) => React.JSX.Element | null,
 		field: FormField

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -148,7 +148,12 @@ export type FieldTypeDefinition< Item > = {
 
 export type Rules< Item > = {
 	required?: boolean;
-	custom?: ( item: Item, field: NormalizedField< Item > ) => null | string;
+	custom?:
+		| ( ( item: Item, field: NormalizedField< Item > ) => null | string )
+		| ( (
+				item: Item,
+				field: NormalizedField< Item >
+		  ) => Promise< null | string > );
 };
 
 /**

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -279,6 +279,7 @@ export type DataFormControlProps< Item > = {
 	data: Item;
 	field: NormalizedField< Item >;
 	onChange: ( value: Record< string, any > ) => void;
+	onValidate: ( isValid: boolean | undefined, isValidating: boolean ) => void;
 	hideLabelFromVision?: boolean;
 	/**
 	 * The currently selected filter operator for this field.
@@ -762,11 +763,36 @@ export interface DataFormProps< Item > {
 	fields: Field< Item >[];
 	form: Form;
 	onChange: ( value: Record< string, any > ) => void;
+	onValidate?: (
+		isValid: boolean | undefined,
+		isValidating: boolean
+	) => void;
 }
 
 export interface FieldLayoutProps< Item > {
 	data: Item;
 	field: FormField;
 	onChange: ( value: any ) => void;
+	onValidate: ( isValid: boolean | undefined, isValidating: boolean ) => void;
 	hideLabelFromVision?: boolean;
+}
+
+export interface DataFormLayoutProps< Item > {
+	data: Item;
+	form: Form;
+	onChange: ( value: any ) => void;
+	onValidate: ( isValid: boolean | undefined, isValidating: boolean ) => void;
+	children?: (
+		FieldLayout: ( props: {
+			data: Item;
+			field: FormField;
+			onChange: ( value: any ) => void;
+			onValidate: (
+				isValid: boolean | undefined,
+				isValidating: boolean
+			) => void;
+			hideLabelFromVision?: boolean;
+		} ) => React.JSX.Element | null,
+		field: FormField
+	) => React.JSX.Element;
 }

--- a/packages/fields/src/actions/reorder-page.tsx
+++ b/packages/fields/src/actions/reorder-page.tsx
@@ -84,7 +84,7 @@ function ReorderModal( {
 					data={ item }
 					fields={ fields }
 					form={ formOrderAction }
-					onValidate={ ( isValid ) => {
+					onValidate={ ( { isValid } ) => {
 						setIsFormValid( isValid );
 					} }
 					onChange={ ( changes ) => {

--- a/packages/fields/src/actions/reorder-page.tsx
+++ b/packages/fields/src/actions/reorder-page.tsx
@@ -30,6 +30,9 @@ function ReorderModal( {
 	closeModal,
 	onActionPerformed,
 }: RenderModalProps< BasePost > ) {
+	const [ isFormValid, setIsFormValid ] = useState< boolean | undefined >(
+		false
+	);
 	const [ item, setItem ] = useState( items[ 0 ] );
 	const orderInput = item.menu_order;
 	const { editEntityRecord, saveEditedEntityRecord } =
@@ -40,7 +43,7 @@ function ReorderModal( {
 	async function onOrder( event: React.FormEvent ) {
 		event.preventDefault();
 
-		if ( ! isItemValid( item, fields, formOrderAction ) ) {
+		if ( ! isFormValid ) {
 			return;
 		}
 
@@ -81,12 +84,15 @@ function ReorderModal( {
 					data={ item }
 					fields={ fields }
 					form={ formOrderAction }
-					onChange={ ( changes ) =>
+					onValidate={ ( isValid ) => {
+						setIsFormValid( isValid );
+					} }
+					onChange={ ( changes ) => {
 						setItem( {
 							...item,
 							...changes,
-						} )
-					}
+						} );
+					} }
 				/>
 				<HStack justify="right">
 					<Button


### PR DESCRIPTION
See alternative PR at https://github.com/WordPress/gutenberg/pull/71412

## What?

This PR enables customers to use async custom validation.

## Why?

Some validation may happen in the server, so consumers need the ability to make async calls.

## How?

- `isValid.custom` can return a Promise.
- DataForm text controls leverage the [async validation for components](https://github.com/WordPress/gutenberg/pull/71184).
- TODO: make `isItemValid` work async.

## Testing Instructions

- Open the storybook (`npm install && npm run storybook:dev`).
- Visit the story "DataViews > DataForm > Validation".



https://github.com/user-attachments/assets/62cfb522-d31b-4d04-adf6-85734c23e242



