### PR TITLE
Fix Navigation Block default link consistency across all insertion methods

### DIFF
--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -46,16 +46,13 @@ import {
 	getNavigationChildBlockProps,
 } from '../navigation/edit/utils';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+import { DEFAULT_BLOCK } from '../navigation/constants';
 
 const ALLOWED_BLOCKS = [
 	'core/navigation-link',
 	'core/navigation-submenu',
 	'core/page-list',
 ];
-
-const DEFAULT_BLOCK = {
-	name: 'core/navigation-link',
-};
 
 /**
  * A React hook to determine if it's dragging within the target element.

--- a/packages/block-library/src/navigation/edit/leaf-more-menu.js
+++ b/packages/block-library/src/navigation/edit/leaf-more-menu.js
@@ -13,6 +13,11 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { BlockTitle, store as blockEditorStore } from '@wordpress/block-editor';
 
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_BLOCK } from '../constants';
+
 const POPOVER_PROPS = {
 	className: 'block-editor-block-settings-menu__popover',
 	placement: 'bottom-start',
@@ -43,7 +48,10 @@ function AddSubmenuItem( {
 			disabled={ isDisabled }
 			onClick={ () => {
 				const updateSelectionOnInsert = false;
-				const newLink = createBlock( 'core/navigation-link' );
+				const newLink = createBlock(
+					DEFAULT_BLOCK.name,
+					DEFAULT_BLOCK.attributes
+				);
 
 				if ( block.name === 'core/navigation-submenu' ) {
 					insertBlock(


### PR DESCRIPTION
## What

Fixes inconsistent default link creation across Navigation Block insertion methods. Previously, List View 'Add submenu link' and Navigation Submenu InnerBlocks were creating custom links instead of page-type links.

## Why

The Navigation Block system had inconsistent behaviour when adding new links:
- In-canvas InnerBlocks correctly created page-type links with `kind: 'post-type'` and `type: 'page'`
- List View 'Add submenu link' created custom links (missing attributes)
- Navigation Submenu InnerBlocks created custom links (missing attributes)

This inconsistency created a confusing user experience where the same action produced different results depending on the insertion method.

Thanks to upgrades to the Link UI to include the `Add block` UX, users can now easily access other Nav Link block variations / other block types. As a result we can safetly normalize the insertion of Page variation as the default experience.

## How

- Updated `AddSubmenuItem` in Navigation Block to use `DEFAULT_BLOCK.name` and `DEFAULT_BLOCK.attributes`
- Updated Navigation Submenu block to import and use the shared `DEFAULT_BLOCK` configuration
- Removed local `DEFAULT_BLOCK` definition that was missing proper attributes

## Testing

1. Create a Navigation Block
2. Use List View sidebar 'Add submenu link' - should create page-type link
3. Add a Navigation Submenu block
4. Use 'Add block' inserter within the submenu within the canvas - should create page-type link
5. Verify all insertion methods now create consistent page-type links

## Screenshots



https://github.com/user-attachments/assets/7c1a8187-4e96-449d-aecb-825bc2156b43


