### PR TITLE
Core Data: Fix field conditions in 'getRevision' selector

### DIFF
--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -1487,7 +1487,7 @@ export const getRevision = createSelector(
 
 		const context = query?.context ?? 'default';
 
-		if ( query === undefined ) {
+		if ( ! query || ! query._fields ) {
 			// If expecting a complete item, validate that completeness.
 			if ( ! queriedState.itemIsComplete[ context ]?.[ revisionKey ] ) {
 				return undefined;
@@ -1497,31 +1497,33 @@ export const getRevision = createSelector(
 		}
 
 		const item = queriedState.items[ context ]?.[ revisionKey ];
-		if ( item && query._fields ) {
-			const filteredItem = {};
-			const fields = getNormalizedCommaSeparable( query._fields ) ?? [];
-
-			for ( let f = 0; f < fields.length; f++ ) {
-				const field = fields[ f ].split( '.' );
-				let value = item;
-				field.forEach( ( fieldName ) => {
-					value = value?.[ fieldName ];
-				} );
-				setNestedValue( filteredItem, field, value );
-			}
-
-			return filteredItem;
+		if ( ! item ) {
+			return item;
 		}
 
-		return item;
+		const filteredItem = {};
+		const fields = getNormalizedCommaSeparable( query._fields ) ?? [];
+
+		for ( let f = 0; f < fields.length; f++ ) {
+			const field = fields[ f ].split( '.' );
+			let value = item;
+			field.forEach( ( fieldName ) => {
+				value = value?.[ fieldName ];
+			} );
+			setNestedValue( filteredItem, field, value );
+		}
+
+		return filteredItem;
 	},
 	( state: State, kind, name, recordKey, revisionKey, query ) => {
 		const context = query?.context ?? 'default';
+		const queriedState =
+			state.entities.records?.[ kind ]?.[ name ]?.revisions?.[
+				recordKey
+			];
 		return [
-			state.entities.records?.[ kind ]?.[ name ]?.revisions?.[ recordKey ]
-				?.items?.[ context ]?.[ revisionKey ],
-			state.entities.records?.[ kind ]?.[ name ]?.revisions?.[ recordKey ]
-				?.itemIsComplete?.[ context ]?.[ revisionKey ],
+			queriedState?.items?.[ context ]?.[ revisionKey ],
+			queriedState?.itemIsComplete?.[ context ]?.[ revisionKey ],
 		];
 	}
 );


### PR DESCRIPTION
## What?
Related #71474.

PR applies recent fixes from the `getEntityRecord` selector to the `getRevision`. Both selectors share 99% of the logic and that unfortunately includes bugs.

## Why?
When a component requests a full entity record, it expects to receive `undefined` or the whole record. Returning partial data can lead to unexpected failures as described in the issue.

## Testing Instructions

```js
// Fetch subset fields.
wp.data.select( 'core' ).getRevision( 'postType', 'post', 12, 2, { _fields: 'id,parent', context: 'edit' } );

// AReturns `undefined` and makes an HTTP request.
wp.data.select( 'core' ).getRevision( 'postType', 'post', 12, 2, { context: 'edit' } );
```
