### PR TITLE
Add paragraph level option to post type label block

### DIFF
--- a/packages/block-library/src/query-title/edit.js
+++ b/packages/block-library/src/query-title/edit.js
@@ -46,7 +46,8 @@ export default function QueryTitleEdit( {
 	const { postTypeLabel } = usePostTypeLabel( query?.postType );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
-	const TagName = `h${ level }`;
+	const TagName = level === 0 ? 'p' : `h${ level }`;
+
 	const blockProps = useBlockProps( {
 		className: clsx( 'wp-block-query-title__placeholder', {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
@@ -61,6 +62,7 @@ export default function QueryTitleEdit( {
 		);
 	}
 
+	let defaultLevelOptions;
 	let titleElement;
 	if ( type === 'archive' ) {
 		let title;
@@ -193,6 +195,8 @@ export default function QueryTitleEdit( {
 			title = showPrefix ? __( 'Post Type: Name' ) : __( 'Name' );
 		}
 
+		defaultLevelOptions = [ 0, 1, 2, 3, 4, 5, 6 ];
+
 		titleElement = (
 			<>
 				<InspectorControls>
@@ -236,7 +240,7 @@ export default function QueryTitleEdit( {
 			<BlockControls group="block">
 				<HeadingLevelDropdown
 					value={ level }
-					options={ levelOptions }
+					options={ levelOptions || defaultLevelOptions }
 					onChange={ ( newLevel ) =>
 						setAttributes( { level: newLevel } )
 					}

--- a/packages/block-library/src/query-title/edit.js
+++ b/packages/block-library/src/query-title/edit.js
@@ -62,7 +62,6 @@ export default function QueryTitleEdit( {
 		);
 	}
 
-	let defaultLevelOptions;
 	let titleElement;
 	if ( type === 'archive' ) {
 		let title;
@@ -195,8 +194,6 @@ export default function QueryTitleEdit( {
 			title = showPrefix ? __( 'Post Type: Name' ) : __( 'Name' );
 		}
 
-		defaultLevelOptions = [ 0, 1, 2, 3, 4, 5, 6 ];
-
 		titleElement = (
 			<>
 				<InspectorControls>
@@ -240,7 +237,7 @@ export default function QueryTitleEdit( {
 			<BlockControls group="block">
 				<HeadingLevelDropdown
 					value={ level }
-					options={ levelOptions || defaultLevelOptions }
+					options={ levelOptions }
 					onChange={ ( newLevel ) =>
 						setAttributes( { level: newLevel } )
 					}

--- a/packages/block-library/src/query-title/index.php
+++ b/packages/block-library/src/query-title/index.php
@@ -74,7 +74,9 @@ function render_block_core_query_title( $attributes, $content, $block ) {
 		}
 	}
 
-	$tag_name           = isset( $attributes['level'] ) ? 'h' . (int) $attributes['level'] : 'h1';
+	$level    = isset( $attributes['level'] ) ? (int) $attributes['level'] : 1;
+	$tag_name = $level === 0 ? 'p' :  'h' . (int) $attributes['level'];
+
 	$align_class_name   = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
 	return sprintf(

--- a/packages/block-library/src/query-title/index.php
+++ b/packages/block-library/src/query-title/index.php
@@ -75,7 +75,7 @@ function render_block_core_query_title( $attributes, $content, $block ) {
 	}
 
 	$level    = isset( $attributes['level'] ) ? (int) $attributes['level'] : 1;
-	$tag_name = $level === 0 ? 'p' :  'h' . (int) $attributes['level'];
+	$tag_name = 0 === $level ? 'p' : 'h' . (int) $attributes['level'];
 
 	$align_class_name   = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );

--- a/packages/block-library/src/query-title/variations.js
+++ b/packages/block-library/src/query-title/variations.js
@@ -40,6 +40,7 @@ const variations = [
 		icon: title,
 		attributes: {
 			type: 'post-type',
+			level: 0,
 		},
 		scope: [ 'inserter' ],
 	},

--- a/packages/block-library/src/query-title/variations.js
+++ b/packages/block-library/src/query-title/variations.js
@@ -40,7 +40,6 @@ const variations = [
 		icon: title,
 		attributes: {
 			type: 'post-type',
-			level: 0,
 		},
 		scope: [ 'inserter' ],
 	},


### PR DESCRIPTION
## What?
Closes #71831

In the `Post Type Label` block, allowing the use of `Paragraph` for formatting with other heading tags and setting it as the default.

## Why?
Based on the comment on the issue introducing the "Post Type Label" block:
https://github.com/WordPress/gutenberg/pull/71167#issuecomment-3277084511

Most layouts don't need the post type to be a heading. Therefore, adding the `Paragraph` level option and setting it as the default.

## How?
This PR is adding the `Paragraph` option to the `Change Level` dropdown and setting default value of `level` to `0` for the `Post Type Label` block variation.

## Testing Instructions
1. Open a post or page.
2. Insert a`Post Type Label` block.
3. The default formatting should be `Paragraph`.
4. Save the post and check the frontend.
5. Confirm that post type labels are rendered correctly in both the editor and frontend.

> [!NOTE]
> Also ensure that it continues working with the existing `Post Type Label` block which was inserted with an older version.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast
|Before|After|
|-|-|
| <img width="383" height="379" alt="Screenshot 2025-09-29 at 6 22 05 PM" src="https://github.com/user-attachments/assets/41380d28-089b-4921-a6eb-94670608ab6a" /> | <img width="276" height="421" alt="Paragraph in level options" src="https://github.com/user-attachments/assets/fb1815b7-37b8-42b7-ba54-8ac419dd9c7c" /> |

