### PR TITLE
Fix: Add aria-hidden to accordion toggle icon

### DIFF
--- a/packages/block-library/src/accordion-header/edit.js
+++ b/packages/block-library/src/accordion-header/edit.js
@@ -81,7 +81,10 @@ export default function Edit( { attributes, setAttributes, context } ) {
 					} }
 				>
 					{ showIcon && iconPosition === 'left' && (
-						<span className="accordion-content__toggle-icon">
+						<span
+							className="accordion-content__toggle-icon"
+							aria-hidden="true"
+						>
 							+
 						</span>
 					) }
@@ -96,7 +99,10 @@ export default function Edit( { attributes, setAttributes, context } ) {
 						placeholder={ __( 'Accordion title' ) }
 					/>
 					{ showIcon && iconPosition === 'right' && (
-						<span className="accordion-content__toggle-icon">
+						<span
+							className="accordion-content__toggle-icon"
+							aria-hidden="true"
+						>
 							+
 						</span>
 					) }

--- a/packages/block-library/src/accordion-header/save.js
+++ b/packages/block-library/src/accordion-header/save.js
@@ -50,7 +50,12 @@ export default function save( { attributes } ) {
 				} }
 			>
 				{ showIcon && iconPosition === 'left' && (
-					<span className="accordion-content__toggle-icon">+</span>
+					<span
+						className="accordion-content__toggle-icon"
+						aria-hidden="true"
+					>
+						+
+					</span>
 				) }
 				<RichText.Content
 					className="accordion-content__toggle-title"
@@ -58,7 +63,12 @@ export default function save( { attributes } ) {
 					value={ title }
 				/>
 				{ showIcon && iconPosition === 'right' && (
-					<span className="accordion-content__toggle-icon">+</span>
+					<span
+						className="accordion-content__toggle-icon"
+						aria-hidden="true"
+					>
+						+
+					</span>
 				) }
 			</button>
 		</TagName>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #71781 

The accordion toggle icon ("+") was being announced by screen readers, when users navigate with assistive technology.

## Why?
When users navigate through accordion headers using assistive technology, the "+" character was being announced along with the accordion title, creating unnecessary noise and a poor user experience.

## How?
Added `aria-hidden="true"` attribute to all accordion toggle icon spans in both the edit and save functions. This attribute tells screen readers and other assistive technology to ignore the decorative "+" character.
