### PR TITLE
Site Editor: Always show Additional CSS button

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -16,7 +16,6 @@ import { isRTL, __ } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -25,13 +24,8 @@ import { IconWithCurrentColor } from './icon-with-current-color';
 import { NavigationButtonAsItem } from './navigation-button';
 import RootMenu from './root-menu';
 import PreviewStyles from './preview-styles';
-import { unlock } from '../../lock-unlock';
-
-const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
 function ScreenRoot() {
-	const [ customCSS ] = useGlobalStyle( 'css' );
-
 	const { hasVariations, canEditCSS } = useSelect( ( select ) => {
 		const {
 			getEntityRecord,
@@ -116,7 +110,7 @@ function ScreenRoot() {
 				</ItemGroup>
 			</CardBody>
 
-			{ canEditCSS && !! customCSS && (
+			{ canEditCSS && (
 				<>
 					<CardDivider />
 					<CardBody>


### PR DESCRIPTION
Extract only a part from #66476

## What?

This PR makes the Additional CSS button always visible in the  Styles panel.

## Why?

When there is no custom CSS defined, the Additional panel isn't displayed. This is the expected behaviour implemented in #47371

However, I realized that many users considered this behavior to be a bug.

- https://github.com/WordPress/gutenberg/issues/66333
- https://github.com/WordPress/gutenberg/issues/71535
- https://github.com/WordPress/gutenberg/issues/70095
- https://github.com/Automattic/wp-calypso/issues/101945

Ideally, we'd move forward with restructuring the Styles panel in #66476, but for now, I believe at least the Additional CSS panel should always be visible.

Another issue is that even though you are accessing the same URL (http://localhost:8888/wp-admin/site-editor.php?p=%2Fstyles&section=%2Fcss), the screen you see will be different depending on whether you have additional CSS (See https://github.com/WordPress/gutenberg/pull/71335#issuecomment-3244664760 for more details).

## Testing Instructions

Confirm that the Additional CSS button is always displayed in the Styles panel.

## Screenshots or screencast <!-- if applicable -->

<img width="712" height="327" alt="image" src="https://github.com/user-attachments/assets/74273b04-854f-4f97-aa43-7b058f978cfe" />
