### PR TITLE
Backport: Avoid warning for non-string class attributes.

### DIFF
--- a/backport-changelog/6.9/5486.md
+++ b/backport-changelog/6.9/5486.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/5486
+
+* https://github.com/WordPress/gutenberg/pull/71594

--- a/lib/block-supports/background.php
+++ b/lib/block-supports/background.php
@@ -74,16 +74,13 @@ function gutenberg_render_background_support( $block_content, $block ) {
 
 		if ( $tags->next_tag() ) {
 			$existing_style = $tags->get_attribute( 'style' );
-			$updated_style  = '';
-
-			if ( ! empty( $existing_style ) ) {
-				$updated_style = $existing_style;
-				if ( ! str_ends_with( $existing_style, ';' ) ) {
-					$updated_style .= ';';
-				}
+			if ( is_string( $existing_style ) && '' !== $existing_style ) {
+				$separator     = str_ends_with( $existing_style, ';' ) ? '' : ';';
+				$updated_style = "{$existing_style}{$separator}{$styles['css']}";
+			} else {
+				$updated_style = $styles['css'];
 			}
 
-			$updated_style .= $styles['css'];
 			$tags->set_attribute( 'style', $updated_style );
 			$tags->add_class( 'has-background' );
 		}


### PR DESCRIPTION
Trac ticket: Core-59622

This is a backport of WordPress/wordpress-develop#5486, which introduces an additional check for non-string values of the `class` attribute when rendering background support for blocks.

This check avoids issuing a warning when a boolean `true` value of the attribute is passed on to `str_ends_with()`.