### PR TITLE
Dataform: Add new `telephone` field type and field control

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Introduce a new `DataViewsPicker` component. [#70971](https://github.com/WordPress/gutenberg/pull/70971)
+- Dataform: Add new `telephone` field type and field control. [#71498](https://github.com/WordPress/gutenberg/pull/71498)
 
 ## 8.0.0 (2025-09-03)
 

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -391,6 +391,7 @@ const ValidationComponent = ( {
 	type ValidatedItem = {
 		text: string;
 		email: string;
+		telephone: string;
 		integer: number;
 		boolean: boolean;
 		customEdit: string;
@@ -399,6 +400,7 @@ const ValidationComponent = ( {
 	const [ post, setPost ] = useState< ValidatedItem >( {
 		text: 'Can have letters and spaces',
 		email: 'hi@example.com',
+		telephone: '+306978241796',
 		integer: 2,
 		boolean: true,
 		customEdit: 'custom control',
@@ -414,6 +416,13 @@ const ValidationComponent = ( {
 	const customEmailRule = ( value: ValidatedItem ) => {
 		if ( ! /^[a-zA-Z0-9._%+-]+@example\.com$/.test( value.email ) ) {
 			return 'Email address must be from @example.com domain.';
+		}
+
+		return null;
+	};
+	const customTelephoneRule = ( value: ValidatedItem ) => {
+		if ( ! /^\+30\d{10}$/.test( value.telephone ) ) {
+			return 'Telephone number must start with +30 and have 10 digits after.';
 		}
 
 		return null;
@@ -452,6 +461,15 @@ const ValidationComponent = ( {
 			},
 		},
 		{
+			id: 'telephone',
+			type: 'telephone',
+			label: 'telephone',
+			isValid: {
+				required,
+				custom: maybeCustomRule( customTelephoneRule ),
+			},
+		},
+		{
 			id: 'integer',
 			type: 'integer',
 			label: 'Integer',
@@ -480,7 +498,14 @@ const ValidationComponent = ( {
 
 	const form = {
 		layout: { type },
-		fields: [ 'text', 'email', 'integer', 'boolean', 'customEdit' ],
+		fields: [
+			'text',
+			'email',
+			'telephone',
+			'integer',
+			'boolean',
+			'customEdit',
+		],
 	};
 
 	const canSave = isItemValid( post, _fields, form );

--- a/packages/dataviews/src/dataform-controls/email.tsx
+++ b/packages/dataviews/src/dataform-controls/email.tsx
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import type { DataFormControlProps } from '../types';
-import Text from './text';
+import Input from './input';
 
 export default function Email< Item >( {
 	data,
@@ -11,7 +11,7 @@ export default function Email< Item >( {
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
 	return (
-		<Text
+		<Input
 			{ ...{ data, field, onChange, hideLabelFromVision, type: 'email' } }
 		/>
 	);

--- a/packages/dataviews/src/dataform-controls/email.tsx
+++ b/packages/dataviews/src/dataform-controls/email.tsx
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import type { DataFormControlProps } from '../types';
-import Input from './input';
+import ValidatedText from './utils/validated-text';
 
 export default function Email< Item >( {
 	data,
@@ -11,7 +11,7 @@ export default function Email< Item >( {
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
 	return (
-		<Input
+		<ValidatedText
 			{ ...{ data, field, onChange, hideLabelFromVision, type: 'email' } }
 		/>
 	);

--- a/packages/dataviews/src/dataform-controls/index.tsx
+++ b/packages/dataviews/src/dataform-controls/index.tsx
@@ -15,6 +15,7 @@ import checkbox from './checkbox';
 import datetime from './datetime';
 import date from './date';
 import email from './email';
+import telephone from './telephone';
 import integer from './integer';
 import radio from './radio';
 import select from './select';
@@ -34,6 +35,7 @@ const FORM_CONTROLS: FormControls = {
 	datetime,
 	date,
 	email,
+	telephone,
 	integer,
 	radio,
 	select,

--- a/packages/dataviews/src/dataform-controls/input.tsx
+++ b/packages/dataviews/src/dataform-controls/input.tsx
@@ -1,0 +1,71 @@
+/**
+ * WordPress dependencies
+ */
+import { privateApis } from '@wordpress/components';
+import { useCallback, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { DataFormInputControlProps } from '../types';
+import { unlock } from '../lock-unlock';
+
+const { ValidatedTextControl } = unlock( privateApis );
+
+export default function Input< Item >( {
+	data,
+	field,
+	onChange,
+	hideLabelFromVision,
+	type,
+}: DataFormInputControlProps< Item > ) {
+	const { id, label, placeholder, description } = field;
+	const value = field.getValue( { item: data } );
+	const [ customValidity, setCustomValidity ] =
+		useState<
+			React.ComponentProps<
+				typeof ValidatedTextControl
+			>[ 'customValidity' ]
+		>( undefined );
+
+	const onChangeControl = useCallback(
+		( newValue: string ) =>
+			onChange( {
+				[ id ]: newValue,
+			} ),
+		[ id, onChange ]
+	);
+
+	return (
+		<ValidatedTextControl
+			required={ !! field.isValid?.required }
+			onValidate={ ( newValue: any ) => {
+				const message = field.isValid?.custom?.(
+					{
+						...data,
+						[ id ]: newValue,
+					},
+					field
+				);
+
+				if ( message ) {
+					setCustomValidity( {
+						type: 'invalid',
+						message,
+					} );
+					return;
+				}
+
+				setCustomValidity( undefined );
+			} }
+			customValidity={ customValidity }
+			label={ label }
+			placeholder={ placeholder }
+			value={ value ?? '' }
+			help={ description }
+			onChange={ onChangeControl }
+			hideLabelFromVision={ hideLabelFromVision }
+			type={ type }
+		/>
+	);
+}

--- a/packages/dataviews/src/dataform-controls/input.tsx
+++ b/packages/dataviews/src/dataform-controls/input.tsx
@@ -7,10 +7,17 @@ import { useCallback, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import type { DataFormInputControlProps } from '../types';
+import type { DataFormControlProps } from '../types';
 import { unlock } from '../lock-unlock';
 
 const { ValidatedTextControl } = unlock( privateApis );
+
+export type DataFormInputControlProps< Item > = DataFormControlProps< Item > & {
+	/**
+	 * The input type of the control.
+	 */
+	type?: 'text' | 'email' | 'tel';
+};
 
 export default function Input< Item >( {
 	data,

--- a/packages/dataviews/src/dataform-controls/telephone.tsx
+++ b/packages/dataviews/src/dataform-controls/telephone.tsx
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import type { DataFormControlProps } from '../types';
-import Input from './input';
+import ValidatedText from './utils/validated-text';
 
 export default function Telephone< Item >( {
 	data,
@@ -11,7 +11,7 @@ export default function Telephone< Item >( {
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
 	return (
-		<Input
+		<ValidatedText
 			{ ...{ data, field, onChange, hideLabelFromVision, type: 'tel' } }
 		/>
 	);

--- a/packages/dataviews/src/dataform-controls/telephone.tsx
+++ b/packages/dataviews/src/dataform-controls/telephone.tsx
@@ -4,7 +4,7 @@
 import type { DataFormControlProps } from '../types';
 import Text from './text';
 
-export default function Email< Item >( {
+export default function Telephone< Item >( {
 	data,
 	field,
 	onChange,
@@ -12,7 +12,7 @@ export default function Email< Item >( {
 }: DataFormControlProps< Item > ) {
 	return (
 		<Text
-			{ ...{ data, field, onChange, hideLabelFromVision, type: 'email' } }
+			{ ...{ data, field, onChange, hideLabelFromVision, type: 'tel' } }
 		/>
 	);
 }

--- a/packages/dataviews/src/dataform-controls/telephone.tsx
+++ b/packages/dataviews/src/dataform-controls/telephone.tsx
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import type { DataFormControlProps } from '../types';
-import Text from './text';
+import Input from './input';
 
 export default function Telephone< Item >( {
 	data,
@@ -11,7 +11,7 @@ export default function Telephone< Item >( {
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
 	return (
-		<Text
+		<Input
 			{ ...{ data, field, onChange, hideLabelFromVision, type: 'tel' } }
 		/>
 	);

--- a/packages/dataviews/src/dataform-controls/text.tsx
+++ b/packages/dataviews/src/dataform-controls/text.tsx
@@ -1,71 +1,14 @@
 /**
- * WordPress dependencies
- */
-import { privateApis } from '@wordpress/components';
-import { useCallback, useState } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import type { DataFormControlProps } from '../types';
-import { unlock } from '../lock-unlock';
-
-const { ValidatedTextControl } = unlock( privateApis );
+import Input from './input';
 
 export default function Text< Item >( {
 	data,
 	field,
 	onChange,
 	hideLabelFromVision,
-	...rest
 }: DataFormControlProps< Item > ) {
-	const { id, label, placeholder, description } = field;
-	const value = field.getValue( { item: data } );
-	const [ customValidity, setCustomValidity ] =
-		useState<
-			React.ComponentProps<
-				typeof ValidatedTextControl
-			>[ 'customValidity' ]
-		>( undefined );
-
-	const onChangeControl = useCallback(
-		( newValue: string ) =>
-			onChange( {
-				[ id ]: newValue,
-			} ),
-		[ id, onChange ]
-	);
-
-	return (
-		<ValidatedTextControl
-			required={ !! field.isValid?.required }
-			onValidate={ ( newValue: any ) => {
-				const message = field.isValid?.custom?.(
-					{
-						...data,
-						[ id ]: newValue,
-					},
-					field
-				);
-
-				if ( message ) {
-					setCustomValidity( {
-						type: 'invalid',
-						message,
-					} );
-					return;
-				}
-
-				setCustomValidity( undefined );
-			} }
-			customValidity={ customValidity }
-			label={ label }
-			placeholder={ placeholder }
-			value={ value ?? '' }
-			help={ description }
-			onChange={ onChangeControl }
-			hideLabelFromVision={ hideLabelFromVision }
-			{ ...rest }
-		/>
-	);
+	return <Input { ...{ data, field, onChange, hideLabelFromVision } } />;
 }

--- a/packages/dataviews/src/dataform-controls/text.tsx
+++ b/packages/dataviews/src/dataform-controls/text.tsx
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import type { DataFormControlProps } from '../types';
-import Input from './input';
+import ValidatedText from './utils/validated-text';
 
 export default function Text< Item >( {
 	data,
@@ -10,5 +10,7 @@ export default function Text< Item >( {
 	onChange,
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
-	return <Input { ...{ data, field, onChange, hideLabelFromVision } } />;
+	return (
+		<ValidatedText { ...{ data, field, onChange, hideLabelFromVision } } />
+	);
 }

--- a/packages/dataviews/src/dataform-controls/text.tsx
+++ b/packages/dataviews/src/dataform-controls/text.tsx
@@ -17,6 +17,7 @@ export default function Text< Item >( {
 	field,
 	onChange,
 	hideLabelFromVision,
+	...rest
 }: DataFormControlProps< Item > ) {
 	const { id, label, placeholder, description } = field;
 	const value = field.getValue( { item: data } );
@@ -63,9 +64,8 @@ export default function Text< Item >( {
 			value={ value ?? '' }
 			help={ description }
 			onChange={ onChangeControl }
-			__next40pxDefaultSize
-			__nextHasNoMarginBottom
 			hideLabelFromVision={ hideLabelFromVision }
+			{ ...rest }
 		/>
 	);
 }

--- a/packages/dataviews/src/dataform-controls/utils/validated-text.tsx
+++ b/packages/dataviews/src/dataform-controls/utils/validated-text.tsx
@@ -7,25 +7,26 @@ import { useCallback, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import type { DataFormControlProps } from '../types';
-import { unlock } from '../lock-unlock';
+import type { DataFormControlProps } from '../../types';
+import { unlock } from '../../lock-unlock';
 
 const { ValidatedTextControl } = unlock( privateApis );
 
-export type DataFormInputControlProps< Item > = DataFormControlProps< Item > & {
-	/**
-	 * The input type of the control.
-	 */
-	type?: 'text' | 'email' | 'tel';
-};
+export type DataFormValidatedTextControlProps< Item > =
+	DataFormControlProps< Item > & {
+		/**
+		 * The input type of the control.
+		 */
+		type?: 'text' | 'email' | 'tel';
+	};
 
-export default function Input< Item >( {
+export default function ValidatedText< Item >( {
 	data,
 	field,
 	onChange,
 	hideLabelFromVision,
 	type,
-}: DataFormInputControlProps< Item > ) {
+}: DataFormValidatedTextControlProps< Item > ) {
 	const { id, label, placeholder, description } = field;
 	const value = field.getValue( { item: data } );
 	const [ customValidity, setCustomValidity ] =

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -21,6 +21,7 @@ import { default as date } from './date';
 import { default as boolean } from './boolean';
 import { default as media } from './media';
 import { default as array } from './array';
+import { default as telephone } from './telephone';
 import { renderFromElements } from '../utils';
 import { ALL_OPERATORS, OPERATOR_IS, OPERATOR_IS_NOT } from '../constants';
 
@@ -63,6 +64,10 @@ export default function getFieldTypeDefinition< Item >(
 
 	if ( 'array' === type ) {
 		return array;
+	}
+
+	if ( 'telephone' === type ) {
+		return telephone;
 	}
 
 	// This is a fallback for fields that don't provide a type.

--- a/packages/dataviews/src/field-types/stories/index.story.tsx
+++ b/packages/dataviews/src/field-types/stories/index.story.tsx
@@ -40,6 +40,7 @@ const meta = {
 				'integer',
 				'radio',
 				'select',
+				'telephone',
 				'text',
 				'toggleGroup',
 			],
@@ -66,6 +67,8 @@ type DataType = {
 	dateWithElements: string;
 	email: string;
 	emailWithElements: string;
+	telephone: string;
+	telephoneWithElements: string;
 	media: string;
 	mediaWithElements: string;
 	array: string[];
@@ -89,6 +92,8 @@ const data: DataType[] = [
 		dateWithElements: '2021-01-01',
 		email: 'hi@example.com',
 		emailWithElements: 'hi@example.com',
+		telephone: '+1-555-123-4567',
+		telephoneWithElements: '+1-555-123-4567',
 		media: 'https://live.staticflickr.com/7398/9458193857_e1256123e3_z.jpg',
 		mediaWithElements:
 			'https://live.staticflickr.com/7398/9458193857_e1256123e3_z.jpg',
@@ -211,6 +216,23 @@ const fields: Field< DataType >[] = [
 		],
 	},
 	{
+		id: 'telephone',
+		type: 'telephone',
+		label: 'Telephone',
+		description: 'Help for telephone.',
+	},
+	{
+		id: 'telephoneWithElements',
+		type: 'telephone',
+		label: 'Telephone (with elements)',
+		description: 'Help for telephone with elements.',
+		elements: [
+			{ value: '+1-555-123-4567', label: 'John Doe' },
+			{ value: '+44-20-7946-0958', label: 'Jane Smith (UK)' },
+			{ value: '+81-3-1234-5678', label: 'Hiroshi Tanaka (Japan)' },
+		],
+	},
+	{
 		id: 'media',
 		type: 'media',
 		label: 'Media',
@@ -296,6 +318,7 @@ type ControlTypes =
 	| 'integer'
 	| 'radio'
 	| 'select'
+	| 'telephone'
 	| 'text'
 	| 'toggleGroup';
 
@@ -522,6 +545,27 @@ export const Email = ( {
 
 	return (
 		<FieldTypeStory fields={ emailFields } type={ type } Edit={ Edit } />
+	);
+};
+
+export const Telephone = ( {
+	type,
+	Edit,
+}: {
+	type: PanelTypes;
+	Edit: ControlTypes;
+} ) => {
+	const telephoneFields = useMemo(
+		() => fields.filter( ( field ) => field.type === 'telephone' ),
+		[]
+	);
+
+	return (
+		<FieldTypeStory
+			fields={ telephoneFields }
+			type={ type }
+			Edit={ Edit }
+		/>
 	);
 };
 

--- a/packages/dataviews/src/field-types/stories/index.story.tsx
+++ b/packages/dataviews/src/field-types/stories/index.story.tsx
@@ -227,9 +227,9 @@ const fields: Field< DataType >[] = [
 		label: 'Telephone (with elements)',
 		description: 'Help for telephone with elements.',
 		elements: [
-			{ value: '+1-555-123-4567', label: 'John Doe' },
-			{ value: '+44-20-7946-0958', label: 'Jane Smith (UK)' },
-			{ value: '+81-3-1234-5678', label: 'Hiroshi Tanaka (Japan)' },
+			{ value: '+1-555-123-4567', label: '+1-555-123-4567' },
+			{ value: '+44-20-7946-0958', label: '+44-20-7946-0958' },
+			{ value: '+81-3-1234-5678', label: '+81-3-1234-5678' },
 		],
 	},
 	{

--- a/packages/dataviews/src/field-types/telephone.tsx
+++ b/packages/dataviews/src/field-types/telephone.tsx
@@ -31,25 +31,12 @@ function sort( valueA: any, valueB: any, direction: SortDirection ) {
 		: valueB.localeCompare( valueA );
 }
 
-// Basic international phone number validation
-// Supports formats like: +1234567890, (123) 456-7890, 123-456-7890, 123.456.7890, etc.
-const phoneRegex =
-	/^[\+]?[(]?[\+]?\d{0,3}[)]?[-\s\.]?\d{0,3}[-\s\.]?\d{3,4}[-\s\.]?\d{3,4}$/;
-
 export default {
 	sort,
 	isValid: {
 		custom: ( item: any, field: NormalizedField< any > ) => {
 			const value = field.getValue( { item } );
-
-			if (
-				! [ undefined, '', null ].includes( value ) &&
-				! phoneRegex.test( value )
-			) {
-				return __( 'Value must be a valid phone number.' );
-			}
-
-			if ( field.elements ) {
+			if ( field?.elements ) {
 				const validValues = field.elements.map( ( f ) => f.value );
 				if ( ! validValues.includes( value ) ) {
 					return __( 'Value must be one of the elements.' );

--- a/packages/dataviews/src/field-types/telephone.tsx
+++ b/packages/dataviews/src/field-types/telephone.tsx
@@ -1,0 +1,84 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type {
+	DataViewRenderFieldProps,
+	SortDirection,
+	NormalizedField,
+	FieldTypeDefinition,
+} from '../types';
+import { renderFromElements } from '../utils';
+import {
+	OPERATOR_IS,
+	OPERATOR_IS_ALL,
+	OPERATOR_IS_NOT_ALL,
+	OPERATOR_IS_ANY,
+	OPERATOR_IS_NONE,
+	OPERATOR_IS_NOT,
+	OPERATOR_CONTAINS,
+	OPERATOR_NOT_CONTAINS,
+	OPERATOR_STARTS_WITH,
+} from '../constants';
+
+function sort( valueA: any, valueB: any, direction: SortDirection ) {
+	return direction === 'asc'
+		? valueA.localeCompare( valueB )
+		: valueB.localeCompare( valueA );
+}
+
+// Basic international phone number validation
+// Supports formats like: +1234567890, (123) 456-7890, 123-456-7890, 123.456.7890, etc.
+const phoneRegex =
+	/^[\+]?[(]?[\+]?\d{0,3}[)]?[-\s\.]?\d{0,3}[-\s\.]?\d{3,4}[-\s\.]?\d{3,4}$/;
+
+export default {
+	sort,
+	isValid: {
+		custom: ( item: any, field: NormalizedField< any > ) => {
+			const value = field.getValue( { item } );
+
+			if (
+				! [ undefined, '', null ].includes( value ) &&
+				! phoneRegex.test( value )
+			) {
+				return __( 'Value must be a valid phone number.' );
+			}
+
+			if ( field.elements ) {
+				const validValues = field.elements.map( ( f ) => f.value );
+				if ( ! validValues.includes( value ) ) {
+					return __( 'Value must be one of the elements.' );
+				}
+			}
+
+			return null;
+		},
+	},
+	Edit: 'telephone',
+	render: ( { item, field }: DataViewRenderFieldProps< any > ) => {
+		return field.elements
+			? renderFromElements( { item, field } )
+			: field.getValue( { item } );
+	},
+	enableSorting: true,
+	filterBy: {
+		defaultOperators: [ OPERATOR_IS_ANY, OPERATOR_IS_NONE ],
+		validOperators: [
+			OPERATOR_IS,
+			OPERATOR_IS_NOT,
+			OPERATOR_CONTAINS,
+			OPERATOR_NOT_CONTAINS,
+			OPERATOR_STARTS_WITH,
+			// Multiple selection
+			OPERATOR_IS_ANY,
+			OPERATOR_IS_NONE,
+			OPERATOR_IS_ALL,
+			OPERATOR_IS_NOT_ALL,
+		],
+	},
+} satisfies FieldTypeDefinition< any >;

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -103,6 +103,7 @@ export type FieldType =
 	| 'media'
 	| 'boolean'
 	| 'email'
+	| 'telephone'
 	| 'array';
 
 /**

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -284,6 +284,13 @@ export type DataFormControlProps< Item > = {
 	operator?: Operator;
 };
 
+export type DataFormInputControlProps< Item > = DataFormControlProps< Item > & {
+	/**
+	 * The input type of the control.
+	 */
+	type?: 'text' | 'email' | 'tel';
+};
+
 export type DataViewRenderFieldProps< Item > = {
 	item: Item;
 	field: NormalizedField< Item >;

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -284,13 +284,6 @@ export type DataFormControlProps< Item > = {
 	operator?: Operator;
 };
 
-export type DataFormInputControlProps< Item > = DataFormControlProps< Item > & {
-	/**
-	 * The input type of the control.
-	 */
-	type?: 'text' | 'email' | 'tel';
-};
-
 export type DataViewRenderFieldProps< Item > = {
 	item: Item;
 	field: NormalizedField< Item >;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR add a new `telephone` field type and field control (input with `tel` type) to provide more controls for consumers to be used out of the box.

Since `email` and `tel` are using the `text` control already and are pretty identical in props and functionality, I reused the `Text` control by just passing the `type` prop.

<!-- In a few words, what is the PR actually doing? -->


## Testing Instructions
1. Everything should work as before
2. In storybook `npm run storybook:dev`
3. You should also test the `email` type/field.



## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
