### PR TITLE
Feat: Add `blocks.syncType` filter for sync toggle

### DIFF
--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -18,6 +18,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -38,7 +39,8 @@ export default function ReusableBlockConvertButton( {
 	rootClientId,
 	onClose,
 } ) {
-	const [ syncType, setSyncType ] = useState( undefined );
+	const defaultSyncType = applyFilters( 'blocks.syncType', undefined );
+	const [ syncType, setSyncType ] = useState( defaultSyncType );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ title, setTitle ] = useState( '' );
 	const canConvert = useSelect(


### PR DESCRIPTION
## What?
Closes #71459 

This PR adds a custom filter `blocks.syncType` to the `wp_block` pattern post type.

## Why?

At the moment, when a new pattern is created, the synced toggle is forced into ON mode. This feels counter-intuitive for users who would prefer that this is OFF by default so that they can decide to toggle it ON if they wish so. Plus, there's no way of customising this whatsoever because the toggle value is hard-coded by default to `undefined`.

<img width="391" height="347" alt="Screenshot 2025-09-02 at 12 57 26" src="https://github.com/user-attachments/assets/b208d467-f03f-443b-a5df-77715c358463" />

## How?

This PR introduces a filter `blocks.syncType` to the `wp_block` pattern post type so that users can be able to correctly set the toggle's default state when a new pattern is created.