### PR TITLE
Dataform: Add new url field type and field control

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Introduce a new `DataViewsPicker` component. [#70971](https://github.com/WordPress/gutenberg/pull/70971)
 - Dataform: Add new `telephone` field type and field control. [#71498](https://github.com/WordPress/gutenberg/pull/71498)
+- Dataform: Add new `url` field type and field control. [#71516](https://github.com/WordPress/gutenberg/pull/71516)
 
 ## 8.0.0 (2025-09-03)
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Introduce a new `DataViewsPicker` component. [#70971](https://github.com/WordPress/gutenberg/pull/70971)
 - Dataform: Add new `telephone` field type and field control. [#71498](https://github.com/WordPress/gutenberg/pull/71498)
-- Dataform: Add new `url` field type and field control. [#71516](https://github.com/WordPress/gutenberg/pull/71516)
+- Dataform: Add new `url` field type and field control. [#71518](https://github.com/WordPress/gutenberg/pull/71518)
 
 ## 8.0.0 (2025-09-03)
 

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -392,6 +392,7 @@ const ValidationComponent = ( {
 		text: string;
 		email: string;
 		telephone: string;
+		url: string;
 		integer: number;
 		boolean: boolean;
 		customEdit: string;
@@ -401,6 +402,7 @@ const ValidationComponent = ( {
 		text: 'Can have letters and spaces',
 		email: 'hi@example.com',
 		telephone: '+306978241796',
+		url: 'https://example.com',
 		integer: 2,
 		boolean: true,
 		customEdit: 'custom control',
@@ -423,6 +425,13 @@ const ValidationComponent = ( {
 	const customTelephoneRule = ( value: ValidatedItem ) => {
 		if ( ! /^\+30\d{10}$/.test( value.telephone ) ) {
 			return 'Telephone number must start with +30 and have 10 digits after.';
+		}
+
+		return null;
+	};
+	const customUrlRule = ( value: ValidatedItem ) => {
+		if ( ! /^https:\/\/example\.com$/.test( value.url ) ) {
+			return 'URL must be from https://example.com domain.';
 		}
 
 		return null;
@@ -470,6 +479,15 @@ const ValidationComponent = ( {
 			},
 		},
 		{
+			id: 'url',
+			type: 'url',
+			label: 'URL',
+			isValid: {
+				required,
+				custom: maybeCustomRule( customUrlRule ),
+			},
+		},
+		{
 			id: 'integer',
 			type: 'integer',
 			label: 'Integer',
@@ -502,6 +520,7 @@ const ValidationComponent = ( {
 			'text',
 			'email',
 			'telephone',
+			'url',
 			'integer',
 			'boolean',
 			'customEdit',

--- a/packages/dataviews/src/dataform-controls/index.tsx
+++ b/packages/dataviews/src/dataform-controls/index.tsx
@@ -16,6 +16,7 @@ import datetime from './datetime';
 import date from './date';
 import email from './email';
 import telephone from './telephone';
+import url from './url';
 import integer from './integer';
 import radio from './radio';
 import select from './select';
@@ -36,6 +37,7 @@ const FORM_CONTROLS: FormControls = {
 	date,
 	email,
 	telephone,
+	url,
 	integer,
 	radio,
 	select,

--- a/packages/dataviews/src/dataform-controls/url.tsx
+++ b/packages/dataviews/src/dataform-controls/url.tsx
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import type { DataFormControlProps } from '../types';
+import ValidatedText from './utils/validated-text';
+
+export default function Url< Item >( {
+	data,
+	field,
+	onChange,
+	hideLabelFromVision,
+}: DataFormControlProps< Item > ) {
+	return (
+		<ValidatedText
+			{ ...{ data, field, onChange, hideLabelFromVision, type: 'url' } }
+		/>
+	);
+}

--- a/packages/dataviews/src/dataform-controls/utils/validated-text.tsx
+++ b/packages/dataviews/src/dataform-controls/utils/validated-text.tsx
@@ -17,7 +17,7 @@ export type DataFormValidatedTextControlProps< Item > =
 		/**
 		 * The input type of the control.
 		 */
-		type?: 'text' | 'email' | 'tel';
+		type?: 'text' | 'email' | 'tel' | 'url';
 	};
 
 export default function ValidatedText< Item >( {

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -22,6 +22,7 @@ import { default as boolean } from './boolean';
 import { default as media } from './media';
 import { default as array } from './array';
 import { default as telephone } from './telephone';
+import { default as url } from './url';
 import { renderFromElements } from '../utils';
 import { ALL_OPERATORS, OPERATOR_IS, OPERATOR_IS_NOT } from '../constants';
 
@@ -68,6 +69,10 @@ export default function getFieldTypeDefinition< Item >(
 
 	if ( 'telephone' === type ) {
 		return telephone;
+	}
+
+	if ( 'url' === type ) {
+		return url;
 	}
 
 	// This is a fallback for fields that don't provide a type.

--- a/packages/dataviews/src/field-types/stories/index.story.tsx
+++ b/packages/dataviews/src/field-types/stories/index.story.tsx
@@ -41,6 +41,7 @@ const meta = {
 				'radio',
 				'select',
 				'telephone',
+				'url',
 				'text',
 				'toggleGroup',
 			],
@@ -69,6 +70,8 @@ type DataType = {
 	emailWithElements: string;
 	telephone: string;
 	telephoneWithElements: string;
+	url: string;
+	urlWithElements: string;
 	media: string;
 	mediaWithElements: string;
 	array: string[];
@@ -94,6 +97,8 @@ const data: DataType[] = [
 		emailWithElements: 'hi@example.com',
 		telephone: '+1-555-123-4567',
 		telephoneWithElements: '+1-555-123-4567',
+		url: 'https://example.com',
+		urlWithElements: 'https://example.com',
 		media: 'https://live.staticflickr.com/7398/9458193857_e1256123e3_z.jpg',
 		mediaWithElements:
 			'https://live.staticflickr.com/7398/9458193857_e1256123e3_z.jpg',
@@ -233,6 +238,23 @@ const fields: Field< DataType >[] = [
 		],
 	},
 	{
+		id: 'url',
+		type: 'url',
+		label: 'URL',
+		description: 'Help for URL.',
+	},
+	{
+		id: 'urlWithElements',
+		type: 'url',
+		label: 'URL (with elements)',
+		description: 'Help for URL with elements.',
+		elements: [
+			{ value: 'https://example.com', label: 'https://example.com' },
+			{ value: 'https://wordpress.org', label: 'https://wordpress.org' },
+			{ value: 'https://github.com', label: 'https://github.com' },
+		],
+	},
+	{
 		id: 'media',
 		type: 'media',
 		label: 'Media',
@@ -319,6 +341,7 @@ type ControlTypes =
 	| 'radio'
 	| 'select'
 	| 'telephone'
+	| 'url'
 	| 'text'
 	| 'toggleGroup';
 
@@ -567,6 +590,21 @@ export const Telephone = ( {
 			Edit={ Edit }
 		/>
 	);
+};
+
+export const Url = ( {
+	type,
+	Edit,
+}: {
+	type: PanelTypes;
+	Edit: ControlTypes;
+} ) => {
+	const urlFields = useMemo(
+		() => fields.filter( ( field ) => field.type === 'url' ),
+		[]
+	);
+
+	return <FieldTypeStory fields={ urlFields } type={ type } Edit={ Edit } />;
 };
 
 export const Media = ( {

--- a/packages/dataviews/src/field-types/url.tsx
+++ b/packages/dataviews/src/field-types/url.tsx
@@ -1,0 +1,71 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type {
+	DataViewRenderFieldProps,
+	SortDirection,
+	NormalizedField,
+	FieldTypeDefinition,
+} from '../types';
+import { renderFromElements } from '../utils';
+import {
+	OPERATOR_IS,
+	OPERATOR_IS_ALL,
+	OPERATOR_IS_NOT_ALL,
+	OPERATOR_IS_ANY,
+	OPERATOR_IS_NONE,
+	OPERATOR_IS_NOT,
+	OPERATOR_CONTAINS,
+	OPERATOR_NOT_CONTAINS,
+	OPERATOR_STARTS_WITH,
+} from '../constants';
+
+function sort( valueA: any, valueB: any, direction: SortDirection ) {
+	return direction === 'asc'
+		? valueA.localeCompare( valueB )
+		: valueB.localeCompare( valueA );
+}
+
+export default {
+	sort,
+	isValid: {
+		custom: ( item: any, field: NormalizedField< any > ) => {
+			const value = field.getValue( { item } );
+			if ( field?.elements ) {
+				const validValues = field.elements.map( ( f ) => f.value );
+				if ( ! validValues.includes( value ) ) {
+					return __( 'Value must be one of the elements.' );
+				}
+			}
+
+			return null;
+		},
+	},
+	Edit: 'url',
+	render: ( { item, field }: DataViewRenderFieldProps< any > ) => {
+		return field.elements
+			? renderFromElements( { item, field } )
+			: field.getValue( { item } );
+	},
+	enableSorting: true,
+	filterBy: {
+		defaultOperators: [ OPERATOR_IS_ANY, OPERATOR_IS_NONE ],
+		validOperators: [
+			OPERATOR_IS,
+			OPERATOR_IS_NOT,
+			OPERATOR_CONTAINS,
+			OPERATOR_NOT_CONTAINS,
+			OPERATOR_STARTS_WITH,
+			// Multiple selection
+			OPERATOR_IS_ANY,
+			OPERATOR_IS_NONE,
+			OPERATOR_IS_ALL,
+			OPERATOR_IS_NOT_ALL,
+		],
+	},
+} satisfies FieldTypeDefinition< any >;

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -104,6 +104,7 @@ export type FieldType =
 	| 'boolean'
 	| 'email'
 	| 'telephone'
+	| 'url'
 	| 'array';
 
 /**

--- a/packages/dataviews/src/validation.ts
+++ b/packages/dataviews/src/validation.ts
@@ -32,6 +32,7 @@ export function isItemValid< Item >(
 			if (
 				( field.type === 'text' && isEmptyNullOrUndefined( value ) ) ||
 				( field.type === 'email' && isEmptyNullOrUndefined( value ) ) ||
+				( field.type === 'url' && isEmptyNullOrUndefined( value ) ) ||
 				( field.type === 'integer' &&
 					isEmptyNullOrUndefined( value ) ) ||
 				( field.type === undefined && isEmptyNullOrUndefined( value ) )

--- a/packages/dataviews/src/validation.ts
+++ b/packages/dataviews/src/validation.ts
@@ -33,6 +33,8 @@ export function isItemValid< Item >(
 				( field.type === 'text' && isEmptyNullOrUndefined( value ) ) ||
 				( field.type === 'email' && isEmptyNullOrUndefined( value ) ) ||
 				( field.type === 'url' && isEmptyNullOrUndefined( value ) ) ||
+				( field.type === 'telephone' &&
+					isEmptyNullOrUndefined( value ) ) ||
 				( field.type === 'integer' &&
 					isEmptyNullOrUndefined( value ) ) ||
 				( field.type === undefined && isEmptyNullOrUndefined( value ) )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Similar to: https://github.com/WordPress/gutenberg/pull/71498

This PR add a new `url` field type and field control  to provide more controls for consumers to be used out of the box.

## Testing Instructions
1. Everything should work as before
2. In storybook npm run storybook:dev
