### PR TITLE
Components: Fix Tab font size when used outside WP

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `Tabs`: Ensure font size inheritance for tab buttons in all contexts ([#71346](https://github.com/WordPress/gutenberg/pull/71346)).
+
+
 ## 30.2.0 (2025-08-20)
 
-### Bug fixes
+### Bug Fixes
 
 -   `MenuItem`: make accessible when disabled ([#71251](https://github.com/WordPress/gutenberg/pull/71251)).
 

--- a/packages/components/src/tabs/styles.ts
+++ b/packages/components/src/tabs/styles.ts
@@ -163,6 +163,7 @@ export const Tab = styled( Ariakit.Tab )`
 		cursor: pointer;
 		line-height: 1.2; // Characters in some languages (e.g. Japanese) may have a native higher line-height.
 		font-weight: 400;
+		font-size: inherit;
 		color: ${ COLORS.theme.foreground };
 
 		&[aria-disabled='true'] {

--- a/packages/components/src/tabs/styles.ts
+++ b/packages/components/src/tabs/styles.ts
@@ -7,7 +7,7 @@ import * as Ariakit from '@ariakit/react';
 /**
  * Internal dependencies
  */
-import { COLORS, CONFIG } from '../utils';
+import { COLORS, CONFIG, font } from '../utils';
 import { space } from '../utils/space';
 import Icon from '../icon';
 
@@ -163,7 +163,7 @@ export const Tab = styled( Ariakit.Tab )`
 		cursor: pointer;
 		line-height: 1.2; // Characters in some languages (e.g. Japanese) may have a native higher line-height.
 		font-weight: 400;
-		font-size: inherit;
+		font-size: ${ font( 'default.fontSize' ) };
 		color: ${ COLORS.theme.foreground };
 
 		&[aria-disabled='true'] {


### PR DESCRIPTION
## What?

One of the principles of our UI components in general is to avoid relying on global "reset" styles that might come from WordPress styles or else. This PR fixes a case in the Tab component where the font size was relying on a a reset applied to the `button` element in the `forms.css` file coming from WordPress. Instead the font size is set to "inherit" to always inherit the default font size of the current application.

## Testing Instructions

- Open the inserter
- Inspect the "tabs" elements in Chrome
- Disable the CSS targetting `button` element that comes from the form.css file of WordPress
- The tabs should still show in the right font size (and not smaller)