### PR TITLE
Fields Components: Add missing style resets for fieldset elements

### DIFF
--- a/packages/fields/src/components/create-template-part-modal/index.tsx
+++ b/packages/fields/src/components/create-template-part-modal/index.tsx
@@ -193,7 +193,7 @@ export function CreateTemplatePartModalContents( {
 					onChange={ setTitle }
 					required
 				/>
-				<fieldset>
+				<fieldset className="fields-create-template-part-modal__area-fieldset">
 					<BaseControl.VisualLabel as="legend">
 						{ __( 'Area' ) }
 					</BaseControl.VisualLabel>

--- a/packages/fields/src/components/create-template-part-modal/style.scss
+++ b/packages/fields/src/components/create-template-part-modal/style.scss
@@ -2,6 +2,13 @@
 	z-index: z-index(".fields-create-template-part-modal");
 }
 
+.fields-create-template-part-modal__area-fieldset {
+	// Reset `fieldset` browser defaults.
+	border: 0;
+	padding: 0;
+	margin: 0;
+}
+
 .fields-create-template-part-modal__area-radio-group {
 	border: $border-width solid $gray-600;
 	border-radius: $radius-small;

--- a/packages/fields/src/fields/featured-image/style.scss
+++ b/packages/fields/src/fields/featured-image/style.scss
@@ -34,6 +34,11 @@
 }
 
 fieldset.fields-controls__featured-image {
+	// Reset `fieldset` browser defaults.
+	border: 0;
+	padding: 0;
+	margin: 0;
+
 	.fields-controls__featured-image-container {
 		border: $border-width solid $gray-300;
 		border-radius: $radius-small;

--- a/packages/fields/src/fields/parent/style.scss
+++ b/packages/fields/src/fields/parent/style.scss
@@ -1,0 +1,6 @@
+.fields-controls__parent {
+	// Reset `fieldset` browser defaults.
+	border: 0;
+	padding: 0;
+	margin: 0;
+}

--- a/packages/fields/src/fields/password/style.scss
+++ b/packages/fields/src/fields/password/style.scss
@@ -1,0 +1,6 @@
+.fields-controls__password {
+	// Reset `fieldset` browser defaults.
+	border: 0;
+	padding: 0;
+	margin: 0;
+}

--- a/packages/fields/src/fields/slug/style.scss
+++ b/packages/fields/src/fields/slug/style.scss
@@ -1,4 +1,9 @@
 .fields-controls__slug {
+	// Reset `fieldset` browser defaults.
+	border: 0;
+	padding: 0;
+	margin: 0;
+
 	.fields-controls__slug-external-icon {
 		margin-left: 5ch;
 	}

--- a/packages/fields/src/fields/template/style.scss
+++ b/packages/fields/src/fields/template/style.scss
@@ -1,3 +1,10 @@
+.fields-controls__template {
+	// Reset `fieldset` browser defaults.
+	border: 0;
+	padding: 0;
+	margin: 0;
+}
+
 .fields-controls__template-modal {
 	z-index: z-index(".fields-controls__template-modal");
 }

--- a/packages/fields/src/style.scss
+++ b/packages/fields/src/style.scss
@@ -1,6 +1,8 @@
 @import "./components/create-template-part-modal/style.scss";
 @import "./fields/slug/style.scss";
 @import "./fields/featured-image/style.scss";
+@import "./fields/parent/style.scss";
+@import "./fields/password/style.scss";
 @import "./fields/template/style.scss";
 @import "./fields/title/style.scss";
 @import "./fields/pattern-title/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Add `fieldset` resets for the components in the `fields` package that use the `fieldset` element. Essentially this will ensure we remove unexpected borders when fields are used in contexts that don't automatically reset these elements.

This is a very similar PR to #70685, which included the same kinds of resets in the block editor package.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Components in the components library already do this, but those in `fields` weren't — ideally, as in #70685, components should be responsible for their own CSS resets for things like `fieldset` and not expect that the containing environment provides it for them.

Right now this issue isn't apparent in Gutenberg, because we currently depend on `common.css`, but ideally we shouldn't really depend on that.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Audit the components in the `fields` package and add missing style resets for the `fieldset` elements
* For those components that didn't already have a classname on that element, add one
* And where they didn't have a `style.scss` file in order to include the reset, add one of those, too

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Testing this will be slightly artificial as things work correctly in Gutenberg already. However, we can approximate how things _might_ look without `common.css` by opening the browser console and entering the following:

```
document.querySelector( 'link#common-css' ).remove()
```

In order to test the affected fields, you'll also need to enable the Quick Edit experiment in order to access the quick edit panel / sidebar within the site editor's view of Pages:

<img width="1522" height="148" alt="image" src="https://github.com/user-attachments/assets/ba3f6c32-3ef6-4081-b924-20073f7ee531" />

### Testing steps

Note: this PR only adjusts `fieldset` resets, so that's all we're focusing on right now — as you're testing, ignore any fonts or font-size changes as that's not in scope for this PR (in general on previous PRs it was considered not to worry about fonts at this stage).

#### Add Template Part modal (note border around "area")

1. In the console run `document.querySelector( 'link#common-css' ).remove()` to hide the common.css resets
2. Go to the Patterns screen of the Site Editor and select Add Pattern > Add Template Part

| Before | After |
| --- | --- |
| <img width="1275" height="750" alt="image" src="https://github.com/user-attachments/assets/a5014768-6b84-4802-a98d-7478df6eaf13" /> | <img width="1271" height="747" alt="image" src="https://github.com/user-attachments/assets/08ba9177-b439-4e91-aed1-b7474bbd97be" /> |

#### Fields used in Quick Edit for Pages

1. As above, make sure you've enabled the Quick Edit experiment in Gutenberg's settings screen
2. In the console run `document.querySelector( 'link#common-css' ).remove()` to hide the common.css resets
3. Go to the Pages screen in the Site Editor, and switch to the Table layout
4. Click on the sidebar icon at the top right of the DataViews controls to show the sidebar
5. Select a page to view the quick edit sidebar
6. Take a look at each of the affected fields in this PR
  - Check that the Featured Image button doesn't have an unexpected border
  - Click on the Status & Visibility to check the Password Protected checkbox doesn't have an unexpected border
  - Click on the Slug to check that the link in the popover doesn't have an unexpected border
  - Click on the Parent and check that the controls in the popover don't have an unexpected border
  - Check that the Template button doesn't have an unexpected border

This is the area we're checking:

| Before | After |
| --- | --- |
| <img width="1274" height="748" alt="image" src="https://github.com/user-attachments/assets/3fe1779a-3c90-4a53-a649-8e772b5c23e7" /> | <img width="1275" height="751" alt="image" src="https://github.com/user-attachments/assets/9f839ca8-651a-4120-afc0-9be9bbb0e2eb" /> |
