### PR TITLE
Content Only: Add the "Edit contents" button to the BlockTool bar

### DIFF
--- a/packages/block-editor/src/components/block-inspector/edit-contents-button.js
+++ b/packages/block-editor/src/components/block-inspector/edit-contents-button.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
+import { Button, ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { store as blockEditorStore } from '../../store';
 
-export default function EditContentsButton( { clientId } ) {
+export default function EditContentsButton( { clientId, isToolbar = false } ) {
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 	const { attributes } = useSelect(
 		( select ) => {
@@ -26,19 +26,31 @@ export default function EditContentsButton( { clientId } ) {
 		return null;
 	}
 
+	const handleClick = () => {
+		const { patternName, ...metadataWithoutPatternName } =
+			attributes?.metadata ?? {};
+		updateBlockAttributes( clientId, {
+			...attributes,
+			metadata: metadataWithoutPatternName,
+		} );
+	};
+
+	if ( isToolbar ) {
+		return (
+			<ToolbarGroup>
+				<ToolbarButton onClick={ handleClick }>
+					{ __( 'Edit contents' ) }
+				</ToolbarButton>
+			</ToolbarGroup>
+		);
+	}
+
 	return (
 		<Button
 			className="block-editor-block-inspector-edit-contents-button"
 			__next40pxDefaultSize
 			variant="secondary"
-			onClick={ () => {
-				const { patternName, ...metadataWithoutPatternName } =
-					attributes?.metadata ?? {};
-				updateBlockAttributes( clientId, {
-					...attributes,
-					metadata: metadataWithoutPatternName,
-				} );
-			} }
+			onClick={ handleClick }
 		>
 			{ __( 'Edit contents' ) }
 		</Button>

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -38,6 +38,7 @@ import { useHasBlockToolbar } from './use-has-block-toolbar';
 import ChangeDesign from './change-design';
 import SwitchSectionStyle from './switch-section-style';
 import { unlock } from '../../lock-unlock';
+import EditContentsButton from '../block-inspector/edit-contents-button';
 
 /**
  * Renders the block toolbar.
@@ -278,6 +279,9 @@ export function PrivateBlockToolbar( {
 					</>
 				) }
 				<BlockEditVisuallyButton clientIds={ blockClientIds } />
+				{ window?.__experimentalContentOnlyPatternInsertion && (
+					<EditContentsButton clientId={ blockClientId } isToolbar />
+				) }
 				<BlockSettingsMenu clientIds={ blockClientIds } />
 			</div>
 		</NavigableToolbar>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds the Edit contents button to the Block Toolbar.

## Why?
It's not very discoverable in the inspector controls.

## How?
Adding a new prop to the Edit Contents button.

## Testing Instructions
1. Enable the content only editing experiment
2. Insert a pattern in your post
3. Confirm that there is now an "Edit Contents" button in the BlockToolbar for the block that wraps the pattern, as well as the same button in the Inspector Controls
4. Check that both buttons "detach" the pattern

## Screenshots or screencast <!-- if applicable -->
<img width="863" height="832" alt="Screenshot 2025-09-25 at 10 32 11" src="https://github.com/user-attachments/assets/45973998-602e-44d3-8869-bb87f6a16f6a" />
