### PR TITLE
Command Palette: Register menu navigation based on Core Menu API

### DIFF
--- a/backport-changelog/6.9/9542.md
+++ b/backport-changelog/6.9/9542.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/9542
 
 * https://github.com/WordPress/gutenberg/pull/71264
+* https://github.com/WordPress/gutenberg/pull/71476

--- a/lib/compat/wordpress-6.9/command-palette.php
+++ b/lib/compat/wordpress-6.9/command-palette.php
@@ -1,6 +1,9 @@
 <?php
 /**
  * Enqueues the assets required for the Command Palette.
+ *
+ * @global array  $menu
+ * @global array  $submenu
  */
 function gutenberg_enqueue_command_palette_assets() {
 	global $menu, $submenu;

--- a/lib/compat/wordpress-6.9/command-palette.php
+++ b/lib/compat/wordpress-6.9/command-palette.php
@@ -20,13 +20,19 @@ function gutenberg_enqueue_command_palette_assets() {
 				$menu_label = preg_replace( '/<[^>]*>.*?<\/[^>]*>|<[^>]*\/>|<[^>]*>/s', '', $menu_label );
 			}
 			$menu_label = trim( $menu_label );
+			$menu_url   = '';
+			$menu_slug  = $menu_item[2];
 
-			// Only add the menu item if the menu_slug point to a PHP file.
-			$menu_slug = $menu_item[2];
-			if ( preg_match( '/\.php($|\?)/', $menu_item[2] ) ) {
+			if ( preg_match( '/\.php($|\?)/', $menu_slug ) || wp_http_validate_url( $menu_slug ) ) {
+				$menu_url = $menu_slug;
+			} elseif ( ! empty( menu_page_url( $menu_slug, false ) ) ) {
+				$menu_url = menu_page_url( $menu_slug, false );
+			}
+
+			if ( $menu_url ) {
 				$menu_commands[] = array(
 					'label' => $menu_label,
-					'url'   => $menu_slug,
+					'url'   => $menu_url,
 					'name'  => $menu_slug,
 				);
 			}
@@ -43,10 +49,16 @@ function gutenberg_enqueue_command_palette_assets() {
 						$submenu_label = preg_replace( '/<[^>]*>.*?<\/[^>]*>|<[^>]*\/>|<[^>]*>/s', '', $submenu_label );
 					}
 					$submenu_label = trim( $submenu_label );
+					$submenu_url   = '';
+					$submenu_slug  = $submenu_item[2];
 
-					// Only add the menu item if the menu_slug point to a PHP file.
-					$menu_slug = $menu_item[2];
-					if ( preg_match( '/\.php($|\?)/', $menu_item[2] ) ) {
+					if ( preg_match( '/\.php($|\?)/', $submenu_slug ) || wp_http_validate_url( $submenu_slug ) ) {
+						$submenu_url = $submenu_slug;
+					} elseif ( ! empty( menu_page_url( $submenu_slug, false ) ) ) {
+						$submenu_url = menu_page_url( $submenu_slug, false );
+					}
+
+					if ( $submenu_url ) {
 						$menu_commands[] = array(
 							'label' => sprintf(
 								/* translators: 1: Menu label, 2: Submenu label. */
@@ -54,7 +66,7 @@ function gutenberg_enqueue_command_palette_assets() {
 								$menu_label,
 								$submenu_label
 							),
-							'url'   => $submenu_item[2],
+							'url'   => $submenu_url,
 							'name'  => $menu_slug . '-' . $submenu_item[2],
 						);
 					}

--- a/lib/compat/wordpress-6.9/command-palette.php
+++ b/lib/compat/wordpress-6.9/command-palette.php
@@ -3,14 +3,78 @@
  * Enqueues the assets required for the Command Palette.
  */
 function gutenberg_enqueue_command_palette_assets() {
-	if ( ! is_admin() ) {
-		return;
+	global $menu, $submenu;
+
+	$command_palette_settings = array();
+
+	if ( $menu ) {
+		$menu_commands = array();
+		foreach ( $menu as $menu_item ) {
+			if ( empty( $menu_item[0] ) || ! empty( $menu_item[1] ) && ! current_user_can( $menu_item[1] ) ) {
+				continue;
+			}
+
+			// Remove all HTML tags and their contents.
+			$menu_label = $menu_item[0];
+			while ( preg_match( '/<[^>]*>/', $menu_label ) ) {
+				$menu_label = preg_replace( '/<[^>]*>.*?<\/[^>]*>|<[^>]*\/>|<[^>]*>/s', '', $menu_label );
+			}
+			$menu_label = trim( $menu_label );
+
+			// Only add the menu item if the menu_slug point to a PHP file.
+			$menu_slug = $menu_item[2];
+			if ( preg_match( '/\.php($|\?)/', $menu_item[2] ) ) {
+				$menu_commands[] = array(
+					'label' => $menu_label,
+					'url'   => $menu_slug,
+					'name'  => $menu_slug,
+				);
+			}
+
+			if ( array_key_exists( $menu_slug, $submenu ) ) {
+				foreach ( $submenu[ $menu_slug ] as $submenu_item ) {
+					if ( empty( $submenu_item[0] ) || ! empty( $submenu_item[1] ) && ! current_user_can( $submenu_item[1] ) ) {
+						continue;
+					}
+
+					// Remove all HTML tags and their contents.
+					$submenu_label = $submenu_item[0];
+					while ( preg_match( '/<[^>]*>/', $submenu_label ) ) {
+						$submenu_label = preg_replace( '/<[^>]*>.*?<\/[^>]*>|<[^>]*\/>|<[^>]*>/s', '', $submenu_label );
+					}
+					$submenu_label = trim( $submenu_label );
+
+					// Only add the menu item if the menu_slug point to a PHP file.
+					$menu_slug = $menu_item[2];
+					if ( preg_match( '/\.php($|\?)/', $menu_item[2] ) ) {
+						$menu_commands[] = array(
+							'label' => sprintf(
+								/* translators: 1: Menu label, 2: Submenu label. */
+								__( '%1$s > %2$s' ),
+								$menu_label,
+								$submenu_label
+							),
+							'url'   => $submenu_item[2],
+							'name'  => $menu_slug . '-' . $submenu_item[2],
+						);
+					}
+				}
+			}
+		}
+		$command_palette_settings['menu_commands'] = $menu_commands;
 	}
 
 	wp_enqueue_script( 'wp-commands' );
 	wp_enqueue_style( 'wp-commands' );
 	wp_enqueue_script( 'wp-core-commands' );
-	wp_add_inline_script( 'wp-core-commands', 'wp.coreCommands.initializeCommandPalette();' );
+
+	wp_add_inline_script(
+		'wp-core-commands',
+		sprintf(
+			'wp.coreCommands.initializeCommandPalette( %s );',
+			wp_json_encode( $command_palette_settings, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
+		)
+	);
 }
 
 if ( has_filter( 'admin_enqueue_scripts', 'wp_enqueue_command_palette_assets' ) ) {

--- a/packages/core-commands/README.md
+++ b/packages/core-commands/README.md
@@ -20,6 +20,10 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 
 Initializes the Command Palette.
 
+_Parameters_
+
+-   _settings_ `Object`: Command palette settings.
+
 ### privateApis
 
 Undocumented declaration.

--- a/packages/core-commands/src/admin-navigation-commands.js
+++ b/packages/core-commands/src/admin-navigation-commands.js
@@ -2,249 +2,40 @@
  * WordPress dependencies
  */
 import { useCommandLoader } from '@wordpress/commands';
-import { __ } from '@wordpress/i18n';
-import { plus, dashboard } from '@wordpress/icons';
-import { getPath } from '@wordpress/url';
-import { store as coreStore } from '@wordpress/core-data';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { useCallback, useMemo } from '@wordpress/element';
-import { store as noticesStore } from '@wordpress/notices';
-import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { __, sprintf } from '@wordpress/i18n';
+import { useMemo } from '@wordpress/element';
 
-/**
- * Internal dependencies
- */
-import { unlock } from './lock-unlock';
-
-const { useHistory } = unlock( routerPrivateApis );
-
-const getAddNewPageCommand = () =>
-	function useAddNewPageCommand() {
-		const canCreatePage = useSelect(
-			( select ) =>
-				select( coreStore ).canUser( 'create', {
-					kind: 'postType',
-					name: 'page',
-				} ),
-			[]
-		);
-		const isSiteEditor = getPath( window.location.href )?.includes(
-			'site-editor.php'
-		);
-		const history = useHistory();
-		const isBlockBasedTheme = useSelect( ( select ) => {
-			return select( coreStore ).getCurrentTheme()?.is_block_theme;
-		}, [] );
-		const { saveEntityRecord } = useDispatch( coreStore );
-		const { createErrorNotice } = useDispatch( noticesStore );
-
-		const createPageEntity = useCallback(
-			async ( { close } ) => {
-				try {
-					const page = await saveEntityRecord(
-						'postType',
-						'page',
-						{
-							status: 'draft',
-						},
-						{
-							throwOnError: true,
-						}
-					);
-					if ( page?.id ) {
-						history.navigate( `/page/${ page.id }?canvas=edit` );
-					}
-				} catch ( error ) {
-					const errorMessage =
-						error.message && error.code !== 'unknown_error'
-							? error.message
-							: __(
-									'An error occurred while creating the item.'
-							  );
-
-					createErrorNotice( errorMessage, {
-						type: 'snackbar',
-					} );
-				} finally {
-					close();
-				}
-			},
-			[ createErrorNotice, history, saveEntityRecord ]
-		);
-
-		const commands = useMemo( () => {
-			if ( ! canCreatePage ) {
-				return [];
-			}
-
-			const addNewPage =
-				isSiteEditor && isBlockBasedTheme
-					? createPageEntity
-					: () =>
-							( document.location.href =
-								'post-new.php?post_type=page' );
-			return [
-				{
-					name: 'core/add-new-page',
-					label: __( 'Add Page' ),
-					icon: plus,
-					callback: addNewPage,
-					keywords: [
-						__( 'page' ),
-						__( 'new' ),
-						__( 'add' ),
-						__( 'create' ),
-					],
-				},
-			];
-		}, [
-			createPageEntity,
-			isSiteEditor,
-			isBlockBasedTheme,
-			canCreatePage,
-		] );
-
-		return {
-			isLoading: false,
-			commands,
-		};
-	};
-
-const getAdminBasicNavigationCommands = () =>
+const getAdminNavigationCommands = ( menuCommands ) =>
 	function useAdminBasicNavigationCommands() {
-		const { isBlockBasedTheme, canCreateTemplate } = useSelect(
-			( select ) => {
-				return {
-					isBlockBasedTheme:
-						select( coreStore ).getCurrentTheme()?.is_block_theme,
-					canCreateTemplate: select( coreStore ).canUser( 'create', {
-						kind: 'postType',
-						name: 'wp_template',
-					} ),
-				};
-			},
-			[]
-		);
-
 		const commands = useMemo( () => {
-			if ( canCreateTemplate && isBlockBasedTheme ) {
-				const isSiteEditor = getPath( window.location.href )?.includes(
-					'site-editor.php'
+			return ( menuCommands ?? [] ).map( ( menuCommand ) => {
+				const label = sprintf(
+					/* translators: %s: menu label */
+					__( 'Go to: %s' ),
+					menuCommand.label
 				);
-				if ( ! isSiteEditor ) {
-					return [
-						{
-							name: 'core/go-to-site-editor',
-							label: __( 'Open Site Editor' ),
-							callback: ( { close } ) => {
-								close();
-								document.location = 'site-editor.php';
-							},
-						},
-					];
-				}
-			}
-
-			return [];
-		}, [ canCreateTemplate, isBlockBasedTheme ] );
-
-		return {
-			commands,
-			isLoading: false,
-		};
-	};
-
-const getDashboardCommand = () =>
-	function useDashboardCommand() {
-		const currentPath = getPath( window.location.href );
-
-		const isEditorScreen =
-			currentPath?.includes( 'site-editor.php' ) ||
-			currentPath?.includes( 'post.php' ) ||
-			currentPath?.includes( 'post-new.php' ) ||
-			currentPath?.includes( 'widgets.php' ) ||
-			currentPath?.includes( 'customize.php' );
-
-		const commands = useMemo( () => {
-			if ( isEditorScreen ) {
-				return [
-					{
-						name: 'core/dashboard',
-						label: __( 'Dashboard' ),
-						icon: dashboard,
-						callback: () => {
-							document.location.assign( 'index.php' );
-						},
+				return {
+					label,
+					searchLabel: label,
+					name: menuCommand.name,
+					url: menuCommand.url,
+					callback: ( { close } ) => {
+						document.location = menuCommand.url;
+						close();
 					},
-				];
-			}
-			return [];
-		}, [ isEditorScreen ] );
+				};
+			} );
+		}, [] );
 
 		return {
-			isLoading: false,
 			commands,
+			isLoading: false,
 		};
 	};
 
-const getAddNewPostCommand = () =>
-	function useAddNewPostCommand() {
-		const canCreatePost = useSelect(
-			( select ) =>
-				select( coreStore ).canUser( 'create', {
-					kind: 'postType',
-					name: 'post',
-				} ),
-			[]
-		);
-
-		const commands = useMemo( () => {
-			if ( ! canCreatePost ) {
-				return [];
-			}
-
-			return [
-				{
-					name: 'core/add-new-post',
-					label: __( 'Add Post' ),
-					icon: plus,
-					callback: () => {
-						document.location.assign( 'post-new.php' );
-					},
-					keywords: [
-						__( 'post' ),
-						__( 'new' ),
-						__( 'add' ),
-						__( 'create' ),
-					],
-				},
-			];
-		}, [ canCreatePost ] );
-
-		return {
-			isLoading: false,
-			commands,
-		};
-	};
-
-export function useAdminNavigationCommands() {
-	useCommandLoader( {
-		name: 'core/add-new-post',
-		hook: getAddNewPostCommand(),
-	} );
-
-	useCommandLoader( {
-		name: 'core/dashboard',
-		hook: getDashboardCommand(),
-	} );
-
-	useCommandLoader( {
-		name: 'core/add-new-page',
-		hook: getAddNewPageCommand(),
-	} );
-
+export function useAdminNavigationCommands( menuCommands ) {
 	useCommandLoader( {
 		name: 'core/admin-navigation',
-		hook: getAdminBasicNavigationCommands(),
+		hook: getAdminNavigationCommands( menuCommands ),
 	} );
 }

--- a/packages/core-commands/src/index.js
+++ b/packages/core-commands/src/index.js
@@ -16,8 +16,9 @@ export { privateApis } from './private-apis';
 const { RouterProvider } = unlock( routerPrivateApis );
 
 // Register core commands and render the Command Palette.
-function CommandPalette() {
-	useAdminNavigationCommands();
+function CommandPalette( { settings } ) {
+	const { menu_commands: menuCommands } = settings;
+	useAdminNavigationCommands( menuCommands );
 	useSiteEditorNavigationCommands();
 	return (
 		<RouterProvider pathArg="p">
@@ -28,13 +29,15 @@ function CommandPalette() {
 
 /**
  * Initializes the Command Palette.
+ *
+ * @param {Object} settings Command palette settings.
  */
-export function initializeCommandPalette() {
+export function initializeCommandPalette( settings ) {
 	const root = document.createElement( 'div' );
 	document.body.appendChild( root );
 	createRoot( root ).render(
 		<StrictMode>
-			<CommandPalette />
+			<CommandPalette settings={ settings } />
 		</StrictMode>
 	);
 }

--- a/test/e2e/specs/site-editor/command-center.spec.js
+++ b/test/e2e/specs/site-editor/command-center.spec.js
@@ -21,56 +21,30 @@ test.describe( 'Site editor command palette', () => {
 	} );
 
 	test( 'Open the command palette and navigate to the page create page', async ( {
+		editor,
 		page,
 	} ) => {
+		await editor.setPreferences( 'core/edit-post', {
+			welcomeGuide: false,
+		} );
+
 		await page
 			.getByRole( 'button', { name: 'Open command palette' } )
 			.click();
 		await page
 			.getByRole( 'combobox', { name: 'Search commands and settings' } )
-			.fill( 'new' );
-		await page.getByRole( 'option', { name: 'Add Page' } ).click();
+			.fill( 'add page' );
+		await page
+			.getByRole( 'option', { name: 'Go to: Pages > Add Page' } )
+			.click();
 		await expect( page ).toHaveURL(
-			/\/wp-admin\/site-editor.php\?p=%2Fpage%2F(\d+)&canvas=edit/
+			/\/wp-admin\/post-new.php\?post_type=page/
 		);
 		await expect(
 			page
 				.getByRole( 'region', { name: 'Editor top bar' } )
 				.getByRole( 'button', { name: 'No title · Page' } )
 		).toBeVisible();
-	} );
-
-	test( 'Open the command palette and create page using "create" keyword', async ( {
-		page,
-	} ) => {
-		await page
-			.getByRole( 'button', { name: 'Open command palette' } )
-			.click();
-		await page
-			.getByRole( 'combobox', { name: 'Search commands and settings' } )
-			.fill( 'create' );
-		await page.getByRole( 'option', { name: 'Add Page' } ).click();
-		await expect( page ).toHaveURL(
-			/\/wp-admin\/site-editor.php\?p=%2Fpage%2F(\d+)&canvas=edit/
-		);
-		await expect(
-			page
-				.getByRole( 'region', { name: 'Editor top bar' } )
-				.getByRole( 'button', { name: 'No title · Page' } )
-		).toBeVisible();
-	} );
-
-	test( 'Open the command palette and create post using "create" keyword', async ( {
-		page,
-	} ) => {
-		await page
-			.getByRole( 'button', { name: 'Open command palette' } )
-			.click();
-		await page
-			.getByRole( 'combobox', { name: 'Search commands and settings' } )
-			.fill( 'create' );
-		await page.getByRole( 'option', { name: 'Add Post' } ).click();
-		await expect( page ).toHaveURL( /\/wp-admin\/post-new\.php/ );
 	} );
 
 	test( 'Open the command palette and navigate to a template', async ( {


### PR DESCRIPTION
Part of #71318
See: https://github.com/WordPress/gutenberg/issues/71318#issuecomment-3242697724
Core backport PR: https://github.com/WordPress/wordpress-develop/pull/9542/files (Needs to be updated along with this PR)

## What?

This PR automatically registers screen navigation commands based on the global `$menu` and `$submenu` variables.


## Why?

This approach has many advantages, but also some disadvantages.

### Pros

- No need to hardcode each menu navigation.
- The user permission check is accurate and simple. Only commands that clear `current_user_can` are registered on the server side, and we don't need to perform `canUser` checks on the client side.
- Menus added by consumers are automatically exposed as commands.

### Cons

- It is no longer possible to associate keywords with commands. See [this removed test](https://github.com/WordPress/gutenberg/pull/71476/files#diff-e9fb453d222560d06973fe7ae0919e9dcfcde24e263d5bda0eaca9a257694818L63-L74).
- We can't dynamically change the destination URL. For example, see [this test](https://github.com/WordPress/gutenberg/pull/71476/files#diff-e9fb453d222560d06973fe7ae0919e9dcfcde24e263d5bda0eaca9a257694818L54): When "Add Page" is executed in the site editor, it should add the draft page in the site editor, but it forces us to go to the post editor.
- There may be too many menus. In fact, this PR adds about 40 menus. It may be better not to add submenus.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="596" height="382" alt="image" src="https://github.com/user-attachments/assets/d537e0eb-4703-48f0-8d57-eddec4ccfb42" />