### PR TITLE
Patterns: Handle multiline paste as inline content for overrides

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
+++ b/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
@@ -166,10 +166,54 @@ export default function useClipboardHandler() {
 						}, [] )
 						.flat();
 				} else {
+					let pasteMode = isFullySelected ? 'BLOCKS' : 'AUTO';
+
+					// Handle multiline paste in partially selected blocks.
+					if ( ! isFullySelected && plainText.includes( '\n' ) ) {
+						const {
+							getBlock,
+							getBlockParentsByBlockName,
+							getBlockEditingMode,
+						} = registry.select( blockEditorStore );
+
+						const isInSyncedPattern = selectedBlockClientIds.some(
+							( clientId ) => {
+								const block = getBlock( clientId );
+								const blockEditingMode =
+									getBlockEditingMode( clientId );
+								const parentPatternClientIds =
+									getBlockParentsByBlockName(
+										clientId,
+										'core/block',
+										true
+									);
+
+								return (
+									blockEditingMode === 'contentOnly' &&
+									parentPatternClientIds.length > 0 &&
+									block?.attributes?.metadata?.bindings &&
+									Object.values(
+										block.attributes.metadata.bindings
+									).some(
+										( binding ) =>
+											binding?.source ===
+											'core/pattern-overrides'
+									)
+								);
+							}
+						);
+
+						// If pasting multiline into a block that is inside a synced pattern,
+						// always paste inline to avoid breaking the pattern structure.
+						if ( isInSyncedPattern ) {
+							pasteMode = 'INLINE';
+						}
+					}
+
 					blocks = pasteHandler( {
 						HTML: html,
 						plainText,
-						mode: isFullySelected ? 'BLOCKS' : 'AUTO',
+						mode: pasteMode,
 						canUserUseUnfilteredHTML,
 					} );
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71371

<!-- In a few words, what is the PR actually doing? -->
This PR fixes and ensure that multiline paste inside synced pattern overrides is treated as inline text instead of creating multiple paragraphs or blocks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Previously, any multiline paste inside a synced pattern did nothing. This happened because line breaks were converted into additional paragraph blocks, which would alter the pattern structure. Because of this, the paste was ignored.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Added check for synced pattern with overridden parts used for pasting content.
- When matched, force paste mode to `INLINE`, so multiline text is inserted with break line instead of extra blocks.

## Testing Instructions
1. Create a synced pattern.
2. Enable content overrides for the text field.
3. Paste multiline text into the override field.
    - Expect: All lines stay within the override block.
4. Paste the same content outside a synced pattern.
    - Expect: Regular behaviour (new paragraphs/blocks).

<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/bb463f10-0549-44c5-9afb-e3ae8ed86df9


