### PR TITLE
Zoom Out: Reset when exiting template editor

### DIFF
--- a/packages/editor/src/components/zoom-out-toggle/index.js
+++ b/packages/editor/src/components/zoom-out-toggle/index.js
@@ -18,11 +18,13 @@ import { isAppleOS } from '@wordpress/keycodes';
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
+import { store as editorStore } from '../../store';
 
 const ZoomOutToggle = ( { disabled } ) => {
-	const { isZoomOut, showIconLabels, isDistractionFree } = useSelect(
-		( select ) => ( {
+	const { isZoomOut, renderingMode, showIconLabels, isDistractionFree } =
+		useSelect( ( select ) => ( {
 			isZoomOut: unlock( select( blockEditorStore ) ).isZoomOut(),
+			renderingMode: select( editorStore ).getRenderingMode(),
 			showIconLabels: select( preferencesStore ).get(
 				'core',
 				'showIconLabels'
@@ -31,8 +33,7 @@ const ZoomOutToggle = ( { disabled } ) => {
 				'core',
 				'distractionFree'
 			),
-		} )
-	);
+		} ) );
 
 	const { resetZoomLevel, setZoomLevel } = unlock(
 		useDispatch( blockEditorStore )
@@ -57,6 +58,12 @@ const ZoomOutToggle = ( { disabled } ) => {
 			unregisterShortcut( 'core/editor/zoom' );
 		};
 	}, [ registerShortcut, unregisterShortcut ] );
+
+	useEffect( () => {
+		if ( renderingMode === 'post-only' ) {
+			resetZoomLevel();
+		}
+	}, [ renderingMode, resetZoomLevel ] );
 
 	useShortcut(
 		'core/editor/zoom',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71349 

<!-- In a few words, what is the PR actually doing? -->
This PR ensures that zoom-out mode is reset when leaving the template editor, since the zoom-out toggle is only available within template editing sessions.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The zoom-out toggle is scoped to template editing. Without this fix, the editor can remain in zoom-out mode even after exiting template mode, which is inconsistent since the toggle is no longer visible in that context.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Checks the `renderingMode` from the editor store.
- When switching to `post-only` mode, resets zoom-out mode.

## Testing Instructions
1. Open the post editor.
2. Enable the "Show template" option.
3. Enable zoom-out mode.
4. Disable the "Show template" option.
5. Confirm that the editor is no longer in zoom-out mode.

<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/3570316e-561e-4f3d-afd2-06203a01d22c


