### PR TITLE
Navigation Link: surface page creation functionality clearly in the LinkUI

### DIFF
--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -135,9 +135,8 @@
 		z-index: 1;
 	}
 
-	&__error {
-		color: #d63638;
-		font-size: 12px;
-		margin-top: -8px;
+	// Add top margin to the form to prevent overlap with the back button
+	form {
+		margin-top: 40px;
 	}
 }

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -124,7 +124,15 @@
 }
 
 .link-ui-page-creator {
+	// Match LinkControl width constraints for consistent UI sizing
+	max-width: 350px;
+	min-width: auto;
+	width: 90vw;
 	padding-top: $grid-unit-10;
+
+	&__inner {
+		padding: $grid-unit-20;
+	}
 
 	&__back {
 		margin-left: $grid-unit-10;

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -124,37 +124,10 @@
 }
 
 .link-ui-page-creator {
-	position: relative;
-	padding: 16px;
-	min-width: 300px;
+	padding-top: $grid-unit-10;
 
 	&__back {
 		margin-left: $grid-unit-10;
 		text-transform: uppercase;
-	}
-
-	// Add top margin to the form to prevent overlap with the back button
-	form {
-		margin-top: 40px;
-	}
-
-	// Add proper spacing between form elements
-	.components-text-control {
-		margin-bottom: 16px;
-	}
-
-	.components-checkbox-control {
-		margin-bottom: 24px;
-	}
-
-	.components-notice {
-		margin-bottom: 24px;
-	}
-
-	&__buttons {
-		display: flex;
-		gap: 8px;
-		justify-content: flex-end;
-		margin-top: 24px;
 	}
 }

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -139,4 +139,24 @@
 	form {
 		margin-top: 40px;
 	}
+
+	// Add proper spacing between form elements
+	.components-text-control {
+		margin-bottom: 16px;
+	}
+
+	.components-checkbox-control {
+		margin-bottom: 24px;
+	}
+
+	.components-notice {
+		margin-bottom: 24px;
+	}
+
+	&__buttons {
+		display: flex;
+		gap: 8px;
+		justify-content: flex-end;
+		margin-top: 24px;
+	}
 }

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -122,3 +122,22 @@
 	gap: $grid-unit-10;
 	height: auto;
 }
+
+.link-ui-page-creator {
+	position: relative;
+	padding: 16px;
+	min-width: 300px;
+
+	&__back {
+		position: absolute;
+		top: 16px;
+		left: 16px;
+		z-index: 1;
+	}
+
+	&__error {
+		color: #d63638;
+		font-size: 12px;
+		margin-top: -8px;
+	}
+}

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -129,10 +129,8 @@
 	min-width: 300px;
 
 	&__back {
-		position: absolute;
-		top: 16px;
-		left: 16px;
-		z-index: 1;
+		margin-left: $grid-unit-10;
+		text-transform: uppercase;
 	}
 
 	// Add top margin to the form to prevent overlap with the back button

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -24,12 +24,7 @@ import {
 } from '@wordpress/element';
 import { useResourcePermissions } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import {
-	chevronLeftSmall,
-	chevronRightSmall,
-	plus,
-	addTemplate as page,
-} from '@wordpress/icons';
+import { chevronLeftSmall, chevronRightSmall, plus } from '@wordpress/icons';
 import { useInstanceId, useFocusOnMount } from '@wordpress/compose';
 
 /**
@@ -304,7 +299,7 @@ const LinkUITools = ( {
 				<Button
 					__next40pxDefaultSize
 					ref={ addPageButtonRef }
-					icon={ page }
+					icon={ plus }
 					onClick={ ( e ) => {
 						e.preventDefault();
 						setAddingPage( true );

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -178,6 +178,10 @@ function UnforwardedLinkUI( props, ref ) {
 		setAddingPage( false );
 	};
 
+	// Only allow page creation for page variations
+	const canCreatePageForThisBlock =
+		permissions.canCreate && type === 'page' && kind === 'post-type';
+
 	const dialogTitleId = useInstanceId(
 		LinkUI,
 		`link-ui-link-control__title`
@@ -233,10 +237,13 @@ function UnforwardedLinkUI( props, ref ) {
 										setFocusAddBlockButton( false );
 									} }
 									setAddingPage={ () => {
-										setAddingPage( true );
-										setFocusAddPageButton( false );
+										// Only allow setting page creation state for page variations
+										if ( canCreatePageForThisBlock ) {
+											setAddingPage( true );
+											setFocusAddPageButton( false );
+										}
 									} }
-									canCreatePage={ permissions.canCreate }
+									canCreatePage={ canCreatePageForThisBlock }
 								/>
 							)
 						}
@@ -254,7 +261,7 @@ function UnforwardedLinkUI( props, ref ) {
 				/>
 			) }
 
-			{ addingPage && (
+			{ addingPage && canCreatePageForThisBlock && (
 				<LinkUIPageCreator
 					postType={ postType }
 					onBack={ () => {

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -7,6 +7,8 @@ import {
 	Button,
 	VisuallyHidden,
 	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	TextControl,
 } from '@wordpress/components';
 import { __, sprintf, isRTL } from '@wordpress/i18n';
 import {
@@ -16,7 +18,6 @@ import {
 	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import {
-	createInterpolateElement,
 	useMemo,
 	useState,
 	useRef,
@@ -29,7 +30,12 @@ import {
 } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { chevronLeftSmall, chevronRightSmall, plus } from '@wordpress/icons';
+import {
+	chevronLeftSmall,
+	chevronRightSmall,
+	plus,
+	page,
+} from '@wordpress/icons';
 import { useInstanceId, useFocusOnMount } from '@wordpress/compose';
 
 /**
@@ -146,46 +152,164 @@ function LinkUIBlockInserter( { clientId, onBack } ) {
 	);
 }
 
+function LinkUIPageCreator( { postType, onBack, onPageCreated } ) {
+	const labels = useSelect(
+		( select ) => select( coreStore ).getPostType( postType )?.labels,
+		[ postType ]
+	);
+	const [ isCreatingPage, setIsCreatingPage ] = useState( false );
+	const [ title, setTitle ] = useState( '' );
+	const [ errorMessage, setErrorMessage ] = useState( '' );
+
+	const { saveEntityRecord } = useDispatch( coreStore );
+	const focusOnMountRef = useFocusOnMount( 'firstElement' );
+
+	const dialogTitleId = useInstanceId(
+		LinkControl,
+		`link-ui-page-creator__title`
+	);
+	const dialogDescriptionId = useInstanceId(
+		LinkControl,
+		`link-ui-page-creator__description`
+	);
+
+	async function createPage( event ) {
+		event.preventDefault();
+
+		if ( isCreatingPage ) {
+			return;
+		}
+
+		if ( ! title.trim() ) {
+			setErrorMessage( __( 'Please enter a title.' ) );
+			return;
+		}
+
+		setIsCreatingPage( true );
+		setErrorMessage( '' );
+
+		try {
+			const newPage = await saveEntityRecord(
+				'postType',
+				postType,
+				{
+					status: 'draft',
+					title: title.trim(),
+					slug: title.trim(),
+				},
+				{ throwOnError: true }
+			);
+
+			// Create the link value in the same format as the existing handleCreate function
+			const pageLink = {
+				id: newPage.id,
+				type: postType,
+				title: decodeEntities( newPage.title.rendered ),
+				url: newPage.link,
+				kind: 'post-type',
+			};
+
+			onPageCreated( pageLink );
+		} catch ( error ) {
+			const errorMsg =
+				error.message && error.code !== 'unknown_error'
+					? error.message
+					: __( 'An error occurred while creating the page.' );
+
+			setErrorMessage( errorMsg );
+		} finally {
+			setIsCreatingPage( false );
+		}
+	}
+
+	return (
+		<div
+			className="link-ui-page-creator"
+			role="dialog"
+			aria-labelledby={ dialogTitleId }
+			aria-describedby={ dialogDescriptionId }
+			ref={ focusOnMountRef }
+		>
+			<VisuallyHidden>
+				<h2 id={ dialogTitleId }>
+					{ sprintf(
+						/* translators: %s: post type singular name, e.g. "page" */
+						__( 'Create new %s' ),
+						labels?.singular_name?.toLowerCase() || 'page'
+					) }
+				</h2>
+				<p id={ dialogDescriptionId }>
+					{ sprintf(
+						/* translators: %s: post type singular name, e.g. "page" */
+						__( 'Create a new %s to link to.' ),
+						labels?.singular_name?.toLowerCase() || 'page'
+					) }
+				</p>
+			</VisuallyHidden>
+
+			<Button
+				className="link-ui-page-creator__back"
+				icon={ isRTL() ? chevronRightSmall : chevronLeftSmall }
+				onClick={ ( e ) => {
+					e.preventDefault();
+					onBack();
+				} }
+				size="small"
+			>
+				{ __( 'Back' ) }
+			</Button>
+
+			<form onSubmit={ createPage }>
+				<VStack spacing={ 4 }>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Title' ) }
+						onChange={ setTitle }
+						placeholder={ __( 'No title' ) }
+						value={ title }
+					/>
+					{ errorMessage && (
+						<div className="link-ui-page-creator__error">
+							{ errorMessage }
+						</div>
+					) }
+					<HStack spacing={ 2 } justify="end">
+						<Button
+							__next40pxDefaultSize
+							variant="tertiary"
+							onClick={ onBack }
+						>
+							{ __( 'Cancel' ) }
+						</Button>
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							type="submit"
+							isBusy={ isCreatingPage }
+							aria-disabled={ isCreatingPage }
+						>
+							{ __( 'Create draft' ) }
+						</Button>
+					</HStack>
+				</VStack>
+			</form>
+		</div>
+	);
+}
+
 function UnforwardedLinkUI( props, ref ) {
 	const { label, url, opensInNewTab, type, kind } = props.link;
 	const postType = type || 'page';
 
 	const [ addingBlock, setAddingBlock ] = useState( false );
+	const [ addingPage, setAddingPage ] = useState( false );
 	const [ focusAddBlockButton, setFocusAddBlockButton ] = useState( false );
-	const { saveEntityRecord } = useDispatch( coreStore );
+	const [ focusAddPageButton, setFocusAddPageButton ] = useState( false );
 	const permissions = useResourcePermissions( {
 		kind: 'postType',
 		name: postType,
 	} );
-
-	// Check if we're in contentOnly mode
-	const blockEditingMode = useBlockEditingMode();
-	const isDefaultBlockEditingMode = blockEditingMode === 'default';
-
-	async function handleCreate( pageTitle ) {
-		const page = await saveEntityRecord( 'postType', postType, {
-			title: pageTitle,
-			status: 'draft',
-		} );
-
-		return {
-			id: page.id,
-			type: postType,
-			// Make `title` property consistent with that in `fetchLinkSuggestions` where the `rendered` title (containing HTML entities)
-			// is also being decoded. By being consistent in both locations we avoid having to branch in the rendering output code.
-			// Ideally in the future we will update both APIs to utilise the "raw" form of the title which is better suited to edit contexts.
-			// e.g.
-			// - title.raw = "Yes & No"
-			// - title.rendered = "Yes &#038; No"
-			// - decodeEntities( title.rendered ) = "Yes & No"
-			// See:
-			// - https://github.com/WordPress/gutenberg/pull/41063
-			// - https://github.com/WordPress/gutenberg/blob/a1e1fdc0e6278457e9f4fc0b31ac6d2095f5450b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js#L212-L218
-			title: decodeEntities( page.title.rendered ),
-			url: page.link,
-			kind: 'post-type',
-		};
-	}
 
 	// Memoize link value to avoid overriding the LinkControl's internal state.
 	// This is a temporary fix. See https://github.com/WordPress/gutenberg/issues/50976#issuecomment-1568226407.
@@ -197,6 +321,13 @@ function UnforwardedLinkUI( props, ref ) {
 		} ),
 		[ label, opensInNewTab, url ]
 	);
+
+	const handlePageCreated = ( pageLink ) => {
+		// Set the new page as the current link
+		props.onChange( pageLink );
+		// Return to main Link UI
+		setAddingPage( false );
+	};
 
 	const dialogTitleId = useInstanceId(
 		LinkUI,
@@ -215,7 +346,7 @@ function UnforwardedLinkUI( props, ref ) {
 			anchor={ props.anchor }
 			shift
 		>
-			{ ! addingBlock && (
+			{ ! addingBlock && ! addingPage && (
 				<div
 					role="dialog"
 					aria-labelledby={ dialogTitleId }
@@ -235,30 +366,7 @@ function UnforwardedLinkUI( props, ref ) {
 						hasRichPreviews
 						value={ link }
 						showInitialSuggestions
-						withCreateSuggestion={ permissions.canCreate }
-						createSuggestion={ handleCreate }
-						createSuggestionButtonText={ ( searchTerm ) => {
-							let format;
-
-							if ( type === 'post' ) {
-								/* translators: %s: search term. */
-								format = __(
-									'Create draft post: <mark>%s</mark>'
-								);
-							} else {
-								/* translators: %s: search term. */
-								format = __(
-									'Create draft page: <mark>%s</mark>'
-								);
-							}
-
-							return createInterpolateElement(
-								sprintf( format, searchTerm ),
-								{
-									mark: <mark />,
-								}
-							);
-						} }
+						withCreateSuggestion={ false }
 						noDirectEntry={ !! type }
 						noURLSuggestion={ !! type }
 						suggestionsQuery={ getSuggestionsQuery( type, kind ) }
@@ -270,10 +378,16 @@ function UnforwardedLinkUI( props, ref ) {
 							isDefaultBlockEditingMode && (
 								<LinkUITools
 									focusAddBlockButton={ focusAddBlockButton }
+									focusAddPageButton={ focusAddPageButton }
 									setAddingBlock={ () => {
 										setAddingBlock( true );
 										setFocusAddBlockButton( false );
 									} }
+									setAddingPage={ () => {
+										setAddingPage( true );
+										setFocusAddPageButton( false );
+									} }
+									canCreatePage={ permissions.canCreate }
 								/>
 							)
 						}
@@ -290,15 +404,33 @@ function UnforwardedLinkUI( props, ref ) {
 					} }
 				/>
 			) }
+
+			{ addingPage && (
+				<LinkUIPageCreator
+					postType={ postType }
+					onBack={ () => {
+						setAddingPage( false );
+						setFocusAddPageButton( true );
+					} }
+					onPageCreated={ handlePageCreated }
+				/>
+			) }
 		</Popover>
 	);
 }
 
 export const LinkUI = forwardRef( UnforwardedLinkUI );
 
-const LinkUITools = ( { setAddingBlock, focusAddBlockButton } ) => {
+const LinkUITools = ( {
+	setAddingBlock,
+	setAddingPage,
+	focusAddBlockButton,
+	focusAddPageButton,
+	canCreatePage,
+} ) => {
 	const blockInserterAriaRole = 'listbox';
 	const addBlockButtonRef = useRef();
+	const addPageButtonRef = useRef();
 
 	// Focus the add block button when the popover is opened.
 	useEffect( () => {
@@ -307,8 +439,29 @@ const LinkUITools = ( { setAddingBlock, focusAddBlockButton } ) => {
 		}
 	}, [ focusAddBlockButton ] );
 
+	// Focus the add page button when the popover is opened.
+	useEffect( () => {
+		if ( focusAddPageButton ) {
+			addPageButtonRef.current?.focus();
+		}
+	}, [ focusAddPageButton ] );
+
 	return (
 		<VStack className="link-ui-tools">
+			{ canCreatePage && (
+				<Button
+					__next40pxDefaultSize
+					ref={ addPageButtonRef }
+					icon={ page }
+					onClick={ ( e ) => {
+						e.preventDefault();
+						setAddingPage( true );
+					} }
+					aria-haspopup={ blockInserterAriaRole }
+				>
+					{ __( 'Add page' ) }
+				</Button>
+			) }
 			<Button
 				__next40pxDefaultSize
 				ref={ addBlockButtonRef }

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -299,7 +299,7 @@ const LinkUITools = ( {
 	}, [ focusAddPageButton ] );
 
 	return (
-		<VStack className="link-ui-tools">
+		<VStack spacing={ 0 } className="link-ui-tools">
 			{ canCreatePage && (
 				<Button
 					__next40pxDefaultSize

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -7,10 +7,8 @@ import {
 	Button,
 	VisuallyHidden,
 	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
-	TextControl,
 } from '@wordpress/components';
-import { __, sprintf, isRTL } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import {
 	LinkControl,
 	store as blockEditorStore,
@@ -24,12 +22,8 @@ import {
 	useEffect,
 	forwardRef,
 } from '@wordpress/element';
-import {
-	store as coreStore,
-	useResourcePermissions,
-} from '@wordpress/core-data';
-import { decodeEntities } from '@wordpress/html-entities';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useResourcePermissions } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 import {
 	chevronLeftSmall,
 	chevronRightSmall,
@@ -42,6 +36,7 @@ import { useInstanceId, useFocusOnMount } from '@wordpress/compose';
  * Internal dependencies
  */
 import { unlock } from '../lock-unlock';
+import { LinkUIPageCreator } from './page-creator';
 
 const { PrivateQuickInserter: QuickInserter } = unlock(
 	blockEditorPrivateApis
@@ -148,152 +143,6 @@ function LinkUIBlockInserter( { clientId, onBack } ) {
 				selectBlockOnInsert
 				hasSearch={ false }
 			/>
-		</div>
-	);
-}
-
-function LinkUIPageCreator( { postType, onBack, onPageCreated } ) {
-	const labels = useSelect(
-		( select ) => select( coreStore ).getPostType( postType )?.labels,
-		[ postType ]
-	);
-	const [ isCreatingPage, setIsCreatingPage ] = useState( false );
-	const [ title, setTitle ] = useState( '' );
-	const [ errorMessage, setErrorMessage ] = useState( '' );
-
-	const { saveEntityRecord } = useDispatch( coreStore );
-	const focusOnMountRef = useFocusOnMount( 'firstElement' );
-
-	const dialogTitleId = useInstanceId(
-		LinkControl,
-		`link-ui-page-creator__title`
-	);
-	const dialogDescriptionId = useInstanceId(
-		LinkControl,
-		`link-ui-page-creator__description`
-	);
-
-	async function createPage( event ) {
-		event.preventDefault();
-
-		if ( isCreatingPage ) {
-			return;
-		}
-
-		if ( ! title.trim() ) {
-			setErrorMessage( __( 'Please enter a title.' ) );
-			return;
-		}
-
-		setIsCreatingPage( true );
-		setErrorMessage( '' );
-
-		try {
-			const newPage = await saveEntityRecord(
-				'postType',
-				postType,
-				{
-					status: 'draft',
-					title: title.trim(),
-					slug: title.trim(),
-				},
-				{ throwOnError: true }
-			);
-
-			// Create the link value in the same format as the existing handleCreate function
-			const pageLink = {
-				id: newPage.id,
-				type: postType,
-				title: decodeEntities( newPage.title.rendered ),
-				url: newPage.link,
-				kind: 'post-type',
-			};
-
-			onPageCreated( pageLink );
-		} catch ( error ) {
-			const errorMsg =
-				error.message && error.code !== 'unknown_error'
-					? error.message
-					: __( 'An error occurred while creating the page.' );
-
-			setErrorMessage( errorMsg );
-		} finally {
-			setIsCreatingPage( false );
-		}
-	}
-
-	return (
-		<div
-			className="link-ui-page-creator"
-			role="dialog"
-			aria-labelledby={ dialogTitleId }
-			aria-describedby={ dialogDescriptionId }
-			ref={ focusOnMountRef }
-		>
-			<VisuallyHidden>
-				<h2 id={ dialogTitleId }>
-					{ sprintf(
-						/* translators: %s: post type singular name, e.g. "page" */
-						__( 'Create new %s' ),
-						labels?.singular_name?.toLowerCase() || 'page'
-					) }
-				</h2>
-				<p id={ dialogDescriptionId }>
-					{ sprintf(
-						/* translators: %s: post type singular name, e.g. "page" */
-						__( 'Create a new %s to link to.' ),
-						labels?.singular_name?.toLowerCase() || 'page'
-					) }
-				</p>
-			</VisuallyHidden>
-
-			<Button
-				className="link-ui-page-creator__back"
-				icon={ isRTL() ? chevronRightSmall : chevronLeftSmall }
-				onClick={ ( e ) => {
-					e.preventDefault();
-					onBack();
-				} }
-				size="small"
-			>
-				{ __( 'Back' ) }
-			</Button>
-
-			<form onSubmit={ createPage }>
-				<VStack spacing={ 4 }>
-					<TextControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						label={ __( 'Title' ) }
-						onChange={ setTitle }
-						placeholder={ __( 'No title' ) }
-						value={ title }
-					/>
-					{ errorMessage && (
-						<div className="link-ui-page-creator__error">
-							{ errorMessage }
-						</div>
-					) }
-					<HStack spacing={ 2 } justify="end">
-						<Button
-							__next40pxDefaultSize
-							variant="tertiary"
-							onClick={ onBack }
-						>
-							{ __( 'Cancel' ) }
-						</Button>
-						<Button
-							__next40pxDefaultSize
-							variant="primary"
-							type="submit"
-							isBusy={ isCreatingPage }
-							aria-disabled={ isCreatingPage }
-						>
-							{ __( 'Create draft' ) }
-						</Button>
-					</HStack>
-				</VStack>
-			</form>
 		</div>
 	);
 }
@@ -413,6 +262,7 @@ function UnforwardedLinkUI( props, ref ) {
 						setFocusAddPageButton( true );
 					} }
 					onPageCreated={ handlePageCreated }
+					initialTitle={ link?.url || '' }
 				/>
 			) }
 		</Popover>

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -178,10 +178,6 @@ function UnforwardedLinkUI( props, ref ) {
 		setAddingPage( false );
 	};
 
-	// Only allow page creation for page variations
-	const canCreatePageForThisBlock =
-		permissions.canCreate && type === 'page' && kind === 'post-type';
-
 	const dialogTitleId = useInstanceId(
 		LinkUI,
 		`link-ui-link-control__title`
@@ -237,13 +233,10 @@ function UnforwardedLinkUI( props, ref ) {
 										setFocusAddBlockButton( false );
 									} }
 									setAddingPage={ () => {
-										// Only allow setting page creation state for page variations
-										if ( canCreatePageForThisBlock ) {
-											setAddingPage( true );
-											setFocusAddPageButton( false );
-										}
+										setAddingPage( true );
+										setFocusAddPageButton( false );
 									} }
-									canCreatePage={ canCreatePageForThisBlock }
+									canCreatePage={ permissions.canCreate }
 								/>
 							)
 						}
@@ -257,16 +250,18 @@ function UnforwardedLinkUI( props, ref ) {
 					onBack={ () => {
 						setAddingBlock( false );
 						setFocusAddBlockButton( true );
+						setFocusAddPageButton( false );
 					} }
 				/>
 			) }
 
-			{ addingPage && canCreatePageForThisBlock && (
+			{ addingPage && (
 				<LinkUIPageCreator
 					postType={ postType }
 					onBack={ () => {
 						setAddingPage( false );
 						setFocusAddPageButton( true );
+						setFocusAddBlockButton( false );
 					} }
 					onPageCreated={ handlePageCreated }
 					initialTitle={ link?.url || '' }

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -28,7 +28,7 @@ import {
 	chevronLeftSmall,
 	chevronRightSmall,
 	plus,
-	page,
+	addTemplate as page,
 } from '@wordpress/icons';
 import { useInstanceId, useFocusOnMount } from '@wordpress/compose';
 

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -182,6 +182,9 @@ function UnforwardedLinkUI( props, ref ) {
 		`link-ui-link-control__description`
 	);
 
+	const blockEditingMode = useBlockEditingMode();
+	const isDefaultBlockEditingMode = blockEditingMode === 'default';
+
 	return (
 		<Popover
 			ref={ ref }

--- a/packages/block-library/src/navigation-link/page-creator.js
+++ b/packages/block-library/src/navigation-link/page-creator.js
@@ -89,9 +89,6 @@ export function LinkUIPageCreator( {
 	}
 
 	const isSubmitDisabled = isSaving || ! isTitleValid;
-	const submitButtonText = shouldPublish
-		? __( 'Publish page' )
-		: __( 'Create draft' );
 
 	return (
 		<div className="link-ui-page-creator">
@@ -152,7 +149,7 @@ export function LinkUIPageCreator( {
 								isBusy={ isSaving }
 								aria-disabled={ isSubmitDisabled }
 							>
-								{ submitButtonText }
+								{ __( 'Create page' ) }
 							</Button>
 						</HStack>
 					</VStack>

--- a/packages/block-library/src/navigation-link/page-creator.js
+++ b/packages/block-library/src/navigation-link/page-creator.js
@@ -3,7 +3,6 @@
  */
 import {
 	Button,
-	VisuallyHidden,
 	TextControl,
 	Notice,
 	CheckboxControl,
@@ -99,13 +98,15 @@ export function LinkUIPageCreator( {
 	return (
 		<div className="link-ui-page-creator">
 			<Button
-				__next40pxDefaultSize
-				variant="tertiary"
-				onClick={ onBack }
 				className="link-ui-page-creator__back"
+				icon={ isRTL() ? chevronRightSmall : chevronLeftSmall }
+				onClick={ ( e ) => {
+					e.preventDefault();
+					onBack();
+				} }
+				size="small"
 			>
-				{ isRTL() ? chevronRightSmall : chevronLeftSmall }
-				<VisuallyHidden>{ __( 'Go back' ) }</VisuallyHidden>
+				{ __( 'Back' ) }
 			</Button>
 
 			<h2>

--- a/packages/block-library/src/navigation-link/page-creator.js
+++ b/packages/block-library/src/navigation-link/page-creator.js
@@ -15,6 +15,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useState } from '@wordpress/element';
 import { chevronLeftSmall, chevronRightSmall } from '@wordpress/icons';
+import { useFocusOnMount } from '@wordpress/compose';
 
 /**
  * Component for creating new pages within the Navigation Link UI.
@@ -33,6 +34,9 @@ export function LinkUIPageCreator( {
 } ) {
 	const [ title, setTitle ] = useState( initialTitle );
 	const [ shouldPublish, setShouldPublish ] = useState( false );
+
+	// Focus the first element when the component mounts
+	const focusOnMountRef = useFocusOnMount( 'firstElement' );
 
 	// Check if the title is valid for submission
 	const isTitleValid = title.trim().length > 0;
@@ -91,7 +95,7 @@ export function LinkUIPageCreator( {
 	const isSubmitDisabled = isSaving || ! isTitleValid;
 
 	return (
-		<div className="link-ui-page-creator">
+		<div className="link-ui-page-creator" ref={ focusOnMountRef }>
 			<Button
 				className="link-ui-page-creator__back"
 				icon={ isRTL() ? chevronRightSmall : chevronLeftSmall }

--- a/packages/block-library/src/navigation-link/page-creator.js
+++ b/packages/block-library/src/navigation-link/page-creator.js
@@ -143,15 +143,26 @@ export function LinkUIPageCreator( {
 						{ lastError.message }
 					</Notice>
 				) }
-				<Button
-					__next40pxDefaultSize
-					variant="primary"
-					type="submit"
-					isBusy={ isSaving }
-					aria-disabled={ isSubmitDisabled }
-				>
-					{ submitButtonText }
-				</Button>
+				<div className="link-ui-page-creator__buttons">
+					<Button
+						__next40pxDefaultSize
+						variant="tertiary"
+						onClick={ onBack }
+						disabled={ isSaving }
+						accessibleWhenDisabled
+					>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						type="submit"
+						isBusy={ isSaving }
+						aria-disabled={ isSubmitDisabled }
+					>
+						{ submitButtonText }
+					</Button>
+				</div>
 			</form>
 		</div>
 	);

--- a/packages/block-library/src/navigation-link/page-creator.js
+++ b/packages/block-library/src/navigation-link/page-creator.js
@@ -55,64 +55,7 @@ export function LinkUIPageCreator( {
 		[ postType ]
 	);
 
-	// Check if we have a newly created page and it's resolved
-	const newPage = useSelect(
-		( select ) => {
-			// Only check for new pages if we're not currently saving and there's no error
-			if ( isSaving || lastError ) {
-				return null;
-			}
-
-			// Get the most recent entity record for this post type
-			const recentRecords = select( coreStore ).getEntityRecords(
-				'postType',
-				postType,
-				{ per_page: 1, orderby: 'date', order: 'desc' }
-			);
-
-			if ( ! recentRecords || recentRecords.length === 0 ) {
-				return null;
-			}
-
-			const mostRecent = recentRecords[ 0 ];
-
-			// Check if this record was created recently (within the last few seconds)
-			const now = Date.now();
-			const createdTime = new Date( mostRecent.date ).getTime();
-			const isRecent = now - createdTime < 10000; // Within 10 seconds
-
-			if ( isRecent ) {
-				// Check if this specific record is resolved
-				const isResolved = select( coreStore ).hasResolved(
-					'postType',
-					'getEntityRecord',
-					[ 'postType', postType, mostRecent.id ]
-				);
-
-				if ( isResolved ) {
-					return mostRecent;
-				}
-			}
-
-			return null;
-		},
-		[ isSaving, lastError, postType ]
-	);
-
 	const { saveEntityRecord } = useDispatch( coreStore );
-
-	// If we have a resolved new page, call the callback and reset
-	if ( newPage ) {
-		const pageLink = {
-			id: newPage.id,
-			type: postType,
-			title: decodeEntities( newPage.title.rendered ),
-			url: newPage.link,
-			kind: 'post-type',
-		};
-		onPageCreated( pageLink );
-		return null; // Don't render anything while transitioning
-	}
 
 	async function createPage( event ) {
 		event.preventDefault();
@@ -121,12 +64,23 @@ export function LinkUIPageCreator( {
 		}
 
 		try {
-			await saveEntityRecord( 'postType', postType, {
+			const savedRecord = await saveEntityRecord( 'postType', postType, {
 				title,
 				status: shouldPublish ? 'publish' : 'draft',
 			} );
-			// No need to manually handle success - the data store will update
-			// and our useSelect hooks will detect the new entity
+
+			if ( savedRecord ) {
+				// Create the page link object from the saved record
+				const pageLink = {
+					id: savedRecord.id,
+					type: postType,
+					title: decodeEntities( savedRecord.title.rendered ),
+					url: savedRecord.link,
+					kind: 'post-type',
+				};
+
+				onPageCreated( pageLink );
+			}
 		} catch ( error ) {
 			// Error handling is done via the data store selectors
 		}

--- a/packages/block-library/src/navigation-link/page-creator.js
+++ b/packages/block-library/src/navigation-link/page-creator.js
@@ -64,10 +64,15 @@ export function LinkUIPageCreator( {
 		}
 
 		try {
-			const savedRecord = await saveEntityRecord( 'postType', postType, {
-				title,
-				status: shouldPublish ? 'publish' : 'draft',
-			} );
+			const savedRecord = await saveEntityRecord(
+				'postType',
+				postType,
+				{
+					title,
+					status: shouldPublish ? 'publish' : 'draft',
+				},
+				{ throwOnError: true }
+			);
 
 			if ( savedRecord ) {
 				// Create the page link object from the saved record

--- a/packages/block-library/src/navigation-link/page-creator.js
+++ b/packages/block-library/src/navigation-link/page-creator.js
@@ -41,7 +41,7 @@ export function LinkUIPageCreator( {
 	const isTitleValid = title.trim().length > 0;
 
 	// Get the last created entity record (without ID) to track creation state
-	const { lastError, isSaving, lastCreatedRecord } = useSelect(
+	const { lastError, isSaving } = useSelect(
 		( select ) => ( {
 			lastError: select( coreStore ).getLastEntitySaveError(
 				'postType',
@@ -51,42 +51,52 @@ export function LinkUIPageCreator( {
 				'postType',
 				postType
 			),
-			lastCreatedRecord: select( coreStore ).getLastEntityRecord(
-				'postType',
-				postType
-			),
 		} ),
 		[ postType ]
 	);
 
 	// Check if we have a newly created page and it's resolved
-	const hasNewPageResolved = useSelect(
-		( select ) => {
-			if ( ! lastCreatedRecord?.id ) {
-				return false;
-			}
-			return select( coreStore ).hasResolved(
-				'postType',
-				'getEntityRecord',
-				[ 'postType', postType, lastCreatedRecord.id ]
-			);
-		},
-		[ lastCreatedRecord?.id, postType ]
-	);
-
-	// Get the full page data once it's resolved
 	const newPage = useSelect(
 		( select ) => {
-			if ( ! lastCreatedRecord?.id || ! hasNewPageResolved ) {
+			// Only check for new pages if we're not currently saving and there's no error
+			if ( isSaving || lastError ) {
 				return null;
 			}
-			return select( coreStore ).getEntityRecord(
+
+			// Get the most recent entity record for this post type
+			const recentRecords = select( coreStore ).getEntityRecords(
 				'postType',
 				postType,
-				lastCreatedRecord.id
+				{ per_page: 1, orderby: 'date', order: 'desc' }
 			);
+
+			if ( ! recentRecords || recentRecords.length === 0 ) {
+				return null;
+			}
+
+			const mostRecent = recentRecords[ 0 ];
+
+			// Check if this record was created recently (within the last few seconds)
+			const now = Date.now();
+			const createdTime = new Date( mostRecent.date ).getTime();
+			const isRecent = now - createdTime < 10000; // Within 10 seconds
+
+			if ( isRecent ) {
+				// Check if this specific record is resolved
+				const isResolved = select( coreStore ).hasResolved(
+					'postType',
+					'getEntityRecord',
+					[ 'postType', postType, mostRecent.id ]
+				);
+
+				if ( isResolved ) {
+					return mostRecent;
+				}
+			}
+
+			return null;
 		},
-		[ lastCreatedRecord?.id, hasNewPageResolved, postType ]
+		[ isSaving, lastError, postType ]
 	);
 
 	const { saveEntityRecord } = useDispatch( coreStore );

--- a/packages/block-library/src/navigation-link/page-creator.js
+++ b/packages/block-library/src/navigation-link/page-creator.js
@@ -1,0 +1,189 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	VisuallyHidden,
+	TextControl,
+	Notice,
+	CheckboxControl,
+} from '@wordpress/components';
+import { __, sprintf, isRTL } from '@wordpress/i18n';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { decodeEntities } from '@wordpress/html-entities';
+import { useState } from '@wordpress/element';
+import { chevronLeftSmall, chevronRightSmall } from '@wordpress/icons';
+
+/**
+ * Component for creating new pages within the Navigation Link UI.
+ *
+ * @param {Object}   props                Component props.
+ * @param {string}   props.postType       The post type to create.
+ * @param {Function} props.onBack         Callback when user wants to go back.
+ * @param {Function} props.onPageCreated  Callback when page is successfully created.
+ * @param {string}   [props.initialTitle] Initial title to pre-fill the form.
+ */
+export function LinkUIPageCreator( {
+	postType,
+	onBack,
+	onPageCreated,
+	initialTitle = '',
+} ) {
+	const labels = useSelect(
+		( select ) => select( coreStore ).getPostType( postType )?.labels,
+		[ postType ]
+	);
+	const [ title, setTitle ] = useState( initialTitle );
+	const [ shouldPublish, setShouldPublish ] = useState( false );
+
+	// Check if the title is valid for submission
+	const isTitleValid = title.trim().length > 0;
+
+	// Get the last created entity record (without ID) to track creation state
+	const { lastError, isSaving, lastCreatedRecord } = useSelect(
+		( select ) => ( {
+			lastError: select( coreStore ).getLastEntitySaveError(
+				'postType',
+				postType
+			),
+			isSaving: select( coreStore ).isSavingEntityRecord(
+				'postType',
+				postType
+			),
+			lastCreatedRecord: select( coreStore ).getLastEntityRecord(
+				'postType',
+				postType
+			),
+		} ),
+		[ postType ]
+	);
+
+	// Check if we have a newly created page and it's resolved
+	const hasNewPageResolved = useSelect(
+		( select ) => {
+			if ( ! lastCreatedRecord?.id ) {
+				return false;
+			}
+			return select( coreStore ).hasResolved(
+				'postType',
+				'getEntityRecord',
+				[ 'postType', postType, lastCreatedRecord.id ]
+			);
+		},
+		[ lastCreatedRecord?.id, postType ]
+	);
+
+	// Get the full page data once it's resolved
+	const newPage = useSelect(
+		( select ) => {
+			if ( ! lastCreatedRecord?.id || ! hasNewPageResolved ) {
+				return null;
+			}
+			return select( coreStore ).getEntityRecord(
+				'postType',
+				postType,
+				lastCreatedRecord.id
+			);
+		},
+		[ lastCreatedRecord?.id, hasNewPageResolved, postType ]
+	);
+
+	const { saveEntityRecord } = useDispatch( coreStore );
+
+	// If we have a resolved new page, call the callback and reset
+	if ( newPage ) {
+		const pageLink = {
+			id: newPage.id,
+			type: postType,
+			title: decodeEntities( newPage.title.rendered ),
+			url: newPage.link,
+			kind: 'post-type',
+		};
+		onPageCreated( pageLink );
+		return null; // Don't render anything while transitioning
+	}
+
+	async function createPage( event ) {
+		event.preventDefault();
+		if ( isSaving || ! isTitleValid ) {
+			return;
+		}
+
+		try {
+			await saveEntityRecord( 'postType', postType, {
+				title,
+				status: shouldPublish ? 'publish' : 'draft',
+			} );
+			// No need to manually handle success - the data store will update
+			// and our useSelect hooks will detect the new entity
+		} catch ( error ) {
+			// Error handling is done via the data store selectors
+		}
+	}
+
+	const isSubmitDisabled = isSaving || ! isTitleValid;
+	const submitButtonText = shouldPublish
+		? __( 'Publish page' )
+		: __( 'Create draft' );
+
+	return (
+		<div className="link-ui-page-creator">
+			<Button
+				__next40pxDefaultSize
+				variant="tertiary"
+				onClick={ onBack }
+				className="link-ui-page-creator__back"
+			>
+				{ isRTL() ? chevronRightSmall : chevronLeftSmall }
+				<VisuallyHidden>{ __( 'Go back' ) }</VisuallyHidden>
+			</Button>
+
+			<h2>
+				{ sprintf(
+					/* translators: %s: post type label */
+					__( 'Add new %s' ),
+					labels?.singular_name || postType
+				) }
+			</h2>
+
+			<form onSubmit={ createPage }>
+				<TextControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ __( 'Title' ) }
+					onChange={ setTitle }
+					placeholder={ __( 'No title' ) }
+					value={ title }
+				/>
+				<CheckboxControl
+					__nextHasNoMarginBottom
+					label={ __( 'Publish immediately' ) }
+					help={ __(
+						'If unchecked, the page will be created as a draft.'
+					) }
+					checked={ shouldPublish }
+					onChange={ setShouldPublish }
+				/>
+				{ lastError && (
+					<Notice
+						status="error"
+						isDismissible={ false }
+						className="link-ui-page-creator__error"
+					>
+						{ lastError.message }
+					</Notice>
+				) }
+				<Button
+					__next40pxDefaultSize
+					variant="primary"
+					type="submit"
+					isBusy={ isSaving }
+					aria-disabled={ isSubmitDisabled }
+				>
+					{ submitButtonText }
+				</Button>
+			</form>
+		</div>
+	);
+}

--- a/packages/block-library/src/navigation-link/page-creator.js
+++ b/packages/block-library/src/navigation-link/page-creator.js
@@ -6,8 +6,10 @@ import {
 	TextControl,
 	Notice,
 	CheckboxControl,
+	VStack,
+	HStack,
 } from '@wordpress/components';
-import { __, sprintf, isRTL } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -29,10 +31,6 @@ export function LinkUIPageCreator( {
 	onPageCreated,
 	initialTitle = '',
 } ) {
-	const labels = useSelect(
-		( select ) => select( coreStore ).getPostType( postType )?.labels,
-		[ postType ]
-	);
 	const [ title, setTitle ] = useState( initialTitle );
 	const [ shouldPublish, setShouldPublish ] = useState( false );
 
@@ -109,62 +107,57 @@ export function LinkUIPageCreator( {
 				{ __( 'Back' ) }
 			</Button>
 
-			<h2>
-				{ sprintf(
-					/* translators: %s: post type label */
-					__( 'Add new %s' ),
-					labels?.singular_name || postType
-				) }
-			</h2>
+			<VStack spacing={ 4 }>
+				<form onSubmit={ createPage }>
+					<VStack spacing={ 4 }>
+						<TextControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={ __( 'Title' ) }
+							onChange={ setTitle }
+							placeholder={ __( 'No title' ) }
+							value={ title }
+						/>
 
-			<form onSubmit={ createPage }>
-				<TextControl
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-					label={ __( 'Title' ) }
-					onChange={ setTitle }
-					placeholder={ __( 'No title' ) }
-					value={ title }
-				/>
-				<CheckboxControl
-					__nextHasNoMarginBottom
-					label={ __( 'Publish immediately' ) }
-					help={ __(
-						'If unchecked, the page will be created as a draft.'
-					) }
-					checked={ shouldPublish }
-					onChange={ setShouldPublish }
-				/>
-				{ lastError && (
-					<Notice
-						status="error"
-						isDismissible={ false }
-						className="link-ui-page-creator__error"
-					>
-						{ lastError.message }
-					</Notice>
-				) }
-				<div className="link-ui-page-creator__buttons">
-					<Button
-						__next40pxDefaultSize
-						variant="tertiary"
-						onClick={ onBack }
-						disabled={ isSaving }
-						accessibleWhenDisabled
-					>
-						{ __( 'Cancel' ) }
-					</Button>
-					<Button
-						__next40pxDefaultSize
-						variant="primary"
-						type="submit"
-						isBusy={ isSaving }
-						aria-disabled={ isSubmitDisabled }
-					>
-						{ submitButtonText }
-					</Button>
-				</div>
-			</form>
+						<CheckboxControl
+							__nextHasNoMarginBottom
+							label={ __( 'Publish immediately' ) }
+							help={ __(
+								'If unchecked, the page will be created as a draft.'
+							) }
+							checked={ shouldPublish }
+							onChange={ setShouldPublish }
+						/>
+
+						{ lastError && (
+							<Notice status="error" isDismissible={ false }>
+								{ lastError.message }
+							</Notice>
+						) }
+
+						<HStack spacing={ 2 } justify="flex-end">
+							<Button
+								__next40pxDefaultSize
+								variant="tertiary"
+								onClick={ onBack }
+								disabled={ isSaving }
+								accessibleWhenDisabled
+							>
+								{ __( 'Cancel' ) }
+							</Button>
+							<Button
+								__next40pxDefaultSize
+								variant="primary"
+								type="submit"
+								isBusy={ isSaving }
+								aria-disabled={ isSubmitDisabled }
+							>
+								{ submitButtonText }
+							</Button>
+						</HStack>
+					</VStack>
+				</form>
+			</VStack>
 		</div>
 	);
 }

--- a/packages/block-library/src/navigation-link/page-creator.js
+++ b/packages/block-library/src/navigation-link/page-creator.js
@@ -6,8 +6,8 @@ import {
 	TextControl,
 	Notice,
 	CheckboxControl,
-	VStack,
-	HStack,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { __, isRTL } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -107,7 +107,7 @@ export function LinkUIPageCreator( {
 				{ __( 'Back' ) }
 			</Button>
 
-			<VStack spacing={ 4 }>
+			<VStack className="link-ui-page-creator__inner" spacing={ 4 }>
 				<form onSubmit={ createPage }>
 					<VStack spacing={ 4 }>
 						<TextControl

--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -16,7 +16,7 @@
 }
 
 .link-ui-tools {
-	border-top: 1px solid $gray-100;
+	outline: 1px solid $gray-100;
 	padding: $grid-unit-10;
 }
 

--- a/packages/block-library/src/navigation/constants.js
+++ b/packages/block-library/src/navigation/constants.js
@@ -1,5 +1,9 @@
 export const DEFAULT_BLOCK = {
 	name: 'core/navigation-link',
+	attributes: {
+		kind: 'post-type',
+		type: 'page',
+	},
 };
 
 export const PRIORITIZED_INSERTER_BLOCKS = [


### PR DESCRIPTION
## What

Improves the page creation experience in the Navigation Link block's LinkUI by making it more discoverable and accessible. Currently, users can create pages through the search interface, but this flow is opaque and hard to discover. This PR adds a dedicated \"Create Page\" button that brings the page creation flow into view without requiring users to enter a search query.

Closes https://github.com/WordPress/gutenberg/issues/66923

## Why

The current LinkUI allows page creation through search results, but this creates several UX problems:
- The page creation option is buried within search results and hard to discover
- Users must enter a search query to access page creation, even when they want to create a new page
- The workflow is opaque and not intuitive for users building navigation menus

This PR makes page creation more accessible by providing a direct path to the feature, improving the overall navigation building experience.

## How

- Added a dedicated \"Create Page\" button in the LinkUI that's always visible
- Created a streamlined page creation form that appears when the button is clicked
- Disabled (hide) the existing search-based page creation option to avoid confusion.
- Added a \"Publish immediately\" checkbox to allow users to opt into creating published pages right away
- Implemented proper error handling and loading states
- Used consistent UI patterns with the existing LinkUI design

## Testing

1. Have a Nav block with a Menu.
2. Add a menu item via the inserter in the canvas.
4. Verify the \"Create Page\" button is visible in the interface
5. Click \"Create Page\" and fill in the page title
6. Test both draft and published page creation modes using the checkbox
7. Submit the form and verify the page is created with the correct title and slug
8. Verify the navigation link is updated with the new page URL
9. Test error handling by attempting to create pages with invalid data
10. Verify the existing search-based page creation still works as before

## Screenshots

<img width="1022" height="750" alt="Screen Shot 2025-08-13 at 11 23 37" src="https://github.com/user-attachments/assets/dc6e7a24-3316-495d-8eee-520ea1881dcc" />
<img width="521" height="322" alt="Screenshot 2025-08-13 at 11 23 47" src="https://github.com/user-attachments/assets/0c9b1a33-085c-4819-98e9-2e63753c0c2b" />


https://github.com/user-attachments/assets/473905dc-b8de-4899-9823-5f29c092aa4a




## Breaking Changes

None - this is a new feature that enhances existing functionality without breaking changes.

## Uncertain Elements

- Whether the page creator should support additional fields like excerpt or featured image
- If we should add support for creating other post types (posts, custom post types) in the future
- Whether the \"Create Page\" button placement is optimal for discoverability"