### PR TITLE
Improve comments panel close icon label

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -377,7 +377,7 @@ export default function CollabSidebar() {
 				// translators: Comments sidebar title
 				title={ __( 'Comments' ) }
 				icon={ commentIcon }
-				closeLabel={ __( 'Close comments panel' ) }
+				closeLabel={ __( 'Close Comments' ) }
 			>
 				<CollabSidebarContent
 					comments={ resultComments }

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -377,6 +377,7 @@ export default function CollabSidebar() {
 				// translators: Comments sidebar title
 				title={ __( 'Comments' ) }
 				icon={ commentIcon }
+				closeLabel={ __( 'Close comments panel' ) }
 			>
 				<CollabSidebarContent
 					comments={ resultComments }


### PR DESCRIPTION
## What?
Adds a label for the close icon of the comments sidebar panel.

Fixes  https://github.com/WordPress/gutenberg/issues/71700

<!-- In a few words, what is the PR actually doing? -->

## Why?
The current default label "Close plugin" doesn't make sense.

## How?
Adding a label.

## Testing Instructions
1. Open the comments sidebar and hover over the close icon

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="608" height="388" alt="image" src="https://github.com/user-attachments/assets/ade8c1f2-56fa-420b-ab4d-b2e33e3ba311" />


After:
<img width="596" height="458" alt="image" src="https://github.com/user-attachments/assets/dd247104-ea3d-4a76-83ab-737db126f9bd" />

