### PR TITLE
Move Style above Navigation in Command Palette

### DIFF
--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -298,25 +298,6 @@ const getSiteEditorBasicNavigationCommands = () =>
 
 			if ( canCreateTemplate && isBlockBasedTheme ) {
 				result.push( {
-					name: 'core/edit-site/open-navigation',
-					label: __( 'Navigation' ),
-					icon: navigation,
-					callback: ( { close } ) => {
-						if ( isSiteEditor ) {
-							history.navigate( '/navigation' );
-						} else {
-							document.location = addQueryArgs(
-								'site-editor.php',
-								{
-									p: '/navigation',
-								}
-							);
-						}
-						close();
-					},
-				} );
-
-				result.push( {
 					name: 'core/edit-site/open-styles',
 					label: __( 'Styles' ),
 					icon: styles,
@@ -328,6 +309,25 @@ const getSiteEditorBasicNavigationCommands = () =>
 								'site-editor.php',
 								{
 									p: '/styles',
+								}
+							);
+						}
+						close();
+					},
+				} );
+
+				result.push( {
+					name: 'core/edit-site/open-navigation',
+					label: __( 'Navigation' ),
+					icon: navigation,
+					callback: ( { close } ) => {
+						if ( isSiteEditor ) {
+							history.navigate( '/navigation' );
+						} else {
+							document.location = addQueryArgs(
+								'site-editor.php',
+								{
+									p: '/navigation',
 								}
 							);
 						}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/53280

<!-- In a few words, what is the PR actually doing? -->
This PR fixes the ordering of items in command palette in site-editor to match the order of item in sidebar. that is This PR moves styles above navigation to matches the order in site-editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
After the merging of https://github.com/WordPress/gutenberg/pull/68582, the order of item listed in menu has been changed which caused minor inconsistency between command palette and menu. 
This PR aims to fix this inconsistency by matching the item order for both command palette and menu. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR addresses this by adjusting the item order that is being pushed to command palette in `packages/core-commands/src/site-editor-navigation-commands.js`. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open Site Editor
2. Open Command Palette
3. See the Order of command palette matches with Menu.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![](https://github.com/user-attachments/assets/37c2ac48-fd4f-412d-945a-7993d3ec21f6)|![](https://github.com/user-attachments/assets/a777df54-5fb6-483b-9126-94a955e9dbc1)|
