### PR TITLE
Make sure "add page" button label only appears once

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -173,7 +173,7 @@
 
 .show-icon-labels {
 	.block-editor-block-toolbar {
-		.components-button.has-icon {
+		.components-button.has-icon:where(:not(.has-text)) {
 			width: auto;
 
 			// Hide the button icons when labels are set to display...

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -112,7 +112,6 @@ function NavigationAddPageButton( { clientId } ) {
 				<ToolbarButton
 					name="add-page"
 					icon={ page }
-					title={ __( 'Add page' ) }
 					onClick={ onAddPage }
 				>
 					{ __( 'Add page' ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Fixes Add page button introduced in #71192 when button text labels are enabled.

The addition of "title" to `ToolbarButton` adds it as an aria-label to the underlying button, and aria-labels are output when text labels are enabled. Given the button has text, it doesn't need an aria-label.

This PR removes the aria-label, and also makes a small adjustment to text label styles so they don't take effect when the button has _both_ icon and text.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Testing this requires adding a `"contentRole": true` to the Nav block supports (or follow the testing steps in #71192)
2. Enable button text labels under Preferences > Accessibility
3. Add a Navigation block to a template and enable write mode
4. Check "Add page" button in Nav block toolbar looks sensible.


|Before|After|
|-|-|
| <img width="511" height="60" alt="Screenshot 2025-09-17 at 2 27 16 pm" src="https://github.com/user-attachments/assets/0916739a-b251-4d15-95a3-13fcbbe7c1e1" /> | <img width="532" height="132" alt="Screenshot 2025-09-17 at 2 42 44 pm" src="https://github.com/user-attachments/assets/1631f162-7dd9-4d05-b926-d7ca92b478ba" /> |
