### PR TITLE
GitHub Actions: Add path filtering to End-to-End Tests workflow

### DIFF
--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -2,32 +2,16 @@ name: End-to-End Tests
 
 on:
     pull_request:
-        paths-ignore:
-            - 'docs/**'
-            - '**/*.md'
-            - 'README.md'
-            - 'CONTRIBUTING.md'
-            - 'LICENSE.md'
-            - 'changelog.txt'
-            - '.github/ISSUE_TEMPLATE/**'
-            - '.github/PULL_REQUEST_TEMPLATE.md'
-            - '.github/CODEOWNERS'
-            - '.browserslistrc'
-            - '.editorconfig'
-            - '.eslintignore'
-            - '.eslintrc.js'
-            - '.git-blame-ignore-revs'
-            - '.gitattributes'
-            - '.gitignore'
-            - '.jshintignore'
-            - '.markdownlint*'
-            - '.npmpackagejsonlintrc.json'
-            - '.npmrc'
-            - '.nvmrc'
-            - '.prettierignore'
-            - '.prettierrc.js'
-            - '.stylelintignore'
-            - '.stylelintrc.js'
+        paths:
+            - 'packages/**'
+            - 'test/e2e/**'
+            - 'lib/**'
+            - 'phpunit/**'
+            - '.wp-env.json'
+            - 'package.json'
+            - 'package-lock.json'
+            - '.github/workflows/end2end-test.yml'
+            - '.github/setup-node/**'
 
     push:
         branches:

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -2,6 +2,33 @@ name: End-to-End Tests
 
 on:
     pull_request:
+        paths-ignore:
+            - 'docs/**'
+            - '**/*.md'
+            - 'README.md'
+            - 'CONTRIBUTING.md'
+            - 'LICENSE.md'
+            - 'changelog.txt'
+            - '.github/ISSUE_TEMPLATE/**'
+            - '.github/PULL_REQUEST_TEMPLATE.md'
+            - '.github/CODEOWNERS'
+            - '.browserslistrc'
+            - '.editorconfig'
+            - '.eslintignore'
+            - '.eslintrc.js'
+            - '.git-blame-ignore-revs'
+            - '.gitattributes'
+            - '.gitignore'
+            - '.jshintignore'
+            - '.markdownlint*'
+            - '.npmpackagejsonlintrc.json'
+            - '.npmrc'
+            - '.nvmrc'
+            - '.prettierignore'
+            - '.prettierrc.js'
+            - '.stylelintignore'
+            - '.stylelintrc.js'
+
     push:
         branches:
             - trunk


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #71526 

Adds comprehensive path filtering to the End-to-End Tests workflow to prevent unnecessary test runs when changes don't affect functionality.

## Why?
The End-to-End Tests workflow currently runs on every PR regardless of the changes being proposed.

## How?
Add `paths-ignore` list in `.github/workflows/end2end-test.yml` to skip E2E tests.
