### PR TITLE
DataForm: refactor `form` prop

### DIFF
--- a/packages/dataviews/src/components/dataform/index.tsx
+++ b/packages/dataviews/src/components/dataform/index.tsx
@@ -22,7 +22,7 @@ export default function DataForm< Item >( {
 		[ fields ]
 	);
 
-	if ( ! form.fields ) {
+	if ( ! form || form.length === 0 ) {
 		return null;
 	}
 

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useMemo, useState } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 import {
 	Button,
 	__experimentalVStack as VStack,
@@ -35,19 +35,6 @@ type SamplePost = {
 const meta = {
 	title: 'DataViews/DataForm',
 	component: DataForm,
-	argTypes: {
-		type: {
-			control: { type: 'select' },
-			description:
-				'Chooses the default layout of each field. "regular" is the default layout.',
-			options: [ 'default', 'regular', 'panel', 'card' ],
-		},
-		labelPosition: {
-			control: { type: 'select' },
-			description: 'Chooses the label position of the layout.',
-			options: [ 'default', 'top', 'side', 'none' ],
-		},
-	},
 };
 export default meta;
 
@@ -160,13 +147,7 @@ const fields = [
 	},
 ] as Field< SamplePost >[];
 
-export const Default = ( {
-	type,
-	labelPosition,
-}: {
-	type: 'default' | 'regular' | 'panel' | 'card';
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-} ) => {
+export const Default = () => {
 	const [ post, setPost ] = useState( {
 		title: 'Hello, World!',
 		order: 2,
@@ -183,31 +164,22 @@ export const Default = ( {
 		tags: [ 'photography' ],
 	} );
 
-	const form = useMemo(
-		() => ( {
-			layout: {
-				type,
-				labelPosition,
-			},
-			fields: [
-				'title',
-				'order',
-				'sticky',
-				'author',
-				'status',
-				'reviewer',
-				'email',
-				'password',
-				'date',
-				'birthdate',
-				'can_comment',
-				'filesize',
-				'dimensions',
-				'tags',
-			],
-		} ),
-		[ type, labelPosition ]
-	) as Form;
+	const form: Form = [
+		'title',
+		'order',
+		'sticky',
+		'author',
+		'status',
+		'reviewer',
+		'email',
+		'password',
+		'date',
+		'birthdate',
+		'can_comment',
+		'filesize',
+		'dimensions',
+		'tags',
+	];
 
 	return (
 		<DataForm< SamplePost >
@@ -224,13 +196,7 @@ export const Default = ( {
 	);
 };
 
-const CombinedFieldsComponent = ( {
-	type,
-	labelPosition,
-}: {
-	type: 'default' | 'regular' | 'panel' | 'card';
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-} ) => {
+const CombinedFieldsComponent = () => {
 	const [ post, setPost ] = useState< SamplePost >( {
 		title: 'Hello, World!',
 		order: 2,
@@ -244,28 +210,19 @@ const CombinedFieldsComponent = ( {
 		tags: [ 'photography' ],
 	} );
 
-	const form = useMemo(
-		() => ( {
-			layout: {
-				type,
-				labelPosition,
-			},
-			fields: [
-				'title',
-				{
-					id: 'status',
-					label: 'Status & Visibility',
-					children: [ 'status', 'password' ],
-				},
-				'order',
-				'author',
-				'filesize',
-				'dimensions',
-				'tags',
-			],
-		} ),
-		[ type, labelPosition ]
-	) as Form;
+	const form: Form = [
+		'title',
+		{
+			id: 'status',
+			label: 'Status & Visibility',
+			children: [ 'status', 'password' ],
+		},
+		'order',
+		'author',
+		'filesize',
+		'dimensions',
+		'tags',
+	];
 
 	return (
 		<DataForm< SamplePost >
@@ -285,12 +242,6 @@ const CombinedFieldsComponent = ( {
 export const CombinedFields = {
 	title: 'DataViews/CombinedFields',
 	render: CombinedFieldsComponent,
-	argTypes: {
-		...meta.argTypes,
-	},
-	args: {
-		type: 'panel',
-	},
 };
 
 function CustomEditControl< Item >( {
@@ -406,16 +357,14 @@ const DataFormValidationComponent = ( { required }: { required: boolean } ) => {
 		},
 	];
 
-	const form = {
-		fields: [
-			'text',
-			'email',
-			'integer',
-			'boolean',
-			'customEdit',
-			'customValidation',
-		],
-	};
+	const form: Form = [
+		'text',
+		'email',
+		'integer',
+		'boolean',
+		'customEdit',
+		'customValidation',
+	];
 
 	const canSave = isItemValid( post, _fields, form );
 
@@ -487,9 +436,7 @@ const DataFormVisibilityComponent = () => {
 			isVisible: ( post ) => post.isActive === true,
 		},
 	] satisfies Field< Post >[];
-	const form = {
-		fields: [ 'isActive', 'name', 'email' ],
-	};
+	const form: Form = [ 'isActive', 'name', 'email' ];
 	return (
 		<DataForm< Post >
 			data={ data }
@@ -614,78 +561,68 @@ const LayoutCardComponent = () => {
 		commission: 5,
 	} );
 
-	const form = useMemo(
-		() =>
-			( {
-				layout: {
-					type: 'card',
-				},
-				fields: [
-					{
-						id: 'customerCard',
-						label: 'Customer',
-						children: [
-							{
-								id: 'customerContact',
-								label: 'Contact',
-								layout: { type: 'panel', labelPosition: 'top' },
-								children: [
-									{
-										id: 'name',
-										layout: {
-											type: 'regular',
-											labelPosition: 'top',
-										},
-									},
-									{
-										id: 'phone',
-										layout: {
-											type: 'regular',
-											labelPosition: 'top',
-										},
-									},
-									{
-										id: 'email',
-										layout: {
-											type: 'regular',
-											labelPosition: 'top',
-										},
-									},
-								],
+	const form: Form = [
+		{
+			id: 'customerCard',
+			label: 'Customer',
+			children: [
+				{
+					id: 'customerContact',
+					label: 'Contact',
+					layout: { type: 'panel', labelPosition: 'top' },
+					children: [
+						{
+							id: 'name',
+							layout: {
+								type: 'regular',
+								labelPosition: 'top',
 							},
-							{
-								id: 'plan',
-								layout: { type: 'panel', labelPosition: 'top' },
-							},
-							{
-								id: 'shippingAddress',
-								layout: { type: 'panel', labelPosition: 'top' },
-							},
-							{
-								id: 'billingAddress',
-								layout: { type: 'panel', labelPosition: 'top' },
-							},
-							'displayPayments',
-						],
-					},
-					{
-						id: 'payments',
-						layout: { type: 'card', withHeader: false },
-					},
-					{
-						id: 'taxConfiguration',
-						label: 'Taxes',
-						layout: {
-							type: 'card',
-							isOpened: false,
 						},
-						children: [ 'vat', 'commission' ],
-					},
-				],
-			} ) satisfies Form,
-		[]
-	);
-
+						{
+							id: 'phone',
+							layout: {
+								type: 'regular',
+								labelPosition: 'top',
+							},
+						},
+						{
+							id: 'email',
+							layout: {
+								type: 'regular',
+								labelPosition: 'top',
+							},
+						},
+					],
+				},
+				{
+					id: 'plan',
+					layout: { type: 'panel', labelPosition: 'top' },
+				},
+				{
+					id: 'shippingAddress',
+					layout: { type: 'panel', labelPosition: 'top' },
+				},
+				{
+					id: 'billingAddress',
+					layout: { type: 'panel', labelPosition: 'top' },
+				},
+				'displayPayments',
+			],
+		},
+		{
+			id: 'payments',
+			layout: { type: 'card', withHeader: false },
+		},
+		{
+			id: 'taxConfiguration',
+			label: 'Taxes',
+			layout: {
+				type: 'card',
+				isOpened: false,
+			},
+			children: [ 'vat', 'commission' ],
+		},
+	];
 	return (
 		<DataForm
 			data={ customer }
@@ -719,28 +656,22 @@ const LayoutMixedComponent = () => {
 		dimensions: '1920x1080',
 	} );
 
-	const form = useMemo(
-		() =>
-			( {
-				fields: [
-					{
-						id: 'title',
-						layout: { type: 'panel', labelPosition: 'top' },
-					},
-					'status',
-					{ id: 'order', layout: { type: 'card' } },
-					{
-						id: 'authorDateCard',
-						label: 'Author & Date',
-						layout: {
-							type: 'card',
-						},
-						children: [ 'author', 'date' ],
-					},
-				],
-			} ) satisfies Form,
-		[]
-	);
+	const form: Form = [
+		{
+			id: 'title',
+			layout: { type: 'panel', labelPosition: 'top' },
+		},
+		'status',
+		{ id: 'order', layout: { type: 'card' } },
+		{
+			id: 'authorDateCard',
+			label: 'Author & Date',
+			layout: {
+				type: 'card',
+			},
+			children: [ 'author', 'date' ],
+		},
+	];
 
 	return (
 		<DataForm< SamplePost >

--- a/packages/dataviews/src/components/stories/index.story.tsx
+++ b/packages/dataviews/src/components/stories/index.story.tsx
@@ -51,8 +51,6 @@ interface FieldTypeStoryProps {
 	titleField?: string;
 	descriptionField?: string;
 	mediaField?: string;
-	type?: 'default' | 'regular' | 'panel';
-	labelPosition?: 'default' | 'top' | 'side' | 'none';
 }
 
 const FieldTypeStory = ( {
@@ -60,17 +58,11 @@ const FieldTypeStory = ( {
 	titleField,
 	descriptionField,
 	mediaField,
-	type = 'default',
-	labelPosition = 'default',
 }: FieldTypeStoryProps ) => {
-	const form = useMemo(
-		() => ( {
-			type,
-			labelPosition,
-			fields: storyFields.map( ( field ) => field.id ),
-		} ),
-		[ type, labelPosition, storyFields ]
-	) as Form;
+	const form: Form = useMemo(
+		() => storyFields.map( ( field ) => field.id ),
+		[ storyFields ]
+	);
 
 	const [ view, setView ] = useState< View >( {
 		type: 'table' as const,
@@ -163,210 +155,94 @@ const FieldTypeStory = ( {
 	);
 };
 
-export const All = ( {
-	type,
-	labelPosition,
-}: {
-	type: 'default' | 'regular' | 'panel';
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-} ) => {
+export const All = () => {
 	return (
 		<FieldTypeStory
 			fields={ fields }
 			titleField="title"
 			descriptionField="description"
 			mediaField="image"
-			type={ type }
-			labelPosition={ labelPosition }
 		/>
 	);
 };
 
-export const Text = ( {
-	type,
-	labelPosition,
-}: {
-	type: 'default' | 'regular' | 'panel';
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-} ) => {
+export const Text = () => {
 	const textFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'text' ),
 		[]
 	);
 
-	return (
-		<FieldTypeStory
-			fields={ textFields }
-			type={ type }
-			labelPosition={ labelPosition }
-		/>
-	);
+	return <FieldTypeStory fields={ textFields } />;
 };
 
-export const Integer = ( {
-	type,
-	labelPosition,
-}: {
-	type: 'default' | 'regular' | 'panel';
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-} ) => {
+export const Integer = () => {
 	const integerFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'integer' ),
 		[]
 	);
 
-	return (
-		<FieldTypeStory
-			fields={ integerFields }
-			type={ type }
-			labelPosition={ labelPosition }
-		/>
-	);
+	return <FieldTypeStory fields={ integerFields } />;
 };
 
-export const Boolean = ( {
-	type,
-	labelPosition,
-}: {
-	type: 'default' | 'regular' | 'panel';
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-} ) => {
+export const Boolean = () => {
 	const booleanFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'boolean' ),
 		[]
 	);
 
-	return (
-		<FieldTypeStory
-			fields={ booleanFields }
-			type={ type }
-			labelPosition={ labelPosition }
-		/>
-	);
+	return <FieldTypeStory fields={ booleanFields } />;
 };
 
-export const DateTime = ( {
-	type,
-	labelPosition,
-}: {
-	type: 'default' | 'regular' | 'panel';
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-} ) => {
+export const DateTime = () => {
 	const dateTimeFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'datetime' ),
 		[]
 	);
 
-	return (
-		<FieldTypeStory
-			fields={ dateTimeFields }
-			type={ type }
-			labelPosition={ labelPosition }
-		/>
-	);
+	return <FieldTypeStory fields={ dateTimeFields } />;
 };
 
-export const Date = ( {
-	type,
-	labelPosition,
-}: {
-	type: 'default' | 'regular' | 'panel';
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-} ) => {
+export const Date = () => {
 	const dateFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'date' ),
 		[]
 	);
 
-	return (
-		<FieldTypeStory
-			fields={ dateFields }
-			type={ type }
-			labelPosition={ labelPosition }
-		/>
-	);
+	return <FieldTypeStory fields={ dateFields } />;
 };
 
-export const Email = ( {
-	type,
-	labelPosition,
-}: {
-	type: 'default' | 'regular' | 'panel';
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-} ) => {
+export const Email = () => {
 	const emailFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'email' ),
 		[]
 	);
 
-	return (
-		<FieldTypeStory
-			fields={ emailFields }
-			type={ type }
-			labelPosition={ labelPosition }
-		/>
-	);
+	return <FieldTypeStory fields={ emailFields } />;
 };
 
-export const Media = ( {
-	type,
-	labelPosition,
-}: {
-	type: 'default' | 'regular' | 'panel';
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-} ) => {
+export const Media = () => {
 	const mediaFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'media' ),
 		[]
 	);
 
-	return (
-		<FieldTypeStory
-			fields={ mediaFields }
-			type={ type }
-			labelPosition={ labelPosition }
-		/>
-	);
+	return <FieldTypeStory fields={ mediaFields } />;
 };
 
-export const Array = ( {
-	type,
-	labelPosition,
-}: {
-	type: 'default' | 'regular' | 'panel';
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-} ) => {
+export const Array = () => {
 	const arrayTextFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'array' ),
 		[]
 	);
 
-	return (
-		<FieldTypeStory
-			fields={ arrayTextFields }
-			type={ type }
-			labelPosition={ labelPosition }
-		/>
-	);
+	return <FieldTypeStory fields={ arrayTextFields } />;
 };
 
-export const NoType = ( {
-	type,
-	labelPosition,
-}: {
-	type: 'default' | 'regular' | 'panel';
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-} ) => {
+export const NoType = () => {
 	const noTypeFields = useMemo(
 		() => fields.filter( ( field ) => field.type === undefined ),
 		[]
 	);
 
-	return (
-		<FieldTypeStory
-			fields={ noTypeFields }
-			type={ type }
-			labelPosition={ labelPosition }
-		/>
-	);
+	return <FieldTypeStory fields={ noTypeFields } />;
 };

--- a/packages/dataviews/src/dataforms-layouts/card/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/card/index.tsx
@@ -17,7 +17,7 @@ import DataFormContext from '../../components/dataform-context';
 import type { NormalizedCardLayout, FieldLayoutProps, Form } from '../../types';
 import { DataFormLayout } from '../data-form-layout';
 import { isCombinedField } from '../is-combined-field';
-import { DEFAULT_LAYOUT, normalizeLayout } from '../../normalize-form-fields';
+import { normalizeLayout } from '../../normalize-form-fields';
 
 export function useCollapsibleCard( initialIsOpen: boolean = true ) {
 	const [ isOpen, setIsOpen ] = useState( initialIsOpen );
@@ -81,10 +81,7 @@ export default function FormCardField< Item >( {
 	} ) as NormalizedCardLayout;
 
 	const form: Form = useMemo(
-		(): Form => ( {
-			layout: DEFAULT_LAYOUT,
-			fields: isCombinedField( field ) ? field.children : [],
-		} ),
+		(): Form => ( isCombinedField( field ) ? field.children : [] ),
 		[ field ]
 	);
 

--- a/packages/dataviews/src/dataforms-layouts/data-form-layout.tsx
+++ b/packages/dataviews/src/dataforms-layouts/data-form-layout.tsx
@@ -48,7 +48,8 @@ export function DataFormLayout< Item >( {
 	);
 
 	return (
-		<VStack spacing={ form.layout?.type === 'panel' ? 2 : 4 }>
+		// <VStack spacing={ form.layout?.type === 'panel' ? 2 : 4 }>
+		<VStack spacing={ 2 }>
 			{ normalizedFormFields.map( ( formField ) => {
 				const FieldLayout = getFormFieldLayout( formField.layout.type )
 					?.component;

--- a/packages/dataviews/src/dataforms-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/index.tsx
@@ -32,7 +32,7 @@ import type {
 import DataFormContext from '../../components/dataform-context';
 import { DataFormLayout } from '../data-form-layout';
 import { isCombinedField } from '../is-combined-field';
-import { DEFAULT_LAYOUT, normalizeLayout } from '../../normalize-form-fields';
+import { normalizeLayout } from '../../normalize-form-fields';
 
 function DropdownHeader( {
 	title,
@@ -86,13 +86,11 @@ function PanelDropdown< Item >( {
 		: fieldDefinition?.label;
 
 	const form: Form = useMemo(
-		(): Form => ( {
-			layout: DEFAULT_LAYOUT,
-			fields: isCombinedField( field )
+		(): Form =>
+			isCombinedField( field )
 				? field.children
 				: // If not explicit children return the field id itself.
 				  [ { id: field.id } ],
-		} ),
 		[ field ]
 	);
 
@@ -159,7 +157,7 @@ function PanelDropdown< Item >( {
 								field={ nestedField }
 								onChange={ onChange }
 								hideLabelFromVision={
-									( form?.fields ?? [] ).length < 2
+									( form ?? [] ).length < 2
 								}
 							/>
 						) }

--- a/packages/dataviews/src/dataforms-layouts/regular/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/regular/index.tsx
@@ -25,7 +25,7 @@ import type {
 import DataFormContext from '../../components/dataform-context';
 import { DataFormLayout } from '../data-form-layout';
 import { isCombinedField } from '../is-combined-field';
-import { DEFAULT_LAYOUT, normalizeLayout } from '../../normalize-form-fields';
+import { normalizeLayout } from '../../normalize-form-fields';
 
 function Header( { title }: { title: string } ) {
 	return (
@@ -49,10 +49,7 @@ export default function FormRegularField< Item >( {
 	const { fields } = useContext( DataFormContext );
 
 	const form: Form = useMemo(
-		(): Form => ( {
-			layout: DEFAULT_LAYOUT,
-			fields: isCombinedField( field ) ? field.children : [],
-		} ),
+		(): Form => ( isCombinedField( field ) ? field.children : [] ),
 		[ field ]
 	);
 

--- a/packages/dataviews/src/normalize-form-fields.ts
+++ b/packages/dataviews/src/normalize-form-fields.ts
@@ -66,19 +66,17 @@ export function normalizeLayout( layout?: Layout ): NormalizedLayout {
 export default function normalizeFormFields(
 	form: Form
 ): NormalizedFormField[] {
-	const formLayout = normalizeLayout( form?.layout );
-
-	return ( form.fields ?? [] ).map( ( field ) => {
+	return ( form ?? [] ).map( ( field ) => {
 		if ( typeof field === 'string' ) {
 			return {
 				id: field,
-				layout: formLayout,
+				layout: DEFAULT_LAYOUT,
 			};
 		}
 
 		const fieldLayout = field.layout
 			? normalizeLayout( field.layout )
-			: formLayout;
+			: DEFAULT_LAYOUT;
 		return {
 			...field,
 			layout: fieldLayout,

--- a/packages/dataviews/src/test/dataform.tsx
+++ b/packages/dataviews/src/test/dataform.tsx
@@ -33,9 +33,7 @@ const fields = [
 	},
 ];
 
-const form = {
-	fields: [ 'title', 'order', 'author' ],
-};
+const form = [ 'title', 'order', 'author' ];
 
 const data = {
 	title: 'Hello World',
@@ -149,10 +147,20 @@ describe( 'DataForm component', () => {
 				<Dataform
 					onChange={ noop }
 					fields={ fields }
-					form={ {
-						...form,
-						layout: { type: 'regular', labelPosition: 'side' },
-					} }
+					form={ [
+						{
+							id: 'title',
+							layout: { type: 'regular', labelPosition: 'side' },
+						},
+						{
+							id: 'order',
+							layout: { type: 'regular', labelPosition: 'side' },
+						},
+						{
+							id: 'author',
+							layout: { type: 'regular', labelPosition: 'side' },
+						},
+					] }
 					data={ data }
 				/>
 			);
@@ -165,16 +173,14 @@ describe( 'DataForm component', () => {
 		} );
 
 		it( 'should render combined fields correctly', async () => {
-			const formWithCombinedFields = {
-				fields: [
-					'order',
-					{
-						id: 'title',
-						children: [ 'title', 'author' ],
-						label: "Title and author's name",
-					},
-				],
-			};
+			const formWithCombinedFields = [
+				'order',
+				{
+					id: 'title',
+					children: [ 'title', 'author' ],
+					label: "Title and author's name",
+				},
+			];
 
 			render(
 				<Dataform
@@ -249,10 +255,20 @@ describe( 'DataForm component', () => {
 				<Dataform
 					onChange={ noop }
 					fields={ fields }
-					form={ {
-						...formPanelMode,
-						layout: { type: 'panel', labelPosition: 'side' },
-					} }
+					form={ [
+						{
+							id: 'title',
+							layout: { type: 'panel', labelPosition: 'side' },
+						},
+						{
+							id: 'order',
+							layout: { type: 'panel', labelPosition: 'side' },
+						},
+						{
+							id: 'author',
+							layout: { type: 'panel', labelPosition: 'side' },
+						},
+					] }
 					data={ data }
 				/>
 			);

--- a/packages/dataviews/src/test/normalize-form-fields.ts
+++ b/packages/dataviews/src/test/normalize-form-fields.ts
@@ -7,13 +7,13 @@ import type { Form } from '../types';
 describe( 'normalizeFormFields', () => {
 	describe( 'empty form', () => {
 		it( 'returns empty array for undefined fields', () => {
-			const form: Form = {};
+			const form: Form = [];
 			const result = normalizeFormFields( form );
 			expect( result ).toEqual( [] );
 		} );
 
 		it( 'returns empty array for empty fields', () => {
-			const form: Form = { fields: [] };
+			const form: Form = [];
 			const result = normalizeFormFields( form );
 			expect( result ).toEqual( [] );
 		} );
@@ -21,9 +21,7 @@ describe( 'normalizeFormFields', () => {
 
 	describe( 'default layout', () => {
 		it( 'applies default layout when layout is not specified', () => {
-			const form: Form = {
-				fields: [ 'field1', 'field2' ],
-			};
+			const form: Form = [ 'field1', 'field2' ];
 			const result = normalizeFormFields( form );
 			expect( result ).toEqual( [
 				{
@@ -38,15 +36,13 @@ describe( 'normalizeFormFields', () => {
 		} );
 
 		it( 'handles mixed string and object field specifications', () => {
-			const form: Form = {
-				fields: [
-					'field1',
-					{
-						id: 'field2',
-						label: 'Field 2',
-					},
-				],
-			};
+			const form: Form = [
+				'field1',
+				{
+					id: 'field2',
+					label: 'Field 2',
+				},
+			];
 			const result = normalizeFormFields( form );
 			expect( result ).toEqual( [
 				{
@@ -64,10 +60,7 @@ describe( 'normalizeFormFields', () => {
 
 	describe( 'layout types', () => {
 		it( 'regular: with default layout options', () => {
-			const form: Form = {
-				layout: { type: 'regular' },
-				fields: [ 'field1' ],
-			};
+			const form: Form = [ 'field1' ];
 			const result = normalizeFormFields( form );
 			expect( result ).toEqual( [
 				{
@@ -78,10 +71,12 @@ describe( 'normalizeFormFields', () => {
 		} );
 
 		it( 'regular: with layout options', () => {
-			const form: Form = {
-				layout: { type: 'regular', labelPosition: 'side' },
-				fields: [ 'field1' ],
-			};
+			const form: Form = [
+				{
+					id: 'field1',
+					layout: { type: 'regular', labelPosition: 'side' },
+				},
+			];
 			const result = normalizeFormFields( form );
 			expect( result ).toEqual( [
 				{
@@ -92,10 +87,7 @@ describe( 'normalizeFormFields', () => {
 		} );
 
 		it( 'panel: with default layout options', () => {
-			const form: Form = {
-				layout: { type: 'panel' },
-				fields: [ 'field1' ],
-			};
+			const form: Form = [ { id: 'field1', layout: { type: 'panel' } } ];
 			const result = normalizeFormFields( form );
 			expect( result ).toEqual( [
 				{
@@ -106,10 +98,12 @@ describe( 'normalizeFormFields', () => {
 		} );
 
 		it( 'panel: with layout options', () => {
-			const form: Form = {
-				layout: { type: 'panel', labelPosition: 'top' },
-				fields: [ 'field1' ],
-			};
+			const form: Form = [
+				{
+					id: 'field1',
+					layout: { type: 'panel', labelPosition: 'top' },
+				},
+			];
 			const result = normalizeFormFields( form );
 			expect( result ).toEqual( [
 				{
@@ -120,10 +114,7 @@ describe( 'normalizeFormFields', () => {
 		} );
 
 		it( 'card: with default layout options', () => {
-			const form: Form = {
-				layout: { type: 'card' },
-				fields: [ 'field1' ],
-			};
+			const form: Form = [ { id: 'field1', layout: { type: 'card' } } ];
 			const result = normalizeFormFields( form );
 			expect( result ).toEqual( [
 				{
@@ -138,11 +129,17 @@ describe( 'normalizeFormFields', () => {
 		} );
 
 		it( 'card: enforces isOpened=true when withHeader=false', () => {
-			const form: Form = {
-				// @ts-ignore - Test intentionally uses invalid type to verify runtime behavior.
-				layout: { type: 'card', withHeader: false, isOpened: false },
-				fields: [ 'field1' ],
-			};
+			const form: Form = [
+				{
+					id: 'field1',
+					layout: {
+						type: 'card',
+						withHeader: false,
+						// @ts-ignore - Test intentionally uses invalid type to verify runtime behavior.
+						isOpened: false,
+					},
+				},
+			];
 			const result = normalizeFormFields( form );
 			expect( result ).toEqual( [
 				{
@@ -157,10 +154,12 @@ describe( 'normalizeFormFields', () => {
 		} );
 
 		it( 'card: respects isOpened when withHeader=true', () => {
-			const form: Form = {
-				layout: { type: 'card', withHeader: true, isOpened: false },
-				fields: [ 'field1' ],
-			};
+			const form: Form = [
+				{
+					id: 'field1',
+					layout: { type: 'card', withHeader: true, isOpened: false },
+				},
+			];
 			const result = normalizeFormFields( form );
 			expect( result ).toEqual( [
 				{
@@ -177,16 +176,16 @@ describe( 'normalizeFormFields', () => {
 
 	describe( 'layout overrides', () => {
 		it( 'fields can override form layout', () => {
-			const form: Form = {
-				layout: { type: 'regular', labelPosition: 'top' },
-				fields: [
-					'field1',
-					{
-						id: 'field2',
-						layout: { type: 'panel', labelPosition: 'side' },
-					},
-				],
-			};
+			const form: Form = [
+				{
+					id: 'field1',
+					layout: { type: 'regular', labelPosition: 'top' },
+				},
+				{
+					id: 'field2',
+					layout: { type: 'panel', labelPosition: 'side' },
+				},
+			];
 			const result = normalizeFormFields( form );
 			expect( result ).toEqual( [
 				{
@@ -201,16 +200,16 @@ describe( 'normalizeFormFields', () => {
 		} );
 
 		it( 'fields do not partially override form layout', () => {
-			const form: Form = {
-				layout: { type: 'card', withHeader: false, isOpened: true },
-				fields: [
-					'field1',
-					{
-						id: 'field2',
-						layout: { type: 'card', isOpened: false },
-					},
-				],
-			};
+			const form: Form = [
+				{
+					id: 'field1',
+					layout: { type: 'card', withHeader: false, isOpened: true },
+				},
+				{
+					id: 'field2',
+					layout: { type: 'card', isOpened: false },
+				},
+			];
 			const result = normalizeFormFields( form );
 			expect( result ).toEqual( [
 				{

--- a/packages/dataviews/src/test/validation.ts
+++ b/packages/dataviews/src/test/validation.ts
@@ -17,7 +17,7 @@ describe( 'validation', () => {
 				type: 'integer',
 			},
 		];
-		const form = { fields: [ 'valid_order' ] };
+		const form = [ 'valid_order' ];
 		const result = isItemValid( item, fields, form );
 		expect( result ).toBe( true );
 	} );
@@ -30,7 +30,7 @@ describe( 'validation', () => {
 				id: 'order',
 			},
 		];
-		const form = { fields: [ 'order' ] };
+		const form = [ 'order' ];
 		const result = isItemValid( item, fields, form );
 		expect( result ).toBe( true );
 	} );
@@ -43,7 +43,7 @@ describe( 'validation', () => {
 				type: 'integer',
 			},
 		];
-		const form = { fields: [ 'order' ] };
+		const form = [ 'order' ];
 		const result = isItemValid( item, fields, form );
 		expect( result ).toBe( false );
 	} );
@@ -60,7 +60,7 @@ describe( 'validation', () => {
 				],
 			},
 		];
-		const form = { fields: [ 'author' ] };
+		const form = [ 'author' ];
 		const result = isItemValid( item, fields, form );
 		expect( result ).toBe( false );
 	} );
@@ -77,7 +77,7 @@ describe( 'validation', () => {
 				],
 			},
 		];
-		const form = { fields: [ 'author' ] };
+		const form = [ 'author' ];
 		const result = isItemValid( item, fields, form );
 		expect( result ).toBe( false );
 	} );
@@ -93,7 +93,7 @@ describe( 'validation', () => {
 				],
 			},
 		];
-		const form = { fields: [ 'author' ] };
+		const form = [ 'author' ];
 		const result = isItemValid( item, fields, form );
 		expect( result ).toBe( false );
 	} );
@@ -113,7 +113,7 @@ describe( 'validation', () => {
 				},
 			},
 		];
-		const form = { fields: [ 'order' ] };
+		const form = [ 'order' ];
 		const result = isItemValid( item, fields, form );
 		expect( result ).toBe( true );
 	} );

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -745,10 +745,7 @@ export type FormField = SimpleFormField | CombinedFormField;
 /**
  * The form configuration.
  */
-export type Form = {
-	layout?: Layout;
-	fields?: Array< FormField | string >;
-};
+export type Form = Array< FormField | string >;
 
 export interface DataFormProps< Item > {
 	data: Item;

--- a/packages/dataviews/src/validation.ts
+++ b/packages/dataviews/src/validation.ts
@@ -19,7 +19,7 @@ export function isItemValid< Item >(
 	form: Form
 ): boolean {
 	const _fields = normalizeFields(
-		fields.filter( ( { id } ) => !! form.fields?.includes( id ) )
+		fields.filter( ( { id } ) => !! form.includes( id ) )
 	);
 
 	const isEmptyNullOrUndefined = ( value: any ) =>

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -74,11 +74,8 @@ function PostEditForm( { postType, postId } ) {
 	);
 
 	const form = useMemo(
-		() => ( {
-			layout: {
-				type: 'panel',
-			},
-			fields: [
+		() =>
+			[
 				{
 					id: 'featured_media',
 					layout: {
@@ -87,14 +84,30 @@ function PostEditForm( { postType, postId } ) {
 				},
 				{
 					id: 'status',
+					layout: { type: 'panel' },
 					label: __( 'Status & Visibility' ),
 					children: [ 'status', 'password' ],
 				},
-				'author',
-				'date',
-				'slug',
-				'parent',
-				'comment_status',
+				{
+					id: 'author',
+					layout: { type: 'panel' },
+				},
+				{
+					id: 'date',
+					layout: { type: 'panel' },
+				},
+				{
+					id: 'slug',
+					layout: { type: 'panel' },
+				},
+				{
+					id: 'parent',
+					layout: { type: 'panel' },
+				},
+				{
+					id: 'comment_status',
+					layout: { type: 'panel' },
+				},
 				{
 					label: __( 'Template' ),
 					id: 'template',
@@ -108,7 +121,6 @@ function PostEditForm( { postType, postId } ) {
 					ids.length === 1 ||
 					fieldsWithBulkEditSupport.includes( field )
 			),
-		} ),
 		[ ids ]
 	);
 	const onChange = ( edits ) => {

--- a/packages/fields/src/actions/duplicate-post.tsx
+++ b/packages/fields/src/actions/duplicate-post.tsx
@@ -23,9 +23,7 @@ import type { BasePost, CoreDataError } from '../types';
 import { getItemTitle } from './utils';
 
 const fields = [ titleField ];
-const formDuplicateAction = {
-	fields: [ 'title' ],
-};
+const formDuplicateAction = [ 'title' ];
 
 const duplicatePost: Action< BasePost > = {
 	id: 'duplicate-post',

--- a/packages/fields/src/actions/reorder-page.tsx
+++ b/packages/fields/src/actions/reorder-page.tsx
@@ -21,9 +21,7 @@ import type { CoreDataError, BasePost } from '../types';
 import { orderField } from '../fields';
 
 const fields = [ orderField ];
-const formOrderAction = {
-	fields: [ 'menu_order' ],
-};
+const formOrderAction = [ 'menu_order' ];
 
 function ReorderModal( {
 	items,


### PR DESCRIPTION
## What?

This PR follows-up on the changes at https://github.com/WordPress/gutenberg/pull/71100/ and updates the `form` prop of DataForm to remove the `layout` and make `fields`.

Before:

```js
const form = {
  layout: { type: 'card' },
  fields: [ 'stringField', { id: 'objectField', layout: { type: 'regular' } } ] 
};
```

After:

```js
const form = [
  { id: 'stringField', layout: { type: 'panel' } },
  { id: 'objectField', layout: { type: 'regular' } }
];
```

## Why?

The existing DataViews-like API (`type`/`layout`, `fields`) wasn't holding up nicely for DataForm.

## How?

- Remove the top-level `layout` prop.
- Make the `fields` prop .

## Testing Instructions

- Test stories.
- Test quick edit in site editor.
- Test "duplicate post" and "reorder page" actions.
