### PR TITLE
Fix issue of css affecting the nested accordion icon.

### DIFF
--- a/packages/block-library/src/accordion/style.scss
+++ b/packages/block-library/src/accordion/style.scss
@@ -85,7 +85,9 @@
 }
 
 .is-open {
-	.accordion-content__toggle-icon.has-icon-plus {
-		transform: rotate(45deg);
+	> .wp-block-accordion-header {
+		.accordion-content__toggle-icon.has-icon-plus {
+			transform: rotate(45deg);
+		}
 	}
 }

--- a/packages/block-library/src/accordion/style.scss
+++ b/packages/block-library/src/accordion/style.scss
@@ -5,6 +5,12 @@
 
 .wp-block-accordion-content.is-open {
 	grid-template-rows: max-content 1fr;
+
+	> .wp-block-accordion-header {
+		.accordion-content__toggle-icon.has-icon-plus {
+			transform: rotate(45deg);
+		}
+	}
 }
 
 .accordion-content__heading {
@@ -81,13 +87,5 @@
 
 	.wp-block-accordion-content {
 		transition: grid-template-rows 0.3s ease-out;
-	}
-}
-
-.is-open {
-	> .wp-block-accordion-header {
-		.accordion-content__toggle-icon.has-icon-plus {
-			transform: rotate(45deg);
-		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/71435
<!-- In a few words, what is the PR actually doing? -->
Fixes CSS selector affects the nested Accordion block icon.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The Accordion block can be nested, and in that some CSS selector affects the nested Accordion block icon.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Made the CSS selector to apply only on the direct child only.

## Testing Instructions
Insert an Accordion block.
Insert an additional Accordion block inside the Accordion panel.
Select the parent Accordion Content block.
Confirm that both toggle icons are rotated.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
