### PR TITLE
DataViews story: rename "Non-interactive" to "Minimal UI"

### DIFF
--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -144,7 +144,7 @@ export const CustomEmpty = () => {
 	);
 };
 
-export const NonInteractive = () => {
+export const Locked = () => {
 	const [ view, setView ] = useState< View >( {
 		...DEFAULT_VIEW,
 		fields: [ 'title', 'description', 'categories' ],

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -144,7 +144,7 @@ export const CustomEmpty = () => {
 	);
 };
 
-export const Locked = () => {
+export const MinimalUI = () => {
 	const [ view, setView ] = useState< View >( {
 		...DEFAULT_VIEW,
 		fields: [ 'title', 'description', 'categories' ],


### PR DESCRIPTION
See conversation https://github.com/WordPress/gutenberg/pull/71173#issuecomment-3179346217

## What?

Renames a story from "non-interactive" to "locked".

## Why?

To better reflect the purpose.


## Testing Instructions

Start storybook and verify the story name has changed.