### PR TITLE
DataViews: Fix grid padding values on mobile viewports

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 -   DataViews: Fix incorrect documentation for `defaultLayouts` prop. [#71334](https://github.com/WordPress/gutenberg/pull/71334)
+-   DataViews: Fix mismatched padding on mobile viewports for grid layout [#71455](https://github.com/WordPress/gutenberg/pull/71455)
 
 ## 7.0.0 (2025-08-20)
 

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -7,10 +7,10 @@
 	padding: 0 $grid-unit-60 $grid-unit-30;
 	container-type: inline-size;
 	/**
-	 * Breakpoints were adjusted from media queries breakpoints to account for
-	 * the sidebar width. This was done to match the existing styles we had.
+	 * Match the padding applied to other DataViews components at the same
+	 * max-width.
 	 */
-	@container (max-width: 480px) {
+	@container (max-width: 430px) {
 		padding-left: $grid-unit-30;
 		padding-right: $grid-unit-30;
 	}

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -162,4 +162,10 @@
 	color: $gray-900;
 	margin: 0 0 $grid-unit-10 0;
 	padding: 0 $grid-unit-60;
+	container-type: inline-size;
+
+	@container (max-width: 430px) {
+		padding-left: $grid-unit-30;
+		padding-right: $grid-unit-30;
+	}
 }


### PR DESCRIPTION
## What?
I noticed that the Grid layout in DataViews has some padding issues on mobile-ish viewports.

The Group By header has incorrect padding, since it's missing a container query.

I also noticed the container query that adjusts padding around the grid layout doesn't match the same values that the rest of DataViews uses.

The grid breaks at 480px, while DataViews components break at 430px. This can lead to a situation where the elements look misaligned. See:
https://github.com/WordPress/gutenberg/blob/6938b0bcd9484a3fed2a09bbead98a71f120b6f8/packages/dataviews/src/components/dataviews/style.scss#L44

## How?
Use 430px for the grid container queries.

Add a new container query for the group by header.

## Testing Instructions
1. `npm run storybook:dev`
2. Navigate to the default DataViews story.
3. Resize your viewport from desktop down to mobile size. Observe that the padding around UI elements should be consistent at all sizes. Compare this to `trunk` and you'll spot the inconsistencies.

## Screenshots or screencast <!-- if applicable -->

#### Before

<img width="472" height="633" alt="Screenshot 2025-09-02 at 3 40 41 pm" src="https://github.com/user-attachments/assets/07ae784c-43e2-42dc-9956-575b4dd926bb" />

#### After

<img width="410" height="541" alt="Screenshot 2025-09-02 at 3 46 59 pm" src="https://github.com/user-attachments/assets/7c33a406-7e21-460b-a4a0-3a15252e4513" />

