### PR TITLE
Accordion Panel: Add role=region

### DIFF
--- a/packages/block-library/src/accordion-panel/edit.js
+++ b/packages/block-library/src/accordion-panel/edit.js
@@ -9,6 +9,7 @@ export default function Edit( { attributes } ) {
 
 	const blockProps = useBlockProps( {
 		'aria-hidden': ! isSelected && ! openByDefault,
+		role: 'region',
 	} );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {

--- a/packages/block-library/src/accordion-panel/save.js
+++ b/packages/block-library/src/accordion-panel/save.js
@@ -4,7 +4,9 @@
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
 export default function save() {
-	const blockProps = useBlockProps.save();
+	const blockProps = useBlockProps.save( {
+		role: 'region',
+	} );
 	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
 	return <div { ...innerBlocksProps } />;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/71779

Adds `role="region"` to the Accordion Panel block.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As the Accordion Panel block has an `aria-labelledby` attribute that points to the panel header, it should also have a corresponding role. Without a role attribute, the aria label will not be announced.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds `role="region"` to the Accordion Panel block via block props.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Insert an Accordion block with at least one heading and some content.
2. Ensure the Accordion Panel block has `role="region"` attribute in its markup.
