### PR TITLE
Template activation: allow empty array to be set

### DIFF
--- a/backport-changelog/6.9/8063.md
+++ b/backport-changelog/6.9/8063.md
@@ -4,3 +4,4 @@ https://github.com/WordPress/wordpress-develop/pull/8063
 * https://github.com/WordPress/gutenberg/pull/71811
 * https://github.com/WordPress/gutenberg/pull/72029
 * https://github.com/WordPress/gutenberg/pull/72049
+* https://github.com/WordPress/gutenberg/pull/72011

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -71,14 +71,16 @@ function gutenberg_setup_static_template() {
 		'active_templates',
 		array(
 			'type'         => 'object',
+			// Do not set the default value to an empty array! For some reason
+			// that will prevent the option from being set to an empty array.
 			'show_in_rest' => array(
 				'schema' => array(
 					'type'                 => 'object',
-					// properties can be integers or false (deactivated).
+					// Properties can be integers, strings, or false
+					// (deactivated).
 					'additionalProperties' => true,
 				),
 			),
-			'default'      => array(),
 			'label'        => 'Active Templates',
 		)
 	);
@@ -438,9 +440,9 @@ function gutenberg_set_active_template_theme( $changes, $request ) {
 // is active.
 add_action( 'init', 'gutenberg_migrate_existing_templates' );
 function gutenberg_migrate_existing_templates() {
-	$active_templates = get_option( 'active_templates' );
+	$active_templates = get_option( 'active_templates', false );
 
-	if ( $active_templates ) {
+	if ( false !== $active_templates ) {
 		return;
 	}
 

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -240,11 +240,38 @@ export const getTemplateId = createRegistrySelector(
 		// First see if the post/page has an assigned template and fetch it.
 		const currentTemplateSlug = editedEntity.template;
 		if ( currentTemplateSlug ) {
-			const currentTemplate = select( STORE_NAME ).getDefaultTemplateId( {
-				slug: currentTemplateSlug,
-			} );
-			if ( currentTemplate ) {
-				return currentTemplate;
+			const userTemplates = select( STORE_NAME ).getEntityRecords(
+				'postType',
+				'wp_template',
+				{ per_page: -1 }
+			);
+			if ( ! userTemplates ) {
+				return;
+			}
+			const userTemplateWithSlug = userTemplates.find(
+				( { slug } ) => slug === currentTemplateSlug
+			);
+
+			if ( userTemplateWithSlug ) {
+				return userTemplateWithSlug.id;
+			}
+
+			const registeredTemplates = select( STORE_NAME ).getEntityRecords(
+				'postType',
+				'wp_registered_template',
+				{ per_page: -1 }
+			);
+
+			if ( ! registeredTemplates ) {
+				return;
+			}
+
+			const registeredTemplateWithSlug = registeredTemplates.find(
+				( { slug } ) => slug === currentTemplateSlug
+			);
+
+			if ( registeredTemplateWithSlug ) {
+				return registeredTemplateWithSlug.id;
 			}
 		}
 		// If no template is assigned, use the default template.

--- a/packages/edit-site/src/components/dataviews-actions/index.js
+++ b/packages/edit-site/src/components/dataviews-actions/index.js
@@ -57,10 +57,6 @@ export const useSetActiveTemplateAction = () => {
 						activeTemplates[ item.slug ] = item.id;
 					}
 				}
-				// To do: figure out why the REST API deletes the option when
-				// it's set to an empty object. That would trigger the migration
-				// function, which will make all templates in the database active.
-				activeTemplates.__preventCollapse = 0;
 				await editEntityRecord( 'root', 'site', undefined, {
 					active_templates: activeTemplates,
 				} );

--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -31,15 +31,10 @@ export default function BlockThemeControl( { id } ) {
 		onNavigateToEntityRecord,
 		getEditorSettings,
 		hasGoBack,
-		hasSpecificTemplate,
 	} = useSelect( ( select ) => {
-		const {
-			getRenderingMode,
-			getEditorSettings: _getEditorSettings,
-			getCurrentPost,
-		} = unlock( select( editorStore ) );
+		const { getRenderingMode, getEditorSettings: _getEditorSettings } =
+			unlock( select( editorStore ) );
 		const editorSettings = _getEditorSettings();
-		const currentPost = getCurrentPost();
 		return {
 			isTemplateHidden: getRenderingMode() === 'post-only',
 			onNavigateToEntityRecord: editorSettings.onNavigateToEntityRecord,
@@ -47,7 +42,6 @@ export default function BlockThemeControl( { id } ) {
 			hasGoBack: editorSettings.hasOwnProperty(
 				'onNavigateToPreviousEntityRecord'
 			),
-			hasSpecificTemplate: !! currentPost.template,
 		};
 	}, [] );
 
@@ -58,8 +52,6 @@ export default function BlockThemeControl( { id } ) {
 		'wp_template',
 		id
 	);
-	const { getEntityRecord } = useSelect( coreStore );
-	const { editEntityRecord } = useDispatch( coreStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const { setRenderingMode, setDefaultRenderingMode } = unlock(
 		useDispatch( editorStore )
@@ -134,45 +126,11 @@ export default function BlockThemeControl( { id } ) {
 						<MenuGroup>
 							{ canCreateTemplate && (
 								<MenuItem
-									onClick={ async () => {
+									onClick={ () => {
 										onNavigateToEntityRecord( {
 											postId: template.id,
 											postType: 'wp_template',
 										} );
-										// When editing a global template,
-										// activate the auto-draft. This is not
-										// immediately live (we're not saving
-										// site options), and when nothing is
-										// saved, the setting will be ignored.
-										// In the future, we should make the
-										// duplication explicit, so there
-										// wouldn't be an "edit" button for
-										// static theme templates.
-										if ( ! hasSpecificTemplate ) {
-											const activeTemplates =
-												await getEntityRecord(
-													'root',
-													'site'
-												).active_templates;
-											if (
-												activeTemplates[
-													template.slug
-												] !== template.id
-											) {
-												editEntityRecord(
-													'root',
-													'site',
-													undefined,
-													{
-														active_templates: {
-															...activeTemplates,
-															[ template.slug ]:
-																template.id,
-														},
-													}
-												);
-											}
-										}
 										onClose();
 										mayShowTemplateEditNotice();
 									} }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

I ran into this issue while demoing the features to @bph and @justintadlock. I had wiped the template option + trashed all my templates. This allows the migration to kick in, but since I had no templates to migrate, it tried to set the `active_templates` option to an empty array. This failed, it seems because the default value of the option is an empty array, and this kept the migration function running until I created my first template, which it then activated. Any following templates that I created would not get activated because filling the option would stop the migration function.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See above.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We need `update_option` to work with an empty array. Debugging reveals that `register_setting` was preventing that, in particular the `default`, probably because it thought the option is already an empty array.

Additionally, some e2e tests started breaking because the first template created was automatically activating these tests, creating false positives. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Go through the steps above: delete all templates and the `active_templates` option in the database. Now duplicate one of the theme templates. Check the front-end to make sure that the template was not immediately activated by itself.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
