### PR TITLE
Time to Read: Change word count character based on word count type

### DIFF
--- a/packages/block-library/src/post-time-to-read/edit.js
+++ b/packages/block-library/src/post-time-to-read/edit.js
@@ -118,11 +118,18 @@ function PostTimeToReadEdit( { attributes, setAttributes, context } ) {
 
 		// Add "word count" part, if enabled.
 		if ( showWordCount ) {
-			const wordCountString = sprintf(
-				/* translators: %s: the number of words in the post. */
-				_n( '%s word', '%s words', totalWords ),
-				totalWords.toLocaleString()
-			);
+			const wordCountString =
+				wordCountType === 'words'
+					? sprintf(
+							/* translators: %s: the number of words in the post. */
+							_n( '%s word', '%s words', totalWords ),
+							totalWords.toLocaleString()
+					  )
+					: sprintf(
+							/* translators: %s: the number of characters in the post. */
+							_n( '%s character', '%s characters', totalWords ),
+							totalWords.toLocaleString()
+					  );
 			parts.push( wordCountString );
 		}
 

--- a/packages/block-library/src/post-time-to-read/index.php
+++ b/packages/block-library/src/post-time-to-read/index.php
@@ -57,9 +57,13 @@ function render_block_core_post_time_to_read( $attributes, $content, $block ) {
 
 	// Add "word count" part, if enabled.
 	if ( $show_word_count ) {
-		$word_count_string = sprintf(
+		$word_count_string = 'words' === $word_count_type ? sprintf(
 			/* translators: %s: the number of words in the post. */
 			_n( '%s word', '%s words', $total_words ),
+			number_format_i18n( $total_words )
+		) : sprintf(
+			/* translators: %s: the number of characters in the post. */
+			_n( '%s character', '%s characters', $total_words ),
 			number_format_i18n( $total_words )
 		);
 		$parts[] = $word_count_string;


### PR DESCRIPTION
Addresses https://github.com/WordPress/gutenberg/pull/71841#issuecomment-3331197706

## What?

The Time to Read block always uses a or b as the unit when the "Show word count" is enabled. This is not correct in locales where the character count type is `characters_excluding_spaces` or `characters_including_spaces`.

## Testing Instructions

- Change the site language to `日本語` (`ja`).
- Create a new post and insert a Time to Read block.
- Confirm that the unit is "character" or "characters".

## Screenshots or screencast <!-- if applicable -->

<img width="1175" height="346" alt="image" src="https://github.com/user-attachments/assets/d9c4882d-e332-490a-b5a1-f1728e5c1474" />