### PR TITLE
DataViews grid layout: rounded corners for media

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -13,6 +13,10 @@
 - DataForm: introduce a new `row` layout, check the README for details. [#71124](https://github.com/WordPress/gutenberg/pull/71124)
 - Dataform: Add new `url` field type and field control. [#71518](https://github.com/WordPress/gutenberg/pull/71518)
 
+### Bug Fixes
+
+- DataViews grid layout: make sure media previews have rounded corners. [#71543](https://github.com/WordPress/gutenberg/pull/71543)
+
 ## 8.0.0 (2025-09-03)
 
 ### Breaking changes

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -43,6 +43,7 @@
 		aspect-ratio: 1/1;
 		background-color: $white;
 		border-radius: $radius-medium;
+		overflow: hidden;
 		position: relative;
 
 		img {


### PR DESCRIPTION
## What?

This PR makes sure the media field has rounded corners.

| Before | After |
| --- | --- |
| <img width="1857" height="1048" alt="Screenshot 2025-09-08 at 12 54 06" src="https://github.com/user-attachments/assets/36fa1b9e-5fe9-41f2-b74d-c9977617f2e0" /> | <img width="1857" height="1048" alt="Screenshot 2025-09-08 at 12 53 49" src="https://github.com/user-attachments/assets/0352ac85-3b31-408f-a690-a59bc8a25106" /> |

## Why?

That's how we want it to be, like list and table layouts.

## How?

By making sure the content doesn't overflow the container.

## Testing Instructions

Visit the storybook (`npm run storybook:dev`) and set the layout to grid. Verify the images have rounded corners.
