### PR TITLE
Fix PHP unit testing jobs to not include version

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -160,7 +160,7 @@ jobs:
                       ./build-module/
 
     test-php:
-        name: PHP ${{ matrix.php }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.wordpress != '' && format( ' (WP {0}) ', matrix.wordpress ) || '' }} on 'ubuntu-24.04'
+        name: PHP ${{ matrix.php }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.wordpress != '' && format( ' (WP {0}) ', matrix.wordpress ) || '' }} on Linux
         needs: [compute-previous-wordpress-version, build-assets]
         runs-on: 'ubuntu-24.04'
         permissions:


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up to #71201.

This adjusts the PHPUnit testing jobs to not be version specific.

GitHub Actions workflow `runs-on` [documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax?s=09#jobsjob_idruns-on).

## Why?
The version of the runner operating system is not important for the test job.