### PR TITLE
DataViews: Fix checkbox visibility in grid layout when media is hidden

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Bug Fixes
 
 - Do not throw exception when `view.layout.previewSize` is smaller than the smallest available size. [#71218](https://github.com/WordPress/gutenberg/pull/71218)
+- Fix checkbox visibility in grid layout when media is hidden. [#71219](https://github.com/WordPress/gutenberg/pull/71219)
 
 ## 6.0.0 (2025-08-07)
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -20,7 +20,7 @@
 ### Bug Fixes
 
 - Do not throw exception when `view.layout.previewSize` is smaller than the smallest available size. [#71218](https://github.com/WordPress/gutenberg/pull/71218)
-- Fix checkbox visibility in grid layout when media is hidden. [#71219](https://github.com/WordPress/gutenberg/pull/71219)
+- Fix checkbox visibility in grid layout when media is hidden. [#71231](https://github.com/WordPress/gutenberg/pull/71231)
 
 ## 6.0.0 (2025-08-07)
 

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -180,6 +180,16 @@ function GridItem< Item >( {
 				justify="space-between"
 				className="dataviews-view-grid__title-actions"
 			>
+				{ hasBulkActions && ! ( showMedia && renderedMediaField ) && (
+					<DataViewsSelectionCheckbox
+						item={ item }
+						selection={ selection }
+						onChangeSelection={ onChangeSelection }
+						getItemId={ getItemId }
+						titleField={ titleField }
+						disabled={ ! hasBulkAction }
+					/>
+				) }
 				<ItemClickWrapper
 					item={ item }
 					isItemClickable={ isItemClickable }

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -152,6 +152,49 @@
 	top: $grid-unit-10;
 }
 
+.dataviews-view-grid__card:not(:has(.dataviews-view-grid__media)) .dataviews-selection-checkbox {
+	position: static;
+	margin-right: 0;
+	width: 0;
+	overflow: hidden;
+	opacity: 0;
+	pointer-events: none;
+
+	@media (hover: none) {
+		width: auto;
+		margin-right: $grid-unit-05;
+		opacity: 1;
+		pointer-events: auto;
+	}
+}
+
+.dataviews-view-grid__card:not(:has(.dataviews-view-grid__media)):hover .dataviews-selection-checkbox,
+.dataviews-view-grid__card:not(:has(.dataviews-view-grid__media)):focus-within .dataviews-selection-checkbox,
+.dataviews-view-grid__card:not(:has(.dataviews-view-grid__media)).is-selected .dataviews-selection-checkbox {
+	position: static;
+	margin-right: $grid-unit-05;
+	width: auto;
+	opacity: 1;
+	pointer-events: auto;
+}
+
+.dataviews-view-grid__card:not(:has(.dataviews-view-grid__media)) .dataviews-view-grid__title-actions {
+	align-items: center;
+	gap: 0;
+}
+
+.dataviews-view-grid__card:not(:has(.dataviews-view-grid__media)):hover .dataviews-view-grid__title-actions,
+.dataviews-view-grid__card:not(:has(.dataviews-view-grid__media)):focus-within .dataviews-view-grid__title-actions,
+.dataviews-view-grid__card:not(:has(.dataviews-view-grid__media)).is-selected .dataviews-view-grid__title-actions {
+	gap: $grid-unit-05;
+}
+
+@media (hover: none) {
+	.dataviews-view-grid__card:not(:has(.dataviews-view-grid__media)) .dataviews-view-grid__title-actions {
+		gap: $grid-unit-05;
+	}
+}
+
 .dataviews-view-grid__media--clickable {
 	cursor: pointer;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes checkbox visibility and positioning in DataViews grid layout when media thumbnails are hidden via "Hide Image" in View Options.

Closes: https://github.com/WordPress/gutenberg/issues/71219

<!-- In a few words, what is the PR actually doing? -->

## Testing Instructions
1. Open the storybook story
3. Switch to Grid view
4. Click View Options → Hide "Image"
5. Hover over items - checkboxes should appear in title row

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/e6bc25b3-bed2-4a85-a778-fee595eed5d1



