### PR TITLE
Template activation: add back compat for saveEntityRecord wp_template

### DIFF
--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -29,13 +29,13 @@ function gutenberg_maintain_templates_routes() {
 	$revisions_controller                    = new WP_REST_Template_Revisions_Controller( 'wp_template' );
 	$wp_post_types['wp_template']->rest_base = 'wp_template';
 
-	$wp_post_types['_old_wp_template'] = clone $wp_post_types['wp_template'];
-	$wp_post_types['_old_wp_template']->name                  = '_old_wp_template';
-	$wp_post_types['_old_wp_template']->rest_base             = 'templates';
-	$wp_post_types['_old_wp_template']->rest_controller_class = 'WP_REST_Templates_Controller';
-	$wp_post_types['_old_wp_template']->rest_controller       = $controller;
-	$wp_post_types['_old_wp_template']->autosave_rest_controller_class = 'WP_REST_Template_Autosaves_Controller';
-	$wp_post_types['_old_wp_template']->autosave_rest_controller       = $autosave_controller;
+	$wp_post_types['_old_wp_template']                                  = clone $wp_post_types['wp_template'];
+	$wp_post_types['_old_wp_template']->name                            = '_old_wp_template';
+	$wp_post_types['_old_wp_template']->rest_base                       = 'templates';
+	$wp_post_types['_old_wp_template']->rest_controller_class           = 'WP_REST_Templates_Controller';
+	$wp_post_types['_old_wp_template']->rest_controller                 = $controller;
+	$wp_post_types['_old_wp_template']->autosave_rest_controller_class  = 'WP_REST_Template_Autosaves_Controller';
+	$wp_post_types['_old_wp_template']->autosave_rest_controller        = $autosave_controller;
 	$wp_post_types['_old_wp_template']->revisions_rest_controller_class = 'WP_REST_Template_Revisions_Controller';
 	$wp_post_types['_old_wp_template']->revisions_rest_controller       = $revisions_controller;
 

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -18,15 +18,30 @@ function gutenberg_modify_wp_template_post_type_args( $args, $post_type ) {
 //    need to deprecate /templates eventually, but we'll still want to be able
 //    to lookup the active template for a specific slug, and probably get a list
 //    of all _active_ templates. For that we can keep /lookup.
-add_action( 'rest_api_init', 'gutenberg_maintain_templates_routes' );
+add_action( 'rest_api_init', 'gutenberg_maintain_templates_routes', 100 );
 function gutenberg_maintain_templates_routes() {
 	// This should later be changed in core so we don't need initialise
 	// WP_REST_Templates_Controller with a post type.
 	global $wp_post_types;
 	$wp_post_types['wp_template']->rest_base = 'templates';
 	$controller                              = new WP_REST_Templates_Controller( 'wp_template' );
+	$autosave_controller                     = new WP_REST_Template_Autosaves_Controller( 'wp_template' );
+	$revisions_controller                    = new WP_REST_Template_Revisions_Controller( 'wp_template' );
 	$wp_post_types['wp_template']->rest_base = 'wp_template';
+
+	$wp_post_types['_old_wp_template'] = clone $wp_post_types['wp_template'];
+	$wp_post_types['_old_wp_template']->name                  = '_old_wp_template';
+	$wp_post_types['_old_wp_template']->rest_base             = 'templates';
+	$wp_post_types['_old_wp_template']->rest_controller_class = 'WP_REST_Templates_Controller';
+	$wp_post_types['_old_wp_template']->rest_controller       = $controller;
+	$wp_post_types['_old_wp_template']->autosave_rest_controller_class = 'WP_REST_Template_Autosaves_Controller';
+	$wp_post_types['_old_wp_template']->autosave_rest_controller       = $autosave_controller;
+	$wp_post_types['_old_wp_template']->revisions_rest_controller_class = 'WP_REST_Template_Revisions_Controller';
+	$wp_post_types['_old_wp_template']->revisions_rest_controller       = $revisions_controller;
+
 	$controller->register_routes();
+	$autosave_controller->register_routes();
+	$revisions_controller->register_routes();
 }
 
 // 3. We need a route to get that raw static templates from themes and plugins.

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -545,7 +545,7 @@ export const saveEntityRecord =
 	async ( { select, resolveSelect, dispatch } ) => {
 		logEntityDeprecation( kind, name, 'saveEntityRecord' );
 		const configs = await resolveSelect.getEntitiesConfig( kind );
-		const entityConfig = configs.find(
+		let entityConfig = configs.find(
 			( config ) => config.kind === kind && config.name === name
 		);
 		if ( ! entityConfig ) {
@@ -553,6 +553,23 @@ export const saveEntityRecord =
 		}
 		const entityIdKey = entityConfig.key || DEFAULT_ENTITY_KEY;
 		const recordId = record[ entityIdKey ];
+
+		// For back-compat, we allow querying for static templates through
+		// wp_template.
+		if (
+			kind === 'postType' &&
+			name === 'wp_template' &&
+			typeof recordId === 'string' &&
+			! /^\d+$/.test( recordId )
+		) {
+			name = '_old_wp_template';
+			entityConfig = configs.find(
+				( config ) => config.kind === kind && config.name === name
+			);
+			if ( ! entityConfig ) {
+				return;
+			}
+		}
 
 		const lock = await dispatch.__unstableAcquireStoreLock(
 			STORE_NAME,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71765

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Template entity operations fail when called with the slug.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We'll have to restore access to the /templates endpoint for getting/creating/editing/deleting an item. We can do so by creating a new entity that uses the old templates endpoint and redirecting calls to entity functions with a template slug as the ID.

To create an entity, we have to also create a hidden post type on the back end (just like we did for the static/registered template entity).

This does not solve the issue for a list of templates. When you get the list of entities through `wp_template`, this will now should user templates rather than all templates. We could potentially add back compat when the query is for `per_page: -1`, but let's see if this is a problem that needs fixing.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Run:

```js
wp.data.dispatch('core').saveEntityRecord(
	'postType',
	'wp_template',
	{
		id: 'twentytwentyfive//home',
		content: 'test',
	},
	{
		throwOnError: true,
	}
);
```

This should not error and create a template in the custom templates tab.

To do: do the same for edit/delete etc.
To do: add e2e tests.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
