### PR TITLE
GitHub Actions: Try to fix storybook smoke tests

### DIFF
--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -34,8 +34,10 @@ jobs:
             - name: Build Storybook
               run: npm run storybook:build
 
-            - name: Install Playwright dependencies
-              run: npx playwright install chromium --with-deps
+            - name: Install test-runner and Playwright dependencies
+              run: |
+                  npm install --no-save @storybook/test-runner@0.22.1
+                  npx playwright install chromium --with-deps
 
             - name: Serve Storybook and run tests
               run: |
@@ -43,6 +45,4 @@ jobs:
                   "npx http-server ./storybook/build --port 50240 --silent" \
                   "npx wait-on tcp:127.0.0.1:50240 && \
                   NODE_PATH=./node_modules \
-                  PLAYWRIGHT_BROWSERS_PATH=0 \
-                  npx --package=@storybook/test-runner@0.22.1 -- \
-                  test-storybook --url http://localhost:50240 --config-dir ./storybook"
+                  npx test-storybook --url http://localhost:50240 --config-dir ./storybook"

--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -43,5 +43,6 @@ jobs:
                   "npx http-server ./storybook/build --port 50240 --silent" \
                   "npx wait-on tcp:127.0.0.1:50240 && \
                   NODE_PATH=./node_modules \
+                  PLAYWRIGHT_BROWSERS_PATH=0 \
                   npx --package=@storybook/test-runner@0.22.1 -- \
                   test-storybook --url http://localhost:50240 --config-dir ./storybook"

--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -35,7 +35,7 @@ jobs:
               run: npm run storybook:build
 
             - name: Install Playwright dependencies
-              run: npx --no playwright install --with-deps
+              run: npx playwright install chromium --with-deps
 
             - name: Serve Storybook and run tests
               run: |

--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -44,5 +44,4 @@ jobs:
                   npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
                   "npx http-server ./storybook/build --port 50240 --silent" \
                   "npx wait-on tcp:127.0.0.1:50240 && \
-                  NODE_PATH=./node_modules \
                   npx test-storybook --url http://localhost:50240 --config-dir ./storybook"

--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -36,6 +36,7 @@ jobs:
 
             - name: Install test-runner and Playwright dependencies
               run: |
+                  # test
                   npm install --no-save @storybook/test-runner@0.22.1
                   npx playwright install chromium --with-deps
 

--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -36,7 +36,6 @@ jobs:
 
             - name: Install test-runner and Playwright dependencies
               run: |
-                  # test
                   npm install --no-save @storybook/test-runner@0.22.1
                   npx playwright install chromium --with-deps
 

--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -37,7 +37,7 @@ jobs:
             - name: Install test-runner and Playwright dependencies
               run: |
                   npm install --no-save @storybook/test-runner@0.22.1
-                  npx playwright install chromium --with-deps
+                  npx playwright install --with-deps
 
             - name: Serve Storybook and run tests
               run: |


### PR DESCRIPTION
## What?

We re-enable the storybook smoke test, but somehow, the CI started to fail again with the following error:

<details><summary>Details</summary>

```
Run npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
  npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
  "npx http-server ./storybook/build --port 50240 --silent" \
  "npx wait-on tcp:127.0.0.1:50240 && \
  NODE_PATH=./node_modules \
  npx --package=@storybook/test-runner@0.22.1 -- \
  test-storybook --url http://localhost:50240 --config-dir ./storybook"
  shell: /usr/bin/bash -e {0}
[SB] npm warn exec The following package was not found and will be installed: http-server@14.1.1
[TEST] npm warn exec The following package was not found and will be installed: @storybook/test-runner@0.22.1
[TEST] npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
[TEST] npm warn deprecated rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
[TEST] npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
[SB] (node:6758) [DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated
[SB] (Use `node --trace-deprecation ...` to show where the warning was created)
[TEST] Test Suites: 0 of 157 total
[TEST] Tests:       0 total
[TEST] Snapshots:   0 total
[TEST] Time:        0.216 s
[TEST] Ran all test suites.
[TEST] Error: Executable doesn't exist at /home/runner/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell
[TEST] ╔═════════════════════════════════════════════════════════════════════════╗
[TEST] ║ Looks like Playwright Test or Playwright was just installed or updated. ║
[TEST] ║ Please run the following command to download new browsers:              ║
[TEST] ║                                                                         ║
[TEST] ║     npx playwright install                                              ║
[TEST] ║                                                                         ║
[TEST] ║ <3 Playwright Team                                                      ║
[TEST] ╚═════════════════════════════════════════════════════════════════════════╝ Failed to launch browser.
[TEST]     at executablePathOrDie (/home/runner/.npm/_npx/8cbbe221a9f534f3/node_modules/playwright-core/lib/server/registry/index.js:517:15)
[TEST]     at Object.executablePathOrDie (/home/runner/.npm/_npx/8cbbe221a9f534f3/node_modules/playwright-core/lib/server/registry/index.js:548:45)
[TEST]     at Chromium._prepareToLaunch (/home/runner/.npm/_npx/8cbbe221a9f534f3/node_modules/playwright-core/lib/server/browserType.js:184:39)
[TEST]     at async Chromium._launchProcess (/home/runner/.npm/_npx/8cbbe221a9f534f3/node_modules/playwright-core/lib/server/browserType.js:196:22)
[TEST]     at async Chromium._innerLaunch (/home/runner/.npm/_npx/8cbbe221a9f534f3/node_modules/playwright-core/lib/server/browserType.js:112:70)
[TEST]     at async Chromium._innerLaunchWithRetries (/home/runner/.npm/_npx/8cbbe221a9f534f3/node_modules/playwright-core/lib/server/browserType.js:99:14)
[TEST]     at async /home/runner/.npm/_npx/8cbbe221a9f534f3/node_modules/playwright-core/lib/browserServerImpl.js:77:18
[TEST]     at async ProgressController.run (/home/runner/.npm/_npx/8cbbe221a9f534f3/node_modules/playwright-core/lib/server/progress.js:78:22)
[TEST]     at async BrowserServerLauncherImpl.launchServer (/home/runner/.npm/_npx/8cbbe221a9f534f3/node_modules/playwright-core/lib/browserServerImpl.js:68:17)
[TEST]     at async BrowserType.launchServer (/home/runner/.npm/_npx/8cbbe221a9f534f3/node_modules/playwright-core/lib/client/browserType.js:73:12)
[TEST] npx wait-on tcp:127.0.0.1:50240 && NODE_PATH=./node_modules npx --package=@storybook/test-runner@0.22.1 -- test-storybook --url http://localhost:50240 --config-dir ./storybook exited with code 1
--> Sending SIGTERM to other processes..
[SB] npx http-server ./storybook/build --port 50240 --silent exited with code null
Error: Process completed with exit code 1.
```

</details> 

> CI example: https://github.com/WordPress/gutenberg/actions/runs/17112981527/job/48538253515
> Actions: https://github.com/WordPress/gutenberg/actions/workflows/storybook-check.yml

The CI failures started around the same time as the [new Playwright v1.55.0](https://github.com/microsoft/playwright/releases/tag/v1.55.0) was released, so I'm sure that the Playwright update is affecting us.


## Why? How?

I believe we pinned all libraries to local versions with this PR, but maybe I missed something. Updating the Playwright version may solve the problem, but it won't be a fundamental solution.

~I'm testing what happens if we explicitly install Chromium: https://github.com/WordPress/gutenberg/pull/71284~

As [this comment says](https://github.com/WordPress/gutenberg/pull/71284#issuecomment-3209168530), the underlying problem may be that the Playwright version, and therefore the Chromium version, is different.

Installing the test runner first seems to resolve the Chromium version differences.

**Note:** In the trunk branch, the Playwright version has been updated to 1.55, so this issue does not occur (See: https://github.com/WordPress/gutenberg/pull/71285). The purpose of this PR is to attempt to fix the fundamental problem, and the Playwright version in this PR is still 1.54.2.