### PR TITLE
Block Comments: Simplify action callbacks

### DIFF
--- a/packages/editor/src/components/collab-sidebar/add-comment.js
+++ b/packages/editor/src/components/collab-sidebar/add-comment.js
@@ -63,7 +63,7 @@ export function AddComment( {
 			</HStack>
 			<CommentForm
 				onSubmit={ ( inputComment ) => {
-					onSubmit( inputComment );
+					onSubmit( { content: inputComment } );
 				} }
 				onCancel={ () => {
 					setShowCommentBoard( false );

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -220,7 +220,10 @@ function Thread( {
 										status: 'hold',
 									} );
 								}
-								onAddReply( inputComment, thread.id );
+								onAddReply( {
+									content: inputComment,
+									parent: thread.id,
+								} );
 							} }
 							onCancel={ ( event ) => {
 								event.stopPropagation(); // Prevent the parent onClick from being triggered

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -41,8 +41,6 @@ const { Menu } = unlock( componentsPrivateApis );
  * @param {Function} props.onEditComment       - The function to handle comment editing.
  * @param {Function} props.onAddReply          - The function to add a reply to a comment.
  * @param {Function} props.onCommentDelete     - The function to delete a comment.
- * @param {Function} props.onCommentResolve    - The function to mark a comment as resolved.
- * @param {Function} props.onCommentReopen     - The function to reopen a resolved comment.
  * @param {Function} props.setShowCommentBoard - The function to set the comment board visibility.
  * @return {React.ReactNode} The rendered Comments component.
  */
@@ -51,8 +49,6 @@ export function Comments( {
 	onEditComment,
 	onAddReply,
 	onCommentDelete,
-	onCommentResolve,
-	onCommentReopen,
 	setShowCommentBoard,
 } ) {
 	const { blockCommentId } = useSelect( ( select ) => {
@@ -90,8 +86,6 @@ export function Comments( {
 			thread={ thread }
 			onAddReply={ onAddReply }
 			onCommentDelete={ onCommentDelete }
-			onCommentResolve={ onCommentResolve }
-			onCommentReopen={ onCommentReopen }
 			onEditComment={ onEditComment }
 			isFocused={ focusThread === thread.id }
 			setFocusThread={ setFocusThread }
@@ -105,8 +99,6 @@ function Thread( {
 	onEditComment,
 	onAddReply,
 	onCommentDelete,
-	onCommentResolve,
-	onCommentReopen,
 	isFocused,
 	setFocusThread,
 	setShowCommentBoard,
@@ -148,8 +140,6 @@ function Thread( {
 		>
 			<CommentBoard
 				thread={ thread }
-				onResolve={ onCommentResolve }
-				onReopen={ onCommentReopen }
 				onEdit={ onEditComment }
 				onDelete={ onCommentDelete }
 				status={ thread.status }
@@ -225,7 +215,10 @@ function Thread( {
 						<CommentForm
 							onSubmit={ ( inputComment ) => {
 								if ( 'approved' === thread.status ) {
-									onCommentReopen( thread.id );
+									onEditComment( {
+										id: thread.id,
+										status: 'hold',
+									} );
 								}
 								onAddReply( inputComment, thread.id );
 							} }
@@ -256,14 +249,7 @@ function Thread( {
 	);
 }
 
-const CommentBoard = ( {
-	thread,
-	onResolve,
-	onReopen,
-	onEdit,
-	onDelete,
-	status,
-} ) => {
+const CommentBoard = ( { thread, onEdit, onDelete, status } ) => {
 	const [ actionState, setActionState ] = useState( false );
 	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
 
@@ -295,17 +281,17 @@ const CommentBoard = ( {
 				setShowConfirmDialog( true );
 			},
 		},
-		onReopen &&
+		onEdit &&
 			status === 'approved' && {
 				id: 'reopen',
 				title: _x( 'Reopen', 'Reopen comment' ),
 				onClick: () => {
-					onReopen( thread.id );
+					onEdit( { id: thread.id, status: 'hold' } );
 				},
 			},
 	];
 
-	const canResolve = thread?.parent === 0 && onResolve;
+	const canResolve = thread?.parent === 0;
 	const moreActions = actions.filter( ( item ) => item?.onClick );
 
 	return (
@@ -329,7 +315,10 @@ const CommentBoard = ( {
 								disabled={ status === 'approved' }
 								accessibleWhenDisabled={ status === 'approved' }
 								onClick={ () => {
-									onResolve( thread.id );
+									onEdit( {
+										id: thread.id,
+										status: 'approved',
+									} );
 								} }
 							/>
 						) }
@@ -367,7 +356,10 @@ const CommentBoard = ( {
 			{ 'edit' === actionState ? (
 				<CommentForm
 					onSubmit={ ( value ) => {
-						onEdit( thread.id, value );
+						onEdit( {
+							id: thread.id,
+							content: value,
+						} );
 						setActionState( false );
 					} }
 					onCancel={ () => handleCancel() }

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -268,7 +268,7 @@ const CommentBoard = ( {
 	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
 
 	const handleConfirmDelete = () => {
-		onDelete( thread.id );
+		onDelete( thread );
 		setActionState( false );
 		setShowConfirmDialog( false );
 	};

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -114,61 +114,33 @@ function CollabSidebarContent( {
 		}
 	};
 
-	const onCommentResolve = async ( commentId ) => {
-		try {
-			await saveEntityRecord(
-				'root',
-				'comment',
-				{
-					id: commentId,
-					status: 'approved',
-				},
-				{ throwOnError: true }
-			);
-			createNotice( 'snackbar', __( 'Comment marked as resolved.' ), {
-				type: 'snackbar',
-				isDismissible: true,
-			} );
-		} catch ( error ) {
-			onError( error );
-		}
-	};
+	const onEditComment = async ( { id, content, status } ) => {
+		const messageType = status ? status : 'updated';
+		const messages = {
+			approved: __( 'Comment marked as resolved.' ),
+			hold: __( 'Comment reopened.' ),
+			updated: __( 'Comment updated.' ),
+		};
 
-	const onCommentReopen = async ( commentId ) => {
 		try {
 			await saveEntityRecord(
 				'root',
 				'comment',
 				{
-					id: commentId,
-					status: 'hold',
+					id,
+					content,
+					status,
 				},
 				{ throwOnError: true }
 			);
-			createNotice( 'snackbar', __( 'Comment reopened.' ), {
-				type: 'snackbar',
-				isDismissible: true,
-			} );
-		} catch ( error ) {
-			onError( error );
-		}
-	};
-
-	const onEditComment = async ( commentId, comment ) => {
-		try {
-			await saveEntityRecord(
-				'root',
-				'comment',
+			createNotice(
+				'snackbar',
+				messages[ messageType ] ?? __( 'Comment updated.' ),
 				{
-					id: commentId,
-					content: comment,
-				},
-				{ throwOnError: true }
+					type: 'snackbar',
+					isDismissible: true,
+				}
 			);
-			createNotice( 'snackbar', __( 'Comment updated.' ), {
-				type: 'snackbar',
-				isDismissible: true,
-			} );
 		} catch ( error ) {
 			onError( error );
 		}
@@ -214,8 +186,6 @@ function CollabSidebarContent( {
 				onEditComment={ onEditComment }
 				onAddReply={ addNewComment }
 				onCommentDelete={ onCommentDelete }
-				onCommentResolve={ onCommentResolve }
-				onCommentReopen={ onCommentReopen }
 				showCommentBoard={ showCommentBoard }
 				setShowCommentBoard={ setShowCommentBoard }
 			/>

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -53,16 +53,7 @@ function CollabSidebarContent( {
 } ) {
 	const { createNotice } = useDispatch( noticesStore );
 	const { saveEntityRecord, deleteEntityRecord } = useDispatch( coreStore );
-
-	const { postId } = useSelect( ( select ) => {
-		const { getCurrentPostId } = select( editorStore );
-		const _postId = getCurrentPostId();
-
-		return {
-			postId: _postId,
-		};
-	}, [] );
-
+	const { getCurrentPostId } = useSelect( editorStore );
 	const { getSelectedBlockClientId } = useSelect( blockEditorStore );
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
@@ -83,7 +74,7 @@ function CollabSidebarContent( {
 				'root',
 				'comment',
 				{
-					post: postId,
+					post: getCurrentPostId(),
 					content: comment,
 					comment_type: 'block_comment',
 					comment_approved: 0,

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -68,23 +68,23 @@ function CollabSidebarContent( {
 		} );
 	};
 
-	const addNewComment = async ( comment, parentCommentId ) => {
+	const addNewComment = async ( { content, parent } ) => {
 		try {
 			const savedRecord = await saveEntityRecord(
 				'root',
 				'comment',
 				{
 					post: getCurrentPostId(),
-					content: comment,
+					content,
 					comment_type: 'block_comment',
 					comment_approved: 0,
-					...( parentCommentId ? { parent: parentCommentId } : {} ),
+					parent: parent || 0,
 				},
 				{ throwOnError: true }
 			);
 
 			// If it's a main comment, update the block attributes with the comment id.
-			if ( ! parentCommentId && savedRecord?.id ) {
+			if ( ! parent && savedRecord?.id ) {
 				updateBlockAttributes( getSelectedBlockClientId(), {
 					blockCommentId: savedRecord.id,
 				} );
@@ -92,7 +92,7 @@ function CollabSidebarContent( {
 
 			createNotice(
 				'snackbar',
-				parentCommentId
+				parent
 					? __( 'Reply added successfully.' )
 					: __( 'Comment added successfully.' ),
 				{

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -2,12 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	useSelect,
-	useDispatch,
-	resolveSelect,
-	subscribe,
-} from '@wordpress/data';
+import { useSelect, useDispatch, subscribe } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 import { comment as commentIcon } from '@wordpress/icons';
@@ -58,7 +53,6 @@ function CollabSidebarContent( {
 } ) {
 	const { createNotice } = useDispatch( noticesStore );
 	const { saveEntityRecord, deleteEntityRecord } = useDispatch( coreStore );
-	const { getEntityRecord } = resolveSelect( coreStore );
 
 	const { postId } = useSelect( ( select ) => {
 		const { getCurrentPostId } = select( editorStore );
@@ -180,18 +174,19 @@ function CollabSidebarContent( {
 		}
 	};
 
-	const onCommentDelete = async ( commentId ) => {
+	const onCommentDelete = async ( comment ) => {
 		try {
-			const childComment = await getEntityRecord(
+			await deleteEntityRecord(
 				'root',
 				'comment',
-				commentId
+				comment.id,
+				undefined,
+				{
+					throwOnError: true,
+				}
 			);
-			await deleteEntityRecord( 'root', 'comment', commentId, undefined, {
-				throwOnError: true,
-			} );
 
-			if ( childComment && ! childComment.parent ) {
+			if ( ! comment.parent ) {
 				updateBlockAttributes( getSelectedBlockClientId(), {
 					blockCommentId: undefined,
 				} );

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -147,9 +147,19 @@ test.describe( 'Block Comments', () => {
 		const resolveButton = page.getByRole( 'button', { name: 'Resolve' } );
 		await resolveButton.click();
 		await expect( resolveButton ).toBeDisabled();
+		await expect(
+			page
+				.getByRole( 'button', { name: 'Dismiss this notice' } )
+				.filter( { hasText: 'Comment marked as resolved.' } )
+		).toBeVisible();
 
 		await blockCommentUtils.clickBlockCommentActionMenuItem( 'Reopen' );
 		await expect( resolveButton ).toBeEnabled();
+		await expect(
+			page
+				.getByRole( 'button', { name: 'Dismiss this notice' } )
+				.filter( { hasText: 'Comment reopened.' } )
+		).toBeVisible();
 	} );
 
 	test( 'selecting a block or comment marks it as an active', async ( {

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -162,6 +162,40 @@ test.describe( 'Block Comments', () => {
 		).toBeVisible();
 	} );
 
+	test( 'can reopen a resolved comment when adding a reply', async ( {
+		page,
+		blockCommentUtils,
+	} ) => {
+		await blockCommentUtils.addBlockWithComment( {
+			type: 'core/heading',
+			attributes: { content: 'Testing block comments' },
+			comment: 'Test comment to resolve.',
+		} );
+
+		const resolveButton = page.getByRole( 'button', { name: 'Resolve' } );
+		await resolveButton.click();
+		await expect( resolveButton ).toBeDisabled();
+		await expect(
+			page
+				.getByRole( 'button', { name: 'Dismiss this notice' } )
+				.filter( { hasText: 'Comment marked as resolved.' } )
+		).toBeVisible();
+
+		const commentForm = page.getByRole( 'textbox', { name: 'Comment' } );
+		await commentForm.fill( 'Test reply that reopens the comment.' );
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Reopen & Reply', exact: true } )
+			.click();
+
+		await expect( resolveButton ).toBeEnabled();
+		await expect(
+			page
+				.getByRole( 'button', { name: 'Dismiss this notice' } )
+				.filter( { hasText: 'Comment reopened.' } )
+		).toBeVisible();
+	} );
+
 	test( 'selecting a block or comment marks it as an active', async ( {
 		editor,
 		page,


### PR DESCRIPTION
## What?
Part of #66377.

PR makes the following modifications for block comments' CRUD callbacks:

* Re-use `onEditComment` for anything comment editing related. Remove separate callbacks for status changes.
* Simplify `onCommentDelete`. There's no need to re-select data from the store; it can access the whole comment object.
* Directly access the current post in `addNewComment`. We can use selectors inside similar callbacks.

PR also includes additions and improvements for e2e tests.

## Testing Instructions
All modifications in question have e2e test coverage.

```
npm run test:e2e -- test/e2e/specs/editor/various/block-comments.spec.js
```

### Testing Instructions for Keyboard
Same.
