### PR TITLE
Update types of getCurrentPostId

### DIFF
--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -218,7 +218,7 @@ _Parameters_
 
 _Returns_
 
--   `?(string|number)`: Template slug or current post ID.
+-   `?(number|string)`: The current post ID (number) or template slug (string).
 
 ### getCurrentPostLastRevisionId
 

--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -218,7 +218,7 @@ _Parameters_
 
 _Returns_
 
--   `?number`: ID of current post.
+-   `?(string|number)`: Template slug or current post ID.
 
 ### getCurrentPostLastRevisionId
 

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -195,7 +195,7 @@ export function getCurrentPostType( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @return {?number} ID of current post.
+ * @return {?(string|number)} Template slug or current post ID.
  */
 export function getCurrentPostId( state ) {
 	return state.postId;

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -195,7 +195,7 @@ export function getCurrentPostType( state ) {
  *
  * @param {Object} state Global application state.
  *
- * @return {?(string|number)} Template slug or current post ID.
+ * @return {?(number|string)} The current post ID (number) or template slug (string).
  */
 export function getCurrentPostId( state ) {
 	return state.postId;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

Updating `select( 'core/editor' ).getCurrentPostId()` return types.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Type of `select( 'core/editor' ).getCurrentPostId()` is incorrect as it may return string or number not only number.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

1. Create new post
2. In console browser run `select( 'core/editor' ).getCurrentPostId()` -> number
3. Go to Editor > Templates > some template
4. In console browser run `select( 'core/editor' ).getCurrentPostId()` -> string

Post Editor | Site Editor
-- | --
<img width="359" height="42" alt="image" src="https://github.com/user-attachments/assets/dc673bcc-0a17-4ab0-8de8-4135f7c2236f" /> | <img width="362" height="41" alt="image" src="https://github.com/user-attachments/assets/d1e840a0-7a48-41ee-ab75-0a7f332b7ce5" />

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
