### PR TITLE
[WIP] DataViews: Try out a previewOnly toggle that only applies in Grid layouts

### DIFF
--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -48,6 +48,7 @@ import { VIEW_LAYOUTS } from '../../dataviews-layouts';
 import type { NormalizedField, View } from '../../types';
 import DataViewsContext from '../dataviews-context';
 import InfiniteScrollToggle from './infinite-scroll-toggle';
+import PreviewOnlyToggle from './preview-only-toggle';
 import { unlock } from '../../lock-unlock';
 
 const { Menu } = unlock( componentsPrivateApis );
@@ -810,6 +811,7 @@ export function DataviewsViewConfigDropdown() {
 							) }
 							<InfiniteScrollToggle />
 							<ItemsPerPageControl />
+							<PreviewOnlyToggle />
 						</SettingsSection>
 						<SettingsSection title={ __( 'Properties' ) }>
 							<FieldControl />

--- a/packages/dataviews/src/components/dataviews-view-config/preview-only-toggle.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/preview-only-toggle.tsx
@@ -1,0 +1,37 @@
+/**
+ * WordPress dependencies
+ */
+import { ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import DataViewsContext from '../dataviews-context';
+
+export default function PreviewOnlyToggle() {
+	const context = useContext( DataViewsContext );
+	const { view, onChangeView } = context;
+	const previewOnlyEnabled = view.previewOnlyEnabled ?? false;
+
+	// Preview Only mode is only available in the grid layout.
+	if ( view.type !== 'grid' ) {
+		return null;
+	}
+
+	return (
+		<ToggleControl
+			__nextHasNoMarginBottom
+			label={ __( 'Preview only' ) }
+			help={ __( 'Hide all properties except for the preview.' ) }
+			checked={ previewOnlyEnabled }
+			onChange={ ( newValue ) => {
+				onChangeView( {
+					...view,
+					previewOnlyEnabled: newValue,
+				} );
+			} }
+		/>
+	);
+}

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -92,6 +92,7 @@ function GridItem< Item >( {
 		showMedia = true,
 		showDescription = true,
 		infiniteScrollEnabled,
+		previewOnlyEnabled,
 	} = view;
 	const hasBulkAction = useHasAPossibleBulkAction( actions, item );
 	const id = getItemId( item );
@@ -105,7 +106,7 @@ function GridItem< Item >( {
 		/>
 	) : null;
 	const renderedTitleField =
-		showTitle && titleField?.render ? (
+		! previewOnlyEnabled && showTitle && titleField?.render ? (
 			<titleField.render item={ item } field={ titleField } />
 		) : null;
 
@@ -176,92 +177,102 @@ function GridItem< Item >( {
 					disabled={ ! hasBulkAction }
 				/>
 			) }
-			<HStack
-				justify="space-between"
-				className="dataviews-view-grid__title-actions"
-			>
-				<ItemClickWrapper
-					item={ item }
-					isItemClickable={ isItemClickable }
-					onClickItem={ onClickItem }
-					renderItemLink={ renderItemLink }
-					className="dataviews-view-grid__title-field dataviews-title-field"
-					{ ...titleA11yProps }
-				>
-					{ renderedTitleField }
-				</ItemClickWrapper>
-				{ !! actions?.length && (
-					<ItemActions item={ item } actions={ actions } isCompact />
-				) }
-			</HStack>
-			<VStack spacing={ 1 }>
-				{ showDescription && descriptionField?.render && (
-					<descriptionField.render
-						item={ item }
-						field={ descriptionField }
-					/>
-				) }
-				{ !! badgeFields?.length && (
+			{ ! previewOnlyEnabled && (
+				<>
 					<HStack
-						className="dataviews-view-grid__badge-fields"
-						spacing={ 2 }
-						wrap
-						alignment="top"
-						justify="flex-start"
+						justify="space-between"
+						className="dataviews-view-grid__title-actions"
 					>
-						{ badgeFields.map( ( field ) => {
-							return (
-								<Badge
-									key={ field.id }
-									className="dataviews-view-grid__field-value"
-								>
-									<field.render
-										item={ item }
-										field={ field }
-									/>
-								</Badge>
-							);
-						} ) }
+						<ItemClickWrapper
+							item={ item }
+							isItemClickable={ isItemClickable }
+							onClickItem={ onClickItem }
+							renderItemLink={ renderItemLink }
+							className="dataviews-view-grid__title-field dataviews-title-field"
+							{ ...titleA11yProps }
+						>
+							{ renderedTitleField }
+						</ItemClickWrapper>
+						{ !! actions?.length && (
+							<ItemActions
+								item={ item }
+								actions={ actions }
+								isCompact
+							/>
+						) }
 					</HStack>
-				) }
-				{ !! regularFields?.length && (
-					<VStack
-						className="dataviews-view-grid__fields"
-						spacing={ 1 }
-					>
-						{ regularFields.map( ( field ) => {
-							return (
-								<Flex
-									className="dataviews-view-grid__field"
-									key={ field.id }
-									gap={ 1 }
-									justify="flex-start"
-									expanded
-									style={ { height: 'auto' } }
-									direction="row"
-								>
-									<>
-										<Tooltip text={ field.label }>
-											<FlexItem className="dataviews-view-grid__field-name">
-												{ field.header }
-											</FlexItem>
-										</Tooltip>
-										<FlexItem
+					<VStack spacing={ 1 }>
+						{ showDescription && descriptionField?.render && (
+							<descriptionField.render
+								item={ item }
+								field={ descriptionField }
+							/>
+						) }
+						{ !! badgeFields?.length && (
+							<HStack
+								className="dataviews-view-grid__badge-fields"
+								spacing={ 2 }
+								wrap
+								alignment="top"
+								justify="flex-start"
+							>
+								{ badgeFields.map( ( field ) => {
+									return (
+										<Badge
+											key={ field.id }
 											className="dataviews-view-grid__field-value"
-											style={ { maxHeight: 'none' } }
 										>
 											<field.render
 												item={ item }
 												field={ field }
 											/>
-										</FlexItem>
-									</>
-								</Flex>
-							);
-						} ) }
+										</Badge>
+									);
+								} ) }
+							</HStack>
+						) }
+						{ !! regularFields?.length && (
+							<VStack
+								className="dataviews-view-grid__fields"
+								spacing={ 1 }
+							>
+								{ regularFields.map( ( field ) => {
+									return (
+										<Flex
+											className="dataviews-view-grid__field"
+											key={ field.id }
+											gap={ 1 }
+											justify="flex-start"
+											expanded
+											style={ { height: 'auto' } }
+											direction="row"
+										>
+											<>
+												<Tooltip text={ field.label }>
+													<FlexItem className="dataviews-view-grid__field-name">
+														{ field.header }
+													</FlexItem>
+												</Tooltip>
+												<FlexItem
+													className="dataviews-view-grid__field-value"
+													style={ {
+														maxHeight: 'none',
+													} }
+												>
+													<field.render
+														item={ item }
+														field={ field }
+													/>
+												</FlexItem>
+											</>
+										</Flex>
+									);
+								} ) }
+							</VStack>
+						) }
 					</VStack>
-				) }
-			</VStack>
+				</>
+			) }
 		</VStack>
 	);
 }

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -448,6 +448,11 @@ interface ViewBase {
 	 * Whether infinite scroll is enabled.
 	 */
 	infiniteScrollEnabled?: boolean;
+
+	/**
+	 * Whether preview only mode is enabled.
+	 */
+	previewOnlyEnabled?: boolean;
 }
 
 export interface ColumnStyle {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

🚧 WIP: Not quite ready for review, but it gets part of the way there 🚧 

Closes #71078

Try adding a preview only toggle to the Grid layout of DataViews that conditionally hides all fields and just shows the media preview.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As a way to support title-less DataViews for a grid of items that just showcases how those items look without any extraneous details. What's described in #71078.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR tries out achieving this with a `previewOnly` toggle that conditionally switches off all fields including the title.

## To-do

* [ ] In preview only mode: still display the actions, but available on hover, similar to how the checkbox for selection works
* [ ] Ensure that the title is displayed in an accessibility friendly way for screen readers
* [ ] Make sure that the preview is always displayed when previewOnly is set
* [ ] Hide the 'Properties' section in the DataView options dialog when previewOnly is set

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

TBC, but for now, you can run `npm run storybook:dev` and go to the DataViews story, switch to Grid layout and toggle the controls

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/2b6bc46b-3432-4608-9c57-387acead080c
