### PR TITLE
Accordion Block: hide "Add" button when multiple blocks are selected

### DIFF
--- a/packages/block-library/src/accordion/edit.js
+++ b/packages/block-library/src/accordion/edit.js
@@ -17,7 +17,7 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	ToolbarButton,
 } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 
 /**
@@ -34,11 +34,11 @@ export default function Edit( {
 	attributes: { autoclose, iconPosition, showIcon },
 	clientId,
 	setAttributes,
+	isSelected: isSingleSelected,
 } ) {
 	const blockProps = useBlockProps();
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const { insertBlock } = useDispatch( blockEditorStore );
-	const { hasMultiSelection } = useSelect( blockEditorStore );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: [ [ ACCORDION_BLOCK_NAME ], [ ACCORDION_BLOCK_NAME ] ],
@@ -54,7 +54,7 @@ export default function Edit( {
 
 	return (
 		<>
-			{ ! hasMultiSelection() && (
+			{ isSingleSelected && (
 				<BlockControls group="other">
 					<ToolbarButton
 						label={ __( 'Add accordion content block' ) }

--- a/packages/block-library/src/accordion/edit.js
+++ b/packages/block-library/src/accordion/edit.js
@@ -17,7 +17,7 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	ToolbarButton,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 
 /**
@@ -38,6 +38,7 @@ export default function Edit( {
 	const blockProps = useBlockProps();
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const { insertBlock } = useDispatch( blockEditorStore );
+	const { hasMultiSelection } = useSelect( blockEditorStore );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: [ [ ACCORDION_BLOCK_NAME ], [ ACCORDION_BLOCK_NAME ] ],
@@ -53,14 +54,16 @@ export default function Edit( {
 
 	return (
 		<>
-			<BlockControls group="other">
-				<ToolbarButton
-					label={ __( 'Add accordion content block' ) }
-					onClick={ addAccordionContentBlock }
-				>
-					{ __( 'Add' ) }
-				</ToolbarButton>
-			</BlockControls>
+			{ ! hasMultiSelection() && (
+				<BlockControls group="other">
+					<ToolbarButton
+						label={ __( 'Add accordion content block' ) }
+						onClick={ addAccordionContentBlock }
+					>
+						{ __( 'Add' ) }
+					</ToolbarButton>
+				</BlockControls>
+			) }
 			<InspectorControls key="setting">
 				<ToolsPanel
 					label={ __( 'Settings' ) }


### PR DESCRIPTION
## What?
Closes #71739 

This PR hides the "Add" button in the Accordion block toolbar when multiple blocks are selected.

## Why?
Currently, when you select multiple Accordion blocks and click the "Add" button in the toolbar, it only adds a new accordion content block to the first selected block. This is confusing behaviour because users expect the button to work on all selected blocks, or at least be hidden when multiple blocks are selected to avoid confusion.

## How?
1. Adding the `hasMultiSelection` selector from the block editor store
2. Conditionally rendering the "Add" button only when `hasMultiSelection()` returns false

## Testing Instructions
1. Open the WordPress editor (post or page editor)
2. Insert multiple Accordion blocks (2 or more)
3. Select just one Accordion block and verify the "Add" button appears in the toolbar
4. Now select multiple Accordion blocks by holding Shift and clicking on them
5. Verify that the "Add" button is no longer visible in the toolbar
6. Deselect the blocks and select just one again
7. Verify the "Add" button reappears and works correctly

## Screenshots or screencast 

### Before
https://github.com/user-attachments/assets/ce900788-ce6d-4b86-946b-17e613578b5b


### After
https://github.com/user-attachments/assets/51bdab5d-45f0-40c3-b910-5c4b3c284f74


