### PR TITLE
DataForm toggleGroup control: support validation

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,7 +12,7 @@
 -   Expose `ValidatedTextareaControl` via Private APIs ([#71495](https://github.com/WordPress/gutenberg/pull/71495))
 -   Add support for ValidatedFormTokenField [#71350](https://github.com/WordPress/gutenberg/pull/71350).
 -   Expose `ValidatedSelectControl` via Private APIs ([#71665](https://github.com/WordPress/gutenberg/pull/71665))
--   Expose `ValidatedToggleGroupControl` via private APIs. ([#71666](https://github.com/WordPress/gutenberg/pull/71666))
+-   Expose `ValidatedToggleGroupControl` via private APIs. Also properly detects `undefined` values for `required` validation ([#71666](https://github.com/WordPress/gutenberg/pull/71666)).
 
 ## 30.3.0 (2025-09-03)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 -   Expose `ValidatedTextareaControl` via Private APIs ([#71495](https://github.com/WordPress/gutenberg/pull/71495))
 -   Add support for ValidatedFormTokenField [#71350](https://github.com/WordPress/gutenberg/pull/71350).
 -   Expose `ValidatedSelectControl` via Private APIs ([#71665](https://github.com/WordPress/gutenberg/pull/71665))
+-   Expose `ValidatedToggleGroupControl` via private APIs. ([#71666](https://github.com/WordPress/gutenberg/pull/71666))
 
 ## 30.3.0 (2025-09-03)
 

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -20,6 +20,7 @@ import {
 	ValidatedTextControl,
 	ValidatedTextareaControl,
 	ValidatedToggleControl,
+	ValidatedToggleGroupControl,
 } from './validated-form-controls';
 import { Picker } from './color-picker/picker';
 
@@ -45,4 +46,5 @@ lock( privateApis, {
 	ValidatedTextControl,
 	ValidatedTextareaControl,
 	ValidatedToggleControl,
+	ValidatedToggleGroupControl,
 } );

--- a/packages/components/src/validated-form-controls/components/toggle-group-control.tsx
+++ b/packages/components/src/validated-form-controls/components/toggle-group-control.tsx
@@ -48,8 +48,6 @@ const UnforwardedValidatedToggleGroupControl = (
 					__nextHasNoMarginBottom
 					__next40pxDefaultSize
 					ref={ forwardedRef }
-					// TODO: Upstream limitation - In uncontrolled mode, starting from an undefined value then
-					// setting a value has a visual bug.
 					onChange={ ( value ) => {
 						valueRef.current = value;
 						onChange?.( value );
@@ -62,7 +60,7 @@ const UnforwardedValidatedToggleGroupControl = (
 				type="radio"
 				ref={ validityTargetRef }
 				required={ required }
-				checked={ restProps.value !== null }
+				checked={ restProps.value !== undefined }
 				tabIndex={ -1 }
 				// A name attribute is needed for the `required` behavior to work.
 				name={ nameAttr }

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -17,6 +17,7 @@
 - DataForm: Add a textarea control for use with the `text` field type ([#71495](https://github.com/WordPress/gutenberg/pull/71495))
 - DataViews: support groupBy in the list layout. [#71548](https://github.com/WordPress/gutenberg/pull/71548)
 - DataForm: support validation in select control [#71665](https://github.com/WordPress/gutenberg/pull/71665)
+- DataForm: support validation in toggleGroup control. ([#71666](https://github.com/WordPress/gutenberg/pull/71666))
 
 ### Bug Fixes
 

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -406,6 +406,8 @@ const ValidationComponent = ( {
 		boolean: boolean;
 		customEdit: string;
 		password: string;
+		toggle?: boolean;
+		toggleGroup?: string;
 	};
 
 	const [ post, setPost ] = useState< ValidatedItem >( {
@@ -420,6 +422,8 @@ const ValidationComponent = ( {
 		boolean: true,
 		customEdit: 'custom control',
 		password: 'secretpassword123',
+		toggle: undefined,
+		toggleGroup: undefined,
 	} );
 
 	const customTextRule = ( value: ValidatedItem ) => {
@@ -474,6 +478,27 @@ const ValidationComponent = ( {
 	const customIntegerRule = ( value: ValidatedItem ) => {
 		if ( value.integer % 2 !== 0 ) {
 			return 'Integer must be an even number.';
+		}
+
+		return null;
+	};
+	const customBooleanRule = ( value: ValidatedItem ) => {
+		if ( value.boolean !== true ) {
+			return 'Boolean must be active.';
+		}
+
+		return null;
+	};
+	const customToggleRule = ( value: ValidatedItem ) => {
+		if ( value.toggle !== true ) {
+			return 'Toggle must be checked.';
+		}
+
+		return null;
+	};
+	const customToggleGroupRule = ( value: ValidatedItem ) => {
+		if ( value.toggleGroup !== 'option1' ) {
+			return 'Toggle must be Option 1.';
 		}
 
 		return null;
@@ -583,6 +608,7 @@ const ValidationComponent = ( {
 			label: 'Boolean',
 			isValid: {
 				required,
+				custom: maybeCustomRule( customBooleanRule ),
 			},
 		},
 		{
@@ -602,6 +628,31 @@ const ValidationComponent = ( {
 				custom: maybeCustomRule( customPasswordRule ),
 			},
 		},
+		{
+			id: 'toggle',
+			type: 'boolean',
+			label: 'Toggle',
+			Edit: 'toggle',
+			isValid: {
+				required,
+				custom: maybeCustomRule( customToggleRule ),
+			},
+		},
+		{
+			id: 'toggleGroup',
+			type: 'text',
+			label: 'Toggle Group',
+			Edit: 'toggleGroup',
+			elements: [
+				{ value: 'option1', label: 'Option 1' },
+				{ value: 'option2', label: 'Option 2' },
+				{ value: 'option3', label: 'Option 3' },
+			],
+			isValid: {
+				required,
+				custom: maybeCustomRule( customToggleGroupRule ),
+			},
+		},
 	];
 
 	const form = {
@@ -616,8 +667,10 @@ const ValidationComponent = ( {
 			'color',
 			'integer',
 			'boolean',
-			'customEdit',
+			'toggle',
+			'toggleGroup',
 			'password',
+			'customEdit',
 		],
 	};
 

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -498,7 +498,7 @@ const ValidationComponent = ( {
 	};
 	const customToggleGroupRule = ( value: ValidatedItem ) => {
 		if ( value.toggleGroup !== 'option1' ) {
-			return 'Toggle must be Option 1.';
+			return 'Value must be Option 1.';
 		}
 
 		return null;


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/71500

## What?

Add support for `required` and `custom` validation in toggle group control.

## Why?

So that all controls support basic validation.

## How?

Use the existing `ValidatedToggleGroupControl` component.

## Testing Instructions

In the storybook (`npm run storybook:dev`) verify that it can take `required` and `custom` validation in the "DataViews > DataForm > Validation" story:

https://github.com/user-attachments/assets/2e42efe8-796b-44b9-99e4-ee6819f3107b


