### PR TITLE
Template activation: redirect theme templates urls to wp_registered_template

### DIFF
--- a/backport-changelog/6.9/8063.md
+++ b/backport-changelog/6.9/8063.md
@@ -2,5 +2,6 @@ https://github.com/WordPress/wordpress-develop/pull/8063
 
 * https://github.com/WordPress/gutenberg/pull/67125
 * https://github.com/WordPress/gutenberg/pull/71811
+* https://github.com/WordPress/gutenberg/pull/72003
 * https://github.com/WordPress/gutenberg/pull/72029
 * https://github.com/WordPress/gutenberg/pull/72049

--- a/lib/compat/wordpress-6.9/site-editor-redirect.php
+++ b/lib/compat/wordpress-6.9/site-editor-redirect.php
@@ -19,7 +19,7 @@ function gutenberg_get_site_editor_redirection_6_9() {
 
 	// The following redirects are for the new permalinks in the site editor.
 	// /wp_template/tt5//home -> /wp_registered_template/tt5//home
-	if ( isset( $_GET['p'] ) && preg_match( '#^/wp_template/([a-zA-Z0-9-]+//[a-zA-Z0-9-]+)$#', $_GET['p'], $matches ) ) {
+	if ( isset( $_REQUEST['p'] ) && preg_match( '#^/wp_template/([a-zA-Z0-9-]+//[a-zA-Z0-9-]+)$#', $_REQUEST['p'], $matches ) ) {
 		return add_query_arg( array( 'p' => '/wp_registered_template/' . $matches[1] ), remove_query_arg( array( 'p' ) ) );
 	}
 

--- a/lib/compat/wordpress-6.9/site-editor-redirect.php
+++ b/lib/compat/wordpress-6.9/site-editor-redirect.php
@@ -19,7 +19,7 @@ function gutenberg_get_site_editor_redirection_6_9() {
 
 	// The following redirects are for the new permalinks in the site editor.
 	// /wp_template/tt5//home -> /wp_registered_template/tt5//home
-	if ( isset( $_GET['p'] ) && preg_match( '_^/wp_template/([a-zA-Z0-9-]+//[a-zA-Z0-9-]+)$_', $_GET['p'], $matches ) ) {
+	if ( isset( $_GET['p'] ) && preg_match( '#^/wp_template/([a-zA-Z0-9-]+//[a-zA-Z0-9-]+)$#', $_GET['p'], $matches ) ) {
 		return add_query_arg( array( 'p' => '/wp_registered_template/' . $matches[1] ), remove_query_arg( array( 'p' ) ) );
 	}
 

--- a/lib/compat/wordpress-6.9/site-editor-redirect.php
+++ b/lib/compat/wordpress-6.9/site-editor-redirect.php
@@ -18,7 +18,8 @@ function gutenberg_get_site_editor_redirection_6_9() {
 	}
 
 	// The following redirects are for the new permalinks in the site editor.
-	if ( isset( $_GET['p'] ) && preg_match( '/^\/wp_template\/([a-zA-Z0-9-]+\/\/[a-zA-Z0-9-]+)$/', $_GET['p'], $matches ) ) {
+	if ( isset( $_GET['p'] ) && preg_match( '_^/wp_template/([a-zA-Z0-9-]+//[a-zA-Z0-9-]+)$_', $_GET['p'], $matches ) ) {
+}
 		return add_query_arg( array( 'p' => '/wp_registered_template/' . $matches[1] ), remove_query_arg( array( 'p' ) ) );
 	}
 

--- a/lib/compat/wordpress-6.9/site-editor-redirect.php
+++ b/lib/compat/wordpress-6.9/site-editor-redirect.php
@@ -18,8 +18,8 @@ function gutenberg_get_site_editor_redirection_6_9() {
 	}
 
 	// The following redirects are for the new permalinks in the site editor.
+	// /wp_template/tt5//home -> /wp_registered_template/tt5//home
 	if ( isset( $_GET['p'] ) && preg_match( '_^/wp_template/([a-zA-Z0-9-]+//[a-zA-Z0-9-]+)$_', $_GET['p'], $matches ) ) {
-}
 		return add_query_arg( array( 'p' => '/wp_registered_template/' . $matches[1] ), remove_query_arg( array( 'p' ) ) );
 	}
 

--- a/lib/compat/wordpress-6.9/site-editor-redirect.php
+++ b/lib/compat/wordpress-6.9/site-editor-redirect.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Maps old site editor urls to the new updated ones.
+ *
+ * @since 6.9.0
+ * @access private
+ *
+ * @global string $pagenow The filename of the current screen.
+ *
+ * @return string|false The new URL to redirect to, or false if no redirection is needed.
+ */
+function gutenberg_get_site_editor_redirection_6_9() {
+	global $pagenow;
+
+	if ( 'site-editor.php' !== $pagenow ) {
+		return false;
+	}
+
+	// The following redirects are for the new permalinks in the site editor.
+	if ( isset( $_GET['p'] ) && preg_match( '/^\/wp_template\/([a-zA-Z0-9-]+\/\/[a-zA-Z0-9-]+)$/', $_GET['p'], $matches ) ) {
+		return add_query_arg( array( 'p' => '/wp_registered_template/' . $matches[1] ), remove_query_arg( array( 'p' ) ) );
+	}
+
+	return false;
+}
+
+/**
+ * Redirect old site editor urls to the new updated ones.
+ */
+function gutenberg_redirect_site_editor_deprecated_urls_6_9() {
+	$redirection = gutenberg_get_site_editor_redirection_6_9();
+	if ( false !== $redirection ) {
+		wp_safe_redirect( $redirection );
+		exit;
+	}
+}
+add_action( 'admin_init', 'gutenberg_redirect_site_editor_deprecated_urls_6_9' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -90,6 +90,7 @@ require __DIR__ . '/compat/wordpress-6.9/customizer-preview-custom-css.php';
 require __DIR__ . '/compat/wordpress-6.9/command-palette.php';
 require __DIR__ . '/compat/wordpress-6.9/preload.php';
 require __DIR__ . '/compat/wordpress-6.9/l10n.php';
+require __DIR__ . '/compat/wordpress-6.9/site-editor-redirect.php';
 
 // WordPress 7.0 compat.
 require __DIR__ . '/compat/wordpress-7.0/php-only-blocks.php';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/72151

The urls for theme templates have changed from `/wp_template/twentytwentyfive//home` to `/wp_registered_template/twentytwentyfive//home`. Let's add redirects.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds redirects server side.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Visit URLs like `http://localhost:8888/wp-admin/site-editor.php?canvas=edit&p=%2Fwp_template%2Ftwentytwentyfive%2F%2Fhome`
Alternatively, click the Edit Site admin bar button on the front-end, which still uses the old URL.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
