### PR TITLE
DataViews: preview size picker falls back to the smallest available size

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 - Add two smaller sizs to the grid layout ([#71077](https://github.com/WordPress/gutenberg/pull/71077)).
 
+### Bug Fixes
+
+- Do not throw exception when `view.layout.previewSize` is smaller than the smallest available size. [#71218](https://github.com/WordPress/gutenberg/pull/71218)
+
 ## 6.0.0 (2025-08-07)
 
 ### Breaking changes
@@ -26,7 +30,7 @@
 
 - Do not render an empty `&nbsp;` when the title field has level 0. [#71021](https://github.com/WordPress/gutenberg/pull/71021)
 - When a field type is `array` and it has elements, the select control should allow multi-selection. [#71000](https://github.com/WordPress/gutenberg/pull/71000)
-- Set minimum and maximum number of items in `pePageSizes`, so that the UI control is disabled when the list exceeds those limits. [#71004](https://github.com/WordPress/gutenberg/pull/71004)
+- Set minimum and maximum number of items in `perPageSizes`, so that the UI control is disabled when the list exceeds those limits. [#71004](https://github.com/WordPress/gutenberg/pull/71004)
 - Fix `filterSortAndPaginate` to handle searching fields that have a type of `array` ([#70785](https://github.com/WordPress/gutenberg/pull/70785)).
 - Fix user-input filters: empty value for text and integer filters means there's no value to search for (so it returns all items). It also fixes a type conversion where empty strings for integer were converted to 0 [#70956](https://github.com/WordPress/gutenberg/pull/70956/).
 - Fix Table layout Title's column wrapping and min-width so that long descriptions can be visualized without scrolling. [#70983](https://github.com/WordPress/gutenberg/pull/70983)

--- a/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
@@ -49,12 +49,11 @@ export default function PreviewSizePicker() {
 	const layoutPreviewSize = view.layout?.previewSize ?? 230; // Default to the third smallest size if no preview size is set.
 	// If the container has resized and the set preview size is no longer available,
 	// we reset it to the next smallest size, or the smallest available size.
-	const previewSizeToUse = breakValues
-		.map( ( size, index ) => ( { ...size, index } ) )
-		.filter(
-			( size ) => size.index === 0 || size.value <= layoutPreviewSize
-		)
-		.sort( ( a, b ) => b.value - a.value )[ 0 ].index;
+	const previewSizeToUse =
+		breakValues
+			.map( ( size, index ) => ( { ...size, index } ) )
+			.filter( ( size ) => size.value <= layoutPreviewSize )
+			.sort( ( a, b ) => b.value - a.value )[ 0 ]?.index ?? 0;
 
 	const marks = breakValues.map( ( size, index ) => {
 		return {

--- a/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
@@ -48,10 +48,12 @@ export default function PreviewSizePicker() {
 
 	const layoutPreviewSize = view.layout?.previewSize ?? 230; // Default to the third smallest size if no preview size is set.
 	// If the container has resized and the set preview size is no longer available,
-	// we reset it to the next smallest size.
+	// we reset it to the next smallest size, or the smallest available size.
 	const previewSizeToUse = breakValues
 		.map( ( size, index ) => ( { ...size, index } ) )
-		.filter( ( size ) => size.value <= layoutPreviewSize )
+		.filter(
+			( size ) => size.index === 0 || size.value <= layoutPreviewSize
+		)
 		.sort( ( a, b ) => b.value - a.value )[ 0 ].index;
 
 	const marks = breakValues.map( ( size, index ) => {


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->


<!-- In a few words, what is the PR actually doing? -->

Fixes a crash caused by `<PreviewSizePicker>` when an invalid `previewSize` is passed to the data view.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When a grid dataview is passed a `previewSize` option which doesn't match one of the discrete sizes available, it falls back to the next smallest option. But if `previewSize` was smaller than the smallest available size it would throw an exception.

`previewSize` could be invalid for a number of reasons. For us it happened because we persist the user's selected size as a page query parameter. Since the page query parameter is editable, it is possible users edit this data and corrupt it. Since dataviews doesn't export the list of valid preview sizes we aren't able to reliably sanitize the input on our end.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The preview size picker control now shows the smallest available size as selected if the `previewSize` prop is too small.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

I've added a unit test to cover this situation, but you could manually test this in storybook.

First change this to `'grid'` so that the default dataview in storybook is a grid.

https://github.com/WordPress/gutenberg/blob/045f89b831f3c54b9b8196877046dcaa71778d32/packages/dataviews/src/components/dataviews/stories/fixtures.tsx#L698

Then add `previewSize: 100` to the to the default layout options.

When you use storybook the dataviews will show small icons, but when you open the view options it will no longer crash. When you change the preview size it will pop back to one of the allowed preview sizes.


https://github.com/user-attachments/assets/716e03ad-0701-49c3-9352-194a66266d3b



Here's the crash:


https://github.com/user-attachments/assets/40ea6b74-e29a-4e46-9e39-6daaa9d7837e



### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
No UI changes.
