### PR TITLE
Update `@tannin/sprintf` for full precision typing support in `@wordpress/i18n`'s sprintf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13223,9 +13223,9 @@
 			"integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw=="
 		},
 		"node_modules/@tannin/sprintf": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@tannin/sprintf/-/sprintf-1.3.1.tgz",
-			"integrity": "sha512-3auu6Wqm4TR6gvOh1Dgh1d2k9+arNmu3T0JLiUJoJMgayeHr450OuWeZIMTE4CUuq51rwn/NI9S5InT0JuTxQw==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@tannin/sprintf/-/sprintf-1.3.2.tgz",
+			"integrity": "sha512-zH2b4ptpfW4mEzt++2nKwTVgBNvfZEH1DgWAlE9uCxZceyH9uUET1Oqvz0LFxaC633WTOHxNxceA0ViJy8X9EA==",
 			"license": "MIT"
 		},
 		"node_modules/@testing-library/dom": {
@@ -51169,7 +51169,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
-				"@tannin/sprintf": "^1.3.1",
+				"@tannin/sprintf": "^1.3.2",
 				"@wordpress/hooks": "file:../hooks",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -32,7 +32,7 @@
 	},
 	"dependencies": {
 		"@babel/runtime": "7.25.7",
-		"@tannin/sprintf": "^1.3.1",
+		"@tannin/sprintf": "^1.3.2",
 		"@wordpress/hooks": "file:../hooks",
 		"gettext-parser": "^1.3.1",
 		"memize": "^2.1.0",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Addresses [`comment`](https://github.com/WordPress/gutenberg/pull/70458#issuecomment-3166078885) 

<!-- In a few words, what is the PR actually doing? -->
Updates `@tannin/sprintf` package to v1.3.2 to incorporate full precision support mentioned in the linked comment.
in nutshell, the precision support of `@tannin/sprintf` didn't cover positional and named placeholders which was addressed and added in https://github.com/aduth/tannin/pull/23.

See: https://github.com/aduth/tannin/issues/22
Changelog: https://github.com/aduth/tannin/blob/master/packages/sprintf/CHANGELOG.md#132-2025-08-12 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, `@wordpress/i18n` sprintf only supports precision types for unnamed placeholders that is `%.2f` , `%.*f` etc and doesn't support typings for positional and named placeholders like `%1$.2f`, `%1$.*f`, %(named).2f` etc due to which it flags a typescript error as for these formats , sprintf resolves the argument type as `never` aka not allowed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
See: https://github.com/aduth/tannin/blob/cc1fe53d2763461438799b9c2352005b2cb6a7d4/packages/sprintf/types/index.d.ts

TLDR: the solution of this issue was to create a precision support helper which will check and parse the format based on a consistent tuple to check for precision , spec and other arguments.
It also fixes the issue of positional arguments to be shown as tuple instead of Record.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Write a sprintf with format using precision
2. See no error when adding arguments for precision placeholders.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![](https://github.com/user-attachments/assets/0dd6dd74-1b57-417e-84f1-9778c34965dd)|![](https://github.com/user-attachments/assets/c1727d63-d4f4-4d28-902f-f2697a9b2474)|

