### PR TITLE
Fix: Add JSON_HEX_TAG flag to wp_json_encode in script tags

### DIFF
--- a/lib/compat/wordpress-6.9/customizer-preview-custom-css.php
+++ b/lib/compat/wordpress-6.9/customizer-preview-custom-css.php
@@ -49,7 +49,7 @@ function gutenberg_add_customizer_block_theme_custom_css_preview_js() {
 JS;
 	wp_add_inline_script(
 		'customize-preview',
-		sprintf( '( %s )( %s )', $js_function, wp_json_encode( $setting_id ) )
+		sprintf( '( %s )( %s )', $js_function, wp_json_encode( $setting_id, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) )
 	);
 }
 

--- a/lib/experimental/posts/load.php
+++ b/lib/experimental/posts/load.php
@@ -44,7 +44,7 @@ function gutenberg_posts_dashboard() {
 	// Preload server-registered block schemas.
 	wp_add_inline_script(
 		'wp-blocks',
-		'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings() ) . ');'
+		'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings(), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ) . ');'
 	);
 
 	/** This action is documented in wp-admin/edit-form-blocks.php */
@@ -61,7 +61,7 @@ function gutenberg_posts_dashboard() {
 			'wp.domReady( function() {
 				wp.editSite.initializePostsDashboard( "gutenberg-posts-dashboard", %s );
 			} );',
-			wp_json_encode( $editor_settings )
+			wp_json_encode( $editor_settings, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
 		)
 	);
 	wp_enqueue_script( 'wp-edit-site' );


### PR DESCRIPTION
## What?
Closes #71278 

Adds proper JSON encoding flags (`JSON_HEX_TAG | JSON_UNESCAPED_SLASHES`) to `wp_json_encode()` calls used within inline script tags to prevent potential security vulnerabilities.

## Why?
When `wp_json_encode()` is used without proper flags in script tags, JSON data containing HTML tags (like `<script>` or `</script>`) can break out of the intended script element, potentially causing:

1. **HTML structure corruption** - Script tags closing prematurely or failing to close
2. **XSS vulnerabilities** - Malicious content executing unintended JavaScript
3. **Parsing errors** - Invalid HTML document structure