### PR TITLE
Fix: Hide "View Post" link for non-viewable post types

### DIFF
--- a/packages/edit-post/src/components/editor-initialization/listener-hooks.js
+++ b/packages/edit-post/src/components/editor-initialization/listener-hooks.js
@@ -4,6 +4,7 @@
 import { useSelect } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import { store as editorStore } from '@wordpress/editor';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -18,12 +19,17 @@ import {
  * post link in the admin bar.
  */
 export const useUpdatePostLinkListener = () => {
-	const { newPermalink } = useSelect(
-		( select ) => ( {
-			newPermalink: select( editorStore ).getCurrentPost().link,
-		} ),
-		[]
-	);
+	const { isViewable, newPermalink } = useSelect( ( select ) => {
+		const { getPostType } = select( coreStore );
+		const { getCurrentPost, getEditedPostAttribute } =
+			select( editorStore );
+		const postType = getPostType( getEditedPostAttribute( 'type' ) );
+		return {
+			isViewable: postType?.viewable,
+			newPermalink: getCurrentPost().link,
+		};
+	}, [] );
+
 	const nodeToUpdateRef = useRef();
 
 	useEffect( () => {
@@ -36,6 +42,12 @@ export const useUpdatePostLinkListener = () => {
 		if ( ! newPermalink || ! nodeToUpdateRef.current ) {
 			return;
 		}
+
+		if ( ! isViewable ) {
+			nodeToUpdateRef.current.style.display = 'none';
+			return;
+		}
+
 		nodeToUpdateRef.current.setAttribute( 'href', newPermalink );
-	}, [ newPermalink ] );
+	}, [ newPermalink, isViewable ] );
 };

--- a/packages/edit-post/src/components/editor-initialization/listener-hooks.js
+++ b/packages/edit-post/src/components/editor-initialization/listener-hooks.js
@@ -48,6 +48,7 @@ export const useUpdatePostLinkListener = () => {
 			return;
 		}
 
+		nodeToUpdateRef.current.style.display = '';
 		nodeToUpdateRef.current.setAttribute( 'href', newPermalink );
 	}, [ newPermalink, isViewable ] );
 };


### PR DESCRIPTION
## What?
Closes #71343 

Hides the "View Post" link in the admin bar when editing synced patterns to prevent 404 errors.

## Why?
When editing a synced pattern via "Edit original", the "View Post" link in the admin bar still appears and leads to a 404 error because patterns don't have public URLs. This creates a confusing user experience.

## How?
Updated the `useUpdatePostLinkListener` hook to check if the current post type is viewable using `postType?.viewable`. For non-viewable post types, the "View Post" link is hidden using `display: none`.

## Testing Instructions
1. Open a new playground
2. Open "Hello World" post in block editor from admin bar or post list in WP-Admin
3. Disable "full screen mode"
4. Insert some block(s) and convert them to a synced pattern
5. Save the post
6. Enter edit mode for that synced pattern via "Edit original" in tools bar
7. Verify that the "View Post" button in the admin bar is now hidden
8. Go back to editing the original post and confirm the "View Post" link is visible again

## Screenshots or screencast
### Before

https://github.com/user-attachments/assets/e68e88a2-ef87-4491-8c33-0495325368ae


### After

https://github.com/user-attachments/assets/cd3a7d88-95f2-4fec-980f-5e46c2b59457

