### PR TITLE
Social Icon: Removed extra spaces in color styles

### DIFF
--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -374,11 +374,11 @@ function block_core_social_link_get_color_styles( $context ) {
 	$styles = array();
 
 	if ( array_key_exists( 'iconColorValue', $context ) ) {
-		$styles[] = 'color: ' . $context['iconColorValue'] . '; ';
+		$styles[] = 'color:' . $context['iconColorValue'] . ';';
 	}
 
 	if ( array_key_exists( 'iconBackgroundColorValue', $context ) ) {
-		$styles[] = 'background-color: ' . $context['iconBackgroundColorValue'] . '; ';
+		$styles[] = 'background-color:' . $context['iconBackgroundColorValue'] . ';';
 	}
 
 	return implode( '', $styles );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Removed spacing in Social Icon color styles to make them consistent with other blocks
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Similar #69405
<!-- In a few words, what is the PR actually doing? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a Social Icons block.
3. You can see that the spaces in the color style have been removed

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="959" height="163" alt="before" src="https://github.com/user-attachments/assets/8adaf40d-c8c5-48bf-9926-613f456e91d3" /> |  <img width="948" height="144" alt="after" src="https://github.com/user-attachments/assets/9b4265d8-1a02-4633-bb3d-74b5fb32d1a7" /> |


