### PR TITLE
Fix/in between inserter for gallery

### DIFF
--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -100,19 +100,54 @@ export function useInBetweenInserter() {
 				const offsetLeft = event.clientX;
 
 				const children = Array.from( event.target.children );
-				let element = children.find( ( blockEl ) => {
-					const blockElRect = blockEl.getBoundingClientRect();
-					return (
-						( blockEl.classList.contains( 'wp-block' ) &&
-							orientation === 'vertical' &&
-							blockElRect.top > offsetTop ) ||
-						( blockEl.classList.contains( 'wp-block' ) &&
-							orientation === 'horizontal' &&
-							( isRTL()
-								? blockElRect.right < offsetLeft
-								: blockElRect.left > offsetLeft ) )
+				/** @type {HTMLElement | null} */
+				let element = null;
+
+				if ( orientation === 'horizontal' ) {
+					const wpBlocks = children.filter(
+						( blockEl ) =>
+							blockEl.classList &&
+							blockEl.classList.contains( 'wp-block' )
 					);
-				} );
+
+					const candidates = wpBlocks.map( ( blockEl ) => ( {
+						el: blockEl,
+						rect: blockEl.getBoundingClientRect(),
+					} ) );
+
+					// Prefer candidates on the same visual row (overlapping Y).
+					const rowCandidates = candidates.filter(
+						( c ) =>
+							offsetTop >= c.rect.top &&
+							offsetTop <= c.rect.bottom
+					);
+
+					const findCandidate = ( list ) =>
+						list.find( ( c ) =>
+							isRTL()
+								? c.rect.right < offsetLeft
+								: c.rect.left > offsetLeft
+						);
+
+					// Pick same-row candidate first, fallback to any candidate.
+					const match =
+						findCandidate( rowCandidates ) ||
+						findCandidate( candidates );
+					element = match ? match.el : null;
+				} else {
+					// Vertical orientation.
+					element =
+						children.find( ( blockEl ) => {
+							if (
+								! blockEl.classList ||
+								! blockEl.classList.contains( 'wp-block' )
+							) {
+								return false;
+							}
+							const blockElRect = blockEl.getBoundingClientRect();
+							return blockElRect.top > offsetTop;
+						} ) || null;
+				}
 
 				if ( ! element ) {
 					hideInsertionPoint();

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -100,22 +100,20 @@ export function useInBetweenInserter() {
 				const offsetLeft = event.clientX;
 
 				const children = Array.from( event.target.children );
-				/** @type {HTMLElement | null} */
-				let element = null;
+				let element;
 
 				if ( orientation === 'horizontal' ) {
-					const wpBlocks = children.filter(
-						( blockEl ) =>
-							blockEl.classList &&
+					// Build candidates: only direct children that are .wp-block
+					const candidates = children
+						.filter( ( blockEl ) =>
 							blockEl.classList.contains( 'wp-block' )
-					);
+						)
+						.map( ( blockEl ) => ( {
+							el: blockEl,
+							rect: blockEl.getBoundingClientRect(),
+						} ) );
 
-					const candidates = wpBlocks.map( ( blockEl ) => ( {
-						el: blockEl,
-						rect: blockEl.getBoundingClientRect(),
-					} ) );
-
-					// Prefer candidates on the same visual row (overlapping Y).
+					// Prefer tiles that overlap the mouse Y (same visual row).
 					const rowCandidates = candidates.filter(
 						( c ) =>
 							offsetTop >= c.rect.top &&
@@ -133,20 +131,16 @@ export function useInBetweenInserter() {
 					const match =
 						findCandidate( rowCandidates ) ||
 						findCandidate( candidates );
-					element = match ? match.el : null;
+					element = match ? match.el : undefined;
 				} else {
 					// Vertical orientation.
-					element =
-						children.find( ( blockEl ) => {
-							if (
-								! blockEl.classList ||
-								! blockEl.classList.contains( 'wp-block' )
-							) {
-								return false;
-							}
-							const blockElRect = blockEl.getBoundingClientRect();
-							return blockElRect.top > offsetTop;
-						} ) || null;
+					element = children.find( ( blockEl ) => {
+						if ( ! blockEl.classList.contains( 'wp-block' ) ) {
+							return false;
+						}
+						const blockElRect = blockEl.getBoundingClientRect();
+						return blockElRect.top > offsetTop;
+					} );
 				}
 
 				if ( ! element ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/64222
Fixes missing block insertion points between items when an InnerBlocks area is laid out horizontally.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When InnerBlocks uses orientation="horizontal":

- If children wrap onto a second row, the blue “insertion line with +” doesn’t appear between items on wrapped rows, so users can’t insert blocks where the cursor is.

- In horizontally scrollable containers (e.g., sliders), insertion points don’t appear between items that are outside the initially visible area until scrolled into view.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
Buttons block (wrap case)

- Create a page/post.
- Insert Buttons. Add enough buttons so they wrap to a second line (reduce editor width if needed).
- Hover between buttons on the second line.
- ✅ An insertion cue appears between the hovered items; clicking + inserts a new Button there.

- Same for the Gallery Block as well.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
