### PR TITLE
Fix: Disable block commenting when postId is not number

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comment-author-info.js
+++ b/packages/editor/src/components/collab-sidebar/comment-author-info.js
@@ -33,7 +33,7 @@ function CommentAuthorInfo( { avatar, name, date } ) {
 		const { __experimentalDiscussionSettings } = getSettings();
 		const defaultAvatar = __experimentalDiscussionSettings?.avatarURL;
 		return {
-			currentUserAvatar: userData?.avatar_urls[ 48 ] ?? defaultAvatar,
+			currentUserAvatar: userData?.avatar_urls?.[ 48 ] ?? defaultAvatar,
 			currentUserName: userData?.name,
 		};
 	}, [] );

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -241,6 +241,8 @@ export default function CollabSidebar() {
 		};
 	}, [] );
 
+	const hasValidPostId = !! postId && typeof postId === 'number';
+
 	const { blockCommentId } = useSelect( ( select ) => {
 		const { getBlockAttributes, getSelectedBlockClientId } =
 			select( blockEditorStore );
@@ -335,6 +337,10 @@ export default function CollabSidebar() {
 	const AddCommentComponent = blockCommentId
 		? AddCommentToolbarButton
 		: AddCommentButton;
+
+	if ( ! hasValidPostId ) {
+		return null;
+	}
 
 	return (
 		<>

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -241,8 +241,6 @@ export default function CollabSidebar() {
 		};
 	}, [] );
 
-	const hasValidPostId = !! postId && typeof postId === 'number';
-
 	const { blockCommentId } = useSelect( ( select ) => {
 		const { getBlockAttributes, getSelectedBlockClientId } =
 			select( blockEditorStore );
@@ -338,7 +336,8 @@ export default function CollabSidebar() {
 		? AddCommentToolbarButton
 		: AddCommentButton;
 
-	if ( ! hasValidPostId ) {
+	// If postId is not a valid number, do not render the comment sidebar.
+	if ( ! ( !! postId && typeof postId === 'number' ) ) {
 		return null;
 	}
 


### PR DESCRIPTION
## What?
Closes #71642 

This PR fixes block commenting functionality to prevent crashes and disable comments when editing templates or other contexts without valid integer post ID.

## Why?
Comments were allowed in template editing (where post ID is a string like `'twentytwentyfive//home'`), but the WordPress REST API requires post IDs to be integers, causing requests to fail

## How?
 Added a check to only show comment functionality when `postId` is a valid number (integer), completely hiding comment UI for templates and other invalid contexts

## Testing Instructions
1. **Test normal post commenting** (should still work):
   - Open any existing post or page for editing
   - Select any block 
   - Verify the comment button appears and works normally

2. **Test template editing** (comments should be disabled):
   - Go to Appearance > Theme Editor > Templates
   - Edit any template (like "Home" or "Single Post")
   - Select any block within the template
   - Verify that NO comment button or comment functionality appears

## Screenshots or screencast 

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="1470" height="956" alt="Screenshot 2025-09-14 at 6 21 59 PM" src="https://github.com/user-attachments/assets/29e14dbf-790b-4b12-9bf5-0d69025691ea" /> | <img width="1470" height="956" alt="Screenshot 2025-09-14 at 6 21 29 PM" src="https://github.com/user-attachments/assets/28872234-f341-4ac1-8254-5a3b1b87e4d9" /> |
