### PR TITLE
Block Commenting: Make buttons in dialogs translatable and clear

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -326,8 +326,7 @@ const CommentBoard = ( { thread, onResolve, onEdit, onDelete, status } ) => {
 					isOpen={ showConfirmDialog }
 					onConfirm={ handleConfirmResolve }
 					onCancel={ handleCancel }
-					confirmButtonText="Yes"
-					cancelButtonText="No"
+					confirmButtonText={ __( 'Resolve' ) }
 				>
 					{
 						// translators: message displayed when confirming an action
@@ -342,8 +341,7 @@ const CommentBoard = ( { thread, onResolve, onEdit, onDelete, status } ) => {
 					isOpen={ showConfirmDialog }
 					onConfirm={ handleConfirmDelete }
 					onCancel={ handleCancel }
-					confirmButtonText="Yes"
-					cancelButtonText="No"
+					confirmButtonText={ __( 'Delete' ) }
 				>
 					{
 						// translators: message displayed when confirming an action


### PR DESCRIPTION
## What?

|Before|After|
|-|-|
| <img width="418" height="172" alt="resolve-confirm-before" src="https://github.com/user-attachments/assets/0082e0bb-4224-4286-8587-8704b35e1d4d" /> | <img width="414" height="179" alt="resolve-confirm-after" src="https://github.com/user-attachments/assets/2edf42bb-8fcd-4363-862f-626aca56d317" /> |
| <img width="375" height="176" alt="delete-confirm-before" src="https://github.com/user-attachments/assets/a155ce6b-1a95-4fc9-9978-eb3653c67bb6" /> | <img width="364" height="173" alt="delete-confirm-after" src="https://github.com/user-attachments/assets/b3ac79d9-d43f-4136-8c8d-63e83be82551" /> |

<!-- In a few words, what is the PR actually doing? -->

## Why? How?

- These button texts aren't translatable.
-  "Yes" is too general. Like any other confirmation dialog, it should represent a specific action.
- Use the default "Cancel" text for the cancel buttons

## Testing Instructions

- Create a draft post.
- Insert a block and add a comment.
- Resolve or delete the omment and confirm the button text inside the confirm dialog.
