### PR TITLE
Block Comments: Fix canceling the form for a selected block

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -86,53 +86,39 @@ export function Comments( {
 				: null,
 		};
 	}, [] );
+	const [ focusThread, setFocusThread ] = useState( blockCommentId ?? null );
 
-	const clearThreadFocus = () => {
-		setFocusThread( null );
-		setShowCommentBoard( false );
-	};
+	const hasThreads = Array.isArray( threads ) && threads.length > 0;
+	if ( ! hasThreads ) {
+		return (
+			<VStack
+				alignment="left"
+				className="editor-collab-sidebar-panel__thread"
+				justify="flex-start"
+				spacing="3"
+			>
+				{
+					// translators: message displayed when there are no comments available
+					__( 'No comments available' )
+				}
+			</VStack>
+		);
+	}
 
-	const [ focusThread, setFocusThread ] = useState(
-		blockCommentId ? blockCommentId : null
-	);
-
-	return (
-		<>
-			{
-				// If there are no comments, show a message indicating no comments are available.
-				( ! Array.isArray( threads ) || threads.length === 0 ) && (
-					<VStack
-						alignment="left"
-						className="editor-collab-sidebar-panel__thread"
-						justify="flex-start"
-						spacing="3"
-					>
-						{
-							// translators: message displayed when there are no comments available
-							__( 'No comments available' )
-						}
-					</VStack>
-				)
-			}
-			{ Array.isArray( threads ) &&
-				threads.length > 0 &&
-				threads.map( ( thread ) => (
-					<Thread
-						key={ thread.id }
-						thread={ thread }
-						onAddReply={ onAddReply }
-						onCommentDelete={ onCommentDelete }
-						onCommentResolve={ onCommentResolve }
-						onCommentReopen={ onCommentReopen }
-						onEditComment={ onEditComment }
-						isFocused={ focusThread === thread.id }
-						clearThreadFocus={ clearThreadFocus }
-						setFocusThread={ setFocusThread }
-						setShowCommentBoard={ setShowCommentBoard }
-					/>
-				) ) }
-		</>
-	);
+	return threads.map( ( thread ) => (
+		<Thread
+			key={ thread.id }
+			thread={ thread }
+			onAddReply={ onAddReply }
+			onCommentDelete={ onCommentDelete }
+			onCommentResolve={ onCommentResolve }
+			onCommentReopen={ onCommentReopen }
+			onEditComment={ onEditComment }
+			isFocused={ focusThread === thread.id }
+			setFocusThread={ setFocusThread }
+			setShowCommentBoard={ setShowCommentBoard }
+		/>
+	) );
 }
 
 function Thread( {
@@ -143,7 +129,6 @@ function Thread( {
 	onCommentResolve,
 	onCommentReopen,
 	isFocused,
-	clearThreadFocus,
 	setFocusThread,
 	setShowCommentBoard,
 } ) {
@@ -174,6 +159,11 @@ function Thread( {
 			} );
 			flashBlock( relatedBlock );
 		}
+	};
+
+	const clearThreadFocus = () => {
+		setFocusThread( null );
+		setShowCommentBoard( false );
 	};
 
 	return (

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useState, RawHTML, useEffect, useMemo } from '@wordpress/element';
+import { useState, RawHTML, useMemo } from '@wordpress/element';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -64,7 +64,6 @@ const findBlockByCommentId = ( commentId, blockList ) => {
  * @param {Function} props.onCommentDelete     - The function to delete a comment.
  * @param {Function} props.onCommentResolve    - The function to mark a comment as resolved.
  * @param {Function} props.onCommentReopen     - The function to reopen a resolved comment.
- * @param {boolean}  props.showCommentBoard    - Whether to show the comment board.
  * @param {Function} props.setShowCommentBoard - The function to set the comment board visibility.
  * @return {React.ReactNode} The rendered Comments component.
  */
@@ -75,7 +74,6 @@ export function Comments( {
 	onCommentDelete,
 	onCommentResolve,
 	onCommentReopen,
-	showCommentBoard,
 	setShowCommentBoard,
 } ) {
 	const { blockCommentId } = useSelect( ( select ) => {
@@ -95,15 +93,8 @@ export function Comments( {
 	};
 
 	const [ focusThread, setFocusThread ] = useState(
-		showCommentBoard && blockCommentId ? blockCommentId : null
+		blockCommentId ? blockCommentId : null
 	);
-
-	useEffect( () => {
-		// Highlight comment when block is selected.
-		if ( blockCommentId && ! focusThread ) {
-			setFocusThread( blockCommentId );
-		}
-	}, [ blockCommentId, focusThread, setFocusThread ] );
 
 	return (
 		<>

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -78,19 +78,16 @@ export function Comments( {
 	showCommentBoard,
 	setShowCommentBoard,
 } ) {
-	const { blockCommentId, blocks } = useSelect( ( select ) => {
-		const { getBlockAttributes, getSelectedBlockClientId, getBlocks } =
+	const { blockCommentId } = useSelect( ( select ) => {
+		const { getBlockAttributes, getSelectedBlockClientId } =
 			select( blockEditorStore );
-		const _clientId = getSelectedBlockClientId();
+		const clientId = getSelectedBlockClientId();
 		return {
-			blockCommentId: _clientId
-				? getBlockAttributes( _clientId )?.blockCommentId
+			blockCommentId: clientId
+				? getBlockAttributes( clientId )?.blockCommentId
 				: null,
-			blocks: getBlocks(),
 		};
 	}, [] );
-
-	const { flashBlock } = useDispatch( blockEditorStore );
 
 	const clearThreadFocus = () => {
 		setFocusThread( null );
@@ -106,7 +103,7 @@ export function Comments( {
 		if ( blockCommentId && ! focusThread ) {
 			setFocusThread( blockCommentId );
 		}
-	}, [ blockCommentId, focusThread, blocks, setFocusThread ] );
+	}, [ blockCommentId, focusThread, setFocusThread ] );
 
 	return (
 		<>
@@ -140,9 +137,6 @@ export function Comments( {
 						isFocused={ focusThread === thread.id }
 						clearThreadFocus={ clearThreadFocus }
 						setFocusThread={ setFocusThread }
-						blockCommentId={ blockCommentId }
-						blocks={ blocks }
-						flashBlock={ flashBlock }
 						setShowCommentBoard={ setShowCommentBoard }
 					/>
 				) ) }
@@ -160,10 +154,15 @@ function Thread( {
 	isFocused,
 	clearThreadFocus,
 	setFocusThread,
-	blocks,
-	flashBlock,
 	setShowCommentBoard,
 } ) {
+	const { flashBlock } = useDispatch( blockEditorStore );
+	const { blocks } = useSelect( ( select ) => {
+		return {
+			blocks: select( blockEditorStore ).getBlocks(),
+		};
+	}, [] );
+
 	// Find first block that has this comment ID - run at component root level.
 	const relatedBlock = useMemo( () => {
 		if ( ! thread.id || ! blocks ) {


### PR DESCRIPTION
## What?
This is a follow-up to #71308.

PR fixes the bug and allows canceling the reply for the currently selected block.

I also did the following refactoring of internal components:

1. Remove the effect to sync the `focusThread` value. It wasn't required and was causing the mentioned bug.
2. Avoid unnecessary prop drilling when possible.
3. Simpify rendering logic for `Comments`.

## Why?

## Testing Instructions
1. Open a post or page.
4. Add multiple blocks and comments for them.
5. Open the comment sidebar.
6. Selecting a block should focus on its comment threads and display form.
7. Canceling the form should remove the focus state.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/c912226c-778f-4397-8ada-45862a5b67dc

**After**

https://github.com/user-attachments/assets/aeebd39e-7180-4575-919e-b70f99a901fc


