### PR TITLE
Added Global Documentation in template-activate file

### DIFF
--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -19,8 +19,12 @@ function gutenberg_modify_wp_template_post_type_args( $args, $post_type ) {
 //    to lookup the active template for a specific slug, and probably get a list
 //    of all _active_ templates. For that we can keep /lookup.
 add_action( 'rest_api_init', 'gutenberg_maintain_templates_routes' );
+
+/**
+ * @global array $wp_post_types List of post types.
+ */
 function gutenberg_maintain_templates_routes() {
-	// This should later be changed in core so we don't need initialise
+	// This should later be changed in core so we don't need initialize
 	// WP_REST_Templates_Controller with a post type.
 	global $wp_post_types;
 	$wp_post_types['wp_template']->rest_base = 'templates';
@@ -33,6 +37,10 @@ function gutenberg_maintain_templates_routes() {
 //    I registered this as a post type route because right now the
 //    EditorProvider assumes templates are posts.
 add_action( 'init', 'gutenberg_setup_static_template' );
+
+/**
+ * @global array $wp_post_types List of post types.
+ */
 function gutenberg_setup_static_template() {
 	global $wp_post_types;
 	$wp_post_types['wp_registered_template']                        = clone $wp_post_types['wp_template'];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? Why?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
- Added Global Documentation in `template-activate.php` file

## How?
- Added Global Documentation for `global $wp_post_types`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open `lib/compat/wordpress-6.9/template-activate.php` file.
2. See Global Documentation is missing for  `global $wp_post_types`.
