### PR TITLE
ContrastChecker: Fix check for button block colors

### DIFF
--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -350,7 +350,10 @@ export function ColorEdit( {
 			}
 		>
 			{ enableContrastChecking && (
-				<BlockColorContrastChecker clientId={ clientId } />
+				<BlockColorContrastChecker
+					clientId={ clientId }
+					name={ name }
+				/>
 			) }
 		</StylesColorPanel>
 	);

--- a/packages/block-editor/src/hooks/contrast-checker.js
+++ b/packages/block-editor/src/hooks/contrast-checker.js
@@ -2,12 +2,15 @@
  * WordPress dependencies
  */
 import { useLayoutEffect, useReducer } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import ContrastChecker from '../components/contrast-checker';
 import { useBlockElement } from '../components/block-list/use-block-props/use-block-refs';
+import { store as blockEditorStore } from '../store';
+import { store as blocksStore } from '@wordpress/blocks';
 
 function getComputedValue( node, property ) {
 	return node.ownerDocument.defaultView
@@ -15,9 +18,22 @@ function getComputedValue( node, property ) {
 		.getPropertyValue( property );
 }
 
-function getBlockElementColors( blockEl ) {
+function getBlockElementColors( blockEl, rootSelector ) {
 	if ( ! blockEl ) {
 		return {};
+	}
+
+	// Use the block's root selector to find the element where colors are applied
+	let targetElement = blockEl;
+	if ( rootSelector ) {
+		// Extract the last part of the selector (e.g., ".wp-block-button__link" from ".wp-block-button .wp-block-button__link")
+		const selectorParts = rootSelector.split( ' ' );
+		const lastSelector = selectorParts[ selectorParts.length - 1 ];
+
+		const selectedElement = blockEl.querySelector( lastSelector );
+		if ( selectedElement ) {
+			targetElement = selectedElement;
+		}
 	}
 
 	const firstLinkElement = blockEl.querySelector( 'a' );
@@ -25,9 +41,9 @@ function getBlockElementColors( blockEl ) {
 		? getComputedValue( firstLinkElement, 'color' )
 		: undefined;
 
-	const textColor = getComputedValue( blockEl, 'color' );
+	const textColor = getComputedValue( targetElement, 'color' );
 
-	let backgroundColorNode = blockEl;
+	let backgroundColorNode = targetElement;
 	let backgroundColor = getComputedValue(
 		backgroundColorNode,
 		'background-color'
@@ -65,6 +81,17 @@ export default function BlockColorContrastChecker( { clientId } ) {
 	const blockEl = useBlockElement( clientId );
 	const [ colors, setColors ] = useReducer( reducer, {} );
 
+	// Get the block's root selector from its block type definition.
+	const rootSelector = useSelect(
+		( select ) => {
+			const blockName =
+				select( blockEditorStore ).getBlockName( clientId );
+			const blockType = select( blocksStore ).getBlockType( blockName );
+			return blockType?.selectors?.root;
+		},
+		[ clientId ]
+	);
+
 	// There are so many things that can change the color of a block
 	// So we perform this check on every render.
 	useLayoutEffect( () => {
@@ -73,7 +100,7 @@ export default function BlockColorContrastChecker( { clientId } ) {
 		}
 
 		function updateColors() {
-			setColors( getBlockElementColors( blockEl ) );
+			setColors( getBlockElementColors( blockEl, rootSelector ) );
 		}
 
 		// Combine `useLayoutEffect` and two rAF calls to ensure that values are read

--- a/packages/block-editor/src/hooks/contrast-checker.js
+++ b/packages/block-editor/src/hooks/contrast-checker.js
@@ -86,7 +86,9 @@ export default function BlockColorContrastChecker( { clientId, name } ) {
 
 	const blockType = useSelect(
 		( select ) => {
-			return name ? select( blocksStore ).getBlockType( name ) : undefined;
+			return name
+				? select( blocksStore ).getBlockType( name )
+				: undefined;
 		},
 		[ name ]
 	);

--- a/packages/block-editor/src/hooks/contrast-checker.js
+++ b/packages/block-editor/src/hooks/contrast-checker.js
@@ -109,6 +109,19 @@ export default function BlockColorContrastChecker( { clientId, name } ) {
 		window.requestAnimationFrame( () =>
 			window.requestAnimationFrame( updateColors )
 		);
+
+		const observer = new window.MutationObserver( () => {
+			window.requestAnimationFrame( updateColors );
+		} );
+
+		observer.observe( blockEl, {
+			attributes: true,
+			attributeFilter: [ 'class', 'style' ],
+		} );
+
+		return () => {
+			observer.disconnect();
+		};
 	} );
 
 	return (

--- a/packages/block-editor/src/hooks/contrast-checker.js
+++ b/packages/block-editor/src/hooks/contrast-checker.js
@@ -42,7 +42,7 @@ function getBlockElementColors( blockEl, blockType ) {
 	// Get computed colors from the appropriate elements
 	const textColor = getComputedValue( textElement, 'color' );
 	const linkColor =
-		linkElement && linkElement.innerText
+		linkElement && linkElement.textContent
 			? getComputedValue( linkElement, 'color' )
 			: undefined;
 
@@ -117,11 +117,7 @@ export default function BlockColorContrastChecker( { clientId, name } ) {
 		}
 
 		const observer = new window.MutationObserver( () => {
-			window.requestAnimationFrame( () =>
-				window.requestAnimationFrame( () =>
-					setColors( getBlockElementColors( blockEl, blockType ) )
-				)
-			);
+			setColors( getBlockElementColors( blockEl, blockType ) );
 		} );
 
 		observer.observe( blockEl, {

--- a/packages/block-editor/src/hooks/contrast-checker.js
+++ b/packages/block-editor/src/hooks/contrast-checker.js
@@ -11,6 +11,7 @@ import ContrastChecker from '../components/contrast-checker';
 import { useBlockElement } from '../components/block-list/use-block-props/use-block-refs';
 import { store as blockEditorStore } from '../store';
 import { store as blocksStore } from '@wordpress/blocks';
+import { getBlockCSSSelector } from '../components/global-styles/get-block-css-selector';
 
 function getComputedValue( node, property ) {
 	return node.ownerDocument.defaultView
@@ -18,32 +19,35 @@ function getComputedValue( node, property ) {
 		.getPropertyValue( property );
 }
 
-function getBlockElementColors( blockEl, rootSelector ) {
-	if ( ! blockEl ) {
+function getBlockElementColors( blockEl, blockType ) {
+	if ( ! blockEl || ! blockType ) {
 		return {};
 	}
 
-	// Use the block's root selector to find the element where colors are applied
-	let targetElement = blockEl;
-	if ( rootSelector ) {
-		// Extract the last part of the selector (e.g., ".wp-block-button__link" from ".wp-block-button .wp-block-button__link")
-		const selectorParts = rootSelector.split( ' ' );
-		const lastSelector = selectorParts[ selectorParts.length - 1 ];
+	// Get color-specific selectors.
+	const textSelector = getBlockCSSSelector( blockType, 'color.text', {
+		fallback: true,
+	} );
+	const backgroundSelector = getBlockCSSSelector(
+		blockType,
+		'color.background',
+		{ fallback: true }
+	);
 
-		const selectedElement = blockEl.querySelector( lastSelector );
-		if ( selectedElement ) {
-			targetElement = selectedElement;
-		}
-	}
+	// Find target elements - querySelector handles all the complexity
+	const textElement = blockEl.querySelector( textSelector ) || blockEl;
+	const backgroundElement =
+		blockEl.querySelector( backgroundSelector ) || blockEl;
+	const linkElement = blockEl.querySelector( 'a' );
 
-	const firstLinkElement = blockEl.querySelector( 'a' );
-	const linkColor = !! firstLinkElement?.innerText
-		? getComputedValue( firstLinkElement, 'color' )
-		: undefined;
+	// Get computed colors from the appropriate elements
+	const textColor = getComputedValue( textElement, 'color' );
+	const linkColor =
+		linkElement && linkElement.innerText
+			? getComputedValue( linkElement, 'color' )
+			: undefined;
 
-	const textColor = getComputedValue( targetElement, 'color' );
-
-	let backgroundColorNode = targetElement;
+	let backgroundColorNode = backgroundElement;
 	let backgroundColor = getComputedValue(
 		backgroundColorNode,
 		'background-color'
@@ -81,13 +85,12 @@ export default function BlockColorContrastChecker( { clientId } ) {
 	const blockEl = useBlockElement( clientId );
 	const [ colors, setColors ] = useReducer( reducer, {} );
 
-	// Get the block's root selector from its block type definition.
-	const rootSelector = useSelect(
+	// Get the block type for selector resolution.
+	const blockType = useSelect(
 		( select ) => {
 			const blockName =
 				select( blockEditorStore ).getBlockName( clientId );
-			const blockType = select( blocksStore ).getBlockType( blockName );
-			return blockType?.selectors?.root;
+			return select( blocksStore ).getBlockType( blockName );
 		},
 		[ clientId ]
 	);
@@ -95,12 +98,12 @@ export default function BlockColorContrastChecker( { clientId } ) {
 	// There are so many things that can change the color of a block
 	// So we perform this check on every render.
 	useLayoutEffect( () => {
-		if ( ! blockEl ) {
+		if ( ! blockEl || ! blockType ) {
 			return;
 		}
 
 		function updateColors() {
-			setColors( getBlockElementColors( blockEl, rootSelector ) );
+			setColors( getBlockElementColors( blockEl, blockType ) );
 		}
 
 		// Combine `useLayoutEffect` and two rAF calls to ensure that values are read

--- a/packages/block-editor/src/hooks/contrast-checker.js
+++ b/packages/block-editor/src/hooks/contrast-checker.js
@@ -93,6 +93,10 @@ export default function BlockColorContrastChecker( { clientId, name } ) {
 		[ name ]
 	);
 
+	function updateColors() {
+		setColors( getBlockElementColors( blockEl, blockType ) );
+	}
+
 	// There are so many things that can change the color of a block
 	// So we perform this check on every render.
 	useLayoutEffect( () => {
@@ -100,15 +104,19 @@ export default function BlockColorContrastChecker( { clientId, name } ) {
 			return;
 		}
 
-		function updateColors() {
-			setColors( getBlockElementColors( blockEl, blockType ) );
-		}
-
 		// Combine `useLayoutEffect` and two rAF calls to ensure that values are read
 		// after the current paint but before the next paint.
 		window.requestAnimationFrame( () =>
 			window.requestAnimationFrame( updateColors )
 		);
+	} );
+
+	// Runs in its own effect with dependencies so the observer is only
+	// recreated when the block element or block type changes.
+	useLayoutEffect( () => {
+		if ( ! blockEl || ! blockType ) {
+			return;
+		}
 
 		const observer = new window.MutationObserver( () => {
 			window.requestAnimationFrame( updateColors );
@@ -122,7 +130,7 @@ export default function BlockColorContrastChecker( { clientId, name } ) {
 		return () => {
 			observer.disconnect();
 		};
-	} );
+	}, [ blockEl, blockType ] );
 
 	return (
 		<ContrastChecker

--- a/packages/block-editor/src/hooks/contrast-checker.js
+++ b/packages/block-editor/src/hooks/contrast-checker.js
@@ -93,10 +93,6 @@ export default function BlockColorContrastChecker( { clientId, name } ) {
 		[ name ]
 	);
 
-	function updateColors() {
-		setColors( getBlockElementColors( blockEl, blockType ) );
-	}
-
 	// There are so many things that can change the color of a block
 	// So we perform this check on every render.
 	useLayoutEffect( () => {
@@ -107,7 +103,9 @@ export default function BlockColorContrastChecker( { clientId, name } ) {
 		// Combine `useLayoutEffect` and two rAF calls to ensure that values are read
 		// after the current paint but before the next paint.
 		window.requestAnimationFrame( () =>
-			window.requestAnimationFrame( updateColors )
+			window.requestAnimationFrame( () =>
+				setColors( getBlockElementColors( blockEl, blockType ) )
+			)
 		);
 	} );
 
@@ -119,7 +117,11 @@ export default function BlockColorContrastChecker( { clientId, name } ) {
 		}
 
 		const observer = new window.MutationObserver( () => {
-			window.requestAnimationFrame( updateColors );
+			window.requestAnimationFrame( () =>
+				window.requestAnimationFrame( () =>
+					setColors( getBlockElementColors( blockEl, blockType ) )
+				)
+			);
 		} );
 
 		observer.observe( blockEl, {

--- a/packages/block-editor/src/hooks/contrast-checker.js
+++ b/packages/block-editor/src/hooks/contrast-checker.js
@@ -80,18 +80,15 @@ function reducer( prevColors, newColors ) {
 	return hasChanged ? newColors : prevColors;
 }
 
-export default function BlockColorContrastChecker( { clientId } ) {
+export default function BlockColorContrastChecker( { clientId, name } ) {
 	const blockEl = useBlockElement( clientId );
 	const [ colors, setColors ] = useReducer( reducer, {} );
-	const blockName = blockEl?.getAttribute( 'data-type' );
 
 	const blockType = useSelect(
 		( select ) => {
-			return blockName
-				? select( blocksStore ).getBlockType( blockName )
-				: undefined;
+			return name ? select( blocksStore ).getBlockType( name ) : undefined;
 		},
-		[ blockName ]
+		[ name ]
 	);
 
 	// There are so many things that can change the color of a block

--- a/packages/block-editor/src/hooks/contrast-checker.js
+++ b/packages/block-editor/src/hooks/contrast-checker.js
@@ -3,15 +3,14 @@
  */
 import { useLayoutEffect, useReducer } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
+import { store as blocksStore } from '@wordpress/blocks';
+import { getBlockSelector } from '@wordpress/global-styles-engine';
 
 /**
  * Internal dependencies
  */
 import ContrastChecker from '../components/contrast-checker';
 import { useBlockElement } from '../components/block-list/use-block-props/use-block-refs';
-import { store as blockEditorStore } from '../store';
-import { store as blocksStore } from '@wordpress/blocks';
-import { getBlockCSSSelector } from '../components/global-styles/get-block-css-selector';
 
 function getComputedValue( node, property ) {
 	return node.ownerDocument.defaultView
@@ -25,10 +24,10 @@ function getBlockElementColors( blockEl, blockType ) {
 	}
 
 	// Get color-specific selectors.
-	const textSelector = getBlockCSSSelector( blockType, 'color.text', {
+	const textSelector = getBlockSelector( blockType, 'color.text', {
 		fallback: true,
 	} );
-	const backgroundSelector = getBlockCSSSelector(
+	const backgroundSelector = getBlockSelector(
 		blockType,
 		'color.background',
 		{ fallback: true }
@@ -84,15 +83,15 @@ function reducer( prevColors, newColors ) {
 export default function BlockColorContrastChecker( { clientId } ) {
 	const blockEl = useBlockElement( clientId );
 	const [ colors, setColors ] = useReducer( reducer, {} );
+	const blockName = blockEl?.getAttribute( 'data-type' );
 
-	// Get the block type for selector resolution.
 	const blockType = useSelect(
 		( select ) => {
-			const blockName =
-				select( blockEditorStore ).getBlockName( clientId );
-			return select( blocksStore ).getBlockType( blockName );
+			return blockName
+				? select( blocksStore ).getBlockType( blockName )
+				: undefined;
 		},
-		[ clientId ]
+		[ blockName ]
 	);
 
 	// There are so many things that can change the color of a block

--- a/test/e2e/specs/editor/various/contrast-checker.spec.js
+++ b/test/e2e/specs/editor/various/contrast-checker.spec.js
@@ -5,7 +5,7 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 const WARNING_TEXT = 'This color combination may be hard for people to read';
 
-test.describe( 'ContrastChecker', () => {
+test.describe( 'Contrast Checker', () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
 	} );
@@ -30,31 +30,23 @@ test.describe( 'ContrastChecker', () => {
 				name: 'Editor settings',
 			} );
 
-			// Check if Styles tab exists and click it if needed
-			const stylesTab = editorSettings.getByRole( 'tab', {
-				name: 'Styles',
-			} );
-			if ( ( await stylesTab.count() ) > 0 ) {
-				await stylesTab.click();
-			}
-
 			const textButton = editorSettings.getByRole( 'button', {
 				name: 'Text',
 			} );
+			const backgroundButton = editorSettings.getByRole( 'button', {
+				name: 'Background',
+			} );
+
 			await expect( textButton ).toBeVisible();
 			await textButton.click();
 			await page.getByRole( 'option', { name: 'Black' } ).click();
 
-			// Close the popover by clicking outside before opening background
+			// Close the popover by clicking outside before opening background.
 			await textButton.click();
-
-			const backgroundButton = page
-				.getByRole( 'region', { name: 'Editor settings' } )
-				.getByRole( 'button', { name: 'Background' } );
 			await backgroundButton.click();
 			await page.getByRole( 'option', { name: 'Black' } ).click();
 
-			// Close the popover to ensure colors are fully applied
+			// Close the popover to ensure colors are fully applied.
 			await backgroundButton.click();
 
 			await expect( lowContrastWarning ).toBeVisible();
@@ -71,14 +63,6 @@ test.describe( 'ContrastChecker', () => {
 				name: 'Editor settings',
 			} );
 
-			// Check if Styles tab exists and click it if needed
-			const stylesTab = editorSettings.getByRole( 'tab', {
-				name: 'Styles',
-			} );
-			if ( ( await stylesTab.count() ) > 0 ) {
-				await stylesTab.click();
-			}
-
 			const textButton = editorSettings.getByRole( 'button', {
 				name: 'Text',
 			} );
@@ -86,7 +70,7 @@ test.describe( 'ContrastChecker', () => {
 			await textButton.click();
 			await page.getByRole( 'option', { name: 'White' } ).click();
 
-			// Close the popover to ensure colors are fully applied
+			// Close the popover to ensure colors are fully applied.
 			await textButton.click();
 
 			await expect( lowContrastWarning ).toBeVisible();
@@ -113,34 +97,25 @@ test.describe( 'ContrastChecker', () => {
 			name: 'Editor settings',
 		} );
 
-		// Check if Styles tab exists and click it if needed
-		const stylesTab = editorSettings.getByRole( 'tab', {
-			name: 'Styles',
-		} );
-		if ( ( await stylesTab.count() ) > 0 ) {
-			await stylesTab.click();
-		}
-
 		const textButton = editorSettings.getByRole( 'button', {
 			name: 'Text',
+		} );
+		const backgroundButton = editorSettings.getByRole( 'button', {
+			name: 'Background',
 		} );
 		await expect( textButton ).toBeVisible();
 		await textButton.click();
 		await page.getByRole( 'option', { name: 'Black' } ).click();
 
-		// Close the popover before opening background
+		// Close the popover before opening background.
 		await textButton.click();
-
-		const backgroundButton = page
-			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'button', { name: 'Background' } );
 		await backgroundButton.click();
 		await page.getByRole( 'option', { name: 'White' } ).click();
 
 		// Close the popover to ensure colors are fully applied
 		await backgroundButton.click();
 
-		await expect( lowContrastWarning ).not.toBeVisible();
+		await expect( lowContrastWarning ).toBeHidden();
 	} );
 
 	test( 'should hide warning when contrast is fixed', async ( {
@@ -162,26 +137,18 @@ test.describe( 'ContrastChecker', () => {
 			name: 'Editor settings',
 		} );
 
-		// Check if Styles tab exists and click it if needed
-		const stylesTab = editorSettings.getByRole( 'tab', {
-			name: 'Styles',
-		} );
-		if ( ( await stylesTab.count() ) > 0 ) {
-			await stylesTab.click();
-		}
-
 		// Set poor contrast: black text on black background
 		const textButton = editorSettings.getByRole( 'button', {
 			name: 'Text',
 		} );
-		await expect( textButton ).toBeVisible();
-		await textButton.click();
-		await page.getByRole( 'option', { name: 'Black' } ).click();
-		await textButton.click();
-
 		const backgroundButton = editorSettings.getByRole( 'button', {
 			name: 'Background',
 		} );
+		await expect( textButton ).toBeVisible();
+		await textButton.click();
+		await page.getByRole( 'option', { name: 'Black' } ).click();
+
+		await textButton.click();
 		await backgroundButton.click();
 		await page.getByRole( 'option', { name: 'Black' } ).click();
 		await backgroundButton.click();
@@ -195,7 +162,7 @@ test.describe( 'ContrastChecker', () => {
 		await backgroundButton.click();
 
 		// Verify warning disappears
-		await expect( lowContrastWarning ).not.toBeVisible();
+		await expect( lowContrastWarning ).toBeHidden();
 	} );
 
 	test( 'should show warning for insufficient link color contrast', async ( {
@@ -220,14 +187,6 @@ test.describe( 'ContrastChecker', () => {
 		const editorSettings = page.getByRole( 'region', {
 			name: 'Editor settings',
 		} );
-
-		// Check if Styles tab exists and click it if needed
-		const stylesTab = editorSettings.getByRole( 'tab', {
-			name: 'Styles',
-		} );
-		if ( ( await stylesTab.count() ) > 0 ) {
-			await stylesTab.click();
-		}
 
 		// Set background to black first
 		const backgroundButton = editorSettings.getByRole( 'button', {
@@ -275,13 +234,11 @@ test.describe( 'ContrastChecker', () => {
 			name: 'Editor settings',
 		} );
 
-		// Check if Styles tab exists and click it if needed
-		const stylesTab = editorSettings.getByRole( 'tab', {
-			name: 'Styles',
-		} );
-		if ( ( await stylesTab.count() ) > 0 ) {
-			await stylesTab.click();
-		}
+		await editorSettings
+			.getByRole( 'tab', {
+				name: 'Styles',
+			} )
+			.click();
 
 		// Set text color to black
 		const textButton = editorSettings.getByRole( 'button', {
@@ -323,13 +280,11 @@ test.describe( 'ContrastChecker', () => {
 			name: 'Editor settings',
 		} );
 
-		// Check if Styles tab exists and click it if needed
-		const stylesTab = editorSettings.getByRole( 'tab', {
-			name: 'Styles',
-		} );
-		if ( ( await stylesTab.count() ) > 0 ) {
-			await stylesTab.click();
-		}
+		await editorSettings
+			.getByRole( 'tab', {
+				name: 'Styles',
+			} )
+			.click();
 
 		// Set text color to black
 		const textButton = editorSettings.getByRole( 'button', {
@@ -349,6 +304,6 @@ test.describe( 'ContrastChecker', () => {
 		await backgroundButton.click();
 
 		// Verify no warning appears
-		await expect( lowContrastWarning ).not.toBeVisible();
+		await expect( lowContrastWarning ).toBeHidden();
 	} );
 } );

--- a/test/e2e/specs/editor/various/contrast-checker.spec.js
+++ b/test/e2e/specs/editor/various/contrast-checker.spec.js
@@ -1,0 +1,354 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const WARNING_TEXT = 'This color combination may be hard for people to read';
+
+test.describe( 'ContrastChecker', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'should show warning for insufficient contrast', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.openDocumentSettingsSidebar();
+
+		const lowContrastWarning = page.locator(
+			'.block-editor-contrast-checker'
+		);
+
+		await test.step( 'Check black text on black background', async () => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'Black text on Black background' },
+			} );
+
+			const editorSettings = page.getByRole( 'region', {
+				name: 'Editor settings',
+			} );
+
+			// Check if Styles tab exists and click it if needed
+			const stylesTab = editorSettings.getByRole( 'tab', {
+				name: 'Styles',
+			} );
+			if ( ( await stylesTab.count() ) > 0 ) {
+				await stylesTab.click();
+			}
+
+			const textButton = editorSettings.getByRole( 'button', {
+				name: 'Text',
+			} );
+			await expect( textButton ).toBeVisible();
+			await textButton.click();
+			await page.getByRole( 'option', { name: 'Black' } ).click();
+
+			// Close the popover by clicking outside before opening background
+			await textButton.click();
+
+			const backgroundButton = page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Background' } );
+			await backgroundButton.click();
+			await page.getByRole( 'option', { name: 'Black' } ).click();
+
+			// Close the popover to ensure colors are fully applied
+			await backgroundButton.click();
+
+			await expect( lowContrastWarning ).toBeVisible();
+			await expect( lowContrastWarning ).toContainText( WARNING_TEXT );
+		} );
+
+		await test.step( 'Check white text on default background', async () => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: { content: 'White text on Default background' },
+			} );
+
+			const editorSettings = page.getByRole( 'region', {
+				name: 'Editor settings',
+			} );
+
+			// Check if Styles tab exists and click it if needed
+			const stylesTab = editorSettings.getByRole( 'tab', {
+				name: 'Styles',
+			} );
+			if ( ( await stylesTab.count() ) > 0 ) {
+				await stylesTab.click();
+			}
+
+			const textButton = editorSettings.getByRole( 'button', {
+				name: 'Text',
+			} );
+			await expect( textButton ).toBeVisible();
+			await textButton.click();
+			await page.getByRole( 'option', { name: 'White' } ).click();
+
+			// Close the popover to ensure colors are fully applied
+			await textButton.click();
+
+			await expect( lowContrastWarning ).toBeVisible();
+			await expect( lowContrastWarning ).toContainText( WARNING_TEXT );
+		} );
+	} );
+
+	test( 'should not show warning for sufficient contrast', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.openDocumentSettingsSidebar();
+
+		const lowContrastWarning = page.locator(
+			'.block-editor-contrast-checker'
+		);
+
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Black text on White background' },
+		} );
+
+		const editorSettings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+
+		// Check if Styles tab exists and click it if needed
+		const stylesTab = editorSettings.getByRole( 'tab', {
+			name: 'Styles',
+		} );
+		if ( ( await stylesTab.count() ) > 0 ) {
+			await stylesTab.click();
+		}
+
+		const textButton = editorSettings.getByRole( 'button', {
+			name: 'Text',
+		} );
+		await expect( textButton ).toBeVisible();
+		await textButton.click();
+		await page.getByRole( 'option', { name: 'Black' } ).click();
+
+		// Close the popover before opening background
+		await textButton.click();
+
+		const backgroundButton = page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Background' } );
+		await backgroundButton.click();
+		await page.getByRole( 'option', { name: 'White' } ).click();
+
+		// Close the popover to ensure colors are fully applied
+		await backgroundButton.click();
+
+		await expect( lowContrastWarning ).not.toBeVisible();
+	} );
+
+	test( 'should hide warning when contrast is fixed', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.openDocumentSettingsSidebar();
+
+		const lowContrastWarning = page.locator(
+			'.block-editor-contrast-checker'
+		);
+
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Text with poor contrast' },
+		} );
+
+		const editorSettings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+
+		// Check if Styles tab exists and click it if needed
+		const stylesTab = editorSettings.getByRole( 'tab', {
+			name: 'Styles',
+		} );
+		if ( ( await stylesTab.count() ) > 0 ) {
+			await stylesTab.click();
+		}
+
+		// Set poor contrast: black text on black background
+		const textButton = editorSettings.getByRole( 'button', {
+			name: 'Text',
+		} );
+		await expect( textButton ).toBeVisible();
+		await textButton.click();
+		await page.getByRole( 'option', { name: 'Black' } ).click();
+		await textButton.click();
+
+		const backgroundButton = editorSettings.getByRole( 'button', {
+			name: 'Background',
+		} );
+		await backgroundButton.click();
+		await page.getByRole( 'option', { name: 'Black' } ).click();
+		await backgroundButton.click();
+
+		// Verify warning appears
+		await expect( lowContrastWarning ).toBeVisible();
+
+		// Fix contrast: change background to white
+		await backgroundButton.click();
+		await page.getByRole( 'option', { name: 'White' } ).click();
+		await backgroundButton.click();
+
+		// Verify warning disappears
+		await expect( lowContrastWarning ).not.toBeVisible();
+	} );
+
+	test( 'should show warning for insufficient link color contrast', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.openDocumentSettingsSidebar();
+
+		const lowContrastWarning = page.locator(
+			'.block-editor-contrast-checker'
+		);
+
+		// Insert paragraph with a link
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content:
+					'<a href="https://example.com">Link text</a> in paragraph',
+			},
+		} );
+
+		const editorSettings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+
+		// Check if Styles tab exists and click it if needed
+		const stylesTab = editorSettings.getByRole( 'tab', {
+			name: 'Styles',
+		} );
+		if ( ( await stylesTab.count() ) > 0 ) {
+			await stylesTab.click();
+		}
+
+		// Set background to black first
+		const backgroundButton = editorSettings.getByRole( 'button', {
+			name: 'Background',
+		} );
+		await backgroundButton.click();
+		await page.getByRole( 'option', { name: 'Black' } ).click();
+		await backgroundButton.click();
+
+		// Try to find and set link color to black (poor contrast with black background)
+		// The link color control might be in a collapsible panel or not visible by default
+		const linkButton = editorSettings.getByRole( 'button', {
+			name: 'Link',
+		} );
+		const linkButtonCount = await linkButton.count();
+
+		if ( linkButtonCount > 0 ) {
+			await linkButton.click();
+			await page.getByRole( 'option', { name: 'Black' } ).click();
+			await linkButton.click();
+
+			// Verify warning appears for link color contrast
+			await expect( lowContrastWarning ).toBeVisible();
+			await expect( lowContrastWarning ).toContainText( WARNING_TEXT );
+		}
+		// Note: If link color control is not available, the test will pass
+		// as the contrast checker only checks link colors when they are set
+	} );
+
+	test( 'should show warning for insufficient contrast on buttons', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.openDocumentSettingsSidebar();
+
+		const lowContrastWarning = page.locator(
+			'.block-editor-contrast-checker'
+		);
+
+		// Insert a button block
+		await editor.insertBlock( { name: 'core/buttons' } );
+		await page.keyboard.type( 'Button text' );
+
+		const editorSettings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+
+		// Check if Styles tab exists and click it if needed
+		const stylesTab = editorSettings.getByRole( 'tab', {
+			name: 'Styles',
+		} );
+		if ( ( await stylesTab.count() ) > 0 ) {
+			await stylesTab.click();
+		}
+
+		// Set text color to black
+		const textButton = editorSettings.getByRole( 'button', {
+			name: 'Text',
+		} );
+		await expect( textButton ).toBeVisible();
+		await textButton.click();
+		await page.getByRole( 'option', { name: 'Black' } ).click();
+		await textButton.click();
+
+		// Set background to black (poor contrast with black text)
+		const backgroundButton = editorSettings.getByRole( 'button', {
+			name: 'Background',
+		} );
+		await backgroundButton.click();
+		await page.getByRole( 'option', { name: 'Black' } ).click();
+		await backgroundButton.click();
+
+		// Verify warning appears for button contrast
+		await expect( lowContrastWarning ).toBeVisible();
+		await expect( lowContrastWarning ).toContainText( WARNING_TEXT );
+	} );
+
+	test( 'should not show warning for sufficient contrast on buttons', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.openDocumentSettingsSidebar();
+
+		const lowContrastWarning = page.locator(
+			'.block-editor-contrast-checker'
+		);
+
+		// Insert a button block
+		await editor.insertBlock( { name: 'core/buttons' } );
+		await page.keyboard.type( 'Button text' );
+
+		const editorSettings = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
+
+		// Check if Styles tab exists and click it if needed
+		const stylesTab = editorSettings.getByRole( 'tab', {
+			name: 'Styles',
+		} );
+		if ( ( await stylesTab.count() ) > 0 ) {
+			await stylesTab.click();
+		}
+
+		// Set text color to black
+		const textButton = editorSettings.getByRole( 'button', {
+			name: 'Text',
+		} );
+		await expect( textButton ).toBeVisible();
+		await textButton.click();
+		await page.getByRole( 'option', { name: 'Black' } ).click();
+		await textButton.click();
+
+		// Set background to white (good contrast with black text)
+		const backgroundButton = editorSettings.getByRole( 'button', {
+			name: 'Background',
+		} );
+		await backgroundButton.click();
+		await page.getByRole( 'option', { name: 'White' } ).click();
+		await backgroundButton.click();
+
+		// Verify no warning appears
+		await expect( lowContrastWarning ).not.toBeVisible();
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/39226
Closes: #68856
Closes: https://github.com/WordPress/gutenberg/issues/68853
Closes: https://github.com/WordPress/gutenberg/pull/71272
Follow-up to https://github.com/WordPress/gutenberg/issues/67035

The contrast checker wasn’t working for buttons, since their colors are applied to a different DOM element.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Without this fix, the contrast checker didn’t display warnings when button text and background colors had poor readability.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

For blocks where the root element is defined, use that element to retrieve colors for the contrast check.

## Testing Instructions

1. Create a page.
2. Add a Button block.
3. Change the button’s text and background colors.
4. Confirm that a contrast notice appears when using low-contrast color combinations.
5. Test with other blocks (paragraph, columns, etc.) and confirm they still behave as expected.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/2afd6c54-6566-4cd5-b03c-af152fac1f46


