### PR TITLE
CI: Check block.json and theme.json according to schemas

### DIFF
--- a/.github/workflows/check-json-schema.yml
+++ b/.github/workflows/check-json-schema.yml
@@ -41,13 +41,22 @@ jobs:
             - name: Install check-jsonschema
               run: pip install check-jsonschema
 
+            - name: Validate JSON schema schemas
+              run: |
+                  files=$(ls './schemas/json/*.json')
+                  if [ -n "$files" ]; then
+                    echo "$files" | xargs check-jsonschema --schemafile 'https://json-schema.org/draft-07/schema'
+                  else
+                    echo "No schema files found to validate."
+                  fi
+
             - name: Validate block.json files
               run: |
                   files=$(find . -name "block.json" -not -path './schemas/**')
                   if [ -n "$files" ]; then
                     echo "$files" | xargs check-jsonschema --schemafile ./schemas/json/block.json
                   else
-                    echo "No block.json files found to validate"
+                    echo "No block.json files found to validate."
                   fi
 
             - name: Validate theme.json files

--- a/.github/workflows/check-json-schema.yml
+++ b/.github/workflows/check-json-schema.yml
@@ -43,18 +43,18 @@ jobs:
 
             - name: Validate block.json files
               run: |
-                  block_files=$(find . -name "block.json" -not -path './schemas/**')
-                  if [ -n "$block_files" ]; then
-                    check-jsonschema --schemafile ./schemas/json/block.json "$block_files"
+                  files=$(find . -name "block.json" -not -path './schemas/**')
+                  if [ -n "$files" ]; then
+                    echo "$files" | xargs check-jsonschema --schemafile ./schemas/json/block.json
                   else
                     echo "No block.json files found to validate"
                   fi
 
             - name: Validate theme.json files
               run: |
-                  theme_files=$(find . -name "theme.json" -not -path './schemas/**')
-                  if [ -n "$theme_files" ]; then
-                    check-jsonschema --schemafile ./schemas/json/theme.json "$theme_files"
+                  files=$(find . -name "theme.json" -not -path './schemas/**')
+                  if [ -n "$files" ]; then
+                    echo "$files" | xargs check-jsonschema --schemafile ./schemas/json/theme.json
                   else
                     echo "No theme.json files found to validate"
                   fi

--- a/.github/workflows/check-json-schema.yml
+++ b/.github/workflows/check-json-schema.yml
@@ -37,7 +37,6 @@ jobs:
               uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
               with:
                   python-version: '3.x'
-                  cache: 'pip'
 
             - name: Install check-jsonschema
               run: pip install check-jsonschema

--- a/.github/workflows/check-json-schema.yml
+++ b/.github/workflows/check-json-schema.yml
@@ -43,7 +43,7 @@ jobs:
 
             - name: Validate JSON schema schemas
               run: |
-                  files=$(ls './schemas/json/*.json')
+                  files=$(ls ./schemas/json/*.json)
                   if [ -n "$files" ]; then
                     echo "$files" | xargs check-jsonschema --schemafile 'https://json-schema.org/draft-07/schema'
                   else

--- a/.github/workflows/check-json-schema.yml
+++ b/.github/workflows/check-json-schema.yml
@@ -1,0 +1,61 @@
+name: JSON Schema Validation
+
+on:
+    pull_request:
+    push:
+        branches:
+            - trunk
+            - 'release/**'
+            - 'wp/**'
+
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+    # The concurrency group contains the workflow name and the branch name for pull requests
+    # or the commit hash for any other events.
+    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
+jobs:
+    validate-schemas:
+        name: Validate JSON Schemas
+        runs-on: 'ubuntu-24.04'
+        permissions:
+            contents: read
+        if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
+
+        steps:
+            - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+              with:
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: false
+
+            - name: Set up Python
+              uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+              with:
+                  python-version: '3.x'
+                  cache: 'pip'
+
+            - name: Install check-jsonschema
+              run: pip install check-jsonschema
+
+            - name: Validate block.json files
+              run: |
+                  block_files=$(find . -name "block.json" -not -path './schemas/**')
+                  if [ -n "$block_files" ]; then
+                    check-jsonschema --schemafile ./schemas/json/block.json "$block_files"
+                  else
+                    echo "No block.json files found to validate"
+                  fi
+
+            - name: Validate theme.json files
+              run: |
+                  theme_files=$(find . -name "theme.json" -not -path './schemas/**')
+                  if [ -n "$theme_files" ]; then
+                    check-jsonschema --schemafile ./schemas/json/theme.json "$theme_files"
+                  else
+                    echo "No theme.json files found to validate"
+                  fi

--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/deferred-store",
 	"title": "E2E Interactivity tests - deferred store",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-bind/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-bind/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-bind",
 	"title": "E2E Interactivity tests - directive bind",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-class/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-class/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-class",
 	"title": "E2E Interactivity tests - directive class",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-context",
 	"title": "E2E Interactivity tests - directive context",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-each/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-each/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-each",
 	"title": "E2E Interactivity tests - directive each",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-init/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-init/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-init",
 	"title": "E2E Interactivity tests - directive init",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-key/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-key/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-key",
 	"title": "E2E Interactivity tests - directive key",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on-document/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on-document/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-on-document",
 	"title": "E2E Interactivity tests - directive on document",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on-window/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on-window/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-on-window",
 	"title": "E2E Interactivity tests - directive on window",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-on",
 	"title": "E2E Interactivity tests - directive on",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-priorities/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-priorities/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-priorities",
 	"title": "E2E Interactivity tests - directive priorities",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-run/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-run/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-run",
 	"title": "E2E Interactivity tests - directive run",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-style/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-style/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-style",
 	"title": "E2E Interactivity tests - directive style",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-text/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-text/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-text",
 	"title": "E2E Interactivity tests - directive text",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-watch/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-watch/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-watch",
 	"title": "E2E Interactivity tests - directive watch",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/generator-scope/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/generator-scope/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/generator-scope",
 	"title": "E2E Interactivity tests - generator scope",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/get-server-context/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/get-server-context/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/get-server-context",
 	"title": "E2E Interactivity tests - getServerContext",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/get-server-state/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/get-server-state/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/get-server-state",
 	"title": "E2E Interactivity tests - getServerState",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/namespace/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/namespace/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test-namespace/directive-bind",
 	"title": "E2E Interactivity tests - directive bind",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/negation-operator/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/negation-operator/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/negation-operator",
 	"title": "E2E Interactivity tests - negation operator",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/router-navigate",
 	"title": "E2E Interactivity tests - router navigate",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/router-regions/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-regions/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/router-regions",
 	"title": "E2E Interactivity tests - router regions",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-alpha/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-alpha/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/router-script-modules-alpha",
 	"title": "E2E Interactivity tests - router modules - Alpha",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-bravo/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-bravo/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/router-script-modules-bravo",
 	"title": "E2E Interactivity tests - router modules - Bravo",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-charlie/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-charlie/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/router-script-modules-charlie",
 	"title": "E2E Interactivity tests - router modules - Charlie",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-wrapper/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-wrapper/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/router-script-modules-wrapper",
 	"title": "E2E Interactivity tests - router modules - Wrapper",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/router-styles-blue/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-styles-blue/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/router-styles-blue",
 	"title": "E2E Interactivity tests - router styles - Blue",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/router-styles-green/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-styles-green/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/router-styles-green",
 	"title": "E2E Interactivity tests - router styles - Green",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/router-styles-red/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-styles-red/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/router-styles-red",
 	"title": "E2E Interactivity tests - router styles - Red",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/router-styles-wrapper",
 	"title": "E2E Interactivity tests - router styles - Wrapper",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/store-tag/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/store-tag/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/store-tag",
 	"title": "E2E Interactivity tests - store tag",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/store/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/store/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/store",
 	"title": "E2E Interactivity tests - store definition",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/tovdom-islands/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/tovdom-islands/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/tovdom-islands",
 	"title": "E2E Interactivity tests - tovdom islands",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/tovdom/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/tovdom/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/tovdom",
 	"title": "E2E Interactivity tests - tovdom",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/with-scope/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/with-scope/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/with-scope",
 	"title": "E2E Interactivity tests - with scope",
 	"category": "text",

--- a/packages/scripts/scripts/test/fixtures/build-blocks-manifest/input/custom-header/block.json
+++ b/packages/scripts/scripts/test/fixtures/build-blocks-manifest/input/custom-header/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "my-plugin/custom-header",
 	"title": "Custom Header",
 	"category": "text",

--- a/packages/scripts/scripts/test/fixtures/build-blocks-manifest/input/image-gallery/block.json
+++ b/packages/scripts/scripts/test/fixtures/build-blocks-manifest/input/image-gallery/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "my-plugin/image-gallery",
 	"title": "Image Gallery",
 	"category": "media",

--- a/packages/scripts/scripts/test/fixtures/build-blocks-manifest/input/simple-button/block.json
+++ b/packages/scripts/scripts/test/fixtures/build-blocks-manifest/input/simple-button/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "my-plugin/simple-button",
 	"title": "Simple Button",
 	"category": "design",

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -302,7 +302,13 @@
 							"type": "boolean",
 							"default": true
 						}
-					}
+					},
+					"patternProperties": {
+						"^__experimental": {
+							"type": [ "array", "boolean", "object", "string" ]
+						}
+					},
+					"additionalProperties": false
 				},
 				"customClassName": {
 					"description": "This property adds a field to define a custom className for the block’s wrapper.",

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -1,6 +1,6 @@
 {
 	"title": "JSON schema for WordPress blocks",
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "https://json-schema.org/draft-07/schema",
 	"definitions": {
 		"//": {
 			"reference": "https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/",

--- a/schemas/json/font-collection.json
+++ b/schemas/json/font-collection.json
@@ -1,6 +1,6 @@
 {
 	"title": "JSON schema for WordPress Font Collections",
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "https://json-schema.org/draft-07/schema",
 	"definitions": {
 		"fontFace": {
 			"description": "Font face settings, with added preview property.",

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1,6 +1,6 @@
 {
 	"title": "JSON schema for WordPress block theme global settings and styles",
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "https://json-schema.org/draft-07/schema",
 	"definitions": {
 		"//": {
 			"explainer": "https://developer.wordpress.org/themes/global-settings-and-styles/",

--- a/schemas/json/wp-env.json
+++ b/schemas/json/wp-env.json
@@ -1,6 +1,6 @@
 {
 	"title": "JSON schema for WordPress wp-env configuration files",
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "https://json-schema.org/draft-07/schema",
 	"definitions": {
 		"//": {
 			"reference": "https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/"


### PR DESCRIPTION


## What?

Add JSON schema checking to CI. This should help prevent issues appearing in schemas in the repo.

This has #71852 merged to fix existing issues.

Closes #71817.

## Why?

It's good to prevent schema errors in the files in the repo. See #71800 for an example.