### PR TITLE
Move `Site Editor` command from `@wordpress/editor` package to `@wordpress/core-commands`

### DIFF
--- a/packages/core-commands/src/admin-navigation-commands.js
+++ b/packages/core-commands/src/admin-navigation-commands.js
@@ -3,7 +3,7 @@
  */
 import { useCommand, useCommandLoader } from '@wordpress/commands';
 import { __ } from '@wordpress/i18n';
-import { plus } from '@wordpress/icons';
+import { plus, edit, layout } from '@wordpress/icons';
 import { getPath } from '@wordpress/url';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -87,6 +87,54 @@ const getAddNewPageCommand = () =>
 		};
 	};
 
+const getAdminBasicNavigationCommands = () =>
+	function useAdminBasicNavigationCommands() {
+		const { isBlockBasedTheme, canCreateTemplate } = useSelect(
+			( select ) => ( {
+				isBlockBasedTheme:
+					select( coreStore ).getCurrentTheme()?.is_block_theme,
+				canCreateTemplate: select( coreStore ).canUser( 'create', {
+					kind: 'postType',
+					name: 'wp_template',
+				} ),
+			} ),
+			[]
+		);
+
+		const commands = useMemo( () => {
+			const result = [];
+
+			if ( canCreateTemplate && isBlockBasedTheme ) {
+				result.push( {
+					name: 'core/admin/open-site-editor',
+					label: __( 'Site Editor' ),
+					icon: layout,
+					callback: ( { close } ) => {
+						document.location.assign( 'site-editor.php' );
+						close();
+					},
+				} );
+			}
+
+			result.push( {
+				name: 'core/admin/open-post-editor',
+				label: __( 'Editor' ),
+				icon: edit,
+				callback: ( { close } ) => {
+					document.location.assign( 'post-new.php' );
+					close();
+				},
+			} );
+
+			return result;
+		}, [ canCreateTemplate, isBlockBasedTheme ] );
+
+		return {
+			commands,
+			isLoading: false,
+		};
+	};
+
 export function useAdminNavigationCommands() {
 	useCommand( {
 		name: 'core/add-new-post',
@@ -100,5 +148,10 @@ export function useAdminNavigationCommands() {
 	useCommandLoader( {
 		name: 'core/add-new-page',
 		hook: getAddNewPageCommand(),
+	} );
+
+	useCommandLoader( {
+		name: 'core/admin-navigation',
+		hook: getAdminBasicNavigationCommands(),
 	} );
 }

--- a/packages/core-commands/src/admin-navigation-commands.js
+++ b/packages/core-commands/src/admin-navigation-commands.js
@@ -3,7 +3,7 @@
  */
 import { useCommand, useCommandLoader } from '@wordpress/commands';
 import { __ } from '@wordpress/i18n';
-import { plus, layout } from '@wordpress/icons';
+import { plus } from '@wordpress/icons';
 import { getPath } from '@wordpress/url';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -90,30 +90,36 @@ const getAddNewPageCommand = () =>
 const getAdminBasicNavigationCommands = () =>
 	function useAdminBasicNavigationCommands() {
 		const { isBlockBasedTheme, canCreateTemplate } = useSelect(
-			( select ) => ( {
-				isBlockBasedTheme:
-					select( coreStore ).getCurrentTheme()?.is_block_theme,
-				canCreateTemplate: select( coreStore ).canUser( 'create', {
-					kind: 'postType',
-					name: 'wp_template',
-				} ),
-			} ),
+			( select ) => {
+				return {
+					isBlockBasedTheme:
+						select( coreStore ).getCurrentTheme()?.is_block_theme,
+					canCreateTemplate: select( coreStore ).canUser( 'create', {
+						kind: 'postType',
+						name: 'wp_template',
+					} ),
+				};
+			},
 			[]
 		);
 
 		const commands = useMemo( () => {
 			if ( canCreateTemplate && isBlockBasedTheme ) {
-				return [
-					{
-						name: 'core/admin/open-site-editor',
-						label: __( 'Site Editor' ),
-						icon: layout,
-						callback: ( { close } ) => {
-							document.location.assign( 'site-editor.php' );
-							close();
+				const isSiteEditor = getPath( window.location.href )?.includes(
+					'site-editor.php'
+				);
+				if ( ! isSiteEditor ) {
+					return [
+						{
+							name: 'core/go-to-site-editor',
+							label: __( 'Open Site Editor' ),
+							callback: ( { close } ) => {
+								close();
+								document.location = 'site-editor.php';
+							},
 						},
-					},
-				];
+					];
+				}
 			}
 
 			return [];

--- a/packages/core-commands/src/admin-navigation-commands.js
+++ b/packages/core-commands/src/admin-navigation-commands.js
@@ -3,7 +3,7 @@
  */
 import { useCommand, useCommandLoader } from '@wordpress/commands';
 import { __ } from '@wordpress/i18n';
-import { plus, edit, layout } from '@wordpress/icons';
+import { plus, layout } from '@wordpress/icons';
 import { getPath } from '@wordpress/url';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -102,31 +102,21 @@ const getAdminBasicNavigationCommands = () =>
 		);
 
 		const commands = useMemo( () => {
-			const result = [];
-
 			if ( canCreateTemplate && isBlockBasedTheme ) {
-				result.push( {
-					name: 'core/admin/open-site-editor',
-					label: __( 'Site Editor' ),
-					icon: layout,
-					callback: ( { close } ) => {
-						document.location.assign( 'site-editor.php' );
-						close();
+				return [
+					{
+						name: 'core/admin/open-site-editor',
+						label: __( 'Site Editor' ),
+						icon: layout,
+						callback: ( { close } ) => {
+							document.location.assign( 'site-editor.php' );
+							close();
+						},
 					},
-				} );
+				];
 			}
 
-			result.push( {
-				name: 'core/admin/open-post-editor',
-				label: __( 'Editor' ),
-				icon: edit,
-				callback: ( { close } ) => {
-					document.location.assign( 'post-new.php' );
-					close();
-				},
-			} );
-
-			return result;
+			return [];
 		}, [ canCreateTemplate, isBlockBasedTheme ] );
 
 		return {

--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -25,7 +25,6 @@ import { store as noticesStore } from '@wordpress/notices';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore, useEntityRecord } from '@wordpress/core-data';
 import { store as interfaceStore } from '@wordpress/interface';
-import { getPath } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
@@ -91,19 +90,6 @@ const getEditorCommandLoader = () =>
 		const { openModal, enableComplementaryArea, disableComplementaryArea } =
 			useDispatch( interfaceStore );
 		const { getCurrentPostId } = useSelect( editorStore );
-		const { isBlockBasedTheme, canCreateTemplate } = useSelect(
-			( select ) => {
-				return {
-					isBlockBasedTheme:
-						select( coreStore ).getCurrentTheme()?.is_block_theme,
-					canCreateTemplate: select( coreStore ).canUser( 'create', {
-						kind: 'postType',
-						name: 'wp_template',
-					} ),
-				};
-			},
-			[]
-		);
 		const allowSwitchEditorMode =
 			isCodeEditingEnabled && isRichEditingEnabled;
 
@@ -284,21 +270,6 @@ const getEditorCommandLoader = () =>
 					window.open( link, `wp-preview-${ postId }` );
 				},
 			} );
-		}
-		if ( canCreateTemplate && isBlockBasedTheme ) {
-			const isSiteEditor = getPath( window.location.href )?.includes(
-				'site-editor.php'
-			);
-			if ( ! isSiteEditor ) {
-				commands.push( {
-					name: 'core/go-to-site-editor',
-					label: __( 'Open Site Editor' ),
-					callback: ( { close } ) => {
-						close();
-						document.location = 'site-editor.php';
-					},
-				} );
-			}
 		}
 
 		return {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71257 

Moves the "Site Editor" navigation command from `@wordpress/editor` package to `@wordpress/core-commands` package to make it available on wp-admin dashboard pages.

## Why?
The "Site Editor" command was only available in the post editor but missing from the admin dashboard Command Palette. The command existed in the `@wordpress/editor` package but needed to be moved to `@wordpress/core-commands` to be available across all admin contexts.

## How?
- Added Site Editor command: Only shown on block themes with template creation permissions.

## Testing Instructions
1. Use a block-based theme to test the site editor command.
2. Navigate to any WordPress admin page.
3. Open the Command Palette using `Cmd` or `Ctrl + K`.
4. Type "Site Editor" → Should show "Site Editor" command.


## screencast

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/f5f40104-36cb-4cca-ae70-f49ff20eb122" /> |<video src="https://github.com/user-attachments/assets/27aee285-7305-467c-9e33-fc6efc45da13" />|
