### PR TITLE
Image block: Remove unused code

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -99,7 +99,6 @@ export function ImageEdit( {
 } ) {
 	const {
 		url = '',
-		alt,
 		caption,
 		id,
 		width,
@@ -126,11 +125,6 @@ export function ImageEdit( {
 		useResizeObserver();
 
 	const isSmallContainer = placeholderWidth && placeholderWidth < 160;
-
-	const altRef = useRef();
-	useEffect( () => {
-		altRef.current = alt;
-	}, [ alt ] );
 
 	const captionRef = useRef();
 	useEffect( () => {


### PR DESCRIPTION
## What?
PR removes unused logic for tracking the latest alt text for an image.

> [!NOTE]
> The logic for caption remains, but it has its issues (#42834). Once there's a resolution for that issue, we should consider applying the same for the alt text.

## Why?
Initially introduced in #24471, to avoid content loss after the image finishes uploading on slow networks, where the user has time to edit the alt text. Became obsolete after #30114.

## Testing Instructions
* Smoke test image replacements.
* CI checks are passing.
