### PR TITLE
Automated testing: Add taxonomy pagination tests

### DIFF
--- a/packages/core-data/src/test/entities.js
+++ b/packages/core-data/src/test/entities.js
@@ -1,10 +1,18 @@
 /**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+jest.mock( '@wordpress/api-fetch' );
+
+/**
  * Internal dependencies
  */
 import {
 	getMethodName,
 	rootEntitiesConfig,
 	prePersistPostType,
+	additionalEntityConfigLoaders,
 } from '../entities';
 
 describe( 'getMethodName', () => {
@@ -66,5 +74,29 @@ describe( 'prePersistPostType', () => {
 			title: 'My Title',
 		};
 		expect( prePersistPostType( record, edits ) ).toEqual( {} );
+	} );
+} );
+
+describe( 'loadTaxonomyEntities', () => {
+	beforeEach( () => {
+		apiFetch.mockReset();
+	} );
+
+	it( 'should add supportsPagination: true to taxonomy entities', async () => {
+		const mockTaxonomies = {
+			category: {
+				name: 'Categories',
+				rest_base: 'categories',
+			},
+		};
+
+		apiFetch.mockResolvedValueOnce( mockTaxonomies );
+
+		const taxonomyLoader = additionalEntityConfigLoaders.find(
+			( loader ) => loader.kind === 'taxonomy'
+		);
+		const entities = await taxonomyLoader.loadEntities();
+
+		expect( entities[ 0 ].supportsPagination ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up to #71302, add tests for taxonomy pagination functionality.


## Why?
To prevent future regressions.

## How?
- Configuration test in `entities.js`: Verifies `loadTaxonomyEntities()` adds `supportsPagination: true` to taxonomy entities
- Integration test in r`esolvers.js`: Verifies pagination behavior by testing API calls use `parse: false` and, most importantly, extract pagination metadata from headers, which were being discarded.

## Testing Instructions
The tests introduced in this PR can be run with:
```
npm run test:unit --  --testPathPattern="core-data.*test.*(entities|resolvers)\.js$" --testNamePattern="(loadTaxonomyEntities|taxonomy pagination)"
```

1. Remove `supportsPagination: true` from `loadTaxonomyEntities` in `packages/core-data/src/entities.js`
3. Run the tests and verify they fail
4. Restore  `supportsPagination: true`
5. Run the tests again, now they should pass
