### PR TITLE
Add blockVisibility support to Synced Pattern and Template Part

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -86,7 +86,7 @@ Reuse this design across your site. ([Source](https://github.com/WordPress/guten
 
 -	**Name:** core/block
 -	**Category:** reusable
--	**Supports:** interactivity (clientNavigation), ~~blockVisibility~~, ~~customClassName~~, ~~html~~, ~~inserter~~, ~~renaming~~
+-	**Supports:** interactivity (clientNavigation), ~~customClassName~~, ~~html~~, ~~inserter~~, ~~renaming~~
 -	**Attributes:** content, ref
 
 ## Button
@@ -975,7 +975,7 @@ Edit the different global regions of your site, like the header, footer, sidebar
 
 -	**Name:** core/template-part
 -	**Category:** theme
--	**Supports:** align, interactivity (clientNavigation), ~~blockVisibility~~, ~~html~~, ~~renaming~~, ~~reusable~~
+-	**Supports:** align, interactivity (clientNavigation), ~~html~~, ~~renaming~~, ~~reusable~~
 -	**Attributes:** area, slug, tagName, theme
 
 ## Term Description

--- a/packages/block-library/src/block/block.json
+++ b/packages/block-library/src/block/block.json
@@ -24,7 +24,6 @@
 		"html": false,
 		"inserter": false,
 		"renaming": false,
-		"blockVisibility": false,
 		"interactivity": {
 			"clientNavigation": true
 		}

--- a/packages/block-library/src/template-part/block.json
+++ b/packages/block-library/src/template-part/block.json
@@ -25,7 +25,6 @@
 		"html": false,
 		"reusable": false,
 		"renaming": false,
-		"blockVisibility": false,
 		"interactivity": {
 			"clientNavigation": true
 		}


### PR DESCRIPTION
- Part of #72001
- Addresses https://github.com/WordPress/gutenberg/pull/71203#discussion_r2393796633

## What?

Add `blockVisibility` support to Synced Pattern and Template Part

## Why?

When I initially implemented the Block Visibility feature, I disabled this feature for generic blocks just to be safe. However, this feature should work perfectly in such blocks.

## Testing Instructions

- Create a synced pattern.
- Open the site editor.
- Try to hide and show template parts and synced pattern.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/4cb8c5e2-1a61-430e-a784-3022612726ed

