### PR TITLE
Fix: Unable to pin comment sidebar after unpinning

### DIFF
--- a/packages/editor/src/components/collab-sidebar/constants.js
+++ b/packages/editor/src/components/collab-sidebar/constants.js
@@ -1,1 +1,2 @@
+export const collabHistorySidebarName = 'edit-post/collab-history-sidebar';
 export const collabSidebarName = 'edit-post/collab-sidebar';

--- a/packages/editor/src/components/collab-sidebar/constants.js
+++ b/packages/editor/src/components/collab-sidebar/constants.js
@@ -1,2 +1,1 @@
-export const collabHistorySidebarName = 'edit-post/collab-history-sidebar';
 export const collabSidebarName = 'edit-post/collab-sidebar';

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -20,7 +20,7 @@ import { store as interfaceStore } from '@wordpress/interface';
  * Internal dependencies
  */
 import PluginSidebar from '../plugin-sidebar';
-import { collabHistorySidebarName, collabSidebarName } from './constants';
+import { collabSidebarName } from './constants';
 import { Comments } from './comments';
 import { AddComment } from './add-comment';
 import { store as editorStore } from '../../store';
@@ -257,7 +257,7 @@ export default function CollabSidebar() {
 
 	const openCollabBoard = () => {
 		setShowCommentBoard( true );
-		enableComplementaryArea( 'core', 'edit-post/collab-sidebar' );
+		enableComplementaryArea( 'core', collabSidebarName );
 	};
 
 	const [ blocks ] = useEntityBlockEditor( 'postType', postType, {
@@ -339,26 +339,18 @@ export default function CollabSidebar() {
 		<>
 			<AddCommentComponent onClick={ openCollabBoard } />
 			<PluginSidebar
-				identifier={ collabHistorySidebarName }
+				isPinnable
+				identifier={ collabSidebarName }
+				className="editor-collab-sidebar"
+				headerClassName="editor-collab-sidebar__header"
 				// translators: Comments sidebar title
 				title={ __( 'Comments' ) }
 				icon={ commentIcon }
 			>
 				<CollabSidebarContent
-					comments={ resultComments }
-					showCommentBoard={ showCommentBoard }
-					setShowCommentBoard={ setShowCommentBoard }
-				/>
-			</PluginSidebar>
-			<PluginSidebar
-				isPinnable={ false }
-				header={ false }
-				identifier={ collabSidebarName }
-				className="editor-collab-sidebar"
-				headerClassName="editor-collab-sidebar__header"
-			>
-				<CollabSidebarContent
-					comments={ sortedThreads }
+					comments={
+						showCommentBoard ? sortedThreads : resultComments
+					}
 					showCommentBoard={ showCommentBoard }
 					setShowCommentBoard={ setShowCommentBoard }
 					styles={ {

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -20,7 +20,7 @@ import { store as interfaceStore } from '@wordpress/interface';
  * Internal dependencies
  */
 import PluginSidebar from '../plugin-sidebar';
-import { collabSidebarName } from './constants';
+import { collabHistorySidebarName, collabSidebarName } from './constants';
 import { Comments } from './comments';
 import { AddComment } from './add-comment';
 import { store as editorStore } from '../../store';
@@ -257,7 +257,7 @@ export default function CollabSidebar() {
 
 	const openCollabBoard = () => {
 		setShowCommentBoard( true );
-		enableComplementaryArea( 'core', collabSidebarName );
+		enableComplementaryArea( 'core', collabHistorySidebarName );
 	};
 
 	const [ blocks ] = useEntityBlockEditor( 'postType', postType, {
@@ -339,18 +339,26 @@ export default function CollabSidebar() {
 		<>
 			<AddCommentComponent onClick={ openCollabBoard } />
 			<PluginSidebar
-				isPinnable
-				identifier={ collabSidebarName }
-				className="editor-collab-sidebar"
-				headerClassName="editor-collab-sidebar__header"
+				identifier={ collabHistorySidebarName }
 				// translators: Comments sidebar title
 				title={ __( 'Comments' ) }
 				icon={ commentIcon }
 			>
 				<CollabSidebarContent
-					comments={
-						showCommentBoard ? sortedThreads : resultComments
-					}
+					comments={ resultComments }
+					showCommentBoard={ showCommentBoard }
+					setShowCommentBoard={ setShowCommentBoard }
+				/>
+			</PluginSidebar>
+			<PluginSidebar
+				isPinnable={ false }
+				header={ false }
+				identifier={ collabSidebarName }
+				className="editor-collab-sidebar"
+				headerClassName="editor-collab-sidebar__header"
+			>
+				<CollabSidebarContent
+					comments={ sortedThreads }
 					showCommentBoard={ showCommentBoard }
 					setShowCommentBoard={ setShowCommentBoard }
 					styles={ {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71377 

This PR tries to resolve issue of not being able to pin the comments sidebar after unpinning it once

Previously, once the sidebar was unpinned, the icon/button disappeared from the toolbar and there was no intuitive way to restore it.

## Why?
Pinning the Comments sidebar is a user setting and should be easily reversible.

## How?
Interactions which open the Comments sidebar now activates pinnable sidebar

This ensures that the star button remains available for user to pin comment sidebar

## Testing Instructions

1. Open a post or page in the editor.
2. Ensure there are comments or add a block comment.
3. Pin the Comments sidebar using the star icon.
4. Unpin the Comments sidebar.
5. Interact with a block comment or use the comment toolbar button to open the sidebar.
6. Confirm the Comments icon/button reappears in the toolbar and can be pinned again.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/832c3a79-ac1d-4975-8d04-b2413f056dee

