### PR TITLE
iAPI: Fix nested `data-wp-each` directives using the same items key

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
@@ -166,6 +166,14 @@
 	<button data-testid="async navigate" data-wp-on--click="actions.asyncNavigate">Async Navigate</button>
 </div>
 
+<!-- Count of succesfull client-side navigations -->
+ <div
+	data-testid="navigation count"
+	data-wp-interactive="directive-context-navigate"
+	data-wp-watch="callbacks.updateNavigationCount"
+	data-wp-text="state.navigationCount"
+></div>
+
 <div
 	data-wp-interactive='{"namespace": "directive-context-non-default"}'
 	data-wp-context--non-default='{ "text": "non default" }'

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/render.php
@@ -167,7 +167,7 @@
 </div>
 
 <!-- Count of succesfull client-side navigations -->
- <div
+<div
 	data-testid="navigation count"
 	data-wp-interactive="directive-context-navigate"
 	data-wp-watch="callbacks.updateNavigationCount"

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-context/view.js
@@ -70,7 +70,14 @@ const html = `
 			<button data-testid="async navigate" data-wp-on--click="actions.asyncNavigate">Async Navigate</button>
 		</div>`;
 
-const { actions } = store( 'directive-context-navigate', {
+const { actions, state } = store( 'directive-context-navigate', {
+	state: {
+		get navigationCount() {
+			const { __navigationCount } = state;
+			return isNaN( __navigationCount ) ? 0 : __navigationCount;
+		},
+		__navigationCount: NaN,
+	},
 	actions: {
 		toggleText() {
 			const ctx = getContext();
@@ -97,6 +104,15 @@ const { actions } = store( 'directive-context-navigate', {
 			yield actions.navigate();
 			const ctx = getContext();
 			ctx.newText = 'changed from async action';
+		},
+	},
+	callbacks: {
+		updateNavigationCount() {
+			const { state: routerState } = store( 'core/router' );
+			if ( routerState.url && isNaN( state.__navigationCount ) ) {
+				state.__navigationCount = 0;
+			}
+			state.__navigationCount++;
 		},
 	},
 } );

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-each/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-each/render.php
@@ -311,3 +311,15 @@
 >
 	<template data-wp-each="state.eachIterator"><p data-wp-text="context.item"></p></template>
 </div>
+
+<ul 
+	data-wp-interactive="directive-each"
+	data-testid="nested-with-same-item-key"
+>
+	<template data-wp-each="context.list" data-wp-context='{"list":["parent1","parent2"]}'>
+		<template data-wp-each="context.list" data-wp-context='{"list":["child1","child2"]}'>
+			<li data-wp-text="context.item"></li>
+		</template>
+		<li data-wp-text="context.item"></li>
+	</template>
+</ul>

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -680,8 +680,11 @@ export default () => {
 			const result: VNode< any >[] = [];
 
 			for ( const item of iterable ) {
+				// Shadows a previous item with the same key.
 				const itemContext = proxifyContext(
-					proxifyState( namespace, {} ),
+					proxifyState( namespace, {
+						[ itemProp ]: item,
+					} ),
 					inheritedValue.client[ namespace ]
 				);
 				const mergedContext = {
@@ -691,9 +694,6 @@ export default () => {
 					},
 					server: { ...inheritedValue.server },
 				};
-
-				// Set the item after proxifying the context.
-				mergedContext.client[ namespace ][ itemProp ] = item;
 
 				const scope = {
 					...getScope(),

--- a/test/e2e/specs/interactivity/directive-context.spec.ts
+++ b/test/e2e/specs/interactivity/directive-context.spec.ts
@@ -252,17 +252,24 @@ test.describe( 'data-wp-context', () => {
 		page,
 	} ) => {
 		const element = page.getByTestId( 'navigation text' );
+		const navCount = page.getByTestId( 'navigation count' );
+		await expect( navCount ).toHaveText( '0' );
 		await page.getByTestId( 'navigate' ).click();
+		await expect( navCount ).toHaveText( '1' );
 		await expect( element ).toHaveText( 'first page' );
 		await page.goBack();
+		await expect( navCount ).toHaveText( '2' );
 		await expect( element ).toHaveText( 'first page' );
 		await page.goForward();
+		await expect( navCount ).toHaveText( '3' );
 		await expect( element ).toHaveText( 'first page' );
 	} );
 
 	test( 'should inherit values on navigation', async ( { page } ) => {
 		const text = page.getByTestId( 'navigation inherited text' );
 		const text2 = page.getByTestId( 'navigation inherited text2' );
+		const navCount = page.getByTestId( 'navigation count' );
+		await expect( navCount ).toHaveText( '0' );
 		await expect( text ).toHaveText( 'first page' );
 		await expect( text2 ).toBeEmpty();
 		await page.getByTestId( 'toggle text' ).click();
@@ -270,12 +277,15 @@ test.describe( 'data-wp-context', () => {
 		await page.getByTestId( 'add text2' ).click();
 		await expect( text2 ).toHaveText( 'some new text' );
 		await page.getByTestId( 'navigate' ).click();
+		await expect( navCount ).toHaveText( '1' );
 		await expect( text ).toHaveText( 'changed dynamically' );
 		await expect( text2 ).toHaveText( 'some new text' );
 		await page.goBack();
+		await expect( navCount ).toHaveText( '2' );
 		await expect( text ).toHaveText( 'changed dynamically' );
 		await expect( text2 ).toHaveText( 'some new text' );
 		await page.goForward();
+		await expect( navCount ).toHaveText( '3' );
 		await expect( text ).toHaveText( 'changed dynamically' );
 		await expect( text2 ).toHaveText( 'some new text' );
 	} );

--- a/test/e2e/specs/interactivity/directive-each.spec.ts
+++ b/test/e2e/specs/interactivity/directive-each.spec.ts
@@ -444,6 +444,21 @@ test.describe( 'data-wp-each', () => {
 		}
 	} );
 
+	test( 'should support nested lists with the same item key', async ( {
+		page,
+	} ) => {
+		const mainElement = page.getByTestId( 'nested-with-same-item-key' );
+		const listItems = mainElement.getByRole( 'listitem' );
+		await expect( listItems ).toHaveText( [
+			'child1',
+			'child2',
+			'parent1',
+			'child1',
+			'child2',
+			'parent2',
+		] );
+	} );
+
 	test( 'should do nothing when used on non-template elements', async ( {
 		page,
 	} ) => {


### PR DESCRIPTION
## What?

Fixes a bug that happens with nested `data-wp-each` elements that use the same key for the items they render. E.g., in the following HTML, there are two different lists that use the same `item` key:

```html
<ul 
	data-wp-interactive="directive-each"
	data-testid="nested-with-same-item-key"
>
	<template data-wp-each="context.list" data-wp-context='{"list":["parent1","parent2"]}'>
		<template data-wp-each="context.list" data-wp-context='{"list":["child1","child2"]}'>
			<li data-wp-text="context.item"></li>
		</template>
		<li data-wp-text="context.item"></li>
	</template>
</ul>
```

The resulting HTML, once the directives are evaluated in the client, is this:

```html
<ul 
	data-wp-interactive="directive-each"
	data-testid="nested-with-same-item-key"
>
	<li data-wp-text="context.item">child2</li>
	<li data-wp-text="context.item">child2</li>
	<li data-wp-text="context.item">child2</li>
	<li data-wp-text="context.item">child2</li>
	<li data-wp-text="context.item">child2</li>
	<li data-wp-text="context.item">child2</li>
</ul>
```

This happens because, instead of shadowing the inherited `item` prop from the parent, the child contexts are modifying the inherited `item` prop. In short, all children modify the same prop sequentially and inherit the same value.

With the changes included in this PR, the final result is as expected.

```html
<ul 
	data-wp-interactive="directive-each"
	data-testid="nested-with-same-item-key"
>
	<li data-wp-text="context.item">child1</li>
	<li data-wp-text="context.item">child2</li>
	<li data-wp-text="context.item">parent1</li>
	<li data-wp-text="context.item">child1</li>
	<li data-wp-text="context.item">child2</li>
	<li data-wp-text="context.item">parent2</li>
</ul>
```

## Why?

This case should be supported. The server-side directive processing already generates the proper HTML.

## How?

Instead of changing the property in the context with key `[itemProp]` after defining the local context, which actually points to the inherited property of the parent context, the local context is instantiated with the `[itemProp]` property, effectively shadowing the parent one.

## Testing Instructions
1. In a page with interactive blocks, add a Custom HTML block with the code above.
2. Visit that page.
3. Ensure the HTML is the expected one.
