### PR TITLE
Accordion Header: Skip serialization correctly

### DIFF
--- a/packages/block-library/src/accordion-header/block.json
+++ b/packages/block-library/src/accordion-header/block.json
@@ -25,7 +25,8 @@
 			"__experimentalDefaultControls": {
 				"padding": true,
 				"margin": true
-			}
+			},
+			"__experimentalSkipSerialization": true
 		},
 		"__experimentalBorder": {
 			"color": true,

--- a/packages/block-library/src/accordion-header/edit.js
+++ b/packages/block-library/src/accordion-header/edit.js
@@ -9,10 +9,7 @@ import { __ } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
 import {
 	useBlockProps,
-	__experimentalUseBorderProps as useBorderProps,
-	__experimentalUseColorProps as useColorProps,
 	__experimentalGetSpacingClassesAndStyles as useSpacingProps,
-	__experimentalGetShadowClassesAndStyles as useShadowProps,
 	BlockControls,
 	HeadingLevelDropdown,
 	RichText,
@@ -37,11 +34,12 @@ export default function Edit( { attributes, setAttributes, context } ) {
 		}
 	}, [ iconPosition, showIcon, setAttributes ] );
 
-	const blockProps = useBlockProps();
-	const borderProps = useBorderProps( attributes );
-	const colorProps = useColorProps( attributes );
+	const blockProps = useBlockProps( {
+		className: clsx( 'accordion-content__heading', {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} ),
+	} );
 	const spacingProps = useSpacingProps( attributes );
-	const shadowProps = useShadowProps( attributes );
 
 	return (
 		<>
@@ -56,24 +54,7 @@ export default function Edit( { attributes, setAttributes, context } ) {
 					/>
 				</ToolbarGroup>
 			</BlockControls>
-			<TagName
-				{ ...blockProps }
-				className={ clsx(
-					blockProps.className,
-					colorProps.className,
-					borderProps.className,
-					'accordion-content__heading',
-					{
-						[ `has-custom-font-size` ]: blockProps.style.fontSize,
-						[ `has-text-align-${ textAlign }` ]: textAlign,
-					}
-				) }
-				style={ {
-					...borderProps.style,
-					...colorProps.style,
-					...shadowProps.style,
-				} }
-			>
+			<TagName { ...blockProps }>
 				<button
 					className={ clsx( 'accordion-content__toggle' ) }
 					style={ {

--- a/packages/block-library/src/accordion-header/save.js
+++ b/packages/block-library/src/accordion-header/save.js
@@ -7,10 +7,7 @@ import clsx from 'clsx';
  */
 import {
 	useBlockProps,
-	__experimentalGetBorderClassesAndStyles as getBorderClassesAndStyles,
-	__experimentalGetColorClassesAndStyles as getColorClassesAndStyles,
 	__experimentalGetSpacingClassesAndStyles as getSpacingClassesAndStyles,
-	__experimentalGetShadowClassesAndStyles as getShadowClassesAndStyles,
 	RichText,
 } from '@wordpress/block-editor';
 
@@ -18,31 +15,15 @@ export default function save( { attributes } ) {
 	const { level, title, iconPosition, textAlign, showIcon } = attributes;
 	const TagName = 'h' + level;
 
-	const blockProps = useBlockProps.save();
-	const borderProps = getBorderClassesAndStyles( attributes );
-	const colorProps = getColorClassesAndStyles( attributes );
+	const blockProps = useBlockProps.save( {
+		className: clsx( 'accordion-content__heading', {
+			[ `has-text-align-${ textAlign }` ]: textAlign,
+		} ),
+	} );
 	const spacingProps = getSpacingClassesAndStyles( attributes );
-	const shadowProps = getShadowClassesAndStyles( attributes );
 
 	return (
-		<TagName
-			{ ...blockProps }
-			className={ clsx(
-				blockProps.className,
-				colorProps.className,
-				borderProps.className,
-				'accordion-content__heading',
-				{
-					[ `has-custom-font-size` ]: blockProps?.style?.fontSize,
-					[ `has-text-align-${ textAlign }` ]: textAlign,
-				}
-			) }
-			style={ {
-				...borderProps.style,
-				...colorProps.style,
-				...shadowProps.style,
-			} }
-		>
+		<TagName { ...blockProps }>
 			<button
 				className={ clsx( 'accordion-content__toggle' ) }
 				style={ {


### PR DESCRIPTION
Related to #71732

## What? Why?

The Accordion Header Block applies some block support styles to the `button` inside the block. While this approach is correct, it is somewhat verbose to implement and prone to breaking in the future when new block support is added.

Additionally, the current implementation does not take into account the inline styles generated by the typography support, so custom font sizes, text decorations, etc. will not work.

## How?

- Apply `__experimentalSkipSerialization` to the spacing support
- Remove the redundant code

## Testing Instructions

All blocks supports should work.
