### PR TITLE
Update: Accordion heading level synchronization.

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -17,7 +17,7 @@ Displays a group of accordion headers and associated expandable content. ([Sourc
 -	**Category:** design
 -	**Allowed Blocks:** core/accordion-content
 -	**Supports:** align (full, wide), background (backgroundImage, backgroundSize), color (background, gradients, text), interactivity, layout, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** autoclose, headingLevel, iconPosition, showIcon
+-	**Attributes:** autoclose, headingLevel, iconPosition, levelOptions, showIcon
 
 ## Accordion Content
 
@@ -40,7 +40,7 @@ Displays an accordion header. ([Source](https://github.com/WordPress/gutenberg/t
 -	**Category:** design
 -	**Parent:** core/accordion-content
 -	**Supports:** anchor, color (background, gradients, text), interactivity, shadow, spacing (padding), typography (fontSize), ~~align~~
--	**Attributes:** iconPosition, level, levelOptions, openByDefault, showIcon, title
+-	**Attributes:** iconPosition, level, openByDefault, showIcon, title
 
 ## Accordion Panel
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -17,7 +17,7 @@ Displays a group of accordion headers and associated expandable content. ([Sourc
 -	**Category:** design
 -	**Allowed Blocks:** core/accordion-content
 -	**Supports:** align (full, wide), background (backgroundImage, backgroundSize), color (background, gradients, text), interactivity, layout, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** autoclose, iconPosition, showIcon
+-	**Attributes:** autoclose, headingLevel, iconPosition, showIcon
 
 ## Accordion Content
 

--- a/packages/block-library/src/accordion-content/edit.js
+++ b/packages/block-library/src/accordion-content/edit.js
@@ -25,7 +25,12 @@ import clsx from 'clsx';
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
-export default function Edit( { attributes, clientId, setAttributes } ) {
+export default function Edit( {
+	attributes,
+	clientId,
+	setAttributes,
+	context,
+} ) {
 	const { openByDefault } = attributes;
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
@@ -70,9 +75,14 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 		} ),
 	} );
 
+	// Get heading level from context.
+	const headingLevel = context && context[ 'core/accordion-heading-level' ];
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: [
-			[ 'core/accordion-header', {} ],
+			[
+				'core/accordion-header',
+				headingLevel ? { level: headingLevel } : {},
+			],
 			[
 				'core/accordion-panel',
 				{

--- a/packages/block-library/src/accordion-header/block.json
+++ b/packages/block-library/src/accordion-header/block.json
@@ -9,7 +9,8 @@
 	"parent": [ "core/accordion-content" ],
 	"usesContext": [
 		"core/accordion-icon-position",
-		"core/accordion-show-icon"
+		"core/accordion-show-icon",
+		"core/accordion-heading-level"
 	],
 	"supports": {
 		"anchor": true,
@@ -67,9 +68,6 @@
 		"level": {
 			"type": "number",
 			"default": 3
-		},
-		"levelOptions": {
-			"type": "array"
 		},
 		"iconPosition": {
 			"type": "string",

--- a/packages/block-library/src/accordion-header/block.json
+++ b/packages/block-library/src/accordion-header/block.json
@@ -66,8 +66,7 @@
 			"role": "content"
 		},
 		"level": {
-			"type": "number",
-			"default": 3
+			"type": "number"
 		},
 		"iconPosition": {
 			"type": "string",

--- a/packages/block-library/src/accordion-header/edit.js
+++ b/packages/block-library/src/accordion-header/edit.js
@@ -6,19 +6,17 @@ import { useEffect } from '@wordpress/element';
 import {
 	useBlockProps,
 	__experimentalGetSpacingClassesAndStyles as useSpacingProps,
-	BlockControls,
-	HeadingLevelDropdown,
 	RichText,
 } from '@wordpress/block-editor';
-import { ToolbarGroup } from '@wordpress/components';
 
 export default function Edit( { attributes, setAttributes, context } ) {
-	const { level, title, levelOptions } = attributes;
+	const { title } = attributes;
 	const {
 		'core/accordion-icon-position': iconPosition,
 		'core/accordion-show-icon': showIcon,
+		'core/accordion-heading-level': headingLevel,
 	} = context;
-	const TagName = 'h' + level;
+	const TagName = 'h' + headingLevel;
 
 	// Set icon attributes.
 	useEffect( () => {
@@ -30,58 +28,53 @@ export default function Edit( { attributes, setAttributes, context } ) {
 		}
 	}, [ iconPosition, showIcon, setAttributes ] );
 
+	// Sync heading level from context.
+	useEffect( () => {
+		if ( headingLevel !== undefined && headingLevel !== attributes.level ) {
+			setAttributes( { level: headingLevel } );
+		}
+	}, [ headingLevel, attributes.level, setAttributes ] )
+
 	const blockProps = useBlockProps();
 	const spacingProps = useSpacingProps( attributes );
 
 	return (
-		<>
-			<BlockControls>
-				<ToolbarGroup>
-					<HeadingLevelDropdown
-						value={ level }
-						options={ levelOptions }
-						onChange={ ( newLevel ) =>
-							setAttributes( { level: newLevel } )
-						}
-					/>
-				</ToolbarGroup>
-			</BlockControls>
-			<TagName { ...blockProps }>
-				<button
-					className="wp-block-accordion-header__toggle"
-					style={ {
-						...spacingProps.style,
-					} }
-				>
-					{ showIcon && iconPosition === 'left' && (
-						<span
-							className="wp-block-accordion-header__toggle-icon"
-							aria-hidden="true"
-						>
-							+
-						</span>
-					) }
-					<RichText
-						withoutInteractiveFormatting
-						disableLineBreaks
-						tagName="span"
-						value={ title }
-						onChange={ ( newTitle ) =>
-							setAttributes( { title: newTitle } )
-						}
-						placeholder={ __( 'Accordion title' ) }
-						className="wp-block-accordion-header__toggle-title"
-					/>
-					{ showIcon && iconPosition === 'right' && (
-						<span
-							className="wp-block-accordion-header__toggle-icon"
-							aria-hidden="true"
-						>
-							+
-						</span>
-					) }
-				</button>
-			</TagName>
-		</>
+		
+		<TagName { ...blockProps }>
+			<button
+				className="wp-block-accordion-header__toggle"
+				style={ {
+					...spacingProps.style,
+				} }
+			>
+				{ showIcon && iconPosition === 'left' && (
+					<span
+						className="wp-block-accordion-header__toggle-icon"
+						aria-hidden="true"
+					>
+						+
+					</span>
+				) }
+				<RichText
+					withoutInteractiveFormatting
+					disableLineBreaks
+					tagName="span"
+					value={ title }
+					onChange={ ( newTitle ) =>
+						setAttributes( { title: newTitle } )
+					}
+					placeholder={ __( 'Accordion title' ) }
+					className="wp-block-accordion-header__toggle-title"
+				/>
+				{ showIcon && iconPosition === 'right' && (
+					<span
+						className="wp-block-accordion-header__toggle-icon"
+						aria-hidden="true"
+					>
+						+
+					</span>
+				) }
+			</button>
+		</TagName>
 	);
 }

--- a/packages/block-library/src/accordion-header/edit.js
+++ b/packages/block-library/src/accordion-header/edit.js
@@ -33,13 +33,12 @@ export default function Edit( { attributes, setAttributes, context } ) {
 		if ( headingLevel !== undefined && headingLevel !== attributes.level ) {
 			setAttributes( { level: headingLevel } );
 		}
-	}, [ headingLevel, attributes.level, setAttributes ] )
+	}, [ headingLevel, attributes.level, setAttributes ] );
 
 	const blockProps = useBlockProps();
 	const spacingProps = useSpacingProps( attributes );
 
 	return (
-		
 		<TagName { ...blockProps }>
 			<button
 				className="wp-block-accordion-header__toggle"

--- a/packages/block-library/src/accordion-header/edit.js
+++ b/packages/block-library/src/accordion-header/edit.js
@@ -28,13 +28,6 @@ export default function Edit( { attributes, setAttributes, context } ) {
 		}
 	}, [ iconPosition, showIcon, setAttributes ] );
 
-	// Sync heading level from context.
-	useEffect( () => {
-		if ( headingLevel !== undefined && headingLevel !== attributes.level ) {
-			setAttributes( { level: headingLevel } );
-		}
-	}, [ headingLevel, attributes.level, setAttributes ] );
-
 	const blockProps = useBlockProps();
 	const spacingProps = useSpacingProps( attributes );
 

--- a/packages/block-library/src/accordion-header/save.js
+++ b/packages/block-library/src/accordion-header/save.js
@@ -9,7 +9,7 @@ import {
 
 export default function save( { attributes } ) {
 	const { level, title, iconPosition, showIcon } = attributes;
-	const TagName = 'h' + level;
+	const TagName = 'h' + ( level || 3 );
 
 	const blockProps = useBlockProps.save();
 	const spacingProps = getSpacingClassesAndStyles( attributes );

--- a/packages/block-library/src/accordion/block.json
+++ b/packages/block-library/src/accordion/block.json
@@ -67,11 +67,19 @@
 		"autoclose": {
 			"type": "boolean",
 			"default": false
+		},
+		"headingLevel": {
+			"type": "number",
+			"default": 3
+		},
+		"levelOptions": {
+			"type": "array"
 		}
 	},
 	"providesContext": {
 		"core/accordion-icon-position": "iconPosition",
-		"core/accordion-show-icon": "showIcon"
+		"core/accordion-show-icon": "showIcon",
+		"core/accordion-heading-level": "headingLevel"
 	},
 	"allowedBlocks": [ "core/accordion-content" ],
 	"textdomain": "default",

--- a/packages/block-library/src/accordion/edit.js
+++ b/packages/block-library/src/accordion/edit.js
@@ -8,6 +8,7 @@ import {
 	BlockControls,
 	useBlockEditingMode,
 	store as blockEditorStore,
+	HeadingLevelDropdown,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import {
@@ -17,6 +18,7 @@ import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	ToolbarButton,
+	ToolbarGroup,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
@@ -32,7 +34,7 @@ const ACCORDION_BLOCK = {
 };
 
 export default function Edit( {
-	attributes: { autoclose, iconPosition, showIcon },
+	attributes: { autoclose, iconPosition, showIcon, headingLevel, levelOptions },
 	clientId,
 	setAttributes,
 	isSelected: isSingleSelected,
@@ -58,11 +60,24 @@ export default function Edit( {
 	return (
 		<>
 			{ isSingleSelected && ! isContentOnlyMode && (
-				<BlockControls group="other">
-					<ToolbarButton onClick={ addAccordionContentBlock }>
-						{ __( 'Add' ) }
-					</ToolbarButton>
-				</BlockControls>
+				<>
+					<BlockControls>
+						<ToolbarGroup>
+							<HeadingLevelDropdown
+								value={ headingLevel }
+								options={ levelOptions }
+								onChange={ ( newLevel ) => 
+									setAttributes( {headingLevel: newLevel } )
+								}
+							/>
+						</ToolbarGroup>
+					</BlockControls>
+					<BlockControls group="other">
+						<ToolbarButton onClick={ addAccordionContentBlock }>
+							{ __( 'Add' ) }
+						</ToolbarButton>
+					</BlockControls>
+				</>
 			) }
 			<InspectorControls key="setting">
 				<ToolsPanel
@@ -72,6 +87,7 @@ export default function Edit( {
 							autoclose: false,
 							showIcon: true,
 							iconPosition: 'right',
+							headingLevel: 3,
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }

--- a/packages/block-library/src/accordion/edit.js
+++ b/packages/block-library/src/accordion/edit.js
@@ -34,7 +34,13 @@ const ACCORDION_BLOCK = {
 };
 
 export default function Edit( {
-	attributes: { autoclose, iconPosition, showIcon, headingLevel, levelOptions },
+	attributes: {
+		autoclose,
+		iconPosition,
+		showIcon,
+		headingLevel,
+		levelOptions,
+	},
 	clientId,
 	setAttributes,
 	isSelected: isSingleSelected,
@@ -66,8 +72,8 @@ export default function Edit( {
 							<HeadingLevelDropdown
 								value={ headingLevel }
 								options={ levelOptions }
-								onChange={ ( newLevel ) => 
-									setAttributes( {headingLevel: newLevel } )
+								onChange={ ( newLevel ) =>
+									setAttributes( { headingLevel: newLevel } )
 								}
 							/>
 						</ToolbarGroup>

--- a/packages/block-library/src/accordion/edit.js
+++ b/packages/block-library/src/accordion/edit.js
@@ -20,7 +20,7 @@ import {
 	ToolbarButton,
 	ToolbarGroup,
 } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect, useRegistry } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 
 /**
@@ -29,6 +29,7 @@ import { createBlock } from '@wordpress/blocks';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const ACCORDION_BLOCK_NAME = 'core/accordion-content';
+const ACCORDION_HEADER_BLOCK_NAME = 'core/accordion-header';
 const ACCORDION_BLOCK = {
 	name: ACCORDION_BLOCK_NAME,
 };
@@ -45,9 +46,12 @@ export default function Edit( {
 	setAttributes,
 	isSelected: isSingleSelected,
 } ) {
+	const registry = useRegistry();
+	const { getBlockOrder } = useSelect( blockEditorStore );
 	const blockProps = useBlockProps();
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
-	const { insertBlock } = useDispatch( blockEditorStore );
+	const { updateBlockAttributes, insertBlock } =
+		useDispatch( blockEditorStore );
 	const blockEditingMode = useBlockEditingMode();
 	const isContentOnlyMode = blockEditingMode === 'contentOnly';
 
@@ -59,8 +63,36 @@ export default function Edit( {
 	} );
 
 	const addAccordionContentBlock = () => {
-		const newAccordionContent = createBlock( ACCORDION_BLOCK_NAME );
+		// When adding, set the header's level to current headingLevel
+		const newAccordionContent = createBlock( ACCORDION_BLOCK_NAME, {}, [
+			createBlock( ACCORDION_HEADER_BLOCK_NAME, { level: headingLevel } ),
+			createBlock( 'core/accordion-panel', {} ),
+		] );
 		insertBlock( newAccordionContent, undefined, clientId );
+	};
+
+	/**
+	 * Update all child Accordion Header blocks with a new heading level
+	 * based on the accordion group setting.
+	 * @param {number} newHeadingLevel The new heading level to set
+	 */
+	const updateHeadingLevel = ( newHeadingLevel ) => {
+		const innerBlockClientIds = getBlockOrder( clientId );
+
+		// Get all accordion-header blocks from all accordion-content blocks.
+		const accordionHeaderClientIds = [];
+		innerBlockClientIds.forEach( ( contentClientId ) => {
+			const headerClientIds = getBlockOrder( contentClientId );
+			accordionHeaderClientIds.push( ...headerClientIds );
+		} );
+
+		// Update own and child block heading levels.
+		registry.batch( () => {
+			setAttributes( { headingLevel: newHeadingLevel } );
+			updateBlockAttributes( accordionHeaderClientIds, {
+				level: newHeadingLevel,
+			} );
+		} );
 	};
 
 	return (
@@ -72,9 +104,7 @@ export default function Edit( {
 							<HeadingLevelDropdown
 								value={ headingLevel }
 								options={ levelOptions }
-								onChange={ ( newLevel ) =>
-									setAttributes( { headingLevel: newLevel } )
-								}
+								onChange={ updateHeadingLevel }
 							/>
 						</ToolbarGroup>
 					</BlockControls>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/71776

This PR changes the Accordion blocks so the heading level is controlled from the Accordion Group instead of from each individual Accordion Header.

- Adds a headingLevel attribute  to the Accordion Group.

- Removes the heading-level control from individual Accordion Header toolbars in the editor UI.

- Accordion Header rendering now uses the group headingLevel so all headers within the same group have the same semantic level in output.

- This keeps the UI simpler (one place to choose the heading level) and fixes inconsistent heading levels and accessibility issues

## Why?
Currently each Accordion Header exposes its own heading-level control in the toolbar. That causes two problems:

- Inconsistent semantic structure 
- Toolbar redundancy and UX clutter 

## How?

- Adds a `headingLevel` attribute to the Accordion Group and expose it in the block settings/inspector.

- Remove the per-header heading-level control from each Accordion Header in the editor UI.

- Pass the group headingLevel to child header components so they render the correct <hN> both in the editor preview and on save.

## Testing Instructions
1. Insert an Accordion block.
2. Add multiple Accordion Header items within the group and fill with content.
3. Use the Accordion Group setting to change the heading level (e.g., H3 → H4).
4. Observe editor preview: all Accordion Headers should now show the selected heading level.
5. Inspect the front-end (Preview) markup: each header should render with the chosen tag (h3 or h4).

### Testing Instructions for Keyboard


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
