### PR TITLE
refactor: remove unnecessary fields from accordion block.json files

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -17,7 +17,7 @@ Displays a group of accordion headers and associated expandable content. ([Sourc
 -	**Category:** design
 -	**Allowed Blocks:** core/accordion-content
 -	**Supports:** align (full, wide), background (backgroundImage, backgroundSize), color (background, gradient, text), interactivity, layout, shadow, spacing (blockGap, margin, padding), ~~html~~
--	**Attributes:** allowedBlocks, autoclose, iconPosition, showIcon
+-	**Attributes:** autoclose, iconPosition, showIcon
 
 ## Accordion Content
 
@@ -28,7 +28,7 @@ Displays a section of content in an accordion, including a header and expandable
 -	**Category:** design
 -	**Parent:** core/accordion
 -	**Allowed Blocks:** core/accordion-header, core/accordion-panel
--	**Supports:** align (full, wide), color (background, gradient, text), interactivity, shadow, spacing (blockGap, margin)
+-	**Supports:** color (background, gradient, text), interactivity, shadow, spacing (blockGap, margin)
 -	**Attributes:** openByDefault
 
 ## Accordion Header
@@ -39,7 +39,7 @@ Displays an accordion header. ([Source](https://github.com/WordPress/gutenberg/t
 -	**Experimental:** true
 -	**Category:** design
 -	**Parent:** core/accordion-content
--	**Supports:** anchor, border, color (background, gradient, text), interactivity, shadow, spacing (margin, padding), typography (fontSize, textAlign), ~~align~~
+-	**Supports:** anchor, color (background, gradient, text), interactivity, shadow, spacing (margin, padding), typography (fontSize, textAlign), ~~align~~
 -	**Attributes:** iconPosition, level, levelOptions, openByDefault, showIcon, textAlignment, title
 
 ## Accordion Panel
@@ -50,7 +50,7 @@ Displays an accordion panel. ([Source](https://github.com/WordPress/gutenberg/tr
 -	**Experimental:** true
 -	**Category:** design
 -	**Parent:** core/accordion-content
--	**Supports:** border, color (background, gradient, text), interactivity, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight)
+-	**Supports:** color (background, gradient, text), interactivity, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight)
 -	**Attributes:** allowedBlocks, isSelected, openByDefault, templateLock
 
 ## Archives

--- a/packages/block-library/src/accordion-content/block.json
+++ b/packages/block-library/src/accordion-content/block.json
@@ -2,7 +2,6 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "core/accordion-content",
-	"version": "0.1.0",
 	"title": "Accordion Content",
 	"category": "design",
 	"description": "Displays a section of content in an accordion, including a header and expandable content.",
@@ -10,7 +9,6 @@
 	"parent": [ "core/accordion" ],
 	"allowedBlocks": [ "core/accordion-header", "core/accordion-panel" ],
 	"supports": {
-		"align": [ "wide", "full" ],
 		"color": {
 			"background": true,
 			"gradient": true

--- a/packages/block-library/src/accordion-header/block.json
+++ b/packages/block-library/src/accordion-header/block.json
@@ -2,7 +2,6 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "core/accordion-header",
-	"version": "0.1.0",
 	"title": "Accordion Header",
 	"category": "design",
 	"description": "Displays an accordion header.",
@@ -19,7 +18,6 @@
 			"gradient": true
 		},
 		"align": false,
-		"border": true,
 		"interactivity": true,
 		"spacing": {
 			"padding": true,

--- a/packages/block-library/src/accordion-panel/block.json
+++ b/packages/block-library/src/accordion-panel/block.json
@@ -2,7 +2,6 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "core/accordion-panel",
-	"version": "0.1.0",
 	"title": "Accordion Panel",
 	"category": "design",
 	"description": "Displays an accordion panel.",
@@ -13,7 +12,6 @@
 			"background": true,
 			"gradient": true
 		},
-		"border": true,
 		"interactivity": true,
 		"spacing": {
 			"padding": true,

--- a/packages/block-library/src/accordion/block.json
+++ b/packages/block-library/src/accordion/block.json
@@ -54,9 +54,6 @@
 		"autoclose": {
 			"type": "boolean",
 			"default": false
-		},
-		"allowedBlocks": {
-			"type": "array"
 		}
 	},
 	"providesContext": {


### PR DESCRIPTION
## What?
Closes #71434 

Removes unnecessary and invalid fields from accordion block.json files to clean up the block definitions and improve code quality.

## Why?
The accordion blocks contained several unnecessary fields that were either unused, invalid:
- Version numbers are not needed for core blocks
- Some attributes were defined but never used in the code
- Invalid support properties that don't exist in the block editor

This cleanup improves maintainability and reduces confusion for developers working with these blocks.

## How?
The following fields were removed from the accordion block.json files:

**Accordion block (`core/accordion`)**:
- Removed `allowedBlocks` attribute

**Accordion Content block (`core/accordion-content`)**:
- Removed `"version": "0.1.0"` field
- Removed `supports.align` 

**Accordion Header block (`core/accordion-header`)**:
- Removed `"version": "0.1.0"` field  
- Removed invalid `supports.border` 

**Accordion Panel block (`core/accordion-panel`)**:
- Removed `"version": "0.1.0"` field
- Removed invalid `supports.border` 