### PR TITLE
DocumentBar: Only show template icon when back button is not present

### DIFF
--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -161,7 +161,7 @@ export default function DocumentBar( props ) {
 					</MotionButton>
 				) }
 			</AnimatePresence>
-			{ ! isTemplate && isTemplatePreview && (
+			{ ! isTemplate && isTemplatePreview && ! hasBackButton && (
 				<BlockIcon
 					icon={ layout }
 					className="editor-document-bar__icon-layout"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Update the DocumentBar so that it only displays the template icon when the back button is not present

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Over in #70986 there's a PR that proposes adding a View link to the navigation links blocks that will redirect a user to the respective page for editing that page. While testing that PR, I noticed that it's possible for the DocumentBar to get into a state where it wants to render the template / layout icon to show that template mode is active while also displaying a back button.

In such cases, I believe we should prioritise showing the back button, and hide the template icon.

Right now, it's a bit of an artificial use case, however once #70986 lands, and more of the write mode / simplified site editing work progresses, I think there's potential for the Back button to be used more as folks navigate between editing their home page and editing a particular page.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update the DocumentBar component to only show the template icon if the back button is not present

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

If you're using a vanilla installation that has a page set at id `2` then the following local URL should hopefully work to take you to the page editor within the site editor, while displaying a Back button (ignore for now that the Back button doesn't take you anywhere useful):

http://localhost:8888/wp-admin/site-editor.php?p=%2Fpage%2F2&canvas=edit&focusMode=true

On `trunk`, you'll likely see the template icon overlapping with the Back button (double check that you've got Template > Show template switched on in the sidebar). With this PR applied, you shouldn't.

### Smoke testing (make sure this still behaves correctly)

* Go to edit the home template and select the header template part and click Edit to go to focus mode on the header template part
* You should see the Back button in the DocumentBar
* Now, go to edit a page within the site editor
* Then in the right hand sidebar, toggle the template preview. It should update the DocumentBar appropriately

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

<img width="2548" height="580" alt="image" src="https://github.com/user-attachments/assets/d68ad8ce-de73-42c5-b49c-9e70424c2a84" />

### After

<img width="2552" height="728" alt="image" src="https://github.com/user-attachments/assets/fa581730-0434-44d4-9a23-ce94e6203a1e" />

### Focus mode should still look like this when editing a template part

<img width="2550" height="1324" alt="image" src="https://github.com/user-attachments/assets/e12f6c00-a4b3-4fe5-a3da-59a4151ff583" />

### Toggling template preview should still look like this

https://github.com/user-attachments/assets/03adb488-6e7e-4b4c-8aa8-dd82ed446893