### PR TITLE
Use multiple rect for menu icon

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -481,7 +481,7 @@ class WP_Navigation_Block_Renderer {
 		$toggle_button_icon        = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5" /><rect x="4" y="15" width="16" height="1.5" /></svg>';
 		if ( isset( $attributes['icon'] ) ) {
 			if ( 'menu' === $attributes['icon'] ) {
-				$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5 5v1.5h14V5H5zm0 7.8h14v-1.5H5v1.5zM5 19h14v-1.5H5V19z" /></svg>';
+				$toggle_button_icon = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="5" y="5" width="14" height="1.5"/><rect x="5" y="11.3" width="14" height="1.5"/><rect x="5" y="17.5" width="14" height="1.5"/></svg>';
 			}
 		}
 		$toggle_button_content       = $should_display_icon_label ? $toggle_button_icon : __( 'Menu' );


### PR DESCRIPTION

## What?
Second option to Closes https://github.com/WordPress/gutenberg/issues/71791

## How?
Solves the issue by spiting the icon into 3 _rect_ tags

## Testing Instructions
1. Add a navigation block to website
2. Set the navigation block to show the menu icon
3. Inspect the menu icon

