### PR TITLE
Time To Read: Make display as range the default, and allow older blocks to migrate to this setting

### DIFF
--- a/packages/block-library/src/post-time-to-read/block.json
+++ b/packages/block-library/src/post-time-to-read/block.json
@@ -14,7 +14,7 @@
 		},
 		"displayAsRange": {
 			"type": "boolean",
-			"default": false
+			"default": true
 		},
 		"averageReadingSpeed": {
 			"type": "number",

--- a/packages/block-library/src/post-time-to-read/edit.js
+++ b/packages/block-library/src/post-time-to-read/edit.js
@@ -7,13 +7,12 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { __, _x, _n, sprintf } from '@wordpress/i18n';
-import { useMemo, useEffect } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import {
 	AlignmentControl,
 	BlockControls,
 	InspectorControls,
 	useBlockProps,
-	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
 	ToggleControl,
@@ -22,7 +21,6 @@ import {
 } from '@wordpress/components';
 import { __unstableSerializeAndClean } from '@wordpress/blocks';
 import { useEntityProp, useEntityBlockEditor } from '@wordpress/core-data';
-import { useDispatch, useSelect } from '@wordpress/data';
 import { count as wordCount } from '@wordpress/wordcount';
 
 /**
@@ -30,41 +28,8 @@ import { count as wordCount } from '@wordpress/wordcount';
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
-function PostTimeToReadEdit( {
-	attributes,
-	setAttributes,
-	clientId,
-	context,
-} ) {
+function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 	const { textAlign, displayAsRange, averageReadingSpeed } = attributes;
-	const { __unstableMarkNextChangeAsNotPersistent } =
-		useDispatch( blockEditorStore );
-
-	const { blockWasJustInserted } = useSelect(
-		( select ) => {
-			const { wasBlockJustInserted } = select( blockEditorStore );
-
-			return {
-				blockWasJustInserted: wasBlockJustInserted( clientId ),
-			};
-		},
-		[ clientId ]
-	);
-
-	// When the block is first inserted, default to displaying as a range.
-	useEffect( () => {
-		if ( blockWasJustInserted ) {
-			__unstableMarkNextChangeAsNotPersistent();
-			setAttributes( {
-				displayAsRange: true,
-			} );
-		}
-	}, [
-		blockWasJustInserted,
-		__unstableMarkNextChangeAsNotPersistent,
-		setAttributes,
-	] );
-
 	const { postId, postType } = context;
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 

--- a/test/integration/fixtures/blocks/core__post-time-to-read.json
+++ b/test/integration/fixtures/blocks/core__post-time-to-read.json
@@ -3,7 +3,7 @@
 		"name": "core/post-time-to-read",
 		"isValid": true,
 		"attributes": {
-			"displayAsRange": false,
+			"displayAsRange": true,
 			"averageReadingSpeed": 189
 		},
 		"innerBlocks": []


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Makes "Display as range" the default setting for the Time To Read block, and removes code that sets this to true for new blocks.

Note that this means that existing blocks will change to display a range now.

<!-- In a few words, what is the PR actually doing? -->

## Why?
The code is cleaner and simpler, and the defaults for the block more accurately represent the behaviour of the block.

## How?
Removes the code that sets "displayAsRange" to true on insertion and just sets that as true for the block.

## Testing Instructions
1. Create a post with some content
2. Add a "Time To Read" block
3. Notice that the block displays a range
4. Open a post created from before this option existed
5. Notice that the block is now updated to display a range.
