### PR TITLE
Template activation: fix saveEntityRecord with theme ID

### DIFF
--- a/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
+++ b/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'calling saveEntityRecord with a theme template ID', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+		await requestUtils.deleteAllTemplates( 'wp_template' );
+		await requestUtils.deleteAllTemplates( 'wp_template_part' );
+	} );
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllTemplates( 'wp_template' );
+		await requestUtils.deleteAllTemplates( 'wp_template_part' );
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+	test( 'should work as expected', async ( { admin, page } ) => {
+		await admin.visitSiteEditor();
+		await page.evaluate( async () => {
+			await window.wp.data.dispatch( 'core' ).saveEntityRecord(
+				'postType',
+				'wp_template',
+				{
+					id: 'emptytheme//index',
+					title: 'saveEntityRecord test',
+					content: 'test',
+				},
+				{ throwOnError: true }
+			);
+		} );
+		await admin.visitSiteEditor( {
+			postType: 'wp_template',
+			activeView: 'user',
+		} );
+		await expect(
+			page
+				.getByRole( 'button', { name: 'saveEntityRecord test' } )
+				.first()
+		).toBeVisible();
+		await expect( page.getByText( 'Template typeIndex' ) ).toBeVisible();
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71765

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

`saveEntityRecord` errors when called with a theme ID.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

When called with a theme ID, we should handle creating a template and activate it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Run:

```js
wp.data.dispatch('core').saveEntityRecord(
	'postType',
	'wp_template',
	{
		id: 'twentytwentyfive//home',
		content: 'test',
	},
	{
		throwOnError: true,
	}
);
```

It should not error, create a template, and activate it.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
