### PR TITLE
Block Comments: Update 'Actions' menu design

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -283,7 +283,7 @@ const CommentBoard = ( {
 			},
 	];
 
-	const canResolve = thread?.parent === 0 && 'hold' === status;
+	const canResolve = thread?.parent === 0 && onResolve;
 	const moreActions = actions.filter( ( item ) => item?.onClick );
 
 	return (

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -12,7 +12,7 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalConfirmDialog as ConfirmDialog,
 	Button,
-	DropdownMenu,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 
 import { published, moreVertical } from '@wordpress/icons';
@@ -31,6 +31,7 @@ import CommentAuthorInfo from './comment-author-info';
 import CommentForm from './comment-form';
 
 const { useBlockElement } = unlock( blockEditorPrivateApis );
+const { Menu } = unlock( componentsPrivateApis );
 
 /**
  * Renders the Comments component.
@@ -282,6 +283,7 @@ const CommentBoard = ( {
 			},
 	];
 
+	const canResolve = thread?.parent === 0 && 'hold' === status;
 	const moreActions = actions.filter( ( item ) => item?.onClick );
 
 	return (
@@ -294,7 +296,7 @@ const CommentBoard = ( {
 				/>
 				<span className="editor-collab-sidebar-panel__comment-status">
 					<HStack alignment="right" justify="flex-end" spacing="0">
-						{ 0 === thread?.parent && onResolve && (
+						{ canResolve && (
 							<Button
 								label={ _x(
 									'Resolve',
@@ -309,17 +311,31 @@ const CommentBoard = ( {
 								} }
 							/>
 						) }
-						{ 0 < moreActions.length && (
-							<DropdownMenu
-								icon={ moreVertical }
-								label={ _x(
-									'Select an action',
-									'Select comment action'
-								) }
-								className="editor-collab-sidebar-panel__comment-dropdown-menu"
-								controls={ moreActions }
+						<Menu placement="bottom-end">
+							<Menu.TriggerButton
+								render={
+									<Button
+										size="small"
+										icon={ moreVertical }
+										label={ __( 'Actions' ) }
+										disabled={ ! moreActions.length }
+										accessibleWhenDisabled
+									/>
+								}
 							/>
-						) }
+							<Menu.Popover>
+								{ moreActions.map( ( action ) => (
+									<Menu.Item
+										key={ action.title }
+										onClick={ action.onClick }
+									>
+										<Menu.ItemLabel>
+											{ action.title }
+										</Menu.ItemLabel>
+									</Menu.Item>
+								) ) }
+							</Menu.Popover>
+						</Menu>
 					</HStack>
 				</span>
 			</HStack>

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -262,12 +262,14 @@ const CommentBoard = ( {
 	const actions = [
 		onEdit &&
 			status !== 'approved' && {
+				id: 'edit',
 				title: _x( 'Edit', 'Edit comment' ),
 				onClick: () => {
 					setActionState( 'edit' );
 				},
 			},
 		onDelete && {
+			id: 'delete',
 			title: _x( 'Delete', 'Delete comment' ),
 			onClick: () => {
 				setActionState( 'delete' );
@@ -276,6 +278,7 @@ const CommentBoard = ( {
 		},
 		onReopen &&
 			status === 'approved' && {
+				id: 'reopen',
 				title: _x( 'Reopen', 'Reopen comment' ),
 				onClick: () => {
 					onReopen( thread.id );
@@ -326,8 +329,11 @@ const CommentBoard = ( {
 							<Menu.Popover>
 								{ moreActions.map( ( action ) => (
 									<Menu.Item
-										key={ action.title }
-										onClick={ action.onClick }
+										key={ action.id }
+										onClick={ ( event ) => {
+											event.stopPropagation();
+											action.onClick();
+										} }
 									>
 										<Menu.ItemLabel>
 											{ action.title }

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -112,10 +112,6 @@
 	}
 }
 
-.editor-collab-sidebar-panel__comment-dropdown-menu {
-	flex-shrink: 0;
-}
-
 .editor-collab-sidebar-panel__show-more-reply {
 	font-weight: 500;
 	font-style: italic;

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -89,8 +89,7 @@ test.describe( 'Block Comments', () => {
 			attributes: { content: 'Testing block comments' },
 			comment: 'test comment before edit',
 		} );
-		await page.getByRole( 'button', { name: 'Select an action' } ).click();
-		await page.getByRole( 'menuitem', { name: 'Edit' } ).click();
+		await blockCommentUtils.clickBlockCommentActionMenuItem( 'Edit' );
 		await page
 			.getByRole( 'textbox', { name: 'Comment' } )
 			.first()
@@ -119,8 +118,7 @@ test.describe( 'Block Comments', () => {
 			attributes: { content: 'Testing block comments' },
 			comment: 'Test comment to delete.',
 		} );
-		await page.getByRole( 'button', { name: 'Select an action' } ).click();
-		await page.getByRole( 'menuitem', { name: 'Delete' } ).click();
+		await blockCommentUtils.clickBlockCommentActionMenuItem( 'Delete' );
 		await page
 			.getByRole( 'dialog' )
 			.getByRole( 'button', { name: 'Delete' } )
@@ -150,8 +148,7 @@ test.describe( 'Block Comments', () => {
 		await resolveButton.click();
 		await expect( resolveButton ).toBeDisabled();
 
-		await page.getByRole( 'button', { name: 'Select an action' } ).click();
-		await page.getByRole( 'menuitem', { name: 'Reopen' } ).click();
+		await blockCommentUtils.clickBlockCommentActionMenuItem( 'Reopen' );
 		await expect( resolveButton ).toBeEnabled();
 	} );
 
@@ -256,5 +253,13 @@ class BlockCommentUtils {
 			},
 			{ box: true }
 		);
+	}
+
+	async clickBlockCommentActionMenuItem( actionName ) {
+		await this.#page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Actions' } )
+			.click();
+		await this.#page.getByRole( 'menuitem', { name: actionName } ).click();
 	}
 }


### PR DESCRIPTION
## What?
Part of #71774.

PR updates the block comment "Actions" menu design, which also fixed its positioning and now has a standard `min-width`.

I've also updated the trigger label to match those used in [similar components](https://github.com/search?q=repo%3AWordPress%2Fgutenberg+%22+%27Actions%27+%22+language%3AJavaScript+path%3A%2F%5Epackages%5C%2F%2F&type=code) around the editors.

## How?
Use the new `Menu` private component, which is also used for Post Actions in document settings.

## Todo

- [x] Add e2e helper for block comment actions and fix tests.

## Testing Instructions
1. Create a post.
2. Add blocks with comments.
3. Try block comments actions.
4. Menu dropdown should have improved styling.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
<img width="259" height="377" alt="CleanShot 2025-09-24 at 20 10 45" src="https://github.com/user-attachments/assets/43442332-bf61-40cb-b43d-be0e0dd16021" />|<img width="244" height="373" alt="CleanShot 2025-09-24 at 20 10 02" src="https://github.com/user-attachments/assets/b2ffa555-e496-4557-8889-1e27309c2b8f" />|

