### PR TITLE
Fixes Accordion block width issue when applying padding

### DIFF
--- a/packages/block-library/src/accordion/style.scss
+++ b/packages/block-library/src/accordion/style.scss
@@ -1,3 +1,7 @@
+.wp-block-accordion {
+	box-sizing: border-box;
+}
+
 .wp-block-accordion-content {
 	display: grid;
 	grid-template-rows: max-content 0fr;

--- a/packages/block-library/src/accordion/style.scss
+++ b/packages/block-library/src/accordion/style.scss
@@ -1,4 +1,5 @@
 .wp-block-accordion {
+	// This block allows custom padding, margin, and border, as it affects how the block’s width and height are calculated.
 	box-sizing: border-box;
 }
 


### PR DESCRIPTION
## What?
Closes  #71803

## Why?
When changes padding from accordion block settings, the width of block is not align with other blocks.

## How?
When adding `box-sizing: border-box` styling to parent of this block `.wp-block-accordion`, then width is looking similar to other blocks.

## Screenshots
### **Before**
<img width="400" height="400" alt="Screenshot 2025-09-22 at 1 53 10 PM" src="https://github.com/user-attachments/assets/639bd02b-871a-4119-8aa4-3a83c84f4e86" />

### **After**
<img width="400" height="400" alt="Screenshot 2025-09-22 at 1 52 06 PM" src="https://github.com/user-attachments/assets/cc624a59-b401-4ba6-8676-311a88dac6d4" />

