### PR TITLE
Post Date: Combine 'core-data' store selectors

### DIFF
--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useEntityProp, store as coreStore } from '@wordpress/core-data';
+import { store as coreStore } from '@wordpress/core-data';
 import { useEffect, useMemo, useState } from '@wordpress/element';
 import {
 	dateI18n,
@@ -81,22 +81,22 @@ export default function PostDateEdit( {
 
 	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 	const dateSettings = getDateSettings();
-	const [ siteFormat = dateSettings.formats.date ] = useEntityProp(
-		'root',
-		'site',
-		'date_format'
-	);
-	const [ siteTimeFormat = dateSettings.formats.time ] = useEntityProp(
-		'root',
-		'site',
-		'time_format'
-	);
 
-	const postType = useSelect(
-		( select ) =>
-			postTypeSlug
-				? select( coreStore ).getPostType( postTypeSlug )
-				: null,
+	const {
+		postType,
+		siteFormat = dateSettings.formats.date,
+		siteTimeFormat = dateSettings.formats.time,
+	} = useSelect(
+		( select ) => {
+			const { getPostType, getEntityRecord } = select( coreStore );
+			const siteSettings = getEntityRecord( 'root', 'site' );
+
+			return {
+				siteFormat: siteSettings?.date_format,
+				siteTimeFormat: siteSettings?.time_format,
+				postType: postTypeSlug ? getPostType( postTypeSlug ) : null,
+			};
+		},
 		[ postTypeSlug ]
 	);
 


### PR DESCRIPTION
## What?
PR combines multiple `core-data` selectors into a single one. Why?

* Avoid multiple store subscriptions.
* Avoids using `useEntityProp` just to read values from the store, without using the setter method.

## Testing Instructions
1. Open a post or page.
2. Insert the Post Date block.
3. Confirm it works as before.
4. Date settings are fetched correctly.

### Testing Instructions for Keyboard
Same.
