### PR TITLE
Button Block: No color contrast warning, regardless of chosen colors

### DIFF
--- a/packages/block-editor/src/hooks/contrast-checker.js
+++ b/packages/block-editor/src/hooks/contrast-checker.js
@@ -2,12 +2,15 @@
  * WordPress dependencies
  */
 import { useLayoutEffect, useReducer } from '@wordpress/element';
+import { getBlockType } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import ContrastChecker from '../components/contrast-checker';
 import { useBlockElement } from '../components/block-list/use-block-props/use-block-refs';
+import { store as blockEditorStore } from '../store';
 
 function getComputedValue( node, property ) {
 	return node.ownerDocument.defaultView
@@ -15,19 +18,32 @@ function getComputedValue( node, property ) {
 		.getPropertyValue( property );
 }
 
-function getBlockElementColors( blockEl ) {
+function getBlockElementColors( blockEl, blockType ) {
 	if ( ! blockEl ) {
 		return {};
 	}
 
-	const firstLinkElement = blockEl.querySelector( 'a' );
+	const rootSelector = blockType?.selectors?.root || null;
+	let targetElement = blockEl;
+
+	if ( rootSelector ) {
+		const [ , ...rest ] = rootSelector.split( ' ' );
+		if ( rest.length ) {
+			const innerSelector = rest.join( ' ' );
+			targetElement = blockEl.querySelector( innerSelector ) || blockEl;
+		}
+	}
+
+	// Retrieve colors from the target element.
+	const firstLinkElement = targetElement.querySelector( 'a' );
 	const linkColor = !! firstLinkElement?.innerText
 		? getComputedValue( firstLinkElement, 'color' )
 		: undefined;
 
-	const textColor = getComputedValue( blockEl, 'color' );
+	const textColor = getComputedValue( targetElement, 'color' );
 
-	let backgroundColorNode = blockEl;
+	// Traverse up the DOM tree to find the background color.
+	let backgroundColorNode = targetElement;
 	let backgroundColor = getComputedValue(
 		backgroundColorNode,
 		'background-color'
@@ -63,6 +79,13 @@ function reducer( prevColors, newColors ) {
 
 export default function BlockColorContrastChecker( { clientId } ) {
 	const blockEl = useBlockElement( clientId );
+	const blockType = useSelect(
+		( select ) => {
+			const block = select( blockEditorStore ).getBlock( clientId );
+			return block ? getBlockType( block.name ) : null;
+		},
+		[ clientId ]
+	);
 	const [ colors, setColors ] = useReducer( reducer, {} );
 
 	// There are so many things that can change the color of a block
@@ -73,7 +96,7 @@ export default function BlockColorContrastChecker( { clientId } ) {
 		}
 
 		function updateColors() {
-			setColors( getBlockElementColors( blockEl ) );
+			setColors( getBlockElementColors( blockEl, blockType ) );
 		}
 
 		// Combine `useLayoutEffect` and two rAF calls to ensure that values are read

--- a/packages/block-editor/src/hooks/contrast-checker.js
+++ b/packages/block-editor/src/hooks/contrast-checker.js
@@ -11,6 +11,7 @@ import { useSelect } from '@wordpress/data';
 import ContrastChecker from '../components/contrast-checker';
 import { useBlockElement } from '../components/block-list/use-block-props/use-block-refs';
 import { store as blockEditorStore } from '../store';
+import { getBlockCSSSelector } from '../components/global-styles/get-block-css-selector';
 
 function getComputedValue( node, property ) {
 	return node.ownerDocument.defaultView
@@ -23,7 +24,7 @@ function getBlockElementColors( blockEl, blockType ) {
 		return {};
 	}
 
-	const rootSelector = blockType?.selectors?.root || null;
+	const rootSelector = getBlockCSSSelector( blockType );
 	let targetElement = blockEl;
 
 	if ( rootSelector ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #39226

<!-- In a few words, what is the PR actually doing? -->

The contrast warning is not appearing for Button blocks in WordPress Gutenberg, despite choosing colors with insufficient contrast, due to the color data being retrieved from the wrong node.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The issue needs to be fixed because the contrast warning is not appearing for Button blocks, even when the text and background colors have low contrast, due to the color data being retrieved from the wrong HTML element (`wp-block-button` instead of `wp-block-button__link`). This means that users may unintentionally create buttons with inaccessible color combinations.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The changes modify the `getBlockElementColors` function in `contrast-checker.js` to handle Button blocks specially. 

When a Button block is detected, the code now uses the `.wp-block-button__link` element instead of the `.wp-block-button` element to determine the text and background colors. This is because the colors are actually applied to the child div `.wp-block-button__link`, not the container element `.wp-block-button`. 

The changes include adding a conditional statement to check if the block element is a Button block, and if so, using the `.wp-block-button__link` element to get the text and background colors. This should fix the issue with the contrast warning not appearing for Button blocks. 

## Testing Instructions

1. Add a Buttons block
2. Select the Button
3. In the sidebar, edit the text & background colors
4. Check if the contrast warning now shows up or not

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/fe18e375-2bf8-4d18-ac1d-73ba11e45f62

### After

https://github.com/user-attachments/assets/1deb303c-22c0-4805-a3f2-d520e9703c0b
