### PR TITLE
Stylelint: Consolidate Lint rules for simplification 

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -17,11 +17,24 @@ module.exports = {
 		],
 		'declaration-property-value-disallowed-list': [
 			{
+				'flex-direction': [ '/-reverse$/' ],
 				'/.*/': [ '/--wp-components-color-/' ],
 			},
 			{
-				message: ( property, value ) =>
-					`Avoid using "${ value }" in "${ property }". --wp-components-color-* variables are not ready to be used outside of the components package.`,
+				message: ( property, value ) => {
+					// Don't allow reverse values for flex-direction.
+					if (
+						property === 'flex-direction' &&
+						/-reverse$/.test( value )
+					) {
+						return `Avoid "${ value }" value for the "${ property }" property. For accessibility reasons, visual, reading, and DOM order must match. Only use the reverse values when they do not affect reading order, meaning, and interaction.`;
+					}
+					// Don't allow --wp-components-color-* variables outside of the components package.
+					if ( /--wp-components-color-/.test( value ) ) {
+						return `Avoid using "${ value }" in "${ property }". --wp-components-color-* variables are not ready to be used outside of the components package.`;
+					}
+					return `Avoid "${ value }" for "${ property }".`;
+				},
 			},
 		],
 		'font-weight-notation': null,

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -13,17 +13,22 @@ module.exports = {
 			},
 			{
 				message: ( property, value ) => {
-					// Don't allow reverse values for flex-direction.
-					if (
-						property === 'flex-direction' &&
-						/-reverse$/.test( value )
-					) {
-						return `Avoid "${ value }" value for the "${ property }" property. For accessibility reasons, visual, reading, and DOM order must match. Only use the reverse values when they do not affect reading order, meaning, and interaction.`;
+					switch ( property ) {
+						// Don't allow reverse values for flex-direction.
+						case 'flex-direction':
+							if ( /-reverse$/.test( value ) ) {
+								return 'Avoid "-reverse" values for the "flex-direction" property.';
+							}
+							break;
+
+						// Don't allow --wp-components-color-* variables outside of the components package.
+						default:
+							if ( /--wp-components-color-/.test( value ) ) {
+								return 'Avoid using "--wp-components-color-*" variables outside of the components package.';
+							}
+							break;
 					}
-					// Don't allow --wp-components-color-* variables outside of the components package.
-					if ( /--wp-components-color-/.test( value ) ) {
-						return `Avoid using "${ value }" in "${ property }". --wp-components-color-* variables are not ready to be used outside of the components package.`;
-					}
+
 					return `Avoid "${ value }" for "${ property }".`;
 				},
 			},

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -6,15 +6,6 @@ module.exports = {
 		'at-rule-empty-line-before': null,
 		'at-rule-no-unknown': null,
 		'comment-empty-line-before': null,
-		'declaration-property-value-allowed-list': [
-			{
-				'flex-direction': '/^(?!(row|column)-reverse).*$/',
-			},
-			{
-				message: ( property, value ) =>
-					`Avoid "${ value }" value for the "${ property }" property. For accessibility reasons, visual, reading, and DOM order must match. Only use the reverse values when they do not affect reading order, meaning, and interaction.`,
-			},
-		],
 		'declaration-property-value-disallowed-list': [
 			{
 				'flex-direction': [ '/-reverse$/' ],


### PR DESCRIPTION

## What?
Closes https://github.com/WordPress/gutenberg/pull/69590#issuecomment-3182329008


## Why?
Consolidate the rules. 

## How?
Use only `declaration-property-value-disallowed-list`


