### PR TITLE
Terms Query: fix console errors

### DIFF
--- a/packages/block-library/src/terms-query/inspector-controls/display-options.js
+++ b/packages/block-library/src/terms-query/inspector-controls/display-options.js
@@ -68,7 +68,6 @@ export default function DisplayOptions( {
 			isShownByDefault
 		>
 			<RadioControl
-				__nextHasNoMarginBottom
 				label={ __( 'Terms to show' ) }
 				options={ getOptions(
 					displayTopLevelControl,

--- a/packages/block-library/src/terms-query/inspector-controls/index.js
+++ b/packages/block-library/src/terms-query/inspector-controls/index.js
@@ -6,6 +6,7 @@ import { __experimentalToolsPanel as ToolsPanel } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -19,6 +20,20 @@ import EmptyTermsControl from './empty-terms-control';
 import MaxTermsControl from './max-terms-control';
 import AdvancedControls from './advanced-controls';
 
+const usePublicTaxonomies = () => {
+	const taxonomies = useSelect(
+		( select ) => select( coreStore ).getTaxonomies( { per_page: -1 } ),
+		[]
+	);
+	return useMemo( () => {
+		return (
+			taxonomies?.filter(
+				( { visibility } ) => visibility?.publicly_queryable
+			) || []
+		);
+	}, [ taxonomies ] );
+};
+
 export default function TermsQueryInspectorControls( {
 	attributes,
 	setQuery,
@@ -28,15 +43,7 @@ export default function TermsQueryInspectorControls( {
 } ) {
 	const { termQuery, termsToShow } = attributes;
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
-
-	const { taxonomies } = useSelect( ( select ) => {
-		const { getEntityRecords } = select( coreStore );
-		const allTaxonomies = getEntityRecords( 'root', 'taxonomy' );
-		return {
-			taxonomies:
-				allTaxonomies?.filter( ( t ) => t.visibility.public ) || [],
-		};
-	}, [] );
+	const taxonomies = usePublicTaxonomies();
 
 	const { templateSlug } = useSelect( ( select ) => {
 		// @wordpress/block-library should not depend on @wordpress/editor.


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Small bug fix that removes the unused `__nextHasNoMarginBottom` in RadioControl in `DisplayOptions` of terms query block. 

Additionally updates how we fetch the taxonomies in inspector controls to avoid the different instances inside `useSelect`. Also uses the same logic for fetching the taxonomies as we do in `usePublicTaxonomies` in site editor.


## Testing Instructions
1. Open dev tools to see the console output
2. insert `Terms Query` block and open the inspector controls
3. Observe that there is no error related to `__nextHasNoMarginBottom`, as opposed to trunk

