### PR TITLE
Button: Suppress __next40pxDefaultSize warning if the variant is link

### DIFF
--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -146,7 +146,8 @@ export function UnforwardedButton(
 	];
 
 	const classes = clsx( 'components-button', className, {
-		'is-next-40px-default-size': __next40pxDefaultSize,
+		'is-next-40px-default-size':
+			__next40pxDefaultSize && variant !== 'link',
 		'is-secondary': variant === 'secondary',
 		'is-primary': variant === 'primary',
 		'is-small': size === 'small',

--- a/packages/components/src/notice/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/notice/test/__snapshots__/index.tsx.snap
@@ -21,7 +21,7 @@ exports[`Notice should match snapshot 1`] = `
         class="components-notice__actions"
       >
         <a
-          class="components-button components-notice__action is-next-40px-default-size is-link"
+          class="components-button components-notice__action is-link"
           href="https://example.com"
         >
           More information

--- a/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
@@ -19,7 +19,7 @@ exports[`DotTip should render correctly 1`] = `
     </p>
     <p>
       <button
-        class="components-button is-next-40px-default-size is-link"
+        class="components-button is-link"
         type="button"
       >
         Got it


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #71683

Suppresses the `__next40pxDefaultSize` ESLint warning when the Button
variant is `link`.

## Why?
Link variant Buttons don’t use a fixed height. The `__next40pxDefaultSize`
prop and related class are not meaningful for this case, so they should
not trigger warnings or extra styles.

## How?
- Updated ESLint rule to ignore Buttons with `variant="link"`.
