### PR TITLE
Fix: Update Duotone filter when switching style variations in Site Editor Template Part

### DIFF
--- a/packages/block-editor/src/components/duotone-control/index.js
+++ b/packages/block-editor/src/components/duotone-control/index.js
@@ -13,6 +13,7 @@ import { __ } from '@wordpress/i18n';
 import { DOWN } from '@wordpress/keycodes';
 import { Icon, filter } from '@wordpress/icons';
 import { useInstanceId } from '@wordpress/compose';
+import { useEffect, useState } from '@wordpress/element';
 
 function DuotoneControl( {
 	id: idProp,
@@ -23,13 +24,20 @@ function DuotoneControl( {
 	value,
 	onChange,
 } ) {
+	const [ currentValue, setCurrentValue ] = useState( value );
+
+	// 🔥 Ensure local state syncs when style variation changes
+	useEffect( () => {
+		setCurrentValue( value );
+	}, [ value ] );
+
 	let toolbarIcon;
-	if ( value === 'unset' ) {
+	if ( currentValue === 'unset' ) {
 		toolbarIcon = (
 			<ColorIndicator className="block-editor-duotone-control__unset-indicator" />
 		);
-	} else if ( value ) {
-		toolbarIcon = <DuotoneSwatch values={ value } />;
+	} else if ( currentValue ) {
+		toolbarIcon = <DuotoneSwatch values={ currentValue } />;
 	} else {
 		toolbarIcon = <Icon icon={ filter } />;
 	}
@@ -77,13 +85,17 @@ function DuotoneControl( {
 						duotonePalette={ duotonePalette }
 						disableCustomColors={ disableCustomColors }
 						disableCustomDuotone={ disableCustomDuotone }
-						value={ value }
-						onChange={ onChange }
+						value={ currentValue }
+						onChange={ ( newValue ) => {
+							setCurrentValue( newValue );
+							onChange( newValue );
+						} }
 					/>
 				</MenuGroup>
 			) }
 		/>
 	);
 }
+
 
 export default DuotoneControl;

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -84,6 +84,23 @@ export function initializeEditor( id, settings ) {
 	}
 
 	dispatch( editSiteStore ).updateSettings( settings );
+	// 🔥 Re-apply settings when style variation changes
+	if ( globalThis.wp?.data ) {
+		const { subscribe, select } = globalThis.wp.data;
+		const previousVariation = { current: null };
+
+		subscribe( () => {
+			const newVariation =
+				select( 'core/edit-site' )?.getSettings()?.styleVariation;
+
+			if ( newVariation && newVariation !== previousVariation.current ) {
+				previousVariation.current = newVariation;
+
+				// Re-dispatch settings to refresh block controls (duotone, spacing, etc.)
+				dispatch( editSiteStore ).updateSettings( settings );
+			}
+		} );
+	}
 
 	// Prevent the default browser action for files dropped outside of dropzones.
 	window.addEventListener( 'dragover', ( e ) => e.preventDefault(), false );


### PR DESCRIPTION
This PR fixes an issue where the Duotone filter was not updating when a style variation was changed for a template part in the Site Editor.

**Problem**

Previously, when users switched between different style variations, the applied duotone filter did not refresh correctly. This caused the UI to display outdated filter settings.

**Solution**

- Updated the component logic to re-render and apply the correct duotone filter whenever a style variation is changed.
- Ensured the style variation change triggers a state update so the duotone is reapplied dynamically.
- Added checks to prevent stale filters from persisting.

**Testing Instructions**

1. Open the Site Editor.
2. Insert a template part with media that supports Duotone filters.
3. Apply a duotone filter.
4. Switch between style variations.
5. Confirm that the duotone filter updates correctly with each variation change.

Related Issue
Closes #71255