### PR TITLE
contentOnly Patterns experiment: Add Edit Contents button to block inspector and show 'Detach' block action

### DIFF
--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -53,9 +53,18 @@ const { Badge } = unlock( componentsPrivateApis );
  * @param {Object}        [props.blockType] Deprecated: Object containing block type data.
  * @param {string}        [props.className] Additional classes to apply to the card.
  * @param {string}        [props.name]      Custom block name to display before the title.
+ * @param {Element}       [props.children]  Children.
  * @return {Element}                        Block card component.
  */
-function BlockCard( { title, icon, description, blockType, className, name } ) {
+function BlockCard( {
+	title,
+	icon,
+	description,
+	blockType,
+	className,
+	name,
+	children,
+} ) {
 	if ( blockType ) {
 		deprecated( '`blockType` property in `BlockCard component`', {
 			since: '5.7',
@@ -109,6 +118,7 @@ function BlockCard( { title, icon, description, blockType, className, name } ) {
 						{ description }
 					</Text>
 				) }
+				{ children }
 			</VStack>
 		</div>
 	);

--- a/packages/block-editor/src/components/block-inspector/edit-contents-button.js
+++ b/packages/block-editor/src/components/block-inspector/edit-contents-button.js
@@ -33,7 +33,7 @@ export default function EditContentsButton( { clientId } ) {
 			variant="secondary"
 			onClick={ () => {
 				const { patternName, ...metadataWithoutPatternName } =
-					attributes?.metadata;
+					attributes?.metadata ?? {};
 				updateBlockAttributes( clientId, {
 					...attributes,
 					metadata: metadataWithoutPatternName,

--- a/packages/block-editor/src/components/block-inspector/edit-contents-button.js
+++ b/packages/block-editor/src/components/block-inspector/edit-contents-button.js
@@ -1,0 +1,46 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
+export default function EditContentsButton( { clientId } ) {
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const { attributes } = useSelect(
+		( select ) => {
+			return {
+				attributes:
+					select( blockEditorStore ).getBlockAttributes( clientId ),
+			};
+		},
+		[ clientId ]
+	);
+
+	if ( ! attributes?.metadata?.patternName ) {
+		return null;
+	}
+
+	return (
+		<Button
+			className="block-editor-block-inspector-edit-contents-button"
+			__next40pxDefaultSize
+			variant="secondary"
+			onClick={ () => {
+				const { patternName, ...metadataWithoutPatternName } =
+					attributes?.metadata;
+				updateBlockAttributes( clientId, {
+					...attributes,
+					metadata: metadataWithoutPatternName,
+				} );
+			} }
+		>
+			{ __( 'Edit contents' ) }
+		</Button>
+	);
+}

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -13,6 +13,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import EditContentsButton from './edit-contents-button';
 import SkipToSelectedBlock from '../skip-to-selected-block';
 import BlockCard from '../block-card';
 import MultiSelectionInspector from '../multi-selection-inspector';
@@ -247,7 +248,11 @@ const BlockInspectorSingleBlock = ( {
 			<BlockCard
 				{ ...blockInformation }
 				className={ blockInformation.isSynced && 'is-synced' }
-			/>
+			>
+				{ window?.__experimentalContentOnlyPatternInsertion && (
+					<EditContentsButton clientId={ clientId } />
+				) }
+			</BlockCard>
 			<BlockVariationTransforms blockClientId={ clientId } />
 			{ showTabs && (
 				<InspectorControlsTabs

--- a/packages/block-editor/src/components/block-inspector/style.scss
+++ b/packages/block-editor/src/components/block-inspector/style.scss
@@ -51,3 +51,8 @@
 .block-editor-block-inspector__no-block-tools {
 	border-top: $border-width solid $gray-300;
 }
+
+.block-editor-block-inspector-edit-contents-button {
+	margin-top: $grid-unit-10;
+	justify-content: center;
+}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2667,6 +2667,86 @@ export function withDerivedBlockEditingModes( reducer ) {
 				}
 				break;
 			}
+			case 'UPDATE_BLOCK_ATTRIBUTES': {
+				// Handle unsynced patterns which indicate their contentOnly-ness via
+				// the `attributes.metadata.patternName` property.
+				// Check when this is added or removed and update blockEditingModes.
+				const addedBlocks = [];
+				const removedClientIds = [];
+
+				for ( const clientId of action?.clientIds ) {
+					const attributes = action.options.uniqueByBlock
+						? action.attributes[ clientId ]
+						: action.attributes;
+
+					if ( ! attributes ) {
+						break;
+					}
+
+					if (
+						// patternName is switching from falsy to truthy, indicating
+						// this block is becoming an unsynced pattern.
+						attributes.metadata.patternName &&
+						! state.blocks.attributes.get( clientId )?.metadata
+							?.patternName
+					) {
+						addedBlocks.push(
+							nextState.blocks.tree.get( clientId )
+						);
+					} else if (
+						// patternName is switching from truthy to falsy, this block is becoming
+						// a regular block but was an unsynced pattern.
+						// Check that `metadata` is part of the included attributes, as
+						// `updateBlockAttributes` merges attributes, if it isn't present
+						// the previous `metadata` would be retained.
+						attributes.metadata &&
+						! attributes.metadata?.patternName &&
+						state.blocks.attributes.get( clientId )?.metadata
+							?.patternName
+					) {
+						// Include it in 'removedClientIds'.
+						removedClientIds.push( clientId );
+					}
+				}
+
+				if ( ! addedBlocks?.length && ! removedClientIds?.length ) {
+					break;
+				}
+
+				const nextDerivedBlockEditingModes =
+					getDerivedBlockEditingModesUpdates( {
+						prevState: state,
+						nextState,
+						addedBlocks,
+						removedClientIds,
+						isNavMode: false,
+					} );
+				const nextDerivedNavModeBlockEditingModes =
+					getDerivedBlockEditingModesUpdates( {
+						prevState: state,
+						nextState,
+						addedBlocks,
+						removedClientIds,
+						isNavMode: true,
+					} );
+
+				if (
+					nextDerivedBlockEditingModes ||
+					nextDerivedNavModeBlockEditingModes
+				) {
+					return {
+						...nextState,
+						derivedBlockEditingModes:
+							nextDerivedBlockEditingModes ??
+							state.derivedBlockEditingModes,
+						derivedNavModeBlockEditingModes:
+							nextDerivedNavModeBlockEditingModes ??
+							state.derivedNavModeBlockEditingModes,
+					};
+				}
+
+				break;
+			}
 			case 'UPDATE_BLOCK_LIST_SETTINGS': {
 				// Handle the addition and removal of contentOnly template locked blocks.
 				const addedBlocks = [];

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2675,7 +2675,7 @@ export function withDerivedBlockEditingModes( reducer ) {
 				const removedClientIds = [];
 
 				for ( const clientId of action?.clientIds ) {
-					const attributes = action.options.uniqueByBlock
+					const attributes = action.options?.uniqueByBlock
 						? action.attributes[ clientId ]
 						: action.attributes;
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2686,7 +2686,7 @@ export function withDerivedBlockEditingModes( reducer ) {
 					if (
 						// patternName is switching from falsy to truthy, indicating
 						// this block is becoming an unsynced pattern.
-						attributes.metadata.patternName &&
+						attributes.metadata?.patternName &&
 						! state.blocks.attributes.get( clientId )?.metadata
 							?.patternName
 					) {

--- a/packages/patterns/src/components/pattern-convert-button.js
+++ b/packages/patterns/src/components/pattern-convert-button.js
@@ -83,7 +83,6 @@ export default function PatternConvertButton( {
 				);
 
 			const isUnsyncedPattern =
-				window?.__experimentalContentOnlyPatternInsertion &&
 				blocks.length === 1 &&
 				blocks?.[ 0 ]?.attributes?.metadata?.patternName;
 

--- a/packages/patterns/src/components/pattern-convert-button.js
+++ b/packages/patterns/src/components/pattern-convert-button.js
@@ -39,11 +39,13 @@ export default function PatternConvertButton( {
 	closeBlockSettingsMenu,
 } ) {
 	const { createSuccessNotice } = useDispatch( noticesStore );
-	const { replaceBlocks } = useDispatch( blockEditorStore );
+	const { replaceBlocks, updateBlockAttributes } =
+		useDispatch( blockEditorStore );
 	// Ignore reason: false positive of the lint rule.
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
 	const { setEditingPattern } = unlock( useDispatch( patternsStore ) );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const { getBlockAttributes } = useSelect( blockEditorStore );
 	const canConvert = useSelect(
 		( select ) => {
 			const { canUser } = select( coreStore );
@@ -116,7 +118,20 @@ export default function PatternConvertButton( {
 	}
 
 	const handleSuccess = ( { pattern } ) => {
-		if ( pattern.wp_pattern_sync_status !== PATTERN_SYNC_TYPES.unsynced ) {
+		if ( pattern.wp_pattern_sync_status === PATTERN_SYNC_TYPES.unsynced ) {
+			if ( clientIds?.length === 1 ) {
+				const existingAttributes = getBlockAttributes( clientIds[ 0 ] );
+				updateBlockAttributes( clientIds[ 0 ], {
+					metadata: {
+						...( existingAttributes?.metadata
+							? existingAttributes.metadata
+							: {} ),
+						patternName: `core/block/${ pattern.id }`,
+						name: pattern.title.raw,
+					},
+				} );
+			}
+		} else {
 			const newBlock = createBlock( 'core/block', {
 				ref: pattern.id,
 			} );

--- a/packages/patterns/src/components/pattern-convert-button.js
+++ b/packages/patterns/src/components/pattern-convert-button.js
@@ -72,7 +72,7 @@ export default function PatternConvertButton( {
 				return hasBlockSupport( blockName, 'reusable', ! hasParent );
 			};
 
-			const isReusable =
+			const isSyncedPattern =
 				blocks.length === 1 &&
 				blocks[ 0 ] &&
 				isReusableBlock( blocks[ 0 ] ) &&
@@ -82,9 +82,15 @@ export default function PatternConvertButton( {
 					blocks[ 0 ].attributes.ref
 				);
 
+			const isUnsyncedPattern =
+				window?.__experimentalContentOnlyPatternInsertion &&
+				blocks.length === 1 &&
+				blocks?.[ 0 ]?.attributes?.metadata?.patternName;
+
 			const _canConvert =
-				// Hide when this is already a synced pattern.
-				! isReusable &&
+				// Hide when this is already a pattern.
+				! isUnsyncedPattern &&
+				! isSyncedPattern &&
 				// Hide when patterns are disabled.
 				canInsertBlockType( 'core/block', rootId ) &&
 				blocks.every(

--- a/packages/patterns/src/components/pattern-convert-button.js
+++ b/packages/patterns/src/components/pattern-convert-button.js
@@ -83,6 +83,7 @@ export default function PatternConvertButton( {
 				);
 
 			const isUnsyncedPattern =
+				window?.__experimentalContentOnlyPatternInsertion &&
 				blocks.length === 1 &&
 				blocks?.[ 0 ]?.attributes?.metadata?.patternName;
 


### PR DESCRIPTION
## What?
Closes #71558
Part of #71517

Does the following when the contentOnly patterns experiment is active:
- Adds an 'Edit contents' button to the BlockCard of unsynced patterns
- Shows the 'Detach' block action for unsynced patterns
- Shows the 'Manage patterns' block action for unsynced patterns
- Hides the 'Create pattern' block action for unsynced patterns

Does the following regardless of whether the experiment is active (they feel like good changes generally, but let me know if you think they should be part of the experiment):
- Fixes an issue where `patternName` isn't added to block metadata when the 'Create pattern' block action is used.
- Fixes an issue where block editing modes were not recalculated when the `patternName` attribute is added or removed.

This ended up being more involved than initially expected, it required quite a few related changes.

## Testing Instructions
First enable the experiment in Gutenberg > Experiments from wp admin:
<img width="932" height="170" alt="image" src="https://github.com/user-attachments/assets/bcb7a3c7-1a2b-4756-be34-c06c5d578d58" />

1. Open one of the editors
2. Insert an Unsynced Pattern
3. Check that the pattern and its contents are in contentOnly mode
4. With the Unsynced Pattern selected and the block inspector open, check that an 'Edit contents' button is present in the block card. Click the button
5. Observe that `contentOnly` mode is now not active on the pattern contents
6. Make some changes to the pattern
7. With the top level block of the pattern selection, click the 'Create pattern' block action and give the pattern a new name. Make the pattern Unsynced.
8. Observe that the pattern becomes contentOnly again
9. With the pattern selected, open the block actions menu
10. See that 'Create pattern' is now hidden
11. Note that there's a Manage Pattern button, which takes you to the Patterns listings
12. See there's the 'Detach' button. Click it. Observe that the pattern is no longer `contentOnly`.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/610e41af-ebce-4368-9f49-208b70659de0

