### PR TITLE
Query Title: Add "Post Type Label" variation

### DIFF
--- a/packages/block-library/src/query-title/block.json
+++ b/packages/block-library/src/query-title/block.json
@@ -34,6 +34,7 @@
 			"type": "search"
 		}
 	},
+	"usesContext": [ "query" ],
 	"supports": {
 		"align": [ "wide", "full" ],
 		"html": false,

--- a/packages/block-library/src/query-title/edit.js
+++ b/packages/block-library/src/query-title/edit.js
@@ -25,9 +25,10 @@ import { __, _x, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useArchiveLabel } from './use-archive-label';
+import { usePostTypeLabel } from './use-post-type-label';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
-const SUPPORTED_TYPES = [ 'archive', 'search' ];
+const SUPPORTED_TYPES = [ 'archive', 'search', 'post-type-label' ];
 
 export default function QueryTitleEdit( {
 	attributes: {
@@ -39,8 +40,10 @@ export default function QueryTitleEdit( {
 		showSearchTerm,
 	},
 	setAttributes,
+	context: { query },
 } ) {
 	const { archiveTypeLabel, archiveNameLabel } = useArchiveLabel();
+	const { postTypeLabel } = usePostTypeLabel( query?.postType );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	const TagName = `h${ level }`;
@@ -169,6 +172,49 @@ export default function QueryTitleEdit( {
 					{ showSearchTerm
 						? __( 'Search results for: “search term”' )
 						: __( 'Search results' ) }
+				</TagName>
+			</>
+		);
+	}
+
+	if ( type === 'post-type-label' ) {
+		titleElement = (
+			<>
+				<InspectorControls>
+					<ToolsPanel
+						label={ __( 'Settings' ) }
+						resetAll={ () =>
+							setAttributes( {
+								showPrefix: true,
+							} )
+						}
+						dropdownMenuProps={ dropdownMenuProps }
+					>
+						<ToolsPanelItem
+							hasValue={ () => ! showPrefix }
+							label={ __( 'Show post type label' ) }
+							onDeselect={ () =>
+								setAttributes( { showPrefix: true } )
+							}
+							isShownByDefault
+						>
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={ __( 'Show post type label prefix' ) }
+								onChange={ () =>
+									setAttributes( {
+										showPrefix: ! showPrefix,
+									} )
+								}
+								checked={ showPrefix }
+							/>
+						</ToolsPanelItem>
+					</ToolsPanel>
+				</InspectorControls>
+				<TagName { ...blockProps }>
+					{ showPrefix
+						? `Post Type: “${ postTypeLabel ?? 'Name' }”`
+						: postTypeLabel ?? 'Name' }
 				</TagName>
 			</>
 		);

--- a/packages/block-library/src/query-title/edit.js
+++ b/packages/block-library/src/query-title/edit.js
@@ -178,6 +178,21 @@ export default function QueryTitleEdit( {
 	}
 
 	if ( type === 'post-type-label' ) {
+		let title;
+		if ( postTypeLabel ) {
+			if ( showPrefix ) {
+				title = sprintf(
+					/* translators: %s: Singular post type name of the queried object */
+					__( 'Post Type: "%s"' ),
+					postTypeLabel
+				);
+			} else {
+				title = postTypeLabel;
+			}
+		} else {
+			title = showPrefix ? __( 'Post Type: Name' ) : __( 'Name' );
+		}
+
 		titleElement = (
 			<>
 				<InspectorControls>
@@ -211,11 +226,7 @@ export default function QueryTitleEdit( {
 						</ToolsPanelItem>
 					</ToolsPanel>
 				</InspectorControls>
-				<TagName { ...blockProps }>
-					{ showPrefix
-						? `Post Type: “${ postTypeLabel ?? 'Name' }”`
-						: postTypeLabel ?? 'Name' }
-				</TagName>
+				<TagName { ...blockProps }>{ title }</TagName>
 			</>
 		);
 	}

--- a/packages/block-library/src/query-title/edit.js
+++ b/packages/block-library/src/query-title/edit.js
@@ -28,7 +28,7 @@ import { useArchiveLabel } from './use-archive-label';
 import { usePostTypeLabel } from './use-post-type-label';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
-const SUPPORTED_TYPES = [ 'archive', 'search', 'post-type-label' ];
+const SUPPORTED_TYPES = [ 'archive', 'search', 'post-type' ];
 
 export default function QueryTitleEdit( {
 	attributes: {
@@ -177,7 +177,7 @@ export default function QueryTitleEdit( {
 		);
 	}
 
-	if ( type === 'post-type-label' ) {
+	if ( type === 'post-type' ) {
 		let title;
 		if ( postTypeLabel ) {
 			if ( showPrefix ) {
@@ -215,7 +215,7 @@ export default function QueryTitleEdit( {
 						>
 							<ToggleControl
 								__nextHasNoMarginBottom
-								label={ __( 'Show post type label prefix' ) }
+								label={ __( 'Show post type label' ) }
 								onChange={ () =>
 									setAttributes( {
 										showPrefix: ! showPrefix,

--- a/packages/block-library/src/query-title/index.php
+++ b/packages/block-library/src/query-title/index.php
@@ -7,23 +7,28 @@
 
 /**
  * Renders the `core/query-title` block on the server.
- * For now it only supports Archive title,
+ * For now it supports Archive title, Search title, and Post Type Label,
  * using queried object information
  *
  * @since 5.8.0
  *
- * @param array $attributes Block attributes.
+ * @param array  $attributes Block attributes.
+ * @param array  $_content   Block content.
+ * @param object $block      Block instance.
  *
  * @return string Returns the query title based on the queried object.
  */
-function render_block_core_query_title( $attributes ) {
+function render_block_core_query_title( $attributes, $_content, $block ) {
 	$type       = isset( $attributes['type'] ) ? $attributes['type'] : null;
 	$is_archive = is_archive();
 	$is_search  = is_search();
+	$post_type  = isset( $block->context['query']['postType'] ) ? $block->context['query']['postType'] : get_post_type();
+
 	if ( ! $type ||
 		( 'archive' === $type && ! $is_archive ) ||
-		( 'search' === $type && ! $is_search )
-		) {
+		( 'search' === $type && ! $is_search ) ||
+		( 'post-type-label' === $type && ! $post_type )
+	) {
 		return '';
 	}
 	$title = '';
@@ -46,6 +51,26 @@ function render_block_core_query_title( $attributes ) {
 				__( 'Search results for: "%s"' ),
 				get_search_query()
 			);
+		}
+	}
+	if ( 'post-type-label' === $type ) {
+		$post_type_object = get_post_type_object( $post_type );
+
+		if ( ! $post_type_object ) {
+			return '';
+		}
+
+		$post_type_name = $post_type_object->labels->singular_name;
+		$show_prefix    = isset( $attributes['showPrefix'] ) ? $attributes['showPrefix'] : true;
+
+		if ( $show_prefix ) {
+			$title = sprintf(
+				/* translators: %s is the post type name. */
+				__( 'Post Type: "%s"' ),
+				$post_type_name
+			);
+		} else {
+			$title = $post_type_name;
 		}
 	}
 

--- a/packages/block-library/src/query-title/index.php
+++ b/packages/block-library/src/query-title/index.php
@@ -18,7 +18,7 @@
  *
  * @return string Returns the query title based on the queried object.
  */
-function render_block_core_query_title( $attributes, $_content, $block ) {
+function render_block_core_query_title( $attributes, $content, $block ) {
 	$type       = isset( $attributes['type'] ) ? $attributes['type'] : null;
 	$is_archive = is_archive();
 	$is_search  = is_search();
@@ -27,7 +27,7 @@ function render_block_core_query_title( $attributes, $_content, $block ) {
 	if ( ! $type ||
 		( 'archive' === $type && ! $is_archive ) ||
 		( 'search' === $type && ! $is_search ) ||
-		( 'post-type-label' === $type && ! $post_type )
+		( 'post-type' === $type && ! $post_type )
 	) {
 		return '';
 	}
@@ -53,7 +53,7 @@ function render_block_core_query_title( $attributes, $_content, $block ) {
 			);
 		}
 	}
-	if ( 'post-type-label' === $type ) {
+	if ( 'post-type' === $type ) {
 		$post_type_object = get_post_type_object( $post_type );
 
 		if ( ! $post_type_object ) {

--- a/packages/block-library/src/query-title/use-post-type-label.js
+++ b/packages/block-library/src/query-title/use-post-type-label.js
@@ -12,7 +12,6 @@ import { useSelect } from '@wordpress/data';
 export function usePostTypeLabel( contextPostType ) {
 	const currentPostType = useSelect( ( select ) => {
 		// Access core/editor by string to avoid @wordpress/editor dependency.
-		// See https://github.com/WordPress/gutenberg/blob/58a5abc7714bdff204d5f6bc350980f73686d54f/packages/block-library/src/query-title/use-archive-label.js#L9-L14
 		// eslint-disable-next-line @wordpress/data-no-store-string-literals
 		const { getCurrentPostType } = select( 'core/editor' );
 		return getCurrentPostType();

--- a/packages/block-library/src/query-title/use-post-type-label.js
+++ b/packages/block-library/src/query-title/use-post-type-label.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Hook to fetch the singular label for the current post type.
+ *
+ * @param {string} contextPostType Context provided post type.
+ */
+export function usePostTypeLabel( contextPostType ) {
+	const currentPostType = useSelect( ( select ) => {
+		// eslint-disable-next-line @wordpress/data-no-store-string-literals
+		const { getCurrentPostType } = select( 'core/editor' );
+		return getCurrentPostType();
+	}, [] );
+
+	// Fetch the post type label from the core data store
+	return useSelect(
+		( select ) => {
+			const { getPostType } = select( coreStore );
+			const postTypeSlug = contextPostType || currentPostType;
+			const postType = getPostType( postTypeSlug );
+
+			// Return the singular name of the post type
+			return {
+				postTypeLabel: postType ? postType.labels.singular_name : '',
+			};
+		},
+		[ contextPostType, currentPostType ]
+	);
+}

--- a/packages/block-library/src/query-title/use-post-type-label.js
+++ b/packages/block-library/src/query-title/use-post-type-label.js
@@ -11,6 +11,7 @@ import { useSelect } from '@wordpress/data';
  */
 export function usePostTypeLabel( contextPostType ) {
 	const currentPostType = useSelect( ( select ) => {
+		// Access core/editor by string to avoid @wordpress/editor dependency.
 		// eslint-disable-next-line @wordpress/data-no-store-string-literals
 		const { getCurrentPostType } = select( 'core/editor' );
 		return getCurrentPostType();

--- a/packages/block-library/src/query-title/use-post-type-label.js
+++ b/packages/block-library/src/query-title/use-post-type-label.js
@@ -12,6 +12,7 @@ import { useSelect } from '@wordpress/data';
 export function usePostTypeLabel( contextPostType ) {
 	const currentPostType = useSelect( ( select ) => {
 		// Access core/editor by string to avoid @wordpress/editor dependency.
+		// See https://github.com/WordPress/gutenberg/blob/58a5abc7714bdff204d5f6bc350980f73686d54f/packages/block-library/src/query-title/use-archive-label.js#L9-L14
 		// eslint-disable-next-line @wordpress/data-no-store-string-literals
 		const { getCurrentPostType } = select( 'core/editor' );
 		return getCurrentPostType();

--- a/packages/block-library/src/query-title/variations.js
+++ b/packages/block-library/src/query-title/variations.js
@@ -30,6 +30,19 @@ const variations = [
 		},
 		scope: [ 'inserter' ],
 	},
+	{
+		isDefault: false,
+		name: 'post-type-label',
+		title: __( 'Post Type Label' ),
+		description: __(
+			'Display the post type label based on the queried object.'
+		),
+		icon: title,
+		attributes: {
+			type: 'post-type-label',
+		},
+		scope: [ 'inserter' ],
+	},
 ];
 
 /**

--- a/packages/block-library/src/query-title/variations.js
+++ b/packages/block-library/src/query-title/variations.js
@@ -39,7 +39,7 @@ const variations = [
 		),
 		icon: title,
 		attributes: {
-			type: 'post-type-label',
+			type: 'post-type',
 		},
 		scope: [ 'inserter' ],
 	},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #55949 

<!-- In a few words, what is the PR actually doing? -->
This PR adds a "Post Type Label" variation to the `core/query-title` block, which displays the singular name of the queried post type.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, there’s no way to dynamically display the post type label in a query context. This variation extends `core/query-title` to support built-in and custom post types.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Added new variation "Post Type Label" to display the queried post type's singular name.
- Retrieves the post type from block context or default to the current post type.

## Testing Instructions
1. Add multiple Query Loop blocks.
2. Change query settings and configure for different post types (posts, pages, custom post types).
3. Add a 'Post Type Label' block inside the Query Loop block.
4. Test the setting for displaying the Post Type prefix.
5. Save the post and check the frontend.
6. Confirm that post type labels are rendered correctly in both the editor and frontend.

<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
Using "Post Type Label" under each post title to show the queried post type (with and without prefix).

<img width="790" height="691" alt="Screenshot 2025-08-11 at 9 28 18 PM" src="https://github.com/user-attachments/assets/fb6e126f-40f5-40e6-9a74-936bfc6f0784" />