### PR TITLE
Navigation Link: Change 'Add page' to 'Create page' button text

### DIFF
--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -309,7 +309,7 @@ const LinkUITools = ( {
 					} }
 					aria-haspopup={ blockInserterAriaRole }
 				>
-					{ __( 'Add page' ) }
+					{ __( 'Create page' ) }
 				</Button>
 			) }
 			<Button


### PR DESCRIPTION
## What

Follow-up to #71188 addressing review feedback from @scruffian.

Changes the button text from 'Add page' to 'Create page' in the Navigation Link UI.

## Why

As noted in the review comment, 'Create' makes more sense here than 'Add' - 'Adding' is the process of putting the link into the navigation, while 'Creating' is the process of actually making the entity.

## How

Simple text change in the button label from `__( 'Add page' )` to `__( 'Create page' )` in the LinkUI component.

## Testing

1. Open the Navigation Link block
2. Click the button to create a new page
3. Verify the button now shows 'Create page' instead of 'Add page'
4. Verify the functionality remains the same

## Screenshots
<img width="1062" height="884" alt="Screen Shot 2025-09-03 at 14 22 00" src="https://github.com/user-attachments/assets/52349cb1-e9e6-4e96-a320-d615795983d5" />

