### PR TITLE
Block Bindings: Add fallback for new features introduced in Core

### DIFF
--- a/backport-changelog/6.9/9469.md
+++ b/backport-changelog/6.9/9469.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/9469
+
+* https://github.com/WordPress/gutenberg/pull/71389

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName // Needed for WP_Block_Context_Extractor helper class.
 /**
  * Block Bindings: Support for generically setting rich-text block attributes.
  *
@@ -172,15 +172,28 @@ function gutenberg_process_block_bindings( $instance ) {
 			continue;
 		}
 
-		// Problem: No access to available_context. Can we use refresh_context_dependents()?
-		// That uses $this->block_type->uses_context rather than $instance->block_type->uses_context :/
+		if ( ! class_exists( 'WP_Block_Context_Extractor' ) ) {
+			// phpcs:ignore Gutenberg.Commenting.SinceTag.MissingClassSinceTag
+			class WP_Block_Context_Extractor extends WP_Block {
+				/**
+				 * Static methods of subclasses have access to protected properties
+				 * of instances of the parent class.
+				 * In this case, this gives us access to `available_context`.
+				 */
+				// phpcs:ignore Gutenberg.Commenting.SinceTag.MissingMethodSinceTag
+				public static function get_available_context( $instance ) {
+					return $instance->available_context;
+				}
+			}
+		}
+		$available_context = WP_Block_Context_Extractor::get_available_context( $instance );
 
 		// Adds the necessary context defined by the source.
 		if ( ! empty( $block_binding_source->uses_context ) ) {
 			foreach ( $block_binding_source->uses_context as $context_name ) {
-				// if ( array_key_exists( $context_name, $this->available_context ) ) {
-				//     $instance->context[ $context_name ] = $this->available_context[ $context_name ];
-				// }
+				if ( array_key_exists( $context_name, $available_context ) ) {
+					$instance->context[ $context_name ] = $available_context[ $context_name ];
+				}
 			}
 		}
 

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -1,0 +1,308 @@
+<?php
+/**
+ * Block Bindings: Support for generically setting rich-text block attributes.
+ *
+ * @since 6.9.0
+ * @package gutenberg
+ * @subpackage Block Bindings
+ */
+
+/**
+ * Callback function for the render_block filter.
+ *
+ * @since 6.9.0
+ *
+ * @param string   $block_content The block content.
+ * @param array    $block         The full block, including name and attributes.
+ * @param WP_Block $instance      The block instance.
+ */
+function gutenberg_block_bindings_render_block( $block_content, $block, $instance ) {
+	static $inside_block_bindings_render = false;
+	if ( $inside_block_bindings_render ) {
+		return $block_content;
+	}
+
+	$attributes = $instance->parsed_block['attrs'];
+	// Process the block bindings and get attributes updated with the values from the sources.
+	$computed_attributes = gutenberg_process_block_bindings( $instance );
+	if ( empty( $computed_attributes ) ) {
+		return $block_content;
+	}
+
+	// Merge the computed attributes with the original attributes.
+	$instance->attributes = array_merge( $attributes, $computed_attributes );
+
+	/**
+	 * This filter is called from WP_Block::render(), after the block content has
+	 * already been rendered. However, dynamic blocks expect their render() method
+	 * to receive block attributes to have their bound values. This means that we have
+	 * to re-render the block here.
+	 * To do so, we'll set a flag that this filter checks when invoked to avoid infinite
+	 * recursion. Furthermore, we can unset all of the block's bindings, as we know that
+	 * they have been processed by the time we reach this point.
+	 */
+	unset( $instance->parsed_block['attrs']['metadata']['bindings'] );
+	$inside_block_bindings_render = true;
+	$block_content                = $instance->render();
+	$inside_block_bindings_render = false;
+
+	if ( ! empty( $computed_attributes ) && ! empty( $block_content ) ) {
+		foreach ( $computed_attributes as $attribute_name => $source_value ) {
+			$block_content = gutenberg_replace_html( $block_content, $attribute_name, $source_value, $instance->block_type );
+		}
+	}
+
+	return $block_content;
+}
+add_filter( 'render_block', 'gutenberg_block_bindings_render_block', 10, 3 );
+
+/**
+ * Processes the block bindings and updates the block attributes with the values from the sources.
+ *
+ * A block might contain bindings in its attributes. Bindings are mappings
+ * between an attribute of the block and a source. A "source" is a function
+ * registered with `register_block_bindings_source()` that defines how to
+ * retrieve a value from outside the block, e.g. from post meta.
+ *
+ * This function will process those bindings and update the block's attributes
+ * with the values coming from the bindings.
+ *
+ * ### Example
+ *
+ * The "bindings" property for an Image block might look like this:
+ *
+ * ```json
+ * {
+ *   "metadata": {
+ *     "bindings": {
+ *       "title": {
+ *         "source": "core/post-meta",
+ *         "args": { "key": "text_custom_field" }
+ *       },
+ *       "url": {
+ *         "source": "core/post-meta",
+ *         "args": { "key": "url_custom_field" }
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * The above example will replace the `title` and `url` attributes of the Image
+ * block with the values of the `text_custom_field` and `url_custom_field` post meta.
+ *
+ * @since 6.9.0
+ *
+ * @param WP_Block $instance The block instance.
+ * @return array The computed block attributes for the provided block bindings.
+ */
+function gutenberg_process_block_bindings( $instance ) {
+	$attributes          = $instance->parsed_block['attrs'];
+	$computed_attributes = array();
+
+	if ( ! isset( $attributes['metadata']['bindings'] ) ) {
+		return array();
+	}
+
+	// List of block attributes supported by Block Bindings in WP 6.8.
+	$block_bindings_supported_attributes_6_8 = array(
+		'core/paragraph' => array( 'content' ),
+		'core/heading'   => array( 'content' ),
+		'core/image'     => array( 'id', 'url', 'title', 'alt' ),
+		'core/button'    => array( 'url', 'text', 'linkTarget', 'rel' ),
+	);
+
+	$block_type = $instance->name;
+	$bindings   = $attributes['metadata']['bindings'];
+
+	// if ( isset( $block_bindings_supported_attributes_6_8[ $block_type ] ) ) {
+	//     $supported_block_attributes = $block_bindings_supported_attributes_6_8[ $block_type ];
+	//     // Remove attributes that we know are processed by WP 6.8 from the list.
+	//     // $bindings = array_diff_key( $bindings, $supported_block_attributes );
+	// }
+
+	$supported_block_attributes =
+		$block_bindings_supported_attributes_6_8[ $block_type ] ??
+		array();
+
+	/**
+	 * Filters the supported block attributes for block bindings.
+	 *
+	 * The dynamic portion of the hook name, `$block_type`, refers to the block type
+	 * whose attributes are being filtered.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param string[] $supported_block_attributes The block's attributes that are supported by block bindings.
+	 */
+	$supported_block_attributes = apply_filters(
+		"block_bindings_supported_attributes_{$block_type}",
+		$supported_block_attributes
+	);
+
+	// if ( empty( $bindings ) ) {
+	//     return array();
+	// }
+
+	// TODO: Include pattern overrides.
+
+	// TODO: Review the following.
+	foreach ( $bindings as $attribute_name => $block_binding ) {
+
+		// If the attribute is not in the supported list, process next attribute.
+		if ( ! in_array( $attribute_name, $supported_block_attributes, true ) ) {
+			continue;
+		}
+
+		// If the attribute was already processed by Core, process next attribute.
+		if (
+			isset( $block_bindings_supported_attributes_6_8[ $block_type ] ) &&
+			in_array( $attribute_name, $block_bindings_supported_attributes_6_8[ $block_type ], true )
+		) {
+			continue;
+		}
+
+		// If no source is provided, or that source is not registered, process next attribute.
+		if ( ! isset( $block_binding['source'] ) || ! is_string( $block_binding['source'] ) ) {
+			continue;
+		}
+
+		$block_binding_source = get_block_bindings_source( $block_binding['source'] );
+		if ( null === $block_binding_source ) {
+			continue;
+		}
+
+		// Problem: No access to available_context. Can we use refresh_context_dependents()?
+		// That uses $this->block_type->uses_context rather than $instance->block_type->uses_context :/
+
+		// Adds the necessary context defined by the source.
+		if ( ! empty( $block_binding_source->uses_context ) ) {
+			foreach ( $block_binding_source->uses_context as $context_name ) {
+				// if ( array_key_exists( $context_name, $this->available_context ) ) {
+				//     $instance->context[ $context_name ] = $this->available_context[ $context_name ];
+				// }
+			}
+		}
+
+		$source_args  = ! empty( $block_binding['args'] ) && is_array( $block_binding['args'] ) ? $block_binding['args'] : array();
+		$source_value = $block_binding_source->get_value( $source_args, $instance, $attribute_name );
+
+		// If the value is not null, process the HTML based on the block and the attribute.
+		if ( ! is_null( $source_value ) ) {
+			$computed_attributes[ $attribute_name ] = $source_value;
+		}
+	}
+
+	return $computed_attributes;
+}
+
+/**
+ * Depending on the block attribute name, replace its value in the HTML based on the value provided.
+ *
+ * @since 6.5.0
+ *
+ * @param string $block_content  Block content.
+ * @param string $attribute_name The attribute name to replace.
+ * @param mixed  $source_value   The value used to replace in the HTML.
+ * @param WP_Block_Type $block_type     The block type.
+ * @return string The modified block content.
+ */
+function gutenberg_replace_html( string $block_content, string $attribute_name, $source_value, WP_Block_Type $block_type ) {
+	if ( ! isset( $block_type->attributes[ $attribute_name ]['source'] ) ) {
+		return $block_content;
+	}
+
+	// Depending on the attribute source, the processing will be different.
+	switch ( $block_type->attributes[ $attribute_name ]['source'] ) {
+		case 'html':
+		case 'rich-text':
+			$block_reader = gutenberg_get_block_bindings_processor( $block_content );
+
+			// TODO: Support for CSS selectors whenever they are ready in the HTML API.
+			// In the meantime, support comma-separated selectors by exploding them into an array.
+			$selectors = explode( ',', $block_type->attributes[ $attribute_name ]['selector'] );
+			// Add a bookmark to the first tag to be able to iterate over the selectors.
+			$block_reader->next_tag();
+			$block_reader->set_bookmark( 'iterate-selectors' );
+
+			foreach ( $selectors as $selector ) {
+				// If the parent tag, or any of its children, matches the selector, replace the HTML.
+				if ( strcasecmp( $block_reader->get_tag(), $selector ) === 0 || $block_reader->next_tag(
+					array(
+						'tag_name' => $selector,
+					)
+				) ) {
+					// TODO: Use `WP_HTML_Processor::set_inner_html` method once it's available.
+					$block_reader->release_bookmark( 'iterate-selectors' );
+					$block_reader->replace_rich_text( wp_kses_post( $source_value ) );
+					return $block_reader->get_updated_html();
+				} else {
+					$block_reader->seek( 'iterate-selectors' );
+				}
+			}
+			$block_reader->release_bookmark( 'iterate-selectors' );
+			return $block_content;
+
+		case 'attribute':
+			$amended_content = new WP_HTML_Tag_Processor( $block_content );
+			if ( ! $amended_content->next_tag(
+				array(
+					// TODO: build the query from CSS selector.
+					'tag_name' => $block_type->attributes[ $attribute_name ]['selector'],
+				)
+			) ) {
+				return $block_content;
+			}
+			$amended_content->set_attribute( $block_type->attributes[ $attribute_name ]['attribute'], $source_value );
+			return $amended_content->get_updated_html();
+
+		default:
+			return $block_content;
+	}
+}
+
+function gutenberg_get_block_bindings_processor( string $block_content ) {
+	$internal_processor_class = new class('', WP_HTML_Processor::CONSTRUCTOR_UNLOCK_CODE) extends WP_HTML_Processor {
+		/**
+		 * Replace the rich text content between a tag opener and matching closer.
+		 *
+		 * When stopped on a tag opener, replace the content enclosed by it and its
+		 * matching closer with the provided rich text.
+		 *
+		 * @param string $rich_text The rich text to replace the original content with.
+		 * @return bool True on success.
+		 */
+		public function replace_rich_text( $rich_text ) {
+			if ( $this->is_tag_closer() || ! $this->expects_closer() ) {
+				return false;
+			}
+
+			$depth = $this->get_current_depth();
+
+			$this->set_bookmark( '_wp_block_bindings_tag_opener' );
+			// The bookmark names are prefixed with `_` so the key below has an extra `_`.
+			$tag_opener = $this->bookmarks['__wp_block_bindings_tag_opener'];
+			$start      = $tag_opener->start + $tag_opener->length;
+			$this->release_bookmark( '_wp_block_bindings_tag_opener' );
+
+			// Find matching tag closer.
+			while ( $this->next_token() && $this->get_current_depth() >= $depth ) {
+			}
+
+			$this->set_bookmark( '_wp_block_bindings_tag_closer' );
+			$tag_closer = $this->bookmarks['__wp_block_bindings_tag_closer'];
+			$end        = $tag_closer->start;
+			$this->release_bookmark( '_wp_block_bindings_tag_closer' );
+
+			$this->lexical_updates[] = new WP_HTML_Text_Replacement(
+				$start,
+				$end - $start,
+				$rich_text
+			);
+
+			return true;
+		}
+	};
+
+	return $internal_processor_class::create_fragment( $block_content );
+}

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -311,6 +311,7 @@ function gutenberg_get_block_bindings_processor( string $block_content ) {
 		 * @param string $rich_text The rich text to replace the original content with.
 		 * @return bool True on success.
 		 */
+		// phpcs:ignore Gutenberg.CodeAnalysis.GuardedFunctionAndClassNames.FunctionNotGuardedAgainstRedeclaration
 		public function replace_rich_text( $rich_text ) {
 			if ( $this->is_tag_closer() || ! $this->expects_closer() ) {
 				return false;

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -151,13 +151,38 @@ function gutenberg_process_block_bindings( $instance ) {
 
 	$bindings = $parsed_block['attrs']['metadata']['bindings'];
 
-	// if ( empty( $bindings ) ) {
-	//     return array();
-	// }
+	/*
+	 * If the default binding is set for pattern overrides, replace it
+	 * with a pattern override binding for all supported attributes.
+	 */
+	if (
+		isset( $bindings['__default']['source'] ) &&
+		'core/pattern-overrides' === $bindings['__default']['source']
+	) {
+		$updated_bindings = array();
 
-	// TODO: Include pattern overrides.
+		/*
+		 * Build a binding array of all supported attributes.
+		 * Note that this also omits the `__default` attribute from the
+		 * resulting array.
+		 */
+		foreach ( $supported_block_attributes as $attribute_name ) {
+			// Retain any non-pattern override bindings that might be present.
+			$updated_bindings[ $attribute_name ] = isset( $bindings[ $attribute_name ] )
+				? $bindings[ $attribute_name ]
+				: array( 'source' => 'core/pattern-overrides' );
+		}
+		$bindings = $updated_bindings;
+		/*
+		 * Update the bindings metadata of the computed attributes.
+		 * This ensures the block receives the expanded __default binding metadata when it renders.
+		 */
+		$computed_attributes['metadata'] = array_merge(
+			$parsed_block['attrs']['metadata'],
+			array( 'bindings' => $bindings )
+		);
+	}
 
-	// TODO: Review the following.
 	foreach ( $bindings as $attribute_name => $block_binding ) {
 
 		// If the attribute is not in the supported list, process next attribute.

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -127,6 +127,18 @@ function gutenberg_process_block_bindings( $instance ) {
 		$supported_block_attributes
 	);
 
+	/*
+	 * Remove attributes that we know are processed by WP 6.8 from the list,
+	 * except if we're dealing with the button block, since WP 6.8 capitalizes its
+	 * tag name (e.g. <DIV>).
+	 */
+	if ( 'core/button' !== $block_type && isset( $block_bindings_supported_attributes_6_8[ $block_type ] ) ) {
+		$supported_block_attributes = array_diff(
+			$supported_block_attributes,
+			$block_bindings_supported_attributes_6_8[ $block_type ]
+		);
+	}
+
 	// If the block doesn't have the bindings property, isn't one of the supported
 	// block types, or the bindings property is not an array, return the block content.
 	if (
@@ -139,13 +151,6 @@ function gutenberg_process_block_bindings( $instance ) {
 
 	$bindings = $parsed_block['attrs']['metadata']['bindings'];
 
-	// if ( isset( $block_bindings_supported_attributes_6_8[ $block_type ] ) ) {
-	//     $supported_block_attributes = $block_bindings_supported_attributes_6_8[ $block_type ];
-	//     // Remove attributes that we know are processed by WP 6.8 from the list.
-	//     // $bindings = array_diff_key( $bindings, $supported_block_attributes );
-	// }
-
-
 	// if ( empty( $bindings ) ) {
 	//     return array();
 	// }
@@ -157,15 +162,6 @@ function gutenberg_process_block_bindings( $instance ) {
 
 		// If the attribute is not in the supported list, process next attribute.
 		if ( ! in_array( $attribute_name, $supported_block_attributes, true ) ) {
-			continue;
-		}
-
-		// If the attribute was already processed by Core, process next attribute.
-		if (
-			isset( $block_bindings_supported_attributes_6_8[ $block_type ] ) &&
-			in_array( $attribute_name, $block_bindings_supported_attributes_6_8[ $block_type ], true ) &&
-			'core/button' !== $block_type // ... except for the Button block, as WP 6.8 capitalizes its tag name (e.g. <DIV>).
-		) {
 			continue;
 		}
 

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -158,7 +158,7 @@ function gutenberg_process_block_bindings( $instance ) {
 		if (
 			isset( $block_bindings_supported_attributes_6_8[ $block_type ] ) &&
 			in_array( $attribute_name, $block_bindings_supported_attributes_6_8[ $block_type ], true ) &&
-			'core/button' !== $block_type // ... except for the Button block, as WP 6.8 capitalizes the tag name (e.g. <DIV>).
+			'core/button' !== $block_type // ... except for the Button block, as WP 6.8 capitalizes its tag name (e.g. <DIV>).
 		) {
 			continue;
 		}

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -97,12 +97,9 @@ add_filter( 'render_block', 'gutenberg_block_bindings_render_block', 10, 3 );
  * @return array The computed block attributes for the provided block bindings.
  */
 function gutenberg_process_block_bindings( $instance ) {
-	$attributes          = $instance->parsed_block['attrs'];
+	$block_type          = $instance->name;
+	$parsed_block        = $instance->parsed_block;
 	$computed_attributes = array();
-
-	if ( ! isset( $attributes['metadata']['bindings'] ) ) {
-		return array();
-	}
 
 	// List of block attributes supported by Block Bindings in WP 6.8.
 	$block_bindings_supported_attributes_6_8 = array(
@@ -111,16 +108,6 @@ function gutenberg_process_block_bindings( $instance ) {
 		'core/image'     => array( 'id', 'url', 'title', 'alt' ),
 		'core/button'    => array( 'url', 'text', 'linkTarget', 'rel' ),
 	);
-
-	$block_type = $instance->name;
-	$bindings   = $attributes['metadata']['bindings'];
-
-	// if ( isset( $block_bindings_supported_attributes_6_8[ $block_type ] ) ) {
-	//     $supported_block_attributes = $block_bindings_supported_attributes_6_8[ $block_type ];
-	//     // Remove attributes that we know are processed by WP 6.8 from the list.
-	//     // $bindings = array_diff_key( $bindings, $supported_block_attributes );
-	// }
-
 	$supported_block_attributes =
 		$block_bindings_supported_attributes_6_8[ $block_type ] ??
 		array();
@@ -139,6 +126,25 @@ function gutenberg_process_block_bindings( $instance ) {
 		"block_bindings_supported_attributes_{$block_type}",
 		$supported_block_attributes
 	);
+
+	// If the block doesn't have the bindings property, isn't one of the supported
+	// block types, or the bindings property is not an array, return the block content.
+	if (
+		empty( $supported_block_attributes ) ||
+		empty( $parsed_block['attrs']['metadata']['bindings'] ) ||
+		! is_array( $parsed_block['attrs']['metadata']['bindings'] )
+	) {
+		return $computed_attributes;
+	}
+
+	$bindings = $parsed_block['attrs']['metadata']['bindings'];
+
+	// if ( isset( $block_bindings_supported_attributes_6_8[ $block_type ] ) ) {
+	//     $supported_block_attributes = $block_bindings_supported_attributes_6_8[ $block_type ];
+	//     // Remove attributes that we know are processed by WP 6.8 from the list.
+	//     // $bindings = array_diff_key( $bindings, $supported_block_attributes );
+	// }
+
 
 	// if ( empty( $bindings ) ) {
 	//     return array();

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -157,7 +157,8 @@ function gutenberg_process_block_bindings( $instance ) {
 		// If the attribute was already processed by Core, process next attribute.
 		if (
 			isset( $block_bindings_supported_attributes_6_8[ $block_type ] ) &&
-			in_array( $attribute_name, $block_bindings_supported_attributes_6_8[ $block_type ], true )
+			in_array( $attribute_name, $block_bindings_supported_attributes_6_8[ $block_type ], true ) &&
+			'core/button' !== $block_type // ... except for the Button block, as WP 6.8 capitalizes the tag name (e.g. <DIV>).
 		) {
 			continue;
 		}

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -184,12 +184,10 @@ function gutenberg_process_block_bindings( $instance ) {
 	}
 
 	foreach ( $bindings as $attribute_name => $block_binding ) {
-
 		// If the attribute is not in the supported list, process next attribute.
 		if ( ! in_array( $attribute_name, $supported_block_attributes, true ) ) {
 			continue;
 		}
-
 		// If no source is provided, or that source is not registered, process next attribute.
 		if ( ! isset( $block_binding['source'] ) || ! is_string( $block_binding['source'] ) ) {
 			continue;

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -108,7 +108,7 @@ function gutenberg_process_block_bindings( $instance ) {
 		'core/image'     => array( 'id', 'url', 'title', 'alt' ),
 		'core/button'    => array( 'url', 'text', 'linkTarget', 'rel' ),
 	);
-	$supported_block_attributes =
+	$supported_block_attributes              =
 		$block_bindings_supported_attributes_6_8[ $block_type ] ??
 		array();
 

--- a/lib/load.php
+++ b/lib/load.php
@@ -39,6 +39,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-6.8/rest-api.php';
 
 	// WordPress 6.9 compat.
+	require __DIR__ . '/compat/wordpress-6.9/block-bindings.php';
 	require __DIR__ . '/compat/wordpress-6.9/post-data-block-bindings.php';
 	require __DIR__ . '/compat/wordpress-6.9/rest-api.php';
 	require __DIR__ . '/compat/wordpress-6.9/class-gutenberg-hierarchical-sort.php';

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -20,19 +20,11 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 	$classes = array();
 
 	if (
-		isset( $attributes['metadata']['bindings']['datetime']['source'] ) &&
-		isset( $attributes['metadata']['bindings']['datetime']['args'] )
+		! isset( $attributes['datetime'] ) && ! (
+			isset( $attributes['metadata']['bindings']['datetime']['source'] ) &&
+			isset( $attributes['metadata']['bindings']['datetime']['args'] )
+		)
 	) {
-		/*
-		 * We might be running on a version of WordPress that doesn't support binding the block's `datetime` attribute
-		 * to a Block Bindings source. In this case, we need to manually set the `datetime` attribute to its correct value.
-		 * This branch can be removed once the minimum required WordPress version is 6.9 or newer.
-		 */
-		$source      = get_block_bindings_source( $attributes['metadata']['bindings']['datetime']['source'] );
-		$source_args = $attributes['metadata']['bindings']['datetime']['args'];
-
-		$attributes['datetime'] = $source->get_value( $source_args, $block, 'datetime' );
-	} elseif ( ! isset( $attributes['datetime'] ) ) {
 		/*
 		 * This is the legacy version of the block that didn't have the `datetime` attribute.
 		 * This branch needs to be kept for backward compatibility.
@@ -61,7 +53,7 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 		// (See https://github.com/WordPress/gutenberg/pull/46839 where this logic was originally
 		// implemented.)
 		// In this case, we have to respect and return the empty value.
-		return $attributes['datetime'];
+		return '';
 	}
 
 	$unformatted_date = $attributes['datetime'];
@@ -111,6 +103,19 @@ function register_block_core_post_date() {
 		array(
 			'render_callback' => 'render_block_core_post_date',
 		)
+	);
+
+	// The following filter can be removed once the minimum required WordPress version is 6.9 or newer.
+	add_filter(
+		'block_bindings_supported_attributes_core/post-date',
+		function ( $attributes ) {
+			if ( ! in_array( 'datetime', $attributes, true ) ) {
+				$attributes[] = 'datetime';
+			}
+			return $attributes;
+		},
+		10,
+		3
 	);
 }
 add_action( 'init', 'register_block_core_post_date' );

--- a/phpunit/block-bindings-test.php
+++ b/phpunit/block-bindings-test.php
@@ -40,8 +40,6 @@ class Tests_Block_Bindings extends WP_UnitTestCase {
 	 * @since 6.5.0
 	 */
 	public function tear_down() {
-		remove_filter( 'render_block', 'gutenberg_block_bindings_render_block', 10 );
-
 		foreach ( get_all_registered_block_bindings_sources() as $source_name => $source_properties ) {
 			if ( str_starts_with( $source_name, 'test/' ) ) {
 				unregister_block_bindings_source( $source_name );
@@ -57,6 +55,8 @@ class Tests_Block_Bindings extends WP_UnitTestCase {
 	 * @since 6.9.0
 	 */
 	public static function wpTearDownAfterClass() {
+		remove_filter( 'render_block', 'gutenberg_block_bindings_render_block', 10 );
+
 		unregister_block_type( 'test/block' );
 	}
 

--- a/phpunit/block-bindings-test.php
+++ b/phpunit/block-bindings-test.php
@@ -1,0 +1,523 @@
+<?php
+/**
+ * Tests for Block Bindings integration with block rendering.
+ *
+ * @package Gutenberg
+ */
+class Tests_Block_Bindings extends WP_UnitTestCase {
+
+	const SOURCE_NAME  = 'test/source';
+	const SOURCE_LABEL = array(
+		'label' => 'Test source',
+	);
+
+	/**
+	 * Sets up shared fixtures.
+	 *
+	 * @since 6.9.0
+	 */
+	public static function wpSetUpBeforeClass() {
+		register_block_type(
+			'test/block',
+			array(
+				'attributes'      => array(
+					'myAttribute' => array(
+						'type' => 'string',
+					),
+				),
+				'render_callback' => function ( $attributes ) {
+					return '<p>' . esc_html( $attributes['myAttribute'] ) . '</p>';
+				},
+			)
+		);
+
+		add_filter( 'render_block', 'gutenberg_block_bindings_render_block', 10, 3 );
+	}
+
+	/**
+	 * Tear down after each test.
+	 *
+	 * @since 6.5.0
+	 */
+	public function tear_down() {
+		remove_filter( 'render_block', 'gutenberg_block_bindings_render_block', 10 );
+
+		foreach ( get_all_registered_block_bindings_sources() as $source_name => $source_properties ) {
+			if ( str_starts_with( $source_name, 'test/' ) ) {
+				unregister_block_bindings_source( $source_name );
+			}
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Tear down after class.
+	 *
+	 * @since 6.9.0
+	 */
+	public static function wpTearDownAfterClass() {
+		unregister_block_type( 'test/block' );
+	}
+
+	public function data_update_block_with_value_from_source() {
+		return array(
+			'paragraph block' => array(
+				'content',
+				<<<HTML
+<!-- wp:paragraph -->
+<p>This should not appear</p>
+<!-- /wp:paragraph -->
+HTML
+				,
+				'<p>test source value</p>',
+			),
+			'button block'    => array(
+				'text',
+				<<<HTML
+<!-- wp:button -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">This should not appear</a></div>
+<!-- /wp:button -->
+HTML
+				,
+				'<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">test source value</a></div>',
+			),
+		);
+	}
+
+	/**
+	 * Test if the block content is updated with the value returned by the source.
+	 *
+	 * @ticket 60282
+	 *
+	 * @covers ::register_block_bindings_source
+	 *
+	 * @dataProvider data_update_block_with_value_from_source
+	 */
+	public function test_update_block_with_value_from_source( $bound_attribute, $block_content, $expected_result ) {
+		$get_value_callback = function () {
+			return 'test source value';
+		};
+
+		register_block_bindings_source(
+			self::SOURCE_NAME,
+			array(
+				'label'              => self::SOURCE_LABEL,
+				'get_value_callback' => $get_value_callback,
+			)
+		);
+
+		$parsed_blocks = parse_blocks( $block_content );
+
+		$parsed_blocks[0]['attrs']['metadata'] = array(
+			'bindings' => array(
+				$bound_attribute => array(
+					'source' => self::SOURCE_NAME,
+				),
+			),
+		);
+
+		$block  = new WP_Block( $parsed_blocks[0] );
+		$result = $block->render();
+
+		$this->assertSame(
+			'test source value',
+			$block->attributes[ $bound_attribute ],
+			"The '{$bound_attribute}' attribute should be updated with the value returned by the source."
+		);
+		$this->assertSame(
+			$expected_result,
+			trim( $result ),
+			'The block content should be updated with the value returned by the source.'
+		);
+	}
+
+	/**
+	 * Test if the block_bindings_supported_attributes_{$block_type} filter is applied correctly.
+	 *
+	 * @ticket 62090
+	 */
+	public function test_filter_block_bindings_supported_attributes() {
+		$get_value_callback = function () {
+			return 'test source value';
+		};
+
+		register_block_bindings_source(
+			self::SOURCE_NAME,
+			array(
+				'label'              => self::SOURCE_LABEL,
+				'get_value_callback' => $get_value_callback,
+			)
+		);
+
+		add_filter(
+			'block_bindings_supported_attributes_test/block',
+			function ( $supported_attributes ) {
+				$supported_attributes[] = 'myAttribute';
+				return $supported_attributes;
+			}
+		);
+
+		$block_content = <<<HTML
+<!-- wp:test/block {"metadata":{"bindings":{"myAttribute":{"source":"test/source"}}}} -->
+<p>This should not appear</p>
+<!-- /wp:test/block -->
+HTML;
+		$parsed_blocks = parse_blocks( $block_content );
+		$block         = new WP_Block( $parsed_blocks[0] );
+		$result        = $block->render();
+
+		$this->assertSame(
+			'test source value',
+			$block->attributes['myAttribute'],
+			"The 'myAttribute' attribute should be updated with the value returned by the source."
+		);
+		$this->assertSame(
+			'<p>test source value</p>',
+			trim( $result ),
+			'The block content should be updated with the value returned by the source.'
+		);
+	}
+
+	/**
+	 * Test passing arguments to the source.
+	 *
+	 * @ticket 60282
+	 *
+	 * @covers ::register_block_bindings_source
+	 */
+	public function test_passing_arguments_to_source() {
+		$get_value_callback = function ( $source_args, $block_instance, $attribute_name ) {
+			$value = $source_args['key'];
+			return "The attribute name is '$attribute_name' and its binding has argument 'key' with value '$value'.";
+		};
+
+		register_block_bindings_source(
+			self::SOURCE_NAME,
+			array(
+				'label'              => self::SOURCE_LABEL,
+				'get_value_callback' => $get_value_callback,
+			)
+		);
+
+		$block_content = <<<HTML
+<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"test/source", "args": {"key": "test"}}}}} -->
+<p>This should not appear</p>
+<!-- /wp:paragraph -->
+HTML;
+		$parsed_blocks = parse_blocks( $block_content );
+		$block         = new WP_Block( $parsed_blocks[0] );
+		$result        = $block->render();
+
+		$this->assertSame(
+			"The attribute name is 'content' and its binding has argument 'key' with value 'test'.",
+			$block->attributes['content'],
+			"The 'content' attribute should be updated with the value returned by the source."
+		);
+		$this->assertSame(
+			"<p>The attribute name is 'content' and its binding has argument 'key' with value 'test'.</p>",
+			trim( $result ),
+			'The block content should be updated with the value returned by the source.'
+		);
+	}
+
+	/**
+	 * Tests passing `uses_context` as argument to the source.
+	 *
+	 * @ticket 60525
+	 *
+	 * @covers ::register_block_bindings_source
+	 */
+	public function test_passing_uses_context_to_source() {
+		$get_value_callback = function ( $source_args, $block_instance, $attribute_name ) {
+			$value = $block_instance->context['sourceContext'];
+			return "Value: $value";
+		};
+
+		register_block_bindings_source(
+			self::SOURCE_NAME,
+			array(
+				'label'              => self::SOURCE_LABEL,
+				'get_value_callback' => $get_value_callback,
+				'uses_context'       => array( 'sourceContext' ),
+			)
+		);
+
+		$block_content = <<<HTML
+<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"test/source", "args": {"key": "test"}}}}} -->
+<p>This should not appear</p>
+<!-- /wp:paragraph -->
+HTML;
+		$parsed_blocks = parse_blocks( $block_content );
+		$block         = new WP_Block( $parsed_blocks[0], array( 'sourceContext' => 'source context value' ) );
+		$result        = $block->render();
+
+		$this->assertSame(
+			'Value: source context value',
+			$block->attributes['content'],
+			"The 'content' should be updated with the value of the source context."
+		);
+		$this->assertSame(
+			'<p>Value: source context value</p>',
+			trim( $result ),
+			'The block content should be updated with the value of the source context.'
+		);
+	}
+
+	/**
+	 * Tests that blocks can only access the context from the specific source.
+	 *
+	 * @ticket 61642
+	 *
+	 * @covers ::register_block_bindings_source
+	 */
+	public function test_blocks_can_just_access_the_specific_uses_context() {
+		register_block_bindings_source(
+			'test/source-one',
+			array(
+				'label'              => 'Test Source One',
+				'get_value_callback' => function () {
+					return;
+				},
+				'uses_context'       => array( 'contextOne' ),
+			)
+		);
+
+		register_block_bindings_source(
+			'test/source-two',
+			array(
+				'label'              => 'Test Source Two',
+				'get_value_callback' => function ( $source_args, $block_instance, $attribute_name ) {
+					$value = $block_instance->context['contextTwo'];
+					// Try to use the context from source one, which shouldn't be available.
+					if ( ! empty( $block_instance->context['contextOne'] ) ) {
+						$value = $block_instance->context['contextOne'];
+					}
+					return "Value: $value";
+				},
+				'uses_context'       => array( 'contextTwo' ),
+			)
+		);
+
+		$block_content = <<<HTML
+<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"test/source-two", "args": {"key": "test"}}}}} -->
+<p>Default content</p>
+<!-- /wp:paragraph -->
+HTML;
+		$parsed_blocks = parse_blocks( $block_content );
+		$block         = new WP_Block(
+			$parsed_blocks[0],
+			array(
+				'contextOne' => 'source one context value',
+				'contextTwo' => 'source two context value',
+			)
+		);
+		$result        = $block->render();
+
+		$this->assertSame(
+			'Value: source two context value',
+			$block->attributes['content'],
+			"The 'content' should be updated with the value of the second source context value."
+		);
+		$this->assertSame(
+			'<p>Value: source two context value</p>',
+			trim( $result ),
+			'The block content should be updated with the value of the source context.'
+		);
+	}
+
+	/**
+	 * Tests if the block content is updated with the value returned by the source
+	 * for the Image block in the placeholder state.
+	 *
+	 * @ticket 60282
+	 *
+	 * @covers ::register_block_bindings_source
+	 */
+	public function test_update_block_with_value_from_source_image_placeholder() {
+		$get_value_callback = function () {
+			return 'https://example.com/image.jpg';
+		};
+
+		register_block_bindings_source(
+			self::SOURCE_NAME,
+			array(
+				'label'              => self::SOURCE_LABEL,
+				'get_value_callback' => $get_value_callback,
+			)
+		);
+
+		$block_content = <<<HTML
+<!-- wp:image {"metadata":{"bindings":{"url":{"source":"test/source"}}}} -->
+<figure class="wp-block-image"><img alt=""/></figure>
+<!-- /wp:image -->
+HTML;
+		$parsed_blocks = parse_blocks( $block_content );
+		$block         = new WP_Block( $parsed_blocks[0] );
+		$result        = $block->render();
+
+		$this->assertSame(
+			'https://example.com/image.jpg',
+			$block->attributes['url'],
+			"The 'url' attribute should be updated with the value returned by the source."
+		);
+		$this->assertSame(
+			'<figure class="wp-block-image"><img src="https://example.com/image.jpg" alt=""/></figure>',
+			trim( $result ),
+			'The block content should be updated with the value returned by the source.'
+		);
+	}
+
+	/**
+	 * Tests if the block content is sanitized when unsafe HTML is passed.
+	 *
+	 * @ticket 60651
+	 *
+	 * @covers ::register_block_bindings_source
+	 */
+	public function test_source_value_with_unsafe_html_is_sanitized() {
+		$get_value_callback = function () {
+			return '<script>alert("Unsafe HTML")</script>';
+		};
+
+		register_block_bindings_source(
+			self::SOURCE_NAME,
+			array(
+				'label'              => self::SOURCE_LABEL,
+				'get_value_callback' => $get_value_callback,
+			)
+		);
+
+		$block_content = <<<HTML
+<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"test/source"}}}} -->
+<p>This should not appear</p>
+<!-- /wp:paragraph -->
+HTML;
+		$parsed_blocks = parse_blocks( $block_content );
+		$block         = new WP_Block( $parsed_blocks[0] );
+		$result        = $block->render();
+
+		$this->assertSame(
+			'<p>alert("Unsafe HTML")</p>',
+			trim( $result ),
+			'The block content should be updated with the value returned by the source.'
+		);
+	}
+
+	/**
+	 * Tests that including symbols and numbers works well with bound attributes.
+	 *
+	 * @ticket 61385
+	 *
+	 * @covers WP_Block::process_block_bindings
+	 */
+	public function test_using_symbols_in_block_bindings_value() {
+		$get_value_callback = function () {
+			return '$12.50';
+		};
+
+		register_block_bindings_source(
+			self::SOURCE_NAME,
+			array(
+				'label'              => self::SOURCE_LABEL,
+				'get_value_callback' => $get_value_callback,
+			)
+		);
+
+		$block_content = <<<HTML
+<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"test/source"}}}} -->
+<p>Default content</p>
+<!-- /wp:paragraph -->
+HTML;
+		$parsed_blocks = parse_blocks( $block_content );
+		$block         = new WP_Block( $parsed_blocks[0] );
+		$result        = $block->render();
+
+		$this->assertSame(
+			'<p>$12.50</p>',
+			trim( $result ),
+			'The block content should properly show the symbol and numbers.'
+		);
+	}
+
+	/**
+	 * Tests if the `__default` attribute is replaced with real attributes for
+	 * pattern overrides.
+	 *
+	 * @ticket 61333
+	 * @ticket 62069
+	 *
+	 * @covers WP_Block::process_block_bindings
+	 */
+	public function test_default_binding_for_pattern_overrides() {
+		$block_content = <<<HTML
+<!-- wp:paragraph {"metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"Test"}} -->
+<p>This should not appear</p>
+<!-- /wp:paragraph -->
+HTML;
+
+		$expected_content = 'This is the content value';
+		$parsed_blocks    = parse_blocks( $block_content );
+		$block            = new WP_Block( $parsed_blocks[0], array( 'pattern/overrides' => array( 'Test' => array( 'content' => $expected_content ) ) ) );
+
+		$result = $block->render();
+
+		$this->assertSame(
+			"<p>$expected_content</p>",
+			trim( $result ),
+			'The `__default` attribute should be replaced with the real attribute prior to the callback.'
+		);
+
+		$expected_bindings_metadata = array(
+			'content' => array( 'source' => 'core/pattern-overrides' ),
+		);
+		$this->assertSame(
+			$expected_bindings_metadata,
+			$block->attributes['metadata']['bindings'],
+			'The __default binding should be updated with the individual binding attributes in the block metadata.'
+		);
+	}
+
+	/**
+	 * Tests that filter `block_bindings_source_value` is applied.
+	 *
+	 * @ticket 61181
+	 */
+	public function test_filter_block_bindings_source_value() {
+		register_block_bindings_source(
+			self::SOURCE_NAME,
+			array(
+				'label'              => self::SOURCE_LABEL,
+				'get_value_callback' => function () {
+					return '';
+				},
+			)
+		);
+
+		$filter_value = function ( $value, $source_name, $source_args, $block_instance, $attribute_name ) {
+			if ( self::SOURCE_NAME !== $source_name ) {
+				return $value;
+			}
+			return "Filtered value: {$source_args['test_key']}. Block instance: {$block_instance->name}. Attribute name: {$attribute_name}.";
+		};
+
+		add_filter( 'block_bindings_source_value', $filter_value, 10, 5 );
+
+		$block_content = <<<HTML
+<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"test/source", "args":{"test_key":"test_arg"}}}}} -->
+<p>Default content</p>
+<!-- /wp:paragraph -->
+HTML;
+		$parsed_blocks = parse_blocks( $block_content );
+		$block         = new WP_Block( $parsed_blocks[0] );
+		$result        = $block->render();
+
+		remove_filter( 'block_bindings_source_value', $filter_value );
+
+		$this->assertSame(
+			'<p>Filtered value: test_arg. Block instance: core/paragraph. Attribute name: content.</p>',
+			trim( $result ),
+			'The block content should show the filtered value.'
+		);
+	}
+}

--- a/phpunit/block-bindings-test.php
+++ b/phpunit/block-bindings-test.php
@@ -32,6 +32,10 @@ class Tests_Block_Bindings extends WP_UnitTestCase {
 				},
 			)
 		);
+	}
+
+	public function set_up() {
+		parent::set_up();
 
 		add_filter(
 			'block_bindings_supported_attributes_test/block',

--- a/phpunit/block-bindings-test.php
+++ b/phpunit/block-bindings-test.php
@@ -32,8 +32,6 @@ class Tests_Block_Bindings extends WP_UnitTestCase {
 				},
 			)
 		);
-
-		add_filter( 'render_block', 'gutenberg_block_bindings_render_block', 10, 3 );
 	}
 
 	/**
@@ -57,8 +55,6 @@ class Tests_Block_Bindings extends WP_UnitTestCase {
 	 * @since 6.9.0
 	 */
 	public static function wpTearDownAfterClass() {
-		remove_filter( 'render_block', 'gutenberg_block_bindings_render_block', 10 );
-
 		unregister_block_type( 'test/block' );
 	}
 

--- a/phpunit/block-bindings-test.php
+++ b/phpunit/block-bindings-test.php
@@ -209,7 +209,7 @@ HTML;
 	 * @covers ::register_block_bindings_source
 	 */
 	public function test_passing_uses_context_to_source() {
-		$get_value_callback = function ( $source_args, $block_instance, $attribute_name ) {
+		$get_value_callback = function ( $source_args, $block_instance ) {
 			$this->assertArrayNotHasKey(
 				'forbiddenSourceContext',
 				$block_instance->context,

--- a/phpunit/block-bindings-test.php
+++ b/phpunit/block-bindings-test.php
@@ -194,11 +194,17 @@ HTML;
 	 * Tests passing `uses_context` as argument to the source.
 	 *
 	 * @ticket 60525
+	 * @ticket 61642
 	 *
 	 * @covers ::register_block_bindings_source
 	 */
 	public function test_passing_uses_context_to_source() {
 		$get_value_callback = function ( $source_args, $block_instance, $attribute_name ) {
+			$this->assertArrayNotHasKey(
+				'forbiddenSourceContext',
+				$block_instance->context,
+				"Only context that was made available through the source's uses_context property should be accessible."
+			);
 			$value = $block_instance->context['sourceContext'];
 			return "Value: $value";
 		};
@@ -218,7 +224,13 @@ HTML;
 <!-- /wp:test/block -->
 HTML;
 		$parsed_blocks = parse_blocks( $block_content );
-		$block         = new WP_Block( $parsed_blocks[0], array( 'sourceContext' => 'source context value' ) );
+		$block         = new WP_Block(
+			$parsed_blocks[0],
+			array(
+				'sourceContext'          => 'source context value',
+				'forbiddenSourceContext' => 'forbidden donut',
+			)
+		);
 		$result        = $block->render();
 
 		$this->assertSame(
@@ -228,57 +240,6 @@ HTML;
 		);
 		$this->assertSame(
 			'<p>Value: source context value</p>',
-			trim( $result ),
-			'The block content should be updated with the value of the source context.'
-		);
-	}
-
-	/**
-	 * Tests that blocks can only access the context from the specific source.
-	 *
-	 * @ticket 61642
-	 *
-	 * @covers ::register_block_bindings_source
-	 */
-	public function test_blocks_can_just_access_the_specific_uses_context() {
-		register_block_bindings_source(
-			'test/source-two',
-			array(
-				'label'              => 'Test Source Two',
-				'get_value_callback' => function ( $source_args, $block_instance, $attribute_name ) {
-					$value = $block_instance->context['contextTwo'];
-					// Try to use the context from source one, which shouldn't be available.
-					if ( ! empty( $block_instance->context['contextOne'] ) ) {
-						$value = $block_instance->context['contextOne'];
-					}
-					return "Value: $value";
-				},
-				'uses_context'       => array( 'contextTwo' ),
-			)
-		);
-
-		$block_content = <<<HTML
-<!-- wp:test/block {"metadata":{"bindings":{"myAttribute":{"source":"test/source-two", "args": {"key": "test"}}}}} -->
-<p>Default content</p>
-<!-- /wp:test/block -->
-HTML;
-		$parsed_blocks = parse_blocks( $block_content );
-		$block         = new WP_Block(
-			$parsed_blocks[0],
-			array(
-				'contextOne' => 'source one context value',
-				'contextTwo' => 'source two context value',
-			)
-		);
-		$result        = $block->render();
-
-		$this->assertSame(
-			'Value: source two context value',
-			$block->attributes['myAttribute'],
-			"The 'myAttribute' should be updated with the value of the second source context value."
-		);
-		$this->assertSame(
-			'<p>Value: source two context value</p>',
 			trim( $result ),
 			'The block content should be updated with the value of the source context.'
 		);

--- a/phpunit/block-bindings-test.php
+++ b/phpunit/block-bindings-test.php
@@ -269,9 +269,9 @@ HTML;
 		);
 
 		$block_content = <<<HTML
-<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"test/source-two", "args": {"key": "test"}}}}} -->
+<!-- wp:test/block {"metadata":{"bindings":{"myAttribute":{"source":"test/source-two", "args": {"key": "test"}}}}} -->
 <p>Default content</p>
-<!-- /wp:paragraph -->
+<!-- /wp:test/block -->
 HTML;
 		$parsed_blocks = parse_blocks( $block_content );
 		$block         = new WP_Block(
@@ -285,8 +285,8 @@ HTML;
 
 		$this->assertSame(
 			'Value: source two context value',
-			$block->attributes['content'],
-			"The 'content' should be updated with the value of the second source context value."
+			$block->attributes['myAttribute'],
+			"The 'myAttribute' should be updated with the value of the second source context value."
 		);
 		$this->assertSame(
 			'<p>Value: source two context value</p>',

--- a/phpunit/block-bindings-test.php
+++ b/phpunit/block-bindings-test.php
@@ -13,8 +13,6 @@ class Tests_Block_Bindings extends WP_UnitTestCase {
 
 	/**
 	 * Sets up shared fixtures.
-	 *
-	 * @since 6.9.0
 	 */
 	public static function wpSetUpBeforeClass() {
 		register_block_type(
@@ -36,8 +34,6 @@ class Tests_Block_Bindings extends WP_UnitTestCase {
 
 	/**
 	 * Sets up the test fixture.
-	 *
-	 * @since 6.9.0
 	 */
 	public function set_up() {
 		parent::set_up();
@@ -53,8 +49,6 @@ class Tests_Block_Bindings extends WP_UnitTestCase {
 
 	/**
 	 * Tear down after each test.
-	 *
-	 * @since 6.5.0
 	 */
 	public function tear_down() {
 		foreach ( get_all_registered_block_bindings_sources() as $source_name => $source_properties ) {
@@ -68,8 +62,6 @@ class Tests_Block_Bindings extends WP_UnitTestCase {
 
 	/**
 	 * Tear down after class.
-	 *
-	 * @since 6.9.0
 	 */
 	public static function wpTearDownAfterClass() {
 		unregister_block_type( 'test/block' );

--- a/phpunit/block-bindings-test.php
+++ b/phpunit/block-bindings-test.php
@@ -242,17 +242,6 @@ HTML;
 	 */
 	public function test_blocks_can_just_access_the_specific_uses_context() {
 		register_block_bindings_source(
-			'test/source-one',
-			array(
-				'label'              => 'Test Source One',
-				'get_value_callback' => function () {
-					return;
-				},
-				'uses_context'       => array( 'contextOne' ),
-			)
-		);
-
-		register_block_bindings_source(
 			'test/source-two',
 			array(
 				'label'              => 'Test Source Two',

--- a/phpunit/block-bindings-test.php
+++ b/phpunit/block-bindings-test.php
@@ -448,15 +448,23 @@ HTML;
 	 * @covers WP_Block::process_block_bindings
 	 */
 	public function test_default_binding_for_pattern_overrides() {
+		add_filter(
+			'block_bindings_supported_attributes_test/block',
+			function ( $supported_attributes ) {
+				$supported_attributes[] = 'myAttribute';
+				return $supported_attributes;
+			}
+		);
+
 		$block_content = <<<HTML
-<!-- wp:paragraph {"metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"Test"}} -->
+<!-- wp:test/block {"metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"Test"}} -->
 <p>This should not appear</p>
-<!-- /wp:paragraph -->
+<!-- /wp:test/block -->
 HTML;
 
 		$expected_content = 'This is the content value';
 		$parsed_blocks    = parse_blocks( $block_content );
-		$block            = new WP_Block( $parsed_blocks[0], array( 'pattern/overrides' => array( 'Test' => array( 'content' => $expected_content ) ) ) );
+		$block            = new WP_Block( $parsed_blocks[0], array( 'pattern/overrides' => array( 'Test' => array( 'myAttribute' => $expected_content ) ) ) );
 
 		$result = $block->render();
 
@@ -467,7 +475,7 @@ HTML;
 		);
 
 		$expected_bindings_metadata = array(
-			'content' => array( 'source' => 'core/pattern-overrides' ),
+			'myAttribute' => array( 'source' => 'core/pattern-overrides' ),
 		);
 		$this->assertSame(
 			$expected_bindings_metadata,

--- a/phpunit/block-bindings-test.php
+++ b/phpunit/block-bindings-test.php
@@ -26,7 +26,9 @@ class Tests_Block_Bindings extends WP_UnitTestCase {
 					),
 				),
 				'render_callback' => function ( $attributes ) {
-					return '<p>' . esc_html( $attributes['myAttribute'] ) . '</p>';
+					if ( isset( $attributes['myAttribute'] ) ) {
+						return '<p>' . esc_html( $attributes['myAttribute'] ) . '</p>';
+					}
 				},
 			)
 		);

--- a/phpunit/block-bindings-test.php
+++ b/phpunit/block-bindings-test.php
@@ -34,6 +34,11 @@ class Tests_Block_Bindings extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Sets up the test fixture.
+	 *
+	 * @since 6.9.0
+	 */
 	public function set_up() {
 		parent::set_up();
 

--- a/phpunit/block-bindings-test.php
+++ b/phpunit/block-bindings-test.php
@@ -148,19 +148,42 @@ HTML
 		);
 	}
 
+	public function data_different_get_value_callbacks() {
+		return array(
+			'pass arguments to source'        => array(
+				function ( $source_args, $block_instance, $attribute_name ) {
+					$value = $source_args['key'];
+					return "The attribute name is '$attribute_name' and its binding has argument 'key' with value '$value'.";
+				},
+				"<p>The attribute name is 'content' and its binding has argument 'key' with value 'test'.</p>",
+			),
+			'unsafe HTML should be sanitized' => array(
+				function () {
+					return '<script>alert("Unsafe HTML")</script>';
+				},
+				'<p>alert("Unsafe HTML")</p>',
+			),
+			'symbols and numbers should be rendered correctly' => array(
+				function () {
+					return '$12.50';
+				},
+				'<p>$12.50</p>',
+			),
+		);
+	}
+
 	/**
 	 * Test passing arguments to the source.
 	 *
 	 * @ticket 60282
+	 * @ticket 60651
+	 * @ticket 61385
 	 *
 	 * @covers ::register_block_bindings_source
+	 *
+	 * @dataProvider data_different_get_value_callbacks
 	 */
-	public function test_passing_arguments_to_source() {
-		$get_value_callback = function ( $source_args, $block_instance, $attribute_name ) {
-			$value = $source_args['key'];
-			return "The attribute name is '$attribute_name' and its binding has argument 'key' with value '$value'.";
-		};
-
+	public function test_different_get_value_callbacks( $get_value_callback, $expected ) {
 		register_block_bindings_source(
 			self::SOURCE_NAME,
 			array(
@@ -179,12 +202,7 @@ HTML;
 		$result        = $block->render();
 
 		$this->assertSame(
-			"The attribute name is 'content' and its binding has argument 'key' with value 'test'.",
-			$block->attributes['content'],
-			"The 'content' attribute should be updated with the value returned by the source."
-		);
-		$this->assertSame(
-			"<p>The attribute name is 'content' and its binding has argument 'key' with value 'test'.</p>",
+			$expected,
 			trim( $result ),
 			'The block content should be updated with the value returned by the source.'
 		);
@@ -284,78 +302,6 @@ HTML;
 			'<figure class="wp-block-image"><img src="https://example.com/image.jpg" alt=""/></figure>',
 			trim( $result ),
 			'The block content should be updated with the value returned by the source.'
-		);
-	}
-
-	/**
-	 * Tests if the block content is sanitized when unsafe HTML is passed.
-	 *
-	 * @ticket 60651
-	 *
-	 * @covers ::register_block_bindings_source
-	 */
-	public function test_source_value_with_unsafe_html_is_sanitized() {
-		$get_value_callback = function () {
-			return '<script>alert("Unsafe HTML")</script>';
-		};
-
-		register_block_bindings_source(
-			self::SOURCE_NAME,
-			array(
-				'label'              => self::SOURCE_LABEL,
-				'get_value_callback' => $get_value_callback,
-			)
-		);
-
-		$block_content = <<<HTML
-<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"test/source"}}}} -->
-<p>This should not appear</p>
-<!-- /wp:paragraph -->
-HTML;
-		$parsed_blocks = parse_blocks( $block_content );
-		$block         = new WP_Block( $parsed_blocks[0] );
-		$result        = $block->render();
-
-		$this->assertSame(
-			'<p>alert("Unsafe HTML")</p>',
-			trim( $result ),
-			'The block content should be updated with the value returned by the source.'
-		);
-	}
-
-	/**
-	 * Tests that including symbols and numbers works well with bound attributes.
-	 *
-	 * @ticket 61385
-	 *
-	 * @covers WP_Block::process_block_bindings
-	 */
-	public function test_using_symbols_in_block_bindings_value() {
-		$get_value_callback = function () {
-			return '$12.50';
-		};
-
-		register_block_bindings_source(
-			self::SOURCE_NAME,
-			array(
-				'label'              => self::SOURCE_LABEL,
-				'get_value_callback' => $get_value_callback,
-			)
-		);
-
-		$block_content = <<<HTML
-<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"test/source"}}}} -->
-<p>Default content</p>
-<!-- /wp:paragraph -->
-HTML;
-		$parsed_blocks = parse_blocks( $block_content );
-		$block         = new WP_Block( $parsed_blocks[0] );
-		$result        = $block->render();
-
-		$this->assertSame(
-			'<p>$12.50</p>',
-			trim( $result ),
-			'The block content should properly show the symbol and numbers.'
 		);
 	}
 

--- a/phpunit/block-bindings-test.php
+++ b/phpunit/block-bindings-test.php
@@ -227,6 +227,14 @@ HTML;
 	 * @covers ::register_block_bindings_source
 	 */
 	public function test_passing_uses_context_to_source() {
+		add_filter(
+			'block_bindings_supported_attributes_test/block',
+			function ( $supported_attributes ) {
+				$supported_attributes[] = 'myAttribute';
+				return $supported_attributes;
+			}
+		);
+
 		$get_value_callback = function ( $source_args, $block_instance, $attribute_name ) {
 			$value = $block_instance->context['sourceContext'];
 			return "Value: $value";
@@ -242,9 +250,9 @@ HTML;
 		);
 
 		$block_content = <<<HTML
-<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"test/source", "args": {"key": "test"}}}}} -->
+<!-- wp:test/block {"metadata":{"bindings":{"myAttribute":{"source":"test/source", "args": {"key": "test"}}}}} -->
 <p>This should not appear</p>
-<!-- /wp:paragraph -->
+<!-- /wp:test/block -->
 HTML;
 		$parsed_blocks = parse_blocks( $block_content );
 		$block         = new WP_Block( $parsed_blocks[0], array( 'sourceContext' => 'source context value' ) );
@@ -252,8 +260,8 @@ HTML;
 
 		$this->assertSame(
 			'Value: source context value',
-			$block->attributes['content'],
-			"The 'content' should be updated with the value of the source context."
+			$block->attributes['myAttribute'],
+			"The 'myAttribute' should be updated with the value of the source context."
 		);
 		$this->assertSame(
 			'<p>Value: source context value</p>',

--- a/phpunit/block-bindings-test.php
+++ b/phpunit/block-bindings-test.php
@@ -32,6 +32,14 @@ class Tests_Block_Bindings extends WP_UnitTestCase {
 				},
 			)
 		);
+
+		add_filter(
+			'block_bindings_supported_attributes_test/block',
+			function ( $supported_attributes ) {
+				$supported_attributes[] = 'myAttribute';
+				return $supported_attributes;
+			}
+		);
 	}
 
 	/**
@@ -80,6 +88,16 @@ HTML
 				,
 				'<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">test source value</a></div>',
 			),
+			'test block'      => array(
+				'myAttribute',
+				<<<HTML
+<!-- wp:test/block -->
+<p>This should not appear</p>
+<!-- /wp:test/block -->
+HTML
+				,
+				'<p>test source value</p>',
+			),
 		);
 	}
 
@@ -125,53 +143,6 @@ HTML
 		);
 		$this->assertSame(
 			$expected_result,
-			trim( $result ),
-			'The block content should be updated with the value returned by the source.'
-		);
-	}
-
-	/**
-	 * Test if the block_bindings_supported_attributes_{$block_type} filter is applied correctly.
-	 *
-	 * @ticket 62090
-	 */
-	public function test_filter_block_bindings_supported_attributes() {
-		$get_value_callback = function () {
-			return 'test source value';
-		};
-
-		register_block_bindings_source(
-			self::SOURCE_NAME,
-			array(
-				'label'              => self::SOURCE_LABEL,
-				'get_value_callback' => $get_value_callback,
-			)
-		);
-
-		add_filter(
-			'block_bindings_supported_attributes_test/block',
-			function ( $supported_attributes ) {
-				$supported_attributes[] = 'myAttribute';
-				return $supported_attributes;
-			}
-		);
-
-		$block_content = <<<HTML
-<!-- wp:test/block {"metadata":{"bindings":{"myAttribute":{"source":"test/source"}}}} -->
-<p>This should not appear</p>
-<!-- /wp:test/block -->
-HTML;
-		$parsed_blocks = parse_blocks( $block_content );
-		$block         = new WP_Block( $parsed_blocks[0] );
-		$result        = $block->render();
-
-		$this->assertSame(
-			'test source value',
-			$block->attributes['myAttribute'],
-			"The 'myAttribute' attribute should be updated with the value returned by the source."
-		);
-		$this->assertSame(
-			'<p>test source value</p>',
 			trim( $result ),
 			'The block content should be updated with the value returned by the source.'
 		);
@@ -227,14 +198,6 @@ HTML;
 	 * @covers ::register_block_bindings_source
 	 */
 	public function test_passing_uses_context_to_source() {
-		add_filter(
-			'block_bindings_supported_attributes_test/block',
-			function ( $supported_attributes ) {
-				$supported_attributes[] = 'myAttribute';
-				return $supported_attributes;
-			}
-		);
-
 		$get_value_callback = function ( $source_args, $block_instance, $attribute_name ) {
 			$value = $block_instance->context['sourceContext'];
 			return "Value: $value";
@@ -456,14 +419,6 @@ HTML;
 	 * @covers WP_Block::process_block_bindings
 	 */
 	public function test_default_binding_for_pattern_overrides() {
-		add_filter(
-			'block_bindings_supported_attributes_test/block',
-			function ( $supported_attributes ) {
-				$supported_attributes[] = 'myAttribute';
-				return $supported_attributes;
-			}
-		);
-
 		$block_content = <<<HTML
 <!-- wp:test/block {"metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"Test"}} -->
 <p>This should not appear</p>

--- a/phpunit/block-bindings-test.php
+++ b/phpunit/block-bindings-test.php
@@ -105,8 +105,6 @@ HTML
 	/**
 	 * Test if the block content is updated with the value returned by the source.
 	 *
-	 * @ticket 60282
-	 *
 	 * @covers ::register_block_bindings_source
 	 *
 	 * @dataProvider data_update_block_with_value_from_source
@@ -176,10 +174,6 @@ HTML
 	/**
 	 * Test passing arguments to the source.
 	 *
-	 * @ticket 60282
-	 * @ticket 60651
-	 * @ticket 61385
-	 *
 	 * @covers ::register_block_bindings_source
 	 *
 	 * @dataProvider data_different_get_value_callbacks
@@ -211,9 +205,6 @@ HTML;
 
 	/**
 	 * Tests passing `uses_context` as argument to the source.
-	 *
-	 * @ticket 60525
-	 * @ticket 61642
 	 *
 	 * @covers ::register_block_bindings_source
 	 */
@@ -268,8 +259,6 @@ HTML;
 	 * Tests if the block content is updated with the value returned by the source
 	 * for the Image block in the placeholder state.
 	 *
-	 * @ticket 60282
-	 *
 	 * @covers ::register_block_bindings_source
 	 */
 	public function test_update_block_with_value_from_source_image_placeholder() {
@@ -310,9 +299,6 @@ HTML;
 	 * Tests if the `__default` attribute is replaced with real attributes for
 	 * pattern overrides.
 	 *
-	 * @ticket 61333
-	 * @ticket 62069
-	 *
 	 * @covers WP_Block::process_block_bindings
 	 */
 	public function test_default_binding_for_pattern_overrides() {
@@ -346,8 +332,6 @@ HTML;
 
 	/**
 	 * Tests that filter `block_bindings_source_value` is applied.
-	 *
-	 * @ticket 61181
 	 */
 	public function test_filter_block_bindings_source_value() {
 		register_block_bindings_source(

--- a/phpunit/blocks/render-block-core-post-date.php
+++ b/phpunit/blocks/render-block-core-post-date.php
@@ -94,7 +94,7 @@ class Test_Render_Block_Core_Post_Date extends WP_UnitTestCase {
 		);
 
 		// Now verify that a fallback value is overridden by Block Bindings.
-		$block->attributes['datetime'] = '2025-01-01 00:00:00';
+		$block->parsed_block['attrs']['datetime'] = '2025-01-01 00:00:00';
 
 		$output = $block->render();
 		$this->assertStringContainsString(


### PR DESCRIPTION
## What?
Gutenberg port of https://github.com/WordPress/wordpress-develop/pull/9469 (and https://github.com/WordPress/wordpress-develop/pull/9392).

## Why?
For backwards compatibility.

## How?
Largely by copying `WP_Block`'s `process_block_bindings` and `replace_html` methods (plus some tweaks to allow accessing some of its `protected` properties), and calling them from a filter that's hooked to `render_block`. Some optimizations are made to avoid running code redundantly for block attributes that are already handled by WP 6.8.

## Testing Instructions
Test both against Core `trunk`, and `6.8`.

Verify that block bindings and pattern override still work as before. For manual smoke testing, follow e.g. the [testing instructions of the Date block](https://github.com/WordPress/gutenberg/pull/70585).

There is ample unit test coverage, largely obtained by copying [this file](https://github.com/WordPress/wordpress-develop/blob/dde9c80724588765fd606b584c4c4835fa8145c6/tests/phpunit/tests/block-bindings/render.php) from Core, and some tweaks to it to make sure unit tests pass for a newly added `test/block` that isn't present in 6.8. (Those test tweaks -- which make the unit tests a bit less verbose and redundant IMO -- are being backported to Core in https://github.com/WordPress/wordpress-develop/pull/9748.)
