### PR TITLE
Content Only Pattern experiment: Restore purple block icon color for synced patterns

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -52,10 +52,8 @@
 			color: var(--wp-block-synced-color);
 		}
 
-		.components-toolbar-button.block-editor-block-switcher__no-switcher-icon {
-			&:disabled .block-editor-block-icon.has-colors {
-				color: var(--wp-block-synced-color);
-			}
+		.block-editor-block-switcher__no-switcher-icon[aria-disabled="true"] .block-editor-block-icon {
+			color: var(--wp-block-synced-color);
 		}
 	}
 


### PR DESCRIPTION
## What?
I noticed that while testing the contentOnly patterns experiment, synced patterns no longer have the purple block icon color on the toolbar.

As part of that experiment the transforms menu in the toolbar is no longer displayed for any section blocks.

It seems like that surfaced a dormant bug where the style for the purple icon is no longer shown correctly when the transform menu is hidden. I think at some point someone changed the button from using `disabled` to `aria-disabled`, and that caused the style to no longer apply.

I updated that to fix the issue, and also simplified the css a little.

## Testing Instructions
First enable the experiment in Gutenberg > Experiments from wp admin:
<img width="932" height="170" alt="image" src="https://github.com/user-attachments/assets/bcb7a3c7-1a2b-4756-be34-c06c5d578d58" />

1. Open one of the editors
2. Insert a Synced Pattern
3. Ensure the inserted pattern is selected in the canvas

Expected: The block icon on the toolbar should be purple
In trunk: The block icon is black

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="393" height="54" alt="Screenshot 2025-09-15 at 5 11 55 pm" src="https://github.com/user-attachments/assets/04feab61-dd3b-453f-b2e5-20369b0eb5fd" /> | <img width="396" height="53" alt="Screenshot 2025-09-15 at 5 10 33 pm" src="https://github.com/user-attachments/assets/b48fce13-e4b7-4e69-b986-695c970693c3" /> |

