### PR TITLE
Link Control: Update button text from Save to Apply

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -488,7 +488,7 @@ function LinkControl( {
 						className="block-editor-link-control__search-submit"
 						aria-disabled={ isDisabled }
 					>
-						{ __( 'Save' ) }
+						{ __( 'Apply' ) }
 					</Button>
 				</HStack>
 			) }

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -795,7 +795,7 @@ describe( 'Manual link entry', () => {
 				}
 
 				const submitButton = screen.queryByRole( 'button', {
-					name: 'Save',
+					name: 'Apply',
 				} );
 
 				// Verify the submission UI is disabled.

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -1035,7 +1035,7 @@ describe( 'Link submission', () => {
 		expect( createSubmitButton ).not.toBeInTheDocument();
 
 		const editSubmitButton = screen.getByRole( 'button', {
-			name: 'Save',
+			name: 'Apply',
 		} );
 
 		expect( editSubmitButton ).toBeVisible();
@@ -2033,7 +2033,7 @@ describe( 'Addition Settings UI', () => {
 
 		// check that the "Apply" button is disabled by default.
 		const submitButton = screen.queryByRole( 'button', {
-			name: 'Save',
+			name: 'Apply',
 		} );
 
 		expect( submitButton ).toHaveAttribute( 'aria-disabled', 'true' );
@@ -2489,7 +2489,7 @@ describe( 'Controlling link title text', () => {
 		expect( textInput ).toHaveValue( textValue );
 
 		const submitButton = screen.queryByRole( 'button', {
-			name: 'Save',
+			name: 'Apply',
 		} );
 
 		await user.click( submitButton );

--- a/packages/block-editor/src/components/media-replace-flow/test/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/test/index.js
@@ -119,7 +119,7 @@ describe( 'General media replace flow', () => {
 
 		await user.click(
 			screen.getByRole( 'button', {
-				name: 'Save',
+				name: 'Apply',
 			} )
 		);
 

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -210,7 +210,7 @@ test.describe( 'Buttons', () => {
 		await page
 			//TODO: change to a better selector when https://github.com/WordPress/gutenberg/issues/51060 is resolved.
 			.locator( '.block-editor-link-control' )
-			.getByRole( 'button', { name: 'Save' } )
+			.getByRole( 'button', { name: 'Apply' } )
 			.click();
 
 		// The link should have been inserted.
@@ -244,7 +244,7 @@ test.describe( 'Buttons', () => {
 		await page
 			//TODO: change to a better selector when https://github.com/WordPress/gutenberg/issues/51060 is resolved.
 			.locator( '.block-editor-link-control' )
-			.getByRole( 'button', { name: 'Save' } )
+			.getByRole( 'button', { name: 'Apply' } )
 			.click();
 
 		// Check the content again.

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -599,7 +599,7 @@ test.describe( 'Links', () => {
 		await expect( checkbox ).toBeFocused();
 
 		// Tab back to the Submit and apply the link.
-		await linkPopover.getByRole( 'button', { name: 'Save' } ).click();
+		await linkPopover.getByRole( 'button', { name: 'Apply' } ).click();
 
 		// The link should have been inserted.
 		await expect.poll( editor.getBlocks ).toMatchObject( [
@@ -666,7 +666,7 @@ test.describe( 'Links', () => {
 		await page.keyboard.type( 'wordpress.org' );
 
 		// Save the link.
-		await linkPopover.getByRole( 'button', { name: 'Save' } ).click();
+		await linkPopover.getByRole( 'button', { name: 'Apply' } ).click();
 
 		// Link UI should be closed.
 		await expect( linkPopover ).toBeHidden();
@@ -824,7 +824,7 @@ test.describe( 'Links', () => {
 		await linkPopover.getByLabel( 'nofollow' ).click();
 
 		// Save the link
-		await linkPopover.getByRole( 'button', { name: 'Save' } ).click();
+		await linkPopover.getByRole( 'button', { name: 'Apply' } ).click();
 
 		// Expect correct attributes to be set on the underlying link.
 		await expect.poll( editor.getBlocks ).toMatchObject( [
@@ -852,7 +852,7 @@ test.describe( 'Links', () => {
 		await linkPopover.getByLabel( 'nofollow' ).click();
 
 		// Save the link
-		await linkPopover.getByRole( 'button', { name: 'Save' } ).click();
+		await linkPopover.getByRole( 'button', { name: 'Apply' } ).click();
 
 		// Expect correct attributes to be set on the underlying link.
 		await expect.poll( editor.getBlocks ).toMatchObject( [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Changes the copy of the "Save" button in Link UI to "Apply"

## Why?
We have two different "Save" buttons on the screen. The Link UI button doesn't actually save the change to the database, it simply updates the setting in the client. Users might think that the "Save" button will persist their change, which it does not. By changing the copy to "Apply" users are more likely to remember that they also need to "Save" the change.

## How?
Text change

## Testing Instructions
1. Edit a link
2. Confirm that the button says "Apply" not "Save"

## Screenshots or screencast <!-- if applicable -->
<img width="952" height="463" alt="Screenshot 2025-10-01 at 15 06 41" src="https://github.com/user-attachments/assets/c34d83f4-c0e9-419f-b101-0695a9b71fb5" />
