### PR TITLE
Prevent Esc from executing change event in Category Widget

### DIFF
--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -101,7 +101,7 @@ function build_dropdown_script_block_core_categories( $dropdown_id ) {
 	ob_start();
 	?>
 	<script>
-	(function() {
+	( function() {
 		var dropdown = document.getElementById('<?php echo esc_js( $dropdown_id ); ?>'), lastKey;
 
 		function onSelectChange(e) {
@@ -135,7 +135,7 @@ function build_dropdown_script_block_core_categories( $dropdown_id ) {
 	})();
 	</script>
 	<?php
-	return wp_get_inline_script_tag(str_replace(array('<script>', '</script>'), '', ob_get_clean()));
+	return wp_get_inline_script_tag( str_replace( array ('<script>', '</script>' ), '', ob_get_clean()));
 }
 
 /**

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -97,7 +97,7 @@ function render_block_core_categories( $attributes, $content, $block ) {
  *
  * @return string Returns the dropdown onChange redirection script.
  */
-function gutenberg_build_dropdown_script_block_core_categories( $dropdown_id ) {
+function build_dropdown_script_block_core_categories( $dropdown_id ) {
 	ob_start();
 	?>
 	<script>

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -112,7 +112,7 @@ function build_dropdown_script_block_core_categories( $dropdown_id ) {
 				}
 				var value = dropdown.options[dropdown.selectedIndex].value;
 				if (value && value !== '-1') {
-					location.href = "<?php echo esc_url(home_url()); ?>/?"
+					location.href = "<?php echo esc_url( home_url() ); ?>/?"
 						+ encodeURIComponent(dropdown.name) + '='
 						+ encodeURIComponent(value);
 				}

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -104,7 +104,7 @@ function build_dropdown_script_block_core_categories( $dropdown_id ) {
 	( function() {
 		var dropdown = document.getElementById('<?php echo esc_js( $dropdown_id ); ?>'), lastKey;
 
-		function onSelectChange(e) {
+		function onCatChange(e) {
 			setTimeout(function() {
 				lastKey = dropdown.getAttribute('data-lastkey');
 				if ('change' === e.type && 'escape' === lastKey) {
@@ -131,7 +131,7 @@ function build_dropdown_script_block_core_categories( $dropdown_id ) {
 			dropdown.removeAttribute('data-lastkey');
 		});
 
-		dropdown.onchange = onSelectChange;
+		dropdown.onchange = onCatChange;
 	})();
 	</script>
 	<?php

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -97,22 +97,45 @@ function render_block_core_categories( $attributes, $content, $block ) {
  *
  * @return string Returns the dropdown onChange redirection script.
  */
-function build_dropdown_script_block_core_categories( $dropdown_id ) {
+function gutenberg_build_dropdown_script_block_core_categories( $dropdown_id ) {
 	ob_start();
 	?>
 	<script>
-	( function() {
-		var dropdown = document.getElementById( '<?php echo esc_js( $dropdown_id ); ?>' );
-		function onCatChange() {
-			if ( dropdown.options[ dropdown.selectedIndex ].value !== -1 ) {
-				location.href = "<?php echo esc_url( home_url() ); ?>/?" + dropdown.name + '=' + dropdown.options[ dropdown.selectedIndex ].value;
-			}
+	(function() {
+		var dropdown = document.getElementById('<?php echo esc_js( $dropdown_id ); ?>'), lastKey;
+
+		function onSelectChange(e) {
+			setTimeout(function() {
+				lastKey = dropdown.getAttribute('data-lastkey');
+				if ('change' === e.type && 'escape' === lastKey) {
+					return;
+				}
+				var value = dropdown.options[dropdown.selectedIndex].value;
+				if (value && value !== '-1') {
+					location.href = "<?php echo esc_url(home_url()); ?>/?"
+						+ encodeURIComponent(dropdown.name) + '='
+						+ encodeURIComponent(value);
+				}
+			}, 250);
 		}
-		dropdown.onchange = onCatChange;
+
+		dropdown.addEventListener('keyup', function(e) {
+			if (e.key === 'Escape') {
+				dropdown.setAttribute('data-lastkey', 'escape');
+			} else {
+				dropdown.removeAttribute('data-lastkey');
+			}
+		});
+
+		dropdown.addEventListener('click', function() {
+			dropdown.removeAttribute('data-lastkey');
+		});
+
+		dropdown.onchange = onSelectChange;
 	})();
 	</script>
 	<?php
-	return wp_get_inline_script_tag( str_replace( array( '<script>', '</script>' ), '', ob_get_clean() ) );
+	return wp_get_inline_script_tag(str_replace(array('<script>', '</script>'), '', ob_get_clean()));
 }
 
 /**

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -135,7 +135,7 @@ function build_dropdown_script_block_core_categories( $dropdown_id ) {
 	})();
 	</script>
 	<?php
-	return wp_get_inline_script_tag( str_replace( array ('<script>', '</script>' ), '', ob_get_clean()));
+	return wp_get_inline_script_tag( str_replace( array( '<script>', '</script>' ), '', ob_get_clean() ) );
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes [#71788](https://github.com/WordPress/gutenberg/issues/71788)

<!-- In a few words, what is the PR actually doing? -->

## Why? How ?
- Modifies the script for the category widget dropdown select to prevent esc from submitting

## Testing Instructions
1. Add a block Category list(Term List) widget.
2. Set as dropdown mode.
3. On Windows/Chrome, Windows/Firefox, or Linux/Chromium, open the select from the keyboard, use the arrow key to navigate, then use esc to close.

