### PR TITLE
Gallery:Hide the Open in New Tab setting when you set up a lightbox

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -565,7 +565,7 @@ export default function GalleryEdit( props ) {
 		);
 	}
 
-	const hasLinkTo = linkTo && linkTo !== 'none';
+	const hasLinkTo = linkTo && linkTo !== 'none' && linkTo !== 'lightbox';
 
 	return (
 		<>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Gallery:Hide the Open in New Tab setting when you set up a lightbox

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The setting lightbox opens in a new tab doesn't make sense.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add a lightbox to `hasLinkTo`.
`hasLinkTo` is a condition variable for the Open images in new tab setting.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a Gallery block.
3. When I set a lightbox from the toolbar, the "Open images in new tab" option in the inspector is not added.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="1600" height="900" alt="lightbox-before" src="https://github.com/user-attachments/assets/d4a2b04c-cb5d-4b5d-80e7-3b2bf797383a" /> |<!-- After screenshot here --> <img width="1600" height="900" alt="lightbox" src="https://github.com/user-attachments/assets/837082fb-1af5-4949-98d3-dc43d1a24e06" />|
