### PR TITLE
Block Comments: Improve error handling for core data actions

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -75,32 +75,25 @@ function CollabSidebarContent( {
 	const { getSelectedBlockClientId } = useSelect( blockEditorStore );
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
-	// Function to save the comment.
 	const addNewComment = async ( comment, parentCommentId ) => {
-		const args = {
-			post: postId,
-			content: comment,
-			comment_type: 'block_comment',
-			comment_approved: 0,
-		};
+		try {
+			const savedRecord = await saveEntityRecord(
+				'root',
+				'comment',
+				{
+					post: postId,
+					content: comment,
+					comment_type: 'block_comment',
+					comment_approved: 0,
+					...( parentCommentId ? { parent: parentCommentId } : {} ),
+				},
+				{ throwOnError: true }
+			);
 
-		// Create a new object, conditionally including the parent property.
-		const updatedArgs = {
-			...args,
-			...( parentCommentId ? { parent: parentCommentId } : {} ),
-		};
-
-		const savedRecord = await saveEntityRecord(
-			'root',
-			'comment',
-			updatedArgs
-		);
-
-		if ( savedRecord ) {
 			// If it's a main comment, update the block attributes with the comment id.
-			if ( ! parentCommentId ) {
+			if ( ! parentCommentId && savedRecord?.id ) {
 				updateBlockAttributes( getSelectedBlockClientId(), {
-					blockCommentId: savedRecord?.id,
+					blockCommentId: savedRecord.id,
 				} );
 			}
 
@@ -114,55 +107,67 @@ function CollabSidebarContent( {
 					isDismissible: true,
 				}
 			);
-		} else {
+		} catch ( error ) {
 			onError();
 		}
 	};
 
 	const onCommentResolve = async ( commentId ) => {
-		const savedRecord = await saveEntityRecord( 'root', 'comment', {
-			id: commentId,
-			status: 'approved',
-		} );
-
-		if ( savedRecord ) {
+		try {
+			await saveEntityRecord(
+				'root',
+				'comment',
+				{
+					id: commentId,
+					status: 'approved',
+				},
+				{ throwOnError: true }
+			);
 			createNotice( 'snackbar', __( 'Comment marked as resolved.' ), {
 				type: 'snackbar',
 				isDismissible: true,
 			} );
-		} else {
+		} catch {
 			onError();
 		}
 	};
 
 	const onCommentReopen = async ( commentId ) => {
-		const savedRecord = await saveEntityRecord( 'root', 'comment', {
-			id: commentId,
-			status: 'hold',
-		} );
-
-		if ( savedRecord ) {
+		try {
+			await saveEntityRecord(
+				'root',
+				'comment',
+				{
+					id: commentId,
+					status: 'hold',
+				},
+				{ throwOnError: true }
+			);
 			createNotice( 'snackbar', __( 'Comment reopened.' ), {
 				type: 'snackbar',
 				isDismissible: true,
 			} );
-		} else {
+		} catch {
 			onError();
 		}
 	};
 
 	const onEditComment = async ( commentId, comment ) => {
-		const savedRecord = await saveEntityRecord( 'root', 'comment', {
-			id: commentId,
-			content: comment,
-		} );
-
-		if ( savedRecord ) {
+		try {
+			await saveEntityRecord(
+				'root',
+				'comment',
+				{
+					id: commentId,
+					content: comment,
+				},
+				{ throwOnError: true }
+			);
 			createNotice( 'snackbar', __( 'Comment edited successfully.' ), {
 				type: 'snackbar',
 				isDismissible: true,
 			} );
-		} else {
+		} catch {
 			onError();
 		}
 	};
@@ -180,23 +185,29 @@ function CollabSidebarContent( {
 	};
 
 	const onCommentDelete = async ( commentId ) => {
-		const childComment = await getEntityRecord(
-			'root',
-			'comment',
-			commentId
-		);
-		await deleteEntityRecord( 'root', 'comment', commentId );
-
-		if ( childComment && ! childComment.parent ) {
-			updateBlockAttributes( getSelectedBlockClientId(), {
-				blockCommentId: undefined,
+		try {
+			const childComment = await getEntityRecord(
+				'root',
+				'comment',
+				commentId
+			);
+			await deleteEntityRecord( 'root', 'comment', commentId, undefined, {
+				throwOnError: true,
 			} );
-		}
 
-		createNotice( 'snackbar', __( 'Comment deleted successfully.' ), {
-			type: 'snackbar',
-			isDismissible: true,
-		} );
+			if ( childComment && ! childComment.parent ) {
+				updateBlockAttributes( getSelectedBlockClientId(), {
+					blockCommentId: undefined,
+				} );
+			}
+
+			createNotice( 'snackbar', __( 'Comment deleted successfully.' ), {
+				type: 'snackbar',
+				isDismissible: true,
+			} );
+		} catch {
+			onError();
+		}
 	};
 
 	return (

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -75,6 +75,17 @@ function CollabSidebarContent( {
 	const { getSelectedBlockClientId } = useSelect( blockEditorStore );
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
+	const onError = ( error ) => {
+		const errorMessage =
+			error.message && error.code !== 'unknown_error'
+				? error.message
+				: __( 'An error occurred while performing an update.' );
+		createNotice( 'error', errorMessage, {
+			type: 'snackbar',
+			isDismissible: true,
+		} );
+	};
+
 	const addNewComment = async ( comment, parentCommentId ) => {
 		try {
 			const savedRecord = await saveEntityRecord(
@@ -108,7 +119,7 @@ function CollabSidebarContent( {
 				}
 			);
 		} catch ( error ) {
-			onError();
+			onError( error );
 		}
 	};
 
@@ -127,8 +138,8 @@ function CollabSidebarContent( {
 				type: 'snackbar',
 				isDismissible: true,
 			} );
-		} catch {
-			onError();
+		} catch ( error ) {
+			onError( error );
 		}
 	};
 
@@ -147,8 +158,8 @@ function CollabSidebarContent( {
 				type: 'snackbar',
 				isDismissible: true,
 			} );
-		} catch {
-			onError();
+		} catch ( error ) {
+			onError( error );
 		}
 	};
 
@@ -167,21 +178,9 @@ function CollabSidebarContent( {
 				type: 'snackbar',
 				isDismissible: true,
 			} );
-		} catch {
-			onError();
+		} catch ( error ) {
+			onError( error );
 		}
-	};
-
-	const onError = () => {
-		createNotice(
-			'error',
-			__(
-				'Something went wrong. Please try publishing the post, or you may have already submitted your comment earlier.'
-			),
-			{
-				isDismissible: true,
-			}
-		);
 	};
 
 	const onCommentDelete = async ( commentId ) => {
@@ -205,8 +204,8 @@ function CollabSidebarContent( {
 				type: 'snackbar',
 				isDismissible: true,
 			} );
-		} catch {
-			onError();
+		} catch ( error ) {
+			onError( error );
 		}
 	};
 


### PR DESCRIPTION
## What?

PR updates C(R)UD actions for block comments to use `try...catch` for error handling and display error messages provided from the server when available.

I've also changed the error notice to a Snackbar to avoid a canvas jump on error.

P.S. I think we can combine edit methods into a single callback, but I'm going to work on that separately to make testing easier.

## Why?

Follows practices used across the editor for similar actions.

## Testing Instructions
1. Apply the testing patch.
2. Open a post.
3. Try adding, modifying or deleting a block comment.
4. Correct errors should be displayed for each action.

<details><summary>Testing patch</summary>
<p>

```diff
diff --git a/lib/experimental/class-gutenberg-rest-comment-controller.php b/lib/experimental/class-gutenberg-rest-comment-controller.php
index 8409c595032..bf2bdee9cc7 100644
--- a/lib/experimental/class-gutenberg-rest-comment-controller.php
+++ b/lib/experimental/class-gutenberg-rest-comment-controller.php
@@ -110,8 +110,20 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 			);
 		}
 
+		if ( comments_open( $post->ID ) ) {
+			return new WP_Error(
+				'rest_comments_closed',
+				__( 'Sorry, comments are closed for this post.', 'gutenberg' ),
+				array( 'status' => 403 )
+			);
+		}
+
 		return true;
 	}
+
+	protected function check_edit_permission( $comment ) {
+		return false;
+	}
 }
 
 add_action(
```

</p>
</details> 

### Testing Instructions for Keyboard
Same.