### PR TITLE
DataViews: Selection does not persist across pages

### DIFF
--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -178,11 +178,7 @@ function DataViews< Item >( {
 		}
 	}
 	const _fields = useMemo( () => normalizeFields( fields ), [ fields ] );
-	const _selection = useMemo( () => {
-		return selection.filter( ( id ) =>
-			data.some( ( item ) => getItemId( item ) === id )
-		);
-	}, [ selection, data, getItemId ] );
+	const _selection = selection;
 
 	const filters = useFilters( _fields, view );
 	const hasPrimaryOrLockedFilters = useMemo(


### PR DESCRIPTION
## What?
This issue fixes the issue when the DataView component is paginated, and selection doesn't persist across multiple pages.

## Why?
Closes #71269

## How?
This PR fixes a bug in the implementation of selection logic that removes the previously selected items when page changes.


## Testing Instructions
1. Open the storybook story for DataViews
2. Select some item on the first page of dataviews (click the checkbox to ensure you multiselect)
3. Go to the second page and select some more items using the checkbox
4. Go back to the first page

Expected: The items selected in step 2 remain selected
Before: The items selected in step 2 are now deselected
After: The items remain selected

## Screenshots or screencast

https://github.com/user-attachments/assets/04638bed-f6cd-4638-93ea-be8696d2effe

