### PR TITLE
fix: prevent scrollbars on accordion header and toggle

### DIFF
--- a/packages/block-library/src/accordion/style.scss
+++ b/packages/block-library/src/accordion/style.scss
@@ -33,7 +33,7 @@
 	padding: var(--wp--preset--spacing--20, 1em) 0;
 	cursor: pointer;
 	outline: none;
-	overflow-x: hidden;
+	overflow: hidden;
 	display: flex;
 	align-items: center;
 	text-align: inherit;


### PR DESCRIPTION
## What?
See https://github.com/WordPress/gutenberg/pull/71446

Fixes visual scrollbars appearing on the Accordion block’s header and toggle button.

## Why?
When expanding or collapsing a full width Accordion block, rotated toggle buttons previously caused horizontal scrollbar, which was flagged for user experience and accessibility concerns. Recent feedback noted a vertical scrollbar regression after the initial fix, requiring adjustment to overflow handling.

## How?
Applies `overflow: hidden` to the `.accordion-content__toggle` CSS selector. This ensures both horizontal and vertical overflow from the toggle button are suppressed. References prior discussion in [PR #71446](https://github.com/WordPress/gutenberg/pull/71446) and suggestion from recent review comments.

## Testing Instructions
1. Open a post or page in the editor.
2. Insert an Accordion block.
3. Set alignment to "Full width" in the toolbar.
4. Save and view the frontend.
5. Expand/collapse accordion header and verify no scrollbars appear.

## Screenshots or screencast 
### Before
https://github.com/user-attachments/assets/5301dd89-29d0-4079-a580-cb947804eacf

### After
https://github.com/user-attachments/assets/e7e8215c-d231-44b1-b249-5114e2465837