### PR TITLE
Add role attribute to title selector in accordion-header block

### DIFF
--- a/packages/block-library/src/accordion-header/block.json
+++ b/packages/block-library/src/accordion-header/block.json
@@ -63,7 +63,8 @@
 		"title": {
 			"type": "rich-text",
 			"source": "rich-text",
-			"selector": "span"
+			"selector": "span",
+			"role": "content"
 		},
 		"level": {
 			"type": "number",


### PR DESCRIPTION
Add role: content to accordion header title attribute

## What?
Added the **role**: `content` property to the title attribute in the accordion-header block configuration.

## Why?
When an Accordion block is wrapped with a Group block that has `templateLock:contentOnly` applied, the accordion header text becomes uneditable, and the list view displays incorrectly by only showing the accordion panel content as editable blocks.

By adding the "role": `content `attribute to the title field, we ensure that:
- The accordion header text remains editable even when template locking is applied
- The list view properly identifies and displays editable content
- Users can interact with accordion headers as expected in locked templates

## Fixes / Reference
Fixes [#71740](https://github.com/WordPress/gutenberg/issues/71740)

## How to test:
1. Create a new Accordion block
2. Wrap it in a Group block
3. Set the Group block's templateLock to `contentOnly`
4. Verify that the accordion header text is now editable
5. Check the list view to ensure proper display of editable elements
6. Confirm that accordion functionality (expand/collapse) still works as expected

## Files changed:
- packages/block-library/src/accordion-header/block.json
