### PR TITLE
Increase taxonomy limit for Terms List dropdown

### DIFF
--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -53,7 +53,7 @@ export default function CategoriesEdit( {
 	const { records: allTaxonomies, isResolvingTaxonomies } = useEntityRecords(
 		'root',
 		'taxonomy',
-		{ per_page: 100 }
+		{ per_page: -1 }
 	);
 
 	const taxonomies = allTaxonomies?.filter( ( t ) => t.visibility.public );

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -52,7 +52,8 @@ export default function CategoriesEdit( {
 
 	const { records: allTaxonomies, isResolvingTaxonomies } = useEntityRecords(
 		'root',
-		'taxonomy'
+		'taxonomy',
+		{ per_page: 100 },
 	);
 
 	const taxonomies = allTaxonomies?.filter( ( t ) => t.visibility.public );

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -53,7 +53,7 @@ export default function CategoriesEdit( {
 	const { records: allTaxonomies, isResolvingTaxonomies } = useEntityRecords(
 		'root',
 		'taxonomy',
-		{ per_page: 100 },
+		{ per_page: 100 }
 	);
 
 	const taxonomies = allTaxonomies?.filter( ( t ) => t.visibility.public );


### PR DESCRIPTION
## What?
This increases the taxonomy limit from 10 to ~~100~~ unlimited (-1).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently if your site has over 10 public taxonomies, the Terms List block taxonomy dropdown only shows the first 10, not allowing you to show terms from any other taxonomies.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds `per_page: 100` to the query.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Register at least 11 different, public taxonomies.
2. Open a post or page.
3. Insert a Terms List block.
4. Try to select a taxonomy and notice some are missing.
