### PR TITLE
Global Styles: Remove unecessary useEffect from ScreenStyleVariations

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -6,10 +6,8 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { Card, CardBody } from '@wordpress/components';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { store as editorStore } from '@wordpress/editor';
-import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -27,11 +25,7 @@ function ScreenStyleVariations() {
 	const isPreviewMode = useSelect( ( select ) => {
 		return select( blockEditorStore ).getSettings().isPreviewMode;
 	}, [] );
-	const { setDeviceType } = useDispatch( editorStore );
 	useZoomOut( ! isPreviewMode );
-	useEffect( () => {
-		setDeviceType( 'desktop' );
-	}, [ setDeviceType ] );
 
 	return (
 		<>


### PR DESCRIPTION
Related:

- https://github.com/WordPress/gutenberg/pull/66023
- https://github.com/WordPress/gutenberg/pull/67146

## What? Why? How?

The styles screen enables the zoom out mode and forces the device preview to be desktop. However, the correct value is `Desktop`, not `desktop`, so I'm not sure why this effect is necessary in the first place. Additionally, [the `getDeviceType` selector forces the Desktop view when zoomed out mode is enabled](https://github.com/WordPress/gutenberg/blob/0f0adcc7e39606ee77713fafb5ab4cc7fd40d88b/packages/editor/src/store/selectors.js#L1353-L1355), so there seems to be no need to explicitly force the Desktop view.

Maybe this code solved the problem for some reason at the time, but everything appears to work correctly without this side effect.

## Testing Instructions

Verify that the issue reported in #65991 has not reoccurred.

1. Open the Site Editor.
2. Change canvas view to Mobile.
3. Open Styles > Browse Styles.
4. Confirm that the view has switched back to Desktop.
5. While still on the Styles screen, manually disable zoom out mode or change device preview.
6. Also check the behavior in preview mode.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/604299dd-4fb5-4ca6-8115-fb07660f78a5

