### PR TITLE
Details Block: remove "accordion" keyword to avoid confusion with Accordion block

### DIFF
--- a/packages/block-library/src/details/block.json
+++ b/packages/block-library/src/details/block.json
@@ -5,7 +5,7 @@
 	"title": "Details",
 	"category": "text",
 	"description": "Hide and show additional content.",
-	"keywords": [ "accordion", "summary", "toggle", "disclosure" ],
+	"keywords": [ "summary", "toggle", "disclosure" ],
 	"textdomain": "default",
 	"attributes": {
 		"showContent": {


### PR DESCRIPTION

## What?
Closes https://github.com/WordPress/gutenberg/issues/71744

Removes the `"accordion"` keyword from the **Details block** to avoid confusion with the experimental **Accordion block**.

## Why?
The Details block is not an accordion, but `"accordion"` was added as a keyword so that users searching for “accordion” could find it.

Now that the Accordion block exists (currently behind the experimental flag), having both blocks appear for the same search term is confusing for users. Removing the keyword makes the distinction clearer.

## How?
- Removed `"accordion"` from the list of keywords in the Details block registration.

## Testing Instructions
1. Open the editor.  
2. In the block inserter, search for **“accordion”**.  
   - ✅ Only the Accordion block should appear.  
   - ❌ The Details block should no longer appear.  
3. Search for **“details”**.  
   - ✅ The Details block should appear as expected.

## Demo
#### Before:
https://github.com/user-attachments/assets/b39bdf58-3f28-4aa7-ad03-466f83fff8a8

#### After
https://github.com/user-attachments/assets/2a40e33f-14cf-4a81-8e6b-5107922c5026
