### PR TITLE
Core Data: Include pagination meta while receiving intermediate results

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -307,13 +307,25 @@ export const getEntityRecords =
 						response.headers.get( 'X-WP-TotalPages' )
 					);
 
+					if ( ! meta ) {
+						meta = {
+							totalItems: parseInt(
+								response.headers.get( 'X-WP-Total' )
+							),
+							totalPages: 1,
+						};
+					}
+
 					records.push( ...pageRecords );
 					registry.batch( () => {
 						dispatch.receiveEntityRecords(
 							kind,
 							name,
 							records,
-							query
+							query,
+							false,
+							undefined,
+							meta
 						);
 						dispatch.finishResolutions(
 							'getEntityRecord',
@@ -322,11 +334,6 @@ export const getEntityRecords =
 					} );
 					page++;
 				} while ( page <= totalPages );
-
-				meta = {
-					totalItems: records.length,
-					totalPages: 1,
-				};
 			} else {
 				records = Object.values( await apiFetch( { path } ) );
 				meta = {


### PR DESCRIPTION
## What?
This is a follow-up to #66713.

PR updates `getEntityRecords` resolver to include pagination meta while store receives intermediate results.

## Why?

The `X-WP-Total` header is available in this case, so there's no need to wait for full resolution to derive and send total items data.

It's helpful when an app displays a loading state that uses the currently fetched records and the total number of expected items.

## Testing Instructions
This is a bit hard to test manually, so confirm that the changed logic has its merit 😓