### PR TITLE
Table of Contents: Add Bulleted lists and optional hierarchical numbering

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -913,7 +913,7 @@ Summarize your post with a list of headings. Add HTML anchors to Heading blocks 
 -	**Experimental:** true
 -	**Category:** design
 -	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** headings, maxLevel, onlyIncludeCurrentPage
+-	**Attributes:** headings, hierarchicalNumbering, maxLevel, onlyIncludeCurrentPage, ordered
 
 ## Tag Cloud
 

--- a/packages/block-library/src/table-of-contents/block.json
+++ b/packages/block-library/src/table-of-contents/block.json
@@ -22,6 +22,14 @@
 		},
 		"maxLevel": {
 			"type": "number"
+		},
+		"ordered": {
+			"type": "boolean",
+			"default": true
+		},
+		"hierarchicalNumbering": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/table-of-contents/edit.js
+++ b/packages/block-library/src/table-of-contents/edit.js
@@ -42,20 +42,37 @@ import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
  * @param {Object}                       props.attributes                        The block attributes.
  * @param {HeadingData[]}                props.attributes.headings               The list of data for each heading in the post.
  * @param {boolean}                      props.attributes.onlyIncludeCurrentPage Whether to only include headings from the current page (if the post is paginated).
- * @param {number|undefined}             props.attributes.maxLevel               The maximum heading level to include, or null to include all levels.
+ * @param {number|undefined}             props.attributes.maxLevel               The maximum heading level to include, or undefined to include all levels.
+ * @param {boolean}                      props.attributes.ordered                Whether to render the table of contents as an ordered list (numbers) or unordered (bullets).
+ * @param {boolean}                      props.attributes.hierarchicalNumbering  Whether to display hierarchical numbering when ordered is true.
  * @param {string}                       props.clientId                          The client id.
  * @param {(attributes: Object) => void} props.setAttributes                     The set attributes function.
  *
  * @return {Component} The component.
  */
 export default function TableOfContentsEdit( {
-	attributes: { headings = [], onlyIncludeCurrentPage, maxLevel },
+	attributes: {
+		headings = [],
+		onlyIncludeCurrentPage,
+		maxLevel,
+		ordered = true,
+		hierarchicalNumbering = false,
+	},
 	clientId,
 	setAttributes,
 } ) {
 	useObserveHeadings( clientId );
 
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( {
+		className: [
+			! ordered ? 'is-unordered' : null,
+			ordered && hierarchicalNumbering
+				? 'is-hierarchical-numbering'
+				: null,
+		]
+			.filter( Boolean )
+			.join( ' ' ),
+	} );
 	const instanceId = useInstanceId(
 		TableOfContentsEdit,
 		'table-of-contents'
@@ -94,10 +111,11 @@ export default function TableOfContentsEdit( {
 						replaceBlocks(
 							clientId,
 							createBlock( 'core/list', {
-								ordered: true,
+								ordered,
 								values: renderToString(
 									<TableOfContentsList
 										nestedHeadingList={ headingTree }
+										ordered={ ordered }
 									/>
 								),
 							} )
@@ -118,10 +136,63 @@ export default function TableOfContentsEdit( {
 					setAttributes( {
 						onlyIncludeCurrentPage: false,
 						maxLevel: undefined,
+						ordered: true,
+						hierarchicalNumbering: false,
 					} );
 				} }
 				dropdownMenuProps={ dropdownMenuProps }
 			>
+				<ToolsPanelItem
+					hasValue={ () => ordered !== true }
+					label={ __( 'List style' ) }
+					onDeselect={ () => setAttributes( { ordered: true } ) }
+					isShownByDefault
+				>
+					<SelectControl
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+						label={ __( 'List style' ) }
+						value={ ordered ? 'ordered' : 'unordered' }
+						options={ [
+							{ value: 'ordered', label: __( 'Numbers' ) },
+							{ value: 'unordered', label: __( 'Bullets' ) },
+						] }
+						onChange={ ( value ) => {
+							const isOrdered = value === 'ordered';
+							setAttributes( {
+								ordered: isOrdered,
+								...( ! isOrdered
+									? { hierarchicalNumbering: false }
+									: {} ),
+							} );
+						} }
+					/>
+				</ToolsPanelItem>
+
+				{ ordered && (
+					<ToolsPanelItem
+						hasValue={ () => !! hierarchicalNumbering }
+						label={ __( 'Hierarchical numbering' ) }
+						onDeselect={ () =>
+							setAttributes( { hierarchicalNumbering: false } )
+						}
+						isShownByDefault
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Hierarchical numbering' ) }
+							help={ __(
+								'Show hierarchical numbers (e.g., 2.1.1).'
+							) }
+							checked={ hierarchicalNumbering }
+							onChange={ ( value ) =>
+								setAttributes( {
+									hierarchicalNumbering: value,
+								} )
+							}
+						/>
+					</ToolsPanelItem>
+				) }
 				<ToolsPanelItem
 					hasValue={ () => !! onlyIncludeCurrentPage }
 					label={ __( 'Only include current page' ) }
@@ -213,13 +284,25 @@ export default function TableOfContentsEdit( {
 	return (
 		<>
 			<nav { ...blockProps }>
-				<ol>
-					<TableOfContentsList
-						nestedHeadingList={ headingTree }
-						disableLinkActivation
-						onClick={ showRedirectionPreventedNotice }
-					/>
-				</ol>
+				{ ordered ? (
+					<ol>
+						<TableOfContentsList
+							nestedHeadingList={ headingTree }
+							disableLinkActivation
+							onClick={ showRedirectionPreventedNotice }
+							ordered={ ordered }
+						/>
+					</ol>
+				) : (
+					<ul>
+						<TableOfContentsList
+							nestedHeadingList={ headingTree }
+							disableLinkActivation
+							onClick={ showRedirectionPreventedNotice }
+							ordered={ ordered }
+						/>
+					</ul>
+				) }
 			</nav>
 			{ toolbarControls }
 			{ inspectorControls }

--- a/packages/block-library/src/table-of-contents/list.tsx
+++ b/packages/block-library/src/table-of-contents/list.tsx
@@ -14,10 +14,12 @@ export default function TableOfContentsList( {
 	nestedHeadingList,
 	disableLinkActivation,
 	onClick,
+	ordered = true,
 }: {
 	nestedHeadingList: NestedHeadingData[];
 	disableLinkActivation?: boolean;
 	onClick?: ( event: MouseEvent< HTMLAnchorElement > ) => void;
+	ordered?: boolean;
 } ): ReactElement {
 	return (
 		<>
@@ -42,25 +44,46 @@ export default function TableOfContentsList( {
 					<span className={ ENTRY_CLASS_NAME }>{ content }</span>
 				);
 
-				return (
-					<li key={ index }>
-						{ entry }
-						{ node.children ? (
+				const childOnClick =
+					disableLinkActivation && 'function' === typeof onClick
+						? onClick
+						: undefined;
+
+				let childrenList: ReactElement | null = null;
+				if ( node.children ) {
+					if ( ordered ) {
+						childrenList = (
 							<ol>
 								<TableOfContentsList
 									nestedHeadingList={ node.children }
 									disableLinkActivation={
 										disableLinkActivation
 									}
-									onClick={
-										disableLinkActivation &&
-										'function' === typeof onClick
-											? onClick
-											: undefined
-									}
+									onClick={ childOnClick }
+									ordered={ ordered }
 								/>
 							</ol>
-						) : null }
+						);
+					} else {
+						childrenList = (
+							<ul>
+								<TableOfContentsList
+									nestedHeadingList={ node.children }
+									disableLinkActivation={
+										disableLinkActivation
+									}
+									onClick={ childOnClick }
+									ordered={ ordered }
+								/>
+							</ul>
+						);
+					}
+				}
+
+				return (
+					<li key={ index }>
+						{ entry }
+						{ childrenList }
 					</li>
 				);
 			} ) }

--- a/packages/block-library/src/table-of-contents/save.js
+++ b/packages/block-library/src/table-of-contents/save.js
@@ -9,17 +9,47 @@ import { useBlockProps } from '@wordpress/block-editor';
 import TableOfContentsList from './list';
 import { linearToNestedHeadingList } from './utils';
 
-export default function save( { attributes: { headings = [] } } ) {
+export default function save( {
+	attributes: {
+		headings = [],
+		ordered = true,
+		hierarchicalNumbering = false,
+	},
+} ) {
 	if ( headings.length === 0 ) {
 		return null;
 	}
+	const blockProps = useBlockProps.save( {
+		className: [
+			! ordered ? 'is-unordered' : null,
+			ordered && hierarchicalNumbering
+				? 'is-hierarchical-numbering'
+				: null,
+		]
+			.filter( Boolean )
+			.join( ' ' ),
+	} );
 	return (
-		<nav { ...useBlockProps.save() }>
-			<ol>
-				<TableOfContentsList
-					nestedHeadingList={ linearToNestedHeadingList( headings ) }
-				/>
-			</ol>
+		<nav { ...blockProps }>
+			{ ordered ? (
+				<ol>
+					<TableOfContentsList
+						nestedHeadingList={ linearToNestedHeadingList(
+							headings
+						) }
+						ordered={ ordered }
+					/>
+				</ol>
+			) : (
+				<ul>
+					<TableOfContentsList
+						nestedHeadingList={ linearToNestedHeadingList(
+							headings
+						) }
+						ordered={ ordered }
+					/>
+				</ul>
+			) }
 		</nav>
 	);
 }

--- a/packages/block-library/src/table-of-contents/style.scss
+++ b/packages/block-library/src/table-of-contents/style.scss
@@ -2,3 +2,34 @@
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 }
+
+:root :where(.wp-block-table-of-contents.is-hierarchical-numbering) {
+	// Remove default bullets and set up counter scope on each list.
+	& ol {
+		list-style: decimal;
+		counter-reset: item;
+		padding-inline-start: revert;
+		margin: revert;
+	}
+
+	& li {
+		counter-increment: item;
+	}
+
+	& li::marker {
+		content: counters(item, ".") ". ";
+	}
+
+	& li > ol {
+		counter-reset: item;
+	}
+}
+
+:root :where(.wp-block-table-of-contents.is-unordered) {
+	& ul {
+		list-style: revert;
+		counter-reset: none;
+		padding-inline-start: revert;
+		margin: revert;
+	}
+}

--- a/test/integration/fixtures/blocks/core__table-of-contents.json
+++ b/test/integration/fixtures/blocks/core__table-of-contents.json
@@ -15,7 +15,9 @@
 					"link": "#heading-id-2"
 				}
 			],
-			"onlyIncludeCurrentPage": false
+			"onlyIncludeCurrentPage": false,
+			"ordered": true,
+			"hierarchicalNumbering": false
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__table-of-contents__empty.json
+++ b/test/integration/fixtures/blocks/core__table-of-contents__empty.json
@@ -4,7 +4,9 @@
 		"isValid": true,
 		"attributes": {
 			"headings": [],
-			"onlyIncludeCurrentPage": false
+			"onlyIncludeCurrentPage": false,
+			"ordered": true,
+			"hierarchicalNumbering": false
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of: https://github.com/WordPress/gutenberg/issues/41769

Adds a list style option (Numbers/Bullets) to the Table of Contents block.
Adds an optional hierarchical numbering mode for ordered lists (e.g., 2.1, 2.1.1) using CSS counters.


## Testing Instructions
1. Create a new post and insert a “Table of Contents” block.
2. Add multiple Heading blocks (e.g., H2, H3 nested under an H2, H4 nested under that H3).
3. In Inspector Controls, change “List style” from Numbers → Bullets.
4. Expected:
    - ToC rerenders as an unordered list.
    - The “Hierarchical numbering” toggle is hidden and its value is reset to false.
5. Change Bullets → Numbers.
    - ToC rerenders as an ordered list.
    - “Hierarchical numbering” toggle is visible again and remains off.
6. With “List style” = Numbers, enable “Hierarchical numbering”.
7. Ensure your post has nested headings (H2 → H3 → H4).
8. Expected:
    - Nested items display composite numbering via CSS counters (e.g., 2.1, 2.1.1).


## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/ea5f3d79-784e-4a2e-8dc1-03206978b082

