### PR TITLE
Experimental: Replace URLInput with ComboboxControl in LinkControl

### DIFF
--- a/packages/block-editor/src/components/link-control/combobox-search-input.js
+++ b/packages/block-editor/src/components/link-control/combobox-search-input.js
@@ -1,0 +1,220 @@
+/**
+ * WordPress dependencies
+ */
+import { forwardRef, useState, useMemo, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { ComboboxControl } from '@wordpress/components';
+import { debounce } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import LinkControlSearchItem from './search-item';
+
+/**
+ * Internal dependencies
+ */
+
+import { CREATE_TYPE } from './constants';
+import useSearchHandler from './use-search-handler';
+
+// Must be a function as otherwise URLInput will default
+// to the fetchLinkSuggestions passed in block editor settings
+// which will cause an unintended http request.
+const noopSearchHandler = () => Promise.resolve( [] );
+
+const noop = () => {};
+
+const ComboboxLinkControlSearchInput = forwardRef(
+	(
+		{
+			value,
+			children,
+			currentLink = {},
+			className = null,
+			placeholder = null,
+			withCreateSuggestion = false,
+			onCreateSuggestion = noop,
+			onChange = noop,
+			onSelect = noop,
+			showSuggestions = true,
+			fetchSuggestions = null,
+			allowDirectEntry = true,
+			suggestionsQuery = {},
+			withURLSuggestion = true,
+			hideLabelFromVision = false,
+		},
+		ref
+	) => {
+		const genericSearchHandler = useSearchHandler(
+			suggestionsQuery,
+			allowDirectEntry,
+			withCreateSuggestion,
+			withURLSuggestion
+		);
+
+		const searchHandler = showSuggestions
+			? fetchSuggestions || genericSearchHandler
+			: noopSearchHandler;
+
+		const [ suggestions, setSuggestions ] = useState( [] );
+		const [ isLoading, setIsLoading ] = useState( false );
+
+		// Ensure we have a value, either from props or currentLink
+		const displayValue = value || currentLink?.url || '';
+
+		// Transform suggestions to ComboboxControl options format
+		const options = useMemo( () => {
+			const suggestionOptions = suggestions.map( ( suggestion ) => ( {
+				label: suggestion.title || suggestion.url,
+				value: suggestion.url,
+				suggestion, // Keep original suggestion data for onSelect
+			} ) );
+
+			// If we have a current value but no suggestions, add it as an option
+			if ( displayValue && ! suggestions.length ) {
+				suggestionOptions.push( {
+					label: displayValue,
+					value: displayValue,
+					suggestion: { url: displayValue, title: displayValue }, // Create a basic suggestion object
+				} );
+			}
+
+			return suggestionOptions;
+		}, [ suggestions, displayValue ] );
+
+		// Debounced search function to prevent aggressive re-rendering
+		const debouncedSearch = useCallback(
+			debounce( async ( inputValue, isInitial = false ) => {
+				if ( ! showSuggestions ) {
+					return;
+				}
+
+				setIsLoading( true );
+				try {
+					const results = await searchHandler( inputValue, {
+						isInitialSuggestions: isInitial,
+					} );
+					setSuggestions( results );
+				} catch ( error ) {
+					setSuggestions( [] );
+				} finally {
+					setIsLoading( false );
+				}
+			}, 500 ),
+			[ searchHandler, showSuggestions ]
+		);
+
+		// Handle search input changes
+		const handleInputChange = ( inputValue ) => {
+			onChange( inputValue );
+
+			if ( ! showSuggestions || ! inputValue?.trim() ) {
+				setSuggestions( [] );
+				return;
+			}
+
+			// Only search if input has at least 3 characters
+			if ( inputValue.trim().length < 3 ) {
+				setSuggestions( [] );
+				return;
+			}
+
+			// Use debounced search to prevent aggressive re-rendering
+			debouncedSearch( inputValue, false );
+		};
+
+		// Handle input focus - show initial suggestions
+		const handleFocus = () => {
+			if ( ! showSuggestions ) {
+				return;
+			}
+
+			// Use debounced search for initial suggestions
+			debouncedSearch( '', true );
+		};
+
+		// Handle option selection
+		const handleOptionSelect = async ( selectedValue ) => {
+			const selectedOption = options.find(
+				( option ) => option.value === selectedValue
+			);
+
+			if ( ! selectedOption ) {
+				// Handle direct entry
+				if ( allowDirectEntry && selectedValue ) {
+					onSelect( { url: selectedValue } );
+				}
+				return;
+			}
+
+			const suggestion = selectedOption.suggestion;
+
+			if ( CREATE_TYPE === suggestion.type ) {
+				// Create a new page and call onSelect with the output from the onCreateSuggestion callback.
+				try {
+					const newSuggestion = await onCreateSuggestion(
+						suggestion.title
+					);
+					if ( newSuggestion?.url ) {
+						onSelect( newSuggestion );
+					}
+				} catch ( e ) {}
+				return;
+			}
+
+			if ( suggestion && Object.keys( suggestion ).length >= 1 ) {
+				const { id, url, ...restLinkProps } = currentLink ?? {};
+				onSelect(
+					// Some direct entries don't have types or IDs, and we still need to clear the previous ones.
+					{ ...restLinkProps, ...suggestion },
+					suggestion
+				);
+			}
+		};
+
+		const _placeholder = placeholder ?? __( 'Search or type URL' );
+		const label =
+			hideLabelFromVision && placeholder !== ''
+				? _placeholder
+				: __( 'Link' );
+
+		return (
+			<div className="block-editor-link-control__search-input-container">
+				<ComboboxControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ label }
+					value={ displayValue }
+					options={ options }
+					onFilterValueChange={ handleInputChange }
+					onChange={ handleOptionSelect }
+					onFocus={ handleFocus }
+					placeholder={ _placeholder }
+					allowReset={ !! displayValue }
+					onReset={ () => {
+						onChange( '' );
+						onSelect( { url: '' } );
+						setSuggestions( [] ); // Clear suggestions so current value isn't shown as an option
+					} }
+					className={ className }
+					ref={ ref }
+					expandOnFocus={ false }
+					isLoading={ isLoading }
+					__experimentalRenderItem={ ( { item } ) => (
+						<LinkControlSearchItem
+							suggestion={ item.suggestion }
+							searchTerm={ displayValue }
+							onClick={ () => handleOptionSelect( item.value ) }
+							isURL={ false }
+							shouldShowType
+						/>
+					) }
+				/>
+				{ children }
+			</div>
+		);
+	}
+);
+
+export default ComboboxLinkControlSearchInput;

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -28,6 +28,7 @@ import { keyboardReturn } from '@wordpress/icons';
  */
 import LinkControlSettingsDrawer from './settings-drawer';
 import LinkControlSearchInput from './search-input';
+import ComboboxLinkControlSearchInput from './combobox-search-input';
 import LinkPreview from './link-preview';
 import LinkSettings from './settings';
 import useCreatePage from './use-create-page';
@@ -142,6 +143,7 @@ function LinkControl( {
 	hasRichPreviews = false,
 	hasTextControl = false,
 	renderControlBottom = null,
+	__nextSearchControl = false,
 } ) {
 	if ( withCreateSuggestion === undefined && createSuggestion ) {
 		withCreateSuggestion = true;
@@ -388,41 +390,69 @@ function LinkControl( {
 								__next40pxDefaultSize
 							/>
 						) }
-						<LinkControlSearchInput
-							currentLink={ value }
-							className="block-editor-link-control__field block-editor-link-control__search-input"
-							placeholder={ searchInputPlaceholder }
-							value={ currentUrlInputValue }
-							withCreateSuggestion={ withCreateSuggestion }
-							onCreateSuggestion={ createPage }
-							onChange={ setInternalURLInputValue }
-							onSelect={ handleSelectSuggestion }
-							showInitialSuggestions={ showInitialSuggestions }
-							allowDirectEntry={ ! noDirectEntry }
-							showSuggestions={ showSuggestions }
-							suggestionsQuery={ suggestionsQuery }
-							withURLSuggestion={ ! noURLSuggestion }
-							createSuggestionButtonText={
-								createSuggestionButtonText
-							}
-							hideLabelFromVision={ ! showTextControl }
-							suffix={
-								showActions ? undefined : (
-									<InputControlSuffixWrapper variant="control">
-										<Button
-											onClick={
-												isDisabled ? noop : handleSubmit
-											}
-											label={ __( 'Submit' ) }
-											icon={ keyboardReturn }
-											className="block-editor-link-control__search-submit"
-											aria-disabled={ isDisabled }
-											size="small"
-										/>
-									</InputControlSuffixWrapper>
-								)
-							}
-						/>
+						{ __nextSearchControl ? (
+							<ComboboxLinkControlSearchInput
+								currentLink={ value }
+								className="block-editor-link-control__field block-editor-link-control__search-input"
+								placeholder={ searchInputPlaceholder }
+								value={ currentUrlInputValue }
+								withCreateSuggestion={ withCreateSuggestion }
+								onCreateSuggestion={ createPage }
+								onChange={ setInternalURLInputValue }
+								onSelect={ handleSelectSuggestion }
+								showInitialSuggestions={
+									showInitialSuggestions
+								}
+								allowDirectEntry={ ! noDirectEntry }
+								showSuggestions={ showSuggestions }
+								suggestionsQuery={ suggestionsQuery }
+								withURLSuggestion={ ! noURLSuggestion }
+								createSuggestionButtonText={
+									createSuggestionButtonText
+								}
+								hideLabelFromVision={ ! showTextControl }
+							/>
+						) : (
+							<LinkControlSearchInput
+								currentLink={ value }
+								className="block-editor-link-control__field block-editor-link-control__search-input"
+								placeholder={ searchInputPlaceholder }
+								value={ currentUrlInputValue }
+								withCreateSuggestion={ withCreateSuggestion }
+								onCreateSuggestion={ createPage }
+								onChange={ setInternalURLInputValue }
+								onSelect={ handleSelectSuggestion }
+								showInitialSuggestions={
+									showInitialSuggestions
+								}
+								allowDirectEntry={ ! noDirectEntry }
+								showSuggestions={ showSuggestions }
+								suggestionsQuery={ suggestionsQuery }
+								withURLSuggestion={ ! noURLSuggestion }
+								createSuggestionButtonText={
+									createSuggestionButtonText
+								}
+								hideLabelFromVision={ ! showTextControl }
+								suffix={
+									showActions ? undefined : (
+										<InputControlSuffixWrapper variant="control">
+											<Button
+												onClick={
+													isDisabled
+														? noop
+														: handleSubmit
+												}
+												label={ __( 'Submit' ) }
+												icon={ keyboardReturn }
+												className="block-editor-link-control__search-submit"
+												aria-disabled={ isDisabled }
+												size="small"
+											/>
+										</InputControlSuffixWrapper>
+									)
+								}
+							/>
+						) }
 					</div>
 					{ errorMessage && (
 						<Notice

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -226,6 +226,7 @@ function UnforwardedLinkUI( props, ref ) {
 						</p>
 					</VisuallyHidden>
 					<LinkControl
+						__nextSearchControl
 						hasTextControl
 						hasRichPreviews
 						value={ link }


### PR DESCRIPTION
## What

This is an experimental proof-of-concept to replace the dated URLInput component with the modern ComboboxControl within LinkControl.

Related to https://github.com/WordPress/gutenberg/pull/71452

## Why

- URLInput is dated and not well maintained
- ComboboxControl provides a more modern, maintained foundation
- Better performance with debounced search (500ms delay)
- Improved user experience with proper value handling

## How

- Created new ComboboxLinkControlSearchInput component
- Added __nextSearchControl prop to LinkControl for opt-in usage
- Integrated with Navigation Link block for testing
- Implemented debounced search to prevent aggressive re-rendering
- Added proper fallback value handling from currentLink.url

## Testing

Test with Navigation Link block:
1. Add a navigation link
2. Click edit on the link
3. Verify the new search input appears and works correctly
4. Check that existing links display their values properly

## Screenshots



https://github.com/user-attachments/assets/605c0815-0050-4960-a0a7-71df30e7da49



## Notes

This is experimental work to evaluate if ComboboxControl can effectively replace URLInput. The implementation includes:
- 500ms debounce for search input
- Proper loading states
- Consistent rendering with LinkControlSearchItem
- Fallback value handling for existing links