### PR TITLE
core-data: Fix `PostStatusObject` export

### DIFF
--- a/packages/core-data/src/entity-types/post-status.ts
+++ b/packages/core-data/src/entity-types/post-status.ts
@@ -52,5 +52,5 @@ declare module './base-entity-records' {
 }
 
 export type PostStatusObject< C extends Context = 'edit' > = OmitNevers<
-	_BaseEntityRecords.Type< C >
+	_BaseEntityRecords.PostStatusObject< C >
 >;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes the `PostStatusObject` type export in `core-data` introduced in #67668 to properly reference the defined interface properties instead of an unrelated type.

<!-- In a few words, what is the PR actually doing? -->

## Why?
  The exported `PostStatusObject` type was incorrectly referencing  `_BaseEntityRecords.Type<C>` instead of `_BaseEntityRecords.PostStatusObject<C>`, causing the type to resolve to the wrong properties: instead of Post Status properties, it would resolve to the Post Type ones.


## Testing Instructions
1. Create a test TypeScript file:
```
  import type { PostStatusObject } from  './packages/core-data/src/entity-types/post-status';

  const status: PostStatusObject = {
    name: 'Published',
    private: false,
    protected: false,
    public: true,
    queryable: true,
    show_in_list: true,
    slug: 'publish',
    date_floating: false,
  };
```
  2. Run `npx tsc --noEmit <filename>` - it should compile without errors
  3. Before the fix, TypeScript would error that properties like `private` and `protected` don't  exist
