### PR TITLE
Embed blocks: Add resize handles

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -264,7 +264,7 @@ Add a block that displays content pulled from other sites, like Twitter or YouTu
 -	**Name:** core/embed
 -	**Category:** embed
 -	**Supports:** align, interactivity (clientNavigation), spacing (margin)
--	**Attributes:** allowResponsive, caption, previewable, providerNameSlug, responsive, type, url
+-	**Attributes:** allowResponsive, caption, height, previewable, providerNameSlug, responsive, type, url, width
 
 ## File
 

--- a/packages/block-library/src/embed/block.json
+++ b/packages/block-library/src/embed/block.json
@@ -38,6 +38,12 @@
 			"type": "boolean",
 			"default": true,
 			"role": "content"
+		},
+		"width": {
+			"type": "string"
+		},
+		"height": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -13,7 +13,8 @@ import EmbedControls from './embed-controls';
 import { embedContentIcon } from './icons';
 import EmbedLoading from './embed-loading';
 import EmbedPlaceholder from './embed-placeholder';
-import EmbedPreview from './embed-preview';
+import ResizableEmbedPreview from './resizable-embed-preview';
+import { useMaxWidthObserver } from './use-max-width-observer';
 
 /**
  * External dependencies
@@ -58,6 +59,7 @@ const EmbedEdit = ( props ) => {
 	const [ url, setURL ] = useState( attributesUrl );
 	const [ isEditingURL, setIsEditingURL ] = useState( false );
 	const { invalidateResolution } = useDispatch( coreStore );
+	const [ maxWidthObserver, maxContentWidth ] = useMaxWidthObserver();
 
 	const {
 		preview,
@@ -249,12 +251,14 @@ const EmbedEdit = ( props ) => {
 	// that `getMergedAttributes` uses is memoized so that we're not
 	// calculating them on every render.
 	const {
-		caption,
 		type,
 		allowResponsive,
 		className: classFromPreview,
+		width,
 	} = getMergedAttributes();
-	const className = clsx( classFromPreview, props.className );
+	const className = clsx( classFromPreview, props.className, {
+		'has-custom-width': !! width,
+	} );
 
 	return (
 		<>
@@ -274,23 +278,24 @@ const EmbedEdit = ( props ) => {
 					[ `wp-block-embed-${ providerNameSlug }` ]:
 						providerNameSlug,
 				} ) }
+				style={ {
+					...blockProps.style,
+					width: width || undefined,
+				} }
 			>
-				<EmbedPreview
+				{ maxWidthObserver }
+				<ResizableEmbedPreview
 					preview={ preview }
 					previewable={ previewable }
 					className={ className }
 					url={ url }
 					type={ type }
-					caption={ caption }
-					onCaptionChange={ ( value ) =>
-						setAttributes( { caption: value } )
-					}
 					isSelected={ isSelected }
 					icon={ icon }
 					label={ label }
-					insertBlocksAfter={ insertBlocksAfter }
 					attributes={ attributes }
 					setAttributes={ setAttributes }
+					maxContentWidth={ maxContentWidth }
 				/>
 				<Caption
 					attributes={ attributes }

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -59,7 +59,7 @@ const EmbedEdit = ( props ) => {
 	const [ url, setURL ] = useState( attributesUrl );
 	const [ isEditingURL, setIsEditingURL ] = useState( false );
 	const { invalidateResolution } = useDispatch( coreStore );
-	const [ maxWidthObserver, maxContentWidth ] = useMaxWidthObserver();
+	const [ maxWidthObserver ] = useMaxWidthObserver();
 
 	const {
 		preview,
@@ -295,7 +295,6 @@ const EmbedEdit = ( props ) => {
 					label={ label }
 					attributes={ attributes }
 					setAttributes={ setAttributes }
-					maxContentWidth={ maxContentWidth }
 				/>
 				<Caption
 					attributes={ attributes }

--- a/packages/block-library/src/embed/editor.scss
+++ b/packages/block-library/src/embed/editor.scss
@@ -39,9 +39,46 @@
 	opacity: 0;
 }
 
+// Resizable embed styles
+.wp-block-embed.is-selected {
+	.wp-block-embed__wrapper {
+		// Ensure the wrapper takes full size when resizing
+		width: 100% !important;
+		height: 100% !important;
+
+		// Maintain proper iframe sizing
+		iframe {
+			width: 100%;
+			height: 100%;
+		}
+	}
+
+	// Style the ResizableBox component
+	.react-resizable {
+		position: relative !important;
+
+		// Ensure resize handles are visible and properly positioned
+		.react-resizable-handle {
+			opacity: 1;
+			z-index: 10;
+
+			&.react-resizable-handle-e {
+				right: -5px;
+				cursor: col-resize;
+				background: var(--wp-admin-theme-color);
+				border-radius: 2px;
+
+				&:hover {
+					background: var(--wp-admin-theme-color-darker-10);
+				}
+			}
+		}
+	}
+}
+
 .wp-block[data-align="left"],
 .wp-block[data-align="right"] {
-	> .wp-block-embed {
+	>.wp-block-embed {
 		max-width: 360px;
 		width: 100%;
 

--- a/packages/block-library/src/embed/resizable-embed-preview.js
+++ b/packages/block-library/src/embed/resizable-embed-preview.js
@@ -122,7 +122,7 @@ export default function ResizableEmbedPreview( {
 		);
 	/* eslint-enable jsx-a11y/no-static-element-interactions */
 
-	const embedContent = (
+	const embedPreview = (
 		<>
 			{ previewable ? (
 				embedWrapper
@@ -156,8 +156,8 @@ export default function ResizableEmbedPreview( {
 		  }
 		: pixelSize;
 
-	// Apply width styling for real-time feedback during resize
-	const embedContentWithResize = (
+	// Wrap embed content with resize container
+	const embedContent = (
 		<div
 			style={ {
 				width: currentSize.width
@@ -166,7 +166,7 @@ export default function ResizableEmbedPreview( {
 				transition: resizeDelta ? 'none' : 'width 0.1s ease',
 			} }
 		>
-			{ embedContent }
+			{ embedPreview }
 		</div>
 	);
 
@@ -226,14 +226,11 @@ export default function ResizableEmbedPreview( {
 					} );
 				} }
 				showHandle
-			/>
+			>
+				{ embedContent }
+			</ResizableBox>
 		);
 	}
 
-	return (
-		<div style={ { position: 'relative' } }>
-			{ embedContentWithResize }
-			{ resizableBox }
-		</div>
-	);
+	return isSelected && previewable ? resizableBox : embedContent;
 }

--- a/packages/block-library/src/embed/resizable-embed-preview.js
+++ b/packages/block-library/src/embed/resizable-embed-preview.js
@@ -9,7 +9,7 @@ import clsx from 'clsx';
 import { __, sprintf } from '@wordpress/i18n';
 import { Placeholder, SandBox, ResizableBox } from '@wordpress/components';
 import { BlockIcon, store as blockEditorStore } from '@wordpress/block-editor';
-import { useState, useRef, useEffect } from '@wordpress/element';
+import { useState, useRef } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { getAuthority } from '@wordpress/url';
 import { useResizeObserver } from '@wordpress/compose';
@@ -19,8 +19,6 @@ import { useResizeObserver } from '@wordpress/compose';
  */
 import { getPhotoHtml } from './util';
 import WpEmbedPreview from './wp-embed-preview';
-
-const MIN_EMBED_WIDTH = 200;
 
 export default function ResizableEmbedPreview( {
 	preview,
@@ -33,7 +31,6 @@ export default function ResizableEmbedPreview( {
 	label,
 	attributes,
 	setAttributes,
-	maxContentWidth,
 } ) {
 	const [ interactive, setInteractive ] = useState( false );
 	const [ resizeDelta, setResizeDelta ] = useState( null );
@@ -48,28 +45,16 @@ export default function ResizableEmbedPreview( {
 			? preview.width / preview.height
 			: 16 / 9; // Default to 16:9 aspect ratio
 
-	const [ observedWidth, setObservedWidth ] = useState();
-	const [ observedHeight, setObservedHeight ] = useState();
-
-	const setResizeObserver = useResizeObserver( ( [ entry ] ) => {
-		setObservedWidth( entry.contentRect.width );
-		setObservedHeight( entry.contentRect.height );
+	// Use resize observer like image block - attach to embed container
+	const setResizeObserved = useResizeObserver( ( [ entry ] ) => {
+		if ( ! resizeDelta ) {
+			const [ box ] = entry.borderBoxSize || [ entry.contentRect ];
+			setPixelSize( {
+				width: box.inlineSize || box.width,
+				height: box.blockSize || box.height,
+			} );
+		}
 	} );
-
-	useEffect( () => {
-		// Set initial size when component mounts
-		if ( containerRef.current && ! pixelSize.width ) {
-			const rect = containerRef.current.getBoundingClientRect();
-			setPixelSize( { width: rect.width, height: rect.height } );
-		}
-	}, [ pixelSize.width ] );
-
-	useEffect( () => {
-		// Update pixel size when observed dimensions change
-		if ( observedWidth && observedHeight && ! resizeDelta ) {
-			setPixelSize( { width: observedWidth, height: observedHeight } );
-		}
-	}, [ observedWidth, observedHeight, resizeDelta ] );
 
 	if ( ! isSelected && interactive ) {
 		// We only want to change this when the block is not selected, because changing it when
@@ -114,7 +99,7 @@ export default function ResizableEmbedPreview( {
 				className="wp-block-embed__wrapper"
 				ref={ ( node ) => {
 					containerRef.current = node;
-					setResizeObserver( node );
+					setResizeObserved( node );
 				} }
 			>
 				<SandBox
@@ -124,10 +109,13 @@ export default function ResizableEmbedPreview( {
 					type={ sandboxClassnames }
 					onFocus={ hideOverlay }
 				/>
-				{ ! interactive && (
+				{ ! interactive && ! isSelected && (
 					<div
 						className="block-library-embed__interactive-overlay"
 						onMouseUp={ hideOverlay }
+						style={ {
+							pointerEvents: isSelected ? 'none' : 'auto',
+						} }
 					/>
 				) }
 			</div>
@@ -160,111 +148,92 @@ export default function ResizableEmbedPreview( {
 		</>
 	);
 
+	// Calculate current size with delta for real-time feedback
+	const currentSize = resizeDelta
+		? {
+				width: pixelSize.width + resizeDelta.width,
+				height: pixelSize.height + resizeDelta.height,
+		  }
+		: pixelSize;
+
+	// Apply width styling for real-time feedback during resize
+	const embedContentWithResize = (
+		<div
+			style={ {
+				width: currentSize.width
+					? `${ currentSize.width }px`
+					: undefined,
+				transition: resizeDelta ? 'none' : 'width 0.1s ease',
+			} }
+		>
+			{ embedContent }
+		</div>
+	);
+
 	// Show resizable box only when selected and previewable
-	if ( isSelected && previewable && pixelSize.width ) {
-		const currentWidth = attributes.width
+	let resizableBox;
+	if ( isSelected && previewable ) {
+		// Calculate current dimensions
+		const numericWidth = attributes.width
 			? parseInt( attributes.width, 10 )
-			: pixelSize.width;
+			: null;
+		const customRatio = pixelSize.width / pixelSize.height;
+		const naturalRatio =
+			preview.width && preview.height
+				? preview.width / preview.height
+				: aspectRatio;
+		const ratio = numericWidth
+			? customRatio || naturalRatio || aspectRatio
+			: naturalRatio || aspectRatio;
 
-		const currentHeight = currentWidth / aspectRatio;
-
-		// Calculate max resize width similar to image block
-		// Allow some wiggle room beyond the content width for better UX
-		const maxWidthBuffer = pixelSize.width * 2.5;
-		const maxResizeWidth = maxContentWidth || maxWidthBuffer;
-
-		return (
-			<div
+		resizableBox = (
+			<ResizableBox
 				style={ {
-					position: 'relative',
-					display: 'inline-block',
-					maxWidth: '100%',
+					position: 'absolute',
+					inset: '0 0 0 0',
 				} }
-			>
-				<ResizableBox
-					style={ {
-						position: 'relative',
-						display: 'block',
-						overflow: 'visible',
-					} }
-					size={ {
-						width: resizeDelta
-							? Math.max(
-									MIN_EMBED_WIDTH,
-									Math.min(
-										maxResizeWidth,
-										currentWidth + resizeDelta.width
-									)
-							  )
-							: currentWidth,
-						height: resizeDelta
-							? Math.max(
-									MIN_EMBED_WIDTH / aspectRatio,
-									Math.min(
-										maxResizeWidth / aspectRatio,
-										( currentWidth + resizeDelta.width ) /
-											aspectRatio
-									)
-							  )
-							: currentHeight,
-					} }
-					minWidth={ MIN_EMBED_WIDTH }
-					maxWidth={ maxResizeWidth }
-					minHeight={ MIN_EMBED_WIDTH / aspectRatio }
-					maxHeight={ maxResizeWidth / aspectRatio }
-					lockAspectRatio={ aspectRatio }
-					enable={ {
-						top: false,
-						right: true,
-						bottom: false,
-						left: false,
-						topRight: false,
-						bottomRight: false,
-						bottomLeft: false,
-						topLeft: false,
-					} }
-					onResizeStart={ () => {
-						toggleSelection( false );
-					} }
-					onResize={ ( event, direction, elt, delta ) => {
-						setResizeDelta( delta );
-					} }
-					onResizeStop={ ( event, direction, elt, delta ) => {
-						toggleSelection( true );
-						setResizeDelta( null );
+				size={ pixelSize }
+				minWidth={ 50 }
+				lockAspectRatio={ ratio }
+				enable={ {
+					top: false,
+					right: true,
+					bottom: false,
+					left: false,
+				} }
+				onResizeStart={ () => {
+					toggleSelection( false );
+				} }
+				onResize={ ( event, direction, elt, delta ) => {
+					setResizeDelta( delta );
+					// Don't update pixelSize here - let ResizableBox handle it
+				} }
+				onResizeStop={ ( event, direction, elt, delta ) => {
+					toggleSelection( true );
+					setResizeDelta( null );
 
-						const newWidth = Math.max(
-							MIN_EMBED_WIDTH,
-							Math.min(
-								maxResizeWidth,
-								currentWidth + delta.width
-							)
-						);
+					// Update pixelSize only after resize is complete
+					const newPixelSize = {
+						width: pixelSize.width + delta.width,
+						height: pixelSize.height + delta.height,
+					};
+					setPixelSize( newPixelSize );
 
-						// Clear hardcoded width if the resized width is close to the max-content width.
-						if (
-							maxContentWidth &&
-							Math.abs( newWidth - maxContentWidth ) < 10
-						) {
-							setAttributes( {
-								width: undefined,
-								height: undefined,
-							} );
-						} else {
-							setAttributes( {
-								width: `${ newWidth }px`,
-								// Remove height to let CSS maintain aspect ratio
-								height: undefined,
-							} );
-						}
-					} }
-					showHandle
-				>
-					{ embedContent }
-				</ResizableBox>
-			</div>
+					// Set the final width
+					setAttributes( {
+						width: `${ newPixelSize.width }px`,
+						height: undefined, // Let CSS maintain aspect ratio
+					} );
+				} }
+				showHandle
+			/>
 		);
 	}
 
-	return embedContent;
+	return (
+		<div style={ { position: 'relative' } }>
+			{ embedContentWithResize }
+			{ resizableBox }
+		</div>
+	);
 }

--- a/packages/block-library/src/embed/resizable-embed-preview.js
+++ b/packages/block-library/src/embed/resizable-embed-preview.js
@@ -1,0 +1,270 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Placeholder, SandBox, ResizableBox } from '@wordpress/components';
+import { BlockIcon, store as blockEditorStore } from '@wordpress/block-editor';
+import { useState, useRef, useEffect } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { getAuthority } from '@wordpress/url';
+import { useResizeObserver } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { getPhotoHtml } from './util';
+import WpEmbedPreview from './wp-embed-preview';
+
+const MIN_EMBED_WIDTH = 200;
+
+export default function ResizableEmbedPreview( {
+	preview,
+	previewable,
+	url,
+	type,
+	isSelected,
+	className,
+	icon,
+	label,
+	attributes,
+	setAttributes,
+	maxContentWidth,
+} ) {
+	const [ interactive, setInteractive ] = useState( false );
+	const [ resizeDelta, setResizeDelta ] = useState( null );
+	const [ pixelSize, setPixelSize ] = useState( {} );
+	const containerRef = useRef();
+
+	const { toggleSelection } = useDispatch( blockEditorStore );
+
+	// Extract aspect ratio from preview dimensions if available
+	const aspectRatio =
+		preview.width && preview.height
+			? preview.width / preview.height
+			: 16 / 9; // Default to 16:9 aspect ratio
+
+	const [ observedWidth, setObservedWidth ] = useState();
+	const [ observedHeight, setObservedHeight ] = useState();
+
+	const setResizeObserver = useResizeObserver( ( [ entry ] ) => {
+		setObservedWidth( entry.contentRect.width );
+		setObservedHeight( entry.contentRect.height );
+	} );
+
+	useEffect( () => {
+		// Set initial size when component mounts
+		if ( containerRef.current && ! pixelSize.width ) {
+			const rect = containerRef.current.getBoundingClientRect();
+			setPixelSize( { width: rect.width, height: rect.height } );
+		}
+	}, [ pixelSize.width ] );
+
+	useEffect( () => {
+		// Update pixel size when observed dimensions change
+		if ( observedWidth && observedHeight && ! resizeDelta ) {
+			setPixelSize( { width: observedWidth, height: observedHeight } );
+		}
+	}, [ observedWidth, observedHeight, resizeDelta ] );
+
+	if ( ! isSelected && interactive ) {
+		// We only want to change this when the block is not selected, because changing it when
+		// the block becomes selected makes the overlap disappear too early. Hiding the overlay
+		// happens on mouseup when the overlay is clicked.
+		setInteractive( false );
+	}
+
+	const hideOverlay = () => {
+		// This is called onMouseUp on the overlay. We can't respond to the `isSelected` prop
+		// changing, because that happens on mouse down, and the overlay immediately disappears,
+		// and the mouse event can end up in the preview content. We can't use onClick on
+		// the overlay to hide it either, because then the editor misses the mouseup event, and
+		// thinks we're multi-selecting blocks.
+		setInteractive( true );
+	};
+
+	const { scripts } = preview;
+
+	const html = 'photo' === type ? getPhotoHtml( preview ) : preview.html;
+	const embedSourceUrl = getAuthority( url );
+	const iframeTitle = sprintf(
+		// translators: %s: host providing embed content e.g: www.youtube.com
+		__( 'Embedded content from %s' ),
+		embedSourceUrl
+	);
+	const sandboxClassnames = clsx(
+		type,
+		className,
+		'wp-block-embed__wrapper'
+	);
+
+	// Disabled because the overlay div doesn't actually have a role or functionality
+	// as far as the user is concerned. We're just catching the first click so that
+	// the block can be selected without interacting with the embed preview that the overlay covers.
+	/* eslint-disable jsx-a11y/no-static-element-interactions */
+	const embedWrapper =
+		'wp-embed' === type ? (
+			<WpEmbedPreview html={ html } />
+		) : (
+			<div
+				className="wp-block-embed__wrapper"
+				ref={ ( node ) => {
+					containerRef.current = node;
+					setResizeObserver( node );
+				} }
+			>
+				<SandBox
+					html={ html }
+					scripts={ scripts }
+					title={ iframeTitle }
+					type={ sandboxClassnames }
+					onFocus={ hideOverlay }
+				/>
+				{ ! interactive && (
+					<div
+						className="block-library-embed__interactive-overlay"
+						onMouseUp={ hideOverlay }
+					/>
+				) }
+			</div>
+		);
+	/* eslint-enable jsx-a11y/no-static-element-interactions */
+
+	const embedContent = (
+		<>
+			{ previewable ? (
+				embedWrapper
+			) : (
+				<Placeholder
+					icon={ <BlockIcon icon={ icon } showColors /> }
+					label={ label }
+				>
+					<p className="components-placeholder__error">
+						<a href={ url }>{ url }</a>
+					</p>
+					<p className="components-placeholder__error">
+						{ sprintf(
+							/* translators: %s: host providing embed content e.g: www.youtube.com */
+							__(
+								"Embedded content from %s can't be previewed in the editor."
+							),
+							embedSourceUrl
+						) }
+					</p>
+				</Placeholder>
+			) }
+		</>
+	);
+
+	// Show resizable box only when selected and previewable
+	if ( isSelected && previewable && pixelSize.width ) {
+		const currentWidth = attributes.width
+			? parseInt( attributes.width, 10 )
+			: pixelSize.width;
+
+		const currentHeight = currentWidth / aspectRatio;
+
+		// Calculate max resize width similar to image block
+		// Allow some wiggle room beyond the content width for better UX
+		const maxWidthBuffer = pixelSize.width * 2.5;
+		const maxResizeWidth = maxContentWidth || maxWidthBuffer;
+
+		return (
+			<div
+				style={ {
+					position: 'relative',
+					display: 'inline-block',
+					maxWidth: '100%',
+				} }
+			>
+				<ResizableBox
+					style={ {
+						position: 'relative',
+						display: 'block',
+						overflow: 'visible',
+					} }
+					size={ {
+						width: resizeDelta
+							? Math.max(
+									MIN_EMBED_WIDTH,
+									Math.min(
+										maxResizeWidth,
+										currentWidth + resizeDelta.width
+									)
+							  )
+							: currentWidth,
+						height: resizeDelta
+							? Math.max(
+									MIN_EMBED_WIDTH / aspectRatio,
+									Math.min(
+										maxResizeWidth / aspectRatio,
+										( currentWidth + resizeDelta.width ) /
+											aspectRatio
+									)
+							  )
+							: currentHeight,
+					} }
+					minWidth={ MIN_EMBED_WIDTH }
+					maxWidth={ maxResizeWidth }
+					minHeight={ MIN_EMBED_WIDTH / aspectRatio }
+					maxHeight={ maxResizeWidth / aspectRatio }
+					lockAspectRatio={ aspectRatio }
+					enable={ {
+						top: false,
+						right: true,
+						bottom: false,
+						left: false,
+						topRight: false,
+						bottomRight: false,
+						bottomLeft: false,
+						topLeft: false,
+					} }
+					onResizeStart={ () => {
+						toggleSelection( false );
+					} }
+					onResize={ ( event, direction, elt, delta ) => {
+						setResizeDelta( delta );
+					} }
+					onResizeStop={ ( event, direction, elt, delta ) => {
+						toggleSelection( true );
+						setResizeDelta( null );
+
+						const newWidth = Math.max(
+							MIN_EMBED_WIDTH,
+							Math.min(
+								maxResizeWidth,
+								currentWidth + delta.width
+							)
+						);
+
+						// Clear hardcoded width if the resized width is close to the max-content width.
+						if (
+							maxContentWidth &&
+							Math.abs( newWidth - maxContentWidth ) < 10
+						) {
+							setAttributes( {
+								width: undefined,
+								height: undefined,
+							} );
+						} else {
+							setAttributes( {
+								width: `${ newWidth }px`,
+								// Remove height to let CSS maintain aspect ratio
+								height: undefined,
+							} );
+						}
+					} }
+					showHandle
+				>
+					{ embedContent }
+				</ResizableBox>
+			</div>
+		);
+	}
+
+	return embedContent;
+}

--- a/packages/block-library/src/embed/resizable-embed-preview.js
+++ b/packages/block-library/src/embed/resizable-embed-preview.js
@@ -6,13 +6,13 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __, sprintf, isRTL } from '@wordpress/i18n';
 import { Placeholder, SandBox, ResizableBox } from '@wordpress/components';
 import { BlockIcon, store as blockEditorStore } from '@wordpress/block-editor';
-import { useState, useRef } from '@wordpress/element';
+import { useState, useCallback } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { getAuthority } from '@wordpress/url';
-import { useResizeObserver } from '@wordpress/compose';
+import { useResizeObserver, useMergeRefs } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -35,7 +35,8 @@ export default function ResizableEmbedPreview( {
 	const [ interactive, setInteractive ] = useState( false );
 	const [ resizeDelta, setResizeDelta ] = useState( null );
 	const [ pixelSize, setPixelSize ] = useState( {} );
-	const containerRef = useRef();
+	const [ offsetTop, setOffsetTop ] = useState( 0 );
+	const [ embedElement, setEmbedElement ] = useState();
 
 	const { toggleSelection } = useDispatch( blockEditorStore );
 
@@ -48,13 +49,21 @@ export default function ResizableEmbedPreview( {
 	// Use resize observer like image block - attach to embed container
 	const setResizeObserved = useResizeObserver( ( [ entry ] ) => {
 		if ( ! resizeDelta ) {
-			const [ box ] = entry.borderBoxSize || [ entry.contentRect ];
+			const [ box ] = entry.borderBoxSize;
 			setPixelSize( {
-				width: box.inlineSize || box.width,
-				height: box.blockSize || box.height,
+				width: box.inlineSize,
+				height: box.blockSize,
 			} );
 		}
+		// This is usually 0 unless the embed height is less than the line-height.
+		setOffsetTop( entry.target.offsetTop );
 	} );
+
+	const effectResizeableBoxPlacement = useCallback( () => {
+		setOffsetTop( embedElement?.offsetTop ?? 0 );
+	}, [ embedElement ] );
+
+	const setRefs = useMergeRefs( [ setEmbedElement, setResizeObserved ] );
 
 	if ( ! isSelected && interactive ) {
 		// We only want to change this when the block is not selected, because changing it when
@@ -97,9 +106,21 @@ export default function ResizableEmbedPreview( {
 		) : (
 			<div
 				className="wp-block-embed__wrapper"
-				ref={ ( node ) => {
-					containerRef.current = node;
-					setResizeObserved( node );
+				ref={ setRefs }
+				style={ {
+					...( resizeDelta
+						? {
+								width: `${
+									pixelSize.width + resizeDelta.width
+								}px`,
+								height: `${
+									pixelSize.height + resizeDelta.height
+								}px`,
+						  }
+						: {
+								width: attributes.width || undefined,
+								height: attributes.height || undefined,
+						  } ),
 				} }
 			>
 				<SandBox
@@ -148,89 +169,104 @@ export default function ResizableEmbedPreview( {
 		</>
 	);
 
-	// Calculate current size with delta for real-time feedback
-	const currentSize = resizeDelta
-		? {
-				width: pixelSize.width + resizeDelta.width,
-				height: pixelSize.height + resizeDelta.height,
-		  }
-		: pixelSize;
-
-	// Wrap embed content with resize container
-	const embedContent = (
-		<div
-			style={ {
-				width: currentSize.width
-					? `${ currentSize.width }px`
-					: undefined,
-				transition: resizeDelta ? 'none' : 'width 0.1s ease',
-			} }
-		>
-			{ embedPreview }
-		</div>
-	);
-
-	// Show resizable box only when selected and previewable
+	// Show resizable box only when selected and previewable - similar to image block
 	let resizableBox;
 	if ( isSelected && previewable ) {
-		// Calculate current dimensions
-		const numericWidth = attributes.width
-			? parseInt( attributes.width, 10 )
-			: null;
+		// Calculate current dimensions - following image block pattern
 		const customRatio = pixelSize.width / pixelSize.height;
 		const naturalRatio =
 			preview.width && preview.height
 				? preview.width / preview.height
 				: aspectRatio;
-		const ratio = numericWidth
-			? customRatio || naturalRatio || aspectRatio
-			: naturalRatio || aspectRatio;
+		const ratio = customRatio || naturalRatio || aspectRatio;
+
+		// Min and max dimensions
+		const minWidth = 50;
+		const minHeight = 50 / ratio;
+		const maxResizeWidth = 1200; // Reasonable max width
+
+		// Determine which resize handles to show based on alignment - exactly like image block
+		const { align } = attributes;
+		let showRightHandle = false;
+		let showLeftHandle = false;
+
+		/* eslint-disable no-lonely-if */
+		// See https://github.com/WordPress/gutenberg/issues/7584.
+		if ( align === 'center' ) {
+			// When the embed is centered, show both handles.
+			showRightHandle = true;
+			showLeftHandle = true;
+		} else if ( isRTL() ) {
+			// In RTL mode the embed is on the right by default.
+			// Show the right handle and hide the left handle only when it is
+			// aligned left. Otherwise always show the left handle.
+			if ( align === 'left' ) {
+				showRightHandle = true;
+			} else {
+				showLeftHandle = true;
+			}
+		} else {
+			// Show the left handle and hide the right handle only when the
+			// embed is aligned right. Otherwise always show the right handle.
+			if ( align === 'right' ) {
+				showLeftHandle = true;
+			} else {
+				showRightHandle = true;
+			}
+		}
+		/* eslint-enable no-lonely-if */
 
 		resizableBox = (
 			<ResizableBox
+				ref={ effectResizeableBoxPlacement }
 				style={ {
 					position: 'absolute',
-					inset: '0 0 0 0',
+					// To match the vertical-align: bottom of the embed (similar to image)
+					// syncs the top with the embed. This matters when the embed height is
+					// less than the line-height.
+					inset: `${ offsetTop }px 0 0 0`,
 				} }
 				size={ pixelSize }
-				minWidth={ 50 }
+				minWidth={ minWidth }
+				maxWidth={ maxResizeWidth }
+				minHeight={ minHeight }
+				maxHeight={ maxResizeWidth / ratio }
 				lockAspectRatio={ ratio }
 				enable={ {
 					top: false,
-					right: true,
-					bottom: false,
-					left: false,
+					right: showRightHandle,
+					bottom: true,
+					left: showLeftHandle,
 				} }
 				onResizeStart={ () => {
 					toggleSelection( false );
 				} }
 				onResize={ ( event, direction, elt, delta ) => {
 					setResizeDelta( delta );
-					// Don't update pixelSize here - let ResizableBox handle it
 				} }
 				onResizeStop={ ( event, direction, elt, delta ) => {
 					toggleSelection( true );
 					setResizeDelta( null );
+					setPixelSize( ( current ) => ( {
+						width: current.width + delta.width,
+						height: current.height + delta.height,
+					} ) );
 
-					// Update pixelSize only after resize is complete
-					const newPixelSize = {
-						width: pixelSize.width + delta.width,
-						height: pixelSize.height + delta.height,
-					};
-					setPixelSize( newPixelSize );
-
-					// Set the final width
+					// Set the final width and height - similar to image block
 					setAttributes( {
-						width: `${ newPixelSize.width }px`,
-						height: undefined, // Let CSS maintain aspect ratio
+						width: `${ elt.offsetWidth }px`,
+						height: 'auto', // Let CSS maintain aspect ratio
 					} );
 				} }
-				showHandle
-			>
-				{ embedContent }
-			</ResizableBox>
+				resizeRatio={ align === 'center' ? 2 : 1 }
+			/>
 		);
 	}
 
-	return isSelected && previewable ? resizableBox : embedContent;
+	return (
+		<div style={ { position: 'relative' } }>
+			{ embedPreview }
+			{ resizableBox }
+		</div>
+	);
 }

--- a/packages/block-library/src/embed/save.js
+++ b/packages/block-library/src/embed/save.js
@@ -13,7 +13,7 @@ import {
 } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { url, caption, type, providerNameSlug } = attributes;
+	const { url, caption, type, providerNameSlug, width } = attributes;
 
 	if ( ! url ) {
 		return null;
@@ -23,10 +23,18 @@ export default function save( { attributes } ) {
 		[ `is-type-${ type }` ]: type,
 		[ `is-provider-${ providerNameSlug }` ]: providerNameSlug,
 		[ `wp-block-embed-${ providerNameSlug }` ]: providerNameSlug,
+		'has-custom-width': !! width,
 	} );
 
 	return (
-		<figure { ...useBlockProps.save( { className } ) }>
+		<figure
+			{ ...useBlockProps.save( {
+				className,
+				style: {
+					width: width || undefined,
+				},
+			} ) }
+		>
 			<div className="wp-block-embed__wrapper">
 				{ `\n${ url }\n` /* URL needs to be on its own line. */ }
 			</div>

--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -33,6 +33,15 @@
 	iframe {
 		max-width: 100%;
 	}
+
+	// Support custom width set by resizing
+	&.has-custom-width {
+		width: fit-content;
+
+		.wp-block-embed__wrapper {
+			max-width: 100%;
+		}
+	}
 }
 
 .wp-block-embed__wrapper {

--- a/packages/block-library/src/embed/use-max-width-observer.js
+++ b/packages/block-library/src/embed/use-max-width-observer.js
@@ -1,0 +1,37 @@
+/**
+ * WordPress dependencies
+ */
+import { useRef, useState } from '@wordpress/element';
+import { useResizeObserver } from '@wordpress/compose';
+
+function useMaxWidthObserver() {
+	const observerRef = useRef();
+	const [ width, setWidth ] = useState();
+
+	const setObserverRef = useResizeObserver( ( [ entry ] ) => {
+		setWidth( entry.contentRect.width );
+	} );
+
+	const maxWidthObserver = (
+		<div
+			// Some themes set max-width on blocks.
+			className="wp-block"
+			aria-hidden="true"
+			style={ {
+				position: 'absolute',
+				inset: 0,
+				width: '100%',
+				height: 0,
+				margin: 0,
+			} }
+			ref={ ( node ) => {
+				observerRef.current = node;
+				setObserverRef( node );
+			} }
+		/>
+	);
+
+	return [ maxWidthObserver, width ];
+}
+
+export { useMaxWidthObserver };


### PR DESCRIPTION
## What?

This PR add support for resizing embeds using resize handles

Closes #14805

## Why?

> TODO: Update description after ready for review

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
