### PR TITLE
Scripts: do not access `window` global

### DIFF
--- a/packages/scripts/scripts/test-playwright.js
+++ b/packages/scripts/scripts/test-playwright.js
@@ -42,7 +42,8 @@ try {
 	// First, try to load the package installed from among the optional peerDependencies.
 	loadConfig = require( '@wordpress/env/lib/config/load-config' );
 } catch ( error ) {
-	window.console.log(
+	// eslint-disable-next-line no-console
+	console.log(
 		'Notice: Could not find @wordpress/env package. Using WP_BASE_URL environment variable or else the default http://localhost:8889 URL for tests.'
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Addresses a regression from #70636

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

These are CLI scripts, so `window` doesn't exist.

Right now, running Playwright tests outside the Gutenberg repo **breaks** with `ReferenceError: window is not defined` because it hits this code path.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Fixes log statement

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Run `wp-scripts test-playwright` outside the Gutenberg repo.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

n/a

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

n/a