### PR TITLE
Inserter: Fix `InserterListbox` rendering for React 19

### DIFF
--- a/packages/block-editor/src/components/inserter-listbox/index.js
+++ b/packages/block-editor/src/components/inserter-listbox/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { Composite } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -11,9 +12,17 @@ export { default as InserterListboxGroup } from './group';
 export { default as InserterListboxRow } from './row';
 export { default as InserterListboxItem } from './item';
 
+function InserterListBoxWrapper( { key, children } ) {
+	return <Fragment key={ key }>{ children }</Fragment>;
+}
+
 function InserterListbox( { children } ) {
 	return (
-		<Composite focusShift focusWrap="horizontal" render={ <></> }>
+		<Composite
+			focusShift
+			focusWrap="horizontal"
+			render={ InserterListBoxWrapper }
+		>
 			{ children }
 		</Composite>
 	);


### PR DESCRIPTION
## What?
This PR fixes an error during `InserterListbox` rendering when using React 19. 

## Why?
To prepare for React 19 compatibility and to fix an error when using React 19.

See #71336 for the full effort.

See #61521 for the PR where the changes came from. 

## How?
We're creating a component to receive the ref, since `Fragment` can't receive refs and React will throw an error.

The change is harmless and won't have any effect in React 18 since the error will be thrown only with React 19.

We're pulling in a part of #61521 to be landed separately.

## Testing Instructions
* Open the post editor
* Open the inserter and verify the warning no longer appears
* Verify all checks are green.

To actually witness the error in React 19:
* Checkout #61521 and do `git revert a72061d862c923d5339c14f5a2ebf77a2441db02` and go through the above testing instructions.
* Without the revert commit, the error is not there.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
<img width="889" height="717" alt="Screenshot 2025-08-29 at 12 22 42" src="https://github.com/user-attachments/assets/b130f537-567a-44b9-b5ba-71dae3eb41f5" />