### PR TITLE
Core Data: Fix error in 'getEntityRecordsTotalPages' selector

### DIFF
--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -642,7 +642,7 @@ export const getEntityRecordsTotalPages = (
 	if ( ! queriedState ) {
 		return null;
 	}
-	if ( query.per_page === -1 ) {
+	if ( query?.per_page === -1 ) {
 		return 1;
 	}
 	const totalItems = getQueriedTotalItems( queriedState, query );
@@ -651,7 +651,7 @@ export const getEntityRecordsTotalPages = (
 	}
 	// If `per_page` is not set and the query relies on the defaults of the
 	// REST endpoint, get the info from query's meta.
-	if ( ! query.per_page ) {
+	if ( ! query?.per_page ) {
 		return getQueriedTotalPages( queriedState, query );
 	}
 	return Math.ceil( totalItems / query.per_page );


### PR DESCRIPTION
## What?
This is a follow-up to #59983.
Noticed while testing the #71302.

PR updates `getEntityRecordsTotalPages` selector and avoids error when the optional query argument isn't provided.

## Testing Instructions
1. Open the block editor.
2. Run the following selector in the console - `wp.data.select( 'core' ).getEntityRecordsTotalPages( 'postType', 'post' )`.
3. It shouldn't trigger an error.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="667" height="188" alt="CleanShot 2025-08-22 at 11 10 38" src="https://github.com/user-attachments/assets/ccf9eb16-205f-4e8c-a9ab-b6d33c44022e" />
