### PR TITLE
DataForm: update stories

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Enhancements
 
+- Update DataForm stories to better highlight the library's capabilities ([#71268](https://github.com/WordPress/gutenberg/pull/71268)).
 - Add two smaller sizs to the grid layout ([#71077](https://github.com/WordPress/gutenberg/pull/71077)).
 
 ### Bug Fixes

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -13,7 +13,15 @@ import {
  */
 import DataForm from '../index';
 import { isItemValid } from '../../../validation';
-import type { Field, Form, DataFormControlProps } from '../../../types';
+import type {
+	Field,
+	Form,
+	DataFormControlProps,
+	Layout,
+	RegularLayout,
+	PanelLayout,
+	CardLayout,
+} from '../../../types';
 import { unlock } from '../../../lock-unlock';
 
 const { ValidatedTextControl } = unlock( privateApis );
@@ -59,26 +67,26 @@ const meta = {
 };
 export default meta;
 
-const fields = [
+const fields: Field< SamplePost >[] = [
 	{
 		id: 'title',
 		label: 'Title',
-		type: 'text' as const,
+		type: 'text',
 	},
 	{
 		id: 'order',
 		label: 'Order',
-		type: 'integer' as const,
+		type: 'integer',
 	},
 	{
 		id: 'date',
 		label: 'Date',
-		type: 'datetime' as const,
+		type: 'datetime',
 	},
 	{
 		id: 'birthdate',
 		label: 'Date as options',
-		type: 'datetime' as const,
+		type: 'datetime',
 		elements: [
 			{ value: '', label: 'Select a date' },
 			{ value: '1970-02-23T12:00:00', label: "Jane's birth date" },
@@ -88,7 +96,7 @@ const fields = [
 	{
 		id: 'author',
 		label: 'Author',
-		type: 'integer' as const,
+		type: 'integer',
 		elements: [
 			{ value: 1, label: 'Jane' },
 			{ value: 2, label: 'John' },
@@ -97,8 +105,8 @@ const fields = [
 	{
 		id: 'reviewer',
 		label: 'Reviewer',
-		type: 'text' as const,
-		Edit: 'radio' as const,
+		type: 'text',
+		Edit: 'radio',
 		elements: [
 			{ value: 'fulano', label: 'Fulano' },
 			{ value: 'mengano', label: 'Mengano' },
@@ -108,8 +116,8 @@ const fields = [
 	{
 		id: 'status',
 		label: 'Status',
-		type: 'text' as const,
-		Edit: 'toggleGroup' as const,
+		type: 'text',
+		Edit: 'toggleGroup',
 		elements: [
 			{ value: 'draft', label: 'Draft' },
 			{ value: 'published', label: 'Published' },
@@ -119,12 +127,12 @@ const fields = [
 	{
 		id: 'email',
 		label: 'Email',
-		type: 'email' as const,
+		type: 'email',
 	},
 	{
 		id: 'password',
 		label: 'Password',
-		type: 'text' as const,
+		type: 'text',
 		isVisible: ( item: SamplePost ) => {
 			return item.status !== 'private';
 		},
@@ -137,25 +145,25 @@ const fields = [
 	{
 		id: 'can_comment',
 		label: 'Allow people to leave a comment',
-		type: 'boolean' as const,
+		type: 'boolean',
 		Edit: 'checkbox',
 	},
 	{
 		id: 'filesize',
 		label: 'File Size',
-		type: 'integer' as const,
+		type: 'integer',
 		readOnly: true,
 	},
 	{
 		id: 'dimensions',
 		label: 'Dimensions',
-		type: 'text' as const,
+		type: 'text',
 		readOnly: true,
 	},
 	{
 		id: 'tags',
 		label: 'Tags',
-		type: 'array' as const,
+		type: 'array',
 		placeholder: 'Enter comma-separated tags',
 		description: 'Add tags separated by commas (e.g., "tag1, tag2, tag3")',
 		elements: [
@@ -169,19 +177,19 @@ const fields = [
 	{
 		id: 'address1',
 		label: 'Address 1',
-		type: 'text' as const,
+		type: 'text',
 	},
 	{
 		id: 'address2',
 		label: 'Address 2',
-		type: 'text' as const,
+		type: 'text',
 	},
 	{
 		id: 'city',
 		label: 'City',
-		type: 'text' as const,
+		type: 'text',
 	},
-] as Field< SamplePost >[];
+];
 
 export const Default = ( {
 	type,
@@ -208,13 +216,9 @@ export const Default = ( {
 		tags: [ 'photography' ],
 	} );
 
-	const form = useMemo(
+	const form: Form = useMemo(
 		() => ( {
-			layout: {
-				type,
-				labelPosition,
-				openAs,
-			},
+			layout: getLayoutFromStoryArgs( type, labelPosition, openAs ),
 			fields: [
 				'title',
 				'order',
@@ -233,7 +237,7 @@ export const Default = ( {
 			],
 		} ),
 		[ type, labelPosition, openAs ]
-	) as Form;
+	);
 
 	return (
 		<DataForm< SamplePost >
@@ -248,6 +252,42 @@ export const Default = ( {
 			}
 		/>
 	);
+};
+
+const getLayoutFromStoryArgs = (
+	type: 'default' | 'regular' | 'panel' | 'card',
+	labelPosition: 'default' | 'top' | 'side' | 'none',
+	openAs: 'default' | 'dropdown' | 'modal'
+) => {
+	let layout: Layout | undefined;
+
+	if ( type === 'default' || type === 'regular' ) {
+		const regularLayout: RegularLayout = {
+			type: 'regular',
+		};
+		if ( labelPosition !== 'default' ) {
+			regularLayout.labelPosition = labelPosition;
+		}
+		layout = regularLayout;
+	} else if ( type === 'panel' ) {
+		const panelLayout: PanelLayout = {
+			type: 'panel',
+		};
+		if ( labelPosition !== 'default' ) {
+			panelLayout.labelPosition = labelPosition;
+		}
+		if ( openAs !== 'default' ) {
+			panelLayout.openAs = openAs;
+		}
+		layout = panelLayout;
+	} else if ( type === 'card' ) {
+		const cardLayout: CardLayout = {
+			type: 'card',
+		};
+		layout = cardLayout;
+	}
+
+	return layout;
 };
 
 const CombinedFieldsComponent = ( {
@@ -275,13 +315,9 @@ const CombinedFieldsComponent = ( {
 		city: 'New York',
 	} );
 
-	const form = useMemo(
-		() => ( {
-			layout: {
-				type,
-				labelPosition,
-				openAs,
-			},
+	const form: Form = useMemo( () => {
+		return {
+			layout: getLayoutFromStoryArgs( type, labelPosition, openAs ),
 			fields: [
 				'title',
 				{
@@ -300,9 +336,8 @@ const CombinedFieldsComponent = ( {
 					children: [ 'address1', 'address2', 'city' ],
 				},
 			],
-		} ),
-		[ type, labelPosition, openAs ]
-	) as Form;
+		};
+	}, [ type, labelPosition, openAs ] );
 
 	return (
 		<DataForm< SamplePost >
@@ -384,7 +419,7 @@ const DataFormValidationComponent = ( { required }: { required: boolean } ) => {
 	const _fields: Field< ValidatedItem >[] = [
 		{
 			id: 'text',
-			type: 'text' as const,
+			type: 'text',
 			label: 'Text',
 			isValid: {
 				required,
@@ -392,7 +427,7 @@ const DataFormValidationComponent = ( { required }: { required: boolean } ) => {
 		},
 		{
 			id: 'email',
-			type: 'email' as const,
+			type: 'email',
 			label: 'e-mail',
 			isValid: {
 				required,
@@ -400,7 +435,7 @@ const DataFormValidationComponent = ( { required }: { required: boolean } ) => {
 		},
 		{
 			id: 'integer',
-			type: 'integer' as const,
+			type: 'integer',
 			label: 'Integer',
 			isValid: {
 				required,
@@ -408,7 +443,7 @@ const DataFormValidationComponent = ( { required }: { required: boolean } ) => {
 		},
 		{
 			id: 'boolean',
-			type: 'boolean' as const,
+			type: 'boolean',
 			label: 'Boolean',
 			isValid: {
 				required,
@@ -509,7 +544,7 @@ const DataFormVisibilityComponent = () => {
 		isActive: true,
 	} );
 
-	const _fields = [
+	const _fields: Field< Post >[] = [
 		{ id: 'isActive', label: 'Is module active?', type: 'boolean' },
 		{
 			id: 'name',
@@ -523,8 +558,8 @@ const DataFormVisibilityComponent = () => {
 			type: 'email',
 			isVisible: ( post ) => post.isActive === true,
 		},
-	] satisfies Field< Post >[];
-	const form = {
+	];
+	const form: Form = {
 		fields: [ 'isActive', 'name', 'email' ],
 	};
 	return (
@@ -651,77 +686,73 @@ const LayoutCardComponent = () => {
 		commission: 5,
 	} );
 
-	const form = useMemo(
-		() =>
-			( {
-				layout: {
-					type: 'card',
-				},
-				fields: [
+	const form: Form = {
+		layout: {
+			type: 'card',
+		},
+		fields: [
+			{
+				id: 'customerCard',
+				label: 'Customer',
+				children: [
 					{
-						id: 'customerCard',
-						label: 'Customer',
+						id: 'customerContact',
+						label: 'Contact',
+						layout: { type: 'panel', labelPosition: 'top' },
 						children: [
 							{
-								id: 'customerContact',
-								label: 'Contact',
-								layout: { type: 'panel', labelPosition: 'top' },
-								children: [
-									{
-										id: 'name',
-										layout: {
-											type: 'regular',
-											labelPosition: 'top',
-										},
-									},
-									{
-										id: 'phone',
-										layout: {
-											type: 'regular',
-											labelPosition: 'top',
-										},
-									},
-									{
-										id: 'email',
-										layout: {
-											type: 'regular',
-											labelPosition: 'top',
-										},
-									},
-								],
+								id: 'name',
+								layout: {
+									type: 'regular',
+									labelPosition: 'top',
+								},
 							},
 							{
-								id: 'plan',
-								layout: { type: 'panel', labelPosition: 'top' },
+								id: 'phone',
+								layout: {
+									type: 'regular',
+									labelPosition: 'top',
+								},
 							},
 							{
-								id: 'shippingAddress',
-								layout: { type: 'panel', labelPosition: 'top' },
+								id: 'email',
+								layout: {
+									type: 'regular',
+									labelPosition: 'top',
+								},
 							},
-							{
-								id: 'billingAddress',
-								layout: { type: 'panel', labelPosition: 'top' },
-							},
-							'displayPayments',
 						],
 					},
 					{
-						id: 'payments',
-						layout: { type: 'card', withHeader: false },
+						id: 'plan',
+						layout: { type: 'panel', labelPosition: 'top' },
 					},
 					{
-						id: 'taxConfiguration',
-						label: 'Taxes',
-						layout: {
-							type: 'card',
-							isOpened: false,
-						},
-						children: [ 'vat', 'commission' ],
+						id: 'shippingAddress',
+						layout: { type: 'panel', labelPosition: 'top' },
 					},
+					{
+						id: 'billingAddress',
+						layout: { type: 'panel', labelPosition: 'top' },
+					},
+					'displayPayments',
 				],
-			} ) satisfies Form,
-		[]
-	);
+			},
+			{
+				id: 'payments',
+				layout: { type: 'card', withHeader: false },
+			},
+			{
+				id: 'taxConfiguration',
+				label: 'Taxes',
+				layout: {
+					type: 'card',
+					isOpened: false,
+				},
+				children: [ 'vat', 'commission' ],
+			},
+		],
+	};
 
 	return (
 		<DataForm
@@ -756,32 +787,33 @@ const LayoutMixedComponent = () => {
 		dimensions: '1920x1080',
 	} );
 
-	const form = useMemo(
-		() =>
-			( {
-				fields: [
-					{
-						id: 'title',
-						layout: {
-							type: 'panel',
-							labelPosition: 'top',
-							openAs: 'dropdown',
-						},
-					},
-					'status',
-					{ id: 'order', layout: { type: 'card' } },
-					{
-						id: 'authorDateCard',
-						label: 'Author & Date',
-						layout: {
-							type: 'card',
-						},
-						children: [ 'author', 'date' ],
-					},
-				],
-			} ) satisfies Form,
-		[]
-	);
+	const form: Form = {
+		fields: [
+			{
+				id: 'title',
+				layout: {
+					type: 'panel',
+					labelPosition: 'top',
+					openAs: 'dropdown',
+				},
+			},
+			'status',
+			{
+				id: 'order',
+				layout: {
+					type: 'card',
+				},
+			},
+			{
+				id: 'authorDateCard',
+				label: 'Author & Date',
+				layout: {
+					type: 'card',
+				},
+				children: [ 'author', 'date' ],
+			},
+		],
+	};
 
 	return (
 		<DataForm< SamplePost >

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -43,30 +43,6 @@ type SamplePost = {
 	city?: string;
 };
 
-const meta = {
-	title: 'DataViews/DataForm',
-	component: DataForm,
-	argTypes: {
-		type: {
-			control: { type: 'select' },
-			description:
-				'Chooses the default layout of each field. "regular" is the default layout.',
-			options: [ 'default', 'regular', 'panel', 'card' ],
-		},
-		labelPosition: {
-			control: { type: 'select' },
-			description: 'Chooses the label position of the layout.',
-			options: [ 'default', 'top', 'side', 'none' ],
-		},
-		openAs: {
-			control: { type: 'select' },
-			description: 'Chooses the type of panel to use.',
-			options: [ 'default', 'dropdown', 'modal' ],
-		},
-	},
-};
-export default meta;
-
 const fields: Field< SamplePost >[] = [
 	{
 		id: 'title',
@@ -100,6 +76,8 @@ const fields: Field< SamplePost >[] = [
 		elements: [
 			{ value: 1, label: 'Jane' },
 			{ value: 2, label: 'John' },
+			{ value: 3, label: 'Alice' },
+			{ value: 4, label: 'Bob' },
 		],
 	},
 	{
@@ -108,9 +86,10 @@ const fields: Field< SamplePost >[] = [
 		type: 'text',
 		Edit: 'radio',
 		elements: [
-			{ value: 'fulano', label: 'Fulano' },
-			{ value: 'mengano', label: 'Mengano' },
-			{ value: 'zutano', label: 'Zutano' },
+			{ value: 'jane', label: 'Jane' },
+			{ value: 'john', label: 'John' },
+			{ value: 'alice', label: 'Alice' },
+			{ value: 'bob', label: 'Bob' },
 		],
 	},
 	{
@@ -191,14 +170,10 @@ const fields: Field< SamplePost >[] = [
 	},
 ];
 
-export const Default = ( {
-	type,
+const LayoutRegularComponent = ( {
 	labelPosition,
-	openAs,
 }: {
-	type: 'default' | 'regular' | 'panel' | 'card';
 	labelPosition: 'default' | 'top' | 'side' | 'none';
-	openAs: 'default' | 'dropdown' | 'modal';
 } ) => {
 	const [ post, setPost ] = useState( {
 		title: 'Hello, World!',
@@ -218,7 +193,10 @@ export const Default = ( {
 
 	const form: Form = useMemo(
 		() => ( {
-			layout: getLayoutFromStoryArgs( type, labelPosition, openAs ),
+			layout: getLayoutFromStoryArgs( {
+				type: 'regular',
+				labelPosition,
+			} ),
 			fields: [
 				'title',
 				'order',
@@ -236,7 +214,7 @@ export const Default = ( {
 				'tags',
 			],
 		} ),
-		[ type, labelPosition, openAs ]
+		[ labelPosition ]
 	);
 
 	return (
@@ -254,11 +232,17 @@ export const Default = ( {
 	);
 };
 
-const getLayoutFromStoryArgs = (
-	type: 'default' | 'regular' | 'panel' | 'card',
-	labelPosition: 'default' | 'top' | 'side' | 'none',
-	openAs: 'default' | 'dropdown' | 'modal'
-) => {
+const getLayoutFromStoryArgs = ( {
+	type,
+	labelPosition,
+	openAs,
+	withHeader,
+}: {
+	type: 'default' | 'regular' | 'panel' | 'card';
+	labelPosition?: 'default' | 'top' | 'side' | 'none';
+	openAs?: 'default' | 'dropdown' | 'modal';
+	withHeader?: boolean;
+} ): Layout | undefined => {
 	let layout: Layout | undefined;
 
 	if ( type === 'default' || type === 'regular' ) {
@@ -284,13 +268,17 @@ const getLayoutFromStoryArgs = (
 		const cardLayout: CardLayout = {
 			type: 'card',
 		};
+		if ( withHeader !== undefined ) {
+			// @ts-ignore We want to demo the effects of configuring withHeader.
+			cardLayout.withHeader = withHeader;
+		}
 		layout = cardLayout;
 	}
 
 	return layout;
 };
 
-const CombinedFieldsComponent = ( {
+const LayoutPanelComponent = ( {
 	type,
 	labelPosition,
 	openAs,
@@ -317,7 +305,11 @@ const CombinedFieldsComponent = ( {
 
 	const form: Form = useMemo( () => {
 		return {
-			layout: getLayoutFromStoryArgs( type, labelPosition, openAs ),
+			layout: getLayoutFromStoryArgs( {
+				type: 'panel',
+				labelPosition,
+				openAs,
+			} ),
 			fields: [
 				'title',
 				{
@@ -354,17 +346,6 @@ const CombinedFieldsComponent = ( {
 	);
 };
 
-export const CombinedFields = {
-	title: 'DataViews/CombinedFields',
-	render: CombinedFieldsComponent,
-	argTypes: {
-		...meta.argTypes,
-	},
-	args: {
-		type: 'panel',
-	},
-};
-
 function CustomEditControl< Item >( {
 	data,
 	field,
@@ -397,7 +378,7 @@ function CustomEditControl< Item >( {
 	);
 }
 
-const DataFormValidationComponent = ( { required }: { required: boolean } ) => {
+const ValidationComponent = ( { required }: { required: boolean } ) => {
 	type ValidatedItem = {
 		text: string;
 		email: string;
@@ -518,21 +499,7 @@ const DataFormValidationComponent = ( { required }: { required: boolean } ) => {
 	);
 };
 
-export const Validation = {
-	title: 'DataForm/Validation',
-	render: DataFormValidationComponent,
-	argTypes: {
-		required: {
-			control: { type: 'boolean' },
-			description: 'Whether or not the fields are required.',
-		},
-	},
-	args: {
-		required: true,
-	},
-};
-
-const DataFormVisibilityComponent = () => {
+const VisibilityComponent = () => {
 	type Post = {
 		name: string;
 		email: string;
@@ -577,12 +544,7 @@ const DataFormVisibilityComponent = () => {
 	);
 };
 
-export const Visibility = {
-	title: 'DataForm/Visibility',
-	render: DataFormVisibilityComponent,
-};
-
-const LayoutCardComponent = () => {
+const LayoutCardComponent = ( { withHeader }: { withHeader: boolean } ) => {
 	type Customer = {
 		name: string;
 		email: string;
@@ -686,73 +648,80 @@ const LayoutCardComponent = () => {
 		commission: 5,
 	} );
 
-	const form: Form = {
-		layout: {
-			type: 'card',
-		},
-		fields: [
-			{
-				id: 'customerCard',
-				label: 'Customer',
-				children: [
-					{
-						id: 'customerContact',
-						label: 'Contact',
-						layout: { type: 'panel', labelPosition: 'top' },
-						children: [
-							{
-								id: 'name',
-								layout: {
-									type: 'regular',
-									labelPosition: 'top',
+	const form: Form = useMemo(
+		() => ( {
+			layout: getLayoutFromStoryArgs( {
+				type: 'card',
+				withHeader,
+			} ),
+			fields: [
+				{
+					id: 'customerCard',
+					label: 'Customer',
+					children: [
+						{
+							id: 'customerContact',
+							label: 'Contact',
+							layout: { type: 'panel', labelPosition: 'top' },
+							children: [
+								{
+									id: 'name',
+									layout: {
+										type: 'regular',
+										labelPosition: 'top',
+									},
 								},
-							},
-							{
-								id: 'phone',
-								layout: {
-									type: 'regular',
-									labelPosition: 'top',
+								{
+									id: 'phone',
+									layout: {
+										type: 'regular',
+										labelPosition: 'top',
+									},
 								},
-							},
-							{
-								id: 'email',
-								layout: {
-									type: 'regular',
-									labelPosition: 'top',
+								{
+									id: 'email',
+									layout: {
+										type: 'regular',
+										labelPosition: 'top',
+									},
 								},
-							},
-						],
-					},
-					{
-						id: 'plan',
-						layout: { type: 'panel', labelPosition: 'top' },
-					},
-					{
-						id: 'shippingAddress',
-						layout: { type: 'panel', labelPosition: 'top' },
-					},
-					{
-						id: 'billingAddress',
-						layout: { type: 'panel', labelPosition: 'top' },
-					},
-					'displayPayments',
-				],
-			},
-			{
-				id: 'payments',
-				layout: { type: 'card', withHeader: false },
-			},
-			{
-				id: 'taxConfiguration',
-				label: 'Taxes',
-				layout: {
-					type: 'card',
-					isOpened: false,
+							],
+						},
+						{
+							id: 'plan',
+							layout: { type: 'panel', labelPosition: 'top' },
+						},
+						{
+							id: 'shippingAddress',
+							layout: { type: 'panel', labelPosition: 'top' },
+						},
+						{
+							id: 'billingAddress',
+							layout: { type: 'panel', labelPosition: 'top' },
+						},
+						'displayPayments',
+					],
 				},
-				children: [ 'vat', 'commission' ],
-			},
-		],
-	};
+				{
+					id: 'payments',
+					layout: {
+						type: 'card',
+						withHeader: false,
+					},
+				},
+				{
+					id: 'taxConfiguration',
+					label: 'Taxes',
+					layout: {
+						type: 'card',
+						isOpened: false,
+					},
+					children: [ 'vat', 'commission' ],
+				},
+			],
+		} ),
+		[ withHeader ]
+	);
 
 	return (
 		<DataForm
@@ -767,11 +736,6 @@ const LayoutCardComponent = () => {
 			}
 		/>
 	);
-};
-
-export const LayoutCard = {
-	title: 'DataForm/LayoutCard',
-	render: LayoutCardComponent,
 };
 
 const LayoutMixedComponent = () => {
@@ -830,7 +794,69 @@ const LayoutMixedComponent = () => {
 	);
 };
 
+const meta = {
+	title: 'DataViews/DataForm',
+	component: DataForm,
+};
+export default meta;
+
+export const LayoutCard = {
+	render: LayoutCardComponent,
+	argTypes: {
+		withHeader: {
+			control: { type: 'boolean' },
+			description: 'Whether the card has a header.',
+		},
+	},
+	args: {
+		withHeader: true,
+	},
+};
+
+export const LayoutPanel = {
+	render: LayoutPanelComponent,
+	argTypes: {
+		labelPosition: {
+			control: { type: 'select' },
+			description: 'Chooses the label position.',
+			options: [ 'default', 'top', 'side', 'none' ],
+		},
+		openAs: {
+			control: { type: 'select' },
+			description: 'Chooses how to open the panel.',
+			options: [ 'default', 'dropdown', 'modal' ],
+		},
+	},
+};
+
+export const LayoutRegular = {
+	render: LayoutRegularComponent,
+	argTypes: {
+		labelPosition: {
+			control: { type: 'select' },
+			description: 'Chooses the label position.',
+			options: [ 'default', 'top', 'side', 'none' ],
+		},
+	},
+};
+
 export const LayoutMixed = {
-	title: 'DataForm/LayoutMixed',
 	render: LayoutMixedComponent,
+};
+
+export const Validation = {
+	render: ValidationComponent,
+	argTypes: {
+		required: {
+			control: { type: 'boolean' },
+			description: 'Whether or not the fields are required.',
+		},
+	},
+	args: {
+		required: true,
+	},
+};
+
+export const Visibility = {
+	render: VisibilityComponent,
 };

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -767,6 +767,7 @@ const LayoutMixedComponent = () => {
 				layout: {
 					type: 'card',
 				},
+				children: [ { id: 'order', layout: { type: 'panel' } } ],
 			},
 			{
 				id: 'authorDateCard',

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -171,8 +171,10 @@ const fields: Field< SamplePost >[] = [
 ];
 
 const LayoutRegularComponent = ( {
+	type = 'default',
 	labelPosition,
 }: {
+	type?: 'default' | 'regular' | 'panel' | 'card';
 	labelPosition: 'default' | 'top' | 'side' | 'none';
 } ) => {
 	const [ post, setPost ] = useState( {
@@ -194,7 +196,7 @@ const LayoutRegularComponent = ( {
 	const form: Form = useMemo(
 		() => ( {
 			layout: getLayoutFromStoryArgs( {
-				type: 'regular',
+				type,
 				labelPosition,
 			} ),
 			fields: [
@@ -214,7 +216,7 @@ const LayoutRegularComponent = ( {
 				'tags',
 			],
 		} ),
-		[ labelPosition ]
+		[ type, labelPosition ]
 	);
 
 	return (
@@ -279,7 +281,6 @@ const getLayoutFromStoryArgs = ( {
 };
 
 const LayoutPanelComponent = ( {
-	type,
 	labelPosition,
 	openAs,
 }: {
@@ -329,7 +330,7 @@ const LayoutPanelComponent = ( {
 				},
 			],
 		};
-	}, [ type, labelPosition, openAs ] );
+	}, [ labelPosition, openAs ] );
 
 	return (
 		<DataForm< SamplePost >
@@ -800,6 +801,17 @@ const meta = {
 	component: DataForm,
 };
 export default meta;
+
+export const Default = {
+	render: LayoutRegularComponent,
+	argTypes: {
+		type: {
+			control: { type: 'select' },
+			description: 'Chooses the layout type.',
+			options: [ 'default', 'card', 'panel', 'regular' ],
+		},
+	},
+};
 
 export const LayoutCard = {
 	render: LayoutCardComponent,


### PR DESCRIPTION
## What?

This PR updates the `DataForm` stories for them to highlight the main characteristics of the library: the different layouts, validation, and visibility control. Each story has relevant controls to interact with.

**Before:**

https://github.com/user-attachments/assets/a9df71e7-dbbf-4e35-984f-8d3826212939

**After:**

https://github.com/user-attachments/assets/fb8768cd-58ac-41e8-b514-96125193904f


## Why?

So it's easier to learn how to work with `DataForm`. Each story has working controls that highlight the specific feature.

## How?

The storybook is now organized in the following stories. Each exposes relevant controls to users:

- Default: interact with layout `type`.
- Layout Card: interact with `withHeader` and `isOpened`.
- Layout Panel: interact with `labelPosition` and `openAs`.
- Layout Regular: interact with `labelPosition`.
- Layout Mixed.
- Validation: interact with `required`.
- Visibility.

## Testing Instructions

Run the storybook locally (`npm install && npm run storybook:dev`) and visit the "DataViews > DataForm" stories.
