### PR TITLE
api-fetch: Check navigator.onLine to improve failure notices

### DIFF
--- a/packages/api-fetch/src/index.ts
+++ b/packages/api-fetch/src/index.ts
@@ -114,11 +114,19 @@ const defaultFetchHandler: FetchHandler = ( nextOptions ) => {
 				throw err;
 			}
 
-			// Otherwise, there is most likely no network connection.
-			// Unfortunately the message might depend on the browser.
+			// If the browser reports being offline, we'll just assume that
+			// this is why the request failed.
+			if ( ! window.navigator.onLine ) {
+				throw {
+					code: 'offline_error',
+					message: __( 'You are offline.' ),
+				};
+			}
+
+			// Hard to diagnose further due to how Window.fetch reports errors.
 			throw {
 				code: 'fetch_error',
-				message: __( 'You are probably offline.' ),
+				message: __( 'An unexpected error occurred.' ),
 			};
 		}
 	);

--- a/packages/api-fetch/src/index.ts
+++ b/packages/api-fetch/src/index.ts
@@ -119,14 +119,18 @@ const defaultFetchHandler: FetchHandler = ( nextOptions ) => {
 			if ( ! window.navigator.onLine ) {
 				throw {
 					code: 'offline_error',
-					message: __( 'You are offline.' ),
+					message: __(
+						'Unable to connect. Please check your Internet connection.'
+					),
 				};
 			}
 
 			// Hard to diagnose further due to how Window.fetch reports errors.
 			throw {
 				code: 'fetch_error',
-				message: __( 'An unexpected error occurred.' ),
+				message: __(
+					'Could not get a valid response from the server.'
+				),
 			};
 		}
 	);

--- a/packages/api-fetch/src/test/index.js
+++ b/packages/api-fetch/src/test/index.js
@@ -168,7 +168,7 @@ describe( 'apiFetch', () => {
 
 		await expect( apiFetch( { path: '/random' } ) ).rejects.toEqual( {
 			code: 'fetch_error',
-			message: 'You are probably offline.',
+			message: 'Could not get a valid response from the server.',
 		} );
 	} );
 

--- a/packages/editor/src/store/utils/notice-builder.js
+++ b/packages/editor/src/store/utils/notice-builder.js
@@ -110,12 +110,13 @@ export function getNotificationArgumentsForSaveFail( data ) {
 		publish: __( 'Publishing failed.' ),
 		private: __( 'Publishing failed.' ),
 		future: __( 'Scheduling failed.' ),
+		default: __( 'Updating failed.' ),
 	};
 
 	let noticeMessage =
 		! isPublished && edits.status in messages
 			? messages[ edits.status ]
-			: __( 'Updating failed.' );
+			: messages.default;
 
 	// Check if message string contains HTML. Notice text is currently only
 	// supported as plaintext, and stripping the tags may muddle the meaning.

--- a/packages/editor/src/store/utils/notice-builder.js
+++ b/packages/editor/src/store/utils/notice-builder.js
@@ -89,15 +89,31 @@ export function getNotificationArgumentsForSaveFail( data ) {
 
 	const publishStatus = [ 'publish', 'private', 'future' ];
 	const isPublished = publishStatus.indexOf( post.status ) !== -1;
-	// If the post was being published, we show the corresponding publish error message
-	// Unless we publish an "updating failed" message.
+
+	if ( error.code === 'offline_error' ) {
+		const messages = {
+			publish: __( 'Publishing failed because you were offline.' ),
+			private: __( 'Publishing failed because you were offline.' ),
+			future: __( 'Scheduling failed because you were offline.' ),
+			default: __( 'Updating failed because you were offline.' ),
+		};
+
+		const noticeMessage =
+			! isPublished && edits.status in messages
+				? messages[ edits.status ]
+				: messages.default;
+
+		return [ noticeMessage, { id: 'editor-save' } ];
+	}
+
 	const messages = {
 		publish: __( 'Publishing failed.' ),
 		private: __( 'Publishing failed.' ),
 		future: __( 'Scheduling failed.' ),
 	};
+
 	let noticeMessage =
-		! isPublished && publishStatus.indexOf( edits.status ) !== -1
+		! isPublished && edits.status in messages
 			? messages[ edits.status ]
 			: __( 'Updating failed.' );
 

--- a/packages/media-utils/src/utils/test/upload-media.ts
+++ b/packages/media-utils/src/utils/test/upload-media.ts
@@ -215,7 +215,7 @@ describe( 'uploadMedia', () => {
 		( uploadToServer as jest.Mock ).mockImplementation( () => {
 			throw {
 				code: 'fetch_error',
-				message: 'You are probably offline.',
+				message: 'Could not get a valid response from the server.',
 			};
 		} );
 
@@ -229,7 +229,7 @@ describe( 'uploadMedia', () => {
 		expect( onError ).toHaveBeenCalledWith(
 			new UploadError( {
 				code: 'GENERAL',
-				message: 'You are probably offline.',
+				message: 'Could not get a valid response from the server.',
 				file: imageFile,
 			} )
 		);

--- a/test/e2e/specs/editor/various/autosave.spec.js
+++ b/test/e2e/specs/editor/various/autosave.spec.js
@@ -270,7 +270,7 @@ test.describe( 'Autosave', () => {
 
 		await expect(
 			page.locator( '.components-notice__content' )
-		).toContainText( 'Updating failed. You are probably offline.' );
+		).toContainText( 'Updating failed because you were offline.' );
 		expect(
 			await page.evaluate( () => window.sessionStorage.length )
 		).toBe( 1 );

--- a/test/e2e/specs/editor/various/change-detection.spec.js
+++ b/test/e2e/specs/editor/various/change-detection.spec.js
@@ -243,7 +243,7 @@ test.describe( 'Change detection', () => {
 		await expect(
 			page
 				.getByRole( 'region', { name: 'Editor content' } )
-				.getByText( 'Updating failed. You are probably offline.' )
+				.getByText( 'Updating failed because you were offline.' )
 		).toBeVisible();
 		await expect(
 			page


### PR DESCRIPTION
## What?

Part of #67141

Change the wording in the error notice that appears when saving/updating a post fails. Instead of "Updating failed. You are probably offline.", the notice might now read one of:
* "Updating failed because you were offline."
* "Updating failed. An unexpected error occurred."

## How?
When handling a failed request, let api-fetch infer from the value of `navigator.onLine` whether the failure likely stems from the fact that the user is disconnected from the network.

This still leaves out other kinds of network error, which right now will still trigger the fallback "Unexpected error" messaging. The spec for `Window.fetch` does not prescribe a standard error for network errors, meaning that browsers each implement their own messaging. See the parent issue for more technical context.

## Testing Instructions
* In the post editor, try saving a draft
  * while the network is on -> success
  * while it is off -> "failed because you were offline"
  * while the server is down -> "unexpected error"

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="503" height="223" alt="Screenshot 2025-09-01 at 10 10 03" src="https://github.com/user-attachments/assets/4dc57087-2a20-43b0-88f9-4825012b0827" />
<img width="306" height="273" alt="Screenshot 2025-09-01 at 10 12 19" src="https://github.com/user-attachments/assets/f7b55c54-6b71-4d5e-9dcb-550b5785adab" />
