### PR TITLE
Modify the "Term Description" block to add a fallback that displays the author description if the archive is in the author template (via an is_author condition).

### DIFF
--- a/packages/block-library/src/term-description/block.json
+++ b/packages/block-library/src/term-description/block.json
@@ -4,7 +4,7 @@
 	"name": "core/term-description",
 	"title": "Term Description",
 	"category": "theme",
-	"description": "Display the description of categories, tags and custom taxonomies when viewing an archive.",
+	"description": "Display the description of categories, tags and custom taxonomies when viewing a taxonomy term archive. Display author description only for author archive.",
 	"textdomain": "default",
 	"attributes": {
 		"textAlign": {

--- a/packages/block-library/src/term-description/index.php
+++ b/packages/block-library/src/term-description/index.php
@@ -21,6 +21,10 @@ function render_block_core_term_description( $attributes ) {
 		$term_description = term_description();
 	}
 
+	if ( is_author() ) {
+		$term_description = get_the_author_meta( 'description' );
+	}
+
 	if ( empty( $term_description ) ) {
 		return '';
 	}


### PR DESCRIPTION
Closes : #71612

