### PR TITLE
Block Comments: Match the comment form UI to the design

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -42,7 +42,10 @@ function CommentForm( { onSubmit, onCancel, thread, submitButtonText } ) {
 		! sanitizeCommentString( inputComment ).length;
 
 	return (
-		<VStack className="editor-collab-sidebar-panel__comment-form">
+		<VStack
+			className="editor-collab-sidebar-panel__comment-form"
+			spacing="4"
+		>
 			<VisuallyHidden as="label" htmlFor={ inputId }>
 				{ __( 'Comment' ) }
 			</VisuallyHidden>
@@ -56,15 +59,11 @@ function CommentForm( { onSubmit, onCancel, thread, submitButtonText } ) {
 				maxRows={ 20 }
 			/>
 			<HStack spacing="2" justify="flex-end" wrap>
-				<Button
-					__next40pxDefaultSize
-					variant="tertiary"
-					onClick={ onCancel }
-				>
+				<Button size="compact" variant="tertiary" onClick={ onCancel }>
 					{ __( 'Cancel' ) }
 				</Button>
 				<Button
-					__next40pxDefaultSize
+					size="compact"
 					accessibleWhenDisabled
 					variant="primary"
 					onClick={ () => {

--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -29,16 +29,9 @@ import { sanitizeCommentString } from './utils';
  * @param {Function} props.onCancel         - The function to call when canceling the comment update.
  * @param {Object}   props.thread           - The comment thread object.
  * @param {string}   props.submitButtonText - The text to display on the submit button.
- * @param {string?}  props.placeholderText  - The placeholder text for the comment input.
  * @return {React.ReactNode} The CommentForm component.
  */
-function CommentForm( {
-	onSubmit,
-	onCancel,
-	thread,
-	submitButtonText,
-	placeholderText,
-} ) {
+function CommentForm( { onSubmit, onCancel, thread, submitButtonText } ) {
 	const [ inputComment, setInputComment ] = useState(
 		thread?.content?.raw ?? ''
 	);
@@ -61,7 +54,6 @@ function CommentForm( {
 				}
 				rows={ 1 }
 				maxRows={ 20 }
-				placeholder={ placeholderText || '' }
 			/>
 			<HStack spacing="2" justify="flex-end" wrap>
 				<Button

--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -10,6 +10,7 @@ import { useState } from '@wordpress/element';
 import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
+	__experimentalTruncate as Truncate,
 	Button,
 	VisuallyHidden,
 } from '@wordpress/components';
@@ -60,7 +61,7 @@ function CommentForm( { onSubmit, onCancel, thread, submitButtonText } ) {
 			/>
 			<HStack spacing="2" justify="flex-end" wrap>
 				<Button size="compact" variant="tertiary" onClick={ onCancel }>
-					{ __( 'Cancel' ) }
+					<Truncate>{ __( 'Cancel' ) }</Truncate>
 				</Button>
 				<Button
 					size="compact"
@@ -71,8 +72,9 @@ function CommentForm( { onSubmit, onCancel, thread, submitButtonText } ) {
 						setInputComment( '' );
 					} }
 					disabled={ isDisabled }
-					text={ submitButtonText }
-				/>
+				>
+					<Truncate>{ submitButtonText }</Truncate>
+				</Button>
 			</HStack>
 		</VStack>
 	);

--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -8,11 +8,12 @@ import TextareaAutosize from 'react-autosize-textarea';
  */
 import { useState } from '@wordpress/element';
 import {
+	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 	Button,
 	VisuallyHidden,
 } from '@wordpress/components';
-import { _x, __ } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
 
 /**
@@ -29,7 +30,6 @@ import { sanitizeCommentString } from './utils';
  * @param {Object}   props.thread           - The comment thread object.
  * @param {string}   props.submitButtonText - The text to display on the submit button.
  * @param {string?}  props.placeholderText  - The placeholder text for the comment input.
- * @param {number?}  props.rows             - The number of rows for the comment input.
  * @return {React.ReactNode} The CommentForm component.
  */
 function CommentForm( {
@@ -38,7 +38,6 @@ function CommentForm( {
 	thread,
 	submitButtonText,
 	placeholderText,
-	rows = 4,
 } ) {
 	const [ inputComment, setInputComment ] = useState(
 		thread?.content?.raw ?? ''
@@ -50,7 +49,7 @@ function CommentForm( {
 		! sanitizeCommentString( inputComment ).length;
 
 	return (
-		<>
+		<VStack className="editor-collab-sidebar-panel__comment-form">
 			<VisuallyHidden as="label" htmlFor={ inputId }>
 				{ __( 'Comment' ) }
 			</VisuallyHidden>
@@ -60,11 +59,18 @@ function CommentForm( {
 				onChange={ ( comment ) =>
 					setInputComment( comment.target.value )
 				}
-				rows={ rows }
+				rows={ 1 }
 				maxRows={ 20 }
 				placeholder={ placeholderText || '' }
 			/>
-			<HStack spacing="3" justify="flex-start" wrap>
+			<HStack spacing="2" justify="flex-end" wrap>
+				<Button
+					__next40pxDefaultSize
+					variant="tertiary"
+					onClick={ onCancel }
+				>
+					{ __( 'Cancel' ) }
+				</Button>
 				<Button
 					__next40pxDefaultSize
 					accessibleWhenDisabled
@@ -76,14 +82,8 @@ function CommentForm( {
 					disabled={ isDisabled }
 					text={ submitButtonText }
 				/>
-				<Button
-					__next40pxDefaultSize
-					variant="tertiary"
-					onClick={ onCancel }
-					text={ _x( 'Cancel', 'Cancel comment button' ) }
-				/>
 			</HStack>
-		</>
+		</VStack>
 	);
 }
 

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -230,10 +230,6 @@ function Thread( {
 								event.stopPropagation(); // Prevent the parent onClick from being triggered
 								clearThreadFocus();
 							} }
-							placeholderText={
-								'approved' === thread.status &&
-								__( 'Comment to reopen' )
-							}
 							submitButtonText={
 								'approved' === thread.status
 									? __( 'Reopen & Reply' )

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -218,10 +218,7 @@ function Thread( {
 					<HStack alignment="left" spacing="3" justify="flex-start">
 						<CommentAuthorInfo />
 					</HStack>
-					<VStack
-						spacing="3"
-						className="editor-collab-sidebar-panel__comment-field"
-					>
+					<VStack spacing="2">
 						<CommentForm
 							onSubmit={ ( inputComment ) => {
 								if ( 'approved' === thread.status ) {
@@ -235,19 +232,13 @@ function Thread( {
 							} }
 							placeholderText={
 								'approved' === thread.status &&
-								__(
-									'Adding a comment will re-open this discussion….'
-								)
+								__( 'Comment to reopen' )
 							}
 							submitButtonText={
 								'approved' === thread.status
-									? _x(
-											'Reopen & Reply',
-											'Reopen comment and add reply'
-									  )
-									: _x( 'Reply', 'Add reply comment' )
+									? __( 'Reopen & Reply' )
+									: __( 'Reply' )
 							}
-							rows={ 'approved' === thread.status ? 2 : 4 }
 						/>
 					</VStack>
 				</VStack>

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -34,15 +34,6 @@
 	box-shadow: 0 5.5px 7.8px -0.3px rgba(0, 0, 0, 0.102);
 }
 
-.editor-collab-sidebar-panel__comment-field {
-	flex: 1;
-
-	button {
-		flex-grow: 1;
-		justify-content: center;
-	}
-}
-
 .editor-collab-sidebar-panel__child-thread {
 	margin-top: 15px;
 }
@@ -130,6 +121,16 @@
 
 .editor-collab-sidebar-panel__more-reply-button {
 	font-weight: 500;
+}
+
+.editor-collab-sidebar-panel__comment-form textarea {
+	@include input-control;
+	// Vertical padding is to match the standard 40px control height when rows=1,
+	// in conjunction with the 20px line-height.
+	// "Standard" metrics are 10px 12px, but subtracts 1px each to account for the border width.
+	padding: 9px 11px;
+	line-height: 20px !important;
+	display: block;
 }
 
 // Comment avatar indicators.


### PR DESCRIPTION
Part of #71774

## What?

Update the UI of the comment form to match the design. There are no changes in functionality.

## Screenshots or screencast <!-- if applicable -->

### Add New Comment

| Header | Header |
|--------|--------|
| <img width="262" height="182" alt="image" src="https://github.com/user-attachments/assets/19bf9af9-78c4-46df-a26a-f7efcc087ccf" /> | <img width="271" height="182" alt="image" src="https://github.com/user-attachments/assets/296e3966-ba26-4f5f-87b0-539ed7897fcc" /> |

### Reply to Unresolved Thread

| Header | Header |
|--------|--------|
| <img width="266" height="265" alt="image" src="https://github.com/user-attachments/assets/16a0cc45-cb1a-423b-986e-d9d2c8bc6b2e" /> | <img width="266" height="268" alt="image" src="https://github.com/user-attachments/assets/9aba83b6-b497-4095-92b7-1eb01740bba1" /> |

### Reply to Resolved Thread

| Header | Header |
|--------|--------|
| <img width="268" height="265" alt="image" src="https://github.com/user-attachments/assets/ac46e079-59a1-4679-affe-deb456a40679" /> | <img width="270" height="266" alt="image" src="https://github.com/user-attachments/assets/6642dd11-8583-4383-944e-02e6a3926721" /> |

