### PR TITLE
Core Commands: Add `Dashboard` option to return to dashboard

### DIFF
--- a/packages/core-commands/src/admin-navigation-commands.js
+++ b/packages/core-commands/src/admin-navigation-commands.js
@@ -139,15 +139,17 @@ const getAdminBasicNavigationCommands = () =>
 
 const getDashboardCommand = () =>
 	function useDashboardCommand() {
-		const isSiteEditor = getPath( window.location.href )?.includes(
-			'site-editor.php'
-		);
-		const isPostEditor =
-			getPath( window.location.href )?.includes( 'post.php' ) ||
-			getPath( window.location.href )?.includes( 'post-new.php' );
+		const currentPath = getPath( window.location.href );
+
+		const isEditorScreen =
+			currentPath?.includes( 'site-editor.php' ) ||
+			currentPath?.includes( 'post.php' ) ||
+			currentPath?.includes( 'post-new.php' ) ||
+			currentPath?.includes( 'widgets.php' ) ||
+			currentPath?.includes( 'customize.php' );
 
 		const commands = useMemo( () => {
-			if ( isSiteEditor || isPostEditor ) {
+			if ( isEditorScreen ) {
 				return [
 					{
 						name: 'core/dashboard',
@@ -160,7 +162,7 @@ const getDashboardCommand = () =>
 				];
 			}
 			return [];
-		}, [ isSiteEditor, isPostEditor ] );
+		}, [ isEditorScreen ] );
 
 		return {
 			isLoading: false,

--- a/packages/core-commands/src/admin-navigation-commands.js
+++ b/packages/core-commands/src/admin-navigation-commands.js
@@ -3,7 +3,7 @@
  */
 import { useCommand, useCommandLoader } from '@wordpress/commands';
 import { __ } from '@wordpress/i18n';
-import { plus } from '@wordpress/icons';
+import { plus, dashboard } from '@wordpress/icons';
 import { getPath } from '@wordpress/url';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -138,6 +138,15 @@ const getAdminBasicNavigationCommands = () =>
 	};
 
 export function useAdminNavigationCommands() {
+	useCommand( {
+		name: 'core/dashboard',
+		label: __( 'Dashboard' ),
+		icon: dashboard,
+		callback: () => {
+			document.location.assign( 'index.php' );
+		},
+	} );
+
 	useCommand( {
 		name: 'core/add-new-post',
 		label: __( 'Add Post' ),

--- a/packages/core-commands/src/admin-navigation-commands.js
+++ b/packages/core-commands/src/admin-navigation-commands.js
@@ -137,16 +137,38 @@ const getAdminBasicNavigationCommands = () =>
 		};
 	};
 
-export function useAdminNavigationCommands() {
-	useCommand( {
-		name: 'core/dashboard',
-		label: __( 'Dashboard' ),
-		icon: dashboard,
-		callback: () => {
-			document.location.assign( 'index.php' );
-		},
-	} );
+const getDashboardCommand = () =>
+	function useDashboardCommand() {
+		const isSiteEditor = getPath( window.location.href )?.includes(
+			'site-editor.php'
+		);
+		const isPostEditor =
+			getPath( window.location.href )?.includes( 'post.php' ) ||
+			getPath( window.location.href )?.includes( 'post-new.php' );
 
+		const commands = useMemo( () => {
+			if ( isSiteEditor || isPostEditor ) {
+				return [
+					{
+						name: 'core/dashboard',
+						label: __( 'Dashboard' ),
+						icon: dashboard,
+						callback: () => {
+							document.location.assign( 'index.php' );
+						},
+					},
+				];
+			}
+			return [];
+		}, [ isSiteEditor, isPostEditor ] );
+
+		return {
+			isLoading: false,
+			commands,
+		};
+	};
+
+export function useAdminNavigationCommands() {
 	useCommand( {
 		name: 'core/add-new-post',
 		label: __( 'Add Post' ),
@@ -155,6 +177,11 @@ export function useAdminNavigationCommands() {
 			document.location.assign( 'post-new.php' );
 		},
 		keywords: [ __( 'post' ), __( 'new' ), __( 'add' ), __( 'create' ) ],
+	} );
+
+	useCommandLoader( {
+		name: 'core/dashboard',
+		hook: getDashboardCommand(),
 	} );
 
 	useCommandLoader( {


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/71258

Adds a "Dashboard" option to the Command Palette that allows users to quickly return to the admin dashboard. The Dashboard command only appears when using the block editor screens, like the post editor or the site editor.

## Why?

Currently, there's no option in the Command Palette to return to the `wp-admin` dashboard when working in editors. 

## How?

Added a new conditional "Dashboard" command to the `useAdminNavigationCommands` hook in `packages/core-commands/src/admin-navigation-commands.js`. The command uses URL detection to only appear in editor contexts.

## Testing Instructions

1. Navigate to the post/site editor
2. Open the Command Palette using `Cmd or Ctrl + K`
3. Type "dashboard" in the search field
4. Verify the "Dashboard" option appears with a dashboard icon and press `Enter`
5. Verify you are redirected to the WordPress admin dashboard

## Screencasts

https://github.com/user-attachments/assets/39c1fe45-9b17-41c2-842e-e0d72771efee



