### PR TITLE
Block Comments: Fix translation comments to say participants in toolbar indicator

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comment-indicator-toolbar.js
+++ b/packages/editor/src/components/collab-sidebar/comment-indicator-toolbar.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { ToolbarButton } from '@wordpress/components';
-import { _x, __, sprintf } from '@wordpress/i18n';
+import { _x, __, _n, sprintf } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
@@ -82,7 +82,11 @@ const CommentAvatarIndicator = ( { onClick, thread, hasMoreComments } ) => {
 			? __( '100+ participants' )
 			: sprintf(
 					// translators: %s: Number of participants.
-					__( '+%s more participants' ),
+					_n(
+						'+%s more participant',
+						'+%s more participants',
+						overflowCount
+					),
 					overflowCount
 			  );
 

--- a/packages/editor/src/components/collab-sidebar/comment-indicator-toolbar.js
+++ b/packages/editor/src/components/collab-sidebar/comment-indicator-toolbar.js
@@ -72,7 +72,7 @@ const CommentAvatarIndicator = ( { onClick, thread, hasMoreComments } ) => {
 		threadHasMoreParticipants && overflowCount > 0
 			? __( '100+' )
 			: sprintf(
-					// translators: %s: Number of comments.
+					// translators: %s: Number of participants.
 					__( '+%s' ),
 					overflowCount
 			  );
@@ -81,7 +81,7 @@ const CommentAvatarIndicator = ( { onClick, thread, hasMoreComments } ) => {
 		threadHasMoreParticipants && overflowCount > 0
 			? __( '100+ participants' )
 			: sprintf(
-					// translators: %s: Number of comments.
+					// translators: %s: Number of participants.
 					__( '+%s more participants' ),
 					overflowCount
 			  );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Stemming from #71271 

Addressed at https://wordpress.slack.com/archives/C02QB2JS7/p1758767400095899?thread_ts=1758754813.891189&cid=C02QB2JS7

In #71271, incorrect translator comments were left out that convey the count is for comments whereas they are for displaying participants.

While working on it, at one point the code used to display number of comments instead of participants.
I must've missed reverting the comment to participants...

Thanks to @talldan for bringing up the issue 🙌

## Why?
Incorrect translation comments can cause confusion to translators & lead to incorrect translations.

## How?
PR fixes the instances of incorrect translation labels.

