### PR TITLE
Experiment: Add content only block controls to Inspector Panel

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -37,6 +37,9 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-editor-write-mode', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEditorWriteMode = true', 'before' );
 	}
+	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-content-only-pattern-insertion', $gutenberg_experiments ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalContentOnlyPatternInsertion = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -199,6 +199,18 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
+	add_settings_field(
+		'gutenberg-content-only-pattern-insertion',
+		__( 'contentOnly: Make patterns contentOnly by default upon insertion', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'When patterns are inserted, default to a simplified content only mode for editing pattern content.', 'gutenberg' ),
+			'id'    => 'gutenberg-content-only-pattern-insertion',
+		)
+	);
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/packages/block-editor/src/autocompleters/block.js
+++ b/packages/block-editor/src/autocompleters/block.js
@@ -3,9 +3,9 @@
  */
 import { useSelect } from '@wordpress/data';
 import {
+	cloneBlock,
 	createBlock,
 	createBlocksFromInnerBlocksTemplate,
-	parse,
 	store as blocksStore,
 } from '@wordpress/blocks';
 import { useMemo } from '@wordpress/element';
@@ -125,21 +125,16 @@ function createBlockCompleter() {
 			return ! ( /\S/.test( before ) || /\S/.test( after ) );
 		},
 		getOptionCompletion( inserterItem ) {
-			const {
-				name,
-				initialAttributes,
-				innerBlocks,
-				syncStatus,
-				content,
-			} = inserterItem;
+			const { name, initialAttributes, innerBlocks, syncStatus, blocks } =
+				inserterItem;
 
 			return {
 				action: 'replace',
 				value:
 					syncStatus === 'unsynced'
-						? parse( content, {
-								__unstableSkipMigrationLogs: true,
-						  } )
+						? ( blocks ?? [] ).map( ( block ) =>
+								cloneBlock( block )
+						  )
 						: createBlock(
 								name,
 								initialAttributes,

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -28,6 +28,7 @@ import PositionControls from '../inspector-controls-tabs/position-controls-panel
 import useBlockInspectorAnimationSettings from './useBlockInspectorAnimationSettings';
 import BlockQuickNavigation from '../block-quick-navigation';
 import { useBorderPanelLabel } from '../../hooks/border';
+import ContentOnlyControls from '../content-only-controls';
 
 import { unlock } from '../../lock-unlock';
 
@@ -264,11 +265,20 @@ const BlockInspectorSingleBlock = ( {
 					) }
 
 					{ contentClientIds && contentClientIds?.length > 0 && (
-						<PanelBody title={ __( 'Content' ) }>
-							<BlockQuickNavigation
-								clientIds={ contentClientIds }
-							/>
-						</PanelBody>
+						<>
+							{ ! window?.__experimentalContentOnlyPatternInsertion && (
+								<PanelBody title={ __( 'Content' ) }>
+									<BlockQuickNavigation
+										clientIds={ contentClientIds }
+									/>
+								</PanelBody>
+							) }
+							{ window?.__experimentalContentOnlyPatternInsertion && (
+								<ContentOnlyControls
+									clientIds={ contentClientIds }
+								/>
+							) }
+						</>
 					) }
 
 					{ ! isSectionBlock && (

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -30,6 +30,7 @@ import { useBlockVariationTransforms } from './block-variation-transformations';
 import BlockStylesMenu from './block-styles-menu';
 import PatternTransformationsMenu from './pattern-transformations-menu';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
+import { unlock } from '../../lock-unlock';
 
 function BlockSwitcherDropdownMenuContents( {
 	onClose,
@@ -196,6 +197,7 @@ export const BlockSwitcher = ( { clientIds } ) => {
 		isReusable,
 		isTemplate,
 		isDisabled,
+		isSection,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -204,7 +206,8 @@ export const BlockSwitcher = ( { clientIds } ) => {
 				getBlockAttributes,
 				canRemoveBlocks,
 				getBlockEditingMode,
-			} = select( blockEditorStore );
+				isSectionBlock,
+			} = unlock( select( blockEditorStore ) );
 			const { getBlockStyles, getBlockType, getActiveBlockVariation } =
 				select( blocksStore );
 			const _blocks = getBlocksByClientId( clientIds );
@@ -250,6 +253,7 @@ export const BlockSwitcher = ( { clientIds } ) => {
 					_isSingleBlockSelected && isTemplatePart( _blocks[ 0 ] ),
 				hasContentOnlyLocking: _hasTemplateLock,
 				isDisabled: editingMode !== 'default',
+				isSection: isSectionBlock( clientIds[ 0 ] ),
 			};
 		},
 		[ clientIds ]
@@ -278,7 +282,10 @@ export const BlockSwitcher = ( { clientIds } ) => {
 			? blockTitle
 			: undefined;
 
+	const hideTransformsForSections =
+		window?.__experimentalContentOnlyPatternInsertion && isSection;
 	const hideDropdown =
+		hideTransformsForSections ||
 		isDisabled ||
 		( ! hasBlockStyles && ! canRemove ) ||
 		hasContentOnlyLocking;

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -154,10 +154,7 @@ export function PrivateBlockToolbar( {
 			showGroupButtons: ! _isZoomOut,
 			showLockButtons: ! _isZoomOut,
 			showSwitchSectionStyleButton:
-				_isZoomOut ||
-				( isNavigationModeEnabled &&
-					editingMode === 'contentOnly' &&
-					isSectionBlock( selectedBlockClientId ) ), // Zoom out or Write Mode Section Blocks
+				_isZoomOut || isSectionBlock( selectedBlockClientId ),
 			hasFixedToolbar: getSettings().hasFixedToolbar,
 			isNavigationMode: isNavigationModeEnabled,
 		};

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -128,6 +128,16 @@ export function PrivateBlockToolbar( {
 
 		const _isZoomOut = isZoomOut();
 
+		// The switch style button appears more prominently with the
+		// content only pattern experiment.
+		const _showSwitchSectionStyleButton =
+			window?.__experimentalContentOnlyPatternInsertion
+				? _isZoomOut || isSectionBlock( selectedBlockClientId )
+				: _isZoomOut ||
+				  ( isNavigationModeEnabled &&
+						editingMode === 'contentOnly' &&
+						isSectionBlock( selectedBlockClientId ) );
+
 		return {
 			blockClientId: selectedBlockClientId,
 			blockClientIds: selectedBlockClientIds,
@@ -153,8 +163,7 @@ export function PrivateBlockToolbar( {
 			showSlots: ! _isZoomOut,
 			showGroupButtons: ! _isZoomOut,
 			showLockButtons: ! _isZoomOut,
-			showSwitchSectionStyleButton:
-				_isZoomOut || isSectionBlock( selectedBlockClientId ),
+			showSwitchSectionStyleButton: _showSwitchSectionStyleButton,
 			hasFixedToolbar: getSettings().hasFixedToolbar,
 			isNavigationMode: isNavigationModeEnabled,
 		};

--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -139,32 +139,40 @@ function VariationsToggleGroupControl( {
 
 function __experimentalBlockVariationTransforms( { blockClientId } ) {
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
-	const { activeBlockVariation, variations, isContentOnly } = useSelect(
-		( select ) => {
-			const { getActiveBlockVariation, getBlockVariations } =
-				select( blocksStore );
+	const { activeBlockVariation, variations, isContentOnly, isSection } =
+		useSelect(
+			( select ) => {
+				const { getActiveBlockVariation, getBlockVariations } =
+					select( blocksStore );
 
-			const { getBlockName, getBlockAttributes, getBlockEditingMode } =
-				select( blockEditorStore );
+				const {
+					getBlockName,
+					getBlockAttributes,
+					getBlockEditingMode,
+				} = select( blockEditorStore );
+				const { isSectionBlock } = unlock( select( blockEditorStore ) );
 
-			const name = blockClientId && getBlockName( blockClientId );
+				const name = blockClientId && getBlockName( blockClientId );
 
-			const { hasContentRoleAttribute } = unlock( select( blocksStore ) );
-			const isContentBlock = hasContentRoleAttribute( name );
+				const { hasContentRoleAttribute } = unlock(
+					select( blocksStore )
+				);
+				const isContentBlock = hasContentRoleAttribute( name );
 
-			return {
-				activeBlockVariation: getActiveBlockVariation(
-					name,
-					getBlockAttributes( blockClientId )
-				),
-				variations: name && getBlockVariations( name, 'transform' ),
-				isContentOnly:
-					getBlockEditingMode( blockClientId ) === 'contentOnly' &&
-					! isContentBlock,
-			};
-		},
-		[ blockClientId ]
-	);
+				return {
+					activeBlockVariation: getActiveBlockVariation(
+						name,
+						getBlockAttributes( blockClientId )
+					),
+					variations: name && getBlockVariations( name, 'transform' ),
+					isContentOnly:
+						getBlockEditingMode( blockClientId ) ===
+							'contentOnly' && ! isContentBlock,
+					isSection: isSectionBlock( blockClientId ),
+				};
+			},
+			[ blockClientId ]
+		);
 
 	const selectedValue = activeBlockVariation?.name;
 
@@ -189,7 +197,7 @@ function __experimentalBlockVariationTransforms( { blockClientId } ) {
 		} );
 	};
 
-	if ( ! variations?.length || isContentOnly ) {
+	if ( ! variations?.length || isContentOnly || isSection ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -149,8 +149,8 @@ function __experimentalBlockVariationTransforms( { blockClientId } ) {
 					getBlockName,
 					getBlockAttributes,
 					getBlockEditingMode,
-				} = select( blockEditorStore );
-				const { isSectionBlock } = unlock( select( blockEditorStore ) );
+					isSectionBlock,
+				} = unlock( select( blockEditorStore ) );
 
 				const name = blockClientId && getBlockName( blockClientId );
 

--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -197,7 +197,10 @@ function __experimentalBlockVariationTransforms( { blockClientId } ) {
 		} );
 	};
 
-	if ( ! variations?.length || isContentOnly || isSection ) {
+	const hideVariationsForSections =
+		window?.__experimentalContentOnlyPatternInsertion && isSection;
+
+	if ( ! variations?.length || isContentOnly || hideVariationsForSections ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -5,8 +5,10 @@ import { store as blocksStore } from '@wordpress/blocks';
 import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	TextControl,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 
 /**
  * Internal dependencies
@@ -14,7 +16,61 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '../../store';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
 
-function RichTextControl() {}
+function RichTextControl( { label, value, setValue } ) {
+	return (
+		<TextControl
+			__nextHasNoMarginBottom
+			__next40pxDefaultSize
+			label={ label }
+			value={ value ? stripHTML( value ) : '' }
+			onChange={ setValue }
+			autoComplete="off"
+		/>
+	);
+}
+
+function getControlForAttribute( attribute ) {
+	if ( attribute.control.type === 'RichText' ) {
+		return RichTextControl;
+	}
+}
+
+function getDefaultValue( attribute ) {
+	if ( attribute.default ) {
+		return attribute.default;
+	}
+
+	return undefined;
+}
+
+function BlockAttributeToolsPanelItem( {
+	attributeDefinition,
+	setValue,
+	value,
+} ) {
+	const Control = getControlForAttribute( attributeDefinition );
+
+	if ( ! Control ) {
+		return null;
+	}
+
+	const defaultValue = getDefaultValue( attributeDefinition );
+
+	return (
+		<ToolsPanelItem
+			label={ attributeDefinition.control.label }
+			hasValue={ () => value !== defaultValue }
+			onDeselect={ () => setValue( defaultValue ) }
+			isShownByDefault={ attributeDefinition.control.shownByDefault }
+		>
+			<Control
+				label={ attributeDefinition.control.label }
+				value={ value }
+				setValue={ setValue }
+			/>
+		</ToolsPanelItem>
+	);
+}
 
 function getContentAttributesWithControls( blockType ) {
 	return Object.keys( blockType?.attributes ?? {} )
@@ -28,24 +84,14 @@ function getContentAttributesWithControls( blockType ) {
 		} ) );
 }
 
-function getControlForAttribute( attribute ) {
-	if ( attribute.control.type === 'RichText' ) {
-		return RichTextControl;
-	}
-}
+function getResetAllValue( attributes ) {
+	const resetValue = {};
 
-function BlockAttributeControl( { attributeDefinition, setAttribute, value } ) {
-	const Control = getControlForAttribute( attributeDefinition );
+	attributes.each( ( attribute ) => {
+		resetValue[ attribute.key ] = getDefaultValue( attribute );
+	} );
 
-	if ( ! Control ) {
-		return null;
-	}
-
-	return (
-		<ToolsPanelItem>
-			<Control value={ value } setAttribute={ setAttribute } />
-		</ToolsPanelItem>
-	);
+	return resetValue;
 }
 
 function BlockControls( { clientId } ) {
@@ -75,16 +121,27 @@ function BlockControls( { clientId } ) {
 	} );
 
 	if ( ! contentAttributesWithControls?.length ) {
+		// TODO - we might still want to show a placeholder for blocks with no controls.
+		// for example, a way to select the block.
 		return null;
 	}
 
 	return (
-		<ToolsPanel label={ blockTitle } panelId={ clientId }>
+		<ToolsPanel
+			label={ blockTitle }
+			panelId={ clientId }
+			resetAll={ () => {
+				updateBlockAttributes(
+					clientId,
+					getResetAllValue( contentAttributesWithControls )
+				);
+			} }
+		>
 			{ contentAttributesWithControls?.each( ( attribute ) => (
-				<BlockAttributeControl
+				<BlockAttributeToolsPanelItem
 					clientId={ clientId }
 					attributeDefinition={ attribute }
-					setAttribute={ ( value ) =>
+					setValue={ ( value ) =>
 						updateBlockAttributes( clientId, {
 							[ attribute.key ]: value,
 						} )

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -5,6 +5,7 @@ import { store as blocksStore } from '@wordpress/blocks';
 import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	__experimentalHStack as HStack,
 	TextControl,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -14,7 +15,9 @@ import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import BlockIcon from '../block-icon';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
+import useBlockDisplayInformation from '../use-block-display-information';
 
 function RichTextControl( { label, value, setValue } ) {
 	return (
@@ -121,6 +124,7 @@ function BlockControls( { clientId } ) {
 		clientId,
 		context: 'list-view',
 	} );
+	const blockInformation = useBlockDisplayInformation( clientId );
 
 	if ( ! contentAttributesWithControls?.length ) {
 		// TODO - we might still want to show a placeholder for blocks with no controls.
@@ -130,7 +134,12 @@ function BlockControls( { clientId } ) {
 
 	return (
 		<ToolsPanel
-			label={ blockTitle }
+			label={
+				<HStack spacing={ 1 }>
+					<BlockIcon icon={ blockInformation?.icon } />
+					<div>{ blockTitle }</div>
+				</HStack>
+			}
 			panelId={ clientId }
 			resetAll={ () => {
 				updateBlockAttributes(

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -44,6 +44,7 @@ function getDefaultValue( attribute ) {
 }
 
 function BlockAttributeToolsPanelItem( {
+	clientId,
 	attributeDefinition,
 	setValue,
 	value,
@@ -58,6 +59,7 @@ function BlockAttributeToolsPanelItem( {
 
 	return (
 		<ToolsPanelItem
+			panelId={ clientId }
 			label={ attributeDefinition.control.label }
 			hasValue={ () => value !== defaultValue }
 			onDeselect={ () => setValue( defaultValue ) }

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -87,7 +87,7 @@ function getContentAttributesWithControls( blockType ) {
 function getResetAllValue( attributes ) {
 	const resetValue = {};
 
-	attributes.each( ( attribute ) => {
+	attributes.forEach( ( attribute ) => {
 		resetValue[ attribute.key ] = getDefaultValue( attribute );
 	} );
 
@@ -137,8 +137,9 @@ function BlockControls( { clientId } ) {
 				);
 			} }
 		>
-			{ contentAttributesWithControls?.each( ( attribute ) => (
+			{ contentAttributesWithControls?.map( ( attribute ) => (
 				<BlockAttributeToolsPanelItem
+					key={ clientId }
 					clientId={ clientId }
 					attributeDefinition={ attribute }
 					setValue={ ( value ) =>

--- a/packages/block-editor/src/components/content-only-controls/index.js
+++ b/packages/block-editor/src/components/content-only-controls/index.js
@@ -1,0 +1,107 @@
+/**
+ * WordPress dependencies
+ */
+import { store as blocksStore } from '@wordpress/blocks';
+import {
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+import useBlockDisplayTitle from '../block-title/use-block-display-title';
+
+function RichTextControl() {}
+
+function getContentAttributesWithControls( blockType ) {
+	return Object.keys( blockType?.attributes ?? {} )
+		.filter( ( attributeKey ) => {
+			const attribute = blockType.attributes[ attributeKey ];
+			return attribute?.role === 'content' && !! attribute.control;
+		} )
+		.map( ( attributeKey ) => ( {
+			key: attributeKey,
+			...blockType?.attributes[ attributeKey ],
+		} ) );
+}
+
+function getControlForAttribute( attribute ) {
+	if ( attribute.control.type === 'RichText' ) {
+		return RichTextControl;
+	}
+}
+
+function BlockAttributeControl( { attributeDefinition, setAttribute, value } ) {
+	const Control = getControlForAttribute( attributeDefinition );
+
+	if ( ! Control ) {
+		return null;
+	}
+
+	return (
+		<ToolsPanelItem>
+			<Control value={ value } setAttribute={ setAttribute } />
+		</ToolsPanelItem>
+	);
+}
+
+function BlockControls( { clientId } ) {
+	const { blockType, attributes } = useSelect(
+		( select ) => {
+			const { getBlockName, getBlockAttributes } =
+				select( blockEditorStore );
+			const { getBlockType } = select( blocksStore );
+
+			const blockName = getBlockName( clientId );
+
+			return {
+				blockType: getBlockType( blockName ),
+				attributes: getBlockAttributes( clientId ),
+			};
+		},
+		[ clientId ]
+	);
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	const contentAttributesWithControls =
+		getContentAttributesWithControls( blockType );
+
+	const blockTitle = useBlockDisplayTitle( {
+		clientId,
+		context: 'list-view',
+	} );
+
+	if ( ! contentAttributesWithControls?.length ) {
+		return null;
+	}
+
+	return (
+		<ToolsPanel label={ blockTitle } panelId={ clientId }>
+			{ contentAttributesWithControls?.each( ( attribute ) => (
+				<BlockAttributeControl
+					clientId={ clientId }
+					attributeDefinition={ attribute }
+					setAttribute={ ( value ) =>
+						updateBlockAttributes( clientId, {
+							[ attribute.key ]: value,
+						} )
+					}
+					value={ attributes[ attribute.key ] }
+				/>
+			) ) }
+		</ToolsPanel>
+	);
+}
+
+export default function ContentOnlyControls( { clientIds } ) {
+	if ( ! clientIds.length ) {
+		return null;
+	}
+
+	return clientIds.map( ( clientId ) => (
+		<BlockControls key={ clientId } clientId={ clientId } />
+	) );
+}

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -18,6 +18,7 @@ import {
 	getClientIdsWithDescendants,
 	isNavigationMode,
 	getBlockRootClientId,
+	getBlockAttributes,
 } from './selectors';
 import {
 	checkAllowListRecursive,
@@ -534,6 +535,11 @@ export function isSectionBlock( state, clientId ) {
 		blockName === 'core/block' ||
 		getTemplateLock( state, clientId ) === 'contentOnly'
 	) {
+		return true;
+	}
+
+	const attributes = getBlockAttributes( state, clientId );
+	if ( attributes?.metadata?.patternName ) {
 		return true;
 	}
 

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -25,8 +25,8 @@ import {
 	getAllPatternsDependants,
 	getInsertBlockTypeDependants,
 	getGrammar,
+	mapUserPattern,
 } from './utils';
-import { INSERTER_PATTERN_TYPES } from '../components/inserter/block-patterns-tab/utils';
 import { STORE_NAME } from './constants';
 import { unlock } from '../lock-unlock';
 import {
@@ -348,26 +348,6 @@ export const hasAllowedPatterns = createRegistrySelector( ( select ) =>
 		]
 	)
 );
-
-function mapUserPattern(
-	userPattern,
-	__experimentalUserPatternCategories = []
-) {
-	return {
-		name: `core/block/${ userPattern.id }`,
-		id: userPattern.id,
-		type: INSERTER_PATTERN_TYPES.user,
-		title: userPattern.title.raw,
-		categories: userPattern.wp_pattern_category?.map( ( catId ) => {
-			const category = __experimentalUserPatternCategories.find(
-				( { id } ) => id === catId
-			);
-			return category ? category.slug : catId;
-		} ),
-		content: userPattern.content.raw,
-		syncStatus: userPattern.wp_pattern_sync_status,
-	};
-}
 
 export const getPatternBySlug = createRegistrySelector( ( select ) =>
 	createSelector(

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -539,7 +539,10 @@ export function isSectionBlock( state, clientId ) {
 	}
 
 	const attributes = getBlockAttributes( state, clientId );
-	if ( attributes?.metadata?.patternName ) {
+	if (
+		attributes?.metadata?.patternName &&
+		!! window?.__experimentalContentOnlyPatternInsertion
+	) {
 		return true;
 	}
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2275,12 +2275,14 @@ function getDerivedBlockEditingModesForTree(
 	);
 	// Use array.from for better back compat. Older versions of the iterator returned
 	// from `keys()` didn't have the `filter` method.
-	const unsyncedPatternClientIds = Array.from(
-		state.blocks.attributes.keys()
-	).filter(
-		( clientId ) =>
-			state.blocks.attributes.get( clientId )?.metadata?.patternName
-	);
+	const unsyncedPatternClientIds =
+		!! window?.__experimentalContentOnlyPatternInsertion
+			? Array.from( state.blocks.attributes.keys() ).filter(
+					( clientId ) =>
+						state.blocks.attributes.get( clientId )?.metadata
+							?.patternName
+			  )
+			: [];
 	const contentOnlyParents = [
 		...contentOnlyTemplateLockedClientIds,
 		...unsyncedPatternClientIds,

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2273,12 +2273,14 @@ function getDerivedBlockEditingModesForTree(
 		( clientId ) =>
 			state.blockListSettings[ clientId ]?.templateLock === 'contentOnly'
 	);
-	const unsyncedPatternClientIds = state.blocks.attributes
-		.keys()
-		.filter(
-			( clientId ) =>
-				state.blocks.attributes.get( clientId )?.metadata?.patternName
-		);
+	// Use array.from for better back compat. Older versions of the iterator returned
+	// from `keys()` didn't have the `filter` method.
+	const unsyncedPatternClientIds = Array.from(
+		state.blocks.attributes.keys()
+	).filter(
+		( clientId ) =>
+			state.blocks.attributes.get( clientId )?.metadata?.patternName
+	);
 	const contentOnlyParents = [
 		...contentOnlyTemplateLockedClientIds,
 		...unsyncedPatternClientIds,

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2273,6 +2273,16 @@ function getDerivedBlockEditingModesForTree(
 		( clientId ) =>
 			state.blockListSettings[ clientId ]?.templateLock === 'contentOnly'
 	);
+	const unsyncedPatternClientIds = state.blocks.attributes
+		.keys()
+		.filter(
+			( clientId ) =>
+				state.blocks.attributes.get( clientId )?.metadata?.patternName
+		);
+	const contentOnlyParents = [
+		...contentOnlyTemplateLockedClientIds,
+		...unsyncedPatternClientIds,
+	];
 
 	traverseBlockTree( state, treeClientId, ( block ) => {
 		const { clientId, name: blockName } = block;
@@ -2464,15 +2474,14 @@ function getDerivedBlockEditingModesForTree(
 			}
 		}
 
-		// `templateLock: 'contentOnly'` derived modes.
-		if ( contentOnlyTemplateLockedClientIds.length ) {
-			const hasContentOnlyTemplateLockedParent =
-				!! findParentInClientIdsList(
-					state,
-					clientId,
-					contentOnlyTemplateLockedClientIds
-				);
-			if ( hasContentOnlyTemplateLockedParent ) {
+		// Handle `templateLock=contentOnly` blocks and unsynced patterns.
+		if ( contentOnlyParents.length ) {
+			const hasContentOnlyParent = !! findParentInClientIdsList(
+				state,
+				clientId,
+				contentOnlyParents
+			);
+			if ( hasContentOnlyParent ) {
 				if ( isContentBlock( blockName ) ) {
 					derivedBlockEditingModes.set( clientId, 'contentOnly' );
 				} else {

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -504,6 +504,10 @@ describe( 'private selectors', () => {
 					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
 					[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'disabled' ],
 				] ),
+				derivedBlockEditingModes: new Map( [
+					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
+					[ 'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c', 'disabled' ],
+				] ),
 				blockListSettings: {},
 			};
 			expect(

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -504,10 +504,6 @@ describe( 'private selectors', () => {
 					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
 					[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'disabled' ],
 				] ),
-				derivedBlockEditingModes: new Map( [
-					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
-					[ 'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c', 'disabled' ],
-				] ),
 				blockListSettings: {},
 			};
 			expect(

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -3402,6 +3402,18 @@ describe( 'selectors', () => {
 				( item ) => item.id === 'core/block/1'
 			);
 			expect( reusableBlockItem ).toEqual( {
+				blocks: [
+					expect.objectContaining( {
+						attributes: {
+							metadata: expect.objectContaining( {
+								name: 'Reusable Block 1',
+								patternName: 'core/block/1',
+							} ),
+						},
+						isValid: true,
+						innerBlocks: [],
+					} ),
+				],
 				category: 'reusable',
 				content: '<!-- /wp:test-block-a -->',
 				frecency: 0,

--- a/packages/block-editor/src/store/utils.js
+++ b/packages/block-editor/src/store/utils.js
@@ -11,10 +11,31 @@ import { selectBlockPatternsKey } from './private-keys';
 import { unlock } from '../lock-unlock';
 import { STORE_NAME } from './constants';
 import { getSectionRootClientId } from './private-selectors';
+import { INSERTER_PATTERN_TYPES } from '../components/inserter/block-patterns-tab/utils';
 
 export const isFiltered = Symbol( 'isFiltered' );
 const parsedPatternCache = new WeakMap();
 const grammarMapCache = new WeakMap();
+
+export function mapUserPattern(
+	userPattern,
+	__experimentalUserPatternCategories = []
+) {
+	return {
+		name: `core/block/${ userPattern.id }`,
+		id: userPattern.id,
+		type: INSERTER_PATTERN_TYPES.user,
+		title: userPattern.title.raw,
+		categories: userPattern.wp_pattern_category?.map( ( catId ) => {
+			const category = __experimentalUserPatternCategories.find(
+				( { id } ) => id === catId
+			);
+			return category ? category.slug : catId;
+		} ),
+		content: userPattern.content.raw,
+		syncStatus: userPattern.wp_pattern_sync_status,
+	};
+}
 
 function parsePattern( pattern ) {
 	const blocks = parse( pattern.content, {

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -15,7 +15,11 @@
 			"type": "rich-text",
 			"source": "rich-text",
 			"selector": "h1,h2,h3,h4,h5,h6",
-			"role": "content"
+			"role": "content",
+			"control": {
+				"type": "RichText",
+				"label": "Content"
+			}
 		},
 		"level": {
 			"type": "number",

--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -18,7 +18,8 @@
 			"role": "content",
 			"control": {
 				"type": "RichText",
-				"label": "Content"
+				"label": "Content",
+				"shownByDefault": true
 			}
 		},
 		"level": {

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -15,7 +15,11 @@
 			"type": "rich-text",
 			"source": "rich-text",
 			"selector": "p",
-			"role": "content"
+			"role": "content",
+			"control": {
+				"type": "RichText",
+				"label": "Content"
+			}
 		},
 		"dropCap": {
 			"type": "boolean",

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -18,7 +18,8 @@
 			"role": "content",
 			"control": {
 				"type": "RichText",
-				"label": "Content"
+				"label": "Content",
+				"shownByDefault": true
 			}
 		},
 		"dropCap": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Experiments with an API for [#71557](https://github.com/WordPress/gutenberg/issues/71557).
Built on top of #71512
Related: [#58233](https://github.com/WordPress/gutenberg/issues/58233).
Similar: #60779.

The goal is to make `role: content` attributes editable in the block inspector in contentOnly mode, as per this design:

<img width="300" alt="Image" src="https://github.com/user-attachments/assets/3c21b9d8-4083-48aa-86ae-5a9541d178de" />

This PR starts with the `content` fields for heading and paragraph blocks.

## Why?
See #71517 for the full reasoning.

## How?
For this PR I'm proposing a new API in the block.json, for each attribute a `control` property can be specified. At the moment only `RichText` control is supported, and to start with this renders a `TextBox` control, so not a rich text, but it's something to build on.

The exact API might need refinement, for example, should it be in block.json or index.js? I like `block.json` because it co-locates with the attribute.

I expect blocks will also need custom controls for more specific things, in which case moving to the index.js might be better, or adding a way to register controls.

In the future this could expand beyond contentOnly and the inspector.

## Testing Instructions
First, enable the experiment in Gutenberg's experiment settings page:

<img width="932" height="170" alt="image" src="https://github.com/user-attachments/assets/bcb7a3c7-1a2b-4756-be34-c06c5d578d58" />

1. Create a new post
2. Open the inserter
3. Add an unsynced pattern that has a heading and a paragraph
4. With the pattern selected in the canvas, open the block inspector
5. Edit the heading/paragraphs in the inspector

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/555af2dd-d849-4bef-8543-e6a7c7d2fb6a

