### PR TITLE
Add color field type and control to DataViews

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50404,6 +50404,7 @@
 				"@wordpress/url": "file:../url",
 				"@wordpress/warning": "file:../warning",
 				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
 				"date-fns": "^4.1.0",
 				"fast-deep-equal": "^3.1.3",
 				"remove-accents": "^0.5.0"

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -13,7 +13,6 @@ import Badge from './badge';
 
 import { DateCalendar, DateRangeCalendar, TZDate } from './calendar';
 import {
-	ValidatedInputControl,
 	ValidatedCheckboxControl,
 	ValidatedInputControl,
 	ValidatedNumberControl,

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -13,12 +13,14 @@ import Badge from './badge';
 
 import { DateCalendar, DateRangeCalendar, TZDate } from './calendar';
 import {
+	ValidatedInputControl,
 	ValidatedCheckboxControl,
 	ValidatedInputControl,
 	ValidatedNumberControl,
 	ValidatedTextControl,
 	ValidatedToggleControl,
 } from './validated-form-controls';
+import { Picker } from './color-picker/picker';
 
 export const privateApis = {};
 lock( privateApis, {
@@ -34,6 +36,7 @@ lock( privateApis, {
 	DateCalendar,
 	DateRangeCalendar,
 	TZDate,
+	Picker,
 	ValidatedInputControl,
 	ValidatedCheckboxControl,
 	ValidatedNumberControl,

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -60,6 +60,7 @@
 		"@wordpress/url": "file:../url",
 		"@wordpress/warning": "file:../warning",
 		"clsx": "^2.1.1",
+		"colord": "^2.7.0",
 		"date-fns": "^4.1.0",
 		"fast-deep-equal": "^3.1.3",
 		"remove-accents": "^0.5.0"

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -391,6 +391,7 @@ const ValidationComponent = ( {
 		email: string;
 		telephone: string;
 		url: string;
+		color: string;
 		integer: number;
 		boolean: boolean;
 		customEdit: string;
@@ -401,6 +402,7 @@ const ValidationComponent = ( {
 		email: 'hi@example.com',
 		telephone: '+306978241796',
 		url: 'https://example.com',
+		color: '#ff6600',
 		integer: 2,
 		boolean: true,
 		customEdit: 'custom control',
@@ -430,6 +432,13 @@ const ValidationComponent = ( {
 	const customUrlRule = ( value: ValidatedItem ) => {
 		if ( ! /^https:\/\/example\.com$/.test( value.url ) ) {
 			return 'URL must be from https://example.com domain.';
+		}
+
+		return null;
+	};
+	const customColorRule = ( value: ValidatedItem ) => {
+		if ( ! /^#[0-9A-Fa-f]{6}$/.test( value.color ) ) {
+			return 'Color must be a valid hex format (e.g., #ff6600).';
 		}
 
 		return null;
@@ -486,6 +495,15 @@ const ValidationComponent = ( {
 			},
 		},
 		{
+			id: 'color',
+			type: 'color',
+			label: 'Color',
+			isValid: {
+				required,
+				custom: maybeCustomRule( customColorRule ),
+			},
+		},
+		{
 			id: 'integer',
 			type: 'integer',
 			label: 'Integer',
@@ -519,6 +537,7 @@ const ValidationComponent = ( {
 			'email',
 			'telephone',
 			'url',
+			'color',
 			'integer',
 			'boolean',
 			'customEdit',

--- a/packages/dataviews/src/dataform-controls/color.tsx
+++ b/packages/dataviews/src/dataform-controls/color.tsx
@@ -1,0 +1,139 @@
+/**
+ * External dependencies
+ */
+import { colord } from 'colord';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	Dropdown,
+	privateApis,
+	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
+} from '@wordpress/components';
+import { useCallback, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { DataFormControlProps } from '../types';
+import { unlock } from '../lock-unlock';
+
+const { ValidatedInputControl, Picker } = unlock( privateApis );
+
+const ColorPicker = ( {
+	color,
+	onColorChange,
+}: {
+	color: string;
+	onColorChange: ( colorObject: any ) => void;
+} ) => {
+	const validColor = color && colord( color ).isValid() ? color : '#ffffff';
+
+	return (
+		<Dropdown
+			renderToggle={ ( { onToggle, isOpen } ) => (
+				<InputControlPrefixWrapper variant="icon">
+					<button
+						type="button"
+						onClick={ onToggle }
+						style={ {
+							width: '24px',
+							height: '24px',
+							borderRadius: '50%',
+							backgroundColor: validColor,
+							border: '1px solid #ddd',
+							cursor: 'pointer',
+							outline: isOpen ? '2px solid #007cba' : 'none',
+							outlineOffset: '2px',
+							display: 'flex',
+							alignItems: 'center',
+							justifyContent: 'center',
+							padding: 0,
+							margin: 0,
+						} }
+						aria-label="Open color picker"
+					/>
+				</InputControlPrefixWrapper>
+			) }
+			renderContent={ () => (
+				<div style={ { padding: '16px' } }>
+					<Picker
+						color={ colord( validColor ) }
+						onChange={ onColorChange }
+						enableAlpha
+					/>
+				</div>
+			) }
+		/>
+	);
+};
+
+export default function Color< Item >( {
+	data,
+	field,
+	onChange,
+	hideLabelFromVision,
+}: DataFormControlProps< Item > ) {
+	const { id, label, placeholder, description } = field;
+	const value = field.getValue( { item: data } ) || '';
+	const [ customValidity, setCustomValidity ] =
+		useState<
+			React.ComponentProps<
+				typeof ValidatedInputControl
+			>[ 'customValidity' ]
+		>( undefined );
+
+	const handleColorChange = useCallback(
+		( colorObject: any ) => {
+			onChange( { [ id ]: colorObject.toHex() } );
+		},
+		[ id, onChange ]
+	);
+
+	const handleInputChange = useCallback(
+		( newValue: string | undefined ) => {
+			onChange( { [ id ]: newValue || '' } );
+		},
+		[ id, onChange ]
+	);
+
+	return (
+		<ValidatedInputControl
+			required={ !! field.isValid?.required }
+			onValidate={ ( newValue: any ) => {
+				const message = field.isValid?.custom?.(
+					{
+						...data,
+						[ id ]: newValue,
+					},
+					field
+				);
+
+				if ( message ) {
+					setCustomValidity( {
+						type: 'invalid',
+						message,
+					} );
+					return;
+				}
+
+				setCustomValidity( undefined );
+			} }
+			customValidity={ customValidity }
+			label={ label }
+			placeholder={ placeholder }
+			value={ value }
+			help={ description }
+			onChange={ handleInputChange }
+			hideLabelFromVision={ hideLabelFromVision }
+			type="text"
+			prefix={
+				<ColorPicker
+					color={ value }
+					onColorChange={ handleColorChange }
+				/>
+			}
+		/>
+	);
+}

--- a/packages/dataviews/src/dataform-controls/index.tsx
+++ b/packages/dataviews/src/dataform-controls/index.tsx
@@ -24,6 +24,7 @@ import text from './text';
 import toggle from './toggle';
 import toggleGroup from './toggle-group';
 import array from './array';
+import color from './color';
 
 interface FormControls {
 	[ key: string ]: ComponentType< DataFormControlProps< any > >;
@@ -32,6 +33,7 @@ interface FormControls {
 const FORM_CONTROLS: FormControls = {
 	array,
 	checkbox,
+	color,
 	datetime,
 	date,
 	email,

--- a/packages/dataviews/src/field-types/color.tsx
+++ b/packages/dataviews/src/field-types/color.tsx
@@ -1,0 +1,115 @@
+/**
+ * External dependencies
+ */
+import { colord } from 'colord';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type {
+	DataViewRenderFieldProps,
+	SortDirection,
+	NormalizedField,
+	FieldTypeDefinition,
+} from '../types';
+import { renderFromElements } from '../utils';
+import {
+	OPERATOR_IS,
+	OPERATOR_IS_ANY,
+	OPERATOR_IS_NONE,
+	OPERATOR_IS_NOT,
+} from '../constants';
+
+function sort( valueA: any, valueB: any, direction: SortDirection ) {
+	// Convert colors to HSL for better sorting
+	const colorA = colord( valueA );
+	const colorB = colord( valueB );
+
+	if ( ! colorA.isValid() && ! colorB.isValid() ) {
+		return 0;
+	}
+	if ( ! colorA.isValid() ) {
+		return direction === 'asc' ? 1 : -1;
+	}
+	if ( ! colorB.isValid() ) {
+		return direction === 'asc' ? -1 : 1;
+	}
+
+	// Sort by hue, then saturation, then lightness
+	const hslA = colorA.toHsl();
+	const hslB = colorB.toHsl();
+
+	if ( hslA.h !== hslB.h ) {
+		return direction === 'asc' ? hslA.h - hslB.h : hslB.h - hslA.h;
+	}
+	if ( hslA.s !== hslB.s ) {
+		return direction === 'asc' ? hslA.s - hslB.s : hslB.s - hslA.s;
+	}
+	return direction === 'asc' ? hslA.l - hslB.l : hslB.l - hslA.l;
+}
+
+export default {
+	sort,
+	isValid: {
+		custom: ( item: any, field: NormalizedField< any > ) => {
+			const value = field.getValue( { item } );
+
+			if (
+				! [ undefined, '', null ].includes( value ) &&
+				! colord( value ).isValid()
+			) {
+				return __( 'Value must be a valid color.' );
+			}
+
+			if ( field.elements ) {
+				const validValues = field.elements.map( ( f ) => f.value );
+				if ( ! validValues.includes( value ) ) {
+					return __( 'Value must be one of the elements.' );
+				}
+			}
+
+			return null;
+		},
+	},
+	Edit: 'color',
+	render: ( { item, field }: DataViewRenderFieldProps< any > ) => {
+		if ( field.elements ) {
+			return renderFromElements( { item, field } );
+		}
+
+		const value = field.getValue( { item } );
+
+		if ( ! value || ! colord( value ).isValid() ) {
+			return value;
+		}
+
+		// Render color with visual preview
+		return (
+			<div
+				style={ { display: 'flex', alignItems: 'center', gap: '8px' } }
+			>
+				<div
+					style={ {
+						width: '16px',
+						height: '16px',
+						borderRadius: '50%',
+						backgroundColor: value,
+						border: '1px solid #ddd',
+						flexShrink: 0,
+					} }
+				/>
+				<span>{ value }</span>
+			</div>
+		);
+	},
+	enableSorting: true,
+	filterBy: {
+		defaultOperators: [ OPERATOR_IS_ANY, OPERATOR_IS_NONE ],
+		validOperators: [ OPERATOR_IS, OPERATOR_IS_NOT ],
+	},
+} satisfies FieldTypeDefinition< any >;

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -22,6 +22,7 @@ import { default as boolean } from './boolean';
 import { default as media } from './media';
 import { default as array } from './array';
 import { default as telephone } from './telephone';
+import { default as color } from './color';
 import { default as url } from './url';
 import { renderFromElements } from '../utils';
 import { ALL_OPERATORS, OPERATOR_IS, OPERATOR_IS_NOT } from '../constants';
@@ -69,6 +70,10 @@ export default function getFieldTypeDefinition< Item >(
 
 	if ( 'telephone' === type ) {
 		return telephone;
+	}
+
+	if ( 'color' === type ) {
+		return color;
 	}
 
 	if ( 'url' === type ) {

--- a/packages/dataviews/src/field-types/stories/index.story.tsx
+++ b/packages/dataviews/src/field-types/stories/index.story.tsx
@@ -103,7 +103,7 @@ const data: DataType[] = [
 		telephone: '+1-555-123-4567',
 		telephoneWithElements: '+1-555-123-4567',
 		color: '#ff6600',
-		colorWithElements: 'rgba(255, 102, 0, 0.8)',
+		colorWithElements: 'rgba(255, 165, 0, 0.8)',
 		url: 'https://example.com',
 		urlWithElements: 'https://example.com',
 		media: 'https://live.staticflickr.com/7398/9458193857_e1256123e3_z.jpg',

--- a/packages/dataviews/src/field-types/stories/index.story.tsx
+++ b/packages/dataviews/src/field-types/stories/index.story.tsx
@@ -33,6 +33,7 @@ const meta = {
 				'default',
 				'array',
 				'checkbox',
+				'color',
 				'date',
 				'datetime',
 				'email',
@@ -71,6 +72,8 @@ type DataType = {
 	emailWithElements: string;
 	telephone: string;
 	telephoneWithElements: string;
+	color: string;
+	colorWithElements: string;
 	url: string;
 	urlWithElements: string;
 	media: string;
@@ -99,6 +102,8 @@ const data: DataType[] = [
 		emailWithElements: 'hi@example.com',
 		telephone: '+1-555-123-4567',
 		telephoneWithElements: '+1-555-123-4567',
+		color: '#ff6600',
+		colorWithElements: 'rgba(255, 102, 0, 0.8)',
 		url: 'https://example.com',
 		urlWithElements: 'https://example.com',
 		media: 'https://live.staticflickr.com/7398/9458193857_e1256123e3_z.jpg',
@@ -342,6 +347,7 @@ type ControlTypes =
 	| 'default'
 	| 'array'
 	| 'checkbox'
+	| 'color'
 	| 'date'
 	| 'datetime'
 	| 'email'

--- a/packages/dataviews/src/field-types/stories/index.story.tsx
+++ b/packages/dataviews/src/field-types/stories/index.story.tsx
@@ -269,6 +269,30 @@ const fields: Field< DataType >[] = [
 		],
 	},
 	{
+		id: 'color',
+		type: 'color',
+		label: 'Color',
+		description:
+			'Help for color. Supports hex, rgb, hsl formats with alpha channel.',
+	},
+	{
+		id: 'colorWithElements',
+		type: 'color',
+		label: 'Color (with elements)',
+		description: 'Help for color with predefined color options.',
+		elements: [
+			{ value: '#ff0000', label: 'Red' },
+			{ value: '#00ff00', label: 'Green' },
+			{ value: '#0000ff', label: 'Blue' },
+			{ value: 'rgba(255, 165, 0, 0.8)', label: 'Orange (80% opacity)' },
+			{ value: 'hsl(300, 100%, 50%)', label: 'Magenta' },
+			{
+				value: 'hsla(120, 100%, 25%, 0.6)',
+				label: 'Dark Green (60% opacity)',
+			},
+		],
+	},
+	{
 		id: 'media',
 		type: 'media',
 		label: 'Media',
@@ -620,6 +644,23 @@ export const Url = ( {
 	);
 
 	return <FieldTypeStory fields={ urlFields } type={ type } Edit={ Edit } />;
+};
+
+export const Color = ( {
+	type,
+	Edit,
+}: {
+	type: PanelTypes;
+	Edit: ControlTypes;
+} ) => {
+	const colorFields = useMemo(
+		() => fields.filter( ( field ) => field.type === 'color' ),
+		[]
+	);
+
+	return (
+		<FieldTypeStory fields={ colorFields } type={ type } Edit={ Edit } />
+	);
 };
 
 export const Media = ( {

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -104,6 +104,7 @@ export type FieldType =
 	| 'boolean'
 	| 'email'
 	| 'telephone'
+	| 'color'
 	| 'url'
 	| 'array';
 


### PR DESCRIPTION
Adds a new `color` field type and control to DataViews that allows users to input color values via text input and visual color picker.

## How

- **New color field type**: Supports validation, sorting (by HSL), and visual rendering with color preview
- **Color control**: Text input with color circle prefix that opens a visual color picker
- **Alpha channel support**: Works with hex, rgb, rgba, hsl, hsla formats


## Screenshot

<img width="388" height="279" alt="Screenshot 2025-09-05 at 15 49 42" src="https://github.com/user-attachments/assets/70dd4c11-fc52-4de4-bf32-47ed23e7f56f" />


## Testing

- Added comprehensive Storybook stories under DataViews field types oppened on http://localhost:50240/?path=/story/dataviews-fieldtypes--color
- Test both basic color fields and fields with predefined color elements
- Verify text input validation and visual color picker functionality
- Check focus behavior and popover closing on outside clicks

## Dependencies

- Added `colord` dependency to dataviews package (already used on other parts of gutenberg) for color validation and manipulation
- Uses private APIs for ValidatedInputControl and Picker components