### PR TITLE
Accordion Block: Hide Add button in write mode 

### DIFF
--- a/packages/block-library/src/accordion/edit.js
+++ b/packages/block-library/src/accordion/edit.js
@@ -6,6 +6,7 @@ import {
 	useInnerBlocksProps,
 	InspectorControls,
 	BlockControls,
+	useBlockEditingMode,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
@@ -39,6 +40,8 @@ export default function Edit( {
 	const blockProps = useBlockProps();
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const { insertBlock } = useDispatch( blockEditorStore );
+	const blockEditingMode = useBlockEditingMode();
+	const isContentOnlyMode = blockEditingMode === 'contentOnly';
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: [ [ ACCORDION_BLOCK_NAME ], [ ACCORDION_BLOCK_NAME ] ],
@@ -54,7 +57,7 @@ export default function Edit( {
 
 	return (
 		<>
-			{ isSingleSelected && (
+			{ isSingleSelected && ! isContentOnlyMode && (
 				<BlockControls group="other">
 					<ToolbarButton onClick={ addAccordionContentBlock }>
 						{ __( 'Add' ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #71935

<!-- In a few words, what is the PR actually doing? -->
Hides the Add button in the Accordion block toolbar when in write mode (contentOnly mode).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The Add button in the Accordion block toolbar was visible in write mode but non-functional, creating a confusing user experience. 

This aligns with the behavior of other blocks like Image and Site Logo that already hide non-functional controls in write mode.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Added `useBlockEditingMode` hook import from `@wordpress/block-editor`
- Added write mode detection using `blockEditingMode === 'contentOnly'`
- Updated the Add button conditional rendering to include `! isContentOnlyMode` check
- Follows the same pattern used by other core blocks (Image, Site Logo) for write mode detection

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the site editor
2. Insert an Accordion block
3. Select the Accordion block - verify the Add button is visible in the toolbar
4. Switch to write mode 
5. Select the Accordion block again
6. Verify that the Add button is no longer visible in the toolbar
7. Switch back to design mode and verify the Add button reappears

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|

