### PR TITLE
Add typing to iAPI's getConfig()

### DIFF
--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -20,7 +20,7 @@ const serverStates = new Map();
  * @param namespace Store's namespace from which to retrieve the config.
  * @return Defined config for the given namespace.
  */
-export const getConfig = ( namespace?: string ) =>
+export const getConfig = < T extends object >( namespace?: string ): T =>
 	storeConfigs.get( namespace || getNamespace() ) || {};
 
 /**

--- a/packages/interactivity/src/store.ts
+++ b/packages/interactivity/src/store.ts
@@ -20,7 +20,7 @@ const serverStates = new Map();
  * @param namespace Store's namespace from which to retrieve the config.
  * @return Defined config for the given namespace.
  */
-export const getConfig = < T extends object >( namespace?: string ): T =>
+export const getConfig = < T extends object = any >( namespace?: string ): T =>
 	storeConfigs.get( namespace || getNamespace() ) || {};
 
 /**


### PR DESCRIPTION
## What?

Initially discussed in https://github.com/woocommerce/woocommerce/commit/3b133f2c5d35f32ec54e526ff6a6ffac96990cb3#r165804930.

This PR types the Interactivity API's `getConfig()` function, similar to how it's done for `getContext()`.

## Why?

This allows consumers to consume it like this:

```TS
const config = getConfig< ConfigType >();
```

instead of missing the types or having to add a type assertion as

```TS
const config = getConfig() as ConfigType;
```

## Testing Instructions

1. Add this code somewhere in the codebase:

```TS
type ConfigType = {
	prop: string;
};

const config = getConfig< ConfigType >();
```

2. Verify you don't get a TS error mentioning `Expected 0 type arguments, but got 1.`.