### PR TITLE
Modal: Replace `justify-content: left` with `flex-start` in modal header

### DIFF
--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -167,7 +167,7 @@
 	flex-grow: 1;
 	display: flex;
 	flex-direction: row;
-	justify-content: left;
+	justify-content: flex-start;
 }
 
 .components-modal__header-icon-container {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/71997

<!-- In a few words, what is the PR actually doing? -->

The PR changes `justify-content: left;` to `justify-content: flex-start;` for the Modal block heading alignment.

ℹ️ I did not add a new record to the changelog for such a small change, but happy to update it if needed.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

With the proposed change there's no need for extra RTL styling adjustment to handle Modal's heading alignment.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Described above - in the _What?_ section.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open a post for editing.
2. Head over to the Preferences modal:
<img width="768" height="1520" alt="Markup on 2025-10-01 at 12:04:45" src="https://github.com/user-attachments/assets/c1d52ff8-4162-4943-a297-9af140f5e6fc" />

3. Review the styling in the browser inspector:
<img width="3072" height="1798" alt="Markup on 2025-10-01 at 11:48:55" src="https://github.com/user-attachments/assets/54cd87e6-9cae-46c3-bd04-27a171494292" />

4. Switch site locale to one of the RTL languages, go back to the Preferences modal and confirm the alignment is correct:
<img width="1608" height="1050" alt="Markup on 2025-10-01 at 11:50:05" src="https://github.com/user-attachments/assets/d757db46-33ee-4bd8-b1b5-778c73cf1873" />
 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Added in the content above.
