### PR TITLE
Time To Read: Add a word count option

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -724,7 +724,7 @@ Show minutes required to finish reading the post. ([Source](https://github.com/W
 -	**Experimental:** true
 -	**Category:** theme
 -	**Supports:** color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** averageReadingSpeed, displayAsRange, textAlign
+-	**Attributes:** averageReadingSpeed, displayAsRange, showTimeToRead, showWordCount, textAlign
 
 ## Title
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -718,7 +718,7 @@ Post terms. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages
 
 ## Time to Read
 
-Show minutes required to finish reading the post. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-time-to-read))
+Show minutes required to finish reading the post. Can also show a word count. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-time-to-read))
 
 -	**Name:** core/post-time-to-read
 -	**Experimental:** true

--- a/packages/block-library/src/post-time-to-read/block.json
+++ b/packages/block-library/src/post-time-to-read/block.json
@@ -5,7 +5,7 @@
 	"name": "core/post-time-to-read",
 	"title": "Time to Read",
 	"category": "theme",
-	"description": "Show minutes required to finish reading the post.",
+	"description": "Show minutes required to finish reading the post. Can also show a word count.",
 	"textdomain": "default",
 	"usesContext": [ "postId", "postType" ],
 	"attributes": {

--- a/packages/block-library/src/post-time-to-read/block.json
+++ b/packages/block-library/src/post-time-to-read/block.json
@@ -16,6 +16,14 @@
 			"type": "boolean",
 			"default": true
 		},
+		"showTimeToRead": {
+			"type": "boolean",
+			"default": true
+		},
+		"showWordCount": {
+			"type": "boolean",
+			"default": false
+		},
 		"averageReadingSpeed": {
 			"type": "number",
 			"default": 189

--- a/packages/block-library/src/post-time-to-read/edit.js
+++ b/packages/block-library/src/post-time-to-read/edit.js
@@ -79,7 +79,7 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 
 		const parts = [];
 
-		// Add time to read part if enabled
+		// Add "time to read" part, if enabled.
 		if ( showTimeToRead ) {
 			let timeString;
 			if ( displayAsRange ) {

--- a/packages/block-library/src/post-time-to-read/edit.js
+++ b/packages/block-library/src/post-time-to-read/edit.js
@@ -29,7 +29,14 @@ import { count as wordCount } from '@wordpress/wordcount';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
-	const { textAlign, displayAsRange, averageReadingSpeed } = attributes;
+	const {
+		textAlign,
+		displayAsRange,
+		showTimeToRead,
+		showWordCount,
+		averageReadingSpeed,
+	} = attributes;
+
 	const { postId, postType } = context;
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
@@ -44,7 +51,7 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 		id: postId,
 	} );
 
-	const minutesToReadString = useMemo( () => {
+	const displayString = useMemo( () => {
 		// Replicates the logic found in getEditedPostContent().
 		let content;
 		if ( contentStructure instanceof Function ) {
@@ -69,38 +76,73 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 		);
 
 		const totalWords = wordCount( content || '', wordCountType );
-		if ( displayAsRange ) {
-			let maxMinutes = Math.max(
-				1,
-				Math.round( ( totalWords / averageReadingSpeed ) * 1.2 )
-			);
-			const minMinutes = Math.max(
-				1,
-				Math.round( ( totalWords / averageReadingSpeed ) * 0.8 )
-			);
 
-			if ( minMinutes === maxMinutes ) {
-				maxMinutes = maxMinutes + 1;
+		const parts = [];
+
+		// Add time to read part if enabled
+		if ( showTimeToRead ) {
+			let timeString;
+			if ( displayAsRange ) {
+				let maxMinutes = Math.max(
+					1,
+					Math.round( ( totalWords / averageReadingSpeed ) * 1.2 )
+				);
+				const minMinutes = Math.max(
+					1,
+					Math.round( ( totalWords / averageReadingSpeed ) * 0.8 )
+				);
+
+				if ( minMinutes === maxMinutes ) {
+					maxMinutes = maxMinutes + 1;
+				}
+				// translators: %1$s: minimum minutes, %2$s: maximum minutes to read the post.
+				const rangeLabel = _x(
+					'%1$s–%2$s minutes',
+					'Range of minutes to read'
+				);
+				timeString = sprintf( rangeLabel, minMinutes, maxMinutes );
+			} else {
+				const minutesToRead = Math.max(
+					1,
+					Math.round( totalWords / averageReadingSpeed )
+				);
+
+				timeString = sprintf(
+					/* translators: %s: the number of minutes to read the post. */
+					_n( '%s minute', '%s minutes', minutesToRead ),
+					minutesToRead
+				);
 			}
-			// translators: %1$s: minimum minutes, %2$s: maximum minutes to read the post.
-			const rangeLabel = _x(
-				'%1$s–%2$s minutes',
-				'Range of minutes to read'
-			);
-			return sprintf( rangeLabel, minMinutes, maxMinutes );
+			parts.push( timeString );
 		}
 
-		const minutesToRead = Math.max(
-			1,
-			Math.round( totalWords / averageReadingSpeed )
-		);
+		// Add word count part
+		if ( showWordCount ) {
+			const wordCountString = sprintf(
+				/* translators: %s: the number of words in the post. */
+				_n( '%s word', '%s words', totalWords ),
+				totalWords.toLocaleString()
+			);
+			parts.push( wordCountString );
+		}
 
-		return sprintf(
-			/* translators: %s: the number of minutes to read the post. */
-			_n( '%s minute', '%s minutes', minutesToRead ),
-			minutesToRead
-		);
-	}, [ contentStructure, blocks, displayAsRange, averageReadingSpeed ] );
+		if ( parts.length === 1 ) {
+			return parts[ 0 ];
+		}
+		return parts.map( ( part, index ) => (
+			<span key={ index }>
+				{ part }
+				{ index < parts.length - 1 && <br /> }
+			</span>
+		) );
+	}, [
+		contentStructure,
+		blocks,
+		displayAsRange,
+		showTimeToRead,
+		showWordCount,
+		averageReadingSpeed,
+	] );
 
 	const blockProps = useBlockProps( {
 		className: clsx( {
@@ -124,37 +166,81 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 					resetAll={ () => {
 						setAttributes( {
 							displayAsRange: true,
+							showTimeToRead: true,
+							showWordCount: false,
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
-						isShownByDefault
-						label={ _x(
-							'Display as range',
-							'Turns reading time range display on or off'
-						) }
-						hasValue={ () => ! displayAsRange }
+						label={ __( 'Show time to read' ) }
+						hasValue={ () => ! showTimeToRead }
 						onDeselect={ () => {
 							setAttributes( {
-								displayAsRange: true,
+								showTimeToRead: true,
 							} );
 						} }
 					>
 						<ToggleControl
 							__nextHasNoMarginBottom
-							label={ __( 'Display as range' ) }
-							checked={ !! displayAsRange }
+							label={ __( 'Show time to read' ) }
+							checked={ !! showTimeToRead }
 							onChange={ () =>
 								setAttributes( {
-									displayAsRange: ! displayAsRange,
+									showTimeToRead: ! showTimeToRead,
+								} )
+							}
+						/>
+					</ToolsPanelItem>
+					{ showTimeToRead && (
+						<ToolsPanelItem
+							isShownByDefault
+							label={ _x(
+								'Display as range',
+								'Turns reading time range display on or off'
+							) }
+							hasValue={ () => ! displayAsRange }
+							onDeselect={ () => {
+								setAttributes( {
+									displayAsRange: true,
+								} );
+							} }
+						>
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={ __( 'Display as range' ) }
+								checked={ !! displayAsRange }
+								onChange={ () =>
+									setAttributes( {
+										displayAsRange: ! displayAsRange,
+									} )
+								}
+							/>
+						</ToolsPanelItem>
+					) }
+					<ToolsPanelItem
+						label={ __( 'Show word count' ) }
+						hasValue={ () => !! showWordCount }
+						onDeselect={ () => {
+							setAttributes( {
+								showWordCount: false,
+							} );
+						} }
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Show word count' ) }
+							checked={ !! showWordCount }
+							onChange={ () =>
+								setAttributes( {
+									showWordCount: ! showWordCount,
 								} )
 							}
 						/>
 					</ToolsPanelItem>
 				</ToolsPanel>
 			</InspectorControls>
-			<div { ...blockProps }>{ minutesToReadString }</div>
+			<div { ...blockProps }>{ displayString }</div>
 		</>
 	);
 }

--- a/packages/block-library/src/post-time-to-read/edit.js
+++ b/packages/block-library/src/post-time-to-read/edit.js
@@ -116,7 +116,7 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 			parts.push( timeString );
 		}
 
-		// Add word count part
+		// Add "word count" part, if enabled.
 		if ( showWordCount ) {
 			const wordCountString = sprintf(
 				/* translators: %s: the number of words in the post. */

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -20,32 +20,52 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 
 	$content              = get_the_content();
 	$average_reading_rate = isset( $attributes['averageReadingSpeed'] ) ? $attributes['averageReadingSpeed'] : 189;
+	$show_time_to_read    = isset( $attributes['showTimeToRead'] ) ? $attributes['showTimeToRead'] : true;
+	$show_word_count      = isset( $attributes['showWordCount'] ) ? $attributes['showWordCount'] : false;
 	$word_count_type      = wp_get_word_count_type();
 	$total_words          = wp_word_count( $content, $word_count_type );
 
-	if ( ! empty( $attributes['displayAsRange'] ) ) {
-		// Calculate faster reading rate with 20% speed = lower minutes,
-		// and slower reading rate with 20% speed = higher minutes.
-		$min_minutes = max( 1, (int) round( $total_words / $average_reading_rate * 0.8 ) );
-		$max_minutes = max( 1, (int) round( $total_words / $average_reading_rate * 1.2 ) );
-		if ( $min_minutes === $max_minutes ) {
-			$max_minutes = $min_minutes + 1;
-		}
-		/* translators: 1: minimum minutes, 2: maximum minutes to read the post. */
-		$minutes_to_read_string = sprintf(
+	$parts = array();
+
+	// Add time to read part if enabled
+	if ( $show_time_to_read ) {
+		if ( ! empty( $attributes['displayAsRange'] ) ) {
+			// Calculate faster reading rate with 20% speed = lower minutes,
+			// and slower reading rate with 20% speed = higher minutes.
+			$min_minutes = max( 1, (int) round( $total_words / $average_reading_rate * 0.8 ) );
+			$max_minutes = max( 1, (int) round( $total_words / $average_reading_rate * 1.2 ) );
+			if ( $min_minutes === $max_minutes ) {
+				$max_minutes = $min_minutes + 1;
+			}
 			/* translators: 1: minimum minutes, 2: maximum minutes to read the post. */
-			_x( '%1$s–%2$s minutes', 'Range of minutes to read' ),
-			$min_minutes,
-			$max_minutes
-		);
-	} else {
-		$minutes_to_read        = max( 1, (int) round( $total_words / $average_reading_rate ) );
-		$minutes_to_read_string = sprintf(
-			/* translators: %s: the number of minutes to read the post. */
-			_n( '%s minute', '%s minutes', $minutes_to_read ),
-			$minutes_to_read
-		);
+			$time_string = sprintf(
+				/* translators: 1: minimum minutes, 2: maximum minutes to read the post. */
+				_x( '%1$s–%2$s minutes', 'Range of minutes to read' ),
+				$min_minutes,
+				$max_minutes
+			);
+		} else {
+			$minutes_to_read = max( 1, (int) round( $total_words / $average_reading_rate ) );
+			$time_string = sprintf(
+				/* translators: %s: the number of minutes to read the post. */
+				_n( '%s minute', '%s minutes', $minutes_to_read ),
+				$minutes_to_read
+			);
+		}
+		$parts[] = $time_string;
 	}
+
+	// Add word count part if enabled
+	if ( $show_word_count ) {
+		$word_count_string = sprintf(
+			/* translators: %s: the number of words in the post. */
+			_n( '%s word', '%s words', $total_words ),
+			number_format_i18n( $total_words )
+		);
+		$parts[] = $word_count_string;
+	}
+
+	$display_string = implode( '<br>', $parts );
 
 	$align_class_name = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 
@@ -54,7 +74,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 	return sprintf(
 		'<div %1$s>%2$s</div>',
 		$wrapper_attributes,
-		$minutes_to_read_string
+		$display_string
 	);
 }
 

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -27,7 +27,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 
 	$parts = array();
 
-	// Add time to read part if enabled
+	// Add "time to read" part, if enabled.
 	if ( $show_time_to_read ) {
 		if ( ! empty( $attributes['displayAsRange'] ) ) {
 			// Calculate faster reading rate with 20% speed = lower minutes,

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -55,7 +55,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 		$parts[] = $time_string;
 	}
 
-	// Add word count part if enabled
+	// Add "word count" part, if enabled.
 	if ( $show_word_count ) {
 		$word_count_string = sprintf(
 			/* translators: %s: the number of words in the post. */

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -46,7 +46,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 			);
 		} else {
 			$minutes_to_read = max( 1, (int) round( $total_words / $average_reading_rate ) );
-			$time_string = sprintf(
+			$time_string     = sprintf(
 				/* translators: %s: the number of minutes to read the post. */
 				_n( '%s minute', '%s minutes', $minutes_to_read ),
 				$minutes_to_read

--- a/phpunit/blocks/render-post-time-to-read-test.php
+++ b/phpunit/blocks/render-post-time-to-read-test.php
@@ -184,4 +184,54 @@ class Tests_Blocks_Render_Post_Time_To_Read extends WP_UnitTestCase {
 
 		$this->assertSame( $expected, $actual );
 	}
+
+	/**
+	 * @covers ::render_block_core_post_time_to_read
+	 */
+	public function test_show_word_count_only() {
+		global $wp_query;
+
+		$wp_query->post  = self::$two_minutes_post;
+		$GLOBALS['post'] = self::$two_minutes_post;
+
+		$page_id       = self::$two_minutes_post->ID;
+		$attributes    = array(
+			'showTimeToRead' => false,
+			'showWordCount'  => true,
+		);
+		$parsed_blocks = parse_blocks( '<!-- wp:post-time-to-read /-->' );
+		$parsed_block  = $parsed_blocks[0];
+		$context       = array( 'postId' => $page_id );
+		$block         = new WP_Block( $parsed_block, $context );
+
+		$actual   = gutenberg_render_block_core_post_time_to_read( $attributes, '', $block );
+		$expected = '<div class="wp-block-post-time-to-read">948 words</div>';
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * @covers ::render_block_core_post_time_to_read
+	 */
+	public function test_show_both_time_and_word_count() {
+		global $wp_query;
+
+		$wp_query->post  = self::$two_minutes_post;
+		$GLOBALS['post'] = self::$two_minutes_post;
+
+		$page_id       = self::$two_minutes_post->ID;
+		$attributes    = array(
+			'showTimeToRead' => true,
+			'showWordCount'  => true,
+		);
+		$parsed_blocks = parse_blocks( '<!-- wp:post-time-to-read /-->' );
+		$parsed_block  = $parsed_blocks[0];
+		$context       = array( 'postId' => $page_id );
+		$block         = new WP_Block( $parsed_block, $context );
+
+		$actual   = gutenberg_render_block_core_post_time_to_read( $attributes, '', $block );
+		$expected = '<div class="wp-block-post-time-to-read">2 minutes<br>948 words</div>';
+
+		$this->assertSame( $expected, $actual );
+	}
 }

--- a/phpunit/blocks/render-post-time-to-read-test.php
+++ b/phpunit/blocks/render-post-time-to-read-test.php
@@ -205,7 +205,7 @@ class Tests_Blocks_Render_Post_Time_To_Read extends WP_UnitTestCase {
 		$block         = new WP_Block( $parsed_block, $context );
 
 		$actual   = gutenberg_render_block_core_post_time_to_read( $attributes, '', $block );
-		$expected = '<div class="wp-block-post-time-to-read">948 words</div>';
+		$expected = '<div class="wp-block-post-time-to-read">341 words</div>';
 
 		$this->assertSame( $expected, $actual );
 	}
@@ -230,7 +230,7 @@ class Tests_Blocks_Render_Post_Time_To_Read extends WP_UnitTestCase {
 		$block         = new WP_Block( $parsed_block, $context );
 
 		$actual   = gutenberg_render_block_core_post_time_to_read( $attributes, '', $block );
-		$expected = '<div class="wp-block-post-time-to-read">2 minutes<br>948 words</div>';
+		$expected = '<div class="wp-block-post-time-to-read">2 minutes<br>341 words</div>';
 
 		$this->assertSame( $expected, $actual );
 	}

--- a/test/integration/fixtures/blocks/core__post-time-to-read.json
+++ b/test/integration/fixtures/blocks/core__post-time-to-read.json
@@ -4,6 +4,8 @@
 		"isValid": true,
 		"attributes": {
 			"displayAsRange": true,
+			"showTimeToRead": true,
+			"showWordCount": false,
 			"averageReadingSpeed": 189
 		},
 		"innerBlocks": []


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Adds a word count option to the Time To Read block.

Closes https://github.com/WordPress/gutenberg/issues/71583

<!-- In a few words, what is the PR actually doing? -->

## Why?
This offers an alternative to time to read, or an additional piece of information, that readers might find helpful.

## How?
Adds a new attribute to display the word count, and also another one to hide the time to read, in case users just want word count.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Add some text to a post
1. Add the Time To Read block
1. Under the ellipsis menu find the "show word count" option and enable it
2. Confirm that the word count appears in the editor and the front end
3. Also enable the "show time to read option"
4. Disable this option.
5. Confirm that the "display as range" option is hidden and that the time to read no longer shows in the editor or the frontend

## Screenshots or screencast <!-- if applicable -->
<img width="1175" height="468" alt="Screenshot 2025-09-23 at 12 25 18" src="https://github.com/user-attachments/assets/8222aa79-fc2c-454c-8c44-6c6b12e7d32e" />

