### PR TITLE
Editor: Disable zoom out mode for non-iframe editor

### DIFF
--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -27,6 +27,7 @@ function InserterLibrary(
 		onSelect = noop,
 		shouldFocusBlock = false,
 		onClose,
+		isEditorIframed,
 	},
 	ref
 ) {
@@ -58,6 +59,7 @@ function InserterLibrary(
 			shouldFocusBlock={ shouldFocusBlock }
 			ref={ ref }
 			onClose={ onClose }
+			isEditorIframed={ isEditorIframed }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -49,6 +49,7 @@ function InserterMenu(
 		shouldFocusBlock = true,
 		onPatternCategorySelection,
 		onClose,
+		isEditorIframed,
 		__experimentalInitialTab,
 		__experimentalInitialCategory,
 	},
@@ -93,7 +94,7 @@ function InserterMenu(
 		hasSectionRootClientId &&
 		( selectedTab === 'patterns' || selectedTab === 'media' );
 
-	useZoomOut( shouldUseZoomOut && isLargeViewport );
+	useZoomOut( shouldUseZoomOut && isLargeViewport && isEditorIframed );
 
 	const [ destinationRootClientId, onInsertBlocks, onToggleInsertionPoint ] =
 		useInsertionPoint( {

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -128,6 +128,7 @@ export default function EditorInterface( {
 						customSaveButton={ customSaveButton }
 						forceDisableBlockTools={ forceDisableBlockTools }
 						title={ title }
+						isEditorIframed={ ! disableIframe }
 					/>
 				)
 			}
@@ -135,7 +136,9 @@ export default function EditorInterface( {
 			secondarySidebar={
 				! isPreviewMode &&
 				mode === 'visual' &&
-				( ( isInserterOpened && <InserterSidebar /> ) ||
+				( ( isInserterOpened && (
+					<InserterSidebar isEditorIframed={ ! disableIframe } />
+				) ) ||
 					( isListViewOpened && <ListViewSidebar /> ) )
 			}
 			sidebar={

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -57,6 +57,7 @@ function Header( {
 	forceDisableBlockTools,
 	setEntitiesSavedStatesCallback,
 	title,
+	isEditorIframed,
 } ) {
 	const isWideViewport = useViewportMatch( 'large' );
 	const isLargeViewport = useViewportMatch( 'medium' );
@@ -179,7 +180,7 @@ function Header( {
 					forceIsAutosaveable={ forceIsDirty }
 				/>
 
-				{ isWideViewport && canBeZoomedOut && (
+				{ isWideViewport && canBeZoomedOut && isEditorIframed && (
 					<ZoomOutToggle disabled={ forceDisableBlockTools } />
 				) }
 

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -20,7 +20,7 @@ import { store as editorStore } from '../../store';
 
 const { PrivateInserterLibrary } = unlock( blockEditorPrivateApis );
 
-export default function InserterSidebar() {
+export default function InserterSidebar( { isEditorIframed } ) {
 	const {
 		blockSectionRootClientId,
 		inserterSidebarToggleRef,
@@ -97,6 +97,7 @@ export default function InserterSidebar() {
 				}
 				ref={ libraryRef }
 				onClose={ closeInserterSidebar }
+				isEditorIframed={ isEditorIframed }
 			/>
 		</div>
 	);


### PR DESCRIPTION
Related:

- https://github.com/WordPress/gutenberg/issues/66884
- https://github.com/WordPress/gutenberg/pull/66789
- https://github.com/WordPress/gutenberg/pull/67232

## What?

This PR disables zoom out mode for the non-iframe editor.

## Why?

I submitted #66789 before the WP 6.8 release to get the zoom out mode working in the non-iframe editor. At the time, the zoom out mode should have worked in the non-iframe editor, but for some reason, it appears to no longer work in the 6.8 release.

As I recall, there were a lot of changes to the zoom out mode in the 6.8 release, which might have caused it to stop working in the non-iframe editor. 

## How?

It's easier to disable zoom out mode than to try to get it to work in a non-iframe editor.

As mentioned in #70743, eventually the editor will always run as an iframe, so in the future we won't need to worry about non-iframe editors. The `isEditorIframed` prop can eventually be removed altogether.

## Testing Instructions

We need to activate a block theme to test this PR, but please note that with block themes and the Gutenberg plugin enabled, the editor always runs as an iframe, so this PR cannot be tested in the usual way:

https://github.com/WordPress/gutenberg/blob/5b9c8dddca987e19b2f158f377b98d153071e0f3/packages/edit-post/src/components/layout/use-should-iframe.js#L21-L25

Therefore, please set `IS_GUTENBERG_PLUGIN` to `false` before building.

https://github.com/WordPress/gutenberg/blob/5b9c8dddca987e19b2f158f377b98d153071e0f3/package.json#L22

- Activate any block theme.
- Open the post editor.
- To make the editor work as a non-iframe, run the following code in your browser console:
  `wp.blocks.registerBlockType( 'test/v2', { apiVersion: '2', title: 'test' } );`
- Click the "Show template" button
  - ❌ Before: The zoom out button appears, but clicking it does nothing.
  - ✅ After The zoom out button doesn't appear.
- Open the block inserter and click the Patterns tab.
  - ❌ Before: The canvas flashes but doesn't zoom out properly. The zoom out button appears, but clicking it does nothing.
  - ✅ After: No change occurs on the canvas and the zoom out button does not appear.
 

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/613cba7a-1795-499a-a51c-a47a3db5acbc

### After

https://github.com/user-attachments/assets/5d59db78-1864-46bd-a7c7-1afa4336cf0d