### PR TITLE
Fix incorrect block editing mode assigned in some cases

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2307,12 +2307,7 @@ function getDerivedBlockEditingModesForTree(
 			let ancestorBlockEditingMode;
 			let parent = state.blocks.parents.get( clientId );
 			while ( parent !== undefined ) {
-				// There's a chance we only just calculated this for the parent,
-				// if so we can return that value for a faster lookup.
-				if ( derivedBlockEditingModes.has( parent ) ) {
-					ancestorBlockEditingMode =
-						derivedBlockEditingModes.get( parent );
-				} else if ( state.blockEditingModes.has( parent ) ) {
+				if ( state.blockEditingModes.has( parent ) ) {
 					// Checking the explicit block editing mode will be slower,
 					// as the block editing mode is more likely to be set on a
 					// distant ancestor.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #71908

## How?
The bug occurred due to an optimization that was added. It assumed that if we'd just assigned a `disabled` mode to a parent, the `disabled` mode should automatically cascade and the child should also be `disabled`. However, that was incorrect, in `contentOnly` mode we often want a `disabled` parent to have a `contentOnly` child, the optimization was not allowing this.

## Testing Instructions
1. Turn on Gutenberg -> experiments: **When patterns are inserted, default to a simplified content only mode for editing pattern content.**
2. Go to a page
3. Use the Show Template option to show the Zoom Out button (Header > Computer Icon > Show Template)
5. Insert or confirm there is a content only pattern
6. Select something within the content only pattern
7. Toggle the Zoom out button on/off

Expected: You should be able to select the content in the pattern
In trunk: You can't select the content in the pattern
