### PR TITLE
Consistently show (no title) as a fallback for pages and templates with empty titles

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -599,7 +599,7 @@ function Layout( {
 							sprintf(
 								// translators: %s: Title of the created post or template, e.g: "Hello world".
 								__( '"%s" successfully created.' ),
-								decodeEntities( title )
+								decodeEntities( title ) || __( '(no title)' )
 							),
 							{
 								type: 'snackbar',

--- a/packages/edit-site/src/components/add-new-post/index.js
+++ b/packages/edit-site/src/components/add-new-post/index.js
@@ -66,7 +66,8 @@ export default function AddNewPostModal( { postType, onSave, onClose } ) {
 				sprintf(
 					// translators: %s: Title of the created post or template, e.g: "Hello world".
 					__( '"%s" successfully created.' ),
-					decodeEntities( newPage.title?.rendered || title )
+					decodeEntities( newPage.title?.rendered || title ) ||
+						__( '(no title)' )
 				),
 				{ type: 'snackbar' }
 			);

--- a/packages/edit-site/src/components/add-new-template/index.js
+++ b/packages/edit-site/src/components/add-new-template/index.js
@@ -225,7 +225,8 @@ function NewTemplateModal( { onClose } ) {
 				sprintf(
 					// translators: %s: Title of the created post or template, e.g: "Hello world".
 					__( '"%s" successfully created.' ),
-					decodeEntities( newTemplate.title?.rendered || title )
+					decodeEntities( newTemplate.title?.rendered || title ) ||
+						__( '(no title)' )
 				),
 				{
 					type: 'snackbar',

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -211,7 +211,7 @@ export default function EditSiteEditor( {
 							sprintf(
 								// translators: %s: Title of the created post or template, e.g: "Hello world".
 								__( '"%s" successfully created.' ),
-								decodeEntities( _title )
+								decodeEntities( _title ) || __( '(no title)' )
 							),
 							{
 								type: 'snackbar',

--- a/packages/fields/src/actions/duplicate-post.tsx
+++ b/packages/fields/src/actions/duplicate-post.tsx
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { useDispatch } from '@wordpress/data';
-import { decodeEntities } from '@wordpress/html-entities';
 import { store as coreStore } from '@wordpress/core-data';
 import { __, sprintf, _x } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
@@ -113,7 +112,7 @@ const duplicatePost: Action< BasePost > = {
 					sprintf(
 						// translators: %s: Title of the created post, e.g: "Hello world".
 						__( '"%s" successfully created.' ),
-						decodeEntities( newItem.title?.rendered || item.title )
+						getItemTitle( newItem )
 					),
 					{
 						id: 'duplicate-post-action',

--- a/packages/fields/src/actions/rename-post.tsx
+++ b/packages/fields/src/actions/rename-post.tsx
@@ -57,7 +57,7 @@ const renamePost: Action< PostWithPermissions > = {
 	},
 	RenderModal: ( { items, closeModal, onActionPerformed } ) => {
 		const [ item ] = items;
-		const [ title, setTitle ] = useState( () => getItemTitle( item ) );
+		const [ title, setTitle ] = useState( () => getItemTitle( item, '' ) );
 		const { editEntityRecord, saveEditedEntityRecord } =
 			useDispatch( coreStore );
 		const { createSuccessNotice, createErrorNotice } =

--- a/packages/fields/src/actions/utils.ts
+++ b/packages/fields/src/actions/utils.ts
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { decodeEntities } from '@wordpress/html-entities';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -22,19 +23,21 @@ export function isTemplateOrTemplatePart(
 	return p.type === 'wp_template' || p.type === 'wp_template_part';
 }
 
-export function getItemTitle( item: {
-	title: string | { rendered: string } | { raw: string };
-} ) {
+export function getItemTitle(
+	item: {
+		title: string | { rendered: string } | { raw: string };
+	},
+	fallback: string = __( '(no title)' )
+) {
+	let title = '';
 	if ( typeof item.title === 'string' ) {
-		return decodeEntities( item.title );
+		title = decodeEntities( item.title );
+	} else if ( item.title && 'rendered' in item.title ) {
+		title = decodeEntities( item.title.rendered );
+	} else if ( item.title && 'raw' in item.title ) {
+		title = decodeEntities( item.title.raw );
 	}
-	if ( item.title && 'rendered' in item.title ) {
-		return decodeEntities( item.title.rendered );
-	}
-	if ( item.title && 'raw' in item.title ) {
-		return decodeEntities( item.title.raw );
-	}
-	return '';
+	return title || fallback;
 }
 
 /**


### PR DESCRIPTION
This is just a small PR that adds a `(no title)` fallback mainly to the different snackbars of actions affecting posts, pages, templates with empty titles. This is the behavior that is used elsewhere, so I'm trying to be consistent here.

**Testing instructions**

 - Open the site editor
 - Try removing, creating, duplicating pages with empty titles.