### PR TITLE
docs: add Storybook story for BlockIcon component

### DIFF
--- a/packages/block-editor/src/components/block-icon/stories/block-icon.stories.js
+++ b/packages/block-editor/src/components/block-icon/stories/block-icon.stories.js
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+/**
+ * Internal dependencies
+ */
+import BlockIcon from '../block-icon';
+
+export default {
+	title: 'Block Editor/BlockIcon',
+	component: BlockIcon,
+	args: {
+		icon: 'smiley',
+		label: 'Sample Icon',
+	},
+};
+
+export const Default = {};


### PR DESCRIPTION
This PR adds a basic Storybook story for the BlockIcon component to improve visual documentation.
Related issue: #67165
