### PR TITLE
Accordion: Remove label from Add button

### DIFF
--- a/packages/block-library/src/accordion/edit.js
+++ b/packages/block-library/src/accordion/edit.js
@@ -54,10 +54,7 @@ export default function Edit( {
 	return (
 		<>
 			<BlockControls group="other">
-				<ToolbarButton
-					label={ __( 'Add accordion content block' ) }
-					onClick={ addAccordionContentBlock }
-				>
+				<ToolbarButton onClick={ addAccordionContentBlock }>
 					{ __( 'Add' ) }
 				</ToolbarButton>
 			</BlockControls>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Addresses https://github.com/WordPress/gutenberg/pull/71388#discussion_r2362238793.

Removes the separate `label` from the Accordion "Add" button.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The button content and `label` should not be different, as this can cause an accessibility issue, particularly for users of assistive technology. This experience relies on a consistent accessible name, and in this case, it won't match what is presented visually.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removes the separate `label` attribute from the button. This is similar to the approach we use in the Gallery block for the "Add" button.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
