### PR TITLE
Accordion Content, Header, Panel: Remove example field

### DIFF
--- a/packages/block-library/src/accordion-content/block.json
+++ b/packages/block-library/src/accordion-content/block.json
@@ -6,7 +6,6 @@
 	"title": "Accordion Content",
 	"category": "design",
 	"description": "Displays a section of content in an accordion, including a header and expandable content.",
-	"example": {},
 	"__experimental": true,
 	"parent": [ "core/accordion" ],
 	"allowedBlocks": [ "core/accordion-header", "core/accordion-panel" ],

--- a/packages/block-library/src/accordion-content/index.js
+++ b/packages/block-library/src/accordion-content/index.js
@@ -13,7 +13,6 @@ export { metadata, name };
 
 export const settings = {
 	icon,
-	example: {},
 	edit,
 	save,
 };

--- a/packages/block-library/src/accordion-header/block.json
+++ b/packages/block-library/src/accordion-header/block.json
@@ -6,7 +6,6 @@
 	"title": "Accordion Header",
 	"category": "design",
 	"description": "Displays an accordion header.",
-	"example": {},
 	"__experimental": true,
 	"parent": [ "core/accordion-content" ],
 	"usesContext": [

--- a/packages/block-library/src/accordion-header/index.js
+++ b/packages/block-library/src/accordion-header/index.js
@@ -13,7 +13,6 @@ export { metadata, name };
 
 export const settings = {
 	icon,
-	example: {},
 	edit,
 	save,
 };

--- a/packages/block-library/src/accordion-panel/block.json
+++ b/packages/block-library/src/accordion-panel/block.json
@@ -6,7 +6,6 @@
 	"title": "Accordion Panel",
 	"category": "design",
 	"description": "Displays an accordion panel.",
-	"example": {},
 	"__experimental": true,
 	"parent": [ "core/accordion-content" ],
 	"supports": {

--- a/packages/block-library/src/accordion-panel/index.js
+++ b/packages/block-library/src/accordion-panel/index.js
@@ -13,7 +13,6 @@ export { metadata, name };
 
 export const settings = {
 	icon,
-	example: {},
 	edit,
 	save,
 };


### PR DESCRIPTION
Related: #71354

## What?

Since the Accordion Content, Header, and Panel block cannot be inserted at the root level of the editor, it doesn't make sense to show the example on Storybook, and the block preview in the sidebar.

## How?

Removes `examples` field. This field is used to determine whether the block preview is to be rendered.

## Testing Instructions

- Opne StyleBook. Check that the Accordion Content, Header, and Panel blocks don't exist in the Theme category.
- Open the Global Styles > Blocks > Accordion Content, Header, and Panel
- Confirm that the block preview isn't rendered.

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="1398" height="668" alt="image" src="https://github.com/user-attachments/assets/c5ea4544-ac4b-4244-b6b4-8fdf925f1af0" />

### After

<img width="1485" height="620" alt="image" src="https://github.com/user-attachments/assets/8398301b-0707-42f7-84b4-8288160a0628" />
