### PR TITLE
Fix: Hide resolved comments in unpinned mode

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -265,7 +265,7 @@ export default function CollabSidebar() {
 	} );
 
 	// Process comments to build the tree structure
-	const { resultComments, sortedThreads } = useMemo( () => {
+	const { resultComments, unresolvedSortedThreads } = useMemo( () => {
 		// Create a compare to store the references to all objects by id
 		const compare = {};
 		const result = [];
@@ -291,7 +291,7 @@ export default function CollabSidebar() {
 		} );
 
 		if ( 0 === result?.length ) {
-			return { resultComments: [], sortedThreads: [] };
+			return { resultComments: [], unresolvedSortedThreads: [] };
 		}
 
 		const updatedResult = result.map( ( item ) => ( {
@@ -305,11 +305,16 @@ export default function CollabSidebar() {
 			updatedResult.map( ( thread ) => [ thread.id, thread ] )
 		);
 
-		const sortedComments = blockCommentIds
+		// Get comments by block order, filter out undefined threads, and exclude resolved comments.
+		const unresolvedSortedComments = blockCommentIds
 			.map( ( id ) => threadIdMap.get( id ) )
-			.filter( ( thread ) => thread !== undefined );
+			.filter( ( thread ) => thread !== undefined )
+			.filter( ( thread ) => thread.status !== 'approved' );
 
-		return { resultComments: updatedResult, sortedThreads: sortedComments };
+		return {
+			resultComments: updatedResult,
+			unresolvedSortedThreads: unresolvedSortedComments,
+		};
 	}, [ threads, blocks ] );
 
 	// Get the global styles to set the background color of the sidebar.
@@ -358,7 +363,7 @@ export default function CollabSidebar() {
 				headerClassName="editor-collab-sidebar__header"
 			>
 				<CollabSidebarContent
-					comments={ sortedThreads }
+					comments={ unresolvedSortedThreads }
 					showCommentBoard={ showCommentBoard }
 					setShowCommentBoard={ setShowCommentBoard }
 					styles={ {

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -308,8 +308,10 @@ export default function CollabSidebar() {
 		// Get comments by block order, filter out undefined threads, and exclude resolved comments.
 		const unresolvedSortedComments = blockCommentIds
 			.map( ( id ) => threadIdMap.get( id ) )
-			.filter( ( thread ) => thread !== undefined )
-			.filter( ( thread ) => thread.status !== 'approved' );
+			.filter(
+				( thread ) =>
+					thread !== undefined && thread.status !== 'approved'
+			);
 
 		return {
 			resultComments: updatedResult,


### PR DESCRIPTION
## What?
Closes #71394 

This PR filters out resolved comments from the unpinned collaboration sidebar to declutter the editor display while keeping them visible in the pinned sidebar for complete comment history.

## Why?
When comments are resolved, they should disappear from the default unpinned view to reduce visual clutter and help editors focus on active, unresolved comments that need attention. Previously, both resolved and unresolved comments were shown in all sidebar modes.

## How?
- Added filtering logic to exclude comments with `status === 'approved'` from the unpinned sidebar
- Preserved all comments (resolved + unresolved) in the pinned sidebar for full history access
- Refactored variable names for clarity (`sortedThreads` → `unresolvedSortedThreads`)

## Testing Instructions
1. Open the Gutenberg editor with a post or page
2. Add some blocks and create comments on them
3. Resolve one or more comments by clicking the "Resolve" button (checkmark icon)
4. Open the unpinned collaboration sidebar
5. Verify that resolved comments do not appear in the unpinned sidebar
6. Open the pinned collaboration sidebar
7. Verify that all comments (resolved + unresolved) appear in the sidebar

## Screenshots or screencast 
### Before
https://github.com/user-attachments/assets/542560dd-850f-4447-8ac9-18490114ed25

### After
https://github.com/user-attachments/assets/2d1720db-6c35-45fc-8c14-4013929f8c6f
