### PR TITLE
Add configurable timeout parameter to flashBlock

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1285,6 +1285,7 @@ Action that "flashes" the block with a given `clientId` by rhythmically highligh
 _Parameters_
 
 -   _clientId_ `string`: Target block client ID.
+-   _timeout_ `number`: Duration in milliseconds to keep the highlight. Defaults to 150ms.
 
 ### hideInsertionPoint
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1876,12 +1876,13 @@ export function toggleBlockHighlight( clientId, isHighlighted ) {
  * Action that "flashes" the block with a given `clientId` by rhythmically highlighting it.
  *
  * @param {string} clientId Target block client ID.
+ * @param {number} timeout  Duration in milliseconds to keep the highlight. Defaults to 150ms.
  */
 export const flashBlock =
-	( clientId ) =>
+	( clientId, timeout = 150 ) =>
 	async ( { dispatch } ) => {
 		dispatch( toggleBlockHighlight( clientId, true ) );
-		await new Promise( ( resolve ) => setTimeout( resolve, 150 ) );
+		await new Promise( ( resolve ) => setTimeout( resolve, timeout ) );
 		dispatch( toggleBlockHighlight( clientId, false ) );
 	};
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Closes https://github.com/WordPress/gutenberg/issues/71751

## What?

This PR updates the flashBlock action in packages/block-editor/src/store/actions.js to support a configurable timeout duration.

Previously, the highlight duration was fixed at 150ms, which could feel too fast in some contexts. With this update, flashBlock accepts an optional timeout parameter, allowing developers to control how long the highlight remains visible.

<!-- In a few words, what is the PR actually doing? -->

## Why?

1. Provides flexibility for different UX needs (e.g., comments sidebar navigation vs. quick copy confirmation).
2. Keeps backward compatibility by defaulting to 150ms when no timeout is specified.

## Testing Instructions

Trigger flashBlock( clientId ) → should behave as before (150ms).

Trigger flashBlock( clientId, 1000 ) → highlight should remain visible for ~1 second.

cc @t-hamano 