### PR TITLE
Template Part: Display icons correctly when in placeholder state

### DIFF
--- a/packages/block-library/src/template-part/edit/placeholder.js
+++ b/packages/block-library/src/template-part/edit/placeholder.js
@@ -17,6 +17,7 @@ import {
 	useTemplatePartArea,
 } from './utils/hooks';
 import TitleModal from './title-modal';
+import { getTemplatePartIcon } from './utils/get-template-part-icon';
 
 export default function TemplatePartPlaceholder( {
 	area,
@@ -54,7 +55,7 @@ export default function TemplatePartPlaceholder( {
 
 	return (
 		<Placeholder
-			icon={ areaObject.icon }
+			icon={ getTemplatePartIcon( areaObject.icon ) }
 			label={ areaObject.label }
 			instructions={
 				isBlockBasedTheme

--- a/packages/block-library/src/template-part/edit/utils/hooks.js
+++ b/packages/block-library/src/template-part/edit/utils/hooks.js
@@ -17,7 +17,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { createTemplatePartId } from './create-template-part-id';
-import { getTemplatePartIcon } from './get-template-part-icon';
 
 /**
  * Retrieves the available template parts for the given area.
@@ -149,9 +148,7 @@ export function useTemplatePartArea( area ) {
 			);
 
 			return {
-				icon: getTemplatePartIcon(
-					selectedArea?.icon || defaultArea?.icon
-				),
+				icon: selectedArea?.icon || defaultArea?.icon,
 				label: selectedArea?.label || __( 'Template Part' ),
 				tagName: selectedArea?.area_tag ?? 'div',
 			};

--- a/packages/block-library/src/template-part/edit/utils/hooks.js
+++ b/packages/block-library/src/template-part/edit/utils/hooks.js
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { createTemplatePartId } from './create-template-part-id';
+import { getTemplatePartIcon } from './get-template-part-icon';
 
 /**
  * Retrieves the available template parts for the given area.
@@ -148,7 +149,9 @@ export function useTemplatePartArea( area ) {
 			);
 
 			return {
-				icon: selectedArea?.icon || defaultArea?.icon,
+				icon: getTemplatePartIcon(
+					selectedArea?.icon || defaultArea?.icon
+				),
 				label: selectedArea?.label || __( 'Template Part' ),
 				tagName: selectedArea?.area_tag ?? 'div',
 			};


### PR DESCRIPTION
Follow-up #66459

## What?

| Before | After |
|--------|--------|
| <img width="666" height="532" alt="image" src="https://github.com/user-attachments/assets/0f41393e-a5f7-402e-bbb0-2b60561fa413" /> | <img width="660" height="540" alt="image" src="https://github.com/user-attachments/assets/a9b71821-1a82-4222-9b23-37314b301dca" /> | 

## Why?

#66549 has changed the way to get the default template areas, from the editor store to the REST API:

```javascript
// From...
const areas = select( 'core/editor' ).__experimentalGetDefaultTemplatePartAreas();

// To...
const areas = select( coreStore ).getEntityRecord( 'root', '__unstableBase' )?.default_template_part_areas;
```

This means that the conversion from icon string to React element that [the `__experimentalGetDefaultTemplatePartAreas` selector used to do internally](https://github.com/WordPress/gutenberg/pull/66459/files#diff-39483f68b2cb13f2413b0af1a6d7798e3262f936e905cde2b211fefde7830a74L1728) must now be done explicitly.

Although [the icons for block variations were converted correctly](https://github.com/WordPress/gutenberg/blob/95108ddbf24f6f67533de27affeb4e91a306f6ff/packages/block-library/src/template-part/variations.js#L49), the icon for placeholders remained as a string, so it was treated as a dash icon, and the intended icon was not displayed.

## How?

Use `getTemplatePartIcon` function inside the `useTemplatePartArea`. This hook is used to get the icon and label for the Placeholder component.


## Testing Instructions

- Open any of the templates.
- Insert the following HTML from the code editor:
  ```html
  <!-- wp:group {"layout":{"type":"constrained"}} -->
  <div class="wp-block-group">
    <!-- wp:template-part /-->
    <!-- wp:template-part {"area":"header"} /-->
    <!-- wp:template-part {"area":"footer"} /-->
  </div>
  <!-- /wp:group -->
  ```
- Confirm that all placeholders show icons correctly.