### PR TITLE
Accordion Block: Simplify script module enqueueing

### DIFF
--- a/lib/experimental/script-modules.php
+++ b/lib/experimental/script-modules.php
@@ -10,7 +10,8 @@
  */
 function gutenberg_filter_block_type_metadata_settings_register_view_module( $settings, $metadata = null ) {
 	$module_fields = array(
-		'viewScriptModule' => 'view_script_module_ids',
+		// @todo remove viewModule support in Gutenberg >= 17.8 (replaced by viewScriptModule).
+		'viewModule' => 'view_script_module_ids',
 	);
 	foreach ( $module_fields as $metadata_field_name => $settings_field_name ) {
 		if ( ! empty( $settings[ $metadata_field_name ] ) ) {
@@ -79,13 +80,7 @@ function gutenberg_register_block_module_id( $metadata, $field_name, $index = 0 
 	$module_id             = gutenberg_generate_block_asset_module_id( $metadata['name'], $field_name, $index );
 	$module_asset_path     = wp_normalize_path( realpath( $module_asset_raw_path ) );
 
-	$build_module_path   = str_replace(
-		'/build/block-library/blocks/',
-		'/build-module/block-library/',
-		$path
-	);
-	$module_path         = str_replace( '.js', '.min.js', $module_path );
-	$module_path_norm    = wp_normalize_path( realpath( $build_module_path . '/' . $module_path ) );
+	$module_path_norm    = wp_normalize_path( realpath( $path . '/' . $module_path ) );
 	$module_uri          = get_block_asset_url( $module_path_norm );
 	$module_asset        = ! empty( $module_asset_path ) ? require $module_asset_path : array();
 	$module_dependencies = isset( $module_asset['dependencies'] ) ? $module_asset['dependencies'] : array();

--- a/lib/experimental/script-modules.php
+++ b/lib/experimental/script-modules.php
@@ -10,8 +10,7 @@
  */
 function gutenberg_filter_block_type_metadata_settings_register_view_module( $settings, $metadata = null ) {
 	$module_fields = array(
-		// @todo remove viewModule support in Gutenberg >= 17.8 (replaced by viewScriptModule).
-		'viewModule' => 'view_script_module_ids',
+		'viewScriptModule' => 'view_script_module_ids',
 	);
 	foreach ( $module_fields as $metadata_field_name => $settings_field_name ) {
 		if ( ! empty( $settings[ $metadata_field_name ] ) ) {
@@ -80,7 +79,13 @@ function gutenberg_register_block_module_id( $metadata, $field_name, $index = 0 
 	$module_id             = gutenberg_generate_block_asset_module_id( $metadata['name'], $field_name, $index );
 	$module_asset_path     = wp_normalize_path( realpath( $module_asset_raw_path ) );
 
-	$module_path_norm    = wp_normalize_path( realpath( $path . '/' . $module_path ) );
+	$build_module_path   = str_replace(
+		'/build/block-library/blocks/',
+		'/build-module/block-library/',
+		$path
+	);
+	$module_path         = str_replace( '.js', '.min.js', $module_path );
+	$module_path_norm    = wp_normalize_path( realpath( $build_module_path . '/' . $module_path ) );
 	$module_uri          = get_block_asset_url( $module_path_norm );
 	$module_asset        = ! empty( $module_asset_path ) ? require $module_asset_path : array();
 	$module_dependencies = isset( $module_asset['dependencies'] ) ? $module_asset['dependencies'] : array();

--- a/packages/block-library/src/accordion/block.json
+++ b/packages/block-library/src/accordion/block.json
@@ -63,5 +63,5 @@
 	"allowedBlocks": [ "core/accordion-content" ],
 	"textdomain": "default",
 	"style": "wp-block-accordion",
-	"viewScriptModule": "file:./view.js"
+	"viewScriptModule": "@wordpress/block-library/accordion"
 }

--- a/packages/block-library/src/accordion/block.json
+++ b/packages/block-library/src/accordion/block.json
@@ -62,5 +62,6 @@
 	},
 	"allowedBlocks": [ "core/accordion-content" ],
 	"textdomain": "default",
-	"style": "wp-block-accordion"
+	"style": "wp-block-accordion",
+	"viewScriptModule": "file:./view.js"
 }

--- a/packages/block-library/src/accordion/block.json
+++ b/packages/block-library/src/accordion/block.json
@@ -63,5 +63,5 @@
 	"allowedBlocks": [ "core/accordion-content" ],
 	"textdomain": "default",
 	"style": "wp-block-accordion",
-	"viewScriptModule": "@wordpress/block-library/accordion"
+	"viewScriptModule": "@wordpress/block-library/accordion/view"
 }

--- a/packages/block-library/src/accordion/index.php
+++ b/packages/block-library/src/accordion/index.php
@@ -15,19 +15,7 @@ function render_block_core_accordion( $attributes, $content ) {
 		return $content;
 	}
 
-	$suffix = wp_scripts_get_suffix();
-	if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-		$module_url = gutenberg_url( '/build-module/block-library/accordion/view.min.js' );
-	}
-
-	wp_register_script_module(
-		'@wordpress/block-library/accordion',
-		isset( $module_url ) ? $module_url : includes_url( "blocks/accordion/view{$suffix}.js" ),
-		array( '@wordpress/interactivity' ),
-		defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
-	);
-
-	wp_enqueue_script_module( '@wordpress/block-library/accordion' );
+	wp_enqueue_script_module( '@wordpress/block-library/accordion/view' );
 
 	$p             = new WP_HTML_Tag_Processor( $content );
 	$autoclose     = $attributes['autoclose'] ? 'true' : 'false';

--- a/packages/block-library/src/accordion/index.php
+++ b/packages/block-library/src/accordion/index.php
@@ -15,8 +15,6 @@ function render_block_core_accordion( $attributes, $content ) {
 		return $content;
 	}
 
-	wp_enqueue_script_module( '@wordpress/block-library/accordion/view' );
-
 	$p             = new WP_HTML_Tag_Processor( $content );
 	$autoclose     = $attributes['autoclose'] ? 'true' : 'false';
 	$icon          = $attributes['icon'] ?? 'plus';


### PR DESCRIPTION
## What?

I'm not sure why such complicated logic is used to enqueue the script module in the Accordion block. It should work by just running `wp_enqueue_script_module`.

## Testing Instructions

Insert an Accordion block and confirm that it's interactive on the frontend.