### PR TITLE
Hide 'Add block' control in Link UI when Navigation Link block is in contentOnly mode

### DIFF
--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -13,6 +13,7 @@ import {
 	LinkControl,
 	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
+	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import {
 	createInterpolateElement,
@@ -157,6 +158,10 @@ function UnforwardedLinkUI( props, ref ) {
 		name: postType,
 	} );
 
+	// Check if we're in contentOnly mode
+	const blockEditingMode = useBlockEditingMode();
+	const isContentOnlyMode = blockEditingMode === 'contentOnly';
+
 	async function handleCreate( pageTitle ) {
 		const page = await saveEntityRecord( 'postType', postType, {
 			title: pageTitle,
@@ -261,7 +266,8 @@ function UnforwardedLinkUI( props, ref ) {
 						onRemove={ props.onRemove }
 						onCancel={ props.onCancel }
 						renderControlBottom={ () =>
-							! link?.url?.length && (
+							! link?.url?.length &&
+							! isContentOnlyMode && (
 								<LinkUITools
 									focusAddBlockButton={ focusAddBlockButton }
 									setAddingBlock={ () => {

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -160,7 +160,7 @@ function UnforwardedLinkUI( props, ref ) {
 
 	// Check if we're in contentOnly mode
 	const blockEditingMode = useBlockEditingMode();
-	const isContentOnlyMode = blockEditingMode === 'contentOnly';
+	const isDefaultBlockEditingMode = blockEditingMode === 'default';
 
 	async function handleCreate( pageTitle ) {
 		const page = await saveEntityRecord( 'postType', postType, {
@@ -267,7 +267,7 @@ function UnforwardedLinkUI( props, ref ) {
 						onCancel={ props.onCancel }
 						renderControlBottom={ () =>
 							! link?.url?.length &&
-							! isContentOnlyMode && (
+							isDefaultBlockEditingMode && (
 								<LinkUITools
 									focusAddBlockButton={ focusAddBlockButton }
 									setAddingBlock={ () => {


### PR DESCRIPTION
## What

Fixes navigation link block UX by hiding the 'Add block' control when the block is in contentOnly mode.

## Why

When the Navigation Link block is in contentOnly mode (which hides non-content UI), the 'Add block' button should also be hidden to provide a cleaner, more focused editing experience. This prevents users from seeing UI elements that are not relevant in content-only editing mode.

## How

- Import `useBlockEditingMode` hook from `@wordpress/block-editor`
- Check if the current block is in contentOnly mode using `useBlockEditingMode()`
- Conditionally render the LinkUITools component only when not in contentOnly mode
- Maintain existing functionality for default and disabled modes

## Testing

### Manual Testing Steps
1. Open a Navigation block in the editor
2. Enter Navigation focus mode (which sets contentOnly mode)
3. Try to add a Navigation Link block
4. Verify that the 'Add block' button is not visible in the link UI
5. Exit Navigation focus mode and verify the 'Add block' button reappears

### Block.json Testing (Temporary Hack)
**IMPORTANT**: The following block.json changes are for testing purposes only and should NOT be committed. They are a temporary workaround to allow Navigation block selection in Write Mode while waiting for a definitive solution.

#### Why This Temporary Hack is Necessary
The Navigation block currently cannot be selected in Write Mode due to block editing mode restrictions. Adding `role: content` to specific attributes allows temporary selection for testing purposes.

#### How to Apply the Temporary Changes
Apply these diffs to your local files for testing (DO NOT COMMIT):

**Navigation Block:**
```diff
diff --git a/packages/block-library/src/navigation/block.json b/packages/block-library/src/navigation/block.json
index c65e0c62246..76f878f4957 100644
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -22,7 +22,8 @@
        "textdomain": "default",
        "attributes": {
                "ref": {
-                       "type": "number"
+                       "type": "number",
+                       "role": "content"
                },
                "textColor": {
                        "type": "string"
```

**Navigation Link Block:**
```diff
diff --git a/packages/block-library/src/navigation-link/block.json b/packages/block-library/src/navigation-link/block.json
index 2762bd24e44..5f2d10b97da 100644
--- a/packages/block-library/src/navigation-link/block.json
+++ b/packages/block-library/src/navigation-link/block.json
@@ -14,7 +14,8 @@
        "textdomain": "default",
        "attributes": {
                "label": {
-                       "type": "string"
+                       "type": "string",
+                       "role": "content"
                },
                "type": {
                        "type": "string"
```

#### Testing with the Temporary Changes
1. Apply the above diffs to your local block.json files
2. Restart the development server
3. Navigate to Write Mode
4. Verify that Navigation blocks can now be selected
5. Test the contentOnly mode functionality
6. **IMPORTANT**: Revert the block.json changes before committing

## Screenshots

[Screenshots to be added]

## Breaking Changes

None - this is a UX improvement that maintains existing functionality.

## Uncertain Elements

- Whether this approach should be extended to other blocks in contentOnly mode
- If the conditional rendering logic should be moved to a higher level component
