### PR TITLE
Fix timezone in Date block

### DIFF
--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -76,7 +76,8 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 			$formatted_date = sprintf( __( '%s ago' ), human_time_diff( $post_timestamp ) );
 		}
 	} else {
-		$formatted_date = gmdate( empty( $attributes['format'] ) ? get_option( 'date_format' ) : $attributes['format'], $post_timestamp );
+		$format         = empty( $attributes['format'] ) ? get_option( 'date_format' ) : $attributes['format'];
+		$formatted_date = wp_date( $format, $post_timestamp );
 	}
 
 	if ( isset( $attributes['textAlign'] ) ) {


### PR DESCRIPTION
Fixes #39984.

The date/time being displayed in the Date block is currently using `gmdate()`:

https://github.com/WordPress/gutenberg/blob/a040815100d6e8fa771e9bd983b956d2f919d09f/packages/block-library/src/post-date/index.php#L79

This is incorrect. For comparison, refer to core's [`get_post_time()`](https://developer.wordpress.org/reference/functions/get_post_time/) function as used by `get_the_date()` as used in classic themes. It [uses](https://github.com/WordPress/wordpress-develop/blob/accf941d0b8c6f894c72818bd410c8206493568a/src/wp-includes/general-template.php#L2894) `wp_date()` as follows:

```php
$time = wp_date( $format, $datetime->getTimestamp(), $gmt ? new DateTimeZone( 'UTC' ) : null );
```

When the `$timezone` parameter is not passed to `wp_date()` then it uses the current timezone as specified in the blog's settings.

# Testing

I added a Date block in a row in the Single template in Twenty Twenty-Five:

> <img width="1163" height="602" alt="Screenshot 2025-08-31 at 22 29 06" src="https://github.com/user-attachments/assets/df74fe48-2ecd-4a1f-a121-f91c2a65e4c6" />

I also have my timezone set to America/Los Angeles:

<img width="895" height="78" alt="image" src="https://github.com/user-attachments/assets/fbf63378-d99e-4dd0-a662-e0f5fee7f5e2" />

The current time for me right now is 22:35 (10:35pm) on August 31st. In the block editor, I see this reflected correctly when showing the template in the block editor:

> <img width="685" height="610" alt="image" src="https://github.com/user-attachments/assets/c1bd5911-cb01-456e-b7a6-b9e07587e033" />

However, if I view the post on the frontend, I see September 1st, since that is the current date in UTC/GMT:

> <img width="526" height="183" alt="image" src="https://github.com/user-attachments/assets/df60d0ed-a04c-4030-b5a3-61195224a9c1" />

When I switch to the code in this branch so that `wp_date()` is used instead, then I see the expected date of August 31st:

> <img width="533" height="183" alt="image" src="https://github.com/user-attachments/assets/31342757-8a0d-48da-9747-995c97ba61e5" />