### PR TITLE
Remove extra traverseBlockTree call

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2544,31 +2544,29 @@ function getDerivedBlockEditingModesUpdates( {
 	} );
 
 	addedBlocks?.forEach( ( addedBlock ) => {
-		traverseBlockTree( nextState, addedBlock.clientId, ( block ) => {
-			const updates = getDerivedBlockEditingModesForTree(
-				nextState,
-				isNavMode,
-				block.clientId
-			);
+		const updates = getDerivedBlockEditingModesForTree(
+			nextState,
+			isNavMode,
+			addedBlock.clientId
+		);
 
-			if ( updates.size ) {
-				if ( ! nextDerivedBlockEditingModes ) {
-					nextDerivedBlockEditingModes = new Map( [
-						...( prevDerivedBlockEditingModes?.size
-							? prevDerivedBlockEditingModes
-							: [] ),
-						...updates,
-					] );
-				} else {
-					nextDerivedBlockEditingModes = new Map( [
-						...( nextDerivedBlockEditingModes?.size
-							? nextDerivedBlockEditingModes
-							: [] ),
-						...updates,
-					] );
-				}
+		if ( updates.size ) {
+			if ( ! nextDerivedBlockEditingModes ) {
+				nextDerivedBlockEditingModes = new Map( [
+					...( prevDerivedBlockEditingModes?.size
+						? prevDerivedBlockEditingModes
+						: [] ),
+					...updates,
+				] );
+			} else {
+				nextDerivedBlockEditingModes = new Map( [
+					...( nextDerivedBlockEditingModes?.size
+						? nextDerivedBlockEditingModes
+						: [] ),
+					...updates,
+				] );
 			}
-		} );
+		}
 	} );
 
 	return nextDerivedBlockEditingModes;


### PR DESCRIPTION
## What?
Best reviewed with whitespace off, as it only removes 2 lines, but unindents a lot of code.

Code tidy up (of my own mess) and probably a performance improvement too.

When new blocks are added in the editor, a higher order reducer calculates whether these blocks should have a derivedBlockEditingMode set. I noticed the code loops through each of the addedBlocks, but then also uses `traverseBlockTree` inside that, which loops through all inner blocks.

I don't think that's needed as some later code already traverses the block tree in the `getDerivedBlockEditingModesForTree` function that's called (the clue is in the name):
https://github.com/WordPress/gutenberg/blob/d411b8f82fc4864d94b8f21540cf290155789d92/packages/block-editor/src/store/reducer.js#L2294

Doing it twice might be bad for performance. 😬 

## Testing Instructions
Everything should be the same as before.

There are quite a lot of unit tests for the reducer, and they should all pass.

Manually also test:
- Zoomed out mode - sections can be selected but the inner blocks of sections are disabled
- Write mode - sections can be selected and inner blocks of sections are in contentOnly mode
- `templateLock: 'contentOnly'` - inner blocks should be in contentOnly mode.
- Synced patterns - all child blocks should be disabled, apart from blocks with pattern overrides or bindings
- The contentOnly patterns experiment - template parts and unsynced patterns should be contentOnly mode.