### PR TITLE
Block Bindings: Add `block_bindings_supported_attributes` filter

### DIFF
--- a/backport-changelog/6.9/9891.md
+++ b/backport-changelog/6.9/9891.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/9891
+
+* https://github.com/WordPress/gutenberg/pull/71663

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -115,6 +115,20 @@ function gutenberg_process_block_bindings( $instance ) {
 	/**
 	 * Filters the supported block attributes for block bindings.
 	 *
+	 * @since 6.9.0
+	 *
+	 * @param string[] $supported_block_attributes The block's attributes that are supported by block bindings.
+	 * @param string   $block_type                 The block type whose attributes are being filtered.
+	 */
+	$supported_block_attributes = apply_filters(
+		'block_bindings_supported_attributes',
+		$supported_block_attributes,
+		$block_type
+	);
+
+	/**
+	 * Filters the supported block attributes for block bindings.
+	 *
 	 * The dynamic portion of the hook name, `$block_type`, refers to the block type
 	 * whose attributes are being filtered.
 	 *


### PR DESCRIPTION
## What?
Add a block-agnostic version of the `block_bindings_supported_attributes_{$block_type}` filter (first introduced by #71389).

## Why?
See https://github.com/WordPress/gutenberg/pull/71662#issuecomment-3291847715. In a nutshell, it's quickly becoming cumbersome to add block bindings support for various attributes of different blocks in the WP compat layer code.