### PR TITLE
[Data Forms]: allow field elements to declare loading state

### DIFF
--- a/packages/dataviews/src/components/dataviews-filters/filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/filter.tsx
@@ -15,6 +15,7 @@ import {
 	SelectControl,
 	Tooltip,
 	Icon,
+	Spinner,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useRef, createInterpolateElement } from '@wordpress/element';
@@ -591,6 +592,14 @@ export default function Filter( {
 				</div>
 			) }
 			renderContent={ () => {
+				const field = fields.find( ( f ) => f.id === filter.field );
+				const isLoading = field?.elementsLoading;
+				const LoadingComponent = field?.LoadingComponent;
+
+				if ( isLoading ) {
+					return LoadingComponent || <Spinner />;
+				}
+
 				return (
 					<VStack spacing={ 0 } justify="flex-start">
 						<OperatorSelector { ...commonProps } />

--- a/packages/dataviews/src/dataform-controls/integer.tsx
+++ b/packages/dataviews/src/dataform-controls/integer.tsx
@@ -6,6 +6,7 @@ import {
 	BaseControl,
 	__experimentalNumberControl as NumberControl,
 	privateApis,
+	Spinner,
 } from '@wordpress/components';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -96,7 +97,7 @@ export default function Integer< Item >( {
 			onChange( {
 				// Do not convert an empty string or undefined to a number,
 				// otherwise there's a mismatch between the UI control (empty)
-				// and the data relied by onChange (0).
+				// and the data relied on by onChange (0).
 				[ id ]: [ '', undefined ].includes( newValue )
 					? undefined
 					: Number( newValue ),
@@ -104,6 +105,10 @@ export default function Integer< Item >( {
 		},
 		[ id, onChange ]
 	);
+
+	if ( field.elementsLoading ) {
+		return field.LoadingComponent || <Spinner />;
+	}
 
 	if ( operator === OPERATOR_BETWEEN ) {
 		return (

--- a/packages/dataviews/src/dataform-controls/select.tsx
+++ b/packages/dataviews/src/dataform-controls/select.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { SelectControl } from '@wordpress/components';
+import { SelectControl, Spinner } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -26,6 +26,8 @@ export default function Select< Item >( {
 			} ),
 		[ id, onChange ]
 	);
+
+	return <Spinner />;
 
 	const fieldElements = field?.elements ?? [];
 	const hasEmptyValue = fieldElements.some(

--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -177,6 +177,8 @@ export function normalizeFields< Item >(
 				true,
 			filterBy,
 			readOnly: field.readOnly ?? fieldTypeDefinition.readOnly ?? false,
+			elementsLoading: field.elementsLoading ?? false,
+			LoadingComponent: field.LoadingComponent,
 		};
 	} );
 }

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -232,6 +232,17 @@ export type Field< Item > = {
 	elements?: Option[];
 
 	/**
+	 * Whether the field elements are currently loading.
+	 */
+	elementsLoading?: boolean;
+
+	/**
+	 * Optional component to display while elements are loading.
+	 * If not provided, a default loading indicator will be used.
+	 */
+	LoadingComponent?: ReactElement;
+
+	/**
 	 * Filter config for the field.
 	 */
 	filterBy?: FilterByConfig | false;
@@ -261,6 +272,8 @@ export type NormalizedField< Item > = Omit< Field< Item >, 'Edit' > & {
 	enableSorting: boolean;
 	filterBy: NormalizedFilterByConfig | false;
 	readOnly: boolean;
+	elementsLoading: boolean;
+	LoadingComponent: ReactElement | undefined;
 };
 
 /**

--- a/packages/editor/src/components/post-fields/index.ts
+++ b/packages/editor/src/components/post-fields/index.ts
@@ -53,6 +53,7 @@ function usePostFields( {
 					if ( field.id === 'author' ) {
 						return {
 							...field,
+							elementsLoading: isLoadingAuthors,
 							elements: authors?.map( ( { id, name } ) => ( {
 								value: id,
 								label: name,
@@ -63,7 +64,7 @@ function usePostFields( {
 					return field;
 				}
 			) as Field< BasePostWithEmbeddedAuthor >[],
-		[ authors, defaultFields ]
+		[ authors, defaultFields, isLoadingAuthors ]
 	);
 
 	return {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
