### PR TITLE
Block Editor: Fix stale insertion point reference

### DIFF
--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -7,7 +7,12 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useRef, createContext, useContext } from '@wordpress/element';
+import {
+	useRef,
+	createContext,
+	useContext,
+	useCallback,
+} from '@wordpress/element';
 import { __unstableMotion as motion } from '@wordpress/components';
 import { useReducedMotion } from '@wordpress/compose';
 
@@ -113,6 +118,18 @@ function InbetweenInsertionPointPopover( {
 		}
 	}
 
+	// Reset the insertion point reference when the Inserter unmounts,
+	// avoids stale references when `onSelectOrClose` is not called.
+	// See: https://github.com/WordPress/gutenberg/issues/65598#issuecomment-3249229264.
+	const maybeResetOpenRef = useCallback(
+		( node ) => {
+			if ( ! node && openRef.current ) {
+				openRef.current = false;
+			}
+		},
+		[ openRef ]
+	);
+
 	const lineVariants = {
 		// Initial position starts from the center and invisible.
 		start: {
@@ -203,6 +220,7 @@ function InbetweenInsertionPointPopover( {
 						) }
 					>
 						<Inserter
+							ref={ maybeResetOpenRef }
 							position="bottom center"
 							clientId={ nextClientId }
 							rootClientId={ rootClientId }


### PR DESCRIPTION
## What?
Closes #65598.

PR fixes stale values for insertion point references, which happens when `BlockPopoverInbetween` unmounts its children.

## Why?

1. Between blocks insertion point, use a special [reference (`openRef.current`) flag](https://github.com/WordPress/gutenberg/blob/3c73dacd60009781f9b8d994b0c26cdbad29ab98/packages/block-editor/src/components/block-list/use-in-between-inserter.js#L47-L51) to avoid triggering other insertion points, while Quick Inserter is open. Its value is set to `true` when an inserter is open and resets to default (`false`) on close.
2. When you scroll down on a large editor canvas, and the relative blocks for the insertion point get hidden, the editor triggers optimizations to hide unnecessary components.
3. The `BlockPopoverInbetween` will [unmount its children ](https://github.com/WordPress/gutenberg/blob/30798552f7fd8e18b29803b1734fac377e7d089d/packages/block-editor/src/components/block-popover/inbetween.js#L213-L218), which results in a stale `openRef` flag, since Popovers don't trigger [`onClose` callback](https://github.com/WordPress/gutenberg/blob/30798552f7fd8e18b29803b1734fac377e7d089d/packages/block-editor/src/components/block-tools/insertion-point.js#L213-L215) during unmount.

## How?

Use a ref callback and reset the reference when the `Inserter` component unmounts. A bit of a hacky solution, but I couldn't think of anything better without making a breaking change to popovers.

## Testing Instructions
1. Open a post.
2. Add 20-30 group blocks.
3. Open the in-between inserter at the top.
4. Scroll down so that the inserter is hidden.
5. Try opening another in-between inserter.
6. It should work on this branch, but fails on trunk.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/9f4b5e3c-404e-411d-94de-9b1fa1ab1412


