### PR TITLE
Accordion: Add an "Add" button

### DIFF
--- a/packages/block-library/src/accordion/edit.js
+++ b/packages/block-library/src/accordion/edit.js
@@ -5,6 +5,8 @@ import {
 	useBlockProps,
 	useInnerBlocksProps,
 	InspectorControls,
+	BlockControls,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import {
@@ -13,7 +15,10 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	ToolbarButton,
 } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -27,10 +32,12 @@ const ACCORDION_BLOCK = {
 
 export default function Edit( {
 	attributes: { autoclose, iconPosition, showIcon },
+	clientId,
 	setAttributes,
 } ) {
 	const blockProps = useBlockProps();
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+	const { insertBlock } = useDispatch( blockEditorStore );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: [ [ ACCORDION_BLOCK_NAME ], [ ACCORDION_BLOCK_NAME ] ],
@@ -39,8 +46,21 @@ export default function Edit( {
 		templateInsertUpdatesSelection: true,
 	} );
 
+	const addAccordionContentBlock = () => {
+		const newAccordionContent = createBlock( ACCORDION_BLOCK_NAME );
+		insertBlock( newAccordionContent, undefined, clientId );
+	};
+
 	return (
 		<>
+			<BlockControls group="other">
+				<ToolbarButton
+					label={ __( 'Add accordion content block' ) }
+					onClick={ addAccordionContentBlock }
+				>
+					{ __( 'Add' ) }
+				</ToolbarButton>
+			</BlockControls>
 			<InspectorControls key="setting">
 				<ToolsPanel
 					label={ __( 'Settings' ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Addresses these comments: https://github.com/WordPress/gutenberg/pull/64119#issuecomment-3183588531 & https://github.com/WordPress/gutenberg/pull/64119#issuecomment-3183647440

Adds an "Add" button to the Accordion block.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This makes it easier to add more Accordion Content blocks to the Accordion block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds an "Add" button to the Accordion block toolbar:

<img width="261" height="132" alt="image" src="https://github.com/user-attachments/assets/bf4ed29a-d4d5-4e43-a85e-f5e8a4e2bee2" />

This implementation is based on the "Add" button in the Gallery block:

<img width="354" height="92" alt="image" src="https://github.com/user-attachments/assets/eab1da2e-3487-4faa-a95c-851abad6b2c1" />


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Ensure experimental blocks are enabled.
2. Insert an Accordion block.
3. View the Accordion toolbar, make sure you see an "Add" button.
4. Click the "Add" button and see that a new Accordion Content block has been added.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="995" height="219" alt="image" src="https://github.com/user-attachments/assets/5e8a2f7d-df0b-47d9-8ff1-fbee192d4d5a" />|<img width="995" height="219" alt="image" src="https://github.com/user-attachments/assets/dbc26e85-3958-4e6d-97c0-8b875303465a" />|
