### PR TITLE
Docs: Use `gutenberg` instead of `Gutenberg` in package name

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -2,7 +2,7 @@
 /**
  * WP_Theme_JSON_Resolver_Gutenberg class
  *
- * @package Gutenberg
+ * @package gutenberg
  * @since 5.8.0
  */
 

--- a/lib/class-wp-theme-json-schema-gutenberg.php
+++ b/lib/class-wp-theme-json-schema-gutenberg.php
@@ -2,7 +2,7 @@
 /**
  * WP_Theme_JSON_Schema_Gutenberg class
  *
- * @package Gutenberg
+ * @package gutenberg
  * @since 5.9.0
  */
 

--- a/lib/experimental/posts/load.php
+++ b/lib/experimental/posts/load.php
@@ -2,7 +2,7 @@
 /**
  * Bootstraps the new posts dashboard page.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 add_action( 'admin_menu', 'gutenberg_replace_posts_dashboard' );

--- a/packages/style-engine/class-wp-style-engine-css-declarations.php
+++ b/packages/style-engine/class-wp-style-engine-css-declarations.php
@@ -4,7 +4,7 @@
  *
  * Holds, sanitizes and prints CSS rules declarations
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 if ( ! class_exists( 'WP_Style_Engine_CSS_Declarations' ) ) {

--- a/packages/style-engine/class-wp-style-engine-css-rule.php
+++ b/packages/style-engine/class-wp-style-engine-css-rule.php
@@ -4,7 +4,7 @@
  *
  * An object for CSS rules.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 if ( ! class_exists( 'WP_Style_Engine_CSS_Rule' ) ) {

--- a/packages/style-engine/class-wp-style-engine-css-rules-store.php
+++ b/packages/style-engine/class-wp-style-engine-css-rules-store.php
@@ -4,7 +4,7 @@
  *
  * A store for WP_Style_Engine_CSS_Rule objects.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 if ( ! class_exists( 'WP_Style_Engine_CSS_Rules_Store' ) ) {

--- a/packages/style-engine/class-wp-style-engine-processor.php
+++ b/packages/style-engine/class-wp-style-engine-processor.php
@@ -4,7 +4,7 @@
  *
  * Compiles styles from stores or collection of CSS rules.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 if ( ! class_exists( 'WP_Style_Engine_Processor' ) ) {

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -4,7 +4,7 @@
  *
  * Generates classnames and block styles.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 if ( ! class_exists( 'WP_Style_Engine' ) ) {

--- a/packages/style-engine/style-engine.php
+++ b/packages/style-engine/style-engine.php
@@ -5,7 +5,7 @@
  * This file contains a variety of public functions developers can use to interact with
  * the Style Engine API.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 /**

--- a/phpunit/block-bindings-test.php
+++ b/phpunit/block-bindings-test.php
@@ -2,7 +2,7 @@
 /**
  * Tests for Block Bindings integration with block rendering.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 class Tests_Block_Bindings extends WP_UnitTestCase {
 

--- a/phpunit/block-supports/aria-label-test.php
+++ b/phpunit/block-supports/aria-label-test.php
@@ -2,7 +2,7 @@
 /**
  * Test the aria-label block support.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 class WP_Block_Supports_Aria_Label_Test extends WP_UnitTestCase {
 	/**

--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -3,7 +3,7 @@
 /**
  * Test the background block support.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 	/**

--- a/phpunit/block-supports/block-style-variations-test.php
+++ b/phpunit/block-supports/block-style-variations-test.php
@@ -5,7 +5,7 @@
  *
  * @since 6.6.0
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {

--- a/phpunit/block-supports/border-test.php
+++ b/phpunit/block-supports/border-test.php
@@ -3,7 +3,7 @@
 /**
  * Test the border block supports.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 class WP_Block_Supports_Border_Test extends WP_UnitTestCase {

--- a/phpunit/block-supports/colors-test.php
+++ b/phpunit/block-supports/colors-test.php
@@ -3,7 +3,7 @@
 /**
  * Test the typography block supports.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {

--- a/phpunit/block-supports/dimensions-test.php
+++ b/phpunit/block-supports/dimensions-test.php
@@ -3,7 +3,7 @@
 /**
  * Test the dimensions block supports.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 class WP_Block_Supports_Dimensions_Test extends WP_UnitTestCase {

--- a/phpunit/block-supports/elements-test.php
+++ b/phpunit/block-supports/elements-test.php
@@ -3,7 +3,7 @@
 /**
  * Test the elements block support.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 class WP_Block_Supports_Elements_Test extends WP_UnitTestCase {

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -3,7 +3,7 @@
 /**
  * Test the block layout support.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {

--- a/phpunit/block-supports/position-test.php
+++ b/phpunit/block-supports/position-test.php
@@ -3,7 +3,7 @@
 /**
  * Test the position block support.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 class WP_Block_Supports_Position_Test extends WP_UnitTestCase {

--- a/phpunit/block-supports/shadow-test.php
+++ b/phpunit/block-supports/shadow-test.php
@@ -3,7 +3,7 @@
 /**
  * Test the shadow block supports.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 class WP_Block_Supports_Shadow_Test extends WP_UnitTestCase {

--- a/phpunit/block-supports/spacing-test.php
+++ b/phpunit/block-supports/spacing-test.php
@@ -3,7 +3,7 @@
 /**
  * Test the spacing block supports.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -2,7 +2,7 @@
 /**
  * Tests the typography block supports.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	/**

--- a/phpunit/blocks/class-wp-navigation-block-renderer-test.php
+++ b/phpunit/blocks/class-wp-navigation-block-renderer-test.php
@@ -3,7 +3,7 @@
 /**
  * Test the block WP_Navigation_Block_Renderer class.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 class WP_Navigation_Block_Renderer_Test extends WP_UnitTestCase {

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * PHPUnit bootstrap file
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 // Debug settings for parity with WordPress Core's PHPUnit tests.

--- a/phpunit/class-block-fixture-test.php
+++ b/phpunit/class-block-fixture-test.php
@@ -2,7 +2,7 @@
 /**
  * Test block fixtures in PHP.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 class Block_Fixture_Test extends WP_UnitTestCase {

--- a/phpunit/class-gutenberg-hierarchical-sort-test.php
+++ b/phpunit/class-gutenberg-hierarchical-sort-test.php
@@ -3,7 +3,7 @@
 /**
  * Test the build_post_ids_to_display function.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 class GutenbergHierarchicalSortTest extends WP_UnitTestCase {
 

--- a/phpunit/class-override-script-test.php
+++ b/phpunit/class-override-script-test.php
@@ -2,7 +2,7 @@
 /**
  * Test `gutenberg_override_script`.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 class Override_Script_Test extends WP_UnitTestCase {

--- a/phpunit/class-phpunit-environment-setup-test.php
+++ b/phpunit/class-phpunit-environment-setup-test.php
@@ -2,7 +2,7 @@
 /**
  * Tests that the environment is configured as expected.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 class Phpunit_Environment_Setup_Test extends WP_UnitTestCase {

--- a/phpunit/class-test-plugin-version-meta-test.php
+++ b/phpunit/class-test-plugin-version-meta-test.php
@@ -2,7 +2,7 @@
 /**
  * Unit tests covering the version checks in the plugin file.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 class Test_PluginMetaData_Test extends WP_UnitTestCase {
 	/**

--- a/phpunit/class-wp-duotone-test.php
+++ b/phpunit/class-wp-duotone-test.php
@@ -3,7 +3,7 @@
 /**
  * Test the block WP_Duotone_Gutenberg class.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 class WP_Duotone_Gutenberg_Test extends WP_UnitTestCase {

--- a/phpunit/class-wp-rest-global-styles-controller-gutenberg-test.php
+++ b/phpunit/class-wp-rest-global-styles-controller-gutenberg-test.php
@@ -2,7 +2,7 @@
 /**
  * Unit tests covering WP_REST_Global_Styles_Controller_Gutenberg functionality.
  *
- * @package Gutenberg
+ * @package gutenberg
  *
  * @covers WP_REST_Global_Styles_Controller_Gutenberg
  */

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -3,7 +3,7 @@
 /**
  * Test WP_Theme_JSON_Resolver_Gutenberg class.
  *
- * @package Gutenberg
+ * @package gutenberg
  *
  * @since 5.8.0
  */

--- a/phpunit/class-wp-theme-json-schema-test.php
+++ b/phpunit/class-wp-theme-json-schema-test.php
@@ -3,7 +3,7 @@
 /**
  * Test WP_Theme_JSON_Schema_Gutenberg class.
  *
- * @package Gutenberg
+ * @package gutenberg
  *
  * @since 5.9.0
  */

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -3,7 +3,7 @@
 /**
  * Test WP_Theme_JSON_Gutenberg class.
  *
- * @package Gutenberg
+ * @package gutenberg
  *
  * @covers WP_Theme_JSON_Gutenberg
  */

--- a/phpunit/script-loader-test.php
+++ b/phpunit/script-loader-test.php
@@ -2,7 +2,7 @@
 /**
  * Tests script and style loading.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 class WP_Script_Loader_Test extends WP_UnitTestCase {

--- a/phpunit/wp-theme-json-test.php
+++ b/phpunit/wp-theme-json-test.php
@@ -2,7 +2,7 @@
 /**
  * Tests theme.json related public APIs.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 class WP_Theme_Json_Test extends WP_UnitTestCase {

--- a/test/emptytheme/functions.php
+++ b/test/emptytheme/functions.php
@@ -2,7 +2,7 @@
 /**
  * Empty theme functions and definitions.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 if ( ! function_exists( 'emptytheme_support' ) ) :

--- a/test/emptytheme/index.php
+++ b/test/emptytheme/index.php
@@ -2,7 +2,7 @@
 /**
  * Empty theme index.php file.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 // Silence is golden.

--- a/test/gutenberg-test-themes/block-bindings/index.php
+++ b/test/gutenberg-test-themes/block-bindings/index.php
@@ -2,7 +2,7 @@
 /**
  * Theme index.php file.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 // Silence is golden.

--- a/test/gutenberg-test-themes/darktheme/index.php
+++ b/test/gutenberg-test-themes/darktheme/index.php
@@ -2,7 +2,7 @@
 /**
  * Theme index.php file.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 // Silence is golden.

--- a/test/gutenberg-test-themes/emptyhybrid/functions.php
+++ b/test/gutenberg-test-themes/emptyhybrid/functions.php
@@ -2,7 +2,7 @@
 /**
  * Empty theme functions and definitions.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 if ( ! function_exists( 'emptyhybrid_support' ) ) :

--- a/test/gutenberg-test-themes/emptyhybrid/index.php
+++ b/test/gutenberg-test-themes/emptyhybrid/index.php
@@ -2,7 +2,7 @@
 /**
  * Empty-Hybrid theme index.php file.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 ?>

--- a/test/gutenberg-test-themes/style-variations/index.php
+++ b/test/gutenberg-test-themes/style-variations/index.php
@@ -2,7 +2,7 @@
 /**
  * Theme index.php file.
  *
- * @package Gutenberg
+ * @package gutenberg
  */
 
 // Silence is golden.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Used `gutenberg` instead of `Gutenberg` in `package` tags for consistency.

<!-- In a few words, what is the PR actually doing? -->

## Why? How?
- Used `gutenberg` instead of `Gutenberg` in `package` tags for consistency in below files.
1. lib/class-wp-theme-json-resolver-gutenberg.php
2. lib/class-wp-theme-json-schema-gutenberg.php
3. lib/experimental/posts/load.php

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open mentioned files
2. See `package` name.