### PR TITLE
Navigation Link: Hide Add Submenu button in contentOnly mode

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -344,6 +344,9 @@ export default function NavigationLinkEdit( {
 	// See: https://github.com/WordPress/gutenberg/pull/61374.
 	const [ isEditingControl, setIsEditingControl ] = useState( false );
 
+	const blockEditingMode = useBlockEditingMode();
+	const isContentOnlyMode = blockEditingMode === 'contentOnly';
+
 	const {
 		isAtMaxNesting,
 		isTopLevelLink,
@@ -562,7 +565,7 @@ export default function NavigationLinkEdit( {
 							setOpenedBy( event.currentTarget );
 						} }
 					/>
-					{ ! isAtMaxNesting && (
+					{ ! isAtMaxNesting && ! isContentOnlyMode && (
 						<ToolbarButton
 							name="submenu"
 							icon={ addSubmenu }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71180 

Modifies the Navigation Link block toolbar to show only content-editing tools when in `contentOnly` editing mode.

## Why?
The Navigation Link block was showing all toolbar controls even in `contentOnly` mode, which should be limited to content-only editing capabilities.

## How?
Hidden add Submenu button in `contentOnly` mode

## Testing Instructions
1. Create a Navigation block with Navigation Link items
2. Select a Navigation Link block (not the parent Navigation)
3. Set to contentOnly mode in browser console or directly via code editor
   ```javascript
   const clientId = wp.data.select('core/block-editor').getSelectedBlockClientId();
   wp.data.dispatch('core/block-editor').setBlockEditingMode(clientId, 'contentOnly');
   ```
4. **Add submenu button** should be hidden

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before | After |
|--------|-------|
| <img width="382" height="53" alt="Screenshot 2025-08-26 at 5 30 59 PM" src="https://github.com/user-attachments/assets/b86bd3ae-67b3-4ea3-ac5c-2678669c90a9" /> | <img width="345" height="52" alt="Screenshot 2025-08-26 at 5 35 36 PM" src="https://github.com/user-attachments/assets/d46b0e11-aa8d-4854-af23-81f77c4d8e61" /> |
