### PR TITLE
Allow block attributes strings to terminate in \ character

### DIFF
--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -300,7 +300,7 @@ export function serializeAttributes( attributes ) {
 			//   - "\\\"" -> "\\\u0022"
 			//
 			// See: https://developer.wordpress.org/reference/functions/wp_kses_stripslashes/
-			.replace( /((?<!\\)(?:\\\\)*)\\"/g, '$1\\u0022' )
+			.replace( /(?<!\\)(\\\\)*\\"/g, '$1\\u0022' )
 	);
 }
 

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -292,8 +292,15 @@ export function serializeAttributes( attributes ) {
 			// Bypass server stripslashes behavior which would unescape stringify's
 			// escaping of quotation mark.
 			//
+			// Replace the escaped quotes '\"' with hex escape '\u0022' to avoid.
+			// Do not replace quotes that are not escaped but are preceded by a backslash,
+			// for example:
+			//   - "\"" -> "\u0022"
+			//   - "\\" -> "\\"
+			//   - "\\\"" -> "\\\u0022"
+			//
 			// See: https://developer.wordpress.org/reference/functions/wp_kses_stripslashes/
-			.replace( /\\"/g, '\\u0022' )
+			.replace( /((?<!\\)(?:\\\\)*)\\"/g, '$1\\u0022' )
 	);
 }
 

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -282,29 +282,19 @@ export function serializeAttributes( attributes ) {
 	return (
 		JSON.stringify( attributes )
 			// Don't break HTML comments.
-			.replace( /--/g, '\\u002d\\u002d' )
+			.replaceAll( '--', '\\u002d\\u002d' )
 
 			// Don't break non-standard-compliant tools.
-			.replace( /</g, '\\u003c' )
-			.replace( />/g, '\\u003e' )
-			.replace( /&/g, '\\u0026' )
+			.replaceAll( '<', '\\u003c' )
+			.replaceAll( '>', '\\u003e' )
+			.replaceAll( '&', '\\u0026' )
 
-			/*
-			 * Replace escaped quotes '\"' with hex escape '\u0022' to prevent
-			 * `wp_kses_stripslashes()` from potentially mangling the content.
-			 *
-			 * This replacement is applied to stringified JSON. `\"` replacement must
-			 * only happen inside string values, `"` may be part of the JSON syntax.
-			 * Notably, `"\\"` contains `\"` that must _not_ be replaced. It is a string
-			 * that contains single character `\`.
-			 *
-			 *   - "\"" -> "\u0022"
-			 *   - "\\" -> "\\"
-			 *   - "\\\"" -> "\\\u0022"
-			 *
-			 * See https://developer.wordpress.org/reference/functions/wp_kses_stripslashes/
-			 */
-			.replace( /(?<!\\)(\\\\)*\\"/g, '$1\\u0022' )
+			// Replace escaped `\` characters with the unicode escape sequence.
+			.replaceAll( '\\\\', '\\u005c' )
+			// Replace escaped quotes (`\"`) to prevent problems with wp_kses_stripsplashes.
+			// This simple replacement is safe because `\\` has already been replaced.
+			// `\"` is not a JSON string quote like `"\\"`.
+			.replaceAll( '\\"', '\\u0022' )
 	);
 }
 

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -289,17 +289,21 @@ export function serializeAttributes( attributes ) {
 			.replace( />/g, '\\u003e' )
 			.replace( /&/g, '\\u0026' )
 
-			// Bypass server stripslashes behavior which would unescape stringify's
-			// escaping of quotation mark.
-			//
-			// Replace the escaped quotes '\"' with hex escape '\u0022' to avoid.
-			// Do not replace quotes that are not escaped but are preceded by a backslash,
-			// for example:
-			//   - "\"" -> "\u0022"
-			//   - "\\" -> "\\"
-			//   - "\\\"" -> "\\\u0022"
-			//
-			// See: https://developer.wordpress.org/reference/functions/wp_kses_stripslashes/
+			/*
+			 * Replace escaped quotes '\"' with hex escape '\u0022' to prevent
+			 * `wp_kses_stripslashes()` from potentially mangling the content.
+			 *
+			 * This replacement is applied to stringified JSON. `\"` replacement must
+			 * only happen inside string values, `"` may be part of the JSON syntax.
+			 * Notably, `"\\"` contains `\"` that must _not_ be replaced. It is a string
+			 * that contains single character `\`.
+			 *
+			 *   - "\"" -> "\u0022"
+			 *   - "\\" -> "\\"
+			 *   - "\\\"" -> "\\\u0022"
+			 *
+			 * See https://developer.wordpress.org/reference/functions/wp_kses_stripslashes/
+			 */
 			.replace( /(?<!\\)(\\\\)*\\"/g, '$1\\u0022' )
 	);
 }

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -281,6 +281,9 @@ export function getCommentAttributes( blockType, attributes ) {
 export function serializeAttributes( attributes ) {
 	return (
 		JSON.stringify( attributes )
+			// Replace escaped `\` characters with the unicode escape sequence.
+			.replaceAll( '\\\\', '\\u005c' )
+
 			// Don't break HTML comments.
 			.replaceAll( '--', '\\u002d\\u002d' )
 
@@ -289,8 +292,6 @@ export function serializeAttributes( attributes ) {
 			.replaceAll( '>', '\\u003e' )
 			.replaceAll( '&', '\\u0026' )
 
-			// Replace escaped `\` characters with the unicode escape sequence.
-			.replaceAll( '\\\\', '\\u005c' )
 			// Replace escaped quotes (`\"`) to prevent problems with wp_kses_stripsplashes.
 			// This simple replacement is safe because `\\` has already been replaced.
 			// `\"` is not a JSON string quote like `"\\"`.

--- a/packages/blocks/src/api/test/serializer.js
+++ b/packages/blocks/src/api/test/serializer.js
@@ -206,10 +206,14 @@ describe( 'block serializer', () => {
 		} );
 
 		it( 'should handle backslash and quote combinations', () => {
-			const orig = { bs: '\\', bsQuote: '\\"', bsQuoteBs: '\\"\\' };
+			const orig = {
+				bs: '\\',
+				bsQuote: '\\"',
+				bsQuoteBs: '\\"\\',
+			};
 			expect( JSON.parse( serializeAttributes( orig ) ) ).toEqual( orig );
 			expect( serializeAttributes( orig ) ).toBe(
-				'{"bs":"\\\\","bsQuote":"\\\\\\u0022","bsQuoteBs":"\\\\\\u0022\\\\"}'
+				'{"bs":"\\u005c","bsQuote":"\\u005c\\u0022","bsQuoteBs":"\\u005c\\u0022\\u005c"}'
 			);
 		} );
 	} );

--- a/packages/blocks/src/api/test/serializer.js
+++ b/packages/blocks/src/api/test/serializer.js
@@ -204,6 +204,14 @@ describe( 'block serializer', () => {
 				'{"a":"\\u0022 and \\u0022"}'
 			);
 		} );
+
+		it( 'should handle backslash and quote combinations', () => {
+			const orig = { bs: '\\', bsQuote: '\\"', bsQuoteBs: '\\"\\' };
+			expect( JSON.parse( serializeAttributes( orig ) ) ).toEqual( orig );
+			expect( serializeAttributes( orig ) ).toBe(
+				'{"bs":"\\\\","bsQuote":"\\\\\\u0022","bsQuoteBs":"\\\\\\u0022\\\\"}'
+			);
+		} );
 	} );
 
 	describe( 'getCommentDelimitedContent()', () => {


### PR DESCRIPTION
## What?

The JSON encoding with additional transformations causes some block attributes to be mis-encoded, resulting in invalid JSON and eliminating all the block attributes.

This is a partial fix, it also requires a fix to the core block serializer proposed in https://github.com/WordPress/wordpress-develop/pull/9558. On its own, this fix prevents JSON from being mis-encoded on the client. However, the server continues to mis-encode JSON and lose the block attributes.

Coordinating the fixes correctly is a difficult challenge, however I think the fixes can be landed independently because if the issue persists in either the client or the server (Gutenberg or Core), the JSON will be mis-encoded and attributes stripped.

Block attribute string values (or keys, but this is much less common) that end in `\` cause the transform to incorrectly replace a JSON string closing `"` with `\u0022`, breaking the JSON:

```json
{
  "desired": "\\",
  "actual": "\\u0022
}
```

Fixes https://github.com/WordPress/gutenberg/issues/16508.

Requires https://github.com/WordPress/wordpress-develop/pull/9558 [(Trac ticket 63917)](https://core.trac.wordpress.org/ticket/63917)

## Why?

`\` is valid string contents and should be allowed.

## How?

Change the block attribute encoding to first replace escaped `\` characters with its unicode escape sequence, then perform subsequent replacements. This ensures that `"` after and escaped `\` character will not be incorrectly replaced. Additionally, this should make the JSON safe from `wp_kses_stripslashes()` because the problematic sequence `\"` should never appear in the JSON.

~Change the escaping regular expression to ensure that the escaped `"` character (`\"`) is not a false escape that is actually preceded by an escaped `\` character like `\\"`.~

## Testing Instructions

Create a new post at `/wp-admin/post-new.php`.
Add a "More" block (`/more`).
Replace the default text with the backslash character: `\`.

Save. Before this patch block would have invalid attributes. Checking the code editor reveals this:

```html
<!-- wp:more {"customText":"\\u0022} -->
<!--more \-->
<!-- /wp:more -->
```

With this patch, the block attributes are encoded as valid JSON and the `\` custom text is preserved in the block.