### PR TITLE
Template activation: call get_block_templates filter when short-circuiting

### DIFF
--- a/backport-changelog/6.9/8063.md
+++ b/backport-changelog/6.9/8063.md
@@ -1,6 +1,7 @@
 https://github.com/WordPress/wordpress-develop/pull/8063
 
 * https://github.com/WordPress/gutenberg/pull/67125
+* https://github.com/WordPress/gutenberg/pull/71840
 * https://github.com/WordPress/gutenberg/pull/71811
 * https://github.com/WordPress/gutenberg/pull/72029
 * https://github.com/WordPress/gutenberg/pull/72049

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -172,11 +172,6 @@ function gutenberg_get_template( $template, $type, $templates ) {
 	return gutenberg_locate_block_template( $template, $type, $templates );
 }
 
-function testtesttest( $templates, $query, $template_type ) {
-	var_dump( $templates, $query, $template_type );
-	return $templates;
-}
-
 ///////////////////////////////////////////////////////////////////////
 // This function is a copy of core's, except for the marked section. //
 ///////////////////////////////////////////////////////////////////////

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -256,7 +256,9 @@ function gutenberg_resolve_block_template( $template_type, $template_hierarchy, 
 			$templates,
 			array(
 				'slug__in' => array_map(
-					fn( $template ) => $template->slug,
+					function ( $template ) {
+						return $template->slug;
+					},
 					$templates
 				),
 			),

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -172,6 +172,11 @@ function gutenberg_get_template( $template, $type, $templates ) {
 	return gutenberg_locate_block_template( $template, $type, $templates );
 }
 
+function testtesttest( $templates, $query, $template_type ) {
+	var_dump( $templates, $query, $template_type );
+	return $templates;
+}
+
 ///////////////////////////////////////////////////////////////////////
 // This function is a copy of core's, except for the marked section. //
 ///////////////////////////////////////////////////////////////////////
@@ -247,6 +252,21 @@ function gutenberg_resolve_block_template( $template_type, $template_hierarchy, 
 		}
 
 		$templates[] = $template;
+	}
+
+	// Apply the filter to the active templates for backward compatibility.
+	if ( ! empty( $templates ) ) {
+		$templates = apply_filters(
+			'get_block_templates',
+			$templates,
+			array(
+				'slug__in' => array_map(
+					fn( $template ) => $template->slug,
+					$templates
+				),
+			),
+			'wp_template'
+		);
 	}
 
 	// For any remaining slugs, use the static template.


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71770



<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Some plugins expect `get_block_templates` to always be called, which no longer happens when we return a template through `pre_get_block_templates`. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Run the `get_block_templates` filter ourselves before returning the new template.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->


```
add_filter(
	'get_block_templates',
	function ( $templates, $query ) {
		do_action( 'qm/debug', $query );
		array_map(
			function ( $template ) {
				do_action( 'qm/debug', $template ); // use any method to log data
			},
			$templates
		);
		return $templates;
	},
	10,
	2
);
```

Run this code to log when `get_block_templates` is called. For example, when activating a custom 404 template, it should still log a call with the 404 template, not just the index template.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
