### PR TITLE
Write Mode: Improve visibility of template part icons and text

### DIFF
--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -110,3 +110,11 @@
 		padding-right: $grid-unit-30;
 	}
 }
+/* Fix icon and text visibility in Write Mode */
+.edit-site-patterns__pattern-icon,
+.edit-site-patterns__title,
+.edit-site-patterns__sub-title {
+	color: var(--wp-admin-white) !important; // text
+	fill: var(--wp-admin-white) !important;  // SVG icons
+}
+


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes <!-- add issue number if there’s one, e.g., #71934 -->  

This PR fixes the visibility of template part icons and synced pattern text in Write Mode.  
The icons and text were difficult to see against the background, so CSS has been updated to improve contrast.

## Why?
The icons and text of template parts and synced patterns were hard to read in Write Mode, especially on darker backgrounds.  
This improves the editor’s usability and accessibility.

## How?
- Updated `.edit-site-patterns__pattern-icon`, `.edit-site-patterns__title`, and `.edit-site-patterns__sub-title` CSS.  
- Set `color` and `fill` to `white` for better visibility while maintaining existing layout and functionality.  

## Testing Instructions
1. Open the site editor in WordPress.  
2. Switch to **Write Mode**.  
3. Observe the icons and text of template parts and synced patterns — they should now be clearly visible in white.  

### Testing Instructions for Keyboard
- Navigate the site editor using Tab/Shift+Tab.  
- Verify that template parts and synced patterns are readable with keyboard focus.  
