### PR TITLE
Block Comments: New 'useBlockComments' hook and perf improvements

### DIFF
--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -47,7 +47,7 @@ export function useBlockComments( postId ) {
 			compare[ item.id ] = {
 				...item,
 				reply: [],
-				blockId:
+				blockClientId:
 					item.parent === 0 ? blocksWithComments[ item.id ] : null,
 			};
 		} );

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -2,14 +2,11 @@
  * WordPress dependencies
  */
 import { useMemo } from '@wordpress/element';
-import { useEntityBlockEditor, useEntityRecords } from '@wordpress/core-data';
+import { useEntityRecords } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
-/**
- * Internal dependencies
- */
-import { getCommentIdsFromBlocks } from './utils';
-
-export function useBlockComments( postId, postType ) {
+export function useBlockComments( postId ) {
 	const queryArgs = {
 		post: postId,
 		type: 'block_comment',
@@ -24,9 +21,18 @@ export function useBlockComments( postId, postType ) {
 		{ enabled: !! postId && typeof postId === 'number' }
 	);
 
-	const [ blocks ] = useEntityBlockEditor( 'postType', postType, {
-		id: postId,
-	} );
+	const blocksWithComments = useSelect( ( select ) => {
+		const { getBlockAttributes, getClientIdsWithDescendants } =
+			select( blockEditorStore );
+
+		return getClientIdsWithDescendants().reduce( ( results, clientId ) => {
+			const commentId = getBlockAttributes( clientId )?.blockCommentId;
+			if ( commentId ) {
+				results[ commentId ] = clientId;
+			}
+			return results;
+		}, {} );
+	}, [] );
 
 	// Process comments to build the tree structure.
 	const { resultComments, unresolvedSortedThreads } = useMemo( () => {
@@ -36,9 +42,14 @@ export function useBlockComments( postId, postType ) {
 
 		const allComments = threads ?? [];
 
-		// Initialize each object with an empty `reply` array.
+		// Initialize each object with an empty `reply` array and map blockClientId.
 		allComments.forEach( ( item ) => {
-			compare[ item.id ] = { ...item, reply: [] };
+			compare[ item.id ] = {
+				...item,
+				reply: [],
+				blockId:
+					item.parent === 0 ? blocksWithComments[ item.id ] : null,
+			};
 		} );
 
 		// Iterate over the data to build the tree structure.
@@ -61,14 +72,12 @@ export function useBlockComments( postId, postType ) {
 			reply: [ ...item.reply ].reverse(),
 		} ) );
 
-		const blockCommentIds = getCommentIdsFromBlocks( blocks );
-
 		const threadIdMap = new Map(
-			updatedResult.map( ( thread ) => [ thread.id, thread ] )
+			updatedResult.map( ( thread ) => [ String( thread.id ), thread ] )
 		);
 
 		// Get comments by block order, filter out undefined threads, and exclude resolved comments.
-		const unresolvedSortedComments = blockCommentIds
+		const unresolvedSortedComments = Object.keys( blocksWithComments )
 			.map( ( id ) => threadIdMap.get( id ) )
 			.filter(
 				( thread ) =>
@@ -79,7 +88,7 @@ export function useBlockComments( postId, postType ) {
 			resultComments: updatedResult,
 			unresolvedSortedThreads: unresolvedSortedComments,
 		};
-	}, [ threads, blocks ] );
+	}, [ threads, blocksWithComments ] );
 
 	return { resultComments, unresolvedSortedThreads, totalPages };
 }

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -1,0 +1,85 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { useEntityBlockEditor, useEntityRecords } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { getCommentIdsFromBlocks } from './utils';
+
+export function useBlockComments( postId, postType ) {
+	const queryArgs = {
+		post: postId,
+		type: 'block_comment',
+		status: 'all',
+		per_page: 100,
+	};
+
+	const { records: threads, totalPages } = useEntityRecords(
+		'root',
+		'comment',
+		queryArgs,
+		{ enabled: !! postId && typeof postId === 'number' }
+	);
+
+	const [ blocks ] = useEntityBlockEditor( 'postType', postType, {
+		id: postId,
+	} );
+
+	// Process comments to build the tree structure.
+	const { resultComments, unresolvedSortedThreads } = useMemo( () => {
+		// Create a compare to store the references to all objects by id.
+		const compare = {};
+		const result = [];
+
+		const allComments = threads ?? [];
+
+		// Initialize each object with an empty `reply` array.
+		allComments.forEach( ( item ) => {
+			compare[ item.id ] = { ...item, reply: [] };
+		} );
+
+		// Iterate over the data to build the tree structure.
+		allComments.forEach( ( item ) => {
+			if ( item.parent === 0 ) {
+				// If parent is 0, it's a root item, push it to the result array.
+				result.push( compare[ item.id ] );
+			} else if ( compare[ item.parent ] ) {
+				// Otherwise, find its parent and push it to the parent's `reply` array.
+				compare[ item.parent ].reply.push( compare[ item.id ] );
+			}
+		} );
+
+		if ( 0 === result?.length ) {
+			return { resultComments: [], unresolvedSortedThreads: [] };
+		}
+
+		const updatedResult = result.map( ( item ) => ( {
+			...item,
+			reply: [ ...item.reply ].reverse(),
+		} ) );
+
+		const blockCommentIds = getCommentIdsFromBlocks( blocks );
+
+		const threadIdMap = new Map(
+			updatedResult.map( ( thread ) => [ thread.id, thread ] )
+		);
+
+		// Get comments by block order, filter out undefined threads, and exclude resolved comments.
+		const unresolvedSortedComments = blockCommentIds
+			.map( ( id ) => threadIdMap.get( id ) )
+			.filter(
+				( thread ) =>
+					thread !== undefined && thread.status !== 'approved'
+			);
+
+		return {
+			resultComments: updatedResult,
+			unresolvedSortedThreads: unresolvedSortedComments,
+		};
+	}, [ threads, blocks ] );
+
+	return { resultComments, unresolvedSortedThreads, totalPages };
+}

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -237,11 +237,10 @@ export default function CollabSidebar() {
 	const { getActiveComplementaryArea } = useSelect( interfaceStore );
 	const isLargeViewport = useViewportMatch( 'medium' );
 
-	const { postId, postType } = useSelect( ( select ) => {
-		const { getCurrentPostId, getCurrentPostType } = select( editorStore );
+	const { postId } = useSelect( ( select ) => {
+		const { getCurrentPostId } = select( editorStore );
 		return {
 			postId: getCurrentPostId(),
-			postType: getCurrentPostType(),
 		};
 	}, [] );
 
@@ -263,7 +262,7 @@ export default function CollabSidebar() {
 	};
 
 	const { resultComments, unresolvedSortedThreads, totalPages } =
-		useBlockComments( postId, postType );
+		useBlockComments( postId );
 
 	const hasMoreComments = totalPages && totalPages > 1;
 

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -8,16 +8,12 @@ import {
 	resolveSelect,
 	subscribe,
 } from '@wordpress/data';
-import { useState, useMemo } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 import { comment as commentIcon } from '@wordpress/icons';
 import { addFilter } from '@wordpress/hooks';
 import { store as noticesStore } from '@wordpress/notices';
-import {
-	store as coreStore,
-	useEntityBlockEditor,
-	useEntityRecords,
-} from '@wordpress/core-data';
+import { store as coreStore } from '@wordpress/core-data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as interfaceStore } from '@wordpress/interface';
 
@@ -32,7 +28,7 @@ import { store as editorStore } from '../../store';
 import AddCommentButton from './comment-button';
 import CommentAvatarIndicator from './comment-indicator-toolbar';
 import { useGlobalStylesContext } from '../global-styles-provider';
-import { getCommentIdsFromBlocks } from './utils';
+import { useBlockComments } from './hooks';
 
 const modifyBlockCommentAttributes = ( settings ) => {
 	if ( ! settings.attributes.blockCommentId ) {
@@ -249,22 +245,6 @@ export default function CollabSidebar() {
 		};
 	}, [] );
 
-	const queryArgs = {
-		post: postId,
-		type: 'block_comment',
-		status: 'all',
-		per_page: 100,
-	};
-
-	const { records: threads, totalPages } = useEntityRecords(
-		'root',
-		'comment',
-		queryArgs,
-		{ enabled: !! postId && typeof postId === 'number' }
-	);
-
-	const hasMoreComments = totalPages && totalPages > 1;
-
 	const { blockCommentId } = useSelect( ( select ) => {
 		const { getBlockAttributes, getSelectedBlockClientId } =
 			select( blockEditorStore );
@@ -282,62 +262,10 @@ export default function CollabSidebar() {
 		enableComplementaryArea( 'core', collabHistorySidebarName );
 	};
 
-	const [ blocks ] = useEntityBlockEditor( 'postType', postType, {
-		id: postId,
-	} );
+	const { resultComments, unresolvedSortedThreads, totalPages } =
+		useBlockComments( postId, postType );
 
-	// Process comments to build the tree structure.
-	const { resultComments, unresolvedSortedThreads } = useMemo( () => {
-		// Create a compare to store the references to all objects by id.
-		const compare = {};
-		const result = [];
-
-		const allComments = threads ?? [];
-
-		// Initialize each object with an empty `reply` array.
-		allComments.forEach( ( item ) => {
-			compare[ item.id ] = { ...item, reply: [] };
-		} );
-
-		// Iterate over the data to build the tree structure.
-		allComments.forEach( ( item ) => {
-			if ( item.parent === 0 ) {
-				// If parent is 0, it's a root item, push it to the result array.
-				result.push( compare[ item.id ] );
-			} else if ( compare[ item.parent ] ) {
-				// Otherwise, find its parent and push it to the parent's `reply` array.
-				compare[ item.parent ].reply.push( compare[ item.id ] );
-			}
-		} );
-
-		if ( 0 === result?.length ) {
-			return { resultComments: [], unresolvedSortedThreads: [] };
-		}
-
-		const updatedResult = result.map( ( item ) => ( {
-			...item,
-			reply: [ ...item.reply ].reverse(),
-		} ) );
-
-		const blockCommentIds = getCommentIdsFromBlocks( blocks );
-
-		const threadIdMap = new Map(
-			updatedResult.map( ( thread ) => [ thread.id, thread ] )
-		);
-
-		// Get comments by block order, filter out undefined threads, and exclude resolved comments.
-		const unresolvedSortedComments = blockCommentIds
-			.map( ( id ) => threadIdMap.get( id ) )
-			.filter(
-				( thread ) =>
-					thread !== undefined && thread.status !== 'approved'
-			);
-
-		return {
-			resultComments: updatedResult,
-			unresolvedSortedThreads: unresolvedSortedComments,
-		};
-	}, [ threads, blocks ] );
+	const hasMoreComments = totalPages && totalPages > 1;
 
 	// Get the global styles to set the background color of the sidebar.
 	const { merged: GlobalStyles } = useGlobalStylesContext();

--- a/packages/editor/src/components/collab-sidebar/utils.js
+++ b/packages/editor/src/components/collab-sidebar/utils.js
@@ -7,39 +7,3 @@
 export function sanitizeCommentString( str ) {
 	return str.trim();
 }
-
-/**
- * Extracts comment IDs from an array of blocks.
- *
- * This function recursively traverses the blocks and their inner blocks to
- * collect all comment IDs found in the block attributes.
- *
- * @param {Array} blocks - The array of blocks to extract comment IDs from.
- * @return {Array} An array of comment IDs extracted from the blocks.
- */
-export function getCommentIdsFromBlocks( blocks ) {
-	// Recursive function to extract comment IDs from blocks
-	const extractCommentIds = ( items ) => {
-		return items.reduce( ( commentIds, block ) => {
-			// Check for comment IDs in the current block's attributes
-			if (
-				block.attributes &&
-				block.attributes.blockCommentId &&
-				! commentIds.includes( block.attributes.blockCommentId )
-			) {
-				commentIds.push( block.attributes.blockCommentId );
-			}
-
-			// Recursively check inner blocks
-			if ( block.innerBlocks && block.innerBlocks.length > 0 ) {
-				const innerCommentIds = extractCommentIds( block.innerBlocks );
-				commentIds.push( ...innerCommentIds );
-			}
-
-			return commentIds;
-		}, [] );
-	};
-
-	// Extract all comment IDs recursively
-	return extractCommentIds( blocks );
-}


### PR DESCRIPTION
## What?

PR extracts all `block-comments` data, querying logic into a separate hook.

**Additional improvements:**

* Improves content block selection and only selects `commentId -> blockClientId` map. Avoiding unwanted re-renders when typing in Canvas. See screencast.
* Assigns `blockClientId` to the top-level comment so that the value can be easily reused later.

Note: I've only made the necessary changes to the comment tree structure logic. We could try improving it after https://github.com/WordPress/gutenberg/pull/71728#issuecomment-3327166007 is resolved.

## Why?
Makes it easier to maintain and reuse, though the latter shouldn't be needed. Also fixes potential performance issues with typing when rendering large comment trees.

## Testing Instructions
1. Open previously created post with comments. You can use the @t-hamano test plugin to generate test data: https://github.com/t-hamano/block-commenting-data-generator.
2. Confirm block comments are rendered as before.
3. Smoke test block comments.
4. Confirm that CI checks are passing.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/68d57012-4d7b-4f42-a31b-b8b93a0262a1


**After**

https://github.com/user-attachments/assets/96ea6146-126c-4d8f-ac54-0cee2d214681


