### PR TITLE
DateCalendar, DateRangeCalendar: use px instead of rem units, better theming support

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Internal
 
 -   Validated form controls: Add support for async validation. This is a breaking API change that splits the `customValidator` prop into an `onValidate` callback and a `customValidity` object. ([#71184](https://github.com/WordPress/gutenberg/pull/71184)).
+-   `DateCalendar`, `DateRangeCalendar`: use `px` instead of `rem` units. ([#71248](https://github.com/WordPress/gutenberg/pull/71248)).
 
 ## 30.1.0 (2025-08-07)
 

--- a/packages/components/src/calendar/style.scss
+++ b/packages/components/src/calendar/style.scss
@@ -1,9 +1,9 @@
 /* Root of the component. */
 // Internal variables
 $wp-components-calendar-outline-focus: var(--wp-admin-border-width-focus) solid $components-color-accent;
-$wp-components-calendar-button-height: 32px;
-$wp-components-calendar-button-width: 32px;
-$wp-components-calendar-nav-height: 32px;
+$wp-components-calendar-button-height: $grid-unit-40;
+$wp-components-calendar-button-width: $grid-unit-40;
+$wp-components-calendar-nav-height: $grid-unit-40;
 $wp-components-calendar-range-middle-background-color: color-mix(in srgb, $components-color-accent 4%, transparent);
 $wp-components-calendar-preview-border-color: color-mix(in srgb, $components-color-accent 16%, transparent);
 
@@ -15,8 +15,8 @@ $wp-components-calendar-preview-border-color: color-mix(in srgb, $components-col
 	display: inline flow-root;
 	color: $gray-900;
 	background-color: $white;
-	font-size: 13px;
-	font-weight: 400;
+	font-size: $font-size-medium;
+	font-weight: $font-weight-regular;
 	z-index: 0; // Create a stacking context and render on top of the background.
 
 	*,
@@ -57,7 +57,7 @@ $wp-components-calendar-preview-border-color: color-mix(in srgb, $components-col
 	height: $wp-components-calendar-button-height;
 
 	border: none;
-	border-radius: 2px;
+	border-radius: $radius-small;
 
 	font: inherit;
 	font-variant-numeric: tabular-nums;
@@ -73,7 +73,7 @@ $wp-components-calendar-preview-border-color: color-mix(in srgb, $components-col
 		z-index: -1;
 		inset: 0;
 		border: none; // No default border to avoid polluting high-contrast mode.
-		border-radius: 2px;
+		border-radius: $radius-small;
 	}
 
 	// Use the button's ::after to show the selection preview.
@@ -117,7 +117,7 @@ $wp-components-calendar-preview-border-color: color-mix(in srgb, $components-col
 .components-calendar__button-next,
 .components-calendar__button-previous {
 	border: none;
-	border-radius: 2px;
+	border-radius: $radius-small;
 	background: none;
 	padding: 0;
 	margin: 0;
@@ -150,8 +150,8 @@ $wp-components-calendar-preview-border-color: color-mix(in srgb, $components-col
 .components-calendar__chevron {
 	display: inline-block;
 	fill: currentColor;
-	width: 16px;
-	height: 16px;
+	width: $grid-unit-20;
+	height: $grid-unit-20;
 }
 
 .components-calendar[dir="rtl"]
@@ -167,7 +167,7 @@ $wp-components-calendar-preview-border-color: color-mix(in srgb, $components-col
 	align-content: center;
 
 	height: $wp-components-calendar-nav-height;
-	margin-bottom: 12px;
+	margin-bottom: $grid-unit-15;
 }
 
 .components-calendar__months {
@@ -175,13 +175,13 @@ $wp-components-calendar-preview-border-color: color-mix(in srgb, $components-col
 	display: flex;
 	justify-content: center;
 	flex-wrap: wrap;
-	gap: 16px;
+	gap: $grid-unit-20;
 	max-width: fit-content;
 }
 
 .components-calendar__month-grid {
 	border-collapse: separate;
-	border-spacing: 0 4px;
+	border-spacing: 0 $grid-unit-05;
 }
 
 .components-calendar__nav {

--- a/packages/components/src/calendar/style.scss
+++ b/packages/components/src/calendar/style.scss
@@ -1,9 +1,9 @@
 /* Root of the component. */
 // Internal variables
 $wp-components-calendar-outline-focus: var(--wp-admin-border-width-focus) solid $components-color-accent;
-$wp-components-calendar-button-height: 2rem;
-$wp-components-calendar-button-width: 2rem;
-$wp-components-calendar-nav-height: 2rem;
+$wp-components-calendar-button-height: 32px;
+$wp-components-calendar-button-width: 32px;
+$wp-components-calendar-nav-height: 32px;
 $wp-components-calendar-range-middle-background-color: color-mix(in srgb, $components-color-accent 4%, transparent);
 $wp-components-calendar-preview-border-color: color-mix(in srgb, $components-color-accent 16%, transparent);
 
@@ -175,7 +175,7 @@ $wp-components-calendar-preview-border-color: color-mix(in srgb, $components-col
 	display: flex;
 	justify-content: center;
 	flex-wrap: wrap;
-	gap: 1rem;
+	gap: 16px;
 	max-width: fit-content;
 }
 

--- a/packages/components/src/calendar/style.scss
+++ b/packages/components/src/calendar/style.scss
@@ -13,8 +13,8 @@ $wp-components-calendar-preview-border-color: color-mix(in srgb, $components-col
 	position: relative; /* Required to position the navigation toolbar. */
 	box-sizing: border-box;
 	display: inline flow-root;
-	color: $gray-900;
-	background-color: $white;
+	color: $components-color-foreground;
+	background-color: $components-color-background;
 	font-size: $font-size-medium;
 	font-weight: $font-weight-regular;
 	z-index: 0; // Create a stacking context and render on top of the background.
@@ -35,7 +35,7 @@ $wp-components-calendar-preview-border-color: color-mix(in srgb, $components-col
 	// date follows the same color as the button's text, since the button
 	// inherits its text color.
 	&:has(.components-calendar__day-button:disabled) {
-		color: $gray-600;
+		color: $components-color-disabled;
 	}
 	&:has(.components-calendar__day-button:hover:not(:disabled)),
 	&:has(.components-calendar__day-button:focus-visible) {
@@ -139,7 +139,7 @@ $wp-components-calendar-preview-border-color: color-mix(in srgb, $components-col
 	&[aria-disabled="true"] {
 		cursor: revert;
 
-		color: $gray-600;
+		color: $components-color-disabled;
 	}
 
 	&:focus-visible {
@@ -202,7 +202,7 @@ $wp-components-calendar-preview-border-color: color-mix(in srgb, $components-col
 	height: $wp-components-calendar-button-height;
 	padding: 0;
 
-	color: $gray-700;
+	color: $components-color-gray-700;
 	text-align: center;
 	text-transform: uppercase;
 }
@@ -227,12 +227,12 @@ $wp-components-calendar-preview-border-color: color-mix(in srgb, $components-col
 	.components-calendar__day-button,
 	.components-calendar__day-button:hover:not(:disabled)
 ) {
-		color: $white;
+		color: $components-color-foreground-inverted;
 	}
 
 	.components-calendar__day-button {
 		&::before {
-			background-color: $gray-900;
+			background-color: $components-color-foreground;
 			// Render a transparent border to highlight the selected day in
 			// forced-colors (high-contrast) mode, since the background is not
 			// visible.
@@ -240,11 +240,11 @@ $wp-components-calendar-preview-border-color: color-mix(in srgb, $components-col
 		}
 
 		&:disabled::before {
-			background-color: $gray-600;
+			background-color: $components-color-disabled;
 		}
 
 		&:hover:not(:disabled)::before {
-			background-color: $gray-800;
+			background-color: $components-color-gray-800;
 		}
 	}
 }

--- a/packages/components/src/utils/theme-variables.scss
+++ b/packages/components/src/utils/theme-variables.scss
@@ -29,3 +29,4 @@ $components-color-light-gray-placeholder: color-mix(in srgb, $components-color-b
 
 // Semantic aliases (prefer these over raw gray values when applicable).
 $components-color-border: #{ $components-color-gray-600 };
+$components-color-disabled: #{ $components-color-gray-600 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Switch from `rem` to `px` units for some internal sizes (day button size, nav height, months gap).


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Until now, the `DateCalendar` and `DateRangeCalendar` components would render in unexpected ways depending on the HTML base font size.

The changes in this PR enforce the same metrics across environments with different base HTML font sizes.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Switch from `rem` to `px`, assuming a `16px` base font size.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Compare Storybook examples on trunk and this PR:

- there shouldn't be any visual differences when the base HTML font size is set to `16px`
- when (manually) changing the HTML base font size, the metrics of the version on trunk are expected to change, while the version from this PR should stay unchanged

![Screenshot 2025-08-19 at 16 30 03](https://github.com/user-attachments/assets/ebc383a3-9cff-4ec6-b96e-624b55fda855)
