### PR TITLE
Core Data: Fix early return check for the record field-level resolutions

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -620,6 +620,24 @@ _Returns_
 
 -   `boolean`: Whether the entity record has edits or not.
 
+### hasEntityRecord
+
+Returns true if a record has been received for the given set of parameters, or false otherwise.
+
+Note: This action does not trigger a request for the entity record from the API if it's not available in the local state.
+
+_Parameters_
+
+-   _state_ `State`: State tree
+-   _kind_ `string`: Entity kind.
+-   _name_ `string`: Entity name.
+-   _key_ `EntityRecordKey`: Record's key.
+-   _query_ `GetRecordsHttpQuery`: Optional query.
+
+_Returns_
+
+-   `boolean`: Whether an entity record has been received.
+
 ### hasEntityRecords
 
 Returns true if records have been received for the given set of parameters, or false otherwise.

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -842,6 +842,24 @@ _Returns_
 
 -   `boolean`: Whether the entity record has edits or not.
 
+### hasEntityRecord
+
+Returns true if a record has been received for the given set of parameters, or false otherwise.
+
+Note: This action does not trigger a request for the entity record from the API if it's not available in the local state.
+
+_Parameters_
+
+-   _state_ `State`: State tree
+-   _kind_ `string`: Entity kind.
+-   _name_ `string`: Entity name.
+-   _key_ `EntityRecordKey`: Record's key.
+-   _query_ `GetRecordsHttpQuery`: Optional query.
+
+_Returns_
+
+-   `boolean`: Whether an entity record has been received.
+
 ### hasEntityRecords
 
 Returns true if records have been received for the given set of parameters, or false otherwise.

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -79,10 +79,6 @@ describe( 'getEntityRecord', () => {
 	it( 'accepts a query that overrides default api path', async () => {
 		const query = { context: 'view', _envelope: '1' };
 
-		const select = {
-			hasEntityRecords: jest.fn( () => {} ),
-		};
-
 		// Provide response
 		triggerFetch.mockImplementation( () => POST_TYPE_RESPONSE );
 
@@ -91,7 +87,7 @@ describe( 'getEntityRecord', () => {
 			'postType',
 			'post',
 			query
-		)( { dispatch, select, registry, resolveSelect } );
+		)( { dispatch, registry, resolveSelect } );
 
 		// Trigger apiFetch, test that the query is present in the url.
 		expect( triggerFetch ).toHaveBeenCalledWith( {
@@ -108,6 +104,31 @@ describe( 'getEntityRecord', () => {
 		);
 
 		// Locks should have been acquired and released.
+		expect( dispatch.__unstableAcquireStoreLock ).toHaveBeenCalledTimes(
+			1
+		);
+		expect( dispatch.__unstableReleaseStoreLock ).toHaveBeenCalledTimes(
+			1
+		);
+	} );
+
+	it( 'does not make a request if the record is already in store', async () => {
+		const select = {
+			hasEntityRecord: jest.fn( () => true ),
+		};
+
+		await getEntityRecord( 'root', 'postType', 'post', {
+			context: 'edit',
+			_fields: 'id,title,slug',
+		} )( { dispatch, select, registry, resolveSelect } );
+
+		// No request should have been made.
+		expect( triggerFetch ).not.toHaveBeenCalled();
+
+		// No record should have been received.
+		expect( dispatch.receiveEntityRecords ).not.toHaveBeenCalled();
+
+		// No locks should have been acquired or released.
 		expect( dispatch.__unstableAcquireStoreLock ).toHaveBeenCalledTimes(
 			1
 		);

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -111,31 +111,6 @@ describe( 'getEntityRecord', () => {
 			1
 		);
 	} );
-
-	it( 'does not make a request if the record is already in store', async () => {
-		const select = {
-			hasEntityRecord: jest.fn( () => true ),
-		};
-
-		await getEntityRecord( 'root', 'postType', 'post', {
-			context: 'edit',
-			_fields: 'id,title,slug',
-		} )( { dispatch, select, registry, resolveSelect } );
-
-		// No request should have been made.
-		expect( triggerFetch ).not.toHaveBeenCalled();
-
-		// No record should have been received.
-		expect( dispatch.receiveEntityRecords ).not.toHaveBeenCalled();
-
-		// No locks should have been acquired or released.
-		expect( dispatch.__unstableAcquireStoreLock ).toHaveBeenCalledTimes(
-			1
-		);
-		expect( dispatch.__unstableReleaseStoreLock ).toHaveBeenCalledTimes(
-			1
-		);
-	} );
 } );
 
 describe( 'getEntityRecords', () => {

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -8,6 +8,7 @@ import deepFreeze from 'deep-freeze';
  */
 import {
 	getEntityRecord,
+	hasEntityRecord,
 	hasEntityRecords,
 	getEntityRecords,
 	getRawEntityRecord,
@@ -276,6 +277,133 @@ describe( 'getEntityRecord', () => {
 				bar: undefined,
 			},
 		} );
+	} );
+} );
+
+describe( 'hasEntityRecord', () => {
+	it( 'returns false if entity record has not been received', () => {
+		const state = deepFreeze( {
+			entities: {
+				records: {
+					postType: {
+						post: {
+							queriedData: {
+								items: {},
+								itemIsComplete: {},
+								queries: {},
+							},
+						},
+					},
+				},
+			},
+		} );
+		expect( hasEntityRecord( state, 'postType', 'post', 1 ) ).toBe( false );
+	} );
+
+	it( 'returns true when full record exists and no fields query', () => {
+		const state = deepFreeze( {
+			entities: {
+				records: {
+					postType: {
+						post: {
+							queriedData: {
+								items: {
+									default: {
+										1: { id: 1, content: 'hello' },
+									},
+								},
+								itemIsComplete: {
+									default: {
+										1: true,
+									},
+								},
+								queries: {},
+							},
+						},
+					},
+				},
+			},
+		} );
+		expect( hasEntityRecord( state, 'postType', 'post', 1 ) ).toBe( true );
+	} );
+
+	it( 'returns true when requested fields exist on the item', () => {
+		const state = deepFreeze( {
+			entities: {
+				records: {
+					postType: {
+						post: {
+							queriedData: {
+								items: {
+									default: {
+										1: {
+											id: 1,
+											content: 'chicken',
+											title: { raw: 'egg' },
+											author: 'bob',
+										},
+									},
+								},
+								itemIsComplete: {
+									default: {
+										1: true,
+									},
+								},
+								queries: {},
+							},
+						},
+					},
+				},
+			},
+		} );
+		expect(
+			hasEntityRecord( state, 'postType', 'post', 1, {
+				_fields: [ 'id', 'content' ],
+			} )
+		).toBe( true );
+		// Test nested field.
+		expect(
+			hasEntityRecord( state, 'postType', 'post', 1, {
+				_fields: [ 'id', 'title.raw' ],
+			} )
+		).toBe( true );
+	} );
+
+	it( 'returns false when a requested fields are missing', () => {
+		const state = deepFreeze( {
+			entities: {
+				records: {
+					postType: {
+						post: {
+							queriedData: {
+								items: {
+									default: {
+										1: { id: 1, author: 'bob' },
+									},
+								},
+								itemIsComplete: {
+									default: {
+										1: true,
+									},
+								},
+								queries: {},
+							},
+						},
+					},
+				},
+			},
+		} );
+		expect(
+			hasEntityRecord( state, 'postType', 'post', 1, {
+				_fields: [ 'id', 'content' ],
+			} )
+		).toBe( false );
+		// Test nested field.
+		expect(
+			hasEntityRecord( state, 'postType', 'post', 1, {
+				_fields: [ 'id', 'title.raw' ],
+			} )
+		).toBe( false );
 	} );
 } );
 

--- a/packages/core-data/src/test/store.js
+++ b/packages/core-data/src/test/store.js
@@ -1,0 +1,114 @@
+/**
+ * WordPress dependencies
+ */
+import triggerFetch from '@wordpress/api-fetch';
+import { createRegistry } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as coreDataStore } from '../index';
+
+jest.mock( '@wordpress/api-fetch' );
+
+function createTestRegistry() {
+	const registry = createRegistry();
+
+	// Register the core-data store
+	registry.register( coreDataStore );
+
+	const postEntityConfig = {
+		kind: 'postType',
+		baseURL: '/wp/v2/posts',
+		baseURLParams: {
+			context: 'edit',
+		},
+		name: 'post',
+		label: 'Posts',
+		transientEdits: {
+			blocks: true,
+			selection: true,
+		},
+		mergedEdits: {
+			meta: true,
+		},
+		rawAttributes: [ 'title', 'excerpt', 'content' ],
+		__unstable_rest_base: 'posts',
+		supportsPagination: true,
+		revisionKey: 'id',
+	};
+
+	// Add the post entity to the store
+	registry.dispatch( coreDataStore ).addEntities( [ postEntityConfig ] );
+
+	return registry;
+}
+
+function createTestPost( id = 1, fields = [] ) {
+	const post = {
+		id,
+		author: 1,
+		content: {
+			raw: '<!-- wp:paragraph -->\n<p>A paragraph</p>\n<!-- /wp:paragraph -->',
+			rendered: '\n<p>A paragraph</p>\n',
+		},
+		excerpt: {
+			raw: '',
+			rendered: '<p>A paragraph</p>\n',
+		},
+		title: {
+			raw: 'Test',
+			rendered: 'Test',
+		},
+		featured_media: 0,
+		type: 'post',
+		status: 'draft',
+		slug: '',
+	};
+
+	if ( fields.length > 0 ) {
+		return Object.fromEntries(
+			fields.map( ( field ) => [ field, post[ field ] ] )
+		);
+	}
+
+	return post;
+}
+
+describe( 'getEntityRecord', () => {
+	let registry;
+
+	beforeEach( () => {
+		registry = createTestRegistry();
+		triggerFetch.mockReset();
+	} );
+
+	it( 'should not make a request if the record is already in store', async () => {
+		const { getEntityRecord } = registry.resolveSelect( coreDataStore );
+		const post = createTestPost( 1 );
+		triggerFetch.mockResolvedValue( {
+			async json() {
+				return post;
+			},
+		} );
+
+		// Resolve the record.
+		await expect(
+			getEntityRecord( 'postType', 'post', post.id, { context: 'edit' } )
+		).resolves.toEqual( post );
+
+		triggerFetch.mockReset();
+
+		await expect(
+			getEntityRecord( 'postType', 'post', post.id, {
+				context: 'edit',
+				_fields: [ 'id', 'author', 'title' ],
+			} )
+		).resolves.toEqual( {
+			id: post.id,
+			author: post.author,
+			title: post.title,
+		} );
+		expect( triggerFetch ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
## What?
Part of #26629.

PR fixes the early return check for the record field-level resolutions, inside the `getEntityRecord`. This restores optimization logic and avoids additional HTTP requests when entity record data already exists in the store.

## Why?
It looks like the `hasEntityRecords` selector has regressed sometime ago, probably when we had to [add `include` to the `stableCacheKey`](https://github.com/WordPress/gutenberg/pull/34583) to avoid incorrect results.

## How?
PR introduces a new `hasEntityRecord` selector, which is now used to perform checks.

## Testing Instructions
1. Open a post.
2. Run the test snippets in DevTools Console.
3. Unit tests cover the rest.

### Test Snippets.
```js
// Request full record.
wp.data.select( 'core' ).getEntityRecord( 'postType', 'attachment', 23, { context: 'view' } )

// Request partial fields for the same record and same context. Won't trigger a request.
wp.data.select( 'core' ).getEntityRecord( 'postType', 'attachment', 23, { _fields: [ 'id', 'source_url', 'alt_text' ], context: 'view' } )

// A different context will trigger a request.
wp.data.select( 'core' ).getEntityRecord( 'postType', 'attachment', 23, { _fields: [ 'id', 'source_url', 'alt_text' ], context: 'edit' } )
```

### Testing Instructions for Keyboard
Same.