### PR TITLE
Post Author Block: Add default avatar fallback for editor display outside postId context

### DIFF
--- a/packages/block-library/src/avatar/hooks.js
+++ b/packages/block-library/src/avatar/hooks.js
@@ -1,10 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore, useEntityProp } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useDefaultAvatar } from '../utils/hooks';
 
 function getAvatarSizes( sizes ) {
 	const minSize = sizes ? sizes[ 0 ] : 24;
@@ -14,15 +18,6 @@ function getAvatarSizes( sizes ) {
 		minSize,
 		maxSize: maxSizeBuffer,
 	};
-}
-
-function useDefaultAvatar() {
-	const { avatarURL: defaultAvatarUrl } = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		const { __experimentalDiscussionSettings } = getSettings();
-		return __experimentalDiscussionSettings;
-	} );
-	return defaultAvatarUrl;
 }
 
 export function useCommentAvatar( { commentId } ) {

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -21,16 +21,19 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { debounce } from '@wordpress/compose';
-import { useMemo, useState } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { __, sprintf } from '@wordpress/i18n';
-import { decodeEntities } from '@wordpress/html-entities';
 import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useMemo, useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+import {
+	useDefaultAvatar,
+	useToolsPanelDropdownMenuProps,
+} from '../utils/hooks';
 
 const AUTHORS_QUERY = {
 	who: 'authors',
@@ -115,6 +118,7 @@ function PostAuthorEdit( {
 } ) {
 	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+	const defaultAvatar = useDefaultAvatar();
 
 	const { authorDetails, canAssignAuthor, supportsAuthor } = useSelect(
 		( select ) => {
@@ -323,12 +327,15 @@ function PostAuthorEdit( {
 			</BlockControls>
 
 			<div { ...blockProps }>
-				{ showAvatar && authorDetails?.avatar_urls && (
+				{ showAvatar && (
 					<div className="wp-block-post-author__avatar">
 						<img
 							width={ avatarSize }
-							src={ authorDetails.avatar_urls[ avatarSize ] }
-							alt={ authorDetails.name }
+							src={
+								authorDetails?.avatar_urls?.[ avatarSize ] ||
+								defaultAvatar
+							}
+							alt={ authorDetails?.name || __( 'Post Author' ) }
 						/>
 					</div>
 				) }

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -335,7 +335,9 @@ function PostAuthorEdit( {
 								authorDetails?.avatar_urls?.[ avatarSize ] ||
 								defaultAvatar
 							}
-							alt={ authorDetails?.name || __( 'Post Author' ) }
+							alt={
+								authorDetails?.name || __( 'Default Avatar' )
+							}
 						/>
 					</div>
 				) }

--- a/packages/block-library/src/utils/hooks.js
+++ b/packages/block-library/src/utils/hooks.js
@@ -93,6 +93,15 @@ export function useUploadMediaFromBlobURL( args = {} ) {
 	}, [ getSettings ] );
 }
 
+export function useDefaultAvatar() {
+	const { avatarURL: defaultAvatarUrl } = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		const { __experimentalDiscussionSettings } = getSettings();
+		return __experimentalDiscussionSettings;
+	} );
+	return defaultAvatarUrl;
+}
+
 export function useToolsPanelDropdownMenuProps() {
 	const isMobile = useViewportMatch( 'medium', '<' );
 	return ! isMobile


### PR DESCRIPTION
**What?**
- Added default avatar fallback support to Post Author Block in editor
- Moved useDefaultAvatar hook to shared utils location for code reusability
- Fixed avatar placeholder display when Post Author Block is used outside postId context

**Why?**
- Post Author Block avatar wasn't showing placeholder in editor when inserted outside postId context (e.g., in single post templates)
- Avatar Block already had proper fallback mechanism showing placeholder correctly
- Code duplication existed with useDefaultAvatar logic in Avatar block but not shared

**Fixes / Reference**
Fixes [#71715](https://github.com/WordPress/gutenberg/issues/71715)

**How to test:**
1. Open Site Editor and navigate to Single Posts template
2. Insert the following HTML into the template:
```
<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group">
	<!-- wp:post-author {"showAvatar":false} /-->

	<!-- wp:avatar /-->
</div>
<!-- /wp:group -->

```
3. Verify that both Avatar and Post Author blocks now show avatar placeholders in the editor
4. Confirm that Post Author Block avatar setting is enabled and placeholder appears

**Files changed:**

- packages/block-library/src/post-author/edit.js - Added useDefaultAvatar import and fallback logic
- packages/block-library/src/utils/hooks.js - Added shared useDefaultAvatar hook
- packages/block-library/src/avatar/hooks.js - Refactored to use shared useDefaultAvatar hook