### PR TITLE
Block Comments: focus on reply textarea when after adding new comment

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -6,7 +6,7 @@ import TextareaAutosize from 'react-autosize-textarea';
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 import {
 	__experimentalHStack as HStack,
 	Button,
@@ -23,13 +23,14 @@ import { sanitizeCommentString } from './utils';
 /**
  * EditComment component.
  *
- * @param {Object}   props                  - The component props.
- * @param {Function} props.onSubmit         - The function to call when updating the comment.
- * @param {Function} props.onCancel         - The function to call when canceling the comment update.
- * @param {Object}   props.thread           - The comment thread object.
- * @param {string}   props.submitButtonText - The text to display on the submit button.
- * @param {string?}  props.placeholderText  - The placeholder text for the comment input.
- * @param {number?}  props.rows             - The number of rows for the comment input.
+ * @param {Object}   props                     - The component props.
+ * @param {Function} props.onSubmit            - The function to call when updating the comment.
+ * @param {Function} props.onCancel            - The function to call when canceling the comment update.
+ * @param {Object}   props.thread              - The comment thread object.
+ * @param {string}   props.submitButtonText    - The text to display on the submit button.
+ * @param {string?}  props.placeholderText     - The placeholder text for the comment input.
+ * @param {number?}  props.rows                - The number of rows for the comment input.
+ * @param {boolean?} props.shouldFocusTextarea - Whether to focus the textarea for accessibility.
  * @return {React.ReactNode} The CommentForm component.
  */
 function CommentForm( {
@@ -39,19 +40,31 @@ function CommentForm( {
 	submitButtonText,
 	placeholderText,
 	rows = 4,
+	shouldFocusTextarea = false,
 } ) {
 	const [ inputComment, setInputComment ] = useState(
 		thread?.content?.raw ?? ''
 	);
 
 	const inputId = useInstanceId( CommentForm, 'comment-input' );
+	const textareaRef = useRef( null );
+
+	// Focus the textarea when shouldFocusTextarea prop is true
+	useEffect( () => {
+		if ( shouldFocusTextarea && textareaRef.current ) {
+			textareaRef.current.focus();
+		}
+	}, [ shouldFocusTextarea ] );
 
 	return (
 		<>
 			<VisuallyHidden as="label" htmlFor={ inputId }>
-				{ __( 'Comment' ) }
+				{ thread?.id
+					? __( 'Edit comment' )
+					: __( 'Add reply to comment thread' ) }
 			</VisuallyHidden>
 			<TextareaAutosize
+				ref={ textareaRef }
 				id={ inputId }
 				value={ inputComment ?? '' }
 				onChange={ ( comment ) =>
@@ -60,6 +73,11 @@ function CommentForm( {
 				rows={ rows }
 				maxRows={ 20 }
 				placeholder={ placeholderText || '' }
+				aria-label={
+					thread?.id
+						? __( 'Edit comment' )
+						: __( 'Add reply to comment thread' )
+				}
 			></TextareaAutosize>
 			<HStack spacing="3" justify="flex-start" wrap>
 				<Button

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -168,10 +168,7 @@ function Thread( {
 							__next40pxDefaultSize
 							variant="link"
 							className="editor-collab-sidebar-panel__show-more-reply"
-							onClick={ () => {
-								setFocusThread( thread.id );
-								// Don't auto-focus textarea when just viewing replies
-							} }
+							onClick={ () => setFocusThread( thread.id ) }
 						>
 							{ sprintf(
 								// translators: %s: number of replies.

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useState, RawHTML } from '@wordpress/element';
+import { useState, RawHTML, useEffect } from '@wordpress/element';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -28,15 +28,17 @@ import CommentForm from './comment-form';
 /**
  * Renders the Comments component.
  *
- * @param {Object}   props                     - The component props.
- * @param {Array}    props.threads             - The array of comment threads.
- * @param {Function} props.onEditComment       - The function to handle comment editing.
- * @param {Function} props.onAddReply          - The function to add a reply to a comment.
- * @param {Function} props.onCommentDelete     - The function to delete a comment.
- * @param {Function} props.onCommentResolve    - The function to mark a comment as resolved.
- * @param {Function} props.onCommentReopen     - The function to reopen a resolved comment.
- * @param {boolean}  props.showCommentBoard    - Whether to show the comment board.
- * @param {Function} props.setShowCommentBoard - The function to set the comment board visibility.
+ * @param {Object}   props                        - The component props.
+ * @param {Array}    props.threads                - The array of comment threads.
+ * @param {Function} props.onEditComment          - The function to handle comment editing.
+ * @param {Function} props.onAddReply             - The function to add a reply to a comment.
+ * @param {Function} props.onCommentDelete        - The function to delete a comment.
+ * @param {Function} props.onCommentResolve       - The function to mark a comment as resolved.
+ * @param {Function} props.onCommentReopen        - The function to reopen a resolved comment.
+ * @param {boolean}  props.showCommentBoard       - Whether to show the comment board.
+ * @param {Function} props.setShowCommentBoard    - The function to set the comment board visibility.
+ * @param {number}   props.newlyAddedCommentId    - ID of newly added comment to focus.
+ * @param {Function} props.setNewlyAddedCommentId - Function to reset the newly added comment ID.
  * @return {React.ReactNode} The rendered Comments component.
  */
 export function Comments( {
@@ -48,6 +50,8 @@ export function Comments( {
 	onCommentReopen,
 	showCommentBoard,
 	setShowCommentBoard,
+	newlyAddedCommentId,
+	setNewlyAddedCommentId,
 } ) {
 	const { blockCommentId } = useSelect( ( select ) => {
 		const { getBlockAttributes, getSelectedBlockClientId } =
@@ -64,6 +68,15 @@ export function Comments( {
 	const [ focusThread, setFocusThread ] = useState(
 		showCommentBoard && blockCommentId ? blockCommentId : null
 	);
+
+	// Auto-focus newly added comments.
+	useEffect( () => {
+		if ( newlyAddedCommentId ) {
+			setFocusThread( newlyAddedCommentId );
+			// Reset the newly added comment ID after focusing.
+			setNewlyAddedCommentId( null );
+		}
+	}, [ newlyAddedCommentId, setNewlyAddedCommentId ] );
 
 	const clearThreadFocus = () => {
 		setFocusThread( null );
@@ -106,6 +119,7 @@ export function Comments( {
 						id={ thread.id }
 						spacing="3"
 						onClick={ () => setFocusThread( thread.id ) }
+						tabIndex="-1"
 					>
 						<Thread
 							thread={ thread }
@@ -117,6 +131,7 @@ export function Comments( {
 							isFocused={ focusThread === thread.id }
 							clearThreadFocus={ clearThreadFocus }
 							setFocusThread={ setFocusThread }
+							newlyAddedCommentId={ newlyAddedCommentId }
 						/>
 					</VStack>
 				) ) }
@@ -134,6 +149,7 @@ function Thread( {
 	isFocused,
 	clearThreadFocus,
 	setFocusThread,
+	newlyAddedCommentId,
 } ) {
 	return (
 		<>
@@ -152,7 +168,10 @@ function Thread( {
 							__next40pxDefaultSize
 							variant="link"
 							className="editor-collab-sidebar-panel__show-more-reply"
-							onClick={ () => setFocusThread( thread.id ) }
+							onClick={ () => {
+								setFocusThread( thread.id );
+								// Don't auto-focus textarea when just viewing replies
+							} }
 						>
 							{ sprintf(
 								// translators: %s: number of replies.
@@ -173,6 +192,7 @@ function Thread( {
 								className="editor-collab-sidebar-panel__child-thread"
 								id={ reply.id }
 								spacing="2"
+								tabIndex="-1"
 							>
 								{ 'approved' !== thread.status && (
 									<CommentBoard
@@ -226,6 +246,9 @@ function Thread( {
 									: _x( 'Reply', 'Add reply comment' )
 							}
 							rows={ 'approved' === thread.status ? 2 : 4 }
+							shouldFocusTextarea={
+								newlyAddedCommentId === thread.id
+							}
 						/>
 					</VStack>
 				</VStack>

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -62,6 +62,7 @@ function CollabSidebarContent( {
 	const { createNotice } = useDispatch( noticesStore );
 	const { saveEntityRecord, deleteEntityRecord } = useDispatch( coreStore );
 	const { getEntityRecord } = resolveSelect( coreStore );
+	const [ newlyAddedCommentId, setNewlyAddedCommentId ] = useState( null );
 
 	const { postId } = useSelect( ( select ) => {
 		const { getCurrentPostId } = select( editorStore );
@@ -116,8 +117,22 @@ function CollabSidebarContent( {
 				{
 					type: 'snackbar',
 					isDismissible: true,
+					speak: true, // Ensure screen reader announcement
+					politeness: 'assertive', // Use assertive for immediate user actions
+					spokenMessage: parentCommentId
+						? __( 'Reply added successfully.' )
+						: __( 'Comment added successfully.' ),
 				}
 			);
+
+			// Set focus on the newly created comment for better accessibility
+			if ( savedRecord?.id ) {
+				// Set the newly added comment ID to trigger focus in Comments component
+				const targetCommentId = parentCommentId || savedRecord.id;
+				setNewlyAddedCommentId( targetCommentId );
+
+				// No need for manual DOM focus since we're handling it in the component
+			}
 		} catch ( error ) {
 			onError( error );
 		}
@@ -226,6 +241,8 @@ function CollabSidebarContent( {
 				onCommentReopen={ onCommentReopen }
 				showCommentBoard={ showCommentBoard }
 				setShowCommentBoard={ setShowCommentBoard }
+				newlyAddedCommentId={ newlyAddedCommentId }
+				setNewlyAddedCommentId={ setNewlyAddedCommentId }
 			/>
 		</div>
 	);

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -117,8 +117,7 @@ function CollabSidebarContent( {
 				{
 					type: 'snackbar',
 					isDismissible: true,
-					speak: true, // Ensure screen reader announcement
-					politeness: 'assertive', // Use assertive for immediate user actions
+					speak: true,
 					spokenMessage: parentCommentId
 						? __( 'Reply added successfully.' )
 						: __( 'Comment added successfully.' ),
@@ -127,11 +126,8 @@ function CollabSidebarContent( {
 
 			// Set focus on the newly created comment for better accessibility
 			if ( savedRecord?.id ) {
-				// Set the newly added comment ID to trigger focus in Comments component
 				const targetCommentId = parentCommentId || savedRecord.id;
 				setNewlyAddedCommentId( targetCommentId );
-
-				// No need for manual DOM focus since we're handling it in the component
 			}
 		} catch ( error ) {
 			onError( error );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71677

<!-- In a few words, what is the PR actually doing? -->

> TODO: Update description after ready for review

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
