### PR TITLE
Avoid using `*-latest` for runner images

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -27,7 +27,7 @@ permissions: {}
 jobs:
     compute-stable-branches:
         name: Compute current and next stable release branches
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
         if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -55,7 +55,7 @@ jobs:
 
     bump-version:
         name: Bump version
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: write
         needs: compute-stable-branches
@@ -180,7 +180,7 @@ jobs:
 
     build:
         name: Build Release Artifact
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
         needs: bump-version
@@ -244,7 +244,7 @@ jobs:
     revert-version-bump:
         name: Revert version bump if build failed
         needs: [bump-version, build]
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: write
         if: |
@@ -300,7 +300,7 @@ jobs:
     create-release:
         name: Create Release Draft and Attach Asset
         needs: [bump-version, build]
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: write
 
@@ -347,7 +347,7 @@ jobs:
 
     npm-publish:
         name: Publish WordPress packages to npm
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
         environment: WordPress packages

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -38,7 +38,7 @@ permissions: {}
 jobs:
     build:
         name: Check
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
             pull-requests: write

--- a/.github/workflows/check-backport-changelog.yml
+++ b/.github/workflows/check-backport-changelog.yml
@@ -26,7 +26,7 @@ permissions: {}
 jobs:
     check:
         name: Check for a Core backport changelog entry
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'No Core Sync Required') && !contains(github.event.pull_request.labels.*.name, 'Backport from WordPress Core') }}

--- a/.github/workflows/check-components-changelog.yml
+++ b/.github/workflows/check-components-changelog.yml
@@ -22,7 +22,7 @@ permissions: {}
 jobs:
     check:
         name: Check CHANGELOG diff
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
         steps:

--- a/.github/workflows/check-dataviews-changelog.yml
+++ b/.github/workflows/check-dataviews-changelog.yml
@@ -22,7 +22,7 @@ permissions: {}
 jobs:
     check:
         name: Check CHANGELOG diff
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
         steps:

--- a/.github/workflows/cherry-pick-wp-release.yml
+++ b/.github/workflows/cherry-pick-wp-release.yml
@@ -22,7 +22,7 @@ permissions: {}
 
 jobs:
     cherry-pick:
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: write
             issues: write

--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -18,7 +18,7 @@ permissions: {}
 
 jobs:
     checks:
-        name: Checks w/Node.js ${{ matrix.node }} on ${{ matrix.os }}
+        name: Checks w/Node.js ${{ matrix.node }} on ${{ contains( inputs.os, 'macos-' ) && 'MacOS' || contains( inputs.os, 'windows-' ) && 'Windows' || 'Linux' }}
         runs-on: ${{ matrix.os }}
         permissions:
             contents: read

--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -27,7 +27,7 @@ jobs:
             fail-fast: false
             matrix:
                 node: ['20', '22', '24']
-                os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
+                os: ['macos-15', 'ubuntu-24.04', 'windows-2025']
 
         steps:
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -18,7 +18,7 @@ permissions: {}
 
 jobs:
     checks:
-        name: Checks w/Node.js ${{ matrix.node }} on ${{ contains( inputs.os, 'macos-' ) && 'MacOS' || contains( inputs.os, 'windows-' ) && 'Windows' || 'Linux' }}
+        name: Checks w/Node.js ${{ matrix.node }} on ${{ contains( matrix.os, 'macos-' ) && 'MacOS' || contains( matrix.os, 'windows-' ) && 'Windows' || 'Linux' }}
         runs-on: ${{ matrix.os }}
         permissions:
             contents: read

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -22,7 +22,7 @@ permissions: {}
 jobs:
     e2e-playwright:
         name: Playwright - ${{ matrix.part }}
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
@@ -80,7 +80,7 @@ jobs:
         name: Merge Artifacts
         if: ${{ !cancelled() }}
         needs: [e2e-playwright]
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions: {}
         outputs:
             has-flaky-test-report: ${{ !!steps.merge-flaky-tests-reports.outputs.artifact-id }}
@@ -108,7 +108,7 @@ jobs:
         name: Report to GitHub
         needs: [merge-artifacts]
         if: ${{ needs.merge-artifacts.outputs.has-flaky-test-report == 'true' }}
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
             issues: write

--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
     type-related-labels:
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             pull-requests: write
         steps:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -8,7 +8,7 @@ permissions: {}
 jobs:
     validation:
         name: 'Validation'
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
         steps:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -31,7 +31,7 @@ jobs:
     performance:
         timeout-minutes: 60
         name: Run performance tests
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
         if: ${{ github.repository == 'WordPress/gutenberg' }}

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -48,7 +48,7 @@ jobs:
     # - Removes the props-bot label, if necessary.
     props-bot:
         name: Generate a list of props
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             # The action needs permission `write` permission for PRs in order to add a comment.
             pull-requests: write

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -31,7 +31,7 @@ permissions: {}
 jobs:
     release:
         name: Release - ${{ github.event.inputs.release_type }}
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
         environment: WordPress packages

--- a/.github/workflows/pull-request-automation.yml
+++ b/.github/workflows/pull-request-automation.yml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
     pull-request-automation:
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
             issues: write

--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -17,7 +17,7 @@ jobs:
     # - Runs actionlint.
     actionlint:
         name: Run actionlint
-        runs-on: ubuntu-24.04
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
         timeout-minutes: 5

--- a/.github/workflows/stale-issue-gardening.yml
+++ b/.github/workflows/stale-issue-gardening.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
     issue-gardening:
         name: ${{ matrix.name }}
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             issues: write
             pull-requests: write

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -22,7 +22,7 @@ permissions: {}
 jobs:
     check:
         name: All
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}

--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -15,7 +15,7 @@ permissions: {}
 
 jobs:
     check:
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}

--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
     deploy:
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: write
         if: ${{ github.repository == 'WordPress/gutenberg' }}

--- a/.github/workflows/sync-assets-to-plugin-repo.yml
+++ b/.github/workflows/sync-assets-to-plugin-repo.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
     sync-assets:
         name: Sync assets to WordPress.org plugin repo
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
         environment: wp.org plugin

--- a/.github/workflows/sync-backport-changelog.yml
+++ b/.github/workflows/sync-backport-changelog.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
     sync-backport-changelog:
         name: Sync Core Backport Issue
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
             issues: write

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,7 +26,7 @@ permissions: {}
 jobs:
     unit-js:
         name: JavaScript (Node.js ${{ matrix.node }}) ${{ matrix.shard }}
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
@@ -71,7 +71,7 @@ jobs:
 
     unit-js-date:
         name: JavaScript Date Tests (Node.js ${{ matrix.node }})
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
@@ -109,7 +109,7 @@ jobs:
 
     compute-previous-wordpress-version:
         name: Compute previous WordPress version
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions: {}
         outputs:
             previous-wordpress-version: ${{ steps.get-previous-wordpress-version.outputs.previous-wordpress-version }}
@@ -136,7 +136,7 @@ jobs:
 
     build-assets:
         name: Build JavaScript assets for PHP unit tests
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
         steps:
@@ -160,9 +160,9 @@ jobs:
                       ./build-module/
 
     test-php:
-        name: PHP ${{ matrix.php }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.wordpress != '' && format( ' (WP {0}) ', matrix.wordpress ) || '' }} on ubuntu-latest
+        name: PHP ${{ matrix.php }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.wordpress != '' && format( ' (WP {0}) ', matrix.wordpress ) || '' }} on 'ubuntu-24.04'
         needs: [compute-previous-wordpress-version, build-assets]
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
         timeout-minutes: 20
@@ -297,7 +297,7 @@ jobs:
 
     phpcs:
         name: PHP coding standards
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
         timeout-minutes: 20
@@ -353,7 +353,7 @@ jobs:
     # This job is deprecated but be present for compatibility reasons.
     unit-php:
         name: PHP
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions: {}
         needs: [test-php, phpcs]
         if: ${{ always() }}
@@ -372,7 +372,7 @@ jobs:
 
     mobile-unit-js:
         name: Mobile
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: read
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}

--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
     compute-should-update-trunk:
         name: Decide if trunk or tag
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions: {}
         # Skip this job if the release is a release candidate. This will in turn skip
         # the upload jobs, which are only relevant for non-RC releases.
@@ -69,7 +69,7 @@ jobs:
 
     get-release-branch:
         name: Get release branch name
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions: {}
         outputs:
             release_branch: ${{ steps.get_release_branch.outputs.release_branch }}
@@ -86,7 +86,7 @@ jobs:
 
     update-changelog:
         name: Update Changelog on ${{ matrix.branch }} branch
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions:
             contents: write
         if: |
@@ -165,7 +165,7 @@ jobs:
 
     upload:
         name: Publish as trunk (and tag)
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions: {}
         environment: wp.org plugin
         needs: [compute-should-update-trunk, update-changelog]
@@ -225,7 +225,7 @@ jobs:
 
     upload-tag:
         name: Publish as tag
-        runs-on: ubuntu-latest
+        runs-on: 'ubuntu-24.04'
         permissions: {}
         environment: wp.org plugin
         needs: [compute-should-update-trunk, update-changelog]


### PR DESCRIPTION
## What?
This switches all workflows to using specific version tags representing the latest non-preview versions, which currently are as follows:

- `ubuntu-24.04`
- `windows-2025`
- `macos-15`

## Why?
While using the `ubuntu-latest`, `macos-latest`, and `windows-latest` runner image tags is convenient, it has proven to be problematic in a number of instances as the runners are slowly updated (see Core-62808 and Core-62843).

Additionally, GitHub uses warnings on workflow runs using the `-latest` tags when there are upcoming changes to the images that the alias points to. There is no way to acknowledge and dismiss these notices, and they can be quite noisy and alarming.