### PR TITLE
Experiment: Make unsynced patterns content only by default

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -37,6 +37,9 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-editor-write-mode', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEditorWriteMode = true', 'before' );
 	}
+	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-content-only-pattern-insertion', $gutenberg_experiments ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalContentOnlyPatternInsertion = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -199,6 +199,18 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
+	add_settings_field(
+		'gutenberg-content-only-pattern-insertion',
+		__( 'contentOnly: Make patterns contentOnly by default upon insertion', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'When patterns are inserted, default to a simplified content only mode for editing pattern content.', 'gutenberg' ),
+			'id'    => 'gutenberg-content-only-pattern-insertion',
+		)
+	);
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/packages/block-editor/src/autocompleters/block.js
+++ b/packages/block-editor/src/autocompleters/block.js
@@ -3,9 +3,9 @@
  */
 import { useSelect } from '@wordpress/data';
 import {
+	cloneBlock,
 	createBlock,
 	createBlocksFromInnerBlocksTemplate,
-	parse,
 	store as blocksStore,
 } from '@wordpress/blocks';
 import { useMemo } from '@wordpress/element';
@@ -125,21 +125,16 @@ function createBlockCompleter() {
 			return ! ( /\S/.test( before ) || /\S/.test( after ) );
 		},
 		getOptionCompletion( inserterItem ) {
-			const {
-				name,
-				initialAttributes,
-				innerBlocks,
-				syncStatus,
-				content,
-			} = inserterItem;
+			const { name, initialAttributes, innerBlocks, syncStatus, blocks } =
+				inserterItem;
 
 			return {
 				action: 'replace',
 				value:
 					syncStatus === 'unsynced'
-						? parse( content, {
-								__unstableSkipMigrationLogs: true,
-						  } )
+						? ( blocks ?? [] ).map( ( block ) =>
+								cloneBlock( block )
+						  )
 						: createBlock(
 								name,
 								initialAttributes,

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -30,6 +30,7 @@ import { useBlockVariationTransforms } from './block-variation-transformations';
 import BlockStylesMenu from './block-styles-menu';
 import PatternTransformationsMenu from './pattern-transformations-menu';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
+import { unlock } from '../../lock-unlock';
 
 function BlockSwitcherDropdownMenuContents( {
 	onClose,
@@ -196,6 +197,7 @@ export const BlockSwitcher = ( { clientIds } ) => {
 		isReusable,
 		isTemplate,
 		isDisabled,
+		isSection,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -204,7 +206,8 @@ export const BlockSwitcher = ( { clientIds } ) => {
 				getBlockAttributes,
 				canRemoveBlocks,
 				getBlockEditingMode,
-			} = select( blockEditorStore );
+				isSectionBlock,
+			} = unlock( select( blockEditorStore ) );
 			const { getBlockStyles, getBlockType, getActiveBlockVariation } =
 				select( blocksStore );
 			const _blocks = getBlocksByClientId( clientIds );
@@ -250,6 +253,7 @@ export const BlockSwitcher = ( { clientIds } ) => {
 					_isSingleBlockSelected && isTemplatePart( _blocks[ 0 ] ),
 				hasContentOnlyLocking: _hasTemplateLock,
 				isDisabled: editingMode !== 'default',
+				isSection: isSectionBlock( clientIds[ 0 ] ),
 			};
 		},
 		[ clientIds ]
@@ -278,7 +282,10 @@ export const BlockSwitcher = ( { clientIds } ) => {
 			? blockTitle
 			: undefined;
 
+	const hideTransformsForSections =
+		window?.__experimentalContentOnlyPatternInsertion && isSection;
 	const hideDropdown =
+		hideTransformsForSections ||
 		isDisabled ||
 		( ! hasBlockStyles && ! canRemove ) ||
 		hasContentOnlyLocking;

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -154,10 +154,7 @@ export function PrivateBlockToolbar( {
 			showGroupButtons: ! _isZoomOut,
 			showLockButtons: ! _isZoomOut,
 			showSwitchSectionStyleButton:
-				_isZoomOut ||
-				( isNavigationModeEnabled &&
-					editingMode === 'contentOnly' &&
-					isSectionBlock( selectedBlockClientId ) ), // Zoom out or Write Mode Section Blocks
+				_isZoomOut || isSectionBlock( selectedBlockClientId ),
 			hasFixedToolbar: getSettings().hasFixedToolbar,
 			isNavigationMode: isNavigationModeEnabled,
 		};

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -128,6 +128,16 @@ export function PrivateBlockToolbar( {
 
 		const _isZoomOut = isZoomOut();
 
+		// The switch style button appears more prominently with the
+		// content only pattern experiment.
+		const _showSwitchSectionStyleButton =
+			window?.__experimentalContentOnlyPatternInsertion
+				? _isZoomOut || isSectionBlock( selectedBlockClientId )
+				: _isZoomOut ||
+				  ( isNavigationModeEnabled &&
+						editingMode === 'contentOnly' &&
+						isSectionBlock( selectedBlockClientId ) );
+
 		return {
 			blockClientId: selectedBlockClientId,
 			blockClientIds: selectedBlockClientIds,
@@ -153,8 +163,7 @@ export function PrivateBlockToolbar( {
 			showSlots: ! _isZoomOut,
 			showGroupButtons: ! _isZoomOut,
 			showLockButtons: ! _isZoomOut,
-			showSwitchSectionStyleButton:
-				_isZoomOut || isSectionBlock( selectedBlockClientId ),
+			showSwitchSectionStyleButton: _showSwitchSectionStyleButton,
 			hasFixedToolbar: getSettings().hasFixedToolbar,
 			isNavigationMode: isNavigationModeEnabled,
 		};

--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -139,32 +139,40 @@ function VariationsToggleGroupControl( {
 
 function __experimentalBlockVariationTransforms( { blockClientId } ) {
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
-	const { activeBlockVariation, variations, isContentOnly } = useSelect(
-		( select ) => {
-			const { getActiveBlockVariation, getBlockVariations } =
-				select( blocksStore );
+	const { activeBlockVariation, variations, isContentOnly, isSection } =
+		useSelect(
+			( select ) => {
+				const { getActiveBlockVariation, getBlockVariations } =
+					select( blocksStore );
 
-			const { getBlockName, getBlockAttributes, getBlockEditingMode } =
-				select( blockEditorStore );
+				const {
+					getBlockName,
+					getBlockAttributes,
+					getBlockEditingMode,
+				} = select( blockEditorStore );
+				const { isSectionBlock } = unlock( select( blockEditorStore ) );
 
-			const name = blockClientId && getBlockName( blockClientId );
+				const name = blockClientId && getBlockName( blockClientId );
 
-			const { hasContentRoleAttribute } = unlock( select( blocksStore ) );
-			const isContentBlock = hasContentRoleAttribute( name );
+				const { hasContentRoleAttribute } = unlock(
+					select( blocksStore )
+				);
+				const isContentBlock = hasContentRoleAttribute( name );
 
-			return {
-				activeBlockVariation: getActiveBlockVariation(
-					name,
-					getBlockAttributes( blockClientId )
-				),
-				variations: name && getBlockVariations( name, 'transform' ),
-				isContentOnly:
-					getBlockEditingMode( blockClientId ) === 'contentOnly' &&
-					! isContentBlock,
-			};
-		},
-		[ blockClientId ]
-	);
+				return {
+					activeBlockVariation: getActiveBlockVariation(
+						name,
+						getBlockAttributes( blockClientId )
+					),
+					variations: name && getBlockVariations( name, 'transform' ),
+					isContentOnly:
+						getBlockEditingMode( blockClientId ) ===
+							'contentOnly' && ! isContentBlock,
+					isSection: isSectionBlock( blockClientId ),
+				};
+			},
+			[ blockClientId ]
+		);
 
 	const selectedValue = activeBlockVariation?.name;
 
@@ -189,7 +197,7 @@ function __experimentalBlockVariationTransforms( { blockClientId } ) {
 		} );
 	};
 
-	if ( ! variations?.length || isContentOnly ) {
+	if ( ! variations?.length || isContentOnly || isSection ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -149,8 +149,8 @@ function __experimentalBlockVariationTransforms( { blockClientId } ) {
 					getBlockName,
 					getBlockAttributes,
 					getBlockEditingMode,
-				} = select( blockEditorStore );
-				const { isSectionBlock } = unlock( select( blockEditorStore ) );
+					isSectionBlock,
+				} = unlock( select( blockEditorStore ) );
 
 				const name = blockClientId && getBlockName( blockClientId );
 

--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -197,7 +197,10 @@ function __experimentalBlockVariationTransforms( { blockClientId } ) {
 		} );
 	};
 
-	if ( ! variations?.length || isContentOnly || isSection ) {
+	const hideVariationsForSections =
+		window?.__experimentalContentOnlyPatternInsertion && isSection;
+
+	if ( ! variations?.length || isContentOnly || hideVariationsForSections ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -18,6 +18,7 @@ import {
 	getClientIdsWithDescendants,
 	isNavigationMode,
 	getBlockRootClientId,
+	getBlockAttributes,
 } from './selectors';
 import {
 	checkAllowListRecursive,
@@ -534,6 +535,11 @@ export function isSectionBlock( state, clientId ) {
 		blockName === 'core/block' ||
 		getTemplateLock( state, clientId ) === 'contentOnly'
 	) {
+		return true;
+	}
+
+	const attributes = getBlockAttributes( state, clientId );
+	if ( attributes?.metadata?.patternName ) {
 		return true;
 	}
 

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -25,8 +25,8 @@ import {
 	getAllPatternsDependants,
 	getInsertBlockTypeDependants,
 	getGrammar,
+	mapUserPattern,
 } from './utils';
-import { INSERTER_PATTERN_TYPES } from '../components/inserter/block-patterns-tab/utils';
 import { STORE_NAME } from './constants';
 import { unlock } from '../lock-unlock';
 import {
@@ -348,26 +348,6 @@ export const hasAllowedPatterns = createRegistrySelector( ( select ) =>
 		]
 	)
 );
-
-function mapUserPattern(
-	userPattern,
-	__experimentalUserPatternCategories = []
-) {
-	return {
-		name: `core/block/${ userPattern.id }`,
-		id: userPattern.id,
-		type: INSERTER_PATTERN_TYPES.user,
-		title: userPattern.title.raw,
-		categories: userPattern.wp_pattern_category?.map( ( catId ) => {
-			const category = __experimentalUserPatternCategories.find(
-				( { id } ) => id === catId
-			);
-			return category ? category.slug : catId;
-		} ),
-		content: userPattern.content.raw,
-		syncStatus: userPattern.wp_pattern_sync_status,
-	};
-}
 
 export const getPatternBySlug = createRegistrySelector( ( select ) =>
 	createSelector(

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -539,7 +539,10 @@ export function isSectionBlock( state, clientId ) {
 	}
 
 	const attributes = getBlockAttributes( state, clientId );
-	if ( attributes?.metadata?.patternName ) {
+	if (
+		attributes?.metadata?.patternName &&
+		!! window?.__experimentalContentOnlyPatternInsertion
+	) {
 		return true;
 	}
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2275,12 +2275,14 @@ function getDerivedBlockEditingModesForTree(
 	);
 	// Use array.from for better back compat. Older versions of the iterator returned
 	// from `keys()` didn't have the `filter` method.
-	const unsyncedPatternClientIds = Array.from(
-		state.blocks.attributes.keys()
-	).filter(
-		( clientId ) =>
-			state.blocks.attributes.get( clientId )?.metadata?.patternName
-	);
+	const unsyncedPatternClientIds =
+		!! window?.__experimentalContentOnlyPatternInsertion
+			? Array.from( state.blocks.attributes.keys() ).filter(
+					( clientId ) =>
+						state.blocks.attributes.get( clientId )?.metadata
+							?.patternName
+			  )
+			: [];
 	const contentOnlyParents = [
 		...contentOnlyTemplateLockedClientIds,
 		...unsyncedPatternClientIds,

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2273,12 +2273,14 @@ function getDerivedBlockEditingModesForTree(
 		( clientId ) =>
 			state.blockListSettings[ clientId ]?.templateLock === 'contentOnly'
 	);
-	const unsyncedPatternClientIds = state.blocks.attributes
-		.keys()
-		.filter(
-			( clientId ) =>
-				state.blocks.attributes.get( clientId )?.metadata?.patternName
-		);
+	// Use array.from for better back compat. Older versions of the iterator returned
+	// from `keys()` didn't have the `filter` method.
+	const unsyncedPatternClientIds = Array.from(
+		state.blocks.attributes.keys()
+	).filter(
+		( clientId ) =>
+			state.blocks.attributes.get( clientId )?.metadata?.patternName
+	);
 	const contentOnlyParents = [
 		...contentOnlyTemplateLockedClientIds,
 		...unsyncedPatternClientIds,

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2273,6 +2273,16 @@ function getDerivedBlockEditingModesForTree(
 		( clientId ) =>
 			state.blockListSettings[ clientId ]?.templateLock === 'contentOnly'
 	);
+	const unsyncedPatternClientIds = state.blocks.attributes
+		.keys()
+		.filter(
+			( clientId ) =>
+				state.blocks.attributes.get( clientId )?.metadata?.patternName
+		);
+	const contentOnlyParents = [
+		...contentOnlyTemplateLockedClientIds,
+		...unsyncedPatternClientIds,
+	];
 
 	traverseBlockTree( state, treeClientId, ( block ) => {
 		const { clientId, name: blockName } = block;
@@ -2464,15 +2474,14 @@ function getDerivedBlockEditingModesForTree(
 			}
 		}
 
-		// `templateLock: 'contentOnly'` derived modes.
-		if ( contentOnlyTemplateLockedClientIds.length ) {
-			const hasContentOnlyTemplateLockedParent =
-				!! findParentInClientIdsList(
-					state,
-					clientId,
-					contentOnlyTemplateLockedClientIds
-				);
-			if ( hasContentOnlyTemplateLockedParent ) {
+		// Handle `templateLock=contentOnly` blocks and unsynced patterns.
+		if ( contentOnlyParents.length ) {
+			const hasContentOnlyParent = !! findParentInClientIdsList(
+				state,
+				clientId,
+				contentOnlyParents
+			);
+			if ( hasContentOnlyParent ) {
 				if ( isContentBlock( blockName ) ) {
 					derivedBlockEditingModes.set( clientId, 'contentOnly' );
 				} else {

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -504,6 +504,10 @@ describe( 'private selectors', () => {
 					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
 					[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'disabled' ],
 				] ),
+				derivedBlockEditingModes: new Map( [
+					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
+					[ 'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c', 'disabled' ],
+				] ),
 				blockListSettings: {},
 			};
 			expect(

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -504,10 +504,6 @@ describe( 'private selectors', () => {
 					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
 					[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'disabled' ],
 				] ),
-				derivedBlockEditingModes: new Map( [
-					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
-					[ 'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c', 'disabled' ],
-				] ),
 				blockListSettings: {},
 			};
 			expect(

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -3402,6 +3402,18 @@ describe( 'selectors', () => {
 				( item ) => item.id === 'core/block/1'
 			);
 			expect( reusableBlockItem ).toEqual( {
+				blocks: [
+					expect.objectContaining( {
+						attributes: {
+							metadata: expect.objectContaining( {
+								name: 'Reusable Block 1',
+								patternName: 'core/block/1',
+							} ),
+						},
+						isValid: true,
+						innerBlocks: [],
+					} ),
+				],
 				category: 'reusable',
 				content: '<!-- /wp:test-block-a -->',
 				frecency: 0,

--- a/packages/block-editor/src/store/utils.js
+++ b/packages/block-editor/src/store/utils.js
@@ -25,14 +25,14 @@ export function mapUserPattern(
 		name: `core/block/${ userPattern.id }`,
 		id: userPattern.id,
 		type: INSERTER_PATTERN_TYPES.user,
-		title: userPattern.title.raw,
+		title: userPattern.title?.raw,
 		categories: userPattern.wp_pattern_category?.map( ( catId ) => {
 			const category = __experimentalUserPatternCategories.find(
 				( { id } ) => id === catId
 			);
 			return category ? category.slug : catId;
 		} ),
-		content: userPattern.content.raw,
+		content: userPattern.content?.raw,
 		syncStatus: userPattern.wp_pattern_sync_status,
 	};
 }

--- a/packages/block-editor/src/store/utils.js
+++ b/packages/block-editor/src/store/utils.js
@@ -11,10 +11,31 @@ import { selectBlockPatternsKey } from './private-keys';
 import { unlock } from '../lock-unlock';
 import { STORE_NAME } from './constants';
 import { getSectionRootClientId } from './private-selectors';
+import { INSERTER_PATTERN_TYPES } from '../components/inserter/block-patterns-tab/utils';
 
 export const isFiltered = Symbol( 'isFiltered' );
 const parsedPatternCache = new WeakMap();
 const grammarMapCache = new WeakMap();
+
+export function mapUserPattern(
+	userPattern,
+	__experimentalUserPatternCategories = []
+) {
+	return {
+		name: `core/block/${ userPattern.id }`,
+		id: userPattern.id,
+		type: INSERTER_PATTERN_TYPES.user,
+		title: userPattern.title.raw,
+		categories: userPattern.wp_pattern_category?.map( ( catId ) => {
+			const category = __experimentalUserPatternCategories.find(
+				( { id } ) => id === catId
+			);
+			return category ? category.slug : catId;
+		} ),
+		content: userPattern.content.raw,
+		syncStatus: userPattern.wp_pattern_sync_status,
+	};
+}
 
 function parsePattern( pattern ) {
 	const blocks = parse( pattern.content, {


### PR DESCRIPTION
## What?
Part of #71517

Fixes https://github.com/WordPress/gutenberg/issues/71552

Tests out an idea of making all unsynced patterns `contentOnly` when inserted.

At the moment this is missing some niceties, like being able to 'unlock' the pattern to edit it fully. The PR is just to see how it feels, but I'd welcome anyone to add commits with additional features.

## How?
this PR is based on [Refactor: Content only template locking block editing modes to reducer](https://github.com/WordPress/gutenberg/pull/67606#top), which makes it much easier to implement.

When a block has a `metadata.patternName` attribute it'll be given the same `blockEditingModes` as a block that has `templateLock: contentOnly`.

## Todo
- [x] Add an experiment toggle for this behavior?
- [x] Add contentOnly mode to unsynced patterns more reliably via the `patternName` attribute (e.g. add it to user created patterns, check that it works for patterns that are included in templates by the theme, as well as bundled patterns)
- [x] Ensure the 'Shuffle Styles' toolbar button is available when an unsynced pattern is content only (https://github.com/WordPress/gutenberg/pull/71512#issuecomment-3257144715)
- [ ] Add the contentOnly default behavior for template parts as well (could also be a follow-up)

## Testing Instructions

First, enable the experiment in Gutenberg's experiment settings page:

<img width="932" height="170" alt="image" src="https://github.com/user-attachments/assets/bcb7a3c7-1a2b-4756-be34-c06c5d578d58" />

1. Create a new post
2. Open the inserter
3. Add an unsynced pattern
4. Try editing the pattern
5. Open List View and check which blocks can be selected

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/81838c65-d410-41c4-985b-1d8f59181e95


