### PR TITLE
Site Editor: Enable interactions in classic theme site preview

### DIFF
--- a/packages/edit-site/src/components/editor/site-preview.js
+++ b/packages/edit-site/src/components/editor/site-preview.js
@@ -4,8 +4,121 @@
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { focus } from '@wordpress/dom';
 import { addQueryArgs } from '@wordpress/url';
+import { speak } from '@wordpress/a11y';
+
+/**
+ * Check if a link is previewable.
+ *
+ * @param {Element} element - The link element.
+ * @return {boolean} True if the link is previewable, false otherwise.
+ */
+function isLinkPreviewable( element ) {
+	if ( 'javascript:' === element.protocol ) {
+		return true;
+	}
+
+	// Only web URLs can be previewed.
+	if ( 'https:' !== element.protocol && 'http:' !== element.protocol ) {
+		return false;
+	}
+
+	const elementHost = element.host.replace( /:(80|443)$/, '' );
+	const currentHost = window.location.host.replace( /:(80|443)$/, '' );
+
+	// Only allow links from the same host
+	if ( elementHost !== currentHost ) {
+		return false;
+	}
+
+	// Skip wp login/signup pages, admin ajax, and admin/includes/content directories.
+	if (
+		/\/wp-(login|signup)\.php$/.test( element.pathname ) ||
+		/\/wp-admin\/admin-ajax\.php$/.test( element.pathname ) ||
+		/\/wp-(admin|includes|content)(\/|$)/.test( element.pathname )
+	) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Handle interactions in the preview iframe.
+ *
+ * @param {Document} document - The document object of the preview iframe.
+ */
+function handleInteractions( document ) {
+	// Handle link clicks in preview.
+	function handleLinkClick( event ) {
+		const link = event.target.closest( 'a' );
+		if ( ! link ) {
+			return;
+		}
+
+		const href = link.getAttribute( 'href' );
+		if ( ! href ) {
+			return;
+		}
+
+		// Allow internal jump links and JS links to behave normally without preventing default.
+		const isInternalJumpLink = href.startsWith( '#' );
+		if ( isInternalJumpLink || ! /^https?:$/.test( link.protocol ) ) {
+			return;
+		}
+
+		// If the link is not previewable, prevent the browser from navigating to it.
+		if ( ! isLinkPreviewable( link ) ) {
+			speak( __( 'This link is not live-previewable.' ) );
+			event.preventDefault();
+			return;
+		}
+
+		// This parameter is used to hide the admin bar in the preview iframe.
+		const previewUrl = addQueryArgs( href, {
+			wp_site_preview: 1,
+		} );
+		document.location.href = previewUrl;
+		event.preventDefault();
+	}
+
+	// Handle form submit.
+	function handleFormSubmit( event ) {
+		const form = event.target.closest( 'form' );
+		if ( ! form ) {
+			return;
+		}
+
+		const action = form.getAttribute( 'action' );
+		if ( ! action ) {
+			return;
+		}
+
+		const method = form.getAttribute( 'method' );
+
+		const urlParser = document.createElement( 'a' );
+		urlParser.href = action;
+
+		// If the link is not previewable, prevent the browser from navigating to it.
+		if (
+			'GET' !== method.toUpperCase() ||
+			! isLinkPreviewable( urlParser )
+		) {
+			speak( __( 'This form is not live-previewable.' ) );
+			event.preventDefault();
+			return;
+		}
+
+		const previewUrl = addQueryArgs( action, {
+			wp_site_preview: 1,
+		} );
+		document.location.href = previewUrl;
+		event.preventDefault();
+	}
+
+	document.addEventListener( 'click', handleLinkClick, true );
+	document.addEventListener( 'submit', handleFormSubmit, true );
+}
 
 export default function SitePreview() {
 	const siteUrl = useSelect( ( select ) => {
@@ -27,15 +140,9 @@ export default function SitePreview() {
 				height: '100%',
 				backgroundColor: '#fff',
 			} }
+			// Make interactive elements unclickable.
 			onLoad={ ( event ) => {
-				// Make interactive elements unclickable.
-				const document = event.target.contentDocument;
-				const focusableElements = focus.focusable.find( document );
-				focusableElements.forEach( ( element ) => {
-					element.style.pointerEvents = 'none';
-					element.tabIndex = -1;
-					element.setAttribute( 'aria-hidden', 'true' );
-				} );
+				handleInteractions( event.target.contentDocument );
 			} }
 		/>
 	);


### PR DESCRIPTION
Closes #70050

## What?

This PR enables interactions such as navigation, javascript events in the site preview.

## Why?

When a classic theme is enabled, the top page of the site editor shows the frontend site preview.

We enforce disabling interactions in the preview, but as discussed in #70050, it's technically impossible to disable all interactions. Furthermore, I'm not sure whether the non-interactive preview is useful from an accessibility perspective.

## How?

Reuse [the Customizer Preview logic](https://github.com/WordPress/wordpress-develop/blob/7289643a4d6a901a04f13b0359c95a1df5af63d3/src/js/_enqueues/wp/customize/preview.js) with almost the same implementation, disabling only unintended interactions. The logic consists of the following two functions:

- [handleLinkClick](https://github.com/WordPress/wordpress-develop/blob/7289643a4d6a901a04f13b0359c95a1df5af63d3/src/js/_enqueues/wp/customize/preview.js#L147): Prevents unintended navigation, such as external links or dashboard links.
- [handleFormSubmit](https://github.com/WordPress/wordpress-develop/blob/7289643a4d6a901a04f13b0359c95a1df5af63d3/src/js/_enqueues/wp/customize/preview.js#L193): Prevents unintended form submissions, such as comment submissions.

**Note:** This PR also allows navigation, but we can disable links if that is not desired.

## Testing Instructions

- Activate any classic theme
- Access Appearance > Design
- Click any link in the preview.
- Confirm that the navigation works correctly.
- Confirm that JS interaction, such as toggling the mobile menu, works.

### Screen reader test:

- When clicking the post edit link, confirm that your screen reader reads "This link is not live-previewable.".
- When clicking the form submit button, confirm that your screen reader reads "This form is not live-previewable.".

## Screenshots or screencast


https://github.com/user-attachments/assets/e5d5edfa-609f-4b31-98d3-88d5c5c50759

