### PR TITLE
Improve UX for adding images to a gallery block from the media library

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -105,6 +105,7 @@ const MOBILE_CONTROL_PROPS_RANGE_CONTROL = Platform.isNative
 	: {};
 
 const DEFAULT_BLOCK = { name: 'core/image' };
+const DEFAULT_TEMPLATE = [ [ 'core/image' ], [ 'core/image' ] ];
 const EMPTY_ARRAY = [];
 
 export default function GalleryEdit( props ) {
@@ -543,6 +544,7 @@ export default function GalleryEdit( props ) {
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		defaultBlock: DEFAULT_BLOCK,
 		directInsert: true,
+		template: DEFAULT_TEMPLATE,
 		orientation: 'horizontal',
 		renderAppender: false,
 		...nativeInnerBlockProps,

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -26,7 +26,6 @@ import {
 	BlockControls,
 	MediaReplaceFlow,
 	useSettings,
-	InnerBlocks,
 } from '@wordpress/block-editor';
 import { Platform, useEffect, useMemo } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
@@ -547,7 +546,7 @@ export default function GalleryEdit( props ) {
 		directInsert: true,
 		template: DEFAULT_TEMPLATE,
 		orientation: 'horizontal',
-		renderAppender: InnerBlocks.defaultBlockAppender,
+		renderAppender: false,
 		...nativeInnerBlockProps,
 	} );
 

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -26,6 +26,7 @@ import {
 	BlockControls,
 	MediaReplaceFlow,
 	useSettings,
+	InnerBlocks,
 } from '@wordpress/block-editor';
 import { Platform, useEffect, useMemo } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
@@ -546,7 +547,7 @@ export default function GalleryEdit( props ) {
 		directInsert: true,
 		template: DEFAULT_TEMPLATE,
 		orientation: 'horizontal',
-		renderAppender: false,
+		renderAppender: InnerBlocks.defaultBlockAppender,
 		...nativeInnerBlockProps,
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #48417

Improves the UX for adding images to a Gallery block when there is only a single image.  
This PR ensures that a placeholder (empty image block) is always available after inserting the first image, making it easier to continue adding more without extra clicks.

## Why?
Currently, when a Gallery block has only one image, it is not obvious how to add additional images from the media library.  
Users must:
1. Select the existing image,
2. Select the gallery via the small toolbar icon,
3. Click "Add",
4. Open the media library,
5. Select more images,
6. Click "Add to gallery",
7. Finally, click "Update gallery".  

This creates unnecessary friction. The “+” appender only becomes visible once the gallery has 2 or more images.  
This PR reduces that friction by always showing an empty Image block placeholder immediately after the first image is added.

## Testing Instructions
1. Create a new post or page.
2. Insert a **Gallery** block.
3. Add a single image from the media library.  
   -  Expected: An empty image placeholder is automatically appended after the first image.
4. Add additional images — the appender and placeholder should behave as before.
5. Remove images back down to one — the placeholder remains available to add another.
6. Confirm drag-and-drop still works as expected.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/8ced628a-ea0b-4768-9ee4-06bd1b359949


