### PR TITLE
Audio and Video: Hide caption controls in contentOnly mode

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -22,6 +22,7 @@ import {
 	MediaPlaceholder,
 	MediaReplaceFlow,
 	useBlockProps,
+	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import { __, _x } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
@@ -51,6 +52,8 @@ function AudioEdit( {
 } ) {
 	const { id, autoplay, loop, preload, src } = attributes;
 	const [ temporaryURL, setTemporaryURL ] = useState( attributes.blob );
+	const blockEditingMode = useBlockEditingMode();
+	const hasNonContentControls = blockEditingMode === 'default';
 
 	useUploadMediaFromBlobURL( {
 		url: temporaryURL,
@@ -264,7 +267,9 @@ function AudioEdit( {
 					isSelected={ isSingleSelected }
 					insertBlocksAfter={ insertBlocksAfter }
 					label={ __( 'Audio caption text' ) }
-					showToolbarButton={ isSingleSelected }
+					showToolbarButton={
+						isSingleSelected && hasNonContentControls
+					}
 				/>
 			</figure>
 		</>

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -20,6 +20,7 @@ import {
 	MediaPlaceholder,
 	MediaReplaceFlow,
 	useBlockProps,
+	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import { useRef, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -55,6 +56,8 @@ function VideoEdit( {
 	const { id, controls, poster, src, tracks } = attributes;
 	const [ temporaryURL, setTemporaryURL ] = useState( attributes.blob );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+	const blockEditingMode = useBlockEditingMode();
+	const hasNonContentControls = blockEditingMode === 'default';
 
 	useUploadMediaFromBlobURL( {
 		url: temporaryURL,
@@ -176,14 +179,16 @@ function VideoEdit( {
 		<>
 			{ isSingleSelected && (
 				<>
-					<BlockControls>
-						<TracksEditor
-							tracks={ tracks }
-							onChange={ ( newTracks ) => {
-								setAttributes( { tracks: newTracks } );
-							} }
-						/>
-					</BlockControls>
+					{ hasNonContentControls && (
+						<BlockControls>
+							<TracksEditor
+								tracks={ tracks }
+								onChange={ ( newTracks ) => {
+									setAttributes( { tracks: newTracks } );
+								} }
+							/>
+						</BlockControls>
+					) }
 					<BlockControls group="other">
 						<MediaReplaceFlow
 							mediaId={ id }
@@ -251,7 +256,9 @@ function VideoEdit( {
 					isSelected={ isSingleSelected }
 					insertBlocksAfter={ insertBlocksAfter }
 					label={ __( 'Video caption text' ) }
-					showToolbarButton={ isSingleSelected }
+					showToolbarButton={
+						isSingleSelected && hasNonContentControls
+					}
 				/>
 			</figure>
 		</>

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -179,16 +179,14 @@ function VideoEdit( {
 		<>
 			{ isSingleSelected && (
 				<>
-					{ hasNonContentControls && (
-						<BlockControls>
-							<TracksEditor
-								tracks={ tracks }
-								onChange={ ( newTracks ) => {
-									setAttributes( { tracks: newTracks } );
-								} }
-							/>
-						</BlockControls>
-					) }
+					<BlockControls>
+						<TracksEditor
+							tracks={ tracks }
+							onChange={ ( newTracks ) => {
+								setAttributes( { tracks: newTracks } );
+							} }
+						/>
+					</BlockControls>
 					<BlockControls group="other">
 						<MediaReplaceFlow
 							mediaId={ id }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Part of https://github.com/WordPress/gutenberg/issues/65778

In the Audio and Video blocks hide the caption controls when in contentOnly mode.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As discussed in https://github.com/WordPress/gutenberg/issues/65778#issuecomment-3210617969 the idea is that write mode is for editing existing content, not introducing new material such as captions. The Image block already hides the Caption control, so this PR extends that to the Audio and Video blocks, helping to improve consistency.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add `useBlockEditingMode` calls to the Video and Audio blocks and only show the Caption controls when we're in the default block editing mode (`hasNonContentControls`, which is the same check used in the Image block)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Enable the simplified site editing experiment in http://localhost:8888/wp-admin/admin.php?page=gutenberg-experiments
2. Open up the site editor and go to edit a page
3. In design mode, add an audio block and a video block
4. In the top toolbar, switch to write mode
5. Click on the Audio block — you shouldn't see a Caption control in the block toolbar
6. Click on the Video block — you shouldn't see a Caption control in the block toolbar
7. In design mode, these controls should still be visible

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
| <img width="1400" height="300" alt="image" src="https://github.com/user-attachments/assets/2dae85af-adb5-4f92-bbf2-e58f8a81a90c" /> | <img width="1374" height="276" alt="image" src="https://github.com/user-attachments/assets/407725cb-e688-4f42-9b85-e8c1e7727b91" /> |
| <img width="1378" height="1144" alt="image" src="https://github.com/user-attachments/assets/f38f5e56-7bd1-49f6-ba3b-cda0f3b813ce" /> | <img width="713" height="589" alt="image" src="https://github.com/user-attachments/assets/94c5af0a-0d1a-4610-8953-3a86ca65315f" /> |