### PR TITLE
Navigation Link: Show 'Create page' button in Write Mode while hiding 'Add block'

### DIFF
--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -184,7 +184,6 @@ function UnforwardedLinkUI( props, ref ) {
 	);
 
 	const blockEditingMode = useBlockEditingMode();
-	const isDefaultBlockEditingMode = blockEditingMode === 'default';
 
 	return (
 		<Popover
@@ -222,8 +221,7 @@ function UnforwardedLinkUI( props, ref ) {
 						onRemove={ props.onRemove }
 						onCancel={ props.onCancel }
 						renderControlBottom={ () =>
-							! link?.url?.length &&
-							isDefaultBlockEditingMode && (
+							! link?.url?.length && (
 								<LinkUITools
 									focusAddBlockButton={ focusAddBlockButton }
 									focusAddPageButton={ focusAddPageButton }
@@ -236,6 +234,7 @@ function UnforwardedLinkUI( props, ref ) {
 										setFocusAddPageButton( false );
 									} }
 									canCreatePage={ permissions.canCreate }
+									blockEditingMode={ blockEditingMode }
 								/>
 							)
 						}
@@ -279,6 +278,7 @@ const LinkUITools = ( {
 	focusAddBlockButton,
 	focusAddPageButton,
 	canCreatePage,
+	blockEditingMode,
 } ) => {
 	const blockInserterAriaRole = 'listbox';
 	const addBlockButtonRef = useRef();
@@ -314,18 +314,20 @@ const LinkUITools = ( {
 					{ __( 'Create page' ) }
 				</Button>
 			) }
-			<Button
-				__next40pxDefaultSize
-				ref={ addBlockButtonRef }
-				icon={ plus }
-				onClick={ ( e ) => {
-					e.preventDefault();
-					setAddingBlock( true );
-				} }
-				aria-haspopup={ blockInserterAriaRole }
-			>
-				{ __( 'Add block' ) }
-			</Button>
+			{ blockEditingMode === 'default' && (
+				<Button
+					__next40pxDefaultSize
+					ref={ addBlockButtonRef }
+					icon={ plus }
+					onClick={ ( e ) => {
+						e.preventDefault();
+						setAddingBlock( true );
+					} }
+					aria-haspopup={ blockInserterAriaRole }
+				>
+					{ __( 'Add block' ) }
+				</Button>
+			) }
 		</VStack>
 	);
 };


### PR DESCRIPTION
## What

Allows "Add page" tool to show in Write Mode (when block is in `contentOnly`).

## Why

PR #71213 previously hid the entire LinkUITools component in contentOnly mode, but this was too restrictive. Users should still be able to create new pages in Write Mode, as this is a content-related action. Only non-content UI elements like 'Add block' should be hidden.

## How

- Pass `blockEditingMode` prop to LinkUITools component
- Conditionally render 'Add block' button only when `blockEditingMode === 'default'`
- Keep 'Create page' button visible in all modes when permissions allow
- Maintain existing functionality for default and disabled modes

## Testing

1. Open a Navigation block in the editor
2. Enter Write Mode (contentOnly mode)
3. Try to add a Navigation Link block
4. Verify that:
   - 'Create page' button is visible (if user has permissions)
   - 'Add block' button is hidden
5. Exit Write Mode and verify both buttons are visible

## Screenshots

[Screenshots to be added]

## Breaking Changes

None - this is a UX improvement that maintains existing functionality.

## Related

- Builds upon #71213 which hid the entire LinkUITools component
- Addresses the specific requirement from #65699 to allow content-related actions in Write Mode