### PR TITLE
MenuItem: make accessible when disabled

### DIFF
--- a/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/test/navigation-menu-selector.js
@@ -295,7 +295,7 @@ describe( 'NavigationMenuSelector', () => {
 					screen.queryByRole( 'menuitem', {
 						name: 'Create new Menu',
 					} )
-				).toBeDisabled();
+				).toHaveAttribute( 'aria-disabled', 'true' );
 
 				// once the menu is created
 				// no more network activity to wait on
@@ -619,7 +619,7 @@ describe( 'NavigationMenuSelector', () => {
 				// Check all menu items are present but disabled.
 				screen.getAllByRole( 'menuitem' ).forEach( ( item ) => {
 					// // Check all menu items are present but disabled.
-					expect( item ).toBeDisabled();
+					expect( item ).toHaveAttribute( 'aria-disabled', 'true' );
 				} );
 
 				// once the menu is imported

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug fixes
+
+-   `MenuItem`: make accessible when disabled ([#71251](https://github.com/WordPress/gutenberg/pull/71251)).
+
 ### Enhancement
 
 -   Upgrade `gradient-parser` to version `1.1.1` to support HSL/HSLA color, CSS variables, and `calc()` expressions ([#71186](https://github.com/WordPress/gutenberg/pull/71186)).

--- a/packages/components/src/menu-item/index.tsx
+++ b/packages/components/src/menu-item/index.tsx
@@ -67,6 +67,7 @@ function UnforwardedMenuItem(
 			role={ role }
 			icon={ iconPosition === 'left' ? icon : undefined }
 			className={ className }
+			accessibleWhenDisabled
 			{ ...buttonProps }
 		>
 			<span className="components-menu-item__item">{ children }</span>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Allow `MenuItem` to be accessible (focusable) even when disabled.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This prevents a bug in `DropdownMenu` where the whole menu would become inaccessible (ie. no keyboard interactions, no close on click outside) if all the menu items are disabled.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding the `accessibleWhenDisabled` prop on `MenuItem`'s internal `Button` component.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Mark all children `MenuItem` of a `DropdownMenu` as disabled
- Make sure that the menu can still be interacted with (esp. with keyboard), and that the menu can be closed when clicking outside of its popover.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <video src="https://github.com/user-attachments/assets/9b716341-5f0a-46d7-b03b-4030912f996c" /> | <video src="https://github.com/user-attachments/assets/bc4f36e6-2f0e-4aa5-806a-27572eddb92f" /> |
