### PR TITLE
Fix: Document title not updating when creating a new post or editing an existing post

### DIFF
--- a/packages/edit-post/src/components/document-title/index.js
+++ b/packages/edit-post/src/components/document-title/index.js
@@ -1,0 +1,104 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
+
+/**
+ * Component responsible for managing the document title based on the current post.
+ */
+function DocumentTitle() {
+	// Store the original document title so we can restore it when unmounting.
+	const originalDocumentTitle = useRef( document.title );
+
+	const { postTitle, postType, siteTitle, isCleanNewPost } = useSelect(
+		( select ) => {
+			const {
+				getEditedPostAttribute,
+				isCleanNewPost: selectIsCleanNewPost,
+			} = select( editorStore );
+			const { getEntityRecord } = select( coreStore );
+
+			return {
+				postTitle: getEditedPostAttribute( 'title' ),
+				postType: getEditedPostAttribute( 'type' ),
+				siteTitle: getEntityRecord( 'root', 'site' )?.title,
+				isCleanNewPost: selectIsCleanNewPost(),
+			};
+		},
+		[]
+	);
+
+	// Update document title when relevant data changes.
+	useEffect( () => {
+		if ( ! siteTitle ) {
+			return;
+		}
+
+		// Determine the action label based on post type and status.
+		const getActionLabel = () => {
+			if ( isCleanNewPost || ! postTitle?.trim() ) {
+				if ( postType === 'post' ) {
+					return __( 'Add Post' );
+				}
+				if ( postType === 'page' ) {
+					return __( 'Add Page' );
+				}
+				return __( 'Add New' );
+			}
+
+			if ( postType === 'post' ) {
+				return __( 'Edit Post' );
+			}
+			if ( postType === 'page' ) {
+				return __( 'Edit Page' );
+			}
+			return __( 'Edit' );
+		};
+
+		const actionLabel = getActionLabel();
+
+		// Format the document title.
+		let documentTitle;
+		if ( postTitle && postTitle.trim() && ! isCleanNewPost ) {
+			// Post has a title: "Edit Post "Hello world!" ‹ Site Name — WordPress"
+			documentTitle = sprintf(
+				/* translators: 1: Action (Edit Post, Add Post, etc.), 2: Post title, 3: Site name. */
+				__( '%1$s "%2$s" ‹ %3$s — WordPress' ),
+				actionLabel,
+				decodeEntities( postTitle.trim() ),
+				decodeEntities( siteTitle )
+			);
+		} else {
+			// No title: "Add Post ‹ Site Name — WordPress" or "Edit Post ‹ Site Name — WordPress"
+			documentTitle = sprintf(
+				/* translators: 1: Action (Edit Post, Add Post, etc.), 2: Site name. */
+				__( '%1$s ‹ %2$s — WordPress' ),
+				actionLabel,
+				decodeEntities( siteTitle )
+			);
+		}
+
+		// Update the document title.
+		document.title = documentTitle;
+	}, [ postTitle, postType, siteTitle, isCleanNewPost ] );
+
+	// Restore original title on unmount.
+	useEffect( () => {
+		const originalTitle = originalDocumentTitle.current;
+		return () => {
+			if ( originalTitle ) {
+				document.title = originalTitle;
+			}
+		};
+	}, [] );
+
+	// This component doesn't render any visible content.
+	return null;
+}
+
+export default DocumentTitle;

--- a/packages/edit-post/src/components/document-title/test/index.js
+++ b/packages/edit-post/src/components/document-title/test/index.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { createReduxStore, register } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import DocumentTitle from '../index';
+
+// Mock the stores
+const mockCoreStore = createReduxStore( 'core', {
+	reducer: () => ( {} ),
+	selectors: {
+		getEntityRecord: () => ( { title: 'Test Site' } ),
+	},
+} );
+
+const mockEditorStore = createReduxStore( 'core/editor', {
+	reducer: () => ( {} ),
+	selectors: {
+		getEditedPostAttribute: ( state, attribute ) => {
+			const mockData = {
+				title: 'Test Post',
+				type: 'post',
+				status: 'publish',
+			};
+			return mockData[ attribute ];
+		},
+		isCleanNewPost: () => false,
+	},
+} );
+
+register( mockCoreStore );
+register( mockEditorStore );
+
+describe( 'DocumentTitle', () => {
+	const originalDocumentTitle = document.title;
+
+	beforeEach( () => {
+		document.title = 'Original Title';
+	} );
+
+	afterEach( () => {
+		document.title = originalDocumentTitle;
+	} );
+
+	it( 'should render without crashing', () => {
+		const { container } = render( <DocumentTitle /> );
+		expect( container ).toBeEmptyDOMElement(); // Component renders null
+	} );
+} );

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -70,6 +70,7 @@ import useEditPostCommands from '../../commands/use-commands';
 import { usePaddingAppender } from './use-padding-appender';
 import { useShouldIframe } from './use-should-iframe';
 import useNavigateToEntityRecord from '../../hooks/use-navigate-to-entity-record';
+import DocumentTitle from '../document-title';
 import { useMetaBoxInitialization } from '../meta-boxes/use-meta-box-initialization';
 
 const { getLayoutStyles } = unlock( blockEditorPrivateApis );
@@ -383,6 +384,7 @@ function Layout( {
 		initialPostType,
 		'post-only'
 	);
+
 	const isEditingTemplate = currentPostType === 'wp_template';
 	const {
 		mode,
@@ -616,6 +618,7 @@ function Layout( {
 						}
 					>
 						<PostLockedModal />
+						<DocumentTitle />
 						<EditorInitialization />
 						<FullscreenMode isActive={ isFullscreenActive } />
 						<BrowserURL />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71472 

This PR fixes issue of document title of post edit page not matching with post's title when editing

> TODO: Update description when ready for review

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
