### PR TITLE
Automated testing: add tests to ensure pagination data when fetching intermediate results

### DIFF
--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -322,8 +322,8 @@ describe( 'getEntityRecords', () => {
 			baseURLParams: { context: 'edit' },
 		},
 		{
-			name: 'media',
-			kind: 'root',
+			name: 'attachment',
+			kind: 'postType',
 			supportsPagination: true,
 		},
 	];
@@ -544,7 +544,7 @@ describe( 'getEntityRecords', () => {
 			} );
 		} );
 
-		await getEntityRecords( 'root', 'media', {
+		await getEntityRecords( 'postType', 'attachment', {
 			per_page: -1,
 			[ RECEIVE_INTERMEDIATE_RESULTS ]: true,
 		} )( { dispatch, registry, resolveSelect } );

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -552,6 +552,17 @@ describe( 'getEntityRecords', () => {
 		// 3 calls for intermediate results (one per page), plus 1 final call with complete records
 		expect( dispatch.receiveEntityRecords ).toHaveBeenCalledTimes( 4 );
 
+		// Check that the first call already includes pagination metadata
+		expect( dispatch.receiveEntityRecords ).toHaveBeenCalledWith(
+			'postType',
+			'attachment',
+			expect.any( Array ),
+			{ per_page: -1, [ RECEIVE_INTERMEDIATE_RESULTS ]: true },
+			false,
+			undefined,
+			expect.objectContaining( { totalItems: 5, totalPages: 1 } )
+		);
+
 		// Check that all calls include pagination metadata
 		dispatch.receiveEntityRecords.mock.calls.forEach( ( call ) => {
 			// 7th parameter is the pagination metadata

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -517,7 +517,7 @@ describe( 'getEntityRecords', () => {
 		);
 	} );
 
-	it( 'provides pagination metadata during intermediate results fetching', async () => {
+	it( 'provides pagination metadata and progressive loading during intermediate results fetching', async () => {
 		const dispatch = Object.assign( jest.fn(), {
 			receiveEntityRecords: jest.fn(),
 			__unstableAcquireStoreLock: jest.fn(),

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -549,19 +549,33 @@ describe( 'getEntityRecords', () => {
 			[ RECEIVE_INTERMEDIATE_RESULTS ]: true,
 		} )( { dispatch, registry, resolveSelect } );
 
-		const calls = dispatch.receiveEntityRecords.mock.calls;
-
 		// 3 calls for intermediate results (one per page), plus 1 final call with complete records
-		expect( calls.length ).toBe( 4 );
+		expect( dispatch.receiveEntityRecords ).toHaveBeenCalledTimes( 4 );
 
-		calls.forEach( ( call ) => {
+		// Check that all calls include pagination metadata
+		dispatch.receiveEntityRecords.mock.calls.forEach( ( call ) => {
 			// 7th parameter is the pagination metadata
-			expect( call[ 6 ] ).toEqual( { totalItems: 5, totalPages: 1 } );
+			expect( call[ 6 ] ).toEqual(
+				expect.objectContaining( { totalItems: 5, totalPages: 1 } )
+			);
 		} );
 
 		// Should process all the data from the 3 mock pages (2+2+1=5 records total)
-		const finalCall = calls[ calls.length - 1 ];
-		expect( finalCall[ 2 ] ).toHaveLength( 5 );
+		expect( dispatch.receiveEntityRecords ).toHaveBeenLastCalledWith(
+			'postType',
+			'attachment',
+			expect.arrayContaining( [
+				expect.objectContaining( { id: 1 } ),
+				expect.objectContaining( { id: 2 } ),
+				expect.objectContaining( { id: 3 } ),
+				expect.objectContaining( { id: 4 } ),
+				expect.objectContaining( { id: 5 } ),
+			] ),
+			{ per_page: -1, [ RECEIVE_INTERMEDIATE_RESULTS ]: true },
+			false,
+			undefined,
+			expect.objectContaining( { totalItems: 5, totalPages: 1 } )
+		);
 	} );
 } );
 

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -26,6 +26,7 @@ import {
 	getAutosaves,
 	getCurrentUser,
 } from '../resolvers';
+import { RECEIVE_INTERMEDIATE_RESULTS } from '../utils';
 
 describe( 'getEntityRecord', () => {
 	const POST_TYPE = { slug: 'post' };
@@ -320,6 +321,11 @@ describe( 'getEntityRecords', () => {
 			baseURL: '/wp/v2/posts',
 			baseURLParams: { context: 'edit' },
 		},
+		{
+			name: 'media',
+			kind: 'root',
+			supportsPagination: true,
+		},
 	];
 	const registry = { batch: ( callback ) => callback() };
 	const resolveSelect = { getEntitiesConfig: jest.fn( () => ENTITIES ) };
@@ -509,6 +515,53 @@ describe( 'getEntityRecords', () => {
 			'getEntityRecord',
 			expect.any( Array )
 		);
+	} );
+
+	it( 'provides pagination metadata during intermediate results fetching', async () => {
+		const dispatch = Object.assign( jest.fn(), {
+			receiveEntityRecords: jest.fn(),
+			__unstableAcquireStoreLock: jest.fn(),
+			__unstableReleaseStoreLock: jest.fn(),
+			finishResolutions: jest.fn(),
+		} );
+
+		const mockPages = [
+			[ { id: 1 }, { id: 2 } ],
+			[ { id: 3 }, { id: 4 } ],
+			[ { id: 5 } ],
+		];
+
+		let callCount = 0;
+		triggerFetch.mockImplementation( () => {
+			const data = mockPages[ callCount % mockPages.length ];
+			callCount++;
+			return Promise.resolve( {
+				json: () => Promise.resolve( data ),
+				headers: new Map( [
+					[ 'X-WP-Total', '5' ],
+					[ 'X-WP-TotalPages', '3' ],
+				] ),
+			} );
+		} );
+
+		await getEntityRecords( 'root', 'media', {
+			per_page: -1,
+			[ RECEIVE_INTERMEDIATE_RESULTS ]: true,
+		} )( { dispatch, registry, resolveSelect } );
+
+		const calls = dispatch.receiveEntityRecords.mock.calls;
+
+		// 3 calls for intermediate results (one per page), plus 1 final call with complete records
+		expect( calls.length ).toBe( 4 );
+
+		calls.forEach( ( call ) => {
+			// 7th parameter is the pagination metadata
+			expect( call[ 6 ] ).toEqual( { totalItems: 5, totalPages: 1 } );
+		} );
+
+		// Should process all the data from our 3 mock pages (2+2+1=5 records total)
+		const finalCall = calls[ calls.length - 1 ];
+		expect( finalCall[ 2 ] ).toHaveLength( 5 );
 	} );
 } );
 

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -559,7 +559,7 @@ describe( 'getEntityRecords', () => {
 			expect( call[ 6 ] ).toEqual( { totalItems: 5, totalPages: 1 } );
 		} );
 
-		// Should process all the data from our 3 mock pages (2+2+1=5 records total)
+		// Should process all the data from the 3 mock pages (2+2+1=5 records total)
 		const finalCall = calls[ calls.length - 1 ];
 		expect( finalCall[ 2 ] ).toHaveLength( 5 );
 	} );


### PR DESCRIPTION
## What?
Follow up to #71401, adds test coverage for pagination metadata extraction during intermediate results fetching in `getEntityRecords`.
  resolver.

## Why?
#71401 fixed a bug where pagination metadata header was undefined during progressive loading. This test ensures the fix works correctly and prevents regressions.

## How?
Adds a test case to the resolvers test suite that mocks paginated API responses 5 items across 3 pages and verifies that all 4 `receiveEntityRecords` calls (3 intermediate + 1 final) include correct totalItems: 5 metadata (was undefined before #71401).

It also checks the paginated fetching, but because of the test environment, it can't reliably replicate that the results are partially fetched (more on that below).

## Testing Instructions
1. Run the test suite with ` npm test -- --testPathPattern="resolvers" --testNamePattern="provides pagination metadata"`, it should pass
2. Undo the changes in #71401 
3. Run the changes again to verify the header expectation fails.

