### PR TITLE
Dataforms: Add object configuration support for Edit property with prefix/suffix options

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -18,6 +18,7 @@
 - DataViews: support groupBy in the list layout. [#71548](https://github.com/WordPress/gutenberg/pull/71548)
 - DataForm: support validation in select control [#71665](https://github.com/WordPress/gutenberg/pull/71665)
 - DataForm: support validation in toggleGroup control. ([#71666](https://github.com/WordPress/gutenberg/pull/71666))
+-  DataForm: Add object configuration support for Edit property with some options. ([#71582](https://github.com/WordPress/gutenberg/pull/71582))
 
 ### Bug Fixes
 

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -30,17 +30,17 @@ const { ValidatedTextControl } = unlock( privateApis );
 
 
 const DollarPrefix = () => (
-	<InputControlPrefixWrapper variant="control">
+	<InputControlPrefixWrapper>
 		<span>$</span>
 	</InputControlPrefixWrapper>
 );
 const PercentSuffix = () => (
-	<InputControlSuffixWrapper variant="control">
+	<InputControlSuffixWrapper>
 		<span>%</span>
 	</InputControlSuffixWrapper>
 );
 const USDSuffix = () => (
-	<InputControlSuffixWrapper variant="control">
+	<InputControlSuffixWrapper>
 		<span>USD</span>
 	</InputControlSuffixWrapper>
 );
@@ -212,7 +212,7 @@ const fields: Field< SamplePost >[] = [
 		type: 'text',
 		Edit: {
 			control: 'text',
-			prefix: <DollarPrefix />,
+			prefix: DollarPrefix,
 		},
 	},
 	{
@@ -221,7 +221,7 @@ const fields: Field< SamplePost >[] = [
 		type: 'text',
 		Edit: {
 			control: 'text',
-			suffix: <PercentSuffix />,
+			suffix: PercentSuffix,
 		},
 	},
 	{
@@ -230,8 +230,8 @@ const fields: Field< SamplePost >[] = [
 		type: 'text',
 		Edit: {
 			control: 'text',
-			prefix: <DollarPrefix />,
-			suffix: <USDSuffix />,
+			prefix: DollarPrefix,
+			suffix: USDSuffix,
 		},
 	},
 ];

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -200,9 +200,9 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'longDescription',
 		label: 'Long Description',
-		type: 'text',
+		control: 'text',
 		Edit: {
-			type: 'textarea',
+			control: 'textarea',
 			rows: 5,
 		},
 	},
@@ -211,7 +211,7 @@ const fields: Field< SamplePost >[] = [
 		label: 'Price with Prefix',
 		type: 'text',
 		Edit: {
-			type: 'text',
+			control: 'text',
 			prefix: <DollarPrefix />,
 		},
 	},
@@ -220,7 +220,7 @@ const fields: Field< SamplePost >[] = [
 		label: 'Percentage with Suffix',
 		type: 'text',
 		Edit: {
-			type: 'text',
+			control: 'text',
 			suffix: <PercentSuffix />,
 		},
 	},
@@ -229,7 +229,7 @@ const fields: Field< SamplePost >[] = [
 		label: 'Price with Prefix and Suffix',
 		type: 'text',
 		Edit: {
-			type: 'text',
+			control: 'text',
 			prefix: <DollarPrefix />,
 			suffix: <USDSuffix />,
 		},

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -6,6 +6,8 @@ import {
 	Button,
 	__experimentalVStack as VStack,
 	privateApis,
+	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
+	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
 } from '@wordpress/components';
 
 /**
@@ -26,9 +28,22 @@ import { unlock } from '../../../lock-unlock';
 
 const { ValidatedTextControl } = unlock( privateApis );
 
-const DollarPrefix = () => <span>$</span>;
-const PercentSuffix = () => <span>%</span>;
-const USDSuffix = () => <span>USD</span>;
+
+const DollarPrefix = () => (
+	<InputControlPrefixWrapper variant="control">
+		<span>$</span>
+	</InputControlPrefixWrapper>
+);
+const PercentSuffix = () => (
+	<InputControlSuffixWrapper variant="control">
+		<span>%</span>
+	</InputControlSuffixWrapper>
+);
+const USDSuffix = () => (
+	<InputControlSuffixWrapper variant="control">
+		<span>USD</span>
+	</InputControlSuffixWrapper>
+);
 
 type SamplePost = {
 	title: string;
@@ -197,7 +212,7 @@ const fields: Field< SamplePost >[] = [
 		type: 'text',
 		Edit: {
 			type: 'text',
-			prefix: DollarPrefix,
+			prefix: <DollarPrefix />,
 		},
 	},
 	{
@@ -215,7 +230,7 @@ const fields: Field< SamplePost >[] = [
 		type: 'text',
 		Edit: {
 			type: 'text',
-			prefix: DollarPrefix,
+			prefix: <DollarPrefix />,
 			suffix: <USDSuffix />,
 		},
 	},

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -6,8 +6,6 @@ import {
 	Button,
 	__experimentalVStack as VStack,
 	privateApis,
-	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
-	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
 } from '@wordpress/components';
 
 /**
@@ -28,22 +26,6 @@ import { unlock } from '../../../lock-unlock';
 
 const { ValidatedTextControl } = unlock( privateApis );
 
-const DollarPrefix = () => (
-	<InputControlPrefixWrapper>
-		<span>$</span>
-	</InputControlPrefixWrapper>
-);
-const PercentSuffix = () => (
-	<InputControlSuffixWrapper>
-		<span>%</span>
-	</InputControlSuffixWrapper>
-);
-const USDSuffix = () => (
-	<InputControlSuffixWrapper>
-		<span>USD</span>
-	</InputControlSuffixWrapper>
-);
-
 type SamplePost = {
 	title: string;
 	order: number;
@@ -60,9 +42,6 @@ type SamplePost = {
 	address2?: string;
 	city?: string;
 	longDescription?: string;
-	priceWithPrefix?: string;
-	percentageWithSuffix?: string;
-	priceWithBoth?: string;
 };
 
 const fields: Field< SamplePost >[] = [
@@ -205,34 +184,6 @@ const fields: Field< SamplePost >[] = [
 			rows: 5,
 		},
 	},
-	{
-		id: 'priceWithPrefix',
-		label: 'Price with Prefix',
-		type: 'text',
-		Edit: {
-			control: 'text',
-			prefix: DollarPrefix,
-		},
-	},
-	{
-		id: 'percentageWithSuffix',
-		label: 'Percentage with Suffix',
-		type: 'text',
-		Edit: {
-			control: 'text',
-			suffix: PercentSuffix,
-		},
-	},
-	{
-		id: 'priceWithBoth',
-		label: 'Price with Prefix and Suffix',
-		type: 'text',
-		Edit: {
-			control: 'text',
-			prefix: DollarPrefix,
-			suffix: USDSuffix,
-		},
-	},
 ];
 
 const LayoutRegularComponent = ( {
@@ -280,9 +231,6 @@ const LayoutRegularComponent = ( {
 				'tags',
 				'description',
 				'longDescription',
-				'priceWithPrefix',
-				'percentageWithSuffix',
-				'priceWithBoth',
 			],
 		} ),
 		[ labelPosition ]

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -200,7 +200,7 @@ const fields: Field< SamplePost >[] = [
 	{
 		id: 'longDescription',
 		label: 'Long Description',
-		control: 'text',
+		type: 'text',
 		Edit: {
 			control: 'textarea',
 			rows: 5,

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -26,6 +26,8 @@ import { unlock } from '../../../lock-unlock';
 
 const { ValidatedTextControl } = unlock( privateApis );
 
+const DollarPrefix = () => <span>$</span>;
+
 type SamplePost = {
 	title: string;
 	order: number;
@@ -41,6 +43,8 @@ type SamplePost = {
 	address1?: string;
 	address2?: string;
 	city?: string;
+	longDescription?: string;
+	priceWithPrefix?: string;
 };
 
 const fields: Field< SamplePost >[] = [
@@ -174,6 +178,24 @@ const fields: Field< SamplePost >[] = [
 		type: 'text',
 		Edit: 'textarea',
 	},
+	{
+		id: 'longDescription',
+		label: 'Long Description',
+		type: 'text',
+		Edit: {
+			type: 'textarea',
+			rows: 5,
+		},
+	},
+	{
+		id: 'priceWithPrefix',
+		label: 'Price with Prefix',
+		type: 'text',
+		Edit: {
+			type: 'text',
+			prefix: DollarPrefix,
+		},
+	},
 ];
 
 const LayoutRegularComponent = ( {
@@ -220,6 +242,8 @@ const LayoutRegularComponent = ( {
 				'dimensions',
 				'tags',
 				'description',
+				'longDescription',
+				'priceWithPrefix',
 			],
 		} ),
 		[ labelPosition ]

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -27,6 +27,8 @@ import { unlock } from '../../../lock-unlock';
 const { ValidatedTextControl } = unlock( privateApis );
 
 const DollarPrefix = () => <span>$</span>;
+const PercentSuffix = () => <span>%</span>;
+const USDSuffix = () => <span>USD</span>;
 
 type SamplePost = {
 	title: string;
@@ -45,6 +47,8 @@ type SamplePost = {
 	city?: string;
 	longDescription?: string;
 	priceWithPrefix?: string;
+	percentageWithSuffix?: string;
+	priceWithBoth?: string;
 };
 
 const fields: Field< SamplePost >[] = [
@@ -196,6 +200,25 @@ const fields: Field< SamplePost >[] = [
 			prefix: DollarPrefix,
 		},
 	},
+	{
+		id: 'percentageWithSuffix',
+		label: 'Percentage with Suffix',
+		type: 'text',
+		Edit: {
+			type: 'text',
+			suffix: <PercentSuffix />,
+		},
+	},
+	{
+		id: 'priceWithBoth',
+		label: 'Price with Prefix and Suffix',
+		type: 'text',
+		Edit: {
+			type: 'text',
+			prefix: DollarPrefix,
+			suffix: <USDSuffix />,
+		},
+	},
 ];
 
 const LayoutRegularComponent = ( {
@@ -244,6 +267,8 @@ const LayoutRegularComponent = ( {
 				'description',
 				'longDescription',
 				'priceWithPrefix',
+				'percentageWithSuffix',
+				'priceWithBoth',
 			],
 		} ),
 		[ labelPosition ]

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -28,7 +28,6 @@ import { unlock } from '../../../lock-unlock';
 
 const { ValidatedTextControl } = unlock( privateApis );
 
-
 const DollarPrefix = () => (
 	<InputControlPrefixWrapper>
 		<span>$</span>

--- a/packages/dataviews/src/dataform-controls/email.tsx
+++ b/packages/dataviews/src/dataform-controls/email.tsx
@@ -1,6 +1,10 @@
 /**
  * WordPress dependencies
  */
+import { 
+	Icon,
+	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
+} from '@wordpress/components';
 import { atSymbol } from '@wordpress/icons';
 
 /**
@@ -23,7 +27,11 @@ export default function Email< Item >( {
 				onChange,
 				hideLabelFromVision,
 				type: 'email',
-				icon: atSymbol,
+				prefix: (
+					<InputControlPrefixWrapper variant="icon">
+						<Icon icon={ atSymbol } />
+					</InputControlPrefixWrapper>
+				),
 			} }
 		/>
 	);

--- a/packages/dataviews/src/dataform-controls/email.tsx
+++ b/packages/dataviews/src/dataform-controls/email.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { 
+import {
 	Icon,
 	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
 } from '@wordpress/components';

--- a/packages/dataviews/src/dataform-controls/index.tsx
+++ b/packages/dataviews/src/dataform-controls/index.tsx
@@ -10,6 +10,7 @@ import type {
 	DataFormControlProps,
 	Field,
 	FieldTypeDefinition,
+	EditConfig,
 } from '../types';
 import checkbox from './checkbox';
 import datetime from './datetime';
@@ -51,6 +52,21 @@ const FORM_CONTROLS: FormControls = {
 	toggleGroup,
 };
 
+function isEditConfig( value: any ): value is EditConfig {
+	return value && typeof value === 'object' && typeof value.type === 'string';
+}
+
+function createConfiguredControl( config: EditConfig ) {
+	const { type, ...controlConfig } = config;
+	const BaseControl = getControlByType( type );
+
+	return function ConfiguredControl< Item >(
+		props: DataFormControlProps< Item >
+	) {
+		return <BaseControl { ...props } { ...controlConfig } />;
+	};
+}
+
 export function getControl< Item >(
 	field: Field< Item >,
 	fieldTypeDefinition: FieldTypeDefinition< Item >
@@ -63,12 +79,20 @@ export function getControl< Item >(
 		return getControlByType( field.Edit );
 	}
 
+	if ( isEditConfig( field.Edit ) ) {
+		return createConfiguredControl( field.Edit );
+	}
+
 	if ( field.elements && field.type !== 'array' ) {
 		return getControlByType( 'select' );
 	}
 
 	if ( typeof fieldTypeDefinition.Edit === 'string' ) {
 		return getControlByType( fieldTypeDefinition.Edit );
+	}
+
+	if ( isEditConfig( fieldTypeDefinition.Edit ) ) {
+		return createConfiguredControl( fieldTypeDefinition.Edit );
 	}
 
 	return fieldTypeDefinition.Edit;

--- a/packages/dataviews/src/dataform-controls/index.tsx
+++ b/packages/dataviews/src/dataform-controls/index.tsx
@@ -53,12 +53,12 @@ const FORM_CONTROLS: FormControls = {
 };
 
 function isEditConfig( value: any ): value is EditConfig {
-	return value && typeof value === 'object' && typeof value.type === 'string';
+	return value && typeof value === 'object' && typeof value.control === 'string';
 }
 
 function createConfiguredControl( config: EditConfig ) {
-	const { type, ...controlConfig } = config;
-	const BaseControl = getControlByType( type );
+	const { control, ...controlConfig } = config;
+	const BaseControl = getControlByType( control );
 
 	return function ConfiguredControl< Item >(
 		props: DataFormControlProps< Item >

--- a/packages/dataviews/src/dataform-controls/index.tsx
+++ b/packages/dataviews/src/dataform-controls/index.tsx
@@ -63,7 +63,7 @@ function createConfiguredControl( config: EditConfig ) {
 	return function ConfiguredControl< Item >(
 		props: DataFormControlProps< Item >
 	) {
-		return <BaseControl { ...props } { ...controlConfig } />;
+		return <BaseControl { ...props } config={ controlConfig } />;
 	};
 }
 

--- a/packages/dataviews/src/dataform-controls/index.tsx
+++ b/packages/dataviews/src/dataform-controls/index.tsx
@@ -60,12 +60,12 @@ function isEditConfig( value: any ): value is EditConfig {
 
 function createConfiguredControl( config: EditConfig ) {
 	const { control, ...controlConfig } = config;
-	const BaseControl = getControlByType( control );
+	const BaseControlType = getControlByType( control );
 
 	return function ConfiguredControl< Item >(
 		props: DataFormControlProps< Item >
 	) {
-		return <BaseControl { ...props } config={ controlConfig } />;
+		return <BaseControlType { ...props } config={ controlConfig } />;
 	};
 }
 

--- a/packages/dataviews/src/dataform-controls/index.tsx
+++ b/packages/dataviews/src/dataform-controls/index.tsx
@@ -53,7 +53,9 @@ const FORM_CONTROLS: FormControls = {
 };
 
 function isEditConfig( value: any ): value is EditConfig {
-	return value && typeof value === 'object' && typeof value.control === 'string';
+	return (
+		value && typeof value === 'object' && typeof value.control === 'string'
+	);
 }
 
 function createConfiguredControl( config: EditConfig ) {

--- a/packages/dataviews/src/dataform-controls/telephone.tsx
+++ b/packages/dataviews/src/dataform-controls/telephone.tsx
@@ -1,6 +1,10 @@
 /**
  * WordPress dependencies
  */
+import { 
+	Icon,
+	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
+} from '@wordpress/components';
 import { mobile } from '@wordpress/icons';
 
 /**
@@ -23,7 +27,11 @@ export default function Telephone< Item >( {
 				onChange,
 				hideLabelFromVision,
 				type: 'tel',
-				icon: mobile,
+				prefix: (
+					<InputControlPrefixWrapper variant="icon">
+						<Icon icon={ mobile } />
+					</InputControlPrefixWrapper>
+				),
 			} }
 		/>
 	);

--- a/packages/dataviews/src/dataform-controls/telephone.tsx
+++ b/packages/dataviews/src/dataform-controls/telephone.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { 
+import {
 	Icon,
 	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
 } from '@wordpress/components';

--- a/packages/dataviews/src/dataform-controls/text.tsx
+++ b/packages/dataviews/src/dataform-controls/text.tsx
@@ -1,5 +1,10 @@
 
 /**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
  * WordPress dependencies
  */
 import { 
@@ -30,8 +35,8 @@ export default function Text< Item >( {
 				field,
 				onChange,
 				hideLabelFromVision,
-				prefix: prefix,
-				suffix: suffix,
+				prefix: prefix ? React.createElement( prefix ) : undefined,
+				suffix: suffix ? React.createElement( suffix ) : undefined,
 			} }
 		/>
 	);

--- a/packages/dataviews/src/dataform-controls/text.tsx
+++ b/packages/dataviews/src/dataform-controls/text.tsx
@@ -1,4 +1,3 @@
-
 /**
  * External dependencies
  */
@@ -7,7 +6,7 @@ import React from 'react';
 /**
  * WordPress dependencies
  */
-import { 
+import {
 	Icon,
 	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
 	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,

--- a/packages/dataviews/src/dataform-controls/text.tsx
+++ b/packages/dataviews/src/dataform-controls/text.tsx
@@ -1,3 +1,4 @@
+
 /**
  * WordPress dependencies
  */
@@ -18,12 +19,10 @@ export default function Text< Item >( {
 	field,
 	onChange,
 	hideLabelFromVision,
-	prefix,
-	suffix,
-}: DataFormControlProps< Item > & {
-	prefix?: React.ReactElement;
-	suffix?: React.ReactElement;
-} ) {
+	config,
+}: DataFormControlProps< Item > ) {
+	const { prefix, suffix } = config || {};
+
 	return (
 		<ValidatedText
 			{ ...{

--- a/packages/dataviews/src/dataform-controls/text.tsx
+++ b/packages/dataviews/src/dataform-controls/text.tsx
@@ -1,16 +1,7 @@
 /**
- * External dependencies
- */
-import React from 'react';
-
-/**
  * WordPress dependencies
  */
-import {
-	Icon,
-	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
-	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
-} from '@wordpress/components';
+import { createElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -34,8 +25,8 @@ export default function Text< Item >( {
 				field,
 				onChange,
 				hideLabelFromVision,
-				prefix: prefix ? React.createElement( prefix ) : undefined,
-				suffix: suffix ? React.createElement( suffix ) : undefined,
+				prefix: prefix ? createElement( prefix ) : undefined,
+				suffix: suffix ? createElement( suffix ) : undefined,
 			} }
 		/>
 	);

--- a/packages/dataviews/src/dataform-controls/text.tsx
+++ b/packages/dataviews/src/dataform-controls/text.tsx
@@ -10,12 +10,21 @@ export default function Text< Item >( {
 	onChange,
 	hideLabelFromVision,
 	prefix,
+	suffix,
 }: DataFormControlProps< Item > & {
 	prefix?: React.ComponentType | React.ReactElement;
+	suffix?: React.ReactElement;
 } ) {
 	return (
 		<ValidatedText
-			{ ...{ data, field, onChange, hideLabelFromVision, icon: prefix } }
+			{ ...{
+				data,
+				field,
+				onChange,
+				hideLabelFromVision,
+				icon: prefix,
+				suffix,
+			} }
 		/>
 	);
 }

--- a/packages/dataviews/src/dataform-controls/text.tsx
+++ b/packages/dataviews/src/dataform-controls/text.tsx
@@ -21,27 +21,9 @@ export default function Text< Item >( {
 	prefix,
 	suffix,
 }: DataFormControlProps< Item > & {
-	prefix?: React.ComponentType | React.ReactElement;
+	prefix?: React.ReactElement;
 	suffix?: React.ReactElement;
 } ) {
-	const wrappedPrefix = prefix ? (
-		typeof prefix === 'function' ? (
-			<InputControlPrefixWrapper variant="icon">
-				<Icon icon={ prefix } />
-			</InputControlPrefixWrapper>
-		) : (
-			<InputControlPrefixWrapper variant="control">
-				{ prefix }
-			</InputControlPrefixWrapper>
-		)
-	) : undefined;
-
-	const wrappedSuffix = suffix ? (
-		<InputControlSuffixWrapper variant="control">
-			{ suffix }
-		</InputControlSuffixWrapper>
-	) : undefined;
-
 	return (
 		<ValidatedText
 			{ ...{
@@ -49,8 +31,8 @@ export default function Text< Item >( {
 				field,
 				onChange,
 				hideLabelFromVision,
-				prefix: wrappedPrefix,
-				suffix: wrappedSuffix,
+				prefix: prefix,
+				suffix: suffix,
 			} }
 		/>
 	);

--- a/packages/dataviews/src/dataform-controls/text.tsx
+++ b/packages/dataviews/src/dataform-controls/text.tsx
@@ -9,8 +9,13 @@ export default function Text< Item >( {
 	field,
 	onChange,
 	hideLabelFromVision,
-}: DataFormControlProps< Item > ) {
+	prefix,
+}: DataFormControlProps< Item > & {
+	prefix?: React.ComponentType | React.ReactElement;
+} ) {
 	return (
-		<ValidatedText { ...{ data, field, onChange, hideLabelFromVision } } />
+		<ValidatedText
+			{ ...{ data, field, onChange, hideLabelFromVision, icon: prefix } }
+		/>
 	);
 }

--- a/packages/dataviews/src/dataform-controls/text.tsx
+++ b/packages/dataviews/src/dataform-controls/text.tsx
@@ -1,4 +1,13 @@
 /**
+ * WordPress dependencies
+ */
+import { 
+	Icon,
+	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
+	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
+} from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
 import type { DataFormControlProps } from '../types';
@@ -15,6 +24,24 @@ export default function Text< Item >( {
 	prefix?: React.ComponentType | React.ReactElement;
 	suffix?: React.ReactElement;
 } ) {
+	const wrappedPrefix = prefix ? (
+		typeof prefix === 'function' ? (
+			<InputControlPrefixWrapper variant="icon">
+				<Icon icon={ prefix } />
+			</InputControlPrefixWrapper>
+		) : (
+			<InputControlPrefixWrapper variant="control">
+				{ prefix }
+			</InputControlPrefixWrapper>
+		)
+	) : undefined;
+
+	const wrappedSuffix = suffix ? (
+		<InputControlSuffixWrapper variant="control">
+			{ suffix }
+		</InputControlSuffixWrapper>
+	) : undefined;
+
 	return (
 		<ValidatedText
 			{ ...{
@@ -22,8 +49,8 @@ export default function Text< Item >( {
 				field,
 				onChange,
 				hideLabelFromVision,
-				icon: prefix,
-				suffix,
+				prefix: wrappedPrefix,
+				suffix: wrappedSuffix,
 			} }
 		/>
 	);

--- a/packages/dataviews/src/dataform-controls/textarea.tsx
+++ b/packages/dataviews/src/dataform-controls/textarea.tsx
@@ -17,8 +17,9 @@ export default function Textarea< Item >( {
 	field,
 	onChange,
 	hideLabelFromVision,
-	rows,
-}: DataFormControlProps< Item > & { rows?: number } ) {
+	config,
+}: DataFormControlProps< Item > ) {
+	const { rows = 4 } = config || {};
 	const { id, label, placeholder, description } = field;
 	const value = field.getValue( { item: data } );
 	const [ customValidity, setCustomValidity ] =

--- a/packages/dataviews/src/dataform-controls/textarea.tsx
+++ b/packages/dataviews/src/dataform-controls/textarea.tsx
@@ -17,7 +17,8 @@ export default function Textarea< Item >( {
 	field,
 	onChange,
 	hideLabelFromVision,
-}: DataFormControlProps< Item > ) {
+	rows,
+}: DataFormControlProps< Item > & { rows?: number } ) {
 	const { id, label, placeholder, description } = field;
 	const value = field.getValue( { item: data } );
 	const [ customValidity, setCustomValidity ] =
@@ -63,6 +64,7 @@ export default function Textarea< Item >( {
 			value={ value ?? '' }
 			help={ description }
 			onChange={ onChangeControl }
+			rows={ rows }
 			__next40pxDefaultSize
 			__nextHasNoMarginBottom
 			hideLabelFromVision={ hideLabelFromVision }

--- a/packages/dataviews/src/dataform-controls/url.tsx
+++ b/packages/dataviews/src/dataform-controls/url.tsx
@@ -1,6 +1,10 @@
 /**
  * WordPress dependencies
  */
+import { 
+	Icon,
+	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
+} from '@wordpress/components';
 import { link } from '@wordpress/icons';
 
 /**
@@ -23,7 +27,11 @@ export default function Url< Item >( {
 				onChange,
 				hideLabelFromVision,
 				type: 'url',
-				icon: link,
+				prefix: (
+					<InputControlPrefixWrapper variant="icon">
+						<Icon icon={ link } />
+					</InputControlPrefixWrapper>
+				),
 			} }
 		/>
 	);

--- a/packages/dataviews/src/dataform-controls/url.tsx
+++ b/packages/dataviews/src/dataform-controls/url.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { 
+import {
 	Icon,
 	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
 } from '@wordpress/components';

--- a/packages/dataviews/src/dataform-controls/utils/validated-input.tsx
+++ b/packages/dataviews/src/dataform-controls/utils/validated-input.tsx
@@ -1,12 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	Icon,
-	privateApis,
-	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
-	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
-} from '@wordpress/components';
+import { privateApis } from '@wordpress/components';
 import { useCallback, useState } from '@wordpress/element';
 
 /**
@@ -24,11 +19,11 @@ export type DataFormValidatedTextControlProps< Item > =
 		 */
 		type?: 'text' | 'email' | 'tel' | 'url' | 'password';
 		/**
-		 * Optional icon to display as prefix.
+		 * Optional prefix element to display before the input.
 		 */
-		icon?: React.ComponentType | React.ReactElement;
+		prefix?: React.ReactElement;
 		/**
-		 * Optional icon to display as suffix.
+		 * Optional suffix element to display after the input.
 		 */
 		suffix?: React.ReactElement;
 	};
@@ -39,7 +34,7 @@ export default function ValidatedText< Item >( {
 	onChange,
 	hideLabelFromVision,
 	type,
-	icon,
+	prefix,
 	suffix,
 }: DataFormValidatedTextControlProps< Item > ) {
 	const { id, label, placeholder, description } = field;
@@ -89,20 +84,8 @@ export default function ValidatedText< Item >( {
 			onChange={ onChangeControl }
 			hideLabelFromVision={ hideLabelFromVision }
 			type={ type }
-			prefix={
-				icon ? (
-					<InputControlPrefixWrapper variant="icon">
-						<Icon icon={ icon } />
-					</InputControlPrefixWrapper>
-				) : undefined
-			}
-			suffix={
-				suffix ? (
-					<InputControlSuffixWrapper variant="control">
-						{ suffix }
-					</InputControlSuffixWrapper>
-				) : undefined
-			}
+			prefix={ prefix }
+			suffix={ suffix }
 			__next40pxDefaultSize
 		/>
 	);

--- a/packages/dataviews/src/field-types/stories/index.story.tsx
+++ b/packages/dataviews/src/field-types/stories/index.story.tsx
@@ -5,7 +5,11 @@ import { useState, useMemo } from '@wordpress/element';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	Icon,
+	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
+	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
 } from '@wordpress/components';
+import { starFilled } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -56,6 +60,27 @@ const meta = {
 };
 export default meta;
 
+const DollarPrefix = () => (
+	<InputControlPrefixWrapper>
+		<span>$</span>
+	</InputControlPrefixWrapper>
+);
+const StarIconPrefix = () => (
+	<InputControlPrefixWrapper variant="icon">
+		<Icon icon={ starFilled } />
+	</InputControlPrefixWrapper>
+);
+const PercentSuffix = () => (
+	<InputControlSuffixWrapper>
+		<span>%</span>
+	</InputControlSuffixWrapper>
+);
+const USDSuffix = () => (
+	<InputControlSuffixWrapper>
+		<span>USD</span>
+	</InputControlSuffixWrapper>
+);
+
 type DataType = {
 	id: number;
 	text: string;
@@ -86,6 +111,10 @@ type DataType = {
 	arrayWithElements: string[];
 	notype: string;
 	notypeWithElements: string;
+	priceWithPrefix?: string;
+	ratingWithIcon?: string;
+	percentageWithSuffix?: string;
+	priceWithBoth?: string;
 };
 
 const data: DataType[] = [
@@ -120,6 +149,10 @@ const data: DataType[] = [
 		arrayWithElements: [ 'item1', 'item2', 'item3' ],
 		notype: 'No type',
 		notypeWithElements: 'No type',
+		priceWithPrefix: '25.99',
+		ratingWithIcon: '4.5',
+		percentageWithSuffix: '85',
+		priceWithBoth: '199.99',
 	},
 ];
 
@@ -394,6 +427,47 @@ const fields: Field< DataType >[] = [
 			{ value: 'item2', label: 'Item 2' },
 			{ value: 'item3', label: 'Item 3' },
 		],
+	},
+	{
+		id: 'priceWithPrefix',
+		label: 'Text with Prefix',
+		type: 'text',
+		description: 'Text field with dollar sign prefix.',
+		Edit: {
+			control: 'text',
+			prefix: DollarPrefix,
+		},
+	},
+	{
+		id: 'ratingWithIcon',
+		label: 'Text with Icon Prefix',
+		type: 'text',
+		description: 'Text field with star icon prefix.',
+		Edit: {
+			control: 'text',
+			prefix: StarIconPrefix,
+		},
+	},
+	{
+		id: 'percentageWithSuffix',
+		label: 'Text with Suffix',
+		type: 'text',
+		description: 'Text field with percent sign suffix.',
+		Edit: {
+			control: 'text',
+			suffix: PercentSuffix,
+		},
+	},
+	{
+		id: 'priceWithBoth',
+		label: 'Text with Prefix and Suffix',
+		type: 'text',
+		description: 'Text field with both dollar prefix and USD suffix.',
+		Edit: {
+			control: 'text',
+			prefix: DollarPrefix,
+			suffix: USDSuffix,
+		},
 	},
 ];
 
@@ -764,5 +838,34 @@ export const NoType = ( {
 
 	return (
 		<FieldTypeStory fields={ noTypeFields } type={ type } Edit={ Edit } />
+	);
+};
+
+export const TextWithPrefixSuffix = ( {
+	type,
+	Edit,
+}: {
+	type: PanelTypes;
+	Edit: ControlTypes;
+} ) => {
+	const prefixSuffixFields = useMemo(
+		() =>
+			fields.filter( ( field ) =>
+				[
+					'priceWithPrefix',
+					'ratingWithIcon',
+					'percentageWithSuffix',
+					'priceWithBoth',
+				].includes( field.id )
+			),
+		[]
+	);
+
+	return (
+		<FieldTypeStory
+			fields={ prefixSuffixFields }
+			type={ type }
+			Edit={ Edit }
+		/>
 	);
 };

--- a/packages/dataviews/src/field-types/stories/index.story.tsx
+++ b/packages/dataviews/src/field-types/stories/index.story.tsx
@@ -840,32 +840,3 @@ export const NoType = ( {
 		<FieldTypeStory fields={ noTypeFields } type={ type } Edit={ Edit } />
 	);
 };
-
-export const TextWithPrefixSuffix = ( {
-	type,
-	Edit,
-}: {
-	type: PanelTypes;
-	Edit: ControlTypes;
-} ) => {
-	const prefixSuffixFields = useMemo(
-		() =>
-			fields.filter( ( field ) =>
-				[
-					'priceWithPrefix',
-					'ratingWithIcon',
-					'percentageWithSuffix',
-					'priceWithBoth',
-				].includes( field.id )
-			),
-		[]
-	);
-
-	return (
-		<FieldTypeStory
-			fields={ prefixSuffixFields }
-			type={ type }
-			Edit={ Edit }
-		/>
-	);
-};

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -160,30 +160,46 @@ export type Rules< Item > = {
 };
 
 /**
- * Edit configuration object for advanced control options.
+ * Edit configuration for textarea controls.
  */
-export type EditConfig = {
+export type EditConfigTextarea = {
+	type: 'textarea';
 	/**
-	 * The type of control to use.
-	 */
-	type: string;
-	/**
-	 * Number of rows for textarea controls.
+	 * Number of rows for the textarea.
 	 */
 	rows?: number;
+};
+
+/**
+ * Edit configuration for text controls.
+ */
+export type EditConfigText = {
+	type: 'text';
 	/**
-	 * Prefix component for text controls.
+	 * Prefix component to display before the input.
 	 */
 	prefix?: React.ComponentType | React.ReactElement;
 	/**
-	 * Suffix component for text controls.
+	 * Suffix component to display after the input.
 	 */
 	suffix?: React.ReactElement;
-	/**
-	 * Additional configuration properties.
-	 */
-	[ key: string ]: any;
 };
+
+/**
+ * Edit configuration for other control types (excluding 'text' and 'textarea').
+ */
+export type EditConfigGeneric = {
+	type: Exclude< FieldType, 'text' | 'textarea' >;
+};
+
+/**
+ * Edit configuration object with type-safe control options.
+ * Each control type has its own specific configuration properties.
+ */
+export type EditConfig =
+	| EditConfigTextarea
+	| EditConfigText
+	| EditConfigGeneric;
 
 /**
  * A dataview field for a specific property of a data type.

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -176,6 +176,10 @@ export type EditConfig = {
 	 */
 	prefix?: React.ComponentType | React.ReactElement;
 	/**
+	 * Suffix component for text controls.
+	 */
+	suffix?: React.ReactElement;
+	/**
 	 * Additional configuration properties.
 	 */
 	[ key: string ]: any;

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -163,7 +163,7 @@ export type Rules< Item > = {
  * Edit configuration for textarea controls.
  */
 export type EditConfigTextarea = {
-	type: 'textarea';
+	control: 'textarea';
 	/**
 	 * Number of rows for the textarea.
 	 */
@@ -174,7 +174,7 @@ export type EditConfigTextarea = {
  * Edit configuration for text controls.
  */
 export type EditConfigText = {
-	type: 'text';
+	control: 'text';
 	/**
 	 * Prefix component to display before the input.
 	 */
@@ -189,7 +189,7 @@ export type EditConfigText = {
  * Edit configuration for other control types (excluding 'text' and 'textarea').
  */
 export type EditConfigGeneric = {
-	type: Exclude< FieldType, 'text' | 'textarea' >;
+	control: Exclude< FieldType, 'text' | 'textarea' >;
 };
 
 /**

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -126,7 +126,11 @@ export type FieldTypeDefinition< Item > = {
 	/**
 	 * Callback used to render an edit control for the field or control name.
 	 */
-	Edit: ComponentType< DataFormControlProps< Item > > | string | null;
+	Edit:
+		| ComponentType< DataFormControlProps< Item > >
+		| string
+		| EditConfig
+		| null;
 
 	/**
 	 * Callback used to render the field.
@@ -153,6 +157,28 @@ export type FieldTypeDefinition< Item > = {
 export type Rules< Item > = {
 	required?: boolean;
 	custom?: ( item: Item, field: NormalizedField< Item > ) => null | string;
+};
+
+/**
+ * Edit configuration object for advanced control options.
+ */
+export type EditConfig = {
+	/**
+	 * The type of control to use.
+	 */
+	type: string;
+	/**
+	 * Number of rows for textarea controls.
+	 */
+	rows?: number;
+	/**
+	 * Prefix component for text controls.
+	 */
+	prefix?: React.ComponentType | React.ReactElement;
+	/**
+	 * Additional configuration properties.
+	 */
+	[ key: string ]: any;
 };
 
 /**
@@ -198,7 +224,7 @@ export type Field< Item > = {
 	/**
 	 * Callback used to render an edit control for the field.
 	 */
-	Edit?: ComponentType< DataFormControlProps< Item > > | string;
+	Edit?: ComponentType< DataFormControlProps< Item > > | string | EditConfig;
 
 	/**
 	 * Callback used to sort the field.

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -331,6 +331,13 @@ export type DataFormControlProps< Item > = {
 	 * Used by DataViews filters to determine which control to render based on the operator type.
 	 */
 	operator?: Operator;
+	/**
+	 * Configuration object for the control.
+	 */
+	config?: {
+		prefix?: React.ReactElement;
+		suffix?: React.ReactElement;
+	};
 };
 
 export type DataViewRenderFieldProps< Item > = {

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -178,11 +178,11 @@ export type EditConfigText = {
 	/**
 	 * Prefix component to display before the input.
 	 */
-	prefix?: React.ComponentType | React.ReactElement;
+	prefix?: React.ComponentType;
 	/**
 	 * Suffix component to display after the input.
 	 */
-	suffix?: React.ReactElement;
+	suffix?: React.ComponentType;
 };
 
 /**
@@ -335,8 +335,8 @@ export type DataFormControlProps< Item > = {
 	 * Configuration object for the control.
 	 */
 	config?: {
-		prefix?: React.ReactElement;
-		suffix?: React.ReactElement;
+		prefix?: React.ComponentType;
+		suffix?: React.ComponentType;
 		rows?: number;
 	};
 };

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -337,6 +337,7 @@ export type DataFormControlProps< Item > = {
 	config?: {
 		prefix?: React.ReactElement;
 		suffix?: React.ReactElement;
+		rows?: number;
 	};
 };
 


### PR DESCRIPTION
This PR extends the DataForm `Edit` property to support object configuration, enabling advanced control options like configuring textarea rows, text input prefixes, and suffixes. This provides a more flexible and declarative API for customizing form controls.

Fixes: https://github.com/WordPress/gutenberg/issues/71560

## Changes Made

### Core Infrastructure:
- **New `EditConfig` type**: Added support for object-based Edit configuration with `type`, `rows`, `prefix`, `suffix`, and extensible properties
- **Enhanced control resolution**: Extended `getControl()` function to handle object configurations via new `createConfiguredControl()` HOC pattern
- **Type safety**: Full TypeScript support with proper type guards and validation

### Control Enhancements:
- **Textarea control**: Added `rows` configuration support for customizable textarea height
- **Text control**: Added `prefix` and `suffix` support for input decorations
- **Backward compatibility**: All existing string/component Edit values continue to work unchanged

### Documentation & Examples:
- **Comprehensive test cases**: Added example fields demonstrating textarea with custom rows, text with prefix, text with suffix, and text with both prefix and suffix
- **Type definitions**: Well-documented interface with clear usage examples

## Usage Examples

```typescript
const fields = [
  // Textarea with custom rows
  {
    id: 'longDescription',
    type: 'text',
    Edit: {
      type: 'textarea',
      rows: 5
    }
  },
  
  // Text with prefix
  {
    id: 'price',
    type: 'text',
    Edit: {
      type: 'text',
      prefix: <DollarIcon />
    }
  },
  
  // Text with suffix
  {
    id: 'percentage',
    type: 'text',
    Edit: {
      type: 'text',
      suffix: <span>%</span>
    }
  },
  
  // Text with both prefix and suffix
  {
    id: 'priceWithCurrency',
    type: 'text',
    Edit: {
      type: 'text',
      prefix: <DollarIcon />,
      suffix: <span>USD</span>
    }
  }
]
```

## Technical Details

- **HOC Pattern**: Uses Higher-Order Component pattern to wrap base controls with configuration
- **Type Guards**: Includes `isEditConfig()` type guard for runtime type checking  
- **Extensible Design**: The `EditConfig` type supports additional properties via index signature
- **Performance**: No impact on existing functionality, configurations only applied when needed

## Testing

Go to http://localhost:50240/?path=/story/dataviews-dataform--default, and verify the fields Long Description, Price with Prefix, Percentage with Suffix, Price with Prefix and Suffix, work as expected.