### PR TITLE
Block Comment: Improve comment thread outline

### DIFF
--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -19,17 +19,17 @@
 	position: relative;
 	padding: $grid-unit-20;
 	border-radius: $radius-large;
-	border: 1.5px solid $gray-300;
+	border: $border-width solid $gray-300;
 	background-color: $gray-100;
 
 	&.is-selected {
 		background-color: $white;
-		border: 1.5px solid #3858e9;
-		box-shadow: 0 5.5px 7.8px -0.3px rgba(0, 0, 0, 0.102);
+		box-shadow: $elevation-medium;
 	}
 
-	&:focus-visible {
-		outline: auto;
+	&:focus {
+		outline: var(--wp-admin-border-width-focus) solid var(--wp-admin-theme-color);
+		outline-offset: calc((-1 * var(--wp-admin-border-width-focus)));
 	}
 }
 


### PR DESCRIPTION
- Closes: #71774
- Addresses: https://github.com/WordPress/gutenberg/pull/71898#pullrequestreview-3268062319

## What?

This PR will apply the correct style based on the design, depending on the state of the comment thread.

## How?

At the same time, this PR avoided hard-coded values ​​and used SCSS variables.

## Testing Instructions

Click on the block, click on the comment, or focus on the comment with your keyboard to see the outline.


## Screenshots or screencast <!-- if applicable -->

Note that in the following screenshots and screencast, the focus outline width is 2px, as my laptop doesn't have a high-resolution screen. If you're using a Retina Mac, the outline width should probably be 1.5px.

| Default | Block is selected | Block is selected and comment is focused| Comment is focused | Input is focused |
|--------|--------|--------|--------|--------|
| <img width="247" height="294" alt="image" src="https://github.com/user-attachments/assets/a06c269c-3c57-4b96-93b3-c6f29cf42f02" /> | <img width="249" height="505" alt="image" src="https://github.com/user-attachments/assets/b9594991-d172-4285-9e98-c9713d4de609" /> | <img width="253" height="507" alt="image" src="https://github.com/user-attachments/assets/1cd0d691-05ab-40a7-80a2-685bba6b8a31" /> | <img width="249" height="300" alt="image" src="https://github.com/user-attachments/assets/42b68c8e-1088-441b-8aa7-d7412f3f3c1c" /> | <img width="250" height="503" alt="image" src="https://github.com/user-attachments/assets/698ec4f2-d21d-4bf4-b0c4-203e5803ca16" /> |

https://github.com/user-attachments/assets/8a3aa9af-5a9d-422b-a559-c9f17995e144


