### PR TITLE
DataViews: Fix ListView focus stealing from search input

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- DataViews: Fix ListView focus stealing from search input during typing. [#71810](https://github.com/WordPress/gutenberg/pull/71810/)
 - DataViews: keep non-hideable fields out of the hidden-fields list when they’re already invisible. [#71729](https://github.com/WordPress/gutenberg/pull/71729/)
 
 ### Enhancements

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -421,11 +421,22 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 	// Update the active composite item when the selected item changes.
 	useEffect( () => {
 		if ( selectedItem ) {
-			setActiveCompositeId(
-				generateItemWrapperCompositeId(
-					generateCompositeItemIdPrefix( selectedItem )
-				)
+			// Check if the search field is currently focused to prevent focus stealing during search.
+			const searchField = document.querySelector(
+				'.dataviews-search input'
 			);
+			const isSearchFocused =
+				searchField &&
+				searchField.ownerDocument.activeElement === searchField;
+
+			// Only update active composite if search is not focused.
+			if ( ! isSearchFocused ) {
+				setActiveCompositeId(
+					generateItemWrapperCompositeId(
+						generateCompositeItemIdPrefix( selectedItem )
+					)
+				);
+			}
 		}
 	}, [ selectedItem, generateCompositeItemIdPrefix ] );
 
@@ -456,7 +467,19 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 			const targetCompositeItemId = generateCompositeId( itemIdPrefix );
 
 			setActiveCompositeId( targetCompositeItemId );
-			document.getElementById( targetCompositeItemId )?.focus();
+
+			// Check if the search field is currently focused to prevent focus stealing during search.
+			const searchField = document.querySelector(
+				'.dataviews-search input'
+			);
+			const isSearchFocused =
+				searchField &&
+				searchField.ownerDocument.activeElement === searchField;
+
+			// Only focus the composite item if search is not focused.
+			if ( ! isSearchFocused ) {
+				document.getElementById( targetCompositeItemId )?.focus();
+			}
 		},
 		[ data, generateCompositeItemIdPrefix ]
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #67758

<!-- In a few words, what is the PR actually doing? -->
It Fixes focus stealing from search input in DataViews ListView layout.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
In the DataViews ListView layout, when users type in the search field, focus would automatically jump to list items as the search
  results updated. This made it impossible to complete typing a search query, as the focus would move away from the search input
  mid-typing.

  This issue was unique to ListView because it uses a `Composite` component with automatic focus management that updates
  `activeCompositeId` whenever the selected item changes. GridView and TableView don't have this problem as they use simpler focus management without automatic focus updates.
  
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The fix adds focus protection by checking if the search input field is currently focused before moving focus to list items.
  Specifically:

  1. **In the `useEffect` for selection changes**: Before updating `activeCompositeId`, check if the search field has focus
  2. **In the `selectCompositeItem` function**: Before calling `focus()` on composite items, check if the search field has focus


 This approach preserves all existing functionality:
  - Keyboard navigation still works when not searching
  - Focus management works normally for mouse interactions
  - All accessibility features remain intact


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
  1. Open the storybook story for DataViews
  2. Switch to ListView layout
  3. Click in the search field
  4. Start typing a search query (e.g., "eu")
  5. Verify that focus remains in the search field throughout typing

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
  1. Open the storybook story for DataViews
  2. Tab to the search field
  3. Type a search query using only the keyboard
  4. Verify focus stays in the search field during typing
  5. Press Tab to move focus away from search and move it to list items
  6. Use arrow keys to navigate through list items
  
## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before
https://github.com/user-attachments/assets/ca38f6d0-3427-4642-92fd-b6689966dc8a

### After
https://github.com/user-attachments/assets/050f68d3-fac8-45ee-b603-95be9fee5b2b








