### PR TITLE
JSON Schema: Update block.json apiVersion to 3

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/deferred-store/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/deferred-store/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/deferred-store",
 	"title": "E2E Interactivity tests - deferred store",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-bind/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-bind/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-bind",
 	"title": "E2E Interactivity tests - directive bind",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-class/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-class/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-class",
 	"title": "E2E Interactivity tests - directive class",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-context",
 	"title": "E2E Interactivity tests - directive context",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-each/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-each/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-each",
 	"title": "E2E Interactivity tests - directive each",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-init/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-init/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-init",
 	"title": "E2E Interactivity tests - directive init",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-key/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-key/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-key",
 	"title": "E2E Interactivity tests - directive key",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on-document/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on-document/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-on-document",
 	"title": "E2E Interactivity tests - directive on document",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on-window/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on-window/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-on-window",
 	"title": "E2E Interactivity tests - directive on window",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-on/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-on/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-on",
 	"title": "E2E Interactivity tests - directive on",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-priorities/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-priorities/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-priorities",
 	"title": "E2E Interactivity tests - directive priorities",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-run/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-run/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-run",
 	"title": "E2E Interactivity tests - directive run",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-style/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-style/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-style",
 	"title": "E2E Interactivity tests - directive style",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-text/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-text/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-text",
 	"title": "E2E Interactivity tests - directive text",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-watch/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-watch/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/directive-watch",
 	"title": "E2E Interactivity tests - directive watch",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/generator-scope/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/generator-scope/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/generator-scope",
 	"title": "E2E Interactivity tests - generator scope",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/get-server-context/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/get-server-context/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/get-server-context",
 	"title": "E2E Interactivity tests - getServerContext",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/get-server-state/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/get-server-state/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/get-server-state",
 	"title": "E2E Interactivity tests - getServerState",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/namespace/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/namespace/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test-namespace/directive-bind",
 	"title": "E2E Interactivity tests - directive bind",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/negation-operator/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/negation-operator/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/negation-operator",
 	"title": "E2E Interactivity tests - negation operator",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/router-navigate/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-navigate/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/router-navigate",
 	"title": "E2E Interactivity tests - router navigate",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/router-regions/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-regions/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/router-regions",
 	"title": "E2E Interactivity tests - router regions",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-alpha/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-alpha/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/router-script-modules-alpha",
 	"title": "E2E Interactivity tests - router modules - Alpha",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-bravo/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-bravo/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/router-script-modules-bravo",
 	"title": "E2E Interactivity tests - router modules - Bravo",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-charlie/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-charlie/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/router-script-modules-charlie",
 	"title": "E2E Interactivity tests - router modules - Charlie",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-wrapper/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-script-modules-wrapper/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/router-script-modules-wrapper",
 	"title": "E2E Interactivity tests - router modules - Wrapper",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/router-styles-blue/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-styles-blue/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/router-styles-blue",
 	"title": "E2E Interactivity tests - router styles - Blue",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/router-styles-green/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-styles-green/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/router-styles-green",
 	"title": "E2E Interactivity tests - router styles - Green",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/router-styles-red/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-styles-red/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/router-styles-red",
 	"title": "E2E Interactivity tests - router styles - Red",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/router-styles-wrapper",
 	"title": "E2E Interactivity tests - router styles - Wrapper",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/store-tag/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/store-tag/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/store-tag",
 	"title": "E2E Interactivity tests - store tag",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/store/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/store/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/store",
 	"title": "E2E Interactivity tests - store definition",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/tovdom-islands/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/tovdom-islands/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/tovdom-islands",
 	"title": "E2E Interactivity tests - tovdom islands",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/tovdom/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/tovdom/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/tovdom",
 	"title": "E2E Interactivity tests - tovdom",
 	"category": "text",

--- a/packages/e2e-tests/plugins/interactive-blocks/with-scope/block.json
+++ b/packages/e2e-tests/plugins/interactive-blocks/with-scope/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "test/with-scope",
 	"title": "E2E Interactivity tests - with scope",
 	"category": "text",

--- a/packages/scripts/scripts/test/__snapshots__/build-blocks-manifest.js.snap
+++ b/packages/scripts/scripts/test/__snapshots__/build-blocks-manifest.js.snap
@@ -6,7 +6,7 @@ exports[`build-blocks-manifest script should generate expected blocks manifest 1
 return array(
 	'custom-header' => array(
 		'$schema' => 'https://schemas.wp.org/trunk/block.json',
-		'apiVersion' => 2,
+		'apiVersion' => 3,
 		'name' => 'my-plugin/custom-header',
 		'title' => 'Custom Header',
 		'category' => 'text',
@@ -39,7 +39,7 @@ return array(
 	),
 	'image-gallery' => array(
 		'$schema' => 'https://schemas.wp.org/trunk/block.json',
-		'apiVersion' => 2,
+		'apiVersion' => 3,
 		'name' => 'my-plugin/image-gallery',
 		'title' => 'Image Gallery',
 		'category' => 'media',
@@ -94,7 +94,7 @@ return array(
 	),
 	'simple-button' => array(
 		'$schema' => 'https://schemas.wp.org/trunk/block.json',
-		'apiVersion' => 2,
+		'apiVersion' => 3,
 		'name' => 'my-plugin/simple-button',
 		'title' => 'Simple Button',
 		'category' => 'design',

--- a/packages/scripts/scripts/test/fixtures/build-blocks-manifest/input/custom-header/block.json
+++ b/packages/scripts/scripts/test/fixtures/build-blocks-manifest/input/custom-header/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "my-plugin/custom-header",
 	"title": "Custom Header",
 	"category": "text",

--- a/packages/scripts/scripts/test/fixtures/build-blocks-manifest/input/image-gallery/block.json
+++ b/packages/scripts/scripts/test/fixtures/build-blocks-manifest/input/image-gallery/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "my-plugin/image-gallery",
 	"title": "Image Gallery",
 	"category": "media",

--- a/packages/scripts/scripts/test/fixtures/build-blocks-manifest/input/simple-button/block.json
+++ b/packages/scripts/scripts/test/fixtures/build-blocks-manifest/input/simple-button/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "my-plugin/simple-button",
 	"title": "Simple Button",
 	"category": "design",

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -302,7 +302,13 @@
 							"type": "boolean",
 							"default": true
 						}
-					}
+					},
+					"patternProperties": {
+						"^__experimental": {
+							"type": [ "array", "boolean", "object", "string" ]
+						}
+					},
+					"additionalProperties": false
 				},
 				"customClassName": {
 					"description": "This property adds a field to define a custom className for the block’s wrapper.",

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -302,13 +302,7 @@
 							"type": "boolean",
 							"default": true
 						}
-					},
-					"patternProperties": {
-						"^__experimental": {
-							"type": [ "array", "boolean", "object", "string" ]
-						}
-					},
-					"additionalProperties": false
+					}
 				},
 				"customClassName": {
 					"description": "This property adds a field to define a custom className for the block’s wrapper.",


### PR DESCRIPTION

## What?

Disallow extra properties in the supports.colors block.json schema.
Fix existing schema errors (tests had some `apiVersion: 2`, only 3 is allowed now).

See #71800.

## Why?

This fixes and helps prevent schema issues.

This is merged to #71851 where JSON schema checking is added to CI.

## Testing Instructions

See tests pass on #71851, specifically JSON schema checks: https://github.com/WordPress/gutenberg/actions/runs/17954394785/job/51061796157
