### PR TITLE
Add contentRole to Query block and make sure Change design always works as expected

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -759,7 +759,7 @@ An advanced block that allows displaying post types based on different query par
 
 -	**Name:** core/query
 -	**Category:** theme
--	**Supports:** align (full, wide), interactivity, layout, ~~html~~
+-	**Supports:** align (full, wide), contentRole, interactivity, layout, ~~html~~
 -	**Attributes:** enhancedPagination, namespace, query, queryId, tagName
 
 ## No Results

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -53,7 +53,8 @@
 		"align": [ "wide", "full" ],
 		"html": false,
 		"layout": true,
-		"interactivity": true
+		"interactivity": true,
+		"contentRole": true
 	},
 	"editorStyle": "wp-block-query-editor"
 }

--- a/packages/block-library/src/query/edit/pattern-selection.js
+++ b/packages/block-library/src/query/edit/pattern-selection.js
@@ -83,18 +83,6 @@ export default function PatternSelection( {
 			blocks,
 			attributes
 		);
-		// console.log(
-		// 	'new blocks',
-		// 	newBlocks,
-		// 	'query client ids',
-		// 	queryClientIds,
-		// 	'pattern',
-		// 	pattern,
-		// 	'blocks',
-		// 	blocks,
-		// 	'attributes',
-		// 	attributes
-		// );
 		replaceBlock( clientId, newBlocks );
 		if ( queryClientIds[ 0 ] ) {
 			selectBlock( queryClientIds[ 0 ] );

--- a/packages/block-library/src/query/edit/pattern-selection.js
+++ b/packages/block-library/src/query/edit/pattern-selection.js
@@ -43,7 +43,16 @@ export function useBlockPatterns( clientId, attributes ) {
 		clientId,
 		attributes
 	);
-	return usePatterns( clientId, blockNameForPatterns );
+	const allPatterns = usePatterns( clientId, blockNameForPatterns );
+	// Filter out any patterns that don't have Query as their root block
+	// so that a Query block is always replaced by another Query block.
+	const rootBlockPatterns = useMemo( () => {
+		return allPatterns.filter( ( pattern ) => {
+			return pattern.blocks?.[ 0 ]?.name === blockNameForPatterns;
+		} );
+	}, [ allPatterns, blockNameForPatterns ] );
+
+	return rootBlockPatterns;
 }
 
 export default function PatternSelection( {
@@ -74,6 +83,18 @@ export default function PatternSelection( {
 			blocks,
 			attributes
 		);
+		// console.log(
+		// 	'new blocks',
+		// 	newBlocks,
+		// 	'query client ids',
+		// 	queryClientIds,
+		// 	'pattern',
+		// 	pattern,
+		// 	'blocks',
+		// 	blocks,
+		// 	'attributes',
+		// 	attributes
+		// );
 		replaceBlock( clientId, newBlocks );
 		if ( queryClientIds[ 0 ] ) {
 			selectBlock( queryClientIds[ 0 ] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Fixes #67763.

The Query block is currently unselectable if it's nested inside a pattern. Adding `contentRole` makes it selectable in instances where it's not buried too deep in the pattern 😅 (see nesting issue I commented on [here](https://github.com/WordPress/gutenberg/issues/67763#issuecomment-3296136212))

Also, when we "Change design", some of the designs that come up don't have Query as their root block, and that can cause all sorts of problems like adding extra layers of nesting to a pattern, which then changes its layout in undesirable ways (you can end up with a really squished Query inside several Groups that each add extra margins). 

I believe the best way of addressing this is by making sure that we always replace a Query with another Query, by not providing more complex patterns as options in the "Change design" modal, so this PR filters out those other patterns.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. With TT5 enabled, go to blog homepage template, select the Query block and click on "Change design" on the block toolbar. 
2. Test a few different designs and see that the Query is always selectable.

<img width="1393" height="900" alt="Screenshot 2025-09-17 at 11 02 57 am" src="https://github.com/user-attachments/assets/ab3d976e-2bb5-4c1e-a3fe-a2c01da86cf3" />

