### PR TITLE
DataViews: support the "Minimal UI" story by using `DataViews.Footer`

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- Revert the ability to hide the view config via `config` prop and export a `DataViews.Footer` component to support the "Minimal UI" story. [#71276](https://github.com/WordPress/gutenberg/pull/71276)
+
 ### Bug Fixes
 
 -   DataViews: Fix incorrect documentation for `defaultLayouts` prop. [#71334](https://github.com/WordPress/gutenberg/pull/71334)

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -416,9 +416,9 @@ The component receives the following props:
 
 React component to be rendered next to the view config button.
 
-#### `config`: false | { perPageSizes: number[] }
+#### `config`: { perPageSizes: number[] }
 
-Optional. Set it to `false` to hide the view config control entirely. Pass an object with a list of `perPageSizes` to control the available item counts per page (defaults to `[10, 20, 50, 100]`). `perPageSizes` needs to have a minimum of 2 items and a maximum of 6, otherwise the UI component won't be displayed.
+Optional. Pass an object with a list of `perPageSizes` to control the available item counts per page (defaults to `[10, 20, 50, 100]`). `perPageSizes` needs to have a minimum of 2 items and a maximum of 6, otherwise the UI component won't be displayed.
 
 #### `empty`: React node
 

--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -54,7 +54,7 @@ type DataViewsContextType< Item > = {
 	filters: NormalizedFilter[];
 	isShowingFilter: boolean;
 	setIsShowingFilter: ( value: boolean ) => void;
-	config: false | { perPageSizes: number[] };
+	config: { perPageSizes: number[] };
 	empty?: ReactNode;
 	hasInfiniteScrollHandler: boolean;
 };

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -66,11 +66,9 @@ type DataViewsProps< Item > = {
 	header?: ReactNode;
 	getItemLevel?: ( item: Item ) => number;
 	children?: ReactNode;
-	config?:
-		| false
-		| {
-				perPageSizes: number[];
-		  };
+	config?: {
+		perPageSizes: number[];
+	};
 	empty?: ReactNode;
 } & ( Item extends ItemWithId
 	? { getItemId?: ( item: Item ) => string }
@@ -90,7 +88,7 @@ function DefaultUI( {
 	search = true,
 	searchLabel = undefined,
 }: DefaultUIProps ) {
-	const { isShowingFilter, config } = useContext( DataViewsContext );
+	const { isShowingFilter } = useContext( DataViewsContext );
 	return (
 		<>
 			<HStack
@@ -107,16 +105,14 @@ function DefaultUI( {
 					{ search && <DataViewsSearch label={ searchLabel } /> }
 					<FiltersToggle />
 				</HStack>
-				{ ( config || header ) && (
-					<HStack
-						spacing={ 1 }
-						expanded={ false }
-						style={ { flexShrink: 0 } }
-					>
-						config && <DataViewsViewConfig />
-						{ header }
-					</HStack>
-				) }
+				<HStack
+					spacing={ 1 }
+					expanded={ false }
+					style={ { flexShrink: 0 } }
+				>
+					<DataViewsViewConfig />
+					{ header }
+				</HStack>
 			</HStack>
 			{ isShowingFilter && (
 				<DataViewsFilters className="dataviews-filters__container" />
@@ -282,6 +278,7 @@ const DataViewsSubComponents = DataViews as typeof DataViews & {
 	Pagination: typeof DataViewsPagination;
 	Search: typeof DataViewsSearch;
 	ViewConfig: typeof DataviewsViewConfigDropdown;
+	Footer: typeof DataViewsFooter;
 };
 
 DataViewsSubComponents.BulkActionToolbar = BulkActionsFooter;
@@ -292,5 +289,6 @@ DataViewsSubComponents.LayoutSwitcher = ViewTypeMenu;
 DataViewsSubComponents.Pagination = DataViewsPagination;
 DataViewsSubComponents.Search = DataViewsSearch;
 DataViewsSubComponents.ViewConfig = DataviewsViewConfigDropdown;
+DataViewsSubComponents.Footer = DataViewsFooter;
 
 export default DataViewsSubComponents;

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -187,13 +187,7 @@ const MinimalUIComponent = ( {
 			defaultLayouts={ { [ layout ]: {} } }
 		>
 			<DataViews.Layout />
-			<HStack
-				expanded={ false }
-				justify="end"
-				className="dataviews-footer"
-			>
-				<DataViews.Pagination />
-			</HStack>
+			<DataViews.Footer />
 		</DataViews>
 	);
 };

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -146,7 +146,11 @@ export const CustomEmpty = () => {
 	);
 };
 
-export const MinimalUI = () => {
+const MinimalUIComponent = ( {
+	layout = 'table',
+}: {
+	layout: 'table' | 'list' | 'grid';
+} ) => {
 	const [ view, setView ] = useState< View >( {
 		...DEFAULT_VIEW,
 		fields: [ 'title', 'description', 'categories' ],
@@ -165,6 +169,13 @@ export const MinimalUI = () => {
 		filterBy: false,
 	} ) );
 
+	useEffect( () => {
+		setView( {
+			...view,
+			type: layout as any,
+		} );
+	}, [ layout ] );
+
 	return (
 		<DataViews
 			getItemId={ ( item ) => item.id.toString() }
@@ -172,14 +183,29 @@ export const MinimalUI = () => {
 			data={ shownData }
 			view={ view }
 			fields={ _fields }
-			config={ false }
-			search={ false }
 			onChangeView={ setView }
-			defaultLayouts={ {
-				table: {},
-			} }
-		/>
+			defaultLayouts={ { [ layout ]: {} } }
+		>
+			<DataViews.Layout />
+			<HStack
+				expanded={ false }
+				justify="end"
+				className="dataviews-footer"
+			>
+				<DataViews.Pagination />
+			</HStack>
+		</DataViews>
 	);
+};
+export const MinimalUI = {
+	render: MinimalUIComponent,
+	argTypes: {
+		layout: {
+			control: 'select',
+			options: [ 'table', 'list', 'grid' ],
+			defaultValue: 'table',
+		},
+	},
 };
 
 /**


### PR DESCRIPTION
## What?

Follow-up to https://github.com/WordPress/gutenberg/pull/71173/ that removes the ability to hide the config. It still leaves the `config.perPageItems` instead of having it as a top-level DataViews option.

## Why?

See [feedback](https://github.com/WordPress/gutenberg/pull/71173#issuecomment-3197465783).

## How?

- The `config` prop cannot longer be false. 
- Update the Minimal UI story to use the "free form" instead.
- Export a new `DataViews.Footer` component ([see](https://github.com/WordPress/gutenberg/pull/71173#issuecomment-3207011410)).

## Testing Instructions

Visit the storybook (`npm install && npm run storybook:dev`).

- Test that you can still modify the perPageItems values in the default story.
- Test the minimal UI.
