### PR TITLE
Gallery Block: Add E2E test for image randomization

### DIFF
--- a/test/e2e/specs/editor/blocks/gallery.spec.js
+++ b/test/e2e/specs/editor/blocks/gallery.spec.js
@@ -219,6 +219,69 @@ test.describe( 'Gallery', () => {
 			mediaLibrary.locator( 'role=button[name="Create a new gallery"i]' )
 		).toBeVisible();
 	} );
+
+	test( 'can randomize the image on the front end', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost();
+		await editor.insertBlock( {
+			name: 'core/gallery',
+			attributes: {
+				randomOrder: true,
+			},
+			innerBlocks: Array.from( { length: 10 }, ( _, i ) => ( {
+				name: 'core/image',
+				attributes: {
+					url: `${ i }.jpg`,
+				},
+			} ) ),
+		} );
+		const postId = await editor.publishPost();
+		await page.goto( `/?p=${ postId }` );
+		const imageElements = page.locator( '.wp-block-gallery img' );
+		const imageNumbers = await imageElements.evaluateAll( ( imgs ) =>
+			imgs.map( ( img ) =>
+				parseInt( img.src.match( /(\d+)\.jpg$/ )[ 1 ], 10 )
+			)
+		);
+		expect( Array.from( { length: 10 }, ( _, i ) => i ) ).not.toEqual(
+			imageNumbers
+		);
+	} );
+
+	test( 'can randomize the image with a lightbox effect order on the front end', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost();
+		await editor.insertBlock( {
+			name: 'core/gallery',
+			attributes: {
+				randomOrder: true,
+			},
+			innerBlocks: Array.from( { length: 10 }, ( _, i ) => ( {
+				name: 'core/image',
+				attributes: {
+					url: `${ i }.jpg`,
+					lightbox: { enabled: true },
+				},
+			} ) ),
+		} );
+		const postId = await editor.publishPost();
+		await page.goto( `/?p=${ postId }` );
+		const imageElements = page.locator( '.wp-block-gallery img' );
+		const imageNumbers = await imageElements.evaluateAll( ( imgs ) =>
+			imgs.map( ( img ) =>
+				parseInt( img.src.match( /(\d+)\.jpg$/ )[ 1 ], 10 )
+			)
+		);
+		expect( Array.from( { length: 10 }, ( _, i ) => i ) ).not.toEqual(
+			imageNumbers
+		);
+	} );
 } );
 
 class GalleryBlockUtils {

--- a/test/e2e/specs/editor/blocks/gallery.spec.js
+++ b/test/e2e/specs/editor/blocks/gallery.spec.js
@@ -250,7 +250,7 @@ test.describe( 'Gallery', () => {
 		expect( numbers ).not.toEqual( imageAltTexts );
 	} );
 
-	test( 'can randomize the image with a lightbox effect order on the front end', async ( {
+	test( 'can randomize the image with a lightbox effect on the front end', async ( {
 		admin,
 		editor,
 		page,

--- a/test/e2e/specs/editor/blocks/gallery.spec.js
+++ b/test/e2e/specs/editor/blocks/gallery.spec.js
@@ -225,30 +225,29 @@ test.describe( 'Gallery', () => {
 		editor,
 		page,
 	} ) => {
+		const numbers = Array.from( { length: 10 }, ( _, i ) => i + 1 );
 		await admin.createNewPost();
 		await editor.insertBlock( {
 			name: 'core/gallery',
 			attributes: {
 				randomOrder: true,
 			},
-			innerBlocks: Array.from( { length: 10 }, ( _, i ) => ( {
+			innerBlocks: numbers.map( ( i ) => ( {
 				name: 'core/image',
 				attributes: {
-					url: `${ i }.jpg`,
+					id: uploadedMedia.id,
+					alt: i.toString(),
+					url: uploadedMedia.source_url,
 				},
 			} ) ),
 		} );
 		const postId = await editor.publishPost();
 		await page.goto( `/?p=${ postId }` );
 		const imageElements = page.locator( '.wp-block-gallery img' );
-		const imageNumbers = await imageElements.evaluateAll( ( imgs ) =>
-			imgs.map( ( img ) =>
-				parseInt( img.src.match( /(\d+)\.jpg$/ )[ 1 ], 10 )
-			)
+		const imageAltTexts = await imageElements.evaluateAll( ( imgs ) =>
+			imgs.map( ( img ) => parseInt( img.alt, 10 ) )
 		);
-		expect( Array.from( { length: 10 }, ( _, i ) => i ) ).not.toEqual(
-			imageNumbers
-		);
+		expect( numbers ).not.toEqual( imageAltTexts );
 	} );
 
 	test( 'can randomize the image with a lightbox effect order on the front end', async ( {
@@ -256,16 +255,19 @@ test.describe( 'Gallery', () => {
 		editor,
 		page,
 	} ) => {
+		const numbers = Array.from( { length: 10 }, ( _, i ) => i + 1 );
 		await admin.createNewPost();
 		await editor.insertBlock( {
 			name: 'core/gallery',
 			attributes: {
 				randomOrder: true,
 			},
-			innerBlocks: Array.from( { length: 10 }, ( _, i ) => ( {
+			innerBlocks: numbers.map( ( i ) => ( {
 				name: 'core/image',
 				attributes: {
-					url: `${ i }.jpg`,
+					id: uploadedMedia.id,
+					alt: i.toString(),
+					url: uploadedMedia.source_url,
 					lightbox: { enabled: true },
 				},
 			} ) ),
@@ -273,14 +275,10 @@ test.describe( 'Gallery', () => {
 		const postId = await editor.publishPost();
 		await page.goto( `/?p=${ postId }` );
 		const imageElements = page.locator( '.wp-block-gallery img' );
-		const imageNumbers = await imageElements.evaluateAll( ( imgs ) =>
-			imgs.map( ( img ) =>
-				parseInt( img.src.match( /(\d+)\.jpg$/ )[ 1 ], 10 )
-			)
+		const imageAltTexts = await imageElements.evaluateAll( ( imgs ) =>
+			imgs.map( ( img ) => parseInt( img.alt, 10 ) )
 		);
-		expect( Array.from( { length: 10 }, ( _, i ) => i ) ).not.toEqual(
-			imageNumbers
-		);
+		expect( numbers ).not.toEqual( imageAltTexts );
 	} );
 } );
 


### PR DESCRIPTION
Closes #71432

## What?

This PR adds e2e tests to ensure that the "Randomize order" setting of the Gallery block works correctly.

## Why?

As commented [here](https://github.com/WordPress/gutenberg/blob/089ea38ae42d959e56ea1dad5ecea5b73f28424b/packages/block-library/src/gallery/index.php#L129-L145), we need to use a regular expression to randomize the images inside the Gallery block.

As a result, if the HTML output by the Image block changes in the future, it may no longer match this regular expression, and randomization may no longer work.

## How?

Test that the randomization works in both scenarios, with and without the lightbox effect on the image. These E2E tests inject sequential numbers into the alt text and verify that they do NOT match between the editor and the front-end. It is highly unlikely that the order of the Alt text will ever change on the front end, so these tests will never fail.

## Testing Instructions

Run `npm run test:e2e test/e2e/specs/editor/blocks/gallery.spec.js`

You can  also make the tests fail intentionally to better understand what it's trying to do:

```diff
diff --git a/test/e2e/specs/editor/blocks/gallery.spec.js b/test/e2e/specs/editor/blocks/gallery.spec.js
index 3ed0090fa7..702742b6fc 100644
--- a/test/e2e/specs/editor/blocks/gallery.spec.js
+++ b/test/e2e/specs/editor/blocks/gallery.spec.js
@@ -247,7 +247,7 @@ test.describe( 'Gallery', () => {
                const imageAltTexts = await imageElements.evaluateAll( ( imgs ) =>
                        imgs.map( ( img ) => parseInt( img.alt, 10 ) )
                );
-               expect( numbers ).not.toEqual( imageAltTexts );
+               expect( numbers ).toEqual( imageAltTexts );
        } );
 
        test( 'can randomize the image with a lightbox effect order on the front end', async ( {
@@ -278,7 +278,7 @@ test.describe( 'Gallery', () => {
                const imageAltTexts = await imageElements.evaluateAll( ( imgs ) =>
                        imgs.map( ( img ) => parseInt( img.alt, 10 ) )
                );
-               expect( numbers ).not.toEqual( imageAltTexts );
+               expect( numbers ).toEqual( imageAltTexts );
        } );
 } );
```

<img width="1096" height="497" alt="image" src="https://github.com/user-attachments/assets/857bfcd5-8df3-4fcb-9e3c-fa8e37c5d9d2" />

