### PR TITLE
DataForm: remove default storybook example

### DIFF
--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -1176,17 +1176,6 @@ const meta = {
 };
 export default meta;
 
-export const Default = {
-	render: LayoutRegularComponent,
-	argTypes: {
-		type: {
-			control: { type: 'select' },
-			description: 'Chooses the layout type.',
-			options: [ 'default', 'card', 'panel', 'regular' ],
-		},
-	},
-};
-
 export const LayoutCard = {
 	render: LayoutCardComponent,
 	argTypes: {


### PR DESCRIPTION
## What?

This removes the Default story for DataForm that pointed to the Regular layout example.

## Why?

It's duplicated. Making it work with different layout changes (e.g., regular vs row) requires adapting the data/fields: that doesn't provide much value as it's already implemented per layout where users can also tweak some options.

## How?

Remove the default export.

## Testing Instructions

Visit the storybook (`npm run storybook:dev`) and verify the default story for DataForm is not present.
