### PR TITLE
Use color panel for contentOnly pattern editing

### DIFF
--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -111,12 +111,13 @@ export function useHasBackgroundColorPanel( settings ) {
 	);
 }
 
-function ColorToolsPanel( {
+export function ColorToolsPanel( {
 	resetAllFilter,
 	onChange,
 	value,
 	panelId,
 	children,
+	label,
 } ) {
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const resetAll = () => {
@@ -124,18 +125,24 @@ function ColorToolsPanel( {
 		onChange( updatedValue );
 	};
 
+	const toolsPanelProps = {
+		resetAll,
+		panelId,
+		hasInnerWrapper: true,
+		headingLevel: 3,
+		className: 'color-block-support-panel',
+		__experimentalFirstVisibleItemClass: 'first',
+		__experimentalLastVisibleItemClass: 'last',
+		dropdownMenuProps,
+	};
+
+	// Only add label if it's not an empty string
+	if ( label !== '' ) {
+		toolsPanelProps.label = label || __( 'Elements' );
+	}
+
 	return (
-		<ToolsPanel
-			label={ __( 'Elements' ) }
-			resetAll={ resetAll }
-			panelId={ panelId }
-			hasInnerWrapper
-			headingLevel={ 3 }
-			className="color-block-support-panel"
-			__experimentalFirstVisibleItemClass="first"
-			__experimentalLastVisibleItemClass="last"
-			dropdownMenuProps={ dropdownMenuProps }
-		>
+		<ToolsPanel { ...toolsPanelProps }>
 			<div className="color-block-support-panel__inner-wrapper">
 				{ children }
 			</div>
@@ -326,6 +333,7 @@ export default function ColorPanel( {
 	settings,
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
+	label,
 	children,
 } ) {
 	const colors = useColorsPerOrigin( settings );
@@ -511,31 +519,34 @@ export default function ColorPanel( {
 		},
 	];
 
-	const resetAllFilter = useCallback( ( previousValue ) => {
-		return {
-			...previousValue,
-			color: undefined,
-			elements: {
-				...previousValue?.elements,
-				link: {
-					...previousValue?.elements?.link,
-					color: undefined,
-					':hover': {
+	const resetAllFilter = useCallback(
+		( previousValue ) => {
+			return {
+				...previousValue,
+				color: undefined,
+				elements: {
+					...previousValue?.elements,
+					link: {
+						...previousValue?.elements?.link,
 						color: undefined,
-					},
-				},
-				...elements.reduce( ( acc, element ) => {
-					return {
-						...acc,
-						[ element.name ]: {
-							...previousValue?.elements?.[ element.name ],
+						':hover': {
 							color: undefined,
 						},
-					};
-				}, {} ),
-			},
-		};
-	}, [] );
+					},
+					...elements.reduce( ( acc, element ) => {
+						return {
+							...acc,
+							[ element.name ]: {
+								...previousValue?.elements?.[ element.name ],
+								color: undefined,
+							},
+						};
+					}, {} ),
+				},
+			};
+		},
+		[ elements ]
+	);
 
 	const items = [
 		showTextPanel && {
@@ -606,7 +617,7 @@ export default function ColorPanel( {
 		},
 	].filter( Boolean );
 
-	elements.forEach( ( { name, label, showPanel } ) => {
+	elements.forEach( ( { name, label: elementLabel, showPanel } ) => {
 		if ( ! showPanel ) {
 			return;
 		}
@@ -680,7 +691,7 @@ export default function ColorPanel( {
 
 		items.push( {
 			key: name,
-			label,
+			label: elementLabel,
 			hasValue: hasElement,
 			resetValue: resetElement,
 			isShownByDefault: defaultControls[ name ],
@@ -731,6 +742,7 @@ export default function ColorPanel( {
 			value={ value }
 			onChange={ onChange }
 			panelId={ panelId }
+			label={ label }
 		>
 			{ items.map( ( item ) => {
 				const { key, ...restItem } = item;

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -125,24 +125,18 @@ export function ColorToolsPanel( {
 		onChange( updatedValue );
 	};
 
-	const toolsPanelProps = {
-		resetAll,
-		panelId,
-		hasInnerWrapper: true,
-		headingLevel: 3,
-		className: 'color-block-support-panel',
-		__experimentalFirstVisibleItemClass: 'first',
-		__experimentalLastVisibleItemClass: 'last',
-		dropdownMenuProps,
-	};
-
-	// Only add label if it's not an empty string
-	if ( label !== '' ) {
-		toolsPanelProps.label = label || __( 'Elements' );
-	}
-
 	return (
-		<ToolsPanel { ...toolsPanelProps }>
+		<ToolsPanel
+			label={ label || __( 'Elements' ) }
+			resetAll={ resetAll }
+			panelId={ panelId }
+			hasInnerWrapper
+			headingLevel={ 3 }
+			className="color-block-support-panel"
+			__experimentalFirstVisibleItemClass="first"
+			__experimentalLastVisibleItemClass="last"
+			dropdownMenuProps={ dropdownMenuProps }
+		>
 			<div className="color-block-support-panel__inner-wrapper">
 				{ children }
 			</div>

--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -105,6 +105,7 @@ export default function InspectorControlsTabs( {
 						clientId={ clientId }
 						hasBlockStyles={ hasBlockStyles }
 						isSectionBlock={ isSectionBlock }
+						contentClientIds={ contentClientIds }
 					/>
 				</Tabs.TabPanel>
 				<Tabs.TabPanel tabId={ TAB_CONTENT.name } focusable={ false }>

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -4,7 +4,6 @@
 import { PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,99 +19,34 @@ import { ColorToolsPanel } from '../global-styles/color-panel';
 function SectionBlockControls( { blockName, clientId, contentClientIds } ) {
 	const settings = useBlockSettings( blockName );
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
-	const [ defaultControls, setDefaultControls ] = useState( {
-		text: true,
-		background: true,
-		button: true,
-		heading: true,
-		caption: true,
-		link: true,
-	} );
 
-	const contentBlocks = useSelect(
+	const { hasButton, hasHeading } = useSelect(
 		( select ) => {
-			const { getBlock } = select( blockEditorStore );
+			const { getBlockName } = select( blockEditorStore );
+			let foundButton = false;
+			let foundHeading = false;
 
-			// Get only the content-exposed blocks
-			return contentClientIds
-				? contentClientIds
-						.map( ( id ) => getBlock( id ) )
-						.filter( Boolean )
-				: [];
-		},
-		[ contentClientIds ]
-	);
+			for ( const contentClientId of contentClientIds ) {
+				const name = getBlockName( contentClientId );
+				if ( name === 'core/heading' ) {
+					foundHeading = true;
+				}
+				if ( name === 'core/button' ) {
+					foundButton = true;
+				}
 
-	useEffect( () => {
-		let hasButton = false;
-		let hasHeading = false;
-		let hasCaption = false;
-		let hasLink = false;
-
-		for ( const block of contentBlocks ) {
-			// Check for button blocks
-			if ( block.name === 'core/button' ) {
-				hasButton = true;
-			}
-			// Check for heading blocks
-			if ( block.name === 'core/heading' ) {
-				hasHeading = true;
-			}
-
-			// Check for actual caption content
-			if (
-				block.name === 'core/image' ||
-				block.name === 'core/video' ||
-				block.name === 'core/audio' ||
-				block.name === 'core/gallery'
-			) {
-				const caption = block.attributes?.caption;
-				// Caption can be a string, array, or rich-text object
-				const hasCaptionContent =
-					caption &&
-					( ( typeof caption === 'string' &&
-						caption.trim() !== '' ) ||
-						( Array.isArray( caption ) && caption.length > 0 ) ||
-						( typeof caption === 'object' &&
-							caption.text &&
-							caption.text.trim() !== '' ) );
-				if ( hasCaptionContent ) {
-					hasCaption = true;
+				if ( foundHeading && foundButton ) {
+					break;
 				}
 			}
 
-			// Check for actual link content
-			let blockHasLink = false;
-
-			if ( block.name === 'core/paragraph' ) {
-				// Check if paragraph content contains anchor tags
-				blockHasLink =
-					block.attributes?.content &&
-					block.attributes.content.includes( '<a ' );
-			} else if ( block.name === 'core/heading' ) {
-				// Check if heading content contains anchor tags
-				blockHasLink =
-					block.attributes?.content &&
-					block.attributes.content.includes( '<a ' );
-			} else if ( block.name === 'core/button' ) {
-				// Buttons always have links
-				blockHasLink = !! block.attributes?.url;
-			}
-
-			if ( blockHasLink ) {
-				hasLink = true;
-			}
-		}
-
-		setDefaultControls( {
-			text: true,
-			background: true,
-			button: hasButton,
-			heading: hasHeading,
-			caption: hasCaption,
-			link: hasLink,
-		} );
-	}, [ contentBlocks ] );
+			return {
+				hasButton: foundButton,
+				hasHeading: foundHeading,
+			};
+		},
+		[ contentClientIds ]
+	);
 
 	const setAttributes = ( newAttributes ) => {
 		updateBlockAttributes( clientId, newAttributes );
@@ -126,7 +60,12 @@ function SectionBlockControls( { blockName, clientId, contentClientIds } ) {
 			setAttributes={ setAttributes }
 			asWrapper={ ColorToolsPanel }
 			label={ __( 'Color' ) }
-			defaultControls={ defaultControls }
+			defaultControls={ {
+				text: true,
+				background: true,
+				button: hasButton,
+				heading: hasHeading,
+			} }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -24,14 +24,28 @@ function SectionBlockControls( { blockName, clientId } ) {
 		updateBlockAttributes( clientId, newAttributes );
 	};
 
+	// This is needed to force the captions setting to show
+	// but there's probably a right way to do it.
+	const newSettings = { ...settings };
+	newSettings.color.caption = true;
+
 	return (
 		<ColorEdit
 			clientId={ clientId }
 			name={ blockName }
-			settings={ settings }
+			settings={ newSettings }
 			setAttributes={ setAttributes }
 			asWrapper={ ColorToolsPanel }
 			label={ __( 'Color' ) }
+			defaultControls={ {
+				// TODO - this is duplicated in packages/block-editor/src/components/global-styles/color-panel.js
+				text: true,
+				background: true,
+				link: true,
+				heading: true,
+				button: true,
+				caption: true,
+			} }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -3,7 +3,8 @@
  */
 import { PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -16,36 +17,116 @@ import { store as blockEditorStore } from '../../store';
 import { ColorEdit } from '../../hooks/color';
 import { ColorToolsPanel } from '../global-styles/color-panel';
 
-function SectionBlockControls( { blockName, clientId } ) {
+function SectionBlockControls( { blockName, clientId, contentClientIds } ) {
 	const settings = useBlockSettings( blockName );
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const [ defaultControls, setDefaultControls ] = useState( {
+		text: true,
+		background: true,
+		button: true,
+		heading: true,
+		caption: true,
+		link: true,
+	} );
+
+	const contentBlocks = useSelect(
+		( select ) => {
+			const { getBlock } = select( blockEditorStore );
+
+			// Get only the content-exposed blocks
+			return contentClientIds
+				? contentClientIds
+						.map( ( id ) => getBlock( id ) )
+						.filter( Boolean )
+				: [];
+		},
+		[ contentClientIds ]
+	);
+
+	useEffect( () => {
+		let hasButton = false;
+		let hasHeading = false;
+		let hasCaption = false;
+		let hasLink = false;
+
+		for ( const block of contentBlocks ) {
+			// Check for button blocks
+			if ( block.name === 'core/button' ) {
+				hasButton = true;
+			}
+			// Check for heading blocks
+			if ( block.name === 'core/heading' ) {
+				hasHeading = true;
+			}
+
+			// Check for actual caption content
+			if (
+				block.name === 'core/image' ||
+				block.name === 'core/video' ||
+				block.name === 'core/audio' ||
+				block.name === 'core/gallery'
+			) {
+				const caption = block.attributes?.caption;
+				// Caption can be a string, array, or rich-text object
+				const hasCaptionContent =
+					caption &&
+					( ( typeof caption === 'string' &&
+						caption.trim() !== '' ) ||
+						( Array.isArray( caption ) && caption.length > 0 ) ||
+						( typeof caption === 'object' &&
+							caption.text &&
+							caption.text.trim() !== '' ) );
+				if ( hasCaptionContent ) {
+					hasCaption = true;
+				}
+			}
+
+			// Check for actual link content
+			let blockHasLink = false;
+
+			if ( block.name === 'core/paragraph' ) {
+				// Check if paragraph content contains anchor tags
+				blockHasLink =
+					block.attributes?.content &&
+					block.attributes.content.includes( '<a ' );
+			} else if ( block.name === 'core/heading' ) {
+				// Check if heading content contains anchor tags
+				blockHasLink =
+					block.attributes?.content &&
+					block.attributes.content.includes( '<a ' );
+			} else if ( block.name === 'core/button' ) {
+				// Buttons always have links
+				blockHasLink = !! block.attributes?.url;
+			}
+
+			if ( blockHasLink ) {
+				hasLink = true;
+			}
+		}
+
+		setDefaultControls( {
+			text: true,
+			background: true,
+			button: hasButton,
+			heading: hasHeading,
+			caption: hasCaption,
+			link: hasLink,
+		} );
+	}, [ contentBlocks ] );
 
 	const setAttributes = ( newAttributes ) => {
 		updateBlockAttributes( clientId, newAttributes );
 	};
 
-	// This is needed to force the captions setting to show
-	// but there's probably a right way to do it.
-	const newSettings = { ...settings };
-	newSettings.color.caption = true;
-
 	return (
 		<ColorEdit
 			clientId={ clientId }
 			name={ blockName }
-			settings={ newSettings }
+			settings={ settings }
 			setAttributes={ setAttributes }
 			asWrapper={ ColorToolsPanel }
 			label={ __( 'Color' ) }
-			defaultControls={ {
-				// TODO - this is duplicated in packages/block-editor/src/components/global-styles/color-panel.js
-				text: true,
-				background: true,
-				link: true,
-				heading: true,
-				button: true,
-				caption: true,
-			} }
+			defaultControls={ defaultControls }
 		/>
 	);
 }
@@ -55,6 +136,7 @@ const StylesTab = ( {
 	clientId,
 	hasBlockStyles,
 	isSectionBlock,
+	contentClientIds,
 } ) => {
 	const borderPanelLabel = useBorderPanelLabel( { blockName } );
 
@@ -71,6 +153,7 @@ const StylesTab = ( {
 				<SectionBlockControls
 					blockName={ blockName }
 					clientId={ clientId }
+					contentClientIds={ contentClientIds }
 				/>
 			) }
 			{ ! isSectionBlock && (

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -16,7 +16,11 @@ import { store as blockEditorStore } from '../../store';
 import { ColorEdit } from '../../hooks/color';
 import { ColorToolsPanel } from '../global-styles/color-panel';
 
-function SectionBlockControls( { blockName, clientId, contentClientIds } ) {
+function SectionBlockColorControls( {
+	blockName,
+	clientId,
+	contentClientIds,
+} ) {
 	const settings = useBlockSettings( blockName );
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
@@ -74,13 +78,14 @@ const StylesTab = ( {
 					</PanelBody>
 				</div>
 			) }
-			{ isSectionBlock && (
-				<SectionBlockControls
-					blockName={ blockName }
-					clientId={ clientId }
-					contentClientIds={ contentClientIds }
-				/>
-			) }
+			{ isSectionBlock &&
+				window?.__experimentalContentOnlyPatternInsertion && (
+					<SectionBlockColorControls
+						blockName={ blockName }
+						clientId={ clientId }
+						contentClientIds={ contentClientIds }
+					/>
+				) }
 			{ ! isSectionBlock && (
 				<>
 					<InspectorControls.Slot

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -3,6 +3,7 @@
  */
 import { PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -10,6 +11,30 @@ import { __ } from '@wordpress/i18n';
 import BlockStyles from '../block-styles';
 import InspectorControls from '../inspector-controls';
 import { useBorderPanelLabel } from '../../hooks/border';
+import { useBlockSettings } from '../../hooks/utils';
+import { store as blockEditorStore } from '../../store';
+import { ColorEdit } from '../../hooks/color';
+import { ColorToolsPanel } from '../global-styles/color-panel';
+
+function SectionBlockControls( { blockName, clientId } ) {
+	const settings = useBlockSettings( blockName );
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	const setAttributes = ( newAttributes ) => {
+		updateBlockAttributes( clientId, newAttributes );
+	};
+
+	return (
+		<ColorEdit
+			clientId={ clientId }
+			name={ blockName }
+			settings={ settings }
+			setAttributes={ setAttributes }
+			asWrapper={ ColorToolsPanel }
+			label={ __( 'Color' ) }
+		/>
+	);
+}
 
 const StylesTab = ( {
 	blockName,
@@ -27,6 +52,12 @@ const StylesTab = ( {
 						<BlockStyles clientId={ clientId } />
 					</PanelBody>
 				</div>
+			) }
+			{ isSectionBlock && (
+				<SectionBlockControls
+					blockName={ blockName }
+					clientId={ clientId }
+				/>
 			) }
 			{ ! isSectionBlock && (
 				<>

--- a/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/styles-tab.js
@@ -22,27 +22,13 @@ function SectionBlockControls( { blockName, clientId, contentClientIds } ) {
 
 	const { hasButton, hasHeading } = useSelect(
 		( select ) => {
-			const { getBlockName } = select( blockEditorStore );
-			let foundButton = false;
-			let foundHeading = false;
-
-			for ( const contentClientId of contentClientIds ) {
-				const name = getBlockName( contentClientId );
-				if ( name === 'core/heading' ) {
-					foundHeading = true;
-				}
-				if ( name === 'core/button' ) {
-					foundButton = true;
-				}
-
-				if ( foundHeading && foundButton ) {
-					break;
-				}
-			}
-
+			const blockNames =
+				select( blockEditorStore ).getBlockNamesByClientId(
+					contentClientIds
+				);
 			return {
-				hasButton: foundButton,
-				hasHeading: foundHeading,
+				hasButton: blockNames.includes( 'core/button' ),
+				hasHeading: blockNames.includes( 'core/heading' ),
 			};
 		},
 		[ contentClientIds ]

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -99,7 +99,11 @@ export default function useInspectorControlsTabs(
 		tabs.push( TAB_SETTINGS );
 	}
 
-	if ( hasBlockStyles || hasStyleFills ) {
+	if (
+		hasBlockStyles ||
+		hasStyleFills ||
+		window?.__experimentalContentOnlyPatternInsertion
+	) {
 		tabs.push( TAB_STYLES );
 	}
 

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -99,7 +99,7 @@ export default function useInspectorControlsTabs(
 		tabs.push( TAB_SETTINGS );
 	}
 
-	if ( isSectionBlock ? hasBlockStyles : hasStyleFills ) {
+	if ( hasBlockStyles || hasStyleFills ) {
 		tabs.push( TAB_STYLES );
 	}
 

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -267,6 +267,7 @@ export function ColorEdit( {
 	settings,
 	asWrapper,
 	label,
+	defaultControls,
 } ) {
 	const isEnabled = useHasColorPanel( settings );
 
@@ -296,10 +297,12 @@ export function ColorEdit( {
 		return null;
 	}
 
-	const defaultControls = getBlockSupport( name, [
-		COLOR_SUPPORT_KEY,
-		'__experimentalDefaultControls',
-	] );
+	defaultControls = defaultControls
+		? defaultControls
+		: getBlockSupport( name, [
+				COLOR_SUPPORT_KEY,
+				'__experimentalDefaultControls',
+		  ] );
 
 	const enableContrastChecking =
 		Platform.OS === 'web' &&

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -260,8 +260,16 @@ function ColorInspectorControl( { children, resetAllFilter } ) {
 	);
 }
 
-export function ColorEdit( { clientId, name, setAttributes, settings } ) {
+export function ColorEdit( {
+	clientId,
+	name,
+	setAttributes,
+	settings,
+	asWrapper,
+	label,
+} ) {
 	const isEnabled = useHasColorPanel( settings );
+
 	function selector( select ) {
 		const { style, textColor, backgroundColor, gradient } =
 			select( blockEditorStore ).getBlockAttributes( clientId ) || {};
@@ -306,14 +314,18 @@ export function ColorEdit( { clientId, name, setAttributes, settings } ) {
 				'enableContrastChecker',
 			] );
 
+	// Use provided wrapper or default to ColorInspectorControl
+	const Wrapper = asWrapper || ColorInspectorControl;
+
 	return (
 		<StylesColorPanel
-			as={ ColorInspectorControl }
+			as={ Wrapper }
 			panelId={ clientId }
 			settings={ settings }
 			value={ value }
 			onChange={ onChange }
 			defaultControls={ defaultControls }
+			label={ label }
 			enableContrastChecker={
 				false !==
 				getBlockSupport( name, [

--- a/test/integration/fixtures/blocks/core__comments__deprecated-1.json
+++ b/test/integration/fixtures/blocks/core__comments__deprecated-1.json
@@ -4,8 +4,8 @@
 		"isValid": true,
 		"attributes": {
 			"tagName": "div",
-			"className": "wp-block-comments-query-loop comments-post-extra",
-			"textColor": "luminous-vivid-orange"
+			"textColor": "luminous-vivid-orange",
+			"className": "wp-block-comments-query-loop comments-post-extra"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__comments__deprecated-1.serialized.html
+++ b/test/integration/fixtures/blocks/core__comments__deprecated-1.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:comments {"className":"wp-block-comments-query-loop comments-post-extra","textColor":"luminous-vivid-orange"} -->
+<!-- wp:comments {"textColor":"luminous-vivid-orange","className":"wp-block-comments-query-loop comments-post-extra"} -->
 <div class="wp-block-comments wp-block-comments-query-loop comments-post-extra has-luminous-vivid-orange-color has-text-color"><!-- wp:comments-title /-->
 
 <!-- wp:comment-template -->

--- a/test/integration/fixtures/blocks/core__group-layout-content-size.json
+++ b/test/integration/fixtures/blocks/core__group-layout-content-size.json
@@ -4,8 +4,8 @@
 		"isValid": true,
 		"attributes": {
 			"tagName": "div",
-			"align": "full",
 			"backgroundColor": "secondary",
+			"align": "full",
 			"layout": {
 				"type": "constrained"
 			}

--- a/test/integration/fixtures/blocks/core__group-layout-content-size.serialized.html
+++ b/test/integration/fixtures/blocks/core__group-layout-content-size.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"align":"full","backgroundColor":"secondary","layout":{"type":"constrained"}} -->
+<!-- wp:group {"backgroundColor":"secondary","align":"full","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-secondary-background-color has-background"><!-- wp:paragraph -->
 <p>This is a group block.</p>
 <!-- /wp:paragraph -->

--- a/test/integration/fixtures/blocks/core__group-layout-content-size__deprecated.json
+++ b/test/integration/fixtures/blocks/core__group-layout-content-size__deprecated.json
@@ -4,8 +4,8 @@
 		"isValid": true,
 		"attributes": {
 			"tagName": "div",
-			"align": "full",
 			"backgroundColor": "secondary",
+			"align": "full",
 			"layout": {
 				"inherit": true,
 				"type": "constrained"

--- a/test/integration/fixtures/blocks/core__group-layout-content-size__deprecated.serialized.html
+++ b/test/integration/fixtures/blocks/core__group-layout-content-size__deprecated.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"align":"full","backgroundColor":"secondary","layout":{"inherit":true,"type":"constrained"}} -->
+<!-- wp:group {"backgroundColor":"secondary","align":"full","layout":{"inherit":true,"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-secondary-background-color has-background"><!-- wp:paragraph -->
 <p>This is a group block.</p>
 <!-- /wp:paragraph -->

--- a/test/integration/fixtures/blocks/core__group.json
+++ b/test/integration/fixtures/blocks/core__group.json
@@ -4,8 +4,8 @@
 		"isValid": true,
 		"attributes": {
 			"tagName": "div",
-			"align": "full",
 			"backgroundColor": "secondary",
+			"align": "full",
 			"layout": {
 				"type": "default"
 			}

--- a/test/integration/fixtures/blocks/core__group.serialized.html
+++ b/test/integration/fixtures/blocks/core__group.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"align":"full","backgroundColor":"secondary","layout":{"type":"default"}} -->
+<!-- wp:group {"backgroundColor":"secondary","align":"full","layout":{"type":"default"}} -->
 <div class="wp-block-group alignfull has-secondary-background-color has-background"><!-- wp:paragraph -->
 <p>This is a group block.</p>
 <!-- /wp:paragraph -->

--- a/test/integration/fixtures/blocks/core__group__deprecated-3.json
+++ b/test/integration/fixtures/blocks/core__group__deprecated-3.json
@@ -4,8 +4,8 @@
 		"isValid": true,
 		"attributes": {
 			"tagName": "div",
-			"align": "full",
-			"backgroundColor": "secondary"
+			"backgroundColor": "secondary",
+			"align": "full"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__group__deprecated-3.serialized.html
+++ b/test/integration/fixtures/blocks/core__group__deprecated-3.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"align":"full","backgroundColor":"secondary"} -->
+<!-- wp:group {"backgroundColor":"secondary","align":"full"} -->
 <div class="wp-block-group alignfull has-secondary-background-color has-background"><!-- wp:paragraph -->
 <p>This is a group block.</p>
 <!-- /wp:paragraph -->

--- a/test/integration/fixtures/blocks/core__group__deprecated-inner-container.json
+++ b/test/integration/fixtures/blocks/core__group__deprecated-inner-container.json
@@ -4,8 +4,8 @@
 		"isValid": true,
 		"attributes": {
 			"tagName": "div",
-			"align": "full",
-			"backgroundColor": "secondary"
+			"backgroundColor": "secondary",
+			"align": "full"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__group__deprecated-inner-container.serialized.html
+++ b/test/integration/fixtures/blocks/core__group__deprecated-inner-container.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"align":"full","backgroundColor":"secondary"} -->
+<!-- wp:group {"backgroundColor":"secondary","align":"full"} -->
 <div class="wp-block-group alignfull has-secondary-background-color has-background"><!-- wp:paragraph -->
 <p>This is a group block.</p>
 <!-- /wp:paragraph -->

--- a/test/integration/fixtures/blocks/core__group__deprecated.json
+++ b/test/integration/fixtures/blocks/core__group__deprecated.json
@@ -4,9 +4,9 @@
 		"isValid": true,
 		"attributes": {
 			"tagName": "div",
+			"backgroundColor": "lighter-blue",
 			"align": "full",
-			"anchor": "test-id",
-			"backgroundColor": "lighter-blue"
+			"anchor": "test-id"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__group__deprecated.serialized.html
+++ b/test/integration/fixtures/blocks/core__group__deprecated.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"align":"full","backgroundColor":"lighter-blue"} -->
+<!-- wp:group {"backgroundColor":"lighter-blue","align":"full"} -->
 <div class="wp-block-group alignfull has-lighter-blue-background-color has-background" id="test-id"><!-- wp:paragraph -->
 <p>test</p>
 <!-- /wp:paragraph --></div>

--- a/test/integration/fixtures/blocks/core__pullquote__custom-colors__deprecated-4.serialized.html
+++ b/test/integration/fixtures/blocks/core__pullquote__custom-colors__deprecated-4.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:pullquote {"className":"has-background is-style-default","textColor":"subtle-background","style":{"border":{"color":"#2207d0"}}} -->
+<!-- wp:pullquote {"textColor":"subtle-background","className":"has-background is-style-default","style":{"border":{"color":"#2207d0"}}} -->
 <figure class="wp-block-pullquote has-background is-style-default has-border-color has-subtle-background-color has-text-color" style="border-color:#2207d0"><blockquote><p>Pullquote custom color</p><cite>my citation</cite></blockquote></figure>
 <!-- /wp:pullquote -->

--- a/test/integration/fixtures/blocks/core__pullquote__deprecated-4.serialized.html
+++ b/test/integration/fixtures/blocks/core__pullquote__deprecated-4.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:pullquote {"textAlign":"left","className":"is-style-solid-color","backgroundColor":"black","textColor":"white"} -->
+<!-- wp:pullquote {"textAlign":"left","backgroundColor":"black","textColor":"white","className":"is-style-solid-color"} -->
 <figure class="wp-block-pullquote has-text-align-left is-style-solid-color has-white-color has-black-background-color has-text-color has-background"><blockquote><p>pullquote</p><cite>before block supports</cite></blockquote></figure>
 <!-- /wp:pullquote -->

--- a/test/integration/fixtures/blocks/core__pullquote__deprecated-main-color.serialized.html
+++ b/test/integration/fixtures/blocks/core__pullquote__deprecated-main-color.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:pullquote {"className":"is-style-default","textColor":"subtle-background","style":{"border":{"color":"#2207d0"}}} -->
+<!-- wp:pullquote {"textColor":"subtle-background","className":"is-style-default","style":{"border":{"color":"#2207d0"}}} -->
 <figure class="wp-block-pullquote is-style-default has-border-color has-subtle-background-color has-text-color" style="border-color:#2207d0"><blockquote><p>Pullquote custom color</p><cite>my citation</cite></blockquote></figure>
 <!-- /wp:pullquote -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/72018
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Try adding a color selection option of the top level item in the pattern selector. 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Seeing if we can reduce the need to exit content only pattern editing by exposing the top level group colors.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Export the ColorToolsPanel so we can use it on a parent group block even though an inner block is selected. I tried to do the minimum untangling to get it to do this.

It uses the group clientId, then checks the blocks within it to see if there are heading or button blocks. If there are, it also offers those color selectors.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->



https://github.com/user-attachments/assets/a1aa3846-5a54-4245-a4ff-c9afc76fe259




|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
