### PR TITLE
Storybook: Set `DateCalendar` and `DateRangeCalendar` components as private.

### DIFF
--- a/packages/components/src/calendar/stories/date-calendar.story.tsx
+++ b/packages/components/src/calendar/stories/date-calendar.story.tsx
@@ -35,6 +35,7 @@ import { DateCalendar, TZDate } from '..';
 const meta: Meta< typeof DateCalendar > = {
 	title: 'Components/Selection & Input/Time & Date/DateCalendar',
 	component: DateCalendar,
+	tags: [ 'status-private' ],
 	argTypes: {
 		locale: {
 			options: [

--- a/packages/components/src/calendar/stories/date-range-calendar.story.tsx
+++ b/packages/components/src/calendar/stories/date-range-calendar.story.tsx
@@ -34,6 +34,7 @@ import { DateRangeCalendar, TZDate } from '..';
 const meta: Meta< typeof DateRangeCalendar > = {
 	title: 'Components/Selection & Input/Time & Date/DateRangeCalendar',
 	component: DateRangeCalendar,
+	tags: [ 'status-private' ],
 	argTypes: {
 		locale: {
 			options: [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

I was trying out a few components on a separate project, and I didn't realized `DateCalendar` and `DateRangeCalendar` were private as it wasn't highlighted in storybook.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Run `nvm use && npm run storybook:dev`
2. Open the storybook locally.
3. Check the `DateCalendar` and `DateRangeCalendar` stories.

## Screenshots or screencast <!-- if applicable -->

<img width="1924" height="806" alt="Screenshot 2025-09-01 at 19 28 10" src="https://github.com/user-attachments/assets/9243fc7d-475e-4e6f-a655-03e6d8aab710" />
