### PR TITLE
Upgrade Playwright to v1.55

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"@octokit/rest": "16.26.0",
 				"@octokit/types": "6.34.0",
 				"@octokit/webhooks-types": "5.8.0",
-				"@playwright/test": "1.54.2",
+				"@playwright/test": "1.55.0",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@react-native/babel-preset": "0.73.10",
 				"@react-native/metro-babel-transformer": "0.73.10",
@@ -8750,13 +8750,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.54.2",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
-			"integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+			"version": "1.55.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+			"integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.54.2"
+				"playwright": "1.55.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -38019,13 +38019,13 @@
 			"dev": true
 		},
 		"node_modules/playwright": {
-			"version": "1.54.2",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
-			"integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+			"version": "1.55.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+			"integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.54.2"
+				"playwright-core": "1.55.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -38038,9 +38038,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.54.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
-			"integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+			"version": "1.55.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+			"integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -52071,7 +52071,7 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.54.2",
+				"@playwright/test": "^1.55.0",
 				"@wordpress/env": "^10.0.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.8.0",
-		"@playwright/test": "1.54.2",
+		"@playwright/test": "1.55.0",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@react-native/babel-preset": "0.73.10",
 		"@react-native/metro-babel-transformer": "0.73.10",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -95,7 +95,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"peerDependencies": {
-		"@playwright/test": "^1.54.2",
+		"@playwright/test": "^1.55.0",
 		"@wordpress/env": "^10.0.0",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -152,6 +152,7 @@ test.describe( 'Pattern Overrides', () => {
 			} );
 			const paragraphs = patternBlocks.first().getByRole( 'document', {
 				name: 'Block: Paragraph',
+				includeHidden: true,
 			} );
 			// Ensure the first pattern is selected.
 			await patternBlocks.first().selectText();
@@ -278,9 +279,11 @@ test.describe( 'Pattern Overrides', () => {
 			} );
 			const patternBlock = editor.canvas.getByRole( 'document', {
 				name: 'Block: Pattern',
+				includeHidden: true,
 			} );
 			const paragraphs = editor.canvas.getByRole( 'document', {
 				name: 'Block: Paragraph',
+				includeHidden: true,
 			} );
 			const blockWithOverrides = paragraphs.filter( {
 				hasText: 'Pattern Overrides',
@@ -541,6 +544,7 @@ test.describe( 'Pattern Overrides', () => {
 			} );
 			const paragraphBlock = editor.canvas.getByRole( 'document', {
 				name: 'Block: Paragraph',
+				includeHidden: true,
 			} );
 			await expect( headingBlock ).toHaveText( 'Outer heading (edited)' );
 			await expect( headingBlock ).not.toHaveAttribute( 'inert', 'true' );
@@ -821,6 +825,7 @@ test.describe( 'Pattern Overrides', () => {
 		} );
 		const headingBlock = patternBlock.getByRole( 'document', {
 			name: 'Block: Heading',
+			includeHidden: true,
 		} );
 		const paragraphBlock = patternBlock.getByRole( 'document', {
 			name: 'Block: Paragraph',
@@ -905,6 +910,7 @@ test.describe( 'Pattern Overrides', () => {
 		} );
 		const paragraphBlock = patternBlock.getByRole( 'document', {
 			name: 'Block: Paragraph',
+			includeHidden: true,
 		} );
 		const resetButton = page
 			.getByRole( 'toolbar', { name: 'Block tools' } )
@@ -969,6 +975,7 @@ test.describe( 'Pattern Overrides', () => {
 
 		const imageBlock = editor.canvas.getByRole( 'document', {
 			name: 'Block: Image',
+			includeHidden: true,
 		} );
 		await editor.selectBlocks( imageBlock );
 		await imageBlock

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -581,7 +581,10 @@ test.describe( 'Synced pattern', () => {
 
 		await expect(
 			editor.canvas
-				.getByRole( 'document', { name: 'Block: Paragraph' } )
+				.getByRole( 'document', {
+					name: 'Block: Paragraph',
+					includeHidden: true,
+				} )
 				.filter( { hasText: 'Awesome Paragraph modified' } )
 		).toHaveCount( 2 );
 	} );


### PR DESCRIPTION
## What?
Upgrade Playwright to v1.55.

## What's new?
* https://playwright.dev/docs/release-notes#version-155

## Testing Instructions
* Run any e2e test locally; the command should download new browsers and run the test successfully.
* CI checks are green.
