### PR TITLE
DataViews: Remove leftover code for Pages

### DIFF
--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -200,7 +200,6 @@ function getItemLevel( item ) {
 
 export default function PostList( { postType } ) {
 	const [ view, setView ] = useView( postType );
-	const defaultViews = useDefaultViews( { postType } );
 	const history = useHistory();
 	const location = useLocation();
 	const {
@@ -266,7 +265,7 @@ export default function PostList( { postType } ) {
 			search: view.search,
 			...filters,
 		};
-	}, [ view, activeView, defaultViews ] );
+	}, [ view ] );
 	const {
 		records,
 		isResolving: isLoadingData,


### PR DESCRIPTION
## What?

PR removes unnecessary `useMemo` dependencies in the `PostList` component. These dependencies were introduced in #65295, but became irrelevant after #71075.

## Testing Instructions
1. Navigate to Site Editor > Pages.
2. Confirm that the pages' DataViews work as before.

### Testing Instructions for Keyboard
Same.
