### PR TITLE
Core Data: Remove unused reducers

### DIFF
--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -20,29 +20,6 @@ import { rootEntitiesConfig, DEFAULT_ENTITY_KEY } from './entities';
 /** @typedef {import('./types').AnyFunction} AnyFunction */
 
 /**
- * Reducer managing terms state. Keyed by taxonomy slug, the value is either
- * undefined (if no request has been made for given taxonomy), null (if a
- * request is in-flight for given taxonomy), or the array of terms for the
- * taxonomy.
- *
- * @param {Object} state  Current state.
- * @param {Object} action Dispatched action.
- *
- * @return {Object} Updated state.
- */
-export function terms( state = {}, action ) {
-	switch ( action.type ) {
-		case 'RECEIVE_TERMS':
-			return {
-				...state,
-				[ action.taxonomy ]: action.terms,
-			};
-	}
-
-	return state;
-}
-
-/**
  * Reducer managing authors state. Keyed by id.
  *
  * @param {Object} state  Current state.
@@ -87,23 +64,6 @@ export function currentUser( state = {}, action ) {
 	switch ( action.type ) {
 		case 'RECEIVE_CURRENT_USER':
 			return action.currentUser;
-	}
-
-	return state;
-}
-
-/**
- * Reducer managing taxonomies.
- *
- * @param {Object} state  Current state.
- * @param {Object} action Dispatched action.
- *
- * @return {Object} Updated state.
- */
-export function taxonomies( state = [], action ) {
-	switch ( action.type ) {
-		case 'RECEIVE_TAXONOMIES':
-			return action.taxonomies;
 	}
 
 	return state;
@@ -648,7 +608,6 @@ export function registeredPostMeta( state = {}, action ) {
 }
 
 export default combineReducers( {
-	terms,
 	users,
 	currentTheme,
 	currentGlobalStylesId,
@@ -656,7 +615,6 @@ export default combineReducers( {
 	themeGlobalStyleVariations,
 	themeBaseGlobalStyles,
 	themeGlobalStyleRevisions,
-	taxonomies,
 	entities,
 	editsReference,
 	undoManager,

--- a/packages/core-data/src/test/reducer.js
+++ b/packages/core-data/src/test/reducer.js
@@ -7,34 +7,12 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import {
-	terms,
 	entities,
 	embedPreviews,
 	userPermissions,
 	autosaves,
 	currentUser,
 } from '../reducer';
-
-describe( 'terms()', () => {
-	it( 'returns an empty object by default', () => {
-		const state = terms( undefined, {} );
-
-		expect( state ).toEqual( {} );
-	} );
-
-	it( 'returns with received terms', () => {
-		const originalState = deepFreeze( {} );
-		const state = terms( originalState, {
-			type: 'RECEIVE_TERMS',
-			taxonomy: 'categories',
-			terms: [ { id: 1 } ],
-		} );
-
-		expect( state ).toEqual( {
-			categories: [ { id: 1 } ],
-		} );
-	} );
-} );
 
 describe( 'entities', () => {
 	// See also unit tests at `queried-data/test/reducer.js`, which are more


### PR DESCRIPTION
## What?
PR removes unused `terms` and `taxonomies` reducers. This data is handled now by entities, and their associated actions were removed years ago. See: #9163, #6939

## Why?
Removes unused code.

## Testing Instructions
CI checks are passing.
