### PR TITLE
Block Comments: Remove period in comment UI text

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -145,10 +145,7 @@ function Thread( {
 						<VStack className="editor-collab-sidebar-panel__show-more-reply">
 							{ sprintf(
 								// translators: %s: number of replies.
-								_x(
-									'%s more replies',
-									'Show replies button'
-								),
+								_x( '%s more replies', 'Show replies button' ),
 								thread?.reply?.length
 							) }
 						</VStack>

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -146,7 +146,7 @@ function Thread( {
 							{ sprintf(
 								// translators: %s: number of replies.
 								_x(
-									'%s more replies.',
+									'%s more replies',
 									'Show replies button'
 								),
 								thread?.reply?.length

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -146,7 +146,7 @@ function Thread( {
 							{ sprintf(
 								// translators: %s: number of replies.
 								_x(
-									'%s more replies..',
+									'%s more replies.',
 									'Show replies button'
 								),
 								thread?.reply?.length


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
<!-- In a few words, what is the PR actually doing? -->
Fix typo in comments.js

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
