### PR TITLE
Image block: Save `<figcaption>` if `caption` attr is bound

### DIFF
--- a/backport-changelog/6.9/9702.md
+++ b/backport-changelog/6.9/9702.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/9702
+
+* https://github.com/WordPress/gutenberg/pull/71483

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -8,29 +8,20 @@
  */
 
 
-// The following filters can be removed once the minimum required WordPress version is 6.9 or newer.
+// The following filter can be removed once the minimum required WordPress version is 6.9 or newer.
 add_filter(
-	'block_bindings_supported_attributes_core/image',
-	function ( $attributes ) {
-		if ( ! in_array( 'caption', $attributes, true ) ) {
+	'block_bindings_supported_attributes',
+	function ( $attributes, $block_type ) {
+		if ( 'core/image' === $block_type && ! in_array( 'caption', $attributes, true ) ) {
 			$attributes[] = 'caption';
 		}
-		return $attributes;
-	},
-	10,
-	3
-);
-
-add_filter(
-	'block_bindings_supported_attributes_core/post-date',
-	function ( $attributes ) {
-		if ( ! in_array( 'datetime', $attributes, true ) ) {
+		if ( 'core/post-date' === $block_type && ! in_array( 'datetime', $attributes, true ) ) {
 			$attributes[] = 'datetime';
 		}
 		return $attributes;
 	},
 	10,
-	3
+	2
 );
 
 /**

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -8,7 +8,19 @@
  */
 
 
-// The following filter can be removed once the minimum required WordPress version is 6.9 or newer.
+// The following filters can be removed once the minimum required WordPress version is 6.9 or newer.
+add_filter(
+	'block_bindings_supported_attributes_core/image',
+	function ( $attributes ) {
+		if ( ! in_array( 'caption', $attributes, true ) ) {
+			$attributes[] = 'caption';
+		}
+		return $attributes;
+	},
+	10,
+	3
+);
+
 add_filter(
 	'block_bindings_supported_attributes_core/post-date',
 	function ( $attributes ) {

--- a/packages/block-editor/src/utils/block-bindings.js
+++ b/packages/block-editor/src/utils/block-bindings.js
@@ -14,7 +14,7 @@ const PATTERN_OVERRIDES_SOURCE = 'core/pattern-overrides';
 const BLOCK_BINDINGS_ALLOWED_BLOCKS = {
 	'core/paragraph': [ 'content' ],
 	'core/heading': [ 'content' ],
-	'core/image': [ 'id', 'url', 'title', 'alt' ],
+	'core/image': [ 'id', 'url', 'title', 'alt', 'caption' ],
 	'core/button': [ 'url', 'text', 'linkTarget', 'rel' ],
 	'core/post-date': [ 'datetime' ],
 };

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -625,7 +625,7 @@ export default function Image( {
 		lockAltControlsMessage,
 		lockTitleControls = false,
 		lockTitleControlsMessage,
-		lockCaption = false,
+		hideCaptionControls = false,
 	} = useSelect(
 		( select ) => {
 			if ( ! isSingleSelected ) {
@@ -635,6 +635,7 @@ export default function Image( {
 				url: urlBinding,
 				alt: altBinding,
 				title: titleBinding,
+				caption: captionBinding,
 			} = metadata?.bindings || {};
 			const hasParentPattern = !! context[ 'pattern/overrides' ];
 			const urlBindingSource = getBlockBindingsSource(
@@ -658,10 +659,7 @@ export default function Image( {
 					// Disable editing the link of the URL if the image is inside a pattern instance.
 					// This is a temporary solution until we support overriding the link on the frontend.
 					hasParentPattern || arePatternOverridesEnabled,
-				lockCaption:
-					// Disable editing the caption if the image is inside a pattern instance.
-					// This is a temporary solution until we support overriding the caption on the frontend.
-					hasParentPattern,
+				hideCaptionControls: !! captionBinding,
 				lockAltControls:
 					!! altBinding &&
 					! altBindingSource?.canUserEditValue?.( {
@@ -1147,10 +1145,9 @@ export default function Image( {
 				label={ __( 'Image caption text' ) }
 				showToolbarButton={
 					isSingleSelected &&
-					hasNonContentControls &&
-					! arePatternOverridesEnabled
+					( hasNonContentControls || isContentOnlyMode ) &&
+					! hideCaptionControls
 				}
-				readOnly={ lockCaption }
 			/>
 		</>
 	);

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -31,6 +31,7 @@ export default function save( { attributes } ) {
 		linkTarget,
 		sizeSlug,
 		title,
+		metadata: { bindings = {} } = {},
 	} = attributes;
 
 	const newRel = ! rel ? undefined : rel;
@@ -70,6 +71,8 @@ export default function save( { attributes } ) {
 		/>
 	);
 
+	const displayCaption = ! RichText.isEmpty( caption ) || bindings.caption;
+
 	const figure = (
 		<>
 			{ href ? (
@@ -84,7 +87,7 @@ export default function save( { attributes } ) {
 			) : (
 				image
 			) }
-			{ ! RichText.isEmpty( caption ) && (
+			{ displayCaption && (
 				<RichText.Content
 					className={ __experimentalGetElementClassName( 'caption' ) }
 					tagName="figcaption"

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -71,7 +71,10 @@ export default function save( { attributes } ) {
 		/>
 	);
 
-	const displayCaption = ! RichText.isEmpty( caption ) || bindings.caption;
+	const displayCaption =
+		! RichText.isEmpty( caption ) ||
+		bindings.caption ||
+		bindings?.__default?.source === 'core/pattern-overrides';
 
 	const figure = (
 		<>

--- a/test/integration/fixtures/blocks/core__image__caption-block-bindings.html
+++ b/test/integration/fixtures/blocks/core__image__caption-block-bindings.html
@@ -1,0 +1,3 @@
+<!-- wp:image {"metadata":{"bindings":{"caption":{"source":"core/post-data","args":{"key":"date"}}}}} -->
+<figure class="wp-block-image"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" /><figcaption class="wp-element-caption"></figcaption></figure>
+<!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__caption-block-bindings.json
+++ b/test/integration/fixtures/blocks/core__image__caption-block-bindings.json
@@ -1,0 +1,22 @@
+[
+	{
+		"name": "core/image",
+		"isValid": true,
+		"attributes": {
+			"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
+			"alt": "",
+			"caption": "",
+			"metadata": {
+				"bindings": {
+					"caption": {
+						"source": "core/post-data",
+						"args": {
+							"key": "date"
+						}
+					}
+				}
+			}
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__image__caption-block-bindings.parsed.json
+++ b/test/integration/fixtures/blocks/core__image__caption-block-bindings.parsed.json
@@ -1,0 +1,22 @@
+[
+	{
+		"blockName": "core/image",
+		"attrs": {
+			"metadata": {
+				"bindings": {
+					"caption": {
+						"source": "core/post-data",
+						"args": {
+							"key": "date"
+						}
+					}
+				}
+			}
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<figure class=\"wp-block-image\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /><figcaption class=\"wp-element-caption\"></figcaption></figure>\n",
+		"innerContent": [
+			"\n<figure class=\"wp-block-image\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /><figcaption class=\"wp-element-caption\"></figcaption></figure>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__image__caption-block-bindings.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__caption-block-bindings.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:image {"metadata":{"bindings":{"caption":{"source":"core/post-data","args":{"key":"date"}}}}} -->
+<figure class="wp-block-image"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt=""/><figcaption class="wp-element-caption"></figcaption></figure>
+<!-- /wp:image -->


### PR DESCRIPTION
## What?
Alternative to https://github.com/WordPress/gutenberg/pull/70642 and https://github.com/WordPress/gutenberg/pull/71462.
Companion to https://github.com/WordPress/wordpress-develop/pull/9702.

When saving the Image Block, include the `<figcaption>` element:
- if the `caption` attribute is set, or
- if it is bound to a Block Bindings source, or
- if the whole block has pattern overrides.

_Note that this PR should only be merged once https://github.com/WordPress/wordpress-develop/pull/9702 has been merged to Core, and backported to GB, since this PR will otherwise lead to empty `<figcaption>`s being rendered on the frontend._

## Why?
To allow Block Bindings to bind the `caption` attribute to a Block Bindings source. If the `<figcaption>` element remains empty -- even after binding -- it will be removed at render time (although probably not by the code in this PR, but by https://github.com/WordPress/wordpress-develop/pull/9702).

## How?
See "What?". Additionally, the caption control is now enabled in the block toolbar if the block is part of a pattern.

Code is largely ~stolen from~ inspired by https://github.com/WordPress/gutenberg/pull/70642.

## Testing Instructions

The following instructions describe using "normal" Block Bindings for testing this PR. Alternatively, you can use Pattern Overrides to test it; @cbravobernal will know how to do that 😬 

- Insert an Image block (and have it display an image that you uploaded or selected from the Media Library).
- In the Code Editor, insert markup to bind its `caption` attribute to a Block Bindings source.
- Switch back to the Visual Editor, and enable its caption.
- Save (and/or publish) the post.
- Reload, and switch to the code editor to verify that the Image block contains an empty `<figcaption>` element.
- View the post on the frontend, and verify that the image caption shows the correct value obtained from the Block Bindings source.