### PR TITLE
Interface: Remove leftover comment

### DIFF
--- a/packages/interface/src/store/index.js
+++ b/packages/interface/src/store/index.js
@@ -23,7 +23,4 @@ export const store = createReduxStore( STORE_NAME, {
 	actions,
 	selectors,
 } );
-
-// Once we build a more generic persistence plugin that works across types of stores
-// we'd be able to replace this with a register call.
 register( store );


### PR DESCRIPTION
## What?

PR removes leftover comment from `@wordpress/interface` package store, which is no longer valid since #39449.

## Testing Instructions
None.
