### PR TITLE
Block Bindings: Fix pattern override bug, editing was allowed on non enabled overrides blocks.

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -253,9 +253,11 @@ export function RichTextWrapper(
 			blockContext,
 		]
 	);
+	const arePatternOverridesEnabled =
+		blockBindings?.__default?.source === 'core/pattern-overrides';
 
-	const shouldDisableEditing = readOnly || disableBoundBlock;
-
+	const shouldDisableEditing =
+		readOnly || disableBoundBlock || ! arePatternOverridesEnabled;
 	const { getSelectionStart, getSelectionEnd, getBlockRootClientId } =
 		useSelect( blockEditorStore );
 	const { selectionChange } = useDispatch( blockEditorStore );

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -253,11 +253,16 @@ export function RichTextWrapper(
 			blockContext,
 		]
 	);
-	const arePatternOverridesEnabled =
+	const isInsidePatternOverrides = !! blockContext?.[ 'pattern/overrides' ];
+	const hasOverrideEnabled =
 		blockBindings?.__default?.source === 'core/pattern-overrides';
 
+	const shouldDisableForPattern =
+		isInsidePatternOverrides && ! hasOverrideEnabled;
+
 	const shouldDisableEditing =
-		readOnly || disableBoundBlock || ! arePatternOverridesEnabled;
+		readOnly || disableBoundBlock || shouldDisableForPattern;
+
 	const { getSelectionStart, getSelectionEnd, getBlockRootClientId } =
 		useSelect( blockEditorStore );
 	const { selectionChange } = useDispatch( blockEditorStore );

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -241,7 +241,7 @@ test.describe( 'Pattern Overrides', () => {
 			<!-- wp:paragraph {"metadata":{"name":"Pattern Overrides","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
 			<p>Pattern Overrides</p>
 			<!-- /wp:paragraph -->
-			<!-- wp:paragraph {"metadata":{"name":"Post Meta Binding","bindings":{"content":{"source":"core/post-meta","args":{"key":"text_custom_field"}}}}} -->
+			<!-- wp:paragraph {"metadata":{"name":"Post Meta Binding","bindings":{"content":{"source":"core/post-meta","args":{"key":"Post Meta Binding"}}}}} -->
 			<p>Post Meta Binding</p>
 			<!-- /wp:paragraph -->
 			<!-- wp:paragraph {"metadata":{"name":"No Overrides or Binding"}} -->

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -789,6 +789,71 @@ test.describe( 'Pattern Overrides', () => {
 		await expect( buttonLink ).toHaveAttribute( 'rel', /^\s*nofollow\s*$/ );
 	} );
 
+	test( 'should disable editing for pattern blocks without overrides enabled, even when mixed with bound attributes', async ( {
+		page,
+		admin,
+		requestUtils,
+		editor,
+	} ) => {
+		const { id } = await requestUtils.createBlock( {
+			title: 'Pattern',
+			content: `<!-- wp:paragraph {"metadata":{"name":"Post Meta Binding","bindings":{"content":{"source":"testing/complete-source","args":{"key":"text_field"}},"__default":{"source":"core/pattern-overrides"}}}} -->
+<p>Post Meta Binding</p>
+<!-- /wp:paragraph -->
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"metadata":{"name":"Read Only Button","bindings":{"url":{"source":"core/post-meta","args":{"key":"Post Meta Binding"}}}}} -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Read Only Button Text</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->`,
+			status: 'publish',
+		} );
+
+		await admin.createNewPost();
+		await editor.insertBlock( {
+			name: 'core/block',
+			attributes: { ref: id },
+		} );
+
+		const patternBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Pattern',
+		} );
+
+		await expect(
+			patternBlock.getByText( 'Text Field Value' )
+		).toBeVisible();
+		await expect(
+			patternBlock.getByText( 'Read Only Button Text' )
+		).toBeVisible();
+
+		const editableParagraph = patternBlock
+			.getByRole( 'document', {
+				name: 'Block: Paragraph',
+				includeHidden: true,
+			} )
+			.filter( { hasText: 'Text Field Value' } );
+		const nonEditableButton = patternBlock
+			.getByRole( 'document', {
+				name: 'Block: Button',
+				exact: true,
+				includeHidden: true,
+			} )
+			.filter( { hasText: 'Read Only Button Text' } );
+
+		await editableParagraph.click();
+		await editableParagraph.focus();
+		await page.keyboard.type( ' Edited' );
+		await expect( editableParagraph ).toHaveText(
+			'Text Field Value Edited'
+		);
+
+		// Button with only URL binding (no pattern overrides) should not have editable text.
+		await nonEditableButton.click();
+		const initialText = await nonEditableButton.textContent();
+		await page.keyboard.type( 'Edited' );
+		const finalText = await nonEditableButton.textContent();
+		expect( initialText ).toBe( finalText );
+	} );
+
 	test( 'resets overrides after clicking the reset button', async ( {
 		page,
 		admin,

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -12,6 +12,9 @@ test.describe( 'Pattern Overrides', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await Promise.all( [
 			requestUtils.activateTheme( 'emptytheme' ),
+			await requestUtils.activatePlugin(
+				'gutenberg-test-block-bindings'
+			),
 			requestUtils.deleteAllBlocks(),
 		] );
 	} );
@@ -24,6 +27,7 @@ test.describe( 'Pattern Overrides', () => {
 	test.afterAll( async ( { requestUtils } ) => {
 		await Promise.all( [
 			requestUtils.activateTheme( 'twentytwentyone' ),
+			requestUtils.deactivatePlugin( 'gutenberg-test-block-bindings' ),
 		] );
 	} );
 
@@ -237,7 +241,7 @@ test.describe( 'Pattern Overrides', () => {
 			<!-- wp:paragraph {"metadata":{"name":"Pattern Overrides","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
 			<p>Pattern Overrides</p>
 			<!-- /wp:paragraph -->
-			<!-- wp:paragraph {"metadata":{"name":"Post Meta Binding","bindings":{"content":{"source":"core/post-meta","args":{"key":"Post Meta Binding"}}}}} -->
+			<!-- wp:paragraph {"metadata":{"name":"Post Meta Binding","bindings":{"content":{"source":"core/post-meta","args":{"key":"text_custom_field"}}}}} -->
 			<p>Post Meta Binding</p>
 			<!-- /wp:paragraph -->
 			<!-- wp:paragraph {"metadata":{"name":"No Overrides or Binding"}} -->
@@ -801,7 +805,7 @@ test.describe( 'Pattern Overrides', () => {
 <p>Edit me</p>
 <!-- /wp:paragraph -->
 <!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button {"metadata":{"name":"Read Only Button","bindings":{"url":{"source":"core/post-meta","args":{"key":"Post Meta Binding"}}}}} -->
+<div class="wp-block-buttons"><!-- wp:button {"metadata":{"name":"Read Only Button","bindings":{"url":{"source":"core/post-meta","args":{"key":"text_custom_field"}}}}} -->
 <div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Read Only Button Text</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->`,
@@ -848,6 +852,35 @@ test.describe( 'Pattern Overrides', () => {
 		await page.keyboard.type( 'Edited' );
 		const finalText = await nonEditableButton.textContent();
 		expect( initialText ).toBe( finalText );
+
+		await nonEditableButton.click();
+		await editor.showBlockToolbar();
+
+		// Open the link control
+		const linkButton = page.getByRole( 'button', {
+			name: 'Link',
+			exact: true,
+		} );
+		await linkButton.click();
+
+		const urlInput = page.getByPlaceholder( 'Search or type URL' );
+		await urlInput.fill( '#test' );
+
+		// Save the link
+		const saveLinkButton = page.locator(
+			'.block-editor-link-control__search-submit'
+		);
+		await saveLinkButton.click();
+
+		// Publish the post
+		const postId = await editor.publishPost();
+
+		// Check on the frontend that the URL was updated
+		await page.goto( `/?p=${ postId }` );
+		const frontendButton = page.getByRole( 'link', {
+			name: 'Button Text',
+		} );
+		await expect( frontendButton ).toHaveAttribute( 'href', '#test' );
 	} );
 
 	test( 'resets overrides after clicking the reset button', async ( {

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -797,8 +797,8 @@ test.describe( 'Pattern Overrides', () => {
 	} ) => {
 		const { id } = await requestUtils.createBlock( {
 			title: 'Pattern',
-			content: `<!-- wp:paragraph {"metadata":{"name":"Post Meta Binding","bindings":{"content":{"source":"testing/complete-source","args":{"key":"text_field"}},"__default":{"source":"core/pattern-overrides"}}}} -->
-<p>Post Meta Binding</p>
+			content: `<!-- wp:paragraph {"metadata":{"name":"Post Meta Binding","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
+<p>Edit me</p>
 <!-- /wp:paragraph -->
 <!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button {"metadata":{"name":"Read Only Button","bindings":{"url":{"source":"core/post-meta","args":{"key":"Post Meta Binding"}}}}} -->
@@ -818,9 +818,7 @@ test.describe( 'Pattern Overrides', () => {
 			name: 'Block: Pattern',
 		} );
 
-		await expect(
-			patternBlock.getByText( 'Text Field Value' )
-		).toBeVisible();
+		await expect( patternBlock.getByText( 'Edit me' ) ).toBeVisible();
 		await expect(
 			patternBlock.getByText( 'Read Only Button Text' )
 		).toBeVisible();
@@ -830,7 +828,7 @@ test.describe( 'Pattern Overrides', () => {
 				name: 'Block: Paragraph',
 				includeHidden: true,
 			} )
-			.filter( { hasText: 'Text Field Value' } );
+			.filter( { hasText: 'Edit me' } );
 		const nonEditableButton = patternBlock
 			.getByRole( 'document', {
 				name: 'Block: Button',
@@ -841,10 +839,8 @@ test.describe( 'Pattern Overrides', () => {
 
 		await editableParagraph.click();
 		await editableParagraph.focus();
-		await page.keyboard.type( ' Edited' );
-		await expect( editableParagraph ).toHaveText(
-			'Text Field Value Edited'
-		);
+		await page.keyboard.type( ' - Edited' );
+		await expect( editableParagraph ).toHaveText( 'Edit me - Edited' );
 
 		// Button with only URL binding (no pattern overrides) should not have editable text.
 		await nonEditableButton.click();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71768

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Explained in #71768. Quick summary:

If you have a pattern override, with one block with overrides enabled, and the other one with overrides disabled. If this second one has any bound attribute, it becomes editable when it should not.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Make an additional check on richtext that contains `__default` attribute that makes the block override enabled.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Create a pattern with this structure.

```html
<!-- wp:paragraph {"metadata":{"name":"Post Meta Binding","bindings":{"content":{"source":"testing/complete-source","args":{"key":"text_field"}},"__default":{"source":"core/pattern-overrides"}}}} -->
<p>Post Meta Binding</p>
<!-- /wp:paragraph -->
<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"metadata":{"name":"Read Only Button","bindings":{"url":{"source":"core/post-meta","args":{"key":"Post Meta Binding"}}}}} -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Read Only Button Text</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->
```
- Register the meta so can be updated.
- Check that the URL button is bound.
- Create a new post, add the pattern.
- Check you can edit the first field.
- Check that the button text is not edited.

The issue has a more detailed explanation about how to debug it. There is also a new e2e.