### PR TITLE
Enabled default block appender in gallery edit component

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -26,6 +26,7 @@ import {
 	BlockControls,
 	MediaReplaceFlow,
 	useSettings,
+	InnerBlocks,
 } from '@wordpress/block-editor';
 import { Platform, useEffect, useMemo } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
@@ -544,7 +545,7 @@ export default function GalleryEdit( props ) {
 		defaultBlock: DEFAULT_BLOCK,
 		directInsert: true,
 		orientation: 'horizontal',
-		renderAppender: false,
+		renderAppender: InnerBlocks.defaultBlockAppender,
 		...nativeInnerBlockProps,
 	} );
 

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -545,7 +545,7 @@ export default function GalleryEdit( props ) {
 		defaultBlock: DEFAULT_BLOCK,
 		directInsert: true,
 		orientation: 'horizontal',
-		renderAppender: InnerBlocks.defaultBlockAppender,
+		renderAppender: InnerBlocks.DefaultBlockAppender,
 		...nativeInnerBlockProps,
 	} );
 


### PR DESCRIPTION
Followed PR of: https://github.com/WordPress/gutenberg/pull/71204#discussion_r2276443672
## What?

> This does seem like a good addition, similar to the Buttons block, and other design-related blocks such as Columns, Grid, and Group, which have an appender. The gallery block currently lacks one. so adding it would improve consistency.
If there’s enough consensus, should we raise a separate follow-up PR to address this?

By @im3dabasia 

<!-- In a few words, what is the PR actually doing? -->

## Screenshots or screencast

## Before
<img width="1469" height="753" alt="Screenshot 2025-08-20 at 5 17 43 PM" src="https://github.com/user-attachments/assets/cd941ea0-35a9-4f5c-871b-5cbfbbddbba3" />

## After
<img width="1462" height="747" alt="Screenshot 2025-08-20 at 5 18 58 PM" src="https://github.com/user-attachments/assets/5ee722a4-5582-48ca-bb3a-eb832eea4fc6" />