### PR TITLE
DataViewsPicker Grid layout: Support hiding the title

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug Fixes
 
 - DataViews: keep non-hideable fields out of the hidden-fields list when they’re already invisible. [#71729](https://github.com/WordPress/gutenberg/pull/71729/)
+- DataViewsPicker: Hide the space reserved for the title when the title is hidden. [#71865](https://github.com/WordPress/gutenberg/pull/71865)
 
 ### Enhancements
 

--- a/packages/dataviews/src/dataviews-layouts/picker-grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/picker-grid/index.tsx
@@ -89,6 +89,11 @@ function GridItem< Item >( {
 
 	return (
 		<Composite.Item
+			aria-label={
+				titleField
+					? titleField.getValue( { item } ) || __( '(no title)' )
+					: undefined
+			}
 			key={ id }
 			render={ ( { children, ...props } ) => (
 				<VStack spacing={ 0 } children={ children } { ...props } />

--- a/packages/dataviews/src/dataviews-layouts/picker-grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/picker-grid/index.tsx
@@ -130,14 +130,16 @@ function GridItem< Item >( {
 					tabIndex={ -1 }
 				/>
 			) }
-			<HStack
-				justify="space-between"
-				className="dataviews-view-picker-grid__title-actions"
-			>
-				<div className="dataviews-view-picker-grid__title-field dataviews-title-field">
-					{ renderedTitleField }
-				</div>
-			</HStack>
+			{ showTitle && (
+				<HStack
+					justify="space-between"
+					className="dataviews-view-picker-grid__title-actions"
+				>
+					<div className="dataviews-view-picker-grid__title-field dataviews-title-field">
+						{ renderedTitleField }
+					</div>
+				</HStack>
+			) }
 			<VStack spacing={ 1 }>
 				{ showDescription && descriptionField?.render && (
 					<descriptionField.render


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Follows:

* #71369

In the DataViewsPicker grid layout, if the title is not being shown, then hide the space reserved for the title.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As in #71369 which dealt with the DataViews grid layout, when the title is hidden, we should remove the space where the title would have been displayed, so that the gap between grid items is consistent horizontally and vertically.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add a simple `showTitle` check before displaying the area where the title appears.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Run `npm run storybook:dev` and navigate to the DataViewsPicker story
* The title will display by default, but if you go to the cog/settings menu on the picker, and hide the title field, you should see that the spacing is consistent with this PR applied

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="900" height="744" alt="image" src="https://github.com/user-attachments/assets/c9f02498-8e81-4c3a-b061-5ca9ee1dcb41" /> | <img width="900" height="762" alt="image" src="https://github.com/user-attachments/assets/f45dd169-3cbc-4de5-a8d7-a30866bc1548" /> |

It should still look fine with the title displayed:

<img width="1054" height="526" alt="image" src="https://github.com/user-attachments/assets/0ed1e827-3c0e-4ebe-b8fc-bca384bc2dfe" />
