### PR TITLE
Fields package: Add Storybook examples

### DIFF
--- a/packages/fields/src/stories/index.story.tsx
+++ b/packages/fields/src/stories/index.story.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import { DataForm, DataViews } from '@wordpress/dataviews';
+import { DataForm, DataViews, type Form } from '@wordpress/dataviews';
 import type { Field, View } from '@wordpress/dataviews';
 
 /**
@@ -10,23 +10,23 @@ import type { Field, View } from '@wordpress/dataviews';
  */
 
 import {
-	slugField,
-	titleField,
-	orderField,
-	passwordField,
-	statusField,
+	authorField,
 	commentStatusField,
 	dateField,
-	authorField,
+	orderField,
+	passwordField,
+	slugField,
+	statusField,
+	titleField,
 } from '../fields';
 
 // Fields not yet covered:
-// pageTitleField,
-// templateTitleField,
-// patternTitleField,
 // featuredImageField,
-// templateField,
+// pageTitleField,
 // parentField,
+// patternTitleField,
+// templateField,
+// templateTitleField,
 
 import type { BasePost, BasePostWithEmbeddedAuthor } from '../types';
 
@@ -74,7 +74,10 @@ const samplePostWithAuthor: BasePostWithEmbeddedAuthor = {
 	},
 };
 
-// Create a comprehensive field showcase
+// Create a showcase of all base fields.
+// This does not include fields that require more complex setups,
+// however this could be extended in the future, by setting up the data
+// stores to contain entities like pages, users, media, etc.
 const showcaseFields: Field< any >[] = [
 	titleField,
 	slugField,
@@ -86,25 +89,28 @@ const showcaseFields: Field< any >[] = [
 	orderField,
 ];
 
-// Form configuration for showcase
-const showcaseForm = {
-	fields: [
-		'title',
-		'slug',
-		'status',
-		'date',
-		'author',
-		'comment_status',
-		'password',
-		'menu_order',
-	],
-};
-
-export const DataFormsPreview = () => {
+const DataFormsComponent = ( { type }: { type: 'regular' | 'panel' } ) => {
 	const [ data, setData ] = useState( samplePostWithAuthor );
 
 	const handleChange = ( updates: Partial< BasePostWithEmbeddedAuthor > ) => {
 		setData( ( prev ) => ( { ...prev, ...updates } ) );
+	};
+
+	// Form configuration for the showcase.
+	const showcaseForm: Form = {
+		layout: {
+			type,
+		},
+		fields: [
+			'title',
+			'slug',
+			'status',
+			'date',
+			'author',
+			'comment_status',
+			'password',
+			'menu_order',
+		],
 	};
 
 	return (
@@ -123,6 +129,20 @@ export const DataFormsPreview = () => {
 			/>
 		</div>
 	);
+};
+
+export const DataFormsPreview = {
+	render: DataFormsComponent,
+	argTypes: {
+		type: {
+			control: { type: 'select' },
+			description: 'Choose the layout type.',
+			options: [ 'regular', 'panel' ],
+		},
+	},
+	args: {
+		type: 'regular',
+	},
 };
 
 export const DataViewsPreview = () => {

--- a/packages/fields/src/stories/index.story.tsx
+++ b/packages/fields/src/stories/index.story.tsx
@@ -1,0 +1,167 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { DataForm, DataViews } from '@wordpress/dataviews';
+import type { Field, View } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+
+import {
+	slugField,
+	titleField,
+	orderField,
+	passwordField,
+	statusField,
+	commentStatusField,
+	dateField,
+	authorField,
+} from '../fields';
+
+// Fields not yet covered:
+// pageTitleField,
+// templateTitleField,
+// patternTitleField,
+// featuredImageField,
+// templateField,
+// parentField,
+
+import type { BasePost, BasePostWithEmbeddedAuthor } from '../types';
+
+export default {
+	title: 'Fields/Base Fields',
+	component: DataForm,
+};
+
+// Sample data for different field types
+const sampleBasePost: BasePost = {
+	id: 1,
+	title: { rendered: 'Sample Post Title', raw: 'Sample Post Title' },
+	content: {
+		rendered: '<p>This is sample content.</p>',
+		raw: 'This is sample content.',
+	},
+	type: 'post',
+	slug: 'sample-post-title',
+	permalink_template: 'http://localhost:8888/%postname%/',
+	date: '2024-01-15T10:30:00',
+	modified: '2024-01-20T14:45:00',
+	status: 'publish',
+	comment_status: 'open',
+	password: '',
+	parent: 0,
+	menu_order: 0,
+	author: 1,
+	featured_media: 123,
+	template: 'single',
+};
+
+const samplePostWithAuthor: BasePostWithEmbeddedAuthor = {
+	...sampleBasePost,
+	_embedded: {
+		author: [
+			{
+				name: 'John Doe',
+				avatar_urls: {
+					'24': 'https://gravatar.com/avatar?d=retro&s=24',
+					'48': 'https://gravatar.com/avatar?d=retro&s=48',
+					'96': 'https://gravatar.com/avatar?d=retro&s=96',
+				},
+			},
+		],
+	},
+};
+
+// Create a comprehensive field showcase
+const showcaseFields: Field< any >[] = [
+	titleField,
+	slugField,
+	statusField,
+	dateField,
+	authorField,
+	commentStatusField,
+	passwordField,
+	orderField,
+];
+
+// Form configuration for showcase
+const showcaseForm = {
+	fields: [
+		'title',
+		'slug',
+		'status',
+		'date',
+		'author',
+		'comment_status',
+		'password',
+		'menu_order',
+	],
+};
+
+export const DataFormsPreview = () => {
+	const [ data, setData ] = useState( samplePostWithAuthor );
+
+	const handleChange = ( updates: Partial< BasePostWithEmbeddedAuthor > ) => {
+		setData( ( prev ) => ( { ...prev, ...updates } ) );
+	};
+
+	return (
+		<div style={ { padding: '20px' } }>
+			<h2>Base Fields</h2>
+			<p>
+				This story demonstrates all the base fields from the
+				@wordpress/fields package within a DataForm.
+			</p>
+
+			<DataForm
+				data={ data }
+				fields={ showcaseFields }
+				form={ showcaseForm }
+				onChange={ handleChange }
+			/>
+		</div>
+	);
+};
+
+export const DataViewsPreview = () => {
+	const [ view, setView ] = useState< View >( {
+		type: 'table',
+		fields: showcaseFields.map( ( f ) => f.id ),
+		titleField: 'title',
+		descriptionField: undefined,
+		mediaField: undefined,
+	} );
+	const [ data ] = useState( [ samplePostWithAuthor ] );
+
+	const paginationInfo = {
+		totalItems: 1,
+		totalPages: 1,
+	};
+
+	const defaultLayouts = {
+		table: {},
+		list: {},
+		grid: {},
+	};
+
+	return (
+		<div style={ { padding: '20px' } }>
+			<h2>Fields Package DataViews Preview</h2>
+			<p>
+				This story demonstrates all the base fields from the
+				@wordpress/fields package, rendered in a DataViews component,
+				allowing preview of view state and layout switching.
+			</p>
+			<DataViews
+				data={ data }
+				fields={ showcaseFields }
+				view={ view }
+				onChangeView={ ( nextView: View ) => setView( nextView ) }
+				paginationInfo={ paginationInfo }
+				defaultLayouts={ defaultLayouts }
+			/>
+		</div>
+	);
+};

--- a/storybook/main.js
+++ b/storybook/main.js
@@ -36,6 +36,7 @@ const stories = [
 	'../packages/icons/src/**/stories/*.story.@(js|tsx|mdx)',
 	'../packages/edit-site/src/**/stories/*.story.@(js|tsx|mdx)',
 	'../packages/dataviews/src/**/stories/*.story.@(js|tsx|mdx)',
+	'../packages/fields/src/**/stories/*.story.@(js|tsx|mdx)',
 ].filter( Boolean );
 
 module.exports = {

--- a/storybook/package-styles/config.js
+++ b/storybook/package-styles/config.js
@@ -13,6 +13,8 @@ import editSiteLtr from '../package-styles/edit-site-ltr.lazy.scss';
 import editSiteRtl from '../package-styles/edit-site-rtl.lazy.scss';
 import dataviewsLtr from '../package-styles/dataviews-ltr.lazy.scss';
 import dataviewsRtl from '../package-styles/dataviews-rtl.lazy.scss';
+import fieldsLtr from '../package-styles/fields-ltr.lazy.scss';
+import fieldsRtl from '../package-styles/fields-rtl.lazy.scss';
 
 /**
  * Stylesheets to lazy load when the story's context.componentId matches the
@@ -57,6 +59,11 @@ const CONFIG = [
 		componentIdMatcher: /^dataviews-/,
 		ltr: [ componentsLtr, dataviewsLtr ],
 		rtl: [ componentsRtl, dataviewsRtl ],
+	},
+	{
+		componentIdMatcher: /^fields-/,
+		ltr: [ componentsLtr, dataviewsLtr, fieldsLtr ],
+		rtl: [ componentsRtl, dataviewsRtl, fieldsRtl ],
 	},
 ];
 

--- a/storybook/package-styles/fields-ltr.lazy.scss
+++ b/storybook/package-styles/fields-ltr.lazy.scss
@@ -1,0 +1,1 @@
+@import "../../packages/fields/build-style/style.css";

--- a/storybook/package-styles/fields-rtl.lazy.scss
+++ b/storybook/package-styles/fields-rtl.lazy.scss
@@ -1,0 +1,1 @@
+@import "../../packages/fields/build-style/style-rtl.css";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Add a couple of Storybook examples for the fields package. These are "base" fields that are used for post and pages, etc, but currently aren't able to be demoed in isolation within Storybook.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I'm working on some ideas for the new media library (proposed in https://github.com/WordPress/gutenberg/issues/55238), which will require adding new media-specific fields.

Before we go to add new fields, though, it would be good to be able to quickly demo the existing fields within an easy to test environment: hence adding Storybook examples. Then, as we start to propose adding in fields for things like media, we'll have a good place to test them.

The couple of examples I've gone to add here are using `DataViews` and `DataForm` to display the fields.

Note that the purpose of this PR is to showcase the fields themselves, and not the DataViews APIs, so (for now at least) I've tried to keep things quite simple.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Set up two stories for the `fields` package, one using DataForm, and one using DataViews
* Make sure that required styles are being loaded in that environment (components, dataviews styles) so that the fields render approximately how they should
* I haven't included all the fields just yet — before I spend too much longer on this, I mostly wanted to get this PR up to gauge interest

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Run `npm run storybook:dev` to develop the stories
2. Navigate to `http://localhost:50240/?path=/story/fields-base-fields--data-forms-preview` to view the story

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/f4e6c494-d821-4322-a12d-35263559039d