### PR TITLE
Remove all legacy browser support code from useFocusOutside hook

### DIFF
--- a/packages/compose/src/hooks/use-focus-outside/index.ts
+++ b/packages/compose/src/hooks/use-focus-outside/index.ts
@@ -87,11 +87,6 @@ export default function useFocusOutside(
 		clearTimeout( blurCheckTimeoutIdRef.current );
 	}, [] );
 
-	// Cancel blur checks on unmount.
-	useEffect( () => {
-		return () => cancelBlurCheck();
-	}, [] );
-
 	// Cancel a blur check if the callback or ref is no longer provided.
 	useEffect( () => {
 		if ( ! onFocusOutside ) {

--- a/packages/compose/src/hooks/use-focus-outside/index.ts
+++ b/packages/compose/src/hooks/use-focus-outside/index.ts
@@ -3,58 +3,8 @@
  */
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 
-/**
- * Input types which are classified as button types, for use in considering
- * whether element is a (focus-normalized) button.
- */
-const INPUT_BUTTON_TYPES = [ 'button', 'submit' ];
-
-/**
- * List of HTML button elements subject to focus normalization
- *
- * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
- */
-type FocusNormalizedButton =
-	| HTMLButtonElement
-	| HTMLLinkElement
-	| HTMLInputElement;
-
-/**
- * Returns true if the given element is a button element subject to focus
- * normalization, or false otherwise.
- *
- * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
- *
- * @param eventTarget The target from a mouse or touch event.
- *
- * @return Whether the element is a button element subject to focus normalization.
- */
-function isFocusNormalizedButton(
-	eventTarget: EventTarget
-): eventTarget is FocusNormalizedButton {
-	if ( ! ( eventTarget instanceof window.HTMLElement ) ) {
-		return false;
-	}
-	switch ( eventTarget.nodeName ) {
-		case 'A':
-		case 'BUTTON':
-			return true;
-
-		case 'INPUT':
-			return INPUT_BUTTON_TYPES.includes(
-				( eventTarget as HTMLInputElement ).type
-			);
-	}
-
-	return false;
-}
-
 type UseFocusOutsideReturn = {
 	onFocus: React.FocusEventHandler;
-	onMouseDown: React.MouseEventHandler;
-	onMouseUp: React.MouseEventHandler;
-	onTouchStart: React.TouchEventHandler;
-	onTouchEnd: React.TouchEventHandler;
 	onBlur: React.FocusEventHandler;
 };
 
@@ -76,8 +26,6 @@ export default function useFocusOutside(
 		currentOnFocusOutsideRef.current = onFocusOutside;
 	}, [ onFocusOutside ] );
 
-	const preventBlurCheckRef = useRef( false );
-
 	const blurCheckTimeoutIdRef = useRef< number | undefined >();
 
 	/**
@@ -85,36 +33,6 @@ export default function useFocusOutside(
 	 */
 	const cancelBlurCheck = useCallback( () => {
 		clearTimeout( blurCheckTimeoutIdRef.current );
-	}, [] );
-
-	// Cancel a blur check if the callback or ref is no longer provided.
-	useEffect( () => {
-		if ( ! onFocusOutside ) {
-			cancelBlurCheck();
-		}
-	}, [ onFocusOutside, cancelBlurCheck ] );
-
-	/**
-	 * Handles a mousedown or mouseup event to respectively assign and
-	 * unassign a flag for preventing blur check on button elements. Some
-	 * browsers, namely Firefox and Safari, do not emit a focus event on
-	 * button elements when clicked, while others do. The logic here
-	 * intends to normalize this as treating click on buttons as focus.
-	 *
-	 * @param event
-	 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
-	 */
-	const normalizeButtonFocus: React.EventHandler<
-		React.MouseEvent | React.TouchEvent
-	> = useCallback( ( event ) => {
-		const { type, target } = event;
-		const isInteractionEnd = [ 'mouseup', 'touchend' ].includes( type );
-
-		if ( isInteractionEnd ) {
-			preventBlurCheckRef.current = false;
-		} else if ( isFocusNormalizedButton( target ) ) {
-			preventBlurCheckRef.current = true;
-		}
 	}, [] );
 
 	/**
@@ -128,28 +46,6 @@ export default function useFocusOutside(
 		// React does not allow using an event reference asynchronously
 		// due to recycling behavior, except when explicitly persisted.
 		event.persist();
-
-		// Skip blur check if clicking button. See `normalizeButtonFocus`.
-		if ( preventBlurCheckRef.current ) {
-			return;
-		}
-
-		// The usage of this attribute should be avoided. The only use case
-		// would be when we load modals that are not React components and
-		// therefore don't exist in the React tree. An example is opening
-		// the Media Library modal from another dialog.
-		// This attribute should contain a selector of the related target
-		// we want to ignore, because we still need to trigger the blur event
-		// on all other cases.
-		const ignoreForRelatedTarget = event.target.getAttribute(
-			'data-unstable-ignore-focus-outside-for-relatedtarget'
-		);
-		if (
-			ignoreForRelatedTarget &&
-			event.relatedTarget?.closest( ignoreForRelatedTarget )
-		) {
-			return;
-		}
 
 		blurCheckTimeoutIdRef.current = setTimeout( () => {
 			// If document is not focused then focus should remain
@@ -169,10 +65,6 @@ export default function useFocusOutside(
 
 	return {
 		onFocus: cancelBlurCheck,
-		onMouseDown: normalizeButtonFocus,
-		onMouseUp: normalizeButtonFocus,
-		onTouchStart: normalizeButtonFocus,
-		onTouchEnd: normalizeButtonFocus,
 		onBlur: queueBlurCheck,
 	};
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
