### PR TITLE
Site Editor: make less prominent Addtional CSS UI

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-css.js
+++ b/packages/edit-site/src/components/global-styles/screen-css.js
@@ -61,7 +61,7 @@ function ScreenCSS() {
 			<Spacer margin={ 0 } paddingX={ 4 }>
 				<Navigator.Button as={ Button } variant="link" path="/blocks">
 					{ __(
-						'Want to change block appearance? Use the Blocs section instead.'
+						'Want to change block appearance? Use the Blocкs section instead.'
 					) }
 				</Navigator.Button>
 			</Spacer>

--- a/packages/edit-site/src/components/global-styles/screen-css.js
+++ b/packages/edit-site/src/components/global-styles/screen-css.js
@@ -2,7 +2,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { ExternalLink } from '@wordpress/components';
+import {
+	Button,
+	Navigator,
+	ExternalLink,
+	__experimentalSpacer as Spacer,
+} from '@wordpress/components';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { useDispatch } from '@wordpress/data';
 
@@ -18,9 +23,6 @@ const { useGlobalStyle, AdvancedPanel: StylesAdvancedPanel } = unlock(
 );
 
 function ScreenCSS() {
-	const description = __(
-		'You can add custom CSS to further customize the appearance and layout of your site.'
-	);
 	const [ style ] = useGlobalStyle( '', undefined, 'user', {
 		shouldDecodeEncode: false,
 	} );
@@ -38,7 +40,9 @@ function ScreenCSS() {
 				title={ __( 'Additional CSS' ) }
 				description={
 					<>
-						{ description }
+						{ __(
+							'You can add custom CSS to further customize the appearance and layout of your site.'
+						) }
 						<br />
 						<ExternalLink
 							href={ __(
@@ -54,6 +58,13 @@ function ScreenCSS() {
 					setEditorCanvasContainerView( undefined );
 				} }
 			/>
+			<Spacer margin={ 0 } paddingX={ 4 }>
+				<Navigator.Button as={ Button } variant="link" path="/blocks">
+					{ __(
+						'Want to change block appearance? Use the Blocs section instead.'
+					) }
+				</Navigator.Button>
+			</Spacer>
 			<div className="edit-site-global-styles-screen-css">
 				<StylesAdvancedPanel
 					value={ style }

--- a/packages/edit-site/src/components/global-styles/screen-css.js
+++ b/packages/edit-site/src/components/global-styles/screen-css.js
@@ -2,12 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	Button,
-	Navigator,
-	ExternalLink,
-	__experimentalSpacer as Spacer,
-} from '@wordpress/components';
+import { ExternalLink } from '@wordpress/components';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { useDispatch } from '@wordpress/data';
 
@@ -58,13 +53,6 @@ function ScreenCSS() {
 					setEditorCanvasContainerView( undefined );
 				} }
 			/>
-			<Spacer margin={ 0 } paddingX={ 4 }>
-				<Navigator.Button as={ Button } variant="link" path="/blocks">
-					{ __(
-						'Want to change block appearance? Use the Blocks section instead.'
-					) }
-				</Navigator.Button>
-			</Spacer>
 			<div className="edit-site-global-styles-screen-css">
 				<StylesAdvancedPanel
 					value={ style }

--- a/packages/edit-site/src/components/global-styles/screen-css.js
+++ b/packages/edit-site/src/components/global-styles/screen-css.js
@@ -61,7 +61,7 @@ function ScreenCSS() {
 			<Spacer margin={ 0 } paddingX={ 4 }>
 				<Navigator.Button as={ Button } variant="link" path="/blocks">
 					{ __(
-						'Want to change block appearance? Use the Blocкs section instead.'
+						'Want to change block appearance? Use the Blocks section instead.'
 					) }
 				</Navigator.Button>
 			</Spacer>

--- a/packages/edit-site/src/components/global-styles/screen-css.js
+++ b/packages/edit-site/src/components/global-styles/screen-css.js
@@ -19,7 +19,7 @@ const { useGlobalStyle, AdvancedPanel: StylesAdvancedPanel } = unlock(
 
 function ScreenCSS() {
 	const description = __(
-		'Add your own CSS to customize the appearance and layout of your site.'
+		'You can add custom CSS to further customize the appearance and layout of your site.'
 	);
 	const [ style ] = useGlobalStyle( '', undefined, 'user', {
 		shouldDecodeEncode: false,
@@ -35,7 +35,7 @@ function ScreenCSS() {
 	return (
 		<>
 			<ScreenHeader
-				title={ __( 'CSS' ) }
+				title={ __( 'Additional CSS' ) }
 				description={
 					<>
 						{ description }

--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -26,24 +26,10 @@ import RootMenu from './root-menu';
 import PreviewStyles from './preview-styles';
 
 function ScreenRoot() {
-	const { hasVariations, canEditCSS } = useSelect( ( select ) => {
-		const {
-			getEntityRecord,
-			__experimentalGetCurrentGlobalStylesId,
-			__experimentalGetCurrentThemeGlobalStylesVariations,
-		} = select( coreStore );
-
-		const globalStylesId = __experimentalGetCurrentGlobalStylesId();
-		const globalStyles = globalStylesId
-			? getEntityRecord( 'root', 'globalStyles', globalStylesId )
-			: undefined;
-
-		return {
-			hasVariations:
-				!! __experimentalGetCurrentThemeGlobalStylesVariations()
-					?.length,
-			canEditCSS: !! globalStyles?._links?.[ 'wp:action-edit-css' ],
-		};
+	const hasVariations = useSelect( ( select ) => {
+		const { __experimentalGetCurrentThemeGlobalStylesVariations } =
+			select( coreStore );
+		return !! __experimentalGetCurrentThemeGlobalStylesVariations()?.length;
 	}, [] );
 
 	return (
@@ -109,28 +95,6 @@ function ScreenRoot() {
 					</NavigationButtonAsItem>
 				</ItemGroup>
 			</CardBody>
-
-			{ canEditCSS && (
-				<>
-					<CardDivider />
-					<CardBody>
-						<ItemGroup>
-							<NavigationButtonAsItem path="/css">
-								<HStack justify="space-between">
-									<FlexItem>
-										{ __( 'Additional CSS' ) }
-									</FlexItem>
-									<IconWithCurrentColor
-										icon={
-											isRTL() ? chevronLeft : chevronRight
-										}
-									/>
-								</HStack>
-							</NavigationButtonAsItem>
-						</ItemGroup>
-					</CardBody>
-				</>
-			) }
 		</Card>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -92,7 +92,7 @@ function ScreenRoot() {
 					 * the nav button inset should be looked at before reusing further.
 					 */
 					paddingX="13px"
-					marginBottom={ 4 }
+					marginBottom={ 2 }
 				>
 					{ __(
 						'Customize the appearance of specific blocks for the whole site.'
@@ -114,16 +114,6 @@ function ScreenRoot() {
 				<>
 					<CardDivider />
 					<CardBody>
-						<Spacer
-							as="p"
-							paddingTop={ 2 }
-							paddingX="13px"
-							marginBottom={ 4 }
-						>
-							{ __(
-								'Add your own CSS to customize the appearance and layout of your site.'
-							) }
-						</Spacer>
 						<ItemGroup>
 							<NavigationButtonAsItem path="/css">
 								<HStack justify="space-between">

--- a/packages/edit-site/src/components/sidebar-global-styles-wrapper/index.js
+++ b/packages/edit-site/src/components/sidebar-global-styles-wrapper/index.js
@@ -2,12 +2,20 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 import { useMemo, useState } from '@wordpress/element';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useViewportMatch } from '@wordpress/compose';
-import { Button } from '@wordpress/components';
+import {
+	Button,
+	__experimentalHStack as HStack,
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
+} from '@wordpress/components';
 import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
-import { seen } from '@wordpress/icons';
+import { seen, moreVertical } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -24,21 +32,59 @@ const GlobalStylesPageActions = ( {
 	path,
 } ) => {
 	const history = useHistory();
+	const canEditCSS = useSelect( ( select ) => {
+		const { getEntityRecord, __experimentalGetCurrentGlobalStylesId } =
+			select( coreStore );
+		const globalStylesId = __experimentalGetCurrentGlobalStylesId();
+		const globalStyles = globalStylesId
+			? getEntityRecord( 'root', 'globalStyles', globalStylesId )
+			: undefined;
+		return !! globalStyles?._links?.[ 'wp:action-edit-css' ];
+	}, [] );
+
 	return (
-		<Button
-			isPressed={ isStyleBookOpened }
-			icon={ seen }
-			label={ __( 'Style Book' ) }
-			onClick={ () => {
-				setIsStyleBookOpened( ! isStyleBookOpened );
-				const updatedPath = ! isStyleBookOpened
-					? addQueryArgs( path, { preview: 'stylebook' } )
-					: removeQueryArgs( path, 'preview' );
-				// Navigate to the updated path.
-				history.navigate( updatedPath );
-			} }
-			size="compact"
-		/>
+		<HStack>
+			<Button
+				isPressed={ isStyleBookOpened }
+				icon={ seen }
+				label={ __( 'Style Book' ) }
+				onClick={ () => {
+					setIsStyleBookOpened( ! isStyleBookOpened );
+					const updatedPath = ! isStyleBookOpened
+						? addQueryArgs( path, { preview: 'stylebook' } )
+						: removeQueryArgs( path, 'preview' );
+					// Navigate to the updated path.
+					history.navigate( updatedPath );
+				} }
+				size="compact"
+			/>
+			{ canEditCSS && (
+				<DropdownMenu
+					icon={ moreVertical }
+					label={ __( 'More' ) }
+					toggleProps={ { size: 'compact' } }
+				>
+					{ ( { onClose } ) => (
+						<MenuGroup>
+							{ canEditCSS && (
+								<MenuItem
+									onClick={ () => {
+										onClose();
+										history.navigate(
+											addQueryArgs( path, {
+												section: '/css',
+											} )
+										);
+									} }
+								>
+									{ __( 'Additional CSS' ) }
+								</MenuItem>
+							) }
+						</MenuGroup>
+					) }
+				</DropdownMenu>
+			) }
+		</HStack>
 	);
 };
 


### PR DESCRIPTION
Follow up #71537

See https://github.com/WordPress/gutenberg/pull/71537#issuecomment-3265969356, https://github.com/WordPress/gutenberg/pull/71537#issuecomment-3266126724

## What?

By making the additional CSS UI less prominent, try to implicitly encourage the use of a more ideal tool (the global styles UI).

## How?

- ~Remove the text above the button.~
- ~Change the screen title from "CSS" to "Additional CSS" to emphasize that this section is optional.~
- ~Change the screen description to a passive one.~

Update: The Add CSS button has been moved into the ellipsis menu in the header. See this discussion for more details: https://github.com/WordPress/gutenberg/pull/71550#discussion_r2347399517

## Testing Instructions

There are no changes in terms of functionality.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/4c7e80ae-2e02-472f-8877-fbacb2ef13db
