### PR TITLE
Fix: Randomization in Gallery Block doesn't work when Lightbox is enabled

### DIFF
--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -142,7 +142,7 @@ function block_core_gallery_render( $attributes, $content ) {
 
 	// This pattern matches figure elements with the `wp-block-image` class to
 	// avoid the gallery's wrapping `figure` element and extract images only.
-	$pattern = '/<figure[^>]*\bwp-block-image\b[^>]*>.*?<\/figure>/';
+	$pattern = '/<figure[^>]*\bwp-block-image\b[^>]*>.*?<\/figure>/s';
 
 	// Find all Image blocks.
 	preg_match_all( $pattern, $updated_content, $matches );


### PR DESCRIPTION
Reclose #65120
See: https://github.com/WordPress/gutenberg/issues/65120#issuecomment-3233412111

## What?

This PR fixes the issue that randomization in the Gallery Block doesn't work when Lightbox is enabled.

<!-- In a few words, what is the PR actually doing? -->

## Why?

We introduced a functionality to randomize images inside the Gallery block in #58733. I realized that the regular expression doesn't work if the provided HTML contains line breaks.

For example, when the lightbox is disabled, the rendered HTML is the following:

```html
<figure class="wp-block-gallery has-nested-images columns-default is-cropped wp-block-gallery-2">
<figure class="wp-block-image size-large"><img data-id="26" src="http://localhost:8888/wp-content/uploads/2025/08/1.png" alt="" class="wp-image-26"/></figure>
<figure class="wp-block-image size-large"><img data-id="27" src="http://localhost:8888/wp-content/uploads/2025/08/2.png" alt="" class="wp-image-27"/></figure>
</figure>
```

On the other hand, when the lightbox is enabled, the image block has the button element, and there are a lot of line breaks and tabs:

<details><summary>Details</summary>

```html
<figure class="wp-block-gallery has-nested-images columns-default is-cropped wp-block-gallery-2">
<figure data-wp-context="{&quot;imageId&quot;:&quot;68b16ea4d77e3&quot;}" data-wp-interactive="core/image" data-wp-key="68b16ea4d77e3" class="wp-block-image size-large wp-lightbox-container"><img data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on-async--click="actions.showLightbox" data-wp-on-async--load="callbacks.setButtonStyles" data-wp-on-async-window--resize="callbacks.setButtonStyles" data-id="26" src="http://localhost:8888/wp-content/uploads/2025/08/1.png" alt="" class="wp-image-26"/><button
			class="lightbox-trigger"
			type="button"
			aria-haspopup="dialog"
			aria-label="Enlarge"
			data-wp-init="callbacks.initTriggerButton"
			data-wp-on-async--click="actions.showLightbox"
			data-wp-style--right="state.imageButtonRight"
			data-wp-style--top="state.imageButtonTop"
		>
			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
			</svg>
		</button></figure>
<figure data-wp-context="{&quot;imageId&quot;:&quot;68b16ea4d79ea&quot;}" data-wp-interactive="core/image" data-wp-key="68b16ea4d79ea" class="wp-block-image size-large wp-lightbox-container"><img data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on-async--click="actions.showLightbox" data-wp-on-async--load="callbacks.setButtonStyles" data-wp-on-async-window--resize="callbacks.setButtonStyles" data-id="27" src="http://localhost:8888/wp-content/uploads/2025/08/2.png" alt="" class="wp-image-27"/><button
			class="lightbox-trigger"
			type="button"
			aria-haspopup="dialog"
			aria-label="Enlarge"
			data-wp-init="callbacks.initTriggerButton"
			data-wp-on-async--click="actions.showLightbox"
			data-wp-style--right="state.imageButtonRight"
			data-wp-style--top="state.imageButtonTop"
		>
			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
			</svg>
		</button></figure>
</figure>
```

</details> 

## How?

Uses the dotall flag (`s`) to make `.` match including newline characters.

Ref: [PHP: Possible modifiers in regex patterns - Manual](https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php)

## Testing Instructions

- Insert a Gallery block and put images inside it.
- Enable the "Expand on Click" from the Gallery block's toolbar.
- Open the post on the front end.
- Confirm that the order of images differs every time you reload your browser.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/63f18899-62c5-405c-86f0-eaefb0fa1732


