### PR TITLE
HTML anchor and Additional CSS class(es) controls: Force dir=ltr and add mono font-family to them

### DIFF
--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -65,6 +65,7 @@ function BlockEditAnchorControlPure( { anchor, setAttributes } ) {
 			<TextControl
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize
+				dir="ltr"
 				className="html-anchor-control"
 				label={ __( 'HTML anchor' ) }
 				help={

--- a/packages/block-editor/src/hooks/anchor.scss
+++ b/packages/block-editor/src/hooks/anchor.scss
@@ -1,0 +1,3 @@
+.html-anchor-control .components-base-control__field .components-text-control__input {
+    font-family: $editor-html-font;
+}

--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -49,7 +49,9 @@ function CustomClassNameControlsPure( { className, setAttributes } ) {
 			<TextControl
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize
+				dir="ltr"
 				autoComplete="off"
+				className="custom-class-name-control"
 				label={ __( 'Additional CSS class(es)' ) }
 				value={ className || '' }
 				onChange={ ( nextValue ) => {

--- a/packages/block-editor/src/hooks/custom-class-name.scss
+++ b/packages/block-editor/src/hooks/custom-class-name.scss
@@ -1,0 +1,3 @@
+.custom-class-name-control .components-base-control__field .components-text-control__input {
+    font-family: $editor-html-font;
+}

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -50,9 +50,11 @@
 @import "./components/url-input/style.scss";
 @import "./components/url-popover/style.scss";
 @import "./hooks/block-hooks.scss";
+@import "./hooks/anchor.scss";
 @import "./hooks/block-bindings.scss";
 @import "./hooks/border.scss";
 @import "./hooks/color.scss";
+@import "./hooks/custom-class-name.scss";
 @import "./hooks/dimensions.scss";
 @import "./hooks/layout.scss";
 @import "./hooks/spacing.scss";


### PR DESCRIPTION
- Adds `dir` attr to `HTML anchor` and `Additional CSS class(es)` controls.
- And sets mono spaced `font-family` to the same controls.

In RTL, some things should stay LTR. For example a code block, should be dir=ltr because code always starts from left. Same with things like classes and code related stuff.

## Testing Instructions

1. Change langauge to Persian/Farsi (فارسی) (or any RTL langauge)
2. Open a page and drop a paragraph block into the page
3. In that paragraph block options, open "Advanced" accordion in Block options sidebar

## Screenshots

|Before|After|
|-|-|
|<img width="257" height="333" alt="image" src="https://github.com/user-attachments/assets/b4d0ee47-4633-4dc1-a2b5-70395a233ab1" />|<img width="255" height="328" alt="image" src="https://github.com/user-attachments/assets/567ed2ca-d9fd-4368-9e40-611e0e1ef8d0" />|

## More stuff

I added the `custom-class-name-control` class in packages/block-editor/src/hooks/custom-class-name.js but I'm not sure if it's a good class. Was inspired by the class name `html-anchor-control`.

I used `dir` attr instead of css `direction` property because ChatGPT said it's better that way. In the code, I found that the css property was used instead of `dir`. so, we may want to change what this PR does, or open another PR to address those codes to replace the css property with the attribute instead.

I could not find a PR or issue related to this issue and PR.

It may be a better idea to have a class in global styles that the class has single font-family mono property and we can just add that class whereever needed instead of creating scss files and classes like `custom-class-name-control`. This can result in reusable and cleaner code.

I think it could be a better idea to use css variables where needed instead of scss varialbes.

the `.html-anchor-control .components-base-control__field .components-text-control__input` selector may need to be shorter like `.html-anchor-control .components-text-control__input`?

i think pre commit hooks have some issues? maybe someone can take a look into them? I tried commiting but didn't work. the issues were not related to may changes. i just bypassed them with `--no-verify`.