### PR TITLE
Section block multi-selection: disable transforms and inspector controls

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -50,6 +50,7 @@ function BlockInspector() {
 	} = useSelect( ( select ) => {
 		const {
 			getSelectedBlockClientId,
+			getSelectedBlockClientIds,
 			getSelectedBlockCount,
 			getBlockName,
 			getParentSectionBlock,
@@ -63,13 +64,17 @@ function BlockInspector() {
 			renderedBlockClientId && getBlockName( renderedBlockClientId );
 		const _blockType =
 			_selectedBlockName && getBlockType( _selectedBlockName );
+		const selectedBlockClientIds = getSelectedBlockClientIds();
+		const isSectionInSelection = selectedBlockClientIds.some( ( id ) =>
+			_isSectionBlock( id )
+		);
 
 		return {
 			count: getSelectedBlockCount(),
 			selectedBlockClientId: renderedBlockClientId,
 			selectedBlockName: _selectedBlockName,
 			blockType: _blockType,
-			isSectionBlock: _isSectionBlock( renderedBlockClientId ),
+			isSectionBlock: isSectionInSelection,
 		};
 	}, [] );
 
@@ -89,7 +94,9 @@ function BlockInspector() {
 		blockName: selectedBlockName,
 	} );
 
-	if ( count > 1 && ! isSectionBlock ) {
+	const hasSelectedBlocks = count > 1;
+
+	if ( hasSelectedBlocks && ! isSectionBlock ) {
 		return (
 			<div className="block-editor-block-inspector">
 				<MultiSelectionInspector />
@@ -122,6 +129,14 @@ function BlockInspector() {
 						<InspectorControls.Slot group="styles" />
 					</>
 				) }
+			</div>
+		);
+	}
+
+	if ( hasSelectedBlocks && isSectionBlock ) {
+		return (
+			<div className="block-editor-block-inspector">
+				<MultiSelectionInspector />
 			</div>
 		);
 	}

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -47,6 +47,7 @@ function BlockInspector() {
 		selectedBlockClientId,
 		blockType,
 		isSectionBlock,
+		isSectionBlockInSelection,
 	} = useSelect( ( select ) => {
 		const {
 			getSelectedBlockClientId,
@@ -65,8 +66,8 @@ function BlockInspector() {
 		const _blockType =
 			_selectedBlockName && getBlockType( _selectedBlockName );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
-		const isSectionInSelection = selectedBlockClientIds.some( ( id ) =>
-			_isSectionBlock( id )
+		const _isSectionBlockInSelection = selectedBlockClientIds.some(
+			( id ) => _isSectionBlock( id )
 		);
 
 		return {
@@ -74,7 +75,8 @@ function BlockInspector() {
 			selectedBlockClientId: renderedBlockClientId,
 			selectedBlockName: _selectedBlockName,
 			blockType: _blockType,
-			isSectionBlock: isSectionInSelection,
+			isSectionBlockInSelection: _isSectionBlockInSelection,
+			isSectionBlock: _isSectionBlock( renderedBlockClientId ),
 		};
 	}, [] );
 
@@ -96,7 +98,7 @@ function BlockInspector() {
 
 	const hasSelectedBlocks = count > 1;
 
-	if ( hasSelectedBlocks && ! isSectionBlock ) {
+	if ( hasSelectedBlocks && ! isSectionBlockInSelection ) {
 		return (
 			<div className="block-editor-block-inspector">
 				<MultiSelectionInspector />
@@ -133,7 +135,7 @@ function BlockInspector() {
 		);
 	}
 
-	if ( hasSelectedBlocks && isSectionBlock ) {
+	if ( hasSelectedBlocks && isSectionBlockInSelection ) {
 		return (
 			<div className="block-editor-block-inspector">
 				<MultiSelectionInspector />

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -199,7 +199,7 @@ export const BlockSwitcher = ( { clientIds } ) => {
 		isReusable,
 		isTemplate,
 		isDisabled,
-		isSection,
+		isSectionInSelection,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -243,7 +243,7 @@ export const BlockSwitcher = ( { clientIds } ) => {
 				_icon = isSelectionOfSameType ? blockType.icon : copy;
 			}
 
-			const isSectionInSelection = clientIds.some( ( id ) =>
+			const _isSectionInSelection = clientIds.some( ( id ) =>
 				isSectionBlock( id )
 			);
 
@@ -259,7 +259,7 @@ export const BlockSwitcher = ( { clientIds } ) => {
 					_isSingleBlockSelected && isTemplatePart( _blocks[ 0 ] ),
 				hasContentOnlyLocking: _hasTemplateLock,
 				isDisabled: editingMode !== 'default',
-				isSection: isSectionInSelection,
+				isSectionInSelection: _isSectionInSelection,
 			};
 		},
 		[ clientIds ]
@@ -289,7 +289,8 @@ export const BlockSwitcher = ( { clientIds } ) => {
 			: undefined;
 
 	const hideTransformsForSections =
-		window?.__experimentalContentOnlyPatternInsertion && isSection;
+		window?.__experimentalContentOnlyPatternInsertion &&
+		isSectionInSelection;
 	const hideDropdown =
 		hideTransformsForSections ||
 		isDisabled ||

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -209,6 +209,7 @@ export const BlockSwitcher = ( { clientIds } ) => {
 				canRemoveBlocks,
 				getBlockEditingMode,
 				isSectionBlock,
+				getSelectedBlockClientIds,
 			} = unlock( select( blockEditorStore ) );
 			const { getBlockStyles, getBlockType, getActiveBlockVariation } =
 				select( blocksStore );
@@ -243,6 +244,11 @@ export const BlockSwitcher = ( { clientIds } ) => {
 				_icon = isSelectionOfSameType ? blockType.icon : copy;
 			}
 
+			const selectedBlockClientIds = getSelectedBlockClientIds();
+			const isSectionInSelection = selectedBlockClientIds.some( ( id ) =>
+				isSectionBlock( id )
+			);
+
 			return {
 				canRemove: canRemoveBlocks( clientIds ),
 				hasBlockStyles:
@@ -255,7 +261,7 @@ export const BlockSwitcher = ( { clientIds } ) => {
 					_isSingleBlockSelected && isTemplatePart( _blocks[ 0 ] ),
 				hasContentOnlyLocking: _hasTemplateLock,
 				isDisabled: editingMode !== 'default',
-				isSection: isSectionBlock( clientIds[ 0 ] ),
+				isSection: isSectionInSelection,
 			};
 		},
 		[ clientIds ]

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -209,7 +209,6 @@ export const BlockSwitcher = ( { clientIds } ) => {
 				canRemoveBlocks,
 				getBlockEditingMode,
 				isSectionBlock,
-				getSelectedBlockClientIds,
 			} = unlock( select( blockEditorStore ) );
 			const { getBlockStyles, getBlockType, getActiveBlockVariation } =
 				select( blocksStore );
@@ -244,8 +243,7 @@ export const BlockSwitcher = ( { clientIds } ) => {
 				_icon = isSelectionOfSameType ? blockType.icon : copy;
 			}
 
-			const selectedBlockClientIds = getSelectedBlockClientIds();
-			const isSectionInSelection = selectedBlockClientIds.some( ( id ) =>
+			const isSectionInSelection = clientIds.some( ( id ) =>
 				isSectionBlock( id )
 			);
 


### PR DESCRIPTION
## What?

Fixes https://github.com/WordPress/gutenberg/issues/71709
Part of https://github.com/WordPress/gutenberg/issues/71517

Context: https://github.com/WordPress/gutenberg/pull/71512#discussion_r2354186126

This PR disables transforms and inspector controls when one or more or all blocks in multi-selection are "section blocks".


## Why?

As part of https://github.com/WordPress/gutenberg/issues/71517, a "section block" — for example patterns or template parts — is displayed in content only mode.

Content only mode describes an editing mode in which the inner block tree of section blocks are filtered to only display common content blocks, and with limited editing in the toolbar and inspector sidebar.

The different toolbar and inspector states of section blocks make them incompatible with regular blocks. 

The idea is to make things more consistent with other "incompatible" multi-block combinations - in these cases `n` blocks is displayed only in the sidebar.


## How?

Checking for section blocks in the `getSelectedBlockClientIds()` return value (Array).

## Testing Instructions

Switch on the patterns + content only experiment:

<img width="895" height="96" alt="Screenshot 2025-09-17 at 2 22 45 pm" src="https://github.com/user-attachments/assets/608de7b7-cdbf-46b8-9fef-3584239f2bfc" />

1. Insert a few patterns and a few blocks 
2. Using the list view menu, select the patterns. Check that the inspector does not display any styles controls or others.
3. Select a pattern and regular block. Check that you cannot transform them in the toolbar, and that the inspector doesn't display controls.

## Screenshots or screencast <!-- if applicable -->

### Before


https://github.com/user-attachments/assets/5070d56d-85fb-49b5-9ea7-af0476a37728



<img width="765" height="367" alt="Screenshot 2025-09-17 at 1 21 58 pm" src="https://github.com/user-attachments/assets/db09cb3c-7b6b-4227-868a-44d1e0df679f" />


-----------------------

### After

https://github.com/user-attachments/assets/e8b042e0-1b1a-4230-bd6d-7cf5d6f249d0


<img width="427" height="236" alt="Screenshot 2025-09-17 at 2 26 49 pm" src="https://github.com/user-attachments/assets/ee011dc5-b66a-4d60-b323-e82ad13e63b0" />

