### PR TITLE
Group Block variation:remove variation text color.

### DIFF
--- a/packages/block-library/src/group/variations.js
+++ b/packages/block-library/src/group/variations.js
@@ -9,11 +9,6 @@ const example = {
 		{
 			name: 'core/paragraph',
 			attributes: {
-				style: {
-					color: {
-						text: '#cf2e2e',
-					},
-				},
 				fontSize: 'large',
 				content: __( 'One.' ),
 			},
@@ -21,11 +16,6 @@ const example = {
 		{
 			name: 'core/paragraph',
 			attributes: {
-				style: {
-					color: {
-						text: '#ff6900',
-					},
-				},
 				fontSize: 'large',
 				content: __( 'Two.' ),
 			},
@@ -33,11 +23,6 @@ const example = {
 		{
 			name: 'core/paragraph',
 			attributes: {
-				style: {
-					color: {
-						text: '#fcb900',
-					},
-				},
 				fontSize: 'large',
 				content: __( 'Three.' ),
 			},
@@ -45,11 +30,6 @@ const example = {
 		{
 			name: 'core/paragraph',
 			attributes: {
-				style: {
-					color: {
-						text: '#00d084',
-					},
-				},
 				fontSize: 'large',
 				content: __( 'Four.' ),
 			},
@@ -57,11 +37,6 @@ const example = {
 		{
 			name: 'core/paragraph',
 			attributes: {
-				style: {
-					color: {
-						text: '#0693e3',
-					},
-				},
 				fontSize: 'large',
 				content: __( 'Five.' ),
 			},
@@ -69,11 +44,6 @@ const example = {
 		{
 			name: 'core/paragraph',
 			attributes: {
-				style: {
-					color: {
-						text: '#9b51e0',
-					},
-				},
 				fontSize: 'large',
 				content: __( 'Six.' ),
 			},

--- a/packages/block-library/src/group/variations.js
+++ b/packages/block-library/src/group/variations.js
@@ -9,7 +9,11 @@ const example = {
 		{
 			name: 'core/paragraph',
 			attributes: {
-				customTextColor: '#cf2e2e',
+				style: {
+					color: {
+						text: '#cf2e2e',
+					},
+				},
 				fontSize: 'large',
 				content: __( 'One.' ),
 			},
@@ -17,7 +21,11 @@ const example = {
 		{
 			name: 'core/paragraph',
 			attributes: {
-				customTextColor: '#ff6900',
+				style: {
+					color: {
+						text: '#ff6900',
+					},
+				},
 				fontSize: 'large',
 				content: __( 'Two.' ),
 			},
@@ -25,7 +33,11 @@ const example = {
 		{
 			name: 'core/paragraph',
 			attributes: {
-				customTextColor: '#fcb900',
+				style: {
+					color: {
+						text: '#fcb900',
+					},
+				},
 				fontSize: 'large',
 				content: __( 'Three.' ),
 			},
@@ -33,7 +45,11 @@ const example = {
 		{
 			name: 'core/paragraph',
 			attributes: {
-				customTextColor: '#00d084',
+				style: {
+					color: {
+						text: '#00d084',
+					},
+				},
 				fontSize: 'large',
 				content: __( 'Four.' ),
 			},
@@ -41,7 +57,11 @@ const example = {
 		{
 			name: 'core/paragraph',
 			attributes: {
-				customTextColor: '#0693e3',
+				style: {
+					color: {
+						text: '#0693e3',
+					},
+				},
 				fontSize: 'large',
 				content: __( 'Five.' ),
 			},
@@ -49,7 +69,11 @@ const example = {
 		{
 			name: 'core/paragraph',
 			attributes: {
-				customTextColor: '#9b51e0',
+				style: {
+					color: {
+						text: '#9b51e0',
+					},
+				},
 				fontSize: 'large',
 				content: __( 'Six.' ),
 			},

--- a/packages/block-library/src/group/variations.js
+++ b/packages/block-library/src/group/variations.js
@@ -9,42 +9,36 @@ const example = {
 		{
 			name: 'core/paragraph',
 			attributes: {
-				fontSize: 'large',
 				content: __( 'One.' ),
 			},
 		},
 		{
 			name: 'core/paragraph',
 			attributes: {
-				fontSize: 'large',
 				content: __( 'Two.' ),
 			},
 		},
 		{
 			name: 'core/paragraph',
 			attributes: {
-				fontSize: 'large',
 				content: __( 'Three.' ),
 			},
 		},
 		{
 			name: 'core/paragraph',
 			attributes: {
-				fontSize: 'large',
 				content: __( 'Four.' ),
 			},
 		},
 		{
 			name: 'core/paragraph',
 			attributes: {
-				fontSize: 'large',
 				content: __( 'Five.' ),
 			},
 		},
 		{
 			name: 'core/paragraph',
 			attributes: {
-				fontSize: 'large',
 				content: __( 'Six.' ),
 			},
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Group Block variation:Displays variation colors correctly.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Change the text color attribute from `customTextColor` to `style > color > text`.

This attribute change was probably made 5 years ago.
#21037

If you don't think you need text color, remove the color.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page. 
2. Hover over the Row block to see the example
3. You'll see that the example text is colored.
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<img width="630" height="528" alt="row" src="https://github.com/user-attachments/assets/281e603e-80f4-431a-90c9-bae4567020e8" />