### PR TITLE
Add post edit link block in core

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -671,6 +671,15 @@ Display the publish date for an entry such as a post or page. ([Source](https://
 -	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** datetime, format, isLink, textAlign
 
+## post Edit Link
+
+Displays a link to edit the post in the WordPress Dashboard. This link is only visible to users with the edit post capability. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-edit-link))
+
+-	**Name:** core/post-edit-link
+-	**Category:** theme
+-	**Supports:** color (background, gradients, link, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** linkTarget, textAlign
+
 ## Excerpt
 
 Display the excerpt. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-excerpt))

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -44,6 +44,7 @@ function gutenberg_reregister_core_block_types() {
 				'text-columns',
 				'verse',
 				'embed',
+				'post-edit-link'
 			),
 			'block_names'   => array(
 				'accordion-content.php'            => 'core/accordion-content',
@@ -103,6 +104,7 @@ function gutenberg_reregister_core_block_types() {
 				'post-terms.php'                   => 'core/post-terms',
 				'post-time-to-read.php'            => 'core/post-time-to-read',
 				'post-title.php'                   => 'core/post-title',
+				'post-edit-link.php'               => 'core/post-edit-link',
 				'query.php'                        => 'core/query',
 				'post-template.php'                => 'core/post-template',
 				'query-no-results.php'             => 'core/query-no-results',

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -44,7 +44,7 @@ function gutenberg_reregister_core_block_types() {
 				'text-columns',
 				'verse',
 				'embed',
-				'post-edit-link'
+				'post-edit-link',
 			),
 			'block_names'   => array(
 				'accordion-content.php'            => 'core/accordion-content',

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -94,6 +94,7 @@ import * as postTemplate from './post-template';
 import * as postTerms from './post-terms';
 import * as postTimeToRead from './post-time-to-read';
 import * as postTitle from './post-title';
+import * as postEditLink from './post-edit-link';
 import * as preformatted from './preformatted';
 import * as pullquote from './pullquote';
 import * as query from './query';
@@ -231,6 +232,7 @@ const getAllBlocks = () => {
 		commentsPaginationNumbers,
 		commentsPaginationPrevious,
 		postCommentsForm,
+		postEditLink,
 		tableOfContents,
 		homeLink,
 		logInOut,

--- a/packages/block-library/src/post-edit-link/block.json
+++ b/packages/block-library/src/post-edit-link/block.json
@@ -1,0 +1,61 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "core/post-edit-link",
+	"title": "post Edit Link",
+	"category": "theme",
+	"description": "Displays a link to edit the post in the WordPress Dashboard. This link is only visible to users with the edit post capability.",
+	"textdomain": "default",
+	"usesContext": [ "postId" ],
+	"attributes": {
+		"linkTarget": {
+			"type": "string",
+			"default": "_self"
+		},
+		"textAlign": {
+			"type": "string"
+		}
+	},
+	"supports": {
+		"html": false,
+		"color": {
+			"link": true,
+			"gradients": true,
+			"text": false,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"link": true
+			}
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		},
+		"interactivity": {
+			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true
+		}
+	}
+}

--- a/packages/block-library/src/post-edit-link/edit.js
+++ b/packages/block-library/src/post-edit-link/edit.js
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	AlignmentControl,
+	BlockControls,
+	InspectorControls,
+	useBlockProps,
+} from '@wordpress/block-editor';
+import {
+	ToggleControl,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+
+export default function Edit( {
+	attributes: { linkTarget, textAlign },
+	setAttributes,
+} ) {
+	const blockProps = useBlockProps( {
+		className: clsx( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} ),
+	} );
+
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+
+	const blockControls = (
+		<BlockControls group="block">
+			<AlignmentControl
+				value={ textAlign }
+				onChange={ ( newAlign ) =>
+					setAttributes( { textAlign: newAlign } )
+				}
+			/>
+		</BlockControls>
+	);
+	const inspectorControls = (
+		<InspectorControls>
+			<ToolsPanel
+				label={ __( 'Settings' ) }
+				resetAll={ () => {
+					setAttributes( {
+						linkTarget: '_self',
+					} );
+				} }
+				dropdownMenuProps={ dropdownMenuProps }
+			>
+				<ToolsPanelItem
+					label={ __( 'Open in new tab' ) }
+					isShownByDefault
+					hasValue={ () => linkTarget === '_blank' }
+					onDeselect={ () =>
+						setAttributes( { linkTarget: '_self' } )
+					}
+				>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Open in new tab' ) }
+						onChange={ ( value ) =>
+							setAttributes( {
+								linkTarget: value ? '_blank' : '_self',
+							} )
+						}
+						checked={ linkTarget === '_blank' }
+					/>
+				</ToolsPanelItem>
+			</ToolsPanel>
+		</InspectorControls>
+	);
+
+	return (
+		<>
+			{ blockControls }
+			{ inspectorControls }
+			<div { ...blockProps }>
+				<a
+					href="#edit-post-pseudo-link"
+					onClick={ ( event ) => event.preventDefault() }
+				>
+					{ __( 'Edit' ) }
+				</a>
+			</div>
+		</>
+	);
+}

--- a/packages/block-library/src/post-edit-link/index.js
+++ b/packages/block-library/src/post-edit-link/index.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { commentEditLink as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import initBlock from '../utils/init-block';
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	icon,
+	edit,
+	example: {},
+};
+
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/post-edit-link/index.php
+++ b/packages/block-library/src/post-edit-link/index.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Server-side rendering of the `core/post-edit-link` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/post-edit-link` block on the server.
+ *
+ * @since 6.0.0
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Return the post post's date.
+ */
+function render_block_core_post_edit_link( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) || ! current_user_can( 'edit_post', $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$edit_post_link = get_edit_post_link( $block->context['postId'] );
+
+	$link_atts = '';
+
+	if ( ! empty( $attributes['linkTarget'] ) ) {
+		$link_atts .= sprintf( 'target="%s"', esc_attr( $attributes['linkTarget'] ) );
+	}
+
+	$classes = array();
+	if ( isset( $attributes['textAlign'] ) ) {
+		$classes[] = 'has-text-align-' . $attributes['textAlign'];
+	}
+	if ( isset( $attributes['style']['elements']['link']['color']['text'] ) ) {
+		$classes[] = 'has-link-color';
+	}
+
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
+
+	return sprintf(
+		'<div %1$s><a href="%2$s" %3$s>%4$s</a></div>',
+		$wrapper_attributes,
+		esc_url( $edit_post_link ),
+		$link_atts,
+		esc_html__( 'Edit' )
+	);
+}
+
+/**
+ * Registers the `core/post-edit-link` block on the server.
+ *
+ * @since 6.0.0
+ */
+function register_block_core_post_edit_link() {
+	register_block_type_from_metadata(
+		__DIR__ . '/post-edit-link',
+		array(
+			'render_callback' => 'render_block_core_post_edit_link',
+		)
+	);
+}
+
+add_action( 'init', 'register_block_core_post_edit_link' );

--- a/packages/block-library/src/post-edit-link/init.js
+++ b/packages/block-library/src/post-edit-link/init.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import { init } from './';
+
+export default init();


### PR DESCRIPTION
### PROOF OF CONCEPT - AWAITING FEATURE APPROVAL

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Closes: https://github.com/WordPress/gutenberg/issues/71328

This PR introduces a new core/post-edit-link block that provides a convenient way for content editors to access the WordPress admin edit screen directly from the frontend. The block displays an "Edit" link that is only visible to users with appropriate edit permissions.

## Why?
There is a PHP function called get_edit_post_link, which renders the link to edit the post. Many classic themes use this function to make users edit the post easily:
However, there is no equivalent block to display the link, so it is not possible to inject the edit link into the theme template.
