### PR TITLE
New block: Playlist

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -588,6 +588,15 @@ Show a block pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trun
 -	**Supports:** interactivity (clientNavigation), ~~html~~, ~~inserter~~, ~~renaming~~
 -	**Attributes:** slug
 
+## Playlist
+
+Display an audio playlist. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/playlist))
+
+-	**Name:** core/playlist
+-	**Category:** media
+-	**Supports:** align, anchor, interactivity (clientNavigation), spacing (margin, padding)
+-	**Attributes:** autoplay, items, loop, showItemList
+
 ## Author
 
 Display post author details such as name, avatar, and bio. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-author))

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -88,6 +88,7 @@ function gutenberg_reregister_core_block_types() {
 				'page-list.php'                    => 'core/page-list',
 				'page-list-item.php'               => 'core/page-list-item',
 				'pattern.php'                      => 'core/pattern',
+				'playlist.php'                     => 'core/playlist',
 				'post-author.php'                  => 'core/post-author',
 				'post-author-name.php'             => 'core/post-author-name',
 				'post-author-biography.php'        => 'core/post-author-biography',

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -32,6 +32,7 @@
 		"./form/view": "./build-module/form/view.js",
 		"./image/view": "./build-module/image/view.js",
 		"./navigation/view": "./build-module/navigation/view.js",
+		"./playlist/view": "./build-module/playlist/view.js",
 		"./query/view": "./build-module/query/view.js",
 		"./search/view": "./build-module/search/view.js"
 	},

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -31,6 +31,7 @@
 @import "./nextpage/editor.scss";
 @import "./page-list/editor.scss";
 @import "./paragraph/editor.scss";
+@import "./playlist/editor.scss";
 @import "./post-excerpt/editor.scss";
 @import "./pullquote/editor.scss";
 @import "./rss/editor.scss";

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -108,6 +108,7 @@ import * as queryPaginationPrevious from './query-pagination-previous';
 import * as queryTitle from './query-title';
 import * as queryTotal from './query-total';
 import * as quote from './quote';
+import * as playlist from './playlist';
 import * as reusableBlock from './block';
 import * as readMore from './read-more';
 import * as rss from './rss';
@@ -152,6 +153,7 @@ const getAllBlocks = () => {
 		// Register all remaining core blocks.
 		archives,
 		audio,
+		playlist,
 		button,
 		buttons,
 		calendar,

--- a/packages/block-library/src/playlist/block.json
+++ b/packages/block-library/src/playlist/block.json
@@ -1,0 +1,61 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "core/playlist",
+	"title": "Playlist",
+	"category": "media",
+	"description": "Display an audio playlist.",
+	"keywords": [ "audio", "music", "sound", "tracks" ],
+	"textdomain": "default",
+	"attributes": {
+		"items": {
+			"type": "array",
+			"default": [],
+			"items": {
+				"type": "number"
+			}
+		},
+		"autoplay": {
+			"type": "boolean",
+			"default": false
+		},
+		"loop": {
+			"type": "boolean",
+			"default": false
+		},
+		"showItemList": {
+			"type": "boolean",
+			"default": true
+		}
+	},
+	"supports": {
+		"anchor": true,
+		"align": true,
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": false,
+				"style": true,
+				"width": true
+			}
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": true
+			}
+		},
+		"interactivity": {
+			"clientNavigation": true
+		}
+	},
+	"editorStyle": "wp-block-playlist-editor",
+	"style": "wp-block-playlist",
+	"viewScriptModule": "@wordpress/block-library/playlist/view"
+}

--- a/packages/block-library/src/playlist/edit.js
+++ b/packages/block-library/src/playlist/edit.js
@@ -1,0 +1,417 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	ToggleControl,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+	__experimentalHStack as HStack,
+	Spinner,
+	Button,
+} from '@wordpress/components';
+import {
+	BlockIcon,
+	InspectorControls,
+	MediaPlaceholder,
+	MediaReplaceFlow,
+	useBlockProps,
+	BlockControls,
+} from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
+import { __, sprintf } from '@wordpress/i18n';
+import { useDispatch, useSelect } from '@wordpress/data';
+import {
+	audio,
+	chevronUp,
+	chevronDown,
+	tableRowDelete,
+} from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
+import { useMemo, useState } from '@wordpress/element';
+import { isBlobURL } from '@wordpress/blob';
+
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+
+const ALLOWED_MEDIA_TYPES = [ 'audio' ];
+
+function PlaylistEdit( {
+	attributes: { items, autoplay, loop, showItemList },
+	setAttributes,
+} ) {
+	const [ currentItem, setCurrentItem ] = useState( 0 );
+	const { createErrorNotice } = useDispatch( noticesStore );
+	const itemsData = useSelect(
+		( select ) => {
+			if ( ! items?.length ) {
+				return;
+			}
+			// We always create a set with the ids and sort them to avoid
+			// unnecessary requests when items change.
+			const uniqueItems = Array.from( new Set( items ) ).sort(
+				( a, b ) => a - b
+			);
+			// TODO: how can we avoid this request if we already have the data?
+			// when removing an item for example.
+			return select( coreStore ).getEntityRecords(
+				'postType',
+				'attachment',
+				{
+					include: uniqueItems.join( ',' ),
+					per_page: -1,
+					orderby: 'include',
+				}
+			);
+		},
+		[ items ]
+	);
+	// Build items array because a playlist can contain the same item multiple times.
+	// Additionally we preserve the order of items that might be different in case of
+	// duplicates.
+	const orderedItemData = useMemo( () => {
+		if ( ! items?.length || ! itemsData?.length ) {
+			return;
+		}
+		return items
+			.map( ( itemId ) => itemsData.find( ( { id } ) => id === itemId ) )
+			.filter( Boolean );
+	}, [ items, itemsData ] );
+	const currentItemData = orderedItemData?.[ currentItem ];
+	function onSelectAudio( media ) {
+		if ( ! media ) {
+			return;
+		}
+
+		const mediaArray = Array.isArray( media ) ? media : [ media ];
+
+		// Skip intermediate calls with blob URLs (upload in progress)
+		const hasBlobURLs = mediaArray.some(
+			( file ) => file.url && isBlobURL( file.url )
+		);
+		if ( hasBlobURLs ) {
+			return;
+		}
+
+		// Filter out invalid entries (missing url or id)
+		// MediaPlaceholder with allowedTypes already filters to audio files only.
+		const validMedia = mediaArray.filter( ( file ) => file.url && file.id );
+
+		if ( validMedia.length === 0 ) {
+			createErrorNotice( __( 'Please select valid audio files.' ), {
+				id: 'playlist-upload-invalid-file',
+				type: 'snackbar',
+			} );
+			return;
+		}
+
+		// Extract IDs from valid media
+		const newItemIds = validMedia.map( ( file ) => file.id );
+
+		setAttributes( {
+			items: [ ...( items || [] ), ...newItemIds ],
+		} );
+	}
+	function onUploadError( message ) {
+		createErrorNotice( message, { type: 'snackbar' } );
+	}
+	function removeItem( index ) {
+		const newItems = items.toSpliced( index, 1 );
+		setAttributes( {
+			items: newItems,
+		} );
+		if ( currentItem >= newItems.length ) {
+			setCurrentItem( Math.max( 0, newItems.length - 1 ) );
+		}
+	}
+	function moveItemUp( index ) {
+		const newItems = [ ...items ];
+		[ newItems[ index - 1 ], newItems[ index ] ] = [
+			newItems[ index ],
+			newItems[ index - 1 ],
+		];
+		// Update current item only if we moved it.
+		if ( currentItem === index ) {
+			setCurrentItem( index - 1 );
+		}
+		setAttributes( { items: newItems } );
+	}
+	function moveItemDown( index ) {
+		const newItems = [ ...items ];
+		[ newItems[ index ], newItems[ index + 1 ] ] = [
+			newItems[ index + 1 ],
+			newItems[ index ],
+		];
+		// Update current item only if we moved it.
+		if ( currentItem === index ) {
+			setCurrentItem( index + 1 );
+		}
+		setAttributes( { items: newItems } );
+	}
+	const blockProps = useBlockProps();
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+	if ( items?.length && ! orderedItemData ) {
+		return (
+			<div { ...blockProps }>
+				<div style={ { textAlign: 'center' } }>
+					<Spinner />
+				</div>
+			</div>
+		);
+	}
+	// TODO: check if it has items but there are no records in database..
+	if ( ! items?.length ) {
+		return (
+			<div { ...blockProps }>
+				<MediaPlaceholder
+					icon={ <BlockIcon icon={ audio } /> }
+					labels={ {
+						title: __( 'Playlist' ),
+						instructions: __(
+							'Drag and drop audio files, upload, or choose from your library.'
+						),
+					} }
+					onSelect={ onSelectAudio }
+					accept="audio/*"
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
+					multiple
+					onError={ onUploadError }
+				/>
+			</div>
+		);
+	}
+	return (
+		<>
+			<BlockControls group="other">
+				{ /* TODO: probably only allow single replace.. */ }
+				<MediaReplaceFlow
+					mediaId={ items }
+					mediaURL={ currentItemData?.source_url }
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
+					accept="audio/*"
+					name={ __( 'Add' ) }
+					onSelect={ onSelectAudio }
+					multiple
+					addToGallery
+				/>
+			</BlockControls>
+			<InspectorControls>
+				<ToolsPanel
+					label={ __( 'Settings' ) }
+					resetAll={ () => {
+						setAttributes( {
+							autoplay: false,
+							loop: false,
+							showItemList: true,
+						} );
+					} }
+					dropdownMenuProps={ dropdownMenuProps }
+				>
+					<ToolsPanelItem
+						hasValue={ () => autoplay !== false }
+						label={ __( 'Autoplay' ) }
+						onDeselect={ () =>
+							setAttributes( { autoplay: false } )
+						}
+						isShownByDefault
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Autoplay' ) }
+							checked={ autoplay }
+							onChange={ ( value ) =>
+								setAttributes( { autoplay: value } )
+							}
+							help={
+								autoplay
+									? __(
+											'Autoplay may cause usability issues for some users.'
+									  )
+									: null
+							}
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						hasValue={ () => loop !== false }
+						label={ __( 'Loop' ) }
+						onDeselect={ () => setAttributes( { loop: false } ) }
+						isShownByDefault
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Loop' ) }
+							checked={ loop }
+							onChange={ ( value ) =>
+								setAttributes( { loop: value } )
+							}
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						hasValue={ () => showItemList !== true }
+						label={ __( 'Show item list' ) }
+						onDeselect={ () =>
+							setAttributes( { showItemList: true } )
+						}
+						isShownByDefault
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Show item list' ) }
+							checked={ showItemList }
+							onChange={ ( value ) =>
+								setAttributes( { showItemList: value } )
+							}
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
+			</InspectorControls>
+			<div { ...blockProps }>
+				<figure className="wp-block-playlist__player">
+					{ currentItemData && (
+						<div className="wp-block-playlist__header">
+							{ currentItemData.media_details?.sizes?.thumbnail
+								?.source_url && (
+								<img
+									src={
+										currentItemData.media_details.sizes
+											.thumbnail.source_url
+									}
+									alt=""
+									className="wp-block-playlist__header-image"
+								/>
+							) }
+							<div className="wp-block-playlist__header-info">
+								<div className="wp-block-playlist__header-title">
+									{ currentItemData.title?.rendered ||
+										currentItemData.title ||
+										__( 'Untitled' ) }
+								</div>
+								{ currentItemData.media_details?.artist && (
+									<div className="wp-block-playlist__header-subtitle">
+										{ sprintf(
+											// translators: %s is the artist name.
+											__( 'by %s' ),
+											currentItemData.media_details.artist
+										) }
+									</div>
+								) }
+							</div>
+						</div>
+					) }
+					{ currentItemData?.source_url && (
+						<audio
+							controls
+							src={ currentItemData.source_url }
+							autoPlay={ autoplay }
+							loop={ loop }
+							className="wp-block-playlist__audio"
+						/>
+					) }
+				</figure>
+				{ showItemList && !! orderedItemData?.length && (
+					<ol className="wp-block-playlist__items">
+						{ orderedItemData.map( ( item, index ) => (
+							// TODO: check this below..
+							// eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions, jsx-a11y/no-noninteractive-element-interactions
+							<li
+								key={ `${ item.id }-${ index }` }
+								className={ clsx( 'wp-block-playlist__item', {
+									'is-active': index === currentItem,
+								} ) }
+								onClick={ () => {
+									if ( currentItem !== index ) {
+										setCurrentItem( index );
+									}
+								} }
+							>
+								<HStack justify="space-between" spacing={ 4 }>
+									<span className="wp-block-playlist__item-number">
+										{ index + 1 }.
+									</span>
+									<div className="wp-block-playlist__item-info">
+										<div className="wp-block-playlist__item-title">
+											{ item.title?.rendered ||
+												item.title ||
+												__( 'Untitled' ) }
+										</div>
+										{ item.media_details?.artist && (
+											<div className="wp-block-playlist__item-artist">
+												{ sprintf(
+													// translators: %s is the artist name.
+													__( 'by %s' ),
+													item.media_details.artist
+												) }
+											</div>
+										) }
+									</div>
+									<HStack
+										justify="flex-end"
+										spacing={ 0 }
+										className="wp-block-playlist__item-controls"
+										expanded={ false }
+									>
+										{ orderedItemData.length !== 1 && (
+											<>
+												<Button
+													icon={ chevronUp }
+													label={ sprintf(
+														/* translators: %d: item position */
+														__( 'Move item %d up' ),
+														index + 1
+													) }
+													onClick={ ( event ) => {
+														moveItemUp( index );
+														event.stopPropagation();
+													} }
+													disabled={ index === 0 }
+													accessibleWhenDisabled
+													size="small"
+												/>
+												<Button
+													icon={ chevronDown }
+													label={ sprintf(
+														/* translators: %d: item position */
+														__(
+															'Move item %d down'
+														),
+														index + 1
+													) }
+													onClick={ ( event ) => {
+														moveItemDown( index );
+														event.stopPropagation();
+													} }
+													accessibleWhenDisabled
+													disabled={
+														index ===
+														items.length - 1
+													}
+													size="small"
+												/>
+											</>
+										) }
+										<Button
+											onClick={ ( event ) => {
+												removeItem( index );
+												event.stopPropagation();
+											} }
+											icon={ tableRowDelete }
+											size="small"
+										/>
+									</HStack>
+								</HStack>
+							</li>
+						) ) }
+					</ol>
+				) }
+			</div>
+		</>
+	);
+}
+
+export default PlaylistEdit;

--- a/packages/block-library/src/playlist/editor.scss
+++ b/packages/block-library/src/playlist/editor.scss
@@ -1,0 +1,5 @@
+// TODO: better way to handle this..
+.wp-block-playlist__item-controls {
+	flex-shrink: 0;
+	margin-left: auto;
+}

--- a/packages/block-library/src/playlist/index.js
+++ b/packages/block-library/src/playlist/index.js
@@ -1,0 +1,27 @@
+/**
+ * WordPress dependencies
+ */
+import { audio as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import initBlock from '../utils/init-block';
+import edit from './edit';
+import metadata from './block.json';
+import save from './save';
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	icon,
+	example: {
+		attributes: {},
+	},
+	edit,
+	save,
+};
+
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/playlist/index.php
+++ b/packages/block-library/src/playlist/index.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * Server-side rendering of the `core/playlist` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/playlist` block on the server.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the playlist block markup.
+ */
+function render_block_core_playlist( $attributes, $content, $block ) {
+	$items        = isset( $attributes['items'] ) ? $attributes['items'] : array();
+	$current_item = 0;
+	$autoplay      = isset( $attributes['autoplay'] ) && $attributes['autoplay'];
+	$loop          = isset( $attributes['loop'] ) && $attributes['loop'];
+	$show_items   = isset( $attributes['showItemList'] ) ? $attributes['showItemList'] : true;
+
+	if ( empty( $items ) ) {
+		return '';
+	}
+
+	// Fetch all attachments in a single query.
+	$attachments = get_posts(
+		array(
+			'post_type'      => 'attachment',
+			'post__in'       => $items,
+			'posts_per_page' => -1,
+		)
+	);
+
+	// Index attachments by ID for quick lookup.
+	$attachments_by_id = array();
+	foreach ( $attachments as $attachment ) {
+		$attachments_by_id[ $attachment->ID ] = $attachment;
+	}
+
+	// Build items data maintaining the order from $items array.
+	$items_data = array();
+	foreach ( $items as $item_id ) {
+		if ( ! isset( $attachments_by_id[ $item_id ] ) ) {
+			continue;
+		}
+
+		$attachment = $attachments_by_id[ $item_id ];
+
+		$item_info = array(
+			'id'     => $item_id,
+			'url'    => wp_get_attachment_url( $item_id ),
+			'title'  => get_the_title( $item_id ),
+			'image'  => '',
+			'artist' => '',
+		);
+
+		// Get thumbnail if available.
+		// TODO: This should probably be a custom field on the attachment..
+		$thumbnail_id = get_post_thumbnail_id( $item_id );
+		if ( $thumbnail_id ) {
+			$thumbnail = wp_get_attachment_image_src( $thumbnail_id, 'thumbnail' );
+			if ( $thumbnail ) {
+				$item_info['image'] = $thumbnail[0];
+			}
+		}
+
+		// Get audio metadata (artist, etc).
+		$metadata = wp_get_attachment_metadata( $item_id );
+		if ( ! empty( $metadata['audio']['artist'] ) ) {
+			$item_info['artist'] = $metadata['audio']['artist'];
+		} elseif ( ! empty( $metadata['artist'] ) ) {
+			$item_info['artist'] = $metadata['artist'];
+		}
+
+		$items_data[] = $item_info;
+	}
+
+	if ( empty( $items_data ) ) {
+		return '';
+	}
+
+	// Current item is always the first item.
+	$current_item_data = $items_data[0];
+
+	// Build the context for Interactivity API.
+	$context = array(
+		'items'       => $items,
+		'itemsData'   => $items_data,
+		'currentItem' => $current_item,
+		'isPlaying'   => false,
+		'autoplay'    => $autoplay,
+		'loop'        => $loop,
+	);
+
+	// Build header image.
+	$header_image = '';
+	if ( ! empty( $current_item_data['image'] ) ) {
+		$img = new WP_HTML_Tag_Processor(
+			sprintf(
+				'<img src="%s" alt="" />',
+				esc_url( $current_item_data['image'] )
+			)
+		);
+		if ( $img->next_tag() ) {
+			$img->add_class( 'wp-block-playlist__header-image' );
+			$img->set_attribute( 'data-wp-bind--src', 'state.currentItemImage' );
+		}
+		$header_image = $img->get_updated_html();
+	}
+
+	// Build header artist.
+	$header_artist = '';
+	if ( ! empty( $current_item_data['artist'] ) ) {
+		$artist_text = sprintf(
+			/* translators: %s is the artist name. */
+			__( 'by %s' ),
+			esc_html( $current_item_data['artist'] )
+		);
+		$artist      = new WP_HTML_Tag_Processor( sprintf( '<div class="wp-block-playlist__header-subtitle">%s</div>', $artist_text ) );
+		if ( $artist->next_tag() ) {
+			$artist->set_attribute( 'data-wp-text', 'state.currentItemArtist' );
+		}
+		$header_artist = $artist->get_updated_html();
+	}
+
+	// Build header title.
+	$title = new WP_HTML_Tag_Processor( sprintf( '<div class="wp-block-playlist__header-title">%s</div>', esc_html( $current_item_data['title'] ) ) );
+	if ( $title->next_tag() ) {
+		$title->set_attribute( 'data-wp-text', 'state.currentItemTitle' );
+	}
+	$header_title = $title->get_updated_html();
+
+	// Build header.
+	$header = sprintf(
+		'<div class="wp-block-playlist__header">%s<div class="wp-block-playlist__header-info">%s%s</div></div>',
+		$header_image,
+		$header_title,
+		$header_artist
+	);
+
+	// Build audio element.
+	$audio = new WP_HTML_Tag_Processor(
+		sprintf(
+			'<audio src="%s" controls %s></audio>',
+			esc_url( $current_item_data['url'] ),
+			$autoplay ? 'autoplay' : ''
+		)
+	);
+	if ( $audio->next_tag() ) {
+		$audio->add_class( 'wp-block-playlist__audio' );
+		$audio->set_attribute( 'data-wp-bind--src', 'state.currentItemSrc' );
+		$audio->set_attribute( 'data-wp-on--ended', 'actions.onItemEnded' );
+		$audio->set_attribute( 'data-wp-on--play', 'actions.onPlay' );
+		$audio->set_attribute( 'data-wp-on--pause', 'actions.onPause' );
+	}
+
+	// Build player.
+	$player = sprintf(
+		'<figure class="wp-block-playlist__player">%s%s</figure>',
+		$header,
+		$audio->get_updated_html()
+	);
+
+	// Build items list.
+	$items_list = '';
+	if ( $show_items ) {
+		$list_items = '';
+		foreach ( $items_data as $index => $item ) {
+			$item_classes = array( 'wp-block-playlist__item' );
+			if ( $index === 0 ) {
+				$item_classes[] = 'is-active';
+			}
+
+			$item_context = wp_json_encode( array( 'itemIndex' => $index ) );
+			$item_number  = sprintf(
+				'<span class="wp-block-playlist__item-number">%d.</span>',
+				(int) $index + 1
+			);
+			$item_artist = '';
+			if ( ! empty( $item['artist'] ) ) {
+				$item_artist = sprintf(
+					'<div class="wp-block-playlist__item-artist">%s</div>',
+					sprintf(
+						/* translators: %s is the artist name. */
+						__( 'by %s' ),
+						esc_html( $item['artist'] )
+					)
+				);
+			}
+
+			$item_title = sprintf(
+				'<div class="wp-block-playlist__item-info"><div class="wp-block-playlist__item-title">%s</div>%s</div>',
+				esc_html( $item['title'] ),
+				$item_artist
+			);
+
+			$list_items .= sprintf(
+				'<li class="%s" data-wp-on--click="actions.selectItem" data-wp-context=\'%s\' data-wp-class--is-active="state.isItemActive">%s%s</li>',
+				esc_attr( implode( ' ', $item_classes ) ),
+				$item_context,
+				$item_number,
+				$item_title
+			);
+		}
+		$items_list = sprintf( '<ol class="wp-block-playlist__items">%s</ol>', $list_items );
+	}
+
+	// Build wrapper with interactivity directives.
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'wp-block-playlist' ) );
+	$interactivity_context = wp_interactivity_data_wp_context( $context );
+
+	return sprintf(
+		'<div %s data-wp-interactive="core/playlist" %s data-wp-watch="callbacks.updateAudio">%s%s</div>',
+		$wrapper_attributes,
+		$interactivity_context,
+		$player,
+		$items_list
+	);
+}
+
+/**
+ * Registers the `core/playlist` block on the server.
+ */
+function register_block_core_playlist() {
+	register_block_type_from_metadata(
+		__DIR__ . '/playlist',
+		array(
+			'render_callback' => 'render_block_core_playlist',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_playlist' );

--- a/packages/block-library/src/playlist/save.js
+++ b/packages/block-library/src/playlist/save.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+export default function save( { attributes } ) {
+	return attributes.items?.length > 0 && <div { ...useBlockProps.save() } />;
+}

--- a/packages/block-library/src/playlist/style.scss
+++ b/packages/block-library/src/playlist/style.scss
@@ -1,0 +1,111 @@
+.wp-block-playlist {
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-15;
+	justify-content: center;
+
+	.wp-block-playlist__player {
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: $grid-unit-15;
+
+		.wp-block-playlist__header {
+			display: flex;
+			flex-direction: row;
+			gap: $grid-unit-05;
+			align-items: flex-start;
+
+			.wp-block-playlist__header-image {
+				width: 80px;
+				height: 80px;
+				object-fit: cover;
+				border-radius: 4px;
+				flex-shrink: 0;
+			}
+
+			.wp-block-playlist__header-info {
+				display: flex;
+				flex-direction: column;
+				gap: $grid-unit-05;
+				min-width: 0;
+
+				.wp-block-playlist__header-title {
+					font-weight: $font-weight-medium;
+					font-size: $font-size-large;
+				}
+
+				.wp-block-playlist__header-subtitle {
+					font-size: $font-size-medium;
+					color: $gray-700;
+				}
+			}
+		}
+
+		.wp-block-playlist__audio {
+			width: 100%;
+		}
+	}
+
+	.wp-block-playlist__items {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+
+		.wp-block-playlist__item {
+			display: flex;
+			flex-direction: row;
+			gap: $grid-unit-20;
+			width: 100%;
+			align-items: center;
+			justify-content: flex-start;
+			padding: $grid-unit-10;
+			background: transparent;
+			transition: background-color 0.2s ease;
+			cursor: pointer;
+			box-sizing: border-box;
+
+			& + .wp-block-playlist__item {
+				border-top: 1px solid $gray-300;
+			}
+
+			&:hover {
+				background: $gray-100;
+			}
+
+			&.is-active {
+				background: $gray-100;
+
+				.wp-block-playlist__item-title {
+					font-weight: $font-weight-medium;
+				}
+			}
+
+			.wp-block-playlist__item-number {
+				font-size: $font-size-medium;
+				flex-shrink: 0;
+			}
+
+			.wp-block-playlist__item-info {
+				display: flex;
+				flex-shrink: 0;
+				flex-direction: column;
+				justify-content: center;
+				gap: $grid-unit-05;
+
+				.wp-block-playlist__item-title {
+					font-size: $font-size-large;
+					line-height: 1.3;
+					text-wrap: balance; /* Fallback for Safari. */
+					text-wrap: pretty;
+					flex-shrink: 0;
+				}
+
+				.wp-block-playlist__item-artist {
+					font-size: $font-size-medium;
+					color: $gray-700;
+				}
+			}
+		}
+	}
+}

--- a/packages/block-library/src/playlist/view.js
+++ b/packages/block-library/src/playlist/view.js
@@ -1,0 +1,120 @@
+/**
+ * WordPress dependencies
+ */
+import { store, getContext, getElement } from '@wordpress/interactivity';
+
+const { state } = store( 'core/playlist', {
+	state: {
+		get currentItemData() {
+			const context = getContext();
+			const { itemsData, currentItem } = context;
+
+			if ( ! itemsData || ! itemsData[ currentItem ] ) {
+				return null;
+			}
+
+			return itemsData[ currentItem ];
+		},
+		get currentItemSrc() {
+			const itemData = state.currentItemData;
+			return itemData?.url || '';
+		},
+		get currentItemTitle() {
+			const itemData = state.currentItemData;
+			return itemData?.title || '';
+		},
+		get currentItemArtist() {
+			const itemData = state.currentItemData;
+			if ( ! itemData?.artist ) {
+				return '';
+			}
+			// translators: %s is the artist name.
+			return `by ${ itemData.artist }`;
+		},
+		get currentItemImage() {
+			const itemData = state.currentItemData;
+			return itemData?.image || '';
+		},
+		get isItemActive() {
+			const context = getContext();
+			const parentContext = getContext( 'core/playlist' );
+			const { itemIndex } = context;
+			return itemIndex === parentContext.currentItem;
+		},
+	},
+	actions: {
+		selectItem: () => {
+			const context = getContext();
+			const { itemIndex } = context;
+
+			// Get the parent context and update current item
+			const parentContext = getContext( 'core/playlist' );
+			const wasPlaying = parentContext.isPlaying;
+			parentContext.currentItem = itemIndex;
+
+			// Get the audio element and play the new item if needed
+			const { ref } = getElement();
+			const container = ref.closest(
+				'[data-wp-interactive="core/playlist"]'
+			);
+			if ( container ) {
+				const audio = container.querySelector(
+					'.wp-block-playlist__audio'
+				);
+				if ( audio ) {
+					audio.load();
+					if ( wasPlaying ) {
+						audio.play();
+					}
+				}
+			}
+		},
+		onItemEnded: () => {
+			const context = getContext();
+			const { itemsData, currentItem, loop } = context;
+
+			// If not the last item, move to next.
+			if ( currentItem < itemsData.length - 1 ) {
+				context.currentItem = currentItem + 1;
+				const { ref } = getElement();
+				if ( ref ) {
+					ref.load();
+					ref.play();
+				}
+			} else if ( loop ) {
+				// Last item and loop enabled - go back to first item.
+				context.currentItem = 0;
+				const { ref } = getElement();
+				if ( ref ) {
+					ref.load();
+					ref.play();
+				}
+			}
+			// If last item and no loop - do nothing (stop playing).
+		},
+		onPlay: () => {
+			const context = getContext();
+			context.isPlaying = true;
+		},
+		onPause: () => {
+			const context = getContext();
+			context.isPlaying = false;
+		},
+	},
+	callbacks: {
+		updateAudio: () => {
+			const context = getContext();
+			const { autoplay, currentItem } = context;
+
+			const { ref } = getElement();
+			if ( ! ref ) {
+				return;
+			}
+
+			const audio = ref.querySelector( '.wp-block-playlist__audio' );
+			if ( audio && autoplay && currentItem === 0 ) {
+				audio.play();
+			}
+		},
+	},
+} );

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -36,6 +36,7 @@
 @import "./navigation-link/style.scss";
 @import "./page-list/style.scss";
 @import "./paragraph/style.scss";
+@import "./playlist/style.scss";
 @import "./post-author/style.scss";
 @import "./post-author-biography/style.scss";
 @import "./post-comments-form/style.scss";

--- a/test/integration/fixtures/blocks/core__playlist.html
+++ b/test/integration/fixtures/blocks/core__playlist.html
@@ -1,0 +1,1 @@
+<!-- wp:playlist /-->

--- a/test/integration/fixtures/blocks/core__playlist.json
+++ b/test/integration/fixtures/blocks/core__playlist.json
@@ -1,0 +1,13 @@
+[
+	{
+		"name": "core/playlist",
+		"isValid": true,
+		"attributes": {
+			"items": [],
+			"autoplay": false,
+			"loop": false,
+			"showItemList": true
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__playlist.parsed.json
+++ b/test/integration/fixtures/blocks/core__playlist.parsed.json
@@ -1,0 +1,9 @@
+[
+	{
+		"blockName": "core/playlist",
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__playlist.serialized.html
+++ b/test/integration/fixtures/blocks/core__playlist.serialized.html
@@ -1,0 +1,1 @@
+<!-- wp:playlist /-->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/71026
Resolves: https://github.com/WordPress/gutenberg/issues/805

This PR add a new `Playlist` block. The current designs in the issue might be outdated, so design feedback is required. Currently I tried to implement only `audio` playlist, but we might want to explore about a video playlist.

### Questions + Notes
1. Right now `audio` files don't have `image/poster` info AFAIK. Should we have a placeholder for each attachment and upload from there? If yes, should we add this field in media library edit? 
2. Should we allow reordering in front end? 
3. Reordering with the arrow buttons is needed for a11y (keyboard). Do we need drag and drop functionality?
4. What should happen when we `hide the playlist`(items)? Should we have a toggle somewhere to show it? Should we update any other UI (for example the list contains x items).


### Tasks
- [ ] Fix placeholder drag and drop and upload of files
- [ ] Add transforms from/to audio blocks
- [ ] When we remove items it might trigger new requests even if we already have the data (due to `include` value change). Investigate if there is a current way to do it with core-data or how to solve this

## Testing Instructions
1. Add a `Playlist` block
6. Add items from the media library (for now I haven't implemented the drag and drop or upload from placeholder)
7. Interact with the block and check in the front end


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Noting that the screenshots are with border and padding applied to the specific block instance. Since users can add their own styles, the default ones should not include anything.

|Front end|Editor|
|-|-|
|<img width="682" height="464" alt="Screenshot 2025-10-01 at 12 18 26 PM" src="https://github.com/user-attachments/assets/7a800cdc-8779-46a1-b555-a94c67f50d95" />|<img width="569" height="480" alt="Screenshot 2025-10-01 at 12 19 12 PM" src="https://github.com/user-attachments/assets/7b476654-49e0-4fdd-812e-077cbed95d22" />|
