### PR TITLE
Block appender: render on empty page in Write mode

### DIFF
--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -21,6 +21,7 @@ import {
 	getClientIdsWithDescendants,
 	getBlockRootClientId,
 	getBlockAttributes,
+	getBlockCount,
 } from './selectors';
 import {
 	checkAllowListRecursive,
@@ -101,15 +102,19 @@ export function isContainerInsertableToInWriteMode(
 	rootClientId
 ) {
 	const isBlockContentBlock = isContentBlock( blockName );
+	const isBlockListEmpty = ! getBlockCount( state, rootClientId );
 	const rootBlockName = getBlockName( state, rootClientId );
 	const isContainerContentBlock = isContentBlock( rootBlockName );
 	const isRootBlockMain = getSectionRootClientId( state ) === rootClientId;
 
 	// In write mode, containers shouldn't be inserted into unless:
-	// 1. they are a section root;
-	// 2. they are a content block and the block to be inserted is also content.
+	// 1. the entire block list is empty and the block to be inserted is also content;
+	// 2. they are a section root;
+	// 3. they are a content block and the block to be inserted is also content.
 	return (
-		isRootBlockMain || ( isContainerContentBlock && isBlockContentBlock )
+		( isBlockContentBlock && isBlockListEmpty ) ||
+		isRootBlockMain ||
+		( isContainerContentBlock && isBlockContentBlock )
 	);
 }
 

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -10,8 +10,16 @@ import {
 	getExpandedBlock,
 	isDragging,
 	getBlockStyles,
+	isContainerInsertableToInWriteMode,
 } from '../private-selectors';
 import { getBlockEditingMode } from '../selectors';
+
+jest.mock( '@wordpress/blocks/src/api/utils', () => {
+	return {
+		...jest.requireActual( '@wordpress/blocks/src/api/utils' ),
+		isContentBlock: jest.fn(),
+	};
+} );
 
 describe( 'private selectors', () => {
 	describe( 'isBlockInterfaceHidden', () => {
@@ -679,6 +687,44 @@ describe( 'private selectors', () => {
 				'block-1': { color: 'red' },
 				'non-existent-block': undefined,
 			} );
+		} );
+	} );
+
+	describe( 'isContainerInsertableToInWriteMode', () => {
+		const { isContentBlock } = require( '@wordpress/blocks/src/api/utils' );
+
+		beforeEach( () => {
+			jest.clearAllMocks();
+		} );
+
+		it( 'should return true if the block list is empty and the block to be inserted is also content', () => {
+			isContentBlock.mockImplementation(
+				( blockName ) => blockName === 'core/paragraph'
+			);
+
+			const state = {
+				blocks: {
+					order: new Map( [
+						[ 'root-1', [] ], // Empty block list
+					] ),
+					byClientId: new Map( [
+						[
+							'root-1',
+							{ clientId: 'root-1', name: 'core/group' },
+						],
+					] ),
+				},
+			};
+			const blockName = 'core/paragraph'; // Content block.
+			const rootClientId = 'root-1';
+
+			const result = isContainerInsertableToInWriteMode(
+				state,
+				blockName,
+				rootClientId
+			);
+
+			expect( result ).toBe( true );
 		} );
 	} );
 } );


### PR DESCRIPTION
Status: pending following work on https://github.com/WordPress/gutenberg/issues/71517


## What? How?

This PR updates the `isContainerInsertableToInWriteMode` function to include a condition that allows insertion via block appender when the block list is empty and the block to be inserted is a content block. 

Note: this is only a bug for Write mode, and therefore depends on the outcome of 

- https://github.com/WordPress/gutenberg/issues/71517

That is, whether Write mode remains a "thing".

## Why?

It's a bit of an edge case. When you open a blank template with Write Mode enabled, the block appender is missing on the canvas.


## Testing Instructions

1. Enable the "Simplified site editing" experiment at `/wp-admin/admin.php?page=gutenberg-experiments`
2. Enter the Site Editor and switch to Write Mode
3. Return to the Template list and create a new blank template
4. Don't add content
5. You should see the default paragraph and appender

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/c3edbf9e-2c1b-4317-a747-4be9a97ed560



### After

https://github.com/user-attachments/assets/1d3d0269-de01-41f3-b4fd-c624f689d15d




