### PR TITLE
Core Data: Remove conditions for selector resolutions

### DIFF
--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -237,7 +237,7 @@ describe( 'getEntityRecords', () => {
 		] );
 	} );
 
-	it( 'caches permissions but does not mark entity records as resolved when using _fields', async () => {
+	it( 'caches permissions and marks entity records as resolved when using _fields', async () => {
 		const finishResolutions = jest.fn();
 		const dispatch = Object.assign( jest.fn(), {
 			receiveEntityRecords: jest.fn(),
@@ -281,9 +281,7 @@ describe( 'getEntityRecords', () => {
 			'canUser',
 			expect.any( Array )
 		);
-
-		// But individual entity records should NOT be marked as resolved
-		expect( finishResolutions ).not.toHaveBeenCalledWith(
+		expect( finishResolutions ).toHaveBeenCalledWith(
 			'getEntityRecord',
 			expect.any( Array )
 		);
@@ -324,9 +322,7 @@ describe( 'getEntityRecords', () => {
 			'canUser',
 			expect.any( Array )
 		);
-
-		// Individual entity records should NOT be marked as resolved
-		expect( finishResolutions ).not.toHaveBeenCalledWith(
+		expect( finishResolutions ).toHaveBeenCalledWith(
 			'getEntityRecord',
 			expect.any( Array )
 		);


### PR DESCRIPTION
## What?
Part of https://github.com/WordPress/gutenberg/issues/26629.
Related #71541.

PR removes the conditions for batch resolving selectors after fetching the collection. If consumers fetch the same record with the same global query parameters down the React tree, they will be pre-resolved.

## Why?
This should improve performance and prevent additional HTTP queries for UIs like DataViews.

## Testing Instructions
1. Open a post.
2. Run test selector snippets in DevTools console.

### Test Snippets

```js
// Fetch collection
const records = await wp.data.resolveSelect( 'core' ).getEntityRecords( 'postType', 'attachment', { _fields: [ 'id', 'source_url', 'alt_text' ], context: 'view' } );

// Select a single record. This should trigger an HTTP request.
wp.data.select( 'core' ).getEntityRecord( 'postType', 'attachment', records[0].id, { context: 'view', _fields: [ 'id', 'source_url', 'alt_text' ] } );
```

### Testing Instructions for Keyboard
Same.
