### PR TITLE
Fix: Add spacing between Latest Posts block items using flex gap

### DIFF
--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -11,13 +11,11 @@
 		margin-left: 2em;
 	}
 	&.wp-block-latest-posts__list {
-		list-style: none;
-
-		li {
-			clear: both;
-			overflow-wrap: break-word;
-		}
-	}
+	list-style: none;
+	display: flex;
+	flex-direction: column;
+	gap: 1em; // 🔥 automatic spacing
+}
 
 	&.is-grid {
 		display: flex;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
<img width="1918" height="898" alt="image" src="https://github.com/user-attachments/assets/daf634f8-7548-47d4-8947-55ba0efa5251" />

