### PR TITLE
Types: Update to be compatible with React 19

### DIFF
--- a/packages/components/src/context/context-connect.ts
+++ b/packages/components/src/context/context-connect.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { ForwardedRef, ReactChild, ReactNode } from 'react';
+import type { ForwardedRef, ReactElement, ReactNode } from 'react';
 
 /**
  * WordPress dependencies
@@ -114,7 +114,7 @@ function _contextConnect<
  * @return The connected namespaces.
  */
 export function getConnectNamespace(
-	Component: ReactChild | undefined | {}
+	Component: ReactElement | number | string | undefined | {}
 ): string[] {
 	if ( ! Component ) {
 		return [];

--- a/packages/components/src/tools-panel/stories/index.story.tsx
+++ b/packages/components/src/tools-panel/stories/index.story.tsx
@@ -54,7 +54,7 @@ export const Default: StoryFn< typeof ToolsPanel > = ( {
 	const [ height, setHeight ] = useState< string | undefined >();
 	const [ minHeight, setMinHeight ] = useState< string | undefined >();
 	const [ width, setWidth ] = useState< string | undefined >();
-	const [ scale, setScale ] = useState< React.ReactText | undefined >();
+	const [ scale, setScale ] = useState< number | string | undefined >();
 
 	const resetAll: typeof resetAllProp = ( filters ) => {
 		setHeight( undefined );
@@ -414,7 +414,7 @@ export const WithConditionalDefaultControl: StoryFn< typeof ToolsPanel > = ( {
 } ) => {
 	const [ attributes, setAttributes ] = useState< {
 		height?: string;
-		scale?: React.ReactText;
+		scale?: number | string;
 	} >( {} );
 	const { height, scale } = attributes;
 
@@ -512,7 +512,7 @@ export const WithConditionallyRenderedControl: StoryFn<
 > = ( { resetAll: resetAllProp, panelId, ...props } ) => {
 	const [ attributes, setAttributes ] = useState< {
 		height?: string;
-		scale?: React.ReactText;
+		scale?: number | string;
 	} >( {} );
 	const { height, scale } = attributes;
 

--- a/packages/components/src/utils/font-size.ts
+++ b/packages/components/src/utils/font-size.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { CSSProperties, ReactText } from 'react';
+import type { CSSProperties } from 'react';
 
 /**
  * Internal dependencies
@@ -61,7 +61,7 @@ export function getFontSize(
 	return `calc(${ ratio } * ${ CONFIG.fontSize })`;
 }
 
-export function getHeadingFontSize( size: ReactText = 3 ): string {
+export function getHeadingFontSize( size: number | string = 3 ): string {
 	if ( ! HEADING_FONT_SIZES.includes( size as HeadingSize ) ) {
 		return getFontSize( size );
 	}

--- a/packages/components/src/utils/get-valid-children.ts
+++ b/packages/components/src/utils/get-valid-children.ts
@@ -1,12 +1,7 @@
 /**
  * External dependencies
  */
-import type {
-	ReactNode,
-	ReactElement,
-	ReactFragment,
-	ReactPortal,
-} from 'react';
+import type { ReactNode, ReactElement, ReactPortal } from 'react';
 
 /**
  * WordPress dependencies
@@ -22,7 +17,9 @@ import { Children, isValidElement } from '@wordpress/element';
  */
 export function getValidChildren(
 	children: ReactNode
-): Array< ReactElement | number | string | ReactFragment | ReactPortal > {
+): Array<
+	ReactElement | number | string | Iterable< ReactNode > | ReactPortal
+> {
 	if ( typeof children === 'string' ) {
 		return [ children ];
 	}

--- a/packages/components/src/utils/get-valid-children.ts
+++ b/packages/components/src/utils/get-valid-children.ts
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import type { ReactNode, ReactChild, ReactFragment, ReactPortal } from 'react';
+import type {
+	ReactNode,
+	ReactElement,
+	ReactFragment,
+	ReactPortal,
+} from 'react';
 
 /**
  * WordPress dependencies
@@ -17,7 +22,7 @@ import { Children, isValidElement } from '@wordpress/element';
  */
 export function getValidChildren(
 	children: ReactNode
-): Array< ReactChild | ReactFragment | ReactPortal > {
+): Array< ReactElement | number | string | ReactFragment | ReactPortal > {
 	if ( typeof children === 'string' ) {
 		return [ children ];
 	}

--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -718,9 +718,9 @@ export function renderComponent(
 /**
  * Serializes an array of children to string.
  *
- * @param {import('react').ReactNodeArray} children        Children to serialize.
- * @param {Object}                         [context]       Context object.
- * @param {Object}                         [legacyContext] Legacy context object.
+ * @param {ReadonlyArray<import('react').ReactNode>} children        Children to serialize.
+ * @param {Object}                                   [context]       Context object.
+ * @param {Object}                                   [legacyContext] Legacy context object.
  *
  * @return {string} Serialized children.
  */


### PR DESCRIPTION
## What?
Removes usage of types that are deprecated in React 19 in favor of their recommended counterparts.

## Why?
To prepare for React 19 compatibility.

See #71336 for the full effort.

See #61521 for the PR where these commits are coming from. 

## How?
We're removing usage of a few types that were deprecated in React 19 in favor of their recommended counterparts:
* `ReactChild`: `ReactElement | number | string`
* `ReactNodeArray`: `ReadonlyArray< ReactNode >`
* `ReactFragment`: `Iterable< ReactNode >`
* `ReactText`: `number | string`

Pulls in part of #61521 to be landed separately.

## Testing Instructions
Verify all checks are green.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None