### PR TITLE
Allow submenu flyout menus to be visible outside of template part canvas

### DIFF
--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -6,7 +6,6 @@ import { Menu } from './menu';
 import { ComponentsContext } from './context/context-system-provider';
 import Theme from './theme';
 import { Tabs } from './tabs';
-import { COLORS } from './utils';
 import { kebabCase, normalizeTextString } from './utils/strings';
 import { withIgnoreIMEEvents } from './utils/with-ignore-ime-events';
 import { lock } from './lock-unlock';
@@ -52,5 +51,4 @@ lock( privateApis, {
 	ValidatedToggleControl,
 	ValidatedToggleGroupControl,
 	ValidatedFormTokenField,
-	COLORS,
 } );

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -6,6 +6,7 @@ import { Menu } from './menu';
 import { ComponentsContext } from './context/context-system-provider';
 import Theme from './theme';
 import { Tabs } from './tabs';
+import { COLORS } from './utils';
 import { kebabCase, normalizeTextString } from './utils/strings';
 import { withIgnoreIMEEvents } from './utils/with-ignore-ime-events';
 import { lock } from './lock-unlock';
@@ -51,4 +52,5 @@ lock( privateApis, {
 	ValidatedToggleControl,
 	ValidatedToggleGroupControl,
 	ValidatedFormTokenField,
+	COLORS,
 } );

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -21,7 +21,6 @@ import { useSelect } from '@wordpress/data';
 import { parse } from '@wordpress/blocks';
 import { store as coreStore } from '@wordpress/core-data';
 import { useMergeRefs, useViewportMatch } from '@wordpress/compose';
-import { privateApis as componentsPrivateApis } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -47,8 +46,6 @@ const {
 	ExperimentalBlockCanvas: BlockCanvas,
 	useFlashEditableBlocks,
 } = unlock( blockEditorPrivateApis );
-
-const { COLORS } = unlock( componentsPrivateApis );
 
 /**
  * These post types have a special editor where they don't allow you to fill the title
@@ -348,11 +345,12 @@ function VisualEditor( {
 				}}
 				${
 					enableResizing
-						? `.block-editor-iframe__html{background:${ COLORS.theme.gray[ 300 ] };display:flex;align-items:center;justify-content:center;min-height:100vh;}.block-editor-iframe__body{width:100%;}`
+						? '.block-editor-iframe__html{background:#ddd;display:flex;align-items:center;justify-content:center;min-height:100vh;}.block-editor-iframe__body{width:100%;}'
 						: ''
 				}`,
 				// The CSS above centers the body content vertically when resizing is enabled and applies a background
 				// color to the iframe HTML element to match the background color of the editor canvas.
+				// TODO: Move the #ddd somewhere else or use a variable.
 			},
 		];
 	}, [ styles, enableResizing ] );

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -21,6 +21,7 @@ import { useSelect } from '@wordpress/data';
 import { parse } from '@wordpress/blocks';
 import { store as coreStore } from '@wordpress/core-data';
 import { useMergeRefs, useViewportMatch } from '@wordpress/compose';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -46,6 +47,8 @@ const {
 	ExperimentalBlockCanvas: BlockCanvas,
 	useFlashEditableBlocks,
 } = unlock( blockEditorPrivateApis );
+
+const { COLORS } = unlock( componentsPrivateApis );
 
 /**
  * These post types have a special editor where they don't allow you to fill the title
@@ -345,12 +348,11 @@ function VisualEditor( {
 				}}
 				${
 					enableResizing
-						? '.block-editor-iframe__html{background:#ddd;display:flex;align-items:center;justify-content:center;min-height:100vh;}.block-editor-iframe__body{width:100%;}'
+						? `.block-editor-iframe__html{background:${ COLORS.theme.gray[ 300 ] };display:flex;align-items:center;justify-content:center;min-height:100vh;}.block-editor-iframe__body{width:100%;}`
 						: ''
 				}`,
 				// The CSS above centers the body content vertically when resizing is enabled and applies a background
 				// color to the iframe HTML element to match the background color of the editor canvas.
-				// TODO: Move the #ddd somewhere else or use a variable.
 			},
 		];
 	}, [ styles, enableResizing ] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Allows thin template parts to have content appear outside the "canvas"

Fixes https://github.com/WordPress/gutenberg/issues/72030, https://github.com/WordPress/gutenberg/issues/73024

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When editing a navigation template part or thin template part with a navigation (like a header), the submenus dropdown menus are contained within the small area, blocked from overflowing. This makes it unusable.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Remove the height manually set on the iframe
- Iframe HTML element receives background color that matches the "blank" area of the space behind it: .editor-visual-editor { #ddd }.
- TODO: don't hardcode the #ddd. Find a way to use a CSS variable.
- Center the body element on the canvas using flex column.

Known bug: The floating toolbar isn't visible when using the mobile navigation view when the menu is expanded. However, it's pretty much just as bad on trunk since you're editing it in a 80px tall area.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Edit a template part with a navigation block
2. Add and interact with the submenu items
3. Submenu should be visible outside the "canvas"

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/be52f4e8-f97e-4462-8596-4571c1f00273


|Before|After|
|-|-|
|<img width="1469" height="1171" alt="Screenshot 2025-10-01 at 2 06 36 PM" src="https://github.com/user-attachments/assets/8320f7b4-af69-4f42-9ebf-55a87154d320" />|<img width="1351" height="1175" alt="Screenshot 2025-10-01 at 2 06 12 PM" src="https://github.com/user-attachments/assets/b931a389-9b75-4ec5-81f6-96099919a71d" />|
