### PR TITLE
Add reset button to BackgroundControlsPanel

### DIFF
--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -59,6 +59,24 @@ const BACKGROUND_POPOVER_PROPS = {
 const noop = () => {};
 
 /**
+ * Focuses the toggle button.
+ * @param {Object} containerRef - ref object containing current element
+ */
+const focusToggleButton = ( containerRef ) => {
+	// Use requestAnimationFrame to ensure DOM updates are complete
+	window.requestAnimationFrame( () => {
+		const [ toggleButton ] = focus.tabbable.find( containerRef?.current );
+		if ( ! toggleButton ) {
+			return;
+		}
+		// Focus the toggle button and close the dropdown menu.
+		// This ensures similar behaviour as to selecting an image, where the dropdown is
+		// closed and focus is redirected to the dropdown toggle button.
+		toggleButton.focus();
+	} );
+};
+
+/**
  * Get the help text for the background size control.
  *
  * @param {string} value backgroundSize value.
@@ -184,8 +202,8 @@ function BackgroundControlsPanel( {
 	onToggle: onToggleCallback = noop,
 	hasImageValue,
 	onReset,
+	containerRef,
 } ) {
-	const backgroundImageDropdownButtonRef = useRef( undefined );
 	if ( ! hasImageValue ) {
 		return;
 	}
@@ -205,7 +223,6 @@ function BackgroundControlsPanel( {
 					'aria-label': __(
 						'Background size, position and repeat options.'
 					),
-					ref: backgroundImageDropdownButtonRef,
 					isOpen,
 				};
 				return (
@@ -227,11 +244,12 @@ function BackgroundControlsPanel( {
 								icon={ resetIcon }
 								onClick={ () => {
 									onReset();
+									// Close the dropdown if open.
 									if ( isOpen ) {
 										onToggle();
-										// Return focus to parent button.
-										backgroundImageDropdownButtonRef.current?.focus();
 									}
+									// Focus the toggle button.
+									focusToggleButton( containerRef );
 								} }
 							/>
 						) }
@@ -342,7 +360,7 @@ function BackgroundImageControls( {
 		);
 		setIsUploading( false );
 		// Close the dropdown and focus the toggle button.
-		closeAndFocus();
+		focusToggleButton( containerRef );
 	};
 
 	// Drag and drop callback, restricting image to one.
@@ -359,22 +377,6 @@ function BackgroundImageControls( {
 	};
 
 	const hasValue = hasBackgroundImageValue( style );
-
-	const closeAndFocus = () => {
-		// Use requestAnimationFrame to ensure DOM updates are complete
-		window.requestAnimationFrame( () => {
-			const [ toggleButton ] = focus.tabbable.find(
-				containerRef?.current
-			);
-			if ( ! toggleButton ) {
-				return;
-			}
-			// Focus the toggle button and close the dropdown menu.
-			// This ensures similar behaviour as to selecting an image, where the dropdown is
-			// closed and focus is redirected to the dropdown toggle button.
-			toggleButton.focus();
-		} );
-	};
 
 	const onRemove = () =>
 		onChange(
@@ -413,14 +415,14 @@ function BackgroundImageControls( {
 				) }
 				onError={ onUploadError }
 				onReset={ () => {
-					closeAndFocus();
+					focusToggleButton( containerRef );
 					onResetImage();
 				} }
 			>
 				{ canRemove && (
 					<MenuItem
 						onClick={ () => {
-							closeAndFocus();
+							focusToggleButton( containerRef );
 							onRemove();
 							onRemoveImage();
 						} }
@@ -737,6 +739,7 @@ export default function BackgroundImagePanel( {
 					onToggle={ setIsDropDownOpen }
 					hasImageValue={ hasImageValue }
 					onReset={ resetBackground }
+					containerRef={ containerRef }
 				>
 					<VStack spacing={ 3 } className="single-column">
 						<BackgroundImageControls

--- a/packages/block-editor/src/components/background-image-control/index.js
+++ b/packages/block-editor/src/components/background-image-control/index.js
@@ -25,6 +25,7 @@ import {
 	__experimentalDropdownContentWrapper as DropdownContentWrapper,
 	Button,
 } from '@wordpress/components';
+import { reset as resetIcon } from '@wordpress/icons';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { getFilename } from '@wordpress/url';
@@ -182,7 +183,9 @@ function BackgroundControlsPanel( {
 	children,
 	onToggle: onToggleCallback = noop,
 	hasImageValue,
+	onReset,
 } ) {
+	const backgroundImageDropdownButtonRef = useRef( undefined );
 	if ( ! hasImageValue ) {
 		return;
 	}
@@ -202,17 +205,37 @@ function BackgroundControlsPanel( {
 					'aria-label': __(
 						'Background size, position and repeat options.'
 					),
+					ref: backgroundImageDropdownButtonRef,
 					isOpen,
 				};
 				return (
-					<InspectorImagePreviewItem
-						imgUrl={ imgUrl }
-						filename={ filename }
-						label={ imgLabel }
-						toggleProps={ toggleProps }
-						as="button"
-						onToggleCallback={ onToggleCallback }
-					/>
+					<>
+						<InspectorImagePreviewItem
+							imgUrl={ imgUrl }
+							filename={ filename }
+							label={ imgLabel }
+							toggleProps={ toggleProps }
+							as="button"
+							onToggleCallback={ onToggleCallback }
+						/>
+						{ onReset && (
+							<Button
+								__next40pxDefaultSize
+								label={ __( 'Reset' ) }
+								className="block-editor-global-styles-background-panel__reset"
+								size="small"
+								icon={ resetIcon }
+								onClick={ () => {
+									onReset();
+									if ( isOpen ) {
+										onToggle();
+										// Return focus to parent button.
+										backgroundImageDropdownButtonRef.current?.focus();
+									}
+								} }
+							/>
+						) }
+					</>
 				);
 			} }
 			renderContent={ () => (
@@ -713,6 +736,7 @@ export default function BackgroundImagePanel( {
 					url={ url }
 					onToggle={ setIsDropDownOpen }
 					hasImageValue={ hasImageValue }
+					onReset={ resetBackground }
 				>
 					<VStack spacing={ 3 } className="single-column">
 						<BackgroundImageControls

--- a/packages/block-editor/src/components/background-image-control/style.scss
+++ b/packages/block-editor/src/components/background-image-control/style.scss
@@ -3,6 +3,7 @@
 	border-radius: $radius-small;
 	// Full width. ToolsPanel lays out children in a grid.
 	grid-column: 1 / -1;
+	position: relative;
 
 	&.is-open {
 		background-color: $gray-100;
@@ -83,6 +84,32 @@
 	height: 100%;
 	width: 100%;
 	padding-left: $grid-unit-15;
+	padding-right: $grid-unit-40;
+}
+
+.block-editor-global-styles-background-panel__reset {
+	position: absolute;
+	right: 0;
+	top: $grid-unit;
+	margin: auto $grid-unit auto;
+	opacity: 0;
+	transition: opacity 0.1s ease-in-out;
+	@include reduce-motion("transition");
+
+	&.block-editor-global-styles-background-panel__reset {
+		border-radius: $radius-small;
+	}
+
+	.block-editor-global-styles-background-panel__dropdown-toggle:hover + &,
+	&:focus,
+	&:hover {
+		opacity: 1;
+	}
+
+	@media (hover: none) {
+		// Show reset button on devices that do not support hover.
+		opacity: 1;
+	}
 }
 
 .block-editor-global-styles-background-panel__inspector-media-replace-title {

--- a/packages/block-editor/src/components/background-image-control/style.scss
+++ b/packages/block-editor/src/components/background-image-control/style.scss
@@ -93,8 +93,9 @@
 	top: $grid-unit;
 	margin: auto $grid-unit auto;
 	opacity: 0;
-	transition: opacity 0.1s ease-in-out;
-	@include reduce-motion("transition");
+	@media not ( prefers-reduced-motion ) {
+		transition: opacity 0.1s ease-in-out;
+	}
 
 	&.block-editor-global-styles-background-panel__reset {
 		border-radius: $radius-small;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Adding a reset button to the background image control. 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To add cohesion with how the colors controls work, making it easier to unset a background image without having to open a menu.

This is a follow up https://github.com/WordPress/gutenberg/issues/41866

## Testing Instructions
1. Open the site editor
2. Go to Styles > Background
3. Add a background image.
4. Confirm that if you hover/focus you have a "reset" option and that it resets the background selection.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/6cf5548b-3339-4dc1-a1cc-ba263b48e98c


