### PR TITLE
Font Library: Fix font loading/unloading failing in Code Editor

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -55,6 +55,7 @@ import {
 	useSyncDeprecatedEntityIntoState,
 } from './use-resolve-edited-entity';
 import SitePreview from './site-preview';
+import { useFontSynchronization } from '../../hooks/use-font-synchronization';
 
 const { Editor, BackButton } = unlock( editorPrivateApis );
 const { useHistory, useLocation } = unlock( routerPrivateApis );
@@ -131,6 +132,9 @@ export default function EditSiteEditor( {
 	// deprecated sync state with url
 	useSyncDeprecatedEntityIntoState( entity );
 	const { postType, postId, context } = entity;
+
+	// Handle font synchronization when switching from code to visual editor
+	useFontSynchronization();
 	const {
 		isBlockBasedTheme,
 		editorCanvasView,

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
@@ -115,10 +115,13 @@ export async function loadFontFaceInBrowser( fontFace, source, addTo = 'all' ) {
 	}
 
 	if ( addTo === 'iframe' || addTo === 'all' ) {
-		const iframeDocument = document.querySelector(
+		const iframeElement = document.querySelector(
 			'iframe[name="editor-canvas"]'
-		).contentDocument;
-		iframeDocument.fonts.add( loadedFace );
+		);
+		// Only try to add to iframe if it exists (visual mode)
+		if ( iframeElement?.contentDocument ) {
+			iframeElement.contentDocument.fonts.add( loadedFace );
+		}
 	}
 }
 
@@ -149,11 +152,52 @@ export function unloadFontFaceInBrowser( fontFace, removeFrom = 'all' ) {
 	}
 
 	if ( removeFrom === 'iframe' || removeFrom === 'all' ) {
-		const iframeDocument = document.querySelector(
+		const iframeElement = document.querySelector(
 			'iframe[name="editor-canvas"]'
-		).contentDocument;
-		unloadFontFace( iframeDocument.fonts );
+		);
+		// Only try to remove from iframe if it exists (visual mode)
+		if ( iframeElement?.contentDocument ) {
+			unloadFontFace( iframeElement.contentDocument.fonts );
+		}
 	}
+}
+
+/*
+ * Copies all font faces from the root document to the iframe document.
+ * This is useful when switching from code editor to visual editor
+ * and fonts were uploaded while in code editor mode.
+ */
+export function copyFontsFromDocumentToIframe() {
+	const iframeElement = document.querySelector(
+		'iframe[name="editor-canvas"]'
+	);
+
+	// If there's no iframe (e.g., still in code editor mode), return early
+	if ( ! iframeElement?.contentDocument ) {
+		return;
+	}
+
+	const iframeDocument = iframeElement.contentDocument;
+
+	// Copy all fonts from the root document to the iframe
+	document.fonts.forEach( ( fontFace ) => {
+		// Check if the font is already in the iframe to avoid duplicates
+		let fontExists = false;
+		iframeDocument.fonts.forEach( ( iframeFontFace ) => {
+			if (
+				iframeFontFace.family === fontFace.family &&
+				iframeFontFace.weight === fontFace.weight &&
+				iframeFontFace.style === fontFace.style
+			) {
+				fontExists = true;
+			}
+		} );
+
+		// Only add if it doesn't already exist
+		if ( ! fontExists ) {
+			iframeDocument.fonts.add( fontFace );
+		}
+	} );
 }
 
 /**

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/test/copyFontsFromDocumentToIframe.spec.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/test/copyFontsFromDocumentToIframe.spec.js
@@ -1,0 +1,115 @@
+/**
+ * Internal dependencies
+ */
+import { copyFontsFromDocumentToIframe } from '../index';
+
+describe( 'copyFontsFromDocumentToIframe', () => {
+	const originalQuerySelector = document.querySelector;
+	const originalDocumentFonts = document.fonts;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		// Mock document.querySelector
+		document.querySelector = jest.fn();
+		// Mock document.fonts with forEach method
+		document.fonts = {
+			forEach: jest.fn(),
+		};
+	} );
+
+	afterEach( () => {
+		// Restore original methods
+		document.querySelector = originalQuerySelector;
+		document.fonts = originalDocumentFonts;
+	} );
+
+	test( 'should not error when iframe does not exist', () => {
+		// Mock querySelector to return null (no iframe)
+		document.querySelector.mockReturnValue( null );
+
+		// This should not throw an error
+		expect( () => copyFontsFromDocumentToIframe() ).not.toThrow();
+	} );
+
+	test( 'should not error when iframe exists but has no contentDocument', () => {
+		// Mock querySelector to return iframe without contentDocument
+		document.querySelector.mockReturnValue( {} );
+
+		// This should not throw an error
+		expect( () => copyFontsFromDocumentToIframe() ).not.toThrow();
+	} );
+
+	test( 'should copy fonts when iframe and contentDocument exist', () => {
+		const mockIframeDocument = {
+			fonts: {
+				forEach: jest.fn(),
+				add: jest.fn(),
+			},
+		};
+
+		const mockIframe = {
+			contentDocument: mockIframeDocument,
+		};
+
+		// Mock document.fonts.forEach to simulate fonts in root document
+		const mockFontFace = {
+			family: 'Test Font',
+			weight: '400',
+			style: 'normal',
+		};
+
+		document.fonts.forEach.mockImplementation( ( callback ) => {
+			callback( mockFontFace );
+		} );
+
+		// Mock iframe.contentDocument.fonts.forEach to simulate no fonts in iframe
+		mockIframeDocument.fonts.forEach.mockImplementation( () => {
+			// No fonts in iframe initially
+		} );
+
+		document.querySelector.mockReturnValue( mockIframe );
+
+		copyFontsFromDocumentToIframe();
+
+		// Should have attempted to add the font to iframe
+		expect( mockIframeDocument.fonts.add ).toHaveBeenCalledWith(
+			mockFontFace
+		);
+	} );
+
+	test( 'should not duplicate fonts that already exist in iframe', () => {
+		const mockFontFace = {
+			family: 'Test Font',
+			weight: '400',
+			style: 'normal',
+		};
+
+		const mockIframeDocument = {
+			fonts: {
+				forEach: jest.fn(),
+				add: jest.fn(),
+			},
+		};
+
+		const mockIframe = {
+			contentDocument: mockIframeDocument,
+		};
+
+		// Mock document.fonts.forEach to simulate fonts in root document
+		document.fonts.forEach.mockImplementation( ( callback ) => {
+			callback( mockFontFace );
+		} );
+
+		// Mock iframe.contentDocument.fonts.forEach to simulate the same font already exists
+		mockIframeDocument.fonts.forEach.mockImplementation( ( callback ) => {
+			callback( mockFontFace ); // Same font already exists
+		} );
+
+		document.querySelector.mockReturnValue( mockIframe );
+
+		copyFontsFromDocumentToIframe();
+
+		// Should NOT have attempted to add the font to iframe since it already exists
+		expect( mockIframeDocument.fonts.add ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/edit-site/src/hooks/use-font-synchronization.js
+++ b/packages/edit-site/src/hooks/use-font-synchronization.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+
+/**
+ * Internal dependencies
+ */
+import { copyFontsFromDocumentToIframe } from '../components/global-styles/font-library-modal/utils';
+
+/**
+ * Hook that monitors editor mode changes and synchronizes fonts
+ * from the root document to the iframe when switching from text to visual mode.
+ * This ensures that fonts uploaded while in code editor mode are available
+ * in the visual editor.
+ *
+ * @see https://github.com/WordPress/gutenberg/issues/69139
+ */
+export function useFontSynchronization() {
+	const previousModeRef = useRef( null );
+
+	const mode = useSelect( ( select ) => {
+		return select( editorStore ).getEditorMode();
+	}, [] );
+
+	useEffect( () => {
+		const previousMode = previousModeRef.current;
+
+		// Check if we're switching from text/code mode to visual mode
+		if ( previousMode === 'text' && mode === 'visual' ) {
+			// Small delay to ensure the iframe is rendered before copying fonts
+			setTimeout( () => {
+				copyFontsFromDocumentToIframe();
+			}, 100 );
+		}
+
+		// Update the previous mode for the next comparison
+		previousModeRef.current = mode;
+	}, [ mode ] );
+}


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #69139 

This PR solves the issue of error when uploading fonts to style editor when in Code editor view of Site editor

## Why?
If we try to upload fonts when in code editor view of site editor, it fails with an error logged to the console

## How?
This PR copies the font properties of the root document to the font properties of the iframe document when returning from the code editor to the visual editor.

Adds new hook `useFontSynchronization()` for the same

Also adds unit test cases for checking copying function in different scenarios

## Testing Instructions
1. Visit the site editor.
2. Open a template.
3. Switch to the code editor.
4. Open the font library.
5. Attempt to upload a font.
6. Try using the new font in site editor

## Screenshots or screencast <!-- if applicable -->

Before

https://github.com/user-attachments/assets/f199f23e-6982-4cba-a049-6e2f6b314e87

After

https://github.com/user-attachments/assets/2583071b-90bd-4cf8-a691-a9985f9bff47
