### PR TITLE
Fix popover not calling onClose on unmount

### DIFF
--- a/packages/compose/src/hooks/use-focus-outside/index.ts
+++ b/packages/compose/src/hooks/use-focus-outside/index.ts
@@ -87,11 +87,6 @@ export default function useFocusOutside(
 		clearTimeout( blurCheckTimeoutIdRef.current );
 	}, [] );
 
-	// Cancel blur checks on unmount.
-	useEffect( () => {
-		return () => cancelBlurCheck();
-	}, [] );
-
 	// Cancel a blur check if the callback or ref is no longer provided.
 	useEffect( () => {
 		if ( ! onFocusOutside ) {

--- a/packages/compose/src/hooks/use-focus-outside/test/index.js
+++ b/packages/compose/src/hooks/use-focus-outside/test/index.js
@@ -117,8 +117,13 @@ describe( 'useFocusOutside', () => {
 	} );
 
 	it( 'should call handler when unmounting while queued', async () => {
-		const { promise, resolve } = Promise.withResolvers();
-		const mockOnFocusOutside = jest.fn().mockImplementation( resolve );
+		let resolvePromise;
+		const promise = new Promise( ( resolve ) => {
+			resolvePromise = resolve;
+		} );
+		const mockOnFocusOutside = jest
+			.fn()
+			.mockImplementation( resolvePromise );
 		const user = userEvent.setup();
 
 		const { unmount } = render(

--- a/packages/compose/src/hooks/use-focus-outside/test/index.js
+++ b/packages/compose/src/hooks/use-focus-outside/test/index.js
@@ -116,7 +116,7 @@ describe( 'useFocusOutside', () => {
 		mockedDocumentHasFocus.mockRestore();
 	} );
 
-	it( 'should cancel check when unmounting while queued', async () => {
+	it( 'should call handler when unmounting while queued', async () => {
 		const mockOnFocusOutside = jest.fn();
 		const user = userEvent.setup();
 
@@ -130,11 +130,19 @@ describe( 'useFocusOutside', () => {
 		} );
 		await user.click( button );
 
-		// Simulate a blur event and the wrapper unmounting while the blur event
-		// handler is queued
-		button.blur();
+		// Click outside the wrapper to trigger a blur event and queue the callback
+		const outsideButton = screen.getByRole( 'button', {
+			name: 'Button outside the wrapper',
+		} );
+		await user.click( outsideButton );
+
+		// Immediately unmount the component while the blur event is queued
+		// The callback should still be called.
 		unmount();
 
-		expect( mockOnFocusOutside ).not.toHaveBeenCalled();
+		// Wait for the queued timeout to execute
+		await new Promise( ( resolve ) => setTimeout( resolve, 10 ) );
+
+		expect( mockOnFocusOutside ).toHaveBeenCalled();
 	} );
 } );

--- a/packages/compose/src/hooks/use-focus-outside/test/index.js
+++ b/packages/compose/src/hooks/use-focus-outside/test/index.js
@@ -117,7 +117,8 @@ describe( 'useFocusOutside', () => {
 	} );
 
 	it( 'should call handler when unmounting while queued', async () => {
-		const mockOnFocusOutside = jest.fn();
+		const { promise, resolve } = Promise.withResolvers();
+		const mockOnFocusOutside = jest.fn().mockImplementation( resolve );
 		const user = userEvent.setup();
 
 		const { unmount } = render(
@@ -140,8 +141,8 @@ describe( 'useFocusOutside', () => {
 		// The callback should still be called.
 		unmount();
 
-		// Wait for the queued timeout to execute
-		await new Promise( ( resolve ) => setTimeout( resolve, 10 ) );
+		// Wait for the callback to be called
+		await promise;
 
 		expect( mockOnFocusOutside ).toHaveBeenCalled();
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes  https://github.com/WordPress/gutenberg/issues/71281, which is a blocking issue in https://github.com/WordPress/gutenberg/pull/71163#issuecomment-3191252617

<!-- In a few words, what is the PR actually doing? -->

When a popover unmounts, it should call its related onClose, if provided.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It makes sense - the popover is closing, so the onClose should be called.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove cancelling the onBlur check when unmounting the popover.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

- All popovers should retain the same behavior as they currently do
- To test what this fixes, checkout this branch: `git checkout test/onclose-popover-unmount`. This is a combination of https://github.com/WordPress/gutenberg/pull/71163/ but with [this commit removed that tried to fix this issue with a prop](https://github.com/WordPress/gutenberg/pull/71163/commits/dbeb8b8156153dd010b842959d10c30d6b1d1071).
- Click a navigation block in the site editor to show the appender
- Open the sidebar 
- Click the appender for the navigation block within the sidebar
- The popover should open and there should be a "Select Page" placeholder in the canvas for where the new link will go
- Click into the canvas
- The popover should be removed and the Select Page should be removed (through the onClose that is called when the popover unmounts).

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

**Before**

https://github.com/user-attachments/assets/44f1933f-d568-4689-8c2f-721c7cea9407

**After**

https://github.com/user-attachments/assets/8d1c62ea-22ae-4c23-bc06-5d64e1c033a9




