### PR TITLE
fix: Firefox pressing up arrow takes two lines up

### DIFF
--- a/packages/dom/src/dom/is-edge.js
+++ b/packages/dom/src/dom/is-edge.js
@@ -121,6 +121,18 @@ export default function isEdge( container, isReverse, onlyVertical = false ) {
 	const hasVerticalDiff = Math.abs( verticalDiff ) <= 1;
 	const hasHorizontalDiff = Math.abs( horizontalDiff ) <= 1;
 
+	if ( onlyVertical && isCollapsed ) {
+		// If horizontal position differs by more than 1px, we're on a wrapped line.
+		if (
+			Math.abs(
+				testRect[ horizontalSide ] -
+					collapsedRangeRect[ horizontalSide ]
+			) > 1
+		) {
+			return false;
+		}
+	}
+
 	return onlyVertical
 		? hasVerticalDiff
 		: hasVerticalDiff && hasHorizontalDiff;

--- a/packages/dom/src/dom/is-edge.js
+++ b/packages/dom/src/dom/is-edge.js
@@ -121,7 +121,9 @@ export default function isEdge( container, isReverse, onlyVertical = false ) {
 	const hasVerticalDiff = Math.abs( verticalDiff ) <= 1;
 	const hasHorizontalDiff = Math.abs( horizontalDiff ) <= 1;
 
-	if ( onlyVertical && isCollapsed ) {
+	/* global navigator */
+	const isFirefox = navigator.userAgent.includes( 'Firefox' );
+	if ( isFirefox && onlyVertical && isCollapsed ) {
 		// If horizontal position differs by more than 1px, we're on a wrapped line.
 		if (
 			Math.abs(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #34215

This PR fixes an issue where pressing the Up arrow key from the start of the second line in a multi-line paragraph would jump the cursor two lines up instead of one. This behavior was observed in Firefox.

## Why?
The current behavior breaks expected navigation and writing flow. When the cursor is at the beginning of the second line in a block (like a paragraph), the user expects it to move to the first line of that same block. Instead, the editor either jumps over the first line or selects the block above.

## How?
The PR adjusts the key handling logic to better detect the current cursor position within the block’s text content.

## Testing Instructions
1. Open a post or page in the editor.
2. Add any block (eg. a paragraph block).
3. Insert a paragraph block directly below it.
4. Write a paragraph (just typing a long enough to make it wrap around multiple lines).
5. Place the cursor at the start of the second line of the paragraph block.
6. Press the Up arrow key.

### Testing Instructions for Keyboard
1. Open a post or page in the editor.
2. Add any block (eg. a paragraph block).
3. Insert a paragraph block directly below it.
4. Type a long paragraph to ensure it wraps to multiple lines.
5. Use arrow keys to navigate within and between lines.
6. Press Up arrow when at the beginning of the second line.

Expected result:
- The cursor should move one line up to the first line of the same paragraph block.
- It should not skip to the block above or highlight another block.

## Screenshots or screencast <!-- if applicable -->

### Expected Behavior: Chrome

https://github.com/user-attachments/assets/e87d8fae-8c8d-4bf5-8411-d3322833a5cb

### Before: Firefox
https://github.com/user-attachments/assets/ea228f2d-3186-4441-a365-b0e29dcbfbd7

### After: Firefox
https://github.com/user-attachments/assets/0bef5e23-c10e-494f-a396-9558ed4823b9

