### PR TITLE
Backport changelog: Update for 9702 (to 9949)

### DIFF
--- a/backport-changelog/6.9/9702.md
+++ b/backport-changelog/6.9/9702.md
@@ -1,3 +1,0 @@
-https://github.com/WordPress/wordpress-develop/pull/9702
-
-* https://github.com/WordPress/gutenberg/pull/71483

--- a/backport-changelog/6.9/9949.md
+++ b/backport-changelog/6.9/9949.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/9949
+
+* https://github.com/WordPress/gutenberg/pull/71483


### PR DESCRIPTION
## What?
Update backport changelog for https://github.com/WordPress/wordpress-develop/pull/9702 to https://github.com/WordPress/wordpress-develop/pull/9949.

The backport changelog was first added by https://github.com/WordPress/gutenberg/pull/71483.

## Why?
I've closed the former PR in former of the latter.