### PR TITLE
Navigation Block: Show pointer cursor for menu items without links

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -47,6 +47,10 @@ $navigation-icon-size: 24px;
 	.wp-block-navigation-item__content {
 		display: block;
 		z-index: 1;
+
+		&:not([href]) {
+			cursor: pointer;
+		}
 	}
 
 	// This rule needs extra specificity so that it inherits the correct color from its parent.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #55672

<!-- In a few words, what is the PR actually doing? -->
This PR updates the navigation block styles so that items without an href (such as submenu parents) display the pointer cursor on hover.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, navigation items without a link fall back to the text selection cursor. This creates an inconsistent and confusing user experience, since these items often serve as interactive submenu toggles. Showing the pointer cursor makes it clear to users that the item is interactive, even if it doesn’t navigate to a URL.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Updated `style.scss` for the navigation block to add `cursor: pointer` on the navigation item content that doesn't have any `href` attribute

## Testing Instructions
1. Create a parent menu item without a ULR (a submenu label).
2. View the frontend and hover over the parent item.
3. Cursor should display as a pointer, indicating interactivity.

<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="370" height="195" alt="Screenshot 2025-09-02 at 2 39 18 PM" src="https://github.com/user-attachments/assets/35daae78-ee91-4253-a731-dbcecfdfd952" />|<img width="400" height="183" alt="Screenshot 2025-09-02 at 2 37 34 PM" src="https://github.com/user-attachments/assets/70b81e0d-85e9-4cea-b263-25978fd0c32e" />|
