### PR TITLE
[WIP] Align comments with their related block (when comment sidebar is not pinned)

### DIFF
--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -1,8 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { useMemo, useContext } from '@wordpress/element';
+import { useMemo, useContext, useRef } from '@wordpress/element';
 import { hasBlockSupport } from '@wordpress/blocks';
+import {
+	Popover,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -19,6 +22,7 @@ import {
 } from './context';
 import { MultipleUsageWarning } from './multiple-usage-warning';
 import { PrivateBlockContext } from '../block-list/private-block-context';
+
 
 /**
  * The `useBlockEditContext` hook provides information about the block this hook is being used in.
@@ -39,6 +43,7 @@ export default function BlockEdit( {
 	// public API!
 	...props
 } ) {
+
 	const {
 		name,
 		isSelected,
@@ -46,12 +51,18 @@ export default function BlockEdit( {
 		attributes = {},
 		__unstableLayoutClassNames,
 	} = props;
+
 	const { layout = null, metadata = {} } = attributes;
 	const { bindings } = metadata;
 	const layoutSupport =
 		hasBlockSupport( name, 'layout', false ) ||
 		hasBlockSupport( name, '__experimentalLayout', false );
 	const { originalBlockClientId } = useContext( PrivateBlockContext );
+
+	const blockCommentId = props.attributes?.blockCommentId;
+
+	const ref = useRef( 'comment-anchor-' + blockCommentId );
+	props.attributes.commentPopoverRef = ref;
 
 	return (
 		<BlockEditContextProvider
@@ -88,6 +99,12 @@ export default function BlockEdit( {
 				]
 			) }
 		>
+			{ blockCommentId && (
+				<Popover.Slot
+					name={ 'block-comment-popover-slot-' + blockCommentId }
+					ref={ ref }
+				/>
+			) }
 			<Edit { ...props } />
 			{ originalBlockClientId && (
 				<MultipleUsageWarning

--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -1,11 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { useMemo, useContext, useRef } from '@wordpress/element';
+import { useMemo, useContext, useRef, useEffect } from '@wordpress/element';
 import { hasBlockSupport } from '@wordpress/blocks';
-import {
-	Popover,
-} from '@wordpress/components';
+import { Popover } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -22,7 +20,6 @@ import {
 } from './context';
 import { MultipleUsageWarning } from './multiple-usage-warning';
 import { PrivateBlockContext } from '../block-list/private-block-context';
-
 
 /**
  * The `useBlockEditContext` hook provides information about the block this hook is being used in.
@@ -43,7 +40,6 @@ export default function BlockEdit( {
 	// public API!
 	...props
 } ) {
-
 	const {
 		name,
 		isSelected,
@@ -60,9 +56,15 @@ export default function BlockEdit( {
 	const { originalBlockClientId } = useContext( PrivateBlockContext );
 
 	const blockCommentId = props.attributes?.blockCommentId;
+	const { setAttributes } = props;
 
 	const ref = useRef( 'comment-anchor-' + blockCommentId );
-	props.attributes.commentPopoverRef = ref;
+
+	useEffect( () => {
+		if ( blockCommentId && ref && setAttributes ) {
+			setAttributes( { commentPopoverRef: ref } );
+		}
+	}, [ blockCommentId, ref, setAttributes ] );
 
 	return (
 		<BlockEditContextProvider

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -13,11 +13,13 @@ import {
 	__experimentalConfirmDialog as ConfirmDialog,
 	Button,
 	DropdownMenu,
+	Popover,
 } from '@wordpress/components';
 import { published, moreVertical } from '@wordpress/icons';
 import { __, _x, _n, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -37,6 +39,7 @@ import CommentForm from './comment-form';
  * @param {Function} props.onCommentReopen     - The function to reopen a resolved comment.
  * @param {boolean}  props.showCommentBoard    - Whether to show the comment board.
  * @param {Function} props.setShowCommentBoard - The function to set the comment board visibility.
+ * @param {boolean}  props.inPopover           - Whether to show comments in a popover.
  * @return {React.ReactNode} The rendered Comments component.
  */
 export function Comments( {
@@ -48,15 +51,19 @@ export function Comments( {
 	onCommentReopen,
 	showCommentBoard,
 	setShowCommentBoard,
+	inPopover,
 } ) {
-	const { blockCommentId } = useSelect( ( select ) => {
+	const { blockCommentId, commentPopoverRef } = useSelect( ( select ) => {
 		const { getBlockAttributes, getSelectedBlockClientId } =
 			select( blockEditorStore );
 		const _clientId = getSelectedBlockClientId();
-
+		console.log( getBlockAttributes( _clientId ) );
 		return {
 			blockCommentId: _clientId
 				? getBlockAttributes( _clientId )?.blockCommentId
+				: null,
+			commentPopoverRef: _clientId
+				? getBlockAttributes( _clientId )?.commentPopoverRef
 				: null,
 		};
 	}, [] );
@@ -69,6 +76,8 @@ export function Comments( {
 		setFocusThread( null );
 		setShowCommentBoard( false );
 	};
+
+	console.log( 'commentPopoverRef: ', commentPopoverRef );
 
 	return (
 		<>
@@ -91,6 +100,43 @@ export function Comments( {
 			{ Array.isArray( threads ) &&
 				threads.length > 0 &&
 				threads.map( ( thread ) => (
+					inPopover ?
+					<Popover
+						key={ thread.id }
+						anchor={ commentPopoverRef ? commentPopoverRef.current : null }
+						placement="bottom-end"
+					>
+						<VStack
+							key={ thread.id }
+							className={ clsx(
+								'editor-collab-sidebar-panel__thread',
+								{
+									'editor-collab-sidebar-panel__active-thread':
+										blockCommentId &&
+										blockCommentId === thread.id,
+									'editor-collab-sidebar-panel__focus-thread':
+										focusThread && focusThread === thread.id,
+								}
+							) }
+							id={ thread.id }
+							spacing="3"
+							onClick={ () => setFocusThread( thread.id ) }
+						>
+							<Thread
+								thread={ thread }
+								onAddReply={ onAddReply }
+								onCommentDelete={ onCommentDelete }
+								onCommentResolve={ onCommentResolve }
+								onCommentReopen={ onCommentReopen }
+								onEditComment={ onEditComment }
+								isFocused={ focusThread === thread.id }
+								clearThreadFocus={ clearThreadFocus }
+								setFocusThread={ setFocusThread }
+							/>
+							<div>comment {thread.id}</div> &&
+
+						</VStack>
+					</Popover> :
 					<VStack
 						key={ thread.id }
 						className={ clsx(
@@ -119,6 +165,7 @@ export function Comments( {
 							setFocusThread={ setFocusThread }
 						/>
 					</VStack>
+
 				) ) }
 		</>
 	);

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -134,6 +134,10 @@ export function Comments( {
 							key={ comment.blockCommentId }
 							placement="bottom-end"
 							anchor={ comment.commentPopoverRef.current }
+							className="editor-collab-sidebar-panel__comment-popover"
+							resize={ false }
+							shift={ false }
+							focusOnMount={ false }
 						>
 							<VStack
 								key={ comment.blockCommentId }

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -19,7 +19,6 @@ import { published, moreVertical } from '@wordpress/icons';
 import { __, _x, _n, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -30,16 +29,17 @@ import CommentForm from './comment-form';
 /**
  * Renders the Comments component.
  *
- * @param {Object}   props                     - The component props.
- * @param {Array}    props.threads             - The array of comment threads.
- * @param {Function} props.onEditComment       - The function to handle comment editing.
- * @param {Function} props.onAddReply          - The function to add a reply to a comment.
- * @param {Function} props.onCommentDelete     - The function to delete a comment.
- * @param {Function} props.onCommentResolve    - The function to mark a comment as resolved.
- * @param {Function} props.onCommentReopen     - The function to reopen a resolved comment.
- * @param {boolean}  props.showCommentBoard    - Whether to show the comment board.
- * @param {Function} props.setShowCommentBoard - The function to set the comment board visibility.
- * @param {boolean}  props.inPopover           - Whether to show comments in a popover.
+ * @param {Object}   props                       - The component props.
+ * @param {Array}    props.threads               - The array of comment threads.
+ * @param {Function} props.onEditComment         - The function to handle comment editing.
+ * @param {Function} props.onAddReply            - The function to add a reply to a comment.
+ * @param {Function} props.onCommentDelete       - The function to delete a comment.
+ * @param {Function} props.onCommentResolve      - The function to mark a comment as resolved.
+ * @param {Function} props.onCommentReopen       - The function to reopen a resolved comment.
+ * @param {boolean}  props.showCommentBoard      - Whether to show the comment board.
+ * @param {Function} props.setShowCommentBoard   - The function to set the comment board visibility.
+ * @param {boolean}  props.inPopover             - Whether to show comments in a popover.
+ * @param {Array}    props.commentToBlockMapping - Mapping of comment IDs to block references.
  * @return {React.ReactNode} The rendered Comments component.
  */
 export function Comments( {
@@ -52,18 +52,15 @@ export function Comments( {
 	showCommentBoard,
 	setShowCommentBoard,
 	inPopover,
+	commentToBlockMapping,
 } ) {
-	const { blockCommentId, commentPopoverRef } = useSelect( ( select ) => {
+	const { blockCommentId } = useSelect( ( select ) => {
 		const { getBlockAttributes, getSelectedBlockClientId } =
 			select( blockEditorStore );
 		const _clientId = getSelectedBlockClientId();
-		console.log( getBlockAttributes( _clientId ) );
 		return {
 			blockCommentId: _clientId
 				? getBlockAttributes( _clientId )?.blockCommentId
-				: null,
-			commentPopoverRef: _clientId
-				? getBlockAttributes( _clientId )?.commentPopoverRef
 				: null,
 		};
 	}, [] );
@@ -76,8 +73,6 @@ export function Comments( {
 		setFocusThread( null );
 		setShowCommentBoard( false );
 	};
-
-	console.log( 'commentPopoverRef: ', commentPopoverRef );
 
 	return (
 		<>
@@ -97,46 +92,10 @@ export function Comments( {
 					</VStack>
 				)
 			}
-			{ Array.isArray( threads ) &&
+			{ ! inPopover &&
+				Array.isArray( threads ) &&
 				threads.length > 0 &&
 				threads.map( ( thread ) => (
-					inPopover ?
-					<Popover
-						key={ thread.id }
-						anchor={ commentPopoverRef ? commentPopoverRef.current : null }
-						placement="bottom-end"
-					>
-						<VStack
-							key={ thread.id }
-							className={ clsx(
-								'editor-collab-sidebar-panel__thread',
-								{
-									'editor-collab-sidebar-panel__active-thread':
-										blockCommentId &&
-										blockCommentId === thread.id,
-									'editor-collab-sidebar-panel__focus-thread':
-										focusThread && focusThread === thread.id,
-								}
-							) }
-							id={ thread.id }
-							spacing="3"
-							onClick={ () => setFocusThread( thread.id ) }
-						>
-							<Thread
-								thread={ thread }
-								onAddReply={ onAddReply }
-								onCommentDelete={ onCommentDelete }
-								onCommentResolve={ onCommentResolve }
-								onCommentReopen={ onCommentReopen }
-								onEditComment={ onEditComment }
-								isFocused={ focusThread === thread.id }
-								clearThreadFocus={ clearThreadFocus }
-								setFocusThread={ setFocusThread }
-							/>
-							<div>comment {thread.id}</div> &&
-
-						</VStack>
-					</Popover> :
 					<VStack
 						key={ thread.id }
 						className={ clsx(
@@ -165,8 +124,58 @@ export function Comments( {
 							setFocusThread={ setFocusThread }
 						/>
 					</VStack>
-
 				) ) }
+			{ inPopover &&
+				commentToBlockMapping &&
+				commentToBlockMapping.length > 0 &&
+				commentToBlockMapping.map( ( comment ) => {
+					return (
+						<Popover
+							key={ comment.blockCommentId }
+							placement="bottom-end"
+							anchor={ comment.commentPopoverRef.current }
+						>
+							<VStack
+								key={ comment.blockCommentId }
+								className={ clsx(
+									'editor-collab-sidebar-panel__thread',
+									{
+										'editor-collab-sidebar-panel__active-thread':
+											blockCommentId &&
+											blockCommentId ===
+												comment.blockCommentId,
+										'editor-collab-sidebar-panel__focus-thread':
+											focusThread &&
+											focusThread ===
+												comment.blockCommentId,
+									}
+								) }
+								id={ comment.blockCommentId }
+								spacing="3"
+								onClick={ () =>
+									setFocusThread( comment.blockCommentId )
+								}
+							>
+								<Thread
+									thread={ threads.find(
+										( thread ) =>
+											thread.id === comment.blockCommentId
+									) }
+									onAddReply={ onAddReply }
+									onCommentDelete={ onCommentDelete }
+									onCommentResolve={ onCommentResolve }
+									onCommentReopen={ onCommentReopen }
+									onEditComment={ onEditComment }
+									isFocused={
+										focusThread === comment.blockCommentId
+									}
+									clearThreadFocus={ clearThreadFocus }
+									setFocusThread={ setFocusThread }
+								/>
+							</VStack>
+						</Popover>
+					);
+				} ) }
 		</>
 	);
 }

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -399,6 +399,7 @@ export default function CollabSidebar() {
 					styles={ {
 						backgroundColor,
 					} }
+					showCommentsinPopover
 				/>
 			</PluginSidebar>
 		</>

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -58,7 +58,6 @@ function CollabSidebarContent( {
 	setShowCommentBoard,
 	styles,
 	comments,
-	showCommentsinPopover,
 } ) {
 	const { createNotice } = useDispatch( noticesStore );
 	const { saveEntityRecord, deleteEntityRecord } = useDispatch( coreStore );
@@ -227,7 +226,6 @@ function CollabSidebarContent( {
 				onCommentReopen={ onCommentReopen }
 				showCommentBoard={ showCommentBoard }
 				setShowCommentBoard={ setShowCommentBoard }
-				showCommentsinPopover = { showCommentsinPopover }
 			/>
 		</div>
 	);
@@ -379,7 +377,6 @@ export default function CollabSidebar() {
 				// translators: Comments sidebar title
 				title={ __( 'Comments' ) }
 				icon={ commentIcon }
-				closeLabel={ __( 'Close comments panel' ) }
 			>
 				<CollabSidebarContent
 					comments={ resultComments }
@@ -401,7 +398,6 @@ export default function CollabSidebar() {
 					styles={ {
 						backgroundColor,
 					} }
-					showCommentsinPopover = { true }
 				/>
 			</PluginSidebar>
 		</>

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -377,6 +377,7 @@ export default function CollabSidebar() {
 				// translators: Comments sidebar title
 				title={ __( 'Comments' ) }
 				icon={ commentIcon }
+				closeLabel={ __( 'Close comments panel' ) }
 			>
 				<CollabSidebarContent
 					comments={ resultComments }

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -58,6 +58,7 @@ function CollabSidebarContent( {
 	setShowCommentBoard,
 	styles,
 	comments,
+	inPopover,
 } ) {
 	const { createNotice } = useDispatch( noticesStore );
 	const { saveEntityRecord, deleteEntityRecord } = useDispatch( coreStore );
@@ -226,6 +227,7 @@ function CollabSidebarContent( {
 				onCommentReopen={ onCommentReopen }
 				showCommentBoard={ showCommentBoard }
 				setShowCommentBoard={ setShowCommentBoard }
+				inPopover={ inPopover }
 			/>
 		</div>
 	);
@@ -398,6 +400,7 @@ export default function CollabSidebar() {
 					styles={ {
 						backgroundColor,
 					} }
+					inPopover
 				/>
 			</PluginSidebar>
 		</>

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -58,6 +58,7 @@ function CollabSidebarContent( {
 	setShowCommentBoard,
 	styles,
 	comments,
+	showCommentsinPopover,
 } ) {
 	const { createNotice } = useDispatch( noticesStore );
 	const { saveEntityRecord, deleteEntityRecord } = useDispatch( coreStore );
@@ -226,6 +227,7 @@ function CollabSidebarContent( {
 				onCommentReopen={ onCommentReopen }
 				showCommentBoard={ showCommentBoard }
 				setShowCommentBoard={ setShowCommentBoard }
+				showCommentsinPopover = { showCommentsinPopover }
 			/>
 		</div>
 	);
@@ -399,7 +401,7 @@ export default function CollabSidebar() {
 					styles={ {
 						backgroundColor,
 					} }
-					showCommentsinPopover
+					showCommentsinPopover = { true }
 				/>
 			</PluginSidebar>
 		</>

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -31,7 +31,7 @@ import { store as editorStore } from '../../store';
 import AddCommentButton from './comment-button';
 import CommentAvatarIndicator from './comment-indicator-toolbar';
 import { useGlobalStylesContext } from '../global-styles-provider';
-import { getCommentIdsFromBlocks } from './utils';
+import { getCommentIdsFromBlocks, getcommentToBlockMapping } from './utils';
 
 const modifyBlockCommentAttributes = ( settings ) => {
 	if ( ! settings.attributes.blockCommentId ) {
@@ -59,6 +59,7 @@ function CollabSidebarContent( {
 	styles,
 	comments,
 	inPopover,
+	commentToBlockMapping,
 } ) {
 	const { createNotice } = useDispatch( noticesStore );
 	const { saveEntityRecord, deleteEntityRecord } = useDispatch( coreStore );
@@ -228,6 +229,7 @@ function CollabSidebarContent( {
 				showCommentBoard={ showCommentBoard }
 				setShowCommentBoard={ setShowCommentBoard }
 				inPopover={ inPopover }
+				commentToBlockMapping={ commentToBlockMapping }
 			/>
 		</div>
 	);
@@ -286,57 +288,59 @@ export default function CollabSidebar() {
 	} );
 
 	// Process comments to build the tree structure.
-	const { resultComments, unresolvedSortedThreads } = useMemo( () => {
-		// Create a compare to store the references to all objects by id.
-		const compare = {};
-		const result = [];
+	const { resultComments, unresolvedSortedThreads, commentToBlockMapping } =
+		useMemo( () => {
+			// Create a compare to store the references to all objects by id.
+			const compare = {};
+			const result = [];
 
-		const allComments = threads ?? [];
+			const allComments = threads ?? [];
 
-		// Initialize each object with an empty `reply` array.
-		allComments.forEach( ( item ) => {
-			compare[ item.id ] = { ...item, reply: [] };
-		} );
+			// Initialize each object with an empty `reply` array.
+			allComments.forEach( ( item ) => {
+				compare[ item.id ] = { ...item, reply: [] };
+			} );
 
-		// Iterate over the data to build the tree structure.
-		allComments.forEach( ( item ) => {
-			if ( item.parent === 0 ) {
-				// If parent is 0, it's a root item, push it to the result array.
-				result.push( compare[ item.id ] );
-			} else if ( compare[ item.parent ] ) {
-				// Otherwise, find its parent and push it to the parent's `reply` array.
-				compare[ item.parent ].reply.push( compare[ item.id ] );
+			// Iterate over the data to build the tree structure.
+			allComments.forEach( ( item ) => {
+				if ( item.parent === 0 ) {
+					// If parent is 0, it's a root item, push it to the result array.
+					result.push( compare[ item.id ] );
+				} else if ( compare[ item.parent ] ) {
+					// Otherwise, find its parent and push it to the parent's `reply` array.
+					compare[ item.parent ].reply.push( compare[ item.id ] );
+				}
+			} );
+
+			if ( 0 === result?.length ) {
+				return { resultComments: [], unresolvedSortedThreads: [] };
 			}
-		} );
 
-		if ( 0 === result?.length ) {
-			return { resultComments: [], unresolvedSortedThreads: [] };
-		}
+			const updatedResult = result.map( ( item ) => ( {
+				...item,
+				reply: [ ...item.reply ].reverse(),
+			} ) );
 
-		const updatedResult = result.map( ( item ) => ( {
-			...item,
-			reply: [ ...item.reply ].reverse(),
-		} ) );
-
-		const blockCommentIds = getCommentIdsFromBlocks( blocks );
-
-		const threadIdMap = new Map(
-			updatedResult.map( ( thread ) => [ thread.id, thread ] )
-		);
-
-		// Get comments by block order, filter out undefined threads, and exclude resolved comments.
-		const unresolvedSortedComments = blockCommentIds
-			.map( ( id ) => threadIdMap.get( id ) )
-			.filter(
-				( thread ) =>
-					thread !== undefined && thread.status !== 'approved'
+			const blockCommentIds = getCommentIdsFromBlocks( blocks );
+			const mappingData = getcommentToBlockMapping( blocks );
+			const threadIdMap = new Map(
+				updatedResult.map( ( thread ) => [ thread.id, thread ] )
 			);
 
-		return {
-			resultComments: updatedResult,
-			unresolvedSortedThreads: unresolvedSortedComments,
-		};
-	}, [ threads, blocks ] );
+			// Get comments by block order, filter out undefined threads, and exclude resolved comments.
+			const unresolvedSortedComments = blockCommentIds
+				.map( ( id ) => threadIdMap.get( id ) )
+				.filter(
+					( thread ) =>
+						thread !== undefined && thread.status !== 'approved'
+				);
+
+			return {
+				resultComments: updatedResult,
+				unresolvedSortedThreads: unresolvedSortedComments,
+				commentToBlockMapping: mappingData,
+			};
+		}, [ threads, blocks ] );
 
 	// Get the global styles to set the background color of the sidebar.
 	const { merged: GlobalStyles } = useGlobalStylesContext();
@@ -386,23 +390,17 @@ export default function CollabSidebar() {
 					setShowCommentBoard={ setShowCommentBoard }
 				/>
 			</PluginSidebar>
-			<PluginSidebar
-				isPinnable={ false }
-				header={ false }
-				identifier={ collabSidebarName }
-				className="editor-collab-sidebar"
-				headerClassName="editor-collab-sidebar__header"
-			>
-				<CollabSidebarContent
-					comments={ unresolvedSortedThreads }
-					showCommentBoard={ showCommentBoard }
-					setShowCommentBoard={ setShowCommentBoard }
-					styles={ {
-						backgroundColor,
-					} }
-					inPopover
-				/>
-			</PluginSidebar>
+
+			<CollabSidebarContent
+				comments={ unresolvedSortedThreads }
+				showCommentBoard={ showCommentBoard }
+				setShowCommentBoard={ setShowCommentBoard }
+				styles={ {
+					backgroundColor,
+				} }
+				inPopover
+				commentToBlockMapping={ commentToBlockMapping }
+			/>
 		</>
 	);
 }

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -198,5 +198,9 @@
 }
 
 .editor-collab-sidebar-panel__comment-popover {
-	margin-left: 250px;
+	margin-left: 300px;
+
+	& .components-popover__content {
+		min-width: 250px;
+	}
 }

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -196,3 +196,7 @@
 	font-weight: 600;
 	flex-shrink: 0;
 }
+
+.editor-collab-sidebar-panel__comment-popover {
+	margin-left: 250px;
+}

--- a/packages/editor/src/components/collab-sidebar/utils.js
+++ b/packages/editor/src/components/collab-sidebar/utils.js
@@ -43,3 +43,43 @@ export function getCommentIdsFromBlocks( blocks ) {
 	// Extract all comment IDs recursively
 	return extractCommentIds( blocks );
 }
+
+/**
+ * Extract a map of comment IDs to their block references from an array of blocks.
+ * This is useful for linking comments to specific blocks in the editor.
+ *
+ * Only top-level comments are mapped to blocks.
+ *
+ * @param {Array} blocks - The array of blocks to extract comment IDs from.
+ * @return {Object} An object mapping comment IDs to their block references.
+ */
+export function getcommentToBlockMapping( blocks ) {
+	const commentToBlockMapping = [];
+
+	// Recursive function to extract comment IDs and their block refs from blocks.
+	const extractCommentIdsAndRefs = ( items ) => {
+		items.forEach( ( block ) => {
+			// Check for comment IDs in the current block's attributes
+			if (
+				block.attributes &&
+				block.attributes.blockCommentId &&
+				! commentToBlockMapping[ block.attributes.blockCommentId ]
+			) {
+				commentToBlockMapping[ block.attributes.blockCommentId ] = {
+					blockCommentId: block.attributes.blockCommentId,
+					commentPopoverRef: block.attributes.commentPopoverRef,
+				};
+			}
+
+			// Recursively check inner blocks
+			if ( block.innerBlocks && block.innerBlocks.length > 0 ) {
+				extractCommentIdsAndRefs( block.innerBlocks );
+			}
+		} );
+	};
+
+	// Extract all comment IDs and their block refs recursively.
+	extractCommentIdsAndRefs( blocks );
+
+	return commentToBlockMapping;
+}


### PR DESCRIPTION
### Note: closed in favor of https://github.com/WordPress/gutenberg/pull/71856

## What?
Fixes https://github.com/WordPress/gutenberg/issues/71393

<!-- In a few words, what is the PR actually doing? -->

This PR visually aligns comments beside (to the right of) the block they are related to. This is in the design spec for inline comments. Note that this does not apply when showing the "pinned" comment sidebar.

## Why?
When commenting on a block, and replying to those comments in a thread, it makes sense to position the comments alongside the block so they are visually related. This becomes increasingly important as the number of comments or the document length increases.


## How?
As discussed previously, this PR will attempt to put comments in a `<Popover>` component. 

### Plan
 - [x] When not in pinned mode, wrap comments in a `Popover` element
 - [x] Anchor the popover to the block itself
 - [ ] Ensure popover sizes to fit comment thread
 - [ ] Ensure comment popovers don't overlap
 - [ ] move the visibility control from the thread to the popover so a resolved comment's container popover disappears

### Challenges
 - [ ] when a document has many comments they will each need some space reserved
 - [ ] scrolling must remain performant even with many comments showing at once


## Testing Instructions
When ready for testing:
1. Ensure comment experiment is enabled
2. leave several comments on blocks in a long test document
3. Scroll up and down in the document to verify the comments appear alongside the blocks they were left on.


### Testing Instructions for Keyboard
- Same as above, scroll with keyboard


## Screenshots or screencast <!-- if applicable -->

