### PR TITLE
Documentation: Add @examples to core/edit-post selectors.

### DIFF
--- a/docs/reference-guides/data/data-core-edit-post.md
+++ b/docs/reference-guides/data/data-core-edit-post.md
@@ -39,10 +39,23 @@ Examples:
 _Usage_
 
 ```js
-import { select } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
+import { store as editPostStore } from '@wordpress/edit-post';
 
-const sidebar = select( 'core/edit-post' ).getActiveGeneralSidebarName();
-console.log( sidebar ); // "edit-post/document" or null
+const ActiveSidebar = () => {
+	const sidebar = useSelect(
+		( select ) => select( editPostStore ).getActiveGeneralSidebarName(),
+		[]
+	);
+
+	return (
+		<p>
+			{ sidebar
+				? `Active sidebar: ${ sidebar }`
+				: 'No general sidebar is active.' }
+		</p>
+	);
+};
 ```
 
 _Parameters_
@@ -64,6 +77,11 @@ import { select } from '@wordpress/data';
 
 const locations = select( 'core/edit-post' ).getActiveMetaBoxLocations();
 console.log( locations ); // e.g. [ 'side', 'normal' ]
+
+// Example usage: check if the "side" location has any meta boxes
+if ( locations.includes( 'side' ) ) {
+	console.log( 'There are meta boxes in the sidebar.' );
+}
 ```
 
 _Parameters_
@@ -85,6 +103,17 @@ import { select } from '@wordpress/data';
 
 const metaBoxes = select( 'core/edit-post' ).getAllMetaBoxes();
 console.log( metaBoxes );
+
+// Example shape of the result:
+// {
+//   side: [
+//     { id: 'submitdiv', title: 'Publish' },
+//     { id: 'tagsdiv-post_tag', title: 'Tags' }
+//   ],
+//   normal: [
+//     { id: 'postexcerpt', title: 'Excerpt' }
+//   ]
+// }
 ```
 
 _Parameters_
@@ -106,6 +135,13 @@ import { select } from '@wordpress/data';
 
 const template = select( 'core/edit-post' ).getEditedPostTemplate();
 console.log( template );
+// Example output:
+// {
+//   slug: "my-custom-template",
+//   theme: "my-theme",
+//   source: "theme",
+//   ...etc
+// }
 ```
 
 _Returns_
@@ -119,10 +155,23 @@ Returns the current editing mode.
 _Usage_
 
 ```js
-import { select } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { store as editPostStore } from '@wordpress/edit-post';
 
-const mode = select( 'core/edit-post' ).getEditorMode();
-console.log( mode ); // e.g. "visual" or "text"
+const EditorModeNotice = () => {
+	const editorMode = useSelect(
+		( select ) => select( editPostStore ).getEditorMode(),
+		[]
+	);
+
+	return (
+		<p>
+			{ __( 'The current editor mode is: ' ) }
+			<strong>{ editorMode }</strong>
+		</p>
+	);
+};
 ```
 
 _Parameters_
@@ -142,8 +191,14 @@ _Usage_
 ```js
 import { select } from '@wordpress/data';
 
+// Get all hidden block types in the editor.
 const hiddenBlocks = select( 'core/edit-post' ).getHiddenBlockTypes();
 console.log( hiddenBlocks );
+// Example output:
+// [ "core/verse", "core/quote" ]
+
+// You can also check if a particular block type is hidden:
+console.log( hiddenBlocks.includes( 'core/verse' ) ); // true or false
 ```
 
 _Returns_
@@ -162,6 +217,11 @@ import { select } from '@wordpress/data';
 const sideMetaBoxes =
 	select( 'core/edit-post' ).getMetaBoxesPerLocation( 'side' );
 console.log( sideMetaBoxes );
+
+// Example: iterate over meta boxes
+sideMetaBoxes.forEach( ( box ) => {
+	console.log( box.id, box.title );
+} );
 ```
 
 _Parameters_
@@ -196,8 +256,16 @@ _Usage_
 ```js
 import { select } from '@wordpress/data';
 
+// Get all preferences for the editor.
 const prefs = select( 'core/edit-post' ).getPreferences();
 console.log( prefs );
+// Example output:
+// {
+//   panels: { 'categories-panel': { opened: true }, ... },
+//   editorMode: 'visual',
+//   hiddenBlockTypes: [ 'core/verse' ],
+//   ...
+// }
 ```
 
 _Parameters_
@@ -215,11 +283,22 @@ Returns true if the post is using Meta Boxes
 _Usage_
 
 ```js
-import { select } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { store as editPostStore } from '@wordpress/edit-post';
 
-// Check if the current post being edited has any meta boxes
-const hasMeta = select( 'core/edit-post' ).hasMetaBoxes();
-console.log( hasMeta ); // true or false
+const ExampleComponent = () => {
+	const hasMetaBoxes = useSelect(
+		( select ) => select( editPostStore ).hasMetaBoxes(),
+		[]
+	);
+
+	return hasMetaBoxes ? (
+		<p>{ __( 'This post type uses meta boxes.' ) }</p>
+	) : (
+		<p>{ __( 'No meta boxes registered for this post type.' ) }</p>
+	);
+};
 ```
 
 _Parameters_
@@ -288,10 +367,17 @@ Returns true if the editor sidebar is opened.
 _Usage_
 
 ```js
-import { select } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
+import { store as editPostStore } from '@wordpress/edit-post';
 
-const open = select( 'core/edit-post' ).isEditorSidebarOpened();
-console.log( open );
+const SidebarStatus = () => {
+	const isOpen = useSelect(
+		( select ) => select( editPostStore ).isEditorSidebarOpened(),
+		[]
+	);
+
+	return <p>Sidebar is { isOpen ? 'open' : 'closed' }.</p>;
+};
 ```
 
 _Parameters_
@@ -311,8 +397,16 @@ _Usage_
 ```js
 import { select } from '@wordpress/data';
 
+// Check if the editor is currently in fullscreen mode.
 const isActive = select( 'core/edit-post' ).isFeatureActive( 'fullscreenMode' );
-console.log( isActive );
+console.log( isActive ); // true or false
+
+// Example usage: toggle UI depending on feature state.
+if ( isActive ) {
+	console.log( 'The editor is in fullscreen mode.' );
+} else {
+	console.log( 'Fullscreen mode is disabled.' );
+}
 ```
 
 _Parameters_
@@ -348,7 +442,7 @@ _Usage_
 import { select } from '@wordpress/data';
 
 const listViewOpen = select( 'core/edit-post' ).isListViewOpened();
-console.log( listViewOpen );
+console.log( listViewOpen ); // true if List View is visible, false otherwise
 ```
 
 _Parameters_
@@ -366,12 +460,22 @@ Returns true if there is an active meta box in the given location, or false othe
 _Usage_
 
 ```js
-import { select } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { store as editPostStore } from '@wordpress/edit-post';
 
-// Check if the "side" location has any active meta boxes
-const sideHasMeta =
-	select( 'core/edit-post' ).isMetaBoxLocationActive( 'side' );
-console.log( sideHasMeta ); // true or false
+const SideMetaBoxesIndicator = () => {
+	const isSideActive = useSelect(
+		( select ) => select( editPostStore ).isMetaBoxLocationActive( 'side' ),
+		[]
+	);
+
+	return isSideActive ? (
+		<p>{ __( 'Side meta boxes are active.' ) }</p>
+	) : (
+		<p>{ __( 'No side meta boxes.' ) }</p>
+	);
+};
 ```
 
 _Parameters_
@@ -390,12 +494,23 @@ Returns true if a metabox location is active and visible
 _Usage_
 
 ```js
-import { select } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { store as editPostStore } from '@wordpress/edit-post';
 
-// Check if the "side" metabox location is active and visible
-const isSideVisible =
-	select( 'core/edit-post' ).isMetaBoxLocationVisible( 'side' );
-console.log( isSideVisible ); // true or false
+const NormalMetaBoxesIndicator = () => {
+	const isNormalVisible = useSelect(
+		( select ) =>
+			select( editPostStore ).isMetaBoxLocationVisible( 'normal' ),
+		[]
+	);
+
+	return isNormalVisible ? (
+		<p>{ __( 'Normal meta boxes are visible.' ) }</p>
+	) : (
+		<p>{ __( 'No visible normal meta boxes.' ) }</p>
+	);
+};
 ```
 
 _Parameters_
@@ -431,8 +546,16 @@ _Usage_
 ```js
 import { select } from '@wordpress/data';
 
+// Check if a plugin toolbar item is pinned.
 const pinned = select( 'core/edit-post' ).isPluginItemPinned( 'my-plugin' );
-console.log( pinned );
+console.log( pinned ); // true or false
+
+// Example: use this to decide whether to render a "pin/unpin" button in your plugin UI.
+if ( pinned ) {
+	console.log( 'The plugin item is pinned in the toolbar.' );
+} else {
+	console.log( 'The plugin item is not pinned.' );
+}
 ```
 
 _Parameters_
@@ -451,10 +574,17 @@ Returns true if the plugin sidebar is opened.
 _Usage_
 
 ```js
-import { select } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
+import { store as editPostStore } from '@wordpress/edit-post';
 
-const pluginSidebarOpen = select( 'core/edit-post' ).isPluginSidebarOpened();
-console.log( pluginSidebarOpen );
+const PluginSidebarStatus = () => {
+	const isOpen = useSelect(
+		( select ) => select( editPostStore ).isPluginSidebarOpened(),
+		[]
+	);
+
+	return <p>Plugin sidebar is { isOpen ? 'open' : 'closed' }.</p>;
+};
 ```
 
 _Parameters_
@@ -489,7 +619,7 @@ _Usage_
 import { select } from '@wordpress/data';
 
 const saving = select( 'core/edit-post' ).isSavingMetaBoxes();
-console.log( saving );
+console.log( saving ); // true while meta boxes are saving, false otherwise
 ```
 
 _Parameters_

--- a/docs/reference-guides/data/data-core-edit-post.md
+++ b/docs/reference-guides/data/data-core-edit-post.md
@@ -10,6 +10,15 @@ Namespace: `core/edit-post`.
 
 Returns true if meta boxes are initialized.
 
+_Usage_
+
+```js
+import { select } from '@wordpress/data';
+
+const initialized = select( 'core/edit-post' ).areMetaBoxesInitialized();
+console.log( initialized ); // true or false
+```
+
 _Parameters_
 
 -   _state_ `Object`: Global application state.
@@ -27,6 +36,15 @@ Examples:
 -   `edit-post/document`
 -   `my-plugin/insert-image-sidebar`
 
+_Usage_
+
+```js
+import { select } from '@wordpress/data';
+
+const sidebar = select( 'core/edit-post' ).getActiveGeneralSidebarName();
+console.log( sidebar ); // "edit-post/document" or null
+```
+
 _Parameters_
 
 -   _state_ `Object`: Global application state.
@@ -38,6 +56,15 @@ _Returns_
 ### getActiveMetaBoxLocations
 
 Returns an array of active meta box locations.
+
+_Usage_
+
+```js
+import { select } from '@wordpress/data';
+
+const locations = select( 'core/edit-post' ).getActiveMetaBoxLocations();
+console.log( locations ); // e.g. [ 'side', 'normal' ]
+```
 
 _Parameters_
 
@@ -51,6 +78,15 @@ _Returns_
 
 Returns the list of all the available meta boxes.
 
+_Usage_
+
+```js
+import { select } from '@wordpress/data';
+
+const metaBoxes = select( 'core/edit-post' ).getAllMetaBoxes();
+console.log( metaBoxes );
+```
+
 _Parameters_
 
 -   _state_ `Object`: Global application state.
@@ -63,6 +99,15 @@ _Returns_
 
 Retrieves the template of the currently edited post.
 
+_Usage_
+
+```js
+import { select } from '@wordpress/data';
+
+const template = select( 'core/edit-post' ).getEditedPostTemplate();
+console.log( template );
+```
+
 _Returns_
 
 -   `?Object`: Post Template.
@@ -70,6 +115,15 @@ _Returns_
 ### getEditorMode
 
 Returns the current editing mode.
+
+_Usage_
+
+```js
+import { select } from '@wordpress/data';
+
+const mode = select( 'core/edit-post' ).getEditorMode();
+console.log( mode ); // e.g. "visual" or "text"
+```
 
 _Parameters_
 
@@ -83,6 +137,15 @@ _Returns_
 
 Returns an array of blocks that are hidden.
 
+_Usage_
+
+```js
+import { select } from '@wordpress/data';
+
+const hiddenBlocks = select( 'core/edit-post' ).getHiddenBlockTypes();
+console.log( hiddenBlocks );
+```
+
 _Returns_
 
 -   `Array`: A list of the hidden block types
@@ -90,6 +153,16 @@ _Returns_
 ### getMetaBoxesPerLocation
 
 Returns the list of all the available meta boxes for a given location.
+
+_Usage_
+
+```js
+import { select } from '@wordpress/data';
+
+const sideMetaBoxes =
+	select( 'core/edit-post' ).getMetaBoxesPerLocation( 'side' );
+console.log( sideMetaBoxes );
+```
 
 _Parameters_
 
@@ -101,6 +174,8 @@ _Returns_
 -   `?Array`: List of meta boxes.
 
 ### getPreference
+
+> **Deprecated**
 
 _Parameters_
 
@@ -116,6 +191,15 @@ _Returns_
 
 Returns the preferences (these preferences are persisted locally).
 
+_Usage_
+
+```js
+import { select } from '@wordpress/data';
+
+const prefs = select( 'core/edit-post' ).getPreferences();
+console.log( prefs );
+```
+
 _Parameters_
 
 -   _state_ `Object`: Global application state.
@@ -127,6 +211,16 @@ _Returns_
 ### hasMetaBoxes
 
 Returns true if the post is using Meta Boxes
+
+_Usage_
+
+```js
+import { select } from '@wordpress/data';
+
+// Check if the current post being edited has any meta boxes
+const hasMeta = select( 'core/edit-post' ).hasMetaBoxes();
+console.log( hasMeta ); // true or false
+```
 
 _Parameters_
 
@@ -191,6 +285,15 @@ _Returns_
 
 Returns true if the editor sidebar is opened.
 
+_Usage_
+
+```js
+import { select } from '@wordpress/data';
+
+const open = select( 'core/edit-post' ).isEditorSidebarOpened();
+console.log( open );
+```
+
 _Parameters_
 
 -   _state_ `Object`: Global application state
@@ -202,6 +305,15 @@ _Returns_
 ### isFeatureActive
 
 Returns whether the given feature is enabled or not.
+
+_Usage_
+
+```js
+import { select } from '@wordpress/data';
+
+const isActive = select( 'core/edit-post' ).isFeatureActive( 'fullscreenMode' );
+console.log( isActive );
+```
 
 _Parameters_
 
@@ -230,6 +342,15 @@ _Returns_
 
 Returns true if the list view is opened.
 
+_Usage_
+
+```js
+import { select } from '@wordpress/data';
+
+const listViewOpen = select( 'core/edit-post' ).isListViewOpened();
+console.log( listViewOpen );
+```
+
 _Parameters_
 
 -   _state_ `Object`: Global application state.
@@ -241,6 +362,17 @@ _Returns_
 ### isMetaBoxLocationActive
 
 Returns true if there is an active meta box in the given location, or false otherwise.
+
+_Usage_
+
+```js
+import { select } from '@wordpress/data';
+
+// Check if the "side" location has any active meta boxes
+const sideHasMeta =
+	select( 'core/edit-post' ).isMetaBoxLocationActive( 'side' );
+console.log( sideHasMeta ); // true or false
+```
 
 _Parameters_
 
@@ -254,6 +386,17 @@ _Returns_
 ### isMetaBoxLocationVisible
 
 Returns true if a metabox location is active and visible
+
+_Usage_
+
+```js
+import { select } from '@wordpress/data';
+
+// Check if the "side" metabox location is active and visible
+const isSideVisible =
+	select( 'core/edit-post' ).isMetaBoxLocationVisible( 'side' );
+console.log( isSideVisible ); // true or false
+```
 
 _Parameters_
 
@@ -283,6 +426,15 @@ _Returns_
 
 Returns true if the plugin item is pinned to the header. When the value is not set it defaults to true.
 
+_Usage_
+
+```js
+import { select } from '@wordpress/data';
+
+const pinned = select( 'core/edit-post' ).isPluginItemPinned( 'my-plugin' );
+console.log( pinned );
+```
+
 _Parameters_
 
 -   _state_ `Object`: Global application state.
@@ -295,6 +447,15 @@ _Returns_
 ### isPluginSidebarOpened
 
 Returns true if the plugin sidebar is opened.
+
+_Usage_
+
+```js
+import { select } from '@wordpress/data';
+
+const pluginSidebarOpen = select( 'core/edit-post' ).isPluginSidebarOpened();
+console.log( pluginSidebarOpen );
+```
 
 _Parameters_
 
@@ -321,6 +482,15 @@ _Returns_
 ### isSavingMetaBoxes
 
 Returns true if the Meta Boxes are being saved.
+
+_Usage_
+
+```js
+import { select } from '@wordpress/data';
+
+const saving = select( 'core/edit-post' ).isSavingMetaBoxes();
+console.log( saving );
+```
 
 _Parameters_
 

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -24,6 +24,14 @@ const EMPTY_OBJECT = {};
  * @param {Object} state Global application state.
  *
  * @return {string} Editing mode.
+ *
+ * @example
+ * ```js
+ * import { select } from '@wordpress/data';
+ *
+ * const mode = select( 'core/edit-post' ).getEditorMode();
+ * console.log( mode ); // e.g. "visual" or "text"
+ * ```
  */
 export const getEditorMode = createRegistrySelector(
 	( select ) => () =>
@@ -36,6 +44,14 @@ export const getEditorMode = createRegistrySelector(
  * @param {Object} state Global application state
  *
  * @return {boolean} Whether the editor sidebar is opened.
+ *
+ * @example
+ * ```js
+ * import { select } from '@wordpress/data';
+ *
+ * const open = select( 'core/edit-post' ).isEditorSidebarOpened();
+ * console.log( open );
+ * ```
  */
 export const isEditorSidebarOpened = createRegistrySelector(
 	( select ) => () => {
@@ -53,6 +69,14 @@ export const isEditorSidebarOpened = createRegistrySelector(
  * @param {Object} state Global application state.
  *
  * @return {boolean} Whether the plugin sidebar is opened.
+ *
+ * @example
+ * ```js
+ * import { select } from '@wordpress/data';
+ *
+ * const pluginSidebarOpen = select( 'core/edit-post' ).isPluginSidebarOpened();
+ * console.log( pluginSidebarOpen );
+ * ```
  */
 export const isPluginSidebarOpened = createRegistrySelector(
 	( select ) => () => {
@@ -80,6 +104,14 @@ export const isPluginSidebarOpened = createRegistrySelector(
  * @param {Object} state Global application state.
  *
  * @return {?string} Active general sidebar name.
+ *
+ * @example
+ * ```js
+ * import { select } from '@wordpress/data';
+ *
+ * const sidebar = select( 'core/edit-post' ).getActiveGeneralSidebarName();
+ * console.log( sidebar ); // "edit-post/document" or null
+ * ```
  */
 export const getActiveGeneralSidebarName = createRegistrySelector(
 	( select ) => () => {
@@ -106,6 +138,21 @@ export const getActiveGeneralSidebarName = createRegistrySelector(
  * @param {string[] | undefined} openPanels     An array of open panel names.
  *
  * @return {Object} The converted panel data.
+ *
+ * @example
+ * ```js
+ * // Example with one inactive and two open panels.
+ * const inactivePanels = [ 'discussion-panel' ];
+ * const openPanels = [ 'discussion-panel', 'categories-panel' ];
+ *
+ * const result = convertPanelsToOldFormat( inactivePanels, openPanels );
+ *
+ * console.log( result );
+ * // {
+ * //   "discussion-panel": { enabled: false, opened: true },
+ * //   "categories-panel": { opened: true }
+ * // }
+ * ```
  */
 function convertPanelsToOldFormat( inactivePanels, openPanels ) {
 	// First reduce the inactive panels.
@@ -145,6 +192,14 @@ function convertPanelsToOldFormat( inactivePanels, openPanels ) {
  * @param {Object} state Global application state.
  *
  * @return {Object} Preferences Object.
+ *
+ * @example
+ * ```js
+ * import { select } from '@wordpress/data';
+ *
+ * const prefs = select( 'core/edit-post' ).getPreferences();
+ * console.log( prefs );
+ * ```
  */
 export const getPreferences = createRegistrySelector( ( select ) => () => {
 	deprecated( `select( 'core/edit-post' ).getPreferences`, {
@@ -185,6 +240,7 @@ export const getPreferences = createRegistrySelector( ( select ) => () => {
 } );
 
 /**
+ * @deprecated
  *
  * @param {Object} state         Global application state.
  * @param {string} preferenceKey Preference Key.
@@ -208,6 +264,14 @@ export function getPreference( state, preferenceKey, defaultValue ) {
  * Returns an array of blocks that are hidden.
  *
  * @return {Array} A list of the hidden block types
+ *
+ * @example
+ * ```js
+ * import { select } from '@wordpress/data';
+ *
+ * const hiddenBlocks = select( 'core/edit-post' ).getHiddenBlockTypes();
+ * console.log( hiddenBlocks );
+ * ```
  */
 export const getHiddenBlockTypes = createRegistrySelector( ( select ) => () => {
 	return (
@@ -325,6 +389,14 @@ export const isModalActive = createRegistrySelector(
  * @param {string} feature Feature slug.
  *
  * @return {boolean} Is active.
+ *
+ * @example
+ * ```js
+ * import { select } from '@wordpress/data';
+ *
+ * const isActive = select( 'core/edit-post' ).isFeatureActive( 'fullscreenMode' );
+ * console.log( isActive );
+ * ```
  */
 export const isFeatureActive = createRegistrySelector(
 	( select ) => ( state, feature ) => {
@@ -340,6 +412,14 @@ export const isFeatureActive = createRegistrySelector(
  * @param {string} pluginName Plugin item name.
  *
  * @return {boolean} Whether the plugin item is pinned.
+ *
+ * @example
+ * ```js
+ * import { select } from '@wordpress/data';
+ *
+ * const pinned = select( 'core/edit-post' ).isPluginItemPinned( 'my-plugin' );
+ * console.log( pinned );
+ * ```
  */
 export const isPluginItemPinned = createRegistrySelector(
 	( select ) => ( state, pluginName ) => {
@@ -353,6 +433,14 @@ export const isPluginItemPinned = createRegistrySelector(
  * @param {Object} state Post editor state.
  *
  * @return {string[]} Active meta box locations.
+ *
+ * @example
+ * ```js
+ * import { select } from '@wordpress/data';
+ *
+ * const locations = select( 'core/edit-post' ).getActiveMetaBoxLocations();
+ * console.log( locations ); // e.g. [ 'side', 'normal' ]
+ * ```
  */
 export const getActiveMetaBoxLocations = createSelector(
 	( state ) => {
@@ -370,6 +458,15 @@ export const getActiveMetaBoxLocations = createSelector(
  * @param {string} location Meta box location to test.
  *
  * @return {boolean} Whether the meta box location is active and visible.
+ *
+ * @example
+ * ```js
+ * import { select } from '@wordpress/data';
+ *
+ * // Check if the "side" metabox location is active and visible
+ * const isSideVisible = select( 'core/edit-post' ).isMetaBoxLocationVisible( 'side' );
+ * console.log( isSideVisible ); // true or false
+ * ```
  */
 export const isMetaBoxLocationVisible = createRegistrySelector(
 	( select ) => ( state, location ) => {
@@ -392,6 +489,15 @@ export const isMetaBoxLocationVisible = createRegistrySelector(
  * @param {string} location Meta box location to test.
  *
  * @return {boolean} Whether the meta box location is active.
+ *
+ * @example
+ * ```js
+ * import { select } from '@wordpress/data';
+ *
+ * // Check if the "side" location has any active meta boxes
+ * const sideHasMeta = select( 'core/edit-post' ).isMetaBoxLocationActive( 'side' );
+ * console.log( sideHasMeta ); // true or false
+ * ```
  */
 export function isMetaBoxLocationActive( state, location ) {
 	const metaBoxes = getMetaBoxesPerLocation( state, location );
@@ -405,6 +511,14 @@ export function isMetaBoxLocationActive( state, location ) {
  * @param {string} location Meta box location to test.
  *
  * @return {?Array} List of meta boxes.
+ *
+ * @example
+ * ```js
+ * import { select } from '@wordpress/data';
+ *
+ * const sideMetaBoxes = select( 'core/edit-post' ).getMetaBoxesPerLocation( 'side' );
+ * console.log( sideMetaBoxes );
+ * ```
  */
 export function getMetaBoxesPerLocation( state, location ) {
 	return state.metaBoxes.locations[ location ];
@@ -416,6 +530,14 @@ export function getMetaBoxesPerLocation( state, location ) {
  * @param {Object} state Global application state.
  *
  * @return {Array} List of meta boxes.
+ *
+ * @example
+ * ```js
+ * import { select } from '@wordpress/data';
+ *
+ * const metaBoxes = select( 'core/edit-post' ).getAllMetaBoxes();
+ * console.log( metaBoxes );
+ * ```
  */
 export const getAllMetaBoxes = createSelector(
 	( state ) => {
@@ -430,6 +552,15 @@ export const getAllMetaBoxes = createSelector(
  * @param {Object} state Global application state
  *
  * @return {boolean} Whether there are metaboxes or not.
+ *
+ * @example
+ * ```js
+ * import { select } from '@wordpress/data';
+ *
+ * // Check if the current post being edited has any meta boxes
+ * const hasMeta = select( 'core/edit-post' ).hasMetaBoxes();
+ * console.log( hasMeta ); // true or false
+ * ```
  */
 export function hasMetaBoxes( state ) {
 	return getActiveMetaBoxLocations( state ).length > 0;
@@ -441,6 +572,14 @@ export function hasMetaBoxes( state ) {
  * @param {Object} state Global application state.
  *
  * @return {boolean} Whether the metaboxes are being saved.
+ *
+ * @example
+ * ```js
+ * import { select } from '@wordpress/data';
+ *
+ * const saving = select( 'core/edit-post' ).isSavingMetaBoxes();
+ * console.log( saving );
+ * ```
  */
 export function isSavingMetaBoxes( state ) {
 	return state.metaBoxes.isSaving;
@@ -514,6 +653,14 @@ export const __experimentalGetInsertionPoint = createRegistrySelector(
  * @param {Object} state Global application state.
  *
  * @return {boolean} Whether the list view is opened.
+ *
+ * @example
+ * ```js
+ * import { select } from '@wordpress/data';
+ *
+ * const listViewOpen = select( 'core/edit-post' ).isListViewOpened();
+ * console.log( listViewOpen );
+ * ```
  */
 export const isListViewOpened = createRegistrySelector( ( select ) => () => {
 	deprecated( `select( 'core/edit-post' ).isListViewOpened`, {
@@ -542,6 +689,14 @@ export const isEditingTemplate = createRegistrySelector( ( select ) => () => {
  * @param {Object} state Global application state.
  *
  * @return {boolean} Whether meta boxes are initialized.
+ *
+ * @example
+ * ```js
+ * import { select } from '@wordpress/data';
+ *
+ * const initialized = select( 'core/edit-post' ).areMetaBoxesInitialized();
+ * console.log( initialized ); // true or false
+ * ```
  */
 export function areMetaBoxesInitialized( state ) {
 	return state.metaBoxes.initialized;
@@ -551,6 +706,14 @@ export function areMetaBoxesInitialized( state ) {
  * Retrieves the template of the currently edited post.
  *
  * @return {?Object} Post Template.
+ *
+ * @example
+ * ```js
+ * import { select } from '@wordpress/data';
+ *
+ * const template = select( 'core/edit-post' ).getEditedPostTemplate();
+ * console.log( template );
+ * ```
  */
 export const getEditedPostTemplate = createRegistrySelector(
 	( select ) => () => {

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -27,10 +27,23 @@ const EMPTY_OBJECT = {};
  *
  * @example
  * ```js
- * import { select } from '@wordpress/data';
+ * import { __ } from '@wordpress/i18n';
+ * import { useSelect } from '@wordpress/data';
+ * import { store as editPostStore } from '@wordpress/edit-post';
  *
- * const mode = select( 'core/edit-post' ).getEditorMode();
- * console.log( mode ); // e.g. "visual" or "text"
+ * const EditorModeNotice = () => {
+ *     const editorMode = useSelect(
+ *         ( select ) => select( editPostStore ).getEditorMode(),
+ *         []
+ *     );
+ *
+ *     return (
+ *         <p>
+ *             { __( 'The current editor mode is: ' ) }
+ *             <strong>{ editorMode }</strong>
+ *         </p>
+ *     );
+ * };
  * ```
  */
 export const getEditorMode = createRegistrySelector(
@@ -47,10 +60,21 @@ export const getEditorMode = createRegistrySelector(
  *
  * @example
  * ```js
- * import { select } from '@wordpress/data';
+ * import { useSelect } from '@wordpress/data';
+ * import { store as editPostStore } from '@wordpress/edit-post';
  *
- * const open = select( 'core/edit-post' ).isEditorSidebarOpened();
- * console.log( open );
+ * const SidebarStatus = () => {
+ *     const isOpen = useSelect(
+ *         ( select ) => select( editPostStore ).isEditorSidebarOpened(),
+ *         []
+ *     );
+ *
+ *     return (
+ *         <p>
+ *             Sidebar is { isOpen ? 'open' : 'closed' }.
+ *         </p>
+ *     );
+ * };
  * ```
  */
 export const isEditorSidebarOpened = createRegistrySelector(
@@ -72,10 +96,21 @@ export const isEditorSidebarOpened = createRegistrySelector(
  *
  * @example
  * ```js
- * import { select } from '@wordpress/data';
+ * import { useSelect } from '@wordpress/data';
+ * import { store as editPostStore } from '@wordpress/edit-post';
  *
- * const pluginSidebarOpen = select( 'core/edit-post' ).isPluginSidebarOpened();
- * console.log( pluginSidebarOpen );
+ * const PluginSidebarStatus = () => {
+ *     const isOpen = useSelect(
+ *         ( select ) => select( editPostStore ).isPluginSidebarOpened(),
+ *         []
+ *     );
+ *
+ *     return (
+ *         <p>
+ *             Plugin sidebar is { isOpen ? 'open' : 'closed' }.
+ *         </p>
+ *     );
+ * };
  * ```
  */
 export const isPluginSidebarOpened = createRegistrySelector(
@@ -107,10 +142,23 @@ export const isPluginSidebarOpened = createRegistrySelector(
  *
  * @example
  * ```js
- * import { select } from '@wordpress/data';
+ * import { useSelect } from '@wordpress/data';
+ * import { store as editPostStore } from '@wordpress/edit-post';
  *
- * const sidebar = select( 'core/edit-post' ).getActiveGeneralSidebarName();
- * console.log( sidebar ); // "edit-post/document" or null
+ * const ActiveSidebar = () => {
+ *     const sidebar = useSelect(
+ *         ( select ) => select( editPostStore ).getActiveGeneralSidebarName(),
+ *         []
+ *     );
+ *
+ *     return (
+ *         <p>
+ *             { sidebar
+ *                 ? `Active sidebar: ${ sidebar }`
+ *                 : 'No general sidebar is active.' }
+ *         </p>
+ *     );
+ * };
  * ```
  */
 export const getActiveGeneralSidebarName = createRegistrySelector(
@@ -141,6 +189,8 @@ export const getActiveGeneralSidebarName = createRegistrySelector(
  *
  * @example
  * ```js
+ * import { convertPanelsToOldFormat } from '@wordpress/edit-post';
+ *
  * // Example with one inactive and two open panels.
  * const inactivePanels = [ 'discussion-panel' ];
  * const openPanels = [ 'discussion-panel', 'categories-panel' ];
@@ -197,8 +247,16 @@ function convertPanelsToOldFormat( inactivePanels, openPanels ) {
  * ```js
  * import { select } from '@wordpress/data';
  *
+ * // Get all preferences for the editor.
  * const prefs = select( 'core/edit-post' ).getPreferences();
  * console.log( prefs );
+ * // Example output:
+ * // {
+ * //   panels: { 'categories-panel': { opened: true }, ... },
+ * //   editorMode: 'visual',
+ * //   hiddenBlockTypes: [ 'core/verse' ],
+ * //   ...
+ * // }
  * ```
  */
 export const getPreferences = createRegistrySelector( ( select ) => () => {
@@ -269,8 +327,14 @@ export function getPreference( state, preferenceKey, defaultValue ) {
  * ```js
  * import { select } from '@wordpress/data';
  *
+ * // Get all hidden block types in the editor.
  * const hiddenBlocks = select( 'core/edit-post' ).getHiddenBlockTypes();
  * console.log( hiddenBlocks );
+ * // Example output:
+ * // [ "core/verse", "core/quote" ]
+ *
+ * // You can also check if a particular block type is hidden:
+ * console.log( hiddenBlocks.includes( "core/verse" ) ); // true or false
  * ```
  */
 export const getHiddenBlockTypes = createRegistrySelector( ( select ) => () => {
@@ -394,8 +458,16 @@ export const isModalActive = createRegistrySelector(
  * ```js
  * import { select } from '@wordpress/data';
  *
+ * // Check if the editor is currently in fullscreen mode.
  * const isActive = select( 'core/edit-post' ).isFeatureActive( 'fullscreenMode' );
- * console.log( isActive );
+ * console.log( isActive ); // true or false
+ *
+ * // Example usage: toggle UI depending on feature state.
+ * if ( isActive ) {
+ *     console.log( 'The editor is in fullscreen mode.' );
+ * } else {
+ *     console.log( 'Fullscreen mode is disabled.' );
+ * }
  * ```
  */
 export const isFeatureActive = createRegistrySelector(
@@ -417,8 +489,16 @@ export const isFeatureActive = createRegistrySelector(
  * ```js
  * import { select } from '@wordpress/data';
  *
+ * // Check if a plugin toolbar item is pinned.
  * const pinned = select( 'core/edit-post' ).isPluginItemPinned( 'my-plugin' );
- * console.log( pinned );
+ * console.log( pinned ); // true or false
+ *
+ * // Example: use this to decide whether to render a "pin/unpin" button in your plugin UI.
+ * if ( pinned ) {
+ *     console.log( 'The plugin item is pinned in the toolbar.' );
+ * } else {
+ *     console.log( 'The plugin item is not pinned.' );
+ * }
  * ```
  */
 export const isPluginItemPinned = createRegistrySelector(
@@ -440,6 +520,11 @@ export const isPluginItemPinned = createRegistrySelector(
  *
  * const locations = select( 'core/edit-post' ).getActiveMetaBoxLocations();
  * console.log( locations ); // e.g. [ 'side', 'normal' ]
+ *
+ * // Example usage: check if the "side" location has any meta boxes
+ * if ( locations.includes( 'side' ) ) {
+ *     console.log( 'There are meta boxes in the sidebar.' );
+ * }
  * ```
  */
 export const getActiveMetaBoxLocations = createSelector(
@@ -461,11 +546,22 @@ export const getActiveMetaBoxLocations = createSelector(
  *
  * @example
  * ```js
- * import { select } from '@wordpress/data';
+ * import { __ } from '@wordpress/i18n';
+ * import { useSelect } from '@wordpress/data';
+ * import { store as editPostStore } from '@wordpress/edit-post';
  *
- * // Check if the "side" metabox location is active and visible
- * const isSideVisible = select( 'core/edit-post' ).isMetaBoxLocationVisible( 'side' );
- * console.log( isSideVisible ); // true or false
+ * const NormalMetaBoxesIndicator = () => {
+ *     const isNormalVisible = useSelect(
+ *         ( select ) => select( editPostStore ).isMetaBoxLocationVisible( 'normal' ),
+ *         []
+ *     );
+ *
+ *     return isNormalVisible ? (
+ *         <p>{ __( 'Normal meta boxes are visible.' ) }</p>
+ *     ) : (
+ *         <p>{ __( 'No visible normal meta boxes.' ) }</p>
+ *     );
+ * };
  * ```
  */
 export const isMetaBoxLocationVisible = createRegistrySelector(
@@ -492,11 +588,22 @@ export const isMetaBoxLocationVisible = createRegistrySelector(
  *
  * @example
  * ```js
- * import { select } from '@wordpress/data';
+ * import { __ } from '@wordpress/i18n';
+ * import { useSelect } from '@wordpress/data';
+ * import { store as editPostStore } from '@wordpress/edit-post';
  *
- * // Check if the "side" location has any active meta boxes
- * const sideHasMeta = select( 'core/edit-post' ).isMetaBoxLocationActive( 'side' );
- * console.log( sideHasMeta ); // true or false
+ * const SideMetaBoxesIndicator = () => {
+ *     const isSideActive = useSelect(
+ *         ( select ) => select( editPostStore ).isMetaBoxLocationActive( 'side' ),
+ *         []
+ *     );
+ *
+ *     return isSideActive ? (
+ *         <p>{ __( 'Side meta boxes are active.' ) }</p>
+ *     ) : (
+ *         <p>{ __( 'No side meta boxes.' ) }</p>
+ *     );
+ * };
  * ```
  */
 export function isMetaBoxLocationActive( state, location ) {
@@ -518,6 +625,11 @@ export function isMetaBoxLocationActive( state, location ) {
  *
  * const sideMetaBoxes = select( 'core/edit-post' ).getMetaBoxesPerLocation( 'side' );
  * console.log( sideMetaBoxes );
+ *
+ * // Example: iterate over meta boxes
+ * sideMetaBoxes.forEach( ( box ) => {
+ *     console.log( box.id, box.title );
+ * } );
  * ```
  */
 export function getMetaBoxesPerLocation( state, location ) {
@@ -537,6 +649,17 @@ export function getMetaBoxesPerLocation( state, location ) {
  *
  * const metaBoxes = select( 'core/edit-post' ).getAllMetaBoxes();
  * console.log( metaBoxes );
+ *
+ * // Example shape of the result:
+ * // {
+ * //   side: [
+ * //     { id: 'submitdiv', title: 'Publish' },
+ * //     { id: 'tagsdiv-post_tag', title: 'Tags' }
+ * //   ],
+ * //   normal: [
+ * //     { id: 'postexcerpt', title: 'Excerpt' }
+ * //   ]
+ * // }
  * ```
  */
 export const getAllMetaBoxes = createSelector(
@@ -555,11 +678,22 @@ export const getAllMetaBoxes = createSelector(
  *
  * @example
  * ```js
- * import { select } from '@wordpress/data';
+ * import { __ } from '@wordpress/i18n';
+ * import { useSelect } from '@wordpress/data';
+ * import { store as editPostStore } from '@wordpress/edit-post';
  *
- * // Check if the current post being edited has any meta boxes
- * const hasMeta = select( 'core/edit-post' ).hasMetaBoxes();
- * console.log( hasMeta ); // true or false
+ * const ExampleComponent = () => {
+ *     const hasMetaBoxes = useSelect(
+ *         ( select ) => select( editPostStore ).hasMetaBoxes(),
+ *         []
+ *     );
+ *
+ *     return hasMetaBoxes ? (
+ *         <p>{ __( 'This post type uses meta boxes.' ) }</p>
+ *     ) : (
+ *         <p>{ __( 'No meta boxes registered for this post type.' ) }</p>
+ *     );
+ * };
  * ```
  */
 export function hasMetaBoxes( state ) {
@@ -578,7 +712,7 @@ export function hasMetaBoxes( state ) {
  * import { select } from '@wordpress/data';
  *
  * const saving = select( 'core/edit-post' ).isSavingMetaBoxes();
- * console.log( saving );
+ * console.log( saving ); // true while meta boxes are saving, false otherwise
  * ```
  */
 export function isSavingMetaBoxes( state ) {
@@ -659,7 +793,7 @@ export const __experimentalGetInsertionPoint = createRegistrySelector(
  * import { select } from '@wordpress/data';
  *
  * const listViewOpen = select( 'core/edit-post' ).isListViewOpened();
- * console.log( listViewOpen );
+ * console.log( listViewOpen ); // true if List View is visible, false otherwise
  * ```
  */
 export const isListViewOpened = createRegistrySelector( ( select ) => () => {
@@ -713,6 +847,13 @@ export function areMetaBoxesInitialized( state ) {
  *
  * const template = select( 'core/edit-post' ).getEditedPostTemplate();
  * console.log( template );
+ * // Example output:
+ * // {
+ * //   slug: "my-custom-template",
+ * //   theme: "my-theme",
+ * //   source: "theme",
+ * //   ...etc
+ * // }
  * ```
  */
 export const getEditedPostTemplate = createRegistrySelector(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
See https://github.com/WordPress/gutenberg/issues/42125

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, the `Data Modules` section in the handbook lacks code examples, making it difficult for developers to understand and use the available selectors. Adding `@example` tags improves documentation and helps developers quickly see how to interact with editor state.

## How?
This PR adds @example tags for all non-deprecated selectors in the @wordpress/edit-post package. Part of the effort in https://github.com/WordPress/gutenberg/issues/42125.
