### PR TITLE
Fix: Prevent submenu hover in contentOnly mode

### DIFF
--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -17,6 +17,7 @@ import {
 	InspectorControls,
 	RichText,
 	useBlockProps,
+	useBlockEditingMode,
 	store as blockEditorStore,
 	getColorClassName,
 } from '@wordpress/block-editor';
@@ -126,7 +127,16 @@ export default function NavigationSubmenuEdit( {
 } ) {
 	const { label, url, description } = attributes;
 
-	const { showSubmenuIcon, maxNestingLevel, openSubmenusOnClick } = context;
+	const {
+		showSubmenuIcon,
+		maxNestingLevel,
+		openSubmenusOnClick: contextOpenSubmenusOnClick,
+	} = context;
+	const blockEditingMode = useBlockEditingMode();
+
+	// Force click-only behavior in contentOnly mode to prevent hover dropdowns
+	const openSubmenusOnClick =
+		blockEditingMode !== 'default' ? true : contextOpenSubmenusOnClick;
 
 	const {
 		__unstableMarkNextChangeAsNotPersistent,


### PR DESCRIPTION
## What

This PR cherry-picks a specific fix from [PR #71137](https://github.com/WordPress/gutenberg/pull/71137) that prevents navigation submenus from displaying on hover when in contentOnly mode (Write Mode).

Closes https://github.com/WordPress/gutenberg/issues/71754

## Why

In Write Mode, navigation submenus opening on hover can be disruptive to the content editing experience. Users should be able to click on navigation items without accidentally triggering submenu dropdowns.

## How

- Added  hook to detect when the block is in contentOnly mode
- Force  to  when not in default editing mode
- This ensures submenus only open on click, not hover, in contentOnly mode

## Testing

1. Enable Write Mode in Gutenberg experiments
2. Add a Navigation block with submenus
3. Verify that hovering over navigation items with submenus does not open the dropdown
4. Verify that clicking on navigation items with submenus still opens the dropdown
5. Verify that normal editing mode (not contentOnly) still respects the original hover behavior

## Screenshots

https://github.com/user-attachments/assets/e8a761c4-0071-42e1-aa63-3a0ba5bac04a

## Related

- Extracted from [PR #71137](https://github.com/WordPress/gutenberg/pull/71137) - Explore Navigation Block contentOnly mode UX via Content Panel
- Addresses submenu hover behavior in Write Mode for Navigation blocks