### PR TITLE
Update CODEOWNERS to remove ndiego

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Documentation
-/docs                                           @ajitbohra @juanmaguitar @fabiankaegy @ndiego
+/docs                                           @ajitbohra @juanmaguitar @fabiankaegy
 /packages/interactivity/docs                    @juanmaguitar
 
 # Schemas
@@ -60,7 +60,7 @@
 # Tooling
 /bin                                            @ntwb @nerrad @ajitbohra
 /bin/api-docs                                   @ntwb @nerrad @ajitbohra
-/docs/tool                                      @ajitbohra @ndiego
+/docs/tool                                      @ajitbohra
 /packages/babel-plugin-import-jsx-pragma        @ntwb @nerrad @ajitbohra
 /packages/babel-plugin-makepot                  @ntwb @nerrad @ajitbohra
 /packages/babel-preset-default                  @gziolo @ntwb @nerrad @ajitbohra


### PR DESCRIPTION
This PR updates the CODEOWNERS to remove @ndiego (myself) as a code owner for documentation. I'm not currently dedicating a significant portion of my time to Gutenberg docs. This change will set better expectations of my role in the project and also cut down on the number of emails I receive daily 😅