### PR TITLE
Components: Fix Autocomplete retriggering when triggerPrefix is included in output

### DIFF
--- a/packages/components/src/autocomplete/index.tsx
+++ b/packages/components/src/autocomplete/index.tsx
@@ -110,7 +110,10 @@ export function useAutocomplete( {
 				? completion
 				: ( {
 						action: 'insert-at-caret',
-						value: completion,
+						value:
+							autocompleter?.triggerPrefix === '@'
+								? completion + '\u00A0'
+								: completion,
 				  } as InsertOption );
 
 			if ( 'replace' === completionObject.action ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #42925
Fixes an issue where the Autocomplete component retriggers immediately after selecting an option if the triggerPrefix (`@`) remains in the output.

## Why?
When a user selects a mention (e.g. `@john`), the autocompleter reopens right away. This creates a poor UX by repeatedly showing the same suggestions after selection.

## How?
- Appended a non-breaking space (`\u00A0`) after inserting a user mention so it no longer matches the completer regex.
- Scoped the change only to the user mention completer so other completers (e.g. slash inserter) remain unaffected.

## Testing Instructions
1. Create two users: `john` and `johndoe`.
2. Create a new post and type `@` to launch the user mention completer.
3. Select `john` by clicking → The autocompleter should **not** reopen.
4. Repeat with `johndoe` → The autocompleter should **not** reopen.
5. Try selecting a user via keyboard (arrows + Enter), then press space and keep typing → The autocompleter should **not** reappear.

### Testing Instructions for Keyboard
- Navigate to a block where you can type.
- Type `@joh`, use arrow keys to highlight `john`, and press Enter.
- Continue typing with the keyboard → The autocompleter should not reopen.
- Verify focus remains in the editor as expected.

## Screenshots or screencast

https://github.com/user-attachments/assets/d619a84d-fa69-409c-b063-3846823d8175

