### PR TITLE
Block Comments: Make "n more replies" text clickable for accessibility

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -114,6 +114,7 @@ export function Comments( {
 							onEditComment={ onEditComment }
 							isFocused={ focusThread === thread.id }
 							clearThreadFocus={ clearThreadFocus }
+							setFocusThread={ setFocusThread }
 						/>
 					</VStack>
 				) ) }
@@ -129,6 +130,7 @@ function Thread( {
 	onCommentResolve,
 	isFocused,
 	clearThreadFocus,
+	setFocusThread,
 } ) {
 	return (
 		<>
@@ -142,13 +144,27 @@ function Thread( {
 			{ 0 < thread?.reply?.length && (
 				<>
 					{ ! isFocused && (
-						<VStack className="editor-collab-sidebar-panel__show-more-reply">
+						<Button
+							__next40pxDefaultSize
+							variant="link"
+							className="editor-collab-sidebar-panel__show-more-reply"
+							onClick={ () => setFocusThread( thread.id ) }
+							aria-expanded="false"
+							aria-label={ sprintf(
+								// translators: %s: number of replies.
+								_x(
+									'Show %s more replies',
+									'Show replies button'
+								),
+								thread?.reply?.length
+							) }
+						>
 							{ sprintf(
 								// translators: %s: number of replies.
 								_x( '%s more replies', 'Show replies button' ),
 								thread?.reply?.length
 							) }
-						</VStack>
+						</Button>
 					) }
 
 					{ isFocused &&

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -149,15 +149,6 @@ function Thread( {
 							variant="link"
 							className="editor-collab-sidebar-panel__show-more-reply"
 							onClick={ () => setFocusThread( thread.id ) }
-							aria-expanded="false"
-							aria-label={ sprintf(
-								// translators: %s: number of replies.
-								_x(
-									'Show %s more replies',
-									'Show replies button'
-								),
-								thread?.reply?.length
-							) }
 						>
 							{ sprintf(
 								// translators: %s: number of replies.

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -128,6 +128,5 @@
 	&__show-more-reply {
 		font-weight: 500;
 		font-style: italic;
-		padding: 0;
 	}
 }


### PR DESCRIPTION
## What?
See #71249 

Converts the static "n more replies" text in block comments to a clickable, keyboard-accessible button that expands hidden comment replies.

## Why?
The block comments feature currently displays "X more replies" as static text when there are many replies to a comment. Users found it unintuitive that they needed to click elsewhere on the comment thread (or use the "Select an action" menu) to expand and view these hidden replies. This creates accessibility barriers for keyboard and screen reader users who cannot easily discover how to access the additional replies.

## How?
- Replaces the static `VStack` element containing "n more replies" text with a `Button` component
- Adds proper accessibility attributes (`aria-expanded="false"`, descriptive `aria-label`)
- Uses `variant="link"` styling to maintain visual consistency while making it clearly interactive
- Implements the same `setFocusThread()` functionality that was previously only available through clicking elsewhere on the comment thread

## Testing Instructions
1. Open the post editor with a draft post
2. Add several blocks (paragraphs, headings, etc.)
3. Add a block comment to one of the blocks using the comment button in the block toolbar
4. Add multiple replies to that comment (3-4 replies work well for testing)
5. Verify that "X more replies" text appears as a clickable button when the comment thread is collapsed
6. Click the "X more replies" button and verify it expands to show all replies

### Testing Instructions for Keyboard
1. Follow steps 1-4 above to create a comment thread with multiple replies
2. Use `Tab` key to navigate through the comment sidebar
3. Verify the "X more replies" button receives keyboard focus (visual focus indicator should appear)
4. Press `Enter` or `Space` while the button is focused
5. Verify the button expands the replies and shows all hidden comments
6. Test with screen reader (if available) to ensure proper announcement of button purpose and state

## Screenshots or screencast 

### Before
https://github.com/user-attachments/assets/7217fcfc-75d5-473b-b0ea-10e56e21e3e3

### After
https://github.com/user-attachments/assets/2bbfff36-38eb-43a1-8ea5-7932fc753a2f