### PR TITLE
Post Quick Edit: Fix bulk edit field filtering logic

### DIFF
--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -111,7 +111,9 @@ function PostEditForm( { postType, postId } ) {
 			].filter(
 				( field ) =>
 					ids.length === 1 ||
-					fieldsWithBulkEditSupport.includes( field )
+					fieldsWithBulkEditSupport.includes(
+						typeof field === 'string' ? field : field.id
+					)
 			),
 		} ),
 		[ ids ]


### PR DESCRIPTION
Fixes a logic bug in the PostEditForm component that was preventing bulk edit from working correctly on object fields.

## Why?

When multiple posts are selected for bulk editing, the form should only show fields that support bulk editing. However, the filtering logic was comparing field objects directly against the `fieldsWithBulkEditSupport` array (which contains string field IDs), causing the comparison to always fail for object-type fields.

For example, the "Status & Visibility" field is defined as:
```javascript
{
    id: 'status',
    label: __( 'Status & Visibility' ),
    children: [ 'status', 'password' ],
}
```

and discussion is defined as 

```javascript
				{
					id: 'discussion',
					label: __( 'Discussion' ),
					children: [ 'comment_status', 'ping_status' ],
					summary: 'discussion',
				},
```

The old logic `fieldsWithBulkEditSupport.includes( field )` would try to match this entire object against strings like `'status'`, which would always return false.

## How?

Updated the field filtering logic to properly handle both string field names and field objects by checking the field type:

```javascript
fieldsWithBulkEditSupport.includes(
    typeof field === 'string' ? field : field.id
)
```

Now when a field is an object, we compare using `field.id` instead of the entire field object.

## Testing Instructions

1. Go to `/wp-admin/site-editor.php?p=%2Fpage&layout=table&quickEdit=true`
2. Select multiple pages (bulk selection)
3. Verify the options Status and Visibility and discussion appear.