### PR TITLE
CODEOWNERS: Remove some block code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,8 +15,6 @@
 # Blocks
 /packages/block-library                         @ajitbohra @fabiankaegy
 /packages/block-library/src/gallery
-/packages/block-library/src/comment-template    @michalczaplinski
-/packages/block-library/src/comments            @michalczaplinski
 /packages/block-library/src/table-of-contents   @ZebulanStanphill
 
 # Duotone

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,7 +18,6 @@
 /packages/block-library/src/comment-template    @michalczaplinski
 /packages/block-library/src/comments            @michalczaplinski
 /packages/block-library/src/table-of-contents   @ZebulanStanphill
-/packages/block-library/src/image               @artemiomorales
 
 # Duotone
 /lib/block-supports/duotone.php


### PR DESCRIPTION
## What?
Remove code owners of the Comments, Comment Template, and Image blocks from the CODEOWNERS file.

## Why?
They're no longer working on Gutenberg and shouldn't be pinged for reviews.