### PR TITLE
Block Comments: Update editing flow

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -63,7 +63,7 @@ function CommentForm( {
 				rows={ rows }
 				maxRows={ 20 }
 				placeholder={ placeholderText || '' }
-			></TextareaAutosize>
+			/>
 			<HStack spacing="3" justify="flex-start" wrap>
 				<Button
 					__next40pxDefaultSize

--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -45,6 +45,9 @@ function CommentForm( {
 	);
 
 	const inputId = useInstanceId( CommentForm, 'comment-input' );
+	const isDisabled =
+		inputComment === thread?.content?.raw ||
+		! sanitizeCommentString( inputComment ).length;
 
 	return (
 		<>
@@ -70,9 +73,7 @@ function CommentForm( {
 						onSubmit( inputComment );
 						setInputComment( '' );
 					} }
-					disabled={
-						0 === sanitizeCommentString( inputComment ).length
-					}
+					disabled={ isDisabled }
 					text={ submitButtonText }
 				/>
 				<Button

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -171,7 +171,7 @@ function CollabSidebarContent( {
 				},
 				{ throwOnError: true }
 			);
-			createNotice( 'snackbar', __( 'Comment edited successfully.' ), {
+			createNotice( 'snackbar', __( 'Comment updated.' ), {
 				type: 'snackbar',
 				isDismissible: true,
 			} );

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -105,7 +105,7 @@ test.describe( 'Block Comments', () => {
 		await expect(
 			page
 				.getByRole( 'button', { name: 'Dismiss this notice' } )
-				.filter( { hasText: 'Comment edited successfully.' } )
+				.filter( { hasText: 'Comment updated.' } )
 		).toBeVisible();
 	} );
 


### PR DESCRIPTION
## What?
Closes #71886.
Part of https://github.com/WordPress/gutenberg/issues/71774.

PR updates the success message when editing a block comment and the disabling condition for the submit button, preventing submission when there are no edits.

## Why?
See #71886.

## Testing Instructions
1. Open a post or page.
2. Add a block and a block comment.
3. Edit the comment.
4. Confirm that the "Update" button is disabled until changes are made.
5. Edit the commit and submit.
6. Confirm that the updated success message is displayed.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
<img width="248" height="437" alt="CleanShot 2025-09-25 at 11 24 24" src="https://github.com/user-attachments/assets/68225b3d-3a5e-4671-bf70-36b74fe0f2cf" />
