### PR TITLE
Pattern content only experiment: Make template parts section blocks

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -900,7 +900,7 @@ Describe in a few words what this site is about. This is important for search re
 
 -	**Name:** core/site-tagline
 -	**Category:** theme
--	**Supports:** align (full, wide), color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), color (background, gradients, text), contentRole, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** level, levelOptions, textAlign
 
 ## Site Title

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -519,8 +519,9 @@ export function isSectionBlock( state, clientId ) {
 	}
 
 	const attributes = getBlockAttributes( state, clientId );
+	const isTemplatePart = blockName === 'core/template-part';
 	if (
-		attributes?.metadata?.patternName &&
+		( attributes?.metadata?.patternName || isTemplatePart ) &&
 		!! window?.__experimentalContentOnlyPatternInsertion
 	) {
 		return true;

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -529,7 +529,7 @@ export function isSectionBlock( state, clientId ) {
 
 	// Template parts become sections in navigation mode.
 	const _isNavigationMode = isNavigationMode( state );
-	if ( _isNavigationMode && blockName === 'core/template-part' ) {
+	if ( _isNavigationMode && isTemplatePart ) {
 		return true;
 	}
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2286,6 +2286,9 @@ function getDerivedBlockEditingModesForTree(
 	const contentOnlyParents = [
 		...contentOnlyTemplateLockedClientIds,
 		...unsyncedPatternClientIds,
+		...( window?.__experimentalContentOnlyPatternInsertion
+			? templatePartClientIds
+			: [] ),
 	];
 
 	traverseBlockTree( state, treeClientId, ( block ) => {

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -36,6 +36,7 @@
 				"text": true
 			}
 		},
+		"contentRole": true,
 		"spacing": {
 			"margin": true,
 			"padding": true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #71571
Contributes to #71517

Adds the contentOnly treatment to template parts by default when the experiment is active.

Also adds `support: contentRole` to the Site Tagline block to make that editable in contentOnly mode. (see: [Audit blocks for writing and contentOnly modes](https://github.com/WordPress/gutenberg/issues/65778#top))

The one drawback of changing template parts this is that a user can no longer switch between different patterns for the template part. This feature was previously available in the block inspector. This might need to be considered, but I don't think it's a blocker for this PR. I think the tab implementation described in [Content Only Pattern experiment: Split inspector controls into tabs for patterns](https://github.com/WordPress/gutenberg/issues/71626#top) is required before this can be brought back.

Also note that the navigation block is not supported yet, but that should come later!

## Testing Instructions
First enable the experiment in Gutenberg > Experiments from wp admin:
<img width="932" height="170" alt="image" src="https://github.com/user-attachments/assets/bcb7a3c7-1a2b-4756-be34-c06c5d578d58" />

1. Open the site editor, open a template that has headers, footers or other template parts.
2. Click on the Header or Footer blocks. Note that the content blocks within are highlighted and shown in the inspector
3. Select the blocks within the template and edit them. Try editing a Site Tagline and note that this also works (there's one in the default TT5 footer).
4. Test that editing the design of the template part is possible using the Edit button on the Template Part's toolbar. (this is in trunk too, but it still works in this PR)
5. Turn the experiment off and check that Template Parts work as they do in trunk

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/e4902203-1e57-4727-a4bd-b4848239b6d5

