### PR TITLE
Ability to modify the icon navigation link submenu icon

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -993,7 +993,9 @@ function block_core_navigation_build_css_font_sizes( $attributes ) {
  * @return string
  */
 function block_core_navigation_render_submenu_icon() {
-	return '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg>';
+	$icon = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg>';
+	// Make it filterable
+	return apply_filters( 'block_core_navigation_link_render_submenu_icon', $icon );
 }
 
 /**


### PR DESCRIPTION
## What?
Closes #[71449](https://github.com/WordPress/gutenberg/issues/71449)

This PR makes the submenu expander icon in the Navigation block filterable at the PHP render layer.
It wraps the default SVG in a filter so themes/plugins can supply their own icon:

## Why?
Menu visual language varies widely across themes and design systems. The current icon is hard-coded, which forces developers to rely on CSS workarounds or to fork markup. Exposing a filter enables safe, theme-level overrides without changing core templates, improving customization while keeping same defaults.

## How?
- Introduce/ensure usage of the block_core_navigation_link_render_submenu_icon filter around the default SVG returned by block_core_navigation_link_render_submenu_icon().
- No behavioral change unless a theme/plugin hooks the filter.
- Default icon and dimensions remain unchanged for full backward compatibility.

## Screenshots or screencast

|Before|After|
|-|-|
|
<img width="1078" height="206" alt="Screenshot 2025-09-03 012803" src="https://github.com/user-attachments/assets/ef325c07-c56f-4780-abec-63c9d326b5ef" />
|
<img width="970" height="239" alt="Screenshot 2025-09-03 012742" src="https://github.com/user-attachments/assets/c1832885-8505-4af2-a857-b45b1ade96df" />
|
