### PR TITLE
Added default focus and hover states to accordion header

### DIFF
--- a/packages/block-library/src/accordion-header/style.scss
+++ b/packages/block-library/src/accordion-header/style.scss
@@ -12,7 +12,6 @@
 	color: inherit;
 	padding: var(--wp--preset--spacing--20, 1em) 0;
 	cursor: pointer;
-	outline: none;
 	overflow: hidden;
 	display: flex;
 	align-items: center;
@@ -20,8 +19,8 @@
 	position: relative;
 	width: 100%;
 
-	&:focus-visible {
-		outline: 2px solid currentColor;
+	&:not(:focus-visible) {
+		outline: none;
 	}
 
 	&:hover {

--- a/packages/block-library/src/accordion-header/style.scss
+++ b/packages/block-library/src/accordion-header/style.scss
@@ -21,8 +21,14 @@
 	width: 100%;
 
 	&:focus-visible {
-		outline: 2px solid -webkit-focus-ring-color;
+		outline: 2px solid currentColor;
 		outline-offset: 2px;
+	}
+
+	&:hover {
+		.wp-block-accordion-header__toggle-title {
+			text-decoration: underline;
+		}
 	}
 }
 

--- a/packages/block-library/src/accordion-header/style.scss
+++ b/packages/block-library/src/accordion-header/style.scss
@@ -22,7 +22,6 @@
 
 	&:focus-visible {
 		outline: 2px solid currentColor;
-		outline-offset: 2px;
 	}
 
 	&:hover {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71777

<!-- In a few words, what is the PR actually doing? -->
This PR adds default hover and focus states to accordion header

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Hover and focus states are important parts of accessibility

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Instead of `-webkit-focus-ring-color` to color the outline ring use `currentColor`
- Added good old text-decoration: underline as hover state
  - Specifically targeting the title element inside the button to add underline. It look bit unpleasant (to me) to underline both because of the empty space between the text and icon

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Remember to add "Blocks: add experimental blocks" in `/wp-admin/admin.php?page=gutenberg-experiments`
2. Insert Accordion to any Page or Post
3. Hover over the Accordion header panel and observe the effect
4. Navigate to the Accordion header with tab and observe the effect

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
