### PR TITLE
Fix: Prevent empty CSS rules when blockGap is null in theme.json

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3141,7 +3141,7 @@ class WP_Theme_JSON_Gutenberg {
 		// Block gap styles will be output unless explicitly set to `null`. See static::PROTECTED_PROPERTIES.
 		if ( isset( $this->theme_json['settings']['spacing']['blockGap'] ) ) {
 			$block_gap_value = static::get_property_value( $this->theme_json, array( 'styles', 'spacing', 'blockGap' ) );
-			if ( ! is_null( $block_gap_value ) && $block_gap_value !== '' ) {
+			if ( null !== $block_gap_value && '' !== $block_gap_value ) {
 				$css .= ":where(.wp-site-blocks) > * { margin-block-start: $block_gap_value; margin-block-end: 0; }";
 				$css .= ':where(.wp-site-blocks) > :first-child { margin-block-start: 0; }';
 				$css .= ':where(.wp-site-blocks) > :last-child { margin-block-end: 0; }';

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3141,12 +3141,14 @@ class WP_Theme_JSON_Gutenberg {
 		// Block gap styles will be output unless explicitly set to `null`. See static::PROTECTED_PROPERTIES.
 		if ( isset( $this->theme_json['settings']['spacing']['blockGap'] ) ) {
 			$block_gap_value = static::get_property_value( $this->theme_json, array( 'styles', 'spacing', 'blockGap' ) );
-			$css            .= ":where(.wp-site-blocks) > * { margin-block-start: $block_gap_value; margin-block-end: 0; }";
-			$css            .= ':where(.wp-site-blocks) > :first-child { margin-block-start: 0; }';
-			$css            .= ':where(.wp-site-blocks) > :last-child { margin-block-end: 0; }';
+			if ( ! is_null( $block_gap_value ) && $block_gap_value !== '' ) {
+				$css .= ":where(.wp-site-blocks) > * { margin-block-start: $block_gap_value; margin-block-end: 0; }";
+				$css .= ':where(.wp-site-blocks) > :first-child { margin-block-start: 0; }';
+				$css .= ':where(.wp-site-blocks) > :last-child { margin-block-end: 0; }';
 
-			// For backwards compatibility, ensure the legacy block gap CSS variable is still available.
-			$css .= static::ROOT_CSS_PROPERTIES_SELECTOR . " { --wp--style--block-gap: $block_gap_value; }";
+				// For backwards compatibility, ensure the legacy block gap CSS variable is still available.
+				$css .= static::ROOT_CSS_PROPERTIES_SELECTOR . " { --wp--style--block-gap: $block_gap_value; }";
+			}
 		}
 		$css .= $this->get_layout_styles( $block_metadata );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
https://github.com/WordPress/gutenberg/issues/71527
Prevents empty CSS rules from being generated when `blockGap` is set to `null` in `theme.json`.

## Why?
This PR fixes a bug where invalid CSS (e.g., `margin-block-start: ;`) was output when `blockGap` was `null`, causing W3C validation errors.

## How?
Adds a conditional check to skip generating blockGap-related CSS if the value is `null` or empty.

## Testing Instructions
1. Set `blockGap: null` in your theme’s `theme.json`.
2. Add blocks (e.g., calendar, search) to a post or page.
3. View the page and inspect the generated CSS.
4. Confirm that no empty blockGap CSS rules are present.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
