### PR TITLE
Update validation story to cover number field type

### DIFF
--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -523,6 +523,7 @@ const ValidationComponent = ( {
 		url: string;
 		color: string;
 		integer: number;
+		number: number;
 		boolean: boolean;
 		customEdit: string;
 		categories: string[];
@@ -542,6 +543,7 @@ const ValidationComponent = ( {
 		url: 'https://example.com',
 		color: '#ff6600',
 		integer: 2,
+		number: 3.14,
 		boolean: true,
 		categories: [ 'astronomy' ],
 		countries: [ 'us' ],
@@ -612,6 +614,13 @@ const ValidationComponent = ( {
 	const customIntegerRule = ( value: ValidatedItem ) => {
 		if ( value.integer % 2 !== 0 ) {
 			return 'Integer must be an even number.';
+		}
+
+		return null;
+	};
+	const customNumberRule = ( value: ValidatedItem ) => {
+		if ( ! /^\d+\.\d{2}$/.test( value?.number?.toString() ) ) {
+			return 'Number must have exactly two decimal places.';
 		}
 
 		return null;
@@ -751,6 +760,15 @@ const ValidationComponent = ( {
 			},
 		},
 		{
+			id: 'number',
+			type: 'number',
+			label: 'Number',
+			isValid: {
+				required,
+				custom: maybeCustomRule( customNumberRule ),
+			},
+		},
+		{
 			id: 'boolean',
 			type: 'boolean',
 			label: 'Boolean',
@@ -850,6 +868,7 @@ const ValidationComponent = ( {
 			'url',
 			'color',
 			'integer',
+			'number',
 			'boolean',
 			'categories',
 			'countries',


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/71797

## What?

Updates validation story to cover `number` field type as well.

## Why?

So the story reflects any kind of field type.

## How?

Add a new `number` data, field, and validation.

## Testing Instructions

- Run storybook locally (`npm install && npm run storybook:dev`).
- Go to the "DataViews > DataForm > Validation" story.
- Verify that the number field works as expected for required validation and for custom as well (see sidebar controls).