### PR TITLE
Term Template Block: Move the Styles control to the very top of inspector controls

### DIFF
--- a/packages/block-library/src/term-template/edit.js
+++ b/packages/block-library/src/term-template/edit.js
@@ -31,6 +31,7 @@ import {
 	createBlocksFromInnerBlocksTemplate,
 	store as blocksStore,
 } from '@wordpress/blocks';
+import { addFilter } from '@wordpress/hooks';
 
 const TEMPLATE = [
 	[
@@ -397,47 +398,6 @@ export default function TermTemplateEdit( {
 				<ToolbarGroup controls={ displayLayoutControls } />
 			</BlockControls>
 
-			<InspectorControls>
-				<PanelBody title={ __( 'Style' ) }>
-					<ToggleGroupControl
-						label={ __( 'Display Layout' ) }
-						value={ layoutType === 'grid' ? 'grid' : 'list' }
-						help={
-							hierarchical
-								? __(
-										'Grid view is not available when the "Show hierarchy" setting is enabled.'
-								  )
-								: undefined
-						}
-						onChange={ ( value ) => {
-							if ( value === 'grid' ) {
-								setAttributes( {
-									layout: { type: 'grid' },
-								} );
-							} else {
-								setAttributes( {
-									layout: { type: 'default' },
-								} );
-							}
-						} }
-						isBlock
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						disabled={ hierarchical }
-					>
-						<ToggleGroupControlOption
-							value="list"
-							label={ __( 'List' ) }
-						/>
-						<ToggleGroupControlOption
-							value="grid"
-							label={ __( 'Grid' ) }
-							disabled={ hierarchical }
-						/>
-					</ToggleGroupControl>
-				</PanelBody>
-			</InspectorControls>
-
 			<ul { ...blockProps }>
 				{ hierarchical
 					? buildTermsTree( filteredTerms ).map( ( termNode ) =>
@@ -477,3 +437,66 @@ export default function TermTemplateEdit( {
 		</>
 	);
 }
+
+export const withStylesControlsOnTop = ( BlockEdit ) => ( props ) => {
+	if ( props.name !== 'core/term-template' ) {
+		return <BlockEdit { ...props } />;
+	}
+
+	const { attributes, context, setAttributes } = props;
+	const {
+		termQuery: { hierarchical },
+	} = context;
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Style' ) }>
+					<ToggleGroupControl
+						label={ __( 'Display Layout' ) }
+						value={
+							attributes?.layout?.type === 'grid'
+								? 'grid'
+								: 'list'
+						}
+						help={
+							hierarchical
+								? __(
+										'Grid view is not available when the "Show hierarchy" setting is enabled.'
+								  )
+								: undefined
+						}
+						onChange={ ( value ) => {
+							if ( value === 'grid' ) {
+								setAttributes( {
+									layout: { type: 'grid' },
+								} );
+							} else {
+								setAttributes( {
+									layout: { type: 'default' },
+								} );
+							}
+						} }
+						isBlock
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						disabled={ hierarchical }
+					>
+						<ToggleGroupControlOption
+							value="list"
+							label={ __( 'List' ) }
+						/>
+						<ToggleGroupControlOption
+							value="grid"
+							label={ __( 'Grid' ) }
+							disabled={ hierarchical }
+						/>
+					</ToggleGroupControl>
+				</PanelBody>
+			</InspectorControls>
+			<BlockEdit { ...props } />
+		</>
+	);
+};
+
+addFilter( 'editor.BlockEdit', 'core/term-template', withStylesControlsOnTop );

--- a/packages/block-library/src/term-template/edit.js
+++ b/packages/block-library/src/term-template/edit.js
@@ -440,7 +440,7 @@ export default function TermTemplateEdit( {
 
 export const withStylesControlsOnTop = ( BlockEdit ) => ( props ) => {
 	if ( props.name !== 'core/term-template' ) {
-		return <BlockEdit { ...props } />;
+		return <BlockEdit key="edit" { ...props } />;
 	}
 
 	const { attributes, context, setAttributes } = props;
@@ -494,7 +494,7 @@ export const withStylesControlsOnTop = ( BlockEdit ) => ( props ) => {
 					</ToggleGroupControl>
 				</PanelBody>
 			</InspectorControls>
-			<BlockEdit { ...props } />
+			<BlockEdit key="edit" { ...props } />
 		</>
 	);
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Part of https://github.com/WordPress/gutenberg/issues/49094.

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

Move the "Styles" section to the very top of Inspector Controls above "Layout" section.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is because the Layout settings follow from the style ones. Raised [in the comment here](https://github.com/WordPress/gutenberg/pull/70720#issuecomment-3245927493).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Use `editor.BlockEdit` filter that allows to push content relative to existing/native inspector controls.

## Testing Instructions
1. Ensure experimental blocks are enabled.
2. Insert the Terms Query block in a template.
3. Focus on Term Template
4. **Expected:** Make sure Styles (List / Grid) is above the Layout section
5. Change the layout to make sure it still works

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
https://github.com/user-attachments/assets/ee7c47af-fd79-4b81-8792-0bce3d95c290 | https://github.com/user-attachments/assets/20bcc94f-c132-4e51-acc2-207d382d47cb


