### PR TITLE
Accordion Blocks: Make block icons internal

### DIFF
--- a/packages/block-library/src/accordion-header/icon.js
+++ b/packages/block-library/src/accordion-header/icon.js
@@ -3,7 +3,7 @@
  */
 import { SVG, Path } from '@wordpress/primitives';
 
-const accordionHeader = (
+export default (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path
 			fillRule="evenodd"
@@ -14,5 +14,3 @@ const accordionHeader = (
 		<Path d="M4.5 9.5L8.5 12L4.5 14.5L4.5 9.5Z" fill="currentColor" />
 	</SVG>
 );
-
-export default accordionHeader;

--- a/packages/block-library/src/accordion-header/index.js
+++ b/packages/block-library/src/accordion-header/index.js
@@ -1,21 +1,18 @@
 /**
- * WordPress dependencies
- */
-import { accordionHeader } from '@wordpress/icons';
-/**
  * Internal dependencies
  */
 import edit from './edit';
 import save from './save';
 import metadata from './block.json';
 import initBlock from '../utils/init-block';
+import icon from './icon';
 
 const { name } = metadata;
 
 export { metadata, name };
 
 export const settings = {
-	icon: accordionHeader,
+	icon,
 	example: {},
 	edit,
 	save,

--- a/packages/block-library/src/accordion-item/icon.js
+++ b/packages/block-library/src/accordion-item/icon.js
@@ -3,7 +3,7 @@
  */
 import { SVG, Path } from '@wordpress/primitives';
 
-const accordionItem = (
+export default (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path
 			fillRule="evenodd"
@@ -26,5 +26,3 @@ const accordionItem = (
 		<Path d="M4.5 6.25L8.5 8.75L4.5 11.25L4.5 6.25Z" fill="currentColor" />
 	</SVG>
 );
-
-export default accordionItem;

--- a/packages/block-library/src/accordion-item/index.js
+++ b/packages/block-library/src/accordion-item/index.js
@@ -1,21 +1,18 @@
 /**
- * WordPress dependencies
- */
-import { accordionItem } from '@wordpress/icons';
-/**
  * Internal dependencies
  */
 import edit from './edit';
 import save from './save';
 import metadata from './block.json';
 import initBlock from '../utils/init-block';
+import icon from './icon';
 
 const { name } = metadata;
 
 export { metadata, name };
 
 export const settings = {
-	icon: accordionItem,
+	icon,
 	example: {},
 	edit,
 	save,

--- a/packages/block-library/src/accordion-panel/icon.js
+++ b/packages/block-library/src/accordion-panel/icon.js
@@ -3,7 +3,7 @@
  */
 import { SVG, Path } from '@wordpress/primitives';
 
-const accordionPanel = (
+export default (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path
 			fillRule="evenodd"
@@ -13,5 +13,3 @@ const accordionPanel = (
 		/>
 	</SVG>
 );
-
-export default accordionPanel;

--- a/packages/block-library/src/accordion-panel/index.js
+++ b/packages/block-library/src/accordion-panel/index.js
@@ -1,21 +1,18 @@
 /**
- * WordPress dependencies
- */
-import { accordionPanel } from '@wordpress/icons';
-/**
  * Internal dependencies
  */
 import edit from './edit';
 import save from './save';
 import metadata from './block.json';
 import initBlock from '../utils/init-block';
+import icon from './icon';
 
 const { name } = metadata;
 
 export { metadata, name };
 
 export const settings = {
-	icon: accordionPanel,
+	icon,
 	example: {},
 	edit,
 	save,

--- a/packages/block-library/src/accordions/icon.js
+++ b/packages/block-library/src/accordions/icon.js
@@ -3,7 +3,7 @@
  */
 import { SVG, Path } from '@wordpress/primitives';
 
-const accordion = (
+export default (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path
 			fillRule="evenodd"
@@ -21,5 +21,3 @@ const accordion = (
 		<Path d="M4.5 13L8.5 15.5L4.5 18L4.5 13Z" fill="currentColor" />
 	</SVG>
 );
-
-export default accordion;

--- a/packages/block-library/src/accordions/index.js
+++ b/packages/block-library/src/accordions/index.js
@@ -1,21 +1,18 @@
 /**
- * WordPress dependencies
- */
-import { accordion } from '@wordpress/icons';
-/**
  * Internal dependencies
  */
 import edit from './edit';
 import save from './save';
 import metadata from './block.json';
 import initBlock from '../utils/init-block';
+import icon from './icon';
 
 const { name } = metadata;
 
 export { metadata, name };
 
 export const settings = {
-	icon: accordion,
+	icon,
 	example: {},
 	edit,
 	save,

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -1,9 +1,5 @@
 export { default as Icon } from './icon';
 
-export { default as accordion } from './library/accordion';
-export { default as accordionHeader } from './library/accordion-header';
-export { default as accordionItem } from './library/accordion-item';
-export { default as accordionPanel } from './library/accordion-panel';
 export { default as addCard } from './library/add-card';
 export { default as addSubmenu } from './library/add-submenu';
 export { default as addTemplate } from './library/add-template';


### PR DESCRIPTION
## What? Why?

Accordion-related blocks are still experimental and subject to breaking changes. They are also unavailable unless explicitly enabled by users.

On the other hand, the icons are published in the icons package, so consumers are free to use them.

Since there is a possibility that the icon names will change or the icon designs will change significantly, I think it would be better not to release the icons until the accordion block is stable. Furthermore, these icons have limited use, so I'm not sure they're worth publishing.

## Testing Instructions

Make sure the block icon is displayed as before.