### PR TITLE
Fix block comment to display correct time.

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comment-author-info.js
+++ b/packages/editor/src/components/collab-sidebar/comment-author-info.js
@@ -3,7 +3,11 @@
  */
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
+import {
+	dateI18n,
+	getDate,
+	getSettings as getDateSettings,
+} from '@wordpress/date';
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
@@ -55,10 +59,16 @@ function CommentAuthorInfo( { avatar, name, date } ) {
 					{ name ?? currentUserName }
 				</span>
 				<time
-					dateTime={ dateI18n( 'c', date ?? currentDate ) }
+					dateTime={ dateI18n(
+						'c',
+						date ? getDate( date ) : currentDate
+					) }
 					className="editor-collab-sidebar-panel__user-time"
 				>
-					{ dateI18n( dateTimeFormat, date ?? currentDate ) }
+					{ dateI18n(
+						dateTimeFormat,
+						date ? getDate( date ) : currentDate
+					) }
 				</time>
 			</VStack>
 		</>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/71650

<!-- In a few words, what is the PR actually doing? -->
This PR fixes the displayed comment time in collaboration to show the correct time based on WordPress Installation.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Earlier, the display time had its timezone offset applied twice ie If WordPress installation is set to UTC and device is set to IST instead of showing the time in UTC, the displayed time was UTC - 530.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR addresses this by using `getDate` function to correctly get the date Object before applying `dateI18n` at [packages/editor/src/components/collab-sidebar/comment-author-info.js#L57-L62](https://github.com/wordpress/gutenberg/blob/trunk/packages/editor/src/components/collab-sidebar/comment-author-info.js#L57-L62)

## Testing Instructions
1. Set your computer to AEST (or another positive time zone)
2. Set your WordPress install to UTC
3. Edit a post
4. Start writing a comment on a block, observe the time stamp (it will be the correct UTC time)
5. Submit the comment, observe the time stamp ( it will be the correct UTC time now )


## Screenshots or screencast <!-- if applicable -->


|Before|After|
|-|-|
|![](https://github.com/user-attachments/assets/f66862e0-2152-4022-91d1-615903652f84)|![](https://github.com/user-attachments/assets/713e89b7-ca63-4dbb-bff8-9bfff6a9e080)|
