### PR TITLE
DataForm Textarea: Add support for resize property

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- DataForm: Add resize property support to `textarea` control. [#71727](https://github.com/WordPress/gutenberg/pull/71727)
+
 ## 9.0.0 (2025-09-17)
 
 ### Breaking changes

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -196,6 +196,7 @@ const fields: Field< SamplePost >[] = [
 		type: 'text',
 		Edit: {
 			control: 'textarea',
+			resize: 'vertical',
 			rows: 5,
 		},
 	},

--- a/packages/dataviews/src/dataform-controls/textarea.tsx
+++ b/packages/dataviews/src/dataform-controls/textarea.tsx
@@ -24,7 +24,7 @@ export default function Textarea< Item >( {
 	hideLabelFromVision,
 	config,
 }: DataFormControlProps< Item > ) {
-	const { rows = 4 } = config || {};
+	const { rows = 4, resize } = config || {};
 	const { label, placeholder, description, setValue } = field;
 	const value = field.getValue( { item: data } );
 	const [ customValidity, setCustomValidity ] =
@@ -80,6 +80,7 @@ export default function Textarea< Item >( {
 			__next40pxDefaultSize
 			__nextHasNoMarginBottom
 			hideLabelFromVision={ hideLabelFromVision }
+			style={ resize ? { resize } : undefined }
 		/>
 	);
 }

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -6,6 +6,7 @@ import type {
 	ReactNode,
 	ComponentType,
 	ComponentProps,
+	CSSProperties,
 } from 'react';
 
 /**
@@ -176,6 +177,10 @@ export type EditConfigTextarea = {
 	 * Number of rows for the textarea.
 	 */
 	rows?: number;
+	/**
+	 * Resize CSS property for the textarea.
+	 */
+	resize?: CSSProperties[ 'resize' ];
 };
 
 /**
@@ -353,6 +358,7 @@ export type DataFormControlProps< Item > = {
 		prefix?: React.ComponentType;
 		suffix?: React.ComponentType;
 		rows?: number;
+		resize?: CSSProperties[ 'resize' ];
 	};
 };
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Follows:

* #71582

Add the ability to configure the `resize` property for the textarea control within DataForm.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's quite common for folks to want to control the ability to resize textareas, so it'd be good to make this easily configurable without consumers needing to add custom CSS. Especially since we already support configuring `rows`, making `resize` configurable should be a useful property (i.e. to restrict to just vertical, or switch resize off completely).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add a `resize` property to the DataForm textarea control
* Update the story for the Long Description field to restrict to vertical resize for demoing

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Run `npm run storybook:dev` to load up Storybook
2. Navigate to the regular layout story: http://localhost:50240/?path=/story/dataviews-dataform--layout-regular
3. You should be able to resize the Description field in all directions
4. For the Long Description field, you should only be able to resize vertically

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/436e8bd2-6076-4fa9-bffc-1d425ed29dce