### PR TITLE
Date block: Move `block_bindings_supported_attributes` filter to compat layer

### DIFF
--- a/backport-changelog/6.9/9299.md
+++ b/backport-changelog/6.9/9299.md
@@ -2,3 +2,4 @@ https://github.com/WordPress/wordpress-develop/pull/9299
 
 * https://github.com/WordPress/gutenberg/pull/70585
 * https://github.com/WordPress/gutenberg/pull/70982
+* https://github.com/WordPress/gutenberg/pull/71662

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -7,6 +7,20 @@
  * @subpackage Block Bindings
  */
 
+
+// The following filter can be removed once the minimum required WordPress version is 6.9 or newer.
+add_filter(
+	'block_bindings_supported_attributes_core/post-date',
+	function ( $attributes ) {
+		if ( ! in_array( 'datetime', $attributes, true ) ) {
+			$attributes[] = 'datetime';
+		}
+		return $attributes;
+	},
+	10,
+	3
+);
+
 /**
  * Callback function for the render_block filter.
  *

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -105,18 +105,5 @@ function register_block_core_post_date() {
 			'render_callback' => 'render_block_core_post_date',
 		)
 	);
-
-	// The following filter can be removed once the minimum required WordPress version is 6.9 or newer.
-	add_filter(
-		'block_bindings_supported_attributes_core/post-date',
-		function ( $attributes ) {
-			if ( ! in_array( 'datetime', $attributes, true ) ) {
-				$attributes[] = 'datetime';
-			}
-			return $attributes;
-		},
-		10,
-		3
-	);
 }
 add_action( 'init', 'register_block_core_post_date' );


### PR DESCRIPTION
## What?
Move the `block_bindings_supported_attributes_core/post-date` that was added in #71389 to add Block Bindings support for the Date block's `datetime` attribute out of the Date block code and into Gutenberg's WP 6.8 compatibility layer code.

## Why?
See related discussion [here](https://github.com/WordPress/gutenberg/pull/71483#issuecomment-3291821453).

## Testing Instructions
Refer to https://github.com/WordPress/gutenberg/pull/70585.