### PR TITLE
fix: hide accordion icon position setting when show icon is disabled

### DIFF
--- a/packages/block-library/src/accordion/edit.js
+++ b/packages/block-library/src/accordion/edit.js
@@ -109,6 +109,9 @@ export default function Edit( {
 							onChange={ ( value ) => {
 								setAttributes( {
 									showIcon: value,
+									iconPosition: value
+										? iconPosition
+										: 'right',
 								} );
 							} }
 							checked={ showIcon }
@@ -117,34 +120,36 @@ export default function Edit( {
 							) }
 						/>
 					</ToolsPanelItem>
-					<ToolsPanelItem
-						label={ __( 'Icon Position' ) }
-						isShownByDefault
-						hasValue={ () => iconPosition !== 'right' }
-						onDeselect={ () =>
-							setAttributes( { iconPosition: 'right' } )
-						}
-					>
-						<ToggleGroupControl
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-							isBlock
+					{ showIcon && (
+						<ToolsPanelItem
 							label={ __( 'Icon Position' ) }
-							value={ iconPosition }
-							onChange={ ( value ) => {
-								setAttributes( { iconPosition: value } );
-							} }
+							isShownByDefault
+							hasValue={ () => iconPosition !== 'right' }
+							onDeselect={ () =>
+								setAttributes( { iconPosition: 'right' } )
+							}
 						>
-							<ToggleGroupControlOption
-								label={ __( 'Left' ) }
-								value="left"
-							/>
-							<ToggleGroupControlOption
-								label={ __( 'Right' ) }
-								value="right"
-							/>
-						</ToggleGroupControl>
-					</ToolsPanelItem>
+							<ToggleGroupControl
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
+								isBlock
+								label={ __( 'Icon Position' ) }
+								value={ iconPosition }
+								onChange={ ( value ) => {
+									setAttributes( { iconPosition: value } );
+								} }
+							>
+								<ToggleGroupControlOption
+									label={ __( 'Left' ) }
+									value="left"
+								/>
+								<ToggleGroupControlOption
+									label={ __( 'Right' ) }
+									value="right"
+								/>
+							</ToggleGroupControl>
+						</ToolsPanelItem>
+					) }
 				</ToolsPanel>
 			</InspectorControls>
 			<div { ...innerBlocksProps } />


### PR DESCRIPTION
## What?
Closes #71738 

Hides the Icon Position setting when the Show icon toggle is turned off in the Accordion block.

## Why?
When the Show icon setting is disabled, the Icon Position setting has no effect but was still visible in the inspector controls. This creates confusion for users as they see a setting that doesn't actually do anything when the icon is hidden.

## How?
- Added conditional rendering to only show the Icon Position setting when `showIcon` is `true`
- Modified the Show icon toggle to reset `iconPosition` to the default value (`'right'`) when the icon is disabled

## Testing Instructions
1. Open the WordPress editor (post or page)
2. Insert an Accordion block
3. Select the Accordion block to open the inspector controls
4. In the Settings panel, you should see both "Show icon" and "Icon Position" settings
5. Toggle the "Show icon" setting to OFF
6. Verify that the "Icon Position" setting disappears from the panel
7. Toggle the "Show icon" setting back to ON
8. Verify that the "Icon Position" setting reappears and is set to "Right" (default)
9. Change the "Icon Position" to "Left", then toggle "Show icon" OFF and back ON
10. Verify that the position resets to "Right" when toggled back on

## Screenshots or screencast 

### Before
https://github.com/user-attachments/assets/a6306cb9-c5ec-47f6-b591-a31d4226e27c 

### After
https://github.com/user-attachments/assets/ccb677bd-2a91-402f-b2d9-62dfb02205cb
