### PR TITLE
Terms Query: Combine Order and Order By control into single dropdown + remove order by slug.

### DIFF
--- a/packages/block-library/src/terms-query/inspector-controls.js
+++ b/packages/block-library/src/terms-query/inspector-controls.js
@@ -89,28 +89,14 @@ export default function TermsQueryInspectorControls( {
 					</ToolsPanelItem>
 
 					<ToolsPanelItem
-						hasValue={ () => termQuery.order !== 'asc' }
-						label={ __( 'Order' ) }
-						onDeselect={ () => setQuery( { order: 'asc' } ) }
-						isShownByDefault
-					>
-						<SelectControl
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-							label={ __( 'Order' ) }
-							options={ [
-								{ label: __( 'Ascending' ), value: 'asc' },
-								{ label: __( 'Descending' ), value: 'desc' },
-							] }
-							value={ termQuery.order }
-							onChange={ ( order ) => setQuery( { order } ) }
-						/>
-					</ToolsPanelItem>
-
-					<ToolsPanelItem
-						hasValue={ () => termQuery.orderBy !== 'name' }
+						hasValue={ () =>
+							termQuery.orderBy !== 'name' ||
+							termQuery.order !== 'asc'
+						}
 						label={ __( 'Order by' ) }
-						onDeselect={ () => setQuery( { orderBy: 'name' } ) }
+						onDeselect={ () =>
+							setQuery( { orderBy: 'name', order: 'asc' } )
+						}
 						isShownByDefault
 					>
 						<SelectControl
@@ -118,12 +104,32 @@ export default function TermsQueryInspectorControls( {
 							__next40pxDefaultSize
 							label={ __( 'Order by' ) }
 							options={ [
-								{ label: __( 'Name' ), value: 'name' },
-								{ label: __( 'Slug' ), value: 'slug' },
-								{ label: __( 'Count' ), value: 'count' },
+								{
+									label: __( 'Name: A → Z' ),
+									value: 'name/asc',
+								},
+								{
+									label: __( 'Name: Z → A' ),
+									value: 'name/desc',
+								},
+								{
+									label: __( 'Count, high to low' ),
+									value: 'count/desc',
+								},
+								{
+									label: __( 'Count, low to high' ),
+									value: 'count/asc',
+								},
 							] }
-							value={ termQuery.orderBy }
-							onChange={ ( orderBy ) => setQuery( { orderBy } ) }
+							value={ termQuery.orderBy + '/' + termQuery.order }
+							onChange={ ( orderBy ) => {
+								const [ newOrderBy, newOrder ] =
+									orderBy.split( '/' );
+								setQuery( {
+									orderBy: newOrderBy,
+									order: newOrder,
+								} );
+							} }
 						/>
 					</ToolsPanelItem>
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

Combine Order and Order By control into single dropdown. cc: @mikachan 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Dropdowns occupy quite a lot of space in Inspector Controls and are pretty heavy. There's no need for separate dropdown for Order and OrderBy while it can be easily combined. [Agreed in this comment](https://github.com/WordPress/gutenberg/pull/70720#issuecomment-3271250017).

I also removed order by slug as I can't really see a use case for it and if so, I treat it a UI pollution.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Ensure experimental blocks are enabled.
2. Insert the Terms Query block in a template.
3. Make sure the default order is `Name: A → Z`
4. Change the ordering and make sure it's reflected in Editor

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="279" height="690" alt="image" src="https://github.com/user-attachments/assets/57b2b462-ce49-4334-9b11-afd729a1fe1a" /> |  <img width="279" height="612" alt="image" src="https://github.com/user-attachments/assets/d944f446-1d11-40d8-9d86-5392a489b3e2" /> <img width="281" height="152" alt="image" src="https://github.com/user-attachments/assets/ce25d75e-b581-4486-a394-52300b346b73" />


