### PR TITLE
Fix failing command center e2e tests

### DIFF
--- a/test/e2e/specs/site-editor/command-center.spec.js
+++ b/test/e2e/specs/site-editor/command-center.spec.js
@@ -25,8 +25,7 @@ test.describe( 'Site editor command palette', () => {
 	} ) => {
 		await page
 			.getByRole( 'button', { name: 'Open command palette' } )
-			.focus();
-		await page.keyboard.press( 'Meta+k' );
+			.click();
 		await page
 			.getByRole( 'combobox', { name: 'Search commands and settings' } )
 			.fill( 'new' );
@@ -46,8 +45,7 @@ test.describe( 'Site editor command palette', () => {
 	} ) => {
 		await page
 			.getByRole( 'button', { name: 'Open command palette' } )
-			.focus();
-		await page.keyboard.press( 'Meta+k' );
+			.click();
 		await page
 			.getByRole( 'combobox', { name: 'Search commands and settings' } )
 			.fill( 'create' );
@@ -67,8 +65,7 @@ test.describe( 'Site editor command palette', () => {
 	} ) => {
 		await page
 			.getByRole( 'button', { name: 'Open command palette' } )
-			.focus();
-		await page.keyboard.press( 'Meta+k' );
+			.click();
 		await page
 			.getByRole( 'combobox', { name: 'Search commands and settings' } )
 			.fill( 'create' );

--- a/test/e2e/specs/site-editor/command-center.spec.js
+++ b/test/e2e/specs/site-editor/command-center.spec.js
@@ -27,7 +27,7 @@ test.describe( 'Site editor command palette', () => {
 			.getByRole( 'button', { name: 'Open command palette' } )
 			.focus();
 		await page.keyboard.press( 'Meta+k' );
-		await page.keyboard.type( 'new page' );
+		await page.keyboard.type( 'new' );
 		await page.getByRole( 'option', { name: 'Add Page' } ).click();
 		await expect( page ).toHaveURL(
 			/\/wp-admin\/site-editor.php\?p=%2Fpage%2F(\d+)&canvas=edit/
@@ -46,8 +46,8 @@ test.describe( 'Site editor command palette', () => {
 			.getByRole( 'button', { name: 'Open command palette' } )
 			.focus();
 		await page.keyboard.press( 'Meta+k' );
-		await page.keyboard.type( 'create page' );
-		await page.getByRole( 'option', { name: 'Add new page' } ).click();
+		await page.keyboard.type( 'create' );
+		await page.getByRole( 'option', { name: 'Add Page' } ).click();
 		await expect( page ).toHaveURL(
 			/\/wp-admin\/site-editor.php\?p=%2Fpage%2F(\d+)&canvas=edit/
 		);
@@ -65,8 +65,8 @@ test.describe( 'Site editor command palette', () => {
 			.getByRole( 'button', { name: 'Open command palette' } )
 			.focus();
 		await page.keyboard.press( 'Meta+k' );
-		await page.keyboard.type( 'create post' );
-		await page.getByRole( 'option', { name: 'Add new post' } ).click();
+		await page.keyboard.type( 'create' );
+		await page.getByRole( 'option', { name: 'Add Post' } ).click();
 		await expect( page ).toHaveURL( /\/wp-admin\/post-new\.php/ );
 	} );
 

--- a/test/e2e/specs/site-editor/command-center.spec.js
+++ b/test/e2e/specs/site-editor/command-center.spec.js
@@ -27,7 +27,9 @@ test.describe( 'Site editor command palette', () => {
 			.getByRole( 'button', { name: 'Open command palette' } )
 			.focus();
 		await page.keyboard.press( 'Meta+k' );
-		await page.keyboard.type( 'new' );
+		await page
+			.getByRole( 'combobox', { name: 'Search commands and settings' } )
+			.fill( 'new' );
 		await page.getByRole( 'option', { name: 'Add Page' } ).click();
 		await expect( page ).toHaveURL(
 			/\/wp-admin\/site-editor.php\?p=%2Fpage%2F(\d+)&canvas=edit/
@@ -46,7 +48,9 @@ test.describe( 'Site editor command palette', () => {
 			.getByRole( 'button', { name: 'Open command palette' } )
 			.focus();
 		await page.keyboard.press( 'Meta+k' );
-		await page.keyboard.type( 'create' );
+		await page
+			.getByRole( 'combobox', { name: 'Search commands and settings' } )
+			.fill( 'create' );
 		await page.getByRole( 'option', { name: 'Add Page' } ).click();
 		await expect( page ).toHaveURL(
 			/\/wp-admin\/site-editor.php\?p=%2Fpage%2F(\d+)&canvas=edit/
@@ -65,7 +69,9 @@ test.describe( 'Site editor command palette', () => {
 			.getByRole( 'button', { name: 'Open command palette' } )
 			.focus();
 		await page.keyboard.press( 'Meta+k' );
-		await page.keyboard.type( 'create' );
+		await page
+			.getByRole( 'combobox', { name: 'Search commands and settings' } )
+			.fill( 'create' );
 		await page.getByRole( 'option', { name: 'Add Post' } ).click();
 		await expect( page ).toHaveURL( /\/wp-admin\/post-new\.php/ );
 	} );


### PR DESCRIPTION
## What?
This is a follow-up to #70624.

PR fixes failing `command-center.spec.js` end-to-end tests. The branch was out of date and didn't include changes to "Add New" strings.

## Why?

## Testing Instructions
CI checks should be green