### PR TITLE
Fix DataViews primary actions horizontal layout consistency

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Bug Fixes
 
 - Do not throw exception when `view.layout.previewSize` is smaller than the smallest available size. [#71218](https://github.com/WordPress/gutenberg/pull/71218)
+- Fix actions horizontal layout consistency when all actions are primary. [#71274](https://github.com/WordPress/gutenberg/pull/71274)
 
 ## 6.0.0 (2025-08-07)
 

--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -179,17 +179,6 @@ export default function ItemActions< Item >( {
 		);
 	}
 
-	// If all actions are primary, there is no need to render the dropdown.
-	if ( primaryActions.length === eligibleActions.length ) {
-		return (
-			<PrimaryActions
-				item={ item }
-				actions={ primaryActions }
-				registry={ registry }
-			/>
-		);
-	}
-
 	return (
 		<HStack
 			spacing={ 1 }
@@ -205,11 +194,13 @@ export default function ItemActions< Item >( {
 				actions={ primaryActions }
 				registry={ registry }
 			/>
-			<CompactItemActions
-				item={ item }
-				actions={ eligibleActions }
-				registry={ registry }
-			/>
+			{ primaryActions.length < eligibleActions.length && (
+				<CompactItemActions
+					item={ item }
+					actions={ eligibleActions }
+					registry={ registry }
+				/>
+			) }
 		</HStack>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Always add the `HStack` wrapper to dataviews actions.

## Why?
Right now, the horizontal wrapper is not added when there are only primary actions, which results in actions:
- Stacking vertically.
- Being always shown instead of only when hovering/selecting the row 

## How?
Adding the `HStack` unconditionally, and conditionally adding the dropdown menu.

## Testing Instructions
1. Before applying this patch, hack `/packages/edit-site/src/components/post-list/index.js` to only show primary actions with `const actions = useMemo(() => [ editAction, ...postTypeActions ].filter( action => action.isPrimary )...);`
2. Go to the post list experiment, verify that all the actions show and are vertically stacked.
3. Apply this PR
4. Go to the post list experiment, verify that all actions show in a row and only when hovering/selecting.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="1410" height="454" alt="image" src="https://github.com/user-attachments/assets/b335e036-335d-40f8-b56d-2ee93dc754b5" /> | <img width="1409" height="433" alt="image" src="https://github.com/user-attachments/assets/011823e5-042b-4668-b8f5-2c1359ee1067" /> |
