### PR TITLE
DataForms regular layout: Remove label style overrides as they cause inconsistent results

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Bug Fixes
 
 - DataViews grid layout: make sure media previews have rounded corners. [#71543](https://github.com/WordPress/gutenberg/pull/71543)
+- DataForm regular layout: Remove label style overrides as they cause inconsistent results. ([#71574](https://github.com/WordPress/gutenberg/pull/71574))
 
 ## 8.0.0 (2025-09-03)
 

--- a/packages/dataviews/src/dataforms-layouts/regular/style.scss
+++ b/packages/dataviews/src/dataforms-layouts/regular/style.scss
@@ -5,12 +5,6 @@
 	align-items: flex-start !important;
 }
 
-.dataforms-layouts-regular__field .components-base-control__label {
-	font-size: inherit;
-	font-weight: normal;
-	text-transform: none;
-}
-
 .dataforms-layouts-regular__field-label {
 	width: 38%;
 	flex-shrink: 0;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Follow-up to: https://github.com/WordPress/gutenberg/pull/71495

Remove the CSS in the DataForms' regular layout that overrides the styles provided by the base control label.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently the styling overrides of the regular layout are inconsistent, and within DataForm controls we have a mix of components that do or don't use the base control label, resulting in different styles for different components.

The idea behind this PR is that the regular layout shouldn't be prescriptive in this way, and let the underlying components do their thing. The result should be a greater level of consistency in controls. To observe this, try looking at the regular layout Storybook story for DataForm in trunk compared to this PR.

In particular I ran into this issue with the textarea control as its label appeared to look different to the other comparable labels.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove the CSS affecting this component.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Run `npm run storybook:dev`
2. Navigate to: http://localhost:50240/?path=/story/dataviews-dataform--layout-regular and look at the components within the story

## Screenshots or screencast <!-- if applicable -->

### Before

Not the label on Description looks different to the label on Tags:

<img width="1440" height="829" alt="image" src="https://github.com/user-attachments/assets/862d7355-06f2-49a3-845a-506f3da45245" />

### After

Now the label is consistent:

<img width="1440" height="441" alt="image" src="https://github.com/user-attachments/assets/2281cc48-bf1b-46b7-8d9d-645c99aa7969" />

---

Note: this change should have no impact on the "side" labelPosition, as these styles have no effect on how labels are rendered in that mode:

<img width="720" height="426" alt="image" src="https://github.com/user-attachments/assets/c88dde49-6bf9-4b36-8f8b-9ae95e7e7203" />