### PR TITLE
Hide Post Date toolbar when child of Query in contentOnly mode

### DIFF
--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -19,6 +19,7 @@ import {
 	InspectorControls,
 	store as blockEditorStore,
 	useBlockProps,
+	useBlockEditingMode,
 	__experimentalDateFormatPicker as DateFormatPicker,
 	__experimentalPublishDateTimePicker as PublishDateTimePicker,
 } from '@wordpress/block-editor';
@@ -99,6 +100,8 @@ export default function PostDateEdit( {
 		[ postTypeSlug ]
 	);
 
+	const blockEditingMode = useBlockEditingMode();
+
 	let postDate = (
 		<time dateTime={ dateI18n( 'c', datetime ) } ref={ setPopoverAnchor }>
 			{ format === 'human-diff'
@@ -120,61 +123,69 @@ export default function PostDateEdit( {
 
 	return (
 		<>
-			<BlockControls group="block">
-				<AlignmentControl
-					value={ textAlign }
-					onChange={ ( nextAlign ) => {
-						setAttributes( { textAlign: nextAlign } );
-					} }
-				/>
-				{ displayType !== 'modified' && ! isDescendentOfQueryLoop && (
-					<ToolbarGroup>
-						<Dropdown
-							popoverProps={ popoverProps }
-							renderContent={ ( { onClose } ) => (
-								<PublishDateTimePicker
-									title={
-										displayType === 'date'
-											? __( 'Publish Date' )
-											: __( 'Date' )
-									}
-									currentDate={ datetime }
-									onChange={ ( newDatetime ) =>
-										setAttributes( {
-											datetime: newDatetime,
-										} )
-									}
-									is12Hour={ is12HourFormat(
-										siteTimeFormat
+			{ ( blockEditingMode === 'default' ||
+				! isDescendentOfQueryLoop ) && (
+				<BlockControls group="block">
+					<AlignmentControl
+						value={ textAlign }
+						onChange={ ( nextAlign ) => {
+							setAttributes( { textAlign: nextAlign } );
+						} }
+					/>
+
+					{ displayType !== 'modified' &&
+						! isDescendentOfQueryLoop && (
+							<ToolbarGroup>
+								<Dropdown
+									popoverProps={ popoverProps }
+									renderContent={ ( { onClose } ) => (
+										<PublishDateTimePicker
+											title={
+												displayType === 'date'
+													? __( 'Publish Date' )
+													: __( 'Date' )
+											}
+											currentDate={ datetime }
+											onChange={ ( newDatetime ) =>
+												setAttributes( {
+													datetime: newDatetime,
+												} )
+											}
+											is12Hour={ is12HourFormat(
+												siteTimeFormat
+											) }
+											onClose={ onClose }
+											dateOrder={
+												/* translators: Order of day, month, and year. Available formats are 'dmy', 'mdy', and 'ymd'. */
+												_x( 'dmy', 'date order' )
+											}
+										/>
 									) }
-									onClose={ onClose }
-									dateOrder={
-										/* translators: Order of day, month, and year. Available formats are 'dmy', 'mdy', and 'ymd'. */
-										_x( 'dmy', 'date order' )
-									}
+									renderToggle={ ( { isOpen, onToggle } ) => {
+										const openOnArrowDown = ( event ) => {
+											if (
+												! isOpen &&
+												event.keyCode === DOWN
+											) {
+												event.preventDefault();
+												onToggle();
+											}
+										};
+										return (
+											<ToolbarButton
+												aria-expanded={ isOpen }
+												icon={ edit }
+												title={ __( 'Change Date' ) }
+												onClick={ onToggle }
+												onKeyDown={ openOnArrowDown }
+											/>
+										);
+									} }
 								/>
-							) }
-							renderToggle={ ( { isOpen, onToggle } ) => {
-								const openOnArrowDown = ( event ) => {
-									if ( ! isOpen && event.keyCode === DOWN ) {
-										event.preventDefault();
-										onToggle();
-									}
-								};
-								return (
-									<ToolbarButton
-										aria-expanded={ isOpen }
-										icon={ edit }
-										title={ __( 'Change Date' ) }
-										onClick={ onToggle }
-										onKeyDown={ openOnArrowDown }
-									/>
-								);
-							} }
-						/>
-					</ToolbarGroup>
-				) }
-			</BlockControls>
+							</ToolbarGroup>
+						) }
+				</BlockControls>
+			) }
 
 			<InspectorControls>
 				<ToolsPanel


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Addresses some concerns around editability of Query children in contentOnly mode. See [this comment](https://github.com/WordPress/gutenberg/issues/66614#issuecomment-3290862405).


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a pattern with a Query that contains Post Date to a template (this ensures the Query is in contentOnly mode).
2. Click on Post Date; the toolbar should have no Align option.


<img width="390" height="114" alt="Screenshot 2025-09-17 at 12 03 29 pm" src="https://github.com/user-attachments/assets/a1e0d974-5a99-4f56-ab24-83b4ca059999" />

It might be nice to have the block settings (or at least the link to post option) available in contentOnly mode but that's probably part of a wider inspector-related change:

<img width="282" height="163" alt="Screenshot 2025-09-17 at 12 04 43 pm" src="https://github.com/user-attachments/assets/6c916496-5682-40d6-bc97-60bc47e9651d" />

