### PR TITLE
List block: Apply ordered/unordered conversion to nested lists

### DIFF
--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -118,6 +118,30 @@ function IndentUI( { clientId } ) {
 	);
 }
 
+function usePropagateOrderedToDescendants( clientId ) {
+	const registry = useRegistry();
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const { getClientIdsOfDescendants, getBlockName } =
+		useSelect( blockEditorStore );
+
+	return useCallback(
+		( nextOrdered ) => {
+			registry.batch( () => {
+				const ids = [
+					clientId,
+					...getClientIdsOfDescendants( clientId ),
+				];
+				for ( const id of ids ) {
+					if ( getBlockName( id ) === 'core/list' ) {
+						updateBlockAttributes( id, { ordered: nextOrdered } );
+					}
+				}
+			} );
+		},
+		[ clientId, getClientIdsOfDescendants, getBlockName ]
+	);
+}
+
 export default function Edit( { attributes, setAttributes, clientId, style } ) {
 	const { ordered, type, reversed, start } = attributes;
 	const blockProps = useBlockProps( {
@@ -141,6 +165,8 @@ export default function Edit( { attributes, setAttributes, clientId, style } ) {
 		__experimentalCaptureToolbars: true,
 	} );
 	useMigrateOnLoad( attributes, clientId );
+	const propagateOrderedToDescendants =
+		usePropagateOrderedToDescendants( clientId );
 
 	const controls = (
 		<BlockControls group="block">
@@ -150,7 +176,7 @@ export default function Edit( { attributes, setAttributes, clientId, style } ) {
 				description={ __( 'Convert to unordered list' ) }
 				isActive={ ordered === false }
 				onClick={ () => {
-					setAttributes( { ordered: false } );
+					propagateOrderedToDescendants( false );
 				} }
 			/>
 			<ToolbarButton
@@ -159,7 +185,7 @@ export default function Edit( { attributes, setAttributes, clientId, style } ) {
 				description={ __( 'Convert to ordered list' ) }
 				isActive={ ordered === true }
 				onClick={ () => {
-					setAttributes( { ordered: true } );
+					propagateOrderedToDescendants( true );
 				} }
 			/>
 			<IndentUI clientId={ clientId } />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of: https://github.com/WordPress/gutenberg/issues/41769

When converting a List block between unordered and ordered, nested lists didn’t follow and required manual selection. This PR propagates the conversion to all nested core/list descendants.

## Testing Instructions
1. Insert a List block with nested lists (multiple levels).
2. Click “Ordered” in the List block toolbar; all nested lists should become ordered.
3. Click “Unordered”; all nested lists should become unordered.
4. Verify a single Undo reverts the entire conversion.