### PR TITLE
Command Palette: Move custom CSS command to `core-commands` from `edit-site` package

### DIFF
--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -428,8 +428,8 @@ const getGlobalStylesOpenCssCommands = () =>
 
 			return [
 				{
-					name: 'core/go-to-custom-css',
-					label: __( 'Go to custom CSS' ),
+					name: 'core/open-styles-css',
+					label: __( 'Open custom CSS' ),
 					icon: brush,
 					callback: ( { close } ) => {
 						close();

--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -14,6 +14,7 @@ import {
 	symbolFilled,
 	styles,
 	navigation,
+	brush,
 } from '@wordpress/icons';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { addQueryArgs, getPath } from '@wordpress/url';
@@ -400,6 +401,61 @@ const getSiteEditorBasicNavigationCommands = () =>
 		};
 	};
 
+const getGlobalStylesOpenCssCommands = () =>
+	function useGlobalStylesOpenCssCommands() {
+		const history = useHistory();
+		const isSiteEditor = getPath( window.location.href )?.includes(
+			'site-editor.php'
+		);
+		const { canEditCSS } = useSelect( ( select ) => {
+			const { getEntityRecord, __experimentalGetCurrentGlobalStylesId } =
+				select( coreStore );
+
+			const globalStylesId = __experimentalGetCurrentGlobalStylesId();
+			const globalStyles = globalStylesId
+				? getEntityRecord( 'root', 'globalStyles', globalStylesId )
+				: undefined;
+
+			return {
+				canEditCSS: !! globalStyles?._links?.[ 'wp:action-edit-css' ],
+			};
+		}, [] );
+
+		const commands = useMemo( () => {
+			if ( ! canEditCSS ) {
+				return [];
+			}
+
+			return [
+				{
+					name: 'core/go-to-custom-css',
+					label: __( 'Go to custom CSS' ),
+					icon: brush,
+					callback: ( { close } ) => {
+						close();
+
+						if ( isSiteEditor ) {
+							history.navigate( '/styles?section=/css' );
+						} else {
+							document.location = addQueryArgs(
+								'site-editor.php',
+								{
+									p: '/styles',
+									section: '/css',
+								}
+							);
+						}
+					},
+				},
+			];
+		}, [ history, canEditCSS, isSiteEditor ] );
+
+		return {
+			isLoading: false,
+			commands,
+		};
+	};
+
 export function useSiteEditorNavigationCommands() {
 	useCommandLoader( {
 		name: 'core/edit-site/navigate-pages',
@@ -420,6 +476,11 @@ export function useSiteEditorNavigationCommands() {
 	useCommandLoader( {
 		name: 'core/edit-site/basic-navigation',
 		hook: getSiteEditorBasicNavigationCommands(),
+		context: 'site-editor',
+	} );
+	useCommandLoader( {
+		name: 'core/edit-site/global-styles-css',
+		hook: getGlobalStylesOpenCssCommands(),
 		context: 'site-editor',
 	} );
 }

--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -481,6 +481,5 @@ export function useSiteEditorNavigationCommands() {
 	useCommandLoader( {
 		name: 'core/edit-site/global-styles-css',
 		hook: getGlobalStylesOpenCssCommands(),
-		context: 'site-editor',
 	} );
 }

--- a/packages/edit-site/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-common-commands.js
@@ -4,7 +4,7 @@
 import { useMemo } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, isRTL } from '@wordpress/i18n';
-import { rotateLeft, rotateRight, help, brush, backup } from '@wordpress/icons';
+import { rotateLeft, rotateRight, help, backup } from '@wordpress/icons';
 import { useCommandLoader } from '@wordpress/commands';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
@@ -94,64 +94,6 @@ const getGlobalStylesResetCommands = () =>
 		};
 	};
 
-const getGlobalStylesOpenCssCommands = () =>
-	function useGlobalStylesOpenCssCommands() {
-		const { openGeneralSidebar, setEditorCanvasContainerView } = unlock(
-			useDispatch( editSiteStore )
-		);
-		const { params } = useLocation();
-		const { canvas = 'view' } = params;
-		const history = useHistory();
-		const { canEditCSS } = useSelect( ( select ) => {
-			const { getEntityRecord, __experimentalGetCurrentGlobalStylesId } =
-				select( coreStore );
-
-			const globalStylesId = __experimentalGetCurrentGlobalStylesId();
-			const globalStyles = globalStylesId
-				? getEntityRecord( 'root', 'globalStyles', globalStylesId )
-				: undefined;
-
-			return {
-				canEditCSS: !! globalStyles?._links?.[ 'wp:action-edit-css' ],
-			};
-		}, [] );
-
-		const commands = useMemo( () => {
-			if ( ! canEditCSS ) {
-				return [];
-			}
-
-			return [
-				{
-					name: 'core/edit-site/open-styles-css',
-					label: __( 'Open custom CSS' ),
-					icon: brush,
-					callback: ( { close } ) => {
-						close();
-						if ( canvas !== 'edit' ) {
-							history.navigate( '/styles?canvas=edit', {
-								transition: 'canvas-mode-edit-transition',
-							} );
-						}
-						openGeneralSidebar( 'edit-site/global-styles' );
-						setEditorCanvasContainerView( 'global-styles-css' );
-					},
-				},
-			];
-		}, [
-			history,
-			openGeneralSidebar,
-			setEditorCanvasContainerView,
-			canEditCSS,
-			canvas,
-		] );
-
-		return {
-			isLoading: false,
-			commands,
-		};
-	};
-
 const getGlobalStylesOpenRevisionsCommands = () =>
 	function useGlobalStylesOpenRevisionsCommands() {
 		const { openGeneralSidebar, setEditorCanvasContainerView } = unlock(
@@ -218,11 +160,6 @@ export function useCommonCommands() {
 	useCommandLoader( {
 		name: 'core/edit-site/reset-global-styles',
 		hook: getGlobalStylesResetCommands(),
-	} );
-
-	useCommandLoader( {
-		name: 'core/edit-site/open-styles-css',
-		hook: getGlobalStylesOpenCssCommands(),
 	} );
 
 	useCommandLoader( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of #71318 

This PR moves custom CSS command from the `@wordpress/edit-site` to the `@wordpress/core-commands` package

## Why?
This move was held back from #71335 because at that time Custom CSS panel was not always available
#71537 has since fixed the problem & Additional CSS panel is now always accessible

## How?
The PR moves `Open custom CSS` command from edit-site package to core-commands, modifying to only perform URL navigations without internal dependencies from edit-site package

## Testing Instructions
1. Open command palette
2. Select `Open custom CSS` option
3. Verify that site edior opens & `Additional CSS` panel shows up

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/ee38300d-75c5-41d3-b2ce-3961200e4255
