### PR TITLE
contentOnly unsynced patterns experiment: Ensure a tab is selected when clicking Edit contents

### DIFF
--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -57,10 +57,10 @@ export default function InspectorControlsTabs( {
 				( tab ) => tab.name === selectedTabId
 			);
 			if ( ! activeTab ) {
-				setSelectedTabId( tabs[ 0 ].name );
+				setSelectedTabId( initialTabName ?? tabs[ 0 ].name );
 			}
 		}
-	}, [ tabs, selectedTabId ] );
+	}, [ tabs, selectedTabId, initialTabName ] );
 
 	return (
 		<div className="block-editor-block-inspector__tabs">

--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -52,12 +52,20 @@ export default function InspectorControlsTabs( {
 	// the list of tabs was changed dynamically with the active one being
 	// removed. Set the active tab back to the first tab.
 	useEffect( () => {
+		// Skip this behavior if `initialTabName` is supplied. In the navigation
+		// block, the list view tab isn't present in `tabs` initially. The early
+		// return here prevents the dynamic behavior that follows from overriding
+		// `initialTabName`.
+		if ( initialTabName ) {
+			return;
+		}
+
 		if ( tabs?.length && selectedTabId ) {
 			const activeTab = tabs.find(
 				( tab ) => tab.name === selectedTabId
 			);
 			if ( ! activeTab ) {
-				setSelectedTabId( initialTabName ?? tabs[ 0 ].name );
+				setSelectedTabId( tabs[ 0 ].name );
 			}
 		}
 	}, [ tabs, selectedTabId, initialTabName ] );

--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -31,7 +31,6 @@ export default function InspectorControlsTabs( {
 	isSectionBlock,
 	contentClientIds,
 } ) {
-	const [ selectedTabId, setSelectedTabId ] = useState( tabs[ 0 ]?.name );
 	const showIconLabels = useSelect( ( select ) => {
 		return select( preferencesStore ).get( 'core', 'showIconLabels' );
 	}, [] );
@@ -44,6 +43,10 @@ export default function InspectorControlsTabs( {
 	const initialTabName = ! useIsListViewTabDisabled( blockName )
 		? TAB_LIST_VIEW.name
 		: undefined;
+
+	const [ selectedTabId, setSelectedTabId ] = useState(
+		initialTabName ?? tabs[ 0 ]?.name
+	);
 
 	// When the active tab is not amongst the available `tabs`, it indicates
 	// the list of tabs was changed dynamically with the active one being

--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -6,6 +6,7 @@ import {
 	Tooltip,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { useSelect } from '@wordpress/data';
 
@@ -30,6 +31,7 @@ export default function InspectorControlsTabs( {
 	isSectionBlock,
 	contentClientIds,
 } ) {
+	const [ selectedTabId, setSelectedTabId ] = useState( tabs[ 0 ]?.name );
 	const showIconLabels = useSelect( ( select ) => {
 		return select( preferencesStore ).get( 'core', 'showIconLabels' );
 	}, [] );
@@ -43,9 +45,28 @@ export default function InspectorControlsTabs( {
 		? TAB_LIST_VIEW.name
 		: undefined;
 
+	// When the active tab is not amongst the available `tabs`, it indicates
+	// the list of tabs was changed dynamically with the active one being
+	// removed. Set the active tab back to the first tab.
+	useEffect( () => {
+		if ( tabs?.length && selectedTabId ) {
+			const activeTab = tabs.find(
+				( tab ) => tab.name === selectedTabId
+			);
+			if ( ! activeTab ) {
+				setSelectedTabId( tabs[ 0 ].name );
+			}
+		}
+	}, [ tabs, selectedTabId ] );
+
 	return (
 		<div className="block-editor-block-inspector__tabs">
-			<Tabs defaultTabId={ initialTabName } key={ clientId }>
+			<Tabs
+				defaultTabId={ initialTabName }
+				selectedTabId={ selectedTabId }
+				onSelect={ setSelectedTabId }
+				key={ clientId }
+			>
 				<Tabs.TabList>
 					{ tabs.map( ( tab ) =>
 						showIconLabels ? (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #71951

In trunk, when clicking the Edit contents button on an unsynced pattern, the Block Inspector becomes empty.

## Why?
The issue is that after clicking the 'Edit contents' button, neither of the tabs (Settings or Styles) is selected. From the 'before' screenshot you can see neither tab has the underline indicating selection.

The `Tabs` component still considers the 'Content' tab as the selected one, even though clicking 'Edit contents' removes it.

## How?
Use the `Tabs` component as a controlled component. When the list of `tabs` changes, an effect checks that the selected tab is still present. If it's no longer present, the code falls back to the first tab being the selected tab.

## Testing Instructions
1. Turn on the Gutenberg > Experiment: contentOnly: make patterns contentOnly by default upon insertion
2. Go to the site editor
3. Open the sidebar inspector
4. Select a pattern that defaults to contentOnly (or insert a new pattern, most should work)
5. Click the Edit contents button

In trunk: Sidebar contents disappear
In this PR: The Settings tab content is shown


## Screenshots or screencast <!-- if applicable -->
|Before|After|
|-|-|
| <img width="276" height="610" alt="Screenshot 2025-10-01 at 11 52 06 am" src="https://github.com/user-attachments/assets/eb9bce89-d4f2-4df8-b629-e1026aa90403" /> | <img width="280" height="779" alt="Screenshot 2025-10-01 at 11 51 37 am" src="https://github.com/user-attachments/assets/f0534cff-7bc0-4667-8ca9-7c708291b77f" /> |

