### PR TITLE
Time to Read: Replace toggles with block variations

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -724,7 +724,7 @@ Show minutes required to finish reading the post. Can also show a word count. ([
 -	**Experimental:** true
 -	**Category:** theme
 -	**Supports:** color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** averageReadingSpeed, displayAsRange, showTimeToRead, showWordCount, textAlign
+-	**Attributes:** averageReadingSpeed, displayAsRange, displayMode, textAlign
 
 ## Title
 

--- a/packages/block-library/src/post-time-to-read/block.json
+++ b/packages/block-library/src/post-time-to-read/block.json
@@ -16,13 +16,9 @@
 			"type": "boolean",
 			"default": true
 		},
-		"showTimeToRead": {
-			"type": "boolean",
-			"default": true
-		},
-		"showWordCount": {
-			"type": "boolean",
-			"default": false
+		"displayMode": {
+			"type": "string",
+			"default": "time"
 		},
 		"averageReadingSpeed": {
 			"type": "number",

--- a/packages/block-library/src/post-time-to-read/edit.js
+++ b/packages/block-library/src/post-time-to-read/edit.js
@@ -15,6 +15,7 @@ import {
 	useBlockProps,
 } from '@wordpress/block-editor';
 import {
+	SelectControl,
 	ToggleControl,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
@@ -29,13 +30,8 @@ import { count as wordCount } from '@wordpress/wordcount';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
-	const {
-		textAlign,
-		displayAsRange,
-		showTimeToRead,
-		showWordCount,
-		averageReadingSpeed,
-	} = attributes;
+	const { textAlign, displayAsRange, displayMode, averageReadingSpeed } =
+		attributes;
 
 	const { postId, postType } = context;
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
@@ -80,7 +76,7 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 		const parts = [];
 
 		// Add "time to read" part, if enabled.
-		if ( showTimeToRead ) {
+		if ( displayMode === 'time' || displayMode === 'both' ) {
 			let timeString;
 			if ( displayAsRange ) {
 				let maxMinutes = Math.max(
@@ -146,8 +142,7 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 		contentStructure,
 		blocks,
 		displayAsRange,
-		showTimeToRead,
-		showWordCount,
+		displayMode,
 		averageReadingSpeed,
 	] );
 
@@ -173,33 +168,49 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 					resetAll={ () => {
 						setAttributes( {
 							displayAsRange: true,
-							showTimeToRead: true,
-							showWordCount: false,
+							displayMode: 'time',
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
-						label={ __( 'Show time to read' ) }
-						hasValue={ () => ! showTimeToRead }
+						label={ __( 'Display options' ) }
+						hasValue={ () => displayMode !== 'time' }
 						onDeselect={ () => {
 							setAttributes( {
-								showTimeToRead: true,
+								displayMode: 'time',
 							} );
 						} }
 					>
-						<ToggleControl
+						<SelectControl
 							__nextHasNoMarginBottom
-							label={ __( 'Show time to read' ) }
-							checked={ !! showTimeToRead }
-							onChange={ () =>
+							__next40pxDefaultSize
+							label={ __( 'Display options' ) }
+							value={ displayMode }
+							options={ [
+								{
+									label: __( 'Show time to read' ),
+									value: 'time',
+								},
+								{
+									label: __( 'Show word count' ),
+									value: 'words',
+								},
+								{
+									label: __(
+										'Show time to read and word count'
+									),
+									value: 'both',
+								},
+							] }
+							onChange={ ( value ) =>
 								setAttributes( {
-									showTimeToRead: ! showTimeToRead,
+									displayMode: value,
 								} )
 							}
 						/>
 					</ToolsPanelItem>
-					{ showTimeToRead && (
+					{ ( displayMode === 'time' || displayMode === 'both' ) && (
 						<ToolsPanelItem
 							isShownByDefault
 							label={ _x(
@@ -225,26 +236,6 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 							/>
 						</ToolsPanelItem>
 					) }
-					<ToolsPanelItem
-						label={ __( 'Show word count' ) }
-						hasValue={ () => !! showWordCount }
-						onDeselect={ () => {
-							setAttributes( {
-								showWordCount: false,
-							} );
-						} }
-					>
-						<ToggleControl
-							__nextHasNoMarginBottom
-							label={ __( 'Show word count' ) }
-							checked={ !! showWordCount }
-							onChange={ () =>
-								setAttributes( {
-									showWordCount: ! showWordCount,
-								} )
-							}
-						/>
-					</ToolsPanelItem>
 				</ToolsPanel>
 			</InspectorControls>
 			<div { ...blockProps }>{ displayString }</div>

--- a/packages/block-library/src/post-time-to-read/edit.js
+++ b/packages/block-library/src/post-time-to-read/edit.js
@@ -174,6 +174,7 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
+						isShownByDefault
 						label={ __( 'Display options' ) }
 						hasValue={ () => displayMode !== 'time' }
 						onDeselect={ () => {

--- a/packages/block-library/src/post-time-to-read/edit.js
+++ b/packages/block-library/src/post-time-to-read/edit.js
@@ -112,7 +112,7 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 		}
 
 		// Add "word count" part, if enabled.
-		if ( showWordCount ) {
+		if ( displayMode === 'words' ) {
 			const wordCountString =
 				wordCountType === 'words'
 					? sprintf(

--- a/packages/block-library/src/post-time-to-read/edit.js
+++ b/packages/block-library/src/post-time-to-read/edit.js
@@ -15,7 +15,6 @@ import {
 	useBlockProps,
 } from '@wordpress/block-editor';
 import {
-	SelectControl,
 	ToggleControl,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
@@ -76,7 +75,7 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 		const parts = [];
 
 		// Add "time to read" part, if enabled.
-		if ( displayMode === 'time' || displayMode === 'both' ) {
+		if ( displayMode === 'time' ) {
 			let timeString;
 			if ( displayAsRange ) {
 				let maxMinutes = Math.max(
@@ -162,56 +161,17 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 					} }
 				/>
 			</BlockControls>
-			<InspectorControls>
-				<ToolsPanel
-					label={ __( 'Settings' ) }
-					resetAll={ () => {
-						setAttributes( {
-							displayAsRange: true,
-							displayMode: 'time',
-						} );
-					} }
-					dropdownMenuProps={ dropdownMenuProps }
-				>
-					<ToolsPanelItem
-						isShownByDefault
-						label={ __( 'Display options' ) }
-						hasValue={ () => displayMode !== 'time' }
-						onDeselect={ () => {
+			{ displayMode === 'time' && (
+				<InspectorControls>
+					<ToolsPanel
+						label={ __( 'Settings' ) }
+						resetAll={ () => {
 							setAttributes( {
-								displayMode: 'time',
+								displayAsRange: true,
 							} );
 						} }
+						dropdownMenuProps={ dropdownMenuProps }
 					>
-						<SelectControl
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-							label={ __( 'Display options' ) }
-							value={ displayMode }
-							options={ [
-								{
-									label: __( 'Show time to read' ),
-									value: 'time',
-								},
-								{
-									label: __( 'Show word count' ),
-									value: 'words',
-								},
-								{
-									label: __(
-										'Show time to read and word count'
-									),
-									value: 'both',
-								},
-							] }
-							onChange={ ( value ) =>
-								setAttributes( {
-									displayMode: value,
-								} )
-							}
-						/>
-					</ToolsPanelItem>
-					{ ( displayMode === 'time' || displayMode === 'both' ) && (
 						<ToolsPanelItem
 							isShownByDefault
 							label={ _x(
@@ -236,9 +196,9 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 								}
 							/>
 						</ToolsPanelItem>
-					) }
-				</ToolsPanel>
-			</InspectorControls>
+					</ToolsPanel>
+				</InspectorControls>
+			) }
 			<div { ...blockProps }>{ displayString }</div>
 		</>
 	);

--- a/packages/block-library/src/post-time-to-read/index.js
+++ b/packages/block-library/src/post-time-to-read/index.js
@@ -5,6 +5,7 @@ import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
 import icon from './icon';
+import variations from './variations';
 
 const { name } = metadata;
 export { metadata, name };
@@ -12,6 +13,7 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
+	variations,
 	example: {},
 };
 

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -30,7 +30,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 	$parts = array();
 
 	// Add "time to read" part, if enabled.
-	if ( 'time' ===  $display_mode || 'both' === $display_mode ) {
+	if ( 'time' === $display_mode ) {
 		if ( ! empty( $attributes['displayAsRange'] ) ) {
 			// Calculate faster reading rate with 20% speed = lower minutes,
 			// and slower reading rate with 20% speed = higher minutes.

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -38,13 +38,13 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 		}
 	}
 
-	$word_count_type      = wp_get_word_count_type();
-	$total_words          = wp_word_count( $content, $word_count_type );
+	$word_count_type = wp_get_word_count_type();
+	$total_words     = wp_word_count( $content, $word_count_type );
 
 	$parts = array();
 
 	// Add "time to read" part, if enabled.
-	if ( $display_mode === 'time' || $display_mode === 'both' ) {
+	if ( 'time' ===  $display_mode || 'both' === $display_mode ) {
 		if ( ! empty( $attributes['displayAsRange'] ) ) {
 			// Calculate faster reading rate with 20% speed = lower minutes,
 			// and slower reading rate with 20% speed = higher minutes.

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -20,15 +20,31 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 
 	$content              = get_the_content();
 	$average_reading_rate = isset( $attributes['averageReadingSpeed'] ) ? $attributes['averageReadingSpeed'] : 189;
-	$show_time_to_read    = isset( $attributes['showTimeToRead'] ) ? $attributes['showTimeToRead'] : true;
-	$show_word_count      = isset( $attributes['showWordCount'] ) ? $attributes['showWordCount'] : false;
+
+	// Handle backward compatibility and new displayMode attribute
+	$display_mode = isset( $attributes['displayMode'] ) ? $attributes['displayMode'] : 'time';
+
+	// Backward compatibility: convert old attributes to new displayMode
+	if ( isset( $attributes['showTimeToRead'] ) || isset( $attributes['showWordCount'] ) ) {
+		$show_time_to_read = isset( $attributes['showTimeToRead'] ) ? $attributes['showTimeToRead'] : true;
+		$show_word_count   = isset( $attributes['showWordCount'] ) ? $attributes['showWordCount'] : false;
+
+		if ( $show_time_to_read && $show_word_count ) {
+			$display_mode = 'both';
+		} elseif ( $show_word_count ) {
+			$display_mode = 'words';
+		} else {
+			$display_mode = 'time';
+		}
+	}
+
 	$word_count_type      = wp_get_word_count_type();
 	$total_words          = wp_word_count( $content, $word_count_type );
 
 	$parts = array();
 
 	// Add "time to read" part, if enabled.
-	if ( $show_time_to_read ) {
+	if ( $display_mode === 'time' || $display_mode === 'both' ) {
 		if ( ! empty( $attributes['displayAsRange'] ) ) {
 			// Calculate faster reading rate with 20% speed = lower minutes,
 			// and slower reading rate with 20% speed = higher minutes.

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -24,20 +24,6 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 	// Handle backward compatibility and new displayMode attribute
 	$display_mode = isset( $attributes['displayMode'] ) ? $attributes['displayMode'] : 'time';
 
-	// Backward compatibility: convert old attributes to new displayMode
-	if ( isset( $attributes['showTimeToRead'] ) || isset( $attributes['showWordCount'] ) ) {
-		$show_time_to_read = isset( $attributes['showTimeToRead'] ) ? $attributes['showTimeToRead'] : true;
-		$show_word_count   = isset( $attributes['showWordCount'] ) ? $attributes['showWordCount'] : false;
-
-		if ( $show_time_to_read && $show_word_count ) {
-			$display_mode = 'both';
-		} elseif ( $show_word_count ) {
-			$display_mode = 'words';
-		} else {
-			$display_mode = 'time';
-		}
-	}
-
 	$word_count_type = wp_get_word_count_type();
 	$total_words     = wp_word_count( $content, $word_count_type );
 
@@ -72,7 +58,7 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 	}
 
 	// Add "word count" part, if enabled.
-	if ( $show_word_count ) {
+	if ( 'words' === $display_mode ) {
 		$word_count_string = 'words' === $word_count_type ? sprintf(
 			/* translators: %s: the number of words in the post. */
 			_n( '%s word', '%s words', $total_words ),

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -21,7 +21,6 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 	$content              = get_the_content();
 	$average_reading_rate = isset( $attributes['averageReadingSpeed'] ) ? $attributes['averageReadingSpeed'] : 189;
 
-	// Handle backward compatibility and new displayMode attribute
 	$display_mode = isset( $attributes['displayMode'] ) ? $attributes['displayMode'] : 'time';
 
 	$word_count_type = wp_get_word_count_type();

--- a/packages/block-library/src/post-time-to-read/variations.js
+++ b/packages/block-library/src/post-time-to-read/variations.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { clock } from '@wordpress/icons';
+
+const variations = [
+	{
+		name: 'time-to-read',
+		title: __( 'Time to Read' ),
+		description: __( 'Show minutes required to finish reading the post.' ),
+		attributes: {
+			displayMode: 'time',
+		},
+		scope: [ 'block', 'inserter', 'transform' ],
+		isActive: ( blockAttributes ) =>
+			blockAttributes?.displayMode === 'time',
+		icon: clock,
+	},
+	{
+		name: 'word-count',
+		title: __( 'Word Count' ),
+		description: __( 'Show the number of words in the post.' ),
+		attributes: {
+			displayMode: 'words',
+		},
+		scope: [ 'block', 'inserter', 'transform' ],
+		isActive: ( blockAttributes ) =>
+			blockAttributes?.displayMode === 'words',
+		icon: clock,
+	},
+];
+
+export default variations;

--- a/packages/block-library/src/post-time-to-read/variations.js
+++ b/packages/block-library/src/post-time-to-read/variations.js
@@ -16,6 +16,7 @@ const variations = [
 		isActive: ( blockAttributes ) =>
 			blockAttributes?.displayMode === 'time',
 		icon: clock,
+		isDefault: true,
 	},
 	{
 		name: 'word-count',

--- a/packages/block-library/src/post-time-to-read/variations.js
+++ b/packages/block-library/src/post-time-to-read/variations.js
@@ -16,7 +16,7 @@ const variations = [
 		attributes: {
 			displayMode: 'time',
 		},
-		scope: [ 'block', 'inserter', 'transform' ],
+		scope: [ 'inserter', 'transform' ],
 		isActive: ( blockAttributes ) =>
 			blockAttributes?.displayMode === 'time',
 		icon,
@@ -29,7 +29,7 @@ const variations = [
 		attributes: {
 			displayMode: 'words',
 		},
-		scope: [ 'block', 'inserter', 'transform' ],
+		scope: [ 'inserter', 'transform' ],
 		isActive: ( blockAttributes ) =>
 			blockAttributes?.displayMode === 'words',
 		icon,

--- a/packages/block-library/src/post-time-to-read/variations.js
+++ b/packages/block-library/src/post-time-to-read/variations.js
@@ -19,7 +19,7 @@ const variations = [
 		scope: [ 'block', 'inserter', 'transform' ],
 		isActive: ( blockAttributes ) =>
 			blockAttributes?.displayMode === 'time',
-		icon: clock,
+		icon,
 		isDefault: true,
 	},
 	{
@@ -32,7 +32,7 @@ const variations = [
 		scope: [ 'block', 'inserter', 'transform' ],
 		isActive: ( blockAttributes ) =>
 			blockAttributes?.displayMode === 'words',
-		icon: clock,
+		icon,
 	},
 ];
 

--- a/packages/block-library/src/post-time-to-read/variations.js
+++ b/packages/block-library/src/post-time-to-read/variations.js
@@ -2,7 +2,11 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { clock } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import icon from './icon';
 
 const variations = [
 	{

--- a/phpunit/blocks/render-post-time-to-read-test.php
+++ b/phpunit/blocks/render-post-time-to-read-test.php
@@ -216,5 +216,4 @@ class Tests_Blocks_Render_Post_Time_To_Read extends WP_UnitTestCase {
 
 		$this->assertSame( $expected, $actual );
 	}
-
 }

--- a/phpunit/blocks/render-post-time-to-read-test.php
+++ b/phpunit/blocks/render-post-time-to-read-test.php
@@ -107,7 +107,9 @@ class Tests_Blocks_Render_Post_Time_To_Read extends WP_UnitTestCase {
 		$GLOBALS['post'] = self::$no_content_post;
 
 		$page_id       = self::$no_content_post->ID;
-		$attributes    = array();
+		$attributes    = array(
+			'displayMode' => 'time',
+		);
 		$parsed_blocks = parse_blocks( '<!-- wp:post-time-to-read /-->' );
 		$parsed_block  = $parsed_blocks[0];
 		$context       = array( 'postId' => $page_id );
@@ -129,7 +131,9 @@ class Tests_Blocks_Render_Post_Time_To_Read extends WP_UnitTestCase {
 		$GLOBALS['post'] = self::$less_than_one_minute_post;
 
 		$page_id       = self::$less_than_one_minute_post->ID;
-		$attributes    = array();
+		$attributes    = array(
+			'displayMode' => 'time',
+		);
 		$parsed_blocks = parse_blocks( '<!-- wp:post-time-to-read /-->' );
 		$parsed_block  = $parsed_blocks[0];
 		$context       = array( 'postId' => $page_id );
@@ -151,7 +155,9 @@ class Tests_Blocks_Render_Post_Time_To_Read extends WP_UnitTestCase {
 		$GLOBALS['post'] = self::$one_minute_post;
 
 		$page_id       = self::$one_minute_post->ID;
-		$attributes    = array();
+		$attributes    = array(
+			'displayMode' => 'time',
+		);
 		$parsed_blocks = parse_blocks( '<!-- wp:post-time-to-read /-->' );
 		$parsed_block  = $parsed_blocks[0];
 		$context       = array( 'postId' => $page_id );
@@ -173,7 +179,9 @@ class Tests_Blocks_Render_Post_Time_To_Read extends WP_UnitTestCase {
 		$GLOBALS['post'] = self::$two_minutes_post;
 
 		$page_id       = self::$two_minutes_post->ID;
-		$attributes    = array();
+		$attributes    = array(
+			'displayMode' => 'time',
+		);
 		$parsed_blocks = parse_blocks( '<!-- wp:post-time-to-read /-->' );
 		$parsed_block  = $parsed_blocks[0];
 		$context       = array( 'postId' => $page_id );
@@ -196,8 +204,7 @@ class Tests_Blocks_Render_Post_Time_To_Read extends WP_UnitTestCase {
 
 		$page_id       = self::$two_minutes_post->ID;
 		$attributes    = array(
-			'showTimeToRead' => false,
-			'showWordCount'  => true,
+			'displayMode' => 'words',
 		);
 		$parsed_blocks = parse_blocks( '<!-- wp:post-time-to-read /-->' );
 		$parsed_block  = $parsed_blocks[0];
@@ -210,28 +217,4 @@ class Tests_Blocks_Render_Post_Time_To_Read extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 
-	/**
-	 * @covers ::render_block_core_post_time_to_read
-	 */
-	public function test_show_both_time_and_word_count() {
-		global $wp_query;
-
-		$wp_query->post  = self::$two_minutes_post;
-		$GLOBALS['post'] = self::$two_minutes_post;
-
-		$page_id       = self::$two_minutes_post->ID;
-		$attributes    = array(
-			'showTimeToRead' => true,
-			'showWordCount'  => true,
-		);
-		$parsed_blocks = parse_blocks( '<!-- wp:post-time-to-read /-->' );
-		$parsed_block  = $parsed_blocks[0];
-		$context       = array( 'postId' => $page_id );
-		$block         = new WP_Block( $parsed_block, $context );
-
-		$actual   = gutenberg_render_block_core_post_time_to_read( $attributes, '', $block );
-		$expected = '<div class="wp-block-post-time-to-read">2 minutes<br>341 words</div>';
-
-		$this->assertSame( $expected, $actual );
-	}
 }

--- a/test/integration/fixtures/blocks/core__post-time-to-read.json
+++ b/test/integration/fixtures/blocks/core__post-time-to-read.json
@@ -4,8 +4,7 @@
 		"isValid": true,
 		"attributes": {
 			"displayAsRange": true,
-			"showTimeToRead": true,
-			"showWordCount": false,
+			"displayMode": "time",
 			"averageReadingSpeed": 189
 		},
 		"innerBlocks": []


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What and Why?
Based on [this feedback](https://github.com/WordPress/gutenberg/pull/71841#issuecomment-3331197706), I changed the way this block works so that its not possible to remove all content from the block.

<!-- In a few words, what is the PR actually doing? -->

## How?
Replaces the toggles with block variations

## Testing Instructions
1. Create a post
2. Add some content
3. Add a time to read block
4. Confirm that you can switch between a time block, a word count block

## Screenshots or screencast <!-- if applicable -->
<img width="1216" height="389" alt="Screenshot 2025-09-29 at 11 18 52" src="https://github.com/user-attachments/assets/b2363ad6-f9a1-4419-955e-1aede6a0917e" />
<img width="1175" height="626" alt="Screenshot 2025-09-29 at 11 19 02" src="https://github.com/user-attachments/assets/6e6ee554-5629-4b35-9a5b-39aafcb7bd5b" />

