### PR TITLE
Global Styles: Add shadow and layout to the global styles changes translation map array

### DIFF
--- a/packages/block-editor/src/components/global-styles/get-global-styles-changes.js
+++ b/packages/block-editor/src/components/global-styles/get-global-styles-changes.js
@@ -28,6 +28,8 @@ const translationMap = {
 	'styles.spacing': __( 'Spacing' ),
 	'styles.background': __( 'Background' ),
 	'styles.typography': __( 'Typography' ),
+	'settings.shadow': __( 'Shadow' ),
+	'settings.layout': __( 'Layout' ),
 };
 const getBlockNames = memoize( () =>
 	getBlockTypes().reduce( ( accumulator, { name, title } ) => {

--- a/packages/block-editor/src/components/global-styles/get-global-styles-changes.js
+++ b/packages/block-editor/src/components/global-styles/get-global-styles-changes.js
@@ -24,12 +24,12 @@ const translationMap = {
 	h6: __( 'H6' ),
 	'settings.color': __( 'Color' ),
 	'settings.typography': __( 'Typography' ),
+	'settings.shadow': __( 'Shadow' ),
+	'settings.layout': __( 'Layout' ),
 	'styles.color': __( 'Colors' ),
 	'styles.spacing': __( 'Spacing' ),
 	'styles.background': __( 'Background' ),
 	'styles.typography': __( 'Typography' ),
-	'settings.shadow': __( 'Shadow' ),
-	'settings.layout': __( 'Layout' ),
 };
 const getBlockNames = memoize( () =>
 	getBlockTypes().reduce( ( accumulator, { name, title } ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->
Adding shadow and layout to the global styles changes translation map array, so that there's more information when reviewing changes.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because we need to show the user what's changing.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adding the proper elements to the translations map array in global styles changes.

## Testing Instructions
1. Open the site editor.
2. Go the the shadow section, modify any or add a new custom one.
3. Click on the "Review" changes saving button. 
4. Confirm that's informing that the changes are related to Shadow settings.
5. Repeat with layout settings.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/a30bfb4d-eb27-4cd5-93d5-86bce4a29962


