### PR TITLE
Block Comments: Apply border color to avatar

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comment-author-info.js
+++ b/packages/editor/src/components/collab-sidebar/comment-author-info.js
@@ -14,20 +14,27 @@ import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
+ * Internal dependencies
+ */
+import { getAvatarBorderColor } from './utils';
+
+/**
  * Render author information for a comment.
  *
  * @param {Object} props        - Component properties.
  * @param {string} props.avatar - URL of the author's avatar.
  * @param {string} props.name   - Name of the author.
  * @param {string} props.date   - Date of the comment.
+ * @param {string} props.userId - User ID of the author.
  *
  * @return {React.ReactNode} The JSX element representing the author's information.
  */
-function CommentAuthorInfo( { avatar, name, date } ) {
+function CommentAuthorInfo( { avatar, name, date, userId } ) {
 	const dateSettings = getDateSettings();
 	const {
 		currentUserAvatar,
 		currentUserName,
+		currentUserId,
 		dateFormat = dateSettings.formats.date,
 	} = useSelect( ( select ) => {
 		const { getCurrentUser, getEntityRecord } = select( coreStore );
@@ -39,6 +46,7 @@ function CommentAuthorInfo( { avatar, name, date } ) {
 		return {
 			currentUserAvatar: userData?.avatar_urls?.[ 48 ] ?? defaultAvatar,
 			currentUserName: userData?.name,
+			currentUserId: userData?.id,
 			dateFormat: siteSettings?.date_format,
 		};
 	}, [] );
@@ -68,6 +76,11 @@ function CommentAuthorInfo( { avatar, name, date } ) {
 				alt={ __( 'User avatar' ) }
 				width={ 32 }
 				height={ 32 }
+				style={ {
+					borderColor: getAvatarBorderColor(
+						userId ?? currentUserId
+					),
+				} }
 			/>
 			<VStack spacing="0">
 				<span className="editor-collab-sidebar-panel__user-name">

--- a/packages/editor/src/components/collab-sidebar/comment-indicator-toolbar.js
+++ b/packages/editor/src/components/collab-sidebar/comment-indicator-toolbar.js
@@ -15,6 +15,7 @@ import clsx from 'clsx';
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
+import { getAvatarBorderColor } from './utils';
 
 const { CommentIconToolbarSlotFill } = unlock( blockEditorPrivateApis );
 
@@ -40,6 +41,7 @@ const CommentAvatarIndicator = ( { onClick, thread, hasMoreComments } ) => {
 						avatar:
 							comment.author_avatar_urls?.[ '48' ] ||
 							comment.author_avatar_urls?.[ '96' ],
+						id: comment.author,
 						isOriginalCommenter: comment.id === thread.id,
 						date: comment.date,
 					} );
@@ -107,7 +109,12 @@ const CommentAvatarIndicator = ( { onClick, thread, hasMoreComments } ) => {
 							src={ participant.avatar }
 							alt={ participant.name }
 							className="comment-avatar"
-							style={ { zIndex: maxAvatars - index } }
+							style={ {
+								zIndex: maxAvatars - index,
+								borderColor: getAvatarBorderColor(
+									participant.id
+								),
+							} }
 						/>
 					) ) }
 					{ overflowCount > 0 && (

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -291,6 +291,7 @@ const CommentBoard = ( { thread, onEdit, onDelete, status } ) => {
 					avatar={ thread?.author_avatar_urls?.[ 48 ] }
 					name={ thread?.author_name }
 					date={ thread?.date }
+					userId={ thread?.author }
 				/>
 				<span className="editor-collab-sidebar-panel__comment-status">
 					<HStack alignment="right" justify="flex-end" spacing="0">

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -64,6 +64,9 @@
 .editor-collab-sidebar-panel__user-avatar {
 	border-radius: $radius-round;
 	flex-shrink: 0;
+	border-width: var(--wp-admin-border-width-focus);
+	border-style: solid;
+	padding: var(--wp-admin-border-width-focus);
 }
 
 .editor-collab-sidebar-panel__thread-overlay {

--- a/packages/editor/src/components/collab-sidebar/utils.js
+++ b/packages/editor/src/components/collab-sidebar/utils.js
@@ -7,3 +7,28 @@
 export function sanitizeCommentString( str ) {
 	return str.trim();
 }
+
+/**
+ * These colors are picked from the WordPress.org design library.
+ * @see https://www.figma.com/design/HOJTpCFfa3tR0EccUlu0CM/WordPress.org-Design-Library?node-id=1-2193&t=M6WdRvTpt0mh8n6T-1
+ */
+const AVATAR_BORDER_COLORS = [
+	'#3858E9', // Blueberry
+	'#9fB1FF', // Blueberry 2
+	'#1D35B4', // Dark Blueberry
+	'#1A1919', // Charcoal 0
+	'#E26F56', // Pomegranate
+	'#33F078', // Acid Green
+	'#FFF972', // Lemon
+	'#7A00DF', // Purple
+];
+
+/**
+ * Gets the border color for an avatar based on the user ID.
+ *
+ * @param {number} userId - The user ID.
+ * @return {string} - The border color.
+ */
+export function getAvatarBorderColor( userId ) {
+	return AVATAR_BORDER_COLORS[ userId % AVATAR_BORDER_COLORS.length ];
+}


### PR DESCRIPTION
Try to address https://github.com/WordPress/gutenberg/issues/71774#issuecomment-3334532567

## What?

Attempts to automatically apply the avatar's border color.

<img width="787" height="406" alt="image" src="https://github.com/user-attachments/assets/ef422ed7-913f-4765-b54f-eb9731e6ab78" />

## How?

Deciding what rules to use to generate colors is a very difficult problem, but in this PR I'm trying the following approach.

- Pick 8 colors from the [.org Design Library](url)
- Divide the user ID number by the length of the color list and get the remainder.
- The remainder number is used as an index to retrieve a color from the color array.

The advantage of this approach is that it ensures that colors will remain consistent for each user across the WordPress site, since the color is calculated from only user ID.

The downside is that we may not get a wide range of color variations, for example, user IDs 8, 16, 24, and 32 will all have the same color.

Any ideas on other approaches are welcome!


## Testing Instructions

- Download, install and activate [Block Commenting Data Generator ](https://github.com/t-hamano/block-commenting-data-generator)to create a lot of comment at once.
- Confirm the color of the avatar's border.
