### PR TITLE
Social: Include developer blog tutorial in README

### DIFF
--- a/packages/block-library/src/social-link/README.md
+++ b/packages/block-library/src/social-link/README.md
@@ -20,5 +20,5 @@ To evaluate if a social service should be added, contributors will consider the 
 
 Starting from WordPress 6.9, it's possible to add custom social icons to your site. See:
 
-* Original ticket where feature was introduced - [#70261](https://github.com/WordPress/gutenberg/pull/70261).
+* Pull Request that introduced custom social icons - [#70261](https://github.com/WordPress/gutenberg/pull/70261).
 * Developer Blog tutorial for custom social icons - [Registering custom social icons in WordPress 6.9](https://developer.wordpress.org/news/2025/08/registering-custom-social-icons-in-wordpress-6-9/).

--- a/packages/block-library/src/social-link/README.md
+++ b/packages/block-library/src/social-link/README.md
@@ -18,4 +18,7 @@ To evaluate if a social service should be added, contributors will consider the 
 
 ## Adding custom social icons
 
-Starting from WordPress 6.9, it's possible to add custom social icons to your site. See: [#70261](https://github.com/WordPress/gutenberg/pull/70261).
+Starting from WordPress 6.9, it's possible to add custom social icons to your site. See:
+
+* Original ticket where feature was introduced - [#70261](https://github.com/WordPress/gutenberg/pull/70261).
+* Developer Blog tutorial for custom social icons - [Registering custom social icons in WordPress 6.9](https://developer.wordpress.org/news/2025/08/registering-custom-social-icons-in-wordpress-6-9/).


### PR DESCRIPTION
## What?
This is a follow-up to #70961.

PR adds a link to the developer blog tutorial for adding custom social icons to the editor - https://developer.wordpress.org/news/2025/08/registering-custom-social-icons-in-wordpress-6-9/.

## Testing Instructions
None.