### PR TITLE
Block Comment: Improve related block highlighting

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useState, RawHTML, useCallback } from '@wordpress/element';
+import { useState, RawHTML } from '@wordpress/element';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -109,13 +109,13 @@ function Thread( {
 		50
 	);
 
-	const onMouseEnter = useCallback( () => {
+	const onMouseEnter = () => {
 		debouncedToggleBlockHighlight( thread.blockClientId, true );
-	}, [ thread.blockClientId, debouncedToggleBlockHighlight ] );
+	};
 
-	const onMouseLeave = useCallback( () => {
+	const onMouseLeave = () => {
 		debouncedToggleBlockHighlight( thread.blockClientId, false );
-	}, [ thread.blockClientId, debouncedToggleBlockHighlight ] );
+	};
 
 	const handleCommentSelect = ( { id, blockClientId } ) => {
 		setShowCommentBoard( false );

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -125,7 +125,6 @@ function Thread( {
 				behavior: 'instant',
 				block: 'center',
 			} );
-			debouncedToggleBlockHighlight( blockClientId, true );
 		}
 	};
 

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useState, RawHTML } from '@wordpress/element';
+import { useState, RawHTML, useCallback } from '@wordpress/element';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -14,6 +14,7 @@ import {
 	Button,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
+import { useDebounce } from '@wordpress/compose';
 
 import { published, moreVertical } from '@wordpress/icons';
 import { __, _x, sprintf, _n } from '@wordpress/i18n';
@@ -101,8 +102,20 @@ function Thread( {
 	setFocusThread,
 	setShowCommentBoard,
 } ) {
-	const { flashBlock } = useDispatch( blockEditorStore );
+	const { toggleBlockHighlight } = useDispatch( blockEditorStore );
 	const relatedBlockElement = useBlockElement( thread.blockClientId );
+	const debouncedToggleBlockHighlight = useDebounce(
+		toggleBlockHighlight,
+		50
+	);
+
+	const onMouseEnter = useCallback( () => {
+		debouncedToggleBlockHighlight( thread.blockClientId, true );
+	}, [ thread.blockClientId, debouncedToggleBlockHighlight ] );
+
+	const onMouseLeave = useCallback( () => {
+		debouncedToggleBlockHighlight( thread.blockClientId, false );
+	}, [ thread.blockClientId, debouncedToggleBlockHighlight ] );
 
 	const handleCommentSelect = ( { id, blockClientId } ) => {
 		setShowCommentBoard( false );
@@ -112,7 +125,7 @@ function Thread( {
 				behavior: 'instant',
 				block: 'center',
 			} );
-			flashBlock( blockClientId );
+			debouncedToggleBlockHighlight( blockClientId, true );
 		}
 	};
 
@@ -135,6 +148,10 @@ function Thread( {
 			id={ thread.id }
 			spacing="2"
 			onClick={ () => handleCommentSelect( thread ) }
+			onMouseEnter={ onMouseEnter }
+			onMouseLeave={ onMouseLeave }
+			onFocus={ onMouseEnter }
+			onBlur={ onMouseLeave }
 		>
 			<CommentBoard
 				thread={ thread }


### PR DESCRIPTION
## What?

Follow up on #71308 to make blocks associated with comments more clear.

## Why?

#71308 dispatches `flashBlock` action when the related comment is selected. Because flashBlock only highlights the block for a split second, it can be difficult to see the block associated with a comment, and you have to click the comment again to flash the block.

## How?

I realized we might be able to reuse [the logic for associating list views with blocks](https://github.com/WordPress/gutenberg/blob/0699639405cfe23699e2a623d4755d6be56b4d75/packages/block-editor/src/components/list-view/block.js#L368-L375). So in this PR, I'm introducing the following behaviors:

- Highlight the block when a thread is focused or moused over.
- Unhighlight the block when a thread loses focus or is moused out.
- Apply `useDebounce` hook to `toggleHighLight` to reduce the nastiness of the block when you move the mouse quickly.

## Testing Instructions

- Add comments on blocks.
- Mouse over or mouse out on a thread and confirm that the releated block is highlighted.

### Testing Instructions for Keyboard

- Use the tab key to focus on an element within a thread.
- When focus moves into a thread, the block is highlighted.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/84463949-14ce-42d8-96ce-5fb8ecb921e5

