### PR TITLE
Comments: Fix potential PHP warning

### DIFF
--- a/packages/block-library/src/comments/index.php
+++ b/packages/block-library/src/comments/index.php
@@ -28,11 +28,11 @@
 function render_block_core_comments( $attributes, $content, $block ) {
 	global $post;
 
-	$post_id = $block->context['postId'];
-	if ( ! isset( $post_id ) ) {
+	if ( ! isset( $block->context['postId'] ) ) {
 		return '';
 	}
 
+	$post_id = $block->context['postId'];
 	// Return early if there are no comments and comments are closed.
 	if ( ! comments_open( $post_id ) && (int) get_comments_number( $post_id ) === 0 ) {
 		return '';


### PR DESCRIPTION
## What?
PR fixes a PHP warning sometimes triggered by the Comments block. I think it happens when a block is pre-rerendered for patterns.

```
PHP Warning:  Undefined array key "postId" in /Users/mamaduka/Projects/gutenberg/wp-content/plugins/gutenberg/build/block-library/blocks/comments.php on line 31
```

## Why?
Block was accessing the context value before checking its existence.

## Testing Instructions
 1. Open a post or page.
 2. Confirm PHP warning isn't logged.
 3. Confirm that the code update makes sense.

### Testing Instructions for Keyboard
Same.
