### PR TITLE
Textarea Component: Add default resize vertical rule

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   `TextareaControl`: Add default resize: vertical rule ([#71736](fix/textarea-control-provide-default-vertical-resize)).
+-   `TextareaControl`: Add default resize: vertical rule ([#71736](https://github.com/WordPress/gutenberg/pull/71736)).
 
 ## 30.4.0 (2025-09-17)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `TextareaControl`: Add default resize: vertical rule ([#71736](fix/textarea-control-provide-default-vertical-resize)).
+
 ## 30.4.0 (2025-09-17)
 
 ### Bug Fixes

--- a/packages/components/src/textarea-control/styles/textarea-control-styles.ts
+++ b/packages/components/src/textarea-control/styles/textarea-control-styles.ts
@@ -39,6 +39,7 @@ export const StyledTextarea = styled.textarea`
 	line-height: 20px;
 	background: ${ COLORS.theme.background };
 	color: ${ COLORS.theme.foreground };
+	resize: vertical;
 
 	// Vertical padding is to match the standard 40px control height when rows=1,
 	// in conjunction with the 20px line-height.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Alternative to:
* #71727

Add a default `resize: vertical` rule to the textarea component.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently within Gutenberg / the block editor, there's a default `resize: vertical` rule supplied by WordPress' `forms.css` file. So, for example, when we use the `TextareaControl` component within the Image block for alt text, the resize is restricted to vertical only:

<img width="696" height="579" alt="image" src="https://github.com/user-attachments/assets/161d7de9-a732-4a8c-8e9a-f6bd911c4bff" />

However, for folks using the component outside of the block editor (or WordPress) context, this rule might not always be present. A good example is when we use DataForm's textarea control within Storybook, where the story examples for textareas can be resized horizontally, which is unexpected.

So, if we update the component to provide this default, we can ensure that consumers using `textarea` either via the component, or DataForm, have a more reliable default to work from.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* One-line code change to include a default `resize: vertical` rule with the `TextareaControl` component.

## Testing Instructions

* Load up Storybook via `npm run storybook:dev`
* Take a look at the DataForm story and the description field: http://localhost:50240/?path=/story/dataviews-dataform--layout-regular and the TextareaControl story: http://localhost:50240/?path=/story/components-textareacontrol--default
* With this PR applied, those components should only allow vertical resizing

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

https://github.com/user-attachments/assets/6a6b02bb-4454-4956-a313-9ac899319095

### After

https://github.com/user-attachments/assets/ecb31bf6-b190-40bc-b919-ffc24cd7a88e


