### PR TITLE
i18n: show "1 more reply" instead of "1 more replies" in block comments

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -15,7 +15,7 @@ import {
 	DropdownMenu,
 } from '@wordpress/components';
 import { published, moreVertical } from '@wordpress/icons';
-import { __, _x, sprintf } from '@wordpress/i18n';
+import { __, _x, _n, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
@@ -156,7 +156,11 @@ function Thread( {
 						>
 							{ sprintf(
 								// translators: %s: number of replies.
-								_x( '%s more replies', 'Show replies button' ),
+								_n(
+									'%s more reply',
+									'%s more replies',
+									thread?.reply?.length
+								),
 								thread?.reply?.length
 							) }
 						</Button>


### PR DESCRIPTION
## What?
Closes #71684 

Fixes the grammatical error in block commenting where "1 more replies" was displayed instead of the correct singular form "1 more reply".

## Why?
When there is exactly one hidden reply in a comment thread, the interface incorrectly shows "1 more replies" which is grammatically wrong. It should show "1 more reply" (singular) for one reply and "X more replies" (plural) for multiple replies. This improves the user experience and ensures proper grammar across all languages that support WordPress pluralization.

## How?
- Replaced `_x()` function with `_n()` function in the comments component
- Added proper singular and plural forms: `'%s more reply'` and `'%s more replies'`

## Testing Instructions
1. Open the WordPress editor (post or page)
2. Add a block (any block type works)
3. Add at least 2 comments to the block
4. Verify that when there's exactly 1 hidden reply, it shows "1 more reply"
5. Verify that when there are 2 or more hidden replies, it shows "X more replies"

## Screenshots or screencast 

|Before|After|
|-|-|
| <img width="1470" height="956" alt="Screenshot 2025-09-16 at 10 04 00 AM" src="https://github.com/user-attachments/assets/8f02f49e-269d-42ee-9396-08c90ba82951" /> | <img width="1470" height="956" alt="Screenshot 2025-09-16 at 10 03 30 AM" src="https://github.com/user-attachments/assets/4cbb7f9e-15b8-4e97-a7f2-77d13f7a51be" /> |
