### PR TITLE
Format Library: Add formatting options for word break and soft hyphen

### DIFF
--- a/packages/format-library/src/default-formats.js
+++ b/packages/format-library/src/default-formats.js
@@ -15,6 +15,7 @@ import { keyboard } from './keyboard';
 import { unknown } from './unknown';
 import { language } from './language';
 import { nonBreakingSpace } from './non-breaking-space';
+import { lineBreakWbr, softHyphen } from './line-break';
 
 export default [
 	bold,
@@ -31,4 +32,6 @@ export default [
 	unknown,
 	language,
 	nonBreakingSpace,
+	lineBreakWbr,
+	softHyphen,
 ];

--- a/packages/format-library/src/line-break/index.js
+++ b/packages/format-library/src/line-break/index.js
@@ -1,0 +1,58 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { insert, insertObject } from '@wordpress/rich-text';
+import { RichTextToolbarButton } from '@wordpress/block-editor';
+import { keyboardReturn, lineDashed } from '@wordpress/icons';
+
+const nameWbr = 'core/line-break-wbr';
+const titleWbr = __( 'Insert word break' );
+
+export const lineBreakWbr = {
+	name: nameWbr,
+	title: titleWbr,
+	tagName: 'wbr',
+	object: true,
+	className: 'wp-inline-wbr',
+	edit( { value, onChange, onFocus } ) {
+		const onClick = () => {
+			onChange( insertObject( value, { type: nameWbr } ) );
+			onFocus();
+		};
+
+		return (
+			<RichTextToolbarButton
+				icon={ keyboardReturn }
+				title={ __( 'Insert word break' ) }
+				onClick={ onClick }
+				role="menuitem"
+			/>
+		);
+	},
+};
+
+const nameShy = 'core/soft-hyphen';
+const titleShy = __( 'Insert soft hyphen' );
+
+export const softHyphen = {
+	name: nameShy,
+	title: titleShy,
+	tagName: 'span',
+	className: 'is-soft-hyphen-format',
+	edit( { value, onChange, onFocus } ) {
+		const onClick = () => {
+			onChange( insert( value, '\u00AD' ) );
+			onFocus();
+		};
+
+		return (
+			<RichTextToolbarButton
+				icon={ lineDashed }
+				title={ titleShy }
+				onClick={ onClick }
+				role="menuitem"
+			/>
+		);
+	},
+};

--- a/packages/format-library/src/line-break/index.js
+++ b/packages/format-library/src/line-break/index.js
@@ -7,7 +7,7 @@ import { RichTextToolbarButton } from '@wordpress/block-editor';
 import { keyboardReturn, lineDashed } from '@wordpress/icons';
 
 const nameWbr = 'core/line-break-wbr';
-const titleWbr = __( 'Insert word break' );
+const titleWbr = __( 'Word break' );
 
 export const lineBreakWbr = {
 	name: nameWbr,
@@ -24,7 +24,7 @@ export const lineBreakWbr = {
 		return (
 			<RichTextToolbarButton
 				icon={ keyboardReturn }
-				title={ __( 'Insert word break' ) }
+				title={ titleWbr }
 				onClick={ onClick }
 				role="menuitem"
 			/>
@@ -33,7 +33,7 @@ export const lineBreakWbr = {
 };
 
 const nameShy = 'core/soft-hyphen';
-const titleShy = __( 'Insert soft hyphen' );
+const titleShy = __( 'Soft hyphen' );
 
 export const softHyphen = {
 	name: nameShy,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #55565 

<!-- In a few words, what is the PR actually doing? -->
This PR introduces two new inline formatting options to the editor:
- Word break (`<wbr>`): allows manual control of where a long word may break without inserting visible characters.
- Soft hyphen (`&shy;`): adds a discretionary hyphen that only appears at line breaks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
In some languages, long words often break incorrectly on smaller screens. Adding options for `<wbr>` and `&shy;` gives authors precise control over word breaking, improving readability across devices and languages.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Added a new `line-break` format module format library.
- Registered two new formats:
  - `core/line-break-wbr`: inserts `<wbr>` at the caret position
  - `core/soft-hyphen`: inserts a soft hyphen (`\u00AD`) at the caret position.

## Testing Instructions
1. Create or edit a post with a Paragraph or a Heading block.
2. Place the cursor inside a long word
3. Open the inline formatting dropdown
4. Select Insert word break or Insert soft hyphen.
    - In the editor, nothing visible may appear if on a desktop view.
    - Switch to the Code editor view -> `<wbr>` or `&shy;` should be inserted at the cursor position.
    - On the smaller screens (editor and frontend), text should break correctly:
        - `<wbr>`: line may break without hyphen.
        - `&shy;`: line may break with hyphen shown.

<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/4e935772-9cea-4430-9feb-9644a15be0c4
