### PR TITLE
Filter comment clause based on current query.

### DIFF
--- a/lib/experimental/block-comments.php
+++ b/lib/experimental/block-comments.php
@@ -47,26 +47,22 @@ if ( ! function_exists( 'update_get_avatar_comment_type' ) ) {
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
+ * @param string[] $clauses The current SQL clauses for the comments query.
  * @param WP_Comment_Query $query The current comments query.
  *
- * @return void
+ * @return string[] The modified SQL clauses for the comments query.
  */
 if ( ! function_exists( 'exclude_block_comments_from_admin' ) ) {
-	function exclude_block_comments_from_admin( $query ) {
+	function exclude_block_comments_from_admin( $clauses, $query ) {
 		// Only modify the query if it's for comments
 		if ( isset( $query->query_vars['type'] ) && '' === $query->query_vars['type'] ) {
 			$query->set( 'type', '' );
 
-			add_filter(
-				'comments_clauses',
-				function ( $clauses ) {
-					global $wpdb;
-					// Exclude comments of type 'block_comment'
-					$clauses['where'] .= " AND {$wpdb->comments}.comment_type != 'block_comment'";
-					return $clauses;
-				}
-			);
+			global $wpdb;
+			$clauses['where'] .= " AND {$wpdb->comments}.comment_type != 'block_comment'";
 		}
+
+		return $clauses;
 	}
-	add_action( 'pre_get_comments', 'exclude_block_comments_from_admin' );
+	add_action( 'comments_clauses', 'exclude_block_comments_from_admin', 10, 2 );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes the comment filtering clause for block comments to avoid affecting subsequent queries.

Closes #71711

## Why?

Affecting subsequent queries is bad.

## How?

Moves the filtering to take place on `comments_clauses` exclusively by checking the query parameters on the clause filter.

The filter for `pre_get_comments` is removed.

## Testing Instructions

1. Create and publish a post
2. Write two block comments on the post via editor
3. Write two actual comments on the post via the front end
4. Approve the front end comments if required by your moderation settings
5. Run the following in `wp shell`, replacing the post ID with the ID created above
```
wp> get_comments( ['post_id' => 89, 'fields' => 'ids'] );
// Ensure the resulting IDs do not include the block comments
wp> get_comments( ['post_id' => 89, 'fields' => 'ids', 'type' => 'block_comment'] );
// Ensure the resulting IDs include the block comments and not the front end comments
```


### Testing Instructions for Keyboard

N/A

## Screenshots or screencast <!-- if applicable -->

N/A