### PR TITLE
Components: Remove pointer styling from Button component

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -12,7 +12,6 @@
 	font-size: $default-font-size;
 	margin: 0;
 	border: 0;
-	cursor: pointer;
 	-webkit-appearance: none;
 	background: none;
 


### PR DESCRIPTION
This PR removes the redundant cursor: pointer styling from the Button component.

Buttons already provide strong visual affordance without needing a pointer cursor.

Keeping the hand cursor (cursor: pointer) can confuse users, since conventionally it indicates links rather than buttons.

This aligns with accessibility guidelines and previous discussions in Gutenberg (see #71316).

Changes Made

Removed cursor: pointer; from packages/components/src/button/style.scss.

Verified that buttons remain functional and visually clear without the pointer cursor.

Testing Instructions

Run Gutenberg locally (npm run dev).

Open the editor and interact with various buttons across the UI.

Verify that:

Buttons still respond correctly on hover and click.

The cursor remains the default (arrow) instead of a hand.

Links (<a> elements) still retain the hand cursor as expected.

Screenshots

Included a Screenshot that demonstrates:

The default cursor on buttons before this change.
![IMG20250823232645 1](https://github.com/user-attachments/assets/f6ed530c-871e-4deb-87eb-6288067ed7ca)

The default cursor on buttons after this change.

![IMG20250823232605](https://github.com/user-attachments/assets/1924b304-adf8-4328-887d-18d742837170)

Checklist

 Removed redundant cursor: pointer; styling.

 Tested buttons across multiple areas of the editor.

 Screen recording attached.

Fixes #71316