### PR TITLE
Buttons Block: Add placeholder for empty blocks to prevent canvas disappearance

### DIFF
--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -6,9 +6,16 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { store as blocksStore } from '@wordpress/blocks';
+import { Placeholder } from '@wordpress/components';
+import { button } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
 
 const DEFAULT_BLOCK = {
 	name: 'core/button',
@@ -25,31 +32,65 @@ const DEFAULT_BLOCK = {
 	],
 };
 
-function ButtonsEdit( { attributes, className } ) {
+function ButtonsEdit( { attributes, className, clientId } ) {
 	const { fontSize, layout, style } = attributes;
+
+	const { hasButtonVariations, hasInnerBlocks, isSelected } = useSelect(
+		( select ) => {
+			const { getBlocks, isBlockSelected, hasSelectedInnerBlock } =
+				select( blockEditorStore );
+			const buttonVariations = select( blocksStore ).getBlockVariations(
+				'core/button',
+				'inserter'
+			);
+			const innerBlocks = getBlocks( clientId );
+			const selected =
+				isBlockSelected( clientId ) ||
+				hasSelectedInnerBlock( clientId, true );
+
+			return {
+				hasButtonVariations: buttonVariations.length > 0,
+				hasInnerBlocks: innerBlocks.length > 0,
+				isSelected: selected,
+			};
+		},
+		[ clientId ]
+	);
+
 	const blockProps = useBlockProps( {
 		className: clsx( className, {
 			'has-custom-font-size': fontSize || style?.typography?.fontSize,
 		} ),
 	} );
-	const { hasButtonVariations } = useSelect( ( select ) => {
-		const buttonVariations = select( blocksStore ).getBlockVariations(
-			'core/button',
-			'inserter'
-		);
-		return {
-			hasButtonVariations: buttonVariations.length > 0,
-		};
-	}, [] );
 
-	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		defaultBlock: DEFAULT_BLOCK,
-		// This check should be handled by the `Inserter` internally to be consistent across all blocks that use it.
-		directInsert: ! hasButtonVariations,
-		template: [ [ 'core/button' ] ],
-		templateInsertUpdatesSelection: true,
-		orientation: layout?.orientation ?? 'horizontal',
-	} );
+	const innerBlocksProps = useInnerBlocksProps(
+		hasInnerBlocks ? blockProps : {},
+		{
+			defaultBlock: DEFAULT_BLOCK,
+			directInsert: ! hasButtonVariations,
+			template: [ [ 'core/button' ] ],
+			templateInsertUpdatesSelection: true,
+			orientation: layout?.orientation ?? 'horizontal',
+		}
+	);
+
+	// Show placeholder when block is empty and not selected.
+	if ( ! hasInnerBlocks && ! isSelected ) {
+		return (
+			<div { ...blockProps }>
+				<Placeholder
+					icon={ button }
+					label={ __( 'Buttons' ) }
+					className="wp-block-buttons-placeholder"
+					isColumnLayout
+				>
+					<div className="wp-block-buttons-placeholder__help">
+						{ __( 'Click to add button.' ) }
+					</div>
+				</Placeholder>
+			</div>
+		);
+	}
 
 	return <div { ...innerBlocksProps } />;
 }


### PR DESCRIPTION
## What?
Closes #65646

Adds a placeholder component to the Buttons block that displays when the block is empty and not selected, preventing the block from completely disappearing from the editor canvas.

## Why?
When a Buttons block has all its inner Button blocks removed, it becomes completely invisible on the editor canvas when not selected. This creates a significant usability issue where users lose track of empty blocks, even though they still exist in the List View. The block effectively "disappears" from the visual editor, making it difficult for users to interact with or locate these empty blocks.

This issue affects content editing workflow and creates inconsistency with how other WordPress blocks handle empty states - most blocks show some form of placeholder or visual indicator when empty.

## Testing Instructions
1. Open a post or page in the block editor
2. Insert a Buttons block (it will come with one default Button block)
3. Select the inner Button block and delete it (using Delete key or trash icon)
4. Click elsewhere in the editor (e.g., click below the block to add a new paragraph)
5. Verify that the Buttons block now shows a placeholder with a button icon and "Click to add buttons" text
6. Click on the placeholder to verify it becomes selected and shows the block appender
7. Add a new Button block and repeat the process to ensure it works consistently

## Screenshots or screencast <!-- if applicable -->

### Before
https://github.com/user-attachments/assets/162ad89f-927d-4126-9fc1-31c7028d996a

### After
https://github.com/user-attachments/assets/3bf750d8-b58f-4bc2-860e-416a10fdf1b9