### PR TITLE
Accordion Header: Remove textAlignment and textAlign

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -39,7 +39,7 @@ Displays an accordion header. ([Source](https://github.com/WordPress/gutenberg/t
 -	**Experimental:** true
 -	**Category:** design
 -	**Parent:** core/accordion-content
--	**Supports:** anchor, color (background, gradients, text), interactivity, shadow, spacing (padding), typography (fontSize, textAlign), ~~align~~
+-	**Supports:** anchor, color (background, gradients, text), interactivity, shadow, spacing (padding), typography (fontSize), ~~align~~
 -	**Attributes:** iconPosition, level, levelOptions, openByDefault, showIcon, title
 
 ## Accordion Panel

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -40,7 +40,7 @@ Displays an accordion header. ([Source](https://github.com/WordPress/gutenberg/t
 -	**Category:** design
 -	**Parent:** core/accordion-content
 -	**Supports:** anchor, color (background, gradients, text), interactivity, shadow, spacing (padding), typography (fontSize, textAlign), ~~align~~
--	**Attributes:** iconPosition, level, levelOptions, openByDefault, showIcon, textAlignment, title
+-	**Attributes:** iconPosition, level, levelOptions, openByDefault, showIcon, title
 
 ## Accordion Panel
 

--- a/packages/block-library/src/accordion-header/block.json
+++ b/packages/block-library/src/accordion-header/block.json
@@ -72,10 +72,6 @@
 		"levelOptions": {
 			"type": "array"
 		},
-		"textAlignment": {
-			"type": "string",
-			"default": "left"
-		},
 		"iconPosition": {
 			"type": "string",
 			"enum": [ "left", "right" ],

--- a/packages/block-library/src/accordion-header/block.json
+++ b/packages/block-library/src/accordion-header/block.json
@@ -39,7 +39,6 @@
 			}
 		},
 		"typography": {
-			"textAlign": true,
 			"fontSize": true,
 			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,

--- a/packages/block-library/src/accordion-header/edit.js
+++ b/packages/block-library/src/accordion-header/edit.js
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -54,7 +50,7 @@ export default function Edit( { attributes, setAttributes, context } ) {
 			</BlockControls>
 			<TagName { ...blockProps }>
 				<button
-					className={ clsx( 'wp-block-accordion-header__toggle' ) }
+					className="wp-block-accordion-header__toggle"
 					style={ {
 						...spacingProps.style,
 					} }

--- a/packages/block-library/src/accordion-header/edit.js
+++ b/packages/block-library/src/accordion-header/edit.js
@@ -30,9 +30,7 @@ export default function Edit( { attributes, setAttributes, context } ) {
 		}
 	}, [ iconPosition, showIcon, setAttributes ] );
 
-	const blockProps = useBlockProps( {
-		className: 'accordion-content__heading',
-	} );
+	const blockProps = useBlockProps();
 	const spacingProps = useSpacingProps( attributes );
 
 	return (

--- a/packages/block-library/src/accordion-header/edit.js
+++ b/packages/block-library/src/accordion-header/edit.js
@@ -17,7 +17,7 @@ import {
 import { ToolbarGroup } from '@wordpress/components';
 
 export default function Edit( { attributes, setAttributes, context } ) {
-	const { level, title, textAlign, levelOptions } = attributes;
+	const { level, title, levelOptions } = attributes;
 	const {
 		'core/accordion-icon-position': iconPosition,
 		'core/accordion-show-icon': showIcon,
@@ -35,9 +35,7 @@ export default function Edit( { attributes, setAttributes, context } ) {
 	}, [ iconPosition, showIcon, setAttributes ] );
 
 	const blockProps = useBlockProps( {
-		className: clsx( 'accordion-content__heading', {
-			[ `has-text-align-${ textAlign }` ]: textAlign,
-		} ),
+		className: 'accordion-content__heading',
 	} );
 	const spacingProps = useSpacingProps( attributes );
 

--- a/packages/block-library/src/accordion-header/save.js
+++ b/packages/block-library/src/accordion-header/save.js
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-/**
  * WordPress dependencies
  */
 import {
@@ -23,7 +19,7 @@ export default function save( { attributes } ) {
 	return (
 		<TagName { ...blockProps }>
 			<button
-				className={ clsx( 'wp-block-accordion-header__toggle' ) }
+				className="wp-block-accordion-header__toggle"
 				style={ {
 					...spacingProps.style,
 				} }

--- a/packages/block-library/src/accordion-header/save.js
+++ b/packages/block-library/src/accordion-header/save.js
@@ -12,13 +12,11 @@ import {
 } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { level, title, iconPosition, textAlign, showIcon } = attributes;
+	const { level, title, iconPosition, showIcon } = attributes;
 	const TagName = 'h' + level;
 
 	const blockProps = useBlockProps.save( {
-		className: clsx( 'accordion-content__heading', {
-			[ `has-text-align-${ textAlign }` ]: textAlign,
-		} ),
+		className: 'accordion-content__heading',
 	} );
 	const spacingProps = getSpacingClassesAndStyles( attributes );
 

--- a/packages/block-library/src/accordion-header/save.js
+++ b/packages/block-library/src/accordion-header/save.js
@@ -11,9 +11,7 @@ export default function save( { attributes } ) {
 	const { level, title, iconPosition, showIcon } = attributes;
 	const TagName = 'h' + level;
 
-	const blockProps = useBlockProps.save( {
-		className: 'accordion-content__heading',
-	} );
+	const blockProps = useBlockProps.save();
 	const spacingProps = getSpacingClassesAndStyles( attributes );
 
 	return (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Addresses part of https://github.com/WordPress/gutenberg/issues/71732.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We don't need the `textAlignment` attribute, as `textAlign` support is already available via the typography block supports.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removes the `textAlignment` attribute from the Accordion Header block, and also removes some unused `textAlign` logic.

Also removes the `clsx` import, as it's no longer being used here.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Insert an Accordion block with content in the Accordion Header
2. Try aligning the header to the left, centre, and right
3. Ensure the alignments work as expected in the editor and the front end
