### PR TITLE
Adjust time range calculation and add average speed input

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -724,7 +724,7 @@ Show minutes required to finish reading the post. ([Source](https://github.com/W
 -	**Experimental:** true
 -	**Category:** theme
 -	**Supports:** color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** displayAsRange, textAlign
+-	**Attributes:** averageReadingSpeed, displayAsRange, textAlign
 
 ## Title
 

--- a/packages/block-library/src/post-time-to-read/block.json
+++ b/packages/block-library/src/post-time-to-read/block.json
@@ -12,10 +12,10 @@
 		"textAlign": {
 			"type": "string"
 		},
-        "averageReadingSpeed": {
-          "type": "string",
-          "default": 189
-        },
+		"averageReadingSpeed": {
+			"type": "number",
+			"default": 189
+		},
 		"displayAsRange": {
 			"type": "boolean",
 			"default": true

--- a/packages/block-library/src/post-time-to-read/block.json
+++ b/packages/block-library/src/post-time-to-read/block.json
@@ -12,6 +12,10 @@
 		"textAlign": {
 			"type": "string"
 		},
+        "averageReadingSpeed": {
+          "type": "string",
+          "default": 189
+        },
 		"displayAsRange": {
 			"type": "boolean",
 			"default": true

--- a/packages/block-library/src/post-time-to-read/edit.js
+++ b/packages/block-library/src/post-time-to-read/edit.js
@@ -130,7 +130,10 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 				>
 					<ToolsPanelItem
 						isShownByDefault
-						hasValue={ () => averageReadingSpeed !== undefined }
+						hasValue={ () =>
+							averageReadingSpeed !==
+							DEFAULT_AVERAGE_READING_SPEED
+						}
 						label={ __( 'Average Reading Speed' ) }
 						onDeselect={ () =>
 							setAttributes( { averageReadingSpeed: undefined } )

--- a/packages/block-library/src/post-time-to-read/edit.js
+++ b/packages/block-library/src/post-time-to-read/edit.js
@@ -18,6 +18,7 @@ import {
 	ToggleControl,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	__experimentalNumberControl as NumberControl,
 } from '@wordpress/components';
 import { __unstableSerializeAndClean } from '@wordpress/blocks';
 import { useEntityProp, useEntityBlockEditor } from '@wordpress/core-data';
@@ -28,17 +29,8 @@ import { count as wordCount } from '@wordpress/wordcount';
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
-/**
- * Average reading rate - based on average taken from
- * https://irisreading.com/average-reading-speed-in-various-languages/
- * (Characters/minute used for Chinese rather than words).
- */
-const AVERAGE_READING_RATE = 189;
-const MIN_READING_RATE = 138;
-const MAX_READING_RATE = 228;
-
 function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
-	const { textAlign, displayAsRange } = attributes;
+	const { textAlign, averageReadingSpeed, displayAsRange } = attributes;
 	const { postId, postType } = context;
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
@@ -79,13 +71,14 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 
 		const totalWords = wordCount( content || '', wordCountType );
 		if ( displayAsRange ) {
+			const readingSpeed = averageReadingSpeed;
 			const minMinutes = Math.max(
 				1,
-				Math.round( totalWords / MAX_READING_RATE )
+				Math.round( totalWords / ( readingSpeed * 1.2 ) )
 			);
 			let maxMinutes = Math.max(
 				1,
-				Math.round( totalWords / MIN_READING_RATE )
+				Math.round( totalWords / ( readingSpeed * 0.8 ) )
 			);
 			if ( minMinutes === maxMinutes ) {
 				maxMinutes = minMinutes + 1;
@@ -100,7 +93,7 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 
 		const minutesToRead = Math.max(
 			1,
-			Math.round( totalWords / AVERAGE_READING_RATE )
+			Math.round( totalWords / averageReadingSpeed )
 		);
 
 		return sprintf(
@@ -108,7 +101,7 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 			_n( '%s minute', '%s minutes', minutesToRead ),
 			minutesToRead
 		);
-	}, [ contentStructure, blocks, displayAsRange ] );
+	}, [ contentStructure, blocks, averageReadingSpeed, displayAsRange ] );
 
 	const blockProps = useBlockProps( {
 		className: clsx( {
@@ -136,6 +129,28 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
 				>
+					<ToolsPanelItem
+						isShownByDefault
+						hasValue={ () => averageReadingSpeed !== undefined }
+						label={ _x(
+							'Average Reading Speed',
+							'Sets the average reading speed in words per minute'
+						) }
+						onDeselect={ () =>
+							setAttributes( { averageReadingSpeed: undefined } )
+						}
+					>
+						<NumberControl
+							isShownByDefault
+							__next40pxDefaultSize
+							min={ 1 }
+							label={ __( 'Average Reading Speed' ) }
+							value={ averageReadingSpeed || 1 }
+							onChange={ ( value ) => {
+								setAttributes( { averageReadingSpeed: value } );
+							} }
+						/>
+					</ToolsPanelItem>
 					<ToolsPanelItem
 						isShownByDefault
 						label={ _x(

--- a/packages/block-library/src/post-time-to-read/edit.js
+++ b/packages/block-library/src/post-time-to-read/edit.js
@@ -71,14 +71,13 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 
 		const totalWords = wordCount( content || '', wordCountType );
 		if ( displayAsRange ) {
-			const readingSpeed = averageReadingSpeed;
 			const minMinutes = Math.max(
 				1,
-				Math.round( totalWords / ( readingSpeed * 1.2 ) )
+				Math.round( totalWords / ( averageReadingSpeed * 1.2 ) )
 			);
 			let maxMinutes = Math.max(
 				1,
-				Math.round( totalWords / ( readingSpeed * 0.8 ) )
+				Math.round( totalWords / ( averageReadingSpeed * 0.8 ) )
 			);
 			if ( minMinutes === maxMinutes ) {
 				maxMinutes = minMinutes + 1;

--- a/packages/block-library/src/post-time-to-read/edit.js
+++ b/packages/block-library/src/post-time-to-read/edit.js
@@ -131,10 +131,7 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 					<ToolsPanelItem
 						isShownByDefault
 						hasValue={ () => averageReadingSpeed !== undefined }
-						label={ _x(
-							'Average Reading Speed',
-							'Sets the average reading speed in words per minute'
-						) }
+						label={ __( 'Average Reading Speed' ) }
 						onDeselect={ () =>
 							setAttributes( { averageReadingSpeed: undefined } )
 						}

--- a/packages/block-library/src/post-time-to-read/edit.js
+++ b/packages/block-library/src/post-time-to-read/edit.js
@@ -15,10 +15,10 @@ import {
 	useBlockProps,
 } from '@wordpress/block-editor';
 import {
+	RangeControl,
 	ToggleControl,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
-	__experimentalNumberControl as NumberControl,
 } from '@wordpress/components';
 import { __unstableSerializeAndClean } from '@wordpress/blocks';
 import { useEntityProp, useEntityBlockEditor } from '@wordpress/core-data';
@@ -30,6 +30,13 @@ import { count as wordCount } from '@wordpress/wordcount';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
+	/**
+	 * Average reading rate - based on average taken from
+	 * https://irisreading.com/average-reading-speed-in-various-languages/
+	 * (Characters/minute used for Chinese rather than words).
+	 */
+	const AVERAGE_READING_RATE = 189;
+
 	const { textAlign, averageReadingSpeed, displayAsRange } = attributes;
 	const { postId, postType } = context;
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
@@ -131,20 +138,23 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 					<ToolsPanelItem
 						isShownByDefault
 						hasValue={ () =>
-							averageReadingSpeed !==
-							DEFAULT_AVERAGE_READING_SPEED
+							averageReadingSpeed !== AVERAGE_READING_RATE
 						}
 						label={ __( 'Average Reading Speed' ) }
 						onDeselect={ () =>
 							setAttributes( { averageReadingSpeed: undefined } )
 						}
 					>
-						<NumberControl
-							isShownByDefault
+						<RangeControl
+							__nextHasNoMarginBottom
 							__next40pxDefaultSize
 							min={ 1 }
+							max={ AVERAGE_READING_RATE * 2 }
 							label={ __( 'Average Reading Speed' ) }
-							value={ averageReadingSpeed || 1 }
+							value={
+								averageReadingSpeed || AVERAGE_READING_RATE
+							}
+							initialPosition={ AVERAGE_READING_RATE }
 							onChange={ ( value ) => {
 								setAttributes( { averageReadingSpeed: value } );
 							} }

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -16,7 +16,7 @@
  * @return string Returns the rendered post author name block.
  */
 function render_block_core_post_time_to_read( $attributes, $content, $block ) {
-	if ( ! isset($block->context['postId'])) {
+	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}
 

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -9,68 +9,71 @@
 /**
  * Renders the `core/post-time-to-read` block on the server.
  *
- * @param  array    $attributes Block attributes.
- * @param  string   $content    Block default content.
- * @param  WP_Block $block      Block instance.
+ * @param  array  $attributes  Block attributes.
+ * @param  string  $content  Block default content.
+ * @param  WP_Block  $block  Block instance.
+ *
  * @return string Returns the rendered post author name block.
  */
-function render_block_core_post_time_to_read( $attributes, $content, $block ) {
-	if ( ! isset( $block->context['postId'] ) ) {
-		return '';
-	}
+function render_block_core_post_time_to_read($attributes, $content, $block)
+{
+    if ( ! isset($block->context['postId'])) {
+        return '';
+    }
 
-	$content = get_the_content();
+    $content = get_the_content();
 
-	/*
-	 * Reading rates (words per minute) - based on averages from
-	 * https://irisreading.com/average-reading-speed-in-various-languages/
-	 * (Characters/minute used for Chinese rather than words).
-	 */
-	$average_reading_rate = 189;
-	$min_reading_rate     = 138;
-	$max_reading_rate     = 228;
+    $average_reading_rate = $attributes['averageReadingSpeed'] ?? 189;
 
-	$word_count_type = wp_get_word_count_type();
+    $word_count_type = wp_get_word_count_type();
 
-	$total_words = wp_word_count( $content, $word_count_type );
+    $total_words = wp_word_count($content, $word_count_type);
 
-	if ( ! empty( $attributes['displayAsRange'] ) ) {
-		$min_minutes = max( 1, (int) round( $total_words / $max_reading_rate ) );
-		$max_minutes = max( 1, (int) round( $total_words / $min_reading_rate ) );
-		if ( $min_minutes === $max_minutes ) {
-			$max_minutes = $min_minutes + 1;
-		}
-		/* translators: 1: minimum minutes, 2: maximum minutes to read the post. */
-		$minutes_to_read_string = sprintf( _x( '%1$s–%2$s minutes', 'Range of minutes to read' ), $min_minutes, $max_minutes );
-	} else {
-		$minutes_to_read        = max( 1, (int) round( $total_words / $average_reading_rate ) );
-		$minutes_to_read_string = sprintf(
-			/* translators: %s: the number of minutes to read the post. */
-			_n( '%s minute', '%s minutes', $minutes_to_read ),
-			$minutes_to_read
-		);
-	}
+    if ( ! empty($attributes['displayAsRange'])) {
+        // Calculate faster reading rate with 20% speed = lower minutes,
+        // and slower reading rate with 20% speed = higher minutes.
+        $min_minutes = max(1, (int) round($total_words / $average_reading_rate * 0.8));
+        $max_minutes = max(1, (int) round($total_words / $average_reading_rate * 1.2));
+        if ($min_minutes === $max_minutes) {
+            $max_minutes = $min_minutes + 1;
+        }
+        /* translators: 1: minimum minutes, 2: maximum minutes to read the post. */
+        $minutes_to_read_string = sprintf(
+            _x('%1$s–%2$s minutes', 'Range of minutes to read'),
+            $min_minutes,
+            $max_minutes
+        );
+    } else {
+        $minutes_to_read        = max(1, (int) round($total_words / $average_reading_rate));
+        $minutes_to_read_string = sprintf(
+        /* translators: %s: the number of minutes to read the post. */
+            _n('%s minute', '%s minutes', $minutes_to_read),
+            $minutes_to_read
+        );
+    }
 
-	$align_class_name = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
+    $align_class_name = empty($attributes['textAlign']) ? '' : "has-text-align-{$attributes['textAlign']}";
 
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
+    $wrapper_attributes = get_block_wrapper_attributes(array('class' => $align_class_name));
 
-	return sprintf(
-		'<div %1$s>%2$s</div>',
-		$wrapper_attributes,
-		$minutes_to_read_string
-	);
+    return sprintf(
+        '<div %1$s>%2$s</div>',
+        $wrapper_attributes,
+        $minutes_to_read_string
+    );
 }
 
 /**
  * Registers the `core/post-time-to-read` block on the server.
  */
-function register_block_core_post_time_to_read() {
-	register_block_type_from_metadata(
-		__DIR__ . '/post-time-to-read',
-		array(
-			'render_callback' => 'render_block_core_post_time_to_read',
-		)
-	);
+function register_block_core_post_time_to_read()
+{
+    register_block_type_from_metadata(
+        __DIR__.'/post-time-to-read',
+        array(
+            'render_callback' => 'render_block_core_post_time_to_read',
+        )
+    );
 }
-add_action( 'init', 'register_block_core_post_time_to_read' );
+
+add_action('init', 'register_block_core_post_time_to_read');

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -21,7 +21,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 
 	$content = get_the_content();
 
-    $average_reading_rate = $attributes['averageReadingSpeed'] ?? 189;
+	$average_reading_rate = $attributes['averageReadingSpeed'] ?? 189;
 
 	$word_count_type = wp_get_word_count_type();
 

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -24,7 +24,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 
     $average_reading_rate = $attributes['averageReadingSpeed'] ?? 189;
 
-    $word_count_type = wp_get_word_count_type();
+	$word_count_type = wp_get_word_count_type();
 
     $total_words = wp_word_count($content, $word_count_type);
 

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -27,7 +27,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 
 	$total_words = wp_word_count( $content, $word_count_type );
 
-	if ( ! empty($attributes['displayAsRange'])) {
+	if ( ! empty( $attributes['displayAsRange'] ) ) {
 		// Calculate faster reading rate with 20% speed = lower minutes,
 		// and slower reading rate with 20% speed = higher minutes.
 		$min_minutes = max(1, (int) round($total_words / $average_reading_rate * 0.8));

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -20,7 +20,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 		return '';
 	}
 
-    $content = get_the_content();
+	$content = get_the_content();
 
     $average_reading_rate = $attributes['averageReadingSpeed'] ?? 189;
 

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -9,10 +9,9 @@
 /**
  * Renders the `core/post-time-to-read` block on the server.
  *
- * @param  array  $attributes  Block attributes.
- * @param  string  $content  Block default content.
- * @param  WP_Block  $block  Block instance.
- *
+ * @param  array    $attributes Block attributes.
+ * @param  string   $content    Block default content.
+ * @param  WP_Block $block      Block instance.
  * @return string Returns the rendered post author name block.
  */
 function render_block_core_post_time_to_read( $attributes, $content, $block ) {

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -42,7 +42,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 			$max_minutes
 		);
 	} else {
-		$minutes_to_read        = max(1, (int) round($total_words / $average_reading_rate));
+		$minutes_to_read        = max( 1, (int) round( $total_words / $average_reading_rate ) );
 		$minutes_to_read_string = sprintf(
 			/* translators: %s: the number of minutes to read the post. */
 			_n( '%s minute', '%s minutes', $minutes_to_read ),

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -54,7 +54,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block )
 
     $align_class_name = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 
-    $wrapper_attributes = get_block_wrapper_attributes(array('class' => $align_class_name));
+	$wrapper_attributes = get_block_wrapper_attributes(array('class' => $align_class_name));
 
     return sprintf(
         '<div %1$s>%2$s</div>',

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -51,7 +51,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
         );
     }
 
-    $align_class_name = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
+	$align_class_name = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 
 	$wrapper_attributes = get_block_wrapper_attributes(array('class' => $align_class_name));
 

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -66,7 +66,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block )
 /**
  * Registers the `core/post-time-to-read` block on the server.
  */
-function register_block_core_post_time_to_read()
+function register_block_core_post_time_to_read() {
 {
     register_block_type_from_metadata(
         __DIR__.'/post-time-to-read',

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -32,7 +32,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 		// and slower reading rate with 20% speed = higher minutes.
 		$min_minutes = max( 1, (int) round( $total_words / $average_reading_rate * 0.8 ) );
 		$max_minutes = max( 1, (int) round( $total_words / $average_reading_rate * 1.2 ) );
-		if ($min_minutes === $max_minutes) {
+		if ( $min_minutes === $max_minutes ) {
 		$max_minutes = $min_minutes + 1;
 		}
 	/* translators: 1: minimum minutes, 2: maximum minutes to read the post. */

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -52,7 +52,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block )
         );
     }
 
-    $align_class_name = empty($attributes['textAlign']) ? '' : "has-text-align-{$attributes['textAlign']}";
+    $align_class_name = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 
     $wrapper_attributes = get_block_wrapper_attributes(array('class' => $align_class_name));
 

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -35,7 +35,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 		if ( $min_minutes === $max_minutes ) {
 			$max_minutes = $min_minutes + 1;
 		}
-	/* translators: 1: minimum minutes, 2: maximum minutes to read the post. */
+		/* translators: 1: minimum minutes, 2: maximum minutes to read the post. */
 		$minutes_to_read_string = sprintf(
 			_x( '%1$s–%2$s minutes', 'Range of minutes to read' ),
 			$min_minutes,

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -45,7 +45,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 		$minutes_to_read        = max(1, (int) round($total_words / $average_reading_rate));
 		$minutes_to_read_string = sprintf(
 			/* translators: %s: the number of minutes to read the post. */
-		_n('%s minute', '%s minutes', $minutes_to_read),
+			_n( '%s minute', '%s minutes', $minutes_to_read ),
 			$minutes_to_read
 		);
 	}

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -53,7 +53,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 
 	$align_class_name = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 
-	$wrapper_attributes = get_block_wrapper_attributes(array('class' => $align_class_name));
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
 
 	return sprintf(
 		'<div %1$s>%2$s</div>',

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -42,6 +42,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 		}
 		/* translators: 1: minimum minutes, 2: maximum minutes to read the post. */
 		$minutes_to_read_string = sprintf(
+			/* translators: 1: minimum minutes, 2: maximum minutes to read the post. */
 			_x( '%1$s–%2$s minutes', 'Range of minutes to read' ),
 			$min_minutes,
 			$max_minutes

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -21,6 +21,11 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 
 	$content = get_the_content();
 
+	/*
+	 * Reading rates (words per minute) - based on averages from
+	 * https://irisreading.com/average-reading-speed-in-various-languages/
+	 * (Characters/minute used for Chinese rather than words).
+	 */
 	$average_reading_rate = $attributes['averageReadingSpeed'] ?? 189;
 
 	$word_count_type = wp_get_word_count_type();

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -16,7 +16,6 @@
  * @return string Returns the rendered post author name block.
  */
 function render_block_core_post_time_to_read( $attributes, $content, $block ) {
-{
     if ( ! isset($block->context['postId'])) {
         return '';
     }

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -67,7 +67,6 @@ function render_block_core_post_time_to_read( $attributes, $content, $block )
  * Registers the `core/post-time-to-read` block on the server.
  */
 function register_block_core_post_time_to_read() {
-{
     register_block_type_from_metadata(
         __DIR__.'/post-time-to-read',
         array(

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -31,7 +31,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 		// Calculate faster reading rate with 20% speed = lower minutes,
 		// and slower reading rate with 20% speed = higher minutes.
 		$min_minutes = max( 1, (int) round( $total_words / $average_reading_rate * 0.8 ) );
-		$max_minutes = max(1, (int) round($total_words / $average_reading_rate * 1.2));
+		$max_minutes = max( 1, (int) round( $total_words / $average_reading_rate * 1.2 ) );
 		if ($min_minutes === $max_minutes) {
 		$max_minutes = $min_minutes + 1;
 		}

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -15,7 +15,7 @@
  *
  * @return string Returns the rendered post author name block.
  */
-function render_block_core_post_time_to_read( $attributes, $content, $block )
+function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 {
     if ( ! isset($block->context['postId'])) {
         return '';

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -56,11 +56,11 @@ function render_block_core_post_time_to_read( $attributes, $content, $block )
 
 	$wrapper_attributes = get_block_wrapper_attributes(array('class' => $align_class_name));
 
-    return sprintf(
-        '<div %1$s>%2$s</div>',
-        $wrapper_attributes,
-        $minutes_to_read_string
-    );
+	return sprintf(
+		'<div %1$s>%2$s</div>',
+		$wrapper_attributes,
+		$minutes_to_read_string
+	);
 }
 
 /**

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -44,7 +44,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 	} else {
 		$minutes_to_read        = max(1, (int) round($total_words / $average_reading_rate));
 		$minutes_to_read_string = sprintf(
-		/* translators: %s: the number of minutes to read the post. */
+			/* translators: %s: the number of minutes to read the post. */
 		_n('%s minute', '%s minutes', $minutes_to_read),
 			$minutes_to_read
 		);

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -27,14 +27,14 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 
 	$total_words = wp_word_count( $content, $word_count_type );
 
-    if ( ! empty($attributes['displayAsRange'])) {
-        // Calculate faster reading rate with 20% speed = lower minutes,
-        // and slower reading rate with 20% speed = higher minutes.
-        $min_minutes = max(1, (int) round($total_words / $average_reading_rate * 0.8));
-        $max_minutes = max(1, (int) round($total_words / $average_reading_rate * 1.2));
-        if ($min_minutes === $max_minutes) {
-            $max_minutes = $min_minutes + 1;
-        }
+	if ( ! empty($attributes['displayAsRange'])) {
+		// Calculate faster reading rate with 20% speed = lower minutes,
+		// and slower reading rate with 20% speed = higher minutes.
+		$min_minutes = max(1, (int) round($total_words / $average_reading_rate * 0.8));
+		$max_minutes = max(1, (int) round($total_words / $average_reading_rate * 1.2));
+		if ($min_minutes === $max_minutes) {
+		$max_minutes = $min_minutes + 1;
+		}
 	/* translators: 1: minimum minutes, 2: maximum minutes to read the post. */
 		$minutes_to_read_string = sprintf(
 			_x('%1$s–%2$s minutes', 'Range of minutes to read'),

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -16,9 +16,9 @@
  * @return string Returns the rendered post author name block.
  */
 function render_block_core_post_time_to_read( $attributes, $content, $block ) {
-    if ( ! isset($block->context['postId'])) {
-        return '';
-    }
+	if ( ! isset($block->context['postId'])) {
+		return '';
+	}
 
     $content = get_the_content();
 

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -73,5 +73,4 @@ function register_block_core_post_time_to_read() {
 		)
 	);
 }
-
 add_action( 'init', 'register_block_core_post_time_to_read' );

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -26,7 +26,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 
 	$word_count_type = wp_get_word_count_type();
 
-    $total_words = wp_word_count($content, $word_count_type);
+	$total_words = wp_word_count($content, $word_count_type);
 
     if ( ! empty($attributes['displayAsRange'])) {
         // Calculate faster reading rate with 20% speed = lower minutes,

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -66,12 +66,12 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
  * Registers the `core/post-time-to-read` block on the server.
  */
 function register_block_core_post_time_to_read() {
-    register_block_type_from_metadata(
-        __DIR__.'/post-time-to-read',
-        array(
-            'render_callback' => 'render_block_core_post_time_to_read',
-        )
-    );
+	register_block_type_from_metadata(
+		__DIR__.'/post-time-to-read',
+		array(
+			'render_callback' => 'render_block_core_post_time_to_read',
+		)
+	);
 }
 
 add_action( 'init', 'register_block_core_post_time_to_read' );

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -30,7 +30,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 	if ( ! empty( $attributes['displayAsRange'] ) ) {
 		// Calculate faster reading rate with 20% speed = lower minutes,
 		// and slower reading rate with 20% speed = higher minutes.
-		$min_minutes = max(1, (int) round($total_words / $average_reading_rate * 0.8));
+		$min_minutes = max( 1, (int) round( $total_words / $average_reading_rate * 0.8 ) );
 		$max_minutes = max(1, (int) round($total_words / $average_reading_rate * 1.2));
 		if ($min_minutes === $max_minutes) {
 		$max_minutes = $min_minutes + 1;

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -35,20 +35,20 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
         if ($min_minutes === $max_minutes) {
             $max_minutes = $min_minutes + 1;
         }
-        /* translators: 1: minimum minutes, 2: maximum minutes to read the post. */
-        $minutes_to_read_string = sprintf(
-            _x('%1$s–%2$s minutes', 'Range of minutes to read'),
-            $min_minutes,
-            $max_minutes
-        );
-    } else {
-        $minutes_to_read        = max(1, (int) round($total_words / $average_reading_rate));
-        $minutes_to_read_string = sprintf(
-        /* translators: %s: the number of minutes to read the post. */
-            _n('%s minute', '%s minutes', $minutes_to_read),
-            $minutes_to_read
-        );
-    }
+	/* translators: 1: minimum minutes, 2: maximum minutes to read the post. */
+		$minutes_to_read_string = sprintf(
+			_x('%1$s–%2$s minutes', 'Range of minutes to read'),
+			$min_minutes,
+			$max_minutes
+		);
+	} else {
+		$minutes_to_read        = max(1, (int) round($total_words / $average_reading_rate));
+		$minutes_to_read_string = sprintf(
+		/* translators: %s: the number of minutes to read the post. */
+		_n('%s minute', '%s minutes', $minutes_to_read),
+			$minutes_to_read
+		);
+	}
 
 	$align_class_name = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -15,7 +15,7 @@
  *
  * @return string Returns the rendered post author name block.
  */
-function render_block_core_post_time_to_read($attributes, $content, $block)
+function render_block_core_post_time_to_read( $attributes, $content, $block )
 {
     if ( ! isset($block->context['postId'])) {
         return '';

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -37,7 +37,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 		}
 	/* translators: 1: minimum minutes, 2: maximum minutes to read the post. */
 		$minutes_to_read_string = sprintf(
-			_x('%1$s–%2$s minutes', 'Range of minutes to read'),
+			_x( '%1$s–%2$s minutes', 'Range of minutes to read' ),
 			$min_minutes,
 			$max_minutes
 		);

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -33,7 +33,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 		$min_minutes = max( 1, (int) round( $total_words / $average_reading_rate * 0.8 ) );
 		$max_minutes = max( 1, (int) round( $total_words / $average_reading_rate * 1.2 ) );
 		if ( $min_minutes === $max_minutes ) {
-		$max_minutes = $min_minutes + 1;
+			$max_minutes = $min_minutes + 1;
 		}
 	/* translators: 1: minimum minutes, 2: maximum minutes to read the post. */
 		$minutes_to_read_string = sprintf(

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -26,7 +26,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 
 	$word_count_type = wp_get_word_count_type();
 
-	$total_words = wp_word_count($content, $word_count_type);
+	$total_words = wp_word_count( $content, $word_count_type );
 
     if ( ! empty($attributes['displayAsRange'])) {
         // Calculate faster reading rate with 20% speed = lower minutes,

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -75,4 +75,4 @@ function register_block_core_post_time_to_read() {
     );
 }
 
-add_action('init', 'register_block_core_post_time_to_read');
+add_action( 'init', 'register_block_core_post_time_to_read' );

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -67,7 +67,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
  */
 function register_block_core_post_time_to_read() {
 	register_block_type_from_metadata(
-		__DIR__.'/post-time-to-read',
+		__DIR__ . '/post-time-to-read',
 		array(
 			'render_callback' => 'render_block_core_post_time_to_read',
 		)

--- a/test/integration/fixtures/blocks/core__post-time-to-read.json
+++ b/test/integration/fixtures/blocks/core__post-time-to-read.json
@@ -3,6 +3,7 @@
 		"name": "core/post-time-to-read",
 		"isValid": true,
 		"attributes": {
+			"averageReadingSpeed": 189,
 			"displayAsRange": true
 		},
 		"innerBlocks": []


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Make updates to [#71606](https://github.com/WordPress/gutenberg/pull/71606)

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The block needs to be more flexible and customizable, based on the discussion in the original PR.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Remove the min / max from the PHP and just add 20% to the time to establish a range
- Add an input for the average speed so users have the option to change it

