### PR TITLE
Accordion Header: Fix RTL toggle button layout

### DIFF
--- a/packages/block-library/src/accordion/style.scss
+++ b/packages/block-library/src/accordion/style.scss
@@ -59,16 +59,6 @@
 	flex-direction: row-reverse;
 }
 
-/* RTL language support */
-[dir="rtl"] .wp-block-accordion-header:not(.icon-position-left) .accordion-content__toggle {
-	/* stylelint-disable-next-line declaration-property-value-allowed-list -- Automatically adjust icon position for RTL languages. */
-	flex-direction: row-reverse;
-}
-
-[dir="rtl"] .wp-block-accordion-header.icon-position-left .accordion-content__toggle {
-	flex-direction: row;
-}
-
 .accordion-content__toggle:focus-visible {
 	outline: 2px solid -webkit-focus-ring-color;
 	outline-offset: 2px;


### PR DESCRIPTION

## What?
Closes https://github.com/WordPress/gutenberg/issues/71478

Removes unnecessary flex-direction CSS rules for RTL languages in the Accordion Header toggle button.

## Why?
Flexbox automatically handles RTL positioning. The manual flex-direction overrides cause incorrect text/icon layout in RTL languages.


## How?
Removes RTL CSS rules in packages/block-library/src/accordion/style.scss.

## Testing Instructions

1. Switch to RTL language (Arabic/Hebrew)
2. Insert Accordion block
3. Verify toggle button text and icon position correctly
4. Test both default and icon-position-left variants


## Screencast  
<img width="2936" height="1506" alt="image" src="https://github.com/user-attachments/assets/810eaa2e-32d7-455b-8aae-f01051b768dd" />