### PR TITLE
Add LinkControl search input to navigation link block sidebar (WIP)

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -85,6 +85,7 @@ $block-editor-link-control-number-of-actions: 1;
 .block-editor-link-control__search-results-wrapper {
 	position: absolute;
 	z-index: 1;
+	width: 100%;
 	background: $white;
 	border: 1px solid $gray-300;
 	border-top: none;

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -83,7 +83,12 @@ $block-editor-link-control-number-of-actions: 1;
 }
 
 .block-editor-link-control__search-results-wrapper {
-	position: relative;
+	position: absolute;
+	z-index: 1;
+	background: $white;
+	border: 1px solid $gray-300;
+	border-top: none;
+	margin-top: -1px;
 
 	&::before,
 	&::after {
@@ -109,8 +114,16 @@ $block-editor-link-control-number-of-actions: 1;
 	}
 }
 
+// Use relative positioning within popovers
+.components-popover .block-editor-link-control__search-results-wrapper {
+	position: relative;
+	// undo the properties
+	background: transparent;
+	border: none;
+	margin-top: auto;
+}
+
 .block-editor-link-control__search-results {
-	margin-top: -$grid-unit-20;
 	padding: $grid-unit-10;
 	max-height: 200px;
 	overflow-y: auto; // allow results list to scroll
@@ -118,6 +131,11 @@ $block-editor-link-control-number-of-actions: 1;
 	&.is-loading {
 		opacity: 0.2;
 	}
+}
+
+// Only apply negative margin when within a popover
+.components-popover .block-editor-link-control__search-results {
+	margin-top: -$grid-unit-20;
 }
 
 .block-editor-link-control__search-item {

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -16,6 +16,7 @@ import {
 	Spinner,
 	withSpokenMessages,
 	Popover,
+	withFocusOutside,
 } from '@wordpress/components';
 import {
 	compose,
@@ -69,6 +70,7 @@ class URLInput extends Component {
 			selectedSuggestion: null,
 			suggestionsListboxId: '',
 			suggestionOptionIdPrefix: '',
+			hasFocus: false,
 		};
 	}
 
@@ -123,8 +125,11 @@ class URLInput extends Component {
 	shouldShowInitialSuggestions() {
 		const { __experimentalShowInitialSuggestions = false, value } =
 			this.props;
+		const { hasFocus } = this.state;
 		return (
-			__experimentalShowInitialSuggestions && ! ( value && value.length )
+			__experimentalShowInitialSuggestions &&
+			hasFocus &&
+			! ( value && value.length )
 		);
 	}
 
@@ -240,6 +245,13 @@ class URLInput extends Component {
 	}
 
 	onFocus() {
+		this.setState( { hasFocus: true }, () => {
+			// Check if we should show initial suggestions after state has updated
+			if ( this.shouldShowInitialSuggestions() ) {
+				this.updateSuggestions();
+			}
+		} );
+
 		const { suggestions } = this.state;
 		const { disableSuggestions, value } = this.props;
 
@@ -375,6 +387,15 @@ class URLInput extends Component {
 		this.selectLink( suggestion );
 		// Move focus to the input field when a link suggestion is clicked.
 		this.inputRef.current.focus();
+	}
+
+	handleFocusOutside() {
+		// Focus has truly left the component - hide suggestions
+		this.setState( {
+			hasFocus: false,
+			showSuggestions: false,
+			selectedSuggestion: null,
+		} );
 	}
 
 	static getDerivedStateFromProps(
@@ -577,5 +598,6 @@ export default compose(
 			__experimentalFetchLinkSuggestions:
 				getSettings().__experimentalFetchLinkSuggestions,
 		};
-	} )
+	} ),
+	withFocusOutside
 )( URLInput );

--- a/packages/block-editor/src/components/url-input/style.scss
+++ b/packages/block-editor/src/components/url-input/style.scss
@@ -9,11 +9,6 @@ $input-size: 300px;
 	position: relative;
 	padding: 1px;
 
-	@include break-small() {
-		min-width: $input-size;
-		width: auto;
-	}
-
 	&.is-full-width {
 		width: 100%;
 
@@ -27,6 +22,15 @@ $input-size: 300px;
 		margin: 0;
 		top: calc(50% - #{$spinner-size} / 2);
 		right: $grid-unit;
+	}
+}
+
+// Only apply min-width to URL inputs within popovers or block list blocks
+.block-editor-block-list__block .block-editor-url-input,
+.components-popover .block-editor-url-input {
+	@include break-small() {
+		min-width: $input-size;
+		width: auto;
 	}
 }
 

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -53,6 +53,7 @@ import TabbedSidebar from './components/tabbed-sidebar';
 import CommentIconSlotFill from './components/collab/block-comment-icon-slot';
 import CommentIconToolbarSlotFill from './components/collab/block-comment-icon-toolbar-slot';
 import HTMLElementControl from './components/html-element-control';
+import LinkControlSearchInput from './components/link-control/search-input';
 /**
  * Private @wordpress/block-editor APIs.
  */
@@ -103,4 +104,5 @@ lock( privateApis, {
 	CommentIconToolbarSlotFill,
 	mediaEditKey,
 	essentialFormatKey,
+	LinkControlSearchInput,
 } );

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -200,7 +200,9 @@ function Controls( { attributes, setAttributes, setIsEditingControl } ) {
 	const [ localUrl, setLocalUrl ] = useState( '' );
 
 	// Use URL prop as the display value, local state only for current input
-	const displayUrl = localUrl || url || '';
+	// For initial suggestions to work properly, we need to distinguish between
+	// "no URL set" (undefined) and "empty URL input" (empty string)
+	const displayUrl = localUrl || url || undefined;
 	return (
 		<ToolsPanel
 			label={ __( 'Settings' ) }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -33,8 +33,9 @@ import {
 	getColorClassName,
 	useInnerBlocksProps,
 	useBlockEditingMode,
-	__experimentalLinkControlSearchInput as LinkControlSearchInput,
+	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
+
 import { isURL, prependHTTP } from '@wordpress/url';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
@@ -54,6 +55,10 @@ import { LinkUI } from './link-ui';
 import { updateAttributes } from './update-attributes';
 import { getColors } from '../navigation/edit/utils';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+import { unlock } from '../lock-unlock';
+
+// Extract the private API component
+const { LinkControlSearchInput } = unlock( blockEditorPrivateApis );
 
 const DEFAULT_BLOCK = { name: 'core/navigation-link' };
 const NESTING_BLOCK_NAMES = [

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -33,7 +33,7 @@ import {
 	getColorClassName,
 	useInnerBlocksProps,
 	useBlockEditingMode,
-	__experimentalLinkControlSearchInput,
+	__experimentalLinkControlSearchInput as LinkControlSearchInput,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
 import { useState, useEffect, useRef } from '@wordpress/element';
@@ -241,7 +241,7 @@ function Controls( { attributes, setAttributes, setIsEditingControl } ) {
 				onDeselect={ () => setAttributes( { url: '' } ) }
 				isShownByDefault
 			>
-				<__experimentalLinkControlSearchInput
+				<LinkControlSearchInput
 					value={ displayUrl }
 					onChange={ ( newUrl ) => {
 						setLocalUrl( newUrl );

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -9,6 +9,10 @@ import clsx from 'clsx';
 import { createBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
+	store as coreStore,
+	useResourcePermissions,
+} from '@wordpress/core-data';
+import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	CheckboxControl,
@@ -16,6 +20,7 @@ import {
 	TextareaControl,
 	ToolbarButton,
 	ToolbarGroup,
+	Button,
 } from '@wordpress/components';
 import { displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
@@ -28,13 +33,18 @@ import {
 	getColorClassName,
 	useInnerBlocksProps,
 	useBlockEditingMode,
+	__experimentalLinkControlSearchInput,
 } from '@wordpress/block-editor';
-import { isURL, prependHTTP, safeDecodeURI } from '@wordpress/url';
+import { isURL, prependHTTP } from '@wordpress/url';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { decodeEntities } from '@wordpress/html-entities';
-import { link as linkIcon, addSubmenu } from '@wordpress/icons';
-import { store as coreStore } from '@wordpress/core-data';
+import {
+	link as linkIcon,
+	addSubmenu,
+	keyboardReturn,
+	closeSmall,
+} from '@wordpress/icons';
 import { useMergeRefs, usePrevious } from '@wordpress/compose';
 
 /**
@@ -177,8 +187,20 @@ function getMissingText( type ) {
  */
 function Controls( { attributes, setAttributes, setIsEditingControl } ) {
 	const { label, url, description, rel, opensInNewTab } = attributes;
-	const lastURLRef = useRef( url );
+
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+	const { saveEntityRecord } = useDispatch( coreStore );
+	const postType = attributes.type || 'page';
+	const permissions = useResourcePermissions( {
+		kind: 'postType',
+		name: postType,
+	} );
+
+	// Local state for URL input - only used for current input value
+	const [ localUrl, setLocalUrl ] = useState( '' );
+
+	// Use URL prop as the display value, local state only for current input
+	const displayUrl = localUrl || url || '';
 	return (
 		<ToolsPanel
 			label={ __( 'Settings' ) }
@@ -219,31 +241,103 @@ function Controls( { attributes, setAttributes, setIsEditingControl } ) {
 				onDeselect={ () => setAttributes( { url: '' } ) }
 				isShownByDefault
 			>
-				<TextControl
-					__nextHasNoMarginBottom
-					__next40pxDefaultSize
-					label={ __( 'Link' ) }
-					value={ url ? safeDecodeURI( url ) : '' }
-					onChange={ ( urlValue ) => {
-						setAttributes( {
-							url: encodeURI( safeDecodeURI( urlValue ) ),
-						} );
+				<__experimentalLinkControlSearchInput
+					value={ displayUrl }
+					onChange={ ( newUrl ) => {
+						setLocalUrl( newUrl );
 					} }
-					autoComplete="off"
-					type="url"
-					onFocus={ () => {
-						lastURLRef.current = url;
-						setIsEditingControl( true );
-					} }
-					onBlur={ () => {
-						// Defer the updateAttributes call to ensure entity connection isn't severed by accident.
+					onSelect={ ( suggestion ) => {
+						// Clear local state and commit to block attributes
+						setLocalUrl( '' );
 						updateAttributes(
-							{ url: ! url ? lastURLRef.current : url },
+							suggestion,
 							setAttributes,
-							{ ...attributes, url: lastURLRef.current }
+							attributes
 						);
-						setIsEditingControl( false );
 					} }
+					currentLink={ attributes }
+					showSuggestions
+					showInitialSuggestions
+					withCreateSuggestion={ permissions.canCreate }
+					onCreateSuggestion={ async ( pageTitle ) => {
+						const suggestionPostType = attributes.type || 'page';
+
+						const page = await saveEntityRecord(
+							'postType',
+							suggestionPostType,
+							{
+								title: pageTitle,
+								status: 'draft',
+							}
+						);
+
+						return {
+							id: page.id,
+							type: suggestionPostType,
+							title: page.title.rendered,
+							url: page.link,
+							kind: 'post-type',
+						};
+					} }
+					suggestionsQuery={ ( () => {
+						const { type, kind } = attributes;
+						switch ( type ) {
+							case 'post':
+							case 'page':
+								return { type: 'post', subtype: type };
+							case 'category':
+								return { type: 'term', subtype: 'category' };
+							case 'tag':
+								return { type: 'term', subtype: 'post_tag' };
+							case 'post_format':
+								return { type: 'post-format' };
+							default:
+								if ( kind === 'taxonomy' ) {
+									return { type: 'term', subtype: type };
+								}
+								if ( kind === 'post-type' ) {
+									return { type: 'post', subtype: type };
+								}
+								return {
+									initialSuggestionsSearchOptions: {
+										type: 'post',
+										subtype: 'page',
+										perPage: 20,
+									},
+								};
+						}
+					} )() }
+					suffix={
+						<Button
+							__next40pxDefaultSize
+							variant="secondary"
+							icon={ url ? closeSmall : keyboardReturn }
+							disabled={
+								url
+									? false
+									: ! localUrl.trim() || localUrl === url
+							}
+							accessibleWhenDisabled
+							onClick={ () => {
+								if ( url ) {
+									// Reset: clear both local state and block attribute
+									setLocalUrl( '' );
+									setAttributes( { url: '' } );
+								} else if ( localUrl.trim() ) {
+									// Submit the manually entered URL
+									updateAttributes(
+										{ url: localUrl },
+										setAttributes,
+										attributes
+									);
+									setLocalUrl( '' );
+								}
+							} }
+							aria-label={
+								url ? __( 'Clear URL' ) : __( 'Apply URL' )
+							}
+						/>
+					}
 				/>
 			</ToolsPanelItem>
 


### PR DESCRIPTION
## What



This PR addresses the UX improvement request for the Navigation Link block by replacing the "static" `Link` field in the  inspector controls with a dynamic variant similar to the Link UI shown in the canvas. 

Fixes #48072: Add LinkControl search input to navigation link block sidebar

Also related to https://github.com/WordPress/gutenberg/issues/65699


## Why

The current navigation link block shows different UIs depending on context - a popover for initial link creation and separate inspector fields for editing. 

This creates a confusing and inconsistent user experience. The issue #48072 describes this in more detail.

By integrating the LinkControl search input directly into the inspector controls, users get a consistent, unified interface for both creating and editing links with search, suggestions, and rich previews.



## How

- Replace Text, Link, and Open in new tab ToolsPanelItems with LinkControlSearchInput
- Add submit button with keyboardReturn icon for manual URL entry
- Add reset button with closeSmall icon when URL exists
- Update CSS to make search results work properly in sidebar context
- Only apply 300px min-width to URL inputs in popovers/block list blocks
- Use absolute positioning for search results in non-popover contexts
- Add white background and border styling for search results in sidebar

## Testing

1. Add a navigation link block to a page
2. Open the block settings sidebar
3. Verify the Link field shows a search input with suggestions
4. Test entering a URL manually and clicking the submit button
5. Test selecting a suggestion from the dropdown
6. Test the reset button when a URL is present
7. Verify search results appear properly positioned in the sidebar

## Screenshots



https://github.com/user-attachments/assets/5552fc5a-863a-4913-8876-1dfc33b448f1



## Breaking Changes

None - this is an enhancement that maintains existing functionality.

## Follow ups

This approach should be extended to navigation submenu block.