### PR TITLE
Fix: Image block link with Interactivity API now transitions correctly

### DIFF
--- a/packages/interactivity-router/src/full-page.ts
+++ b/packages/interactivity-router/src/full-page.ts
@@ -1,3 +1,6 @@
+// File extensions that should bypass client-side navigation.
+const imageExtensions = [ '.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg' ];
+
 // Check if the link is valid for client-side navigation.
 const isValidLink = ( ref: HTMLAnchorElement ) =>
 	ref &&
@@ -8,7 +11,11 @@ const isValidLink = ( ref: HTMLAnchorElement ) =>
 	! ref.pathname.startsWith( '/wp-admin' ) &&
 	! ref.pathname.startsWith( '/wp-login.php' ) &&
 	! ref.getAttribute( 'href' ).startsWith( '#' ) &&
-	! new URL( ref.href ).searchParams.has( '_wpnonce' );
+	! new URL( ref.href ).searchParams.has( '_wpnonce' ) &&
+	// skip image links
+	! imageExtensions.some( ( ext ) =>
+		ref.pathname.toLowerCase().endsWith( ext )
+	);
 
 // Check if the event is valid for client-side navigation.
 const isValidEvent = ( event: MouseEvent ) =>


### PR DESCRIPTION
## Description
This PR fixes an issue where the Image block, when linked to an image file, would not transition to a new page when the Interactivity API’s Full-page client-side navigation experiment was enabled. The image only appeared after a manual reload.

## Changes
- Updated Image block link handling to correctly trigger a full-page navigation when linking to image files.
- Ensured smooth navigation without requiring a reload.

## Testing Instructions
1. Enable **Interactivity API: Full-page client-side navigation** under Gutenberg > Experiments.
2. Insert an Image block in a post or page.
3. Set the link option to "Media File".
4. Publish and click the image:
   - Before fix → The page does not transition, reload required.
   - After fix → The image opens correctly as a new page.

## Screen Recording

After Update

https://github.com/user-attachments/assets/752c15db-c1b0-4aad-ae00-9e20970eae57

## Environment
- WordPress 6.8.2
- Gutenberg 21.4.0
- Theme: Twenty Twenty-Five v1.3

Fixes #71324
