### PR TITLE
Block Commenting: Don't show unpinnable sidebar on mobile viewports

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -9,6 +9,7 @@ import {
 	subscribe,
 } from '@wordpress/data';
 import { useState, useMemo } from '@wordpress/element';
+import { useViewportMatch } from '@wordpress/compose';
 import { comment as commentIcon } from '@wordpress/icons';
 import { addFilter } from '@wordpress/hooks';
 import { store as noticesStore } from '@wordpress/notices';
@@ -238,6 +239,7 @@ export default function CollabSidebar() {
 	const [ showCommentBoard, setShowCommentBoard ] = useState( false );
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
 	const { getActiveComplementaryArea } = useSelect( interfaceStore );
+	const isLargeViewport = useViewportMatch( 'medium' );
 
 	const { postId, postType } = useSelect( ( select ) => {
 		const { getCurrentPostId, getCurrentPostType } = select( editorStore );
@@ -386,22 +388,24 @@ export default function CollabSidebar() {
 					setShowCommentBoard={ setShowCommentBoard }
 				/>
 			</PluginSidebar>
-			<PluginSidebar
-				isPinnable={ false }
-				header={ false }
-				identifier={ collabSidebarName }
-				className="editor-collab-sidebar"
-				headerClassName="editor-collab-sidebar__header"
-			>
-				<CollabSidebarContent
-					comments={ unresolvedSortedThreads }
-					showCommentBoard={ showCommentBoard }
-					setShowCommentBoard={ setShowCommentBoard }
-					styles={ {
-						backgroundColor,
-					} }
-				/>
-			</PluginSidebar>
+			{ isLargeViewport && (
+				<PluginSidebar
+					isPinnable={ false }
+					header={ false }
+					identifier={ collabSidebarName }
+					className="editor-collab-sidebar"
+					headerClassName="editor-collab-sidebar__header"
+				>
+					<CollabSidebarContent
+						comments={ unresolvedSortedThreads }
+						showCommentBoard={ showCommentBoard }
+						setShowCommentBoard={ setShowCommentBoard }
+						styles={ {
+							backgroundColor,
+						} }
+					/>
+				</PluginSidebar>
+			) }
 		</>
 	);
 }


### PR DESCRIPTION
## What?

This PR fixes the issue of not being able to edit content on the mobile viewport by not rendering the unpinnable sidebar on the mobile viewport.

Closes #71718

## Why?

There are two types of sidebars.

### Pinnable Sidebar

It can be accessed from the block toolbar or the comments button in the header. This sidebar has a close button.

<img width="663" height="368" alt="image" src="https://github.com/user-attachments/assets/f293b22b-83a7-4c5d-826c-5f6db6d61009" />

### Unpinnable Sidebar

Shown by default when the Post Sidebar is hidden. This sidebar doesn't have a close button:

<img width="726" height="353" alt="image" src="https://github.com/user-attachments/assets/749ed962-2091-49dd-ac4d-902d605babd4" />

The fundamental problem is that this unpinnable sidebar takes up the entire screen in mobile layouts and cannot be closed.

## How?

Don't show the unpinnable sidebar on mobile viewports. Even without the unpinnable sidebar, there is still a way to access the comments sidebar from the mobile layout by clicking the Comment button on the block toolbar.

## Testing Instructions

Narrow your browser and make sure you can always access the comments.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/ee08e94d-8e84-449f-92e6-4dbc04cb9a64
