### PR TITLE
Accordion: Add example block preview

### DIFF
--- a/packages/block-library/src/accordion/index.js
+++ b/packages/block-library/src/accordion/index.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import edit from './edit';
@@ -21,7 +26,9 @@ export const settings = {
 					{
 						name: 'core/accordion-header',
 						attributes: {
-							title: 'Accordion Header Example 1',
+							title: __(
+								'Lorem ipsum dolor sit amet, consectetur.'
+							),
 						},
 					},
 				],
@@ -32,7 +39,9 @@ export const settings = {
 					{
 						name: 'core/accordion-header',
 						attributes: {
-							title: 'Accordion Header Example 2',
+							title: __(
+								'Suspendisse commodo lacus, interdum et.'
+							),
 						},
 					},
 				],

--- a/packages/block-library/src/accordion/index.js
+++ b/packages/block-library/src/accordion/index.js
@@ -13,7 +13,32 @@ export { metadata, name };
 
 export const settings = {
 	icon,
-	example: {},
+	example: {
+		innerBlocks: [
+			{
+				name: 'core/accordion-content',
+				innerBlocks: [
+					{
+						name: 'core/accordion-header',
+						attributes: {
+							title: 'Accordion Header Example 1',
+						},
+					},
+				],
+			},
+			{
+				name: 'core/accordion-content',
+				innerBlocks: [
+					{
+						name: 'core/accordion-header',
+						attributes: {
+							title: 'Accordion Header Example 2',
+						},
+					},
+				],
+			},
+		],
+	},
 	edit,
 	save,
 };


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/71354

Updates the Accordion block preview to display two example headers.

## Why?

Previously, the Accordion block preview was empty, making it difficult to visualize how accordion sections would appear. This change improves clarity for users by showing a more realistic example.

## How?
Defines two `core/accordion-content` inner blocks in the Accordion block’s `example` field, each with its own header.

## Testing Instructions

1. Enable experimental blocks ( Gutenberg > Experiments > enable `Blocks: add experimental blocks` )
2. Open a post or page.
3. Check the Accordion block example preview.
4. Confirm that the block preview displays two example headers.


## Screenshots


|Before|After|
|-|-|
|<img width="542" height="536" alt="image" src="https://github.com/user-attachments/assets/c08d59b1-f2b0-4f65-9b7e-2152d146b127" />|<img width="548" height="548" alt="image" src="https://github.com/user-attachments/assets/526e9c84-2226-4edb-87a4-c5c4a458e0ff" />|
