### PR TITLE
[DO NOT MERGE] Hack in a media view within the site editor to see what the limitations of DataViews might be for dealing with media

### DIFF
--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -188,7 +188,7 @@ function useView( postType ) {
 	return [ view, setViewWithUrlUpdate ];
 }
 
-const DEFAULT_STATUSES = 'draft,future,pending,private,publish'; // All but 'trash'.
+export const DEFAULT_STATUSES = 'draft,future,pending,private,publish'; // All but 'trash'.
 
 function getItemId( item ) {
 	return item.id.toString();
@@ -253,7 +253,7 @@ export default function PostList( { postType } ) {
 		// We want to provide a different default item for the status filter
 		// than the REST API provides.
 		if ( ! filters.status || filters.status === '' ) {
-			filters.status = DEFAULT_STATUSES;
+			// filters.status = DEFAULT_STATUSES;
 		}
 
 		return {

--- a/packages/edit-site/src/components/site-editor-routes/index.js
+++ b/packages/edit-site/src/components/site-editor-routes/index.js
@@ -22,6 +22,7 @@ import { pagesRoute } from './pages';
 import { pageItemRoute } from './page-item';
 import { stylebookRoute } from './stylebook';
 import { notFoundRoute } from './notfound';
+import { mediaRoute } from './media';
 
 const routes = [
 	pageItemRoute,
@@ -37,6 +38,7 @@ const routes = [
 	homeRoute,
 	stylebookRoute,
 	notFoundRoute,
+	mediaRoute,
 ];
 
 export function useRegisterSiteEditorRoutes() {

--- a/packages/edit-site/src/components/site-editor-routes/media.js
+++ b/packages/edit-site/src/components/site-editor-routes/media.js
@@ -1,0 +1,90 @@
+/**
+ * WordPress dependencies
+ */
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import SidebarNavigationScreen from '../sidebar-navigation-screen';
+import DataViewsSidebarContent from '../sidebar-dataviews';
+import SidebarNavigationScreenUnsupported from '../sidebar-navigation-screen-unsupported';
+import PostList from '../post-list';
+import Editor from '../editor';
+import { PostEdit } from '../post-edit';
+
+const { useLocation } = unlock( routerPrivateApis );
+
+function MobilePagesView() {
+	const { query = {} } = useLocation();
+	const { canvas = 'view' } = query;
+
+	return canvas === 'edit' ? <Editor /> : <PostList postType="attachment" />;
+}
+
+export const mediaRoute = {
+	name: 'media',
+	path: '/media',
+	areas: {
+		sidebar( { siteData } ) {
+			const isBlockTheme = siteData.currentTheme?.is_block_theme;
+			return isBlockTheme ? (
+				<SidebarNavigationScreen
+					title={ __( 'Media' ) }
+					backPath="/"
+					content={
+						<DataViewsSidebarContent postType="attachment" />
+					}
+				/>
+			) : (
+				<SidebarNavigationScreenUnsupported />
+			);
+		},
+		content( { siteData } ) {
+			const isBlockTheme = siteData.currentTheme?.is_block_theme;
+			return isBlockTheme ? (
+				<PostList postType="attachment" />
+			) : undefined;
+		},
+		preview( { query, siteData } ) {
+			const isBlockTheme = siteData.currentTheme?.is_block_theme;
+			if ( ! isBlockTheme ) {
+				return undefined;
+			}
+			const isListView =
+				( query.layout === 'list' || ! query.layout ) &&
+				query.isCustom !== 'true';
+			return isListView ? <Editor /> : undefined;
+		},
+		mobile( { siteData } ) {
+			const isBlockTheme = siteData.currentTheme?.is_block_theme;
+			return isBlockTheme ? (
+				<MobilePagesView />
+			) : (
+				<SidebarNavigationScreenUnsupported />
+			);
+		},
+		edit( { query } ) {
+			const hasQuickEdit =
+				( query.layout ?? 'list' ) !== 'list' && !! query.quickEdit;
+			return hasQuickEdit ? (
+				<PostEdit postType="attachment" postId={ query.postId } />
+			) : undefined;
+		},
+	},
+	widths: {
+		content( { query } ) {
+			const isListView =
+				( query.layout === 'list' || ! query.layout ) &&
+				query.isCustom !== 'true';
+			return isListView ? 380 : undefined;
+		},
+		edit( { query } ) {
+			const hasQuickEdit =
+				( query.layout ?? 'list' ) !== 'list' && !! query.quickEdit;
+			return hasQuickEdit ? 380 : undefined;
+		},
+	},
+};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Related to https://github.com/WordPress/gutenberg/issues/55238

⚠️ NOTE: This is ***not*** a prototype of a new media library, it's simply a test of DataViews to see what the limitations might be for dealing with media / attachments ⚠️ 

However, hopefully we might discover a few things along the way that might help with a new media library.

---

## Testing

With this PR applied, you should be able to navigate to `http://localhost:8888/wp-admin/site-editor.php?p=%2Fmedia&layout=table` and see a list of media items rendered in DataViews. It's very much hacked in there, but I was curious to see if it works:

<img width="1273" height="799" alt="image" src="https://github.com/user-attachments/assets/8b8196aa-4f67-480c-84dd-4366d050cfe7" />

From first glance, this seems to expose that at least a couple of the default post actions appear for `attachment` post types that probably shouldn't:

* `Duplicate` and
* `Move to trash` (for media items this should probably just be permanently delete since I don't think they really support trashing properly)

<img width="467" height="347" alt="image" src="https://github.com/user-attachments/assets/d4a70964-c611-486b-af70-8a39771d5fec" />
