### PR TITLE
Block Comment: Display message when there is no related block

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -151,11 +151,17 @@ function Thread( {
 		stripHTML( thread.content.rendered ),
 		10
 	);
-	const ariaLabel = sprintf(
-		// translators: %s: comment excerpt
-		__( 'Comment: %s' ),
-		commentExcerpt
-	);
+	const ariaLabel = relatedBlockElement
+		? sprintf(
+				// translators: %s: comment excerpt
+				__( 'Comment: %s' ),
+				commentExcerpt
+		  )
+		: sprintf(
+				// translators: %s: comment excerpt
+				__( 'Original block deleted. Comment: %s' ),
+				commentExcerpt
+		  );
 
 	return (
 		// Disable reason: role="listitem" does in fact support aria-expanded.
@@ -195,6 +201,11 @@ function Thread( {
 			aria-label={ ariaLabel }
 			aria-expanded={ isSelected }
 		>
+			{ ! relatedBlockElement && (
+				<p className="editor-collab-sidebar-panel__thread-warning">
+					{ __( 'Original block deleted.' ) }
+				</p>
+			) }
 			<CommentBoard
 				thread={ thread }
 				onEdit={ ( params = {} ) => {

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -8,6 +8,7 @@ import clsx from 'clsx';
  */
 import { useState, RawHTML, useRef } from '@wordpress/element';
 import {
+	__experimentalText as Text,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalConfirmDialog as ConfirmDialog,
@@ -202,9 +203,9 @@ function Thread( {
 			aria-expanded={ isSelected }
 		>
 			{ ! relatedBlockElement && (
-				<p className="editor-collab-sidebar-panel__thread-warning">
+				<Text as="p" weight={ 500 } variant="muted">
 					{ __( 'Original block deleted.' ) }
-				</p>
+				</Text>
 			) }
 			<CommentBoard
 				thread={ thread }

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -37,6 +37,12 @@
 	margin-top: 15px;
 }
 
+.editor-collab-sidebar-panel__thread-warning {
+	font-weight: 500;
+	font-style: italic;
+	margin-bottom: 0;
+}
+
 .editor-collab-sidebar-panel__user-name {
 	font-size: 12px;
 	font-weight: 400;

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -37,12 +37,6 @@
 	margin-top: 15px;
 }
 
-.editor-collab-sidebar-panel__thread-warning {
-	font-weight: 500;
-	font-style: italic;
-	margin-bottom: 0;
-}
-
 .editor-collab-sidebar-panel__user-name {
 	font-size: 12px;
 	font-weight: 400;


### PR DESCRIPTION
Fixes #71868

## What?

If the block linked in a block comment does not exist in the content, show a message at the top of the comment thread.

| Header | Header |
|--------|--------|
| Cell | Cell | 
| <img width="283" height="342" alt="image" src="https://github.com/user-attachments/assets/0e1e2e57-a403-4886-86eb-b5b6c883fcca" /> | <img width="284" height="408" alt="image" src="https://github.com/user-attachments/assets/9dbeae54-f57b-4cae-9a8b-639a6e1e0c21" /> |


## Why?

Without this message, it would be difficult for users to notice that the block has been removed.

## How?

Very basic text and style. Italic style may not be necessary.

Also, this implementation is based on [this comment](https://github.com/WordPress/gutenberg/issues/71868#issuecomment-3349715082):

> In chatting with @adamsilverstein @kadamwhite @roseg43 @poojabhimani12, it felt like `Original block deleted` was a good enough place to start from for now.  Lacking strong design direction otherwise, I suggest we go that path for resolution here.

## Testing Instructions

- Insert a block and add comment on it.
- Remove the block and confirm the comment thread.

### Testing Instructions for Keyboard

- Focus the comment thread.
- Confirm that your screen reader reads out like this: `Original block deleted. Comment: [Comment-Excerpt-Text].  expanded  1 of 2  level 1`