### PR TITLE
List block: Add empty state placeholder to prevent block from disappearing

### DIFF
--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -7,7 +7,7 @@ import {
 	useInnerBlocksProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { ToolbarButton } from '@wordpress/components';
+import { ToolbarButton, Placeholder } from '@wordpress/components';
 import { useDispatch, useSelect, useRegistry } from '@wordpress/data';
 import { isRTL, __ } from '@wordpress/i18n';
 import {
@@ -120,6 +120,24 @@ function IndentUI( { clientId } ) {
 
 export default function Edit( { attributes, setAttributes, clientId, style } ) {
 	const { ordered, type, reversed, start } = attributes;
+
+	const { hasInnerBlocks, isSelected } = useSelect(
+		( select ) => {
+			const { getBlocks, isBlockSelected, hasSelectedInnerBlock } =
+				select( blockEditorStore );
+			const innerBlocks = getBlocks( clientId );
+			const selected =
+				isBlockSelected( clientId ) ||
+				hasSelectedInnerBlock( clientId, true );
+
+			return {
+				hasInnerBlocks: innerBlocks.length > 0,
+				isSelected: selected,
+			};
+		},
+		[ clientId ]
+	);
+
 	const blockProps = useBlockProps( {
 		style: {
 			...( Platform.isNative && style ),
@@ -127,19 +145,23 @@ export default function Edit( { attributes, setAttributes, clientId, style } ) {
 		},
 	} );
 
-	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		defaultBlock: DEFAULT_BLOCK,
-		directInsert: true,
-		template: TEMPLATE,
-		templateLock: false,
-		templateInsertUpdatesSelection: true,
-		...( Platform.isNative && {
-			marginVertical: NATIVE_MARGIN_SPACING,
-			marginHorizontal: NATIVE_MARGIN_SPACING,
-			renderAppender: false,
-		} ),
-		__experimentalCaptureToolbars: true,
-	} );
+	const innerBlocksProps = useInnerBlocksProps(
+		hasInnerBlocks ? blockProps : {},
+		{
+			defaultBlock: DEFAULT_BLOCK,
+			directInsert: true,
+			template: TEMPLATE,
+			templateLock: false,
+			templateInsertUpdatesSelection: true,
+			...( Platform.isNative && {
+				marginVertical: NATIVE_MARGIN_SPACING,
+				marginHorizontal: NATIVE_MARGIN_SPACING,
+				renderAppender: false,
+			} ),
+			__experimentalCaptureToolbars: true,
+		}
+	);
+
 	useMigrateOnLoad( attributes, clientId );
 
 	const controls = (
@@ -165,6 +187,35 @@ export default function Edit( { attributes, setAttributes, clientId, style } ) {
 			<IndentUI clientId={ clientId } />
 		</BlockControls>
 	);
+
+	// Show placeholder when block is empty and not selected.
+	if ( ! hasInnerBlocks && ! isSelected ) {
+		return (
+			<div { ...blockProps }>
+				<Placeholder
+					icon={
+						// eslint-disable-next-line no-nested-ternary
+						ordered
+							? isRTL()
+								? formatListNumberedRTL
+								: formatListNumbered
+							: isRTL()
+							? formatListBulletsRTL
+							: formatListBullets
+					}
+					label={
+						ordered ? __( 'Ordered List' ) : __( 'Unordered List' )
+					}
+					className="wp-block-list-placeholder"
+					isColumnLayout
+				>
+					<div className="wp-block-list-placeholder__help">
+						{ __( 'Click to add list item.' ) }
+					</div>
+				</Placeholder>
+			</div>
+		);
+	}
 
 	return (
 		<>


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/gutenberg/issues/65646

Add empty state placeholder for List block to prevent it from disappearing when it has no inner blocks.

## Why?
When a List block has all its inner list-item blocks deleted, it becomes completely invisible in the editor canvas when not selected. This creates a poor user experience where users cannot see or interact with the empty block, even though it still exists in the block hierarchy. This inconsistency with other core blocks (like Buttons, Social Icons, etc.) that show placeholders when empty needed to be addressed.

## Testing Instructions
1. Open a post or page in the block editor
2. Insert a List block (it will have one default list item)
3. Select the inner list item and delete it (the List block should now be empty)
4. Click elsewhere to deselect the List block (e.g., click below to add a Paragraph)
5. Verify that the List block now shows a placeholder with the list icon and "Click to add list item" text
6. Click on the placeholder to select the List block
7. Verify that the block appender appears and you can add list items normally
8. Test with both ordered and unordered lists to ensure appropriate icons are shown

## Screenshots or screencast <!-- if applicable -->

### Before
https://github.com/user-attachments/assets/af396639-daa8-4ad9-a2b8-8d8baea617b6

### After
https://github.com/user-attachments/assets/6f0d2294-9559-41a6-829d-1104b39af591


