### PR TITLE
CI: Skip mobile unit tests

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -375,6 +375,8 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
+        # React 19 breaks these tests, and upgrading React Native to a compatible version is paused.
+        # See: https://github.com/WordPress/gutenberg/issues/71336
         if: false
         #if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -375,7 +375,8 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
-        if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
+        if: false
+        #if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
 
         steps:
             - name: Checkout repository


### PR DESCRIPTION
## What?

Skipping the mobile unit tests.

Part of #71336.

## Why?
As we're moving forward with the React 19 upgrade, they will inevitably break, so we're disabling them for the time being. 

See #71336 for more info.

## How?
Just skipping them.

## Testing Instructions
* Make sure the mobile unit tests don't run
* Make sure the rest of the unit tests keep running.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None