### PR TITLE
Site editor e2e: ensure dismissal notice waits for the first occurrence of an updated/published notice

### DIFF
--- a/packages/e2e-test-utils-playwright/src/editor/site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/site-editor.ts
@@ -50,5 +50,6 @@ export async function saveSiteEditorEntities(
 	await this.page
 		.getByRole( 'button', { name: 'Dismiss this notice' } )
 		.getByText( /(updated|published)\./ )
+		.first()
 		.waitFor();
 }


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? How? Why?

Handle the case where there could be multiple snackbar notices in the editor e2e tests by waiting for the first occurrence of the relevant notice.

This approach was proposed over in https://github.com/WordPress/gutenberg/issues/69042 as a way to avoid flaky tests.

cc @ralucaStan 

Closes https://github.com/WordPress/gutenberg/issues/69042



## Testing Instructions


Run an e2e test that calls the `saveSiteEditorEntities` helper function, e.g., `test/e2e/specs/site-editor/block-style-variations.spec.js`

I do it through the GUI.

`npx playwright test --ui --headed --config test/e2e/playwright.config.ts`

The search for block-style-variations.spec.js and run it.

## Screenshots or screencast <!-- if applicable -->

An example of the failing flakey test:

<img width="1623" height="862" alt="Screenshot 2025-08-14 at 10 01 32 am" src="https://github.com/user-attachments/assets/d69b082e-92fa-4f2d-a760-f294167eb41d" />

