### PR TITLE
contentOnly: Fix canInsertBlockType dependencies to fix selector caching issues

### DIFF
--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -2669,6 +2669,7 @@ describe( 'selectors', () => {
 				},
 				blockListSettings: {},
 				settings: {},
+				blockEditingModes: new Map(),
 			};
 			expect( canInsertBlockType( state, 'core/invalid' ) ).toBe( false );
 		} );
@@ -2683,6 +2684,7 @@ describe( 'selectors', () => {
 				settings: {
 					allowedBlockTypes: [],
 				},
+				blockEditingModes: new Map(),
 			};
 			expect( canInsertBlockType( state, 'core/test-block-a' ) ).toBe(
 				false
@@ -2719,6 +2721,7 @@ describe( 'selectors', () => {
 				settings: {
 					templateLock: 'all',
 				},
+				blockEditingModes: new Map(),
 			};
 			expect( canInsertBlockType( state, 'core/test-block-a' ) ).toBe(
 				false

--- a/packages/block-editor/src/store/utils.js
+++ b/packages/block-editor/src/store/utils.js
@@ -10,10 +10,8 @@ import { parse as grammarParse } from '@wordpress/block-serialization-default-pa
 import { selectBlockPatternsKey } from './private-keys';
 import { unlock } from '../lock-unlock';
 import { STORE_NAME } from './constants';
-import {
-	getSectionRootClientId,
-	getParentSectionBlock,
-} from './private-selectors';
+import { getSectionRootClientId } from './private-selectors';
+import { getBlockEditingMode } from './selectors';
 import { INSERTER_PATTERN_TYPES } from '../components/inserter/block-patterns-tab/utils';
 
 export const isFiltered = Symbol( 'isFiltered' );
@@ -141,9 +139,8 @@ export const getInsertBlockTypeDependants =
 			state.blocks.byClientId.get( rootClientId ),
 			state.settings.allowedBlockTypes,
 			state.settings.templateLock,
-			state.blockEditingModes,
+			getBlockEditingMode( state, rootClientId ),
 			select( STORE_NAME ).__unstableGetEditorMode( state ),
 			getSectionRootClientId( state ),
-			getParentSectionBlock( state, rootClientId ),
 		];
 	};

--- a/packages/block-editor/src/store/utils.js
+++ b/packages/block-editor/src/store/utils.js
@@ -10,7 +10,10 @@ import { parse as grammarParse } from '@wordpress/block-serialization-default-pa
 import { selectBlockPatternsKey } from './private-keys';
 import { unlock } from '../lock-unlock';
 import { STORE_NAME } from './constants';
-import { getSectionRootClientId } from './private-selectors';
+import {
+	getSectionRootClientId,
+	getParentSectionBlock,
+} from './private-selectors';
 import { INSERTER_PATTERN_TYPES } from '../components/inserter/block-patterns-tab/utils';
 
 export const isFiltered = Symbol( 'isFiltered' );
@@ -141,5 +144,6 @@ export const getInsertBlockTypeDependants =
 			state.blockEditingModes,
 			select( STORE_NAME ).__unstableGetEditorMode( state ),
 			getSectionRootClientId( state ),
+			getParentSectionBlock( state, rootClientId ),
 		];
 	};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Fixes #71955
Fixes #71956

<!--
⚠️ ***NOTE: This is likely the wrong way to solve this problem! My hunch is that this is too expensive a call to add in the list of dependencies, so I'd love to hear if anyone has other ideas for how to solve this***. -->

Fix issues with contentOnly mode when clicking "Edit contents" after selecting a block within a pattern.

In `trunk`, doing so results in the Add Before / Add After / Duplicate options being unavailable, and it not being possible to drag blocks within groups within the pattern.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This appears to be because when we update the parent block to no longer be recognised as a pattern for the purposes of content only mode, the cache for the canInsertBlockType selector is not invalidated.

To put it differently, the unmemoized version of the selector performs lookups to see if its parents are section blocks / tries to figure out the block editing mode. However the current list of cache values does not include anything about the state of the parents or the _derived_ block editing mode of the block in question.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

~In the list of `getInsertBlockTypeDependants` add a call to `getParentSectionBlock` so that we check that for the current clientId. This ensures that if the parent section block is changed, the cache is (effectively) invalidated.~

~However, this is likely an expensive call, so is probably not the ideal fix. My hope is that this PR can help us come up with a better fix. (The unit tests are failing because this change expects a broader set of things in `state`, I've left them failing while we investigate the right fix for this)~

Thanks to Dan's suggestion, I've updated this PR to use the `getBlockEditingMode( state, rootClientId )` which is relatively inexpensive as it just uses `has` checks on the computed values that are (elsewhere) updated via `getDerivedBlockEditingModesForTree`. This appears to be the right fix now, I believe, as the check is inexpensive, but it's looking in the right place for determining the current state of the block.

## Testing Instructions

1. Turn on the Gutenberg > Experiment: contentOnly: make patterns contentOnly by default upon insertion
2. Go to the site editor
3. Open the sidebar inspector
4. Select a pattern that defaults to contentOnly (or insert a new pattern, most should work)
5. Select a block within the pattern (not the top level group)
6. Press Edit contents button
7. Click three dots from toolbar
8. You should see the Add Before, Add After, and Duplicate options
9. You should also be able to drag within the pattern

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

For before videos, see #71955 and #71956. With this PR applied, this is possible:

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/55f9f388-efa8-431d-846d-e2042b218cbb