### PR TITLE
Localize labels in getVisualTypeName() for link control search items

### DIFF
--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -22,23 +22,23 @@ import deprecated from '@wordpress/deprecated';
 const TYPES = {
 	post: {
 		icon: postList,
-		label: __( 'post' ),
+		label: __( 'Post' ),
 	},
 	page: {
 		icon: page,
-		label: __( 'page' ),
+		label: __( 'Page' ),
 	},
 	post_tag: {
 		icon: tag,
-		label: __( 'tag' ),
+		label: __( 'Tag' ),
 	},
 	category: {
 		icon: category,
-		label: __( 'category' ),
+		label: __( 'Category' ),
 	},
 	attachment: {
 		icon: file,
-		label: __( 'attachment' ),
+		label: __( 'Attachment' ),
 	},
 };
 
@@ -164,11 +164,11 @@ export const LinkControlSearchItem = ( {
 
 function getVisualTypeName( suggestion ) {
 	if ( suggestion.isFrontPage ) {
-		return __( 'front page' );
+		return __( 'Front page' );
 	}
 
 	if ( suggestion.isBlogHome ) {
-		return __( 'blog home' );
+		return __( 'Blog home' );
 	}
 
 	// Provide translated labels for built-in post types. Ideally, the API would return the localised CPT or taxonomy label.

--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -149,15 +149,27 @@ export const LinkControlSearchItem = ( {
 
 function getVisualTypeName( suggestion ) {
 	if ( suggestion.isFrontPage ) {
-		return 'front page';
+		return __( 'Front page' );
 	}
 
 	if ( suggestion.isBlogHome ) {
-		return 'blog home';
+		return __( 'Blog home' );
 	}
 
 	// Rename 'post_tag' to 'tag'. Ideally, the API would return the localised CPT or taxonomy label.
-	return suggestion.type === 'post_tag' ? 'tag' : suggestion.type;
+	const builtInLabels = {
+		post: __( 'Post' ),
+		page: __( 'Page' ),
+		post_tag: __( 'Tag' ),
+		category: __( 'Category' ),
+		attachment: __( 'Media' ),
+	};
+
+	if ( suggestion.type in builtInLabels ) {
+		return builtInLabels[ suggestion.type ];
+	}
+
+	return suggestion.type;
 }
 
 export default LinkControlSearchItem;

--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -149,20 +149,20 @@ export const LinkControlSearchItem = ( {
 
 function getVisualTypeName( suggestion ) {
 	if ( suggestion.isFrontPage ) {
-		return __( 'Front page' );
+		return __( 'front page' );
 	}
 
 	if ( suggestion.isBlogHome ) {
-		return __( 'Blog home' );
+		return __( 'blog home' );
 	}
 
 	// Rename 'post_tag' to 'tag'. Ideally, the API would return the localised CPT or taxonomy label.
 	const builtInLabels = {
-		post: __( 'Post' ),
-		page: __( 'Page' ),
-		post_tag: __( 'Tag' ),
-		category: __( 'Category' ),
-		attachment: __( 'Media' ),
+		post: __( 'post' ),
+		page: __( 'page' ),
+		post_tag: __( 'tag' ),
+		category: __( 'category' ),
+		attachment: __( 'attachment' ),
 	};
 
 	if ( suggestion.type in builtInLabels ) {

--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -19,12 +19,27 @@ import { safeDecodeURI, filterURLForDisplay, getPath } from '@wordpress/url';
 import { pipe } from '@wordpress/compose';
 import deprecated from '@wordpress/deprecated';
 
-const ICONS_MAP = {
-	post: postList,
-	page,
-	post_tag: tag,
-	category,
-	attachment: file,
+const TYPES = {
+	post: {
+		icon: postList,
+		label: __( 'post' ),
+	},
+	page: {
+		icon: page,
+		label: __( 'page' ),
+	},
+	post_tag: {
+		icon: tag,
+		label: __( 'tag' ),
+	},
+	category: {
+		icon: category,
+		label: __( 'category' ),
+	},
+	attachment: {
+		icon: file,
+		label: __( 'attachment' ),
+	},
 };
 
 function SearchItemIcon( { isURL, suggestion } ) {
@@ -32,8 +47,8 @@ function SearchItemIcon( { isURL, suggestion } ) {
 
 	if ( isURL ) {
 		icon = globe;
-	} else if ( suggestion.type in ICONS_MAP ) {
-		icon = ICONS_MAP[ suggestion.type ];
+	} else if ( suggestion.type in TYPES ) {
+		icon = TYPES[ suggestion.type ].icon;
 		if ( suggestion.type === 'page' ) {
 			if ( suggestion.isFrontPage ) {
 				icon = home;
@@ -156,17 +171,9 @@ function getVisualTypeName( suggestion ) {
 		return __( 'blog home' );
 	}
 
-	// Rename 'post_tag' to 'tag'. Ideally, the API would return the localised CPT or taxonomy label.
-	const builtInLabels = {
-		post: __( 'post' ),
-		page: __( 'page' ),
-		post_tag: __( 'tag' ),
-		category: __( 'category' ),
-		attachment: __( 'attachment' ),
-	};
-
-	if ( suggestion.type in builtInLabels ) {
-		return builtInLabels[ suggestion.type ];
+	// Provide translated labels for built-in post types. Ideally, the API would return the localised CPT or taxonomy label.
+	if ( suggestion.type in TYPES ) {
+		return TYPES[ suggestion.type ].label;
 	}
 
 	return suggestion.type;

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -144,7 +144,6 @@ $block-editor-link-control-number-of-actions: 1;
 
 	.components-menu-item__shortcut {
 		color: $gray-700;
-		text-transform: capitalize;
 		white-space: nowrap; // tags shouldn't go over two lines.
 	}
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -30,11 +30,11 @@ const mockFetchSearchSuggestions = jest.fn();
 
 function getExpectedVisualTypeName( type ) {
 	const builtInLabels = {
-		post: 'post',
-		page: 'page',
-		post_tag: 'tag',
-		category: 'category',
-		attachment: 'attachment',
+		post: 'Post',
+		page: 'Page',
+		post_tag: 'Tag',
+		category: 'Category',
+		attachment: 'Attachment',
 	};
 
 	return builtInLabels[ type ] || type;

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -30,11 +30,11 @@ const mockFetchSearchSuggestions = jest.fn();
 
 function getExpectedVisualTypeName( type ) {
 	const builtInLabels = {
-		post: 'Post',
-		page: 'Page',
-		post_tag: 'Tag',
-		category: 'Category',
-		attachment: 'Media',
+		post: 'post',
+		page: 'page',
+		post_tag: 'tag',
+		category: 'category',
+		attachment: 'attachment',
 	};
 
 	return builtInLabels[ type ] || type;

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -28,6 +28,18 @@ import {
 
 const mockFetchSearchSuggestions = jest.fn();
 
+function getExpectedVisualTypeName( type ) {
+	const builtInLabels = {
+		post: 'Post',
+		page: 'Page',
+		post_tag: 'Tag',
+		category: 'Category',
+		attachment: 'Media',
+	};
+
+	return builtInLabels[ type ] || type;
+}
+
 /**
  * The call to the real method `fetchRichUrlData` is wrapped in a promise in order to make it cancellable.
  * Therefore if we pass any value as the mock of `fetchRichUrlData` then ALL of the tests will require
@@ -510,7 +522,7 @@ describe( 'Searching for a link', () => {
 				firstSuggestion.title
 			);
 			expect( searchResultElements[ 0 ] ).toHaveTextContent(
-				firstSuggestion.type
+				getExpectedVisualTypeName( firstSuggestion.type )
 			);
 
 			// The fallback URL suggestion should not be shown when input is not URL-like.
@@ -2078,7 +2090,7 @@ describe( 'Post types', () => {
 
 		searchResultElements.forEach( ( resultItem, index ) => {
 			expect( resultItem ).toHaveTextContent(
-				fauxEntitySuggestions[ index ].type
+				getExpectedVisualTypeName( fauxEntitySuggestions[ index ].type )
 			);
 		} );
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71492 

Localizes the labels shown in link control search items by fixing the `getVisualTypeName()` function to use proper translatable strings instead of raw post type slugs.

## Why?
The link control search items were showing raw post type slugs that weren't translatable. Inconsistent capitalization handled via CSS transforms

## How?
Added `__()` translation functions for all user-facing strings



