### PR TITLE
Accordion: Refactor settings panel to use ToolsPanel

### DIFF
--- a/packages/block-library/src/accordion-item/edit.js
+++ b/packages/block-library/src/accordion-item/edit.js
@@ -10,17 +10,28 @@ import {
 } from '@wordpress/block-editor';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
-import { PanelBody, ToggleControl } from '@wordpress/components';
+import {
+	ToggleControl,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
 /**
  * External dependencies
  */
 import clsx from 'clsx';
+
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 export default function Edit( {
 	attributes: { openByDefault },
 	clientId,
 	setAttributes,
 } ) {
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+
 	const { isSelected, getBlockOrder } = useSelect(
 		( select ) => {
 			const {
@@ -83,26 +94,54 @@ export default function Edit( {
 	return (
 		<>
 			<InspectorControls key="setting">
-				<PanelBody title={ __( 'Settings' ) }>
-					<ToggleControl
-						label={ __( 'Open by default' ) }
-						__nextHasNoMarginBottom
-						onChange={ ( value ) => {
-							setAttributes( {
-								openByDefault: value,
+				<ToolsPanel
+					label={ __( 'Settings' ) }
+					resetAll={ () => {
+						setAttributes( { openByDefault: false } );
+						if ( contentBlockClientId ) {
+							updateBlockAttributes( contentBlockClientId, {
+								openByDefault: false,
 							} );
+						}
+					} }
+					dropdownMenuProps={ dropdownMenuProps }
+				>
+					<ToolsPanelItem
+						label={ __( 'Open by default' ) }
+						isShownByDefault
+						hasValue={ () => !! openByDefault }
+						onDeselect={ () => {
+							setAttributes( { openByDefault: false } );
 							if ( contentBlockClientId ) {
 								updateBlockAttributes( contentBlockClientId, {
-									openByDefault: value,
+									openByDefault: false,
 								} );
 							}
 						} }
-						checked={ openByDefault }
-						help={ __(
-							'Accordion content will be displayed by default.'
-						) }
-					/>
-				</PanelBody>
+					>
+						<ToggleControl
+							label={ __( 'Open by default' ) }
+							__nextHasNoMarginBottom
+							onChange={ ( value ) => {
+								setAttributes( {
+									openByDefault: value,
+								} );
+								if ( contentBlockClientId ) {
+									updateBlockAttributes(
+										contentBlockClientId,
+										{
+											openByDefault: value,
+										}
+									);
+								}
+							} }
+							checked={ openByDefault }
+							help={ __(
+								'Accordion content will be displayed by default.'
+							) }
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
 			</InspectorControls>
 			<div { ...innerBlocksProps } />
 		</>

--- a/packages/block-library/src/accordions/edit.js
+++ b/packages/block-library/src/accordions/edit.js
@@ -116,11 +116,11 @@ export default function Edit( {
 							} }
 						>
 							<ToggleGroupControlOption
-								label="Left"
+								label={ __( 'Left' ) }
 								value="left"
 							/>
 							<ToggleGroupControlOption
-								label="Right"
+								label={ __( 'Right' ) }
 								value="right"
 							/>
 						</ToggleGroupControl>

--- a/packages/block-library/src/accordions/edit.js
+++ b/packages/block-library/src/accordions/edit.js
@@ -8,11 +8,17 @@ import {
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import {
-	PanelBody,
 	ToggleControl,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const ACCORDION_BLOCK_NAME = 'core/accordion-item';
 const ACCORDION_BLOCK = {
@@ -24,6 +30,7 @@ export default function Edit( {
 	setAttributes,
 } ) {
 	const blockProps = useBlockProps();
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: [ [ ACCORDION_BLOCK_NAME ], [ ACCORDION_BLOCK_NAME ] ],
@@ -35,49 +42,90 @@ export default function Edit( {
 	return (
 		<>
 			<InspectorControls key="setting">
-				<PanelBody title={ __( 'Settings' ) } initialOpen>
-					<ToggleControl
-						isBlock
-						__nextHasNoMarginBottom
+				<ToolsPanel
+					label={ __( 'Settings' ) }
+					resetAll={ () => {
+						setAttributes( {
+							autoclose: false,
+							showIcon: true,
+							iconPosition: 'right',
+						} );
+					} }
+					dropdownMenuProps={ dropdownMenuProps }
+				>
+					<ToolsPanelItem
 						label={ __( 'Auto-close' ) }
-						onChange={ ( value ) => {
-							setAttributes( {
-								autoclose: value,
-							} );
-						} }
-						checked={ autoclose }
-						help={ __(
-							'Automatically close accordions when a new one is opened.'
-						) }
-					/>
-					<ToggleControl
-						isBlock
-						__nextHasNoMarginBottom
-						label={ __( 'Show icon' ) }
-						onChange={ ( value ) => {
-							setAttributes( {
-								showIcon: value,
-							} );
-						} }
-						checked={ showIcon }
-						help={ __(
-							'Display a plus icon next to the accordion header.'
-						) }
-					/>
-					<ToggleGroupControl
-						__nextHasNoMarginBottom
-						__next40pxDefaultSize
-						isBlock
-						label={ __( 'Icon Position' ) }
-						value={ iconPosition }
-						onChange={ ( value ) => {
-							setAttributes( { iconPosition: value } );
-						} }
+						isShownByDefault
+						hasValue={ () => !! autoclose }
+						onDeselect={ () =>
+							setAttributes( { autoclose: false } )
+						}
 					>
-						<ToggleGroupControlOption label="Left" value="left" />
-						<ToggleGroupControlOption label="Right" value="right" />
-					</ToggleGroupControl>
-				</PanelBody>
+						<ToggleControl
+							isBlock
+							__nextHasNoMarginBottom
+							label={ __( 'Auto-close' ) }
+							onChange={ ( value ) => {
+								setAttributes( {
+									autoclose: value,
+								} );
+							} }
+							checked={ autoclose }
+							help={ __(
+								'Automatically close accordions when a new one is opened.'
+							) }
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						label={ __( 'Show icon' ) }
+						isShownByDefault
+						hasValue={ () => ! showIcon }
+						onDeselect={ () => setAttributes( { showIcon: true } ) }
+					>
+						<ToggleControl
+							isBlock
+							__nextHasNoMarginBottom
+							label={ __( 'Show icon' ) }
+							onChange={ ( value ) => {
+								setAttributes( {
+									showIcon: value,
+								} );
+							} }
+							checked={ showIcon }
+							help={ __(
+								'Display a plus icon next to the accordion header.'
+							) }
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						label={ __( 'Icon Position' ) }
+						isShownByDefault
+						hasValue={ () => iconPosition !== 'right' }
+						onDeselect={ () =>
+							setAttributes( { iconPosition: 'right' } )
+						}
+					>
+						<ToggleGroupControl
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+							isBlock
+							label={ __( 'Icon Position' ) }
+							value={ iconPosition }
+							onChange={ ( value ) => {
+								setAttributes( { iconPosition: value } );
+							} }
+						>
+							<ToggleGroupControlOption
+								label="Left"
+								value="left"
+							/>
+							<ToggleGroupControlOption
+								label="Right"
+								value="right"
+							/>
+						</ToggleGroupControl>
+					</ToolsPanelItem>
+				</ToolsPanel>
 			</InspectorControls>
 			<div { ...innerBlocksProps } />
 		</>


### PR DESCRIPTION
## What?
Closes #71223 

This PR refactors the Accordions and Accordion Item blocks to use the `ToolsPanel` component instead of the `PanelBody` component in their inspector controls.

## Why?
This change aligns the Accordion block with the ongoing effort to standardize block inspector controls across Gutenberg using `ToolsPanel`. The `ToolsPanel` component provides a better user experience with reset capabilities, improved organization, and consistent UI patterns across all blocks.

## Screenshots or screencast 

### Before
**Accordions**
<img width="282" height="671" alt="Screenshot 2025-08-15 at 5 10 16 PM" src="https://github.com/user-attachments/assets/f7cec683-7d74-4a72-bf68-bce603e59ce1" />

**Accordion List**
<img width="285" height="397" alt="Screenshot 2025-08-15 at 5 10 26 PM" src="https://github.com/user-attachments/assets/89490816-e100-47b3-906a-a7a8ef3ddd2d" />

### After

https://github.com/user-attachments/assets/c3910277-3ecc-44da-a8a0-9ad06744bae8

