### PR TITLE
useClipboardHandler: Prevent file paste for users without media upload permissions

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
+++ b/packages/block-editor/src/components/writing-flow/use-clipboard-handler.js
@@ -137,6 +137,7 @@ export default function useClipboardHandler() {
 				const {
 					__experimentalCanUserUseUnfilteredHTML:
 						canUserUseUnfilteredHTML,
+					mediaUpload,
 				} = getSettings();
 				const isInternal =
 					event.clipboardData.getData( 'rich-text' ) === 'true';
@@ -148,6 +149,11 @@ export default function useClipboardHandler() {
 				let blocks = [];
 
 				if ( files.length ) {
+					if ( ! mediaUpload ) {
+						event.preventDefault();
+						return;
+					}
+
 					const fromTransforms = getBlockTransforms( 'from' );
 					blocks = files
 						.reduce( ( accumulator, file ) => {

--- a/packages/block-library/src/utils/hooks.js
+++ b/packages/block-library/src/utils/hooks.js
@@ -66,6 +66,10 @@ export function useUploadMediaFromBlobURL( args = {} ) {
 		const { url, allowedTypes, onChange, onError } = latestArgsRef.current;
 		const { mediaUpload } = getSettings();
 
+		if ( ! mediaUpload ) {
+			return;
+		}
+
 		hasUploadStartedRef.current = true;
 
 		mediaUpload( {


### PR DESCRIPTION
## What?

Closes #71581

This pull request updates the clipboard handler logic to prevent a critical error when users who can't upload media try to paste local files.

## Why?

If the pasted event data contains files, the `useClipboardHandler` tries to find block transformations with `type: files` and performs the transformation.

The mounted block then tries to upload a file via `useUploadMediaFromBlobURL`, but for users without access to the media library, the block breaks because `mediaUpload` is `undefined`.

## How?

When pasting, I added an early return so that if `mediaUpload` is `undefined`, the transformation itself won't be executed.  There is already a similar early return in the processing when a file is "dropped".

https://github.com/WordPress/gutenberg/blob/bc8fd77d91356e9364b0946777c188584258e1e5/packages/block-editor/src/components/use-on-block-drop/index.js#L172-L174

If we want to allow block transformations to be performed, we might be able to modify the `useUploadMediaFromBlobURL` hook instead.

## Testing Instructions

- Create a user with the contributor role. This user can't access media, but can create a post.
- Log in as the user you created.
- Open a post and paste any of the files from your local.
- Confirm that nothing happened.

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/365bce3d-81fa-4a7a-9fb8-4317c9c40041

### After


https://github.com/user-attachments/assets/3ca63c55-2142-474c-bcfc-bb5a1233f976

