### PR TITLE
Block Inspector: Add content tab for section blocks

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/content-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/content-tab.js
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { PanelBody } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import BlockQuickNavigation from '../block-quick-navigation';
+
+const ContentTab = ( { contentClientIds } ) => {
+	if ( ! contentClientIds || contentClientIds.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<PanelBody title={ __( 'Content' ) }>
+			<BlockQuickNavigation clientIds={ contentClientIds } />
+		</PanelBody>
+	);
+};
+
+export default ContentTab;

--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -12,9 +12,10 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { TAB_SETTINGS, TAB_STYLES, TAB_LIST_VIEW } from './utils';
+import { TAB_SETTINGS, TAB_STYLES, TAB_LIST_VIEW, TAB_CONTENT } from './utils';
 import SettingsTab from './settings-tab';
 import StylesTab from './styles-tab';
+import ContentTab from './content-tab';
 import InspectorControls from '../inspector-controls';
 import useIsListViewTabDisabled from './use-is-list-view-tab-disabled';
 import { unlock } from '../../lock-unlock';
@@ -26,6 +27,8 @@ export default function InspectorControlsTabs( {
 	clientId,
 	hasBlockStyles,
 	tabs,
+	isSectionBlock,
+	contentClientIds,
 } ) {
 	const showIconLabels = useSelect( ( select ) => {
 		return select( preferencesStore ).get( 'core', 'showIconLabels' );
@@ -69,7 +72,11 @@ export default function InspectorControlsTabs( {
 						blockName={ blockName }
 						clientId={ clientId }
 						hasBlockStyles={ hasBlockStyles }
+						isSectionBlock={ isSectionBlock }
 					/>
+				</Tabs.TabPanel>
+				<Tabs.TabPanel tabId={ TAB_CONTENT.name } focusable={ false }>
+					<ContentTab contentClientIds={ contentClientIds } />
 				</Tabs.TabPanel>
 				<Tabs.TabPanel tabId={ TAB_LIST_VIEW.name } focusable={ false }>
 					<InspectorControls.Slot group="list" />

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -11,7 +11,12 @@ import BlockStyles from '../block-styles';
 import InspectorControls from '../inspector-controls';
 import { useBorderPanelLabel } from '../../hooks/border';
 
-const StylesTab = ( { blockName, clientId, hasBlockStyles } ) => {
+const StylesTab = ( {
+	blockName,
+	clientId,
+	hasBlockStyles,
+	isSectionBlock,
+} ) => {
 	const borderPanelLabel = useBorderPanelLabel( { blockName } );
 
 	return (
@@ -23,26 +28,33 @@ const StylesTab = ( { blockName, clientId, hasBlockStyles } ) => {
 					</PanelBody>
 				</div>
 			) }
-			<InspectorControls.Slot
-				group="color"
-				label={ __( 'Color' ) }
-				className="color-block-support-panel__inner-wrapper"
-			/>
-			<InspectorControls.Slot
-				group="background"
-				label={ __( 'Background image' ) }
-			/>
-			<InspectorControls.Slot group="filter" />
-			<InspectorControls.Slot
-				group="typography"
-				label={ __( 'Typography' ) }
-			/>
-			<InspectorControls.Slot
-				group="dimensions"
-				label={ __( 'Dimensions' ) }
-			/>
-			<InspectorControls.Slot group="border" label={ borderPanelLabel } />
-			<InspectorControls.Slot group="styles" />
+			{ ! isSectionBlock && (
+				<>
+					<InspectorControls.Slot
+						group="color"
+						label={ __( 'Color' ) }
+						className="color-block-support-panel__inner-wrapper"
+					/>
+					<InspectorControls.Slot
+						group="background"
+						label={ __( 'Background image' ) }
+					/>
+					<InspectorControls.Slot group="filter" />
+					<InspectorControls.Slot
+						group="typography"
+						label={ __( 'Typography' ) }
+					/>
+					<InspectorControls.Slot
+						group="dimensions"
+						label={ __( 'Dimensions' ) }
+					/>
+					<InspectorControls.Slot
+						group="border"
+						label={ borderPanelLabel }
+					/>
+					<InspectorControls.Slot group="styles" />
+				</>
+			) }
 		</>
 	);
 };

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -10,7 +10,7 @@ import { useSelect } from '@wordpress/data';
 import InspectorControlsGroups from '../inspector-controls/groups';
 import useIsListViewTabDisabled from './use-is-list-view-tab-disabled';
 import { InspectorAdvancedControls } from '../inspector-controls';
-import { TAB_LIST_VIEW, TAB_SETTINGS, TAB_STYLES } from './utils';
+import { TAB_LIST_VIEW, TAB_SETTINGS, TAB_STYLES, TAB_CONTENT } from './utils';
 import { store as blockEditorStore } from '../../store';
 
 const EMPTY_ARRAY = [];
@@ -29,7 +29,12 @@ function getShowTabs( blockName, tabSettings = {} ) {
 	return true;
 }
 
-export default function useInspectorControlsTabs( blockName ) {
+export default function useInspectorControlsTabs(
+	blockName,
+	contentClientIds,
+	isSectionBlock,
+	hasBlockStyles
+) {
 	const tabs = [];
 	const {
 		bindings: bindingsGroup,
@@ -76,17 +81,25 @@ export default function useInspectorControlsTabs( blockName ) {
 		...( hasListFills && hasStyleFills > 1 ? advancedFills : [] ),
 	];
 
+	const hasContentTab = !! (
+		contentClientIds && contentClientIds.length > 0
+	);
+
 	// Add the tabs in the order that they will default to if available.
-	// List View > Settings > Styles.
+	// List View > Content > Settings > Styles.
 	if ( hasListFills ) {
 		tabs.push( TAB_LIST_VIEW );
 	}
 
-	if ( settingsFills.length ) {
+	if ( hasContentTab ) {
+		tabs.push( TAB_CONTENT );
+	}
+
+	if ( settingsFills.length && ! isSectionBlock ) {
 		tabs.push( TAB_SETTINGS );
 	}
 
-	if ( hasStyleFills ) {
+	if ( isSectionBlock ? hasBlockStyles : hasStyleFills ) {
 		tabs.push( TAB_STYLES );
 	}
 

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -87,7 +87,7 @@ export default function useInspectorControlsTabs(
 
 	// Add the tabs in the order that they will default to if available.
 	// List View > Content > Settings > Styles.
-	if ( hasListFills ) {
+	if ( hasListFills && ! isSectionBlock ) {
 		tabs.push( TAB_LIST_VIEW );
 	}
 

--- a/packages/block-editor/src/components/inspector-controls-tabs/utils.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/utils.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { cog, styles, listView } from '@wordpress/icons';
+import { cog, styles, listView, page } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 export const TAB_SETTINGS = {
@@ -16,6 +16,13 @@ export const TAB_STYLES = {
 	title: __( 'Styles' ),
 	value: 'styles',
 	icon: styles,
+};
+
+export const TAB_CONTENT = {
+	name: 'content',
+	title: __( 'Content' ),
+	value: 'content',
+	icon: page,
 };
 
 export const TAB_LIST_VIEW = {


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/gutenberg/issues/71626
Depends on: https://github.com/WordPress/gutenberg/pull/71608

Introduces a **Content tab** for section blocks that displays content-only descendant blocks via quick navigation

## Why?

There are ongoing explorations to simplify the editing of patterns using `contentOnly` mode by default for them. Part of these efforts is to also allow editing of descendant blocks via a content panel in the inspector. For more complex patterns, the number of descendant blocks can result in a very crowded inspector. This PR introduces a "content" tab to provided more real estate and better separation of content, setting, and style controls.

## How?

Introduces a new content tab that is similar in approach to the existing styles tab.

## Testing Instructions

- [ ] Confirm section blocks, regular blocks, and multi-selections match the after screenshots below
- [ ] Ensure the block inspector tabs work as expected, including overriding block editor settings to opt-out of tabs for a block type
- [ ] Make sure the quick navigation within the new content tab in the block inspector works

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Description|Before|After|
|-|-|-|
| Template Part | <img width="1103" height="682" alt="Screenshot 2025-09-18 at 7 03 19 pm" src="https://github.com/user-attachments/assets/3ce6afe5-2373-43b4-a110-23542c993dcc" /> | <img width="1105" height="514" alt="Screenshot 2025-09-18 at 6 38 17 pm" src="https://github.com/user-attachments/assets/7db7ae5e-d7c3-47de-b813-a099b2c1cbb0" /> |
| Unsynced Pattern | <img width="1101" height="1152" alt="Screenshot 2025-09-18 at 7 03 25 pm" src="https://github.com/user-attachments/assets/3d161143-4adb-4d5d-8ee3-1a44d2e8921a" /> | <img width="1100" height="969" alt="Screenshot 2025-09-18 at 6 38 28 pm" src="https://github.com/user-attachments/assets/03ae52ff-79c4-4c92-ae92-6d10b90de0f5" /> |
| Synced Pattern | <img width="1102" height="899" alt="Screenshot 2025-09-18 at 7 03 34 pm" src="https://github.com/user-attachments/assets/663aafef-2df2-46e1-b192-06fdd29019f0" /> | <img width="1102" height="934" alt="Screenshot 2025-09-18 at 6 38 41 pm" src="https://github.com/user-attachments/assets/d736d06f-e5e8-45ef-8b15-a74ecd49147c" /> |
| Single Regular Block | <img width="1099" height="1112" alt="Screenshot 2025-09-18 at 7 03 43 pm" src="https://github.com/user-attachments/assets/5d22598a-188f-434e-922e-b133c2877fcd" /> | <img width="1102" height="1108" alt="Screenshot 2025-09-18 at 6 38 52 pm" src="https://github.com/user-attachments/assets/6cec1f4e-07ed-4554-a341-6d4f7fffe95c" /> |
| Multiple Regular Blocks (same type) | <img width="1101" height="897" alt="Screenshot 2025-09-18 at 7 03 59 pm" src="https://github.com/user-attachments/assets/b5266dd7-93c4-4bf3-bcfc-c304eacc2569" /> | <img width="1100" height="837" alt="Screenshot 2025-09-18 at 6 39 21 pm" src="https://github.com/user-attachments/assets/394d014f-7f5d-4b03-ba00-f55233ffa58b" /> |
| Multi-selection Between Regular Block & Synced Pattern | <img width="1102" height="848" alt="Screenshot 2025-09-18 at 7 04 24 pm" src="https://github.com/user-attachments/assets/c96bbac3-50cd-485c-8e85-0e88f8abdedf" /> | <img width="1099" height="930" alt="Screenshot 2025-09-18 at 6 39 45 pm" src="https://github.com/user-attachments/assets/3006e984-eae3-4dfd-9676-fd85983a0648" /> |
