### PR TITLE
Block Bindings: Fix back-compat layer

### DIFF
--- a/backport-changelog/6.9/9469.md
+++ b/backport-changelog/6.9/9469.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/9469
 
 * https://github.com/WordPress/gutenberg/pull/71389
+* https://github.com/WordPress/gutenberg/pull/71691

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -36,26 +36,30 @@ function gutenberg_block_bindings_render_block( $block_content, $block, $instanc
 		return $block_content;
 	}
 
-	$attributes = $instance->parsed_block['attrs'];
 	// Process the block bindings and get attributes updated with the values from the sources.
 	$computed_attributes = gutenberg_process_block_bindings( $instance );
 	if ( empty( $computed_attributes ) ) {
 		return $block_content;
 	}
 
-	// Merge the computed attributes with the original attributes.
-	$instance->attributes = array_merge( $attributes, $computed_attributes );
+	/**
+	 * Merge the computed attributes with the original attributes.
+	 *
+	 * Note that this is not a recursive merge, meaning that nested attributes --
+	 * such as block bindings metadata -- will be completely replaced.
+	 * This is desirable. At this point, Core has already processed any block
+	 * bindings that it supports. What remains to be processed are only the attributes
+	 * for which support was added later (through the `block_bindings_supported_attributes`
+	 * filter). To do so, we'll run `$instance->render()` once more
+	 * so the block can update its content based on those attributes.
+	 */
+	$instance->attributes = array_merge( $instance->attributes, $computed_attributes );
 
 	/**
-	 * This filter is called from WP_Block::render(), after the block content has
-	 * already been rendered. However, dynamic blocks expect their render() method
-	 * to receive block attributes to have their bound values. This means that we have
-	 * to re-render the block here.
-	 * To do so, we'll set a flag that this filter checks when invoked to avoid infinite
-	 * recursion. Furthermore, we can unset all of the block's bindings, as we know that
-	 * they have been processed by the time we reach this point.
+	 * This filter (`gutenberg_block_bindings_render_block`) is called from `WP_Block::render()`.
+	 * To avoid infinite recursion, we set a flag that this filter checks when invoked which tells
+	 * it to exit early.
 	 */
-	unset( $instance->parsed_block['attrs']['metadata']['bindings'] );
 	$inside_block_bindings_render = true;
 	$block_content                = $instance->render();
 	$inside_block_bindings_render = false;

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -43,15 +43,6 @@ function gutenberg_block_bindings_render_block( $block_content, $block, $instanc
 	}
 
 	/*
-	 * If we're dealing with the Button block, we remove the bindings metadata
-	 * in order to avoid having it reprocessed, which would lead to Core
-	 * capitalizing the wrapper tag (e.g. <DIV>).
-	 */
-	if ( 'core/button' === $instance->name ) {
-		unset( $instance->parsed_block['attrs']['metadata']['bindings'] );
-	}
-
-	/*
 	 * Merge the computed attributes with the original attributes.
 	 *
 	 * Note that this is not a recursive merge, meaning that nested attributes --
@@ -63,6 +54,15 @@ function gutenberg_block_bindings_render_block( $block_content, $block, $instanc
 	 * so the block can update its content based on those attributes.
 	 */
 	$instance->attributes = array_merge( $instance->attributes, $computed_attributes );
+
+	/*
+	 * If we're dealing with the Button block, we remove the bindings metadata
+	 * in order to avoid having it reprocessed, which would lead to Core
+	 * capitalizing the wrapper tag (e.g. <DIV>).
+	 */
+	if ( 'core/button' === $instance->name ) {
+		unset( $instance->parsed_block['attrs']['metadata']['bindings'] );
+	}
 
 	/**
 	 * This filter (`gutenberg_block_bindings_render_block`) is called from `WP_Block::render()`.

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -42,7 +42,16 @@ function gutenberg_block_bindings_render_block( $block_content, $block, $instanc
 		return $block_content;
 	}
 
-	/**
+	/*
+	 * If we're dealing with the Button block, we remove the bindings metadata
+	 * in order to avoid having it reprocessed, which would lead to Core
+	 * capitalizing the wrapper tag (e.g. <DIV>).
+	 */
+	if ( 'core/button' === $instance->name ) {
+		unset( $instance->parsed_block['attrs']['metadata']['bindings'] );
+	}
+
+	/*
 	 * Merge the computed attributes with the original attributes.
 	 *
 	 * Note that this is not a recursive merge, meaning that nested attributes --


### PR DESCRIPTION
## What?
Fix a bug in the Block Bindings compat layer (which was introduced in https://github.com/WordPress/gutenberg/pull/71389).

## Why?
See https://github.com/WordPress/gutenberg/pull/71483#issuecomment-3285125446. In short, pattern overrides would break for the Image block if Block Bindings support was added for another Image block attribute (like `caption` in case of https://github.com/WordPress/gutenberg/pull/71483).

## How?
When updating `$instance->attributes`, merge the computed attributes with `$instance->attributes` instead of `$instance->parsed_block['attrs']`. (In hindsight, this one was a silly mistake.)

Additionally, the logic in the code relies on the fact that `array_merge` doesn't do recursive merges (but replaces `$instance->attributes['metadata']` with `$computed_attributes['metadata']`, thus overriding block bindings that have already been processed). See the inline comments for more details.

## Testing Instructions
See https://github.com/WordPress/gutenberg/pull/71483#issuecomment-3285125446: Check out that PR's branch locally and try to reproduced the bug. Then, cherry-pick the commit from this branch on top. Verify that the bug is fixed.

Note that I've opted to file a separate PR to fix this bug instead of including the fix in https://github.com/WordPress/gutenberg/pull/71483 for added visibility, and to avoid e.g. losing the bugfix in case https://github.com/WordPress/gutenberg/pull/71483 gets reverted.