### PR TITLE
Refactor Link UI controls with better props

### DIFF
--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -142,24 +142,34 @@ function UnforwardedLinkUI( props, ref ) {
 						onChange={ props.onChange }
 						onRemove={ props.onRemove }
 						onCancel={ props.onCancel }
-						renderControlBottom={ () => (
-							<LinkUITools
-								focusAddBlockButton={ focusAddBlockButton }
-								focusAddPageButton={ focusAddPageButton }
-								setAddingBlock={ () => {
-									setAddingBlock( true );
-									setFocusAddBlockButton( false );
-								} }
-								setAddingPage={ () => {
-									setAddingPage( true );
-									setFocusAddPageButton( false );
-								} }
-								canAddPage={
-									permissions?.canCreate && type === 'page'
-								}
-								canAddBlock={ blockEditingMode === 'default' }
-							/>
-						) }
+						renderControlBottom={ () => {
+							// Don't show the tools when there is submitted link (preview state).
+							if ( link?.url?.length ) {
+								return null;
+							}
+
+							return (
+								<LinkUITools
+									focusAddBlockButton={ focusAddBlockButton }
+									focusAddPageButton={ focusAddPageButton }
+									setAddingBlock={ () => {
+										setAddingBlock( true );
+										setFocusAddBlockButton( false );
+									} }
+									setAddingPage={ () => {
+										setAddingPage( true );
+										setFocusAddPageButton( false );
+									} }
+									canAddPage={
+										permissions?.canCreate &&
+										type === 'page'
+									}
+									canAddBlock={
+										blockEditingMode === 'default'
+									}
+								/>
+							);
+						} }
 					/>
 				</div>
 			) }

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -73,7 +73,7 @@ function UnforwardedLinkUI( props, ref ) {
 	const [ addingPage, setAddingPage ] = useState( false );
 	const [ focusAddBlockButton, setFocusAddBlockButton ] = useState( false );
 	const [ focusAddPageButton, setFocusAddPageButton ] = useState( false );
-	const { canCreate: canCreatePage } = useResourcePermissions( {
+	const permissions = useResourcePermissions( {
 		kind: 'postType',
 		name: postType,
 	} );
@@ -142,24 +142,24 @@ function UnforwardedLinkUI( props, ref ) {
 						onChange={ props.onChange }
 						onRemove={ props.onRemove }
 						onCancel={ props.onCancel }
-						renderControlBottom={ () =>
-							! link?.url?.length && (
-								<LinkUITools
-									focusAddBlockButton={ focusAddBlockButton }
-									focusAddPageButton={ focusAddPageButton }
-									setAddingBlock={ () => {
-										setAddingBlock( true );
-										setFocusAddBlockButton( false );
-									} }
-									setAddingPage={ () => {
-										setAddingPage( true );
-										setFocusAddPageButton( false );
-									} }
-									blockEditingMode={ blockEditingMode }
-									canCreatePage={ canCreatePage }
-								/>
-							)
-						}
+						renderControlBottom={ () => (
+							<LinkUITools
+								focusAddBlockButton={ focusAddBlockButton }
+								focusAddPageButton={ focusAddPageButton }
+								setAddingBlock={ () => {
+									setAddingBlock( true );
+									setFocusAddBlockButton( false );
+								} }
+								setAddingPage={ () => {
+									setAddingPage( true );
+									setFocusAddPageButton( false );
+								} }
+								canAddPage={
+									permissions?.canCreate && type === 'page'
+								}
+								canAddBlock={ blockEditingMode === 'default' }
+							/>
+						) }
 					/>
 				</div>
 			) }
@@ -199,8 +199,8 @@ const LinkUITools = ( {
 	setAddingPage,
 	focusAddBlockButton,
 	focusAddPageButton,
-	canCreatePage,
-	blockEditingMode,
+	canAddPage,
+	canAddBlock,
 } ) => {
 	const blockInserterAriaRole = 'listbox';
 	const addBlockButtonRef = useRef();
@@ -220,9 +220,14 @@ const LinkUITools = ( {
 		}
 	}, [ focusAddPageButton ] );
 
+	// Don't render anything if neither button should be shown
+	if ( ! canAddPage && ! canAddBlock ) {
+		return null;
+	}
+
 	return (
 		<VStack spacing={ 0 } className="link-ui-tools">
-			{ canCreatePage && (
+			{ canAddPage && (
 				<Button
 					__next40pxDefaultSize
 					ref={ addPageButtonRef }
@@ -236,7 +241,7 @@ const LinkUITools = ( {
 					{ __( 'Create page' ) }
 				</Button>
 			) }
-			{ blockEditingMode === 'default' && (
+			{ canAddBlock && (
 				<Button
 					__next40pxDefaultSize
 					ref={ addBlockButtonRef }


### PR DESCRIPTION
Cherry-picked from #71137

The main purpose is to make it clearer what factors govern the rendering of the Add block and Add page buttons. The component itself shouldn't decide this, it should be simple. 

Previously there was a mix where `<LinkUITools>` did some of the decision logic internally (i.e. via `blockEditingMode`) prop and some of it was passed in as props (i.e. `canCreatePage`).

This change standardises the approach.