### PR TITLE
DataForm: Sort day, month, and year of DateTime control according to locale

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- Dataform: Sort day, month, and year of `DateTime` control according to locale. [#/](https://github.com/WordPress/gutenberg/pull//)
+
 ### Breaking changes
 
 - Remove `boolean` form control. Fields using `Edit: 'boolean'` must now use `Edit: 'checkbox'` or `Edit: 'toggle'` instead. Boolean field types now use checkboxes by default. [#71505](https://github.com/WordPress/gutenberg/pull/71505)

--- a/packages/dataviews/src/dataform-controls/datetime.tsx
+++ b/packages/dataviews/src/dataform-controls/datetime.tsx
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { _x } from '@wordpress/i18n';
 import { BaseControl, TimePicker, VisuallyHidden } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 
@@ -55,6 +56,10 @@ export default function DateTime< Item >( {
 				currentTime={ typeof value === 'string' ? value : undefined }
 				onChange={ onChangeControl }
 				hideLabelFromVision
+				dateOrder={
+					/* translators: Order of day, month, and year. Available formats are 'dmy', 'mdy', and 'ymd'. */
+					_x( 'dmy', 'date order' ) as 'dmy' | 'mdy' | 'ymd'
+				}
 			/>
 		</fieldset>
 	);


### PR DESCRIPTION
## What?

This PR adds the `dateOrder` prop to the `TimePicker` component in the `DateTime` control so that the day, month, and year are sorted appropriately for the locale.

## Why?

The order of days, months, and years varies by country. The `TimePicker` component supports the `dateProp`, whose value changes the order of the control. By making the value of the `dateOrder` prop translatable, the correct order will be automatically guaranteed depending on the locale.

See https://github.com/WordPress/gutenberg/pull/62481 for more details.

## How?

I realized that if the translatable text is simply passed to the `dateOrder` prop, the following type error occurs. The `dateOrder` prop is already used [here](https://github.com/WordPress/gutenberg/blob/0732dcd15b5fef25273fc3952d1c26ff252fa3c5/packages/editor/src/components/post-schedule/index.js#L102), but I didn't notice this type error because the PrivatePublishDateTimePicker component is written in JavaScript, not TypeScript.

```
Type 'TranslatableText<"dmy">' is not assignable to type '"dmy" | "mdy" | "ymd" | undefined'.
```

To avoid this, type assertions were needed.

Another approach would be to allow `TranslatableText` in the type itself, but I'm not sure which is the ideal approach:

```typescript
export type TimePickerProps = {
	// ...
	dateOrder?:
		| 'dmy'
		| 'mdy'
		| 'ymd'
		| TranslatableText< 'dmy' >
		| TranslatableText< 'mdy' >
		| TranslatableText< 'ymd' >;
	// ...
};
```

## Testing Instructions

- Change the site language to Japanese.
-  Go to Appearance (`外観`) > Editor (`エディター`) > Pages (`固定ページ`)
- Change the dataviews layout to Table (`テーブル`)
- Expand the Details panel
- Click any of the pages
- Click the date field and check the order of the day, month, and year.

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="729" height="227" alt="image" src="https://github.com/user-attachments/assets/8b493e04-7381-4539-8544-7123b3d54563" />

### After

<img width="731" height="238" alt="image" src="https://github.com/user-attachments/assets/cb943060-d9a8-48f1-a339-cf5586eefb78" />
