### PR TITLE
Hide Spacer resizable box in write mode

### DIFF
--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -12,6 +12,7 @@ import {
 	getSpacingPresetCssVar,
 	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
+	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import { ResizableBox } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
@@ -346,6 +347,8 @@ const SpacerEdit = ( {
 		__unstableMarkNextChangeAsNotPersistent,
 	] );
 
+	const blockEditingMode = useBlockEditingMode();
+
 	return (
 		<>
 			<View
@@ -356,7 +359,8 @@ const SpacerEdit = ( {
 					} ),
 				} ) }
 			>
-				{ resizableBoxWithOrientation( inheritedOrientation ) }
+				{ blockEditingMode === 'default' &&
+					resizableBoxWithOrientation( inheritedOrientation ) }
 			</View>
 			{ ! isFlexLayout && (
 				<SpacerControls


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

Part of #65778.

Hides the resizable box controls for Spacer block when in write mode.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Spacer to a template;
2. Enable write mode. The Spacer shouldn't be resizable.


| Design mode | Write mode |
|-|-|
| <img width="1215" height="430" alt="Screenshot 2025-09-16 at 10 06 02 am" src="https://github.com/user-attachments/assets/a1ac14b1-db1f-48fe-8b18-4c5256cae2ca" /> | <img width="1217" height="435" alt="Screenshot 2025-09-16 at 10 06 24 am" src="https://github.com/user-attachments/assets/d48a765a-f0c2-48c6-8aa4-f112bf059647" /> |
