### PR TITLE
DataViews: Custom `empty` elements are no longer wrapped in `<p>` tags to improve accessibility

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking changes
 
 - Remove `boolean` form control. Fields using `Edit: 'boolean'` must now use `Edit: 'checkbox'` or `Edit: 'toggle'` instead. Boolean field types now use checkboxes by default. [#71505](https://github.com/WordPress/gutenberg/pull/71505)
+- DataViews: Custom `empty` elements are no longer wrapped in `<p>` tags to improve accessibility. [#71561](https://github.com/WordPress/gutenberg/pull/71561)
 
 ### Features
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -426,7 +426,7 @@ Optional. Pass an object with a list of `perPageSizes` to control the available 
 
 #### `empty`: React node
 
-A message or element to be displayed instead of the dataview's default empty message.
+An element to display when the `data` prop is empty. Defaults to `<p>No results</p>`.
 
 ### Composition modes
 

--- a/packages/dataviews/src/components/dataviews-layout/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layout/index.tsx
@@ -37,7 +37,7 @@ export default function DataViewsLayout( { className }: DataViewsLayoutProps ) {
 		isItemClickable,
 		renderItemLink,
 		defaultLayouts,
-		empty = __( 'No results' ),
+		empty = <p>{ __( 'No results' ) }</p>,
 	} = useContext( DataViewsContext );
 
 	const ViewComponent = VIEW_LAYOUTS.find(

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -155,7 +155,7 @@ export const CustomEmpty = () => {
 			onChangeView={ setView }
 			actions={ actions }
 			defaultLayouts={ defaultLayouts }
-			empty={ view.search ? 'No sites found' : 'No sites' }
+			empty={ <p>{ view.search ? 'No sites found' : 'No sites' }</p> }
 		/>
 	);
 };

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -474,7 +474,13 @@ function ViewGrid< Item >( {
 							'dataviews-no-results': ! isLoading,
 						} ) }
 					>
-						<p>{ isLoading ? <Spinner /> : empty }</p>
+						{ isLoading ? (
+							<p>
+								<Spinner />
+							</p>
+						) : (
+							empty
+						) }
 					</div>
 				)
 			}

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -512,7 +512,14 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 					'dataviews-no-results': ! hasData && ! isLoading,
 				} ) }
 			>
-				{ ! hasData && <p>{ isLoading ? <Spinner /> : empty }</p> }
+				{ ! hasData &&
+					( isLoading ? (
+						<p>
+							<Spinner />
+						</p>
+					) : (
+						empty
+					) ) }
 			</div>
 		);
 	}

--- a/packages/dataviews/src/dataviews-layouts/picker-grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/picker-grid/index.tsx
@@ -474,7 +474,13 @@ function ViewPickerGrid< Item >( {
 							'dataviews-no-results': ! isLoading,
 						} ) }
 					>
-						<p>{ isLoading ? <Spinner /> : empty }</p>
+						{ isLoading ? (
+							<p>
+								<Spinner />
+							</p>
+						) : (
+							empty
+						) }
 					</div>
 				)
 			}

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -578,7 +578,14 @@ function ViewTable< Item >( {
 				} ) }
 				id={ tableNoticeId }
 			>
-				{ ! hasData && <p>{ isLoading ? <Spinner /> : empty }</p> }
+				{ ! hasData &&
+					( isLoading ? (
+						<p>
+							<Spinner />
+						</p>
+					) : (
+						empty
+					) ) }
 				{ hasData && isLoading && (
 					<p className="dataviews-loading-more">
 						<Spinner />


### PR DESCRIPTION




<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Fixes an accessibility error when providing a custom empty element.

<img width="603" height="53" alt="Screenshot 2025-09-03 at 17 35 17" src="https://github.com/user-attachments/assets/2dbd5146-132f-4ec9-900f-8d9021dacce9" />

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The custom empty element can be anything arbitrary, including divs and headings. These elements are not semantically allowed to be children of paragraphs.

Raised here https://github.com/WordPress/gutenberg/pull/70867#discussion_r2319253911

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

If a dataviews user wants to have a wrapping paragraph for their custom message, they now need to provide their own. The margin provided by the paragraph element doesn't usually do anything, since the message is usually centred in a full height dataview in Gutenberg.

The spinner continues to be wrapped in a paragraph. This is allowed semantically (the spinner is just an <svg> element), it keeps the vertical margins of the spinner consistent with the default empty message, and it is consistent with the spinners which show when the dataviews are loading more data in infinite scroll mode.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

There should be no visual changes.

You can check the custom messages in storybook. First run `npm run storybook:dev`. Then check out the custom empty message stories.

**DataViews : Custom Empty**

<img width="2236" height="512" alt="CleanShot 2025-09-09 at 22 08 04@2x" src="https://github.com/user-attachments/assets/c73ce643-749c-4a94-9676-7a277c281055" />


**DataViews : Free Composition**

<img width="2242" height="1322" alt="CleanShot 2025-09-09 at 22 08 19@2x" src="https://github.com/user-attachments/assets/f523b34f-76e7-490d-a4d7-750efec086d2" />


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

No keyboard changes.
