### PR TITLE
Try: Editable pre element for Block and Post Text Editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50795,7 +50795,6 @@
 				"fast-deep-equal": "^3.1.3",
 				"is-plain-object": "^5.0.0",
 				"memize": "^2.1.0",
-				"react-autosize-textarea": "^7.1.0",
 				"remove-accents": "^0.5.0",
 				"uuid": "^9.0.1"
 			},

--- a/packages/block-editor/src/components/block-list/block-html.js
+++ b/packages/block-editor/src/components/block-list/block-html.js
@@ -1,12 +1,7 @@
 /**
- * External dependencies
- */
-import TextareaAutosize from 'react-autosize-textarea';
-
-/**
  * WordPress dependencies
  */
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useState, useRef } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	getBlockAttributes,
@@ -23,11 +18,13 @@ import { store as blockEditorStore } from '../../store';
 
 function BlockHTML( { clientId } ) {
 	const [ html, setHtml ] = useState( '' );
+	const editableElementRef = useRef( null );
 	const block = useSelect(
 		( select ) => select( blockEditorStore ).getBlock( clientId ),
 		[ clientId ]
 	);
 	const { updateBlock } = useDispatch( blockEditorStore );
+
 	const onChange = () => {
 		const blockType = getBlockType( block.name );
 
@@ -64,15 +61,33 @@ function BlockHTML( { clientId } ) {
 	};
 
 	useEffect( () => {
-		setHtml( getBlockContent( block ) );
+		const blockContent = getBlockContent( block );
+		setHtml( blockContent );
+		if ( editableElementRef.current ) {
+			editableElementRef.current.textContent = blockContent;
+		}
 	}, [ block ] );
 
+	const onInput = () => {
+		if ( editableElementRef.current ) {
+			setHtml( editableElementRef.current.textContent );
+		}
+	};
+
 	return (
-		<TextareaAutosize
+		<pre
+			ref={ editableElementRef }
 			className="block-editor-block-list__block-html-textarea"
-			value={ html }
+			contentEditable="plaintext-only"
+			suppressContentEditableWarning
+			// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
+			role="textbox"
 			onBlur={ onChange }
-			onChange={ ( event ) => setHtml( event.target.value ) }
+			onInput={ onInput }
+			onPaste={ ( event ) => {
+				event.stopPropagation();
+				onInput();
+			} }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -372,6 +372,8 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 	font-family: $editor-html-font;
 	font-size: $text-editor-font-size;
 	line-height: 1.5;
+	white-space: pre-wrap;
+
 	@media not ( prefers-reduced-motion ) {
 		transition: padding 0.2s linear;
 	}

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -77,7 +77,6 @@
 		"fast-deep-equal": "^3.1.3",
 		"is-plain-object": "^5.0.0",
 		"memize": "^2.1.0",
-		"react-autosize-textarea": "^7.1.0",
 		"remove-accents": "^0.5.0",
 		"uuid": "^9.0.1"
 	},

--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -1,12 +1,7 @@
 /**
- * External dependencies
- */
-import TextareaAutosize from 'react-autosize-textarea';
-
-/**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState, useRef, useEffect } from '@wordpress/element';
 import {
 	__experimentalHStack as HStack,
 	Button,
@@ -36,21 +31,38 @@ function CommentForm( { onSubmit, onCancel, thread, submitButtonText } ) {
 	);
 
 	const inputId = useInstanceId( CommentForm, 'comment-input' );
+	const editableElementRef = useRef( null );
+
+	useEffect( () => {
+		if (
+			editableElementRef.current &&
+			editableElementRef.current.textContent !== inputComment
+		) {
+			editableElementRef.current.textContent = inputComment;
+		}
+	}, [ inputComment ] );
 
 	return (
 		<>
 			<VisuallyHidden as="label" htmlFor={ inputId }>
 				{ __( 'Comment' ) }
 			</VisuallyHidden>
-			<TextareaAutosize
+			<pre
+				ref={ editableElementRef }
+				contentEditable="plaintext-only"
+				// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
+				role="textbox"
+				onInput={ () => {
+					if ( editableElementRef.current ) {
+						setInputComment(
+							editableElementRef.current.textContent
+						);
+					}
+				} }
+				className="editor-collab-sidebar-panel__comment-form-editable-area"
 				id={ inputId }
-				value={ inputComment ?? '' }
-				onChange={ ( comment ) =>
-					setInputComment( comment.target.value )
-				}
-				rows={ 4 }
-				maxRows={ 20 }
-			></TextareaAutosize>
+				data-placeholder={ __( 'Write a comment…' ) }
+			/>
 			<HStack alignment="left" spacing="3" justify="flex-start">
 				<Button
 					__next40pxDefaultSize

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -130,4 +130,17 @@
 		font-style: italic;
 		padding: 0;
 	}
+
+	&__comment-form-editable-area {
+		@include input-control;
+		min-height: 80px !important;
+		max-height: 400px;
+		margin: 0;
+		white-space: pre-wrap;
+		overflow-y: auto;
+
+		&:focus-visible {
+			outline: none;
+		}
+	}
 }

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -1,18 +1,11 @@
 /**
- * External dependencies
- */
-import Textarea from 'react-autosize-textarea';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
-import { useMemo } from '@wordpress/element';
+import { useMemo, useRef, useEffect } from '@wordpress/element';
 import { __unstableSerializeAndClean } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useInstanceId } from '@wordpress/compose';
-import { VisuallyHidden } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -25,7 +18,7 @@ import { store as editorStore } from '../../store';
  * @return {React.ReactNode} The rendered PostTextEditor component.
  */
 export default function PostTextEditor() {
-	const instanceId = useInstanceId( PostTextEditor );
+	const editableElementRef = useRef( null );
 	const { content, blocks, type, id } = useSelect( ( select ) => {
 		const { getEditedEntityRecord } = select( coreStore );
 		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
@@ -54,29 +47,34 @@ export default function PostTextEditor() {
 		return content;
 	}, [ content, blocks ] );
 
+	useEffect( () => {
+		if (
+			editableElementRef.current &&
+			editableElementRef.current.textContent !== value
+		) {
+			editableElementRef.current.textContent = value;
+		}
+	}, [ value ] );
+
 	return (
-		<>
-			<VisuallyHidden
-				as="label"
-				htmlFor={ `post-content-${ instanceId }` }
-			>
-				{ __( 'Type text or HTML' ) }
-			</VisuallyHidden>
-			<Textarea
-				autoComplete="off"
-				dir="auto"
-				value={ value }
-				onChange={ ( event ) => {
+		<pre
+			ref={ editableElementRef }
+			contentEditable="plaintext-only"
+			suppressContentEditableWarning
+			// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
+			role="textbox"
+			onInput={ () => {
+				if ( editableElementRef.current ) {
 					editEntityRecord( 'postType', type, id, {
-						content: event.target.value,
+						content: editableElementRef.current.textContent,
 						blocks: undefined,
 						selection: undefined,
 					} );
-				} }
-				className="editor-post-text-editor"
-				id={ `post-content-${ instanceId }` }
-				placeholder={ __( 'Start writing with text or HTML' ) }
-			/>
-		</>
+				}
+			} }
+			className="editor-post-text-editor"
+			data-placeholder={ __( 'Start writing with text or HTML' ) }
+			aria-label={ __( 'Type text or HTML' ) }
+		/>
 	);
 }

--- a/packages/editor/src/components/post-text-editor/style.scss
+++ b/packages/editor/src/components/post-text-editor/style.scss
@@ -1,4 +1,4 @@
-textarea.editor-post-text-editor {
+.editor-post-text-editor {
 	border: $border-width solid $gray-600;
 	border-radius: 0;
 	display: block;
@@ -10,6 +10,7 @@ textarea.editor-post-text-editor {
 	font-family: $editor-html-font;
 	line-height: 2.4;
 	min-height: 200px;
+	white-space: pre-wrap;
 
 	@media not (prefers-reduced-motion) {
 		transition: border 0.1s ease-out, box-shadow 0.1s linear;
@@ -27,6 +28,10 @@ textarea.editor-post-text-editor {
 		font-size: $text-editor-font-size !important;
 	}
 
+	&:focus-visible {
+		outline: none;
+	}
+
 	&:focus {
 		border-color: var(--wp-admin-theme-color);
 		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
@@ -35,15 +40,12 @@ textarea.editor-post-text-editor {
 		position: relative;
 	}
 
-	&::-webkit-input-placeholder {
+	// Show placeholder when empty or only contains br tags
+	&:empty::before,
+	&:has(br:only-child)::before {
+		content: attr(data-placeholder);
 		color: $dark-gray-placeholder;
-	}
-
-	&::-moz-placeholder {
-		color: $dark-gray-placeholder;
-	}
-
-	&:-ms-input-placeholder {
-		color: $dark-gray-placeholder;
+		pointer-events: none;
+		position: absolute;
 	}
 }

--- a/test/e2e/specs/editor/blocks/list.spec.js
+++ b/test/e2e/specs/editor/blocks/list.spec.js
@@ -1323,7 +1323,7 @@ test.describe( 'List (@firefox)', () => {
 		await pageUtils.pressKeys( 'secondary+M' ); // Emulates CTRL+Shift+Alt + M => toggle code editor
 
 		// Add empty list block
-		await page.getByPlaceholder( 'Start writing with text or HTML' )
+		await page.getByRole( 'textbox', { name: 'Type text or HTML' } )
 			.fill( `<!-- wp:list -->
 <ul class="wp-block-list"><!-- wp:list-item -->
 <li></li>
@@ -1334,11 +1334,9 @@ test.describe( 'List (@firefox)', () => {
 		await pageUtils.pressKeys( 'secondary+M' ); // Emulates CTRL+Shift+Alt + M => toggle code editor
 
 		// Verify no WSOD and content is proper.
-		expect( await editor.getEditedPostContent() ).toBe( `<!-- wp:list -->
-<ul class="wp-block-list"><!-- wp:list-item -->
-<li></li>
-<!-- /wp:list-item --></ul>
-<!-- /wp:list -->` );
+		expect( await editor.getEditedPostContent() ).toBe(
+			`<!-- wp:list --><ul class="wp-block-list"><!-- wp:list-item --><li></li><!-- /wp:list-item --></ul><!-- /wp:list -->`
+		);
 	} );
 
 	test( 'should merge two list with same attributes', async ( {

--- a/test/e2e/specs/editor/plugins/annotations.spec.js
+++ b/test/e2e/specs/editor/plugins/annotations.spec.js
@@ -55,7 +55,7 @@ test.describe( 'Annotations', () => {
 		// There should be no <mark> tags in the raw content.
 		await expect(
 			block.locator( '.block-editor-block-list__block-html-textarea' )
-		).toHaveValue( '<p>Paragraph to annotate</p>' );
+		).toHaveText( '<p>Paragraph to annotate</p>' );
 	} );
 
 	test( 'keeps the cursor in the same location when applying annotation', async ( {

--- a/test/e2e/specs/editor/various/content-only-lock.spec.js
+++ b/test/e2e/specs/editor/various/content-only-lock.spec.js
@@ -16,7 +16,7 @@ test.describe( 'Content-only lock', () => {
 		// Add content only locked block in the code editor
 		await pageUtils.pressKeys( 'secondary+M' ); // Emulates CTRL+Shift+Alt + M => toggle code editor
 
-		await page.getByPlaceholder( 'Start writing with text or HTML' )
+		await page.getByRole( 'textbox', { name: 'Type text or HTML' } )
 			.fill( `<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:paragraph -->
 <p>Hello</p>
@@ -40,7 +40,7 @@ test.describe( 'Content-only lock', () => {
 		// Add content only locked block in the code editor
 		await pageUtils.pressKeys( 'secondary+M' ); // Emulates CTRL+Shift+Alt + M => toggle code editor
 
-		await page.getByPlaceholder( 'Start writing with text or HTML' )
+		await page.getByRole( 'textbox', { name: 'Type text or HTML' } )
 			.fill( `<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:paragraph -->
@@ -85,17 +85,17 @@ test.describe( 'Content-only lock', () => {
 		// Add content only locked block in the code editor
 		await pageUtils.pressKeys( 'secondary+M' ); // Emulates CTRL+Shift+Alt + M => toggle code editor
 
-		await page.getByPlaceholder( 'Start writing with text or HTML' )
+		await page.getByRole( 'textbox', { name: 'Type text or HTML' } )
 			.fill( `<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
 			<div class="wp-block-group"><!-- wp:paragraph -->
 			<p>Locked block a</p>
 			<!-- /wp:paragraph -->
-			
+
 			<!-- wp:paragraph -->
 			<p>Locked block b</p>
 			<!-- /wp:paragraph --></div>
 			<!-- /wp:group -->
-			
+
 			<!-- wp:heading -->
 			<h2 class="wp-block-heading"><strong>outside block</strong></h2>
 			<!-- /wp:heading -->` );

--- a/test/e2e/specs/editor/various/editor-modes.spec.js
+++ b/test/e2e/specs/editor/various/editor-modes.spec.js
@@ -67,7 +67,7 @@ test.describe( 'Editing modes (visual/HTML)', () => {
 			.getByRole( 'textbox' );
 
 		// Make sure the paragraph content is rendered as expected.
-		await expect( paragraphHTML ).toHaveValue( '<p>Hello world!</p>' );
+		await expect( paragraphHTML ).toHaveText( '<p>Hello world!</p>' );
 
 		// Change the `drop cap` using the sidebar.
 		await page
@@ -79,7 +79,7 @@ test.describe( 'Editing modes (visual/HTML)', () => {
 		await page.getByRole( 'checkbox', { name: 'Drop cap' } ).check();
 
 		// Make sure the HTML content updated.
-		await expect( paragraphHTML ).toHaveValue(
+		await expect( paragraphHTML ).toHaveText(
 			'<p class="has-drop-cap">Hello world!</p>'
 		);
 	} );


### PR DESCRIPTION
Try to fix #39619

## What?

This PR replaces the following three auto-growing textareas with editable `pre` elements to get rid of the `react-autosize-textarea` lib dependencies:

### `BlockHTML`: Used to edit the block's content HTML

<img width="682" height="154" alt="image" src="https://github.com/user-attachments/assets/b4c7a989-124a-4072-aea9-254e94831b74" />

### `PostTextEditor`: Used to edit posts' or sites' content HTML

<img width="1082" height="405" alt="image" src="https://github.com/user-attachments/assets/f0711265-07e0-4098-9a8c-7bba526d8f21" />

### `CommentForm`: Used to add a block-level comment (experimental feature)

<img width="306" height="293" alt="image" src="https://github.com/user-attachments/assets/5c1f7965-3ecf-4987-b572-fe8613c7fcb5" />

## Why?

The `react-autosize-textarea` project has been archived and is not maintained anymore.

This library depends on React 16, so there is a problem with updating to React 18 (See https://github.com/WordPress/gutenberg/issues/48009#issue-1581935312).

There was an effort to switch `react-autosize-textarea` to `react-textarea-autosize`, but this was halted due to remaining issues that needed to be resolved on the library side.

## How?

Replace `textarea` with `pre` element with `contentEditable` attribute. The reason I used the `pre` tag is to make HTML entities editable. The `contentEditable="plaintext-only"` is needed to disable rich text formatting when rich text is pasted from outside.

There should be no changes to functionality or behavior.

**Note**: If this approach works fine, I plan to apply this approach to [the `PlainText` component v1](https://github.com/WordPress/gutenberg/blob/60526a2dae790f202571f3a581c5c3e67dee4e3f/packages/block-editor/src/components/plain-text/index.js#L62-L67) as well.

If that can be achieved, we can remove `react-autosize-textarea` lib from Gutenberg repo completely.

## Testing Instructions

Check the three components I mentioned above.

- The component should fit the height of the inner text in initial rendering and while editing text.
- The `PostTextEditor` and `CommentForm` components should have a minimum height.
- The `PostTextEditor` component should display placeholder text if there is no content. 
- The `CommentForm` component should have a maximum height and automatically scroll if the text inside it overflows.
- Should be able to insert HTML tags.
