### PR TITLE
Block Editor: Remove duplicate 'InsertionPointOpenRef' context definition

### DIFF
--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -7,12 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import {
-	useMemo,
-	createContext,
-	useReducer,
-	useLayoutEffect,
-} from '@wordpress/element';
+import { useMemo, useReducer, useLayoutEffect } from '@wordpress/element';
 import { Popover } from '@wordpress/components';
 import { isRTL } from '@wordpress/i18n';
 
@@ -24,9 +19,6 @@ import { useBlockElement } from '../block-list/use-block-props/use-block-refs';
 import usePopoverScroll from './use-popover-scroll';
 
 const MAX_POPOVER_RECOMPUTE_COUNTER = Number.MAX_SAFE_INTEGER;
-
-export const InsertionPointOpenRef = createContext();
-InsertionPointOpenRef.displayName = 'InsertionPointOpenRefContext';
 
 function BlockPopoverInbetween( {
 	previousClientId,


### PR DESCRIPTION
## What?

PR removes duplicated `InsertionPointOpenRef` context definition. I think this was a copy-paste accident in #40441.

The context is [consumed](https://github.com/search?q=repo%3AWordPress%2Fgutenberg%20InsertionPointOpenRef&type=code) from the `insertion-point.js` file.

## Testing Instructions
1. Open a post or a page.
2. Add multiple blocks.
3. Confirm that the in-between inserter works as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="762" height="539" alt="CleanShot 2025-09-02 at 20 36 19" src="https://github.com/user-attachments/assets/4f150242-9efb-4c00-8db9-e051422d687b" />

