### PR TITLE
DataForm: Streamline validation behavior

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   DataViews: Fix incorrect documentation for `defaultLayouts` prop. [#71334](https://github.com/WordPress/gutenberg/pull/71334)
 
+### Breaking changes
+
+-   DataForm: Add second argument to the `onChange` callback that contains an `isValid` boolean property and remove `isItemValid` utility. [#71345](https://github.com/WordPress/gutenberg/pull/71345)
+
 ## 7.0.0 (2025-08-20)
 
 ### Breaking changes

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 -   DataViews: Fix incorrect documentation for `defaultLayouts` prop. [#71334](https://github.com/WordPress/gutenberg/pull/71334)
 
-### Breaking changes
+### Enhancements
 
 -   DataForm: Add second argument to the `onChange` callback that contains an `isValid` boolean property and remove `isItemValid` utility. [#71345](https://github.com/WordPress/gutenberg/pull/71345)
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -640,6 +640,18 @@ Returns an object containing:
     -   `totalItems`: total number of items for the current view config.
     -   `totalPages`: total number of pages for the current view config.
 
+### `isItemValid`
+
+Utility is used to determine whether or not the given item's value is valid according to the current fields and form configuration.
+
+Parameters:
+
+-   `item`: the item, as described in the "data" property of DataForm.
+-   `fields`: the fields config, as described in the "fields" property of DataForm.
+-   `form`: the form config, as described in the "form" property of DataForm.
+
+Returns a boolean indicating if the item is valid (true) or not (false).
+
 ## Actions API
 
 ### `id`

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -586,7 +586,7 @@ const form = {
 
 #### `onChange`: `function`
 
-Callback function that receives an object with the edits done by the user.
+Callback function that receives an object with the edits done by the user. It also receives a second parameter that indicates whether the current item is valid or not according to the current fields and form configuration.
 
 Example:
 
@@ -598,7 +598,7 @@ const data = {
 	date: '2012-04-23T18:25:43.511Z',
 };
 
-const onChange = ( edits ) => {
+const onChange = ( edits, { isValid } ) => {
 	/*
 	 * edits will contain user edits.
 	 * For example, if the user edited the title
@@ -639,18 +639,6 @@ Returns an object containing:
 -   `paginationInfo`: object containing the following properties:
     -   `totalItems`: total number of items for the current view config.
     -   `totalPages`: total number of pages for the current view config.
-
-### `isItemValid`
-
-Utility is used to determine whether or not the given item's value is valid according to the current fields and form configuration.
-
-Parameters:
-
--   `item`: the item, as described in the "data" property of DataForm.
--   `fields`: the fields config, as described in the "fields" property of DataForm.
--   `form`: the form config, as described in the "form" property of DataForm.
-
-Returns a boolean indicating if the item is valid (true) or not (false).
 
 ## Actions API
 

--- a/packages/dataviews/src/components/dataform/index.tsx
+++ b/packages/dataviews/src/components/dataform/index.tsx
@@ -10,6 +10,7 @@ import type { DataFormProps } from '../../types';
 import { DataFormProvider } from '../dataform-context';
 import { normalizeFields } from '../../normalize-fields';
 import { DataFormLayout } from '../../dataforms-layouts/data-form-layout';
+import { isItemValid } from '../../validation';
 
 export default function DataForm< Item >( {
 	data,
@@ -22,13 +23,33 @@ export default function DataForm< Item >( {
 		[ fields ]
 	);
 
+	const onChangeWithValidation = ( updatedData: Partial< Item > ) => {
+		if ( ! onChange ) {
+			return;
+		}
+
+		const isValid = isItemValid(
+			{
+				...data,
+				...updatedData,
+			},
+			fields,
+			form
+		);
+		onChange( updatedData, { isValid } );
+	};
+
 	if ( ! form.fields ) {
 		return null;
 	}
 
 	return (
 		<DataFormProvider fields={ normalizedFields }>
-			<DataFormLayout data={ data } form={ form } onChange={ onChange } />
+			<DataFormLayout
+				data={ data }
+				form={ form }
+				onChange={ onChangeWithValidation }
+			/>
 		</DataFormProvider>
 	);
 }

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -12,7 +12,6 @@ import {
  * Internal dependencies
  */
 import DataForm from '../index';
-import { isItemValid } from '../../../validation';
 import type {
 	Field,
 	Form,
@@ -403,6 +402,7 @@ const ValidationComponent = ( {
 		boolean: true,
 		customEdit: 'custom control',
 	} );
+	const [ isPostValid, setIsValid ] = useState( true );
 
 	const customTextRule = ( value: ValidatedItem ) => {
 		if ( ! /^[a-zA-Z ]+$/.test( value.text ) ) {
@@ -483,8 +483,6 @@ const ValidationComponent = ( {
 		fields: [ 'text', 'email', 'integer', 'boolean', 'customEdit' ],
 	};
 
-	const canSave = isItemValid( post, _fields, form );
-
 	return (
 		<form>
 			<VStack alignment="left">
@@ -492,17 +490,19 @@ const ValidationComponent = ( {
 					data={ post }
 					fields={ _fields }
 					form={ form }
-					onChange={ ( edits ) =>
+					onChange={ ( edits, { isValid } ) => {
 						setPost( ( prev ) => ( {
 							...prev,
 							...edits,
-						} ) )
-					}
+						} ) );
+
+						setIsValid( isValid );
+					} }
 				/>
 				<Button
 					__next40pxDefaultSize
 					accessibleWhenDisabled
-					disabled={ ! canSave }
+					disabled={ ! isPostValid }
 					variant="primary"
 				>
 					Submit

--- a/packages/dataviews/src/index.ts
+++ b/packages/dataviews/src/index.ts
@@ -3,3 +3,4 @@ export { default as DataForm } from './components/dataform';
 export { VIEW_LAYOUTS } from './dataviews-layouts';
 export { filterSortAndPaginate } from './filter-and-sort-data-view';
 export type * from './types';
+export { isItemValid } from './validation';

--- a/packages/dataviews/src/index.ts
+++ b/packages/dataviews/src/index.ts
@@ -3,4 +3,3 @@ export { default as DataForm } from './components/dataform';
 export { VIEW_LAYOUTS } from './dataviews-layouts';
 export { filterSortAndPaginate } from './filter-and-sort-data-view';
 export type * from './types';
-export { isItemValid } from './validation';

--- a/packages/dataviews/src/test/dataform.tsx
+++ b/packages/dataviews/src/test/dataform.tsx
@@ -138,9 +138,13 @@ describe( 'DataForm component', () => {
 			await user.type( titleInput, newValue );
 			expect( onChange ).toHaveBeenCalledTimes( newValue.length );
 			for ( let i = 0; i < newValue.length; i++ ) {
-				expect( onChange ).toHaveBeenNthCalledWith( i + 1, {
-					title: newValue[ i ],
-				} );
+				expect( onChange ).toHaveBeenNthCalledWith(
+					i + 1,
+					{
+						title: newValue[ i ],
+					},
+					{ isValid: true }
+				);
 			}
 		} );
 
@@ -384,7 +388,10 @@ describe( 'DataForm component', () => {
 
 			// Modal should be closed and onChange should be called
 			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
-			expect( onChange ).toHaveBeenCalledWith( { title: 'New Title' } );
+			expect( onChange ).toHaveBeenCalledWith(
+				{ title: 'New Title' },
+				{ isValid: true }
+			);
 		} );
 
 		it( 'should call onChange with the correct value for each typed character', async () => {
@@ -407,9 +414,13 @@ describe( 'DataForm component', () => {
 			await user.type( input, newValue );
 			expect( onChange ).toHaveBeenCalledTimes( newValue.length );
 			for ( let i = 0; i < newValue.length; i++ ) {
-				expect( onChange ).toHaveBeenNthCalledWith( i + 1, {
-					title: newValue[ i ],
-				} );
+				expect( onChange ).toHaveBeenNthCalledWith(
+					i + 1,
+					{
+						title: newValue[ i ],
+					},
+					{ isValid: true }
+				);
 			}
 		} );
 

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -756,7 +756,11 @@ export interface DataFormProps< Item > {
 	data: Item;
 	fields: Field< Item >[];
 	form: Form;
-	onChange: ( value: Record< string, any > ) => void;
+	onChange: (
+		value: Record< string, any >,
+		validation: { isValid: boolean }
+	) => void;
+	applyChanges?: ( item: Item, changes: Partial< Item > ) => Item;
 }
 
 export interface FieldLayoutProps< Item > {

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -760,7 +760,6 @@ export interface DataFormProps< Item > {
 		value: Record< string, any >,
 		validation: { isValid: boolean }
 	) => void;
-	applyChanges?: ( item: Item, changes: Partial< Item > ) => Item;
 }
 
 export interface FieldLayoutProps< Item > {

--- a/packages/fields/src/actions/reorder-page.tsx
+++ b/packages/fields/src/actions/reorder-page.tsx
@@ -6,7 +6,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from '@wordpress/element';
-import { DataForm, isItemValid } from '@wordpress/dataviews';
+import { DataForm } from '@wordpress/dataviews';
 import {
 	Button,
 	__experimentalHStack as HStack,
@@ -31,6 +31,7 @@ function ReorderModal( {
 	onActionPerformed,
 }: RenderModalProps< BasePost > ) {
 	const [ item, setItem ] = useState( items[ 0 ] );
+	const [ isItemValid, setIsValid ] = useState( true );
 	const orderInput = item.menu_order;
 	const { editEntityRecord, saveEditedEntityRecord } =
 		useDispatch( coreStore );
@@ -40,7 +41,7 @@ function ReorderModal( {
 	async function onOrder( event: React.FormEvent ) {
 		event.preventDefault();
 
-		if ( ! isItemValid( item, fields, formOrderAction ) ) {
+		if ( ! isItemValid ) {
 			return;
 		}
 
@@ -68,7 +69,6 @@ function ReorderModal( {
 			} );
 		}
 	}
-	const isSaveDisabled = ! isItemValid( item, fields, formOrderAction );
 	return (
 		<form onSubmit={ onOrder }>
 			<VStack spacing="5">
@@ -81,12 +81,13 @@ function ReorderModal( {
 					data={ item }
 					fields={ fields }
 					form={ formOrderAction }
-					onChange={ ( changes ) =>
+					onChange={ ( changes, { isValid } ) => {
 						setItem( {
 							...item,
 							...changes,
-						} )
-					}
+						} );
+						setIsValid( isValid );
+					} }
 				/>
 				<HStack justify="right">
 					<Button
@@ -103,7 +104,7 @@ function ReorderModal( {
 						variant="primary"
 						type="submit"
 						accessibleWhenDisabled
-						disabled={ isSaveDisabled }
+						disabled={ ! isItemValid }
 					>
 						{ __( 'Save' ) }
 					</Button>


### PR DESCRIPTION
## What?

This PR proposes a better Dev Experience when working with DataForm and validation. Instead of assuming the consumer is going to run 'isltemValid' manually and think about when and how to run validation properly, this PR runs validation on each change and passes the result as a second argument for the onChange callback.
This is kind of inline with how most form libraries work, they take care of the validation... and they only give you a state.

## Testing Instructions

There shouldn't be any impact, the only place that uses validation right now is the "reoder page" action. You can test that action quickly or the validation story in storybook.