### PR TITLE
Accordion Header: use withoutInteractiveFormatting instead of hardcoded formats

### DIFF
--- a/packages/block-library/src/accordion-header/edit.js
+++ b/packages/block-library/src/accordion-header/edit.js
@@ -82,12 +82,7 @@ export default function Edit( { attributes, setAttributes, context } ) {
 					} }
 				>
 					<RichText
-						allowedFormats={ [
-							'core/bold',
-							'core/italic',
-							'core/image',
-							'core/strikethrough',
-						] }
+						withoutInteractiveFormatting
 						disableLineBreaks
 						tagName="span"
 						value={ title }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/71741

This PR updates the Accordion Header block to use the withoutInteractiveFormatting prop in RichText, instead of hardcoding a limited list of allowedFormats.

## Why?
Currently, the Accordion Header places a RichText component inside a <button>.
This code does not prevent the insertion of interactive elements, as consumers may add custom formatting.

Using withoutInteractiveFormatting ensures that only safe, non-interactive text formats (bold, italic, strikethrough, etc.) are allowed, and interactive content tags are automatically blocked. This makes the block more robust and future-proof.

## How?
Removed the hardcoded allowedFormats array.
Added withoutInteractiveFormatting to the Accordion Header’s RichText component.
No change in the user experience for text styling

## Testing Instructions

1. Create or edit a post or page.
2. Insert an Accordion block.
3. Add text to the Accordion Header.
4. Try applying basic formatting (bold, italic, strikethrough) → ✅ works.
5. Try inserting interactive elements such as links or media → ❌ not allowed.

