### PR TITLE
Deps: Bump `framer-motion` to `v11.15.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5171,7 +5171,6 @@
 			"version": "2.0.8",
 			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
 			"integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
-			"license": "MIT",
 			"dependencies": {
 				"@floating-ui/dom": "^1.6.1"
 			},
@@ -25611,30 +25610,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/framer-motion": {
-			"version": "11.1.9",
-			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.1.9.tgz",
-			"integrity": "sha512-flECDIPV4QDNcOrDafVFiIazp8X01HFpzc01eDKJsdNH/wrATcYydJSH9JbPWMS8UD5lZlw+J1sK8LG2kICgqw==",
-			"dependencies": {
-				"tslib": "^2.4.0"
-			},
-			"peerDependencies": {
-				"@emotion/is-prop-valid": "*",
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@emotion/is-prop-valid": {
-					"optional": true
-				},
-				"react": {
-					"optional": true
-				},
-				"react-dom": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/fresh": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -34573,6 +34548,16 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
+		},
+		"node_modules/motion-dom": {
+			"version": "11.14.3",
+			"resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.14.3.tgz",
+			"integrity": "sha512-lW+D2wBy5vxLJi6aCP0xyxTxlTfiu+b+zcpVbGVFUxotwThqhdpPRSmX8xztAgtZMPMeU0WGVn/k1w4I+TbPqA=="
+		},
+		"node_modules/motion-utils": {
+			"version": "11.14.3",
+			"resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.14.3.tgz",
+			"integrity": "sha512-Xg+8xnqIJTpr0L/cidfTTBFkvRw26ZtGGuIhA94J9PQ2p4mEa06Xx7QVYZH0BP+EpMSaDlu+q0I0mmvwADPsaQ=="
 		},
 		"node_modules/mousetrap": {
 			"version": "1.6.5",
@@ -50112,7 +50097,7 @@
 				"date-fns": "^3.6.0",
 				"deepmerge": "^4.3.0",
 				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^11.1.9",
+				"framer-motion": "^11.15.0",
 				"gradient-parser": "1.1.1",
 				"highlight-words-core": "^1.2.2",
 				"is-plain-object": "^5.0.0",
@@ -50131,6 +50116,32 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"packages/components/node_modules/framer-motion": {
+			"version": "11.15.0",
+			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.15.0.tgz",
+			"integrity": "sha512-MLk8IvZntxOMg7lDBLw2qgTHHv664bYoYmnFTmE0Gm/FW67aOJk0WM3ctMcG+Xhcv+vh5uyyXwxvxhSeJzSe+w==",
+			"dependencies": {
+				"motion-dom": "^11.14.3",
+				"motion-utils": "^11.14.3",
+				"tslib": "^2.4.0"
+			},
+			"peerDependencies": {
+				"@emotion/is-prop-valid": "*",
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@emotion/is-prop-valid": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				}
 			}
 		},
 		"packages/components/node_modules/path-to-regexp": {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 -   `Tabs`: Ensure font size inheritance for tab buttons in all contexts ([#71346](https://github.com/WordPress/gutenberg/pull/71346)).
 
+### Internal
+
+-   Upgrade `framer-motion` package to version `^11.15.0` ([#71442](https://github.com/WordPress/gutenberg/pull/71442)).
 
 ## 30.2.0 (2025-08-20)
 
@@ -22,7 +25,6 @@
 -   Validated form controls: Add support for async validation. This is a breaking API change that splits the `customValidator` prop into an `onValidate` callback and a `customValidity` object. ([#71184](https://github.com/WordPress/gutenberg/pull/71184)).
 -   Validated form controls: Fix bug where "validating" state was not shown when transitioning from error state ([#71260](https://github.com/WordPress/gutenberg/pull/71260)).
 -   `DateCalendar`, `DateRangeCalendar`: use `px` instead of `rem` units. ([#71248](https://github.com/WordPress/gutenberg/pull/71248)).
--   Upgrade `framer-motion` package to version `^11.15.0` ([#71442](https://github.com/WordPress/gutenberg/pull/71442)).
 
 ## 30.1.0 (2025-08-07)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -22,6 +22,7 @@
 -   Validated form controls: Add support for async validation. This is a breaking API change that splits the `customValidator` prop into an `onValidate` callback and a `customValidity` object. ([#71184](https://github.com/WordPress/gutenberg/pull/71184)).
 -   Validated form controls: Fix bug where "validating" state was not shown when transitioning from error state ([#71260](https://github.com/WordPress/gutenberg/pull/71260)).
 -   `DateCalendar`, `DateRangeCalendar`: use `px` instead of `rem` units. ([#71248](https://github.com/WordPress/gutenberg/pull/71248)).
+-   Upgrade `framer-motion` package to version `^11.15.0` ([#71442](https://github.com/WordPress/gutenberg/pull/71442)).
 
 ## 30.1.0 (2025-08-07)
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -67,7 +67,7 @@
 		"date-fns": "^3.6.0",
 		"deepmerge": "^4.3.0",
 		"fast-deep-equal": "^3.1.3",
-		"framer-motion": "^11.1.9",
+		"framer-motion": "^11.15.0",
 		"gradient-parser": "1.1.1",
 		"highlight-words-core": "^1.2.2",
 		"is-plain-object": "^5.0.0",

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -34,7 +34,7 @@ import { getTemplateInfo } from '../../utils/get-template-info';
 
 /** @typedef {import("@wordpress/components").IconType} IconType */
 
-const MotionButton = motion( Button );
+const MotionButton = motion.create( Button );
 
 /**
  * This component renders a navigation bar at the top of the editor. It displays the title of the current document,


### PR DESCRIPTION
## What?
This PR updates `framer-motion` to `v11.15.0` and updates the deprecated syntax `motion()` to use `motion.create()` instead.

## Why?
To prepare for React 19 compatibility.

See #71336 for the full effort.

See #61521 for the PR where the changes came from. 

## How?
We're updating to `v11.15.0`.

~In this new version, `motion()` was deprecated in favor of `motion.create()`, but this is addressed in a separate commit of #61521, and I'll land it separately.~ This fails tests due to the extra warnings, so I'll include it.
 
We're pulling in a part of #61521 to be landed separately.

## Testing Instructions
* All checks should be green
* Go to `/wp-admin/post-new.php`
* In the sidebar, in "Post", click on the template name and click "Edit template" to edit it.
* Close the pattern popover if it opens
* Click the "Back" button in the editor header title section
* Verify you can still see the animation

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/6ba522ea-50e6-4db8-bd02-171e5d2060c4

<img width="393" height="45" alt="Screenshot 2025-09-01 at 13 32 11" src="https://github.com/user-attachments/assets/8121f097-6841-4975-9746-1558e33f7d08" />
