### PR TITLE
Editor: Fix drag and drop to the top of the page

### DIFF
--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -148,6 +148,10 @@ export function getDropTargetPosition(
 		} ) => {
 			const rect = getBoundingClientRect();
 
+			if ( ! rect ) {
+				return;
+			}
+
 			let [ distance, edge ] = getDistanceToNearestEdge(
 				position,
 				rect,
@@ -428,10 +432,14 @@ export default function useBlockDropZone( {
 					return {
 						isUnmodifiedDefaultBlock:
 							getIsUnmodifiedDefaultBlock( block ),
-						getBoundingClientRect: () =>
-							ownerDocument
-								.getElementById( `block-${ clientId }` )
-								.getBoundingClientRect(),
+						getBoundingClientRect: () => {
+							const blockElement = ownerDocument.getElementById(
+								`block-${ clientId }`
+							);
+							return blockElement
+								? blockElement.getBoundingClientRect()
+								: null;
+						},
 						blockIndex: getBlockIndex( clientId ),
 						blockOrientation:
 							getBlockListSettings( clientId )?.orientation,

--- a/packages/block-library/src/post-comments-link/edit.js
+++ b/packages/block-library/src/post-comments-link/edit.js
@@ -60,7 +60,13 @@ function PostCommentsLinkEdit( { context, attributes, setAttributes } ) {
 	);
 
 	if ( ! post ) {
-		return null;
+		return (
+			<div { ...blockProps }>
+				<Warning>
+					{ __( 'Post Comments Link block: post not found.' ) }
+				</Warning>
+			</div>
+		);
 	}
 
 	const { link } = post;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71198 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- The drag and drop feature in Editor doesn't work as expected if `useBlockProps` used incorrectly or if the block doesn't render any markup.
- Logs the following error in console `Uncaught TypeError: Cannot read properties of null (reading 'getBoundingClientRect')`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Guard `getElementById` calls and return `null` if no block element exists and add null-safe checks around `dropZoneElement.getBoundingClientRect()`
- In PostCommentsLinkEdit:
    -  Remove early return `null` and render warning.

## Testing Instructions
1. While editing the template add the `Comments Link` block
2. Check if drag and drop works as expected
3. Confirm no errors in console

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
Before and After


https://github.com/user-attachments/assets/8f6e3f47-08e0-4507-8c5d-b817aee02dd6

