### PR TITLE
DataViews: allow hiding config

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking changes
 
 - DataForm: introduce a new `card` layout. The `form.type` has been moved under a new `layout` object and it is now `form.layout.type`, check the README for details. [#71100](https://github.com/WordPress/gutenberg/pull/71100)
+- Adds a new `config` prop to DataViews that allows hiding the view config control entirely. The `perPageSizes` prop has been moved to be part of this new prop. [#71173](https://github.com/WordPress/gutenberg/pull/71173)
 
 ### Features
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -416,9 +416,9 @@ The component receives the following props:
 
 React component to be rendered next to the view config button.
 
-#### `perPageSizes`: `number[]`
+#### `config`: false | { perPageSizes: number[] }
 
-A list of numbers used to control the available item counts per page. It's optional. Defaults to `[10, 20, 50, 100]`. The list needs to have a minimum of 2 items and a maximum of 6, otherwise the UI component won't be displayed.
+Optional. Set it to `false` to hide the view config control entirely. Pass an object with a list of `perPageSizes` to control the available item counts per page (defaults to `[10, 20, 50, 100]`). `perPageSizes` needs to have a minimum of 2 items and a maximum of 6, otherwise the UI component won't be displayed.
 
 #### `empty`: React node
 

--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -54,7 +54,7 @@ type DataViewsContextType< Item > = {
 	filters: NormalizedFilter[];
 	isShowingFilter: boolean;
 	setIsShowingFilter: ( value: boolean ) => void;
-	config?: false | { perPageSizes?: number[] };
+	config: false | { perPageSizes: number[] };
 	empty?: ReactNode;
 	hasInfiniteScrollHandler: boolean;
 };

--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -54,7 +54,7 @@ type DataViewsContextType< Item > = {
 	filters: NormalizedFilter[];
 	isShowingFilter: boolean;
 	setIsShowingFilter: ( value: boolean ) => void;
-	perPageSizes: number[];
+	config?: false | { perPageSizes?: number[] };
 	empty?: ReactNode;
 	hasInfiniteScrollHandler: boolean;
 };
@@ -82,8 +82,10 @@ const DataViewsContext = createContext< DataViewsContextType< any > >( {
 	filters: [],
 	isShowingFilter: false,
 	setIsShowingFilter: () => {},
-	perPageSizes: [],
 	hasInfiniteScrollHandler: false,
+	config: {
+		perPageSizes: [],
+	},
 } );
 
 export default DataViewsContext;

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -214,11 +214,13 @@ function SortDirectionControl() {
 }
 
 function ItemsPerPageControl() {
-	const { view, perPageSizes, onChangeView } = useContext( DataViewsContext );
+	const { view, config, onChangeView } = useContext( DataViewsContext );
 	const { infiniteScrollEnabled } = view;
 	if (
-		perPageSizes.length < 2 ||
-		perPageSizes.length > 6 ||
+		! config ||
+		! config.perPageSizes ||
+		config.perPageSizes.length < 2 ||
+		config.perPageSizes.length > 6 ||
 		infiniteScrollEnabled
 	) {
 		return null;
@@ -245,7 +247,7 @@ function ItemsPerPageControl() {
 				} );
 			} }
 		>
-			{ perPageSizes.map( ( value ) => {
+			{ config.perPageSizes.map( ( value ) => {
 				return (
 					<ToggleGroupControlOption
 						key={ value }

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -69,7 +69,7 @@ type DataViewsProps< Item > = {
 	config?:
 		| false
 		| {
-				perPageSizes?: number[];
+				perPageSizes: number[];
 		  };
 	empty?: ReactNode;
 } & ( Item extends ItemWithId
@@ -147,7 +147,7 @@ function DataViews< Item >( {
 	isItemClickable = defaultIsItemClickable,
 	header,
 	children,
-	config,
+	config = { perPageSizes: [ 10, 20, 50, 100 ] },
 	empty,
 }: DataViewsProps< Item > ) {
 	const { infiniteScrollHandler } = paginationInfo;

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -66,7 +66,11 @@ type DataViewsProps< Item > = {
 	header?: ReactNode;
 	getItemLevel?: ( item: Item ) => number;
 	children?: ReactNode;
-	perPageSizes?: number[];
+	config?:
+		| false
+		| {
+				perPageSizes?: number[];
+		  };
 	empty?: ReactNode;
 } & ( Item extends ItemWithId
 	? { getItemId?: ( item: Item ) => string }
@@ -86,7 +90,7 @@ function DefaultUI( {
 	search = true,
 	searchLabel = undefined,
 }: DefaultUIProps ) {
-	const { isShowingFilter } = useContext( DataViewsContext );
+	const { isShowingFilter, config } = useContext( DataViewsContext );
 	return (
 		<>
 			<HStack
@@ -103,14 +107,16 @@ function DefaultUI( {
 					{ search && <DataViewsSearch label={ searchLabel } /> }
 					<FiltersToggle />
 				</HStack>
-				<HStack
-					spacing={ 1 }
-					expanded={ false }
-					style={ { flexShrink: 0 } }
-				>
-					<DataViewsViewConfig />
-					{ header }
-				</HStack>
+				{ ( config || header ) && (
+					<HStack
+						spacing={ 1 }
+						expanded={ false }
+						style={ { flexShrink: 0 } }
+					>
+						config && <DataViewsViewConfig />
+						{ header }
+					</HStack>
+				) }
 			</HStack>
 			{ isShowingFilter && (
 				<DataViewsFilters className="dataviews-filters__container" />
@@ -141,7 +147,7 @@ function DataViews< Item >( {
 	isItemClickable = defaultIsItemClickable,
 	header,
 	children,
-	perPageSizes = [ 10, 20, 50, 100 ],
+	config,
 	empty,
 }: DataViewsProps< Item > ) {
 	const { infiniteScrollHandler } = paginationInfo;
@@ -248,7 +254,7 @@ function DataViews< Item >( {
 				filters,
 				isShowingFilter,
 				setIsShowingFilter,
-				perPageSizes,
+				config,
 				empty,
 				hasInfiniteScrollHandler: !! infiniteScrollHandler,
 			} }

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -89,7 +89,7 @@ export const Default = ( { perPageSizes = [ 10, 25, 50, 100 ] } ) => {
 			) }
 			isItemClickable={ () => true }
 			defaultLayouts={ defaultLayouts }
-			perPageSizes={ perPageSizes }
+			config={ { perPageSizes } }
 		/>
 	);
 };
@@ -172,7 +172,7 @@ export const MinimalUI = () => {
 			data={ shownData }
 			view={ view }
 			fields={ _fields }
-			perPageSizes={ [] }
+			config={ false }
 			search={ false }
 			onChangeView={ setView }
 			defaultLayouts={ {


### PR DESCRIPTION
## What?

This PR explores making the view config hidable:

<img width="1917" height="1157" alt="Screenshot 2025-08-13 at 16 35 07" src="https://github.com/user-attachments/assets/942ac998-ebbc-45f2-a0ed-fb5ae38781b5" />


## Why?

There are some cases in which DataViews would benefit from not providing any controls other than the data itself. A big part of this is already possible through the existing props, the major offender is the view config cog (see "[Minimal UI](https://wordpress.github.io/gutenberg/?path=/story/dataviews-dataviews--minimal-ui)" story).

I've noticed that we've already introduced some props that control the view config (items per page). We can group them under a "view config" prop and so if/when we want to add more configurability, we'd have a place for growing without expanding top-level DataViews props ad infinitum.

## How?

- Adds a new `config` prop to DataViews. Name TBD. It can be `false` or an object.
- Moves the existing top-level DataViews prop `perPageSizes` to that new `config` prop.

## Testing Instructions

Visit the storybook (`npm install && npm run storybook:dev`) and try the default (per page sizes control) and the minimal UI stories.
