### PR TITLE
Accordion Panel: Remove unnecessary wrapper div and simplify save 

### DIFF
--- a/packages/block-library/src/accordion-panel/edit.js
+++ b/packages/block-library/src/accordion-panel/edit.js
@@ -7,16 +7,15 @@ export default function Edit( { attributes } ) {
 	const { allowedBlocks, templateLock, openByDefault, isSelected } =
 		attributes;
 
-	const blockProps = useBlockProps();
-	const innerBlocksProps = useInnerBlocksProps( {
+	const blockProps = useBlockProps( {
+		'aria-hidden': ! isSelected && ! openByDefault,
+	} );
+
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks,
 		template: [ [ 'core/paragraph', {} ] ],
 		templateLock,
 	} );
 
-	return (
-		<div { ...blockProps } aria-hidden={ ! isSelected && ! openByDefault }>
-			<div { ...innerBlocksProps } />
-		</div>
-	);
+	return <div { ...innerBlocksProps } />;
 }

--- a/packages/block-library/src/accordion-panel/edit.js
+++ b/packages/block-library/src/accordion-panel/edit.js
@@ -1,60 +1,21 @@
 /**
  * WordPress dependencies
  */
-import {
-	useBlockProps,
-	useInnerBlocksProps,
-	__experimentalUseBorderProps as useBorderProps,
-	__experimentalUseColorProps as useColorProps,
-	__experimentalGetSpacingClassesAndStyles as useSpacingProps,
-	__experimentalGetShadowClassesAndStyles as useShadowProps,
-} from '@wordpress/block-editor';
-/**
- * External dependencies
- */
-import clsx from 'clsx';
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
 export default function Edit( { attributes } ) {
 	const { allowedBlocks, templateLock, openByDefault, isSelected } =
 		attributes;
-	const borderProps = useBorderProps( attributes );
-	const colorProps = useColorProps( attributes );
-	const spacingProps = useSpacingProps( attributes );
-	const shadowProps = useShadowProps( attributes );
 
 	const blockProps = useBlockProps();
-	const innerBlocksProps = useInnerBlocksProps(
-		{
-			className: 'accordion-content__wrapper',
-			style: {
-				...spacingProps.style,
-			},
-		},
-		{
-			allowedBlocks,
-			template: [ [ 'core/paragraph', {} ] ],
-			templateLock,
-		}
-	);
+	const innerBlocksProps = useInnerBlocksProps( {
+		allowedBlocks,
+		template: [ [ 'core/paragraph', {} ] ],
+		templateLock,
+	} );
 
 	return (
-		<div
-			{ ...blockProps }
-			className={ clsx(
-				blockProps.className,
-				colorProps.className,
-				borderProps.className,
-				{
-					[ `has-custom-font-size` ]: blockProps?.style?.fontSize,
-				}
-			) }
-			style={ {
-				...borderProps.style,
-				...colorProps.style,
-				...shadowProps.style,
-			} }
-			aria-hidden={ ! isSelected && ! openByDefault }
-		>
+		<div { ...blockProps } aria-hidden={ ! isSelected && ! openByDefault }>
 			<div { ...innerBlocksProps } />
 		</div>
 	);

--- a/packages/block-library/src/accordion-panel/save.js
+++ b/packages/block-library/src/accordion-panel/save.js
@@ -1,51 +1,10 @@
 /**
  * WordPress dependencies
  */
-import {
-	InnerBlocks,
-	useBlockProps,
-	__experimentalGetBorderClassesAndStyles as getBorderClassesAndStyles,
-	__experimentalGetColorClassesAndStyles as getColorClassesAndStyles,
-	__experimentalGetSpacingClassesAndStyles as getSpacingClassesAndStyles,
-	__experimentalGetShadowClassesAndStyles as getShadowClassesAndStyles,
-} from '@wordpress/block-editor';
-/**
- * External dependencies
- */
-import clsx from 'clsx';
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
-export default function save( { attributes } ) {
+export default function save() {
 	const blockProps = useBlockProps.save();
-	const borderProps = getBorderClassesAndStyles( attributes );
-	const colorProps = getColorClassesAndStyles( attributes );
-	const spacingProps = getSpacingClassesAndStyles( attributes );
-	const shadowProps = getShadowClassesAndStyles( attributes );
-
-	return (
-		<div
-			{ ...blockProps }
-			className={ clsx(
-				blockProps.className,
-				colorProps.className,
-				borderProps.className,
-				{
-					[ `has-custom-font-size` ]: blockProps?.style?.fontSize,
-				}
-			) }
-			style={ {
-				...borderProps.style,
-				...colorProps.style,
-				...shadowProps.style,
-			} }
-		>
-			<div
-				className="accordion-content__wrapper"
-				style={ {
-					...spacingProps.style,
-				} }
-			>
-				<InnerBlocks.Content />
-			</div>
-		</div>
-	);
+	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
+	return <div { ...innerBlocksProps } />;
 }


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/71436

Removes the unnecessary `accordion-content__wrapper` div from the Accordion Panel block and simplifies the edit and save function.



## Why?

The Accordion Panel block was generating redundant HTML markup with an extra wrapper div that served no functional purpose. There was also some complexity with the save function, with manual styling extraction.


## How?

Replaced manual styling extraction with the standard `useBlockProps.save()` pattern that automatically handles all declared block supports (color, spacing, border, typography, shadow).

## Testing Instructions

- Insert an Accordion block
- Add content to the Accordion Panel
- Apply various styling options like - Background colors, Text colors, Padding/margins, Borders, and border radius, Typography settings
- Save and view the post on the frontend
- Inspect the HTML output - verify there's no extra  div
- Confirm all styling is still applied correctly to the main block wrapper


## Screencasts 

### Before 


https://github.com/user-attachments/assets/e7d18626-146b-478c-bccb-d7e90b88cad3




### After 


https://github.com/user-attachments/assets/4fe72588-3018-44e4-be3c-9f659d7c8359



