### PR TITLE
Enhance Term Description Block with Context Support

### DIFF
--- a/packages/block-library/src/term-description/block.json
+++ b/packages/block-library/src/term-description/block.json
@@ -6,6 +6,7 @@
 	"category": "theme",
 	"description": "Display the description of categories, tags and custom taxonomies when viewing an archive.",
 	"textdomain": "default",
+	"usesContext": [ "termId", "taxonomy" ],
 	"attributes": {
 		"textAlign": {
 			"type": "string"

--- a/packages/block-library/src/term-description/edit.js
+++ b/packages/block-library/src/term-description/edit.js
@@ -13,18 +13,27 @@ import {
 	AlignmentControl,
 } from '@wordpress/block-editor';
 
+/**
+ * Internal dependencies
+ */
+import { useTermDescription } from './use-term-description';
+
 export default function TermDescriptionEdit( {
 	attributes,
 	setAttributes,
 	mergedStyle,
+	context: { termId, taxonomy },
 } ) {
 	const { textAlign } = attributes;
+	const { termDescription } = useTermDescription( termId, taxonomy );
+
 	const blockProps = useBlockProps( {
 		className: clsx( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
 		style: mergedStyle,
 	} );
+
 	return (
 		<>
 			<BlockControls group="block">
@@ -36,9 +45,15 @@ export default function TermDescriptionEdit( {
 				/>
 			</BlockControls>
 			<div { ...blockProps }>
-				<div className="wp-block-term-description__placeholder">
-					<span>{ __( 'Term Description' ) }</span>
-				</div>
+				{ termDescription ? (
+					<div
+						dangerouslySetInnerHTML={ { __html: termDescription } }
+					/>
+				) : (
+					<div className="wp-block-term-description__placeholder">
+						<span>{ __( 'Term Description' ) }</span>
+					</div>
+				) }
 			</div>
 		</>
 	);

--- a/packages/block-library/src/term-description/use-term-description.js
+++ b/packages/block-library/src/term-description/use-term-description.js
@@ -1,0 +1,112 @@
+/**
+ * WordPress dependencies
+ */
+import { store as coreStore, useEntityProp } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Hook to fetch term description based on context or fallback to template parsing.
+ *
+ * This hook prioritizes context-provided termId and taxonomy, but falls back to
+ * template-based detection when no context is available.
+ *
+ * @param {string|number} termId   The term ID from context
+ * @param {string}        taxonomy The taxonomy name from context
+ */
+export function useTermDescription( termId, taxonomy ) {
+	const [ description, setDescription, fullDescription ] = useEntityProp(
+		'taxonomy',
+		taxonomy,
+		'description',
+		termId
+	);
+
+	// Fallback approach: Parse template slug when no context is available
+	const templateBasedData = useTemplateBasedTermData();
+
+	const hasContext = Boolean( termId && taxonomy );
+
+	return {
+		hasContext,
+		setDescription,
+		termDescription: hasContext
+			? fullDescription?.rendered || description || ''
+			: templateBasedData.termDescription,
+	};
+}
+
+/**
+ * Fallback hook to fetch term data from template context (backward compatibility).
+ * This maintains the same logic as the original implementation for cases where
+ * no termId/taxonomy context is provided.
+ */
+function useTemplateBasedTermData() {
+	const templateSlug = useSelect( ( select ) => {
+		// Access core/editor by string to avoid @wordpress/editor dependency.
+		// eslint-disable-next-line @wordpress/data-no-store-string-literals
+		const { getCurrentPostId, getCurrentPostType, getCurrentTemplateId } =
+			select( 'core/editor' );
+		const currentPostType = getCurrentPostType();
+		const templateId =
+			getCurrentTemplateId() ||
+			( currentPostType === 'wp_template' ? getCurrentPostId() : null );
+
+		return templateId
+			? select( coreStore ).getEditedEntityRecord(
+					'postType',
+					'wp_template',
+					templateId
+			  )?.slug
+			: null;
+	}, [] );
+
+	const taxonomyMatches = templateSlug?.match(
+		/^(category|tag|taxonomy-([^-]+))$|^(((category|tag)|taxonomy-([^-]+))-(.+))$/
+	);
+
+	let taxonomy;
+	let termSlug;
+
+	if ( taxonomyMatches ) {
+		// If it's for all taxonomies of a type (e.g., category, tag)
+		if ( taxonomyMatches[ 1 ] ) {
+			taxonomy = taxonomyMatches[ 2 ]
+				? taxonomyMatches[ 2 ]
+				: taxonomyMatches[ 1 ];
+		}
+		// If it's for a specific term (e.g., category-news, tag-featured)
+		else if ( taxonomyMatches[ 3 ] ) {
+			taxonomy = taxonomyMatches[ 6 ]
+				? taxonomyMatches[ 6 ]
+				: taxonomyMatches[ 4 ];
+			termSlug = taxonomyMatches[ 7 ];
+		}
+
+		taxonomy = taxonomy === 'tag' ? 'post_tag' : taxonomy;
+	}
+
+	return useSelect(
+		( select ) => {
+			if ( ! taxonomy || ! termSlug ) {
+				return { termDescription: '' };
+			}
+
+			const { getEntityRecords } = select( coreStore );
+
+			const termRecords = getEntityRecords( 'taxonomy', taxonomy, {
+				slug: termSlug,
+				per_page: 1,
+			} );
+
+			let termDescription = '';
+			if ( termRecords && termRecords[ 0 ] ) {
+				termDescription = termRecords[ 0 ].description || '';
+			}
+
+			return {
+				termDescription,
+			};
+		},
+		[ taxonomy, termSlug ]
+	);
+}

--- a/packages/block-library/src/term-description/use-term-description.js
+++ b/packages/block-library/src/term-description/use-term-description.js
@@ -31,7 +31,7 @@ export function useTermDescription( termId, taxonomy ) {
 		setDescription,
 		termDescription: hasContext
 			? fullDescription?.rendered || description || ''
-			: templateBasedData.termDescription,
+			: templateBasedData,
 	};
 }
 
@@ -88,7 +88,7 @@ function useTemplateBasedTermData() {
 	return useSelect(
 		( select ) => {
 			if ( ! taxonomy || ! termSlug ) {
-				return { termDescription: '' };
+				return '';
 			}
 
 			const { getEntityRecords } = select( coreStore );
@@ -98,14 +98,11 @@ function useTemplateBasedTermData() {
 				per_page: 1,
 			} );
 
-			let termDescription = '';
 			if ( termRecords && termRecords[ 0 ] ) {
-				termDescription = termRecords[ 0 ].description || '';
+				return termRecords[ 0 ].description || '';
 			}
 
-			return {
-				termDescription,
-			};
+			return '';
 		},
 		[ taxonomy, termSlug ]
 	);

--- a/packages/block-library/src/term-description/use-term-description.js
+++ b/packages/block-library/src/term-description/use-term-description.js
@@ -21,7 +21,7 @@ export function useTermDescription( termId, taxonomy ) {
 		termId
 	);
 
-	// Fallback approach: Parse template slug when no context is available
+	// Fallback approach: Parse template slug when no context is available.
 	const templateBasedData = useTemplateBasedTermData();
 
 	const hasContext = Boolean( termId && taxonomy );
@@ -68,13 +68,13 @@ function useTemplateBasedTermData() {
 	let termSlug;
 
 	if ( taxonomyMatches ) {
-		// If it's for all taxonomies of a type (e.g., category, tag)
+		// If it's for all taxonomies of a type (e.g., category, tag).
 		if ( taxonomyMatches[ 1 ] ) {
 			taxonomy = taxonomyMatches[ 2 ]
 				? taxonomyMatches[ 2 ]
 				: taxonomyMatches[ 1 ];
 		}
-		// If it's for a specific term (e.g., category-news, tag-featured)
+		// If it's for a specific term (e.g., category-news, tag-featured).
 		else if ( taxonomyMatches[ 3 ] ) {
 			taxonomy = taxonomyMatches[ 6 ]
 				? taxonomyMatches[ 6 ]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
## What?
The `term-description` block, as opposed to the `post-title` or the `query-title`, always showed a placeholder, even when the data was technically available (e.g. if the user was modifying a specific category template). 

This PR fixes that by allowing the `term-description` block to either receive context from a parent (like the `post-title`), or fallback to the parsing of the template slug (like the `query-title`).

<!-- In a few words, what is the PR actually doing? -->

## Why?
Not showing the actual content is not only a degraded user experience (as the user can't preview the template correctly without displaying the actual description), but also inconsistent with the behavior of other blocks.

## How?
The PR basically implements already available patterns from `post-title` and `query-title`. This allows the block to be quite versatile and reusable in different contexts.

## Testing Instructions

### Preserving original functionality
1. Open the All Archives template.
2. Insert the `term-description` block.
3. Verify that it displays a placeholder.

### New functionality
1. Create a new template for a specific Category (with a description).
2. Insert the `term-description` block.
3. Verify that the actual description is shown, and not a placeholder.