### PR TITLE
Editor: Improve the 'Design' sidebar panel performance

### DIFF
--- a/packages/editor/src/components/post-transform-panel/hooks.js
+++ b/packages/editor/src/components/post-transform-panel/hooks.js
@@ -40,7 +40,7 @@ function injectThemeAttributeInBlockTemplateContent(
  * Filter all patterns and return only the ones that are compatible with the current template.
  *
  * @param {Array}  patterns An array of patterns.
- * @param {Object} template The current template.
+ * @param {Object} template The current template. Required values are `area`, `name`, and `slug`.
  * @return {Array} Array of patterns that are compatible with the current template.
  */
 function filterPatterns( patterns, template ) {
@@ -83,7 +83,7 @@ function preparePatterns( patterns, currentThemeStylesheet ) {
 	} ) );
 }
 
-export function useAvailablePatterns( template ) {
+export function useAvailablePatterns( { area, name, slug } ) {
 	const { blockPatterns, restBlockPatterns, currentThemeStylesheet } =
 		useSelect( ( select ) => {
 			const { getEditorSettings } = select( editorStore );
@@ -104,7 +104,18 @@ export function useAvailablePatterns( template ) {
 			...( blockPatterns || [] ),
 			...( restBlockPatterns || [] ),
 		];
-		const filteredPatterns = filterPatterns( mergedPatterns, template );
+		const filteredPatterns = filterPatterns( mergedPatterns, {
+			area,
+			name,
+			slug,
+		} );
 		return preparePatterns( filteredPatterns, currentThemeStylesheet );
-	}, [ blockPatterns, restBlockPatterns, template, currentThemeStylesheet ] );
+	}, [
+		area,
+		name,
+		slug,
+		blockPatterns,
+		restBlockPatterns,
+		currentThemeStylesheet,
+	] );
 }

--- a/packages/editor/src/components/post-transform-panel/index.js
+++ b/packages/editor/src/components/post-transform-panel/index.js
@@ -34,19 +34,23 @@ function TemplatesList( { availableTemplates, onSelect } ) {
 }
 
 function PostTransform() {
-	const { record, postType, postId } = useSelect( ( select ) => {
+	const { area, name, slug, postType, postId } = useSelect( ( select ) => {
 		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
 		const { getEditedEntityRecord } = select( coreStore );
 		const type = getCurrentPostType();
 		const id = getCurrentPostId();
+		const record = getEditedEntityRecord( 'postType', type, id );
+
 		return {
+			area: record?.area,
+			name: record?.name,
+			slug: record?.slug,
 			postType: type,
 			postId: id,
-			record: getEditedEntityRecord( 'postType', type, id ),
 		};
 	}, [] );
 	const { editEntityRecord } = useDispatch( coreStore );
-	const availablePatterns = useAvailablePatterns( record );
+	const availablePatterns = useAvailablePatterns( { area, name, slug } );
 	const onTemplateSelect = async ( selectedTemplate ) => {
 		await editEntityRecord( 'postType', postType, postId, {
 			blocks: selectedTemplate.blocks,
@@ -60,7 +64,7 @@ function PostTransform() {
 	return (
 		<PanelBody
 			title={ __( 'Design' ) }
-			initialOpen={ record.type === TEMPLATE_PART_POST_TYPE }
+			initialOpen={ postType === TEMPLATE_PART_POST_TYPE }
 		>
 			<TemplatesList
 				availableTemplates={ availablePatterns }


### PR DESCRIPTION
## What?
~~"Stacks" on #71332.~~

PR tries to improve the "Design" sidebar panel performance by avoiding unnecessary re-renders every time a record is updated. The data needed for filtering patterns doesn't change often, and the panel doesn't have to react to content edits.

Rendering previews can be expensive. Components should avoid re-rendering them when possible.

## Why?
* Avoids flickers of the rendered previews.
* Improves panel performance when the design is selected.

## Testing Instructions
1. Go to the Site Editor.
2. Open Template or Template Parts.
3. Switch between the designs.
4. Confirm that previews don't flicker when the design is changed.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<details><summary>Templates</summary>
<p>

**Before**

https://github.com/user-attachments/assets/ad530613-cde0-483f-a352-b86756958b6b

**After**

https://github.com/user-attachments/assets/88b9fb27-bec9-4ab2-aca8-b3dade0a7312



</p>
</details> 

<details><summary>Template Parts</summary>
<p>


**Before**

https://github.com/user-attachments/assets/4b5ca1da-46f1-47da-991b-2de54d6e3373

**After**

https://github.com/user-attachments/assets/7b018864-06d0-4a2c-8fe1-f4a4d4c44f31

</p>
</details> 

