### PR TITLE
Accordion: Add BlockGap support to content & panel

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -28,7 +28,7 @@ Displays a section of content in an accordion, including a header and expandable
 -	**Category:** design
 -	**Parent:** core/accordion
 -	**Allowed Blocks:** core/accordion-header, core/accordion-panel
--	**Supports:** color (background, gradient, text), interactivity, shadow, spacing (blockGap, margin)
+-	**Supports:** color (background, gradient, text), interactivity, layout, shadow, spacing (blockGap, margin)
 -	**Attributes:** openByDefault
 
 ## Accordion Header
@@ -50,7 +50,7 @@ Displays an accordion panel. ([Source](https://github.com/WordPress/gutenberg/tr
 -	**Experimental:** true
 -	**Category:** design
 -	**Parent:** core/accordion-content
--	**Supports:** color (background, gradient, text), interactivity, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight)
+-	**Supports:** color (background, gradient, text), interactivity, layout, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight)
 -	**Attributes:** allowedBlocks, isSelected, openByDefault, templateLock
 
 ## Archives

--- a/packages/block-library/src/accordion-content/block.json
+++ b/packages/block-library/src/accordion-content/block.json
@@ -30,7 +30,8 @@
 				"width": true
 			}
 		},
-		"shadow": true
+		"shadow": true,
+		"layout": true
 	},
 	"attributes": {
 		"openByDefault": {

--- a/packages/block-library/src/accordion-content/edit.js
+++ b/packages/block-library/src/accordion-content/edit.js
@@ -7,7 +7,6 @@ import {
 	useInnerBlocksProps,
 	InspectorControls,
 	store as blockEditorStore,
-	__experimentalGetSpacingClassesAndStyles as useSpacingProps,
 } from '@wordpress/block-editor';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -29,7 +28,6 @@ import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 export default function Edit( { attributes, clientId, setAttributes } ) {
 	const { openByDefault } = attributes;
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
-	const spacingProps = useSpacingProps( attributes );
 
 	const { isSelected, getBlockOrder } = useSelect(
 		( select ) => {
@@ -66,33 +64,26 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 		updateBlockAttributes,
 	] );
 
-	const blockProps = useBlockProps();
-	const innerBlocksProps = useInnerBlocksProps(
-		{
-			...blockProps,
-			className: clsx( blockProps.className, {
-				'is-open': openByDefault || isSelected,
-			} ),
-			style: {
-				...blockProps.style,
-				...spacingProps.style,
-			},
-		},
-		{
-			template: [
-				[ 'core/accordion-header', {} ],
-				[
-					'core/accordion-panel',
-					{
-						openByDefault,
-					},
-				],
+	const blockProps = useBlockProps( {
+		className: clsx( {
+			'is-open': openByDefault || isSelected,
+		} ),
+	} );
+
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		template: [
+			[ 'core/accordion-header', {} ],
+			[
+				'core/accordion-panel',
+				{
+					openByDefault,
+				},
 			],
-			templateLock: 'all',
-			directInsert: true,
-			templateInsertUpdatesSelection: true,
-		}
-	);
+		],
+		templateLock: 'all',
+		directInsert: true,
+		templateInsertUpdatesSelection: true,
+	} );
 
 	return (
 		<>

--- a/packages/block-library/src/accordion-content/edit.js
+++ b/packages/block-library/src/accordion-content/edit.js
@@ -7,6 +7,7 @@ import {
 	useInnerBlocksProps,
 	InspectorControls,
 	store as blockEditorStore,
+	__experimentalGetSpacingClassesAndStyles as useSpacingProps,
 } from '@wordpress/block-editor';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -25,12 +26,10 @@ import clsx from 'clsx';
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
-export default function Edit( {
-	attributes: { openByDefault },
-	clientId,
-	setAttributes,
-} ) {
+export default function Edit( { attributes, clientId, setAttributes } ) {
+	const { openByDefault } = attributes;
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+	const spacingProps = useSpacingProps( attributes );
 
 	const { isSelected, getBlockOrder } = useSelect(
 		( select ) => {
@@ -74,6 +73,10 @@ export default function Edit( {
 			className: clsx( blockProps.className, {
 				'is-open': openByDefault || isSelected,
 			} ),
+			style: {
+				...blockProps.style,
+				...spacingProps.style,
+			},
 		},
 		{
 			template: [

--- a/packages/block-library/src/accordion-panel/block.json
+++ b/packages/block-library/src/accordion-panel/block.json
@@ -47,7 +47,8 @@
 				"fontSize": true
 			}
 		},
-		"shadow": true
+		"shadow": true,
+		"layout": true
 	},
 	"attributes": {
 		"allowedBlocks": {

--- a/packages/block-library/src/accordion/style.scss
+++ b/packages/block-library/src/accordion/style.scss
@@ -45,10 +45,10 @@
 	overflow: hidden;
 }
 
-// Override block spacing for closed accordion panels specifically.
-// Higher specificity to ensure it overrides block spacing margins.
-.wp-block-accordion-content:not(.is-open) > * + .wp-block-accordion-panel {
-	margin-block-start: 0 !important;
+// Prevent blockGap from Accordion Content block from adding extra margin between accordions.
+.wp-block-accordion-panel[inert],
+.wp-block-accordion-panel[aria-hidden="true"] {
+	margin-block-start: 0;
 }
 
 .accordion-panel__wrapper {

--- a/packages/block-library/src/accordion/style.scss
+++ b/packages/block-library/src/accordion/style.scss
@@ -44,7 +44,7 @@
 }
 
 // Prevent block spacing from affecting closed panels.
-.wp-block-accordion-panel:not(.is-open) {
+:where(.wp-block-accordion-panel:not(.is-open)) {
 	margin: 0;
 }
 

--- a/packages/block-library/src/accordion/style.scss
+++ b/packages/block-library/src/accordion/style.scss
@@ -43,6 +43,11 @@
 	margin: 0;
 }
 
+// Prevent block spacing from affecting closed panels.
+.wp-block-accordion-panel:not(.is-open) {
+	margin: 0;
+}
+
 .accordion-panel__wrapper {
 	padding-bottom: var(--wp--preset--spacing--20, 1em);
 }

--- a/packages/block-library/src/accordion/style.scss
+++ b/packages/block-library/src/accordion/style.scss
@@ -43,9 +43,10 @@
 	margin: 0;
 }
 
-// Prevent block spacing from affecting closed panels.
-:where(.wp-block-accordion-panel:not(.is-open)) {
-	margin: 0;
+// Override block spacing for closed accordion panels specifically.
+// Higher specificity to ensure it overrides block spacing margins.
+.wp-block-accordion-content:not(.is-open) > * + .wp-block-accordion-panel {
+	margin-block-start: 0 !important;
 }
 
 .accordion-panel__wrapper {

--- a/packages/block-library/src/accordion/style.scss
+++ b/packages/block-library/src/accordion/style.scss
@@ -13,11 +13,6 @@
 	}
 }
 
-:where(.accordion-content__heading) {
-	margin-block-start: 0;
-	margin-block-end: 0;
-}
-
 .accordion-content__toggle {
 	font-family: inherit;
 	font-size: inherit;
@@ -45,9 +40,9 @@
 	width: 100%;
 }
 
-:where(.is-layout-flow > .wp-block-accordion-panel, .wp-block-accordion-panel) {
+.is-layout-flow > .wp-block-accordion-panel,
+.wp-block-accordion-panel {
 	overflow: hidden;
-	margin: 0;
 }
 
 // Override block spacing for closed accordion panels specifically.

--- a/packages/block-library/src/accordion/style.scss
+++ b/packages/block-library/src/accordion/style.scss
@@ -7,7 +7,7 @@
 	grid-template-rows: max-content 1fr;
 }
 
-.accordion-content__heading {
+:where(.accordion-content__heading) {
 	margin-block-start: 0;
 	margin-block-end: 0;
 }
@@ -38,8 +38,7 @@
 	width: 100%;
 }
 
-.is-layout-flow > .wp-block-accordion-panel,
-.wp-block-accordion-panel {
+:where(.is-layout-flow > .wp-block-accordion-panel, .wp-block-accordion-panel) {
 	overflow: hidden;
 	margin: 0;
 }


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71433 

This PR fixes issue of block spacing setting not working for accordion content

## Why?
Currently, changing the value of Block spacing from Inspector doesn't have any effect. Ideally it should add block spacing styles to accordion content

## How?
This PR adds `layout` field to `block.json` for Accordion content & panel so that block spacing setting works
For `accordion-content` block, addtional handling via use of `useSpacingProps` was needed for blockGap changes to reflect
Styling specificity is modified so that the margin applied by blockSpacing settings of AccordionContent block don't affect the spacing when accordions are closed (this one is handled by spacing set by main parent Accordion block) & instead is only utilized for separation between Accordion header & panel.

## Testing Instructions
1. Enable experimental blocks
2. Create a new post or page
3. Insert Accordion block
4. Click the Accordion Content or Accordion Panel block.
5. Change the Block Spacing setting.
6. Observe the changes

## Screenshots or screencast <!-- if applicable -->

### Before


https://github.com/user-attachments/assets/88f8c4bf-d254-4066-927c-bbd2ba1b899f



### After


https://github.com/user-attachments/assets/ca34ee6f-8ea5-4832-afed-7bdb8227ca74

