### PR TITLE
Block Comments: use TextareaAutosize for comment field

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -1,12 +1,13 @@
 /**
+ * External dependencies
+ */
+import TextareaAutosize from 'react-autosize-textarea';
+
+/**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import {
-	__experimentalHStack as HStack,
-	Button,
-	TextareaControl,
-} from '@wordpress/components';
+import { __experimentalHStack as HStack, Button } from '@wordpress/components';
 import { _x, __ } from '@wordpress/i18n';
 
 /**
@@ -31,13 +32,12 @@ function CommentForm( { onSubmit, onCancel, thread, submitButtonText } ) {
 
 	return (
 		<>
-			<TextareaControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
+			<TextareaAutosize
 				value={ inputComment ?? '' }
-				onChange={ setInputComment }
+				onChange={ ( comment ) =>
+					setInputComment( comment.target.value )
+				}
 				label={ __( 'Comment' ) }
-				hideLabelFromVision
 			/>
 			<HStack alignment="left" spacing="3" justify="flex-start">
 				<Button

--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -45,7 +45,6 @@ function CommentForm( { onSubmit, onCancel, thread, submitButtonText } ) {
 				onChange={ ( comment ) =>
 					setInputComment( comment.target.value )
 				}
-				label={ __( 'Comment' ) }
 				rows={ 4 }
 				maxRows={ 20 }
 			>

--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -39,6 +39,9 @@ function CommentForm( { onSubmit, onCancel, thread, submitButtonText } ) {
 
 	return (
 		<>
+			<VisuallyHidden as="label" htmlFor={ inputId }>
+				{ __( 'Comment' ) }
+			</VisuallyHidden>
 			<TextareaAutosize
 				id={ inputId }
 				value={ inputComment ?? '' }
@@ -47,11 +50,7 @@ function CommentForm( { onSubmit, onCancel, thread, submitButtonText } ) {
 				}
 				rows={ 4 }
 				maxRows={ 20 }
-			>
-				<VisuallyHidden as="label" htmlFor={ inputId }>
-					{ __( 'Comment' ) }
-				</VisuallyHidden>
-			</TextareaAutosize>
+			></TextareaAutosize>
 			<HStack alignment="left" spacing="3" justify="flex-start">
 				<Button
 					__next40pxDefaultSize

--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -7,8 +7,13 @@ import TextareaAutosize from 'react-autosize-textarea';
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import { __experimentalHStack as HStack, Button } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	Button,
+	VisuallyHidden,
+} from '@wordpress/components';
 import { _x, __ } from '@wordpress/i18n';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -30,15 +35,24 @@ function CommentForm( { onSubmit, onCancel, thread, submitButtonText } ) {
 		thread?.content?.raw ?? ''
 	);
 
+	const inputId = useInstanceId( CommentForm, 'comment-input' );
+
 	return (
 		<>
 			<TextareaAutosize
+				id={ inputId }
 				value={ inputComment ?? '' }
 				onChange={ ( comment ) =>
 					setInputComment( comment.target.value )
 				}
 				label={ __( 'Comment' ) }
-			/>
+				rows={ 4 }
+				maxRows={ 20 }
+			>
+				<VisuallyHidden as="label" htmlFor={ inputId }>
+					{ __( 'Comment' ) }
+				</VisuallyHidden>
+			</TextareaAutosize>
 			<HStack alignment="left" spacing="3" justify="flex-start">
 				<Button
 					__next40pxDefaultSize


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Makes the comment input resize to the contained text.

Closes:  https://github.com/WordPress/gutenberg/issues/71425

<!-- In a few words, what is the PR actually doing? -->

## Why?
Currently the comment box has a fixed size. Instead, the textarea should scale to the contained comment text with a minimum size similar to the current display.


## How?
Use the TextareaAutosize component.


## Testing Instructions
1. make sure inline commenting experiment is enabled
2. leave a comment that is much larger than the input box

expected results: 
The text area should expand to show the full text. 

### Testing Instructions for Keyboard
same
