### PR TITLE
Block Commenting: Use rendered comment content

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -295,32 +295,21 @@ const CommentBoard = ( { thread, onResolve, onEdit, onDelete, status } ) => {
 					) }
 				</span>
 			</HStack>
-			<HStack
-				alignment="left"
-				spacing="3"
-				justify="flex-start"
-				className="editor-collab-sidebar-panel__user-comment"
-			>
-				<VStack
-					spacing="3"
-					className="editor-collab-sidebar-panel__comment-field"
-				>
-					{ 'edit' === actionState && (
-						<CommentForm
-							onSubmit={ ( value ) => {
-								onEdit( thread.id, value );
-								setActionState( false );
-							} }
-							onCancel={ () => handleCancel() }
-							thread={ thread }
-							submitButtonText={ _x( 'Update', 'verb' ) }
-						/>
-					) }
-					{ 'edit' !== actionState && (
-						<RawHTML>{ thread?.content?.raw }</RawHTML>
-					) }
-				</VStack>
-			</HStack>
+			{ 'edit' === actionState ? (
+				<CommentForm
+					onSubmit={ ( value ) => {
+						onEdit( thread.id, value );
+						setActionState( false );
+					} }
+					onCancel={ () => handleCancel() }
+					thread={ thread }
+					submitButtonText={ _x( 'Update', 'verb' ) }
+				/>
+			) : (
+				<RawHTML className="editor-collab-sidebar-panel__user-comment">
+					{ thread?.content?.rendered }
+				</RawHTML>
+			) }
 			{ 'resolve' === actionState && (
 				<ConfirmDialog
 					isOpen={ showConfirmDialog }

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -59,13 +59,7 @@
 	}
 
 	&__user-comment {
-		font-size: 13px;
-		font-weight: 400;
-		line-height: 20px;
-		text-align: left;
-		color: $gray-900;
-
-		p {
+		p:last-child {
 			margin-bottom: 0;
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR uses `rendered` fields instead of `raw` fields to better display block comment content.

## Why?

Comment text has[ various default filters applied on the server-side](https://github.com/WordPress/wordpress-develop/blob/7289643a4d6a901a04f13b0359c95a1df5af63d3/src/wp-includes/default-filters.php#L224-L229). For example, these filters wrap clickable text into HTML links, wrap each paragraph with a `<p>` tag, and so on. The comments rest api also has these filters, but [only in the `rendered` field, not the `raw` field](https://github.com/WordPress/wordpress-develop/blob/c7f4298956fb1f34d83c61cdb3ce149791c878ae/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php#L1108-L1112).

I think block comments should use the rendered field just like post comments.

## How?

This PR also contains a small refactoring, which removes unnecessary Stack components.

## Testing Instructions

- Create a draft post.
- Insert a block and add a comment with the following content:
  ```
  Visit http://wordpress.org for more details :)
  
  If you would like to contact me, email test@example.com 👍
  ```
- Check the rendered comment content.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
| <img width="284" height="224" alt="image" src="https://github.com/user-attachments/assets/86983118-5a59-4906-ae38-f14ccb6ce804" /> | <img width="290" height="260" alt="image" src="https://github.com/user-attachments/assets/83d78d9d-12fe-4087-8d62-336964165a75" /> |