### PR TITLE
Fix popover scroll hook’s simultaneous scrolling

### DIFF
--- a/packages/block-editor/src/components/block-popover/use-popover-scroll.js
+++ b/packages/block-editor/src/components/block-popover/use-popover-scroll.js
@@ -17,14 +17,24 @@ function usePopoverScroll( contentRef ) {
 	const effect = useRefEffect(
 		( node ) => {
 			function onWheel( event ) {
-				const { deltaX, deltaY } = event;
+				const { deltaX, deltaY, target } = event;
 				const contentEl = contentRef.current;
 				let scrollContainer = scrollContainerCache.get( contentEl );
 				if ( ! scrollContainer ) {
 					scrollContainer = getScrollContainer( contentEl );
 					scrollContainerCache.set( contentEl, scrollContainer );
 				}
-				scrollContainer.scrollBy( deltaX, deltaY );
+				let eventScrollContainer = scrollContainerCache.get( target );
+				if ( ! eventScrollContainer ) {
+					eventScrollContainer = getScrollContainer( target );
+					scrollContainerCache.set( target, eventScrollContainer );
+				}
+				const { scrollHeight, offsetHeight } = eventScrollContainer;
+				// Scrolls “through” the popover only if the event target wasn’t within
+				// a scrollable container and thereby avoids scrolling both containers.
+				if ( scrollHeight === offsetHeight ) {
+					scrollContainer.scrollBy( deltaX, deltaY );
+				}
 			}
 			// Tell the browser that we do not call event.preventDefault
 			// See https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#improving_scrolling_performance_with_passive_listeners

--- a/packages/block-editor/src/components/block-popover/use-popover-scroll.js
+++ b/packages/block-editor/src/components/block-popover/use-popover-scroll.js
@@ -24,15 +24,13 @@ function usePopoverScroll( contentRef ) {
 					scrollContainer = getScrollContainer( contentEl );
 					scrollContainerCache.set( contentEl, scrollContainer );
 				}
-				let eventScrollContainer = scrollContainerCache.get( target );
-				if ( ! eventScrollContainer ) {
-					eventScrollContainer = getScrollContainer( target );
-					scrollContainerCache.set( target, eventScrollContainer );
-				}
-				const { scrollHeight, offsetHeight } = eventScrollContainer;
-				// Scrolls “through” the popover only if the event target wasn’t within
-				// a scrollable container and thereby avoids scrolling both containers.
-				if ( scrollHeight === offsetHeight ) {
+				// Finds a scrollable ancestor of the event’s target. It's not cached because the
+				// it may not remain scrollable due to popover position changes. The cache is also
+				// less likely to be utilized because the target may be different every event.
+				const eventScrollContainer = getScrollContainer( target );
+				// Scrolls “through” the popover only if another contained scrollable area isn’t
+				// in front of it. This is to avoid scrolling both containers simultaneously.
+				if ( ! node.contains( eventScrollContainer ) ) {
 					scrollContainer.scrollBy( deltaX, deltaY );
 				}
 			}


### PR DESCRIPTION
## What?

Closes #70594

The hook now scrolls “through” the popover only if the `wheel` event’s target wasn’t within a scrollable container.

## Why?
Without this some popovers are scrolling their own content while simultaneously scrolling the editor canvas and causing unexpected movement of the popover. 

## How?
- Checks for whether a scrollable container encloses the wheel event’s target element
- Checks that the scrollable container is within the node the hook is attached to
- Scrolls the canvas only if the above conditions are met

## Testing Instructions
1. Open a post or page
2. If there is not overflow in the canvas add some content to enable scrolling
3. Create an inline link in some text
4. Verify that scroll gestures (mouse wheeling or touch) over the link suggestions doesn't cause the canvas to scroll


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/04d3146d-4d50-4da4-8bc0-a29fb90cf1ec"/>|<video src="https://github.com/user-attachments/assets/7f7db2a5-c0a0-4ef4-a2fb-01665e5bf75c"/>|
