### PR TITLE
Add ability to toggle meta box pane open and closed

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -226,7 +226,10 @@ function MetaBoxesMain( { isLegacy } ) {
 				'metaBoxesMainOpenHeight',
 				candidateHeight
 			);
-		} else if ( ! isShort ) {
+		}
+		// Updates aria-valuenow only when not persisting the value because otherwise
+		// it's done by the render that persisting the value causes.
+		else if ( ! isShort ) {
 			separatorRef.current.ariaValueNow =
 				getAriaValueNow( candidateHeight );
 		}

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -355,16 +355,7 @@ function MetaBoxesMain( { isLegacy } ) {
 		defaultSize: { height: isOpen ? openHeight : 0 },
 		minHeight: min,
 		maxHeight: isShort ? null : usedMax,
-		enable: {
-			top: true,
-			right: false,
-			bottom: false,
-			left: false,
-			topLeft: false,
-			topRight: false,
-			bottomRight: false,
-			bottomLeft: false,
-		},
+		enable: { top: true },
 		handleClasses: { top: 'edit-post-meta-boxes-main__presenter' },
 		handleComponent: {
 			top: (

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -48,7 +48,9 @@ import {
 	__unstableUseNavigateRegions as useNavigateRegions,
 } from '@wordpress/components';
 import {
+	useEvent,
 	useMediaQuery,
+	useMergeRefs,
 	useRefEffect,
 	useViewportMatch,
 } from '@wordpress/compose';
@@ -164,6 +166,15 @@ function MetaBoxesMain( { isLegacy } ) {
 	const metaBoxesMainRef = useRef();
 	const isShort = useMediaQuery( '(max-height: 549px)' );
 
+	const getRenderValues = useEvent( () => [ min, openHeight ] );
+	const effectResizableToggle = useRefEffect( () => {
+		const [ freshMin, freshOpenHeight ] = getRenderValues();
+		applyHeight( isOpen ? freshOpenHeight : freshMin, false, true );
+	}, [ isOpen ] );
+	const setResizableRefs = useMergeRefs( [
+		metaBoxesMainRef,
+		effectResizableToggle,
+	] );
 	const [ { min, max }, setHeightConstraints ] = useState( () => ( {} ) );
 	// Keeps the resizable area’s size constraints updated taking into account
 	// editor notices. The constraints are also used to derive the value for the
@@ -224,6 +235,8 @@ function MetaBoxesMain( { isLegacy } ) {
 			} );
 		}
 	};
+
+	const shouldAbortToggleRef = useRef( false );
 
 	if ( ! hasAnyVisible ) {
 		return;
@@ -286,9 +299,9 @@ function MetaBoxesMain( { isLegacy } ) {
 		Pane = ResizableBox;
 		paneProps = /** @type {Parameters<typeof ResizableBox>[0]} */ ( {
 			as: NavigableRegion,
-			ref: metaBoxesMainRef,
+			ref: setResizableRefs,
 			className: clsx( className, 'is-resizable' ),
-			defaultSize: { height: openHeight },
+			defaultSize: { height: isOpen ? openHeight : min },
 			minHeight: min,
 			maxHeight: usedMax,
 			enable: {
@@ -305,6 +318,20 @@ function MetaBoxesMain( { isLegacy } ) {
 			handleComponent: {
 				top: (
 					<>
+						<button
+							aria-expanded={ isOpen }
+							onPointerDown={ () => {
+								shouldAbortToggleRef.current = false;
+							} }
+							onClick={ () => {
+								if ( ! shouldAbortToggleRef.current ) {
+									toggle();
+								}
+							} }
+						>
+							{ paneLabel }
+							<Icon icon={ isOpen ? chevronUp : chevronDown } />
+						</button>
 						<Tooltip text={ __( 'Drag to resize' ) }>
 							<button // eslint-disable-line jsx-a11y/role-supports-aria-props
 								ref={ separatorRef }
@@ -330,6 +357,7 @@ function MetaBoxesMain( { isLegacy } ) {
 				if ( separatorRef.current.parentElement.contains( target ) ) {
 					target.setPointerCapture( pointerId );
 				}
+				shouldAbortToggleRef.current = false;
 			},
 			onResizeStart: ( event, direction, elementRef ) => {
 				if ( isAutoHeight ) {
@@ -341,8 +369,19 @@ function MetaBoxesMain( { isLegacy } ) {
 			},
 			onResize: () =>
 				applyHeight( metaBoxesMainRef.current.state.height ),
-			onResizeStop: () =>
-				applyHeight( metaBoxesMainRef.current.state.height, true ),
+			onResizeStop: ( event, direction, elementRef, delta ) => {
+				if ( delta.height ) {
+					if ( metaBoxesMainRef.current.state.height > min ) {
+						shouldAbortToggleRef.current = true;
+						setPreference(
+							'core/edit-post',
+							'metaBoxesMainIsOpen',
+							true
+						);
+					}
+					applyHeight( metaBoxesMainRef.current.state.height, true );
+				}
+			},
 		} );
 	}
 

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -293,10 +293,6 @@ function MetaBoxesMain( { isLegacy } ) {
 	// TODO: Support more/all keyboard interactions from the window splitter pattern:
 	// https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/
 	const onSeparatorKeyDown = ( event ) => {
-		// Bails unless the event target is the separator.
-		if ( event.target !== separatorRef.current ) {
-			return;
-		}
 		const delta = { ArrowUp: 20, ArrowDown: -20 }[ event.key ];
 		if ( delta ) {
 			const pane = metaBoxesMainRef.current.resizable;
@@ -309,10 +305,9 @@ function MetaBoxesMain( { isLegacy } ) {
 	};
 	const paneLabel = __( 'Meta Boxes' );
 
-	const resizeHandle = (
+	const toggle = (
 		<button
 			aria-expanded={ isOpen }
-			onKeyDown={ onSeparatorKeyDown }
 			onClick={ ( { detail } ) => {
 				const { isToggleInferred } = resizeDataRef.current;
 				if ( isShort || ! detail || isToggleInferred ) {
@@ -329,26 +324,28 @@ function MetaBoxesMain( { isLegacy } ) {
 			} ) }
 		>
 			{ paneLabel }
-			{ ! isShort && (
-				<>
-					<Tooltip text={ __( 'Drag to resize' ) }>
-						<span // eslint-disable-line jsx-a11y/role-supports-aria-props
-							ref={ separatorRef }
-							role="separator"
-							aria-valuenow={ usedAriaValueNow }
-							aria-label={ __( 'Drag to resize' ) }
-							aria-describedby={ separatorHelpId }
-						/>
-					</Tooltip>
-					<VisuallyHidden id={ separatorHelpId }>
-						{ __(
-							'Use up and down arrow keys to resize the meta box panel.'
-						) }
-					</VisuallyHidden>
-				</>
-			) }
 			<Icon icon={ isOpen ? chevronUp : chevronDown } />
 		</button>
+	);
+
+	const separator = ! isShort && (
+		<>
+			<Tooltip text={ __( 'Drag to resize' ) }>
+				<button // eslint-disable-line jsx-a11y/role-supports-aria-props
+					ref={ separatorRef }
+					role="separator" // eslint-disable-line jsx-a11y/no-interactive-element-to-noninteractive-role
+					aria-valuenow={ usedAriaValueNow }
+					aria-label={ __( 'Drag to resize' ) }
+					aria-describedby={ separatorHelpId }
+					onKeyDown={ onSeparatorKeyDown }
+				/>
+			</Tooltip>
+			<VisuallyHidden id={ separatorHelpId }>
+				{ __(
+					'Use up and down arrow keys to resize the meta box panel.'
+				) }
+			</VisuallyHidden>
+		</>
 	);
 
 	const paneProps = /** @type {Parameters<typeof ResizableBox>[0]} */ ( {
@@ -370,7 +367,12 @@ function MetaBoxesMain( { isLegacy } ) {
 		},
 		handleClasses: { top: 'edit-post-meta-boxes-main__presenter' },
 		handleComponent: {
-			top: resizeHandle,
+			top: (
+				<>
+					{ toggle }
+					{ separator }
+				</>
+			),
 		},
 		// Avoids hiccups while dragging over objects like iframes and ensures that
 		// the event to end the drag is captured by the target (resize handle)

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -237,9 +237,12 @@ function MetaBoxesMain( { isLegacy } ) {
 	// preferred height when resizable.
 	useEffect( () => {
 		const fresh = getRenderValues();
-		const usedOpenHeight = isShort ? 'auto' : fresh.openHeight;
-		const usedHeight = fresh.isOpen ? usedOpenHeight : fresh.min;
-		applyHeight( usedHeight, false, true );
+		// Tests for `min` having a value to skip the first render.
+		if ( fresh.min !== undefined && metaBoxesMainRef.current ) {
+			const usedOpenHeight = isShort ? 'auto' : fresh.openHeight;
+			const usedHeight = fresh.isOpen ? usedOpenHeight : fresh.min;
+			applyHeight( usedHeight, false, true );
+		}
 	}, [ isShort ] );
 
 	if ( ! hasAnyVisible ) {
@@ -297,47 +300,45 @@ function MetaBoxesMain( { isLegacy } ) {
 	const paneLabel = __( 'Meta Boxes' );
 
 	const resizeHandle = (
-		<>
-			<button
-				aria-expanded={ isOpen }
-				onKeyDown={ onSeparatorKeyDown }
-				onClick={ ( { detail } ) => {
-					const { isToggleInferred } = resizeDataRef.current;
-					if ( isShort || ! detail || isToggleInferred ) {
-						persistIsOpen();
-						const usedOpenHeight = isShort ? 'auto' : openHeight;
-						const usedHeight = isOpen ? min : usedOpenHeight;
-						applyHeight( usedHeight, false, true );
-					}
-				} }
-				// Prevents resizing in short viewports.
-				{ ...( isShort && {
-					onMouseDown: ( event ) => event.stopPropagation(),
-					onTouchStart: ( event ) => event.stopPropagation(),
-				} ) }
-			>
-				{ paneLabel }
-				{ ! isShort && (
-					<>
-						<Tooltip text={ __( 'Drag to resize' ) }>
-							<div // eslint-disable-line jsx-a11y/role-supports-aria-props
-								ref={ separatorRef }
-								role="separator"
-								aria-valuenow={ usedAriaValueNow }
-								aria-label={ __( 'Drag to resize' ) }
-								aria-describedby={ separatorHelpId }
-							/>
-						</Tooltip>
-						<VisuallyHidden id={ separatorHelpId }>
-							{ __(
-								'Use up and down arrow keys to resize the meta box panel.'
-							) }
-						</VisuallyHidden>
-					</>
-				) }
-				<Icon icon={ isOpen ? chevronUp : chevronDown } />
-			</button>
-		</>
+		<button
+			aria-expanded={ isOpen }
+			onKeyDown={ onSeparatorKeyDown }
+			onClick={ ( { detail } ) => {
+				const { isToggleInferred } = resizeDataRef.current;
+				if ( isShort || ! detail || isToggleInferred ) {
+					persistIsOpen();
+					const usedOpenHeight = isShort ? 'auto' : openHeight;
+					const usedHeight = isOpen ? min : usedOpenHeight;
+					applyHeight( usedHeight, false, true );
+				}
+			} }
+			// Prevents resizing in short viewports.
+			{ ...( isShort && {
+				onMouseDown: ( event ) => event.stopPropagation(),
+				onTouchStart: ( event ) => event.stopPropagation(),
+			} ) }
+		>
+			{ paneLabel }
+			{ ! isShort && (
+				<>
+					<Tooltip text={ __( 'Drag to resize' ) }>
+						<div // eslint-disable-line jsx-a11y/role-supports-aria-props
+							ref={ separatorRef }
+							role="separator"
+							aria-valuenow={ usedAriaValueNow }
+							aria-label={ __( 'Drag to resize' ) }
+							aria-describedby={ separatorHelpId }
+						/>
+					</Tooltip>
+					<VisuallyHidden id={ separatorHelpId }>
+						{ __(
+							'Use up and down arrow keys to resize the meta box panel.'
+						) }
+					</VisuallyHidden>
+				</>
+			) }
+			<Icon icon={ isOpen ? chevronUp : chevronDown } />
+		</button>
 	);
 
 	const paneProps = /** @type {Parameters<typeof ResizableBox>[0]} */ ( {
@@ -365,8 +366,7 @@ function MetaBoxesMain( { isLegacy } ) {
 		// the event to end the drag is captured by the target (resize handle)
 		// whether or not it’s under the pointer.
 		onPointerDown: ( { pointerId, target } ) => {
-			const paneResizeHandle = separatorRef.current.parentElement;
-			if ( ! isShort && paneResizeHandle.contains( target ) ) {
+			if ( separatorRef.current?.parentElement.contains( target ) ) {
 				target.setPointerCapture( pointerId );
 			}
 		},

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -308,7 +308,6 @@ function MetaBoxesMain( { isLegacy } ) {
 			event.preventDefault();
 		}
 	};
-	const className = 'edit-post-meta-boxes-main';
 	const paneLabel = __( 'Meta Boxes' );
 
 	const resizeHandle = (
@@ -356,7 +355,7 @@ function MetaBoxesMain( { isLegacy } ) {
 	const paneProps = /** @type {Parameters<typeof ResizableBox>[0]} */ ( {
 		as: NavigableRegion,
 		ref: metaBoxesMainRef,
-		className,
+		className: 'edit-post-meta-boxes-main',
 		defaultSize: { height: isOpen ? openHeight : 0 },
 		minHeight: min,
 		maxHeight: usedMax,

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -358,7 +358,7 @@ function MetaBoxesMain( { isLegacy } ) {
 		className: 'edit-post-meta-boxes-main',
 		defaultSize: { height: isOpen ? openHeight : 0 },
 		minHeight: min,
-		maxHeight: usedMax,
+		maxHeight: isShort ? null : usedMax,
 		enable: {
 			top: true,
 			right: false,

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -26,6 +26,7 @@ import { PluginArea } from '@wordpress/plugins';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	useCallback,
+	useEffect,
 	useMemo,
 	useId,
 	useRef,
@@ -48,9 +49,8 @@ import {
 	__unstableUseNavigateRegions as useNavigateRegions,
 } from '@wordpress/components';
 import {
-    useEvent,
+	useEvent,
 	useMediaQuery,
-	useMergeRefs,
 	useRefEffect,
 	useViewportMatch,
 } from '@wordpress/compose';
@@ -166,21 +166,6 @@ function MetaBoxesMain( { isLegacy } ) {
 	const metaBoxesMainRef = useRef();
 	const isShort = useMediaQuery( '(max-height: 549px)' );
 
-	const getIsOpen = useEvent( () => isOpen );
-	// When going from resizable to not (isShort), the height should made 'auto'.
-	const effectShort = useRefEffect(
-		( { resizable } ) => {
-			if ( getIsOpen() ) {
-				console.log(`go ${ isShort ? 'short' : 'resizable'}`, metaBoxesMainRef.current.state.height)
-			} else {
-				resizable.style.height = isShort
-					? 'auto'
-					: `${ metaBoxesMainRef.current.state.height }px`;
-			}
-		},
-		[ isShort ]
-	);
-	const setResizableRefs = useMergeRefs( [ metaBoxesMainRef, effectShort ] );
 	const [ { min, max }, setHeightConstraints ] = useState( () => ( {} ) );
 	// Keeps the resizable area’s size constraints updated taking into account
 	// editor notices. The constraints are also used to derive the value for the
@@ -215,24 +200,30 @@ function MetaBoxesMain( { isLegacy } ) {
 		return () => observer.disconnect();
 	}, [] );
 
+	const resizeDataRef = useRef( {} );
 	const separatorRef = useRef();
 	const separatorHelpId = useId();
 
 	const [ isUntouched, setIsUntouched ] = useState( true );
 	const applyHeight = ( candidateHeight, isPersistent, isInstant ) => {
-		const nextHeight = Math.min( max, Math.max( min, candidateHeight ) );
+		if ( candidateHeight === 'auto' ) {
+			isPersistent = false; // Just in case — “auto” should never persist.
+		} else {
+			candidateHeight = Math.min( max, Math.max( min, candidateHeight ) );
+		}
 		if ( isPersistent ) {
 			setPreference(
 				'core/edit-post',
 				'metaBoxesMainOpenHeight',
-				nextHeight
+				candidateHeight
 			);
 		} else if ( ! isShort ) {
-			separatorRef.current.ariaValueNow = getAriaValueNow( nextHeight );
+			separatorRef.current.ariaValueNow =
+				getAriaValueNow( candidateHeight );
 		}
 		if ( isInstant ) {
 			metaBoxesMainRef.current.updateSize( {
-				height: nextHeight,
+				height: candidateHeight,
 				// Oddly, when the event that triggered this was not from the mouse (e.g. keydown),
 				// if `width` is left unspecified a subsequent drag gesture applies a fixed
 				// width and the pane fails to widen/narrow with parent width changes from
@@ -241,8 +232,15 @@ function MetaBoxesMain( { isLegacy } ) {
 			} );
 		}
 	};
-
-	const resizeStatsRef = useRef( {} );
+	const getRenderValues = useEvent( () => ( { isOpen, openHeight, min } ) );
+	// Sets the height to 'auto' when not resizable (isShort) and to the
+	// preferred height when resizable.
+	useEffect( () => {
+		const fresh = getRenderValues();
+		const usedOpenHeight = isShort ? 'auto' : fresh.openHeight;
+		const usedHeight = fresh.isOpen ? usedOpenHeight : fresh.min;
+		applyHeight( usedHeight, false, true );
+	}, [ isShort ] );
 
 	if ( ! hasAnyVisible ) {
 		return;
@@ -275,23 +273,23 @@ function MetaBoxesMain( { isLegacy } ) {
 	const usedAriaValueNow =
 		max === undefined || isAutoHeight ? 50 : getAriaValueNow( openHeight );
 
-	const toggle = () =>
-		setPreference( 'core/edit-post', 'metaBoxesMainIsOpen', ! isOpen );
+	const persistIsOpen = ( to = ! isOpen ) =>
+		setPreference( 'core/edit-post', 'metaBoxesMainIsOpen', to );
 
 	// TODO: Support more/all keyboard interactions from the window splitter pattern:
 	// https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/
 	const onSeparatorKeyDown = ( event ) => {
+		// Bails unless the event target is the separator.
+		if ( event.target !== separatorRef.current ) {
+			return;
+		}
 		const delta = { ArrowUp: 20, ArrowDown: -20 }[ event.key ];
 		if ( delta ) {
 			const pane = metaBoxesMainRef.current.resizable;
 			const fromHeight = isAutoHeight ? pane.offsetHeight : openHeight;
 			const nextHeight = delta + fromHeight;
 			applyHeight( nextHeight, true, true );
-			setPreference(
-				'core/edit-post',
-				'metaBoxesMainIsOpen',
-				nextHeight > min
-			);
+			persistIsOpen( nextHeight > min );
 			event.preventDefault();
 		}
 	};
@@ -302,33 +300,14 @@ function MetaBoxesMain( { isLegacy } ) {
 		<>
 			<button
 				aria-expanded={ isOpen }
-				onPointerDown={ ( { timeStamp } ) => {
-					if ( ! isShort ) {
-						resizeStatsRef.current.startTime = timeStamp;
-					}
-				} }
-				onKeyDown={ ( event ) => {
-					onSeparatorKeyDown( event );
-				} }
-				onClick={ ( { timeStamp, detail } ) => {
-					const { startTime, deltaY, nextHeight, finishResize } =
-						resizeStatsRef.current;
-					resizeStatsRef.current = {};
-					const duration = timeStamp - startTime;
-					// When the “click” is from keypress or after a resize of very short distance
-					// or duration then expand or collapse the pane. Otherwise, persist the resize.
-					if ( isShort || ! detail || duration < 144 || deltaY < 5 ) {
-						toggle();
-						if ( ! isShort ) {
-							applyHeight(
-								isOpen ? min : openHeight,
-								false,
-								true
-							);
-						}
-					} else {
-						applyHeight( nextHeight, true );
-						finishResize();
+				onKeyDown={ onSeparatorKeyDown }
+				onClick={ ( { detail } ) => {
+					const { isToggleInferred } = resizeDataRef.current;
+					if ( isShort || ! detail || isToggleInferred ) {
+						persistIsOpen();
+						const usedOpenHeight = isShort ? 'auto' : openHeight;
+						const usedHeight = isOpen ? min : usedOpenHeight;
+						applyHeight( usedHeight, false, true );
 					}
 				} }
 				// Prevents resizing in short viewports.
@@ -338,35 +317,34 @@ function MetaBoxesMain( { isLegacy } ) {
 				} ) }
 			>
 				{ paneLabel }
+				{ ! isShort && (
+					<>
+						<Tooltip text={ __( 'Drag to resize' ) }>
+							<div // eslint-disable-line jsx-a11y/role-supports-aria-props
+								ref={ separatorRef }
+								role="separator"
+								aria-valuenow={ usedAriaValueNow }
+								aria-label={ __( 'Drag to resize' ) }
+								aria-describedby={ separatorHelpId }
+							/>
+						</Tooltip>
+						<VisuallyHidden id={ separatorHelpId }>
+							{ __(
+								'Use up and down arrow keys to resize the meta box panel.'
+							) }
+						</VisuallyHidden>
+					</>
+				) }
 				<Icon icon={ isOpen ? chevronUp : chevronDown } />
 			</button>
-			{ ! isShort && (
-				<>
-					<Tooltip text={ __( 'Drag to resize' ) }>
-						<button // eslint-disable-line jsx-a11y/role-supports-aria-props
-							ref={ separatorRef }
-							role="separator" // eslint-disable-line jsx-a11y/no-interactive-element-to-noninteractive-role
-							aria-valuenow={ usedAriaValueNow }
-							aria-label={ __( 'Drag to resize' ) }
-							aria-describedby={ separatorHelpId }
-							onKeyDown={ onSeparatorKeyDown }
-						/>
-					</Tooltip>
-					<VisuallyHidden id={ separatorHelpId }>
-						{ __(
-							'Use up and down arrow keys to resize the meta box panel.'
-						) }
-					</VisuallyHidden>
-				</>
-			) }
 		</>
 	);
 
 	const paneProps = /** @type {Parameters<typeof ResizableBox>[0]} */ ( {
 		as: NavigableRegion,
-		ref: setResizableRefs,
+		ref: metaBoxesMainRef,
 		className,
-		defaultSize: { height: isOpen ? openHeight : 0 }, //
+		defaultSize: { height: isOpen ? openHeight : 0 },
 		minHeight: min,
 		maxHeight: usedMax,
 		enable: {
@@ -387,13 +365,12 @@ function MetaBoxesMain( { isLegacy } ) {
 		// the event to end the drag is captured by the target (resize handle)
 		// whether or not it’s under the pointer.
 		onPointerDown: ( { pointerId, target } ) => {
-			if ( ! isShort ) {
-				if ( separatorRef.current.parentElement.contains( target ) ) {
-					target.setPointerCapture( pointerId );
-				}
+			const paneResizeHandle = separatorRef.current.parentElement;
+			if ( ! isShort && paneResizeHandle.contains( target ) ) {
+				target.setPointerCapture( pointerId );
 			}
 		},
-		onResizeStart: ( event, direction, elementRef ) => {
+		onResizeStart: ( { timeStamp }, direction, elementRef ) => {
 			if ( isAutoHeight ) {
 				// Sets the starting height to avoid visual jumps in height and
 				// aria-valuenow being `NaN` for the first (few) resize events.
@@ -401,29 +378,34 @@ function MetaBoxesMain( { isLegacy } ) {
 				setIsUntouched( false );
 			}
 			elementRef.classList.add( 'is-resizing' );
+			resizeDataRef.current = { timeStamp, maxDelta: 0 };
 		},
-		onResize: () => applyHeight( metaBoxesMainRef.current.state.height ),
-		onResizeStop: ( event, direction, elementRef, delta ) => {
-			const { height } = metaBoxesMainRef.current.state;
-			const finishResize = () => {
-				elementRef.classList.remove( 'is-resizing' );
-				setPreference(
-					'core/edit-post',
-					'metaBoxesMainIsOpen',
-					height > min
-				);
-			};
-			if ( event.target === separatorRef.current ) {
-				applyHeight( height, true );
-				finishResize();
-			}
-			// The interaction was on the toggle button inside the handle and
-			// may act as either a toggle or resize. For that, it needs
-			// this data from the resize to be recorded.
-			else {
-				resizeStatsRef.current.deltaY = Math.abs( delta.height );
-				resizeStatsRef.current.nextHeight = height;
-				resizeStatsRef.current.finishResize = finishResize;
+		onResize: ( event, direction, elementRef, delta ) => {
+			const { maxDelta } = resizeDataRef.current;
+			const newDelta = Math.abs( delta.height );
+			resizeDataRef.current.maxDelta = Math.max( maxDelta, newDelta );
+			applyHeight( metaBoxesMainRef.current.state.height );
+		},
+		onResizeStop: ( event, direction, elementRef ) => {
+			elementRef.classList.remove( 'is-resizing' );
+			const duration = event.timeStamp - resizeDataRef.current.timeStamp;
+			const wasSeparator = event.target === separatorRef.current;
+			const { maxDelta } = resizeDataRef.current;
+			const isToggleInferred =
+				maxDelta < 1 || ( duration < 144 && maxDelta < 5 );
+			if ( isShort || ( ! wasSeparator && isToggleInferred ) ) {
+				resizeDataRef.current.isToggleInferred = true;
+			} else {
+				const { height } = metaBoxesMainRef.current.state;
+				const nextIsOpen = height > min;
+				persistIsOpen( nextIsOpen );
+				// Persists height only if still open. This is so that when closed by a drag the
+				// prior height can be restored by the toggle button instead of having to drag
+				// the pane open again. Also, if already closed, a click on the separator won’t
+				// persist the height as the minimum.
+				if ( nextIsOpen ) {
+					applyHeight( height, true );
+				}
 			}
 		},
 	} );

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -334,7 +334,7 @@ function MetaBoxesMain( { isLegacy } ) {
 			{ ! isShort && (
 				<>
 					<Tooltip text={ __( 'Drag to resize' ) }>
-						<div // eslint-disable-line jsx-a11y/role-supports-aria-props
+						<span // eslint-disable-line jsx-a11y/role-supports-aria-props
 							ref={ separatorRef }
 							role="separator"
 							aria-valuenow={ usedAriaValueNow }

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -155,7 +155,7 @@ function MetaBoxesMain( { isLegacy } ) {
 		const { get } = select( preferencesStore );
 		const { isMetaBoxLocationVisible } = select( editPostStore );
 		return [
-			get( 'core/edit-post', 'metaBoxesMainIsOpen' ),
+			!! get( 'core/edit-post', 'metaBoxesMainIsOpen' ),
 			get( 'core/edit-post', 'metaBoxesMainOpenHeight' ),
 			isMetaBoxLocationVisible( 'normal' ) ||
 				isMetaBoxLocationVisible( 'advanced' ) ||

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -204,7 +204,6 @@ function MetaBoxesMain( { isLegacy } ) {
 	const separatorRef = useRef();
 	const separatorHelpId = useId();
 
-	const [ isUntouched, setIsUntouched ] = useState( true );
 	/**
 	 * @param {number|'auto'} [candidateHeight] Height in pixels or 'auto'.
 	 * @param {boolean}       isPersistent      Whether to persist the height in preferences.
@@ -280,7 +279,7 @@ function MetaBoxesMain( { isLegacy } ) {
 	let usedMax = '50%'; // Approximation before max has a value.
 	if ( max !== undefined ) {
 		// Halves the available max height until a user height is set.
-		usedMax = isAutoHeight && isUntouched ? max / 2 : max;
+		usedMax = isAutoHeight ? max / 2 : max;
 	}
 
 	const getAriaValueNow = ( height ) =>
@@ -386,7 +385,6 @@ function MetaBoxesMain( { isLegacy } ) {
 				// Sets the starting height to avoid visual jumps in height and
 				// aria-valuenow being `NaN` for the first (few) resize events.
 				applyHeight( elementRef.offsetHeight, false, true );
-				setIsUntouched( false );
 			}
 			elementRef.classList.add( 'is-resizing' );
 			resizeDataRef.current = { timeStamp, maxDelta: 0 };

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -48,7 +48,7 @@ import {
 	__unstableUseNavigateRegions as useNavigateRegions,
 } from '@wordpress/components';
 import {
-	useEvent,
+    useEvent,
 	useMediaQuery,
 	useMergeRefs,
 	useRefEffect,
@@ -166,15 +166,21 @@ function MetaBoxesMain( { isLegacy } ) {
 	const metaBoxesMainRef = useRef();
 	const isShort = useMediaQuery( '(max-height: 549px)' );
 
-	const getRenderValues = useEvent( () => [ min, openHeight ] );
-	const effectResizableToggle = useRefEffect( () => {
-		const [ freshMin, freshOpenHeight ] = getRenderValues();
-		applyHeight( isOpen ? freshOpenHeight : freshMin, false, true );
-	}, [ isOpen ] );
-	const setResizableRefs = useMergeRefs( [
-		metaBoxesMainRef,
-		effectResizableToggle,
-	] );
+	const getIsOpen = useEvent( () => isOpen );
+	// When going from resizable to not (isShort), the height should made 'auto'.
+	const effectShort = useRefEffect(
+		( { resizable } ) => {
+			if ( getIsOpen() ) {
+				console.log(`go ${ isShort ? 'short' : 'resizable'}`, metaBoxesMainRef.current.state.height)
+			} else {
+				resizable.style.height = isShort
+					? 'auto'
+					: `${ metaBoxesMainRef.current.state.height }px`;
+			}
+		},
+		[ isShort ]
+	);
+	const setResizableRefs = useMergeRefs( [ metaBoxesMainRef, effectShort ] );
 	const [ { min, max }, setHeightConstraints ] = useState( () => ( {} ) );
 	// Keeps the resizable area’s size constraints updated taking into account
 	// editor notices. The constraints are also used to derive the value for the
@@ -221,7 +227,7 @@ function MetaBoxesMain( { isLegacy } ) {
 				'metaBoxesMainOpenHeight',
 				nextHeight
 			);
-		} else {
+		} else if ( ! isShort ) {
 			separatorRef.current.ariaValueNow = getAriaValueNow( nextHeight );
 		}
 		if ( isInstant ) {
@@ -236,7 +242,7 @@ function MetaBoxesMain( { isLegacy } ) {
 		}
 	};
 
-	const shouldAbortToggleRef = useRef( false );
+	const resizeStatsRef = useRef( {} );
 
 	if ( ! hasAnyVisible ) {
 		return;
@@ -244,12 +250,9 @@ function MetaBoxesMain( { isLegacy } ) {
 
 	const contents = (
 		<div
-			className={ clsx(
-				// The class name 'edit-post-layout__metaboxes' is retained because some plugins use it.
-				'edit-post-layout__metaboxes',
-				! isLegacy && 'edit-post-meta-boxes-main__liner'
-			) }
-			hidden={ ! isLegacy && isShort && ! isOpen }
+			// The class name 'edit-post-layout__metaboxes' is retained because some plugins use it.
+			className="edit-post-layout__metaboxes edit-post-meta-boxes-main__liner"
+			hidden={ ! isOpen }
 		>
 			<MetaBoxes location="normal" />
 			<MetaBoxes location="advanced" />
@@ -284,123 +287,152 @@ function MetaBoxesMain( { isLegacy } ) {
 			const fromHeight = isAutoHeight ? pane.offsetHeight : openHeight;
 			const nextHeight = delta + fromHeight;
 			applyHeight( nextHeight, true, true );
+			setPreference(
+				'core/edit-post',
+				'metaBoxesMainIsOpen',
+				nextHeight > min
+			);
 			event.preventDefault();
 		}
 	};
 	const className = 'edit-post-meta-boxes-main';
 	const paneLabel = __( 'Meta Boxes' );
-	let Pane, paneProps;
-	if ( isShort ) {
-		Pane = NavigableRegion;
-		paneProps = {
-			className: clsx( className, 'is-toggle-only' ),
-		};
-	} else {
-		Pane = ResizableBox;
-		paneProps = /** @type {Parameters<typeof ResizableBox>[0]} */ ( {
-			as: NavigableRegion,
-			ref: setResizableRefs,
-			className: clsx( className, 'is-resizable' ),
-			defaultSize: { height: isOpen ? openHeight : min },
-			minHeight: min,
-			maxHeight: usedMax,
-			enable: {
-				top: true,
-				right: false,
-				bottom: false,
-				left: false,
-				topLeft: false,
-				topRight: false,
-				bottomRight: false,
-				bottomLeft: false,
-			},
-			handleClasses: { top: 'edit-post-meta-boxes-main__presenter' },
-			handleComponent: {
-				top: (
-					<>
-						<button
-							aria-expanded={ isOpen }
-							onPointerDown={ () => {
-								shouldAbortToggleRef.current = false;
-							} }
-							onClick={ () => {
-								if ( ! shouldAbortToggleRef.current ) {
-									toggle();
-								}
-							} }
-						>
-							{ paneLabel }
-							<Icon icon={ isOpen ? chevronUp : chevronDown } />
-						</button>
-						<Tooltip text={ __( 'Drag to resize' ) }>
-							<button // eslint-disable-line jsx-a11y/role-supports-aria-props
-								ref={ separatorRef }
-								role="separator" // eslint-disable-line jsx-a11y/no-interactive-element-to-noninteractive-role
-								aria-valuenow={ usedAriaValueNow }
-								aria-label={ __( 'Drag to resize' ) }
-								aria-describedby={ separatorHelpId }
-								onKeyDown={ onSeparatorKeyDown }
-							/>
-						</Tooltip>
-						<VisuallyHidden id={ separatorHelpId }>
-							{ __(
-								'Use up and down arrow keys to resize the meta box panel.'
-							) }
-						</VisuallyHidden>
-					</>
-				),
-			},
-			// Avoids hiccups while dragging over objects like iframes and ensures that
-			// the event to end the drag is captured by the target (resize handle)
-			// whether or not it’s under the pointer.
-			onPointerDown: ( { pointerId, target } ) => {
+
+	const resizeHandle = (
+		<>
+			<button
+				aria-expanded={ isOpen }
+				onPointerDown={ ( { timeStamp } ) => {
+					if ( ! isShort ) {
+						resizeStatsRef.current.startTime = timeStamp;
+					}
+				} }
+				onKeyDown={ ( event ) => {
+					onSeparatorKeyDown( event );
+				} }
+				onClick={ ( { timeStamp, detail } ) => {
+					const { startTime, deltaY, nextHeight, finishResize } =
+						resizeStatsRef.current;
+					resizeStatsRef.current = {};
+					const duration = timeStamp - startTime;
+					// When the “click” is from keypress or after a resize of very short distance
+					// or duration then expand or collapse the pane. Otherwise, persist the resize.
+					if ( isShort || ! detail || duration < 144 || deltaY < 5 ) {
+						toggle();
+						if ( ! isShort ) {
+							applyHeight(
+								isOpen ? min : openHeight,
+								false,
+								true
+							);
+						}
+					} else {
+						applyHeight( nextHeight, true );
+						finishResize();
+					}
+				} }
+				// Prevents resizing in short viewports.
+				{ ...( isShort && {
+					onMouseDown: ( event ) => event.stopPropagation(),
+					onTouchStart: ( event ) => event.stopPropagation(),
+				} ) }
+			>
+				{ paneLabel }
+				<Icon icon={ isOpen ? chevronUp : chevronDown } />
+			</button>
+			{ ! isShort && (
+				<>
+					<Tooltip text={ __( 'Drag to resize' ) }>
+						<button // eslint-disable-line jsx-a11y/role-supports-aria-props
+							ref={ separatorRef }
+							role="separator" // eslint-disable-line jsx-a11y/no-interactive-element-to-noninteractive-role
+							aria-valuenow={ usedAriaValueNow }
+							aria-label={ __( 'Drag to resize' ) }
+							aria-describedby={ separatorHelpId }
+							onKeyDown={ onSeparatorKeyDown }
+						/>
+					</Tooltip>
+					<VisuallyHidden id={ separatorHelpId }>
+						{ __(
+							'Use up and down arrow keys to resize the meta box panel.'
+						) }
+					</VisuallyHidden>
+				</>
+			) }
+		</>
+	);
+
+	const paneProps = /** @type {Parameters<typeof ResizableBox>[0]} */ ( {
+		as: NavigableRegion,
+		ref: setResizableRefs,
+		className,
+		defaultSize: { height: isOpen ? openHeight : 0 }, //
+		minHeight: min,
+		maxHeight: usedMax,
+		enable: {
+			top: true,
+			right: false,
+			bottom: false,
+			left: false,
+			topLeft: false,
+			topRight: false,
+			bottomRight: false,
+			bottomLeft: false,
+		},
+		handleClasses: { top: 'edit-post-meta-boxes-main__presenter' },
+		handleComponent: {
+			top: resizeHandle,
+		},
+		// Avoids hiccups while dragging over objects like iframes and ensures that
+		// the event to end the drag is captured by the target (resize handle)
+		// whether or not it’s under the pointer.
+		onPointerDown: ( { pointerId, target } ) => {
+			if ( ! isShort ) {
 				if ( separatorRef.current.parentElement.contains( target ) ) {
 					target.setPointerCapture( pointerId );
 				}
-				shouldAbortToggleRef.current = false;
-			},
-			onResizeStart: ( event, direction, elementRef ) => {
-				if ( isAutoHeight ) {
-					// Sets the starting height to avoid visual jumps in height and
-					// aria-valuenow being `NaN` for the first (few) resize events.
-					applyHeight( elementRef.offsetHeight, false, true );
-					setIsUntouched( false );
-				}
-			},
-			onResize: () =>
-				applyHeight( metaBoxesMainRef.current.state.height ),
-			onResizeStop: ( event, direction, elementRef, delta ) => {
-				if ( delta.height ) {
-					if ( metaBoxesMainRef.current.state.height > min ) {
-						shouldAbortToggleRef.current = true;
-						setPreference(
-							'core/edit-post',
-							'metaBoxesMainIsOpen',
-							true
-						);
-					}
-					applyHeight( metaBoxesMainRef.current.state.height, true );
-				}
-			},
-		} );
-	}
+			}
+		},
+		onResizeStart: ( event, direction, elementRef ) => {
+			if ( isAutoHeight ) {
+				// Sets the starting height to avoid visual jumps in height and
+				// aria-valuenow being `NaN` for the first (few) resize events.
+				applyHeight( elementRef.offsetHeight, false, true );
+				setIsUntouched( false );
+			}
+			elementRef.classList.add( 'is-resizing' );
+		},
+		onResize: () => applyHeight( metaBoxesMainRef.current.state.height ),
+		onResizeStop: ( event, direction, elementRef, delta ) => {
+			const { height } = metaBoxesMainRef.current.state;
+			const finishResize = () => {
+				elementRef.classList.remove( 'is-resizing' );
+				setPreference(
+					'core/edit-post',
+					'metaBoxesMainIsOpen',
+					height > min
+				);
+			};
+			if ( event.target === separatorRef.current ) {
+				applyHeight( height, true );
+				finishResize();
+			}
+			// The interaction was on the toggle button inside the handle and
+			// may act as either a toggle or resize. For that, it needs
+			// this data from the resize to be recorded.
+			else {
+				resizeStatsRef.current.deltaY = Math.abs( delta.height );
+				resizeStatsRef.current.nextHeight = height;
+				resizeStatsRef.current.finishResize = finishResize;
+			}
+		},
+	} );
 
 	return (
-		<Pane aria-label={ paneLabel } { ...paneProps }>
-			{ isShort ? (
-				<button
-					aria-expanded={ isOpen }
-					className="edit-post-meta-boxes-main__presenter"
-					onClick={ toggle }
-				>
-					{ paneLabel }
-					<Icon icon={ isOpen ? chevronUp : chevronDown } />
-				</button>
-			) : (
-				<meta ref={ effectSizeConstraints } />
-			) }
+		<ResizableBox aria-label={ paneLabel } { ...paneProps }>
+			<meta ref={ effectSizeConstraints } />
 			{ contents }
-		</Pane>
+		</ResizableBox>
 	);
 }
 

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -205,7 +205,16 @@ function MetaBoxesMain( { isLegacy } ) {
 	const separatorHelpId = useId();
 
 	const [ isUntouched, setIsUntouched ] = useState( true );
-	const applyHeight = ( candidateHeight, isPersistent, isInstant ) => {
+	/**
+	 * @param {number|'auto'} [candidateHeight] Height in pixels or 'auto'.
+	 * @param {boolean}       isPersistent      Whether to persist the height in preferences.
+	 * @param {boolean}       isInstant         Whether to update the height in the DOM.
+	 */
+	const applyHeight = (
+		candidateHeight = 'auto',
+		isPersistent,
+		isInstant
+	) => {
 		if ( candidateHeight === 'auto' ) {
 			isPersistent = false; // Just in case — “auto” should never persist.
 		} else {

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -276,12 +276,6 @@ function MetaBoxesMain( { isLegacy } ) {
 	}
 
 	const isAutoHeight = openHeight === undefined;
-	let usedMax = '50%'; // Approximation before max has a value.
-	if ( max !== undefined ) {
-		// Halves the available max height until a user height is set.
-		usedMax = isAutoHeight ? max / 2 : max;
-	}
-
 	const getAriaValueNow = ( height ) =>
 		Math.round( ( ( height - min ) / ( max - min ) ) * 100 );
 	const usedAriaValueNow =
@@ -354,7 +348,7 @@ function MetaBoxesMain( { isLegacy } ) {
 		className: 'edit-post-meta-boxes-main',
 		defaultSize: { height: isOpen ? openHeight : 0 },
 		minHeight: min,
-		maxHeight: isShort ? null : usedMax,
+		maxHeight: max,
 		enable: { top: true },
 		handleClasses: { top: 'edit-post-meta-boxes-main__presenter' },
 		handleComponent: {

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -90,7 +90,10 @@
 }
 
 .edit-post-meta-boxes-main__liner {
-	overflow: auto;
+	// Enable scrolling only for the split view.
+	.edit-post-meta-boxes-main & {
+		overflow: auto;
+	}
 	// Keep the contents behind the resize handle.
 	isolation: isolate;
 

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -6,10 +6,7 @@
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
-
-	&.is-resizable {
-		padding-block-start: $button-size-compact;
-	}
+	padding-block-start: $button-size-compact;
 }
 
 .edit-post-meta-boxes-main__presenter {
@@ -18,11 +15,14 @@
 	// Windows High Contrast mode will show this outline, but not the shadow.
 	outline: 1px solid transparent;
 	position: relative;
-	z-index: 1;
+	// Re-resizable adds an invisible overlay during resizes (apparently meant to avoid text selections)
+	// and this has to appear in front of it or else click events will be blocked on touch devices.
+	z-index: 10000;
+	inset: 0 0 auto;
+	height: $button-size-compact;
 
-	// Button style reset for both toggle or resizable.
-	.is-toggle-only > &,
-	.is-resizable.edit-post-meta-boxes-main & > button {
+	// Button style reset for both toggle and separator.
+	> button {
 		appearance: none;
 		padding: 0;
 		border: none;
@@ -30,10 +30,10 @@
 		background-color: transparent;
 	}
 
-	.is-toggle-only > & {
-		flex-shrink: 0;
+	> button:first-child {
 		cursor: pointer;
-		height: $button-size-compact;
+		width: 100%;
+		display: flex;
 		justify-content: space-between;
 		align-items: center;
 		padding-inline: $grid-unit-30 $grid-unit-15;
@@ -52,66 +52,56 @@
 		}
 	}
 
-	.is-resizable.edit-post-meta-boxes-main & {
-		inset: 0 0 auto;
-		height: $button-size-compact;
+	> button[role="separator"] {
+		cursor: inherit;
+		width: $grid-unit-80;
+		margin: auto;
+		position: absolute;
+		inset: 0;
 
-		// TODO: it may be worth trying to share styles with the `.is-toggle-only > &` selector above.
-		> button:first-child {
-			cursor: pointer;
-			width: 100%;
-			display: flex;
-			justify-content: space-between;
-			align-items: center;
-			padding-inline: $grid-unit-30 $grid-unit-15;
+		&::before {
+			content: "";
+			background-color: $gray-300;
+			// Windows High Contrast mode will show this outline, but not the background-color.
+			outline: 2px solid transparent;
+			outline-offset: -2px;
+			position: absolute;
+			inset-block: calc(50% - #{$grid-unit-05} / 2) auto;
+			transform: translateX(-50%);
+			width: inherit;
+			height: $grid-unit-05;
+			border-radius: $radius-small;
+			@media not (prefers-reduced-motion) {
+				transition: width 0.3s ease-out;
+			}
 		}
 
-		> button[role="separator"] {
-			cursor: inherit;
-			width: $grid-unit-80;
-			margin: auto;
-			position: absolute;
-			inset: 0;
-
-			&::before {
-				content: "";
-				background-color: $gray-300;
-				// Windows High Contrast mode will show this outline, but not the background-color.
-				outline: 2px solid transparent;
-				outline-offset: -2px;
-				position: absolute;
-				inset-block: calc(50% - #{$grid-unit-05} / 2) auto;
-				transform: translateX(-50%);
-				width: inherit;
-				height: $grid-unit-05;
-				border-radius: $radius-small;
-				@media not (prefers-reduced-motion) {
-					transition: width 0.3s ease-out;
-				}
-			}
-
-			&:is(:hover, :focus-visible)::before {
-				background-color: var(--wp-admin-theme-color);
-				width: $grid-unit-80 + $grid-unit-20;
-			}
+		&:is(:hover, :focus-visible)::before {
+			background-color: var(--wp-admin-theme-color);
+			width: $grid-unit-80 + $grid-unit-20;
 		}
 	}
 }
 
+// Enlarge the toggle/resizable hit area on touch devices.
 @media (pointer: coarse) {
-	.is-resizable.edit-post-meta-boxes-main {
-		padding-block-start: $button-size-compact;
-
-		.edit-post-meta-boxes-main__presenter > button {
-			height: $button-size-compact;
-		}
+	.edit-post-meta-boxes-main {
+		padding-block-start: $button-size;
+	}
+	.edit-post-meta-boxes-main__presenter {
+		height: $button-size;
 	}
 }
 
 .edit-post-meta-boxes-main__liner {
 	overflow: auto;
-	// Keep the contents behind the resize handle or details summary.
+	// Keep the contents behind the resize handle.
 	isolation: isolate;
+
+	// While resizing override hidden attribute in case starting from closed state.
+	.is-resizing.edit-post-meta-boxes-main & {
+		display: unset;
+	}
 }
 
 // In case the canvas is not iframe’d.

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -54,6 +54,7 @@
 		margin: auto;
 		position: absolute;
 		inset: 0;
+		outline: none;
 
 		&::before {
 			content: "";

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -27,12 +27,16 @@
 	inset: 0 0 auto;
 	height: $button-size-compact;
 
+	// Style reset for both toggle and separator buttons.
 	> button {
 		appearance: none;
 		padding: 0;
 		border: none;
 		outline: none;
 		background-color: transparent;
+	}
+
+	> button[aria-expanded] {
 		cursor: pointer;
 		width: 100%;
 		display: flex;
@@ -54,13 +58,12 @@
 		}
 	}
 
-	[role="separator"] {
+	button[role="separator"] {
 		cursor: row-resize;
 		width: $grid-unit-80;
 		margin: auto;
 		position: absolute;
 		inset: 0;
-		outline: none;
 
 		&::before {
 			content: "";

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -7,6 +7,12 @@
 	flex-direction: column;
 	overflow: hidden;
 	padding-block-start: $button-size-compact;
+
+	&.is-resizing {
+		// Ths is only for the case that a user height has not been set because the max-height is half
+		// of what’s available and should not apply when resizing.
+		max-height: none !important;
+	}
 }
 
 .edit-post-meta-boxes-main__presenter {

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -7,12 +7,6 @@
 	flex-direction: column;
 	overflow: hidden;
 	padding-block-start: $button-size-compact;
-
-	&.is-resizing {
-		// Ths is only for the case that a user height has not been set because the max-height is half
-		// of what’s available and should not apply when resizing.
-		max-height: none !important;
-	}
 }
 
 .edit-post-meta-boxes-main__presenter {

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -8,7 +8,7 @@
 	overflow: hidden;
 
 	&.is-resizable {
-		padding-block-start: $grid-unit-30;
+		padding-block-start: $button-size-compact;
 	}
 }
 
@@ -54,12 +54,24 @@
 
 	.is-resizable.edit-post-meta-boxes-main & {
 		inset: 0 0 auto;
+		height: $button-size-compact;
 
-		> button {
+		// TODO: it may be worth trying to share styles with the `.is-toggle-only > &` selector above.
+		> button:first-child {
+			cursor: pointer;
+			width: 100%;
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+			padding-inline: $grid-unit-30 $grid-unit-15;
+		}
+
+		> button[role="separator"] {
 			cursor: inherit;
 			width: $grid-unit-80;
-			height: $grid-unit-30;
 			margin: auto;
+			position: absolute;
+			inset: 0;
 
 			&::before {
 				content: "";
@@ -77,11 +89,11 @@
 					transition: width 0.3s ease-out;
 				}
 			}
-		}
 
-		&:is(:hover, :focus-within) > button::before {
-			background-color: var(--wp-admin-theme-color);
-			width: $grid-unit-80 + $grid-unit-20;
+			&:is(:hover, :focus-visible)::before {
+				background-color: var(--wp-admin-theme-color);
+				width: $grid-unit-80 + $grid-unit-20;
+			}
 		}
 	}
 }

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -21,16 +21,12 @@
 	inset: 0 0 auto;
 	height: $button-size-compact;
 
-	// Button style reset for both toggle and separator.
 	> button {
 		appearance: none;
 		padding: 0;
 		border: none;
 		outline: none;
 		background-color: transparent;
-	}
-
-	> button:first-child {
 		cursor: pointer;
 		width: 100%;
 		display: flex;
@@ -52,8 +48,8 @@
 		}
 	}
 
-	> button[role="separator"] {
-		cursor: inherit;
+	[role="separator"] {
+		cursor: row-resize;
 		width: $grid-unit-80;
 		margin: auto;
 		position: absolute;

--- a/test/e2e/specs/editor/plugins/wp-editor-meta-box.spec.js
+++ b/test/e2e/specs/editor/plugins/wp-editor-meta-box.spec.js
@@ -27,7 +27,7 @@ test.describe( 'WP Editor Meta Boxes', () => {
 		// Open the meta box pane. The click isn’t in the center because that
 		// would hit the resize handle instead of the located element.
 		await page
-			.getByRole( 'button', { name: /Meta Boxes/i } )
+			.getByRole( 'button', { name: 'Meta Boxes' } )
 			.click( { position: { x: 0, y: 0 } } );
 		// Switch tinymce to Text mode, first waiting for it to initialize
 		// because otherwise it will flip back to Visual mode once initialized.

--- a/test/e2e/specs/editor/plugins/wp-editor-meta-box.spec.js
+++ b/test/e2e/specs/editor/plugins/wp-editor-meta-box.spec.js
@@ -24,6 +24,11 @@ test.describe( 'WP Editor Meta Boxes', () => {
 			.locator( 'role=textbox[name="Add title"i]' )
 			.type( 'Hello Meta' );
 
+		// Open the meta box pane. The click isn’t in the center because that
+		// would hit the resize handle instead of the located element.
+		await page
+			.getByRole( 'button', { name: /Meta Boxes/i } )
+			.click( { position: { x: 0, y: 0 } } );
 		// Switch tinymce to Text mode, first waiting for it to initialize
 		// because otherwise it will flip back to Visual mode once initialized.
 		await page.locator( '#test_tinymce_id_ifr' ).waitFor();


### PR DESCRIPTION
In the interest of [#59246](https://github.com/WordPress/gutenberg/issues/59246).

## What?
1. Makes the meta box pane able to be toggled open and closed.
2. Fixes an obscure bug related to fields utilizing TinyMCE editors. See [comment](https://github.com/WordPress/gutenberg/issues/69923#issuecomment-2829290575).

## Why?
1. To offer a quicker way to maximize the view of post content or the meta boxes.
2. Avoids potential frustration of a broken TinyMCE field.

## How?
1. Add label and styling to the resize handle thereby making it appear like a collapsible pane.
2. Monopolize the component used for both tall and short viewports thereby avoiding reparenting of the meta boxes.

## Testing Instructions
### General
1. Open a post with meta boxes (in a viewport > 549 pixels tall).
2. Click the “Meta Boxes” button and verify it opens and closes as expected.
4. Drag from either the button or the handle in its center and verify the pane resizes as expected.

### With unset height preference
1. Reload a post with meta boxes after clearing the height preference by running the following in the console: 
   ```js
   wp.data.dispatch('core/preferences').set('core/edit-post','metaBoxesMainOpenHeight')
   ```
2. Click the “Meta Boxes” button and verify it opens and closes as expected.
3. Drag from either the button or the handle in its center and verify the pane resizes as expected.

### Window resizes that switch between the resizable pane to toggle-only
1. Open a post with meta boxes (in a viewport > 549 pixels tall).
2. Resize the window vertically to less than 549 pixels.
4. Verify the pane’s height switches to `auto` (visually it takes over the entire content area unless its contained meta boxes are very short in which case it fits to their height).
5. Resize the window vertically to greater than 549 pixels.
6. Verify the pane’s height is restored to the height it was before.

### Testing Instructions for Keyboard
1. Open a post with meta boxes (in a viewport > 549 pixels tall).
2. Tab the “Meta Boxes” button.
4. Press <kbd>Space</kbd> or <kbd>Enter</kbd> to open or close the pane.
5. Tab to the separator within the “Meta Boxes” button.
6. Press <kbd>↑</kbd> or <kbd>↓</kbd> to resize the pane.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

