### PR TITLE
element: Make createInterpolateElement TS/type smart

### DIFF
--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -110,7 +110,7 @@ You would have something like this as the conversionMap value:
 _Parameters_
 
 -   _interpolatedString_ `T`: The interpolation string to be parsed.
--   _conversionMap_ `ConversionMap< T >`: The map used to convert the string to a react element.
+-   _conversionMap_ `ConversionMap<  >`: The map used to convert the string to a react element.
 
 _Returns_
 

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -109,8 +109,8 @@ You would have something like this as the conversionMap value:
 
 _Parameters_
 
--   _interpolatedString_ `T`: The interpolation string to be parsed.
--   _conversionMap_ `ConversionMap<  >`: The map used to convert the string to a react element.
+-   _interpolatedString_ `Input`: The interpolation string to be parsed.
+-   _conversionMap_ `ConversionMap< InterpolationString< Input > >`: The map used to convert the string to a react element.
 
 _Returns_
 

--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -109,8 +109,8 @@ You would have something like this as the conversionMap value:
 
 _Parameters_
 
--   _interpolatedString_ `string`: The interpolation string to be parsed.
--   _conversionMap_ `Record< string, ReactElement >`: The map used to convert the string to a react element.
+-   _interpolatedString_ `T`: The interpolation string to be parsed.
+-   _conversionMap_ `ConversionMap< T >`: The map used to convert the string to a react element.
 
 _Returns_
 

--- a/packages/element/src/create-interpolate-element.ts
+++ b/packages/element/src/create-interpolate-element.ts
@@ -8,6 +8,7 @@ import {
 	isValidElement,
 	type Element as ReactElement,
 } from './react';
+import type { ConversionMap } from './types';
 
 let indoc: string;
 let offset: number;
@@ -126,9 +127,9 @@ function createFrame(
  * @throws {TypeError}
  * @return A wp element.
  */
-const createInterpolateElement = (
-	interpolatedString: string,
-	conversionMap: Record< string, ReactElement >
+const createInterpolateElement = < T extends string >(
+	interpolatedString: T,
+	conversionMap: ConversionMap< T >
 ): ReactElement => {
 	indoc = interpolatedString;
 	offset = 0;

--- a/packages/element/src/create-interpolate-element.ts
+++ b/packages/element/src/create-interpolate-element.ts
@@ -8,7 +8,7 @@ import {
 	isValidElement,
 	type Element as ReactElement,
 } from './react';
-import type { ConversionMap } from './types';
+import type { ConversionMap, TranslatableText } from './types';
 
 let indoc: string;
 let offset: number;
@@ -127,10 +127,14 @@ function createFrame(
  * @throws {TypeError}
  * @return A wp element.
  */
-const createInterpolateElement = < T extends string >(
+function createInterpolateElement<
+	T extends string | TranslatableText< string >,
+>(
 	interpolatedString: T,
-	conversionMap: ConversionMap< T >
-): ReactElement => {
+	conversionMap: ConversionMap<
+		T extends TranslatableText< infer Text > ? Text : T
+	>
+): ReactElement {
 	indoc = interpolatedString;
 	offset = 0;
 	output = [];
@@ -147,7 +151,7 @@ const createInterpolateElement = < T extends string >(
 		// twiddle our thumbs
 	} while ( proceed( conversionMap ) );
 	return createElement( Fragment, null, ...output );
-};
+}
 
 /**
  * Validate conversion map.

--- a/packages/element/src/create-interpolate-element.ts
+++ b/packages/element/src/create-interpolate-element.ts
@@ -8,7 +8,11 @@ import {
 	isValidElement,
 	type Element as ReactElement,
 } from './react';
-import type { ConversionMap, TranslatableText } from './types';
+import type {
+	ConversionMap,
+	InterpolationInput,
+	InterpolationString,
+} from './types';
 
 let indoc: string;
 let offset: number;
@@ -127,13 +131,9 @@ function createFrame(
  * @throws {TypeError}
  * @return A wp element.
  */
-function createInterpolateElement<
-	T extends string | TranslatableText< string >,
->(
-	interpolatedString: T,
-	conversionMap: ConversionMap<
-		T extends TranslatableText< infer Text > ? Text : T
-	>
+function createInterpolateElement< Input extends InterpolationInput >(
+	interpolatedString: Input,
+	conversionMap: ConversionMap< InterpolationString< Input > >
 ): ReactElement {
 	indoc = interpolatedString;
 	offset = 0;

--- a/packages/element/src/test/create-interpolate-element.tsx
+++ b/packages/element/src/test/create-interpolate-element.tsx
@@ -26,10 +26,11 @@ describe( 'createInterpolateElement', () => {
 	it( 'throws an error when there is an invalid conversion map', () => {
 		const testString = 'This is a <someValue/> string';
 		expect( () =>
-			createInterpolateElement( testString, [
-				'someValue',
-				{ value: 10 },
-			] )
+			createInterpolateElement(
+				testString,
+				// @ts-expect-error - Invalid argument type
+				[ 'someValue', { value: 10 } ]
+			)
 		).toThrow( TypeError );
 	} );
 	it(
@@ -40,6 +41,7 @@ describe( 'createInterpolateElement', () => {
 			expect( () =>
 				createInterpolateElement( testString, {
 					someValue: <em />,
+					// @ts-expect-error - Invalid type for somethingElse
 					somethingElse: 10,
 				} )
 			).toThrow( TypeError );
@@ -53,6 +55,7 @@ describe( 'createInterpolateElement', () => {
 			const expectedElement = <>{ testString }</>;
 			expect(
 				createInterpolateElement( testString, {
+					// @ts-expect-error - Unknown tag
 					someValue: <strong />,
 				} )
 			).toEqual( expectedElement );
@@ -162,8 +165,8 @@ describe( 'createInterpolateElement', () => {
 	} );
 	it( 'returns expected output for complex replacement', () => {
 		class TestComponent extends Component {
-			render( props ) {
-				return <div { ...props } />;
+			render() {
+				return <div { ...this.props } />;
 			}
 		}
 		const testString =

--- a/packages/element/src/test/create-interpolate-element.tsx
+++ b/packages/element/src/test/create-interpolate-element.tsx
@@ -40,7 +40,7 @@ describe( 'createInterpolateElement', () => {
 			const testString = 'This is a <item /> string and <somethingElse/>';
 			expect( () =>
 				createInterpolateElement( testString, {
-					someValue: <em />,
+					item: <em />,
 					// @ts-expect-error - Invalid type for somethingElse
 					somethingElse: 10,
 				} )

--- a/packages/element/src/test/create-interpolate-element.tsx
+++ b/packages/element/src/test/create-interpolate-element.tsx
@@ -8,6 +8,7 @@ import { render } from '@testing-library/react';
  */
 import { createElement, Fragment, Component } from '../react';
 import createInterpolateElement from '../create-interpolate-element';
+import type { ExtractTags, InterpolationString } from '../types';
 
 describe( 'createInterpolateElement', () => {
 	it( 'throws an error when there is no conversion map', () => {
@@ -219,6 +220,23 @@ describe( 'createInterpolateElement', () => {
 
 		expect( container ).toContainHTML( '<strong>string!</strong>' );
 		expect( container ).not.toContainHTML( '<em>' );
+	} );
+	it( 'extracts all tag names from a template literal string', () => {
+		// Type-level test: verify ExtractTags extracts all tags correctly.
+		type Tags = ExtractTags< '<a>link</a> and <b>bold <c>nested</c></b>' >;
+		const tags: Tags[] = [ 'a', 'b', 'c' ];
+		expect( tags ).toHaveLength( 3 );
+	} );
+	it( 'extracts tags from a TranslatableText input', () => {
+		// Type-level test: verify InterpolationString unwraps TranslatableText.
+		type Text = InterpolationString<
+			string & {
+				readonly __translatableText: '<a>link</a> and <em>emphasis</em>';
+			}
+		>;
+		type Tags = ExtractTags< Text >;
+		const tags: Tags[] = [ 'a', 'em' ];
+		expect( tags ).toHaveLength( 2 );
 	} );
 	it( 'handles parsing emojii correctly', () => {
 		const testString = '👳‍♀️<icon>🚨🤷‍♂️⛈️fully</icon> here';

--- a/packages/element/src/types.ts
+++ b/packages/element/src/types.ts
@@ -41,9 +41,7 @@ type ExtractTagName< T extends string > = T extends `/${ string }`
  */
 export type ExtractTags< T extends string > =
 	T extends `${ string }<${ infer Tag }>${ infer After }`
-		? ExtractTagName< Tag > extends never
-			? ExtractTags< After >
-			: ExtractTagName< Tag > | ExtractTags< After >
+		? ExtractTagName< Tag > | ExtractTags< After >
 		: never;
 
 /**

--- a/packages/element/src/types.ts
+++ b/packages/element/src/types.ts
@@ -1,0 +1,32 @@
+/**
+ * Helper type to extract tag name and handle closing/self-closing indicators
+ * Matches the tokenizer regex: /<(\/)?(\w+)\s*(\/)?>/g
+ * Filters out tags with spaces as they won't be parsed by the tokenizer
+ */
+type ExtractTagName< T extends string > = T extends `/${ string }`
+	? never // Skip closing tags like "/div"
+	: T extends `${ string } ${ string }`
+	? never // Skip tags with spaces like "spaced token"
+	: T extends `${ infer Name }/`
+	? Name // Self-closing tags like "br/"
+	: T; // Regular opening tags like "div"
+
+/**
+ * Utility type to extract all tag names from a template literal string.
+ * Only handles simple tags without attributes, matching the runtime tokenizer.
+ */
+export type ExtractTags< T extends string > =
+	T extends `${ string }<${ infer Tag }>${ infer After }`
+		? ExtractTagName< Tag > extends never
+			? ExtractTags< After >
+			: ExtractTagName< Tag > | ExtractTags< After >
+		: never;
+
+/**
+ * Utility type to create a conversion map that:
+ * - Makes extracted tag keys optional
+ * - Only allows properties for tags found in the template literal
+ */
+export type ConversionMap< T extends string > = Partial<
+	Record< ExtractTags< T >, React.ReactElement >
+>;

--- a/packages/element/src/types.ts
+++ b/packages/element/src/types.ts
@@ -25,7 +25,6 @@ export type InterpolationString< Input > = Input extends TranslatableText<
 
 /**
  * Helper type to extract tag name and handle closing/self-closing indicators
- * Matches the tokenizer regex: /<(\/)?(\w+)\s*(\/)?>/g
  * Filters out tags with spaces as they won't be parsed by the tokenizer
  */
 type ExtractTagName< T extends string > = T extends `/${ string }`

--- a/packages/element/src/types.ts
+++ b/packages/element/src/types.ts
@@ -24,20 +24,30 @@ export type InterpolationString< Input > = Input extends TranslatableText<
 	: Input;
 
 /**
- * Helper type to extract tag name and handle closing/self-closing indicators
- * Filters out tags with spaces as they won't be parsed by the tokenizer
+ * Recursively trims trailing spaces from a string type.
+ * Matches the runtime tokenizer's `\s*` before the closing `>` or `/>`.
  */
-type ExtractTagName< T extends string > = T extends `/${ string }`
-	? never // Skip closing tags like "/div"
-	: T extends `${ infer Name } /`
-	? Name extends `${ string } ${ string }`
-		? never // Skip if name itself has spaces
-		: Name // Self-closing tags with space like "item /"
-	: T extends `${ infer Name }/`
-	? Name // Self-closing tags like "br/"
-	: T extends `${ string } ${ string }`
-	? never // Skip tags with spaces like "spaced token"
-	: T; // Regular opening tags like "div"
+type TrimTrailingSpaces< S extends string > = S extends `${ infer Rest } `
+	? TrimTrailingSpaces< Rest >
+	: S;
+
+/**
+ * Helper type to extract tag name and handle closing/self-closing indicators.
+ * Filters out tags with spaces as they won't be parsed by the tokenizer.
+ */
+type ExtractTagName< T extends string > =
+	// Skip closing tags like "/div"
+	T extends `/${ string }`
+		? never
+		: TrimTrailingSpaces< T > extends infer Name extends string
+		? Name extends ''
+			? never // Empty tag name
+			: Name extends `${ string } ${ string }`
+			? never // Skip tags with inner spaces like "spaced token"
+			: Name extends `${ infer Base }/`
+			? Base // Self-closing tags like "br/"
+			: Name // Regular opening tags like "div"
+		: never;
 
 /**
  * Utility type to extract all tag names from a template literal string.

--- a/packages/element/src/types.ts
+++ b/packages/element/src/types.ts
@@ -1,4 +1,13 @@
 /**
+ * This type is used by @wordpress/i18n to make sprintf type-safe.
+ *
+ * We don't want to import from there directly to avoid a circular dependency.
+ */
+export type TranslatableText< T extends string > = string & {
+	readonly __translatableText: T;
+};
+
+/**
  * Helper type to extract tag name and handle closing/self-closing indicators
  * Matches the tokenizer regex: /<(\/)?(\w+)\s*(\/)?>/g
  * Filters out tags with spaces as they won't be parsed by the tokenizer

--- a/packages/element/src/types.ts
+++ b/packages/element/src/types.ts
@@ -29,10 +29,14 @@ export type InterpolationString< Input > = Input extends TranslatableText<
  */
 type ExtractTagName< T extends string > = T extends `/${ string }`
 	? never // Skip closing tags like "/div"
-	: T extends `${ string } ${ string }`
-	? never // Skip tags with spaces like "spaced token"
+	: T extends `${ infer Name } /`
+	? Name extends `${ string } ${ string }`
+		? never // Skip if name itself has spaces
+		: Name // Self-closing tags with space like "item /"
 	: T extends `${ infer Name }/`
 	? Name // Self-closing tags like "br/"
+	: T extends `${ string } ${ string }`
+	? never // Skip tags with spaces like "spaced token"
 	: T; // Regular opening tags like "div"
 
 /**

--- a/packages/element/src/types.ts
+++ b/packages/element/src/types.ts
@@ -1,11 +1,27 @@
+import type { ReactElement } from 'react';
+
 /**
  * This type is used by @wordpress/i18n to make sprintf type-safe.
  *
  * We don't want to import from there directly to avoid a circular dependency.
  */
-export type TranslatableText< T extends string > = string & {
+type TranslatableText< T extends string > = string & {
 	readonly __translatableText: T;
 };
+
+/**
+ * The input that can be passed to `createInterpolateElement`.
+ */
+export type InterpolationInput = string | TranslatableText< string >;
+
+/**
+ * The literal string extracted from the input.
+ */
+export type InterpolationString< Input > = Input extends TranslatableText<
+	infer Text
+>
+	? Text
+	: Input;
 
 /**
  * Helper type to extract tag name and handle closing/self-closing indicators
@@ -37,5 +53,5 @@ export type ExtractTags< T extends string > =
  * - Only allows properties for tags found in the template literal
  */
 export type ConversionMap< T extends string > = Partial<
-	Record< ExtractTags< T >, React.ReactElement >
+	Record< ExtractTags< T >, ReactElement >
 >;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR makes `createInterpolateElement` type/TS smart by interpolating the string passed as the first argument and then providing type-checking for the `conversionMap` provided as the second argument

```ts
import { createInterpolateElement } from '@wordpress/element';

const str =
	'This is a <span>string</span> with <a>a link</a> and a self-closing <CustomComponentA/> tag';
// Example usage demonstrating the enhanced typing:
createInterpolateElement( str, {
	// TypeScript will now enforce that only
	// 'span', 'a', and 'CustomComponentA' keys are allowed
	// and will provide autocompletion for these keys
	span: createElement( 'span' ),
	a: createElement( 'a', { href: 'https://github.com' } ),
	CustomComponentA: createElement( 'div' ),
	// It will not allow keys not present in the string
	CustomComponentB: createElement( 'div' ), // This would cause a TypeScript error
} );

// This will validate that the values are React elements
createInterpolateElement( str, {
	span: createElement( 'span' ),
	a: createElement( 'a' ),
	CustomComponentA: 'not an element', // This would cause a TypeScript error
} );
```

## Why?

To enhance type-safety and allow auto-completions for `createInterpolateElement`

## How?

The PR uses some advanced TypeScrip string interpolation to create types like `ConversionMap` which uses another type `ExtractTags` which extracts tags from the passed string. The types are commented enough to make them readable and maintainable

## Testing Instructions

- Copy the above snippet in your editor
- Confirm that you see the auto-completions
- Confirm that conversion map is type-checked as demonstrated

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="979" height="926" alt="Screenshot 2025-09-05 at 12 19 31 PM" src="https://github.com/user-attachments/assets/cf828f72-939a-4aa7-955a-3c0de9fe4498" />

