### PR TITLE
Fix creating templates for posts with long slugs

### DIFF
--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
@@ -17,6 +17,7 @@ import { useEntityRecords } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useDebouncedInput } from '@wordpress/compose';
 import { focus } from '@wordpress/dom';
+import { safeDecodeURI } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -67,7 +68,7 @@ function SuggestionListItem( {
 					lineHeight={ 1.53846153846 } // 20px
 					className={ `${ baseCssClass }__info` }
 				>
-					{ suggestion.link }
+					{ safeDecodeURI( suggestion.link ) }
 				</Text>
 			) }
 		</Composite.Item>

--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -7,6 +7,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { useMemo, useCallback } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { blockMeta, post, archive } from '@wordpress/icons';
+import { safeDecodeURI } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -28,6 +29,20 @@ const getValueFromObjectPath = ( object, path ) => {
 	} );
 	return value;
 };
+
+/**
+ * Helper that adds a prefix to a post slug. The slug needs to be URL-decoded first,
+ * so that we have raw Unicode characters there. The server will truncate the slug to
+ * 200 characters, respecing Unicode char boundary. On the other hand, the server
+ * doesn't detect urlencoded octet boundary and can possibly construct slugs that
+ * are not valid urlencoded strings.
+ * @param {string} prefix The prefix to add to the slug.
+ * @param {string} slug   The slug to add the prefix to.
+ * @return {string} The slug with the prefix.
+ */
+function prefixSlug( prefix, slug ) {
+	return `${ prefix }-${ safeDecodeURI( slug ) }`;
+}
 
 /**
  * Helper util to map records to add a `name` prop from a
@@ -306,7 +321,10 @@ export const usePostTypeMenuItems = ( onClickMenuItem ) => {
 								};
 							},
 							getSpecificTemplate: ( suggestion ) => {
-								const templateSlug = `${ templatePrefixes[ slug ] }-${ suggestion.slug }`;
+								const templateSlug = prefixSlug(
+									templatePrefixes[ slug ],
+									suggestion.slug
+								);
 								return {
 									title: templateSlug,
 									slug: templateSlug,
@@ -460,7 +478,10 @@ export const useTaxonomiesMenuItems = ( onClickMenuItem ) => {
 								};
 							},
 							getSpecificTemplate: ( suggestion ) => {
-								const templateSlug = `${ templatePrefixes[ slug ] }-${ suggestion.slug }`;
+								const templateSlug = prefixSlug(
+									templatePrefixes[ slug ],
+									suggestion.slug
+								);
 								return {
 									title: templateSlug,
 									slug: templateSlug,
@@ -545,7 +566,10 @@ export function useAuthorMenuItem( onClickMenuItem ) {
 						};
 					},
 					getSpecificTemplate: ( suggestion ) => {
-						const templateSlug = `author-${ suggestion.slug }`;
+						const templateSlug = prefixSlug(
+							'author',
+							suggestion.slug
+						);
 						return {
 							title: sprintf(
 								// translators: %s: Name of the author e.g: "Admin".


### PR DESCRIPTION
Fixes the following bug when creating a template for a single post:
1. Create post with a long non-latin title: `รีวิว Secretlab MAGNUS Pro Lamborghini Edition: เมื่อโต๊ะเกมมิ่งไม่ใช่แค่โต๊ะ แต่คือ “Supercar” ในห้องคุณ`
2. Go to Site Editor, Templates, click "Add Template", choose "Single item: Post", for a specific post, and choose the new post with the long title as the post that the template applies to.
3. Creating the template will fail, the REST request will return a 500 internal server error and there will be a PHP fatal on the server.

What happened?
1. The post has a long title, and the database column for post slugs (`wp_posts.post_name`) is limited to 200 chars. The new post's slug will be longer than that, especially when urlencoded. But the PHP `sanitize_title_with_dashes` function in Core will correctly truncate it to 200 chars, carefully respecting boundaries of utf-8 multiple-byte characters and of urlencoded octets.
2. Things get worse when Gutenberg tries to create a template from this post, generating a slug with a prefix: `single-post-${ postSlug }`. Here we are acting on urlencoded `postSlug` and the urlencoded template slug (now longer than 200 chars) will be sent as payload of the REST request that creates the template.
3. Unfortunately `sanitize_title_with_dashes` is careful only when dealing with a string that's not urlencoded. It correctly truncates and encodes raw utf-8 characters. But an urlencoded string will be truncated bluntly, and we're left with a slug that's not a valid urlencoded string. It looks something like `...%b8%81%e`.
4. Things will start going downhill. The `create_item` function of the templates controller will crash. Requests to DELETE the new template will be rejected by the Apache server itself, because the URL contains the wrongly encoded slug.

I'm fixing this by decoding the original post slug before appending the prefix. Then the REST request will contain a slug string with raw utf-8 characters, and `sanitize_title_with_dashes` will be able to truncate it nicely.

We should also do a companion Core patch that addresses the crashes. But this Gutenberg fix is good enough to get rid of the issue.