### PR TITLE
Block Comments: Unfold custom styles

### DIFF
--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -13,112 +13,112 @@
 .editor-collab-sidebar-panel {
 	padding: $grid-unit-20;
 	height: 100%;
+}
 
-	&__thread {
-		position: relative;
-		padding: $grid-unit-20;
-		border-radius: $radius-large;
-		border: 1.5px solid $gray-300;
-		background-color: $gray-100;
-		margin-bottom: $grid-unit-20;
+.editor-collab-sidebar-panel__thread {
+	position: relative;
+	padding: $grid-unit-20;
+	border-radius: $radius-large;
+	border: 1.5px solid $gray-300;
+	background-color: $gray-100;
+	margin-bottom: $grid-unit-20;
+}
+
+.editor-collab-sidebar-panel__active-thread {
+	border: 1.5px solid #3858e9;
+}
+
+.editor-collab-sidebar-panel__focus-thread {
+	border: 1.5px solid #3858e9;
+	background-color: $white;
+	box-shadow: 0 5.5px 7.8px -0.3px rgba(0, 0, 0, 0.102);
+}
+
+.editor-collab-sidebar-panel__comment-field {
+	flex: 1;
+
+	button {
+		flex-grow: 1;
+		justify-content: center;
+	}
+}
+
+.editor-collab-sidebar-panel__child-thread {
+	margin-top: 15px;
+}
+
+.editor-collab-sidebar-panel__user-name {
+	font-size: 12px;
+	font-weight: 400;
+	line-height: 16px;
+	text-align: left;
+	color: $gray-700;
+	text-transform: capitalize;
+}
+
+.editor-collab-sidebar-panel__user-time {
+	font-size: 12px;
+	font-weight: 400;
+	line-height: 16px;
+	text-align: left;
+	color: $gray-700;
+}
+
+.editor-collab-sidebar-panel__user-comment {
+	p:last-child {
+		margin-bottom: 0;
+	}
+}
+
+.editor-collab-sidebar-panel__user-avatar {
+	border-radius: $radius-round;
+	flex-shrink: 0;
+}
+
+.editor-collab-sidebar-panel__thread-overlay {
+	background-color: rgba(0, 0, 0, 0.7);
+	width: 100%;
+	height: 100%;
+	text-align: center;
+	position: absolute;
+	top: 0;
+	left: 0;
+	z-index: 1;
+	padding: 15px;
+	border-radius: $radius-large;
+	color: $white;
+
+	p {
+		margin-bottom: 15px;
 	}
 
-	&__active-thread {
-		border: 1.5px solid #3858e9;
-	}
-
-	&__focus-thread {
-		border: 1.5px solid #3858e9;
-		background-color: $white;
-		box-shadow: 0 5.5px 7.8px -0.3px rgba(0, 0, 0, 0.102);
-	}
-
-	&__comment-field {
-		flex: 1;
-
-		button {
-			flex-grow: 1;
-			justify-content: center;
-		}
-	}
-
-	&__child-thread {
-		margin-top: 15px;
-	}
-
-	&__user-name {
-		font-size: 12px;
-		font-weight: 400;
-		line-height: 16px;
-		text-align: left;
-		color: $gray-700;
-		text-transform: capitalize;
-	}
-
-	&__user-time {
-		font-size: 12px;
-		font-weight: 400;
-		line-height: 16px;
-		text-align: left;
-		color: $gray-700;
-	}
-
-	&__user-comment {
-		p:last-child {
-			margin-bottom: 0;
-		}
-	}
-
-	&__user-avatar {
-		border-radius: $radius-round;
-		flex-shrink: 0;
-	}
-
-	&__thread-overlay {
-		background-color: rgba(0, 0, 0, 0.7);
-		width: 100%;
-		height: 100%;
-		text-align: center;
-		position: absolute;
-		top: 0;
-		left: 0;
-		z-index: 1;
-		padding: 15px;
-		border-radius: $radius-large;
+	button {
+		padding: 4px 10px;
 		color: $white;
-
-		p {
-			margin-bottom: 15px;
-		}
-
-		button {
-			padding: 4px 10px;
-			color: $white;
-		}
 	}
+}
 
-	&__comment-status {
-		margin-left: auto;
+.editor-collab-sidebar-panel__comment-status {
+	margin-left: auto;
 
-		button {
-			&.has-icon:not(.has-text) {
-				min-width: 24px;
-				padding: 0;
-				width: 24px;
-				height: 24px;
-				flex-shrink: 0;
-			}
+	button {
+		&.has-icon:not(.has-text) {
+			min-width: 24px;
+			padding: 0;
+			width: 24px;
+			height: 24px;
+			flex-shrink: 0;
 		}
 	}
+}
 
-	&__comment-dropdown-menu {
-		flex-shrink: 0;
-	}
+.editor-collab-sidebar-panel__comment-dropdown-menu {
+	flex-shrink: 0;
+}
 
-	&__show-more-reply {
-		font-weight: 500;
-		font-style: italic;
-	}
+.editor-collab-sidebar-panel__show-more-reply {
+	font-weight: 500;
+	font-style: italic;
 }
 
 // Comment avatar indicators.


### PR DESCRIPTION
## What?
PR updates Block Comments style definition and removes [Sass suffixing](https://sass-lang.com/documentation/style-rules/parent-selector/#adding-suffixes). It makes classnames easier to search in the codebase and can avoid accidental leftovers.

The code is easier to review with hidden whitespace changes - https://github.com/WordPress/gutenberg/pull/71766/files?diff=unified&w=1.

## Testing Instructions
1. Enable block-level comments experiment.
2. Add a couple of comments.
3. Confirm there are no visual regressions compared to `trunk`.

### Testing Instructions for Keyboard
Same.