### PR TITLE
Fix accordion gradient background.

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -16,7 +16,7 @@ Displays a group of accordion headers and associated expandable content. ([Sourc
 -	**Experimental:** true
 -	**Category:** design
 -	**Allowed Blocks:** core/accordion-content
--	**Supports:** align (full, wide), background (backgroundImage, backgroundSize), color (background, gradient, text), interactivity, layout, shadow, spacing (blockGap, margin, padding), ~~html~~
+-	**Supports:** align (full, wide), background (backgroundImage, backgroundSize), color (background, gradients, text), interactivity, layout, shadow, spacing (blockGap, margin, padding), ~~html~~
 -	**Attributes:** autoclose, iconPosition, showIcon
 
 ## Accordion Content
@@ -28,7 +28,7 @@ Displays a section of content in an accordion, including a header and expandable
 -	**Category:** design
 -	**Parent:** core/accordion
 -	**Allowed Blocks:** core/accordion-header, core/accordion-panel
--	**Supports:** color (background, gradient, text), interactivity, layout, shadow, spacing (blockGap, margin)
+-	**Supports:** color (background, gradients, text), interactivity, layout, shadow, spacing (blockGap, margin)
 -	**Attributes:** openByDefault
 
 ## Accordion Header
@@ -39,7 +39,7 @@ Displays an accordion header. ([Source](https://github.com/WordPress/gutenberg/t
 -	**Experimental:** true
 -	**Category:** design
 -	**Parent:** core/accordion-content
--	**Supports:** anchor, color (background, gradient, text), interactivity, shadow, spacing (margin, padding), typography (fontSize, textAlign), ~~align~~
+-	**Supports:** anchor, color (background, gradients, text), interactivity, shadow, spacing (margin, padding), typography (fontSize, textAlign), ~~align~~
 -	**Attributes:** iconPosition, level, levelOptions, openByDefault, showIcon, textAlignment, title
 
 ## Accordion Panel
@@ -50,7 +50,7 @@ Displays an accordion panel. ([Source](https://github.com/WordPress/gutenberg/tr
 -	**Experimental:** true
 -	**Category:** design
 -	**Parent:** core/accordion-content
--	**Supports:** color (background, gradient, text), interactivity, layout, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight)
+-	**Supports:** color (background, gradients, text), interactivity, layout, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight)
 -	**Attributes:** allowedBlocks, isSelected, openByDefault, templateLock
 
 ## Archives

--- a/packages/block-library/src/accordion-content/block.json
+++ b/packages/block-library/src/accordion-content/block.json
@@ -11,7 +11,7 @@
 	"supports": {
 		"color": {
 			"background": true,
-			"gradient": true
+			"gradients": true
 		},
 		"interactivity": true,
 		"spacing": {

--- a/packages/block-library/src/accordion-header/block.json
+++ b/packages/block-library/src/accordion-header/block.json
@@ -15,7 +15,7 @@
 		"anchor": true,
 		"color": {
 			"background": true,
-			"gradient": true
+			"gradients": true
 		},
 		"align": false,
 		"interactivity": true,

--- a/packages/block-library/src/accordion-panel/block.json
+++ b/packages/block-library/src/accordion-panel/block.json
@@ -10,7 +10,7 @@
 	"supports": {
 		"color": {
 			"background": true,
-			"gradient": true
+			"gradients": true
 		},
 		"interactivity": true,
 		"spacing": {

--- a/packages/block-library/src/accordion/block.json
+++ b/packages/block-library/src/accordion/block.json
@@ -19,7 +19,7 @@
 		},
 		"color": {
 			"background": true,
-			"gradient": true
+			"gradients": true
 		},
 		"__experimentalBorder": {
 			"color": true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/71800

<!-- In a few words, what is the PR actually doing? -->

## Why?
Adding  correct support name `gradients` in accordion block.json here:

- Accordion header
- Accordion Content
- Accordion Panel
- Accordion

## How?
Correcting the supports from the `gradient` to `gradients` will let to add the background color in gradients.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Insert an Accordion block.
2. Try to add background color on accordion header/content/panel or whole accordiion group.
3. Now it will also let you to add the gradient color for that section.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|

Before
![before_img](https://github.com/user-attachments/assets/e4823601-bfb6-4d46-a350-6042993cf264)

After
![after_img](https://github.com/user-attachments/assets/7826ee74-47c5-4d5f-9205-7845765d53a1)

