### PR TITLE
Accordion: add group role and aria-label block support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -16,7 +16,7 @@ Displays a group of accordion headings and associated expandable content. ([Sour
 -	**Experimental:** true
 -	**Category:** design
 -	**Allowed Blocks:** core/accordion-item
--	**Supports:** align (full, wide), background (backgroundImage, backgroundSize), color (background, gradients, text), interactivity, layout, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), ariaLabel, background (backgroundImage, backgroundSize), color (background, gradients, text), interactivity, layout, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** autoclose, headingLevel, iconPosition, levelOptions, showIcon
 
 ## Accordion Heading

--- a/packages/block-library/src/accordion/block.json
+++ b/packages/block-library/src/accordion/block.json
@@ -40,6 +40,7 @@
 		},
 		"shadow": true,
 		"layout": true,
+		"ariaLabel": true,
 		"interactivity": true,
 		"typography": {
 			"fontSize": true,

--- a/packages/block-library/src/accordion/edit.js
+++ b/packages/block-library/src/accordion/edit.js
@@ -48,7 +48,9 @@ export default function Edit( {
 } ) {
 	const registry = useRegistry();
 	const { getBlockOrder } = useSelect( blockEditorStore );
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( {
+		role: 'group',
+	} );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const { updateBlockAttributes, insertBlock } =
 		useDispatch( blockEditorStore );

--- a/packages/block-library/src/accordion/save.js
+++ b/packages/block-library/src/accordion/save.js
@@ -4,6 +4,8 @@
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
 export default function save() {
-	const blockProps = useBlockProps.save();
+	const blockProps = useBlockProps.save( {
+		role: 'group',
+	} );
 	return <div { ...useInnerBlocksProps.save( blockProps ) } />;
 }


### PR DESCRIPTION
Closes #71780

## What? Why?

Add `role="group"` and `ariaLabel` block support to improve accessibility.

## How?

For now, I don't expose a UI for editing `aria-label` because the `ariaLabel` block support itself does not expose a UI by default, and there are no core blocks that expose a UI for `aria-label`. However, if a UI is required to add `role=group`, I'm happy to implement that.

## Testing Instructions

- Add an Accordion block and open the post.
- Confirm that the block has the `role="group"` attribute.

### Testing Instructions for Keyboard

Use the following HTML to create an Accordion block with the custom `aria-label` attribute:

```html
<!-- wp:accordion { "ariaLabel": "My Accordion" } -->
<div role="group" class="wp-block-accordion" aria-label="My Accordion">
	<!-- wp:accordion-item -->
	<div class="wp-block-accordion-item">
		<!-- wp:accordion-heading -->
		<h3 class="wp-block-accordion-heading"><button class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title">Accordion Title</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h3>
		<!-- /wp:accordion-heading -->
		<!-- wp:accordion-panel -->
		<div role="region" class="wp-block-accordion-panel">
			<!-- wp:paragraph -->
			<p>Accordion Content</p>
			<!-- /wp:paragraph -->
		</div>
		<!-- /wp:accordion-panel -->
	</div>
	<!-- /wp:accordion-item -->
	<!-- wp:accordion-item -->
	<div class="wp-block-accordion-item">
		<!-- wp:accordion-heading -->
		<h3 class="wp-block-accordion-heading"><button class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title">Accordion Title</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h3>
		<!-- /wp:accordion-heading -->
		<!-- wp:accordion-panel -->
		<div role="region" class="wp-block-accordion-panel">
			<!-- wp:paragraph -->
			<p>Accordion Content</p>
			<!-- /wp:paragraph -->
		</div>
		<!-- /wp:accordion-panel -->
	</div>
	<!-- /wp:accordion-item -->
</div>
<!-- /wp:accordion -->
```

- Open the post and focus the first header inside the Accordion button.
- Your screen reader should read it something like this:
  ```
  My Accordion  grouping
  Accordion Title  heading
  Accordion Title  button  collapsed
  ```