### PR TITLE
Release Workflow: Add github.ref validation

### DIFF
--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -9,10 +9,24 @@ on:
 permissions: {}
 
 jobs:
+    validate-github-ref:
+        name: Validate github.ref
+        runs-on: 'ubuntu-24.04'
+        permissions: {}
+        steps:
+            - name: Check github.ref
+              run: |
+                  if [ -z "${{ github.ref }}" ]; then
+                    echo "::error::github.ref is empty ('${{ github.ref }}')"
+                    exit 1
+                  fi
+                  echo "github.ref is valid: ${{ github.ref }}"
+
     compute-should-update-trunk:
         name: Decide if trunk or tag
         runs-on: 'ubuntu-24.04'
         permissions: {}
+        needs: validate-github-ref
         # Skip this job if the release is a release candidate. This will in turn skip
         # the upload jobs, which are only relevant for non-RC releases.
         # We first check if the release is a prerelease, and then if the ref contains
@@ -71,6 +85,7 @@ jobs:
         name: Get release branch name
         runs-on: 'ubuntu-24.04'
         permissions: {}
+        needs: validate-github-ref
         outputs:
             release_branch: ${{ steps.get_release_branch.outputs.release_branch }}
 


### PR DESCRIPTION
See the discussion on Slack for more details: https://wordpress.slack.com/archives/C02QB2JS7/p1756287157774339

## What?

This PR adds a `github.ref` validation to prevent unintended SVN commit when publishing the plugin.

## Why?

When I ran the 21.5 stable release, I encountered a strange problem where commits were only added to `tags` and not `trunk`.

https://github.com/WordPress/gutenberg/actions/runs/17263363144/attempts/1

<img width="1004" height="284" alt="workflow" src="https://github.com/user-attachments/assets/c48cb250-b706-4fda-a002-2ecd13884971" />

After investigation, we found that for some reason `github.ref` was empty, which caused the newly released version to be determined to be "lower" than the plugin version already released, resulting in `should_update_trunk` being set to `false`.

<img width="208" height="80" alt="image" src="https://github.com/user-attachments/assets/c64976bf-2b9f-4a83-91d6-450c5d363f97" />

This variable should be `true` when a stable version is released:

<img width="249" height="83" alt="image" src="https://github.com/user-attachments/assets/9bdff0e8-11f0-47f0-a40e-d7b206d42c02" />

Maybe I did something wrong in the release process, but we haven't found out the reason yet.

## How?

At the beginning of the two jobs, add a new job that checks if the `github.ref` value is empty. We should investigate why the `github.ref` can be empty in the first place, but this new job should prevent unintended changelog updates and SVN commits. 

<img width="1325" height="249" alt="validate-github-ref" src="https://github.com/user-attachments/assets/17fa87f9-2002-4271-8041-65cef9e58bed" />

## Testing Instructions

We are not able to test this PR at the moment, but I would like to share this PR with the 21.6 release lead and explain that the workflow has changed slightly.