### PR TITLE
DataForm: Add summary field support for composed fields

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -19,6 +19,7 @@
 - DataForm: support validation in select control [#71665](https://github.com/WordPress/gutenberg/pull/71665)
 - DataForm: support validation in toggleGroup control. ([#71666](https://github.com/WordPress/gutenberg/pull/71666))
 -  DataForm: Add object configuration support for Edit property with some options. ([#71582](https://github.com/WordPress/gutenberg/pull/71582))
+- DataForm: Add summary field support for composed fields. ([#71614](https://github.com/WordPress/gutenberg/pull/71614))
 
 ### Bug Fixes
 

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -420,6 +420,12 @@ const LayoutPanelComponent = ( {
 				'dimensions',
 				'tags',
 				{
+					id: 'discussion',
+					label: 'Discussion',
+					children: [ 'comment_status', 'ping_status' ],
+					summary: 'discussion',
+				},
+				{
 					id: 'address1',
 					label: 'Combined Address',
 					children: [ 'address1', 'address2', 'city' ],
@@ -440,12 +446,6 @@ const LayoutPanelComponent = ( {
 					label: 'Passenger Details',
 					children: [ 'author', 'seat' ],
 					summary: [ 'author', 'seat' ],
-				},
-				{
-					id: 'discussion',
-					label: 'Discussion',
-					children: [ 'comment_status', 'ping_status' ],
-					summary: 'discussion',
 				},
 			],
 		};

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -41,6 +41,8 @@ type SamplePost = {
 	address1?: string;
 	address2?: string;
 	city?: string;
+	comment_status?: string;
+	ping_status?: boolean;
 	longDescription?: string;
 };
 
@@ -184,6 +186,22 @@ const fields: Field< SamplePost >[] = [
 			rows: 5,
 		},
 	},
+	{
+		id: 'comment_status',
+		label: 'Comment Status',
+		type: 'text',
+		Edit: 'radio',
+		elements: [
+			{ value: 'open', label: 'Allow comments' },
+			{ value: 'closed', label: 'Comments closed' },
+		],
+	},
+	{
+		id: 'ping_status',
+		label: 'Allow Pings/Trackbacks',
+		type: 'boolean',
+		Edit: 'checkbox',
+	},
 ];
 
 const LayoutRegularComponent = ( {
@@ -319,6 +337,8 @@ const LayoutPanelComponent = ( {
 		address1: '123 Main St',
 		address2: 'Apt 4B',
 		city: 'New York',
+		comment_status: 'open',
+		ping_status: true,
 	} );
 
 	const form: Form = useMemo( () => {
@@ -344,6 +364,11 @@ const LayoutPanelComponent = ( {
 					id: 'address1',
 					label: 'Combined Address',
 					children: [ 'address1', 'address2', 'city' ],
+				},
+				{
+					id: 'discussion',
+					label: 'Discussion',
+					children: [ 'comment_status', 'ping_status' ],
 				},
 			],
 		};

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -44,6 +44,11 @@ type SamplePost = {
 	comment_status?: string;
 	ping_status?: boolean;
 	longDescription?: string;
+	origin?: string;
+	destination?: string;
+	flight_status?: string;
+	gate?: string;
+	seat?: string;
 };
 
 const fields: Field< SamplePost >[] = [
@@ -220,6 +225,37 @@ const fields: Field< SamplePost >[] = [
 				</span>
 			);
 		},
+	},
+	{
+		id: 'origin',
+		label: 'Origin',
+		type: 'text',
+	},
+	{
+		id: 'destination',
+		label: 'Destination',
+		type: 'text',
+	},
+	{
+		id: 'flight_status',
+		label: 'Flight Status',
+		type: 'text',
+		Edit: 'radio',
+		elements: [
+			{ value: 'on-time', label: 'On Time' },
+			{ value: 'delayed', label: 'Delayed' },
+			{ value: 'cancelled', label: 'Cancelled' },
+		],
+	},
+	{
+		id: 'gate',
+		label: 'Gate',
+		type: 'text',
+	},
+	{
+		id: 'seat',
+		label: 'Seat',
+		type: 'text',
 	},
 ];
 
@@ -1302,6 +1338,68 @@ const LayoutMixedComponent = () => {
 	);
 };
 
+const MultipleSummaryPanelComponent = ( {
+	labelPosition,
+	openAs,
+}: {
+	labelPosition: 'default' | 'top' | 'side' | 'none';
+	openAs: 'default' | 'dropdown' | 'modal';
+} ) => {
+	const [ post, setPost ] = useState< SamplePost >( {
+		title: 'Flight Booking',
+		order: 1,
+		author: 1,
+		status: 'confirmed',
+		reviewer: 'system',
+		date: '2024-03-15T10:30:00',
+		birthdate: '1985-06-15T00:00:00',
+		origin: 'New York (JFK)',
+		destination: 'Los Angeles (LAX)',
+		flight_status: 'on-time',
+		gate: 'A12',
+		seat: '14F',
+	} );
+
+	const form: Form = useMemo( () => {
+		return {
+			layout: getLayoutFromStoryArgs( {
+				type: 'panel',
+				labelPosition,
+				openAs,
+			} ),
+			fields: [
+				'title',
+				{
+					id: 'flight_info',
+					label: 'Flight Information',
+					children: [ 'origin', 'destination', 'flight_status', 'gate' ],
+					summary: [ 'origin', 'destination', 'flight_status' ],
+				},
+				{
+					id: 'passenger_details',
+					label: 'Passenger Details',
+					children: [ 'author', 'seat' ],
+					summary: [ 'author', 'seat' ],
+				},
+			],
+		};
+	}, [ labelPosition, openAs ] );
+
+	return (
+		<DataForm< SamplePost >
+			data={ post }
+			fields={ fields }
+			form={ form }
+			onChange={ ( edits ) =>
+				setPost( ( prev ) => ( {
+					...prev,
+					...edits,
+				} ) )
+			}
+		/>
+	);
+};
+
 const meta = {
 	title: 'DataViews/DataForm',
 	component: DataForm,
@@ -1392,4 +1490,24 @@ export const Validation = {
 
 export const Visibility = {
 	render: VisibilityComponent,
+};
+
+export const MultipleSummaryFields = {
+	render: MultipleSummaryPanelComponent,
+	argTypes: {
+		labelPosition: {
+			control: { type: 'select' },
+			description: 'Chooses the label position.',
+			options: [ 'default', 'top', 'side', 'none' ],
+		},
+		openAs: {
+			control: { type: 'select' },
+			description: 'Chooses how to open the panel.',
+			options: [ 'default', 'dropdown', 'modal' ],
+		},
+	},
+	args: {
+		labelPosition: 'side',
+		openAs: 'dropdown',
+	},
 };

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -393,6 +393,11 @@ const LayoutPanelComponent = ( {
 		city: 'New York',
 		comment_status: 'open',
 		ping_status: true,
+		origin: 'New York (JFK)',
+		destination: 'Los Angeles (LAX)',
+		flight_status: 'on-time',
+		gate: 'A12',
+		seat: '14F',
 	} );
 
 	const form: Form = useMemo( () => {
@@ -418,6 +423,23 @@ const LayoutPanelComponent = ( {
 					id: 'address1',
 					label: 'Combined Address',
 					children: [ 'address1', 'address2', 'city' ],
+				},
+				{
+					id: 'flight_info',
+					label: 'Flight Information',
+					children: [
+						'origin',
+						'destination',
+						'flight_status',
+						'gate',
+					],
+					summary: [ 'origin', 'destination', 'flight_status' ],
+				},
+				{
+					id: 'passenger_details',
+					label: 'Passenger Details',
+					children: [ 'author', 'seat' ],
+					summary: [ 'author', 'seat' ],
 				},
 				{
 					id: 'discussion',
@@ -1337,68 +1359,6 @@ const LayoutMixedComponent = () => {
 	);
 };
 
-const MultipleSummaryPanelComponent = ( {
-	labelPosition,
-	openAs,
-}: {
-	labelPosition: 'default' | 'top' | 'side' | 'none';
-	openAs: 'default' | 'dropdown' | 'modal';
-} ) => {
-	const [ post, setPost ] = useState< SamplePost >( {
-		title: 'Flight Booking',
-		order: 1,
-		author: 1,
-		status: 'confirmed',
-		reviewer: 'system',
-		date: '2024-03-15T10:30:00',
-		birthdate: '1985-06-15T00:00:00',
-		origin: 'New York (JFK)',
-		destination: 'Los Angeles (LAX)',
-		flight_status: 'on-time',
-		gate: 'A12',
-		seat: '14F',
-	} );
-
-	const form: Form = useMemo( () => {
-		return {
-			layout: getLayoutFromStoryArgs( {
-				type: 'panel',
-				labelPosition,
-				openAs,
-			} ),
-			fields: [
-				'title',
-				{
-					id: 'flight_info',
-					label: 'Flight Information',
-					children: [ 'origin', 'destination', 'flight_status', 'gate' ],
-					summary: [ 'origin', 'destination', 'flight_status' ],
-				},
-				{
-					id: 'passenger_details',
-					label: 'Passenger Details',
-					children: [ 'author', 'seat' ],
-					summary: [ 'author', 'seat' ],
-				},
-			],
-		};
-	}, [ labelPosition, openAs ] );
-
-	return (
-		<DataForm< SamplePost >
-			data={ post }
-			fields={ fields }
-			form={ form }
-			onChange={ ( edits ) =>
-				setPost( ( prev ) => ( {
-					...prev,
-					...edits,
-				} ) )
-			}
-		/>
-	);
-};
-
 const meta = {
 	title: 'DataViews/DataForm',
 	component: DataForm,
@@ -1489,24 +1449,4 @@ export const Validation = {
 
 export const Visibility = {
 	render: VisibilityComponent,
-};
-
-export const MultipleSummaryFields = {
-	render: MultipleSummaryPanelComponent,
-	argTypes: {
-		labelPosition: {
-			control: { type: 'select' },
-			description: 'Chooses the label position.',
-			options: [ 'default', 'top', 'side', 'none' ],
-		},
-		openAs: {
-			control: { type: 'select' },
-			description: 'Chooses how to open the panel.',
-			options: [ 'default', 'dropdown', 'modal' ],
-		},
-	},
-	args: {
-		labelPosition: 'side',
-		openAs: 'dropdown',
-	},
 };

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -205,7 +205,6 @@ const fields: Field< SamplePost >[] = [
 		id: 'ping_status',
 		label: 'Allow Pings/Trackbacks',
 		type: 'boolean',
-		Edit: 'checkbox',
 	},
 	{
 		id: 'discussion',

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -202,6 +202,25 @@ const fields: Field< SamplePost >[] = [
 		type: 'boolean',
 		Edit: 'checkbox',
 	},
+	{
+		id: 'discussion',
+		label: 'Discussion',
+		type: 'text',
+		render: ( { item } ) => {
+			const commentLabel =
+				item.comment_status === 'open'
+					? 'Allow comments'
+					: 'Comments closed';
+			const pingLabel = item.ping_status
+				? 'Pings enabled'
+				: 'Pings disabled';
+			return (
+				<span>
+					{ commentLabel }, { pingLabel }
+				</span>
+			);
+		},
+	},
 ];
 
 const LayoutRegularComponent = ( {
@@ -369,6 +388,7 @@ const LayoutPanelComponent = ( {
 					id: 'discussion',
 					label: 'Discussion',
 					children: [ 'comment_status', 'ping_status' ],
+					summary: 'discussion',
 				},
 			],
 		};

--- a/packages/dataviews/src/dataforms-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/dropdown.tsx
@@ -20,6 +20,7 @@ import type { Form, FormField, NormalizedField } from '../../types';
 import { DataFormLayout } from '../data-form-layout';
 import { isCombinedField } from '../is-combined-field';
 import { DEFAULT_LAYOUT } from '../../normalize-form-fields';
+import SummaryButton from './summary-button';
 
 function DropdownHeader( {
 	title,
@@ -126,38 +127,20 @@ function PanelDropdown< Item >( {
 					onClick={ onToggle }
 					disabled={ fieldDefinition.readOnly === true }
 					accessibleWhenDisabled
-					style={ summaryFields.length > 1 ? {
-						minHeight: 'auto',
-						height: 'auto',
-						alignItems: 'flex-start'
-					} : undefined }
+					style={
+						summaryFields.length > 1
+							? {
+									minHeight: 'auto',
+									height: 'auto',
+									alignItems: 'flex-start',
+							  }
+							: undefined
+					}
 				>
-					{ summaryFields.length > 1 ? (
-						<div style={ { 
-							display: 'flex', 
-							flexDirection: 'column', 
-							alignItems: 'flex-start',
-							width: '100%',
-							gap: '2px'
-						} }>
-							{ summaryFields.map( ( summaryField ) => (
-								<div key={ summaryField.id } style={ { width: '100%' } }>
-									<summaryField.render
-										item={ data }
-										field={ summaryField }
-									/>
-								</div>
-							) ) }
-						</div>
-					) : (
-						summaryFields.map( ( summaryField ) => (
-							<summaryField.render
-								key={ summaryField.id }
-								item={ data }
-								field={ summaryField }
-							/>
-						) )
-					) }
+					<SummaryButton
+						summaryFields={ summaryFields }
+						data={ data }
+					/>
 				</Button>
 			) }
 			renderContent={ ( { onClose } ) => (

--- a/packages/dataviews/src/dataforms-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/dropdown.tsx
@@ -55,6 +55,7 @@ function DropdownHeader( {
 
 function PanelDropdown< Item >( {
 	fieldDefinition,
+	summaryFields,
 	popoverAnchor,
 	labelPosition = 'side',
 	data,
@@ -62,6 +63,7 @@ function PanelDropdown< Item >( {
 	field,
 }: {
 	fieldDefinition: NormalizedField< Item >;
+	summaryFields: NormalizedField< Item >[];
 	popoverAnchor: HTMLElement | null;
 	labelPosition: 'side' | 'top' | 'none';
 	data: Item;
@@ -124,11 +126,38 @@ function PanelDropdown< Item >( {
 					onClick={ onToggle }
 					disabled={ fieldDefinition.readOnly === true }
 					accessibleWhenDisabled
+					style={ summaryFields.length > 1 ? {
+						minHeight: 'auto',
+						height: 'auto',
+						alignItems: 'flex-start'
+					} : undefined }
 				>
-					<fieldDefinition.render
-						item={ data }
-						field={ fieldDefinition }
-					/>
+					{ summaryFields.length > 1 ? (
+						<div style={ { 
+							display: 'flex', 
+							flexDirection: 'column', 
+							alignItems: 'flex-start',
+							width: '100%',
+							gap: '2px'
+						} }>
+							{ summaryFields.map( ( summaryField ) => (
+								<div key={ summaryField.id } style={ { width: '100%' } }>
+									<summaryField.render
+										item={ data }
+										field={ summaryField }
+									/>
+								</div>
+							) ) }
+						</div>
+					) : (
+						summaryFields.map( ( summaryField ) => (
+							<summaryField.render
+								key={ summaryField.id }
+								item={ data }
+								field={ summaryField }
+							/>
+						) )
+					) }
 				</Button>
 			) }
 			renderContent={ ( { onClose } ) => (

--- a/packages/dataviews/src/dataforms-layouts/panel/dropdown.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/dropdown.tsx
@@ -9,7 +9,7 @@ import {
 	Dropdown,
 	Button,
 } from '@wordpress/components';
-import { sprintf, __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
 
@@ -110,38 +110,15 @@ function PanelDropdown< Item >( {
 				tooltipPosition: 'middle left',
 			} }
 			renderToggle={ ( { isOpen, onToggle } ) => (
-				<Button
-					className="dataforms-layouts-panel__field-control"
-					size="compact"
-					variant={
-						[ 'none', 'top' ].includes( labelPosition )
-							? 'link'
-							: 'tertiary'
-					}
-					aria-expanded={ isOpen }
-					aria-label={ sprintf(
-						// translators: %s: Field name.
-						_x( 'Edit %s', 'field' ),
-						fieldLabel || ''
-					) }
-					onClick={ onToggle }
+				<SummaryButton
+					summaryFields={ summaryFields }
+					data={ data }
+					labelPosition={ labelPosition }
+					fieldLabel={ fieldLabel }
 					disabled={ fieldDefinition.readOnly === true }
-					accessibleWhenDisabled
-					style={
-						summaryFields.length > 1
-							? {
-									minHeight: 'auto',
-									height: 'auto',
-									alignItems: 'flex-start',
-							  }
-							: undefined
-					}
-				>
-					<SummaryButton
-						summaryFields={ summaryFields }
-						data={ data }
-					/>
-				</Button>
+					onClick={ onToggle }
+					aria-expanded={ isOpen }
+				/>
 			) }
 			renderContent={ ( { onClose } ) => (
 				<>

--- a/packages/dataviews/src/dataforms-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/index.tsx
@@ -32,32 +32,43 @@ export default function FormPanelField< Item >( {
 	onChange,
 }: FieldLayoutProps< Item > ) {
 	const { fields } = useContext( DataFormContext );
-	const fieldDefinition = fields.find( ( _field ) => {
-		// Use summary field if specified for combined fields, otherwise default to the first simple child.
-		if ( isCombinedField( field ) ) {
-			if ( field.summary ) {
-				return _field.id === field.summary;
-			}
-
-			const simpleChildren = field.children.filter(
-				( child ): child is string | SimpleFormField =>
-					typeof child === 'string' || ! isCombinedField( child )
-			);
-
-			if ( simpleChildren.length === 0 ) {
-				return false;
-			}
-
-			const firstChildFieldId =
-				typeof simpleChildren[ 0 ] === 'string'
-					? simpleChildren[ 0 ]
-					: simpleChildren[ 0 ].id;
-
-			return _field.id === firstChildFieldId;
+	const getSummaryFields = () => {
+		if ( ! isCombinedField( field ) ) {
+			const fieldDef = fields.find( ( _field ) => _field.id === field.id );
+			return fieldDef ? [ fieldDef ] : [];
 		}
 
-		return _field.id === field.id;
-	} );
+		// Use summary field(s) if specified for combined fields
+		if ( field.summary ) {
+			const summaryIds = Array.isArray( field.summary ) 
+				? field.summary 
+				: [ field.summary ];
+			return summaryIds
+				.map( summaryId => fields.find( _field => _field.id === summaryId ) )
+				.filter( Boolean );
+		}
+
+		// Default to the first simple child
+		const simpleChildren = field.children.filter(
+			( child ): child is string | SimpleFormField =>
+				typeof child === 'string' || ! isCombinedField( child )
+		);
+
+		if ( simpleChildren.length === 0 ) {
+			return [];
+		}
+
+		const firstChildFieldId =
+			typeof simpleChildren[ 0 ] === 'string'
+				? simpleChildren[ 0 ]
+				: simpleChildren[ 0 ].id;
+
+		const fieldDef = fields.find( _field => _field.id === firstChildFieldId );
+		return fieldDef ? [ fieldDef ] : [];
+	};
+
+	const summaryFields = getSummaryFields();
+	const fieldDefinition = summaryFields[ 0 ]; // For backward compatibility
 
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
@@ -88,6 +99,7 @@ export default function FormPanelField< Item >( {
 			<PanelModal
 				field={ field }
 				fieldDefinition={ fieldDefinition }
+				summaryFields={ summaryFields }
 				data={ data }
 				onChange={ onChange }
 				labelPosition={ labelPosition }
@@ -97,6 +109,7 @@ export default function FormPanelField< Item >( {
 				field={ field }
 				popoverAnchor={ popoverAnchor }
 				fieldDefinition={ fieldDefinition }
+				summaryFields={ summaryFields }
 				data={ data }
 				onChange={ onChange }
 				labelPosition={ labelPosition }

--- a/packages/dataviews/src/dataforms-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/index.tsx
@@ -45,7 +45,7 @@ export default function FormPanelField< Item >( {
 				: [ field.summary ];
 			return summaryIds
 				.map( summaryId => fields.find( _field => _field.id === summaryId ) )
-				.filter( Boolean );
+				.filter( field => field !== undefined );
 		}
 
 		// Default to the first simple child

--- a/packages/dataviews/src/dataforms-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/index.tsx
@@ -34,18 +34,22 @@ export default function FormPanelField< Item >( {
 	const { fields } = useContext( DataFormContext );
 	const getSummaryFields = () => {
 		if ( ! isCombinedField( field ) ) {
-			const fieldDef = fields.find( ( _field ) => _field.id === field.id );
+			const fieldDef = fields.find(
+				( _field ) => _field.id === field.id
+			);
 			return fieldDef ? [ fieldDef ] : [];
 		}
 
 		// Use summary field(s) if specified for combined fields
 		if ( field.summary ) {
-			const summaryIds = Array.isArray( field.summary ) 
-				? field.summary 
+			const summaryIds = Array.isArray( field.summary )
+				? field.summary
 				: [ field.summary ];
 			return summaryIds
-				.map( summaryId => fields.find( _field => _field.id === summaryId ) )
-				.filter( field => field !== undefined );
+				.map( ( summaryId ) =>
+					fields.find( ( _field ) => _field.id === summaryId )
+				)
+				.filter( ( field ) => field !== undefined );
 		}
 
 		// Default to the first simple child
@@ -63,7 +67,9 @@ export default function FormPanelField< Item >( {
 				? simpleChildren[ 0 ]
 				: simpleChildren[ 0 ].id;
 
-		const fieldDef = fields.find( _field => _field.id === firstChildFieldId );
+		const fieldDef = fields.find(
+			( _field ) => _field.id === firstChildFieldId
+		);
 		return fieldDef ? [ fieldDef ] : [];
 	};
 

--- a/packages/dataviews/src/dataforms-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/index.tsx
@@ -33,8 +33,12 @@ export default function FormPanelField< Item >( {
 }: FieldLayoutProps< Item > ) {
 	const { fields } = useContext( DataFormContext );
 	const fieldDefinition = fields.find( ( _field ) => {
-		// Default to the first simple child if it is a combined field.
+		// Use summary field if specified for combined fields, otherwise default to the first simple child.
 		if ( isCombinedField( field ) ) {
+			if ( field.summary ) {
+				return _field.id === field.summary;
+			}
+
 			const simpleChildren = field.children.filter(
 				( child ): child is string | SimpleFormField =>
 					typeof child === 'string' || ! isCombinedField( child )

--- a/packages/dataviews/src/dataforms-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/index.tsx
@@ -49,7 +49,7 @@ export default function FormPanelField< Item >( {
 				.map( ( summaryId ) =>
 					fields.find( ( _field ) => _field.id === summaryId )
 				)
-				.filter( ( field ) => field !== undefined );
+				.filter( ( _field ) => _field !== undefined );
 		}
 
 		// Default to the first simple child

--- a/packages/dataviews/src/dataforms-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/modal.tsx
@@ -7,7 +7,7 @@ import {
 	Button,
 	Modal,
 } from '@wordpress/components';
-import { __, sprintf, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useState, useMemo } from '@wordpress/element';
 
 /**
@@ -129,35 +129,15 @@ function PanelModal< Item >( {
 
 	return (
 		<>
-			<Button
-				className="dataforms-layouts-modal__field-control"
-				size="compact"
-				variant={
-					[ 'none', 'top' ].includes( labelPosition )
-						? 'link'
-						: 'tertiary'
-				}
-				aria-expanded={ isOpen }
-				aria-label={ sprintf(
-					// translators: %s: Field name.
-					_x( 'Edit %s', 'field' ),
-					fieldLabel || ''
-				) }
-				onClick={ () => setIsOpen( true ) }
+			<SummaryButton
+				summaryFields={ summaryFields }
+				data={ data }
+				labelPosition={ labelPosition }
+				fieldLabel={ fieldLabel }
 				disabled={ fieldDefinition.readOnly === true }
-				accessibleWhenDisabled
-				style={
-					summaryFields.length > 1
-						? {
-								minHeight: 'auto',
-								height: 'auto',
-								alignItems: 'flex-start',
-						  }
-						: undefined
-				}
-			>
-				<SummaryButton summaryFields={ summaryFields } data={ data } />
-			</Button>
+				onClick={ () => setIsOpen( true ) }
+				aria-expanded={ isOpen }
+			/>
 			{ isOpen && (
 				<ModalContent
 					data={ data }

--- a/packages/dataviews/src/dataforms-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/modal.tsx
@@ -96,12 +96,14 @@ function ModalContent< Item >( {
 
 function PanelModal< Item >( {
 	fieldDefinition,
+	summaryFields,
 	labelPosition,
 	data,
 	onChange,
 	field,
 }: {
 	fieldDefinition: NormalizedField< Item >;
+	summaryFields: NormalizedField< Item >[];
 	labelPosition: 'side' | 'top' | 'none';
 	data: Item;
 	onChange: ( value: any ) => void;
@@ -143,11 +145,38 @@ function PanelModal< Item >( {
 				onClick={ () => setIsOpen( true ) }
 				disabled={ fieldDefinition.readOnly === true }
 				accessibleWhenDisabled
+				style={ summaryFields.length > 1 ? {
+					minHeight: 'auto',
+					height: 'auto',
+					alignItems: 'flex-start'
+				} : undefined }
 			>
-				<fieldDefinition.render
-					item={ data }
-					field={ fieldDefinition }
-				/>
+				{ summaryFields.length > 1 ? (
+					<div style={ { 
+						display: 'flex', 
+						flexDirection: 'column', 
+						alignItems: 'flex-start',
+						width: '100%',
+						gap: '2px'
+					} }>
+						{ summaryFields.map( ( summaryField ) => (
+							<div key={ summaryField.id } style={ { width: '100%' } }>
+								<summaryField.render
+									item={ data }
+									field={ summaryField }
+								/>
+							</div>
+						) ) }
+					</div>
+				) : (
+					summaryFields.map( ( summaryField ) => (
+						<summaryField.render
+							key={ summaryField.id }
+							item={ data }
+							field={ summaryField }
+						/>
+					) )
+				) }
 			</Button>
 			{ isOpen && (
 				<ModalContent

--- a/packages/dataviews/src/dataforms-layouts/panel/modal.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/modal.tsx
@@ -17,6 +17,7 @@ import type { Form, FormField, NormalizedField } from '../../types';
 import { DataFormLayout } from '../data-form-layout';
 import { isCombinedField } from '../is-combined-field';
 import { DEFAULT_LAYOUT } from '../../normalize-form-fields';
+import SummaryButton from './summary-button';
 
 function ModalContent< Item >( {
 	data,
@@ -145,38 +146,17 @@ function PanelModal< Item >( {
 				onClick={ () => setIsOpen( true ) }
 				disabled={ fieldDefinition.readOnly === true }
 				accessibleWhenDisabled
-				style={ summaryFields.length > 1 ? {
-					minHeight: 'auto',
-					height: 'auto',
-					alignItems: 'flex-start'
-				} : undefined }
+				style={
+					summaryFields.length > 1
+						? {
+								minHeight: 'auto',
+								height: 'auto',
+								alignItems: 'flex-start',
+						  }
+						: undefined
+				}
 			>
-				{ summaryFields.length > 1 ? (
-					<div style={ { 
-						display: 'flex', 
-						flexDirection: 'column', 
-						alignItems: 'flex-start',
-						width: '100%',
-						gap: '2px'
-					} }>
-						{ summaryFields.map( ( summaryField ) => (
-							<div key={ summaryField.id } style={ { width: '100%' } }>
-								<summaryField.render
-									item={ data }
-									field={ summaryField }
-								/>
-							</div>
-						) ) }
-					</div>
-				) : (
-					summaryFields.map( ( summaryField ) => (
-						<summaryField.render
-							key={ summaryField.id }
-							item={ data }
-							field={ summaryField }
-						/>
-					) )
-				) }
+				<SummaryButton summaryFields={ summaryFields } data={ data } />
 			</Button>
 			{ isOpen && (
 				<ModalContent

--- a/packages/dataviews/src/dataforms-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/summary-button.tsx
@@ -1,4 +1,10 @@
 /**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { sprintf, _x } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import type { NormalizedField } from '../../types';
@@ -6,34 +12,80 @@ import type { NormalizedField } from '../../types';
 function SummaryButton< Item >( {
 	summaryFields,
 	data,
+	labelPosition,
+	fieldLabel,
+	disabled,
+	onClick,
+	'aria-expanded': ariaExpanded,
 }: {
 	summaryFields: NormalizedField< Item >[];
 	data: Item;
+	labelPosition: 'side' | 'top' | 'none';
+	fieldLabel?: string;
+	disabled?: boolean;
+	onClick: () => void;
+	'aria-expanded'?: boolean;
 } ) {
-	return summaryFields.length > 1 ? (
-		<div
-			style={ {
-				display: 'flex',
-				flexDirection: 'column',
-				alignItems: 'flex-start',
-				width: '100%',
-				gap: '2px',
-			} }
+	return (
+		<Button
+			className="dataforms-layouts-panel__summary-button"
+			size="compact"
+			variant={
+				[ 'none', 'top' ].includes( labelPosition )
+					? 'link'
+					: 'tertiary'
+			}
+			aria-expanded={ ariaExpanded }
+			aria-label={ sprintf(
+				// translators: %s: Field name.
+				_x( 'Edit %s', 'field' ),
+				fieldLabel || ''
+			) }
+			onClick={ onClick }
+			disabled={ disabled }
+			accessibleWhenDisabled
+			style={
+				summaryFields.length > 1
+					? {
+							minHeight: 'auto',
+							height: 'auto',
+							alignItems: 'flex-start',
+					  }
+					: undefined
+			}
 		>
-			{ summaryFields.map( ( summaryField ) => (
-				<div key={ summaryField.id } style={ { width: '100%' } }>
-					<summaryField.render item={ data } field={ summaryField } />
+			{ summaryFields.length > 1 ? (
+				<div
+					style={ {
+						display: 'flex',
+						flexDirection: 'column',
+						alignItems: 'flex-start',
+						width: '100%',
+						gap: '2px',
+					} }
+				>
+					{ summaryFields.map( ( summaryField ) => (
+						<div
+							key={ summaryField.id }
+							style={ { width: '100%' } }
+						>
+							<summaryField.render
+								item={ data }
+								field={ summaryField }
+							/>
+						</div>
+					) ) }
 				</div>
-			) ) }
-		</div>
-	) : (
-		summaryFields.map( ( summaryField ) => (
-			<summaryField.render
-				key={ summaryField.id }
-				item={ data }
-				field={ summaryField }
-			/>
-		) )
+			) : (
+				summaryFields.map( ( summaryField ) => (
+					<summaryField.render
+						key={ summaryField.id }
+						item={ data }
+						field={ summaryField }
+					/>
+				) )
+			) }
+		</Button>
 	);
 }
 

--- a/packages/dataviews/src/dataforms-layouts/panel/summary-button.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/summary-button.tsx
@@ -1,0 +1,40 @@
+/**
+ * Internal dependencies
+ */
+import type { NormalizedField } from '../../types';
+
+function SummaryButton< Item >( {
+	summaryFields,
+	data,
+}: {
+	summaryFields: NormalizedField< Item >[];
+	data: Item;
+} ) {
+	return summaryFields.length > 1 ? (
+		<div
+			style={ {
+				display: 'flex',
+				flexDirection: 'column',
+				alignItems: 'flex-start',
+				width: '100%',
+				gap: '2px',
+			} }
+		>
+			{ summaryFields.map( ( summaryField ) => (
+				<div key={ summaryField.id } style={ { width: '100%' } }>
+					<summaryField.render item={ data } field={ summaryField } />
+				</div>
+			) ) }
+		</div>
+	) : (
+		summaryFields.map( ( summaryField ) => (
+			<summaryField.render
+				key={ summaryField.id }
+				item={ data }
+				field={ summaryField }
+			/>
+		) )
+	);
+}
+
+export default SummaryButton;

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -847,6 +847,7 @@ export type CombinedFormField = {
 	description?: string;
 	layout?: Layout;
 	children: Array< FormField | string >;
+	summary?: string;
 };
 
 export type FormField = SimpleFormField | CombinedFormField;

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -847,7 +847,7 @@ export type CombinedFormField = {
 	description?: string;
 	layout?: Layout;
 	children: Array< FormField | string >;
-	summary?: string;
+	summary?: string | string[];
 };
 
 export type FormField = SimpleFormField | CombinedFormField;


### PR DESCRIPTION
This PR adds support for custom summary rendering in composed DataForm fields through an optional `summary` property. Previously, composed fields would always display the first child field's value as the summary. Now, developers can specify which field's render method should be used for the summary display.

## Problem

When using composed fields (fields with children), the panel layout would always use the first simple child field to display the summary value. This limitation prevented meaningful summaries for complex composed fields where a custom rendering logic would be more appropriate.

For example, a "Discussion" field containing both comment status and ping status would only show the comment status, missing the complete picture.

## Solution

### Type Changes

- Extended `CombinedFormField` type with optional `summary?: string` property
- The summary property references a field ID whose render method will be used for display

### Implementation

- Modified panel field resolution logic in `dataforms-layouts/panel/index.tsx`
- When a composed field has a `summary` property, the system looks for that field definition instead of defaulting to the first child
- Maintains backward compatibility - existing composed fields continue to work unchanged

### Usage Example

```typescript
// Field definition with custom render
{
  id: 'discussion',
  label: 'Discussion',
  type: 'text',
  render: ({ item }) => {
    const commentLabel = item.comment_status === 'open' 
      ? 'Allow comments' 
      : 'Comments closed';
    const pingLabel = item.ping_status 
      ? 'Pings enabled' 
      : 'Pings disabled';
    return <span>{commentLabel}, {pingLabel}</span>;
  },
}

// Composed field using custom summary
{
  id: 'discussion',
  label: 'Discussion', 
  children: ['comment_status', 'ping_status'],
  summary: 'discussion', // References the field above
}
```

## Benefits

- **Enhanced UX**: Composed fields can now show meaningful, context-aware summaries
- **Flexible**: Any field's render method can be used for summary display
- **Backward Compatible**: No breaking changes to existing implementations

## Testing

Go to http://localhost:50240/?path=/story/dataviews-dataform--layout-panel and verify the Discussion field works as expected.