### PR TITLE
Fix: Avatar block alignment

### DIFF
--- a/packages/block-library/src/avatar/editor.scss
+++ b/packages/block-library/src/avatar/editor.scss
@@ -2,8 +2,22 @@
 	width: 100%;
 }
 
-.wp-block-avatar.aligncenter {
-	.components-resizable-box__container {
-		margin: 0 auto;
+.wp-block-avatar {
+	&.aligncenter {
+		.components-resizable-box__container {
+			margin: 0 auto;
+		}
+	}
+
+	&.alignleft {
+		.components-resizable-box__container {
+			margin-right: auto;
+		}
+	}
+
+	&.alignright {
+		.components-resizable-box__container {
+			margin-left: auto;
+		}
 	}
 }

--- a/packages/block-library/src/avatar/style.scss
+++ b/packages/block-library/src/avatar/style.scss
@@ -9,4 +9,12 @@
 	&.aligncenter {
 		text-align: center;
 	}
+
+	&.alignleft {
+		text-align: left;
+	}
+
+	&.alignright {
+		text-align: right;
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #40271 

This PR fixes alignment issues in the Avatar block, when it is used within Comment Template in a Comments Query Loop.

## Why?
The Avatar block's alignment classes (`alignleft`, `alignright`) were not applying the correct layout on the frontend or backend. This created inconsistency as we have option to align the block without visually adhering to it.

## How?
This PR adds alignment-specific styles alongside the existing `aligncenter` styles and ensures it works consistently at both frontend and backend.

## Testing Instructions

1. Open a template using the site editor which contains a Comments Query Loop block.
2. Flatten out the comment template blocks like in the image:
    <img width="360" height="447" alt="image" src="https://github.com/user-attachments/assets/bca29752-1dcc-4b8e-9fb8-bbc22578cfdd" />
3. In the Avatar block, change the alignment to right using the block toolbar.
4. Observe in the editor Avatar should align to the right.
5. Save and view the frontend, Avatar should also align to the right on the published page.
6. Repeat for left and center alignments to confirm consistent behavior.

## Screenshots or screencast 

### Before

https://github.com/user-attachments/assets/f7137570-a9b3-4ad6-975e-e7d67ca4c92f

### After

https://github.com/user-attachments/assets/206d334f-2c12-482f-93fb-00af0645974d

