### PR TITLE
Block Editor: fix BlockSwitcher to prevent transforms on reusable blocks

### DIFF
--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -102,18 +102,16 @@ function BlockSwitcherDropdownMenuContents( {
 		selectForMultipleBlocks( transformedBlocks );
 	}
 	/**
-	 * The `isTemplate` check is a stopgap solution here.
+	 * The `isSynced` check is a stopgap solution here.
 	 * Ideally, the Transforms API should handle this
 	 * by allowing to exclude blocks from wildcard transformations.
 	 */
 	const isSingleBlock = blocks.length === 1;
-	const isTemplate = isSingleBlock && isTemplatePart( blocks[ 0 ] );
-	const isReusable = isSingleBlock && isReusableBlock( blocks[ 0 ] );
+	const isSynced =
+		isSingleBlock &&
+		( isTemplatePart( blocks[ 0 ] ) || isReusableBlock( blocks[ 0 ] ) );
 	const hasPossibleBlockTransformations =
-		!! possibleBlockTransformations.length &&
-		canRemove &&
-		! isTemplate &&
-		! isReusable;
+		!! possibleBlockTransformations.length && canRemove && ! isSynced;
 	const hasPossibleBlockVariationTransformations =
 		!! blockVariationTransformations?.length;
 	const hasPatternTransformation = !! patterns?.length && canRemove;

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -108,8 +108,12 @@ function BlockSwitcherDropdownMenuContents( {
 	 */
 	const isSingleBlock = blocks.length === 1;
 	const isTemplate = isSingleBlock && isTemplatePart( blocks[ 0 ] );
+	const isReusable = isSingleBlock && isReusableBlock( blocks[ 0 ] );
 	const hasPossibleBlockTransformations =
-		!! possibleBlockTransformations.length && canRemove && ! isTemplate;
+		!! possibleBlockTransformations.length &&
+		canRemove &&
+		! isTemplate &&
+		! isReusable;
 	const hasPossibleBlockVariationTransformations =
 		!! blockVariationTransformations?.length;
 	const hasPatternTransformation = !! patterns?.length && canRemove;

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -111,7 +111,7 @@ function BlockSwitcherDropdownMenuContents( {
 		isSingleBlock &&
 		( isTemplatePart( blocks[ 0 ] ) || isReusableBlock( blocks[ 0 ] ) );
 	const hasPossibleBlockTransformations =
-		!! possibleBlockTransformations.length && canRemove && ! isSynced;
+		!! possibleBlockTransformations?.length && canRemove && ! isSynced;
 	const hasPossibleBlockVariationTransformations =
 		!! blockVariationTransformations?.length;
 	const hasPatternTransformation = !! patterns?.length && canRemove;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/67710

<!-- In a few words, what is the PR actually doing? -->
This PR updates the BlockSwitcher component to disable block transformations for reusable (synced) blocks. Template parts were already excluded; now reusable blocks will also hide transform options in the dropdown.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, the BlockSwitcher allows transformations on reusable blocks. Transforming a reusable block can cause unexpected behavior, since all instances of the block are linked. Preventing transforms for these blocks ensures consistency across instances and prevents accidental data loss.

See https://github.com/WordPress/gutenberg/issues/67710#issuecomment-2550799023

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Added an isReusable check in BlockSwitcherDropdownMenuContents.
- Updated hasPossibleBlockTransformations to be false for reusable blocks

## Testing Instructions
1. Create a reusable block (or synced pattern).
2. Select it in the editor and open the Block Switcher.
    - Before: Transform options are available.
    - After: Transform options are hidden/disabled.
3. Select a normal block. Verify that the transform dropdown still works as expected.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before 
https://github.com/user-attachments/assets/6931c0ee-ad7e-483e-8e55-32b25a29721c

### After
https://github.com/user-attachments/assets/2528380b-b141-4f29-9aff-f104f05e991d
