### PR TITLE
DataForm: add description support for the combined fields and show the description in the Card layout

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Revert the ability to hide the view config via `config` prop and export a `DataViews.Footer` component to support the "Minimal UI" story. [#71276](https://github.com/WordPress/gutenberg/pull/71276)
 
+### Enhancements
+
+-   DataForm: add description support for the combined fields and show the description in the Card layout ([#71380](https://github.com/WordPress/gutenberg/pull/71380)).
+
 ### Bug Fixes
 
 -   DataViews: Fix incorrect documentation for `defaultLayouts` prop. [#71334](https://github.com/WordPress/gutenberg/pull/71334)

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -671,6 +671,8 @@ const LayoutCardComponent = ( { withHeader }: { withHeader: boolean } ) => {
 				{
 					id: 'customerCard',
 					label: 'Customer',
+					description:
+						'Enter your contact details, plan type, and addresses to complete your customer information.',
 					children: [
 						{
 							id: 'customerContact',

--- a/packages/dataviews/src/dataforms-layouts/card/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/card/index.tsx
@@ -104,6 +104,11 @@ export default function FormCardField< Item >( {
 					// If it doesn't have a header, keep it open.
 					// Otherwise, the card will not be visible.
 					<CardBody className="dataforms-layouts-card__field-control">
+						{ field.description && (
+							<div className="dataforms-layouts-card__field-description">
+								{ field.description }
+							</div>
+						) }
 						<DataFormLayout
 							data={ data }
 							form={ form }

--- a/packages/dataviews/src/dataforms-layouts/card/style.scss
+++ b/packages/dataviews/src/dataforms-layouts/card/style.scss
@@ -3,7 +3,8 @@
 }
 
 .dataforms-layouts-card__field-description {
-	display: block;
 	color: $gray-700;
+	display: block;
+	font-size: $font-size-medium;
 	margin-bottom: $grid-unit-20;
 }

--- a/packages/dataviews/src/dataforms-layouts/card/style.scss
+++ b/packages/dataviews/src/dataforms-layouts/card/style.scss
@@ -1,3 +1,9 @@
 .dataforms-layouts-card__field {
 	width: 100%;
 }
+
+.dataforms-layouts-card__field-description {
+	display: block;
+	color: $gray-700;
+	margin-bottom: $grid-unit-20;
+}

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -14,3 +14,4 @@
 @import "./dataform-controls/style.scss";
 @import "./dataforms-layouts/panel/style.scss";
 @import "./dataforms-layouts/regular/style.scss";
+@import "./dataforms-layouts/card/style.scss";

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -738,6 +738,7 @@ export type SimpleFormField = {
 export type CombinedFormField = {
 	id: string;
 	label?: string;
+	description?: string;
 	layout?: Layout;
 	children: Array< FormField | string >;
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

 ## What?
This PR adds description support for the combined fields and shows that description in the Card layout

  ## Why?
For the combined field, we might also want to inform users of the purpose of the section. This is why we added the new description property here. In this PR, we are only showing that description for the Card layout because it should be handled at the layout level, as each layout has different needs and positions to display the description.

  ## How?
  - Added `description?: string` property to `CombinedFormField` type
  - Updated card layout component to render descriptions inside CardBody before fields (combined fields only)
  - Simple fields continue using the existing description handling from field definitions

  ## Testing Instructions
  1. Open DataViews DataForm storybook
  2. Navigate to "LayoutCard" story
  3. Verify combined fields display descriptions below the card header and above the fields

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1537" height="850" alt="image" src="https://github.com/user-attachments/assets/9e6da10c-fcd4-43fe-8ce9-60f69acf26ae" />|<img width="1537" height="850" alt="image" src="https://github.com/user-attachments/assets/aad3db01-b26a-4645-823d-7bc9b153a92a" />|
