### PR TITLE
Experimental - Add content attribute controls to "Content" sidebar in contentOnly

### DIFF
--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -46,6 +46,7 @@
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",
+		"@wordpress/dataviews": "file:../dataviews",
 		"@wordpress/date": "file:../date",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -13,7 +13,6 @@ import {
 } from '@wordpress/components';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
 import { getBlockType } from '@wordpress/blocks';
-import { useMemo } from '@wordpress/element';
 import { DataForm } from '@wordpress/dataviews';
 
 /**
@@ -77,6 +76,26 @@ function SingleContentAttributeControl( {
 	);
 }
 
+function getEditableContentAttributes( block ) {
+	const attributes = [];
+	if ( block?.name ) {
+		const blockType = getBlockType( block.name );
+		if ( blockType?.attributes ) {
+			Object.entries( blockType.attributes ).forEach(
+				( [ attrName, attrDef ] ) => {
+					if ( attrDef.role === 'content' ) {
+						attributes.push( {
+							name: attrName,
+							definition: attrDef,
+							value: block.attributes?.[ attrName ],
+						} );
+					}
+				}
+			);
+		}
+	}
+	return attributes;
+}
 // Block Content Attributes View for Navigator sub-screen
 function BlockContentAttributesView( { clientId } ) {
 	const blockInformation = useBlockDisplayInformation( clientId );
@@ -95,26 +114,7 @@ function BlockContentAttributesView( { clientId } ) {
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
 	// Get content attributes for this block
-	const contentAttributes = useMemo( () => {
-		const attributes = [];
-		if ( block?.name ) {
-			const blockType = getBlockType( block.name );
-			if ( blockType?.attributes ) {
-				Object.entries( blockType.attributes ).forEach(
-					( [ attrName, attrDef ] ) => {
-						if ( attrDef.role === 'content' ) {
-							attributes.push( {
-								name: attrName,
-								definition: attrDef,
-								value: block.attributes?.[ attrName ],
-							} );
-						}
-					}
-				);
-			}
-		}
-		return attributes;
-	}, [ block ] );
+	const contentAttributes = getEditableContentAttributes( block );
 
 	return (
 		<VStack spacing={ 2 }>
@@ -249,23 +249,7 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 		useDispatch( blockEditorStore );
 
 	// Get content attributes for this block
-	const contentAttributes = [];
-	if ( block?.name ) {
-		const blockType = getBlockType( block.name );
-		if ( blockType?.attributes ) {
-			Object.entries( blockType.attributes ).forEach(
-				( [ attrName, attrDef ] ) => {
-					if ( attrDef.role === 'content' ) {
-						contentAttributes.push( {
-							name: attrName,
-							definition: attrDef,
-							value: block.attributes?.[ attrName ],
-						} );
-					}
-				}
-			);
-		}
-	}
+	const contentAttributes = getEditableContentAttributes( block );
 
 	// Determine if this block has multiple content attributes
 	const hasMultipleContentAttributes = contentAttributes.length > 1;

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -397,15 +397,11 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 	const blockTitle = useBlockDisplayTitle( {
 		clientId,
 	} );
-	const { isSelected, block } = useSelect(
+	const { block } = useSelect(
 		( select ) => {
-			const { isBlockSelected, hasSelectedInnerBlock, getBlock } =
-				select( blockEditorStore );
+			const { getBlock } = select( blockEditorStore );
 
 			return {
-				isSelected:
-					isBlockSelected( clientId ) ||
-					hasSelectedInnerBlock( clientId, /* deep: */ true ),
 				block: getBlock( clientId ),
 			};
 		},
@@ -446,7 +442,6 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 			<Navigator.Button
 				path={ `/block/${ clientId }` }
 				__next40pxDefaultSize
-				isPressed={ isSelected }
 				onClick={ async () => {
 					await selectBlock( clientId );
 					if ( onSelect ) {
@@ -490,27 +485,4 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 			/>
 		);
 	}
-
-	// Fallback: show regular block button if no content attributes or multiple
-	return (
-		<Button
-			__next40pxDefaultSize
-			isPressed={ isSelected }
-			onClick={ async () => {
-				await selectBlock( clientId );
-				if ( onSelect ) {
-					onSelect( clientId );
-				}
-			} }
-		>
-			<Flex>
-				<FlexItem>
-					<BlockIcon icon={ blockInformation?.icon } />
-				</FlexItem>
-				<FlexBlock style={ { textAlign: 'left' } }>
-					<Truncate>{ blockTitle }</Truncate>
-				</FlexBlock>
-			</Flex>
-		</Button>
-	);
 }

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -196,7 +196,7 @@ function createDataFormFields( contentAttributes, blockInformation ) {
 			id: attr.name,
 			type: fieldType,
 			label:
-				blockInformation?.name || blockInformation?.title || attr.name,
+				attr.name || blockInformation?.name || blockInformation?.title,
 		};
 	} );
 }

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -4,12 +4,15 @@
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	Button,
+	TextControl,
+	ToggleControl,
 	__experimentalVStack as VStack,
 	__experimentalTruncate as Truncate,
 	Flex,
 	FlexBlock,
 	FlexItem,
 } from '@wordpress/components';
+import { getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -42,40 +45,112 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 		clientId,
 		context: 'list-view',
 	} );
-	const { isSelected } = useSelect(
+	const { isSelected, block } = useSelect(
 		( select ) => {
-			const { isBlockSelected, hasSelectedInnerBlock } =
+			const { isBlockSelected, hasSelectedInnerBlock, getBlock } =
 				select( blockEditorStore );
 
 			return {
 				isSelected:
 					isBlockSelected( clientId ) ||
 					hasSelectedInnerBlock( clientId, /* deep: */ true ),
+				block: getBlock( clientId ),
 			};
 		},
 		[ clientId ]
 	);
-	const { selectBlock } = useDispatch( blockEditorStore );
+	const { updateBlockAttributes, selectBlock } =
+		useDispatch( blockEditorStore );
+
+	// Get content attributes for this block
+	const contentAttributes = [];
+	if ( block?.name ) {
+		const blockType = getBlockType( block.name );
+		if ( blockType?.attributes ) {
+			Object.entries( blockType.attributes ).forEach(
+				( [ attrName, attrDef ] ) => {
+					if ( attrDef.role === 'content' ) {
+						contentAttributes.push( {
+							name: attrName,
+							definition: attrDef,
+							value: block.attributes?.[ attrName ],
+						} );
+					}
+				}
+			);
+		}
+	}
 
 	return (
-		<Button
-			__next40pxDefaultSize
-			isPressed={ isSelected }
-			onClick={ async () => {
-				await selectBlock( clientId );
-				if ( onSelect ) {
-					onSelect( clientId );
+		<VStack spacing={ 1 }>
+			<Button
+				__next40pxDefaultSize
+				isPressed={ isSelected }
+				onClick={ async () => {
+					await selectBlock( clientId );
+					if ( onSelect ) {
+						onSelect( clientId );
+					}
+				} }
+			>
+				<Flex>
+					<FlexItem>
+						<BlockIcon icon={ blockInformation?.icon } />
+					</FlexItem>
+					<FlexBlock style={ { textAlign: 'left' } }>
+						<Truncate>{ blockTitle }</Truncate>
+					</FlexBlock>
+				</Flex>
+			</Button>
+
+			{ /* Content attribute controls */ }
+			{ contentAttributes.map( ( attr ) => {
+				const handleChange = ( newValue ) => {
+					updateBlockAttributes( clientId, {
+						[ attr.name ]: newValue,
+					} );
+				};
+
+				if ( attr.definition.type === 'string' ) {
+					return (
+						<TextControl
+							key={ attr.name }
+							label={ attr.name }
+							value={ attr.value || '' }
+							onChange={ handleChange }
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+						/>
+					);
 				}
-			} }
-		>
-			<Flex>
-				<FlexItem>
-					<BlockIcon icon={ blockInformation?.icon } />
-				</FlexItem>
-				<FlexBlock style={ { textAlign: 'left' } }>
-					<Truncate>{ blockTitle }</Truncate>
-				</FlexBlock>
-			</Flex>
-		</Button>
+
+				if ( attr.definition.type === 'boolean' ) {
+					return (
+						<ToggleControl
+							key={ attr.name }
+							label={ attr.name }
+							checked={ attr.value || false }
+							onChange={ handleChange }
+							__nextHasNoMarginBottom
+						/>
+					);
+				}
+
+				if ( attr.definition.type === 'rich-text' ) {
+					return (
+						<TextControl
+							key={ attr.name }
+							label={ attr.name }
+							value={ attr.value || '' }
+							onChange={ handleChange }
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+						/>
+					);
+				}
+
+				return null;
+			} ) }
+		</VStack>
 	);
 }

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -15,7 +15,7 @@ import {
 	FlexBlock,
 	FlexItem,
 } from '@wordpress/components';
-import { chevronRight } from '@wordpress/icons';
+import { chevronRight, chevronLeft } from '@wordpress/icons';
 import { getBlockType } from '@wordpress/blocks';
 import { useState, useRef } from '@wordpress/element';
 
@@ -35,7 +35,14 @@ function SingleContentAttributeControl( {
 	updateBlockAttributes,
 	singleLinkPopoverOpen,
 	setSingleLinkPopoverOpen,
+	blockIcon,
+	blockTitle,
 } ) {
+	// Safety check for attr object
+	if ( ! attr || ! attr.definition ) {
+		return null;
+	}
+
 	const handleChange = ( newValue ) => {
 		updateBlockAttributes( clientId, {
 			[ attr.name ]: newValue,
@@ -46,26 +53,40 @@ function SingleContentAttributeControl( {
 
 	if ( controlType === 'TextControl' ) {
 		return (
-			<TextControl
-				key={ attr.name }
-				label={ attr.name }
-				value={ attr.value || '' }
-				onChange={ handleChange }
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-			/>
+			<div>
+				<Flex style={ { marginBottom: '8px' } }>
+					<FlexItem>
+						<BlockIcon icon={ blockIcon } />
+					</FlexItem>
+					<FlexItem>{ blockTitle }</FlexItem>
+				</Flex>
+				<TextControl
+					key={ attr.name }
+					value={ attr.value || '' }
+					onChange={ handleChange }
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+				/>
+			</div>
 		);
 	}
 
 	if ( controlType === 'ToggleControl' ) {
 		return (
-			<ToggleControl
-				key={ attr.name }
-				label={ attr.name }
-				checked={ attr.value || false }
-				onChange={ handleChange }
-				__nextHasNoMarginBottom
-			/>
+			<div>
+				<Flex style={ { marginBottom: '8px' } }>
+					<FlexItem>
+						<BlockIcon icon={ blockIcon } />
+					</FlexItem>
+					<FlexItem>{ blockTitle }</FlexItem>
+				</Flex>
+				<ToggleControl
+					key={ attr.name }
+					checked={ attr.value || false }
+					onChange={ handleChange }
+					__nextHasNoMarginBottom
+				/>
+			</div>
 		);
 	}
 
@@ -85,7 +106,7 @@ function SingleContentAttributeControl( {
 		return (
 			<LinkControlWithPopover
 				key={ attr.name }
-				attrName={ attr.name }
+				attrName={ blockTitle }
 				attrValue={ attr.value }
 				linkValue={ linkValue }
 				isPopoverOpen={ singleLinkPopoverOpen }
@@ -100,6 +121,7 @@ function SingleContentAttributeControl( {
 					} );
 					setSingleLinkPopoverOpen( false );
 				} }
+				blockIcon={ blockIcon }
 			/>
 		);
 	}
@@ -112,7 +134,6 @@ function BlockContentAttributesView( { clientId } ) {
 	const blockInformation = useBlockDisplayInformation( clientId );
 	const blockTitle = useBlockDisplayTitle( {
 		clientId,
-		context: 'list-view',
 	} );
 	const { block } = useSelect(
 		( select ) => {
@@ -166,7 +187,9 @@ function BlockContentAttributesView( { clientId } ) {
 		<VStack spacing={ 2 }>
 			<Flex>
 				<FlexItem>
-					<Navigator.BackButton>Back</Navigator.BackButton>
+					<Navigator.BackButton>
+						<Icon icon={ chevronLeft } />
+					</Navigator.BackButton>
 				</FlexItem>
 				<FlexBlock>
 					<Flex>
@@ -267,11 +290,18 @@ function LinkControlWithPopover( {
 	onClosePopover,
 	onLinkChange,
 	onRemoveLink,
+	blockIcon,
 } ) {
 	const buttonRef = useRef( null );
 
 	return (
 		<div>
+			<Flex style={ { marginBottom: '8px' } }>
+				<FlexItem>
+					<BlockIcon icon={ blockIcon } />
+				</FlexItem>
+				<FlexItem>{ attrName }</FlexItem>
+			</Flex>
 			<Button
 				ref={ buttonRef }
 				variant="secondary"
@@ -279,7 +309,7 @@ function LinkControlWithPopover( {
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 			>
-				{ attrName }: { attrValue || 'Set link' }
+				{ attrValue || 'Set link' }
 			</Button>
 			{ isPopoverOpen && (
 				<Popover
@@ -362,7 +392,6 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 	const blockInformation = useBlockDisplayInformation( clientId );
 	const blockTitle = useBlockDisplayTitle( {
 		clientId,
-		context: 'list-view',
 	} );
 	const { isSelected, block } = useSelect(
 		( select ) => {
@@ -425,7 +454,7 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 					<FlexItem>
 						<BlockIcon icon={ blockInformation?.icon } />
 					</FlexItem>
-					<FlexBlock style={ { textAlign: 'left' } }>
+					<FlexBlock>
 						<Truncate>{ blockTitle }</Truncate>
 					</FlexBlock>
 					<FlexItem>
@@ -436,39 +465,41 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 		);
 	}
 
-	// If single content attribute, show inline controls
-	return (
-		<VStack spacing={ 1 }>
-			<Button
-				__next40pxDefaultSize
-				isPressed={ isSelected }
-				onClick={ async () => {
-					await selectBlock( clientId );
-					if ( onSelect ) {
-						onSelect( clientId );
-					}
-				} }
-			>
-				<Flex>
-					<FlexItem>
-						<BlockIcon icon={ blockInformation?.icon } />
-					</FlexItem>
-					<FlexBlock style={ { textAlign: 'left' } }>
-						<Truncate>{ blockTitle }</Truncate>
-					</FlexBlock>
-				</Flex>
-			</Button>
+	// If single content attribute, show inline controls without block title
+	if ( contentAttributes.length === 1 && contentAttributes[ 0 ] ) {
+		return (
+			<SingleContentAttributeControl
+				attr={ contentAttributes[ 0 ] }
+				clientId={ clientId }
+				updateBlockAttributes={ updateBlockAttributes }
+				singleLinkPopoverOpen={ singleLinkPopoverOpen }
+				setSingleLinkPopoverOpen={ setSingleLinkPopoverOpen }
+				blockIcon={ blockInformation?.icon }
+				blockTitle={ blockTitle }
+			/>
+		);
+	}
 
-			{ /* Single content attribute control */ }
-			{ contentAttributes.length === 1 && (
-				<SingleContentAttributeControl
-					attr={ contentAttributes[ 0 ] }
-					clientId={ clientId }
-					updateBlockAttributes={ updateBlockAttributes }
-					singleLinkPopoverOpen={ singleLinkPopoverOpen }
-					setSingleLinkPopoverOpen={ setSingleLinkPopoverOpen }
-				/>
-			) }
-		</VStack>
+	// Fallback: show regular block button if no content attributes or multiple
+	return (
+		<Button
+			__next40pxDefaultSize
+			isPressed={ isSelected }
+			onClick={ async () => {
+				await selectBlock( clientId );
+				if ( onSelect ) {
+					onSelect( clientId );
+				}
+			} }
+		>
+			<Flex>
+				<FlexItem>
+					<BlockIcon icon={ blockInformation?.icon } />
+				</FlexItem>
+				<FlexBlock style={ { textAlign: 'left' } }>
+					<Truncate>{ blockTitle }</Truncate>
+				</FlexBlock>
+			</Flex>
+		</Button>
 	);
 }

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -6,36 +6,355 @@ import {
 	Button,
 	TextControl,
 	ToggleControl,
+	Popover,
+	Navigator,
+	Icon,
 	__experimentalVStack as VStack,
 	__experimentalTruncate as Truncate,
 	Flex,
 	FlexBlock,
 	FlexItem,
 } from '@wordpress/components';
+import { chevronRight } from '@wordpress/icons';
 import { getBlockType } from '@wordpress/blocks';
+import { useState, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
+import LinkControl from '../link-control';
 import { store as blockEditorStore } from '../../store';
 import BlockIcon from '../block-icon';
 import useBlockDisplayInformation from '../use-block-display-information';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
+
+// Single Content Attribute Control component
+function SingleContentAttributeControl( {
+	attr,
+	clientId,
+	updateBlockAttributes,
+	singleLinkPopoverOpen,
+	setSingleLinkPopoverOpen,
+} ) {
+	const handleChange = ( newValue ) => {
+		updateBlockAttributes( clientId, {
+			[ attr.name ]: newValue,
+		} );
+	};
+
+	const controlType = getControlForAttribute( attr.definition, attr.name );
+
+	if ( controlType === 'TextControl' ) {
+		return (
+			<TextControl
+				key={ attr.name }
+				label={ attr.name }
+				value={ attr.value || '' }
+				onChange={ handleChange }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+			/>
+		);
+	}
+
+	if ( controlType === 'ToggleControl' ) {
+		return (
+			<ToggleControl
+				key={ attr.name }
+				label={ attr.name }
+				checked={ attr.value || false }
+				onChange={ handleChange }
+				__nextHasNoMarginBottom
+			/>
+		);
+	}
+
+	if ( controlType === 'LinkControl' ) {
+		const linkValue = {
+			url: attr.value || '',
+			title: '',
+			opensInNewTab: false,
+		};
+
+		const handleLinkChange = ( newLinkValue ) => {
+			updateBlockAttributes( clientId, {
+				[ attr.name ]: newLinkValue?.url || '',
+			} );
+		};
+
+		return (
+			<LinkControlWithPopover
+				key={ attr.name }
+				attrName={ attr.name }
+				attrValue={ attr.value }
+				linkValue={ linkValue }
+				isPopoverOpen={ singleLinkPopoverOpen }
+				onTogglePopover={ () =>
+					setSingleLinkPopoverOpen( ! singleLinkPopoverOpen )
+				}
+				onClosePopover={ () => setSingleLinkPopoverOpen( false ) }
+				onLinkChange={ handleLinkChange }
+				onRemoveLink={ () => {
+					updateBlockAttributes( clientId, {
+						[ attr.name ]: '',
+					} );
+					setSingleLinkPopoverOpen( false );
+				} }
+			/>
+		);
+	}
+
+	return null;
+}
+
+// Block Content Attributes View for Navigator sub-screen
+function BlockContentAttributesView( { clientId } ) {
+	const blockInformation = useBlockDisplayInformation( clientId );
+	const blockTitle = useBlockDisplayTitle( {
+		clientId,
+		context: 'list-view',
+	} );
+	const { block } = useSelect(
+		( select ) => {
+			const { getBlock } = select( blockEditorStore );
+			return {
+				block: getBlock( clientId ),
+			};
+		},
+		[ clientId ]
+	);
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	// State for popover visibility per attribute
+	const [ popoverStates, setPopoverStates ] = useState( {} );
+
+	// Helper functions for popover state
+	const togglePopover = ( attrName ) => {
+		setPopoverStates( ( prev ) => ( {
+			...prev,
+			[ attrName ]: ! prev[ attrName ],
+		} ) );
+	};
+
+	const closePopover = ( attrName ) => {
+		setPopoverStates( ( prev ) => ( {
+			...prev,
+			[ attrName ]: false,
+		} ) );
+	};
+
+	// Get content attributes for this block
+	const contentAttributes = [];
+	if ( block?.name ) {
+		const blockType = getBlockType( block.name );
+		if ( blockType?.attributes ) {
+			Object.entries( blockType.attributes ).forEach(
+				( [ attrName, attrDef ] ) => {
+					if ( attrDef.role === 'content' ) {
+						contentAttributes.push( {
+							name: attrName,
+							definition: attrDef,
+							value: block.attributes?.[ attrName ],
+						} );
+					}
+				}
+			);
+		}
+	}
+
+	return (
+		<VStack spacing={ 2 }>
+			<Flex>
+				<FlexItem>
+					<Navigator.BackButton>Back</Navigator.BackButton>
+				</FlexItem>
+				<FlexBlock>
+					<Flex>
+						<FlexItem>
+							<BlockIcon icon={ blockInformation?.icon } />
+						</FlexItem>
+						<FlexBlock>
+							<Truncate>{ blockTitle }</Truncate>
+						</FlexBlock>
+					</Flex>
+				</FlexBlock>
+			</Flex>
+
+			{ contentAttributes.map( ( attr ) => {
+				const handleChange = ( newValue ) => {
+					updateBlockAttributes( clientId, {
+						[ attr.name ]: newValue,
+					} );
+				};
+
+				const controlType = getControlForAttribute(
+					attr.definition,
+					attr.name
+				);
+
+				if ( controlType === 'TextControl' ) {
+					return (
+						<TextControl
+							key={ attr.name }
+							label={ attr.name }
+							value={ attr.value || '' }
+							onChange={ handleChange }
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+						/>
+					);
+				}
+
+				if ( controlType === 'ToggleControl' ) {
+					return (
+						<ToggleControl
+							key={ attr.name }
+							label={ attr.name }
+							checked={ attr.value || false }
+							onChange={ handleChange }
+							__nextHasNoMarginBottom
+						/>
+					);
+				}
+
+				if ( controlType === 'LinkControl' ) {
+					const isPopoverOpen = popoverStates[ attr.name ];
+					const linkValue = {
+						url: attr.value || '',
+						title: '',
+						opensInNewTab: false,
+					};
+
+					const handleLinkChange = ( newLinkValue ) => {
+						updateBlockAttributes( clientId, {
+							[ attr.name ]: newLinkValue?.url || '',
+						} );
+					};
+
+					return (
+						<LinkControlWithPopover
+							key={ attr.name }
+							attrName={ attr.name }
+							attrValue={ attr.value }
+							linkValue={ linkValue }
+							isPopoverOpen={ isPopoverOpen }
+							onTogglePopover={ () => togglePopover( attr.name ) }
+							onClosePopover={ () => closePopover( attr.name ) }
+							onLinkChange={ handleLinkChange }
+							onRemoveLink={ () => {
+								updateBlockAttributes( clientId, {
+									[ attr.name ]: '',
+								} );
+								closePopover( attr.name );
+							} }
+						/>
+					);
+				}
+
+				return null;
+			} ) }
+		</VStack>
+	);
+}
+
+// LinkControl with Popover component
+function LinkControlWithPopover( {
+	attrName,
+	attrValue,
+	linkValue,
+	isPopoverOpen,
+	onTogglePopover,
+	onClosePopover,
+	onLinkChange,
+	onRemoveLink,
+} ) {
+	const buttonRef = useRef( null );
+
+	return (
+		<div>
+			<Button
+				ref={ buttonRef }
+				variant="secondary"
+				onClick={ onTogglePopover }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+			>
+				{ attrName }: { attrValue || 'Set link' }
+			</Button>
+			{ isPopoverOpen && (
+				<Popover
+					anchor={ buttonRef.current }
+					onClose={ onClosePopover }
+					placement="bottom-start"
+				>
+					<LinkControl
+						value={ linkValue }
+						onChange={ onLinkChange }
+						onRemove={ onRemoveLink }
+						onCancel={ onClosePopover }
+					/>
+				</Popover>
+			) }
+		</div>
+	);
+}
+
+// Simple mapping function for attribute types to UI controls
+function getControlForAttribute( attrDef, attrName ) {
+	// Check if this is a URL attribute
+	const isUrlAttribute =
+		attrDef.type === 'string' &&
+		( attrName.includes( 'url' ) ||
+			attrName.includes( 'src' ) ||
+			attrName.includes( 'href' ) ||
+			attrName.includes( 'link' ) ||
+			attrDef.attribute === 'href' ||
+			attrDef.attribute === 'src' );
+
+	if ( isUrlAttribute ) {
+		return 'LinkControl';
+	}
+
+	switch ( attrDef.type ) {
+		case 'string':
+			return 'TextControl';
+		case 'boolean':
+			return 'ToggleControl';
+		case 'rich-text':
+			return 'TextControl'; // Using TextControl for now to avoid selection issues
+		case 'number':
+			return 'TextControl'; // Using TextControl for now, could be NumberControl later
+		default:
+			return 'TextControl'; // Fallback
+	}
+}
 
 export default function BlockQuickNavigation( { clientIds, onSelect } ) {
 	if ( ! clientIds.length ) {
 		return null;
 	}
 	return (
-		<VStack spacing={ 1 }>
+		<Navigator initialPath="/">
+			<Navigator.Screen path="/">
+				<VStack spacing={ 1 }>
+					{ clientIds.map( ( clientId ) => (
+						<BlockQuickNavigationItem
+							onSelect={ onSelect }
+							key={ clientId }
+							clientId={ clientId }
+						/>
+					) ) }
+				</VStack>
+			</Navigator.Screen>
 			{ clientIds.map( ( clientId ) => (
-				<BlockQuickNavigationItem
-					onSelect={ onSelect }
+				<Navigator.Screen
 					key={ clientId }
-					clientId={ clientId }
-				/>
+					path={ `/block/${ clientId }` }
+				>
+					<BlockContentAttributesView clientId={ clientId } />
+				</Navigator.Screen>
 			) ) }
-		</VStack>
+		</Navigator>
 	);
 }
 
@@ -81,6 +400,43 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 		}
 	}
 
+	// Determine if this block has multiple content attributes
+	const hasMultipleContentAttributes = contentAttributes.length > 1;
+
+	// State for single LinkControl popover (only used when there's exactly 1 content attribute)
+	const [ singleLinkPopoverOpen, setSingleLinkPopoverOpen ] =
+		useState( false );
+
+	// If multiple content attributes, show navigation button with chevron
+	if ( hasMultipleContentAttributes ) {
+		return (
+			<Navigator.Button
+				path={ `/block/${ clientId }` }
+				__next40pxDefaultSize
+				isPressed={ isSelected }
+				onClick={ async () => {
+					await selectBlock( clientId );
+					if ( onSelect ) {
+						onSelect( clientId );
+					}
+				} }
+			>
+				<Flex>
+					<FlexItem>
+						<BlockIcon icon={ blockInformation?.icon } />
+					</FlexItem>
+					<FlexBlock style={ { textAlign: 'left' } }>
+						<Truncate>{ blockTitle }</Truncate>
+					</FlexBlock>
+					<FlexItem>
+						<Icon icon={ chevronRight } />
+					</FlexItem>
+				</Flex>
+			</Navigator.Button>
+		);
+	}
+
+	// If single content attribute, show inline controls
 	return (
 		<VStack spacing={ 1 }>
 			<Button
@@ -103,54 +459,16 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 				</Flex>
 			</Button>
 
-			{ /* Content attribute controls */ }
-			{ contentAttributes.map( ( attr ) => {
-				const handleChange = ( newValue ) => {
-					updateBlockAttributes( clientId, {
-						[ attr.name ]: newValue,
-					} );
-				};
-
-				if ( attr.definition.type === 'string' ) {
-					return (
-						<TextControl
-							key={ attr.name }
-							label={ attr.name }
-							value={ attr.value || '' }
-							onChange={ handleChange }
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-						/>
-					);
-				}
-
-				if ( attr.definition.type === 'boolean' ) {
-					return (
-						<ToggleControl
-							key={ attr.name }
-							label={ attr.name }
-							checked={ attr.value || false }
-							onChange={ handleChange }
-							__nextHasNoMarginBottom
-						/>
-					);
-				}
-
-				if ( attr.definition.type === 'rich-text' ) {
-					return (
-						<TextControl
-							key={ attr.name }
-							label={ attr.name }
-							value={ attr.value || '' }
-							onChange={ handleChange }
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-						/>
-					);
-				}
-
-				return null;
-			} ) }
+			{ /* Single content attribute control */ }
+			{ contentAttributes.length === 1 && (
+				<SingleContentAttributeControl
+					attr={ contentAttributes[ 0 ] }
+					clientId={ clientId }
+					updateBlockAttributes={ updateBlockAttributes }
+					singleLinkPopoverOpen={ singleLinkPopoverOpen }
+					setSingleLinkPopoverOpen={ setSingleLinkPopoverOpen }
+				/>
+			) }
 		</VStack>
 	);
 }

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -23,6 +23,7 @@ import { store as blockEditorStore } from '../../store';
 import BlockIcon from '../block-icon';
 import useBlockDisplayInformation from '../use-block-display-information';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
+import ContentOnlyBlockEditor from '../content-only-editor';
 
 // Single Content Attribute Control component using DataForm
 function SingleContentAttributeControl( {
@@ -171,6 +172,35 @@ function BlockContentAttributesView( { clientId } ) {
 	);
 }
 
+// Group successive paragraph and list blocks
+function groupContentBlocks( clientIds, blocks ) {
+	const groups = [];
+	let currentGroup = [];
+
+	for ( let i = 0; i < clientIds.length; i++ ) {
+		const clientId = clientIds[ i ];
+		const block = blocks.find( ( b ) => b.clientId === clientId );
+
+		if (
+			block &&
+			( block.name === 'core/paragraph' || block.name === 'core/list' )
+		) {
+			currentGroup.push( clientId );
+		} else {
+			if ( currentGroup.length > 0 ) {
+				groups.push( currentGroup );
+				currentGroup = [];
+			}
+			groups.push( [ clientId ] );
+		}
+	}
+
+	if ( currentGroup.length > 0 ) {
+		groups.push( currentGroup );
+	}
+	return groups;
+}
+
 // Create DataForm fields from content attributes
 function createDataFormFields( contentAttributes ) {
 	return contentAttributes.map( ( attr ) => {
@@ -211,20 +241,69 @@ function createDataFormFields( contentAttributes ) {
 }
 
 export default function BlockQuickNavigation( { clientIds, onSelect } ) {
+	// Get all blocks for the client IDs
+	const blocks = useSelect(
+		( select ) => {
+			const { getBlocksByClientId } = select( blockEditorStore );
+			return getBlocksByClientId( clientIds );
+		},
+		[ clientIds ]
+	);
+
 	if ( ! clientIds.length ) {
 		return null;
 	}
+
+	// Group consecutive paragraph and list blocks
+	const blockGroups = groupContentBlocks( clientIds, blocks );
+
 	return (
 		<Navigator initialPath="/" style={ { overflow: 'visible' } }>
 			<Navigator.Screen path="/" style={ { overflow: 'visible' } }>
 				<VStack spacing={ 1 }>
-					{ clientIds.map( ( clientId ) => (
-						<BlockQuickNavigationItem
-							onSelect={ onSelect }
-							key={ clientId }
-							clientId={ clientId }
-						/>
-					) ) }
+					{ blockGroups.map( ( group, groupIndex ) => {
+						// Check if this group contains only paragraph and list blocks
+						const isContentGroup = group.every( ( clientId ) => {
+							const block = blocks.find(
+								( b ) => b.clientId === clientId
+							);
+							return (
+								block &&
+								( block.name === 'core/paragraph' ||
+									block.name === 'core/list' )
+							);
+						} );
+
+						if ( isContentGroup && group.length > 1 ) {
+							// Get the blocks for this group
+							const groupedContentBlocks = group
+								.map( ( clientId ) =>
+									blocks.find(
+										( b ) => b.clientId === clientId
+									)
+								)
+								.filter( Boolean );
+							// Render ContentOnlyBlockEditor for grouped content blocks
+							return (
+								<div>
+									<h3>Content</h3>
+									<ContentOnlyBlockEditor
+										key={ `content-only-block-editor-${ groupIndex }` }
+										blocks={ groupedContentBlocks }
+									/>
+								</div>
+							);
+						}
+
+						// Render individual blocks for non-content groups or single blocks
+						return group.map( ( clientId ) => (
+							<BlockQuickNavigationItem
+								onSelect={ onSelect }
+								key={ clientId }
+								clientId={ clientId }
+							/>
+						) );
+					} ) }
 				</VStack>
 			</Navigator.Screen>
 			{ clientIds.map( ( clientId ) => (

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -10,6 +10,7 @@ import {
 	Flex,
 	FlexBlock,
 	FlexItem,
+	__experimentalView as View,
 } from '@wordpress/components';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
 import { getBlockType } from '@wordpress/blocks';
@@ -52,27 +53,34 @@ function SingleContentAttributeControl( {
 
 	// Create form configuration
 	const form = {
-		layout: { type: 'regular' },
+		layout: {
+			type: 'regular',
+			labelPosition: 'none',
+		},
 		fields: [ attr.name ],
 	};
 
 	return (
-		<div>
-			<Flex style={ { marginBottom: '8px' } }>
-				<FlexItem>
-					<BlockIcon icon={ blockIcon } />
-				</FlexItem>
-				<FlexItem>
-					{ blockInformation?.name || blockInformation?.title }
-				</FlexItem>
-			</Flex>
-			<DataForm
-				data={ data }
-				fields={ fields }
-				form={ form }
-				onChange={ handleChange }
-			/>
-		</div>
+		<VStack spacing={ 1 }>
+			<View>
+				<Flex justify="flex-start">
+					<FlexItem>
+						<BlockIcon icon={ blockIcon } />
+					</FlexItem>
+					<FlexItem>
+						{ blockInformation?.name || blockInformation?.title }
+					</FlexItem>
+				</Flex>
+			</View>
+			<View>
+				<DataForm
+					data={ data }
+					fields={ fields }
+					form={ form }
+					onChange={ handleChange }
+				/>
+			</View>
+		</VStack>
 	);
 }
 
@@ -146,7 +154,9 @@ function BlockContentAttributesView( { clientId } ) {
 					blockInformation
 				) }
 				form={ {
-					layout: { type: 'regular' },
+					layout: {
+						type: 'regular',
+					},
 					fields: contentAttributes.map( ( attr ) => attr.name ),
 				} }
 				onChange={ ( edits ) => {
@@ -162,7 +172,7 @@ function BlockContentAttributesView( { clientId } ) {
 }
 
 // Create DataForm fields from content attributes
-function createDataFormFields( contentAttributes, blockInformation ) {
+function createDataFormFields( contentAttributes ) {
 	return contentAttributes.map( ( attr ) => {
 		const isUrlAttribute =
 			attr.definition.type === 'string' &&
@@ -195,8 +205,7 @@ function createDataFormFields( contentAttributes, blockInformation ) {
 		return {
 			id: attr.name,
 			type: fieldType,
-			label:
-				attr.name || blockInformation?.name || blockInformation?.title,
+			label: attr.name,
 		};
 	} );
 }

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -128,7 +128,7 @@ function BlockContentAttributesView( { clientId } ) {
 		<VStack spacing={ 2 }>
 			<Flex>
 				<FlexItem>
-					<Navigator.BackButton>
+					<Navigator.BackButton style={ { paddingLeft: 0 } }>
 						<Icon icon={ chevronLeft } />
 					</Navigator.BackButton>
 				</FlexItem>

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -53,8 +53,8 @@ function SingleContentAttributeControl( {
 
 	if ( controlType === 'TextControl' ) {
 		return (
-			<div>
-				<Flex style={ { marginBottom: '8px' } }>
+			<>
+				<Flex justify="flex-start">
 					<FlexItem>
 						<BlockIcon icon={ blockIcon } />
 					</FlexItem>
@@ -69,7 +69,7 @@ function SingleContentAttributeControl( {
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom
 				/>
-			</div>
+			</>
 		);
 	}
 
@@ -368,8 +368,8 @@ export default function BlockQuickNavigation( { clientIds, onSelect } ) {
 		return null;
 	}
 	return (
-		<Navigator initialPath="/">
-			<Navigator.Screen path="/">
+		<Navigator initialPath="/" style={ { overflow: 'visible' } }>
+			<Navigator.Screen path="/" style={ { overflow: 'visible' } }>
 				<VStack spacing={ 1 }>
 					{ clientIds.map( ( clientId ) => (
 						<BlockQuickNavigationItem
@@ -453,14 +453,21 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 						onSelect( clientId );
 					}
 				} }
+				style={ {
+					width: 'calc(100% + 16px)',
+					marginLeft: '-8px',
+					overflow: 'visible',
+				} }
 			>
 				<Flex>
-					<FlexItem>
-						<BlockIcon icon={ blockInformation?.icon } />
-					</FlexItem>
-					<FlexBlock>
-						<Truncate>{ blockTitle }</Truncate>
-					</FlexBlock>
+					<Flex justify="flex-start">
+						<FlexItem>
+							<BlockIcon icon={ blockInformation?.icon } />
+						</FlexItem>
+						<FlexItem>
+							<Truncate>{ blockTitle }</Truncate>
+						</FlexItem>
+					</Flex>
 					<FlexItem>
 						<Icon icon={ chevronRight } />
 					</FlexItem>

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -3,10 +3,6 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
-	Button,
-	TextControl,
-	ToggleControl,
-	Popover,
 	Navigator,
 	Icon,
 	__experimentalVStack as VStack,
@@ -17,24 +13,22 @@ import {
 } from '@wordpress/components';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
 import { getBlockType } from '@wordpress/blocks';
-import { useState, useRef } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
+import { DataForm } from '@wordpress/dataviews';
 
 /**
  * Internal dependencies
  */
-import LinkControl from '../link-control';
 import { store as blockEditorStore } from '../../store';
 import BlockIcon from '../block-icon';
 import useBlockDisplayInformation from '../use-block-display-information';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
 
-// Single Content Attribute Control component
+// Single Content Attribute Control component using DataForm
 function SingleContentAttributeControl( {
 	attr,
 	clientId,
 	updateBlockAttributes,
-	singleLinkPopoverOpen,
-	setSingleLinkPopoverOpen,
 	blockIcon,
 	blockInformation,
 } ) {
@@ -43,94 +37,44 @@ function SingleContentAttributeControl( {
 		return null;
 	}
 
-	const handleChange = ( newValue ) => {
-		updateBlockAttributes( clientId, {
-			[ attr.name ]: newValue,
+	const handleChange = ( edits ) => {
+		Object.keys( edits ).forEach( ( key ) => {
+			updateBlockAttributes( clientId, {
+				[ key ]: edits[ key ],
+			} );
 		} );
 	};
 
-	const controlType = getControlForAttribute( attr.definition, attr.name );
+	// Create data object
+	const data = { [ attr.name ]: attr.value || '' };
 
-	if ( controlType === 'TextControl' ) {
-		return (
-			<>
-				<Flex justify="flex-start">
-					<FlexItem>
-						<BlockIcon icon={ blockIcon } />
-					</FlexItem>
-					<FlexItem>
-						{ blockInformation?.name || blockInformation?.title }
-					</FlexItem>
-				</Flex>
-				<TextControl
-					key={ attr.name }
-					value={ attr.value || '' }
-					onChange={ handleChange }
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-				/>
-			</>
-		);
-	}
+	// Create fields for DataForm
+	const fields = createDataFormFields( [ attr ], blockInformation );
 
-	if ( controlType === 'ToggleControl' ) {
-		return (
-			<div>
-				<Flex style={ { marginBottom: '8px' } }>
-					<FlexItem>
-						<BlockIcon icon={ blockIcon } />
-					</FlexItem>
-					<FlexItem>
-						{ blockInformation?.name || blockInformation?.title }
-					</FlexItem>
-				</Flex>
-				<ToggleControl
-					key={ attr.name }
-					checked={ attr.value || false }
-					onChange={ handleChange }
-					__nextHasNoMarginBottom
-				/>
-			</div>
-		);
-	}
+	// Create form configuration
+	const form = {
+		layout: { type: 'regular' },
+		fields: [ attr.name ],
+	};
 
-	if ( controlType === 'LinkControl' ) {
-		const linkValue = {
-			url: attr.value || '',
-			title: '',
-			opensInNewTab: false,
-		};
-
-		const handleLinkChange = ( newLinkValue ) => {
-			updateBlockAttributes( clientId, {
-				[ attr.name ]: newLinkValue?.url || '',
-			} );
-		};
-
-		return (
-			<LinkControlWithPopover
-				key={ attr.name }
-				attrValue={ attr.value }
-				linkValue={ linkValue }
-				isPopoverOpen={ singleLinkPopoverOpen }
-				onTogglePopover={ () =>
-					setSingleLinkPopoverOpen( ! singleLinkPopoverOpen )
-				}
-				onClosePopover={ () => setSingleLinkPopoverOpen( false ) }
-				onLinkChange={ handleLinkChange }
-				onRemoveLink={ () => {
-					updateBlockAttributes( clientId, {
-						[ attr.name ]: '',
-					} );
-					setSingleLinkPopoverOpen( false );
-				} }
-				blockIcon={ blockIcon }
-				blockInformation={ blockInformation }
+	return (
+		<div>
+			<Flex style={ { marginBottom: '8px' } }>
+				<FlexItem>
+					<BlockIcon icon={ blockIcon } />
+				</FlexItem>
+				<FlexItem>
+					{ blockInformation?.name || blockInformation?.title }
+				</FlexItem>
+			</Flex>
+			<DataForm
+				data={ data }
+				fields={ fields }
+				form={ form }
+				onChange={ handleChange }
 			/>
-		);
-	}
-
-	return null;
+		</div>
+	);
 }
 
 // Block Content Attributes View for Navigator sub-screen
@@ -150,42 +94,27 @@ function BlockContentAttributesView( { clientId } ) {
 	);
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
-	// State for popover visibility per attribute
-	const [ popoverStates, setPopoverStates ] = useState( {} );
-
-	// Helper functions for popover state
-	const togglePopover = ( attrName ) => {
-		setPopoverStates( ( prev ) => ( {
-			...prev,
-			[ attrName ]: ! prev[ attrName ],
-		} ) );
-	};
-
-	const closePopover = ( attrName ) => {
-		setPopoverStates( ( prev ) => ( {
-			...prev,
-			[ attrName ]: false,
-		} ) );
-	};
-
 	// Get content attributes for this block
-	const contentAttributes = [];
-	if ( block?.name ) {
-		const blockType = getBlockType( block.name );
-		if ( blockType?.attributes ) {
-			Object.entries( blockType.attributes ).forEach(
-				( [ attrName, attrDef ] ) => {
-					if ( attrDef.role === 'content' ) {
-						contentAttributes.push( {
-							name: attrName,
-							definition: attrDef,
-							value: block.attributes?.[ attrName ],
-						} );
+	const contentAttributes = useMemo( () => {
+		const attributes = [];
+		if ( block?.name ) {
+			const blockType = getBlockType( block.name );
+			if ( blockType?.attributes ) {
+				Object.entries( blockType.attributes ).forEach(
+					( [ attrName, attrDef ] ) => {
+						if ( attrDef.role === 'content' ) {
+							attributes.push( {
+								name: attrName,
+								definition: attrDef,
+								value: block.attributes?.[ attrName ],
+							} );
+						}
 					}
-				}
-			);
+				);
+			}
 		}
-	}
+		return attributes;
+	}, [ block ] );
 
 	return (
 		<VStack spacing={ 2 }>
@@ -207,160 +136,69 @@ function BlockContentAttributesView( { clientId } ) {
 				</FlexBlock>
 			</Flex>
 
-			{ contentAttributes.map( ( attr ) => {
-				const handleChange = ( newValue ) => {
-					updateBlockAttributes( clientId, {
-						[ attr.name ]: newValue,
-					} );
-				};
-
-				const controlType = getControlForAttribute(
-					attr.definition,
-					attr.name
-				);
-
-				if ( controlType === 'TextControl' ) {
-					return (
-						<TextControl
-							key={ attr.name }
-							label={ attr.name }
-							value={ attr.value || '' }
-							onChange={ handleChange }
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-						/>
-					);
-				}
-
-				if ( controlType === 'ToggleControl' ) {
-					return (
-						<ToggleControl
-							key={ attr.name }
-							label={ attr.name }
-							checked={ attr.value || false }
-							onChange={ handleChange }
-							__nextHasNoMarginBottom
-						/>
-					);
-				}
-
-				if ( controlType === 'LinkControl' ) {
-					const isPopoverOpen = popoverStates[ attr.name ];
-					const linkValue = {
-						url: attr.value || '',
-						title: '',
-						opensInNewTab: false,
-					};
-
-					const handleLinkChange = ( newLinkValue ) => {
+			<DataForm
+				data={ contentAttributes.reduce( ( acc, attr ) => {
+					acc[ attr.name ] = attr.value || '';
+					return acc;
+				}, {} ) }
+				fields={ createDataFormFields(
+					contentAttributes,
+					blockInformation
+				) }
+				form={ {
+					layout: { type: 'regular' },
+					fields: contentAttributes.map( ( attr ) => attr.name ),
+				} }
+				onChange={ ( edits ) => {
+					Object.keys( edits ).forEach( ( key ) => {
 						updateBlockAttributes( clientId, {
-							[ attr.name ]: newLinkValue?.url || '',
+							[ key ]: edits[ key ],
 						} );
-					};
-
-					return (
-						<LinkControlWithPopover
-							key={ attr.name }
-							attrName={ attr.name }
-							attrValue={ attr.value }
-							linkValue={ linkValue }
-							isPopoverOpen={ isPopoverOpen }
-							onTogglePopover={ () => togglePopover( attr.name ) }
-							onClosePopover={ () => closePopover( attr.name ) }
-							onLinkChange={ handleLinkChange }
-							onRemoveLink={ () => {
-								updateBlockAttributes( clientId, {
-									[ attr.name ]: '',
-								} );
-								closePopover( attr.name );
-							} }
-						/>
-					);
-				}
-
-				return null;
-			} ) }
+					} );
+				} }
+			/>
 		</VStack>
 	);
 }
 
-// LinkControl with Popover component
-function LinkControlWithPopover( {
-	attrValue,
-	linkValue,
-	isPopoverOpen,
-	onTogglePopover,
-	onClosePopover,
-	onLinkChange,
-	onRemoveLink,
-	blockIcon,
-	blockInformation,
-} ) {
-	const buttonRef = useRef( null );
+// Create DataForm fields from content attributes
+function createDataFormFields( contentAttributes, blockInformation ) {
+	return contentAttributes.map( ( attr ) => {
+		const isUrlAttribute =
+			attr.definition.type === 'string' &&
+			( attr.name.includes( 'url' ) ||
+				attr.name.includes( 'src' ) ||
+				attr.name.includes( 'href' ) ||
+				attr.name.includes( 'link' ) ||
+				attr.definition.attribute === 'href' ||
+				attr.definition.attribute === 'src' );
 
-	return (
-		<div>
-			<Flex style={ { marginBottom: '8px' } }>
-				<FlexItem>
-					<BlockIcon icon={ blockIcon } />
-				</FlexItem>
-				<FlexItem>{ blockInformation?.title }</FlexItem>
-			</Flex>
-			<Button
-				ref={ buttonRef }
-				variant="secondary"
-				onClick={ onTogglePopover }
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-			>
-				{ attrValue || 'Set link' }
-			</Button>
-			{ isPopoverOpen && (
-				<Popover
-					anchor={ buttonRef.current }
-					onClose={ onClosePopover }
-					placement="bottom-start"
-				>
-					<LinkControl
-						value={ linkValue }
-						onChange={ onLinkChange }
-						onRemove={ onRemoveLink }
-						onCancel={ onClosePopover }
-					/>
-				</Popover>
-			) }
-		</div>
-	);
-}
+		let fieldType = 'text';
+		if ( isUrlAttribute ) {
+			fieldType = 'url';
+		} else {
+			switch ( attr.definition.type ) {
+				case 'boolean':
+					fieldType = 'toggle';
+					break;
+				case 'rich-text':
+					fieldType = 'text';
+					break;
+				case 'number':
+					fieldType = 'text';
+					break;
+				default:
+					fieldType = 'text';
+			}
+		}
 
-// Simple mapping function for attribute types to UI controls
-function getControlForAttribute( attrDef, attrName ) {
-	// Check if this is a URL attribute
-	const isUrlAttribute =
-		attrDef.type === 'string' &&
-		( attrName.includes( 'url' ) ||
-			attrName.includes( 'src' ) ||
-			attrName.includes( 'href' ) ||
-			attrName.includes( 'link' ) ||
-			attrDef.attribute === 'href' ||
-			attrDef.attribute === 'src' );
-
-	if ( isUrlAttribute ) {
-		return 'LinkControl';
-	}
-
-	switch ( attrDef.type ) {
-		case 'string':
-			return 'TextControl';
-		case 'boolean':
-			return 'ToggleControl';
-		case 'rich-text':
-			return 'TextControl'; // Using TextControl for now to avoid selection issues
-		case 'number':
-			return 'TextControl'; // Using TextControl for now, could be NumberControl later
-		default:
-			return 'TextControl'; // Fallback
-	}
+		return {
+			id: attr.name,
+			type: fieldType,
+			label:
+				blockInformation?.name || blockInformation?.title || attr.name,
+		};
+	} );
 }
 
 export default function BlockQuickNavigation( { clientIds, onSelect } ) {
@@ -432,10 +270,6 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 	// Determine if this block has multiple content attributes
 	const hasMultipleContentAttributes = contentAttributes.length > 1;
 
-	// State for single LinkControl popover (only used when there's exactly 1 content attribute)
-	const [ singleLinkPopoverOpen, setSingleLinkPopoverOpen ] =
-		useState( false );
-
 	// If multiple content attributes, show navigation button with chevron
 	if ( hasMultipleContentAttributes ) {
 		return (
@@ -478,8 +312,6 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 				attr={ contentAttributes[ 0 ] }
 				clientId={ clientId }
 				updateBlockAttributes={ updateBlockAttributes }
-				singleLinkPopoverOpen={ singleLinkPopoverOpen }
-				setSingleLinkPopoverOpen={ setSingleLinkPopoverOpen }
 				blockIcon={ blockInformation?.icon }
 				blockInformation={ blockInformation }
 			/>

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -36,7 +36,7 @@ function SingleContentAttributeControl( {
 	singleLinkPopoverOpen,
 	setSingleLinkPopoverOpen,
 	blockIcon,
-	blockTitle,
+	blockInformation,
 } ) {
 	// Safety check for attr object
 	if ( ! attr || ! attr.definition ) {
@@ -58,7 +58,9 @@ function SingleContentAttributeControl( {
 					<FlexItem>
 						<BlockIcon icon={ blockIcon } />
 					</FlexItem>
-					<FlexItem>{ blockTitle }</FlexItem>
+					<FlexItem>
+						{ blockInformation?.name || blockInformation?.title }
+					</FlexItem>
 				</Flex>
 				<TextControl
 					key={ attr.name }
@@ -78,7 +80,9 @@ function SingleContentAttributeControl( {
 					<FlexItem>
 						<BlockIcon icon={ blockIcon } />
 					</FlexItem>
-					<FlexItem>{ blockTitle }</FlexItem>
+					<FlexItem>
+						{ blockInformation?.name || blockInformation?.title }
+					</FlexItem>
 				</Flex>
 				<ToggleControl
 					key={ attr.name }
@@ -106,7 +110,6 @@ function SingleContentAttributeControl( {
 		return (
 			<LinkControlWithPopover
 				key={ attr.name }
-				attrName={ blockTitle }
 				attrValue={ attr.value }
 				linkValue={ linkValue }
 				isPopoverOpen={ singleLinkPopoverOpen }
@@ -122,6 +125,7 @@ function SingleContentAttributeControl( {
 					setSingleLinkPopoverOpen( false );
 				} }
 				blockIcon={ blockIcon }
+				blockInformation={ blockInformation }
 			/>
 		);
 	}
@@ -282,7 +286,6 @@ function BlockContentAttributesView( { clientId } ) {
 
 // LinkControl with Popover component
 function LinkControlWithPopover( {
-	attrName,
 	attrValue,
 	linkValue,
 	isPopoverOpen,
@@ -291,6 +294,7 @@ function LinkControlWithPopover( {
 	onLinkChange,
 	onRemoveLink,
 	blockIcon,
+	blockInformation,
 } ) {
 	const buttonRef = useRef( null );
 
@@ -300,7 +304,7 @@ function LinkControlWithPopover( {
 				<FlexItem>
 					<BlockIcon icon={ blockIcon } />
 				</FlexItem>
-				<FlexItem>{ attrName }</FlexItem>
+				<FlexItem>{ blockInformation?.title }</FlexItem>
 			</Flex>
 			<Button
 				ref={ buttonRef }
@@ -475,7 +479,7 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 				singleLinkPopoverOpen={ singleLinkPopoverOpen }
 				setSingleLinkPopoverOpen={ setSingleLinkPopoverOpen }
 				blockIcon={ blockInformation?.icon }
-				blockTitle={ blockTitle }
+				blockInformation={ blockInformation }
 			/>
 		);
 	}

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -11,8 +11,9 @@ import {
 	FlexBlock,
 	FlexItem,
 	__experimentalView as View,
+	Button,
 } from '@wordpress/components';
-import { chevronRight, chevronLeft } from '@wordpress/icons';
+import { chevronRight, chevronLeft, media } from '@wordpress/icons';
 import { getBlockType } from '@wordpress/blocks';
 import { DataForm } from '@wordpress/dataviews';
 
@@ -24,6 +25,34 @@ import BlockIcon from '../block-icon';
 import useBlockDisplayInformation from '../use-block-display-information';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
 import ContentOnlyBlockEditor from '../content-only-editor';
+import MediaUpload from '../media-upload';
+import MediaUploadCheck from '../media-upload/check';
+
+// Image Media Selector Component
+function ImageMediaSelector( { value, onChange } ) {
+	return (
+		<MediaUploadCheck>
+			<MediaUpload
+				onSelect={ ( selectedMedia ) => {
+					onChange( selectedMedia.url );
+				} }
+				allowedTypes={ [ 'image' ] }
+				value={ value }
+				render={ ( { open } ) => (
+					<Button
+						__next40pxDefaultSize
+						variant="secondary"
+						onClick={ open }
+						icon={ media }
+						style={ { width: '100%' } }
+					>
+						{ value ? 'Change Image' : 'Select Image' }
+					</Button>
+				) }
+			/>
+		</MediaUploadCheck>
+	);
+}
 
 // Single Content Attribute Control component using DataForm
 function SingleContentAttributeControl( {
@@ -50,7 +79,7 @@ function SingleContentAttributeControl( {
 	const data = { [ attr.name ]: attr.value || '' };
 
 	// Create fields for DataForm
-	const fields = createDataFormFields( [ attr ], blockInformation );
+	const fields = createDataFormFields( [ attr ] );
 
 	// Create form configuration
 	const form = {
@@ -74,12 +103,21 @@ function SingleContentAttributeControl( {
 				</Flex>
 			</View>
 			<View>
-				<DataForm
-					data={ data }
-					fields={ fields }
-					form={ form }
-					onChange={ handleChange }
-				/>
+				{ isImageSrcAttribute( attr ) ? (
+					<ImageMediaSelector
+						value={ attr.value || '' }
+						onChange={ ( newValue ) => {
+							handleChange( { [ attr.name ]: newValue } );
+						} }
+					/>
+				) : (
+					<DataForm
+						data={ data }
+						fields={ fields }
+						form={ form }
+						onChange={ handleChange }
+					/>
+				) }
 			</View>
 		</VStack>
 	);
@@ -125,6 +163,20 @@ function BlockContentAttributesView( { clientId } ) {
 	// Get content attributes for this block
 	const contentAttributes = getEditableContentAttributes( block );
 
+	// Separate image src attributes from other attributes
+	const imageSrcAttributes = contentAttributes.filter( isImageSrcAttribute );
+	const otherAttributes = contentAttributes.filter(
+		( contentAttribute ) => ! isImageSrcAttribute( contentAttribute )
+	);
+
+	const handleAttributeChange = ( edits ) => {
+		Object.keys( edits ).forEach( ( key ) => {
+			updateBlockAttributes( clientId, {
+				[ key ]: edits[ key ],
+			} );
+		} );
+	};
+
 	return (
 		<VStack spacing={ 2 }>
 			<Flex>
@@ -144,30 +196,33 @@ function BlockContentAttributesView( { clientId } ) {
 					</Flex>
 				</FlexBlock>
 			</Flex>
-
-			<DataForm
-				data={ contentAttributes.reduce( ( acc, attr ) => {
-					acc[ attr.name ] = attr.value || '';
-					return acc;
-				}, {} ) }
-				fields={ createDataFormFields(
-					contentAttributes,
-					blockInformation
-				) }
-				form={ {
-					layout: {
-						type: 'regular',
-					},
-					fields: contentAttributes.map( ( attr ) => attr.name ),
-				} }
-				onChange={ ( edits ) => {
-					Object.keys( edits ).forEach( ( key ) => {
-						updateBlockAttributes( clientId, {
-							[ key ]: edits[ key ],
-						} );
-					} );
-				} }
-			/>
+			{ /* Render ImageMediaSelector for image src attributes */ }
+			{ imageSrcAttributes.map( ( attr ) => (
+				<ImageMediaSelector
+					key={ attr.name }
+					value={ attr.value || '' }
+					onChange={ ( newValue ) => {
+						handleAttributeChange( { [ attr.name ]: newValue } );
+					} }
+				/>
+			) ) }
+			{ /* Render DataForm for other attributes */ }
+			{ otherAttributes.length > 0 && (
+				<DataForm
+					data={ otherAttributes.reduce( ( acc, attr ) => {
+						acc[ attr.name ] = attr.value || '';
+						return acc;
+					}, {} ) }
+					fields={ createDataFormFields( otherAttributes ) }
+					form={ {
+						layout: {
+							type: 'regular',
+						},
+						fields: otherAttributes.map( ( attr ) => attr.name ),
+					} }
+					onChange={ handleAttributeChange }
+				/>
+			) }
 		</VStack>
 	);
 }
@@ -201,43 +256,54 @@ function groupContentBlocks( clientIds, blocks ) {
 	return groups;
 }
 
+const isUrlAttribute = ( contentAttribute ) => {
+	return (
+		contentAttribute.definition.type === 'string' &&
+		( contentAttribute.definition.attribute === 'href' ||
+			contentAttribute.definition.attribute === 'src' )
+	);
+};
+
+const isImageSrcAttribute = ( contentAttribute ) => {
+	return (
+		contentAttribute.definition.attribute === 'src' &&
+		contentAttribute.definition.selector === 'img'
+	);
+};
+
 // Create DataForm fields from content attributes
 function createDataFormFields( contentAttributes ) {
-	return contentAttributes.map( ( attr ) => {
-		const isUrlAttribute =
-			attr.definition.type === 'string' &&
-			( attr.name.includes( 'url' ) ||
-				attr.name.includes( 'src' ) ||
-				attr.name.includes( 'href' ) ||
-				attr.name.includes( 'link' ) ||
-				attr.definition.attribute === 'href' ||
-				attr.definition.attribute === 'src' );
-
-		let fieldType = 'text';
-		if ( isUrlAttribute ) {
-			fieldType = 'url';
-		} else {
-			switch ( attr.definition.type ) {
-				case 'boolean':
-					fieldType = 'toggle';
-					break;
-				case 'rich-text':
-					fieldType = 'text';
-					break;
-				case 'number':
-					fieldType = 'text';
-					break;
-				default:
-					fieldType = 'text';
+	return contentAttributes
+		.map( ( contentAttribute ) => {
+			let fieldType = 'text';
+			if ( isImageSrcAttribute( contentAttribute ) ) {
+				// Skip image src attributes as they're handled separately
+				return null;
+			} else if ( isUrlAttribute( contentAttribute ) ) {
+				fieldType = 'url';
+			} else {
+				switch ( contentAttribute.definition.type ) {
+					case 'boolean':
+						fieldType = 'toggle';
+						break;
+					case 'rich-text':
+						fieldType = 'text';
+						break;
+					case 'number':
+						fieldType = 'text';
+						break;
+					default:
+						fieldType = 'text';
+				}
 			}
-		}
 
-		return {
-			id: attr.name,
-			type: fieldType,
-			label: attr.name,
-		};
-	} );
+			return {
+				id: contentAttribute.name,
+				type: fieldType,
+				label: contentAttribute.name,
+			};
+		} )
+		.filter( Boolean );
 }
 
 export default function BlockQuickNavigation( { clientIds, onSelect } ) {

--- a/packages/block-editor/src/components/content-only-editor/index.js
+++ b/packages/block-editor/src/components/content-only-editor/index.js
@@ -1,0 +1,76 @@
+/**
+ * WordPress dependencies
+ */
+/**
+ * Internal dependencies
+ */
+import { ExperimentalBlockEditorProvider } from '../provider';
+import { ExperimentalBlockCanvas } from '../block-canvas';
+
+/**
+ * ContentOnlyBlockEditor component that provides a sidebar block canvas
+ * that syncs with the main canvas blocks in real-time.
+ *
+ * @param {Object} props        Component props.
+ * @param {Array}  props.blocks Array of block objects to sync with.
+ */
+export default function ContentOnlyBlockEditor( { blocks = [] } ) {
+	// Minimal editor settings for content-only editor
+	const editorSettings = {
+		// Enable block selection by disabling automatic selection clearing
+		clearBlockSelection: false,
+
+		// Disable UI elements that aren't needed for content-only editing
+		hasFixedToolbar: false,
+		hasReducedUI: true,
+		hasBlockBreadcrumbs: false,
+		hasBlockToolbar: false,
+		hasSidebar: false,
+		hasOutline: false,
+		hasList: false,
+		hasInserter: false,
+		hasGlobalStyles: false,
+		hasBlockSettings: false,
+		hasInspector: false,
+		hasTopToolbar: false,
+		hasCommandPalette: false,
+		hasKeyboardShortcuts: true,
+		hasHelp: false,
+		hasWelcomeGuide: false,
+		hasBlockPatterns: false,
+		hasReusableBlocks: false,
+		hasBlockDirectory: false,
+		hasBlockNavigation: false,
+		hasBlockQuickNavigation: false,
+
+		// Allow all block types for content editing
+		allowedBlockTypes: true,
+
+		// Disable focus mode to prevent contenteditable conflicts
+		focusMode: false,
+
+		// Additional settings to prevent editing conflicts
+		keepCaretInsideBlock: false,
+		isDistractionFree: true,
+	};
+	// TODO: This canvas is locked in canvas only mode. Is it possible to allow a different editing mode for this editor canvas?
+	// TODO: Can we only register the content blocks we want? like core/paragraph, core/list, and core/list-item?
+	// TODO: We can pass the blocks, but can we two-way sync them?
+	// TODO: Allow some shortcuts such as redo, undo, copy, paste, bold, italic, strikethrough, and command+k for links
+	return (
+		<div style={ { border: '1px solid #ddd', padding: '10px' } }>
+			<ExperimentalBlockEditorProvider
+				value={ blocks }
+				settings={ editorSettings }
+				onInput={ () => {
+					// onChange( blocks );
+				} }
+				onChange={ () => {
+					// onChange( blocks );
+				} }
+			>
+				<ExperimentalBlockCanvas />
+			</ExperimentalBlockEditorProvider>
+		</div>
+	);
+}

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -32,8 +32,7 @@
 			"type": "string",
 			"source": "attribute",
 			"selector": "a,button",
-			"attribute": "title",
-			"role": "content"
+			"attribute": "title"
 		},
 		"text": {
 			"type": "rich-text",
@@ -45,15 +44,13 @@
 			"type": "string",
 			"source": "attribute",
 			"selector": "a",
-			"attribute": "target",
-			"role": "content"
+			"attribute": "target"
 		},
 		"rel": {
 			"type": "string",
 			"source": "attribute",
 			"selector": "a",
-			"attribute": "rel",
-			"role": "content"
+			"attribute": "rel"
 		},
 		"placeholder": {
 			"type": "string"

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -51,8 +51,7 @@
 			"type": "string",
 			"source": "attribute",
 			"selector": "img",
-			"attribute": "title",
-			"role": "content"
+			"attribute": "title"
 		},
 		"href": {
 			"type": "string",
@@ -74,8 +73,7 @@
 			"attribute": "class"
 		},
 		"id": {
-			"type": "number",
-			"role": "content"
+			"type": "number"
 		},
 		"width": {
 			"type": "string"


### PR DESCRIPTION
This PR has been co-authored by @jeryj.


## What

This PR _explores_ (this is a WIP/prototype!) an **automatic approach** to displaying standardized UI controls for attributes with `role: 'content'` in the block quick navigation sidebar. Unlike the alternative approach in [#71577](https://github.com/WordPress/gutenberg/pull/71577), this implementation requires **no changes to existing block.json files** and works automatically with all blocks (core and third-party).

@jeryj and I are not sure which approach is best so we felt that prototyping this might help contributors to decide on which approach is best.

Closes [#71557](https://github.com/WordPress/gutenberg/issues/71557): Add automatic content attribute controls to block quick navigation sidebar

### Key Features

- **Automatic Control Inference**: Automatically detects and renders appropriate UI controls based on attribute type and naming patterns
- **DataForm Integration**: Uses `@wordpress/dataviews` DataForm components as suggested in [#71577#issuecomment-3274658200](https://github.com/WordPress/gutenberg/pull/71577#issuecomment-3274658200) - cc @youknowriad 
- **Smart "Drill Down" Navigation**: Single-attribute blocks show inline controls; multi-attribute blocks use Navigator sub-views with drill-down functionality
- **Comprehensive Type Support**: Handles `string`, `boolean`, `rich-text`, `number`, and URL attributes with intelligent field type mapping
- **Zero Configuration**: Works immediately with all existing blocks without requiring block authors to update their `block.json`

## Why

The current contentOnly mode lacks standardized controls for editing block content attributes in the sidebar. This creates an inconsistent user experience where users must switch between the canvas and sidebar to edit different aspects of their content.

**This automatic approach addresses the core concern raised in [#71577](https://github.com/WordPress/gutenberg/pull/71577#issuecomment-3274658200)**: ensuring write mode works for third-party blocks without requiring updates from block authors.

### Comparison with Alternative Approach

| Aspect | This PR (Automatic) | [#71577](https://github.com/WordPress/gutenberg/pull/71577) (Manual) |
|--------|-------------------|---------------------------------------------------------------------|
| **Configuration** | Zero - works automatically | Requires `control` property in `block.json` |
| **Third-party compatibility** | ✅ Works immediately | ❌ Requires block updates |
| **Maintenance** | Low - centralized logic | High - per-block configuration |
| **Customization** | Limited to inferred types | Full control per attribute |
| **Adoption barrier** | None | High - requires ecosystem updates |

**We acknowledge that both approaches have merit and the optimal solution may be a hybrid approach** that combines automatic inference with optional manual overrides.

## How

### Automatic Control Inference

The system automatically maps attribute types to appropriate DataForm field types:

- **String attributes** → `text` field
- **Boolean attributes** → `toggle` field  
- **Rich-text attributes** → `text` field (with future RichText support)
- **Number attributes** → `text` field
- **URL attributes** → `url` field (detected by name patterns: `url`, `src`, `href`, `link`)

### Smart UI Layout

- **Single Content Attribute**: Displays inline with block icon and custom label
- **Multiple Content Attributes**: Shows navigation button with chevron arrow, leading to dedicated sub-view
- **Sub-view Navigation**: Uses Navigator component with back button for seamless drill-down experience

### DataForm Integration

Leverages `@wordpress/dataviews` DataForm components for:
- Consistent styling and behavior
- Built-in validation and error handling
- Accessibility compliance
- Future extensibility

### Implementation Details

- **Location**: `packages/block-editor/src/components/block-quick-navigation/index.js`
- **Dependencies**: Added `@wordpress/dataviews` to block-editor package
- **Performance**: Uses `useMemo` for attribute processing and `useSelect` for efficient data access
- **State Management**: Integrates with existing block editor store for attribute updates

## Testing

### Manual Testing

1. **Enable contentOnly mode** in Gutenberg settings
2. **Create a post** with various block types (heading, paragraph, image, etc.)
3. **Select a pattern** containing multiple blocks
4. **Open block quick navigation** sidebar
5. **Verify controls appear** for blocks with `role: 'content'` attributes
6. **Test single-attribute blocks** show inline controls with block icons
7. **Test multi-attribute blocks** show navigation buttons with chevrons
8. **Test sub-view navigation** by clicking multi-attribute blocks
9. **Verify attribute updates** are reflected in the canvas
10. **Test with third-party blocks** to ensure automatic compatibility

### Keyboard Testing

1. **Tab navigation** through all controls
2. **Enter/Space** to activate buttons and toggles
3. **Arrow keys** for navigation between fields
4. **Escape** to close popovers and return to main view
5. **Tab** to navigate between single-attribute controls
6. **Enter** to activate multi-attribute navigation buttons

## Screenshots

<img width="677" height="590" alt="Screenshot 2025-09-10 at 16 52 45" src="https://github.com/user-attachments/assets/508e78b0-e66f-4d65-b8a2-1962c46bf328" />


https://github.com/user-attachments/assets/9cc69001-7999-4f03-9883-1cf63ca69a20


## Breaking Changes

None - this is purely additive functionality.

## Uncertain Elements

- **RichText Integration**: Currently renders as text field; full RichText support may require additional work
- **Custom Control Support**: Future enhancement could allow block authors to override inferred controls
- **Performance**: Large numbers of attributes may impact rendering; monitoring needed
- **Hybrid Approach**: Whether to combine with manual configuration from [#71577](https://github.com/WordPress/gutenberg/pull/71577)

## Related Issues

- Addresses [#71557](https://github.com/WordPress/gutenberg/issues/71557) - Patterns: standardize representation of controls
- Alternative approach: [#71577](https://github.com/WordPress/gutenberg/pull/71577) - Manual control configuration
- Related: [#58233](https://github.com/WordPress/gutenberg/issues/58233) - Features with limited control over block UI
- Similar: [#60779](https://github.com/WordPress/gutenberg/issues/60779) - Block controls standardization
