### PR TITLE
Comments loading performance doesn't scale

### DIFF
--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -17,7 +17,7 @@ export function useBlockComments( postId ) {
 	const { records: threads, totalPages } = useEntityRecords(
 		'root',
 		'comment',
-		queryArgs,
+		{ ...queryArgs, parent: 0 },
 		{ enabled: !! postId && typeof postId === 'number' }
 	);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix a scalability issue where posts with may comment replies may not load properly.

Part of https://github.com/WordPress/gutenberg/issues/71668

* Only load top level comments initially, 
* load the count of all replies for all comments, letting us show the "plus X comments" message
* then load most recent comment for each comment (or possibly combine with first query)
* Lazy load remaining replies
  * Could we do this when the comment or its block is activated? How?
  * Could we start loading the data on hover so the comment opens with replies quicker?

<!-- In a few words, what is the PR actually doing? -->

## Why?
If a post has many comments, it may take a long time or struggle to load. Only loading what is needed for the initial display will reduce the initial payload.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Create a test post and add many comments and replies, possibly with this tool - https://github.com/t-hamano/block-commenting-data-generator
2. Test with for example 50 comments with 50 replies each, 100 comments with 100 replies each or 150 comments with 150 replies each. 
3. Test loading the post. Test using network throttling and reduced CPU with DevTools.

### Expected Result
The editor works as expected 
