### PR TITLE
Core Data: Add 'supportsPagination' to all appropriate entities

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -159,6 +159,7 @@ export const rootEntitiesConfig = [
 		baseURLParams: { context: 'edit' },
 		plural: 'menus',
 		label: __( 'Menu' ),
+		supportsPagination: true,
 	},
 	{
 		name: 'menuItem',
@@ -168,6 +169,7 @@ export const rootEntitiesConfig = [
 		plural: 'menuItems',
 		label: __( 'Menu Item' ),
 		rawAttributes: [ 'title' ],
+		supportsPagination: true,
 	},
 	{
 		name: 'menuLocation',
@@ -209,7 +211,6 @@ export const rootEntitiesConfig = [
 		baseURLParams: { context: 'edit' },
 		plural: 'plugins',
 		key: 'plugin',
-		supportsPagination: true,
 	},
 	{
 		label: __( 'Status' ),
@@ -396,6 +397,7 @@ async function loadTaxonomyEntities() {
 			name,
 			label: taxonomy.name,
 			getTitle: ( record ) => record?.name,
+			supportsPagination: true,
 		};
 	} );
 }

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -141,6 +141,7 @@ export const rootEntitiesConfig = [
 		getTitle: ( record ) => record?.name || record?.slug,
 		baseURLParams: { context: 'edit' },
 		plural: 'users',
+		supportsPagination: true,
 	},
 	{
 		name: 'comment',
@@ -149,6 +150,7 @@ export const rootEntitiesConfig = [
 		baseURLParams: { context: 'edit' },
 		plural: 'comments',
 		label: __( 'Comment' ),
+		supportsPagination: true,
 	},
 	{
 		name: 'menu',
@@ -207,6 +209,7 @@ export const rootEntitiesConfig = [
 		baseURLParams: { context: 'edit' },
 		plural: 'plugins',
 		key: 'plugin',
+		supportsPagination: true,
 	},
 	{
 		label: __( 'Status' ),


### PR DESCRIPTION
## What? How? Why?

This PR adds the `supportsPagination `property to rootEntitiesConfig for user, comment, and taxonomy entities. 

This is so `totalItems` and `totalPages` are correctly set in meta from the `X-WP-Total` and `X-WP-TotalPages` headers.

Also, to quote https://github.com/WordPress/gutenberg/pull/55164

> This allows us to avoid the extra apiFetch request we're doing to fetch these headers in the page list in the site editor.



An example use case would be rendering a dataviews list of comments or users, and accurate totals are required.

See: https://github.com/WordPress/gutenberg/blob/add/entities-support-pagination/packages/core-data/src/resolvers.js#L281


Closes https://github.com/WordPress/gutenberg/issues/59520



## Testing Instructions

I tested by adding a lot of users, e.g., 

```
wp cli -- wp user generate --count=150 --role=editor
```

Then I fetched users:

```
await wp.data.resolveSelect( 'core' ).getEntityRecords( 'root', 'user' )

```

This will return 10 entries by default.

Then I checked the total:

```
await wp.data.resolveSelect( 'core' ).getEntityRecordsTotalItems( 'root', 'user' )

```

This should return 150 (plus how many users you had already).

In trunk, you'd see `10` because that's how many users are in the store.
