### PR TITLE
Core Data: Forward resolvers for pagination selectors

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -435,6 +435,16 @@ getEntityRecords.shouldInvalidate = ( action, kind, name ) => {
 };
 
 /**
+ * Requests the total number of entity records.
+ */
+export const getEntityRecordsTotalItems = forwardResolver( 'getEntityRecords' );
+
+/**
+ * Requests the number of available pages for the given query.
+ */
+export const getEntityRecordsTotalPages = forwardResolver( 'getEntityRecords' );
+
+/**
  * Requests the current theme.
  */
 export const getCurrentTheme =


### PR DESCRIPTION
## What?
Addresses https://github.com/WordPress/gutenberg/pull/55164#issuecomment-3062140631.

Calling the `getEntityRecordsTotalItems` or `getEntityRecordsTotalPages` will now trigger a matching entity records resolution and return data. Allowing use for pagination selectors without the need to call `getEntityRecords` explicitly.

## Testing Instructions
1. Open a post or page.
2. Call the following selector in DevTools - `wp.data.select( 'core' ).getEntityRecordsTotalItems( 'postType', 'post' )`.
3. Confirm that it triggers HTTP requests.
4. Calling it a second time should return the total items.

### Testing Instructions for Keyboard
Same.

## Screenshot
<img width="916" height="123" alt="CleanShot 2025-08-22 at 11 23 44" src="https://github.com/user-attachments/assets/5a6f30d7-bb8a-4a5f-a3a8-6fc47464225d" />
