### PR TITLE
Image: Don't allow convert to cover controls in contentOnly mode

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -706,7 +706,8 @@ export default function Image( {
 		! lockHrefControls &&
 		! lockUrlControls;
 
-	const showCoverControls = isSingleSelected && canInsertCover;
+	const showCoverControls =
+		isSingleSelected && canInsertCover && ! isContentOnlyMode;
 
 	const showBlockControls = showUrlInput || allowCrop || showCoverControls;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #65778 

In the image block, hide the cover controls (Add text over image) when in contentOnly mode.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As discussed in https://github.com/WordPress/gutenberg/issues/65778#issuecomment-3210617969 the idea is that write mode is for editing existing content, not introducing new material such as captions. And for the case of these cover controls, it's a destructive action that replaces the Image block with a Cover block. Further, since we don't allow block transformations in write mode, I think that makes another argument for hiding them.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* In the Image block, update the condition for showing the cover controls to also factor in that we're not in content only mode

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Enable the simplified site editing experiment in http://localhost:8888/wp-admin/admin.php?page=gutenberg-experiments
2. Open up the site editor and go to edit a page
3. In design mode, add an image block and select an image
4. In the top toolbar, switch to write mode
5. Click on the image block
6. In `trunk` there'll be an option to "Add text over image"
7. With this PR applied that option should not be available
8. In design mode, it should still be available

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

In write mode (the pencil icon in the top toolbar)

|Before|After|
|-|-|
| <img width="1440" height="963" alt="image" src="https://github.com/user-attachments/assets/34fcd00c-a8c8-40d8-9c41-d6539cdfa79c" /> | <img width="1440" height="976" alt="image" src="https://github.com/user-attachments/assets/13d38e7e-45d1-4c8b-b25f-34a4fbd8107d" /> |

In design mode, it should still be available:

<img width="1440" height="578" alt="image" src="https://github.com/user-attachments/assets/63c68769-edb5-48fb-9b9b-99ec246fa21c" />