### PR TITLE
[Button Block]: add support for pseudo elements for the block and its variations on theme.json

### DIFF
--- a/backport-changelog/7.0/10523.md
+++ b/backport-changelog/7.0/10523.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10523
+
+* https://github.com/WordPress/gutenberg/pull/71418

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1039,7 +1039,7 @@ class WP_Theme_JSON_Gutenberg {
 			$schema_styles_blocks[ $block ]             = $styles_non_top_level;
 			$schema_styles_blocks[ $block ]['elements'] = $schema_styles_elements;
 
-			// Add pseudo-selectors for blocks that support them
+			// Add pseudo-selectors for blocks that support them.
 			if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] ) ) {
 				foreach ( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] as $pseudo_selector ) {
 					$schema_styles_blocks[ $block ][ $pseudo_selector ] = $styles_non_top_level;

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -591,6 +591,16 @@ class WP_Theme_JSON_Gutenberg {
 	);
 
 	/**
+	 * The valid pseudo-selectors that can be used for blocks.
+	 *
+	 * @since 6.1.0
+	 * @var array
+	 */
+	const VALID_BLOCK_PSEUDO_SELECTORS = array(
+		'core/button' => array( ':hover', ':focus', ':focus-visible', ':active' ),
+	);
+
+	/**
 	 * The valid elements that can be found under styles.
 	 *
 	 * @since 5.8.0
@@ -1001,6 +1011,13 @@ class WP_Theme_JSON_Gutenberg {
 			$schema_settings_blocks[ $block ]           = static::VALID_SETTINGS;
 			$schema_styles_blocks[ $block ]             = $styles_non_top_level;
 			$schema_styles_blocks[ $block ]['elements'] = $schema_styles_elements;
+			
+			// Add pseudo-selectors for blocks that support them
+			if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] ) ) {
+				foreach ( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] as $pseudo_selector ) {
+					$schema_styles_blocks[ $block ][ $pseudo_selector ] = $styles_non_top_level;
+				}
+			}
 		}
 
 		$block_style_variation_styles             = static::VALID_STYLES;
@@ -1347,6 +1364,7 @@ class WP_Theme_JSON_Gutenberg {
 		if ( null === $origins ) {
 			$origins = static::VALID_ORIGINS;
 		}
+
 
 		if ( is_string( $types ) ) {
 			// Dispatch error and map old arguments to new ones.
@@ -2815,6 +2833,23 @@ class WP_Theme_JSON_Gutenberg {
 					'variations' => $variation_selectors,
 					'css'        => $selector,
 				);
+
+				// Handle any pseudo selectors for the block.
+				if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $name ] ) ) {
+					foreach ( static::VALID_BLOCK_PSEUDO_SELECTORS[ $name ] as $pseudo_selector ) {
+						if ( isset( $theme_json['styles']['blocks'][ $name ][ $pseudo_selector ] ) ) {
+							$nodes[] = array(
+								'name'       => $name,
+								'path'       => array( 'styles', 'blocks', $name, $pseudo_selector ),
+								'selector'   => static::append_to_selector( $selector, $pseudo_selector ),
+								'selectors'  => $feature_selectors,
+								'duotone'    => $duotone_selector,
+								'variations' => $variation_selectors,
+								'css'        => static::append_to_selector( $selector, $pseudo_selector ),
+							);
+						}
+					}
+				}
 			}
 			if ( isset( $theme_json['styles']['blocks'][ $name ]['elements'] ) ) {
 				foreach ( $theme_json['styles']['blocks'][ $name ]['elements'] as $element => $node ) {
@@ -2937,6 +2972,23 @@ class WP_Theme_JSON_Gutenberg {
 		}
 
 		/*
+		 * Check if we're processing a block pseudo-selector.
+		 * $block_metadata['path'] = array( 'styles', 'blocks', 'core/button', ':hover' );
+		 */
+		$is_processing_block_pseudo = false;
+		$block_pseudo_selector = null;
+		if ( in_array( 'blocks', $block_metadata['path'], true ) && count( $block_metadata['path'] ) >= 4 ) {
+			$block_name = $block_metadata['path'][2]; // 'core/button'
+			$last_path_element = $block_metadata['path'][ count( $block_metadata['path'] ) - 1 ]; // ':hover'
+			
+			if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block_name ] ) && 
+				 in_array( $last_path_element, static::VALID_BLOCK_PSEUDO_SELECTORS[ $block_name ], true ) ) {
+				$is_processing_block_pseudo = true;
+				$block_pseudo_selector = $last_path_element;
+			}
+		}
+
+		/*
 		 * Check for allowed pseudo classes (e.g. ":hover") from the $selector ("a:hover").
 		 * This also resets the array keys.
 		 */
@@ -2965,6 +3017,14 @@ class WP_Theme_JSON_Gutenberg {
 			&& in_array( $pseudo_selector, static::VALID_ELEMENT_PSEUDO_SELECTORS[ $current_element ], true )
 		) {
 			$declarations = static::compute_style_properties( $node[ $pseudo_selector ], $settings, null, $this->theme_json, $selector, $use_root_padding );
+		} elseif ( $is_processing_block_pseudo ) {
+			// Process block pseudo-selector styles
+			// For block pseudo-selectors, we need to get the block data first, then access the pseudo-selector
+			$block_name = $block_metadata['path'][2]; // 'core/button'
+			$block_data = _wp_array_get( $this->theme_json, array( 'styles', 'blocks', $block_name ), array() );
+			$pseudo_data = isset( $block_data[ $block_pseudo_selector ] ) ? $block_data[ $block_pseudo_selector ] : array();
+			
+			$declarations = static::compute_style_properties( $pseudo_data, $settings, null, $this->theme_json, $selector, $use_root_padding );
 		} else {
 			$declarations = static::compute_style_properties( $node, $settings, null, $this->theme_json, $selector, $use_root_padding );
 		}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1070,7 +1070,7 @@ class WP_Theme_JSON_Gutenberg {
 				foreach ( $style_variation_names as $variation_name ) {
 					$variation_schema = $block_style_variation_styles;
 
-					// Add pseudo-selectors to variations for blocks that support them
+					// Add pseudo-selectors to variations for blocks that support them.
 					if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] ) ) {
 						foreach ( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] as $pseudo_selector ) {
 							$variation_schema[ $pseudo_selector ] = $styles_non_top_level;

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -593,7 +593,7 @@ class WP_Theme_JSON_Gutenberg {
 	/**
 	 * The valid pseudo-selectors that can be used for blocks.
 	 *
-	 * @since 6.1.0
+	 * @since 7.0.0
 	 * @var array
 	 */
 	const VALID_BLOCK_PSEUDO_SELECTORS = array(

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2991,7 +2991,7 @@ class WP_Theme_JSON_Gutenberg {
 				$style_variation_declarations[ $style_variation['selector'] ] = static::compute_style_properties( $style_variation_node, $settings, null, $this->theme_json );
 
 				// Process pseudo-selectors for this variation (e.g., :hover, :focus).
-				$block_name                    = isset( $block_metadata['name'] ) ? $block_metadata['name'] : ( in_array( 'blocks', $block_metadata['path'], true ) && count( $block_metadata['path'] ) >= 3 ? get_block_name_from_metadata_path( $block_metadata ) : null );
+				$block_name                    = isset( $block_metadata['name'] ) ? $block_metadata['name'] : ( in_array( 'blocks', $block_metadata['path'], true ) && count( $block_metadata['path'] ) >= 3 ? static::get_block_name_from_metadata_path( $block_metadata ) : null );
 				$variation_pseudo_declarations = static::process_pseudo_selectors( $style_variation_node, $style_variation['selector'], $settings, $block_name );
 				$style_variation_declarations  = array_merge( $style_variation_declarations, $variation_pseudo_declarations );
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2991,7 +2991,7 @@ class WP_Theme_JSON_Gutenberg {
 				$style_variation_declarations[ $style_variation['selector'] ] = static::compute_style_properties( $style_variation_node, $settings, null, $this->theme_json );
 
 				// Process pseudo-selectors for this variation (e.g., :hover, :focus).
-				$block_name                    = isset( $block_metadata['name'] ) ? $block_metadata['name'] : ( in_array( 'blocks', $block_metadata['path'], true ) && count( $block_metadata['path'] ) >= 3 ? $block_metadata['path'][2] : null );
+				$block_name                    = isset( $block_metadata['name'] ) ? $block_metadata['name'] : ( in_array( 'blocks', $block_metadata['path'], true ) && count( $block_metadata['path'] ) >= 3 ? get_block_name_from_metadata_path( $block_metadata ) : null );
 				$variation_pseudo_declarations = static::process_pseudo_selectors( $style_variation_node, $style_variation['selector'], $settings, $block_name );
 				$style_variation_declarations  = array_merge( $style_variation_declarations, $variation_pseudo_declarations );
 
@@ -3025,7 +3025,7 @@ class WP_Theme_JSON_Gutenberg {
 		$is_processing_block_pseudo = false;
 		$block_pseudo_selector      = null;
 		if ( in_array( 'blocks', $block_metadata['path'], true ) && count( $block_metadata['path'] ) >= 4 ) {
-			$block_name        = $block_metadata['path'][2]; // 'core/button'
+			$block_name        = static::get_block_name_from_metadata_path( $block_metadata ); // 'core/button'
 			$last_path_element = $block_metadata['path'][ count( $block_metadata['path'] ) - 1 ]; // ':hover'
 
 			if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block_name ] ) &&
@@ -3067,7 +3067,7 @@ class WP_Theme_JSON_Gutenberg {
 		} elseif ( $is_processing_block_pseudo ) {
 			// Process block pseudo-selector styles.
 			// For block pseudo-selectors, we need to get the block data first, then access the pseudo-selector.
-			$block_name  = $block_metadata['path'][2]; // 'core/button'
+			$block_name  = static::get_block_name_from_metadata_path( $block_metadata ); // 'core/button'
 			$block_data  = _wp_array_get( $this->theme_json, array( 'styles', 'blocks', $block_name ), array() );
 			$pseudo_data = isset( $block_data[ $block_pseudo_selector ] ) ? $block_data[ $block_pseudo_selector ] : array();
 
@@ -4723,4 +4723,19 @@ class WP_Theme_JSON_Gutenberg {
 
 		return $valid_variations;
 	}
+
+	/**
+	 * Extracts the block name from the block metadata path.
+	 *
+	 * @since 7.0
+	 *
+	 * @param array $block_metadata Block metadata.
+	 * @return string|null The block name or null if not found.
+	 */
+	private static function get_block_name_from_metadata_path( $block_metadata ) {
+		if ( isset( $block_metadata['path'] ) ) {
+			return $block_metadata['path'][2];
+		}
+	}
+
 }

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3065,8 +3065,8 @@ class WP_Theme_JSON_Gutenberg {
 		) {
 			$declarations = static::compute_style_properties( $node[ $pseudo_selector ], $settings, null, $this->theme_json, $selector, $use_root_padding );
 		} elseif ( $is_processing_block_pseudo ) {
-			// Process block pseudo-selector styles
-			// For block pseudo-selectors, we need to get the block data first, then access the pseudo-selector
+			// Process block pseudo-selector styles.
+			// For block pseudo-selectors, we need to get the block data first, then access the pseudo-selector.
 			$block_name  = $block_metadata['path'][2]; // 'core/button'
 			$block_data  = _wp_array_get( $this->theme_json, array( 'styles', 'blocks', $block_name ), array() );
 			$pseudo_data = isset( $block_data[ $block_pseudo_selector ] ) ? $block_data[ $block_pseudo_selector ] : array();

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -691,6 +691,40 @@ class WP_Theme_JSON_Gutenberg {
 	}
 
 	/**
+	 * Processes pseudo-selectors for any node (block or variation).
+	 *
+	 * @param array  $node The node data (block or variation).
+	 * @param string $base_selector The base selector.
+	 * @param array  $settings The theme settings.
+	 * @param string $block_name The block name.
+	 * @return array Array of pseudo-selector declarations.
+	 */
+	private static function process_pseudo_selectors( $node, $base_selector, $settings, $block_name ) {
+		$pseudo_declarations = array();
+		
+		// Check if this block supports pseudo-selectors
+		if ( ! isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block_name ] ) ) {
+			return $pseudo_declarations;
+		}
+		
+		// Process each valid pseudo-selector for this block
+		foreach ( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block_name ] as $pseudo_selector ) {
+			if ( isset( $node[ $pseudo_selector ] ) ) {
+				// Create the combined selector (base + pseudo-selector)
+				$combined_selector = static::append_to_selector( $base_selector, $pseudo_selector );
+				
+				// Compute the style properties for this pseudo-selector
+				$declarations = static::compute_style_properties( $node[ $pseudo_selector ], $settings, null, null );
+				
+				// Add to the declarations array
+				$pseudo_declarations[ $combined_selector ] = $declarations;
+			}
+		}
+		
+		return $pseudo_declarations;
+	}
+
+	/**
 	 * Returns a class name by an element name.
 	 *
 	 * @since 6.1.0
@@ -1040,7 +1074,18 @@ class WP_Theme_JSON_Gutenberg {
 
 			$schema_styles_variations = array();
 			if ( ! empty( $style_variation_names ) ) {
-				$schema_styles_variations = array_fill_keys( $style_variation_names, $block_style_variation_styles );
+				foreach ( $style_variation_names as $variation_name ) {
+					$variation_schema = $block_style_variation_styles;
+					
+					// Add pseudo-selectors to variations for blocks that support them
+					if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] ) ) {
+						foreach ( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] as $pseudo_selector ) {
+							$variation_schema[ $pseudo_selector ] = $styles_non_top_level;
+						}
+					}
+					
+					$schema_styles_variations[ $variation_name ] = $variation_schema;
+				}
 			}
 
 			$schema_styles_blocks[ $block ]['variations'] = $schema_styles_variations;
@@ -2680,7 +2725,11 @@ class WP_Theme_JSON_Gutenberg {
 			return $nodes;
 		}
 
-		$block_nodes = static::get_block_nodes( $theme_json, $selectors, $options );
+		$block_options = $options;
+		if ( ! isset( $block_options['include_block_style_variations'] ) ) {
+			$block_options['include_block_style_variations'] = true;
+		}
+		$block_nodes = static::get_block_nodes( $theme_json, $selectors, $block_options );
 		foreach ( $block_nodes as $block_node ) {
 			$nodes[] = $block_node;
 		}
@@ -2947,6 +2996,12 @@ class WP_Theme_JSON_Gutenberg {
 				}
 				// Compute declarations for remaining styles not covered by feature level selectors.
 				$style_variation_declarations[ $style_variation['selector'] ] = static::compute_style_properties( $style_variation_node, $settings, null, $this->theme_json );
+				
+				// Process pseudo-selectors for this variation (e.g., :hover, :focus)
+				$block_name = isset( $block_metadata['name'] ) ? $block_metadata['name'] : ( in_array( 'blocks', $block_metadata['path'], true ) && count( $block_metadata['path'] ) >= 3 ? $block_metadata['path'][2] : null );
+				$variation_pseudo_declarations = static::process_pseudo_selectors( $style_variation_node, $style_variation['selector'], $settings, $block_name );
+				$style_variation_declarations = array_merge( $style_variation_declarations, $variation_pseudo_declarations );
+				
 				// Store custom CSS for the style variation.
 				if ( isset( $style_variation_node['css'] ) ) {
 					$style_variation_custom_css[ $style_variation['selector'] ] = $this->process_blocks_custom_css( $style_variation_node['css'], $style_variation['selector'] );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -702,21 +702,14 @@ class WP_Theme_JSON_Gutenberg {
 	private static function process_pseudo_selectors( $node, $base_selector, $settings, $block_name ) {
 		$pseudo_declarations = array();
 		
-		// Check if this block supports pseudo-selectors
 		if ( ! isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block_name ] ) ) {
 			return $pseudo_declarations;
 		}
 		
-		// Process each valid pseudo-selector for this block
 		foreach ( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block_name ] as $pseudo_selector ) {
 			if ( isset( $node[ $pseudo_selector ] ) ) {
-				// Create the combined selector (base + pseudo-selector)
 				$combined_selector = static::append_to_selector( $base_selector, $pseudo_selector );
-				
-				// Compute the style properties for this pseudo-selector
 				$declarations = static::compute_style_properties( $node[ $pseudo_selector ], $settings, null, null );
-				
-				// Add to the declarations array
 				$pseudo_declarations[ $combined_selector ] = $declarations;
 			}
 		}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -4737,5 +4737,4 @@ class WP_Theme_JSON_Gutenberg {
 			return $block_metadata['path'][2];
 		}
 	}
-
 }

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2990,7 +2990,7 @@ class WP_Theme_JSON_Gutenberg {
 				// Compute declarations for remaining styles not covered by feature level selectors.
 				$style_variation_declarations[ $style_variation['selector'] ] = static::compute_style_properties( $style_variation_node, $settings, null, $this->theme_json );
 
-				// Process pseudo-selectors for this variation (e.g., :hover, :focus)
+				// Process pseudo-selectors for this variation (e.g., :hover, :focus).
 				$block_name                    = isset( $block_metadata['name'] ) ? $block_metadata['name'] : ( in_array( 'blocks', $block_metadata['path'], true ) && count( $block_metadata['path'] ) >= 3 ? $block_metadata['path'][2] : null );
 				$variation_pseudo_declarations = static::process_pseudo_selectors( $style_variation_node, $style_variation['selector'], $settings, $block_name );
 				$style_variation_declarations  = array_merge( $style_variation_declarations, $variation_pseudo_declarations );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1011,7 +1011,7 @@ class WP_Theme_JSON_Gutenberg {
 			$schema_settings_blocks[ $block ]           = static::VALID_SETTINGS;
 			$schema_styles_blocks[ $block ]             = $styles_non_top_level;
 			$schema_styles_blocks[ $block ]['elements'] = $schema_styles_elements;
-			
+
 			// Add pseudo-selectors for blocks that support them
 			if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] ) ) {
 				foreach ( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] as $pseudo_selector ) {
@@ -1364,7 +1364,6 @@ class WP_Theme_JSON_Gutenberg {
 		if ( null === $origins ) {
 			$origins = static::VALID_ORIGINS;
 		}
-
 
 		if ( is_string( $types ) ) {
 			// Dispatch error and map old arguments to new ones.
@@ -2976,15 +2975,15 @@ class WP_Theme_JSON_Gutenberg {
 		 * $block_metadata['path'] = array( 'styles', 'blocks', 'core/button', ':hover' );
 		 */
 		$is_processing_block_pseudo = false;
-		$block_pseudo_selector = null;
+		$block_pseudo_selector      = null;
 		if ( in_array( 'blocks', $block_metadata['path'], true ) && count( $block_metadata['path'] ) >= 4 ) {
-			$block_name = $block_metadata['path'][2]; // 'core/button'
+			$block_name        = $block_metadata['path'][2]; // 'core/button'
 			$last_path_element = $block_metadata['path'][ count( $block_metadata['path'] ) - 1 ]; // ':hover'
-			
-			if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block_name ] ) && 
-				 in_array( $last_path_element, static::VALID_BLOCK_PSEUDO_SELECTORS[ $block_name ], true ) ) {
+
+			if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block_name ] ) &&
+				in_array( $last_path_element, static::VALID_BLOCK_PSEUDO_SELECTORS[ $block_name ], true ) ) {
 				$is_processing_block_pseudo = true;
-				$block_pseudo_selector = $last_path_element;
+				$block_pseudo_selector      = $last_path_element;
 			}
 		}
 
@@ -3020,10 +3019,10 @@ class WP_Theme_JSON_Gutenberg {
 		} elseif ( $is_processing_block_pseudo ) {
 			// Process block pseudo-selector styles
 			// For block pseudo-selectors, we need to get the block data first, then access the pseudo-selector
-			$block_name = $block_metadata['path'][2]; // 'core/button'
-			$block_data = _wp_array_get( $this->theme_json, array( 'styles', 'blocks', $block_name ), array() );
+			$block_name  = $block_metadata['path'][2]; // 'core/button'
+			$block_data  = _wp_array_get( $this->theme_json, array( 'styles', 'blocks', $block_name ), array() );
 			$pseudo_data = isset( $block_data[ $block_pseudo_selector ] ) ? $block_data[ $block_pseudo_selector ] : array();
-			
+
 			$declarations = static::compute_style_properties( $pseudo_data, $settings, null, $this->theme_json, $selector, $use_root_padding );
 		} else {
 			$declarations = static::compute_style_properties( $node, $settings, null, $this->theme_json, $selector, $use_root_padding );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -701,19 +701,19 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	private static function process_pseudo_selectors( $node, $base_selector, $settings, $block_name ) {
 		$pseudo_declarations = array();
-		
+
 		if ( ! isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block_name ] ) ) {
 			return $pseudo_declarations;
 		}
-		
+
 		foreach ( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block_name ] as $pseudo_selector ) {
 			if ( isset( $node[ $pseudo_selector ] ) ) {
-				$combined_selector = static::append_to_selector( $base_selector, $pseudo_selector );
-				$declarations = static::compute_style_properties( $node[ $pseudo_selector ], $settings, null, null );
+				$combined_selector                         = static::append_to_selector( $base_selector, $pseudo_selector );
+				$declarations                              = static::compute_style_properties( $node[ $pseudo_selector ], $settings, null, null );
 				$pseudo_declarations[ $combined_selector ] = $declarations;
 			}
 		}
-		
+
 		return $pseudo_declarations;
 	}
 
@@ -1069,14 +1069,14 @@ class WP_Theme_JSON_Gutenberg {
 			if ( ! empty( $style_variation_names ) ) {
 				foreach ( $style_variation_names as $variation_name ) {
 					$variation_schema = $block_style_variation_styles;
-					
+
 					// Add pseudo-selectors to variations for blocks that support them
 					if ( isset( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] ) ) {
 						foreach ( static::VALID_BLOCK_PSEUDO_SELECTORS[ $block ] as $pseudo_selector ) {
 							$variation_schema[ $pseudo_selector ] = $styles_non_top_level;
 						}
 					}
-					
+
 					$schema_styles_variations[ $variation_name ] = $variation_schema;
 				}
 			}
@@ -2989,12 +2989,12 @@ class WP_Theme_JSON_Gutenberg {
 				}
 				// Compute declarations for remaining styles not covered by feature level selectors.
 				$style_variation_declarations[ $style_variation['selector'] ] = static::compute_style_properties( $style_variation_node, $settings, null, $this->theme_json );
-				
+
 				// Process pseudo-selectors for this variation (e.g., :hover, :focus)
-				$block_name = isset( $block_metadata['name'] ) ? $block_metadata['name'] : ( in_array( 'blocks', $block_metadata['path'], true ) && count( $block_metadata['path'] ) >= 3 ? $block_metadata['path'][2] : null );
+				$block_name                    = isset( $block_metadata['name'] ) ? $block_metadata['name'] : ( in_array( 'blocks', $block_metadata['path'], true ) && count( $block_metadata['path'] ) >= 3 ? $block_metadata['path'][2] : null );
 				$variation_pseudo_declarations = static::process_pseudo_selectors( $style_variation_node, $style_variation['selector'], $settings, $block_name );
-				$style_variation_declarations = array_merge( $style_variation_declarations, $variation_pseudo_declarations );
-				
+				$style_variation_declarations  = array_merge( $style_variation_declarations, $variation_pseudo_declarations );
+
 				// Store custom CSS for the style variation.
 				if ( isset( $style_variation_node['css'] ) ) {
 					$style_variation_custom_css[ $style_variation['selector'] ] = $this->process_blocks_custom_css( $style_variation_node['css'], $style_variation['selector'] );

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -287,8 +287,8 @@ function gutenberg_add_global_styles_for_blocks() {
 
 	foreach ( $block_nodes as $metadata ) {
 		if ( $can_use_cached ) {
-			// Use the block name as the key for cached CSS data. Otherwise, use a hash of the metadata.
-			$cache_node_key = isset( $metadata['name'] ) ? $metadata['name'] : md5( wp_json_encode( $metadata ) );
+			// Generate a unique cache key based on the full metadata to ensure pseudo-selectors and other variations get unique keys.
+			$cache_node_key = md5( wp_json_encode( $metadata ) );
 
 			if ( isset( $cached['blocks'][ $cache_node_key ] ) ) {
 				$block_css = $cached['blocks'][ $cache_node_key ];

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -6172,13 +6172,13 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'styles'  => array(
 					'blocks' => array(
 						'core/button' => array(
-							'color'      => array(
+							'color'  => array(
 								'text'       => 'white',
 								'background' => 'blue',
 							),
 							'variations' => array(
 								'outline' => array(
-									'color'  => array(
+									'color' => array(
 										'text'       => 'currentColor',
 										'background' => 'transparent',
 									),

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -6136,7 +6136,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'styles'  => array(
 					'blocks' => array(
 						'core/button' => array(
-							'color' => array(
+							'color'  => array(
 								'text'       => 'white',
 								'background' => 'blue',
 							),
@@ -6221,11 +6221,11 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'styles'  => array(
 					'blocks' => array(
 						'core/button' => array(
-							'color' => array(
+							'color'     => array(
 								'text'       => 'white',
 								'background' => 'blue',
 							),
-							':hover' => array(
+							':hover'    => array(
 								'color' => array(
 									'text'       => 'blue',
 									'background' => 'white',
@@ -6258,7 +6258,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'styles'  => array(
 					'blocks' => array(
 						'core/paragraph' => array(
-							'color' => array(
+							'color'  => array(
 								'text' => 'black',
 							),
 							':hover' => array(
@@ -6287,11 +6287,11 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'styles'  => array(
 					'blocks' => array(
 						'core/button' => array(
-							'color' => array(
+							'color'    => array(
 								'text'       => 'white',
 								'background' => 'blue',
 							),
-							':hover' => array(
+							':hover'   => array(
 								'color' => array(
 									'text'       => 'blue',
 									'background' => 'white',
@@ -6299,7 +6299,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 							),
 							'elements' => array(
 								'button' => array(
-									'color' => array(
+									'color'  => array(
 										'text' => 'green',
 									),
 									':hover' => array(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -6123,7 +6123,73 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					),
 				),
 			),
+			'default'
 		);
+		$theme    = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'blocks' => array(
+						'core/image' => array(
+							'color' => array(
+								'defaultDuotone' => false,
+								'duotone'        => array(
+									array(
+										'slug'   => 'dark-grayscale',
+										'colors' => array( '#000000', '#7f7f7f' ),
+										'name'   => 'Theme Dark grayscale',
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$expected = array(
+			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'settings' => array(
+				'color'  => array(
+					'defaultDuotone' => true,
+					'duotone'        => array(
+						'default' => array(
+							array(
+								'slug'   => 'dark-grayscale',
+								'colors' => array( '#000000', '#7f7f7f' ),
+								'name'   => 'Default Dark grayscale',
+							),
+							array(
+								'slug'   => 'blue-orange',
+								'colors' => array( '#0000ff', '#ff8800' ),
+								'name'   => 'Blue Orange',
+							),
+						),
+					),
+				),
+				'blocks' => array(
+					'core/image' => array(
+						'color' => array(
+							'defaultDuotone' => false,
+							'duotone'        => array(
+								'theme' => array(
+									array(
+										'slug'   => 'dark-grayscale',
+										'colors' => array( '#000000', '#7f7f7f' ),
+										'name'   => 'Theme Dark grayscale',
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$defaults->merge( $theme );
+		$actual = $defaults->get_raw_data();
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
 	}
 
 	/**

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -6221,7 +6221,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-			),
+			)
 		);
 
 		$expected = ':root :where(.wp-block-button .wp-block-button__link){background-color: blue;color: white;}:root :where(.wp-block-button .wp-block-button__link:hover){background-color: white;color: blue;}:root :where(.wp-block-button .wp-block-button__link:focus){background-color: yellow;color: red;}';

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -6123,21 +6123,81 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					),
 				),
 			),
-			'default'
 		);
-		$theme    = new WP_Theme_JSON_Gutenberg(
+	}
+
+	/**
+	 * Test that block pseudo selectors are processed correctly.
+	 */
+	public function test_block_pseudo_selectors_are_processed() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
-				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-				'settings' => array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
 					'blocks' => array(
-						'core/image' => array(
+						'core/button' => array(
 							'color' => array(
-								'defaultDuotone' => false,
-								'duotone'        => array(
-									array(
-										'slug'   => 'dark-grayscale',
-										'colors' => array( '#000000', '#7f7f7f' ),
-										'name'   => 'Theme Dark grayscale',
+								'text'       => 'white',
+								'background' => 'blue',
+							),
+							':hover' => array(
+								'color' => array(
+									'text'       => 'blue',
+									'background' => 'white',
+								),
+							),
+							':focus' => array(
+								'color' => array(
+									'text'       => 'red',
+									'background' => 'yellow',
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$expected = ':root :where(.wp-block-button .wp-block-button__link){background-color: blue;color: white;}:root :where(.wp-block-button .wp-block-button__link:hover){background-color: white;color: blue;}:root :where(.wp-block-button .wp-block-button__link:focus){background-color: yellow;color: red;}';
+		$this->assertSameCSS( $expected, $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) ) );
+	}
+
+	/**
+	 * Test that block pseudo selectors are processed correctly within variations.
+	 */
+	public function test_block_variation_pseudo_selectors_are_processed() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/button' => array(
+							'color'      => array(
+								'text'       => 'white',
+								'background' => 'blue',
+							),
+							'variations' => array(
+								'outline' => array(
+									'color'  => array(
+										'text'       => 'currentColor',
+										'background' => 'transparent',
+									),
+									'border' => array(
+										'color' => 'currentColor',
+										'width' => '1px',
+										'style' => 'solid',
+									),
+									':hover' => array(
+										'color' => array(
+											'text'       => 'white',
+											'background' => 'red',
+										),
+									),
+									':focus' => array(
+										'color' => array(
+											'text'       => 'black',
+											'background' => 'yellow',
+										),
 									),
 								),
 							),
@@ -6147,49 +6207,116 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$expected = array(
-			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-			'settings' => array(
-				'color'  => array(
-					'defaultDuotone' => true,
-					'duotone'        => array(
-						'default' => array(
-							array(
-								'slug'   => 'dark-grayscale',
-								'colors' => array( '#000000', '#7f7f7f' ),
-								'name'   => 'Default Dark grayscale',
+		$expected = ':root :where(.wp-block-button .wp-block-button__link){background-color: blue;color: white;}:root :where(.wp-block-button.is-style-outline .wp-block-button__link){background-color: transparent;border-color: currentColor;border-width: 1px;border-style: solid;color: currentColor;}:root :where(.wp-block-button.is-style-outline .wp-block-button__link:hover){background-color: red;color: white;}:root :where(.wp-block-button.is-style-outline .wp-block-button__link:focus){background-color: yellow;color: black;}';
+		$this->assertSameCSS( $expected, $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) ) );
+	}
+
+	/**
+	 * Test that non-whitelisted pseudo selectors are ignored for blocks.
+	 */
+	public function test_block_pseudo_selectors_ignores_non_whitelisted() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/button' => array(
+							'color' => array(
+								'text'       => 'white',
+								'background' => 'blue',
 							),
-							array(
-								'slug'   => 'blue-orange',
-								'colors' => array( '#0000ff', '#ff8800' ),
-								'name'   => 'Blue Orange',
+							':hover' => array(
+								'color' => array(
+									'text'       => 'blue',
+									'background' => 'white',
+								),
+							),
+							':levitate' => array(
+								'color' => array(
+									'text'       => 'yellow',
+									'background' => 'black',
+								),
 							),
 						),
 					),
 				),
-				'blocks' => array(
-					'core/image' => array(
-						'color' => array(
-							'defaultDuotone' => false,
-							'duotone'        => array(
-								'theme' => array(
-									array(
-										'slug'   => 'dark-grayscale',
-										'colors' => array( '#000000', '#7f7f7f' ),
-										'name'   => 'Theme Dark grayscale',
+			)
+		);
+
+		$expected = ':root :where(.wp-block-button .wp-block-button__link){background-color: blue;color: white;}:root :where(.wp-block-button .wp-block-button__link:hover){background-color: white;color: blue;}';
+		$this->assertSameCSS( $expected, $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) ) );
+		$this->assertStringNotContainsString( '.wp-block-button .wp-block-button__link:levitate{', $theme_json->get_stylesheet( array( 'styles' ) ) );
+	}
+
+	/**
+	 * Test that blocks without pseudo selector support ignore pseudo selectors.
+	 */
+	public function test_blocks_without_pseudo_support_ignore_pseudo_selectors() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/paragraph' => array(
+							'color' => array(
+								'text' => 'black',
+							),
+							':hover' => array(
+								'color' => array(
+									'text' => 'red',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$expected = ':root :where(p){color: black;}';
+		$this->assertSameCSS( $expected, $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) ) );
+		$this->assertStringNotContainsString( 'p:hover{', $theme_json->get_stylesheet( array( 'styles' ) ) );
+	}
+
+	/**
+	 * Test that block pseudo selectors work with elements within blocks.
+	 */
+	public function test_block_pseudo_selectors_with_elements() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/button' => array(
+							'color' => array(
+								'text'       => 'white',
+								'background' => 'blue',
+							),
+							':hover' => array(
+								'color' => array(
+									'text'       => 'blue',
+									'background' => 'white',
+								),
+							),
+							'elements' => array(
+								'button' => array(
+									'color' => array(
+										'text' => 'green',
+									),
+									':hover' => array(
+										'color' => array(
+											'text' => 'orange',
+										),
 									),
 								),
 							),
 						),
 					),
 				),
-			),
+			)
 		);
 
-		$defaults->merge( $theme );
-		$actual = $defaults->get_raw_data();
-
-		$this->assertEqualSetsWithIndex( $expected, $actual );
+		$expected = ':root :where(.wp-block-button .wp-block-button__link){background-color: blue;color: white;}:root :where(.wp-block-button .wp-block-button__link:hover){background-color: white;color: blue;}:root :where(.wp-block-button .wp-block-button__link .wp-element-button,.wp-block-button .wp-block-button__link  .wp-block-button__link){color: green;}:root :where(.wp-block-button .wp-block-button__link .wp-element-button:hover,.wp-block-button .wp-block-button__link  .wp-block-button__link:hover){color: orange;}';
+		$this->assertSameCSS( $expected, $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) ) );
 	}
 
 	public function test_merge_incoming_data_block_level_inherits_global_default_setting() {

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -6172,13 +6172,13 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'styles'  => array(
 					'blocks' => array(
 						'core/button' => array(
-							'color'  => array(
+							'color'      => array(
 								'text'       => 'white',
 								'background' => 'blue',
 							),
 							'variations' => array(
 								'outline' => array(
-									'color' => array(
+									'color'  => array(
 										'text'       => 'currentColor',
 										'background' => 'transparent',
 									),

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1927,40 +1927,10 @@
 				"core/button": {
 					"allOf": [
 						{
-							"$ref": "#/definitions/stylesProperties"
-						},
-						{
-							"$ref": "#/definitions/stylesElementsPropertiesComplete"
+							"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 						},
 						{
 							"$ref": "#/definitions/stylesBlocksPseudoSelectorsProperties"
-						},
-						{
-							"type": "object",
-							"properties": {
-								"elements": {
-									"$ref": "#/definitions/stylesElementsPropertiesComplete"
-								},
-								"variations": {
-									"$ref": "#/definitions/stylesVariationsPropertiesComplete"
-								}
-							},
-							"propertyNames": {
-								"anyOf": [
-									{
-										"$ref": "#/definitions/stylesPropertyNames"
-									},
-									{
-										"$ref": "#/definitions/stylesElementsPseudoSelectorsPropertyNames"
-									},
-									{
-										"$ref": "#/definitions/stylesBlocksPseudoSelectorsPropertyNames"
-									},
-									{
-										"enum": [ "elements", "variations" ]
-									}
-								]
-							}
 						}
 					]
 				},

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1807,9 +1807,6 @@
 				":visited"
 			]
 		},
-		"stylesBlocksPseudoSelectorsPropertyNames": {
-			"enum": [ ":hover", ":focus", ":focus-visible", ":active" ]
-		},
 		"stylesElementsPropertiesComplete": {
 			"description": "Styles defined on a per-element basis using the element's selector.",
 			"type": "object",

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1779,6 +1779,23 @@
 				}
 			}
 		},
+		"stylesBlocksPseudoSelectorsProperties": {
+			"type": "object",
+			"properties": {
+				":hover": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":focus": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":focus-visible": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				":active": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				}
+			}
+		},
 		"stylesElementsPseudoSelectorsPropertyNames": {
 			"enum": [
 				":active",
@@ -1789,6 +1806,9 @@
 				":link",
 				":visited"
 			]
+		},
+		"stylesBlocksPseudoSelectorsPropertyNames": {
+			"enum": [ ":hover", ":focus", ":focus-visible", ":active" ]
 		},
 		"stylesElementsPropertiesComplete": {
 			"description": "Styles defined on a per-element basis using the element's selector.",
@@ -1905,7 +1925,44 @@
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
 				"core/button": {
-					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+					"allOf": [
+						{
+							"$ref": "#/definitions/stylesProperties"
+						},
+						{
+							"$ref": "#/definitions/stylesElementsPropertiesComplete"
+						},
+						{
+							"$ref": "#/definitions/stylesBlocksPseudoSelectorsProperties"
+						},
+						{
+							"type": "object",
+							"properties": {
+								"elements": {
+									"$ref": "#/definitions/stylesElementsPropertiesComplete"
+								},
+								"variations": {
+									"$ref": "#/definitions/stylesVariationsPropertiesComplete"
+								}
+							},
+							"propertyNames": {
+								"anyOf": [
+									{
+										"$ref": "#/definitions/stylesPropertyNames"
+									},
+									{
+										"$ref": "#/definitions/stylesElementsPseudoSelectorsPropertyNames"
+									},
+									{
+										"$ref": "#/definitions/stylesBlocksPseudoSelectorsPropertyNames"
+									},
+									{
+										"enum": [ "elements", "variations" ]
+									}
+								]
+							}
+						}
+					]
 				},
 				"core/buttons": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/55359<!-- #ISSUE-NUMBER or URL -->

Adds support for pseudo elements on the `core/button` block for ( ':hover', ':focus', ':focus-visible', ':active' ) at the theme.json level. This is also allowing the block's variations to control the same pseudo elements, so now we can style hover for the outline variation too.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is needed ahead of https://github.com/WordPress/gutenberg/issues/38277 since right now we are only supporting pseudo elements on links and button elements, we also want to support them at the block level. This PR brings them in alignment and opens the door to support things like :hover for other blocks that don't have an element (like group for example)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By allowing the pseudo elements for the specific blocks in VALID_BLOCK_PSEUDO_SELECTORS, in a similar way we do for elements.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Add the following to your theme and check that it behaves as expected on the frontend:

```
"styles": {
	"blocks": {
		"core/button": {
			"color": {
				"background": "blue"
			},
			":hover": {
				"color": {
					"background": "green"
				}
			},
			":focus": {
				"color": {
					"background": "purple"
				}
			},
			"variations": {
				"outline": {
					":hover": {
						"color": {
							"background": "pink"
						}
					}
				}
			}
		}
	}
}
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

![Screen Capture on 2025-09-05 at 11-51-00](https://github.com/user-attachments/assets/7e215a0c-f841-4650-b2a0-a2d2f3f4dd49)
