### PR TITLE
Edit Post: Check for meta box container before adding constraints

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -172,6 +172,9 @@ function MetaBoxesMain( { isLegacy } ) {
 		const container = node.closest(
 			'.interface-interface-skeleton__content'
 		);
+		if ( ! container ) {
+			return;
+		}
 		const noticeLists = container.querySelectorAll(
 			':scope > .components-notice-list'
 		);


### PR DESCRIPTION
## What?
This PR fixes an error during the initial rendering of `MetaBoxesMain` when using React 19. 

## Why?
To prepare for React 19 compatibility and to fix an error when using React 19.

See #71336 for the full effort.

See #61521 for the PR where the changes came from. 

## How?
We're making sure that before applying any constraints to the meta box container, we're making sure that it exists.

The change is harmless and won't have any effect in React 18 since the error will be thrown only with React 19.

We're pulling in a part of #61521 to be landed separately.

## Testing Instructions
* Open the post editor
* Make sure the custom fields are enabled (from Preferences > General > Advanced > Custom fields)
* Verify you no longer see the error 
* Verify all checks are green.

To actually witness the error in React 19:
* Checkout #61521 and do `git revert 9cd7b845a86f66118446d1dfe8a8463ac89911c9` and go through the above testing instructions.
* Without the revert commit, the error is not there.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
<img width="781" height="485" alt="Screenshot 2025-08-30 at 15 12 07" src="https://github.com/user-attachments/assets/7397ff81-0f78-4d99-965c-15952c2365c1" />
