### PR TITLE
style-engine: Add string check to prevent fatal errors from malformed block attributes

### DIFF
--- a/backport-changelog/6.9/9727.md
+++ b/backport-changelog/6.9/9727.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/9727
+
+* https://github.com/WordPress/gutenberg/pull/71493

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -49,6 +49,10 @@ if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {
 			if ( empty( $property ) ) {
 				return $this;
 			}
+			// Bails early if the value is not a string.
+			if ( ! is_string( $value ) ) {
+				return $this;
+			}
 
 			// Trims the value. If empty, bail early.
 			$value = trim( $value );


### PR DESCRIPTION
## What?

This fixes an fatal error I saw from a client site with a malformed site-logo block:

```
<!-- wp:site-logo {"width":61,"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","position":{"type":"fixed","top":"0px"},"z-index":"500px","bottom":"var:preset|spacing|40","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}}} /-->
```

There is no such attribute as padding-position, or padding-z-index. Not sure how they got there. The array value on padding->position is causing a fatal error. This PR at least stops the fatal error.

```
Fatal error:  Uncaught TypeError: trim(): Argument #1 ($string) must be of type string, array given in /home/wpcom/public_html/wp-content/plugins/gutenberg-core/v20.6.0/build/style-engine/class-wp-style-engine-css-declarations-gutenberg.php:54
Stack trace:
#0 wp-content/plugins/gutenberg-core/v20.6.0/build/style-engine/class-wp-style-engine-css-declarations-gutenberg.php(54): trim(Array)
#1 wp-content/plugins/gutenberg-core/v20.6.0/build/style-engine/class-wp-style-engine-css-declarations-gutenberg.php(86): WP_Style_Engine_CSS_Declarations_Gutenberg->add_declaration('padding-positio...', Array)
#2 wp-content/plugins/gutenberg-core/v20.6.0/build/style-engine/class-wp-style-engine-css-declarations-gutenberg.php(34): WP_Style_Engine_CSS_Declarations_Gutenberg->add_declarations(Array)
#3 wp-content/plugins/gutenberg-core/v20.6.0/build/style-engine/class-wp-style-engine-gutenberg.php(655): WP_Style_Engine_CSS_Declarations_Gutenberg->__construct(Array)
#4 wp-content/plugins/gutenberg-core/v20.6.0/build/style-engine/style-engine-gutenberg.php(57): WP_Style_Engine_Gutenberg::compile_css(Array, NULL)
#5 wp-content/plugins/gutenberg-core/v20.6.0/lib/block-supports/spacing.php(67): gutenberg_style_engine_get_styles(Array)
#6 wp-includes/class-wp-block-supports.php(119): gutenberg_apply_spacing_support(Object(WP_Block_Type), Array)
#7 wp-includes/class-wp-block-supports.php(176): WP_Block_Supports->apply_block_supports()
#8 wp-content/plugins/gutenberg-core/v20.6.0/build/block-library/blocks/site-logo.php(60): get_block_wrapper_attributes(Array)
#9 wp-includes/class-wp-block.php(587): gutenberg_render_block_core_site_logo(Array, '', Object(WP_Block))
#10 wp-includes/class-wp-block.php(566): WP_Block->render()
#11 wp-includes/class-wp-block.php(566): WP_Block->render()
```

## Why?

To gracefully handle malformed content without crashing.

## How?

By checking if $value is really a string before running `trim()` on it.

## Testing Instructions

* Have a site with either a custom logo or [this return early](https://github.com/mreishus/gutenberg/blob/4b9884eb03c9f05590084fa17612bde9933e1a85/packages/block-library/src/site-logo/index.php#L32-L34) commented out.
* Create a new post and use the code editor to make the following the contents:

```
<!-- wp:site-logo {"width":61,"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","position":{"type":"fixed","top":"0px"},"z-index":"500px","bottom":"var:preset|spacing|40"}}}} /-->
```

Without the PR, viewing this post should create a crash. With the PR, it should display.



### Testing Instructions for Keyboard

## Screenshots or screencast 

|Before|After|
|-|-|
|||
