### PR TITLE
fix: prevent accordion toggle button overflow at full width

### DIFF
--- a/packages/block-library/src/accordion/style.scss
+++ b/packages/block-library/src/accordion/style.scss
@@ -10,7 +10,6 @@
 .accordion-content__heading {
 	margin-block-start: 0;
 	margin-block-end: 0;
-	overflow-x: hidden;
 }
 
 .accordion-content__toggle {
@@ -28,6 +27,7 @@
 	padding: var(--wp--preset--spacing--20, 1em) 0;
 	cursor: pointer;
 	outline: none;
+	overflow-x: hidden;
 	display: flex;
 	align-items: center;
 	text-align: inherit;

--- a/packages/block-library/src/accordion/style.scss
+++ b/packages/block-library/src/accordion/style.scss
@@ -10,6 +10,7 @@
 .accordion-content__heading {
 	margin-block-start: 0;
 	margin-block-end: 0;
+	overflow-x: hidden;
 }
 
 .accordion-content__toggle {


### PR DESCRIPTION
## What?
Closes #71437

Fixes the accordion toggle button overflow issue when the accordion block is set to full width alignment.

## Why?
When an Accordion block is set to full width and the Accordion Header is clicked to expand the panel, the rotated toggle button element overflows horizontally, causing an unwanted horizontal scrollbar to appear. This creates a poor user experience and visual inconsistency.

The issue was occurring because the accordion heading container didn't have proper overflow handling for the rotated toggle icon.

## How?
Added `overflow-x: hidden` to the `.accordion-content__toggle` CSS selector. This prevents the rotated toggle button from causing horizontal overflow while maintaining the visual rotation effect.

## Testing Instructions
1) Open a post or page in the editor
2) Insert an Accordion block
3) Select the accordion block and set its alignment to "Full width" using the alignment controls in the toolbar
4) Save and view the post on the frontend
5) Click on the Accordion Header to expand/collapse the panel
6) Verify that no horizontal scrollbar appears when the toggle button rotates

## Screenshots or screencast 
### Before
<img width="1470" height="956" alt="Before" src="https://github.com/user-attachments/assets/be917971-762d-4408-aa5d-ede5d84385dc" />

### After
<img width="1470" height="956" alt="After" src="https://github.com/user-attachments/assets/0aecb51e-1e0b-4dd4-926e-d4abbded3af8" />
