### PR TITLE
Fix: use valid html for citations in quotes

### DIFF
--- a/packages/block-library/src/pullquote/block.json
+++ b/packages/block-library/src/pullquote/block.json
@@ -16,7 +16,7 @@
 		"citation": {
 			"type": "rich-text",
 			"source": "rich-text",
-			"selector": "cite",
+			"selector": "cite, p",
 			"role": "content"
 		},
 		"textAlign": {

--- a/packages/block-library/src/pullquote/deprecated.js
+++ b/packages/block-library/src/pullquote/deprecated.js
@@ -68,6 +68,58 @@ function multilineToInline( value ) {
 	return values.join( '<br>' );
 }
 
+const v6 = {
+	attributes: {
+		value: {
+			type: 'rich-text',
+			source: 'rich-text',
+			selector: 'blockquote',
+			multiline: 'p',
+			role: 'content',
+		},
+		citation: {
+			type: 'rich-text',
+			source: 'rich-text',
+			selector: 'cite',
+			role: 'content',
+		},
+		textAlign: {
+			type: 'string',
+		},
+	},
+	save( { attributes } ) {
+		const { textAlign, citation, value } = attributes;
+		const shouldShowCitation = ! RichText.isEmpty( citation );
+
+		return (
+			<figure
+				{ ...useBlockProps.save( {
+					className: clsx( {
+						[ `has-text-align-${ textAlign }` ]: textAlign,
+					} ),
+				} ) }
+			>
+				<blockquote>
+					<RichText.Content tagName="p" value={ value } />
+					{ shouldShowCitation && (
+						<RichText.Content
+							tagName="p"
+							className="wp-block-pullquote__citation"
+							value={ citation }
+						/>
+					) }
+				</blockquote>
+			</figure>
+		);
+	},
+	migrate( { value, ...attributes } ) {
+		return {
+			value: multilineToInline( value ),
+			...attributes,
+		};
+	},
+};
+
 const v5 = {
 	attributes: {
 		value: {
@@ -103,7 +155,11 @@ const v5 = {
 				<blockquote>
 					<RichText.Content value={ value } multiline />
 					{ shouldShowCitation && (
-						<RichText.Content tagName="cite" value={ citation } />
+						<RichText.Content
+							tagName="p"
+							className="wp-block-pullquote__citation"
+							value={ citation }
+						/>
 					) }
 				</blockquote>
 			</figure>
@@ -186,7 +242,11 @@ const v4 = {
 				>
 					<RichText.Content value={ value } multiline />
 					{ ! RichText.isEmpty( citation ) && (
-						<RichText.Content tagName="cite" value={ citation } />
+						<RichText.Content
+							tagName="p"
+							className="wp-block-pullquote__citation"
+							value={ citation }
+						/>
 					) }
 				</blockquote>
 			</figure>
@@ -324,7 +384,11 @@ const v3 = {
 				>
 					<RichText.Content value={ value } multiline />
 					{ ! RichText.isEmpty( citation ) && (
-						<RichText.Content tagName="cite" value={ citation } />
+						<RichText.Content
+							tagName="p"
+							className="wp-block-pullquote__citation"
+							value={ citation }
+						/>
 					) }
 				</blockquote>
 			</figure>
@@ -461,7 +525,11 @@ const v2 = {
 				>
 					<RichText.Content value={ value } multiline />
 					{ ! RichText.isEmpty( citation ) && (
-						<RichText.Content tagName="cite" value={ citation } />
+						<RichText.Content
+							tagName="p"
+							className="wp-block-pullquote__citation"
+							value={ citation }
+						/>
 					) }
 				</blockquote>
 			</figure>
@@ -526,7 +594,11 @@ const v1 = {
 			<blockquote>
 				<RichText.Content value={ value } multiline />
 				{ ! RichText.isEmpty( citation ) && (
-					<RichText.Content tagName="cite" value={ citation } />
+					<RichText.Content
+						tagName="p"
+						className="wp-block-pullquote__citation"
+						value={ citation }
+					/>
 				) }
 			</blockquote>
 		);
@@ -581,4 +653,4 @@ const v0 = {
  *
  * See block-deprecation.md
  */
-export default [ v5, v4, v3, v2, v1, v0 ];
+export default [ v6, v5, v4, v3, v2, v1, v0 ];

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -14,15 +14,12 @@ import {
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
-import { Platform } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { Figure } from './figure';
 import { BlockQuote } from './blockquote';
-
-const isWebPlatform = Platform.OS === 'web';
 
 function PullQuoteEdit( {
 	attributes,
@@ -69,7 +66,7 @@ function PullQuoteEdit( {
 					{ shouldShowCitation && (
 						<RichText
 							identifier="citation"
-							tagName={ isWebPlatform ? 'cite' : undefined }
+							tagName="p"
 							style={ { display: 'block' } }
 							value={ citation }
 							aria-label={ __( 'Pullquote citation text' ) }

--- a/packages/block-library/src/pullquote/save.js
+++ b/packages/block-library/src/pullquote/save.js
@@ -23,7 +23,11 @@ export default function save( { attributes } ) {
 			<blockquote>
 				<RichText.Content tagName="p" value={ value } />
 				{ shouldShowCitation && (
-					<RichText.Content tagName="cite" value={ citation } />
+					<RichText.Content
+						tagName="p"
+						className="wp-block-pullquote__citation"
+						value={ citation }
+					/>
 				) }
 			</blockquote>
 		</figure>

--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -28,7 +28,8 @@
 	}
 
 	cite,
-	footer {
+	footer,
+	.wp-block-pullquote__citation {
 		position: relative;
 	}
 	.has-text-color a {
@@ -60,20 +61,23 @@
 		margin-right: auto;
 		max-width: 60%;
 
-		p {
+		p:not(.wp-block-pullquote__citation) {
 			margin-top: 0;
 			margin-bottom: 0;
 			font-size: 2em;
 		}
 
-		cite {
+		cite,
+		.wp-block-pullquote__citation {
 			text-transform: none;
 			font-style: normal;
 		}
 	}
 }
 
-.wp-block-pullquote :where(cite) {
+.wp-block-pullquote :where(cite),
+.wp-block-pullquote .wp-block-pullquote__citation {
 	color: inherit;
 	display: block;
+	font-size: 0.875rem;
 }

--- a/packages/block-library/src/pullquote/test/__snapshots__/transforms.native.js.snap
+++ b/packages/block-library/src/pullquote/test/__snapshots__/transforms.native.js.snap
@@ -4,7 +4,7 @@ exports[`Pullquote block transforms to Columns block 1`] = `
 "<!-- wp:columns -->
 <div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
 <div class="wp-block-column" style="flex-basis:100%"><!-- wp:pullquote -->
-<figure class="wp-block-pullquote"><blockquote><p>One of the hardest things to do in technology is disrupt yourself.</p><cite>Matt Mullenweg</cite></blockquote></figure>
+<figure class="wp-block-pullquote"><blockquote><p>One of the hardest things to do in technology is disrupt yourself.</p><p>Matt Mullenweg</p></blockquote></figure>
 <!-- /wp:pullquote --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->"
@@ -13,7 +13,7 @@ exports[`Pullquote block transforms to Columns block 1`] = `
 exports[`Pullquote block transforms to Group block 1`] = `
 "<!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:pullquote -->
-<figure class="wp-block-pullquote"><blockquote><p>One of the hardest things to do in technology is disrupt yourself.</p><cite>Matt Mullenweg</cite></blockquote></figure>
+<figure class="wp-block-pullquote"><blockquote><p>One of the hardest things to do in technology is disrupt yourself.</p><p>Matt Mullenweg</p></blockquote></figure>
 <!-- /wp:pullquote --></div>
 <!-- /wp:group -->"
 `;
@@ -42,6 +42,6 @@ exports[`Pullquote block transforms to Quote block 1`] = `
 "<!-- wp:quote -->
 <blockquote class="wp-block-quote"><!-- wp:paragraph -->
 <p>One of the hardest things to do in technology is disrupt yourself.</p>
-<!-- /wp:paragraph --><cite>Matt Mullenweg</cite></blockquote>
+<!-- /wp:paragraph --><p>Matt Mullenweg</p></blockquote>
 <!-- /wp:quote -->"
 `;

--- a/packages/block-library/src/pullquote/test/edit.native.js
+++ b/packages/block-library/src/pullquote/test/edit.native.js
@@ -62,7 +62,7 @@ describe( 'Pullquote', () => {
 		// Assert
 		expect( getEditorHtml() ).toMatchInlineSnapshot( `
 		"<!-- wp:pullquote -->
-		<figure class="wp-block-pullquote"><blockquote><p>A great statement.<br>Again</p><cite>A <br>person</cite></blockquote></figure>
+		<figure class="wp-block-pullquote"><blockquote><p>A great statement.<br>Again</p><p>A <br>person</p></blockquote></figure>
 		<!-- /wp:pullquote -->
 
 		<!-- wp:paragraph -->

--- a/packages/block-library/src/pullquote/test/transforms.native.js
+++ b/packages/block-library/src/pullquote/test/transforms.native.js
@@ -12,7 +12,7 @@ import {
 const block = 'Pullquote';
 const initialHtml = `
 <!-- wp:pullquote -->
-<figure class="wp-block-pullquote"><blockquote><p>One of the hardest things to do in technology is disrupt yourself.</p><cite>Matt Mullenweg</cite></blockquote></figure>
+<figure class="wp-block-pullquote"><blockquote><p>One of the hardest things to do in technology is disrupt yourself.</p><p>Matt Mullenweg</p></blockquote></figure>
 <!-- /wp:pullquote -->`;
 
 const transformsWithInnerBlocks = [ 'Quote', 'Columns', 'Group' ];

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -19,7 +19,7 @@
 		"citation": {
 			"type": "rich-text",
 			"source": "rich-text",
-			"selector": "cite",
+			"selector": "cite, p",
 			"role": "content"
 		},
 		"textAlign": {

--- a/packages/block-library/src/quote/deprecated.js
+++ b/packages/block-library/src/quote/deprecated.js
@@ -61,6 +61,94 @@ const migrateLargeStyle = ( attributes, innerBlocks ) => {
 	];
 };
 
+// Version with cite element (deprecated for HTML validity)
+const v5 = {
+	attributes: {
+		citation: {
+			type: 'rich-text',
+			source: 'rich-text',
+			selector: 'cite',
+			role: 'content',
+		},
+		textAlign: {
+			type: 'string',
+		},
+		anchor: {
+			type: 'string',
+		},
+	},
+	supports: {
+		anchor: true,
+		html: false,
+		__experimentalOnEnter: true,
+		__experimentalOnMerge: true,
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalFontWeight: true,
+			__experimentalFontStyle: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalLetterSpacing: true,
+			__experimentalDefaultControls: {
+				fontSize: true,
+				fontAppearance: true,
+			},
+		},
+		color: {
+			gradients: true,
+			heading: true,
+			link: true,
+			__experimentalDefaultControls: {
+				background: true,
+				text: true,
+			},
+		},
+		spacing: {
+			blockGap: true,
+			__experimentalDefaultControls: {
+				blockGap: true,
+			},
+		},
+		__experimentalBorder: {
+			color: true,
+			radius: true,
+			style: true,
+			width: true,
+			__experimentalDefaultControls: {
+				color: true,
+				radius: true,
+				style: true,
+				width: true,
+			},
+		},
+	},
+	save( { attributes } ) {
+		const { textAlign, citation } = attributes;
+
+		const className = clsx( {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} );
+
+		return (
+			<blockquote { ...useBlockProps.save( { className } ) }>
+				<InnerBlocks.Content />
+				{ ! RichText.isEmpty( citation ) && (
+					<RichText.Content
+						tagName="p"
+						className="wp-block-quote__citation"
+						value={ citation }
+					/>
+				) }
+			</blockquote>
+		);
+	},
+	migrate( attributes, innerBlocks ) {
+		return [ attributes, innerBlocks ];
+	},
+};
+
 // Version before the 'align' attribute was replaced with 'textAlign'.
 const v4 = {
 	attributes: {
@@ -122,7 +210,11 @@ const v4 = {
 			<blockquote { ...useBlockProps.save( { className } ) }>
 				<InnerBlocks.Content />
 				{ ! RichText.isEmpty( citation ) && (
-					<RichText.Content tagName="cite" value={ citation } />
+					<RichText.Content
+						tagName="p"
+						className="wp-block-quote__citation"
+						value={ citation }
+					/>
 				) }
 			</blockquote>
 		);
@@ -178,7 +270,11 @@ const v3 = {
 			<blockquote { ...useBlockProps.save( { className } ) }>
 				<RichText.Content multiline value={ value } />
 				{ ! RichText.isEmpty( citation ) && (
-					<RichText.Content tagName="cite" value={ citation } />
+					<RichText.Content
+						tagName="p"
+						className="wp-block-quote__citation"
+						value={ citation }
+					/>
 				) }
 			</blockquote>
 		);
@@ -217,7 +313,11 @@ const v2 = {
 			<blockquote style={ { textAlign: align ? align : null } }>
 				<RichText.Content multiline value={ value } />
 				{ ! RichText.isEmpty( citation ) && (
-					<RichText.Content tagName="cite" value={ citation } />
+					<RichText.Content
+						tagName="p"
+						className="wp-block-quote__citation"
+						value={ citation }
+					/>
 				) }
 			</blockquote>
 		);
@@ -269,7 +369,11 @@ const v1 = {
 			>
 				<RichText.Content multiline value={ value } />
 				{ ! RichText.isEmpty( citation ) && (
-					<RichText.Content tagName="cite" value={ citation } />
+					<RichText.Content
+						tagName="p"
+						className="wp-block-quote__citation"
+						value={ citation }
+					/>
 				) }
 			</blockquote>
 		);
@@ -334,4 +438,4 @@ const v0 = {
  *
  * See block-deprecation.md
  */
-export default [ v4, v3, v2, v1, v0 ];
+export default [ v5, v4, v3, v2, v1, v0 ];

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -106,7 +106,7 @@ export default function QuoteEdit( {
 				{ innerBlocksProps.children }
 				<Caption
 					attributeKey="citation"
-					tagName={ isWebPlatform ? 'cite' : 'p' }
+					tagName="p"
 					style={ isWebPlatform && { display: 'block' } }
 					isSelected={ isSelected }
 					attributes={ attributes }

--- a/packages/block-library/src/quote/save.js
+++ b/packages/block-library/src/quote/save.js
@@ -19,7 +19,11 @@ export default function save( { attributes } ) {
 		<blockquote { ...useBlockProps.save( { className } ) }>
 			<InnerBlocks.Content />
 			{ ! RichText.isEmpty( citation ) && (
-				<RichText.Content tagName="cite" value={ citation } />
+				<RichText.Content
+					tagName="p"
+					className="wp-block-quote__citation"
+					value={ citation }
+				/>
 			) }
 		</blockquote>
 	);

--- a/packages/block-library/src/quote/style.scss
+++ b/packages/block-library/src/quote/style.scss
@@ -14,13 +14,16 @@
 		}
 
 		cite,
-		footer {
+		footer,
+		.wp-block-quote__citation {
 			font-size: 1.125em;
 			text-align: right;
 		}
 
 	}
-	> cite {
+	> cite,
+	.wp-block-quote__citation {
 		display: block;
+		font-size: 0.875rem;
 	}
 }

--- a/packages/block-library/src/quote/test/__snapshots__/transforms.native.js.snap
+++ b/packages/block-library/src/quote/test/__snapshots__/transforms.native.js.snap
@@ -6,7 +6,7 @@ exports[`Quote block transforms to Columns block 1`] = `
 <div class="wp-block-column" style="flex-basis:100%"><!-- wp:quote {"textAlign":"left","className":"is-style-large"} -->
 <blockquote class="wp-block-quote has-text-align-left is-style-large"><!-- wp:paragraph -->
 <p>"This will make running your own blog a viable alternative again."</p>
-<!-- /wp:paragraph --><cite>— <a href="https://twitter.com/azumbrunnen_/status/1019347243084800005">Adrian Zumbrunnen</a></cite></blockquote>
+<!-- /wp:paragraph --><p>— <a href="https://twitter.com/azumbrunnen_/status/1019347243084800005">Adrian Zumbrunnen</a></p></blockquote>
 <!-- /wp:quote --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->"
@@ -17,7 +17,7 @@ exports[`Quote block transforms to Group block 1`] = `
 <div class="wp-block-group"><!-- wp:quote {"textAlign":"left","className":"is-style-large"} -->
 <blockquote class="wp-block-quote has-text-align-left is-style-large"><!-- wp:paragraph -->
 <p>"This will make running your own blog a viable alternative again."</p>
-<!-- /wp:paragraph --><cite>— <a href="https://twitter.com/azumbrunnen_/status/1019347243084800005">Adrian Zumbrunnen</a></cite></blockquote>
+<!-- /wp:paragraph --><p>— <a href="https://twitter.com/azumbrunnen_/status/1019347243084800005">Adrian Zumbrunnen</a></p></blockquote>
 <!-- /wp:quote --></div>
 <!-- /wp:group -->"
 `;
@@ -34,7 +34,7 @@ exports[`Quote block transforms to Paragraph block 1`] = `
 
 exports[`Quote block transforms to Pullquote block 1`] = `
 "<!-- wp:pullquote -->
-<figure class="wp-block-pullquote"><blockquote><p>"This will make running your own blog a viable alternative again."</p><cite>— <a href="https://twitter.com/azumbrunnen_/status/1019347243084800005">Adrian Zumbrunnen</a></cite></blockquote></figure>
+<figure class="wp-block-pullquote"><blockquote><p>"This will make running your own blog a viable alternative again."</p><p>— <a href="https://twitter.com/azumbrunnen_/status/1019347243084800005">Adrian Zumbrunnen</a></p></blockquote></figure>
 <!-- /wp:pullquote -->"
 `;
 

--- a/packages/block-library/src/quote/test/edit.native.js
+++ b/packages/block-library/src/quote/test/edit.native.js
@@ -83,7 +83,7 @@ describe( 'Quote', () => {
 
 		<!-- wp:paragraph -->
 		<p>Again.</p>
-		<!-- /wp:paragraph --><cite>A <br>person</cite></blockquote>
+		<!-- /wp:paragraph --><p>A <br>person</p></blockquote>
 		<!-- /wp:quote -->
 
 		<!-- wp:paragraph -->

--- a/packages/block-library/src/quote/test/transforms.native.js
+++ b/packages/block-library/src/quote/test/transforms.native.js
@@ -15,9 +15,7 @@ import {
 const block = 'Quote';
 const initialHtml = `
 <!-- wp:quote {"textAlign":"left","className":"is-style-large"} -->
-<blockquote class="wp-block-quote has-text-align-left is-style-large"><!-- wp:paragraph -->
-<p>"This will make running your own blog a viable alternative again."</p>
-<!-- /wp:paragraph --><cite>— <a href="https://twitter.com/azumbrunnen_/status/1019347243084800005">Adrian Zumbrunnen</a></cite></blockquote>
+<figure class="wp-block-pullquote"><blockquote><p>"This will make running your own blog a viable alternative again."</p><p>— <a href="https://twitter.com/azumbrunnen_/status/1019347243084800005">Adrian Zumbrunnen</a></p></blockquote></figure>
 <!-- /wp:quote -->`;
 
 const transformsWithInnerBlocks = [ 'Columns', 'Group' ];

--- a/packages/block-library/src/quote/theme.scss
+++ b/packages/block-library/src/quote/theme.scss
@@ -3,7 +3,8 @@
 	margin: 0 0 1.75em 0;
 	padding-left: 1em;
 	cite,
-	footer {
+	footer,
+	.wp-block-quote__citation {
 		color: currentColor;
 		font-size: 0.8125em;
 		position: relative;

--- a/test/e2e/specs/editor/blocks/quote.spec.js
+++ b/test/e2e/specs/editor/blocks/quote.spec.js
@@ -252,7 +252,7 @@ test.describe( 'Quote', () => {
 		await editor.transformBlockTo( 'core/pullquote' );
 		expect( await editor.getEditedPostContent() ).toBe(
 			`<!-- wp:pullquote -->
-<figure class="wp-block-pullquote"><blockquote><p>one<br>two</p><cite>cite</cite></blockquote></figure>
+<figure class="wp-block-pullquote"><blockquote><p>one<br>two</p><p>cite</p></blockquote></figure>
 <!-- /wp:pullquote -->`
 		);
 	} );
@@ -317,7 +317,7 @@ test.describe( 'Quote', () => {
 			`<!-- wp:quote -->
 <blockquote class="wp-block-quote"><!-- wp:paragraph -->
 <p>1</p>
-<!-- /wp:paragraph --><cite>2</cite></blockquote>
+<!-- /wp:paragraph --><p>2</p></blockquote>
 <!-- /wp:quote -->`
 		);
 		// Move the cursor to the start of the first paragraph of the quoted block.
@@ -329,7 +329,7 @@ test.describe( 'Quote', () => {
 <!-- /wp:paragraph -->
 
 <!-- wp:quote -->
-<blockquote class="wp-block-quote"><cite>2</cite></blockquote>
+<blockquote class="wp-block-quote"><p>2</p></blockquote>
 <!-- /wp:quote -->`
 		);
 	} );

--- a/test/integration/fixtures/blocks/core__pullquote.parsed.json
+++ b/test/integration/fixtures/blocks/core__pullquote.parsed.json
@@ -3,9 +3,9 @@
 		"blockName": "core/pullquote",
 		"attrs": {},
 		"innerBlocks": [],
-		"innerHTML": "\n<figure class=\"wp-block-pullquote\">\n    <blockquote>\n    <p>Testing pullquote block...</p><cite>...with a caption</cite>\n    </blockquote>\n</figure>\n",
+		"innerHTML": "\n<figure class=\"wp-block-pullquote\">\n    <blockquote>\n    <p>Testing pullquote block...</p><p class=\"wp-block-pullquote__citation\">...with a caption</p>\n    </blockquote>\n</figure>\n",
 		"innerContent": [
-			"\n<figure class=\"wp-block-pullquote\">\n    <blockquote>\n    <p>Testing pullquote block...</p><cite>...with a caption</cite>\n    </blockquote>\n</figure>\n"
+			"\n<figure class=\"wp-block-pullquote\">\n    <blockquote>\n    <p>Testing pullquote block...</p><p class=\"wp-block-pullquote__citation\">...with a caption</p>\n    </blockquote>\n</figure>\n"
 		]
 	}
 ]

--- a/test/integration/fixtures/blocks/core__quote__style-1.serialized.html
+++ b/test/integration/fixtures/blocks/core__quote__style-1.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:quote -->
 <blockquote class="wp-block-quote"><!-- wp:paragraph -->
 <p>The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.</p>
-<!-- /wp:paragraph --><cite>Matt Mullenweg, 2017</cite></blockquote>
+<!-- /wp:paragraph --><p class="wp-block-quote__citation">Matt Mullenweg, 2017</p></blockquote>
 <!-- /wp:quote -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #20606

<!-- In a few words, what is the PR actually doing? -->
This pull request updates the markup and styling for the citation field in both the Pullquote and Quote blocks to improve HTML validity and consistency. The main change replaces the use of the `<cite>` element with a `<p>` element (with a specific class) for citations, updates block attributes and deprecations accordingly, and adjusts styles and tests to match the new markup.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
According to the [living standards](https://html.spec.whatwg.org/#the-blockquote-element), a `<p>` tag is the ideal tag in most cases as discussed in the linked issue.

<img width="1684" height="594" alt="image" src="https://github.com/user-attachments/assets/3775a211-4be2-45f0-a80d-372b683fb4bf" />


These changes ensure that citations in Pullquote and Quote blocks use valid HTML and consistent styling across the editor and front end.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Markup and block attribute changes:

* Pullquote and Quote blocks now use `<p class="wp-block-pullquote__citation">` and `<p class="wp-block-quote__citation">` for citations instead of `<cite>`, and the block attributes/selectors are updated to reflect this change. (`packages/block-library/src/pullquote/block.json`, `packages/block-library/src/quote/block.json`, [[1]](diffhunk://#diff-40bc7db495e24e708751a4b4662618ad756d321cac8d0bf806973d0010c22993L19-R19) [[2]](diffhunk://#diff-40e0108841c04ccc4a785133b06929614ecfe5565193eee91a3a3a4706e8f305L22-R22)
* Deprecated versions of both blocks are updated to use the new citation markup, and new deprecation entries are added to handle migration and saving logic. (`packages/block-library/src/pullquote/deprecated.js`, `packages/block-library/src/quote/deprecated.js`, [[1]](diffhunk://#diff-9f8162c8a4e64eafe65af6866d3d2ffb30cc8dc72b71e5a13ab9f783865b038eR71-R122) [[2]](diffhunk://#diff-7738b5475aaea9fb23b676cf65a1896601ee702cf11b32617d7e215ecd91400aR64-R151)
* Block edit and save components now render citations using `<p>` elements with the appropriate class. (`packages/block-library/src/pullquote/edit.js`, `packages/block-library/src/pullquote/save.js`, `packages/block-library/src/quote/edit.js`, `packages/block-library/src/quote/save.js`, [[1]](diffhunk://#diff-999a5253d2f2822cbda55ab53c6c98ec7f1faa8968be9de70bd629e8c5dd6749L72-R69) [[2]](diffhunk://#diff-51e81379dce2caeaf2cea268562eb5a29a15ee1831fe48c348f5c0bbf70edd1dL26-R30) [[3]](diffhunk://#diff-35d71c57180a12d701aa9a76005f967369f250a2f462e725ffe4633dc89dcb0cL109-R109) [[4]](diffhunk://#diff-49fc9a3ab438398b7be15b81832648d5fdcd4d859224d406c49b4b613010e577L22-R26)

Styling updates:

* CSS is updated to style the new citation class selectors for both blocks, ensuring visual consistency and correct font sizing. (`packages/block-library/src/pullquote/style.scss`, `packages/block-library/src/quote/style.scss`, [[1]](diffhunk://#diff-0d4f8ec1d9f99a9316da8dedecb250e5dcb5b0536f0314c1da4b478c51127f23L31-R32) [[2]](diffhunk://#diff-0d4f8ec1d9f99a9316da8dedecb250e5dcb5b0536f0314c1da4b478c51127f23L63-R82) [[3]](diffhunk://#diff-2299363882f94b49a02425491993852c6a4d3c1312b52f32ba962f5be953ca83L17-R27)

Test and snapshot updates:

* Unit tests and snapshots are updated to expect the new citation markup, ensuring all transforms and renders correctly use the `<p>` element for citations. (`packages/block-library/src/pullquote/test/__snapshots__/transforms.native.js.snap`, `packages/block-library/src/quote/test/__snapshots__/transforms.native.js.snap`, [[1]](diffhunk://#diff-4ff8ba29d955310b7b947ea6e88483d2e8d924936faa27bdc37ceab25f44428eL7-R7) [[2]](diffhunk://#diff-75a5b3883831c63e077a0b00f03586158331ea6ef516f9d2ffebd8013b8e6200L9-R9)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
-   Open a post/page in the block editor.
-   Insert a Pullquote block. Enter quote text and a citation.
-   Verify in the editor that Citation renders correctly and visually the same as earlier .
-   Switch to Code editor and confirm serialization uses <p> with citation classes:
    -   Quote:  `<p class="wp-block-quote__citation">…</p>`
    -   Pullquote:  `<p class="wp-block-pullquote__citation">…</p>`
    -   No  `<cite>`  elements in newly created content.
-   Preview the post on the front end and verify visuals match the editor.
-   No “This block contains unexpected or invalid content” warnings should appear.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Screen|Before|After|
|-|-|-|
|Editor|<img width="602" height="325" alt="Screenshot 2025-09-03 at 1 01 49 PM" src="https://github.com/user-attachments/assets/5197d361-9156-4ed5-a950-00eda3b2b3cf" />|<img width="628" height="330" alt="Screenshot 2025-09-03 at 1 03 31 PM" src="https://github.com/user-attachments/assets/b511eaea-1266-4391-8a1a-fd8573a5b388" />|
|Frontend|<img width="646" height="314" alt="Screenshot 2025-09-03 at 1 01 58 PM" src="https://github.com/user-attachments/assets/c0fbb47a-b636-49bc-87b9-220798c018fd" />|<img width="695" height="301" alt="Screenshot 2025-09-03 at 1 03 40 PM" src="https://github.com/user-attachments/assets/af2170b3-6ea4-474d-bf36-06c7c8d69f2c" />|
