### PR TITLE
site editor - disabled preview by default in Templates and Patterns

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -45,7 +45,7 @@ const defaultLayouts = {
 					width: '1%',
 				},
 			},
-      showMedia: false,
+		showMedia: false,
 		},
 	},
 	[ LAYOUT_GRID ]: {

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -52,7 +52,7 @@ const defaultLayouts = {
 		layout: {
 			badgeFields: [ 'sync-status' ],
 		},
-    showMedia: false,
+	showMedia: false,
 	},
 };
 const DEFAULT_VIEW = {

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -52,7 +52,7 @@ const defaultLayouts = {
 		layout: {
 			badgeFields: [ 'sync-status' ],
 		},
-	showMedia: false,
+		showMedia: false,
 	},
 };
 const DEFAULT_VIEW = {

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -45,12 +45,14 @@ const defaultLayouts = {
 					width: '1%',
 				},
 			},
+      showMedia: false,
 		},
 	},
 	[ LAYOUT_GRID ]: {
 		layout: {
 			badgeFields: [ 'sync-status' ],
 		},
+    showMedia: false,
 	},
 };
 const DEFAULT_VIEW = {

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -45,7 +45,7 @@ const defaultLayouts = {
 					width: '1%',
 				},
 			},
-		showMedia: false,
+			showMedia: false,
 		},
 	},
 	[ LAYOUT_GRID ]: {

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -48,7 +48,7 @@ const defaultLayouts = {
 		showMedia: false,
 	},
 	[ LAYOUT_GRID ]: {
-		showMedia: true,
+		showMedia: false,
 	},
 	[ LAYOUT_LIST ]: {
 		showMedia: false,


### PR DESCRIPTION
## What?
See  https://github.com/woocommerce/woocommerce/issues/60795
See https://github.com/WordPress/gutenberg/issues/68979

Disables preview of Templates and Patterns of site editor by default

## Why?
Loading preview of Templates or Patterns pages within site editor generates a lot of requests causing site overload and inaccessibility on a low resource server. The site editor's Templates or Patterns list contains a 'View options' setting, where user can change parameters of list display including preview visibility. 'Hide Preview' and 'Show Preview' toggles the visibility of the preview. This change sets the preview to be hidden by default. Without preview the site overload does not happen. Changing the preview from view options remains possible.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Within site editor's Templates or Patterns pages this change sets the preview to false by default preventing site overload. This is just a quick workaround, not fixing the real root cause but keeps the low resource environment operational.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Install WordPress, WooCommerce, Gutenberg to a local server with low memory (1GB) e.g. to VirtualBox Linux
2. Use admin menu's Appearance / Editor then access Templates or Patterns menu
3. You can observe the parallel background processes by checking running processes e.g. top when Templates or Patterns page is opened with preview enabled

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1839" height="723" alt="image" src="https://github.com/user-attachments/assets/1d3d7f46-d80c-4661-97fc-39a2ca84c321" />|<img width="1910" height="768" alt="image" src="https://github.com/user-attachments/assets/ed250ae8-50f0-4442-a73e-60e361e2f840" />|
|<img width="1858" height="742" alt="image" src="https://github.com/user-attachments/assets/ffe08fd3-df7c-4610-b7df-6c9b2d05d3fa" />|<img width="1909" height="796" alt="image" src="https://github.com/user-attachments/assets/bcb5f43a-9f1f-4093-9c38-f6b8f185e005" />|
