### PR TITLE
Navigation Link: Use block bindings to dynamically fetch the URL in the editor and on front end. 

### DIFF
--- a/backport-changelog/6.9/10141.md
+++ b/backport-changelog/6.9/10141.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10141
+
+-   https://github.com/WordPress/gutenberg/pull/71630

--- a/backport-changelog/6.9/10141.md
+++ b/backport-changelog/6.9/10141.md
@@ -1,3 +1,3 @@
 https://github.com/WordPress/wordpress-develop/pull/10141
 
--   https://github.com/WordPress/gutenberg/pull/71630
+* https://github.com/WordPress/gutenberg/pull/71630

--- a/docs/reference-guides/block-api/block-bindings.md
+++ b/docs/reference-guides/block-api/block-bindings.md
@@ -20,18 +20,18 @@ An example could be connecting an Image block `url` attribute to a function that
 } -->
 ```
 
-
 ## Compatible blocks and their attributes
 
 Right now, not all block attributes are compatible with block bindings. There is some ongoing effort to increase this compatibility, but for now, this is the list:
 
-| Supported Blocks    | Supported Attributes       |
-| ----------------    | --------------------       |
-| Paragraph           | content                    |
-| Heading             | content                    |
-| Image               | id, url, title, alt        |
-| Button              | text, url, linkTarget, rel |
-| Navigation Link     | url                        |
+| Supported Blocks   | Supported Attributes       |
+| ------------------ | -------------------------- |
+| Paragraph          | content                    |
+| Heading            | content                    |
+| Image              | id, url, title, alt        |
+| Button             | text, url, linkTarget, rel |
+| Navigation Link    | url                        |
+| Navigation Submenu | url                        |
 
 ## Registering a custom source
 
@@ -49,11 +49,11 @@ Server registration allows applying a callback that will be executed on the fron
 
 The function to register a custom source is `register_block_bindings_source($name, $args)`:
 
-- `name`: `string` that sets the unique ID for the custom source.
-- `args`: `array` that contains:
-    - `label`: `string` with the human-readable name of the custom source.
-    - `uses_context`: `array` with the block context that is passed to the callback (optional).
-    - `get_value_callback`: `function` that will run on the bound block's render function. It accepts three arguments: `source_args`, `block_instance` and `attribute_name`. This value can be overridden with the filter `block_bindings_source_value`.
+-   `name`: `string` that sets the unique ID for the custom source.
+-   `args`: `array` that contains:
+    -   `label`: `string` with the human-readable name of the custom source.
+    -   `uses_context`: `array` with the block context that is passed to the callback (optional).
+    -   `get_value_callback`: `function` that will run on the bound block's render function. It accepts three arguments: `source_args`, `block_instance` and `attribute_name`. This value can be overridden with the filter `block_bindings_source_value`.
 
 Note that `register_block_bindings_source()` should be called from a handler attached to the `init` hook.
 
@@ -111,11 +111,11 @@ _**Note:** Since WordPress 6.7._
 The value returned by `get_value_callback` can be modified with the `block_bindings_source_value` filter.
 The filter has the following parameters:
 
-- `value`: The value to be filtered.
-- `name`: The name of the source.
-- `source_args`: `array` containing source arguments.
-- `block_instance`: The block instance object.
-- `attribute_name`: The name of the attribute.
+-   `value`: The value to be filtered.
+-   `name`: The name of the source.
+-   `source_args`: `array` containing source arguments.
+-   `block_instance`: The block instance object.
+-   `attribute_name`: The name of the attribute.
 
 Example:
 
@@ -138,10 +138,9 @@ add_filter( 'block_bindings_source_value', 'wpmovies_format_visualization_date',
 
 There are a few examples in Core that can be used as reference.
 
-- Post Meta. [Source code](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/block-bindings/post-meta.php)
-- Pattern overrides. [Source code](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/block-bindings/pattern-overrides.php)
-- Twenty Twenty-Five theme. [Source code](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-content/themes/twentytwentyfive/functions.php)
-
+-   Post Meta. [Source code](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/block-bindings/post-meta.php)
+-   Pattern overrides. [Source code](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/block-bindings/pattern-overrides.php)
+-   Twenty Twenty-Five theme. [Source code](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-content/themes/twentytwentyfive/functions.php)
 
 ### Editor registration
 
@@ -151,21 +150,18 @@ Editor registration on the client allows defining what the bound block will do w
 
 The function to register a custom source is `registerBlockBindingsSource( args )`:
 
-- `args`: `object` with the following structure:
-    - `name`: `string` with the unique and machine-readable name.
-    - `label`: `string` with the human readable name of the custom source. In case it was defined already on the server, the server label will be overridden by this one, in that case, it is not recommended to be defined here. (optional)
-    - `usesContext`: `array` with the block context that the custom source may need. In case it was defined already on the server, it should not be defined here. (optional)
-    - `getValues`: `function` that retrieves the values from the source. (optional)
-    - `setValues`: `function` that allows updating the values connected to the source. (optional)
-    - `canUserEditValue`: `function` to determine if the user can edit the value. The user won't be able to edit by default. (optional)
-
+-   `args`: `object` with the following structure:
+    -   `name`: `string` with the unique and machine-readable name.
+    -   `label`: `string` with the human readable name of the custom source. In case it was defined already on the server, the server label will be overridden by this one, in that case, it is not recommended to be defined here. (optional)
+    -   `usesContext`: `array` with the block context that the custom source may need. In case it was defined already on the server, it should not be defined here. (optional)
+    -   `getValues`: `function` that retrieves the values from the source. (optional)
+    -   `setValues`: `function` that allows updating the values connected to the source. (optional)
+    -   `canUserEditValue`: `function` to determine if the user can edit the value. The user won't be able to edit by default. (optional)
 
 This example will show a custom post meta date in the editor and, if it doesn't exist, it will show today's date. The user can edit the value of the date. (Caution: This example does not format the user input as a date—it's only for educational purposes.)
 
 ```js
-import {
-	registerBlockBindingsSource,
-} from '@wordpress/blocks';
+import { registerBlockBindingsSource } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { store as coreDataStore } from '@wordpress/core-data';
 
@@ -215,10 +211,10 @@ registerBlockBindingsSource( {
 
 The `getValues` function retrieves the value from the source on block loading. It receives an `object` as an argument with the following properties:
 
-- `bindings` returns the bindings object of the specific source. It must have the attributes as a key, and the value can be a `string` or an `object` with arguments.
-- `clientId` returns a `string` with the current block client ID.
-- `context` returns an `object` of the current block context, defined in the `usesContext` property. [More about block context.](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-context/).
-- `select` returns an `object` of a given store's selectors. [More info in their docs.](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-data/#select).
+-   `bindings` returns the bindings object of the specific source. It must have the attributes as a key, and the value can be a `string` or an `object` with arguments.
+-   `clientId` returns a `string` with the current block client ID.
+-   `context` returns an `object` of the current block context, defined in the `usesContext` property. [More about block context.](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-context/).
+-   `select` returns an `object` of a given store's selectors. [More info in their docs.](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-data/#select).
 
 The function must return an `object` with this structure:
 `{ 'block attribute' : value }`
@@ -227,19 +223,18 @@ The function must return an `object` with this structure:
 
 The `setValues` function updates all the values of the source of the block bound. It receives an `object` as an argument with the following properties:
 
-- `bindings` returns the bindings object of the specific source. It must have the attributes as a key, and the value can be a `string` or an `object` with arguments. This object contains a `newValue` property with the user's input.
-- `clientId` returns a `string` with the current block client ID.
-- `context` returns an `object` of the current block context, defined in the `usesContext` property. [More about block context.](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-context/).
-- `dispatch` returns an `object` of the store's action creators. [More about dispatch](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-data/#dispatch).
-- `select` returns an `object` of a given store's selectors. [More info in their docs.](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-data/#select).
-
+-   `bindings` returns the bindings object of the specific source. It must have the attributes as a key, and the value can be a `string` or an `object` with arguments. This object contains a `newValue` property with the user's input.
+-   `clientId` returns a `string` with the current block client ID.
+-   `context` returns an `object` of the current block context, defined in the `usesContext` property. [More about block context.](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-context/).
+-   `dispatch` returns an `object` of the store's action creators. [More about dispatch](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-data/#dispatch).
+-   `select` returns an `object` of a given store's selectors. [More info in their docs.](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-data/#select).
 
 #### Editor registration Core examples
 
 There are a few examples in Core that can be used as reference.
 
-- Post Meta. [Source code](https://github.com/WordPress/gutenberg/blob/5afd6c27bfba2be2e06b502257753fbfff1ae9f0/packages/editor/src/bindings/post-meta.js#L74-L146)
-- Pattern overrides. [Source code](https://github.com/WordPress/gutenberg/blob/5afd6c27bfba2be2e06b502257753fbfff1ae9f0/packages/editor/src/bindings/pattern-overrides.js#L8-L100)
+-   Post Meta. [Source code](https://github.com/WordPress/gutenberg/blob/5afd6c27bfba2be2e06b502257753fbfff1ae9f0/packages/editor/src/bindings/post-meta.js#L74-L146)
+-   Pattern overrides. [Source code](https://github.com/WordPress/gutenberg/blob/5afd6c27bfba2be2e06b502257753fbfff1ae9f0/packages/editor/src/bindings/pattern-overrides.js#L8-L100)
 
 ## Unregistering a source
 
@@ -304,11 +299,11 @@ import { useBlockBindingsUtils } from '@wordpress/block-editor';
 const { updateBlockBindings } = useBlockBindingsUtils();
 
 function updateBlockBindingsURLSource( url ) {
-	updateBlockBindings({
+	updateBlockBindings( {
 		url: {
 			source: 'myplugin/new-source',
-		}
-	})
+		},
+	} );
 }
 
 // Remove binding from url attribute.
@@ -330,6 +325,3 @@ function clearBlockBindings() {
 	removeAllBlockBindings();
 }
 ```
-
-
-

--- a/docs/reference-guides/block-api/block-bindings.md
+++ b/docs/reference-guides/block-api/block-bindings.md
@@ -31,6 +31,7 @@ Right now, not all block attributes are compatible with block bindings. There is
 | Heading             | content                    |
 | Image               | id, url, title, alt        |
 | Button              | text, url, linkTarget, rel |
+| Navigation Link     | url                        |
 
 ## Registering a custom source
 

--- a/docs/reference-guides/block-api/block-bindings.md
+++ b/docs/reference-guides/block-api/block-bindings.md
@@ -20,18 +20,17 @@ An example could be connecting an Image block `url` attribute to a function that
 } -->
 ```
 
+
 ## Compatible blocks and their attributes
 
 Right now, not all block attributes are compatible with block bindings. There is some ongoing effort to increase this compatibility, but for now, this is the list:
 
-| Supported Blocks   | Supported Attributes       |
-| ------------------ | -------------------------- |
-| Paragraph          | content                    |
-| Heading            | content                    |
-| Image              | id, url, title, alt        |
-| Button             | text, url, linkTarget, rel |
-| Navigation Link    | url                        |
-| Navigation Submenu | url                        |
+| Supported Blocks    | Supported Attributes       |
+| ----------------    | --------------------       |
+| Paragraph           | content                    |
+| Heading             | content                    |
+| Image               | id, url, title, alt        |
+| Button              | text, url, linkTarget, rel |
 
 ## Registering a custom source
 
@@ -49,11 +48,11 @@ Server registration allows applying a callback that will be executed on the fron
 
 The function to register a custom source is `register_block_bindings_source($name, $args)`:
 
--   `name`: `string` that sets the unique ID for the custom source.
--   `args`: `array` that contains:
-    -   `label`: `string` with the human-readable name of the custom source.
-    -   `uses_context`: `array` with the block context that is passed to the callback (optional).
-    -   `get_value_callback`: `function` that will run on the bound block's render function. It accepts three arguments: `source_args`, `block_instance` and `attribute_name`. This value can be overridden with the filter `block_bindings_source_value`.
+- `name`: `string` that sets the unique ID for the custom source.
+- `args`: `array` that contains:
+    - `label`: `string` with the human-readable name of the custom source.
+    - `uses_context`: `array` with the block context that is passed to the callback (optional).
+    - `get_value_callback`: `function` that will run on the bound block's render function. It accepts three arguments: `source_args`, `block_instance` and `attribute_name`. This value can be overridden with the filter `block_bindings_source_value`.
 
 Note that `register_block_bindings_source()` should be called from a handler attached to the `init` hook.
 
@@ -111,11 +110,11 @@ _**Note:** Since WordPress 6.7._
 The value returned by `get_value_callback` can be modified with the `block_bindings_source_value` filter.
 The filter has the following parameters:
 
--   `value`: The value to be filtered.
--   `name`: The name of the source.
--   `source_args`: `array` containing source arguments.
--   `block_instance`: The block instance object.
--   `attribute_name`: The name of the attribute.
+- `value`: The value to be filtered.
+- `name`: The name of the source.
+- `source_args`: `array` containing source arguments.
+- `block_instance`: The block instance object.
+- `attribute_name`: The name of the attribute.
 
 Example:
 
@@ -138,9 +137,10 @@ add_filter( 'block_bindings_source_value', 'wpmovies_format_visualization_date',
 
 There are a few examples in Core that can be used as reference.
 
--   Post Meta. [Source code](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/block-bindings/post-meta.php)
--   Pattern overrides. [Source code](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/block-bindings/pattern-overrides.php)
--   Twenty Twenty-Five theme. [Source code](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-content/themes/twentytwentyfive/functions.php)
+- Post Meta. [Source code](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/block-bindings/post-meta.php)
+- Pattern overrides. [Source code](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/block-bindings/pattern-overrides.php)
+- Twenty Twenty-Five theme. [Source code](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-content/themes/twentytwentyfive/functions.php)
+
 
 ### Editor registration
 
@@ -150,18 +150,21 @@ Editor registration on the client allows defining what the bound block will do w
 
 The function to register a custom source is `registerBlockBindingsSource( args )`:
 
--   `args`: `object` with the following structure:
-    -   `name`: `string` with the unique and machine-readable name.
-    -   `label`: `string` with the human readable name of the custom source. In case it was defined already on the server, the server label will be overridden by this one, in that case, it is not recommended to be defined here. (optional)
-    -   `usesContext`: `array` with the block context that the custom source may need. In case it was defined already on the server, it should not be defined here. (optional)
-    -   `getValues`: `function` that retrieves the values from the source. (optional)
-    -   `setValues`: `function` that allows updating the values connected to the source. (optional)
-    -   `canUserEditValue`: `function` to determine if the user can edit the value. The user won't be able to edit by default. (optional)
+- `args`: `object` with the following structure:
+    - `name`: `string` with the unique and machine-readable name.
+    - `label`: `string` with the human readable name of the custom source. In case it was defined already on the server, the server label will be overridden by this one, in that case, it is not recommended to be defined here. (optional)
+    - `usesContext`: `array` with the block context that the custom source may need. In case it was defined already on the server, it should not be defined here. (optional)
+    - `getValues`: `function` that retrieves the values from the source. (optional)
+    - `setValues`: `function` that allows updating the values connected to the source. (optional)
+    - `canUserEditValue`: `function` to determine if the user can edit the value. The user won't be able to edit by default. (optional)
+
 
 This example will show a custom post meta date in the editor and, if it doesn't exist, it will show today's date. The user can edit the value of the date. (Caution: This example does not format the user input as a date—it's only for educational purposes.)
 
 ```js
-import { registerBlockBindingsSource } from '@wordpress/blocks';
+import {
+	registerBlockBindingsSource,
+} from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { store as coreDataStore } from '@wordpress/core-data';
 
@@ -211,10 +214,10 @@ registerBlockBindingsSource( {
 
 The `getValues` function retrieves the value from the source on block loading. It receives an `object` as an argument with the following properties:
 
--   `bindings` returns the bindings object of the specific source. It must have the attributes as a key, and the value can be a `string` or an `object` with arguments.
--   `clientId` returns a `string` with the current block client ID.
--   `context` returns an `object` of the current block context, defined in the `usesContext` property. [More about block context.](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-context/).
--   `select` returns an `object` of a given store's selectors. [More info in their docs.](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-data/#select).
+- `bindings` returns the bindings object of the specific source. It must have the attributes as a key, and the value can be a `string` or an `object` with arguments.
+- `clientId` returns a `string` with the current block client ID.
+- `context` returns an `object` of the current block context, defined in the `usesContext` property. [More about block context.](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-context/).
+- `select` returns an `object` of a given store's selectors. [More info in their docs.](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-data/#select).
 
 The function must return an `object` with this structure:
 `{ 'block attribute' : value }`
@@ -223,18 +226,19 @@ The function must return an `object` with this structure:
 
 The `setValues` function updates all the values of the source of the block bound. It receives an `object` as an argument with the following properties:
 
--   `bindings` returns the bindings object of the specific source. It must have the attributes as a key, and the value can be a `string` or an `object` with arguments. This object contains a `newValue` property with the user's input.
--   `clientId` returns a `string` with the current block client ID.
--   `context` returns an `object` of the current block context, defined in the `usesContext` property. [More about block context.](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-context/).
--   `dispatch` returns an `object` of the store's action creators. [More about dispatch](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-data/#dispatch).
--   `select` returns an `object` of a given store's selectors. [More info in their docs.](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-data/#select).
+- `bindings` returns the bindings object of the specific source. It must have the attributes as a key, and the value can be a `string` or an `object` with arguments. This object contains a `newValue` property with the user's input.
+- `clientId` returns a `string` with the current block client ID.
+- `context` returns an `object` of the current block context, defined in the `usesContext` property. [More about block context.](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-context/).
+- `dispatch` returns an `object` of the store's action creators. [More about dispatch](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-data/#dispatch).
+- `select` returns an `object` of a given store's selectors. [More info in their docs.](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-data/#select).
+
 
 #### Editor registration Core examples
 
 There are a few examples in Core that can be used as reference.
 
--   Post Meta. [Source code](https://github.com/WordPress/gutenberg/blob/5afd6c27bfba2be2e06b502257753fbfff1ae9f0/packages/editor/src/bindings/post-meta.js#L74-L146)
--   Pattern overrides. [Source code](https://github.com/WordPress/gutenberg/blob/5afd6c27bfba2be2e06b502257753fbfff1ae9f0/packages/editor/src/bindings/pattern-overrides.js#L8-L100)
+- Post Meta. [Source code](https://github.com/WordPress/gutenberg/blob/5afd6c27bfba2be2e06b502257753fbfff1ae9f0/packages/editor/src/bindings/post-meta.js#L74-L146)
+- Pattern overrides. [Source code](https://github.com/WordPress/gutenberg/blob/5afd6c27bfba2be2e06b502257753fbfff1ae9f0/packages/editor/src/bindings/pattern-overrides.js#L8-L100)
 
 ## Unregistering a source
 
@@ -299,11 +303,11 @@ import { useBlockBindingsUtils } from '@wordpress/block-editor';
 const { updateBlockBindings } = useBlockBindingsUtils();
 
 function updateBlockBindingsURLSource( url ) {
-	updateBlockBindings( {
+	updateBlockBindings({
 		url: {
 			source: 'myplugin/new-source',
-		},
-	} );
+		}
+	})
 }
 
 // Remove binding from url attribute.
@@ -325,3 +329,6 @@ function clearBlockBindings() {
 	removeAllBlockBindings();
 }
 ```
+
+
+

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -112,10 +112,11 @@ add_filter( 'render_block', 'gutenberg_block_bindings_render_block', 10, 3 );
 function gutenberg_get_block_bindings_supported_attributes( $block_type ) {
 	// List of block attributes supported by Block Bindings in WP 6.8.
 	$block_bindings_supported_attributes_6_8 = array(
-		'core/paragraph' => array( 'content' ),
-		'core/heading'   => array( 'content' ),
-		'core/image'     => array( 'id', 'url', 'title', 'alt' ),
-		'core/button'    => array( 'url', 'text', 'linkTarget', 'rel' ),
+		'core/paragraph'       => array( 'content' ),
+		'core/heading'         => array( 'content' ),
+		'core/image'           => array( 'id', 'url', 'title', 'alt' ),
+		'core/button'          => array( 'url', 'text', 'linkTarget', 'rel' ),
+		'core/navigation-link' => array( 'url' ),
 	);
 
 	$supported_block_attributes =

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -112,11 +112,11 @@ add_filter( 'render_block', 'gutenberg_block_bindings_render_block', 10, 3 );
 function gutenberg_get_block_bindings_supported_attributes( $block_type ) {
 	// List of block attributes supported by Block Bindings in WP 6.8.
 	$block_bindings_supported_attributes_6_8 = array(
-		'core/paragraph'         => array( 'content' ),
-		'core/heading'           => array( 'content' ),
-		'core/image'             => array( 'id', 'url', 'title', 'alt' ),
-		'core/button'            => array( 'url', 'text', 'linkTarget', 'rel' ),
-		'core/navigation-link'   => array( 'url' ),
+		'core/paragraph'          => array( 'content' ),
+		'core/heading'            => array( 'content' ),
+		'core/image'              => array( 'id', 'url', 'title', 'alt' ),
+		'core/button'             => array( 'url', 'text', 'linkTarget', 'rel' ),
+		'core/navigation-link'    => array( 'url' ),
 		'core/navigation-submenu' => array( 'url' ),
 	);
 
@@ -203,11 +203,11 @@ function gutenberg_process_block_bindings( $instance ) {
 
 	// List of block attributes supported by Block Bindings in WP 6.8.
 	$block_bindings_supported_attributes_6_8 = array(
-		'core/paragraph'         => array( 'content' ),
-		'core/heading'           => array( 'content' ),
-		'core/image'             => array( 'id', 'url', 'title', 'alt' ),
-		'core/button'            => array( 'url', 'text', 'linkTarget', 'rel' ),
-		'core/navigation-link'   => array( 'url' ),
+		'core/paragraph'          => array( 'content' ),
+		'core/heading'            => array( 'content' ),
+		'core/image'              => array( 'id', 'url', 'title', 'alt' ),
+		'core/button'             => array( 'url', 'text', 'linkTarget', 'rel' ),
+		'core/navigation-link'    => array( 'url' ),
 		'core/navigation-submenu' => array( 'url' ),
 	);
 

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -112,11 +112,12 @@ add_filter( 'render_block', 'gutenberg_block_bindings_render_block', 10, 3 );
 function gutenberg_get_block_bindings_supported_attributes( $block_type ) {
 	// List of block attributes supported by Block Bindings in WP 6.8.
 	$block_bindings_supported_attributes_6_8 = array(
-		'core/paragraph'       => array( 'content' ),
-		'core/heading'         => array( 'content' ),
-		'core/image'           => array( 'id', 'url', 'title', 'alt' ),
-		'core/button'          => array( 'url', 'text', 'linkTarget', 'rel' ),
-		'core/navigation-link' => array( 'url' ),
+		'core/paragraph'         => array( 'content' ),
+		'core/heading'           => array( 'content' ),
+		'core/image'             => array( 'id', 'url', 'title', 'alt' ),
+		'core/button'            => array( 'url', 'text', 'linkTarget', 'rel' ),
+		'core/navigation-link'   => array( 'url' ),
+		'core/navigation-submenu' => array( 'url' ),
 	);
 
 	$supported_block_attributes =
@@ -202,10 +203,12 @@ function gutenberg_process_block_bindings( $instance ) {
 
 	// List of block attributes supported by Block Bindings in WP 6.8.
 	$block_bindings_supported_attributes_6_8 = array(
-		'core/paragraph' => array( 'content' ),
-		'core/heading'   => array( 'content' ),
-		'core/image'     => array( 'id', 'url', 'title', 'alt' ),
-		'core/button'    => array( 'url', 'text', 'linkTarget', 'rel' ),
+		'core/paragraph'         => array( 'content' ),
+		'core/heading'           => array( 'content' ),
+		'core/image'             => array( 'id', 'url', 'title', 'alt' ),
+		'core/button'            => array( 'url', 'text', 'linkTarget', 'rel' ),
+		'core/navigation-link'   => array( 'url' ),
+		'core/navigation-submenu' => array( 'url' ),
 	);
 
 	$supported_block_attributes = gutenberg_get_block_bindings_supported_attributes( $block_type );

--- a/lib/compat/wordpress-6.9/entity-block-bindings.php
+++ b/lib/compat/wordpress-6.9/entity-block-bindings.php
@@ -40,11 +40,6 @@ function gutenberg_block_bindings_entity_get_value( array $source_args, $block_i
 		return null;
 	}
 
-	// TODO: Add validation to ensure required attributes exist
-	// TODO: Add error handling for invalid entity types or missing data
-	// TODO: Consider property mapping between posts and terms for future keys
-	// TODO: Support additional keys beyond 'url' in the future
-
 	try {
 		// Handle post types
 		if ( 'post-type' === $kind ) {

--- a/lib/compat/wordpress-6.9/entity-block-bindings.php
+++ b/lib/compat/wordpress-6.9/entity-block-bindings.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Entity source for the block bindings.
+ *
+ * @since 6.9.0
+ * @package gutenberg
+ * @subpackage Block Bindings
+ */
+
+/**
+ * Gets value for Entity source.
+ *
+ * @since 6.9.0
+ * @access private
+ *
+ * @param array    $source_args    Array containing source arguments used to look up the override value.
+ *                                 Example: array( "key" => "url" ).
+ * @param WP_Block $block_instance The block instance.
+ * @return mixed The value computed for the source.
+ */
+function gutenberg_block_bindings_entity_get_value( array $source_args, $block_instance ) {
+	// Get the key from source args - no key means invalid binding
+	if ( empty( $source_args['key'] ) ) {
+		return null;
+	}
+
+	$key = $source_args['key'];
+
+	// For now, only support 'url' key
+	if ( 'url' !== $key ) {
+		return null;
+	}
+
+	// Read entity data from block attributes
+	$entity_id = $block_instance->attributes['id'] ?? null;
+	$type      = $block_instance->attributes['type'] ?? '';
+	$kind      = $block_instance->attributes['kind'] ?? '';
+
+	if ( empty( $entity_id ) ) {
+		return null;
+	}
+
+	// TODO: Add validation to ensure required attributes exist
+	// TODO: Add error handling for invalid entity types or missing data
+	// TODO: Consider property mapping between posts and terms for future keys
+	// TODO: Support additional keys beyond 'url' in the future
+
+	try {
+		// Handle post types
+		if ( 'post-type' === $kind ) {
+			$post = get_post( $entity_id );
+			if ( ! $post ) {
+				return null;
+			}
+
+			$permalink = get_permalink( $entity_id );
+			if ( is_wp_error( $permalink ) ) {
+				return null;
+			}
+
+			return esc_url( $permalink );
+		}
+
+		// Handle taxonomies
+		if ( 'taxonomy' === $kind ) {
+			// Convert 'tag' back to 'post_tag' for API calls
+			// See update-attributes.js line 166 for the reverse conversion
+			$taxonomy_slug = ( 'tag' === $type ) ? 'post_tag' : $type;
+			$term          = get_term( $entity_id, $taxonomy_slug );
+
+			if ( is_wp_error( $term ) || ! $term ) {
+				return null;
+			}
+
+			$term_link = get_term_link( $term );
+			if ( is_wp_error( $term_link ) ) {
+				return null;
+			}
+
+			return esc_url( $term_link );
+		}
+
+		// Unknown entity kind
+		return null;
+	} catch ( Exception $e ) {
+		return null;
+	}
+}
+
+/**
+ * Registers Entity source in the block bindings registry.
+ *
+ * @since 6.9.0
+ * @access private
+ */
+function gutenberg_register_block_bindings_entity_source() {
+	if ( get_block_bindings_source( 'core/entity' ) ) {
+		// The source is already registered.
+		return;
+	}
+
+	register_block_bindings_source(
+		'core/entity',
+		array(
+			'label'              => _x( 'Entity', 'block bindings source' ),
+			'get_value_callback' => 'gutenberg_block_bindings_entity_get_value',
+		)
+	);
+}
+
+add_action( 'init', 'gutenberg_register_block_bindings_entity_source' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -45,6 +45,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-6.9/block-bindings.php';
 	require __DIR__ . '/compat/wordpress-6.9/post-data-block-bindings.php';
 	require __DIR__ . '/compat/wordpress-6.9/term-data-block-bindings.php';
+	require __DIR__ . '/compat/wordpress-6.9/entity-block-bindings.php';
 	require __DIR__ . '/compat/wordpress-6.9/rest-api.php';
 	require __DIR__ . '/compat/wordpress-6.9/class-gutenberg-hierarchical-sort.php';
 

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -437,35 +437,15 @@ function LinkControl( {
 							}
 							hideLabelFromVision={ ! showTextControl }
 							isEntity={ isEntity }
-							suffix={ ( () => {
-								if ( isEntity ) {
-									return (
-										<Button
-											icon={ linkOff }
-											onClick={ handleUnlink }
-											aria-label={ __( 'Unlink' ) }
-											__next40pxDefaultSize
-										/>
-									);
-								}
-								if ( showActions ) {
-									return undefined;
-								}
-								return (
-									<InputControlSuffixWrapper variant="control">
-										<Button
-											onClick={
-												isDisabled ? noop : handleSubmit
-											}
-											label={ __( 'Submit' ) }
-											icon={ keyboardReturn }
-											className="block-editor-link-control__search-submit"
-											aria-disabled={ isDisabled }
-											size="small"
-										/>
-									</InputControlSuffixWrapper>
-								);
-							} )() }
+							suffix={
+								<SearchSuffixControl
+									isEntity={ isEntity }
+									showActions={ showActions }
+									isDisabled={ isDisabled }
+									onUnlink={ handleUnlink }
+									onSubmit={ handleSubmit }
+								/>
+							}
 						/>
 					</div>
 					{ errorMessage && (
@@ -539,6 +519,53 @@ function LinkControl( {
 
 			{ ! isCreatingPage && renderControlBottom && renderControlBottom() }
 		</div>
+	);
+}
+
+/**
+ * Suffix control component for LinkControl search input.
+ * Handles the display of unlink button for entities and submit button for regular links.
+ *
+ * @param {Object}   props             - Component props
+ * @param {boolean}  props.isEntity    - Whether the link is bound to an entity
+ * @param {boolean}  props.showActions - Whether to show action buttons
+ * @param {boolean}  props.isDisabled  - Whether the submit button should be disabled
+ * @param {Function} props.onUnlink    - Callback when unlink button is clicked
+ * @param {Function} props.onSubmit    - Callback when submit button is clicked
+ */
+function SearchSuffixControl( {
+	isEntity,
+	showActions,
+	isDisabled,
+	onUnlink,
+	onSubmit,
+} ) {
+	if ( isEntity ) {
+		return (
+			<Button
+				icon={ linkOff }
+				onClick={ onUnlink }
+				aria-label={ __( 'Unlink' ) }
+				__next40pxDefaultSize
+			/>
+		);
+	}
+
+	if ( showActions ) {
+		return undefined;
+	}
+
+	return (
+		<InputControlSuffixWrapper variant="control">
+			<Button
+				onClick={ isDisabled ? noop : onSubmit }
+				label={ __( 'Submit' ) }
+				icon={ keyboardReturn }
+				className="block-editor-link-control__search-submit"
+				aria-disabled={ isDisabled }
+				size="small"
+			/>
+		</InputControlSuffixWrapper>
 	);
 }
 

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -21,7 +21,7 @@ import { ENTER } from '@wordpress/keycodes';
 import { isShallowEqualObjects } from '@wordpress/is-shallow-equal';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
-import { keyboardReturn } from '@wordpress/icons';
+import { keyboardReturn, linkOff } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -108,6 +108,7 @@ import deprecated from '@wordpress/deprecated';
  * @property {boolean=}                   hasTextControl             Whether to add a text field to the UI to update the value.title.
  * @property {string|Function|undefined}  createSuggestionButtonText The text to use in the button that calls createSuggestion.
  * @property {Function}                   renderControlBottom        Optional controls to be rendered at the bottom of the component.
+ * @property {boolean=}                   handleEntities             Whether to handle entity links (links with ID). When true and a link has an ID, the input will be disabled and show an unlink button.
  */
 
 const noop = () => {};
@@ -142,6 +143,7 @@ function LinkControl( {
 	hasRichPreviews = false,
 	hasTextControl = false,
 	renderControlBottom = null,
+	handleEntities = false,
 } ) {
 	if ( withCreateSuggestion === undefined && createSuggestion ) {
 		withCreateSuggestion = true;
@@ -185,6 +187,7 @@ function LinkControl( {
 	const isMountingRef = useRef( true );
 	const wrapperNode = useRef();
 	const textInputRef = useRef();
+	const searchInputRef = useRef();
 	const isEndingEditWithFocusRef = useRef( false );
 
 	const settingsKeys = settings.map( ( { id } ) => id );
@@ -196,6 +199,9 @@ function LinkControl( {
 		setInternalTextInputValue,
 		createSetInternalSettingValueHandler,
 	] = useInternalValue( value );
+
+	// Compute isEntity internally based on handleEntities prop and presence of ID
+	const isEntity = handleEntities && !! internalControlValue?.id;
 
 	const valueHasChanges =
 		value && ! isShallowEqualObjects( internalControlValue, value );
@@ -336,6 +342,29 @@ function LinkControl( {
 		onCancel?.();
 	};
 
+	const [ shouldFocusSearchInput, setShouldFocusSearchInput ] =
+		useState( false );
+
+	const handleUnlink = () => {
+		// Clear the internal state to remove the ID and re-enable the field
+		// The user will need to submit to commit this change
+		const { id, ...restValue } = internalControlValue;
+		setInternalControlValue( { ...restValue, url: '' } );
+
+		// Request focus after the component re-renders with the cleared state
+		// We can't focus immediately because the input might still be disabled
+		setShouldFocusSearchInput( true );
+	};
+
+	// Focus the search input when requested, once the component has re-rendered
+	// This ensures the input is enabled and ready to receive focus
+	useEffect( () => {
+		if ( shouldFocusSearchInput ) {
+			searchInputRef.current?.focus();
+			setShouldFocusSearchInput( false );
+		}
+	}, [ shouldFocusSearchInput ] );
+
 	const currentUrlInputValue =
 		propInputValue || internalControlValue?.url || '';
 
@@ -389,6 +418,7 @@ function LinkControl( {
 							/>
 						) }
 						<LinkControlSearchInput
+							ref={ searchInputRef }
 							currentLink={ value }
 							className="block-editor-link-control__field block-editor-link-control__search-input"
 							placeholder={ searchInputPlaceholder }
@@ -406,8 +436,22 @@ function LinkControl( {
 								createSuggestionButtonText
 							}
 							hideLabelFromVision={ ! showTextControl }
-							suffix={
-								showActions ? undefined : (
+							isEntity={ isEntity }
+							suffix={ ( () => {
+								if ( isEntity ) {
+									return (
+										<Button
+											icon={ linkOff }
+											onClick={ handleUnlink }
+											aria-label={ __( 'Unlink' ) }
+											__next40pxDefaultSize
+										/>
+									);
+								}
+								if ( showActions ) {
+									return undefined;
+								}
+								return (
 									<InputControlSuffixWrapper variant="control">
 										<Button
 											onClick={
@@ -420,8 +464,8 @@ function LinkControl( {
 											size="small"
 										/>
 									</InputControlSuffixWrapper>
-								)
-							}
+								);
+							} )() }
 						/>
 					</div>
 					{ errorMessage && (

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -14,8 +14,9 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useRef, useState, useEffect } from '@wordpress/element';
+import { useInstanceId } from '@wordpress/compose';
 import { focus } from '@wordpress/dom';
 import { ENTER } from '@wordpress/keycodes';
 import { isShallowEqualObjects } from '@wordpress/is-shallow-equal';
@@ -202,6 +203,10 @@ function LinkControl( {
 
 	// Compute isEntity internally based on handleEntities prop and presence of ID
 	const isEntity = handleEntities && !! internalControlValue?.id;
+
+	// Generate help text ID for accessibility association
+	const baseId = useInstanceId( LinkControl, 'link-control' );
+	const helpTextId = isEntity ? `${ baseId }__help` : null;
 
 	const valueHasChanges =
 		value && ! isShallowEqualObjects( internalControlValue, value );
@@ -444,9 +449,22 @@ function LinkControl( {
 									isDisabled={ isDisabled }
 									onUnlink={ handleUnlink }
 									onSubmit={ handleSubmit }
+									helpTextId={ helpTextId }
 								/>
 							}
 						/>
+						{ isEntity && helpTextId && (
+							<p
+								id={ helpTextId }
+								className="block-editor-link-control__help"
+							>
+								{ sprintf(
+									/* translators: %s: entity type (e.g., page, post) */
+									__( 'Synced with the selected %s.' ),
+									internalControlValue?.type || 'item'
+								) }
+							</p>
+						) }
 					</div>
 					{ errorMessage && (
 						<Notice
@@ -532,6 +550,7 @@ function LinkControl( {
  * @param {boolean}  props.isDisabled  - Whether the submit button should be disabled
  * @param {Function} props.onUnlink    - Callback when unlink button is clicked
  * @param {Function} props.onSubmit    - Callback when submit button is clicked
+ * @param {string}   props.helpTextId  - ID of the help text element for accessibility
  */
 function SearchSuffixControl( {
 	isEntity,
@@ -539,13 +558,16 @@ function SearchSuffixControl( {
 	isDisabled,
 	onUnlink,
 	onSubmit,
+	helpTextId,
 } ) {
 	if ( isEntity ) {
 		return (
 			<Button
 				icon={ linkOff }
 				onClick={ onUnlink }
-				aria-label={ __( 'Unlink' ) }
+				aria-describedby={ helpTextId }
+				showTooltip
+				label={ __( 'Unsync and edit' ) }
 				__next40pxDefaultSize
 			/>
 		);

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -126,7 +126,7 @@ const LinkControlSearchInput = forwardRef(
 		const helpText = isEntity
 			? sprintf(
 					/* translators: %s: entity type (e.g., page, post) */
-					__( 'Link stays in sync with the selected %s.' ),
+					__( 'Synced with the selected %s.' ),
 					currentLink?.type || 'item'
 			  )
 			: null;

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { forwardRef, useState } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -122,15 +122,6 @@ const LinkControlSearchInput = forwardRef(
 				? _placeholder
 				: __( 'Link' );
 
-		// Help text for entity links
-		const helpText = isEntity
-			? sprintf(
-					/* translators: %s: entity type (e.g., page, post) */
-					__( 'Synced with the selected %s.' ),
-					currentLink?.type || 'item'
-			  )
-			: null;
-
 		return (
 			<div className="block-editor-link-control__search-input-container">
 				<URLInput
@@ -165,7 +156,6 @@ const LinkControlSearchInput = forwardRef(
 					inputRef={ ref }
 					suffix={ suffix }
 					disabled={ isEntity }
-					help={ helpText }
 				/>
 				{ children }
 			</div>

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { forwardRef, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -44,6 +44,7 @@ const LinkControlSearchInput = forwardRef(
 			createSuggestionButtonText,
 			hideLabelFromVision = false,
 			suffix,
+			isEntity = false,
 		},
 		ref
 	) => {
@@ -121,6 +122,15 @@ const LinkControlSearchInput = forwardRef(
 				? _placeholder
 				: __( 'Link' );
 
+		// Help text for entity links
+		const helpText = isEntity
+			? sprintf(
+					/* translators: %s: entity type (e.g., page, post) */
+					__( 'Link stays in sync with the selected %s.' ),
+					currentLink?.type || 'item'
+			  )
+			: null;
+
 		return (
 			<div className="block-editor-link-control__search-input-container">
 				<URLInput
@@ -152,8 +162,10 @@ const LinkControlSearchInput = forwardRef(
 							);
 						}
 					} }
-					ref={ ref }
+					inputRef={ ref }
 					suffix={ suffix }
+					disabled={ isEntity }
+					help={ helpText }
 				/>
 				{ children }
 			</div>

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -59,6 +59,15 @@ $block-editor-link-control-number-of-actions: 1;
 	position: relative;
 }
 
+.block-editor-link-control__help {
+	padding: 0 $grid-unit-20;
+	margin-top: -$grid-unit-10;
+	margin-bottom: 0;
+	font-size: $helptext-font-size;
+	font-style: normal;
+	color: $gray-700;
+}
+
 // Provides positioning context for search actions
 .block-editor-link-control__search-input-container,
 .block-editor-link-control__search-input-wrapper {

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -2719,7 +2719,9 @@ describe( 'Entity handling', () => {
 		expect( searchInput ).toBeDisabled();
 
 		// Click the unlink button
-		const unlinkButton = screen.getByRole( 'button', { name: 'Unlink' } );
+		const unlinkButton = screen.getByRole( 'button', {
+			name: 'Unsync and edit',
+		} );
 		await user.click( unlinkButton );
 
 		// Input should now be enabled and value should be cleared
@@ -2742,6 +2744,99 @@ describe( 'Entity handling', () => {
 			title: 'Test Page', // Component preserves original title
 			type: 'page',
 			url: 'https://example.com/different-page',
+		} );
+	} );
+
+	describe( 'Accessibility association for entity links', () => {
+		it( 'should associate unlink button with help text via aria-describedby', () => {
+			const entityLink = {
+				id: 123,
+				url: 'https://example.com/page',
+				title: 'Test Page',
+				type: 'page',
+			};
+
+			render(
+				<LinkControl
+					value={ entityLink }
+					handleEntities
+					forceIsEditingLink
+				/>
+			);
+
+			// Find the unlink button
+			const unlinkButton = screen.getByRole( 'button', {
+				name: 'Unsync and edit',
+			} );
+
+			// Get the help text ID from the button's aria-describedby
+			const helpTextId = unlinkButton.getAttribute( 'aria-describedby' );
+			expect( helpTextId ).toBeTruthy();
+			expect( helpTextId ).toMatch( /^link-control-\d+__help$/ );
+
+			// Verify the help text element exists with the correct content
+			expect(
+				screen.getByText( 'Synced with the selected page.' )
+			).toBeInTheDocument();
+		} );
+
+		it( 'should generate unique help text IDs for multiple LinkControl instances', () => {
+			const entityLink1 = {
+				id: 123,
+				url: 'https://example.com/page1',
+				title: 'Page 1',
+				type: 'page',
+			};
+
+			const entityLink2 = {
+				id: 456,
+				url: 'https://example.com/page2',
+				title: 'Page 2',
+				type: 'page',
+			};
+
+			render(
+				<div>
+					<LinkControl
+						value={ entityLink1 }
+						handleEntities
+						forceIsEditingLink
+					/>
+					<LinkControl
+						value={ entityLink2 }
+						handleEntities
+						forceIsEditingLink
+					/>
+				</div>
+			);
+
+			const unlinkButtons = screen.getAllByRole( 'button', {
+				name: 'Unsync and edit',
+			} );
+
+			// Get help text IDs from both buttons
+			const helpTextId1 =
+				unlinkButtons[ 0 ].getAttribute( 'aria-describedby' );
+			const helpTextId2 =
+				unlinkButtons[ 1 ].getAttribute( 'aria-describedby' );
+
+			// IDs should be different
+			expect( helpTextId1 ).not.toBe( helpTextId2 );
+
+			// Each button should be associated with its corresponding help text
+			expect( unlinkButtons[ 0 ] ).toHaveAttribute(
+				'aria-describedby',
+				helpTextId1
+			);
+			expect( unlinkButtons[ 1 ] ).toHaveAttribute(
+				'aria-describedby',
+				helpTextId2
+			);
+
+			// Help text elements should exist with correct content
+			expect(
+				screen.getAllByText( 'Synced with the selected page.' )
+			).toHaveLength( 2 );
 		} );
 	} );
 } );

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -2633,7 +2633,7 @@ describe( 'Entity handling', () => {
 
 		// Should show help text indicating this is an entity link
 		expect(
-			screen.getByText( 'Link stays in sync with the selected page.' )
+			screen.getByText( 'Synced with the selected page.' )
 		).toBeVisible();
 	} );
 
@@ -2661,7 +2661,7 @@ describe( 'Entity handling', () => {
 
 		// Should not show entity help text for non-entity links
 		expect(
-			screen.queryByText( 'Link stays in sync with the selected page.' )
+			screen.queryByText( 'Synced with the selected page.' )
 		).not.toBeInTheDocument();
 	} );
 

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -2583,6 +2583,169 @@ describe( 'Controlling link title text', () => {
 	} );
 } );
 
+describe( 'Entity handling', () => {
+	it( 'should enable input when handleEntities is false', () => {
+		const entityLink = {
+			id: 123, // provide an id to be considered an entity
+			url: 'https://example.com/page',
+			title: 'Test Page',
+			type: 'page',
+		};
+
+		render(
+			<LinkControl
+				value={ entityLink }
+				handleEntities={ false }
+				forceIsEditingLink
+			/>
+		);
+
+		const searchInput = screen.getByRole( 'combobox', {
+			name: 'Search or type URL',
+		} );
+
+		expect( searchInput ).toBeVisible();
+		expect( searchInput ).toBeEnabled();
+	} );
+
+	it( 'should disable input when handleEntities is true and link has id', () => {
+		const entityLink = {
+			id: 123, // provide an id to be considered an entity
+			url: 'https://example.com/page',
+			title: 'Test Page',
+			type: 'page',
+		};
+
+		render(
+			<LinkControl
+				value={ entityLink }
+				handleEntities
+				forceIsEditingLink
+			/>
+		);
+
+		const searchInput = screen.getByRole( 'combobox', {
+			name: 'Search or type URL',
+		} );
+
+		expect( searchInput ).toBeVisible();
+		expect( searchInput ).toBeDisabled();
+
+		// Should show help text indicating this is an entity link
+		expect(
+			screen.getByText( 'Link stays in sync with the selected page.' )
+		).toBeVisible();
+	} );
+
+	it( 'should enable input when handleEntities is true but link has no id', () => {
+		const nonEntityLink = {
+			url: 'https://example.com/external',
+			title: 'External Link',
+			// No id property - not an entity
+		};
+
+		render(
+			<LinkControl
+				value={ nonEntityLink }
+				handleEntities
+				forceIsEditingLink
+			/>
+		);
+
+		const searchInput = screen.getByRole( 'combobox', {
+			name: 'Search or type URL',
+		} );
+
+		expect( searchInput ).toBeVisible();
+		expect( searchInput ).toBeEnabled();
+
+		// Should not show entity help text for non-entity links
+		expect(
+			screen.queryByText( 'Link stays in sync with the selected page.' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should allow unlinking and selecting different entity', async () => {
+		const user = userEvent.setup();
+
+		// Mock search suggestions to return multiple entities
+		mockFetchSearchSuggestions.mockImplementation( () =>
+			Promise.resolve( [
+				{
+					id: 456, // Different ID from original entity
+					title: 'Different Page',
+					type: 'page',
+					url: 'https://example.com/different-page',
+				},
+				{
+					id: 789,
+					title: 'Another Post',
+					type: 'post',
+					url: 'https://example.com/another-post',
+				},
+				{
+					id: 101,
+					title: 'Third Option',
+					type: 'page',
+					url: 'https://example.com/third-option',
+				},
+			] )
+		);
+
+		const entityLink = {
+			id: 123, // provide an id to be considered an entity
+			url: 'https://example.com/page',
+			title: 'Test Page',
+			type: 'page',
+		};
+
+		const onChange = jest.fn();
+
+		render(
+			<LinkControl
+				value={ entityLink }
+				handleEntities
+				forceIsEditingLink
+				onChange={ onChange }
+				showInitialSuggestions
+			/>
+		);
+
+		const searchInput = screen.getByRole( 'combobox', {
+			name: 'Search or type URL',
+		} );
+
+		// Initially should be disabled
+		expect( searchInput ).toBeDisabled();
+
+		// Click the unlink button
+		const unlinkButton = screen.getByRole( 'button', { name: 'Unlink' } );
+		await user.click( unlinkButton );
+
+		// Input should now be enabled and value should be cleared
+		expect( searchInput ).toBeEnabled();
+		expect( searchInput ).toHaveValue( '' );
+
+		// Wait for initial suggestions to appear automatically
+		const suggestionsList = await screen.findByRole( 'listbox' );
+		expect( suggestionsList ).toBeVisible();
+
+		// Click on a different entity suggestion
+		const differentSuggestion = screen.getByRole( 'option', {
+			name: 'Different Page /different-page Page',
+		} );
+		await user.click( differentSuggestion );
+
+		// Verify that onChange was called with the correct entity data
+		expect( onChange ).toHaveBeenCalledWith( {
+			id: 456,
+			title: 'Test Page', // Component preserves original title
+			type: 'page',
+			url: 'https://example.com/different-page',
+		} );
+	} );
+} );
+
 function getSettingsDrawerToggle() {
 	return screen.queryByRole( 'button', {
 		name: 'Advanced',

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -52,7 +52,7 @@ class URLInput extends Component {
 		this.handleOnClick = this.handleOnClick.bind( this );
 		this.bindSuggestionNode = this.bindSuggestionNode.bind( this );
 		this.autocompleteRef = props.autocompleteRef || createRef();
-		this.inputRef = createRef();
+		this.inputRef = props.inputRef || createRef();
 		this.updateSuggestions = debounce(
 			this.updateSuggestions.bind( this ),
 			200
@@ -424,6 +424,8 @@ class URLInput extends Component {
 			__experimentalRenderControl: renderControl,
 			value = '',
 			hideLabelFromVision = false,
+			help = null,
+			disabled = false,
 		} = this.props;
 
 		const {
@@ -443,6 +445,7 @@ class URLInput extends Component {
 				'is-full-width': isFullWidth,
 			} ),
 			hideLabelFromVision,
+			help,
 		};
 
 		const inputProps = {
@@ -450,10 +453,10 @@ class URLInput extends Component {
 			value,
 			required: true,
 			type: 'text',
-			onChange: this.onChange,
-			onFocus: this.onFocus,
+			onChange: disabled ? () => {} : this.onChange, // Disable onChange when disabled
+			onFocus: disabled ? () => {} : this.onFocus, // Disable onFocus when disabled
 			placeholder,
-			onKeyDown: this.onKeyDown,
+			onKeyDown: disabled ? () => {} : this.onKeyDown, // Disable onKeyDown when disabled
 			role: 'combobox',
 			'aria-label': label ? undefined : __( 'URL' ), // Ensure input always has an accessible label
 			'aria-expanded': showSuggestions,
@@ -464,6 +467,7 @@ class URLInput extends Component {
 					? `${ suggestionOptionIdPrefix }-${ selectedSuggestion }`
 					: undefined,
 			ref: this.inputRef,
+			disabled,
 			suffix: this.props.suffix,
 		};
 

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -426,6 +426,7 @@ class URLInput extends Component {
 			hideLabelFromVision = false,
 			help = null,
 			disabled = false,
+			'aria-describedby': ariaDescribedBy,
 		} = this.props;
 
 		const {
@@ -445,7 +446,6 @@ class URLInput extends Component {
 				'is-full-width': isFullWidth,
 			} ),
 			hideLabelFromVision,
-			help,
 		};
 
 		const inputProps = {
@@ -469,6 +469,8 @@ class URLInput extends Component {
 			ref: this.inputRef,
 			disabled,
 			suffix: this.props.suffix,
+			help,
+			'aria-describedby': ariaDescribedBy,
 		};
 
 		if ( renderControl ) {

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -426,7 +426,6 @@ class URLInput extends Component {
 			hideLabelFromVision = false,
 			help = null,
 			disabled = false,
-			'aria-describedby': ariaDescribedBy,
 		} = this.props;
 
 		const {
@@ -470,7 +469,6 @@ class URLInput extends Component {
 			disabled,
 			suffix: this.props.suffix,
 			help,
-			'aria-describedby': ariaDescribedBy,
 		};
 
 		if ( renderControl ) {

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -8,23 +8,9 @@ import clsx from 'clsx';
  */
 import { createBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
-<<<<<<< HEAD
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
-=======
-import {
-	__experimentalToolsPanel as ToolsPanel,
-	__experimentalToolsPanelItem as ToolsPanelItem,
-	Button,
-	CheckboxControl,
-	TextControl,
-	TextareaControl,
-	ToolbarButton,
-	ToolbarGroup,
-	__experimentalInputControl as InputControl,
-} from '@wordpress/components';
->>>>>>> f8975048f3e (Initial commit)
 import { displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
 	BlockControls,
 	InspectorControls,
@@ -36,20 +22,10 @@ import {
 	useBlockEditingMode,
 	useBlockBindingsUtils,
 } from '@wordpress/block-editor';
-<<<<<<< HEAD
 import { isURL, prependHTTP } from '@wordpress/url';
-import { useState, useEffect, useRef } from '@wordpress/element';
-=======
-import { isURL, prependHTTP, safeDecodeURI } from '@wordpress/url';
 import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
-import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
->>>>>>> f8975048f3e (Initial commit)
 import { decodeEntities } from '@wordpress/html-entities';
-import {
-	link as linkIcon,
-	addSubmenu,
-	linkOff as unlinkIcon,
-} from '@wordpress/icons';
+import { link as linkIcon, addSubmenu } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 import { useMergeRefs, usePrevious } from '@wordpress/compose';
 
@@ -183,222 +159,6 @@ function getMissingText( type ) {
 
 	return missingText;
 }
-
-function getEntityTypeName( type, kind ) {
-	// Return the type name if available, otherwise use fallback based on kind
-	if ( type ) {
-		return type;
-	}
-
-	// Use appropriate fallback based on kind
-	if ( kind === 'post-type' ) {
-		return __( 'post' );
-	}
-
-	if ( kind === 'taxonomy' ) {
-		return __( 'term' );
-	}
-
-	// Default fallback
-	return __( 'item' );
-}
-
-/*
- * Warning, this duplicated in
- * packages/block-library/src/navigation-submenu/edit.js
- * Consider reusing this components for both blocks.
- */
-<<<<<<< HEAD
-=======
-function Controls( {
-	attributes,
-	setAttributes,
-	setIsEditingControl,
-	hasUrlBinding = false,
-	updateBlockBindings,
-} ) {
-	const { label, url, description, rel, opensInNewTab } = attributes;
-	const lastURLRef = useRef( url );
-	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
-
-	// Function to edit the bound link - removes binding and clears url/id to allow picking new entity
-	const editBoundLink = () => {
-		// Remove the binding
-		updateBlockBindings( { url: undefined } );
-
-		// Clear url and id to allow picking a new entity (keep type and kind)
-		setAttributes( {
-			url: undefined,
-			id: undefined,
-		} );
-	};
-	return (
-		<ToolsPanel
-			label={ __( 'Settings' ) }
-			resetAll={ () => {
-				setAttributes( {
-					label: '',
-					url: '',
-					description: '',
-					rel: '',
-					opensInNewTab: false,
-				} );
-			} }
-			dropdownMenuProps={ dropdownMenuProps }
-		>
-			<ToolsPanelItem
-				hasValue={ () => !! label }
-				label={ __( 'Text' ) }
-				onDeselect={ () => setAttributes( { label: '' } ) }
-				isShownByDefault
-			>
-				<TextControl
-					__nextHasNoMarginBottom
-					__next40pxDefaultSize
-					label={ __( 'Text' ) }
-					value={ label ? stripHTML( label ) : '' }
-					onChange={ ( labelValue ) => {
-						setAttributes( { label: labelValue } );
-					} }
-					autoComplete="off"
-					onFocus={ () => setIsEditingControl( true ) }
-					onBlur={ () => setIsEditingControl( false ) }
-				/>
-			</ToolsPanelItem>
-
-			<ToolsPanelItem
-				hasValue={ () => !! url }
-				label={ __( 'Link' ) }
-				onDeselect={ () => {
-					if ( ! hasUrlBinding ) {
-						setAttributes( { url: '' } );
-					}
-				} }
-				isShownByDefault
-			>
-				<InputControl
-					__nextHasNoMarginBottom
-					__next40pxDefaultSize
-					label={ __( 'Link' ) }
-					value={ url ? safeDecodeURI( url ) : '' }
-					onChange={ ( urlValue ) => {
-						if ( hasUrlBinding ) {
-							return; // Prevent editing when URL is bound
-						}
-						setAttributes( {
-							url: encodeURI( safeDecodeURI( urlValue ) ),
-						} );
-					} }
-					autoComplete="off"
-					type="url"
-					disabled={ hasUrlBinding }
-					onFocus={ () => {
-						if ( hasUrlBinding ) {
-							return;
-						}
-						lastURLRef.current = url;
-						setIsEditingControl( true );
-					} }
-					onBlur={ () => {
-						if ( hasUrlBinding ) {
-							return;
-						}
-						// Defer the updateAttributes call to ensure entity connection isn't severed by accident.
-						updateAttributes(
-							{ url: ! url ? lastURLRef.current : url },
-							setAttributes,
-							{ ...attributes, url: lastURLRef.current }
-						);
-						setIsEditingControl( false );
-					} }
-					help={
-						hasUrlBinding &&
-						( () => {
-							const entityType = getEntityTypeName(
-								attributes.type,
-								attributes.kind
-							);
-							return sprintf(
-								/* translators: %s is the entity type (e.g., "page", "post", "category") */
-								__(
-									'Link stays in sync with the selected %s.'
-								),
-								entityType
-							);
-						} )()
-					}
-					suffix={
-						hasUrlBinding && (
-							<Button
-								icon={ unlinkIcon }
-								onClick={ editBoundLink }
-								aria-label={ __( 'Unlink and edit' ) }
-								__next40pxDefaultSize
-							/>
-						)
-					}
-				/>
-			</ToolsPanelItem>
-
-			<ToolsPanelItem
-				hasValue={ () => !! opensInNewTab }
-				label={ __( 'Open in new tab' ) }
-				onDeselect={ () => setAttributes( { opensInNewTab: false } ) }
-				isShownByDefault
-			>
-				<CheckboxControl
-					__nextHasNoMarginBottom
-					label={ __( 'Open in new tab' ) }
-					checked={ opensInNewTab }
-					onChange={ ( value ) =>
-						setAttributes( { opensInNewTab: value } )
-					}
-				/>
-			</ToolsPanelItem>
-
-			<ToolsPanelItem
-				hasValue={ () => !! description }
-				label={ __( 'Description' ) }
-				onDeselect={ () => setAttributes( { description: '' } ) }
-				isShownByDefault
-			>
-				<TextareaControl
-					__nextHasNoMarginBottom
-					label={ __( 'Description' ) }
-					value={ description || '' }
-					onChange={ ( descriptionValue ) => {
-						setAttributes( { description: descriptionValue } );
-					} }
-					help={ __(
-						'The description will be displayed in the menu if the current theme supports it.'
-					) }
-				/>
-			</ToolsPanelItem>
-
-			<ToolsPanelItem
-				hasValue={ () => !! rel }
-				label={ __( 'Rel attribute' ) }
-				onDeselect={ () => setAttributes( { rel: '' } ) }
-				isShownByDefault
-			>
-				<TextControl
-					__nextHasNoMarginBottom
-					__next40pxDefaultSize
-					label={ __( 'Rel attribute' ) }
-					value={ rel || '' }
-					onChange={ ( relValue ) => {
-						setAttributes( { rel: relValue } );
-					} }
-					autoComplete="off"
-					help={ __(
-						'The relationship of the linked URL as space-separated link types.'
-					) }
-				/>
-			</ToolsPanelItem>
-		</ToolsPanel>
-	);
-}
->>>>>>> f8975048f3e (Initial commit)
 
 export default function NavigationLinkEdit( {
 	attributes,
@@ -675,7 +435,6 @@ export default function NavigationLinkEdit( {
 					) }
 				</ToolbarGroup>
 			</BlockControls>
-			{ /* Warning, this duplicated in packages/block-library/src/navigation-submenu/edit.js */ }
 			<InspectorControls>
 				<Controls
 					attributes={ attributes }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -250,7 +250,7 @@ export default function NavigationLinkEdit( {
 	// URL binding logic
 	const { updateBlockBindings } = useBlockBindingsUtils( clientId );
 
-	const hasUrlBinding = isSelected && !! metadata?.bindings?.url && !! id;
+	const hasUrlBinding = !! metadata?.bindings?.url && !! id;
 
 	const [ isInvalid, isDraft ] = useIsInvalidLink(
 		kind,

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -8,9 +8,23 @@ import clsx from 'clsx';
  */
 import { createBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
+<<<<<<< HEAD
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
+=======
+import {
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+	Button,
+	CheckboxControl,
+	TextControl,
+	TextareaControl,
+	ToolbarButton,
+	ToolbarGroup,
+	__experimentalInputControl as InputControl,
+} from '@wordpress/components';
+>>>>>>> f8975048f3e (Initial commit)
 import { displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	BlockControls,
 	InspectorControls,
@@ -20,11 +34,22 @@ import {
 	getColorClassName,
 	useInnerBlocksProps,
 	useBlockEditingMode,
+	useBlockBindingsUtils,
 } from '@wordpress/block-editor';
+<<<<<<< HEAD
 import { isURL, prependHTTP } from '@wordpress/url';
 import { useState, useEffect, useRef } from '@wordpress/element';
+=======
+import { isURL, prependHTTP, safeDecodeURI } from '@wordpress/url';
+import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
+import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
+>>>>>>> f8975048f3e (Initial commit)
 import { decodeEntities } from '@wordpress/html-entities';
-import { link as linkIcon, addSubmenu } from '@wordpress/icons';
+import {
+	link as linkIcon,
+	addSubmenu,
+	linkOff as unlinkIcon,
+} from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 import { useMergeRefs, usePrevious } from '@wordpress/compose';
 
@@ -159,11 +184,221 @@ function getMissingText( type ) {
 	return missingText;
 }
 
+function getEntityTypeName( type, kind ) {
+	// Return the type name if available, otherwise use fallback based on kind
+	if ( type ) {
+		return type;
+	}
+
+	// Use appropriate fallback based on kind
+	if ( kind === 'post-type' ) {
+		return __( 'post' );
+	}
+
+	if ( kind === 'taxonomy' ) {
+		return __( 'term' );
+	}
+
+	// Default fallback
+	return __( 'item' );
+}
+
 /*
  * Warning, this duplicated in
  * packages/block-library/src/navigation-submenu/edit.js
  * Consider reusing this components for both blocks.
  */
+<<<<<<< HEAD
+=======
+function Controls( {
+	attributes,
+	setAttributes,
+	setIsEditingControl,
+	hasUrlBinding = false,
+	updateBlockBindings,
+} ) {
+	const { label, url, description, rel, opensInNewTab } = attributes;
+	const lastURLRef = useRef( url );
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+
+	// Function to edit the bound link - removes binding and clears url/id to allow picking new entity
+	const editBoundLink = () => {
+		// Remove the binding
+		updateBlockBindings( { url: undefined } );
+
+		// Clear url and id to allow picking a new entity (keep type and kind)
+		setAttributes( {
+			url: undefined,
+			id: undefined,
+		} );
+	};
+	return (
+		<ToolsPanel
+			label={ __( 'Settings' ) }
+			resetAll={ () => {
+				setAttributes( {
+					label: '',
+					url: '',
+					description: '',
+					rel: '',
+					opensInNewTab: false,
+				} );
+			} }
+			dropdownMenuProps={ dropdownMenuProps }
+		>
+			<ToolsPanelItem
+				hasValue={ () => !! label }
+				label={ __( 'Text' ) }
+				onDeselect={ () => setAttributes( { label: '' } ) }
+				isShownByDefault
+			>
+				<TextControl
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+					label={ __( 'Text' ) }
+					value={ label ? stripHTML( label ) : '' }
+					onChange={ ( labelValue ) => {
+						setAttributes( { label: labelValue } );
+					} }
+					autoComplete="off"
+					onFocus={ () => setIsEditingControl( true ) }
+					onBlur={ () => setIsEditingControl( false ) }
+				/>
+			</ToolsPanelItem>
+
+			<ToolsPanelItem
+				hasValue={ () => !! url }
+				label={ __( 'Link' ) }
+				onDeselect={ () => {
+					if ( ! hasUrlBinding ) {
+						setAttributes( { url: '' } );
+					}
+				} }
+				isShownByDefault
+			>
+				<InputControl
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+					label={ __( 'Link' ) }
+					value={ url ? safeDecodeURI( url ) : '' }
+					onChange={ ( urlValue ) => {
+						if ( hasUrlBinding ) {
+							return; // Prevent editing when URL is bound
+						}
+						setAttributes( {
+							url: encodeURI( safeDecodeURI( urlValue ) ),
+						} );
+					} }
+					autoComplete="off"
+					type="url"
+					disabled={ hasUrlBinding }
+					onFocus={ () => {
+						if ( hasUrlBinding ) {
+							return;
+						}
+						lastURLRef.current = url;
+						setIsEditingControl( true );
+					} }
+					onBlur={ () => {
+						if ( hasUrlBinding ) {
+							return;
+						}
+						// Defer the updateAttributes call to ensure entity connection isn't severed by accident.
+						updateAttributes(
+							{ url: ! url ? lastURLRef.current : url },
+							setAttributes,
+							{ ...attributes, url: lastURLRef.current }
+						);
+						setIsEditingControl( false );
+					} }
+					help={
+						hasUrlBinding &&
+						( () => {
+							const entityType = getEntityTypeName(
+								attributes.type,
+								attributes.kind
+							);
+							return sprintf(
+								/* translators: %s is the entity type (e.g., "page", "post", "category") */
+								__(
+									'Link stays in sync with the selected %s.'
+								),
+								entityType
+							);
+						} )()
+					}
+					suffix={
+						hasUrlBinding && (
+							<Button
+								icon={ unlinkIcon }
+								onClick={ editBoundLink }
+								aria-label={ __( 'Unlink and edit' ) }
+								__next40pxDefaultSize
+							/>
+						)
+					}
+				/>
+			</ToolsPanelItem>
+
+			<ToolsPanelItem
+				hasValue={ () => !! opensInNewTab }
+				label={ __( 'Open in new tab' ) }
+				onDeselect={ () => setAttributes( { opensInNewTab: false } ) }
+				isShownByDefault
+			>
+				<CheckboxControl
+					__nextHasNoMarginBottom
+					label={ __( 'Open in new tab' ) }
+					checked={ opensInNewTab }
+					onChange={ ( value ) =>
+						setAttributes( { opensInNewTab: value } )
+					}
+				/>
+			</ToolsPanelItem>
+
+			<ToolsPanelItem
+				hasValue={ () => !! description }
+				label={ __( 'Description' ) }
+				onDeselect={ () => setAttributes( { description: '' } ) }
+				isShownByDefault
+			>
+				<TextareaControl
+					__nextHasNoMarginBottom
+					label={ __( 'Description' ) }
+					value={ description || '' }
+					onChange={ ( descriptionValue ) => {
+						setAttributes( { description: descriptionValue } );
+					} }
+					help={ __(
+						'The description will be displayed in the menu if the current theme supports it.'
+					) }
+				/>
+			</ToolsPanelItem>
+
+			<ToolsPanelItem
+				hasValue={ () => !! rel }
+				label={ __( 'Rel attribute' ) }
+				onDeselect={ () => setAttributes( { rel: '' } ) }
+				isShownByDefault
+			>
+				<TextControl
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+					label={ __( 'Rel attribute' ) }
+					value={ rel || '' }
+					onChange={ ( relValue ) => {
+						setAttributes( { rel: relValue } );
+					} }
+					autoComplete="off"
+					help={ __(
+						'The relationship of the linked URL as space-separated link types.'
+					) }
+				/>
+			</ToolsPanelItem>
+		</ToolsPanel>
+	);
+}
+>>>>>>> f8975048f3e (Initial commit)
 
 export default function NavigationLinkEdit( {
 	attributes,
@@ -175,7 +410,7 @@ export default function NavigationLinkEdit( {
 	context,
 	clientId,
 } ) {
-	const { id, label, type, url, description, kind } = attributes;
+	const { id, label, type, url, description, kind, metadata } = attributes;
 	const { maxNestingLevel } = context;
 
 	const {
@@ -252,6 +487,11 @@ export default function NavigationLinkEdit( {
 	);
 	const { getBlocks } = useSelect( blockEditorStore );
 
+	// URL binding logic
+	const { updateBlockBindings } = useBlockBindingsUtils( clientId );
+
+	const hasUrlBinding = isSelected && !! metadata?.bindings?.url && !! id;
+
 	const [ isInvalid, isDraft ] = useIsInvalidLink(
 		kind,
 		type,
@@ -262,7 +502,7 @@ export default function NavigationLinkEdit( {
 	/**
 	 * Transform to submenu block.
 	 */
-	const transformToSubmenu = () => {
+	const transformToSubmenu = useCallback( () => {
 		let innerBlocks = getBlocks( clientId );
 		if ( innerBlocks.length === 0 ) {
 			innerBlocks = [ createBlock( 'core/navigation-link' ) ];
@@ -274,7 +514,7 @@ export default function NavigationLinkEdit( {
 			innerBlocks
 		);
 		replaceBlock( clientId, newSubmenu );
-	};
+	}, [ getBlocks, clientId, selectBlock, replaceBlock, attributes ] );
 
 	useEffect( () => {
 		// If block has inner blocks, transform to Submenu.
@@ -441,13 +681,17 @@ export default function NavigationLinkEdit( {
 					attributes={ attributes }
 					setAttributes={ setAttributes }
 					setIsEditingControl={ setIsEditingControl }
+					hasUrlBinding={ hasUrlBinding }
+					updateBlockBindings={ updateBlockBindings }
 				/>
 			</InspectorControls>
 			<div { ...blockProps }>
 				{ /* eslint-disable jsx-a11y/anchor-is-valid */ }
 				<a className={ classes }>
 					{ /* eslint-enable */ }
-					{ ! url && ! isEditingControl ? (
+					{ ! url &&
+					! isEditingControl &&
+					! metadata?.bindings?.url ? (
 						<div className="wp-block-navigation-link__placeholder-text">
 							<span>{ missingText }</span>
 						</div>
@@ -566,6 +810,21 @@ export default function NavigationLinkEdit( {
 									setAttributes,
 									attributes
 								);
+
+								// Auto-bind URL if a post is selected and no binding exists
+								if (
+									updatedValue.id &&
+									! metadata?.bindings?.url
+								) {
+									updateBlockBindings( {
+										url: {
+											source: 'core/entity',
+											args: {
+												key: 'url',
+											},
+										},
+									} );
+								}
 							} }
 						/>
 					) }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -20,7 +20,6 @@ import {
 	getColorClassName,
 	useInnerBlocksProps,
 	useBlockEditingMode,
-	useBlockBindingsUtils,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
 import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
@@ -33,7 +32,7 @@ import { useMergeRefs, usePrevious } from '@wordpress/compose';
  * Internal dependencies
  */
 import { getColors } from '../navigation/edit/utils';
-import { Controls, LinkUI, updateAttributes } from './shared';
+import { Controls, LinkUI, updateAttributes, useEntityBinding } from './shared';
 
 const DEFAULT_BLOCK = { name: 'core/navigation-link' };
 const NESTING_BLOCK_NAMES = [
@@ -248,9 +247,10 @@ export default function NavigationLinkEdit( {
 	const { getBlocks } = useSelect( blockEditorStore );
 
 	// URL binding logic
-	const { updateBlockBindings } = useBlockBindingsUtils( clientId );
-
-	const hasUrlBinding = !! metadata?.bindings?.url && !! id;
+	const { clearBinding, createBinding } = useEntityBinding( {
+		clientId,
+		attributes,
+	} );
 
 	const [ isInvalid, isDraft ] = useIsInvalidLink(
 		kind,
@@ -440,8 +440,7 @@ export default function NavigationLinkEdit( {
 					attributes={ attributes }
 					setAttributes={ setAttributes }
 					setIsEditingControl={ setIsEditingControl }
-					hasUrlBinding={ hasUrlBinding }
-					updateBlockBindings={ updateBlockBindings }
+					clientId={ clientId }
 				/>
 			</InspectorControls>
 			<div { ...blockProps }>
@@ -570,19 +569,11 @@ export default function NavigationLinkEdit( {
 									attributes
 								);
 
-								// Auto-bind URL if a post is selected and no binding exists
-								if (
-									updatedValue.id &&
-									! metadata?.bindings?.url
-								) {
-									updateBlockBindings( {
-										url: {
-											source: 'core/entity',
-											args: {
-												key: 'url',
-											},
-										},
-									} );
+								// Handle URL binding
+								if ( ! updatedValue?.id ) {
+									clearBinding();
+								} else {
+									createBinding();
 								}
 							} }
 						/>

--- a/packages/block-library/src/navigation-link/link-ui/index.js
+++ b/packages/block-library/src/navigation-link/link-ui/index.js
@@ -66,7 +66,7 @@ export function getSuggestionsQuery( type, kind ) {
 }
 
 function UnforwardedLinkUI( props, ref ) {
-	const { label, url, opensInNewTab, type, kind } = props.link;
+	const { label, url, opensInNewTab, type, kind, id } = props.link;
 	const postType = type || 'page';
 
 	const [ addingBlock, setAddingBlock ] = useState( false );
@@ -85,8 +85,11 @@ function UnforwardedLinkUI( props, ref ) {
 			url,
 			opensInNewTab,
 			title: label && stripHTML( label ),
+			kind,
+			type,
+			id,
 		} ),
-		[ label, opensInNewTab, url ]
+		[ label, opensInNewTab, url, kind, type, id ]
 	);
 
 	const handlePageCreated = ( pageLink ) => {
@@ -142,6 +145,7 @@ function UnforwardedLinkUI( props, ref ) {
 						onChange={ props.onChange }
 						onRemove={ props.onRemove }
 						onCancel={ props.onCancel }
+						handleEntities
 						renderControlBottom={ () => {
 							// Don't show the tools when there is submitted link (preview state).
 							if ( link?.url?.length ) {

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -165,18 +165,12 @@ export function Controls( {
 						setIsEditingControl( false );
 					} }
 					help={
-						hasUrlBinding &&
-						( () => {
-							const entityType = getEntityTypeName(
-								attributes.type,
-								attributes.kind
-							);
-							return sprintf(
-								/* translators: %s is the entity type (e.g., "page", "post", "category") */
-								__( 'Synced with the selected %s.' ),
-								entityType
-							);
-						} )()
+						hasUrlBinding && (
+							<BindingHelpText
+								type={ attributes.type }
+								kind={ attributes.kind }
+							/>
+						)
 					}
 					suffix={
 						hasUrlBinding && (
@@ -249,5 +243,22 @@ export function Controls( {
 				/>
 			</ToolsPanelItem>
 		</ToolsPanel>
+	);
+}
+
+/**
+ * Component to display help text for bound URL attributes.
+ *
+ * @param {Object} props      - Component props
+ * @param {string} props.type - The entity type
+ * @param {string} props.kind - The entity kind
+ * @return {string} Help text for the bound URL
+ */
+function BindingHelpText( { type, kind } ) {
+	const entityType = getEntityTypeName( type, kind );
+	return sprintf(
+		/* translators: %s is the entity type (e.g., "page", "post", "category") */
+		__( 'Synced with the selected %s.' ),
+		entityType
 	);
 }

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -4,6 +4,7 @@
 import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	__experimentalInputControl as InputControl,
 	CheckboxControl,
 	TextControl,
 	TextareaControl,
@@ -34,10 +35,20 @@ export function Controls( {
 	attributes,
 	setAttributes,
 	setIsEditingControl = () => {},
+	updateBlockBindings,
+	hasUrlBinding,
 } ) {
 	const { label, url, description, rel, opensInNewTab } = attributes;
 	const lastURLRef = useRef( url );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+
+	const editBoundLink = () => {
+		// Remove the binding
+		updateBlockBindings( { url: undefined } );
+
+		// Clear url and id to allow picking a new entity (keep type and kind)
+		setAttributes( { url: undefined, id: undefined } );
+	};
 
 	return (
 		<ToolsPanel
@@ -79,23 +90,33 @@ export function Controls( {
 				onDeselect={ () => setAttributes( { url: '' } ) }
 				isShownByDefault
 			>
-				<TextControl
+				<InputControl
 					__nextHasNoMarginBottom
 					__next40pxDefaultSize
 					label={ __( 'Link' ) }
 					value={ url ? safeDecodeURI( url ) : '' }
 					onChange={ ( urlValue ) => {
+						if ( hasUrlBinding ) {
+							return; // Prevent editing when URL is bound
+						}
 						setAttributes( {
 							url: encodeURI( safeDecodeURI( urlValue ) ),
 						} );
 					} }
 					autoComplete="off"
 					type="url"
+					disabled={ hasUrlBinding }
 					onFocus={ () => {
+						if ( hasUrlBinding ) {
+							return;
+						}
 						lastURLRef.current = url;
 						setIsEditingControl( true );
 					} }
 					onBlur={ () => {
+						if ( hasUrlBinding ) {
+							return;
+						}
 						// Defer the updateAttributes call to ensure entity connection isn't severed by accident.
 						updateAttributes(
 							{ url: ! url ? lastURLRef.current : url },
@@ -104,6 +125,32 @@ export function Controls( {
 						);
 						setIsEditingControl( false );
 					} }
+					help={
+						hasUrlBinding &&
+						( () => {
+							const entityType = getEntityTypeName(
+								attributes.type,
+								attributes.kind
+							);
+							return sprintf(
+								/* translators: %s is the entity type (e.g., "page", "post", "category") */
+								__(
+									'Link stays in sync with the selected %s.'
+								),
+								entityType
+							);
+						} )()
+					}
+					suffix={
+						hasUrlBinding && (
+							<Button
+								icon={ unlinkIcon }
+								onClick={ editBoundLink }
+								aria-label={ __( 'Unlink and edit' ) }
+								__next40pxDefaultSize
+							/>
+						)
+					}
 				/>
 			</ToolsPanelItem>
 

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -22,6 +22,7 @@ import { linkOff as unlinkIcon } from '@wordpress/icons';
  */
 import { useToolsPanelDropdownMenuProps } from '../../utils/hooks';
 import { updateAttributes } from './update-attributes';
+import { useEntityBinding } from './use-entity-binding';
 
 /**
  * Get a human-readable entity type name.
@@ -64,15 +65,13 @@ function getEntityTypeName( type, kind ) {
  * @param {Object}   props.attributes          - Block attributes
  * @param {Function} props.setAttributes       - Function to update block attributes
  * @param {Function} props.setIsEditingControl - Function to set editing state (optional)
- * @param {Function} props.updateBlockBindings - Function to update block bindings
- * @param {boolean}  props.hasUrlBinding       - Whether the URL is bound to an entity
+ * @param {string}   props.clientId            - Block client ID
  */
 export function Controls( {
 	attributes,
 	setAttributes,
 	setIsEditingControl = () => {},
-	updateBlockBindings,
-	hasUrlBinding,
+	clientId,
 } ) {
 	const { label, url, description, rel, opensInNewTab } = attributes;
 	const lastURLRef = useRef( url );
@@ -80,9 +79,15 @@ export function Controls( {
 	const inputId = useInstanceId( Controls, 'link-input' );
 	const helpTextId = `${ inputId }__help`;
 
+	// Use the entity binding hook internally
+	const { hasUrlBinding, clearBinding } = useEntityBinding( {
+		clientId,
+		attributes,
+	} );
+
 	const editBoundLink = () => {
 		// Remove the binding
-		updateBlockBindings( { url: undefined } );
+		clearBinding();
 
 		// Clear url and id to allow picking a new entity (keep type and kind)
 		setAttributes( { url: undefined, id: undefined } );

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -12,6 +12,7 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useRef } from '@wordpress/element';
+import { useInstanceId } from '@wordpress/compose';
 import { safeDecodeURI } from '@wordpress/url';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { linkOff as unlinkIcon } from '@wordpress/icons';
@@ -76,6 +77,8 @@ export function Controls( {
 	const { label, url, description, rel, opensInNewTab } = attributes;
 	const lastURLRef = useRef( url );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+	const inputId = useInstanceId( Controls, 'link-input' );
+	const helpTextId = `${ inputId }__help`;
 
 	const editBoundLink = () => {
 		// Remove the binding
@@ -128,6 +131,7 @@ export function Controls( {
 				<InputControl
 					__nextHasNoMarginBottom
 					__next40pxDefaultSize
+					id={ inputId }
 					label={ __( 'Link' ) }
 					value={ url ? safeDecodeURI( url ) : '' }
 					onChange={ ( urlValue ) => {
@@ -179,7 +183,9 @@ export function Controls( {
 							<Button
 								icon={ unlinkIcon }
 								onClick={ editBoundLink }
-								aria-label={ __( 'Unlink and edit' ) }
+								aria-describedby={ helpTextId }
+								showTooltip
+								label={ __( 'Unsync and edit' ) }
 								__next40pxDefaultSize
 							/>
 						)

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -5,20 +5,53 @@ import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalInputControl as InputControl,
+	Button,
 	CheckboxControl,
 	TextControl,
 	TextareaControl,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useRef } from '@wordpress/element';
 import { safeDecodeURI } from '@wordpress/url';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
+import { linkOff as unlinkIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import { useToolsPanelDropdownMenuProps } from '../../utils/hooks';
 import { updateAttributes } from './update-attributes';
+
+/**
+ * Get a human-readable entity type name.
+ *
+ * @param {string} type - The entity type
+ * @param {string} kind - The entity kind
+ * @return {string} Human-readable entity type name
+ */
+function getEntityTypeName( type, kind ) {
+	if ( kind === 'post-type' ) {
+		switch ( type ) {
+			case 'post':
+				return __( 'post' );
+			case 'page':
+				return __( 'page' );
+			default:
+				return type || __( 'post' );
+		}
+	}
+	if ( kind === 'taxonomy' ) {
+		switch ( type ) {
+			case 'category':
+				return __( 'category' );
+			case 'tag':
+				return __( 'tag' );
+			default:
+				return type || __( 'term' );
+		}
+	}
+	return type || __( 'item' );
+}
 
 /**
  * Shared Controls component for Navigation Link and Navigation Submenu blocks.
@@ -30,6 +63,8 @@ import { updateAttributes } from './update-attributes';
  * @param {Object}   props.attributes          - Block attributes
  * @param {Function} props.setAttributes       - Function to update block attributes
  * @param {Function} props.setIsEditingControl - Function to set editing state (optional)
+ * @param {Function} props.updateBlockBindings - Function to update block bindings
+ * @param {boolean}  props.hasUrlBinding       - Whether the URL is bound to an entity
  */
 export function Controls( {
 	attributes,

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -169,9 +169,7 @@ export function Controls( {
 							);
 							return sprintf(
 								/* translators: %s is the entity type (e.g., "page", "post", "category") */
-								__(
-									'Link stays in sync with the selected %s.'
-								),
+								__( 'Synced with the selected %s.' ),
 								entityType
 							);
 						} )()

--- a/packages/block-library/src/navigation-link/shared/index.js
+++ b/packages/block-library/src/navigation-link/shared/index.js
@@ -7,4 +7,5 @@
 
 export { Controls } from './controls';
 export { updateAttributes } from './update-attributes';
+export { useEntityBinding } from './use-entity-binding';
 export { LinkUI } from '../link-ui';

--- a/packages/block-library/src/navigation-link/shared/test/controls.js
+++ b/packages/block-library/src/navigation-link/shared/test/controls.js
@@ -207,4 +207,91 @@ describe( 'Controls', () => {
 			opensInNewTab: true,
 		} );
 	} );
+
+	describe( 'URL binding help text', () => {
+		it( 'shows help text when URL is bound to an entity', () => {
+			const propsWithBinding = {
+				...defaultProps,
+				attributes: {
+					...defaultProps.attributes,
+					type: 'page',
+					kind: 'post-type',
+				},
+				hasUrlBinding: true,
+			};
+
+			render( <Controls { ...propsWithBinding } /> );
+
+			expect(
+				screen.getByText( 'Synced with the selected page.' )
+			).toBeInTheDocument();
+		} );
+
+		it( 'shows help text for different entity types', () => {
+			const propsWithCategoryBinding = {
+				...defaultProps,
+				attributes: {
+					...defaultProps.attributes,
+					type: 'category',
+					kind: 'taxonomy',
+				},
+				hasUrlBinding: true,
+			};
+
+			render( <Controls { ...propsWithCategoryBinding } /> );
+
+			expect(
+				screen.getByText( 'Synced with the selected category.' )
+			).toBeInTheDocument();
+		} );
+
+		it( 'does not show help text when URL is not bound', () => {
+			const propsWithoutBinding = {
+				...defaultProps,
+				hasUrlBinding: false,
+			};
+
+			render( <Controls { ...propsWithoutBinding } /> );
+
+			expect(
+				screen.queryByText( /Synced with the selected/ )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'shows help text for post entity type', () => {
+			const propsWithPostBinding = {
+				...defaultProps,
+				attributes: {
+					...defaultProps.attributes,
+					type: 'post',
+					kind: 'post-type',
+				},
+				hasUrlBinding: true,
+			};
+
+			render( <Controls { ...propsWithPostBinding } /> );
+
+			expect(
+				screen.getByText( 'Synced with the selected post.' )
+			).toBeInTheDocument();
+		} );
+
+		it( 'shows help text for tag entity type', () => {
+			const propsWithTagBinding = {
+				...defaultProps,
+				attributes: {
+					...defaultProps.attributes,
+					type: 'tag',
+					kind: 'taxonomy',
+				},
+				hasUrlBinding: true,
+			};
+
+			render( <Controls { ...propsWithTagBinding } /> );
+
+			expect(
+				screen.getByText( 'Synced with the selected tag.' )
+			).toBeInTheDocument();
+		} );
+	} );
 } );

--- a/packages/block-library/src/navigation-link/shared/test/controls.js
+++ b/packages/block-library/src/navigation-link/shared/test/controls.js
@@ -23,6 +23,14 @@ jest.mock( '../../../utils/hooks', () => ( {
 	useToolsPanelDropdownMenuProps: () => ( {} ),
 } ) );
 
+// Mock the useEntityBinding hook
+jest.mock( '../use-entity-binding', () => ( {
+	useEntityBinding: jest.fn( () => ( {
+		hasUrlBinding: false,
+		clearBinding: jest.fn(),
+	} ) ),
+} ) );
+
 describe( 'Controls', () => {
 	// Initialize the mock function
 	beforeAll( () => {
@@ -39,6 +47,7 @@ describe( 'Controls', () => {
 		},
 		setAttributes: jest.fn(),
 		setIsEditingControl: jest.fn(),
+		clientId: 'test-client-id',
 	};
 
 	beforeEach( () => {
@@ -210,6 +219,12 @@ describe( 'Controls', () => {
 
 	describe( 'URL binding help text', () => {
 		it( 'shows help text when URL is bound to an entity', () => {
+			const { useEntityBinding } = require( '../use-entity-binding' );
+			useEntityBinding.mockReturnValue( {
+				hasUrlBinding: true,
+				clearBinding: jest.fn(),
+			} );
+
 			const propsWithBinding = {
 				...defaultProps,
 				attributes: {
@@ -217,7 +232,6 @@ describe( 'Controls', () => {
 					type: 'page',
 					kind: 'post-type',
 				},
-				hasUrlBinding: true,
 			};
 
 			render( <Controls { ...propsWithBinding } /> );
@@ -228,6 +242,12 @@ describe( 'Controls', () => {
 		} );
 
 		it( 'shows help text for different entity types', () => {
+			const { useEntityBinding } = require( '../use-entity-binding' );
+			useEntityBinding.mockReturnValue( {
+				hasUrlBinding: true,
+				clearBinding: jest.fn(),
+			} );
+
 			const propsWithCategoryBinding = {
 				...defaultProps,
 				attributes: {
@@ -235,7 +255,6 @@ describe( 'Controls', () => {
 					type: 'category',
 					kind: 'taxonomy',
 				},
-				hasUrlBinding: true,
 			};
 
 			render( <Controls { ...propsWithCategoryBinding } /> );
@@ -246,12 +265,13 @@ describe( 'Controls', () => {
 		} );
 
 		it( 'does not show help text when URL is not bound', () => {
-			const propsWithoutBinding = {
-				...defaultProps,
+			const { useEntityBinding } = require( '../use-entity-binding' );
+			useEntityBinding.mockReturnValue( {
 				hasUrlBinding: false,
-			};
+				clearBinding: jest.fn(),
+			} );
 
-			render( <Controls { ...propsWithoutBinding } /> );
+			render( <Controls { ...defaultProps } /> );
 
 			expect(
 				screen.queryByText( /Synced with the selected/ )
@@ -259,6 +279,12 @@ describe( 'Controls', () => {
 		} );
 
 		it( 'shows help text for post entity type', () => {
+			const { useEntityBinding } = require( '../use-entity-binding' );
+			useEntityBinding.mockReturnValue( {
+				hasUrlBinding: true,
+				clearBinding: jest.fn(),
+			} );
+
 			const propsWithPostBinding = {
 				...defaultProps,
 				attributes: {
@@ -266,7 +292,6 @@ describe( 'Controls', () => {
 					type: 'post',
 					kind: 'post-type',
 				},
-				hasUrlBinding: true,
 			};
 
 			render( <Controls { ...propsWithPostBinding } /> );
@@ -277,6 +302,12 @@ describe( 'Controls', () => {
 		} );
 
 		it( 'shows help text for tag entity type', () => {
+			const { useEntityBinding } = require( '../use-entity-binding' );
+			useEntityBinding.mockReturnValue( {
+				hasUrlBinding: true,
+				clearBinding: jest.fn(),
+			} );
+
 			const propsWithTagBinding = {
 				...defaultProps,
 				attributes: {
@@ -284,7 +315,6 @@ describe( 'Controls', () => {
 					type: 'tag',
 					kind: 'taxonomy',
 				},
-				hasUrlBinding: true,
 			};
 
 			render( <Controls { ...propsWithTagBinding } /> );

--- a/packages/block-library/src/navigation-link/shared/test/use-entity-binding.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-entity-binding.js
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useBlockBindingsUtils } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { useEntityBinding } from '../use-entity-binding';
+
+// Mock the useBlockBindingsUtils hook
+jest.mock( '@wordpress/block-editor', () => ( {
+	...jest.requireActual( '@wordpress/block-editor' ),
+	useBlockBindingsUtils: jest.fn(),
+} ) );
+
+describe( 'useEntityBinding', () => {
+	const mockUpdateBlockBindings = jest.fn();
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		useBlockBindingsUtils.mockReturnValue( {
+			updateBlockBindings: mockUpdateBlockBindings,
+		} );
+	} );
+
+	it( 'should return hasUrlBinding as false when no binding exists', () => {
+		const attributes = {
+			metadata: {},
+			id: null,
+		};
+
+		const { result } = renderHook( () =>
+			useEntityBinding( {
+				clientId: 'test-client-id',
+				attributes,
+			} )
+		);
+
+		expect( result.current.hasUrlBinding ).toBe( false );
+	} );
+
+	it( 'should return hasUrlBinding as true when binding exists', () => {
+		const attributes = {
+			metadata: {
+				bindings: {
+					url: {
+						source: 'core/entity',
+						args: { key: 'url' },
+					},
+				},
+			},
+			id: 123,
+		};
+
+		const { result } = renderHook( () =>
+			useEntityBinding( {
+				clientId: 'test-client-id',
+				attributes,
+			} )
+		);
+
+		expect( result.current.hasUrlBinding ).toBe( true );
+	} );
+
+	it( 'should clear binding when clearBinding is called', () => {
+		const attributes = {
+			metadata: {
+				bindings: {
+					url: {
+						source: 'core/entity',
+						args: { key: 'url' },
+					},
+				},
+			},
+			id: 123,
+		};
+
+		const { result } = renderHook( () =>
+			useEntityBinding( {
+				clientId: 'test-client-id',
+				attributes,
+			} )
+		);
+
+		act( () => {
+			result.current.clearBinding();
+		} );
+
+		expect( mockUpdateBlockBindings ).toHaveBeenCalledWith( {
+			url: {
+				source: null,
+				args: null,
+			},
+		} );
+	} );
+
+	it( 'should create binding when createBinding is called', () => {
+		const attributes = {
+			metadata: {},
+			id: null,
+		};
+
+		const { result } = renderHook( () =>
+			useEntityBinding( {
+				clientId: 'test-client-id',
+				attributes,
+			} )
+		);
+
+		act( () => {
+			result.current.createBinding();
+		} );
+
+		expect( mockUpdateBlockBindings ).toHaveBeenCalledWith( {
+			url: {
+				source: 'core/entity',
+				args: {
+					key: 'url',
+				},
+			},
+		} );
+	} );
+} );

--- a/packages/block-library/src/navigation-link/shared/use-entity-binding.js
+++ b/packages/block-library/src/navigation-link/shared/use-entity-binding.js
@@ -1,0 +1,49 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+import { useBlockBindingsUtils } from '@wordpress/block-editor';
+
+/**
+ * Shared hook for entity binding functionality in Navigation blocks.
+ *
+ * This hook provides common entity binding logic that can be used by both
+ * Navigation Link and Navigation Submenu blocks to maintain feature parity.
+ *
+ * @param {Object} props            - Hook parameters
+ * @param {string} props.clientId   - Block client ID
+ * @param {Object} props.attributes - Block attributes
+ * @return {Object} Hook return value
+ */
+export function useEntityBinding( { clientId, attributes } ) {
+	const { updateBlockBindings } = useBlockBindingsUtils( clientId );
+	const { metadata, id } = attributes;
+
+	const hasUrlBinding = !! metadata?.bindings?.url && !! id;
+
+	const clearBinding = useCallback( () => {
+		updateBlockBindings( {
+			url: {
+				source: null,
+				args: null,
+			},
+		} );
+	}, [ updateBlockBindings ] );
+
+	const createBinding = useCallback( () => {
+		updateBlockBindings( {
+			url: {
+				source: 'core/entity',
+				args: {
+					key: 'url',
+				},
+			},
+		} );
+	}, [ updateBlockBindings ] );
+
+	return {
+		hasUrlBinding,
+		clearBinding,
+		createBinding,
+	};
+}

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -31,7 +31,12 @@ import { useMergeRefs, usePrevious } from '@wordpress/compose';
  * Internal dependencies
  */
 import { ItemSubmenuIcon } from './icons';
-import { Controls, LinkUI, updateAttributes } from '../navigation-link/shared';
+import {
+	Controls,
+	LinkUI,
+	updateAttributes,
+	useEntityBinding,
+} from '../navigation-link/shared';
 import {
 	getColors,
 	getNavigationChildBlockProps,
@@ -125,6 +130,12 @@ export default function NavigationSubmenuEdit( {
 	const { label, url, description } = attributes;
 
 	const { showSubmenuIcon, maxNestingLevel, openSubmenusOnClick } = context;
+
+	// URL binding logic
+	const { clearBinding, createBinding } = useEntityBinding( {
+		clientId,
+		attributes,
+	} );
 
 	const {
 		__unstableMarkNextChangeAsNotPersistent,
@@ -373,6 +384,7 @@ export default function NavigationSubmenuEdit( {
 				<Controls
 					attributes={ attributes }
 					setAttributes={ setAttributes }
+					clientId={ clientId }
 				/>
 			</InspectorControls>
 			<div { ...blockProps }>
@@ -428,6 +440,13 @@ export default function NavigationSubmenuEdit( {
 									setAttributes,
 									attributes
 								);
+
+								// Handle URL binding
+								if ( ! updatedValue?.id ) {
+									clearBinding();
+								} else {
+									createBinding();
+								}
 							} }
 						/>
 					) }

--- a/packages/editor/src/bindings/api.js
+++ b/packages/editor/src/bindings/api.js
@@ -10,6 +10,7 @@ import patternOverrides from './pattern-overrides';
 import postData from './post-data';
 import postMeta from './post-meta';
 import termData from './term-data';
+import entity from './entity';
 
 /**
  * Function to register core block bindings sources provided by the editor.
@@ -26,4 +27,5 @@ export function registerCoreBlockBindingsSources() {
 	registerBlockBindingsSource( postData );
 	registerBlockBindingsSource( postMeta );
 	registerBlockBindingsSource( termData );
+	registerBlockBindingsSource( entity );
 }

--- a/packages/editor/src/bindings/entity.js
+++ b/packages/editor/src/bindings/entity.js
@@ -31,21 +31,31 @@ export default {
 			return {};
 		}
 
-		const { getEntityRecord } = select( coreDataStore );
-
 		// Get the entity type and kind from block attributes
 		const { type, kind } = blockAttributes || {};
 
+		// Validate required attributes exist
+		if ( ! type || ! kind ) {
+			return {};
+		}
+
+		// Validate entity kind is supported
+		if ( kind !== 'post-type' && kind !== 'taxonomy' ) {
+			return {};
+		}
+
+		const { getEntityRecord } = select( coreDataStore );
 		let value = '';
 
 		// Handle post types
 		if ( kind === 'post-type' ) {
-			const post = getEntityRecord(
-				'postType',
-				type || 'post',
-				entityId
-			);
-			value = post?.link || '';
+			const post = getEntityRecord( 'postType', type, entityId );
+
+			if ( ! post ) {
+				return {};
+			}
+
+			value = post.link || '';
 		}
 		// Handle taxonomies
 		else if ( kind === 'taxonomy' ) {
@@ -53,13 +63,18 @@ export default {
 			// See https://github.com/WordPress/gutenberg/issues/71979.
 			const taxonomySlug = type === 'tag' ? 'post_tag' : type;
 			const term = getEntityRecord( 'taxonomy', taxonomySlug, entityId );
-			value = term?.link || '';
+
+			if ( ! term ) {
+				return {};
+			}
+
+			value = term.link || '';
 		}
 
-		// TODO: Add validation to ensure required attributes exist
-		// TODO: Add error handling for invalid entity types or missing data
-		// TODO: Consider property mapping between posts and terms for future keys
-		// TODO: Support additional keys beyond 'url' in the future
+		// If we couldn't get a valid URL, return empty object
+		if ( ! value ) {
+			return {};
+		}
 
 		return {
 			url: value,

--- a/packages/editor/src/bindings/entity.js
+++ b/packages/editor/src/bindings/entity.js
@@ -1,0 +1,74 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { store as coreDataStore } from '@wordpress/core-data';
+
+export default {
+	name: 'core/entity',
+	label: __( 'Entity' ),
+	getValues( { select, clientId, bindings } ) {
+		const { getBlockAttributes } = select( 'core/block-editor' );
+
+		// Get the nav link's id attribute
+		const blockAttributes = getBlockAttributes( clientId );
+		const entityId = blockAttributes?.id;
+
+		if ( ! entityId ) {
+			return {};
+		}
+
+		// Get the key from binding args - no key means invalid binding
+		const urlBinding = bindings.url;
+		if ( ! urlBinding?.args?.key ) {
+			return {};
+		}
+
+		const key = urlBinding.args.key;
+
+		// For now, only support 'url' key
+		if ( key !== 'url' ) {
+			return {};
+		}
+
+		const { getEntityRecord } = select( coreDataStore );
+
+		// Get the entity type and kind from block attributes
+		const { type, kind } = blockAttributes || {};
+
+		let value = '';
+
+		// Handle post types
+		if ( kind === 'post-type' ) {
+			const post = getEntityRecord(
+				'postType',
+				type || 'post',
+				entityId
+			);
+			value = post?.link || '';
+		}
+		// Handle taxonomies
+		else if ( kind === 'taxonomy' ) {
+			// Convert 'tag' back to 'post_tag' for API calls
+			// See https://github.com/WordPress/gutenberg/issues/71979.
+			const taxonomySlug = type === 'tag' ? 'post_tag' : type;
+			const term = getEntityRecord( 'taxonomy', taxonomySlug, entityId );
+			value = term?.link || '';
+		}
+
+		// TODO: Add validation to ensure required attributes exist
+		// TODO: Add error handling for invalid entity types or missing data
+		// TODO: Consider property mapping between posts and terms for future keys
+		// TODO: Support additional keys beyond 'url' in the future
+
+		return {
+			url: value,
+		};
+	},
+	canUserEditValue() {
+		// This binding source provides read-only URLs derived from entity data
+		// Users cannot manually edit these values as they are automatically
+		// generated from the linked post/term's permalink
+		return false;
+	},
+};

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -824,7 +824,7 @@ test.describe( 'Navigation block', () => {
 			// - enables the input
 			// - clears the input
 			const unlinkButton = settingsControls.getByRole( 'button', {
-				name: 'Unlink and edit',
+				name: 'Unsync and edit',
 			} );
 			await unlinkButton.click();
 			await expect( linkInput ).toBeEnabled();

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -749,6 +749,74 @@ test.describe( 'Navigation block', () => {
 			await expect( linkInput ).toBeDisabled();
 			await expect( linkInput ).toHaveValue( testPage1.link );
 
+			// Save the Post and check frontend
+			const postId = await editor.publishPost();
+
+			// Navigate to the frontend post page
+			await page.goto( `/?p=${ postId }` );
+
+			// Verify the navigation link on the frontend has the correct URL
+			const frontendLink = page.getByRole( 'link', {
+				name: 'Test Page 1',
+			} );
+			await expect( frontendLink ).toHaveAttribute(
+				'href',
+				testPage1.link
+			);
+
+			// Update the page slug via REST API
+			const updatedPage = await requestUtils.rest( {
+				method: 'PUT',
+				path: `/wp/v2/pages/${ testPage1.id }`,
+				data: {
+					slug: 'page-1-changed',
+				},
+			} );
+
+			// Check that the frontend immediately shows the updated URL
+			await page.goto( `/?p=${ postId }` );
+
+			const updatedFrontendLink = page.getByRole( 'link', {
+				name: 'Test Page 1',
+			} );
+			await expect( updatedFrontendLink ).toHaveAttribute(
+				'href',
+				updatedPage.link
+			);
+
+			// Now check that the editor also shows the updated URL
+			await admin.editPost( postId );
+
+			// Wait for and select the Navigation block first
+			const navBlock = navigation.getNavBlock();
+			await expect( navBlock ).toBeVisible();
+			await editor.selectBlocks( navBlock );
+
+			// Then select the Navigation Link block
+			const navLinkBlock = navBlock
+				.getByRole( 'document', {
+					name: 'Block: Page Link',
+				} )
+				.first(); // there is a draggable ghost block so we need to select the actual block!
+
+			await expect( navLinkBlock ).toBeVisible( {
+				// Wait for the Navigation Link block to be available
+				timeout: 10000,
+			} );
+			await editor.selectBlocks( navLinkBlock );
+
+			// Check that the link input now shows the updated URL
+			await editor.openDocumentSettingsSidebar();
+			const updatedLinkInput = page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'tabpanel', { name: 'Settings' } )
+				.getByRole( 'textbox', {
+					name: 'Link',
+					description: 'Synced with the selected page',
+				} );
+
+			await expect( updatedLinkInput ).toHaveValue( updatedPage.link );
+
 			// Todo: we need to find a way to better communicate the relationship
 			// between the control and the input.
 			// Assert that clicking the unlink button:

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -748,6 +748,19 @@ test.describe( 'Navigation block', () => {
 
 			await expect( linkInput ).toBeDisabled();
 			await expect( linkInput ).toHaveValue( testPage1.link );
+
+			// Todo: we need to find a way to better communicate the relationship
+			// between the control and the input.
+			// Assert that clicking the unlink button:
+			// - unbinds the entity
+			// - enables the input
+			// - clears the input
+			const unlinkButton = settingsControls.getByRole( 'button', {
+				name: 'Unlink and edit',
+			} );
+			await unlinkButton.click();
+			await expect( linkInput ).toBeEnabled();
+			await expect( linkInput ).toHaveValue( '' );
 		} );
 	} );
 } );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -817,14 +817,13 @@ test.describe( 'Navigation block', () => {
 
 			await expect( updatedLinkInput ).toHaveValue( updatedPage.link );
 
-			// Todo: we need to find a way to better communicate the relationship
-			// between the control and the input.
-			// Assert that clicking the unlink button:
-			// - unbinds the entity
-			// - enables the input
-			// - clears the input
+			// Find the button using its name and aria-describedby ID
+			// The button has aria-describedby pointing to the help text element
+			const helpTextId =
+				await linkInput.getAttribute( 'aria-describedby' );
 			const unlinkButton = settingsControls.getByRole( 'button', {
 				name: 'Unsync and edit',
+				description: helpTextId,
 			} );
 			await unlinkButton.click();
 			await expect( linkInput ).toBeEnabled();

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -671,6 +671,85 @@ test.describe( 'Navigation block', () => {
 			} )
 		).toHaveLength( 1 );
 	} );
+
+	test.describe( 'Navigation Link Entity bindings', () => {
+		// eslint-disable-next-line no-unused-vars
+		let testPage1, testPage2, testPage3;
+
+		test.beforeEach( async ( { requestUtils } ) => {
+			testPage1 = await requestUtils.createPage( {
+				title: 'Test Page 1',
+				status: 'publish',
+			} );
+
+			testPage2 = await requestUtils.createPage( {
+				title: 'Test Page 2',
+				status: 'publish',
+			} );
+
+			testPage3 = await requestUtils.createPage( {
+				title: 'Test Page 3',
+				status: 'publish',
+			} );
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await requestUtils.deleteAllPages();
+		} );
+
+		test( 'can bind to a page', async ( {
+			editor,
+			page,
+			admin,
+			navigation,
+			requestUtils,
+			pageUtils,
+		} ) => {
+			await admin.createNewPost();
+
+			// create an empty menu for use - avoids Page List block
+			const menu = await requestUtils.createNavigationMenu( {
+				title: 'Test Menu',
+				content: '',
+			} );
+
+			await editor.insertBlock( {
+				name: 'core/navigation',
+				attributes: {
+					ref: menu.id,
+				},
+			} );
+
+			// Insert a link to a Page
+			await expect( navigation.getNavBlockInserter() ).toBeVisible();
+			await pageUtils.pressKeys( 'ArrowDown' );
+			await navigation.useBlockInserter();
+			await navigation.addPage( 'Test Page 1' );
+
+			// Select the Nav Link block we just inserted
+			// await editor.selectBlocks( navBlock );
+
+			// Check the Inspector controls for the Nav Link block
+			// to verify the Link field is:
+			// - disabled
+			// - has the correct URL matching the page URL
+			// - has the correct help text (description)
+			await editor.openDocumentSettingsSidebar();
+			const settingsControls = page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'tabpanel', { name: 'Settings' } );
+
+			await expect( settingsControls ).toBeVisible();
+
+			const linkInput = settingsControls.getByRole( 'textbox', {
+				name: 'Link',
+				description: 'Synced with the selected page',
+			} );
+
+			await expect( linkInput ).toBeDisabled();
+			await expect( linkInput ).toHaveValue( testPage1.link );
+		} );
+	} );
 } );
 
 class Navigation {
@@ -758,6 +837,13 @@ class Navigation {
 		await expect( linkControlSearch ).toBeFocused();
 
 		await this.page.keyboard.type( label, { delay: 50 } );
+
+		// Wait for the search results to be visible
+		await expect(
+			this.page.getByRole( 'listbox', {
+				name: 'Search results',
+			} )
+		).toBeVisible();
 
 		await this.pageUtils.pressKeys( 'ArrowDown' );
 


### PR DESCRIPTION
## What

This PR improves the Navigation Link block in two key ways:

* makes Navigation Link blocks' URL attribute _dynamic_ if the link is to an entity (e.g. Page, Post...etc) using the Block Bindings API
* makes it clear when a Nav Link block is linking to an _entity_ vs a static URL through improved UI indicators

Closes #18345

## Why

### The Core Problem

The Navigation Link block has never dynamically fetched URLs for linked entities (e.g. Pages, Posts):

* When a user selects a Page/Post in the Editor, the block stores:
  * `id`: the ID of the entity.
  * `url`: a static copy of the permalink at that time.
* This url remains fixed — even if the entity's actual permalink changes later.
* Critically, the front end also uses this static URL. There is no dynamic lookup on render, which was previously assumed.

This means:

* If you change a page's URL (e.g. change the slug), existing Nav Links break silently.
* There is a false sense of safety — users believe they are linking to an entity, but the system never tracks or updates the link.

### Why This Is a Major Usability Issue

1. **WYSIWYG Mismatch**
   * Editor shows outdated links.
   * Front end shows exactly the same outdated links.
   * This contradicts user expectations and introduces subtle bugs.

2. **Invisible Link Types**
   * There's no visual difference between a link to a Page and a manually entered static URL.
   * Users can't tell if their link is "safe" (entity-bound) or "fragile" (static).

3. **Poor Content Resilience**
   * If you rename or move content, your menus don't adapt.
   * This leads to 404s and broken navigation — especially problematic on large or client-managed sites.

## How

Using the Block Bindings API, we bind the `url` attribute of the block to the entity represented by the `id` attribute of the block through a new `core/entity` binding source.

Key implementation details:

* Created a generic `core/entity` binding source that uses `source_args['key']` to determine which property to return (e.g., `url`)
* Updated the Navigation Link block to automatically create bindings when an entity is selected
* Enhanced the `LinkControl` UI to clearly indicate when a link is bound to an entity
* Disabled manual URL editing for bound links with an "unlink" option to break the binding
* Updated PHP rendering to use the Block Bindings API for automatic URL resolution

This creates a unified approach between editor and frontend, with clear visual indicators for dynamic vs static links.

**Note:** After discussion with subject matter experts (@ockham and @cbravobernal), we agreed to implement a generic `core/entity` binding source for now. @ockham will investigate the possibility of normalizing this with existing data sources in the future.

## Proposed Followups

The following items are being pushed to immediate follow ups:

* update design to follow mockups in [this comment](https://github.com/WordPress/gutenberg/pull/71630#issuecomment-3337893348)
* automatically update the `Text` content of the Nav Link item to match the chosen entity. This is the most likely workflow.
* update the Submenu block to match the implementation. Requires a quick refactor to align and share code between the blocks first to make this refactor easier.
* remove `entity` block binding and utilise existing post-data and term-data bindings once they have been made more extensible (see [this comment](https://github.com/WordPress/gutenberg/pull/71630#issuecomment-3354889752))
* [Avoid using state to manage focus](https://github.com/WordPress/gutenberg/pull/71630#discussion_r2397279884)