### PR TITLE
Editor: Fix theme stylesheet injection in 'useAvailablePatterns'

### DIFF
--- a/packages/editor/src/components/post-transform-panel/hooks.js
+++ b/packages/editor/src/components/post-transform-panel/hooks.js
@@ -105,10 +105,6 @@ export function useAvailablePatterns( template ) {
 			...( restBlockPatterns || [] ),
 		];
 		const filteredPatterns = filterPatterns( mergedPatterns, template );
-		return preparePatterns(
-			filteredPatterns,
-			template,
-			currentThemeStylesheet
-		);
+		return preparePatterns( filteredPatterns, currentThemeStylesheet );
 	}, [ blockPatterns, restBlockPatterns, template, currentThemeStylesheet ] );
 }


### PR DESCRIPTION
## What?
PR fixes arguments passed to the `preparePatterns` in `useAvailablePatterns`. It only accepts the theme stylesheet string as the second arg. Passing template isn't required.

https://github.com/WordPress/gutenberg/blob/469c98c5dca74ea54bd694b3f0fe4ca4c201c152/packages/editor/src/components/post-transform-panel/hooks.js#L70

## Testing Instructions
CI checks are passing.

### Testing Instructions for Keyboard
Same.
