### PR TITLE
List Item Block: Fix deletion of empty list items with nested children

### DIFF
--- a/packages/block-library/src/list-item/hooks/use-merge.js
+++ b/packages/block-library/src/list-item/hooks/use-merge.js
@@ -17,8 +17,9 @@ export default function useMerge( clientId, onMerge ) {
 		getBlockOrder,
 		getBlockRootClientId,
 		getBlockName,
+		getBlock,
 	} = useSelect( blockEditorStore );
-	const { mergeBlocks, moveBlocksToPosition } =
+	const { mergeBlocks, moveBlocksToPosition, removeBlock } =
 		useDispatch( blockEditorStore );
 	const outdentListItem = useOutdentListItem();
 
@@ -83,6 +84,60 @@ export default function useMerge( clientId, onMerge ) {
 		return getBlockOrder( order[ 0 ] )[ 0 ];
 	}
 
+	/**
+	 * Handle deletion of an empty list item that has nested children.
+	 * Promotes the nested children to the parent level.
+	 *
+	 * @param {string} id The client ID of the empty list item.
+	 * @return {boolean} True if handled, false otherwise.
+	 */
+	function handleEmptyListItemWithChildren( id ) {
+		const block = getBlock( id );
+		const content = block?.attributes?.content || '';
+		const isEmpty = ! content || content.trim() === '';
+		const hasNestedItems =
+			block?.innerBlocks && block.innerBlocks.length > 0;
+
+		if ( ! isEmpty || ! hasNestedItems ) {
+			return false;
+		}
+
+		registry.batch( () => {
+			// Get the list container that holds this list-item.
+			const listContainerId = getBlockRootClientId( id );
+			const currentItemIndex =
+				getBlockOrder( listContainerId ).indexOf( id );
+
+			// Move each nested list item to become a top-level item.
+			block.innerBlocks.forEach( ( nestedBlock, index ) => {
+				// Get the nested list container (first inner block should be core/list).
+				const nestedListId = nestedBlock.clientId;
+				const nestedListItems = getBlockOrder( nestedListId );
+
+				// Move each nested list item to the parent list level.
+				nestedListItems.forEach( ( nestedItemId, itemIndex ) => {
+					moveBlocksToPosition(
+						[ nestedItemId ],
+						nestedListId,
+						listContainerId,
+						currentItemIndex +
+							1 +
+							index * nestedListItems.length +
+							itemIndex
+					);
+				} );
+
+				// Remove the now-empty nested list container.
+				removeBlock( nestedListId );
+			} );
+
+			// Remove the empty parent list item.
+			removeBlock( id );
+		} );
+
+		return true;
+	}
+
 	return ( forward ) => {
 		function mergeWithNested( clientIdA, clientIdB ) {
 			registry.batch( () => {
@@ -130,7 +185,12 @@ export default function useMerge( clientId, onMerge ) {
 				mergeWithNested( clientId, nextBlockClientId );
 			}
 		} else {
-			// Merging is only done from the top level. For lowel levels, the
+			// Check if this is an empty list item with nested children.
+			if ( handleEmptyListItemWithChildren( clientId ) ) {
+				return;
+			}
+
+			// Merging is only done from the top level. For lower levels, the
 			// list item is outdented instead.
 			const previousBlockClientId = getPreviousBlockClientId( clientId );
 			if ( getParentListItemId( clientId ) ) {


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/56223

## What?

Fixes the deletion behavior of empty list items that contain nested sub-items, ensuring nested items are promoted to top-level instead of being deleted entirely.

## Why?
Currently, when you delete an empty list item at the top of a nested list structure, all nested items underneath are also deleted. This is unexpected behavior - users expect the nested items to be promoted to become top-level list items instead of being lost entirely. This creates a poor user experience and potential data loss.

## Testing Instructions
1. Open a post or page in the block editor
2. Insert a List block
3. Add a few list items with text
4. Create nested items by indenting some items (use Tab or the indent button)
5. Clear the content of the top-level item that has nested children (make it completely empty)
6. Press Backspace or Delete to remove the empty item
7. Verify that the nested items are promoted to become top-level items instead of being deleted

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/cfb2f06f-3e9c-4f8f-a002-1ab0f14745d0

### After

https://github.com/user-attachments/assets/a72d75b3-36ed-4005-844e-743e38ad090d