### PR TITLE
Table of Contents: Update toolbar controls

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -958,7 +958,7 @@ Summarize your post with a list of headings. Add HTML anchors to Heading blocks 
 -	**Experimental:** true
 -	**Category:** design
 -	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** headings, maxLevel, onlyIncludeCurrentPage
+-	**Attributes:** headings, maxLevel, onlyIncludeCurrentPage, ordered
 
 ## Tag Cloud
 

--- a/packages/block-library/src/table-of-contents/block.json
+++ b/packages/block-library/src/table-of-contents/block.json
@@ -22,6 +22,10 @@
 		},
 		"maxLevel": {
 			"type": "number"
+		},
+		"ordered": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/table-of-contents/list.tsx
+++ b/packages/block-library/src/table-of-contents/list.tsx
@@ -14,10 +14,12 @@ export default function TableOfContentsList( {
 	nestedHeadingList,
 	disableLinkActivation,
 	onClick,
+	ordered = true,
 }: {
 	nestedHeadingList: NestedHeadingData[];
 	disableLinkActivation?: boolean;
 	onClick?: ( event: MouseEvent< HTMLAnchorElement > ) => void;
+	ordered?: boolean;
 } ): ReactElement {
 	return (
 		<>
@@ -42,11 +44,13 @@ export default function TableOfContentsList( {
 					<span className={ ENTRY_CLASS_NAME }>{ content }</span>
 				);
 
+				const NestedListTag = ordered ? 'ol' : 'ul';
+
 				return (
 					<li key={ index }>
 						{ entry }
 						{ node.children ? (
-							<ol>
+							<NestedListTag>
 								<TableOfContentsList
 									nestedHeadingList={ node.children }
 									disableLinkActivation={
@@ -58,8 +62,9 @@ export default function TableOfContentsList( {
 											? onClick
 											: undefined
 									}
+									ordered={ ordered }
 								/>
-							</ol>
+							</NestedListTag>
 						) : null }
 					</li>
 				);

--- a/packages/block-library/src/table-of-contents/save.js
+++ b/packages/block-library/src/table-of-contents/save.js
@@ -9,17 +9,21 @@ import { useBlockProps } from '@wordpress/block-editor';
 import TableOfContentsList from './list';
 import { linearToNestedHeadingList } from './utils';
 
-export default function save( { attributes: { headings = [] } } ) {
+export default function save( {
+	attributes: { headings = [], ordered = true },
+} ) {
 	if ( headings.length === 0 ) {
 		return null;
 	}
+	const ListTag = ordered ? 'ol' : 'ul';
 	return (
 		<nav { ...useBlockProps.save() }>
-			<ol>
+			<ListTag>
 				<TableOfContentsList
 					nestedHeadingList={ linearToNestedHeadingList( headings ) }
+					ordered={ ordered }
 				/>
-			</ol>
+			</ListTag>
 		</nav>
 	);
 }

--- a/test/integration/fixtures/blocks/core__table-of-contents.json
+++ b/test/integration/fixtures/blocks/core__table-of-contents.json
@@ -15,7 +15,8 @@
 					"link": "#heading-id-2"
 				}
 			],
-			"onlyIncludeCurrentPage": false
+			"onlyIncludeCurrentPage": false,
+			"ordered": true
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__table-of-contents__empty.json
+++ b/test/integration/fixtures/blocks/core__table-of-contents__empty.json
@@ -4,7 +4,8 @@
 		"isValid": true,
 		"attributes": {
 			"headings": [],
-			"onlyIncludeCurrentPage": false
+			"onlyIncludeCurrentPage": false,
+			"ordered": true
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Addresses one of the issues listed in https://github.com/WordPress/gutenberg/issues/42229:

> Use the same block toolbar controls as the List block (being able to switch between bullet styles)

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This allows users to easily switch between an unordered list and an ordered list for the Table of Cotents block, similar to the List block controls.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds an "unordered" list option to the block toolbar.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Insert some headings into your post content, including more than one of the same heading level (e.g. two H2s), and some mixed levels (H3, H4)
2. Insert the Table of Contents block
3. Make sure you can switch between an ordered list and an unordered list via the block toolbar

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|List Block|
|-|-|-|
|<img width="1508" height="754" alt="image" src="https://github.com/user-attachments/assets/ddc36e29-573d-4e02-9c3b-df1baa344596" />|<img width="1508" height="754" alt="image" src="https://github.com/user-attachments/assets/2c37406e-1fff-4485-aa07-60f4bcec028f" />|<img width="1508" height="754" alt="image" src="https://github.com/user-attachments/assets/9a2c004a-71dd-4294-a530-d1d89a7e37f9" />|
