### PR TITLE
Editor: Try displaying intermediate results for hierarchical terms

### DIFF
--- a/packages/edit-post/src/components/back-button/test/fullscreen-mode-close.js
+++ b/packages/edit-post/src/components/back-button/test/fullscreen-mode-close.js
@@ -18,8 +18,6 @@ jest.mock( '@wordpress/data/src/components/use-select', () => {
 	return jest.fn();
 } );
 
-jest.mock( '@wordpress/core-data' );
-
 describe( 'FullscreenModeClose', () => {
 	describe( 'when in full screen mode', () => {
 		it( 'should display a user uploaded site icon if it exists', () => {

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -427,7 +427,15 @@ export function HierarchicalTermSelector( { slug } ) {
 				/>
 			) }
 			{ loading && (
-				<FlexItem>
+				<FlexItem
+					display="flex"
+					style={ {
+						justifyContent: 'center',
+						alignItems: 'center',
+						// Match SearchControl height to prevent layout shift.
+						height: '40px',
+					} }
+				>
 					<Spinner />
 				</FlexItem>
 			) }

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -192,14 +192,14 @@ export function HierarchicalTermSelector( { slug } ) {
 
 			return {
 				hasCreateAction: _taxonomy
-					? post._links?.[
+					? !! post._links?.[
 							'wp:action-create-' + _taxonomy.rest_base
-					  ] ?? false
+					  ]
 					: false,
 				hasAssignAction: _taxonomy
-					? post._links?.[
+					? !! post._links?.[
 							'wp:action-assign-' + _taxonomy.rest_base
-					  ] ?? false
+					  ]
 					: false,
 				terms: _taxonomy
 					? getEditedPostAttribute( _taxonomy.rest_base )

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -13,11 +13,15 @@ import {
 	Flex,
 	FlexItem,
 	SearchControl,
+	Spinner,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useDebounce } from '@wordpress/compose';
-import { store as coreStore } from '@wordpress/core-data';
+import {
+	store as coreStore,
+	privateApis as coreDataPrivateApis,
+} from '@wordpress/core-data';
 import { speak } from '@wordpress/a11y';
 import { decodeEntities } from '@wordpress/html-entities';
 
@@ -28,6 +32,9 @@ import { buildTermsTree } from '../../utils/terms';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
+const { normalizeTextString } = unlock( componentsPrivateApis );
+const { RECEIVE_INTERMEDIATE_RESULTS } = unlock( coreDataPrivateApis );
+
 /**
  * Module Constants
  */
@@ -37,11 +44,10 @@ const DEFAULT_QUERY = {
 	order: 'asc',
 	_fields: 'id,name,parent',
 	context: 'view',
+	[ RECEIVE_INTERMEDIATE_RESULTS ]: true,
 };
 const MIN_TERMS_COUNT_FOR_FILTER = 8;
 const EMPTY_ARRAY = [];
-
-const { normalizeTextString } = unlock( componentsPrivateApis );
 
 /**
  * Sort Terms by Selected.
@@ -410,7 +416,7 @@ export function HierarchicalTermSelector( { slug } ) {
 
 	return (
 		<Flex direction="column" gap="4">
-			{ showFilter && (
+			{ showFilter && ! loading && (
 				<SearchControl
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom
@@ -419,6 +425,11 @@ export function HierarchicalTermSelector( { slug } ) {
 					value={ filterValue }
 					onChange={ setFilter }
 				/>
+			) }
+			{ loading && (
+				<FlexItem>
+					<Spinner />
+				</FlexItem>
 			) }
 			<div
 				className="editor-post-taxonomies__hierarchical-terms-list"

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -13,7 +13,6 @@ import {
 	Flex,
 	FlexItem,
 	SearchControl,
-	Spinner,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -180,13 +179,18 @@ export function HierarchicalTermSelector( { slug } ) {
 		terms,
 		loading,
 		availableTerms,
+		totalTermsCount,
 		taxonomy,
 	} = useSelect(
 		( select ) => {
 			const { getCurrentPost, getEditedPostAttribute } =
 				select( editorStore );
-			const { getEntityRecord, getEntityRecords, isResolving } =
-				select( coreStore );
+			const {
+				getEntityRecord,
+				getEntityRecords,
+				getEntityRecordsTotalItems,
+				isResolving,
+			} = select( coreStore );
 			const _taxonomy = getEntityRecord( 'root', 'taxonomy', slug );
 			const post = getCurrentPost();
 
@@ -212,6 +216,12 @@ export function HierarchicalTermSelector( { slug } ) {
 				availableTerms:
 					getEntityRecords( 'taxonomy', slug, DEFAULT_QUERY ) ||
 					EMPTY_ARRAY,
+				totalTermsCount:
+					getEntityRecordsTotalItems(
+						'taxonomy',
+						slug,
+						DEFAULT_QUERY
+					) ?? 0,
 				taxonomy: _taxonomy,
 			};
 		},
@@ -428,7 +438,12 @@ export function HierarchicalTermSelector( { slug } ) {
 			) }
 			{ loading && (
 				<FlexItem>
-					<Spinner />
+					{ sprintf(
+						/* translators: 1: number of displayed terms, 2: total number of terms. */
+						__( 'Displaying %1$d of %2$d terms…' ),
+						availableTerms.length,
+						totalTermsCount
+					) }
 				</FlexItem>
 			) }
 			<div

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -13,6 +13,7 @@ import {
 	Flex,
 	FlexItem,
 	SearchControl,
+	Spinner,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -179,18 +180,13 @@ export function HierarchicalTermSelector( { slug } ) {
 		terms,
 		loading,
 		availableTerms,
-		totalTermsCount,
 		taxonomy,
 	} = useSelect(
 		( select ) => {
 			const { getCurrentPost, getEditedPostAttribute } =
 				select( editorStore );
-			const {
-				getEntityRecord,
-				getEntityRecords,
-				getEntityRecordsTotalItems,
-				isResolving,
-			} = select( coreStore );
+			const { getEntityRecord, getEntityRecords, isResolving } =
+				select( coreStore );
 			const _taxonomy = getEntityRecord( 'root', 'taxonomy', slug );
 			const post = getCurrentPost();
 
@@ -216,12 +212,6 @@ export function HierarchicalTermSelector( { slug } ) {
 				availableTerms:
 					getEntityRecords( 'taxonomy', slug, DEFAULT_QUERY ) ||
 					EMPTY_ARRAY,
-				totalTermsCount:
-					getEntityRecordsTotalItems(
-						'taxonomy',
-						slug,
-						DEFAULT_QUERY
-					) ?? 0,
 				taxonomy: _taxonomy,
 			};
 		},
@@ -438,12 +428,7 @@ export function HierarchicalTermSelector( { slug } ) {
 			) }
 			{ loading && (
 				<FlexItem>
-					{ sprintf(
-						/* translators: 1: number of displayed terms, 2: total number of terms. */
-						__( 'Displaying %1$d of %2$d terms…' ),
-						availableTerms.length,
-						totalTermsCount
-					) }
+					<Spinner />
 				</FlexItem>
 			) }
 			<div

--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -427,17 +427,15 @@ export function HierarchicalTermSelector( { slug } ) {
 				/>
 			) }
 			{ loading && (
-				<FlexItem
-					display="flex"
+				<Flex
+					justify="center"
 					style={ {
-						justifyContent: 'center',
-						alignItems: 'center',
 						// Match SearchControl height to prevent layout shift.
 						height: '40px',
 					} }
 				>
 					<Spinner />
-				</FlexItem>
+				</Flex>
 			) }
 			<div
 				className="editor-post-taxonomies__hierarchical-terms-list"


### PR DESCRIPTION
## What?
Closes #10169.
Previous work #29393.
Depends on #71401.

PR updates the query in the `HierarchicalTermSelector` component to start displaying intermediate results as it fetches all terms. The search and "create new term" fields aren't displayed while fetching is still in progress.

## Why?
Improves the perceived performance of the hierarchical terms panel by starting rendering it early. Waiting for the full, unbound query to finish can take a couple of seconds, depending on the number of terms.

## How?
This is possible thanks to the new private `RECEIVE_INTERMEDIATE_RESULTS` query option (#66713).

## Testing Instructions.
1. Create test data - `wp term generate category --count=5000 --max_depth=3`.
2. Open a post.
3. Confirm that the category list is immediately displayed, with a loading indicator.
4. The search box and create new category fields are hidden until loading finishes.


### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/11a9d0e2-b0c7-4315-94c6-7605486062f0


