### PR TITLE
Edit Post: Fix misplaced icon on back button

### DIFF
--- a/packages/edit-post/src/components/back-button/style.scss
+++ b/packages/edit-post/src/components/back-button/style.scss
@@ -6,6 +6,7 @@
 		display: flex;
 		align-items: center;
 		align-self: stretch;
+		justify-content: center;
 		border: none;
 		background: $gray-900;
 		color: $white;
@@ -31,7 +32,7 @@
 			position: absolute;
 			top: 9px;
 			right: 9px;
-			bottom: 9px + $border-width; // Height of toolbar in edit-post (not edit-site) is 61px tall.
+			bottom: 9px;
 			left: 9px;
 			border-radius: $radius-small + $border-width + $border-width;
 			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $gray-900;

--- a/packages/edit-post/src/components/back-button/style.scss
+++ b/packages/edit-post/src/components/back-button/style.scss
@@ -30,10 +30,10 @@
 			content: "";
 			display: block;
 			position: absolute;
-			top: 9px;
-			right: 9px;
-			bottom: 9px;
-			left: 9px;
+			top: $grid-unit-10 + $border-width;
+			right: $grid-unit-10 + $border-width;
+			bottom: $grid-unit-10 + $border-width;
+			left: $grid-unit-10 + $border-width;
 			border-radius: $radius-small + $border-width + $border-width;
 			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $gray-900;
 		}

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -207,10 +207,10 @@ html.canvas-mode-edit-transition::view-transition-group(toggle) {
 		content: "";
 		display: block;
 		position: absolute;
-		top: 9px;
-		right: 9px;
-		bottom: 9px;
-		left: 9px;
+		top: $grid-unit-10 + $border-width;
+		right: $grid-unit-10 + $border-width;
+		bottom: $grid-unit-10 + $border-width;
+		left: $grid-unit-20 + $border-width;
 		border-radius: $radius-medium;
 		box-shadow: none;
 


### PR DESCRIPTION
Fixes #71403

## What?

This PR fixes the misplaced icon on the back button.

## Why?

In #60729, we unified the header height to 64px in all editors. As a result, the back button size increased from 60px to 64px, creating new internal space, but there was no CSS to align the icon horizontally.

## Testing Instructions

Open the post editor and hover or focus on the back button.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="350" height="95" alt="before" src="https://github.com/user-attachments/assets/4ef71b86-c9eb-4abb-8938-022653d81ceb" /> | <img width="350" height="95" alt="after" src="https://github.com/user-attachments/assets/7d996451-cd23-409f-b5cd-e862ef0307b5" /> |

