### PR TITLE
Fix: exclude non-hideable fields from the Properties list in the view config

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- DataViews: keep non-hideable fields out of the hidden-fields list when they’re already invisible.
+
 ## 9.0.0 (2025-09-17)
 
 ### Breaking changes

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- DataViews: keep non-hideable fields out of the hidden-fields list when they’re already invisible.
+- DataViews: keep non-hideable fields out of the hidden-fields list when they’re already invisible. [#71729](https://github.com/WordPress/gutenberg/pull/71729/)
 
 ## 9.0.0 (2025-09-17)
 

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -562,7 +562,8 @@ function FieldControl() {
 		( f ) =>
 			! visibleFieldIds.includes( f.id ) &&
 			! togglableFields.includes( f.id ) &&
-			f.type !== 'media'
+			f.type !== 'media' &&
+			f.enableHiding !== false
 	);
 	const visibleFields = visibleFieldIds
 		.map( ( fieldId ) => fields.find( ( f ) => f.id === fieldId ) )

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -280,7 +280,7 @@ export type Field< Item > = {
 	enableGlobalSearch?: boolean;
 
 	/**
-	 * Whether the field is filterable.
+	 * Whether the field can be hidden in the UI.
 	 */
 	enableHiding?: boolean;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR hides fields with `enableHiding` set to false from the hidden properties list in the view config panel.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

If a non-hideable field is not visible in the view, it should be excluded from the properties list. Because it can't be toggled, it doesn't make sense to keep them in the list. This will keep the list clean and let consumers hide internal fields that they may not want to expose to end users.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR updates the condition to filter out fields with `enableHiding` set to `false`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the DataViews story.
2. See the Type field not visible in the Hidden list anymore.
3. See you can still filter the list using Type.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1538" height="851" alt="image" src="https://github.com/user-attachments/assets/37e59a30-8738-4d19-917d-8cb7489e72ab" />|<img width="1538" height="851" alt="image" src="https://github.com/user-attachments/assets/66a5f52e-ef56-4ca4-b97e-c65d693691d6" />|
