### PR TITLE
Block Comments: Update REST API permissions for this type

### DIFF
--- a/lib/experimental/class-gutenberg-rest-comment-controller.php
+++ b/lib/experimental/class-gutenberg-rest-comment-controller.php
@@ -11,7 +11,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 
 	public function get_items_permissions_check( $request ) {
 		$is_block_comment = ! empty( $request['type'] ) && 'block_comment' === $request['type'];
-		$is_edit_context = ! empty( $request['context'] ) && 'edit' === $request['context'];
+		$is_edit_context  = ! empty( $request['context'] ) && 'edit' === $request['context'];
 
 		if ( ! empty( $request['post'] ) ) {
 			foreach ( (array) $request['post'] as $post_id ) {

--- a/lib/experimental/class-gutenberg-rest-comment-controller.php
+++ b/lib/experimental/class-gutenberg-rest-comment-controller.php
@@ -9,16 +9,126 @@
 // Create a new class that extends WP_REST_Comments_Controller
 class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 
-	public function create_item_permissions_check( $request ) {
-		if ( empty( $request['comment_type'] ) || 'comment' === $request['comment_type'] ) {
-			return parent::create_item_permissions_check( $request );
+	public function get_items_permissions_check( $request ) {
+		if ( ! empty( $request['post'] ) ) {
+			foreach ( (array) $request['post'] as $post_id ) {
+				$post = get_post( $post_id );
+
+				// Note: This is only relevant change for the backport.
+				if ( $post && ! $this->check_post_type_supports_block_comments( $post->post_type ) ) {
+					return new WP_Error(
+						'rest_comment_not_supported_post_type',
+						__( 'Sorry, this post type does not support block comments.', 'gutenberg' ),
+						array( 'status' => 403 )
+					);
+				}
+
+				if ( ! empty( $post_id ) && $post && ! $this->check_read_post_permission( $post, $request ) ) {
+					return new WP_Error(
+						'rest_cannot_read_post',
+						__( 'Sorry, you are not allowed to read the post for this comment.' ),
+						array( 'status' => rest_authorization_required_code() )
+					);
+				} elseif ( 0 === $post_id && ! current_user_can( 'moderate_comments' ) ) {
+					return new WP_Error(
+						'rest_cannot_read',
+						__( 'Sorry, you are not allowed to read comments without a post.' ),
+						array( 'status' => rest_authorization_required_code() )
+					);
+				}
+			}
 		}
 
-		if ( ! is_user_logged_in() ) {
+		// Re-map edit context capabilities when requesting `block_comment` for a post.
+		// Note: This is only relevant change for the backport.
+		$edit_cap = ! empty( $request['post'] ) && 'block_comment' === $request['type'] ? 'edit_posts' : 'moderate_comments';
+		if ( ! empty( $request['context'] ) && 'edit' === $request['context'] && ! current_user_can( $edit_cap ) ) {
+			return new WP_Error(
+				'rest_forbidden_context',
+				__( 'Sorry, you are not allowed to edit comments.' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			$protected_params = array( 'author', 'author_exclude', 'author_email', 'type', 'status' );
+			$forbidden_params = array();
+
+			foreach ( $protected_params as $param ) {
+				if ( 'status' === $param ) {
+					if ( 'approve' !== $request[ $param ] ) {
+						$forbidden_params[] = $param;
+					}
+				} elseif ( 'type' === $param ) {
+					if ( 'comment' !== $request[ $param ] ) {
+						$forbidden_params[] = $param;
+					}
+				} elseif ( ! empty( $request[ $param ] ) ) {
+					$forbidden_params[] = $param;
+				}
+			}
+
+			if ( ! empty( $forbidden_params ) ) {
+				return new WP_Error(
+					'rest_forbidden_param',
+					/* translators: %s: List of forbidden parameters. */
+					sprintf( __( 'Query parameter not permitted: %s' ), implode( ', ', $forbidden_params ) ),
+					array( 'status' => rest_authorization_required_code() )
+				);
+			}
+		}
+
+		return true;
+	}
+
+	public function get_item_permissions_check( $request ) {
+		$comment = $this->get_comment( $request['id'] );
+		if ( is_wp_error( $comment ) ) {
+			return $comment;
+		}
+
+		// Re-map edit context capabilities when requesting `block_comment` type.
+		// Note: This is only relevant change for the backport.
+		$edit_cap = 'block_comment' === $comment->comment_type ? 'edit_posts' : 'moderate_comments';
+		if ( ! empty( $request['context'] ) && 'edit' === $request['context'] && ! current_user_can( $edit_cap ) ) {
+			return new WP_Error(
+				'rest_forbidden_context',
+				__( 'Sorry, you are not allowed to edit comments.' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		$post = get_post( $comment->comment_post_ID );
+
+		if ( ! $this->check_read_permission( $comment, $request ) ) {
+			return new WP_Error(
+				'rest_cannot_read',
+				__( 'Sorry, you are not allowed to read this comment.' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		if ( $post && ! $this->check_read_post_permission( $post, $request ) ) {
+			return new WP_Error(
+				'rest_cannot_read_post',
+				__( 'Sorry, you are not allowed to read the post for this comment.' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	public function create_item_permissions_check( $request ) {
+		// This should be an `block_comment` type check when backporting.
+		$non_block_comment = empty( $request['comment_type'] ) || 'comment' === $request['comment_type'];
+
+		// Note: This is only relevant change for the backport.
+		if ( ! is_user_logged_in() && $non_block_comment ) {
 			if ( get_option( 'comment_registration' ) ) {
 				return new WP_Error(
 					'rest_comment_login_required',
-					__( 'Sorry, you must be logged in to comment.', 'gutenberg' ),
+					__( 'Sorry, you must be logged in to comment.' ),
 					array( 'status' => 401 )
 				);
 			}
@@ -40,7 +150,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 			if ( ! $allow_anonymous ) {
 				return new WP_Error(
 					'rest_comment_login_required',
-					__( 'Sorry, you must be logged in to comment.', 'gutenberg' ),
+					__( 'Sorry, you must be logged in to comment.' ),
 					array( 'status' => 401 )
 				);
 			}
@@ -51,7 +161,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 			return new WP_Error(
 				'rest_comment_invalid_author',
 				/* translators: %s: Request parameter. */
-				sprintf( __( "Sorry, you are not allowed to edit '%s' for comments.", 'gutenberg' ), 'author' ),
+				sprintf( __( "Sorry, you are not allowed to edit '%s' for comments." ), 'author' ),
 				array( 'status' => rest_authorization_required_code() )
 			);
 		}
@@ -61,7 +171,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 				return new WP_Error(
 					'rest_comment_invalid_author_ip',
 					/* translators: %s: Request parameter. */
-					sprintf( __( "Sorry, you are not allowed to edit '%s' for comments.", 'gutenberg' ), 'author_ip' ),
+					sprintf( __( "Sorry, you are not allowed to edit '%s' for comments." ), 'author_ip' ),
 					array( 'status' => rest_authorization_required_code() )
 				);
 			}
@@ -71,7 +181,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 			return new WP_Error(
 				'rest_comment_invalid_status',
 				/* translators: %s: Request parameter. */
-				sprintf( __( "Sorry, you are not allowed to edit '%s' for comments.", 'gutenberg' ), 'status' ),
+				sprintf( __( "Sorry, you are not allowed to edit '%s' for comments." ), 'status' ),
 				array( 'status' => rest_authorization_required_code() )
 			);
 		}
@@ -79,7 +189,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		if ( empty( $request['post'] ) ) {
 			return new WP_Error(
 				'rest_comment_invalid_post_id',
-				__( 'Sorry, you are not allowed to create this comment without a post.', 'gutenberg' ),
+				__( 'Sorry, you are not allowed to create this comment without a post.' ),
 				array( 'status' => 403 )
 			);
 		}
@@ -89,7 +199,25 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		if ( ! $post ) {
 			return new WP_Error(
 				'rest_comment_invalid_post_id',
-				__( 'Sorry, you are not allowed to create this comment without a post.', 'gutenberg' ),
+				__( 'Sorry, you are not allowed to create this comment without a post.' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		// Note: This is only relevant change for the backport.
+		if ( ! $this->check_post_type_supports_block_comments( $post->post_type ) ) {
+			return new WP_Error(
+				'rest_comment_not_supported_post_type',
+				__( 'Sorry, this post type does not support block comments.', 'gutenberg' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		// Note: This is only relevant change for the backport.
+		if ( 'draft' === $post->post_status && $non_block_comment ) {
+			return new WP_Error(
+				'rest_comment_draft_post',
+				__( 'Sorry, you are not allowed to create a comment on this post.' ),
 				array( 'status' => 403 )
 			);
 		}
@@ -97,7 +225,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		if ( 'trash' === $post->post_status ) {
 			return new WP_Error(
 				'rest_comment_trash_post',
-				__( 'Sorry, you are not allowed to create a comment on this post.', 'gutenberg' ),
+				__( 'Sorry, you are not allowed to create a comment on this post.' ),
 				array( 'status' => 403 )
 			);
 		}
@@ -105,15 +233,16 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		if ( ! $this->check_read_post_permission( $post, $request ) ) {
 			return new WP_Error(
 				'rest_cannot_read_post',
-				__( 'Sorry, you are not allowed to read the post for this comment.', 'gutenberg' ),
+				__( 'Sorry, you are not allowed to read the post for this comment.' ),
 				array( 'status' => rest_authorization_required_code() )
 			);
 		}
 
-		if ( ! $this->check_post_type_supports_block_comments( $post->post_type ) ) {
+		// Note: This is only relevant change for the backport.
+		if ( ! comments_open( $post->ID ) && $non_block_comment ) {
 			return new WP_Error(
-				'rest_comment_block_comments_not_supported',
-				__( 'Sorry, this post type does not support block comments.', 'gutenberg' ),
+				'rest_comment_closed',
+				__( 'Sorry, comments are closed for this item.' ),
 				array( 'status' => 403 )
 			);
 		}
@@ -141,6 +270,25 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 			}
 		}
 		return true;
+	}
+
+	/**
+	 * Override the schema to change `type` property.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema                       = parent::get_item_schema();
+		$schema['properties']['type'] = array(
+			'description' => __( 'Type of the comment.' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit', 'embed' ),
+			'arg_options' => array(
+				'sanitize_callback' => 'sanitize_key',
+			),
+		);
+
+		return $schema;
 	}
 }
 

--- a/lib/experimental/class-gutenberg-rest-comment-controller.php
+++ b/lib/experimental/class-gutenberg-rest-comment-controller.php
@@ -10,12 +10,14 @@
 class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 
 	public function get_items_permissions_check( $request ) {
+		$is_block_comment = ! empty( $request['type'] ) && 'block_comment' === $request['type'];
+
 		if ( ! empty( $request['post'] ) ) {
 			foreach ( (array) $request['post'] as $post_id ) {
 				$post = get_post( $post_id );
 
 				// Note: This is only relevant change for the backport.
-				if ( $post && ! $this->check_post_type_supports_block_comments( $post->post_type ) ) {
+				if ( $post && $is_block_comment && ! $this->check_post_type_supports_block_comments( $post->post_type ) ) {
 					return new WP_Error(
 						'rest_comment_not_supported_post_type',
 						__( 'Sorry, this post type does not support block comments.', 'gutenberg' ),
@@ -41,7 +43,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 
 		// Re-map edit context capabilities when requesting `block_comment` for a post.
 		// Note: This is only relevant change for the backport.
-		$edit_cap = ! empty( $request['post'] ) && 'block_comment' === $request['type'] ? 'edit_posts' : 'moderate_comments';
+		$edit_cap = ! empty( $request['post'] ) && $is_block_comment ? 'edit_posts' : 'moderate_comments';
 		if ( ! empty( $request['context'] ) && 'edit' === $request['context'] && ! current_user_can( $edit_cap ) ) {
 			return new WP_Error(
 				'rest_forbidden_context',
@@ -120,11 +122,10 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 	}
 
 	public function create_item_permissions_check( $request ) {
-		// This should be an `block_comment` type check when backporting.
-		$non_block_comment = empty( $request['comment_type'] ) || 'comment' === $request['comment_type'];
+		$is_block_comment = ! empty( $request['comment_type'] ) && 'block_comment' === $request['comment_type'];
 
 		// Note: This is only relevant change for the backport.
-		if ( ! is_user_logged_in() && $non_block_comment ) {
+		if ( ! is_user_logged_in() && ! $is_block_comment ) {
 			if ( get_option( 'comment_registration' ) ) {
 				return new WP_Error(
 					'rest_comment_login_required',
@@ -205,7 +206,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		}
 
 		// Note: This is only relevant change for the backport.
-		if ( ! $this->check_post_type_supports_block_comments( $post->post_type ) ) {
+		if ( $is_block_comment && ! $this->check_post_type_supports_block_comments( $post->post_type ) ) {
 			return new WP_Error(
 				'rest_comment_not_supported_post_type',
 				__( 'Sorry, this post type does not support block comments.', 'gutenberg' ),
@@ -214,7 +215,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		}
 
 		// Note: This is only relevant change for the backport.
-		if ( 'draft' === $post->post_status && $non_block_comment ) {
+		if ( 'draft' === $post->post_status && ! $is_block_comment ) {
 			return new WP_Error(
 				'rest_comment_draft_post',
 				__( 'Sorry, you are not allowed to create a comment on this post.', 'gutenberg' ),
@@ -239,7 +240,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		}
 
 		// Note: This is only relevant change for the backport.
-		if ( ! comments_open( $post->ID ) && $non_block_comment ) {
+		if ( ! comments_open( $post->ID ) && ! $is_block_comment ) {
 			return new WP_Error(
 				'rest_comment_closed',
 				__( 'Sorry, comments are closed for this item.', 'gutenberg' ),
@@ -283,6 +284,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 			'description' => __( 'Type of the comment.', 'gutenberg' ),
 			'type'        => 'string',
 			'context'     => array( 'view', 'edit', 'embed' ),
+			// Note: This is only relevant change for the backport.
 			'arg_options' => array(
 				'sanitize_callback' => 'sanitize_key',
 			),

--- a/lib/experimental/class-gutenberg-rest-comment-controller.php
+++ b/lib/experimental/class-gutenberg-rest-comment-controller.php
@@ -11,6 +11,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 
 	public function get_items_permissions_check( $request ) {
 		$is_block_comment = ! empty( $request['type'] ) && 'block_comment' === $request['type'];
+		$is_edit_context = ! empty( $request['context'] ) && 'edit' === $request['context'];
 
 		if ( ! empty( $request['post'] ) ) {
 			foreach ( (array) $request['post'] as $post_id ) {
@@ -43,8 +44,17 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 
 		// Re-map edit context capabilities when requesting `block_comment` for a post.
 		// Note: This is only relevant change for the backport.
-		$edit_cap = ! empty( $request['post'] ) && $is_block_comment ? 'edit_posts' : 'moderate_comments';
-		if ( ! empty( $request['context'] ) && 'edit' === $request['context'] && ! current_user_can( $edit_cap ) ) {
+		if ( $is_edit_context && $is_block_comment && ! empty( $request['post'] ) ) {
+			foreach ( (array) $request['post'] as $post_id ) {
+				if ( ! current_user_can( 'edit_post', $post_id ) ) {
+					return new WP_Error(
+						'rest_forbidden_context',
+						__( 'Sorry, you are not allowed to edit comments.', 'gutenberg' ),
+						array( 'status' => rest_authorization_required_code() )
+					);
+				}
+			}
+		} elseif ( $is_edit_context && ! current_user_can( 'moderate_comments' ) ) {
 			return new WP_Error(
 				'rest_forbidden_context',
 				__( 'Sorry, you are not allowed to edit comments.', 'gutenberg' ),

--- a/lib/experimental/class-gutenberg-rest-comment-controller.php
+++ b/lib/experimental/class-gutenberg-rest-comment-controller.php
@@ -26,13 +26,13 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 				if ( ! empty( $post_id ) && $post && ! $this->check_read_post_permission( $post, $request ) ) {
 					return new WP_Error(
 						'rest_cannot_read_post',
-						__( 'Sorry, you are not allowed to read the post for this comment.' ),
+						__( 'Sorry, you are not allowed to read the post for this comment.', 'gutenberg' ),
 						array( 'status' => rest_authorization_required_code() )
 					);
 				} elseif ( 0 === $post_id && ! current_user_can( 'moderate_comments' ) ) {
 					return new WP_Error(
 						'rest_cannot_read',
-						__( 'Sorry, you are not allowed to read comments without a post.' ),
+						__( 'Sorry, you are not allowed to read comments without a post.', 'gutenberg' ),
 						array( 'status' => rest_authorization_required_code() )
 					);
 				}
@@ -45,7 +45,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		if ( ! empty( $request['context'] ) && 'edit' === $request['context'] && ! current_user_can( $edit_cap ) ) {
 			return new WP_Error(
 				'rest_forbidden_context',
-				__( 'Sorry, you are not allowed to edit comments.' ),
+				__( 'Sorry, you are not allowed to edit comments.', 'gutenberg' ),
 				array( 'status' => rest_authorization_required_code() )
 			);
 		}
@@ -72,7 +72,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 				return new WP_Error(
 					'rest_forbidden_param',
 					/* translators: %s: List of forbidden parameters. */
-					sprintf( __( 'Query parameter not permitted: %s' ), implode( ', ', $forbidden_params ) ),
+					sprintf( __( 'Query parameter not permitted: %s', 'gutenberg' ), implode( ', ', $forbidden_params ) ),
 					array( 'status' => rest_authorization_required_code() )
 				);
 			}
@@ -93,7 +93,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		if ( ! empty( $request['context'] ) && 'edit' === $request['context'] && ! current_user_can( $edit_cap ) ) {
 			return new WP_Error(
 				'rest_forbidden_context',
-				__( 'Sorry, you are not allowed to edit comments.' ),
+				__( 'Sorry, you are not allowed to edit comments.', 'gutenberg' ),
 				array( 'status' => rest_authorization_required_code() )
 			);
 		}
@@ -103,7 +103,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		if ( ! $this->check_read_permission( $comment, $request ) ) {
 			return new WP_Error(
 				'rest_cannot_read',
-				__( 'Sorry, you are not allowed to read this comment.' ),
+				__( 'Sorry, you are not allowed to read this comment.', 'gutenberg' ),
 				array( 'status' => rest_authorization_required_code() )
 			);
 		}
@@ -111,7 +111,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		if ( $post && ! $this->check_read_post_permission( $post, $request ) ) {
 			return new WP_Error(
 				'rest_cannot_read_post',
-				__( 'Sorry, you are not allowed to read the post for this comment.' ),
+				__( 'Sorry, you are not allowed to read the post for this comment.', 'gutenberg' ),
 				array( 'status' => rest_authorization_required_code() )
 			);
 		}
@@ -128,7 +128,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 			if ( get_option( 'comment_registration' ) ) {
 				return new WP_Error(
 					'rest_comment_login_required',
-					__( 'Sorry, you must be logged in to comment.' ),
+					__( 'Sorry, you must be logged in to comment.', 'gutenberg' ),
 					array( 'status' => 401 )
 				);
 			}
@@ -150,7 +150,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 			if ( ! $allow_anonymous ) {
 				return new WP_Error(
 					'rest_comment_login_required',
-					__( 'Sorry, you must be logged in to comment.' ),
+					__( 'Sorry, you must be logged in to comment.', 'gutenberg' ),
 					array( 'status' => 401 )
 				);
 			}
@@ -161,7 +161,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 			return new WP_Error(
 				'rest_comment_invalid_author',
 				/* translators: %s: Request parameter. */
-				sprintf( __( "Sorry, you are not allowed to edit '%s' for comments." ), 'author' ),
+				sprintf( __( "Sorry, you are not allowed to edit '%s' for comments.", 'gutenberg' ), 'author' ),
 				array( 'status' => rest_authorization_required_code() )
 			);
 		}
@@ -171,7 +171,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 				return new WP_Error(
 					'rest_comment_invalid_author_ip',
 					/* translators: %s: Request parameter. */
-					sprintf( __( "Sorry, you are not allowed to edit '%s' for comments." ), 'author_ip' ),
+					sprintf( __( "Sorry, you are not allowed to edit '%s' for comments.", 'gutenberg' ), 'author_ip' ),
 					array( 'status' => rest_authorization_required_code() )
 				);
 			}
@@ -181,7 +181,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 			return new WP_Error(
 				'rest_comment_invalid_status',
 				/* translators: %s: Request parameter. */
-				sprintf( __( "Sorry, you are not allowed to edit '%s' for comments." ), 'status' ),
+				sprintf( __( "Sorry, you are not allowed to edit '%s' for comments.", 'gutenberg' ), 'status' ),
 				array( 'status' => rest_authorization_required_code() )
 			);
 		}
@@ -189,7 +189,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		if ( empty( $request['post'] ) ) {
 			return new WP_Error(
 				'rest_comment_invalid_post_id',
-				__( 'Sorry, you are not allowed to create this comment without a post.' ),
+				__( 'Sorry, you are not allowed to create this comment without a post.', 'gutenberg' ),
 				array( 'status' => 403 )
 			);
 		}
@@ -199,7 +199,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		if ( ! $post ) {
 			return new WP_Error(
 				'rest_comment_invalid_post_id',
-				__( 'Sorry, you are not allowed to create this comment without a post.' ),
+				__( 'Sorry, you are not allowed to create this comment without a post.', 'gutenberg' ),
 				array( 'status' => 403 )
 			);
 		}
@@ -217,7 +217,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		if ( 'draft' === $post->post_status && $non_block_comment ) {
 			return new WP_Error(
 				'rest_comment_draft_post',
-				__( 'Sorry, you are not allowed to create a comment on this post.' ),
+				__( 'Sorry, you are not allowed to create a comment on this post.', 'gutenberg' ),
 				array( 'status' => 403 )
 			);
 		}
@@ -225,7 +225,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		if ( 'trash' === $post->post_status ) {
 			return new WP_Error(
 				'rest_comment_trash_post',
-				__( 'Sorry, you are not allowed to create a comment on this post.' ),
+				__( 'Sorry, you are not allowed to create a comment on this post.', 'gutenberg' ),
 				array( 'status' => 403 )
 			);
 		}
@@ -233,7 +233,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		if ( ! $this->check_read_post_permission( $post, $request ) ) {
 			return new WP_Error(
 				'rest_cannot_read_post',
-				__( 'Sorry, you are not allowed to read the post for this comment.' ),
+				__( 'Sorry, you are not allowed to read the post for this comment.', 'gutenberg' ),
 				array( 'status' => rest_authorization_required_code() )
 			);
 		}
@@ -242,7 +242,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		if ( ! comments_open( $post->ID ) && $non_block_comment ) {
 			return new WP_Error(
 				'rest_comment_closed',
-				__( 'Sorry, comments are closed for this item.' ),
+				__( 'Sorry, comments are closed for this item.', 'gutenberg' ),
 				array( 'status' => 403 )
 			);
 		}
@@ -280,7 +280,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 	public function get_item_schema() {
 		$schema                       = parent::get_item_schema();
 		$schema['properties']['type'] = array(
-			'description' => __( 'Type of the comment.' ),
+			'description' => __( 'Type of the comment.', 'gutenberg' ),
 			'type'        => 'string',
 			'context'     => array( 'view', 'edit', 'embed' ),
 			'arg_options' => array(

--- a/lib/experimental/class-gutenberg-rest-comment-controller.php
+++ b/lib/experimental/class-gutenberg-rest-comment-controller.php
@@ -101,8 +101,8 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 
 		// Re-map edit context capabilities when requesting `block_comment` type.
 		// Note: This is only relevant change for the backport.
-		$edit_cap = 'block_comment' === $comment->comment_type ? 'edit_posts' : 'moderate_comments';
-		if ( ! empty( $request['context'] ) && 'edit' === $request['context'] && ! current_user_can( $edit_cap ) ) {
+		$edit_cap = 'block_comment' === $comment->comment_type ? array( 'edit_comment', $comment->comment_ID ) : array( 'moderate_comments' );
+		if ( ! empty( $request['context'] ) && 'edit' === $request['context'] && ! current_user_can( ...$edit_cap ) ) {
 			return new WP_Error(
 				'rest_forbidden_context',
 				__( 'Sorry, you are not allowed to edit comments.', 'gutenberg' ),

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -91,6 +91,7 @@ $GLOBALS['wp_tests_options'] = array(
 		'gutenberg-form-blocks'        => 1,
 		'gutenberg-block-experiments'  => 1,
 		'gutenberg-media-processing'   => 1,
+		'gutenberg-block-comment'      => 1,
 	),
 );
 

--- a/phpunit/experimental/rest-api-comment-permissions-test.php
+++ b/phpunit/experimental/rest-api-comment-permissions-test.php
@@ -69,12 +69,8 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 					'comment_post_ID'  => $post_id,
 					'comment_type'     => 'block_comment',
 					'comment_approved' => $i % 2 === 0 ? 1 : 0,
-					// 'user_id'          => $user_id,
 				)
 			);
-
-			$comment = get_comment( $cid );
-			var_dump( $comment->user_id );
 		}
 
 		return $post_id;
@@ -182,7 +178,7 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 		$request->set_param( 'type', 'block_comment' );
 		$request->set_param( 'status', 'all' );
 		$request->set_param( 'per_page', 100 );
-		$request->set_param( 'context', 'view' );
+		$request->set_param( 'context', 'edit' );
 		$response = rest_get_server()->dispatch( $request );
 
 		if ( $can_read ) {
@@ -199,11 +195,11 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 	public function data_get_block_comment_permissions_data_provider() {
 		return array(
 			'Administrator can see block comments on other posts' => array( 'administrator', 'author', true ),
-			'Editor can see block comments on other posts'        => array( 'editor', 'contributor', true ),
-			'Author cannot see block comments on other posts'     => array( 'author', 'editor', false ),
+			'Editor can see block comments on other posts' => array( 'editor', 'contributor', true ),
+			'Author cannot see block comments on other posts' => array( 'author', 'editor', false ),
 			'Contributor cannot see block comments on other posts' => array( 'contributor', 'author', false ),
-			'Subscriber cannot see block comments'  => array( 'subscriber', 'contributor', false ),
-			'Author can see block comments on own post' => array( 'author', 'author', true ),
+			'Subscriber cannot see block comments'         => array( 'subscriber', 'contributor', false ),
+			'Author can see block comments on own post'    => array( 'author', 'author', true ),
 			// Reason: It only returns partial data for contributors, only unit tests, not sure why.
 			// 'Contributor can see block comments on own post' => array( 'contributor', 'contributor', true ),
 		);

--- a/phpunit/experimental/rest-api-comment-permissions-test.php
+++ b/phpunit/experimental/rest-api-comment-permissions-test.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * REST API test for block_comment permissions.
+ *
+ * Test that permissions are adjusted successfully for block comments.
+ * The block comments feature should be available for any user who can edit the post.
+ *
+ * @package Gutenberg
+ * @group block-comments
+ */
+class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
+
+	/**
+	 * @var int The number of comments to create for testing.
+	 */
+	protected static $num_comments = 10;
+
+	/**
+	 * User IDs for various roles.
+	 *
+	 * @var array<string, int> Associative array mapping role names to user IDs.
+	 */
+	protected static $user_ids = array();
+
+	/**
+	 * Test post to add comments to.
+	 *
+	 * @var int The post ID.
+	 */
+	protected static $post_id;
+
+	/**
+	 * Setup helper, create test users of admin, editor, author, contributor, and subscriber roles.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$roles = array( 'administrator', 'editor', 'author', 'contributor', 'subscriber' );
+		foreach ( $roles as $role ) {
+			self::$user_ids[ $role ] = $this->factory->user->create( array( 'role' => $role ) );
+		}
+	}
+
+	public function tear_down() {
+		foreach ( self::$user_ids as $user_id ) {
+			wp_delete_user( $user_id );
+		}
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a test post with standard comments and block comments.
+	 *
+	 * @return int The post ID.
+	 */
+	function create_test_post_with_block_comment( $user_id ) {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_title'   => 'Test Post for Block Comments',
+				'post_content' => 'This is a test post to check block comment permissions.',
+				'post_status'  => 'publish',
+				'post_author'  => $user_id,
+			)
+		);
+
+		for ( $i = 0; $i < self::$num_comments; $i++ ) {
+			$this->factory->comment->create(
+				array(
+					'comment_post_ID'  => $post_id,
+					'comment_type'     => 'block_comment',
+					'comment_approved' => $i % 2 === 0 ? 1 : 0,
+
+				)
+			);
+			$this->factory->comment->create(
+				array(
+					'comment_post_ID'  => $post_id,
+					'comment_type'     => 'comment',
+					'comment_approved' => 1,
+
+				)
+			);
+		}
+
+		return $post_id;
+	}
+
+	public function test_cannot_read_comments_without_post_type_support() {
+		register_post_type(
+			'no-block-comments',
+			array(
+				'label'        => 'No Block Comments',
+				'supports'     => array( 'title', 'editor', 'author', 'comments' ),
+				'show_in_rest' => true,
+				'public'       => true,
+			)
+		);
+
+		// Core calls this method but it fails for gutenberg tests.
+		// See: https://github.com/WordPress/wordpress-develop/blob/8c2ec298ad82d32f6bd66fae5ec567d287bd6bbf/tests/phpunit/tests/rest-api/rest-comments-controller.php#L3461-L3470.
+		// create_initial_rest_routes();
+
+		wp_set_current_user( self::$user_ids['administrator'] );
+
+		$post_id = self::factory()->post->create( array( 'post_type' => 'no-block-comments' ) );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
+		$request->set_param( 'post', $post_id );
+		$request->set_param( 'type', 'block_comment' );
+		$request->set_param( 'context', 'edit' );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_comment_not_supported_post_type', $response, 403 );
+	}
+
+	public function test_cannot_create_block_comment_without_post_type_support() {
+		register_post_type(
+			'no-block-comments',
+			array(
+				'label'        => 'No Block Comments',
+				'supports'     => array( 'title', 'editor', 'author', 'comments' ),
+				'show_in_rest' => true,
+				'public'       => true,
+			)
+		);
+
+		wp_set_current_user( self::$user_ids['administrator'] );
+		$post_id = self::factory()->post->create( array( 'post_type' => 'no-block-comments' ) );
+		$params  = array(
+			'post'         => $post_id,
+			'author_name'  => 'Ishmael',
+			'author_email' => 'herman-melville@earthlink.net',
+			'author_url'   => 'https://en.wikipedia.org/wiki/Herman_Melville',
+			'content'      => 'Call me Ishmael.',
+			'author'       => self::$user_ids['administrator'],
+			'comment_type' => 'block_comment',
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( $params ) );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_comment_not_supported_post_type', $response, 403 );
+	}
+
+	public function test_create_block_comment_draft_post() {
+		wp_set_current_user( self::$user_ids['editor'] );
+		$draft_id = $this->factory->post->create(
+			array(
+				'post_status' => 'draft',
+			)
+		);
+		$params   = array(
+			'post'         => $draft_id,
+			'author_name'  => 'Ishmael',
+			'author_email' => 'herman-melville@earthlink.net',
+			'author_url'   => 'https://en.wikipedia.org/wiki/Herman_Melville',
+			'content'      => 'Call me Ishmael.',
+			'author'       => self::$user_ids['editor'],
+			'comment_type' => 'block_comment',
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( $params ) );
+
+		$response    = rest_get_server()->dispatch( $request );
+		$data        = $response->get_data();
+		$new_comment = get_comment( $data['id'] );
+		$this->assertSame( 'Call me Ishmael.', $new_comment->comment_content );
+	}
+
+	/**
+	 * Test that for each user role, the permissions are correct when accessing comments.
+	 *
+	 * @param string $role The user role to test.
+	 * @param string $comment type The type of comment to test.
+	 * @param bool $expected_permission The expected permission result.
+	 *
+	 * @dataProvider data_comment_read_permissions_data_provider
+	 */
+	public function test_comment_read_permissions( $role, $comment_type, $expected_permission ) {
+		$this->markTestSkipped( "there's somethin' strange in your neighborhood" );
+
+		wp_set_current_user( self::$user_ids[ $role ] );
+		$post_id = $this->create_test_post_with_block_comment( self::$user_ids[ $role ] );
+
+		// Use the REST API to read all comments of type $comment_type for the test post.
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
+		$request->set_param( 'post', $post_id );
+		$request->set_param( 'type', $comment_type );
+		$request->set_param( 'per_page', 100 );
+		if ( 'block_comment' === $comment_type ) {
+			$request->set_param( 'context', 'edit' );
+		}
+		$response = rest_get_server()->dispatch( $request );
+
+		if ( $expected_permission ) {
+			$this->assertTrue( current_user_can( 'edit_post', $post_id ) );
+			$comments = $response->get_data();
+			$this->assertEquals( self::$num_comments, count( $comments ) );
+
+		} else {
+			$this->assertFalse( current_user_can( 'edit_post', $post_id ) );
+		}
+
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Data provider for comment permissions tests.
+	 * Each entry is an array of ( role, comment_type, expected_permission ).
+	 * @return array[]
+	 */
+	public function data_comment_read_permissions_data_provider() {
+		return array(
+			// 'Administrator can see standard comments' => array( 'administrator', 'comment', true ),
+			// 'Administrator can see Block comments'    => array( 'administrator', 'block_comment', true ),
+
+			// 'Editor can see standard comments'        => array( 'editor', 'comment', true ),
+			// 'Editor can see Block comments'           => array( 'editor', 'block_comment', true ),
+
+			// 'Author can see standard comments'        => array( 'author', 'comment', true ),
+			// 'Author can see Block comments'           => array( 'author', 'block_comment', true ),
+
+			// 'Contributor can see standard comments'   => array( 'contributor', 'comment', false ),
+			// 'Contributor can see Block comments'      => array( 'contributor', 'block_comment', false ),
+
+			// 'subscriber can see standard comments'    => array( 'subscriber', 'comment', false ),
+			// 'subscriber can see Block comments'       => array( 'subscriber', 'block_comment', false ),
+		);
+	}
+}

--- a/phpunit/experimental/rest-api-comment-permissions-test.php
+++ b/phpunit/experimental/rest-api-comment-permissions-test.php
@@ -51,24 +51,25 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 	/**
 	 * Create a test post with standard comments and block comments.
 	 *
-	 * @return int The post ID.
+	 * @return string $role The role of the user creating the post.
 	 */
-	function create_test_post_with_block_comment( $user_id ) {
+	public function create_test_post_with_block_comment( $role ) {
+		$user_id = self::$user_ids[ $role ];
 		$post_id = $this->factory->post->create(
 			array(
 				'post_title'   => 'Test Post for Block Comments',
 				'post_content' => 'This is a test post to check block comment permissions.',
-				'post_status'  => 'publish',
+				'post_status'  => 'contributor' === $role ? 'draft' : 'publish',
 				'post_author'  => $user_id,
 			)
 		);
 
 		for ( $i = 0; $i < self::$num_comments; $i++ ) {
-			$cid = $this->factory->comment->create(
+			$this->factory->comment->create(
 				array(
 					'comment_post_ID'  => $post_id,
 					'comment_type'     => 'block_comment',
-					'comment_approved' => $i % 2 === 0 ? 1 : 0,
+					'comment_approved' => 0 === $i % 2 ? 1 : 0,
 				)
 			);
 		}
@@ -171,7 +172,7 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 	 */
 	public function test_block_comment_get_items_permissions_edit_context( $role, $post_author_role, $can_read ) {
 		wp_set_current_user( self::$user_ids[ $role ] );
-		$post_id = $this->create_test_post_with_block_comment( self::$user_ids[ $post_author_role ] );
+		$post_id = $this->create_test_post_with_block_comment( $post_author_role );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 		$request->set_param( 'post', $post_id );
@@ -192,16 +193,61 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 		wp_delete_post( $post_id, true );
 	}
 
+	/**
+	 * Test that for each user role, the permissions are correct when accessing a comment.
+	 *
+	 * @param string $role The user role to test.
+	 * @param string $post_author_role The role of the post author.
+	 * @param bool $can_read The expected permission result.
+	 *
+	 * @dataProvider data_block_comment_get_items_permissions_data_provider
+	 */
+	public function test_block_comment_get_item_permissions_edit_context( $role, $post_author_role, $can_read ) {
+		wp_set_current_user( self::$user_ids[ $role ] );
+
+		$post_id = $this->factory->post->create(
+			array(
+				'post_title'   => 'Test Post for Block Comments',
+				'post_content' => 'This is a test post to check block comment permissions.',
+				'post_status'  => 'contributor' === $post_author_role ? 'draft' : 'publish',
+				'post_author'  => self::$user_ids[ $post_author_role ],
+			)
+		);
+
+		$comment_id = $this->factory->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_type'     => 'block_comment',
+				// Test with unapproved comment, which is more restrictive.
+				'comment_approved' => 0,
+				'user_id'          => self::$user_ids[ $post_author_role ],
+			)
+		);
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments/' . $comment_id );
+		$request->set_param( 'context', 'edit' );
+		$response = rest_get_server()->dispatch( $request );
+
+		if ( $can_read ) {
+			$comment = $response->get_data();
+			$this->assertEquals( $comment_id, $comment['id'] );
+
+		} else {
+			$this->assertErrorResponse( 'rest_forbidden_context', $response, 403 );
+		}
+
+		wp_delete_post( $post_id, true );
+	}
+
 	public function data_block_comment_get_items_permissions_data_provider() {
 		return array(
 			'Administrator can see block comments on other posts' => array( 'administrator', 'author', true ),
 			'Editor can see block comments on other posts' => array( 'editor', 'contributor', true ),
 			'Author cannot see block comments on other posts' => array( 'author', 'editor', false ),
 			'Contributor cannot see block comments on other posts' => array( 'contributor', 'author', false ),
-			'Subscriber cannot see block comments'         => array( 'subscriber', 'contributor', false ),
+			'Subscriber cannot see block comments'         => array( 'subscriber', 'author', false ),
 			'Author can see block comments on own post'    => array( 'author', 'author', true ),
-			// Reason: It only returns partial data for contributors, only unit tests, not sure why.
-			// 'Contributor can see block comments on own post' => array( 'contributor', 'contributor', true ),
+			'Contributor can see block comments on own post' => array( 'contributor', 'contributor', true ),
 		);
 	}
 }

--- a/phpunit/experimental/rest-api-comment-permissions-test.php
+++ b/phpunit/experimental/rest-api-comment-permissions-test.php
@@ -167,9 +167,9 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 	 * @param string $post_author_role The role of the post author.
 	 * @param bool $can_read The expected permission result.
 	 *
-	 * @dataProvider data_get_block_comment_permissions_data_provider
+	 * @dataProvider data_block_comment_get_items_permissions_data_provider
 	 */
-	public function test_get_block_comment_permissions_edit_context( $role, $post_author_role, $can_read ) {
+	public function test_block_comment_get_items_permissions_edit_context( $role, $post_author_role, $can_read ) {
 		wp_set_current_user( self::$user_ids[ $role ] );
 		$post_id = $this->create_test_post_with_block_comment( self::$user_ids[ $post_author_role ] );
 
@@ -192,7 +192,7 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 		wp_delete_post( $post_id, true );
 	}
 
-	public function data_get_block_comment_permissions_data_provider() {
+	public function data_block_comment_get_items_permissions_data_provider() {
 		return array(
 			'Administrator can see block comments on other posts' => array( 'administrator', 'author', true ),
 			'Editor can see block comments on other posts' => array( 'editor', 'contributor', true ),

--- a/phpunit/experimental/rest-api-comment-permissions-test.php
+++ b/phpunit/experimental/rest-api-comment-permissions-test.php
@@ -194,6 +194,30 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 	}
 
 	/**
+	 * Verify that when querying block comments for multiple posts, if the user does not have
+	 * permission to read comments on all of the posts, a 403 is returned.
+	 */
+	public function test_block_comment_get_items_permissions_mixed_post_authors() {
+		$author_post_id = $this->create_test_post_with_block_comment( 'author' );
+		$editor_post_id = $this->create_test_post_with_block_comment( 'editor' );
+
+		wp_set_current_user( self::$user_ids['author'] );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
+		$request->set_param( 'post', array( $author_post_id, $editor_post_id ) );
+		$request->set_param( 'type', 'block_comment' );
+		$request->set_param( 'status', 'all' );
+		$request->set_param( 'per_page', 100 );
+		$request->set_param( 'context', 'edit' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_forbidden_context', $response, 403 );
+
+		wp_delete_post( $author_post_id, true );
+		wp_delete_post( $editor_post_id, true );
+	}
+
+	/**
 	 * Test that for each user role, the permissions are correct when accessing a comment.
 	 *
 	 * @param string $role The user role to test.

--- a/phpunit/experimental/rest-api-comment-permissions-test.php
+++ b/phpunit/experimental/rest-api-comment-permissions-test.php
@@ -64,22 +64,17 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 		);
 
 		for ( $i = 0; $i < self::$num_comments; $i++ ) {
-			$this->factory->comment->create(
+			$cid = $this->factory->comment->create(
 				array(
 					'comment_post_ID'  => $post_id,
 					'comment_type'     => 'block_comment',
 					'comment_approved' => $i % 2 === 0 ? 1 : 0,
-
+					// 'user_id'          => $user_id,
 				)
 			);
-			$this->factory->comment->create(
-				array(
-					'comment_post_ID'  => $post_id,
-					'comment_type'     => 'comment',
-					'comment_approved' => 1,
 
-				)
-			);
+			$comment = get_comment( $cid );
+			var_dump( $comment->user_id );
 		}
 
 		return $post_id;
@@ -173,60 +168,44 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 	 * Test that for each user role, the permissions are correct when accessing comments.
 	 *
 	 * @param string $role The user role to test.
-	 * @param string $comment type The type of comment to test.
-	 * @param bool $expected_permission The expected permission result.
+	 * @param string $post_author_role The role of the post author.
+	 * @param bool $can_read The expected permission result.
 	 *
-	 * @dataProvider data_comment_read_permissions_data_provider
+	 * @dataProvider data_get_block_comment_permissions_data_provider
 	 */
-	public function test_comment_read_permissions( $role, $comment_type, $expected_permission ) {
-		$this->markTestSkipped( "there's somethin' strange in your neighborhood" );
-
+	public function test_get_block_comment_permissions_edit_context( $role, $post_author_role, $can_read ) {
 		wp_set_current_user( self::$user_ids[ $role ] );
-		$post_id = $this->create_test_post_with_block_comment( self::$user_ids[ $role ] );
+		$post_id = $this->create_test_post_with_block_comment( self::$user_ids[ $post_author_role ] );
 
-		// Use the REST API to read all comments of type $comment_type for the test post.
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 		$request->set_param( 'post', $post_id );
-		$request->set_param( 'type', $comment_type );
+		$request->set_param( 'type', 'block_comment' );
+		$request->set_param( 'status', 'all' );
 		$request->set_param( 'per_page', 100 );
-		if ( 'block_comment' === $comment_type ) {
-			$request->set_param( 'context', 'edit' );
-		}
+		$request->set_param( 'context', 'view' );
 		$response = rest_get_server()->dispatch( $request );
 
-		if ( $expected_permission ) {
-			$this->assertTrue( current_user_can( 'edit_post', $post_id ) );
+		if ( $can_read ) {
 			$comments = $response->get_data();
 			$this->assertEquals( self::$num_comments, count( $comments ) );
 
 		} else {
-			$this->assertFalse( current_user_can( 'edit_post', $post_id ) );
+			$this->assertErrorResponse( 'rest_forbidden_context', $response, 403 );
 		}
 
 		wp_delete_post( $post_id, true );
 	}
 
-	/**
-	 * Data provider for comment permissions tests.
-	 * Each entry is an array of ( role, comment_type, expected_permission ).
-	 * @return array[]
-	 */
-	public function data_comment_read_permissions_data_provider() {
+	public function data_get_block_comment_permissions_data_provider() {
 		return array(
-			// 'Administrator can see standard comments' => array( 'administrator', 'comment', true ),
-			// 'Administrator can see Block comments'    => array( 'administrator', 'block_comment', true ),
-
-			// 'Editor can see standard comments'        => array( 'editor', 'comment', true ),
-			// 'Editor can see Block comments'           => array( 'editor', 'block_comment', true ),
-
-			// 'Author can see standard comments'        => array( 'author', 'comment', true ),
-			// 'Author can see Block comments'           => array( 'author', 'block_comment', true ),
-
-			// 'Contributor can see standard comments'   => array( 'contributor', 'comment', false ),
-			// 'Contributor can see Block comments'      => array( 'contributor', 'block_comment', false ),
-
-			// 'subscriber can see standard comments'    => array( 'subscriber', 'comment', false ),
-			// 'subscriber can see Block comments'       => array( 'subscriber', 'block_comment', false ),
+			'Administrator can see block comments on other posts' => array( 'administrator', 'author', true ),
+			'Editor can see block comments on other posts'        => array( 'editor', 'contributor', true ),
+			'Author cannot see block comments on other posts'     => array( 'author', 'editor', false ),
+			'Contributor cannot see block comments on other posts' => array( 'contributor', 'author', false ),
+			'Subscriber cannot see block comments'  => array( 'subscriber', 'contributor', false ),
+			'Author can see block comments on own post' => array( 'author', 'author', true ),
+			// Reason: It only returns partial data for contributors, only unit tests, not sure why.
+			// 'Contributor can see block comments on own post' => array( 'contributor', 'contributor', true ),
 		);
 	}
 }


### PR DESCRIPTION
## What?
Part of #71896.

PR updates `WP_REST_Comments_Controller` override and tweaks permission callbacks to allow fetching `block_comment` type with `edit` context.

> [!NOTE]
>  The actual lines to backport are minimal; they're marked with inline comments, and I'll also highlight them here for easier review.

## Why?
* The `core-data` uses and expects this context when making the changes to entities.
* The block comments feature should be available for any user who can edit the post.

## How

* Re-map `moderate_comments` capability to `edit_post` when requesting `block_comment` type. This is similar to how `edit_comment` [capability is mapped](https://github.com/WordPress/wordpress-develop/blob/70d00508e950f0e63de82386d453bca5ad899474/src/wp-includes/capabilities.php#L554-L586).
* Require `post` argument when querying the `block_comment` type collections.
* Update `create_item_permissions_check` override and make it easier to backport.

P.S. Ideally, similar capabilities would be mapped via a better API, such as `register_comment_type`, but I don't think that's possible for WP 6.9. Track ticket: https://core.trac.wordpress.org/ticket/35214.

## Todos

- [x] Add PHP unit test coverage for REST API controller changes.

## Testing Instructions
1. Enable block-level comments experiment.
2. Create a test user without `moderate_comments` - Author or Contributor.
3. Switch to this user.
4. Confirm that you can add and reply to comments.
5. Confirm that you can perform actions on your comments - edit, resolve, re-open, and delete.

### Testing Instructions for Keyboard
Same.
