### PR TITLE
Accordion Header: fix toggle icon position in the editor

### DIFF
--- a/packages/block-library/src/accordion-header/edit.js
+++ b/packages/block-library/src/accordion-header/edit.js
@@ -78,6 +78,7 @@ export default function Edit( { attributes, setAttributes, context } ) {
 							setAttributes( { title: newTitle } )
 						}
 						placeholder={ __( 'Accordion title' ) }
+						className="wp-block-accordion-header__toggle-title"
 					/>
 					{ showIcon && iconPosition === 'right' && (
 						<span


### PR DESCRIPTION
## What?

Fix a problem where the accordion header icon is misplaced.

## Why?

I'm not sure when this bug appeared, but it may have occurred during a modification or refactoring of the accordion block.

## Testing Instructions

- Create a new post and insert an Accordion block.
- Confirm that the toggle icon is placed on the right edge correctly.

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="989" height="404" alt="before" src="https://github.com/user-attachments/assets/9ea6f5ff-f6f7-443e-ba25-502c4dfab1d5" />

### After

<img width="989" height="405" alt="after" src="https://github.com/user-attachments/assets/a9673fec-586c-4e88-a283-363701647974" />