### PR TITLE
api-fetch: clean up error handling

### DIFF
--- a/packages/api-fetch/src/middlewares/media-upload.ts
+++ b/packages/api-fetch/src/middlewares/media-upload.ts
@@ -63,9 +63,9 @@ const mediaUploadMiddleware: APIFetchMiddleware = ( options, next ) => {
 	};
 
 	return next( { ...options, parse: false } )
-		.catch( ( response ) => {
+		.catch( ( response: Response ) => {
 			// `response` could actually be an error thrown by `defaultFetchHandler`.
-			if ( ! response.headers ) {
+			if ( ! ( response instanceof globalThis.Response ) ) {
 				return Promise.reject( response );
 			}
 
@@ -92,7 +92,7 @@ const mediaUploadMiddleware: APIFetchMiddleware = ( options, next ) => {
 			}
 			return parseAndThrowError( response, options.parse );
 		} )
-		.then( ( response ) =>
+		.then( ( response: Response ) =>
 			parseResponseAndNormalizeError( response, options.parse )
 		);
 };


### PR DESCRIPTION
This PR (and also #71439) is inspired by @mcsf comment in https://github.com/WordPress/gutenberg/issues/67141#issuecomment-3213916271:

> IIRC, most of api-fetch's development happened early on in Gutenberg's history and it could use more love.

Here I'm trying to deliver some love for `api-fetch` 🙂

1. Clean up error handling in `defaultFetchHandler`. The current code is a bit chaotic: using promises in synchronous code, doing some unnecessary check or doing them twice...
2. Isolate unit tests from each other, so that middlewares registered in one test don't leak into other tests. In the current code we had to carefully choose the test order, and some tests depended on something done in a previous test.
3. Throw a better error when refreshing a nonce fails. And also adding unit tests for nonce refreshing.

I'll be adding much more detail in inline comments.