### PR TITLE
refactor: validate author selection in post author components

### DIFF
--- a/packages/editor/src/components/post-author/combobox.js
+++ b/packages/editor/src/components/post-author/combobox.js
@@ -29,6 +29,15 @@ export default function PostAuthorCombobox() {
 		if ( ! postAuthorId ) {
 			return;
 		}
+
+		const isValidAuthor = authorOptions.some(
+			( option ) => option.value === postAuthorId
+		);
+
+		if ( ! isValidAuthor ) {
+			return;
+		}
+
 		editPost( { author: postAuthorId } );
 	};
 

--- a/packages/editor/src/components/post-author/select.js
+++ b/packages/editor/src/components/post-author/select.js
@@ -17,6 +17,15 @@ export default function PostAuthorSelect() {
 
 	const setAuthorId = ( value ) => {
 		const author = Number( value );
+
+		const isValidAuthor = authorOptions.some(
+			( option ) => option.value === author
+		);
+
+		if ( ! isValidAuthor ) {
+			return;
+		}
+
 		editPost( { author } );
 	};
 


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71299 

Adds client-side validation to post author selection components to prevent assignment of posts to users without proper authoring capabilities.

## Why?
Currently, the Gutenberg editor correctly filters the author dropdown to show only users with authoring capabilities (Administrator, Editor, Contributor). However, there's no validation when the author field is updated programmatically. This allows malicious users to assign posts to Subscribers (who shouldn't be able to author content) by manipulating the dropdown value through browser developer tools, bypassing WordPress role-based security.

## How?
- Added validation in `PostAuthorSelect` and `PostAuthorCombobox` components
- Invalid assignments are silently rejected to maintain user experience

## Testing Instructions
Follow the steps provided in the issue description, and in the end, verify that the post author remains unchanged and is not reassigned to the Subscriber.

## Screenshots or screencast 

https://github.com/user-attachments/assets/c76b9e50-a140-46d9-8799-329458b8a7cc

