### PR TITLE
Data Bindings: Update terms data with markup content type

### DIFF
--- a/lib/compat/wordpress-6.9/term-data-block-bindings.php
+++ b/lib/compat/wordpress-6.9/term-data-block-bindings.php
@@ -16,9 +16,10 @@
  * @param array    $source_args    Array containing source arguments used to look up the override value.
  *                                 Example: array( "key" => "name" ).
  * @param WP_Block $block_instance The block instance.
+ * @param string   $attribute_name The name of the attribute being bound.
  * @return mixed The value computed for the source.
  */
-function gutenberg_block_bindings_term_data_get_value( array $source_args, $block_instance ) {
+function gutenberg_block_bindings_term_data_get_value( array $source_args, $block_instance, $attribute_name = '' ) {
 	if ( empty( $source_args['key'] ) ) {
 		return null;
 	}
@@ -53,6 +54,13 @@ function gutenberg_block_bindings_term_data_get_value( array $source_args, $bloc
 
 		case 'link':
 			return esc_url( get_term_link( $term ) );
+
+		case 'nameWithLink':
+			if ( 'content' === $attribute_name ) {
+				return '<a href="' . esc_url( get_term_link( $term ) ) . '">' . esc_html( $term->name ) . '</a>';
+			}
+			// Return null for non-content attributes.
+			return null;
 
 		case 'slug':
 			return esc_html( $term->slug );

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -80,6 +80,13 @@ function BlockBindingsPanelMenuContent( { fieldsList, attribute, binding } ) {
 							.filter(
 								( [ , args ] ) => args?.type === attributeType
 							)
+							.filter( ( [ , args ] ) => {
+								// Filter out markup for non-content attributes.
+								if ( args?.markup && attribute !== 'content' ) {
+									return false;
+								}
+								return true;
+							} )
 							.map( ( [ key, args ] ) => (
 								<Menu.RadioItem
 									key={ key }

--- a/packages/editor/src/bindings/term-data.js
+++ b/packages/editor/src/bindings/term-data.js
@@ -23,14 +23,23 @@ function createDataFields( termDataValues, idValue ) {
 			value: termDataValues?.name,
 			type: 'string',
 		},
-		slug: {
-			label: __( 'Slug' ),
-			value: termDataValues?.slug,
-			type: 'string',
-		},
 		link: {
 			label: __( 'Link' ),
 			value: termDataValues?.link,
+			type: 'string',
+		},
+		nameWithLink: {
+			label: __( 'Name with Link' ),
+			value:
+				termDataValues?.name && termDataValues?.link
+					? `<a href="${ termDataValues.link }">${ termDataValues.name }</a>`
+					: termDataValues?.nameWithLink,
+			type: 'string',
+			markup: true,
+		},
+		slug: {
+			label: __( 'Slug' ),
+			value: termDataValues?.slug,
 			type: 'string',
 		},
 		description: {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Originally discussed in https://github.com/WordPress/gutenberg/pull/71596, this tries adding a new data binding attribute for the terms data, "Name with Link", that uses a new type of attribute, `markup`. This means we can combine data such as term name and link to create a link to a term.

cc @cr0ybot 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's not currently possible to add a link format to a paragraph block, where the paragraph block is attached to a content attribute and the link is attached to a URL attribute. This PR allows us to combine these two pieces of data so that we're able to use both in the same block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a new attribute, "Name with Link", and a new attribute parameter, `markup`. The new `markup` type can only be used on `content` attributes.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
