### PR TITLE
RN: Remove `react-test-renderer` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -140,7 +140,6 @@
 				"react-native-url-polyfill": "1.1.2",
 				"react-refresh": "0.14.0",
 				"react-scanner": "1.2.0",
-				"react-test-renderer": "18.3.1",
 				"reassure": "0.7.1",
 				"redux": "5.0.1",
 				"resize-observer-polyfill": "1.5.1",
@@ -40227,26 +40226,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/react-test-renderer": {
-			"version": "18.3.1",
-			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.3.1.tgz",
-			"integrity": "sha512-KkAgygexHUkQqtvvx/otwxtuFu5cVjfzTCtjXLH9boS19/Nbtg84zS7wIQn39G8IlrhThBpQsMKkq5ZHZIYFXA==",
-			"dev": true,
-			"dependencies": {
-				"react-is": "^18.3.1",
-				"react-shallow-renderer": "^16.15.0",
-				"scheduler": "^0.23.2"
-			},
-			"peerDependencies": {
-				"react": "^18.3.1"
-			}
-		},
-		"node_modules/react-test-renderer/node_modules/react-is": {
-			"version": "18.3.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-			"dev": true
 		},
 		"node_modules/read": {
 			"version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,6 @@
 		"react-native-url-polyfill": "1.1.2",
 		"react-refresh": "0.14.0",
 		"react-scanner": "1.2.0",
-		"react-test-renderer": "18.3.1",
 		"reassure": "0.7.1",
 		"redux": "5.0.1",
 		"resize-observer-polyfill": "1.5.1",

--- a/packages/block-editor/src/components/block-draggable/test/helpers.native.js
+++ b/packages/block-editor/src/components/block-draggable/test/helpers.native.js
@@ -108,11 +108,11 @@ export const initializeWithBlocksLayouts = async ( blocks ) => {
 /**
  * Fires long-press gesture event on a block.
  *
- * @param {import('react-test-renderer').ReactTestInstance} block                  Block test instance.
- * @param {string}                                          testID                 Id for querying the draggable trigger element.
- * @param {Object}                                          [options]              Configuration options for the gesture event.
- * @param {boolean}                                         [options.failed]       Determines if the gesture should fail.
- * @param {number}                                          [options.triggerIndex] In case there are multiple draggable triggers, this specifies the index to use.
+ * @param {ReturnType<import('@testing-library/react-native').RenderAPI['getByTestId']>} block                  Block test instance.
+ * @param {string}                                                                       testID                 Id for querying the draggable trigger element.
+ * @param {Object}                                                                       [options]              Configuration options for the gesture event.
+ * @param {boolean}                                                                      [options.failed]       Determines if the gesture should fail.
+ * @param {number}                                                                       [options.triggerIndex] In case there are multiple draggable triggers, this specifies the index to use.
  */
 export const fireLongPress = (
 	block,
@@ -140,8 +140,8 @@ export const fireLongPress = (
 /**
  * Fires pan gesture event on a BlockDraggable component.
  *
- * @param {import('react-test-renderer').ReactTestInstance} blockDraggable BlockDraggable test instance.
- * @param {Object}                                          [touchEvents]  Array of touch events to dispatch on the pan gesture.
+ * @param {ReturnType<import('@testing-library/react-native').RenderAPI['getByTestId']>} blockDraggable BlockDraggable test instance.
+ * @param {Object}                                                                       [touchEvents]  Array of touch events to dispatch on the pan gesture.
  */
 export const firePanGesture = (
 	blockDraggable,
@@ -169,7 +169,7 @@ export const firePanGesture = (
  *
  * @param {import('@testing-library/react-native').RenderAPI} screen The Testing Library screen.
  *
- * @return {import('react-test-renderer').ReactTestInstance} Draggable chip test instance.
+ * @return {ReturnType<import('@testing-library/react-native').RenderAPI['getByTestId']>} Draggable chip test instance.
  */
 export const getDraggableChip = ( { getByTestId } ) => {
 	let draggableChip;

--- a/packages/block-library/src/gallery/test/helpers.native.js
+++ b/packages/block-library/src/gallery/test/helpers.native.js
@@ -65,9 +65,9 @@ export const initializeWithGalleryBlock = async ( {
 /**
  * Gets a gallery item within a Gallery block.
  *
- * @param {import('react-test-renderer').ReactTestInstance} galleryBlock Gallery block instance.
- * @param {number}                                          rowIndex     Row position within the Gallery block.
- * @return {import('react-test-renderer').ReactTestInstance} Gallery item.
+ * @param {ReturnType<import('@testing-library/react-native').RenderAPI['getByTestId']>} galleryBlock Gallery block instance.
+ * @param {number}                                                                       rowIndex     Row position within the Gallery block.
+ * @return {ReturnType<import('@testing-library/react-native').RenderAPI['getByTestId']>} Gallery item.
  */
 export const getGalleryItem = ( galleryBlock, rowIndex ) =>
 	getInnerBlock( galleryBlock, 'Image', { rowIndex } );

--- a/test/native/integration-test-helpers/dismiss-modal.js
+++ b/test/native/integration-test-helpers/dismiss-modal.js
@@ -6,7 +6,7 @@ import { fireEvent } from '@testing-library/react-native';
 /**
  * Dismisses a modal.
  *
- * @param {import('react-test-renderer').ReactTestInstance} modalInstance Modal test instance.
+ * @param {ReturnType<import('@testing-library/react-native').RenderAPI['getByTestId']>} modalInstance Modal test instance.
  */
 export const dismissModal = async ( modalInstance ) =>
 	fireEvent( modalInstance, 'backdropPress' );

--- a/test/native/integration-test-helpers/get-block-transform-options.js
+++ b/test/native/integration-test-helpers/get-block-transform-options.js
@@ -14,7 +14,7 @@ import { openBlockActionsMenu } from './open-block-actions-menu';
  *
  * @param {import('@testing-library/react-native').RenderAPI} screen    A Testing Library screen.
  * @param {string}                                            blockName Name of the block.
- * @return {[import('react-test-renderer').ReactTestInstance]} Block transform options.
+ * @return {ReturnType<import('@testing-library/react-native').RenderAPI['geyAllByRole']>} Block transform options.
  */
 export const getBlockTransformOptions = async ( screen, blockName ) => {
 	const { getByTestId, getByText } = screen;

--- a/test/native/integration-test-helpers/get-block.js
+++ b/test/native/integration-test-helpers/get-block.js
@@ -5,7 +5,7 @@
  * @param {string}                                            blockName          Name of the block.
  * @param {Object}                                            options            Configuration options for getting the block.
  * @param {number}                                            [options.rowIndex] Row index of the block.
- * @return {import('react-test-renderer').ReactTestInstance} Block instance.
+ * @return {ReturnType<import('@testing-library/react-native').RenderAPI['getByTestId']>} Block instance.
  */
 export const getBlock = ( screen, blockName, { rowIndex = 1 } = {} ) => {
 	return screen.getAllByLabelText(

--- a/test/native/integration-test-helpers/get-inner-block.js
+++ b/test/native/integration-test-helpers/get-inner-block.js
@@ -6,11 +6,11 @@ import { within } from '@testing-library/react-native';
 /**
  * Gets an inner block from another block.
  *
- * @param {import('react-test-renderer').ReactTestInstance} parentBlock        Parent block from where to get the block.
- * @param {string}                                          blockName          Name of the block.
- * @param {Object}                                          options            Configuration options for getting the block.
- * @param {number}                                          [options.rowIndex] Row index of the block.
- * @return {import('react-test-renderer').ReactTestInstance} Block instance.
+ * @param {ReturnType<import('@testing-library/react-native').RenderAPI['getByTestId']>} parentBlock        Parent block from where to get the block.
+ * @param {string}                                                                       blockName          Name of the block.
+ * @param {Object}                                                                       options            Configuration options for getting the block.
+ * @param {number}                                                                       [options.rowIndex] Row index of the block.
+ * @return {ReturnType<import('@testing-library/react-native').RenderAPI['getByTestId']>} Block instance.
  */
 export const getInnerBlock = (
 	parentBlock,

--- a/test/native/integration-test-helpers/rich-text-paste.js
+++ b/test/native/integration-test-helpers/rich-text-paste.js
@@ -6,11 +6,11 @@ import { fireEvent } from '@testing-library/react-native';
 /**
  * Paste content into a RichText component.
  *
- * @param {import('react-test-renderer').ReactTestInstance} richText        RichText test instance.
- * @param {Object}                                          content         Content to paste.
- * @param {string}                                          content.text    Text format of the content.
- * @param {string}                                          [content.html]  HTML format of the content. If not provided, text format will be used.
- * @param {string}                                          [content.files] Files array to add to the editor.
+ * @param {ReturnType<import('@testing-library/react-native').RenderAPI['getByTestId']>} richText        RichText test instance.
+ * @param {Object}                                                                       content         Content to paste.
+ * @param {string}                                                                       content.text    Text format of the content.
+ * @param {string}                                                                       [content.html]  HTML format of the content. If not provided, text format will be used.
+ * @param {string}                                                                       [content.files] Files array to add to the editor.
  */
 export const pasteIntoRichText = ( richText, { text, html, files = [] } ) => {
 	fireEvent( richText, 'focus' );

--- a/test/native/integration-test-helpers/rich-text-select-range.js
+++ b/test/native/integration-test-helpers/rich-text-select-range.js
@@ -6,9 +6,9 @@ import { typeInRichText } from './rich-text-type';
 /**
  * Select a range within a RichText component.
  *
- * @param {import('react-test-renderer').ReactTestInstance} richText RichText test instance.
- * @param {number}                                          start    Selection start position.
- * @param {number}                                          end      Selection end position.
+ * @param {ReturnType<import('@testing-library/react-native').RenderAPI['getByTestId']>} richText RichText test instance.
+ * @param {number}                                                                       start    Selection start position.
+ * @param {number}                                                                       end      Selection end position.
  */
 export const selectRangeInRichText = ( richText, start, end = start ) => {
 	if ( typeof start !== 'number' ) {

--- a/test/native/integration-test-helpers/rich-text-type.js
+++ b/test/native/integration-test-helpers/rich-text-type.js
@@ -16,13 +16,13 @@ function insertTextAtPosition( text, newText, start, end ) {
 /**
  * Changes the text and selection of a RichText component.
  *
- * @param {import('react-test-renderer').ReactTestInstance} richText                        RichText test instance.
- * @param {string}                                          text                            Text to set.
- * @param {Object}                                          options                         Configuration options for selection.
- * @param {number}                                          [options.initialSelectionStart] Selection start position before the text is inserted.
- * @param {number}                                          [options.initialSelectionEnd]   Selection end position before the text is inserted.
- * @param {number}                                          [options.finalSelectionStart]   Selection start position after the text is inserted.
- * @param {number}                                          [options.finalSelectionEnd]     Selection end position after the text is inserted.
+ * @param {ReturnType<import('@testing-library/react-native').RenderAPI['getByTestId']>} richText                        RichText test instance.
+ * @param {string}                                                                       text                            Text to set.
+ * @param {Object}                                                                       options                         Configuration options for selection.
+ * @param {number}                                                                       [options.initialSelectionStart] Selection start position before the text is inserted.
+ * @param {number}                                                                       [options.initialSelectionEnd]   Selection end position before the text is inserted.
+ * @param {number}                                                                       [options.finalSelectionStart]   Selection start position after the text is inserted.
+ * @param {number}                                                                       [options.finalSelectionEnd]     Selection end position after the text is inserted.
  */
 export const typeInRichText = ( richText, text, options = {} ) => {
 	const currentValueSansOuterHtmlTags = stripOuterHtmlTags(

--- a/test/native/integration-test-helpers/text-input-change-text.js
+++ b/test/native/integration-test-helpers/text-input-change-text.js
@@ -6,8 +6,8 @@ import { fireEvent } from '@testing-library/react-native';
 /**
  * Changes the text of a TextInput component.
  *
- * @param {import('react-test-renderer').ReactTestInstance} textInput TextInput test instance.
- * @param {string}                                          text      Text to be set.
+ * @param {ReturnType<import('@testing-library/react-native').RenderAPI['getByTestId']>} textInput TextInput test instance.
+ * @param {string}                                                                       text      Text to be set.
  */
 export const changeTextOfTextInput = ( textInput, text ) => {
 	fireEvent( textInput, 'focus' );

--- a/test/native/integration-test-helpers/transform-block.js
+++ b/test/native/integration-test-helpers/transform-block.js
@@ -21,7 +21,7 @@ const apiFetchPromise = Promise.resolve( {} );
  * @param {Object}                                            [options]                Configuration options for the transformation.
  * @param {number}                                            [options.isMediaBlock]   True if the block transformation will result in a media block.
  * @param {number}                                            [options.hasInnerBlocks] True if the block transformation will result in a block that contains inner blocks.
- * @return {import('react-test-renderer').ReactTestInstance} Block instance after the block transformation result.
+ * @return {ReturnType<import('@testing-library/react-native').RenderAPI['getByTestId']>} Block instance after the block transformation result.
  */
 export const transformBlock = async (
 	screen,

--- a/test/native/integration-test-helpers/trigger-block-list-layout.js
+++ b/test/native/integration-test-helpers/trigger-block-list-layout.js
@@ -15,10 +15,10 @@ import { waitForStoreResolvers } from './wait-for-store-resolvers';
  * case any of the inner elements use selectors that are associated with store
  * resolvers.
  *
- * @param {import('react-test-renderer').ReactTestInstance} block                    Block test instance to trigger layout event.
- * @param {Object}                                          [options]                Configuration options for the event.
- * @param {number}                                          [options.width]          Width value to be passed to the event.
- * @param {number}                                          [options.blockListIndex] Block list index, for cases when there is more than one, like in inner blocks.
+ * @param {ReturnType<import('@testing-library/react-native').RenderAPI['getByTestId']>} block                    Block test instance to trigger layout event.
+ * @param {Object}                                                                       [options]                Configuration options for the event.
+ * @param {number}                                                                       [options.width]          Width value to be passed to the event.
+ * @param {number}                                                                       [options.blockListIndex] Block list index, for cases when there is more than one, like in inner blocks.
  */
 export const triggerBlockListLayout = async (
 	block,

--- a/test/native/integration-test-helpers/wait-for-modal-visible.js
+++ b/test/native/integration-test-helpers/wait-for-modal-visible.js
@@ -6,7 +6,7 @@ import { waitFor } from '@testing-library/react-native';
 /**
  * Waits for a modal to be visible.
  *
- * @param {import('react-test-renderer').ReactTestInstance} modalInstance Modal test instance.
+ * @param {ReturnType<import('@testing-library/react-native').RenderAPI['getByTestId']>} modalInstance Modal test instance.
  */
 export const waitForModalVisible = async ( modalInstance ) => {
 	return waitFor( () =>

--- a/test/native/matchers/to-be-visible.js
+++ b/test/native/matchers/to-be-visible.js
@@ -38,7 +38,7 @@ function isElementVisible( element ) {
  * - it is not a "Modal" component or it does not have the prop "visible" set to "false".
  * - its ancestor elements are also visible.
  *
- * @param {import('react-test-renderer').ReactTestInstance} element
+ * @param {ReturnType<import('@testing-library/react-native').RenderAPI['getByTestId']>} element
  * @return {boolean} True if the given element is visible.
  */
 export function toBeVisible( element ) {


### PR DESCRIPTION
## What?
This PR suggests removing the `react-test-renderer` dependency. 

Part of #71336. 

## Why?
`react-test-renderer` is [deprecated in React 19](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#deprecated-react-test-renderer) and removing it helps the React 19 upgrade and keeps it smaller (see #61521 and #71336). 

This dependency was only used for JSDoc types, so removing it is cheap.

## How?
We're retrieving the corresponding types from `@testing-library/react-native`, which still uses `react-test-renderer` under the hood, but we're no longer directly depending on it. That means that when RN migrates away from it, we won't have to do anything.

We're also removing the `react-test-renderer` dependency from the repo altogether.

## Testing Instructions
* Verify there are no usages of `react-test-renderer`
* Verify all checks are green.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

None