### PR TITLE
Block Comments: Prevent commenting on empty blocks

### DIFF
--- a/packages/editor/src/components/collab-sidebar/add-comment.js
+++ b/packages/editor/src/components/collab-sidebar/add-comment.js
@@ -8,6 +8,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -29,16 +30,26 @@ export function AddComment( {
 	showCommentBoard,
 	setShowCommentBoard,
 } ) {
-	const { clientId, blockCommentId } = useSelect( ( select ) => {
-		const { getSelectedBlock } = select( blockEditorStore );
-		const selectedBlock = getSelectedBlock();
-		return {
-			clientId: selectedBlock?.clientId,
-			blockCommentId: selectedBlock?.attributes?.blockCommentId,
-		};
-	} );
+	const { clientId, blockCommentId, isEmptyDefaultBlock } = useSelect(
+		( select ) => {
+			const { getSelectedBlock } = select( blockEditorStore );
+			const selectedBlock = getSelectedBlock();
+			return {
+				clientId: selectedBlock?.clientId,
+				blockCommentId: selectedBlock?.attributes?.blockCommentId,
+				isEmptyDefaultBlock: selectedBlock
+					? isUnmodifiedDefaultBlock( selectedBlock )
+					: false,
+			};
+		}
+	);
 
-	if ( ! showCommentBoard || ! clientId || undefined !== blockCommentId ) {
+	if (
+		! showCommentBoard ||
+		! clientId ||
+		undefined !== blockCommentId ||
+		isEmptyDefaultBlock
+	) {
 		return null;
 	}
 


### PR DESCRIPTION
## What?
Closes #71496 

Prevents users from adding comments to empty blocks (unmodified default blocks) and the block inserter placeholder, addressing unexpected behavior in the collaborative commenting feature.

## Why?
Currently, the block commenting feature allows users to add comments to empty paragraph blocks and the block inserter placeholder, which feels unexpected and unintuitive. When a user clicks into an empty block or the inserter area, they shouldn't be able to add comments since there's no actual content to comment on.

This issue was identified as part of the Block Commenting iteration for WordPress 6.9 and affects the user experience of the collaborative workflows feature.

## How?
The fix adds a check in the `AddComment` component to detect unmodified default blocks using the existing `isUnmodifiedDefaultBlock` utility function from `@wordpress/blocks`. When an empty default block is selected, the comment form is not rendered, preventing users from adding comments to these blocks.

Key changes:
- Import `isUnmodifiedDefaultBlock` from `@wordpress/blocks`
- Add `isEmptyDefaultBlock` check in the `useSelect` hook
- Prevent rendering the comment form when `isEmptyDefaultBlock` is true

## Testing Instructions
1. Enable the comments experiment in Gutenberg
2. Create a new post or page
3. Add a paragraph block with some content
4. Add a comment to the paragraph block (this should work normally)
5. Click on an empty paragraph block or the block inserter placeholder
6. Verify that no comment form appears in the collaboration sidebar
7. Try clicking on other content blocks to ensure commenting still works normally

## Screenshots or screencast 
### Before
https://github.com/user-attachments/assets/4eb70679-1a91-4d79-b9fd-ef46be1b7c3c


### After
https://github.com/user-attachments/assets/7276c6ff-b159-4b34-af03-e08711795266

