### PR TITLE
add decodeEntities for CollabSideBarContent errors

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -11,6 +11,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as interfaceStore } from '@wordpress/interface';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -60,7 +61,7 @@ function CollabSidebarContent( {
 	const onError = ( error ) => {
 		const errorMessage =
 			error.message && error.code !== 'unknown_error'
-				? error.message
+				? decodeEntities( error.message )
 				: __( 'An error occurred while performing an update.' );
 		createNotice( 'error', errorMessage, {
 			type: 'snackbar',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix Duplicate comment reply message contains encoding with decodeEntities.




<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/71880

## Testing Instructions

1. Add a comment
2. Add a reply
3. Add the same reply again

## Screenshots or screencast <!-- if applicable -->

----

### Before
<img width="531" height="49" alt="image" src="https://github.com/user-attachments/assets/2cad851f-3710-4af3-a9f1-778e651a0733" />
----

### After
<img width="495" height="57" alt="image" src="https://github.com/user-attachments/assets/f50e85b2-12eb-4047-99e8-7d826c9e80c9" />|
