### PR TITLE
Block Bindings: Add support for Media & Text block image

### DIFF
--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -26,7 +26,9 @@
 		},
 		"mediaId": {
 			"type": "number",
-			"role": "content"
+			"default": 0,
+			"__experimentalRole": "content",
+			"__experimentalBlockBindings": true
 		},
 		"mediaUrl": {
 			"type": "string",


### PR DESCRIPTION


This PR adds **block bindings support** for the Media & Text block’s `mediaId` attribute. as this issue mentioned in #68637  
With this change, the image inside the Media & Text block can be dynamically sourced (e.g., post featured image, custom fields, or other bindings), rather than being limited to a fixed image or the featured image only.

## Why?
Currently, the Media & Text block is useful in templates but restricted in flexibility since the image must either be manually uploaded or set to the featured image.  
By enabling block bindings on the `mediaId`, template authors and developers can connect the block to other dynamic image sources (e.g., post meta, custom fields, reusable bindings), making it far more versatile for building dynamic templates.

## How?
- Added bindings support to the `mediaId` attribute of the Media & Text block.  

And we need to below pattern code
```
<!-- wp:media-text {"blockBindings":{"mediaId":{"source":"core/post-featured-image"}}} -->
<div class="wp-block-media-text is-stacked-on-mobile">
    <figure class="wp-block-media-text__media"></figure>
    <div class="wp-block-media-text__content">
        <p>This should now display the Featured Image.</p>
    </div>
</div>
<!-- /wp:media-text -->
```

