### PR TITLE
Block Comments: Add general e2e test coverage

### DIFF
--- a/packages/e2e-test-utils-playwright/src/request-utils/comments.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/comments.ts
@@ -49,16 +49,17 @@ export async function createComment(
  * Delete all comments using the REST API.
  *
  * @param this
+ * @param type - Optional comment type to delete.
  */
-export async function deleteAllComments( this: RequestUtils ) {
+export async function deleteAllComments( this: RequestUtils, type?: string ) {
 	// List all comments.
 	// https://developer.wordpress.org/rest-api/reference/comments/#list-comments
 	const comments = await this.rest( {
 		path: '/wp/v2/comments',
 		params: {
 			per_page: 100,
-			// All possible statuses.
-			status: 'unapproved,approved,spam,trash',
+			status: 'all',
+			type: type || 'comment',
 		},
 	} );
 

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -86,7 +86,7 @@ export function Comments( {
 				: null,
 		};
 	}, [] );
-	const [ focusThread, setFocusThread ] = useState( blockCommentId ?? null );
+	const [ focusThread = blockCommentId, setFocusThread ] = useState();
 
 	const hasThreads = Array.isArray( threads ) && threads.length > 0;
 	if ( ! hasThreads ) {

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -1,0 +1,174 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Block Comments', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.setGutenbergExperiments( [
+			'gutenberg-block-comment',
+		] );
+	} );
+
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await Promise.all( [
+			requestUtils.deleteAllComments( 'block_comment' ),
+			requestUtils.setGutenbergExperiments( [] ),
+		] );
+	} );
+
+	test( 'can pin and unpin comments sidebar', async ( { page } ) => {
+		const topBarButton = page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Comments', exact: true } );
+		await topBarButton.click();
+
+		await page
+			.getByRole( 'button', { name: 'Unpin from toolbar' } )
+			.click();
+		await expect( topBarButton ).toBeHidden();
+		await page.getByRole( 'button', { name: 'Pin to toolbar' } ).click();
+		await expect( topBarButton ).toBeVisible();
+	} );
+
+	test( 'can add a comment to a block', async ( { editor, page } ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content: 'Testing block comments',
+			},
+		} );
+		await editor.clickBlockOptionsMenuItem( 'Comment' );
+		await page
+			.getByRole( 'textbox', { name: 'Comment' } )
+			.fill( 'Test comment' );
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Comment', exact: true } )
+			.click();
+
+		// Currently, the class locator is the easiest way to find the comment text.
+		await expect(
+			page.locator( '.editor-collab-sidebar-panel__user-comment' )
+		).toHaveText( 'Test comment' );
+	} );
+
+	test( 'can reply to a block comment', async ( { editor, page } ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content: 'Testing block comments',
+			},
+		} );
+		const commentForm = page.getByRole( 'textbox', { name: 'Comment' } );
+		const commentText = page
+			.locator( '.editor-collab-sidebar-panel__user-comment' )
+			.last();
+
+		await editor.clickBlockOptionsMenuItem( 'Comment' );
+
+		await commentForm.fill( 'Test comment' );
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Comment', exact: true } )
+			.click();
+		await expect( commentText ).toHaveText( 'Test comment' );
+
+		await commentForm.fill( 'Test reply' );
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Reply', exact: true } )
+			.click();
+		await expect( commentText ).toHaveText( 'Test reply' );
+	} );
+
+	test( 'can edit a block comment', async ( { editor, page } ) => {
+		await editor.insertBlock( {
+			name: 'core/heading',
+			attributes: {
+				content: 'Testing block comments',
+			},
+		} );
+		await editor.clickBlockOptionsMenuItem( 'Comment' );
+		await page
+			.getByRole( 'textbox', { name: 'Comment' } )
+			.fill( 'Test comment before edit.' );
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Comment', exact: true } )
+			.click();
+		await page.getByRole( 'button', { name: 'Select an action' } ).click();
+		await page.getByRole( 'menuitem', { name: 'Edit' } ).click();
+		await page
+			.getByRole( 'textbox', { name: 'Comment' } )
+			.first()
+			.fill( 'Test comment after edit.' );
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Update', exact: true } )
+			.click();
+
+		await expect(
+			page.locator( '.editor-collab-sidebar-panel__user-comment' )
+		).toHaveText( 'Test comment after edit.' );
+	} );
+
+	test( 'can delete a block comment', async ( { editor, page } ) => {
+		await editor.insertBlock( {
+			name: 'core/heading',
+			attributes: {
+				content: 'Testing block comments',
+			},
+		} );
+		await editor.clickBlockOptionsMenuItem( 'Comment' );
+		await page
+			.getByRole( 'textbox', { name: 'Comment' } )
+			.fill( 'Test comment to delete.' );
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Comment', exact: true } )
+			.click();
+		await page.getByRole( 'button', { name: 'Select an action' } ).click();
+		await page.getByRole( 'menuitem', { name: 'Delete' } ).click();
+		await page
+			.getByRole( 'dialog' )
+			.getByRole( 'button', { name: 'Delete' } )
+			.click();
+
+		await expect(
+			page.locator( '.editor-collab-sidebar-panel__user-comment' )
+		).toBeHidden();
+	} );
+
+	test( 'can resolve and reopen a block comment', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/heading',
+			attributes: {
+				content: 'Testing block comments',
+			},
+		} );
+		await editor.clickBlockOptionsMenuItem( 'Comment' );
+		await page
+			.getByRole( 'textbox', { name: 'Comment' } )
+			.fill( 'Test comment to resolve.' );
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Comment', exact: true } )
+			.click();
+
+		const resolveButton = page.getByRole( 'button', { name: 'Resolve' } );
+		await resolveButton.click();
+		await expect( resolveButton ).toBeDisabled();
+
+		await page.getByRole( 'button', { name: 'Select an action' } ).click();
+		await page.getByRole( 'menuitem', { name: 'Reopen' } ).click();
+		await expect( resolveButton ).toBeEnabled();
+	} );
+} );

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -46,7 +46,7 @@ test.describe( 'Block Comments', () => {
 	} ) => {
 		await blockCommentUtils.addBlockWithComment( {
 			type: 'core/paragraph',
-			content: 'Testing block comments',
+			attributes: { content: 'Testing block comments' },
 			comment: 'Test comment',
 		} );
 
@@ -62,7 +62,7 @@ test.describe( 'Block Comments', () => {
 	} ) => {
 		await blockCommentUtils.addBlockWithComment( {
 			type: 'core/paragraph',
-			content: 'Testing block comments',
+			attributes: { content: 'Testing block comments' },
 			comment: 'Test comment',
 		} );
 		const commentForm = page.getByRole( 'textbox', { name: 'Comment' } );
@@ -86,7 +86,7 @@ test.describe( 'Block Comments', () => {
 	test( 'can edit a block comment', async ( { page, blockCommentUtils } ) => {
 		await blockCommentUtils.addBlockWithComment( {
 			type: 'core/heading',
-			content: 'Testing block comments',
+			attributes: { content: 'Testing block comments' },
 			comment: 'test comment before edit',
 		} );
 		await page.getByRole( 'button', { name: 'Select an action' } ).click();
@@ -116,7 +116,7 @@ test.describe( 'Block Comments', () => {
 	} ) => {
 		await blockCommentUtils.addBlockWithComment( {
 			type: 'core/paragraph',
-			content: 'Testing block comments',
+			attributes: { content: 'Testing block comments' },
 			comment: 'Test comment to delete.',
 		} );
 		await page.getByRole( 'button', { name: 'Select an action' } ).click();
@@ -142,7 +142,7 @@ test.describe( 'Block Comments', () => {
 	} ) => {
 		await blockCommentUtils.addBlockWithComment( {
 			type: 'core/heading',
-			content: 'Testing block comments',
+			attributes: { content: 'Testing block comments' },
 			comment: 'Test comment to resolve.',
 		} );
 
@@ -162,18 +162,18 @@ test.describe( 'Block Comments', () => {
 	} ) => {
 		await blockCommentUtils.addBlockWithComment( {
 			type: 'core/heading',
-			content: 'First block',
+			attributes: { content: 'First block' },
 			comment: 'First block comment',
 		} );
 		await blockCommentUtils.addBlockWithComment( {
 			type: 'core/paragraph',
-			content: 'Second block',
+			attributes: { content: 'Second block' },
 			comment: 'Second block comment',
 		} );
 		await editor.insertBlock( { name: 'core/spacer' } );
 		await blockCommentUtils.addBlockWithComment( {
 			type: 'core/heading',
-			content: 'Third block',
+			attributes: { content: 'Third block' },
 			comment: 'Third block comment',
 		} );
 
@@ -233,15 +233,13 @@ class BlockCommentUtils {
 		return toggleButton;
 	}
 
-	async addBlockWithComment( { type, content, comment } ) {
+	async addBlockWithComment( { type, attributes = {}, comment } ) {
 		await test.step(
 			`Insert a ${ type } block with a comment`,
 			async () => {
 				await this.#editor.insertBlock( {
 					name: type,
-					attributes: {
-						content,
-					},
+					attributes,
 				} );
 				await this.#editor.clickBlockOptionsMenuItem( 'Comment' );
 				await this.#page

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -3,6 +3,12 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
+test.use( {
+	blockCommentUtils: async ( { page, editor }, use ) => {
+		await use( new BlockCommentUtils( { page, editor } ) );
+	},
+} );
+
 test.describe( 'Block Comments', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.setGutenbergExperiments( [
@@ -21,12 +27,11 @@ test.describe( 'Block Comments', () => {
 		] );
 	} );
 
-	test( 'can pin and unpin comments sidebar', async ( { page } ) => {
-		const topBarButton = page
-			.getByRole( 'region', { name: 'Editor top bar' } )
-			.getByRole( 'button', { name: 'Comments', exact: true } );
-		await topBarButton.click();
-
+	test( 'can pin and unpin comments sidebar', async ( {
+		page,
+		blockCommentUtils,
+	} ) => {
+		const topBarButton = await blockCommentUtils.openBlockCommentSidebar();
 		await page
 			.getByRole( 'button', { name: 'Unpin from toolbar' } )
 			.click();
@@ -35,21 +40,15 @@ test.describe( 'Block Comments', () => {
 		await expect( topBarButton ).toBeVisible();
 	} );
 
-	test( 'can add a comment to a block', async ( { editor, page } ) => {
-		await editor.insertBlock( {
-			name: 'core/paragraph',
-			attributes: {
-				content: 'Testing block comments',
-			},
+	test( 'can add a comment to a block', async ( {
+		page,
+		blockCommentUtils,
+	} ) => {
+		await blockCommentUtils.addBlockWithComment( {
+			type: 'core/paragraph',
+			content: 'Testing block comments',
+			comment: 'Test comment',
 		} );
-		await editor.clickBlockOptionsMenuItem( 'Comment' );
-		await page
-			.getByRole( 'textbox', { name: 'Comment' } )
-			.fill( 'Test comment' );
-		await page
-			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'button', { name: 'Comment', exact: true } )
-			.click();
 
 		// Currently, the class locator is the easiest way to find the comment text.
 		await expect(
@@ -57,26 +56,19 @@ test.describe( 'Block Comments', () => {
 		).toHaveText( 'Test comment' );
 	} );
 
-	test( 'can reply to a block comment', async ( { editor, page } ) => {
-		await editor.insertBlock( {
-			name: 'core/paragraph',
-			attributes: {
-				content: 'Testing block comments',
-			},
+	test( 'can reply to a block comment', async ( {
+		page,
+		blockCommentUtils,
+	} ) => {
+		await blockCommentUtils.addBlockWithComment( {
+			type: 'core/paragraph',
+			content: 'Testing block comments',
+			comment: 'Test comment',
 		} );
 		const commentForm = page.getByRole( 'textbox', { name: 'Comment' } );
 		const commentText = page
 			.locator( '.editor-collab-sidebar-panel__user-comment' )
 			.last();
-
-		await editor.clickBlockOptionsMenuItem( 'Comment' );
-
-		await commentForm.fill( 'Test comment' );
-		await page
-			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'button', { name: 'Comment', exact: true } )
-			.click();
-		await expect( commentText ).toHaveText( 'Test comment' );
 
 		await commentForm.fill( 'Test reply' );
 		await page
@@ -84,23 +76,19 @@ test.describe( 'Block Comments', () => {
 			.getByRole( 'button', { name: 'Reply', exact: true } )
 			.click();
 		await expect( commentText ).toHaveText( 'Test reply' );
+		await expect(
+			page
+				.getByRole( 'button', { name: 'Dismiss this notice' } )
+				.filter( { hasText: 'Reply added successfully.' } )
+		).toBeVisible();
 	} );
 
-	test( 'can edit a block comment', async ( { editor, page } ) => {
-		await editor.insertBlock( {
-			name: 'core/heading',
-			attributes: {
-				content: 'Testing block comments',
-			},
+	test( 'can edit a block comment', async ( { page, blockCommentUtils } ) => {
+		await blockCommentUtils.addBlockWithComment( {
+			type: 'core/heading',
+			content: 'Testing block comments',
+			comment: 'test comment before edit',
 		} );
-		await editor.clickBlockOptionsMenuItem( 'Comment' );
-		await page
-			.getByRole( 'textbox', { name: 'Comment' } )
-			.fill( 'Test comment before edit.' );
-		await page
-			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'button', { name: 'Comment', exact: true } )
-			.click();
 		await page.getByRole( 'button', { name: 'Select an action' } ).click();
 		await page.getByRole( 'menuitem', { name: 'Edit' } ).click();
 		await page
@@ -115,23 +103,22 @@ test.describe( 'Block Comments', () => {
 		await expect(
 			page.locator( '.editor-collab-sidebar-panel__user-comment' )
 		).toHaveText( 'Test comment after edit.' );
+		await expect(
+			page
+				.getByRole( 'button', { name: 'Dismiss this notice' } )
+				.filter( { hasText: 'Comment edited successfully.' } )
+		).toBeVisible();
 	} );
 
-	test( 'can delete a block comment', async ( { editor, page } ) => {
-		await editor.insertBlock( {
-			name: 'core/heading',
-			attributes: {
-				content: 'Testing block comments',
-			},
+	test( 'can delete a block comment', async ( {
+		page,
+		blockCommentUtils,
+	} ) => {
+		await blockCommentUtils.addBlockWithComment( {
+			type: 'core/paragraph',
+			content: 'Testing block comments',
+			comment: 'Test comment to delete.',
 		} );
-		await editor.clickBlockOptionsMenuItem( 'Comment' );
-		await page
-			.getByRole( 'textbox', { name: 'Comment' } )
-			.fill( 'Test comment to delete.' );
-		await page
-			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'button', { name: 'Comment', exact: true } )
-			.click();
 		await page.getByRole( 'button', { name: 'Select an action' } ).click();
 		await page.getByRole( 'menuitem', { name: 'Delete' } ).click();
 		await page
@@ -142,26 +129,22 @@ test.describe( 'Block Comments', () => {
 		await expect(
 			page.locator( '.editor-collab-sidebar-panel__user-comment' )
 		).toBeHidden();
+		await expect(
+			page
+				.getByRole( 'button', { name: 'Dismiss this notice' } )
+				.filter( { hasText: 'Comment deleted successfully.' } )
+		).toBeVisible();
 	} );
 
 	test( 'can resolve and reopen a block comment', async ( {
-		editor,
 		page,
+		blockCommentUtils,
 	} ) => {
-		await editor.insertBlock( {
-			name: 'core/heading',
-			attributes: {
-				content: 'Testing block comments',
-			},
+		await blockCommentUtils.addBlockWithComment( {
+			type: 'core/heading',
+			content: 'Testing block comments',
+			comment: 'Test comment to resolve.',
 		} );
-		await editor.clickBlockOptionsMenuItem( 'Comment' );
-		await page
-			.getByRole( 'textbox', { name: 'Comment' } )
-			.fill( 'Test comment to resolve.' );
-		await page
-			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'button', { name: 'Comment', exact: true } )
-			.click();
 
 		const resolveButton = page.getByRole( 'button', { name: 'Resolve' } );
 		await resolveButton.click();
@@ -172,3 +155,61 @@ test.describe( 'Block Comments', () => {
 		await expect( resolveButton ).toBeEnabled();
 	} );
 } );
+
+class BlockCommentUtils {
+	/** @type {import('@playwright/test').Page} */
+	#page;
+	/** @type {import('@wordpress/e2e-test-utils-playwright').Editor} */
+	#editor;
+
+	constructor( { page, editor } ) {
+		this.#page = page;
+		this.#editor = editor;
+	}
+
+	async openBlockCommentSidebar() {
+		const toggleButton = this.#page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Comments', exact: true } );
+
+		const isClosed =
+			( await toggleButton.getAttribute( 'aria-expanded' ) ) === 'false';
+
+		if ( isClosed ) {
+			await toggleButton.click();
+			await this.#page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Close Comments' } )
+				.waitFor();
+		}
+
+		return toggleButton;
+	}
+
+	async addBlockWithComment( { type, content, comment } ) {
+		await test.step(
+			`Insert a ${ type } block with a comment`,
+			async () => {
+				await this.#editor.insertBlock( {
+					name: type,
+					attributes: {
+						content,
+					},
+				} );
+				await this.#editor.clickBlockOptionsMenuItem( 'Comment' );
+				await this.#page
+					.getByRole( 'textbox', { name: 'Comment' } )
+					.fill( comment );
+				await this.#page
+					.getByRole( 'region', { name: 'Editor settings' } )
+					.getByRole( 'button', { name: 'Comment', exact: true } )
+					.click();
+				await this.#page
+					.getByRole( 'button', { name: 'Dismiss this notice' } )
+					.filter( { hasText: 'Comment added successfully.' } )
+					.click();
+			},
+			{ box: true }
+		);
+	}
+}

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -154,6 +154,53 @@ test.describe( 'Block Comments', () => {
 		await page.getByRole( 'menuitem', { name: 'Reopen' } ).click();
 		await expect( resolveButton ).toBeEnabled();
 	} );
+
+	test( 'selecting a block or comment marks it as an active', async ( {
+		editor,
+		page,
+		blockCommentUtils,
+	} ) => {
+		await blockCommentUtils.addBlockWithComment( {
+			type: 'core/heading',
+			content: 'First block',
+			comment: 'First block comment',
+		} );
+		await blockCommentUtils.addBlockWithComment( {
+			type: 'core/paragraph',
+			content: 'Second block',
+			comment: 'Second block comment',
+		} );
+		await editor.insertBlock( { name: 'core/spacer' } );
+		await blockCommentUtils.addBlockWithComment( {
+			type: 'core/heading',
+			content: 'Third block',
+			comment: 'Third block comment',
+		} );
+
+		const threads = page.locator( '.editor-collab-sidebar-panel__thread' );
+		const activeThread = page.locator(
+			'.editor-collab-sidebar-panel__focus-thread'
+		);
+		const replyTextbox = activeThread.getByRole( 'textbox', {
+			name: 'Comment',
+		} );
+
+		// Comment and reply textbox should active for last inserter block.
+		await expect( activeThread ).toContainText( 'Third block comment' );
+		await expect( replyTextbox ).toBeVisible();
+
+		// Clicking on a block comment should make it active.
+		await threads.last().click();
+		await expect( activeThread ).toContainText( 'First block comment' );
+		await expect( replyTextbox ).toBeVisible();
+
+		// Clicking on a block in canvas should make its comment active.
+		await editor.canvas
+			.getByRole( 'document', { name: 'Block: Paragraph' } )
+			.click();
+		await expect( activeThread ).toContainText( 'Second block comment' );
+		await expect( replyTextbox ).toBeVisible();
+	} );
 } );
 
 class BlockCommentUtils {


### PR DESCRIPTION
## What?
Part of https://github.com/WordPress/gutenberg/issues/66377.

PR adds e2e test coverage for Block Comments' general functionality to prevent regressions as we iterate over the feature.

P.S. I noticed that it's not easy to target sub-elements in the Block Comments sidebar, using a11y locators. Related #71843.

## Todo

- [x] Add any missing tests.
- [x] Extract repeated actions into a test-specific helper class.

## Testing Instructions
* Confirm all CI checks are passing.
* Confirm new e2e tests are passing - `npm run test:e2e -- test/e2e/specs/editor/various/block-comments.spec.js`.

### Testing Instructions for Keyboard
Same.
