### PR TITLE
Clean up LinkUI duplication for Add block and Create page flows

### DIFF
--- a/packages/block-library/src/navigation-link/block-inserter.js
+++ b/packages/block-library/src/navigation-link/block-inserter.js
@@ -1,0 +1,65 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import {
+	store as blockEditorStore,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import DialogWrapper from './dialog-wrapper';
+import { unlock } from '../lock-unlock';
+
+const { PrivateQuickInserter: QuickInserter } = unlock(
+	blockEditorPrivateApis
+);
+
+/**
+ * Component for inserting blocks within the Navigation Link UI.
+ *
+ * @param {Object}   props               Component props.
+ * @param {string}   props.clientId      Client ID of the navigation link block.
+ * @param {Function} props.onBack        Callback when user wants to go back.
+ * @param {Function} props.onBlockInsert Callback when a block is inserted.
+ */
+function LinkUIBlockInserter( { clientId, onBack, onBlockInsert } ) {
+	const { rootBlockClientId } = useSelect(
+		( select ) => {
+			const { getBlockRootClientId } = select( blockEditorStore );
+
+			return {
+				rootBlockClientId: getBlockRootClientId( clientId ),
+			};
+		},
+		[ clientId ]
+	);
+
+	if ( ! clientId ) {
+		return null;
+	}
+
+	return (
+		<DialogWrapper
+			className="link-ui-block-inserter"
+			title={ __( 'Add block' ) }
+			description={ __( 'Choose a block to add to your Navigation.' ) }
+			onBack={ onBack }
+		>
+			<QuickInserter
+				rootClientId={ rootBlockClientId }
+				clientId={ clientId }
+				isAppender={ false }
+				prioritizePatterns={ false }
+				selectBlockOnInsert={ ! onBlockInsert }
+				onSelect={ onBlockInsert ? onBlockInsert : undefined }
+				hasSearch={ false }
+			/>
+		</DialogWrapper>
+	);
+}
+
+export default LinkUIBlockInserter;

--- a/packages/block-library/src/navigation-link/dialog-wrapper.js
+++ b/packages/block-library/src/navigation-link/dialog-wrapper.js
@@ -5,12 +5,6 @@ import { Button, VisuallyHidden } from '@wordpress/components';
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronLeftSmall, chevronRightSmall } from '@wordpress/icons';
 import { useInstanceId, useFocusOnMount } from '@wordpress/compose';
-import { LinkControl } from '@wordpress/block-editor';
-
-/**
- * Internal dependencies
- */
-import { LinkUIPageCreator } from './page-creator';
 
 /**
  * Shared BackButton component for consistent navigation across LinkUI sub-components.
@@ -46,22 +40,13 @@ function BackButton( { className, onBack } ) {
  * @param {Object}   props.children    Child components to render inside the dialog.
  */
 function DialogWrapper( { className, title, description, onBack, children } ) {
-	// Derive component and componentName from className
-	let component = LinkControl;
-	if ( className === 'link-ui-block-inserter' ) {
-		component = LinkControl;
-	} else if ( className === 'link-ui-page-creator' ) {
-		component = LinkUIPageCreator;
-	}
-	const componentName = className;
-
 	const dialogTitleId = useInstanceId(
-		component,
-		`${ componentName }__title`
+		DialogWrapper,
+		`${ className }__title`
 	);
 	const dialogDescriptionId = useInstanceId(
-		component,
-		`${ componentName }__description`
+		DialogWrapper,
+		`${ className }__description`
 	);
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );
 	const backButtonClassName = `${ className }__back`;

--- a/packages/block-library/src/navigation-link/dialog-wrapper.js
+++ b/packages/block-library/src/navigation-link/dialog-wrapper.js
@@ -1,0 +1,89 @@
+/**
+ * WordPress dependencies
+ */
+import { Button, VisuallyHidden } from '@wordpress/components';
+import { __, isRTL } from '@wordpress/i18n';
+import { chevronLeftSmall, chevronRightSmall } from '@wordpress/icons';
+import { useInstanceId, useFocusOnMount } from '@wordpress/compose';
+import { LinkControl } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { LinkUIPageCreator } from './page-creator';
+
+/**
+ * Shared BackButton component for consistent navigation across LinkUI sub-components.
+ *
+ * @param {Object}   props           Component props.
+ * @param {string}   props.className CSS class name for the button.
+ * @param {Function} props.onBack    Callback when user wants to go back.
+ */
+function BackButton( { className, onBack } ) {
+	return (
+		<Button
+			className={ className }
+			icon={ isRTL() ? chevronRightSmall : chevronLeftSmall }
+			onClick={ ( e ) => {
+				e.preventDefault();
+				onBack();
+			} }
+			size="small"
+		>
+			{ __( 'Back' ) }
+		</Button>
+	);
+}
+
+/**
+ * Shared DialogWrapper component for consistent dialog structure across LinkUI sub-components.
+ *
+ * @param {Object}   props             Component props.
+ * @param {string}   props.className   CSS class name for the dialog container.
+ * @param {string}   props.title       Dialog title for accessibility.
+ * @param {string}   props.description Dialog description for accessibility.
+ * @param {Function} props.onBack      Callback when user wants to go back.
+ * @param {Object}   props.children    Child components to render inside the dialog.
+ */
+function DialogWrapper( { className, title, description, onBack, children } ) {
+	// Derive component and componentName from className
+	let component = LinkControl;
+	if ( className === 'link-ui-block-inserter' ) {
+		component = LinkControl;
+	} else if ( className === 'link-ui-page-creator' ) {
+		component = LinkUIPageCreator;
+	}
+	const componentName = className;
+
+	const dialogTitleId = useInstanceId(
+		component,
+		`${ componentName }__title`
+	);
+	const dialogDescriptionId = useInstanceId(
+		component,
+		`${ componentName }__description`
+	);
+	const focusOnMountRef = useFocusOnMount( 'firstElement' );
+	const backButtonClassName = `${ className }__back`;
+
+	return (
+		<div
+			className={ className }
+			role="dialog"
+			aria-labelledby={ dialogTitleId }
+			aria-describedby={ dialogDescriptionId }
+			ref={ focusOnMountRef }
+		>
+			<VisuallyHidden>
+				<h2 id={ dialogTitleId }>{ title }</h2>
+				<p id={ dialogDescriptionId }>{ description }</p>
+			</VisuallyHidden>
+
+			<BackButton className={ backButtonClassName } onBack={ onBack } />
+
+			{ children }
+		</div>
+	);
+}
+
+export default DialogWrapper;

--- a/packages/block-library/src/navigation-link/dialog-wrapper.js
+++ b/packages/block-library/src/navigation-link/dialog-wrapper.js
@@ -42,11 +42,11 @@ function BackButton( { className, onBack } ) {
 function DialogWrapper( { className, title, description, onBack, children } ) {
 	const dialogTitleId = useInstanceId(
 		DialogWrapper,
-		`${ className }__title`
+		'link-ui-dialog-title'
 	);
 	const dialogDescriptionId = useInstanceId(
 		DialogWrapper,
-		`${ className }__description`
+		'link-ui-dialog-description'
 	);
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );
 	const backButtonClassName = `${ className }__back`;

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -8,13 +8,8 @@ import {
 	VisuallyHidden,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { __, isRTL } from '@wordpress/i18n';
-import {
-	LinkControl,
-	store as blockEditorStore,
-	privateApis as blockEditorPrivateApis,
-	useBlockEditingMode,
-} from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import { LinkControl, useBlockEditingMode } from '@wordpress/block-editor';
 import {
 	useMemo,
 	useState,
@@ -23,93 +18,14 @@ import {
 	forwardRef,
 } from '@wordpress/element';
 import { useResourcePermissions } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
-import { chevronLeftSmall, chevronRightSmall, plus } from '@wordpress/icons';
-import { useInstanceId, useFocusOnMount } from '@wordpress/compose';
+import { plus } from '@wordpress/icons';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
-import { unlock } from '../lock-unlock';
 import { LinkUIPageCreator } from './page-creator';
-
-/**
- * Shared BackButton component for consistent navigation across LinkUI sub-components.
- *
- * @param {Object}   props           Component props.
- * @param {string}   props.className CSS class name for the button.
- * @param {Function} props.onBack    Callback when user wants to go back.
- */
-function BackButton( { className, onBack } ) {
-	return (
-		<Button
-			className={ className }
-			icon={ isRTL() ? chevronRightSmall : chevronLeftSmall }
-			onClick={ ( e ) => {
-				e.preventDefault();
-				onBack();
-			} }
-			size="small"
-		>
-			{ __( 'Back' ) }
-		</Button>
-	);
-}
-
-/**
- * Shared DialogWrapper component for consistent dialog structure across LinkUI sub-components.
- *
- * @param {Object}   props             Component props.
- * @param {string}   props.className   CSS class name for the dialog container.
- * @param {string}   props.title       Dialog title for accessibility.
- * @param {string}   props.description Dialog description for accessibility.
- * @param {Function} props.onBack      Callback when user wants to go back.
- * @param {Object}   props.children    Child components to render inside the dialog.
- */
-function DialogWrapper( { className, title, description, onBack, children } ) {
-	// Derive component and componentName from className
-	let component = LinkUI;
-	if ( className === 'link-ui-block-inserter' ) {
-		component = LinkControl;
-	} else if ( className === 'link-ui-page-creator' ) {
-		component = LinkUIPageCreator;
-	}
-	const componentName = className;
-
-	const dialogTitleId = useInstanceId(
-		component,
-		`${ componentName }__title`
-	);
-	const dialogDescriptionId = useInstanceId(
-		component,
-		`${ componentName }__description`
-	);
-	const focusOnMountRef = useFocusOnMount( 'firstElement' );
-	const backButtonClassName = `${ className }__back`;
-
-	return (
-		<div
-			className={ className }
-			role="dialog"
-			aria-labelledby={ dialogTitleId }
-			aria-describedby={ dialogDescriptionId }
-			ref={ focusOnMountRef }
-		>
-			<VisuallyHidden>
-				<h2 id={ dialogTitleId }>{ title }</h2>
-				<p id={ dialogDescriptionId }>{ description }</p>
-			</VisuallyHidden>
-
-			<BackButton className={ backButtonClassName } onBack={ onBack } />
-
-			{ children }
-		</div>
-	);
-}
-
-const { PrivateQuickInserter: QuickInserter } = unlock(
-	blockEditorPrivateApis
-);
+import LinkUIBlockInserter from './block-inserter';
 
 /**
  * Given the Link block's type attribute, return the query params to give to
@@ -149,42 +65,6 @@ export function getSuggestionsQuery( type, kind ) {
 	}
 }
 
-function LinkUIBlockInserter( { clientId, onBack, onBlockInsert } ) {
-	const { rootBlockClientId } = useSelect(
-		( select ) => {
-			const { getBlockRootClientId } = select( blockEditorStore );
-
-			return {
-				rootBlockClientId: getBlockRootClientId( clientId ),
-			};
-		},
-		[ clientId ]
-	);
-
-	if ( ! clientId ) {
-		return null;
-	}
-
-	return (
-		<DialogWrapper
-			className="link-ui-block-inserter"
-			title={ __( 'Add block' ) }
-			description={ __( 'Choose a block to add to your Navigation.' ) }
-			onBack={ onBack }
-		>
-			<QuickInserter
-				rootClientId={ rootBlockClientId }
-				clientId={ clientId }
-				isAppender={ false }
-				prioritizePatterns={ false }
-				selectBlockOnInsert={ ! onBlockInsert }
-				onSelect={ onBlockInsert ? onBlockInsert : undefined }
-				hasSearch={ false }
-			/>
-		</DialogWrapper>
-	);
-}
-
 function UnforwardedLinkUI( props, ref ) {
 	const { label, url, opensInNewTab, type, kind } = props.link;
 	const postType = type || 'page';
@@ -193,7 +73,7 @@ function UnforwardedLinkUI( props, ref ) {
 	const [ addingPage, setAddingPage ] = useState( false );
 	const [ focusAddBlockButton, setFocusAddBlockButton ] = useState( false );
 	const [ focusAddPageButton, setFocusAddPageButton ] = useState( false );
-	const permissions = useResourcePermissions( {
+	const { canCreate: canCreatePage } = useResourcePermissions( {
 		kind: 'postType',
 		name: postType,
 	} );
@@ -275,8 +155,8 @@ function UnforwardedLinkUI( props, ref ) {
 										setAddingPage( true );
 										setFocusAddPageButton( false );
 									} }
-									canCreatePage={ permissions.canCreate }
 									blockEditingMode={ blockEditingMode }
+									canCreatePage={ canCreatePage }
 								/>
 							)
 						}
@@ -313,8 +193,6 @@ function UnforwardedLinkUI( props, ref ) {
 }
 
 export const LinkUI = forwardRef( UnforwardedLinkUI );
-
-export { BackButton, DialogWrapper };
 
 const LinkUITools = ( {
 	setAddingBlock,

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -34,29 +34,6 @@ import { unlock } from '../lock-unlock';
 import { LinkUIPageCreator } from './page-creator';
 
 /**
- * Hook for generating consistent dialog accessibility IDs.
- *
- * @param {Object} component     The component to use for ID generation.
- * @param {string} componentName The name of the component for ID generation.
- * @return {Object} Object containing dialogTitleId and dialogDescriptionId.
- */
-function useDialogIds( component, componentName ) {
-	const dialogTitleId = useInstanceId(
-		component,
-		`${ componentName }__title`
-	);
-	const dialogDescriptionId = useInstanceId(
-		component,
-		`${ componentName }__description`
-	);
-
-	return {
-		dialogTitleId,
-		dialogDescriptionId,
-	};
-}
-
-/**
  * Shared BackButton component for consistent navigation across LinkUI sub-components.
  *
  * @param {Object}   props           Component props.
@@ -76,6 +53,57 @@ function BackButton( { className, onBack } ) {
 		>
 			{ __( 'Back' ) }
 		</Button>
+	);
+}
+
+/**
+ * Shared DialogWrapper component for consistent dialog structure across LinkUI sub-components.
+ *
+ * @param {Object}   props             Component props.
+ * @param {string}   props.className   CSS class name for the dialog container.
+ * @param {string}   props.title       Dialog title for accessibility.
+ * @param {string}   props.description Dialog description for accessibility.
+ * @param {Function} props.onBack      Callback when user wants to go back.
+ * @param {Object}   props.children    Child components to render inside the dialog.
+ */
+function DialogWrapper( { className, title, description, onBack, children } ) {
+	// Derive component and componentName from className
+	let component = LinkUI;
+	if ( className === 'link-ui-block-inserter' ) {
+		component = LinkControl;
+	} else if ( className === 'link-ui-page-creator' ) {
+		component = LinkUIPageCreator;
+	}
+	const componentName = className;
+
+	const dialogTitleId = useInstanceId(
+		component,
+		`${ componentName }__title`
+	);
+	const dialogDescriptionId = useInstanceId(
+		component,
+		`${ componentName }__description`
+	);
+	const focusOnMountRef = useFocusOnMount( 'firstElement' );
+	const backButtonClassName = `${ className }__back`;
+
+	return (
+		<div
+			className={ className }
+			role="dialog"
+			aria-labelledby={ dialogTitleId }
+			aria-describedby={ dialogDescriptionId }
+			ref={ focusOnMountRef }
+		>
+			<VisuallyHidden>
+				<h2 id={ dialogTitleId }>{ title }</h2>
+				<p id={ dialogDescriptionId }>{ description }</p>
+			</VisuallyHidden>
+
+			<BackButton className={ backButtonClassName } onBack={ onBack } />
+
+			{ children }
+		</div>
 	);
 }
 
@@ -133,37 +161,17 @@ function LinkUIBlockInserter( { clientId, onBack, onBlockInsert } ) {
 		[ clientId ]
 	);
 
-	const focusOnMountRef = useFocusOnMount( 'firstElement' );
-	const { dialogTitleId, dialogDescriptionId } = useDialogIds(
-		LinkControl,
-		'link-ui-block-inserter'
-	);
-
 	if ( ! clientId ) {
 		return null;
 	}
 
 	return (
-		<div
+		<DialogWrapper
 			className="link-ui-block-inserter"
-			role="dialog"
-			aria-labelledby={ dialogTitleId }
-			aria-describedby={ dialogDescriptionId }
-			ref={ focusOnMountRef }
+			title={ __( 'Add block' ) }
+			description={ __( 'Choose a block to add to your Navigation.' ) }
+			onBack={ onBack }
 		>
-			<VisuallyHidden>
-				<h2 id={ dialogTitleId }>{ __( 'Add block' ) }</h2>
-
-				<p id={ dialogDescriptionId }>
-					{ __( 'Choose a block to add to your Navigation.' ) }
-				</p>
-			</VisuallyHidden>
-
-			<BackButton
-				className="link-ui-block-inserter__back"
-				onBack={ onBack }
-			/>
-
 			<QuickInserter
 				rootClientId={ rootBlockClientId }
 				clientId={ clientId }
@@ -173,7 +181,7 @@ function LinkUIBlockInserter( { clientId, onBack, onBlockInsert } ) {
 				onSelect={ onBlockInsert ? onBlockInsert : undefined }
 				hasSearch={ false }
 			/>
-		</div>
+		</DialogWrapper>
 	);
 }
 
@@ -208,9 +216,13 @@ function UnforwardedLinkUI( props, ref ) {
 		setAddingPage( false );
 	};
 
-	const { dialogTitleId, dialogDescriptionId } = useDialogIds(
+	const dialogTitleId = useInstanceId(
 		LinkUI,
-		'link-ui-link-control'
+		'link-ui-link-control__title'
+	);
+	const dialogDescriptionId = useInstanceId(
+		LinkUI,
+		'link-ui-link-control__description'
 	);
 
 	const blockEditingMode = useBlockEditingMode();
@@ -302,7 +314,7 @@ function UnforwardedLinkUI( props, ref ) {
 
 export const LinkUI = forwardRef( UnforwardedLinkUI );
 
-export { BackButton, useDialogIds };
+export { BackButton, DialogWrapper };
 
 const LinkUITools = ( {
 	setAddingBlock,

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -33,6 +33,29 @@ import { useInstanceId, useFocusOnMount } from '@wordpress/compose';
 import { unlock } from '../lock-unlock';
 import { LinkUIPageCreator } from './page-creator';
 
+/**
+ * Shared BackButton component for consistent navigation across LinkUI sub-components.
+ *
+ * @param {Object}   props           Component props.
+ * @param {string}   props.className CSS class name for the button.
+ * @param {Function} props.onBack    Callback when user wants to go back.
+ */
+function BackButton( { className, onBack } ) {
+	return (
+		<Button
+			className={ className }
+			icon={ isRTL() ? chevronRightSmall : chevronLeftSmall }
+			onClick={ ( e ) => {
+				e.preventDefault();
+				onBack();
+			} }
+			size="small"
+		>
+			{ __( 'Back' ) }
+		</Button>
+	);
+}
+
 const { PrivateQuickInserter: QuickInserter } = unlock(
 	blockEditorPrivateApis
 );
@@ -118,17 +141,10 @@ function LinkUIBlockInserter( { clientId, onBack, onBlockInsert } ) {
 				</p>
 			</VisuallyHidden>
 
-			<Button
+			<BackButton
 				className="link-ui-block-inserter__back"
-				icon={ isRTL() ? chevronRightSmall : chevronLeftSmall }
-				onClick={ ( e ) => {
-					e.preventDefault();
-					onBack();
-				} }
-				size="small"
-			>
-				{ __( 'Back' ) }
-			</Button>
+				onBack={ onBack }
+			/>
 
 			<QuickInserter
 				rootClientId={ rootBlockClientId }
@@ -271,6 +287,8 @@ function UnforwardedLinkUI( props, ref ) {
 }
 
 export const LinkUI = forwardRef( UnforwardedLinkUI );
+
+export { BackButton };
 
 const LinkUITools = ( {
 	setAddingBlock,

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -34,6 +34,29 @@ import { unlock } from '../lock-unlock';
 import { LinkUIPageCreator } from './page-creator';
 
 /**
+ * Hook for generating consistent dialog accessibility IDs.
+ *
+ * @param {Object} component     The component to use for ID generation.
+ * @param {string} componentName The name of the component for ID generation.
+ * @return {Object} Object containing dialogTitleId and dialogDescriptionId.
+ */
+function useDialogIds( component, componentName ) {
+	const dialogTitleId = useInstanceId(
+		component,
+		`${ componentName }__title`
+	);
+	const dialogDescriptionId = useInstanceId(
+		component,
+		`${ componentName }__description`
+	);
+
+	return {
+		dialogTitleId,
+		dialogDescriptionId,
+	};
+}
+
+/**
  * Shared BackButton component for consistent navigation across LinkUI sub-components.
  *
  * @param {Object}   props           Component props.
@@ -111,14 +134,9 @@ function LinkUIBlockInserter( { clientId, onBack, onBlockInsert } ) {
 	);
 
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );
-
-	const dialogTitleId = useInstanceId(
+	const { dialogTitleId, dialogDescriptionId } = useDialogIds(
 		LinkControl,
-		`link-ui-block-inserter__title`
-	);
-	const dialogDescriptionId = useInstanceId(
-		LinkControl,
-		`link-ui-block-inserter__description`
+		'link-ui-block-inserter'
 	);
 
 	if ( ! clientId ) {
@@ -190,13 +208,9 @@ function UnforwardedLinkUI( props, ref ) {
 		setAddingPage( false );
 	};
 
-	const dialogTitleId = useInstanceId(
+	const { dialogTitleId, dialogDescriptionId } = useDialogIds(
 		LinkUI,
-		`link-ui-link-control__title`
-	);
-	const dialogDescriptionId = useInstanceId(
-		LinkUI,
-		`link-ui-link-control__description`
+		'link-ui-link-control'
 	);
 
 	const blockEditingMode = useBlockEditingMode();
@@ -288,7 +302,7 @@ function UnforwardedLinkUI( props, ref ) {
 
 export const LinkUI = forwardRef( UnforwardedLinkUI );
 
-export { BackButton };
+export { BackButton, useDialogIds };
 
 const LinkUITools = ( {
 	setAddingBlock,

--- a/packages/block-library/src/navigation-link/page-creator.js
+++ b/packages/block-library/src/navigation-link/page-creator.js
@@ -14,12 +14,11 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useState } from '@wordpress/element';
-import { useFocusOnMount } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
-import { BackButton } from './link-ui';
+import { DialogWrapper } from './link-ui';
 
 /**
  * Component for creating new pages within the Navigation Link UI.
@@ -38,9 +37,6 @@ export function LinkUIPageCreator( {
 } ) {
 	const [ title, setTitle ] = useState( initialTitle );
 	const [ shouldPublish, setShouldPublish ] = useState( false );
-
-	// Focus the first element when the component mounts
-	const focusOnMountRef = useFocusOnMount( 'firstElement' );
 
 	// Check if the title is valid for submission
 	const isTitleValid = title.trim().length > 0;
@@ -99,12 +95,12 @@ export function LinkUIPageCreator( {
 	const isSubmitDisabled = isSaving || ! isTitleValid;
 
 	return (
-		<div className="link-ui-page-creator" ref={ focusOnMountRef }>
-			<BackButton
-				className="link-ui-page-creator__back"
-				onBack={ onBack }
-			/>
-
+		<DialogWrapper
+			className="link-ui-page-creator"
+			title={ __( 'Create page' ) }
+			description={ __( 'Create a new page to add to your Navigation.' ) }
+			onBack={ onBack }
+		>
 			<VStack className="link-ui-page-creator__inner" spacing={ 4 }>
 				<form onSubmit={ createPage }>
 					<VStack spacing={ 4 }>
@@ -156,6 +152,6 @@ export function LinkUIPageCreator( {
 					</VStack>
 				</form>
 			</VStack>
-		</div>
+		</DialogWrapper>
 	);
 }

--- a/packages/block-library/src/navigation-link/page-creator.js
+++ b/packages/block-library/src/navigation-link/page-creator.js
@@ -18,7 +18,7 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { DialogWrapper } from './link-ui';
+import DialogWrapper from './dialog-wrapper';
 
 /**
  * Component for creating new pages within the Navigation Link UI.

--- a/packages/block-library/src/navigation-link/page-creator.js
+++ b/packages/block-library/src/navigation-link/page-creator.js
@@ -9,13 +9,17 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
-import { __, isRTL } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useState } from '@wordpress/element';
-import { chevronLeftSmall, chevronRightSmall } from '@wordpress/icons';
 import { useFocusOnMount } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { BackButton } from './link-ui';
 
 /**
  * Component for creating new pages within the Navigation Link UI.
@@ -96,17 +100,10 @@ export function LinkUIPageCreator( {
 
 	return (
 		<div className="link-ui-page-creator" ref={ focusOnMountRef }>
-			<Button
+			<BackButton
 				className="link-ui-page-creator__back"
-				icon={ isRTL() ? chevronRightSmall : chevronLeftSmall }
-				onClick={ ( e ) => {
-					e.preventDefault();
-					onBack();
-				} }
-				size="small"
-			>
-				{ __( 'Back' ) }
-			</Button>
+				onBack={ onBack }
+			/>
 
 			<VStack className="link-ui-page-creator__inner" spacing={ 4 }>
 				<form onSubmit={ createPage }>


### PR DESCRIPTION
## What

Follow-up to [PR #71163](https://github.com/WordPress/gutenberg/pull/71163#issuecomment-3249596557): Refactor to avoid the duplication that's growing in LinkUI to enable Add block and Create page flows.

## Why

As mentioned in the follow-up comment from PR #71163, we're duplicating a lot of a11y focus handling and other componentry. This refactoring improves maintainability without over-engineering the solution into a design system component.

## How

- **Extract DialogWrapper component**: Created shared component that handles dialog structure, accessibility IDs, focus management, and back button
- **Extract LinkUIBlockInserter**: Moved block inserter component to separate file for consistency with page-creator.js
- **Consolidate BackButton**: Moved BackButton into DialogWrapper since it's only used there
- **Clean up imports**: Removed unused imports and organized file structure
- **Maintain existing functionality**: All existing behavior is preserved

## Testing

Verify the existing behavior on trunk is maintained:
- ✅ Ability to add block
- ✅ Ability to add page  
- ✅ Back buttons work correctly
- ✅ Focus management works as expected
- ✅ Accessibility features maintained
- ✅ All CSS styling preserved

## Screenshots

No visual changes - this is a refactoring that maintains existing functionality.

## Breaking Changes

None - this is a refactoring that maintains all existing APIs and behavior.

## Uncertain Elements

- Focus management could be further simplified by using direct ref calls instead of state variables, but this was kept as-is to minimize changes
- Consider extracting LinkUITools to separate file in future if more tools are added