### PR TITLE
Block Comments: Match the show more replies button UI to the design

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -131,7 +131,7 @@ function Thread( {
 		setShowCommentBoard( false );
 	};
 
-	const replies = thread?.reply || [];
+	const replies = thread?.reply;
 	const lastReply = !! replies.length
 		? replies[ replies.length - 1 ]
 		: undefined;

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -73,7 +73,7 @@ export function Comments( {
 				alignment="left"
 				className="editor-collab-sidebar-panel__thread"
 				justify="flex-start"
-				spacing="3"
+				spacing="2"
 			>
 				{
 					// translators: message displayed when there are no comments available
@@ -130,13 +130,19 @@ function Thread( {
 		setShowCommentBoard( false );
 	};
 
+	const replies = thread?.reply || [];
+	const lastReply = !! replies.length
+		? replies[ replies.length - 1 ]
+		: undefined;
+	const restReplies = !! replies.length ? replies.slice( 0, -1 ) : [];
+
 	return (
 		<VStack
 			className={ clsx( 'editor-collab-sidebar-panel__thread', {
 				'editor-collab-sidebar-panel__focus-thread': isFocused,
 			} ) }
 			id={ thread.id }
-			spacing="3"
+			spacing="2"
 			onClick={ () => handleCommentSelect( thread ) }
 		>
 			<CommentBoard
@@ -147,48 +153,61 @@ function Thread( {
 				onDelete={ onCommentDelete }
 				status={ thread.status }
 			/>
-			{ 0 < thread?.reply?.length && (
-				<>
-					{ ! isFocused && (
-						<Button
-							__next40pxDefaultSize
-							variant="link"
-							className="editor-collab-sidebar-panel__show-more-reply"
-							onClick={ () => setFocusThread( thread.id ) }
-						>
-							{ sprintf(
-								// translators: %s: number of replies.
-								_n(
-									'%s more reply',
-									'%s more replies',
-									thread?.reply?.length
-								),
-								thread?.reply?.length
-							) }
-						</Button>
-					) }
-
-					{ isFocused &&
-						thread.reply.map( ( reply ) => (
-							<VStack
-								key={ reply.id }
-								className="editor-collab-sidebar-panel__child-thread"
-								id={ reply.id }
-								spacing="2"
-							>
-								{ 'approved' !== thread.status && (
-									<CommentBoard
-										thread={ reply }
-										onEdit={ onEditComment }
-										onDelete={ onCommentDelete }
-									/>
-								) }
-								{ 'approved' === thread.status && (
-									<CommentBoard thread={ reply } />
-								) }
-							</VStack>
-						) ) }
-				</>
+			{ isFocused &&
+				replies.map( ( reply ) => (
+					<VStack
+						key={ reply.id }
+						className="editor-collab-sidebar-panel__child-thread"
+						id={ reply.id }
+						spacing="2"
+					>
+						<CommentBoard
+							thread={ reply }
+							onEdit={
+								'approved' !== thread.status
+									? onEditComment
+									: undefined
+							}
+							onDelete={
+								'approved' !== thread.status
+									? onCommentDelete
+									: undefined
+							}
+						/>
+					</VStack>
+				) ) }
+			{ ! isFocused && restReplies.length > 0 && (
+				<HStack className="editor-collab-sidebar-panel__more-reply-separator">
+					<Button
+						size="compact"
+						variant="tertiary"
+						className="editor-collab-sidebar-panel__more-reply-button"
+						onClick={ () => setFocusThread( thread.id ) }
+					>
+						{ sprintf(
+							// translators: %s: number of replies.
+							_n(
+								'%s more reply',
+								'%s more replies',
+								restReplies.length
+							),
+							restReplies.length
+						) }
+					</Button>
+				</HStack>
+			) }
+			{ ! isFocused && lastReply && (
+				<CommentBoard
+					thread={ lastReply }
+					onEdit={
+						'approved' !== thread.status ? onEditComment : undefined
+					}
+					onDelete={
+						'approved' !== thread.status
+							? onCommentDelete
+							: undefined
+					}
+				/>
 			) }
 			{ isFocused && (
 				<VStack

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -116,9 +116,20 @@
 	flex-shrink: 0;
 }
 
-.editor-collab-sidebar-panel__show-more-reply {
+.editor-collab-sidebar-panel__more-reply-separator {
+	&::before,
+	&::after {
+		content: "";
+		display: block;
+		width: 100%;
+		height: 1px;
+		background-color: $gray-300;
+		flex: 1;
+	}
+}
+
+.editor-collab-sidebar-panel__more-reply-button {
 	font-weight: 500;
-	font-style: italic;
 }
 
 // Comment avatar indicators.


### PR DESCRIPTION
Part of #71774

## What?

Update the UI of the more replies button to match the design. There are no changes in functionality.

### Design

<img width="1464" height="440" alt="491055619-dd223388-e9fb-4313-9532-0a2879665d0c" src="https://github.com/user-attachments/assets/46e39cb8-8bd6-4bc5-b901-0f0a284cb73f" />


## Screenshots or screencast <!-- if applicable -->

| A comment | Two comments | Three or more comments |
|--------|--------|--------|
| <img width="247" height="126" alt="image" src="https://github.com/user-attachments/assets/dd870df3-9e1e-4e51-b50f-0fd1e98c7b56" /> | <img width="248" height="219" alt="image" src="https://github.com/user-attachments/assets/924de59b-c976-4b29-8b20-82c94b6222f8" /> | <img width="247" height="254" alt="image" src="https://github.com/user-attachments/assets/bcc9e0cf-bf7d-4b88-935f-551b7534e3b4" /> |

| Hovered state | Focused state |
|--------|--------|
| <img width="253" height="233" alt="image" src="https://github.com/user-attachments/assets/90df85ce-b471-452b-a8f8-044570c7dc07" /> | <img width="252" height="239" alt="image" src="https://github.com/user-attachments/assets/e28ec63a-72ab-4630-9c3f-637063eaf507" /> |
