### PR TITLE
Field Types: update storybook

### DIFF
--- a/packages/dataviews/src/field-types/stories/index.story.tsx
+++ b/packages/dataviews/src/field-types/stories/index.story.tsx
@@ -215,17 +215,40 @@ const fields: Field< DataType >[] = [
 		type: 'media',
 		label: 'Media',
 		description: 'Help for media.',
+		render: ( { item } ) => {
+			return (
+				<img src={ item.media } alt="" style={ { width: '100%' } } />
+			);
+		},
 	},
 	{
-		id: 'media',
+		id: 'mediaWithElements',
 		type: 'media',
-		label: 'Media',
-		description: 'Help for media.',
+		label: 'Media (with elements)',
+		description: 'Help for media with elements.',
 		elements: [
-			{ value: 'image.jpg', label: 'Image' },
-			{ value: 'video.mp4', label: 'Video' },
-			{ value: 'audio.mp3', label: 'Audio' },
+			{
+				value: 'https://live.staticflickr.com/7398/9458193857_e1256123e3_z.jpg',
+				label: 'Moon',
+			},
+			{
+				value: 'https://live.staticflickr.com/8151/7651156426_e047f4d219_z.jpg',
+				label: 'Mars',
+			},
+			{
+				value: 'https://live.staticflickr.com/3762/9460163562_964fe6af07_z.jpg',
+				label: 'Earth',
+			},
 		],
+		render: ( { item } ) => {
+			return (
+				<img
+					src={ item.mediaWithElements }
+					alt=""
+					style={ { width: '100%' } }
+				/>
+			);
+		},
 	},
 	{
 		id: 'array',

--- a/packages/dataviews/src/field-types/stories/index.story.tsx
+++ b/packages/dataviews/src/field-types/stories/index.story.tsx
@@ -10,14 +10,14 @@ import {
 /**
  * Internal dependencies
  */
-import DataViews from '../dataviews/index';
-import DataForm from '../dataform/index';
+import DataViews from '../../components/dataviews/index';
+import DataForm from '../../components/dataform/index';
 import {
 	actions,
 	data,
 	fields,
 	type SpaceObject,
-} from '../dataviews/stories/fixtures';
+} from '../../components/dataviews/stories/fixtures';
 import { filterSortAndPaginate } from '../../filter-and-sort-data-view';
 import type { View, Form, Field } from '../../types';
 

--- a/packages/dataviews/src/field-types/stories/index.story.tsx
+++ b/packages/dataviews/src/field-types/stories/index.story.tsx
@@ -35,28 +35,47 @@ export default meta;
 type DataType = {
 	id: number;
 	text: string;
+	textWithElements: string;
 	integer: number;
+	integerWithElements: number;
 	boolean: boolean;
+	booleanWithElements: boolean;
 	datetime: string;
+	datetimeWithElements: string;
 	date: string;
+	dateWithElements: string;
 	email: string;
+	emailWithElements: string;
 	media: string;
+	mediaWithElements: string;
 	array: string[];
+	arrayWithElements: string[];
 	notype: string;
+	notypeWithElements: string;
 };
 
 const data: DataType[] = [
 	{
 		id: 1,
 		text: 'Text',
+		textWithElements: 'Item 1',
 		integer: 1,
+		integerWithElements: 1,
 		boolean: true,
+		booleanWithElements: true,
 		datetime: '2021-01-01T14:30:00Z',
+		datetimeWithElements: '2021-01-01T14:30:00Z',
 		date: '2021-01-01',
+		dateWithElements: '2021-01-01',
 		email: 'hi@example.com',
+		emailWithElements: 'hi@example.com',
 		media: 'https://live.staticflickr.com/7398/9458193857_e1256123e3_z.jpg',
+		mediaWithElements:
+			'https://live.staticflickr.com/7398/9458193857_e1256123e3_z.jpg',
 		array: [ 'item1', 'item2', 'item3' ],
+		arrayWithElements: [ 'item1', 'item2', 'item3' ],
 		notype: 'No type',
+		notypeWithElements: 'No type',
 	},
 ];
 
@@ -68,10 +87,32 @@ const fields: Field< DataType >[] = [
 		description: 'Help for text.',
 	},
 	{
+		id: 'textWithElements',
+		type: 'text',
+		label: 'Text (with elements)',
+		description: 'Help for text with elements.',
+		elements: [
+			{ value: 'item1', label: 'Item 1' },
+			{ value: 'item2', label: 'Item 2' },
+			{ value: 'item3', label: 'Item 3' },
+		],
+	},
+	{
 		id: 'integer',
 		type: 'integer',
 		label: 'Integer',
 		description: 'Help for integer.',
+	},
+	{
+		id: 'integerWithElements',
+		type: 'integer',
+		label: 'Integer (with elements)',
+		description: 'Help for integer with elements.',
+		elements: [
+			{ value: 1, label: 'One' },
+			{ value: 2, label: 'Two' },
+			{ value: 3, label: 'Three' },
+		],
 	},
 	{
 		id: 'boolean',
@@ -80,10 +121,40 @@ const fields: Field< DataType >[] = [
 		description: 'Help for boolean.',
 	},
 	{
+		id: 'booleanWithElements',
+		type: 'boolean',
+		label: 'Boolean (with elements)',
+		description: 'Help for boolean with elements.',
+		elements: [
+			{ value: true, label: 'It is true' },
+			{ value: false, label: 'It is false' },
+		],
+	},
+	{
 		id: 'datetime',
 		type: 'datetime',
 		label: 'Datetime',
 		description: 'Help for datetime.',
+	},
+	{
+		id: 'datetimeWithElements',
+		type: 'datetime',
+		label: 'Datetime (with elements)',
+		description: 'Help for datetime with elements.',
+		elements: [
+			{
+				value: '2021-01-01T14:30:00Z',
+				label: 'January 1st, 2021. 14:30UTC',
+			},
+			{
+				value: '2021-02-01T14:30:00Z',
+				label: 'February 1st, 2021. 14:30UTC',
+			},
+			{
+				value: '2021-03-01T14:30:00Z',
+				label: 'March 1st, 2021. 14:30UTC',
+			},
+		],
 	},
 	{
 		id: 'date',
@@ -92,10 +163,32 @@ const fields: Field< DataType >[] = [
 		description: 'Help for date.',
 	},
 	{
+		id: 'dateWithElements',
+		type: 'date',
+		label: 'Date (with elements)',
+		description: 'Help for date with elements.',
+		elements: [
+			{ value: '2021-01-01', label: 'January 1st, 2021' },
+			{ value: '2021-02-01', label: 'February 1st, 2021' },
+			{ value: '2021-03-01', label: 'March 1st, 2021' },
+		],
+	},
+	{
 		id: 'email',
 		type: 'email',
 		label: 'Email',
 		description: 'Help for email.',
+	},
+	{
+		id: 'emailWithElements',
+		type: 'email',
+		label: 'Email (with elements)',
+		description: 'Help for email with elements.',
+		elements: [
+			{ value: 'john@example.com', label: 'John Doe' },
+			{ value: 'jane@example.com', label: 'Jane Doe' },
+			{ value: 'bob@example.com', label: 'Bob Smith' },
+		],
 	},
 	{
 		id: 'media',
@@ -104,15 +197,47 @@ const fields: Field< DataType >[] = [
 		description: 'Help for media.',
 	},
 	{
+		id: 'media',
+		type: 'media',
+		label: 'Media',
+		description: 'Help for media.',
+		elements: [
+			{ value: 'image.jpg', label: 'Image' },
+			{ value: 'video.mp4', label: 'Video' },
+			{ value: 'audio.mp3', label: 'Audio' },
+		],
+	},
+	{
 		id: 'array',
 		type: 'array',
 		label: 'Array',
 		description: 'Help for array.',
 	},
 	{
+		id: 'arrayWithElements',
+		type: 'array',
+		label: 'Array (with elements)',
+		description: 'Help for array with elements.',
+		elements: [
+			{ value: 'item1', label: 'Item 1' },
+			{ value: 'item2', label: 'Item 2' },
+			{ value: 'item3', label: 'Item 3' },
+		],
+	},
+	{
 		id: 'notype',
 		label: 'Without type',
 		description: 'Help for notype.',
+	},
+	{
+		id: 'notypeWithElements',
+		label: 'Without type (with elements)',
+		description: 'Help for notype with elements.',
+		elements: [
+			{ value: 'item1', label: 'Item 1' },
+			{ value: 'item2', label: 'Item 2' },
+			{ value: 'item3', label: 'Item 3' },
+		],
 	},
 ];
 

--- a/packages/dataviews/src/field-types/stories/index.story.tsx
+++ b/packages/dataviews/src/field-types/stories/index.story.tsx
@@ -12,12 +12,6 @@ import {
  */
 import DataViews from '../../components/dataviews/index';
 import DataForm from '../../components/dataform/index';
-import {
-	actions,
-	data,
-	fields,
-	type SpaceObject,
-} from '../../components/dataviews/stories/fixtures';
 import { filterSortAndPaginate } from '../../filter-and-sort-data-view';
 import type { View, Form, Field } from '../../types';
 
@@ -29,47 +23,114 @@ const meta = {
 			control: { type: 'select' },
 			description:
 				'Chooses the default layout of each field. "regular" is the default layout.',
-			options: [ 'default', 'regular', 'panel' ],
-		},
-		labelPosition: {
-			control: { type: 'select' },
-			description: 'Chooses the label position of the layout.',
-			options: [ 'default', 'top', 'side', 'none' ],
+			options: [ 'regular', 'panel' ],
 		},
 	},
-} as const;
+	args: {
+		type: 'regular',
+	},
+};
 export default meta;
 
-const defaultLayouts = {
-	table: {},
-	grid: {},
-	list: {},
+type DataType = {
+	id: number;
+	text: string;
+	integer: number;
+	boolean: boolean;
+	datetime: string;
+	date: string;
+	email: string;
+	media: string;
+	array: string[];
+	notype: string;
 };
 
+const data: DataType[] = [
+	{
+		id: 1,
+		text: 'Text',
+		integer: 1,
+		boolean: true,
+		datetime: '2021-01-01T14:30:00Z',
+		date: '2021-01-01',
+		email: 'hi@example.com',
+		media: 'https://live.staticflickr.com/7398/9458193857_e1256123e3_z.jpg',
+		array: [ 'item1', 'item2', 'item3' ],
+		notype: 'No type',
+	},
+];
+
+const fields: Field< DataType >[] = [
+	{
+		id: 'text',
+		type: 'text',
+		label: 'Text',
+		description: 'Help for text.',
+	},
+	{
+		id: 'integer',
+		type: 'integer',
+		label: 'Integer',
+		description: 'Help for integer.',
+	},
+	{
+		id: 'boolean',
+		type: 'boolean',
+		label: 'Boolean',
+		description: 'Help for boolean.',
+	},
+	{
+		id: 'datetime',
+		type: 'datetime',
+		label: 'Datetime',
+		description: 'Help for datetime.',
+	},
+	{
+		id: 'date',
+		type: 'date',
+		label: 'Date',
+		description: 'Help for date.',
+	},
+	{
+		id: 'email',
+		type: 'email',
+		label: 'Email',
+		description: 'Help for email.',
+	},
+	{
+		id: 'media',
+		type: 'media',
+		label: 'Media',
+		description: 'Help for media.',
+	},
+	{
+		id: 'array',
+		type: 'array',
+		label: 'Array',
+		description: 'Help for array.',
+	},
+	{
+		id: 'notype',
+		label: 'Without type',
+		description: 'Help for notype.',
+	},
+];
+
 interface FieldTypeStoryProps {
-	fields: Field< SpaceObject >[];
-	titleField?: string;
-	descriptionField?: string;
-	mediaField?: string;
-	type?: 'default' | 'regular' | 'panel';
-	labelPosition?: 'default' | 'top' | 'side' | 'none';
+	fields: Field< DataType >[];
+	type: 'regular' | 'panel';
 }
 
 const FieldTypeStory = ( {
 	fields: storyFields,
-	titleField,
-	descriptionField,
-	mediaField,
-	type = 'default',
-	labelPosition = 'default',
+	type,
 }: FieldTypeStoryProps ) => {
 	const form = useMemo(
 		() => ( {
-			type,
-			labelPosition,
+			layout: { type },
 			fields: storyFields.map( ( field ) => field.id ),
 		} ),
-		[ type, labelPosition, storyFields ]
+		[ type, storyFields ]
 	) as Form;
 
 	const [ view, setView ] = useState< View >( {
@@ -79,21 +140,11 @@ const FieldTypeStory = ( {
 		perPage: 10,
 		layout: {},
 		filters: [],
-		titleField,
-		descriptionField,
-		mediaField,
-		fields: storyFields
-			.filter(
-				( field ) =>
-					! [ titleField, descriptionField, mediaField ].includes(
-						field.id
-					)
-			)
-			.map( ( field ) => field.id ),
+		fields: storyFields.map( ( field ) => field.id ),
 	} );
 
 	const [ selectedIds, setSelectedIds ] = useState< number[] >( [] );
-	const [ modifiedData, setModifiedData ] = useState< SpaceObject[] >( data );
+	const [ modifiedData, setModifiedData ] = useState< DataType[] >( data );
 
 	const { data: shownData, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( modifiedData, view, storyFields );
@@ -114,16 +165,24 @@ const FieldTypeStory = ( {
 					view={ view }
 					fields={ storyFields }
 					onChangeView={ setView }
-					actions={ actions }
-					defaultLayouts={ defaultLayouts }
+					actions={ [
+						{
+							id: 'edit',
+							label: 'Edit',
+							callback: () => {},
+							disabled: true,
+							supportsBulk: true,
+						},
+					] }
+					defaultLayouts={ {
+						table: {},
+					} }
 					selection={ selectedIds.map( ( id ) => id.toString() ) }
 					onChangeSelection={ ( newSelection ) =>
 						setSelectedIds(
 							newSelection.map( ( id ) => parseInt( id, 10 ) )
 						)
 					}
-					// eslint-disable-next-line no-alert
-					onClickItem={ ( item ) => alert( 'clicked ' + item.title ) }
 				/>
 			</div>
 			{ selectedItem ? (
@@ -163,210 +222,87 @@ const FieldTypeStory = ( {
 	);
 };
 
-export const All = ( {
-	type,
-	labelPosition,
-}: {
-	type: 'default' | 'regular' | 'panel';
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-} ) => {
-	return (
-		<FieldTypeStory
-			fields={ fields }
-			titleField="title"
-			descriptionField="description"
-			mediaField="image"
-			type={ type }
-			labelPosition={ labelPosition }
-		/>
-	);
+export const All = ( { type }: { type: 'regular' | 'panel' } ) => {
+	return <FieldTypeStory fields={ fields } type={ type } />;
 };
 
-export const Text = ( {
-	type,
-	labelPosition,
-}: {
-	type: 'default' | 'regular' | 'panel';
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-} ) => {
+export const Text = ( { type }: { type: 'regular' | 'panel' } ) => {
 	const textFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'text' ),
 		[]
 	);
 
-	return (
-		<FieldTypeStory
-			fields={ textFields }
-			type={ type }
-			labelPosition={ labelPosition }
-		/>
-	);
+	return <FieldTypeStory fields={ textFields } type={ type } />;
 };
 
-export const Integer = ( {
-	type,
-	labelPosition,
-}: {
-	type: 'default' | 'regular' | 'panel';
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-} ) => {
+export const Integer = ( { type }: { type: 'regular' | 'panel' } ) => {
 	const integerFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'integer' ),
 		[]
 	);
 
-	return (
-		<FieldTypeStory
-			fields={ integerFields }
-			type={ type }
-			labelPosition={ labelPosition }
-		/>
-	);
+	return <FieldTypeStory fields={ integerFields } type={ type } />;
 };
 
-export const Boolean = ( {
-	type,
-	labelPosition,
-}: {
-	type: 'default' | 'regular' | 'panel';
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-} ) => {
+export const Boolean = ( { type }: { type: 'regular' | 'panel' } ) => {
 	const booleanFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'boolean' ),
 		[]
 	);
 
-	return (
-		<FieldTypeStory
-			fields={ booleanFields }
-			type={ type }
-			labelPosition={ labelPosition }
-		/>
-	);
+	return <FieldTypeStory fields={ booleanFields } type={ type } />;
 };
 
-export const DateTime = ( {
-	type,
-	labelPosition,
-}: {
-	type: 'default' | 'regular' | 'panel';
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-} ) => {
+export const DateTime = ( { type }: { type: 'regular' | 'panel' } ) => {
 	const dateTimeFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'datetime' ),
 		[]
 	);
 
-	return (
-		<FieldTypeStory
-			fields={ dateTimeFields }
-			type={ type }
-			labelPosition={ labelPosition }
-		/>
-	);
+	return <FieldTypeStory fields={ dateTimeFields } type={ type } />;
 };
 
-export const Date = ( {
-	type,
-	labelPosition,
-}: {
-	type: 'default' | 'regular' | 'panel';
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-} ) => {
+export const Date = ( { type }: { type: 'regular' | 'panel' } ) => {
 	const dateFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'date' ),
 		[]
 	);
 
-	return (
-		<FieldTypeStory
-			fields={ dateFields }
-			type={ type }
-			labelPosition={ labelPosition }
-		/>
-	);
+	return <FieldTypeStory fields={ dateFields } type={ type } />;
 };
 
-export const Email = ( {
-	type,
-	labelPosition,
-}: {
-	type: 'default' | 'regular' | 'panel';
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-} ) => {
+export const Email = ( { type }: { type: 'regular' | 'panel' } ) => {
 	const emailFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'email' ),
 		[]
 	);
 
-	return (
-		<FieldTypeStory
-			fields={ emailFields }
-			type={ type }
-			labelPosition={ labelPosition }
-		/>
-	);
+	return <FieldTypeStory fields={ emailFields } type={ type } />;
 };
 
-export const Media = ( {
-	type,
-	labelPosition,
-}: {
-	type: 'default' | 'regular' | 'panel';
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-} ) => {
+export const Media = ( { type }: { type: 'regular' | 'panel' } ) => {
 	const mediaFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'media' ),
 		[]
 	);
 
-	return (
-		<FieldTypeStory
-			fields={ mediaFields }
-			type={ type }
-			labelPosition={ labelPosition }
-		/>
-	);
+	return <FieldTypeStory fields={ mediaFields } type={ type } />;
 };
 
-export const Array = ( {
-	type,
-	labelPosition,
-}: {
-	type: 'default' | 'regular' | 'panel';
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-} ) => {
+export const Array = ( { type }: { type: 'regular' | 'panel' } ) => {
 	const arrayTextFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'array' ),
 		[]
 	);
 
-	return (
-		<FieldTypeStory
-			fields={ arrayTextFields }
-			type={ type }
-			labelPosition={ labelPosition }
-		/>
-	);
+	return <FieldTypeStory fields={ arrayTextFields } type={ type } />;
 };
 
-export const NoType = ( {
-	type,
-	labelPosition,
-}: {
-	type: 'default' | 'regular' | 'panel';
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-} ) => {
+export const NoType = ( { type }: { type: 'regular' | 'panel' } ) => {
 	const noTypeFields = useMemo(
 		() => fields.filter( ( field ) => field.type === undefined ),
 		[]
 	);
 
-	return (
-		<FieldTypeStory
-			fields={ noTypeFields }
-			type={ type }
-			labelPosition={ labelPosition }
-		/>
-	);
+	return <FieldTypeStory fields={ noTypeFields } type={ type } />;
 };

--- a/packages/dataviews/src/field-types/stories/index.story.tsx
+++ b/packages/dataviews/src/field-types/stories/index.story.tsx
@@ -226,12 +226,12 @@ const fields: Field< DataType >[] = [
 	},
 	{
 		id: 'notype',
-		label: 'Without type',
+		label: 'No type',
 		description: 'Help for notype.',
 	},
 	{
 		id: 'notypeWithElements',
-		label: 'Without type (with elements)',
+		label: 'No type (with elements)',
 		description: 'Help for notype with elements.',
 		elements: [
 			{ value: 'item1', label: 'Item 1' },

--- a/packages/dataviews/src/field-types/stories/index.story.tsx
+++ b/packages/dataviews/src/field-types/stories/index.story.tsx
@@ -25,9 +25,29 @@ const meta = {
 				'Chooses the default layout of each field. "regular" is the default layout.',
 			options: [ 'regular', 'panel' ],
 		},
+		Edit: {
+			control: { type: 'select' },
+			description:
+				'Chooses the Edit function for the field. "Default" means use the default Edit function for the field type.',
+			options: [
+				'default',
+				'array',
+				'boolean',
+				'checkbox',
+				'date',
+				'datetime',
+				'email',
+				'integer',
+				'radio',
+				'select',
+				'text',
+				'toggleGroup',
+			],
+		},
 	},
 	args: {
 		type: 'regular',
+		Edit: 'default',
 	},
 };
 export default meta;
@@ -241,15 +261,42 @@ const fields: Field< DataType >[] = [
 	},
 ];
 
+type PanelTypes = 'regular' | 'panel';
+type ControlTypes =
+	| 'default'
+	| 'array'
+	| 'boolean'
+	| 'checkbox'
+	| 'date'
+	| 'datetime'
+	| 'email'
+	| 'integer'
+	| 'radio'
+	| 'select'
+	| 'text'
+	| 'toggleGroup';
+
 interface FieldTypeStoryProps {
 	fields: Field< DataType >[];
-	type: 'regular' | 'panel';
+	type: PanelTypes;
+	Edit: ControlTypes;
 }
 
 const FieldTypeStory = ( {
-	fields: storyFields,
+	fields: _fields,
 	type,
+	Edit,
 }: FieldTypeStoryProps ) => {
+	const storyFields = useMemo( () => {
+		if ( Edit === 'default' ) {
+			return _fields;
+		}
+
+		return _fields.map( ( field: Field< DataType > ) => ( {
+			...field,
+			Edit,
+		} ) );
+	}, [ _fields, Edit ] );
 	const form = useMemo(
 		() => ( {
 			layout: { type },
@@ -347,87 +394,165 @@ const FieldTypeStory = ( {
 	);
 };
 
-export const All = ( { type }: { type: 'regular' | 'panel' } ) => {
-	return <FieldTypeStory fields={ fields } type={ type } />;
+export const All = ( {
+	type,
+	Edit,
+}: {
+	type: PanelTypes;
+	Edit: ControlTypes;
+} ) => {
+	return <FieldTypeStory fields={ fields } type={ type } Edit={ Edit } />;
 };
 
-export const Text = ( { type }: { type: 'regular' | 'panel' } ) => {
+export const Text = ( {
+	type,
+	Edit,
+}: {
+	type: PanelTypes;
+	Edit: ControlTypes;
+} ) => {
 	const textFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'text' ),
 		[]
 	);
 
-	return <FieldTypeStory fields={ textFields } type={ type } />;
+	return <FieldTypeStory fields={ textFields } type={ type } Edit={ Edit } />;
 };
 
-export const Integer = ( { type }: { type: 'regular' | 'panel' } ) => {
+export const Integer = ( {
+	type,
+	Edit,
+}: {
+	type: PanelTypes;
+	Edit: ControlTypes;
+} ) => {
 	const integerFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'integer' ),
 		[]
 	);
 
-	return <FieldTypeStory fields={ integerFields } type={ type } />;
+	return (
+		<FieldTypeStory fields={ integerFields } type={ type } Edit={ Edit } />
+	);
 };
 
-export const Boolean = ( { type }: { type: 'regular' | 'panel' } ) => {
+export const Boolean = ( {
+	type,
+	Edit,
+}: {
+	type: PanelTypes;
+	Edit: ControlTypes;
+} ) => {
 	const booleanFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'boolean' ),
 		[]
 	);
 
-	return <FieldTypeStory fields={ booleanFields } type={ type } />;
+	return (
+		<FieldTypeStory fields={ booleanFields } type={ type } Edit={ Edit } />
+	);
 };
 
-export const DateTime = ( { type }: { type: 'regular' | 'panel' } ) => {
+export const DateTime = ( {
+	type,
+	Edit,
+}: {
+	type: PanelTypes;
+	Edit: ControlTypes;
+} ) => {
 	const dateTimeFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'datetime' ),
 		[]
 	);
 
-	return <FieldTypeStory fields={ dateTimeFields } type={ type } />;
+	return (
+		<FieldTypeStory fields={ dateTimeFields } type={ type } Edit={ Edit } />
+	);
 };
 
-export const Date = ( { type }: { type: 'regular' | 'panel' } ) => {
+export const Date = ( {
+	type,
+	Edit,
+}: {
+	type: PanelTypes;
+	Edit: ControlTypes;
+} ) => {
 	const dateFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'date' ),
 		[]
 	);
 
-	return <FieldTypeStory fields={ dateFields } type={ type } />;
+	return <FieldTypeStory fields={ dateFields } type={ type } Edit={ Edit } />;
 };
 
-export const Email = ( { type }: { type: 'regular' | 'panel' } ) => {
+export const Email = ( {
+	type,
+	Edit,
+}: {
+	type: PanelTypes;
+	Edit: ControlTypes;
+} ) => {
 	const emailFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'email' ),
 		[]
 	);
 
-	return <FieldTypeStory fields={ emailFields } type={ type } />;
+	return (
+		<FieldTypeStory fields={ emailFields } type={ type } Edit={ Edit } />
+	);
 };
 
-export const Media = ( { type }: { type: 'regular' | 'panel' } ) => {
+export const Media = ( {
+	type,
+	Edit,
+}: {
+	type: PanelTypes;
+	Edit: ControlTypes;
+} ) => {
 	const mediaFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'media' ),
 		[]
 	);
 
-	return <FieldTypeStory fields={ mediaFields } type={ type } />;
+	return (
+		<FieldTypeStory fields={ mediaFields } type={ type } Edit={ Edit } />
+	);
 };
 
-export const Array = ( { type }: { type: 'regular' | 'panel' } ) => {
+export const Array = ( {
+	type,
+	Edit,
+}: {
+	type: PanelTypes;
+	Edit: ControlTypes;
+} ) => {
 	const arrayTextFields = useMemo(
 		() => fields.filter( ( field ) => field.type === 'array' ),
 		[]
 	);
 
-	return <FieldTypeStory fields={ arrayTextFields } type={ type } />;
+	return (
+		<FieldTypeStory
+			fields={ arrayTextFields }
+			type={ type }
+			Edit={ Edit }
+		/>
+	);
 };
 
-export const NoType = ( { type }: { type: 'regular' | 'panel' } ) => {
+export const NoType = ( {
+	type,
+	Edit,
+}: {
+	type: PanelTypes;
+	Edit: ControlTypes;
+} ) => {
 	const noTypeFields = useMemo(
 		() => fields.filter( ( field ) => field.type === undefined ),
 		[]
 	);
 
-	return <FieldTypeStory fields={ noTypeFields } type={ type } />;
+	return (
+		<FieldTypeStory fields={ noTypeFields } type={ type } Edit={ Edit } />
+	);
 };


### PR DESCRIPTION
## What?

<img width="2285" height="1113" alt="Screenshot 2025-09-01 at 12 54 21" src="https://github.com/user-attachments/assets/4f19b0de-10e9-4a8a-8560-682ef9678934" />

Update the existing Field Types story so that each field type (text, integer, email, array, etc.) displays:

- the default state: `{id: '…', type: '…' }`.
- how it renders when it has a list of elements: `{ id: '', type: '...', elements: [ ... ] }`.
- how it renders when using a specific Edit control: `{ id: '…', type: '…', Edit: 'checkbox' }`.

This affects both DataForm (the control displayed in regular layout) and DataViews (the control used for filtering).

## Why?

So that we have documentation for people onboarding into DataForm/DataViews development (either contributing or consuming the libraries).

## How

- Review every field type and update data/config so it has an example with and without elements.
- Introduce the `Edit` control for the whole story, so that users can switch to using a different Edit control and see the effects it causes.

## Testing Instructions

Run the storybook locally (`npm install && npm run storybook:dev`) and visit "DatViews > Field Types" story.
