### PR TITLE
Add summaries for required tests

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -38,11 +38,6 @@ jobs:
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
                   persist-credentials: false
 
-            - name: Fail Part 1.
-              if: ${{ matrix.part == 1 }}
-              run: |
-                  exit 1
-
             - name: Setup Node.js and install dependencies
               uses: ./.github/setup-node
 

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -144,7 +144,7 @@ jobs:
                   artifact-path: flaky-tests
 
     required-e2e-playwright-status-checks:
-        name: All end-to-end tests passing.
+        name: All end-to-end tests passing
         runs-on: 'ubuntu-24.04'
         needs: ['e2e-playwright']
         if: ${{ always() }}

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -38,6 +38,11 @@ jobs:
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
                   persist-credentials: false
 
+            - name: Fail Part 1.
+              if: ${{ matrix.part == 1 }}
+              run: |
+                  exit 1
+
             - name: Setup Node.js and install dependencies
               uses: ./.github/setup-node
 

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -142,3 +142,13 @@ jobs:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
                   label: '[Type] Flaky Test'
                   artifact-path: flaky-tests
+
+    required-e2e-playwright-status-checks:
+        name: All end-to-end tests passing.
+        runs-on: 'ubuntu-24.04'
+        needs: ['e2e-playwright']
+        if: ${{ always() }}
+        steps:
+            - name: Detect any failed status checks
+              run: |
+                  [[ "${{ join(needs.*.result, ' ') }}" =~ ^(success ?)+$ ]] || exit 1

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -418,7 +418,7 @@ jobs:
     required-js-unit-status-checks:
         name: All JavaScript unit tests passing.
         runs-on: 'ubuntu-24.04'
-        needs: ['unit-js', 'unit-js-date', 'mobile-unit-js']
+        needs: ['unit-js', 'unit-js-date']
         if: ${{ always() }}
         steps:
             - name: Detect any failed status checks

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -33,7 +33,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node: ['20', '22', '24']
+                node: ['20', '22', '24', '42']
                 shard: ['1/4', '2/4', '3/4', '4/4']
 
         steps:
@@ -78,7 +78,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node: ['20', '22', '24']
+                node: ['20', '22', '24', '42']
 
         steps:
             - name: Checkout repository
@@ -171,6 +171,7 @@ jobs:
             fail-fast: true
             matrix:
                 php:
+                    - '5.6'
                     - '7.2'
                     - '7.3'
                     - '7.4'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -33,7 +33,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node: ['20', '22', '24', '42']
+                node: ['20', '22', '24']
                 shard: ['1/4', '2/4', '3/4', '4/4']
 
         steps:
@@ -78,7 +78,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node: ['20', '22', '24', '42']
+                node: ['20', '22', '24']
 
         steps:
             - name: Checkout repository
@@ -171,7 +171,6 @@ jobs:
             fail-fast: true
             matrix:
                 php:
-                    - '5.6'
                     - '7.2'
                     - '7.3'
                     - '7.4'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -404,3 +404,23 @@ jobs:
               env:
                   MAXWORKERS: ${{ steps.cpu-cores.outputs.count }}
               run: npm run test:native -- --ci --maxWorkers="$MAXWORKERS" --cacheDirectory="$HOME/.jest-cache"
+
+    required-php-unit-status-checks:
+        name: All PHPUnit tests passing.
+        runs-on: 'ubuntu-24.04'
+        needs: ['test-php']
+        if: ${{ always() }}
+        steps:
+            - name: Detect any failed status checks
+              run: |
+                  [[ "${{ join(needs.*.result, ' ') }}" =~ ^(success ?)+$ ]] || exit 1
+
+    required-js-unit-status-checks:
+        name: All JavaScript unit tests passing.
+        runs-on: 'ubuntu-24.04'
+        needs: ['unit-js', 'unit-js-date', 'mobile-unit-js']
+        if: ${{ always() }}
+        steps:
+            - name: Detect any failed status checks
+              run: |
+                  [[ "${{ join(needs.*.result, ' ') }}" =~ ^(success ?)+$ ]] || exit 1


### PR DESCRIPTION
## What?
Closes #71470

Adds summary jobs to various tests to allow a single job to pass or fail as a result of all the jobs in the required test suite.


## Why?

This allows the repository settings to list the summary jobs as required rather than each individual job.

The benefit is that as the main jobs are modified (eg, a new version of PHP added to the PHP Unit tests; the E2E tests further split up) the required tests do not need to be updated.

This will allow existing PRs to pass and make repository management a little easier.

## How?

Adds summary jobs to:

* PHP unit test suite
* JavaScript unit test suite
* E2E test suite

## Testing Instructions

These will be tested in the "checks" tab of this pull request.

1. Ensure the following tests are in the test suite:
   * All end-to-end tests passing.
   * All JavaScript unit tests passing.
   * All PHPUnit tests passing.
2. Ensure these tests are passing when all the associated tests pass. Provided there are no flaky tests, this should happen on the commit with the message "Remove skipped mobile tests."
3. Ensure these test are failing on the commit with the message "These should fail."
4. Ensure the tests pass after the commit "These should fail" is reverted.

### Testing Instructions for Keyboard

N/A

## Screenshots or screencast <!-- if applicable -->

N/A
