### PR TITLE
Buttons: Add support for text color at the `Buttons` block level

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -106,7 +106,7 @@ Prompt visitors to take action with a group of button-style links. ([Source](htt
 -	**Name:** core/buttons
 -	**Category:** design
 -	**Allowed Blocks:** core/button
--	**Supports:** align (full, wide), anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), anchor, color (background, gradients, text), interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 
 ## Calendar
 

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -20,6 +20,10 @@ $blocks-block__margin: 0.5em;
 		/*rtl:ignore*/
 		text-align: right;
 	}
+
+	.has-text-color & {
+		color: inherit;
+	}
 }
 
 // These rules are set to zero specificity to keep the default styles for buttons.

--- a/packages/block-library/src/buttons/block.json
+++ b/packages/block-library/src/buttons/block.json
@@ -15,9 +15,9 @@
 		"__experimentalExposeControlsToChildren": true,
 		"color": {
 			"gradients": true,
-			"text": false,
 			"__experimentalDefaultControls": {
-				"background": true
+				"background": true,
+				"text": true
 			}
 		},
 		"spacing": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds support for text color at the Buttons block level, similar to what is already available on individual Button block
Closes #57606

<!-- In a few words, what is the PR actually doing? -->

## Why?

There is a need to provide a text color option at the Buttons block level so that all inner Button blocks can consistently inherit the same color from the parent, instead of setting the color on each Button individually.

Additionally, when Buttons are placed inside a Group and the Group has a text color applied, the Buttons block currently does not inherit this color. This PR fixes that inheritance issue as well.

## How?

- Enabled text color support in `packages/block-library/src/buttons/block.json`.

## Testing Instructions

- Add a Buttons block.
- In block settings, set a text or background color → confirm styles apply.

<br/>

- Add a Buttons block inside a Group block.
- Apply a text color to the Group block → confirm the Buttons block inherits the color.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

The button block is not inheritting colors given from group block. Intuitively one would want everything inside the group block to have the color chosen by the Group block 

<img width="1469" height="749" alt="image" src="https://github.com/user-attachments/assets/400b2413-0cd0-4fd8-a62e-5b9bb9c371c9" />


### After

Now, the Button correctly inherits the color from the Group block. If a color is set at the Buttons block level, that color is used instead. Lastly, if a color is applied directly to the Button block, that color is applied.

https://github.com/user-attachments/assets/c04642fe-27f5-4618-a8a7-3b246130439c

 this would have the highest priority


