### PR TITLE
Accordion Header: Add content role to title attribute

### DIFF
--- a/packages/block-library/src/accordion-header/block.json
+++ b/packages/block-library/src/accordion-header/block.json
@@ -63,7 +63,8 @@
 		"title": {
 			"type": "rich-text",
 			"source": "rich-text",
-			"selector": "span"
+			"selector": "span",
+			"role": "content"
 		},
 		"level": {
 			"type": "number",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71740 

Adds `"role": "content"` to the title attribute in the accordion header block to make it editable when `templateLock: "contentOnly"` is applied to parent blocks.

## Why?
When an Accordion block is wrapped with a Group block that has `templateLock: "contentOnly"` applied, users cannot edit the accordion header text.

## How?
Added `"role": "content"` to the `title` attribute of accordion header block

## Testing Instructions
1. Create a new post or page in the block editor.
2. Insert a Group block.
3. Inside the Group block, add an Accordion block.
4. Apply 1"templateLock": "contentOnly"` to the  Group block (parent container).
5. The accordion header text should remain editable.

## Screenshots 

| Before | After |
|--------|-------|
| <img width="1468" height="636" alt="Screenshot 2025-09-19 at 3 51 30 PM" src="https://github.com/user-attachments/assets/4d776f79-0dc4-4cbb-abb8-6e9094e8b226" /> | <img width="1465" height="632" alt="Screenshot 2025-09-19 at 3 52 09 PM" src="https://github.com/user-attachments/assets/be9b6d36-3d35-497c-9b63-2edb19dfacde" /> |
