### PR TITLE
Fix missing text toolbar item in social media link block in content only mode

### DIFF
--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -173,7 +173,7 @@ const SocialLinkEdit = ( {
 
 	return (
 		<>
-			{ ( isContentOnlyMode || showLabels ) && (
+			{ isContentOnlyMode && (
 				// Add an extra control to modify the label attribute when content only mode is active.
 				// With content only mode active, the inspector is hidden, so users need another way
 				// to edit this attribute.
@@ -196,7 +196,7 @@ const SocialLinkEdit = ( {
 								className="wp-block-social-link__toolbar_content_text"
 								label={ __( 'Text' ) }
 								help={ __(
-									'Provide a text label or use the default.'
+									'The text is visible when enabled from the parent Social Icons block.'
 								) }
 								value={ label }
 								onChange={ ( value ) =>

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -13,7 +13,6 @@ import {
 	InspectorControls,
 	URLPopover,
 	URLInput,
-	useBlockEditingMode,
 	useBlockProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
@@ -138,16 +137,18 @@ const SocialLinkEdit = ( {
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
-	const isContentOnlyMode = useBlockEditingMode() === 'contentOnly';
 
-	const { activeVariation } = useSelect(
+	const { activeVariation, isContentOnlyMode } = useSelect(
 		( select ) => {
 			const { getActiveBlockVariation } = select( blocksStore );
+			const { getBlockEditingMode } = select( blockEditorStore );
 			return {
 				activeVariation: getActiveBlockVariation( name, attributes ),
+				isContentOnlyMode:
+					getBlockEditingMode( clientId ) === 'contentOnly',
 			};
 		},
-		[ name, attributes ]
+		[ name, attributes, clientId ]
 	);
 
 	const { icon, label: socialLinkName } = getSocialService( activeVariation );

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -173,7 +173,7 @@ const SocialLinkEdit = ( {
 
 	return (
 		<>
-			{ isContentOnlyMode && showLabels && (
+			{ ( isContentOnlyMode || showLabels ) && (
 				// Add an extra control to modify the label attribute when content only mode is active.
 				// With content only mode active, the inspector is hidden, so users need another way
 				// to edit this attribute.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
In contentOnly mode, the Text edit button is missing unless you also have the "Show Labels" accessibility setting on.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Text option should always be available in content only mode, as the ability to change text is removed from the inspector in write mode. This brings it in line with things like setting alt text for an image block from the toolbar while in content only mode.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
1. **perf/code quality**: Switch from `useBlockEditingMode` (a hook to set the editing mode) to `getBlockEditingMode`
2. Remove the showLabels check for showing the toolbar item.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add a social icons block 
- Set the Social Icons block "Show text" option to true in the sidebar inspector
- Add a social icon block
- Switch to contentOnly mode (write mode)
- A "Text" button should be in the toolbar
- Remove the "Show text" option from the parent social icons block
- Go back to the social icon block in content only mode
- Text toolbar item should still be present

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
