### PR TITLE
Site Editor: Fix the PHP warning for the URL query

### DIFF
--- a/lib/compat/wordpress-6.9/preload.php
+++ b/lib/compat/wordpress-6.9/preload.php
@@ -13,10 +13,10 @@ function gutenberg_block_editor_preload_paths_6_9( $paths, $context ) {
 		// Only prefetch for the root. If we preload it for all pages and it's not used
 		// it won't be possible to invalidate.
 		// To do: perhaps purge all preloaded paths when client side navigating.
-		if ( '/' !== $_GET['p'] ) {
+		if ( isset( $_GET['p'] ) && '/' !== $_GET['p'] ) {
 			$paths = array_filter(
 				$paths,
-				function ( $path ) {
+				static function ( $path ) {
 					return '/wp/v2/templates/lookup?slug=front-page' !== $path && '/wp/v2/templates/lookup?slug=home' !== $path;
 				}
 			);

--- a/test/e2e/specs/site-editor/preload.spec.js
+++ b/test/e2e/specs/site-editor/preload.spec.js
@@ -46,13 +46,9 @@ test.describe( 'Preload', () => {
 
 		// To do: these should all be removed or preloaded.
 		expect( requests ).toEqual( [
-			// I'm not quite sure why this is needed, because it is preloaded.
-			// It might be that there's a request that invalides the resolver
-			// and then triggers a new request.
-			'/wp/v2/templates/lookup?slug=front-page',
+			'/wp/v2/wp_template',
 			// Seems to be coming from `enableComplementaryArea`.
 			'/wp/v2/users/me',
-			'/wp/v2/wp_template',
 			// This is the auto-draft template.
 			expect.stringMatching( /\/wp\/v2\/wp_template\/\d+\?context=edit/ ),
 			// There are two separate settings OPTIONS requests. We should fix


### PR DESCRIPTION
## What?
Related #71735.

PR fixes the PHP warning triggered by the missing `p` query argument when updating preloaded paths.

```
PHP Warning:  Undefined array key "p" in /Users/mamaduka/Projects/gutenberg/wp-content/plugins/gutenberg/lib/compat/wordpress-6.9/preload.php on line 16
```

## Testing Instructions
1. Open the Site Editor.
2. Confirm that the mentioned PHP warning isn't logged.
