### PR TITLE
DataForms regular layout: Use BaseControl visual label for readonly fields when in top labelPosition

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - DataViews grid layout: make sure media previews have rounded corners. [#71543](https://github.com/WordPress/gutenberg/pull/71543)
 - DataForm regular layout: Remove label style overrides as they cause inconsistent results. ([#71574](https://github.com/WordPress/gutenberg/pull/71574))
+- DataForm regular layout: Use BaseControl visual label for readonly fields when in top labelPosition. ([#71597](https://github.com/WordPress/gutenberg/pull/71597))
 
 ## 8.0.0 (2025-09-03)
 

--- a/packages/dataviews/src/dataforms-layouts/regular/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/regular/index.tsx
@@ -12,6 +12,7 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHeading as Heading,
 	__experimentalSpacer as Spacer,
+	BaseControl,
 } from '@wordpress/components';
 
 /**
@@ -120,17 +121,17 @@ export default function FormRegularField< Item >( {
 		<div className="dataforms-layouts-regular__field">
 			{ fieldDefinition.readOnly === true ? (
 				<>
-					{ ! hideLabelFromVision && labelPosition !== 'none' && (
-						<div className="dataforms-layouts-regular__field-label">
-							{ fieldDefinition.label }
-						</div>
-					) }
-					<div className="dataforms-layouts-regular__field-control">
+					<>
+						{ ! hideLabelFromVision && labelPosition !== 'none' && (
+							<BaseControl.VisualLabel>
+								{ fieldDefinition.label }
+							</BaseControl.VisualLabel>
+						) }
 						<fieldDefinition.render
 							item={ data }
 							field={ fieldDefinition }
 						/>
-					</div>
+					</>
 				</>
 			) : (
 				<fieldDefinition.Edit


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Follows #71574

This PR proposes to remove the wrapping `div`s on the DataForm regular layout for readonly fields, and use a `BaseControl.VisualLabel` for wrapping just the label field.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

All other DataForms controls in the top position regular layout now defer to the Edit component to handle the display of the label. In most cases this will be (or will be consistent with) the base control visual label.

In short: this PR provides better default visual consistency between fields. It's a little clearer when we look at the storybook examples / screenshots below.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Remove the wrapping `div`s that used classnames that were more applicable to the `side` labelPosition
* Add a visual label for the read only fields

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Fire up storybook (`npm run storybook:dev`) and navigate to the regular layout story: http://localhost:50240/?path=/story/dataviews-dataform--layout-regular&args=labelPosition:top
* Observe how the read only fields (file size and dimensions) look compared to all the other fields
* Update the controls in the story to use labelPosition of "side"
* Things should look as they do on trunk for the side labelPosition

## Before (look at the file size and dimensions fields)

<img width="1115" height="688" alt="image" src="https://github.com/user-attachments/assets/58390158-9cf4-4a11-bc7f-94580503a692" />

## After (look at the file size and dimensions fields)

<img width="2228" height="1476" alt="image" src="https://github.com/user-attachments/assets/947fe0c5-1a2c-4aad-b8b5-ade8ae4ce025" />

## Side label position (should be unaffected by this PR)

<img width="1219" height="660" alt="image" src="https://github.com/user-attachments/assets/d514c5f0-42be-4299-84fe-2d0b1a34d430" />
