### PR TITLE
Zoom out: Correctly scale canvas in non-iframe editor

### DIFF
--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -319,12 +319,11 @@ export function useScaleCanvas( {
 		const trigger =
 			iframeDocument && previousIsZoomedOut.current !== isZoomedOut;
 
-		previousIsZoomedOut.current = isZoomedOut;
-
 		if ( ! trigger ) {
 			return;
 		}
 
+		previousIsZoomedOut.current = isZoomedOut;
 		startAnimationRef.current = true;
 
 		if ( ! isZoomedOut ) {

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -316,14 +316,19 @@ export function useScaleCanvas( {
 	 * changes due to the container resizing.
 	 */
 	useEffect( () => {
-		const trigger =
-			iframeDocument && previousIsZoomedOut.current !== isZoomedOut;
-
-		if ( ! trigger ) {
+		// If we don't have an iframe document, we don't run or track the animation.
+		if ( ! iframeDocument ) {
 			return;
 		}
 
+		const triggerAnimation = isZoomedOut !== previousIsZoomedOut.current;
 		previousIsZoomedOut.current = isZoomedOut;
+
+		// Zoom state has not changed, so we don't need to run the animation.
+		if ( ! triggerAnimation ) {
+			return;
+		}
+
 		startAnimationRef.current = true;
 
 		if ( ! isZoomedOut ) {


### PR DESCRIPTION
- Alternatives to #71233
 
## What?

This PR correctly triggers canvas scaling in the non-iframe post editor, and ensures that the iframe editor canvas scales out correctly.

## Why?

The Post Editor may not be an iframe under certain conditions. Therefore, when zoom-out mode is enabled, the `useScaleCanvas()` hook executes before the iframe element is rendered, resulting in the `iframeDocument` prop being `undefined`.

Even though this conditional statement becomes `false` and scale-out is not triggered, `previousIsZoomedOut.current` is updated to `true`:

https://github.com/WordPress/gutenberg/blob/55d79f3c6fda4bfa3071bbe92ed06b1ef5011d5f/packages/block-editor/src/components/iframe/use-scale-canvas.js#L318-L326

As a result, the `trigger` variable is always evaluated as `false`, and the canvas doesn't scale out, even though zoom-out mode is enabled internally.

```javascript
const trigger = iframeDocument && previousIsZoomedOut.current !== isZoomedOut;

const trigger = true && true !== true; => false
```

## How?

Update `previousIsZoomedOut` state _after_ the scaling is actually been triggered. I'm not sure if this is the correct approach, but it all appears to work correctly.

## Testing Instructions

First, delete the following lines in this branch. These changes are necessary to mimic the behavior in core and make the post editor work as a non-iframe editor:

```diff
diff --git a/packages/edit-post/src/components/layout/use-should-iframe.js b/packages/edit-post/src/components/layout/use-should-iframe.js
index 250f98afca..2a3cddd76e 100644
--- a/packages/edit-post/src/components/layout/use-should-iframe.js
+++ b/packages/edit-post/src/components/layout/use-should-iframe.js
@@ -18,11 +18,6 @@ export function useShouldIframe() {
                const { getEditorSettings, getCurrentPostType, getDeviceType } =
                        select( editorStore );
                return (
-                       // If the theme is block based and the Gutenberg plugin is active,
-                       // we ALWAYS use the iframe for consistency across the post and site
-                       // editor.
-                       ( isGutenbergPlugin &&
-                               getEditorSettings().__unstableIsBlockBasedTheme ) ||
                        // We also still want to iframe all the special
                        // editor features and modes such as device previews, zoom out, and
                        // template/pattern editing.
```

- Open a post.
- Enable "Show template".
- To make the editor work as a non-iframe, run the following code in your browser console: `wp.blocks.registerBlockType( 'test/v2', { apiVersion: '2', title: 'test' } );`
- Click the Zoom out button.
- Confirm that the canvas is scaled out (with no animation).
- Disable zoom out mode.
- Open the main inserter > Patterns tab.
- Confirm that the zoom out mode is automatically enabled and the canvas is scaled out (with no animation).

### Additional Tests

- Make sure it still works correctly even if the default editor is an iframe.
- Access the following URL directly: `/wp-admin/site-editor.php?p=%2Fstyles&section=%2Fblocks%2Fcore%252Fheading`
  - No errors should occur (This issue has been fixed in #67481).

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/a4dfffe8-e146-4ac1-bdac-88576640c4ef


