### PR TITLE
Table Of Contents: Use getEditedPostSlug instead of permalink

### DIFF
--- a/packages/block-library/src/table-of-contents/hooks.js
+++ b/packages/block-library/src/table-of-contents/hooks.js
@@ -26,11 +26,29 @@ function getLatestHeadings( select, clientId ) {
 	// store by string. When the store is not available, editorSelectors
 	// will be null, and the block's saved markup will lack permalinks.
 	// eslint-disable-next-line @wordpress/data-no-store-string-literals
-	const permalink = select( 'core/editor' ).getPermalink() ?? null;
+	const editorSelectors = select( 'core/editor' );
+
+	// Get the current slug being edited (includes temporary slug for new posts)
+	const currentSlug = editorSelectors?.getEditedPostSlug() ?? null;
+	const permalinkTemplate =
+		editorSelectors?.getEditedPostAttribute( 'permalink_template' ) ?? null;
+
+	// Get block attributes
+	const attributes = getBlockAttributes( clientId ) ?? {};
+	const slug = currentSlug;
+
+	// Construct permalink using slug and template
+	let permalink = null;
+	if ( slug && permalinkTemplate ) {
+		const PERMALINK_POSTNAME_REGEX = /%postname%/;
+		const [ prefix, suffix ] = permalinkTemplate.split(
+			PERMALINK_POSTNAME_REGEX
+		);
+		permalink = prefix + slug + suffix;
+	}
 
 	const isPaginated = getBlocksByName( 'core/nextpage' ).length !== 0;
-	const { onlyIncludeCurrentPage, maxLevel } =
-		getBlockAttributes( clientId ) ?? {};
+	const { onlyIncludeCurrentPage, maxLevel } = attributes;
 
 	// Get post-content block client ID.
 	const [ postContentClientId = '' ] = getBlocksByName( 'core/post-content' );
@@ -147,7 +165,9 @@ function observeCallback( select, dispatch, clientId ) {
 	}
 
 	const headings = getLatestHeadings( select, clientId );
-	if ( ! fastDeepEqual( headings, attributes.headings ) ) {
+	const headingsChanged = ! fastDeepEqual( headings, attributes.headings );
+
+	if ( headingsChanged ) {
 		// Executing the update in a microtask ensures that the non-persistent marker doesn't affect an attribute triggering the change.
 		window.queueMicrotask( () => {
 			__unstableMarkNextChangeAsNotPersistent();
@@ -159,8 +179,7 @@ function observeCallback( select, dispatch, clientId ) {
 export function useObserveHeadings( clientId ) {
 	const registry = useRegistry();
 	useEffect( () => {
-		// Todo: Limit subscription to block editor store when data no longer depends on `getPermalink`.
-		// See: https://github.com/WordPress/gutenberg/pull/45513
+		// Subscribe to all relevant store changes in one listener
 		return registry.subscribe( () =>
 			observeCallback( registry.select, registry.dispatch, clientId )
 		);

--- a/packages/block-library/src/table-of-contents/hooks.js
+++ b/packages/block-library/src/table-of-contents/hooks.js
@@ -162,9 +162,7 @@ function observeCallback( select, dispatch, clientId ) {
 	}
 
 	const headings = getLatestHeadings( select, clientId );
-	const headingsChanged = ! fastDeepEqual( headings, attributes.headings );
-
-	if ( headingsChanged ) {
+	if ( ! fastDeepEqual( headings, attributes.headings ) ) {
 		// Executing the update in a microtask ensures that the non-persistent marker doesn't affect an attribute triggering the change.
 		window.queueMicrotask( () => {
 			__unstableMarkNextChangeAsNotPersistent();
@@ -176,7 +174,8 @@ function observeCallback( select, dispatch, clientId ) {
 export function useObserveHeadings( clientId ) {
 	const registry = useRegistry();
 	useEffect( () => {
-		// Subscribe to all relevant store changes in one listener
+		// Todo: Limit subscription to block editor store when data no longer depends on `getPermalink`.
+		// See: https://github.com/WordPress/gutenberg/pull/45513
 		return registry.subscribe( () =>
 			observeCallback( registry.select, registry.dispatch, clientId )
 		);

--- a/packages/block-library/src/table-of-contents/hooks.js
+++ b/packages/block-library/src/table-of-contents/hooks.js
@@ -38,7 +38,7 @@ function getLatestHeadings( select, clientId ) {
 	let permalink = permalinkTemplate;
 	// Detect if this is a postname or pagename permalink.
 	const permalinkRegexResult =
-		permalinkTemplate.match( /%postname%|%pagename%/ )[ 0 ] ?? null;
+		permalinkTemplate?.match( /%postname%|%pagename%/ )?.[ 0 ] ?? null;
 	// If this is a postname or pagename permalink,
 	// replace the postname or pagename with the editedPostSlug.
 	if ( editedPostSlug && permalinkRegexResult ) {

--- a/packages/block-library/src/table-of-contents/hooks.js
+++ b/packages/block-library/src/table-of-contents/hooks.js
@@ -29,18 +29,20 @@ function getLatestHeadings( select, clientId ) {
 	const editorSelectors = select( 'core/editor' );
 
 	// Get the current slug being edited (includes temporary slug for new posts)
-	const currentSlug = editorSelectors?.getEditedPostSlug() ?? null;
+	const editedPostSlug = editorSelectors?.getEditedPostSlug() ?? null;
 	const permalinkTemplate =
 		editorSelectors?.getEditedPostAttribute( 'permalink_template' ) ?? null;
 
-	// Construct permalink using currentSlug and template
-	let permalink = null;
-	if ( currentSlug && permalinkTemplate ) {
-		const PERMALINK_POSTNAME_REGEX = /%postname%/;
+	// Construct permalink using editedPostSlug and template
+	let permalink = permalinkTemplate;
+	const permalinkRegexResult =
+		permalinkTemplate.match( /%postname%|%pagename%/ )[ 0 ] ?? null;
+	if ( editedPostSlug && permalinkRegexResult ) {
+		const PERMALINK_POSTNAME_REGEX = new RegExp( permalinkRegexResult );
 		const [ prefix, suffix ] = permalinkTemplate.split(
 			PERMALINK_POSTNAME_REGEX
 		);
-		permalink = prefix + currentSlug + suffix;
+		permalink = prefix + editedPostSlug + suffix;
 	}
 
 	const isPaginated = getBlocksByName( 'core/nextpage' ).length !== 0;

--- a/packages/block-library/src/table-of-contents/hooks.js
+++ b/packages/block-library/src/table-of-contents/hooks.js
@@ -33,10 +33,14 @@ function getLatestHeadings( select, clientId ) {
 	const permalinkTemplate =
 		editorSelectors?.getEditedPostAttribute( 'permalink_template' ) ?? null;
 
-	// Construct permalink using editedPostSlug and template
+	// Construct permalink using editedPostSlug and template.
+	// If this is a numerical permalink, just use the template.
 	let permalink = permalinkTemplate;
+	// Detect if this is a postname or pagename permalink.
 	const permalinkRegexResult =
 		permalinkTemplate.match( /%postname%|%pagename%/ )[ 0 ] ?? null;
+	// If this is a postname or pagename permalink,
+	// replace the postname or pagename with the editedPostSlug.
 	if ( editedPostSlug && permalinkRegexResult ) {
 		const PERMALINK_POSTNAME_REGEX = new RegExp( permalinkRegexResult );
 		const [ prefix, suffix ] = permalinkTemplate.split(

--- a/packages/block-library/src/table-of-contents/hooks.js
+++ b/packages/block-library/src/table-of-contents/hooks.js
@@ -33,22 +33,19 @@ function getLatestHeadings( select, clientId ) {
 	const permalinkTemplate =
 		editorSelectors?.getEditedPostAttribute( 'permalink_template' ) ?? null;
 
-	// Get block attributes
-	const attributes = getBlockAttributes( clientId ) ?? {};
-	const slug = currentSlug;
-
-	// Construct permalink using slug and template
+	// Construct permalink using currentSlug and template
 	let permalink = null;
-	if ( slug && permalinkTemplate ) {
+	if ( currentSlug && permalinkTemplate ) {
 		const PERMALINK_POSTNAME_REGEX = /%postname%/;
 		const [ prefix, suffix ] = permalinkTemplate.split(
 			PERMALINK_POSTNAME_REGEX
 		);
-		permalink = prefix + slug + suffix;
+		permalink = prefix + currentSlug + suffix;
 	}
 
 	const isPaginated = getBlocksByName( 'core/nextpage' ).length !== 0;
-	const { onlyIncludeCurrentPage, maxLevel } = attributes;
+	const { onlyIncludeCurrentPage, maxLevel } =
+		getBlockAttributes( clientId ) ?? {};
 
 	// Get post-content block client ID.
 	const [ postContentClientId = '' ] = getBlocksByName( 'core/post-content' );


### PR DESCRIPTION
## What?
Closes: https://github.com/WordPress/gutenberg/issues/43595

Fixes Table of Contents block links that don't work on initial page save.

## Testing Instructions
1. Set WordPress permalink structure to "Post name" (Settings > Permalinks)
2. Create a new Page
3. Add several heading blocks (H2, H3) with content
4. Add the Table of Contents block
5. Publish the page
6. View the published page
7. Verify TOC links work correctly on initial publish (no "Page not found" errors)
8. Also test in Preview mode to confirm links work there too
9. Also test for different permalink structures
10. Also test for pages
11. Also test in the Site Editor


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/983b6c18-e322-471a-b670-1ab7519f765a


