### PR TITLE
Bugfix/70733 add white backing in editor

### DIFF
--- a/packages/block-editor/src/components/block-preview/content.scss
+++ b/packages/block-editor/src/components/block-preview/content.scss
@@ -1,3 +1,5 @@
+@use "@wordpress/base-styles/colors" as *;
+
 // Hide inserter from previews.
 .block-editor-block-preview__content-iframe .block-list-appender {
 	display: none;

--- a/packages/block-editor/src/components/block-preview/content.scss
+++ b/packages/block-editor/src/components/block-preview/content.scss
@@ -3,6 +3,11 @@
 	display: none;
 }
 
+.block-editor-block-preview__content-iframe {
+	// Ensure a white backing layer for consistent semi-transparent color blending
+	background-color: $white;
+}
+
 .block-editor-block-preview__live-content {
 	* {
 		pointer-events: none;

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -4,6 +4,7 @@
 @use "@wordpress/base-styles/mixins" as *;
 @use "@wordpress/base-styles/variables" as *;
 @use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/default-custom-properties" as *;
 
 .block-editor-iframe__body {
 	position: relative;

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -60,6 +60,15 @@
 		body {
 			min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});
 
+			// Add a white backing layer for consistent semi-transparent color blending
+			&::before {
+				content: "";
+				position: absolute;
+				inset: 0;
+				background-color: $white;
+				z-index: -1;
+			}
+
 			> .is-root-container:not(.wp-block-post-content) {
 				flex: 1;
 				display: flex;

--- a/packages/editor/src/components/visual-editor/style.scss
+++ b/packages/editor/src/components/visual-editor/style.scss
@@ -7,18 +7,11 @@
 	// like the "focused entities".
 	background-color: var(--wp-editor-canvas-background);
 
-	&::before {
-		content: "";
-		position: absolute;
-		inset: 0;
-		background-color: $white;
-	}
-
 	// This overrides the iframe background since it's applied again here
 	// It also prevents some style glitches if `editor-visual-editor`
 	// like when hovering the preview in the site editor.
 	iframe[name="editor-canvas"] {
-		background-color: transparent;
+		background-color: $white;
 	}
 
 	// Centralize the editor horizontally (flex-direction is column).

--- a/packages/editor/src/components/visual-editor/style.scss
+++ b/packages/editor/src/components/visual-editor/style.scss
@@ -7,6 +7,13 @@
 	// like the "focused entities".
 	background-color: var(--wp-editor-canvas-background);
 
+	&::before {
+		content: "";
+		position: absolute;
+		inset: 0;
+		background-color: $white;
+	}
+
 	// This overrides the iframe background since it's applied again here
 	// It also prevents some style glitches if `editor-visual-editor`
 	// like when hovering the preview in the site editor.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/70733

It's worth pointing out that this PR is a step forward to aligning GB with the front-end, but isn't likely to be completely exhaustive in reference to treatment of alpha transparency on site elements.

<!-- In a few words, what is the PR actually doing? -->

Adds white "backing layers" to the editor canvas so that semi-transparent site background colours blend accurately and match the frontend.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The site editor canvas isn't always white - when inserting patterns, normal template editing or using the left hand navigation to change things. This causes transparent RGBA site backgrounds (e.g., #F5F6FE30) to blend against that background instead of the intended white, leading to a visible color mismatch between the editor and the frontend.

This change builds upon an unmerged PR #70737 that @R1shabh-Gupta started and @t-hamano reviewed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

 * Added a new white background layer behind the editor canvas
 * Did something very similar for zoomed out mode

## Testing Instructions

 1. Open the Site Editor.
 2. In the left panel, open Styles, then go to Background.
 3. Set a background color with transparency (e.g. #F5F6FE30).
 4. Observe the canvas: the background should now blend with white, matching the frontend appearance.
 5. Go to the template list
 6. Observe the canvas: the background of each template in the grid should now blend with white, matching the frontend appearance.
 7. Edit a template
 8. Observe the canvas: the background colour should remain blended with white
 9. Open the inserter, and then choose Patterns
 10. Observe the canvas: the background colour should remain blended with white

## Screenshots or screencast <!-- if applicable -->

(Using a test background colour of `#503aa830`)

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| |Before|After|
|-|-|-|
| Left nav | <img width="1079" height="785" alt="Screenshot 2025-09-09 at 23 26 54" src="https://github.com/user-attachments/assets/3164bc43-08ea-4679-8dfa-0b2775a254ae" /> | <img width="1079" height="785" alt="Screenshot 2025-09-09 at 23 23 15" src="https://github.com/user-attachments/assets/2a89b4c9-ea35-4d11-9578-d475fc7b6200" />
| Template grid | <img width="1079" height="785" alt="Screenshot 2025-09-09 at 23 43 00" src="https://github.com/user-attachments/assets/1dcdef0c-11ed-4c62-9e86-0fdc6b6c7338" /> | <img width="1079" height="785" alt="Screenshot 2025-09-09 at 23 42 27" src="https://github.com/user-attachments/assets/9342c5b4-fe76-44fd-a06a-804015348dc7" /> | 
| Editor | <img width="1079" height="785" alt="Screenshot 2025-09-09 at 23 27 10" src="https://github.com/user-attachments/assets/fe1e5db2-64af-4f38-a567-bac21b350076" /> | <img width="1079" height="785" alt="Screenshot 2025-09-09 at 23 24 21" src="https://github.com/user-attachments/assets/03b43912-7804-4ffe-93d2-439a3331e480" />|
| Zoomed-out | <img width="1079" height="785" alt="Screenshot 2025-09-09 at 23 27 33" src="https://github.com/user-attachments/assets/fa5c1f48-7e4d-4d64-83c1-d8715c665e29" /> | <img width="1079" height="785" alt="Screenshot 2025-09-09 at 23 25 11" src="https://github.com/user-attachments/assets/e7476948-852a-4bd1-a2e9-fe159eeff09b" />
| Part editing | <img width="1429" height="1038" alt="Screenshot 2025-10-13 at 17 12 40" src="https://github.com/user-attachments/assets/892f5857-9f66-47b4-aa8d-3eef5d888f63" />  |  <img width="1429" height="1038" alt="Screenshot 2025-10-13 at 17 13 32" src="https://github.com/user-attachments/assets/eba77633-68bf-48d3-842b-5933cd8891b8" /> |
 




