### PR TITLE
Block Commenting: Prevent unnecessary API requests when post ID is not integer

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -351,7 +351,7 @@ export default function CollabSidebar() {
 		? resultComments.find( ( thread ) => thread.id === blockCommentId )
 		: null;
 
-	// If postId is not a valid number, do not render the comment sidebar. 1Code has comments. Press enter to view.
+	// If postId is not a valid number, do not render the comment sidebar.
 	if ( ! ( !! postId && typeof postId === 'number' ) ) {
 		return null;
 	}

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -247,7 +247,8 @@ export default function CollabSidebar() {
 	const { records: threads, totalPages } = useEntityRecords(
 		'root',
 		'comment',
-		queryArgs
+		queryArgs,
+		{ enabled: !! postId && typeof postId === 'number' }
 	);
 
 	const hasMoreComments = totalPages && totalPages > 1;
@@ -349,6 +350,11 @@ export default function CollabSidebar() {
 	const currentThread = blockCommentId
 		? resultComments.find( ( thread ) => thread.id === blockCommentId )
 		: null;
+
+	// If postId is not a valid number, do not render the comment sidebar. 1Code has comments. Press enter to view.
+	if ( ! ( !! postId && typeof postId === 'number' ) ) {
+		return null;
+	}
 
 	return (
 		<>

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -350,11 +350,6 @@ export default function CollabSidebar() {
 		? resultComments.find( ( thread ) => thread.id === blockCommentId )
 		: null;
 
-	// If postId is not a valid number, do not render the comment sidebar.
-	if ( ! ( !! postId && typeof postId === 'number' ) ) {
-		return null;
-	}
-
 	return (
 		<>
 			<AddCommentComponent

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -74,7 +74,6 @@ function Header( {
 		const {
 			getEditorMode,
 			getCurrentPostType,
-			getCurrentPostId,
 			isPublishSidebarOpened: _isPublishSidebarOpened,
 		} = select( editorStore );
 		const { getBlockSelectionStart, getSectionRootClientId } = unlock(
@@ -83,7 +82,6 @@ function Header( {
 
 		return {
 			postType: getCurrentPostType(),
-			postId: getCurrentPostId(),
 			isTextEditor: getEditorMode() === 'text',
 			isPublishSidebarOpened: _isPublishSidebarOpened(),
 			showIconLabels: getPreference( 'core', 'showIconLabels' ),
@@ -113,9 +111,6 @@ function Header( {
 			( hasFixedToolbar &&
 				( ! hasBlockSelection || isBlockToolsCollapsed ) ) );
 	const hasBackButton = useHasBackButton();
-
-	const shouldRenderCollabSidebar =
-		isBlockCommentExperimentEnabled && typeof postId === 'number';
 
 	/*
 	 * The edit-post-header classname is only kept for backward compatibility
@@ -201,7 +196,9 @@ function Header( {
 					/>
 				) }
 
-				{ shouldRenderCollabSidebar && <CollabSidebar /> }
+				{ isBlockCommentExperimentEnabled ? (
+					<CollabSidebar />
+				) : undefined }
 
 				{ customSaveButton }
 				<MoreMenu />

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -74,6 +74,7 @@ function Header( {
 		const {
 			getEditorMode,
 			getCurrentPostType,
+			getCurrentPostId,
 			isPublishSidebarOpened: _isPublishSidebarOpened,
 		} = select( editorStore );
 		const { getBlockSelectionStart, getSectionRootClientId } = unlock(
@@ -82,6 +83,7 @@ function Header( {
 
 		return {
 			postType: getCurrentPostType(),
+			postId: getCurrentPostId(),
 			isTextEditor: getEditorMode() === 'text',
 			isPublishSidebarOpened: _isPublishSidebarOpened(),
 			showIconLabels: getPreference( 'core', 'showIconLabels' ),
@@ -111,6 +113,9 @@ function Header( {
 			( hasFixedToolbar &&
 				( ! hasBlockSelection || isBlockToolsCollapsed ) ) );
 	const hasBackButton = useHasBackButton();
+
+	const shouldRenderCollabSidebar =
+		isBlockCommentExperimentEnabled && typeof postId === 'number';
 
 	/*
 	 * The edit-post-header classname is only kept for backward compatibility
@@ -196,9 +201,7 @@ function Header( {
 					/>
 				) }
 
-				{ isBlockCommentExperimentEnabled ? (
-					<CollabSidebar />
-				) : undefined }
+				{ shouldRenderCollabSidebar && <CollabSidebar /> }
 
 				{ customSaveButton }
 				<MoreMenu />


### PR DESCRIPTION
Follow-up #71643

## What?

I noticed that when the current post id is not an integer (Example: `twentytwentyfive/home`), one of the rest api requests fails:

<img width="567" height="293" alt="image" src="https://github.com/user-attachments/assets/0d7823f3-b08a-43d9-80ad-a88b17fff8a1" />

## How?

Check if the `postId` is an integer or not upstream, and don't render the `CollabSidebar` component itself.

## Testing Instructions

- Open the site editor > Blog home template.
- Confirm that there is no bad request error in your browser console.