### PR TITLE
Fix interval time format typo in API reference

### DIFF
--- a/docs/reference-guides/interactivity-api/api-reference.md
+++ b/docs/reference-guides/interactivity-api/api-reference.md
@@ -1246,7 +1246,7 @@ store( 'mySliderPlugin', {
 				withScope( () => {
 					actions.nextImage();
 				} ),
-				3_000
+				3000
 			);
 		},
 	},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Minor typo in docs

Fixes a minor typo interval format in the documented example of using withScope and setInterval

## Why?
Copy paste of existing example does not work

## How?
Remove extra _ in interval
