### PR TITLE
Block Visibility: show snackbar when hiding block

### DIFF
--- a/packages/block-editor/src/components/block-visibility/menu-item.js
+++ b/packages/block-editor/src/components/block-visibility/menu-item.js
@@ -72,7 +72,7 @@ export default function BlockVisibilityMenuItem( { clientIds } ) {
 					sprintf(
 						// translators: %s: The shortcut key to access the List view.
 						__(
-							'Block hidden. You can access it via the List view (%s).'
+							'Block hidden. You can access it via the List View (%s).'
 						),
 						listViewShortcut
 					),

--- a/packages/block-editor/src/components/block-visibility/menu-item.js
+++ b/packages/block-editor/src/components/block-visibility/menu-item.js
@@ -1,10 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { MenuItem } from '@wordpress/components';
 import { seen, unseen } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 
 /**
  * Internal dependencies
@@ -14,6 +16,7 @@ import { store as blockEditorStore } from '../../store';
 
 export default function BlockVisibilityMenuItem( { clientIds } ) {
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const { createSuccessNotice } = useDispatch( noticesStore );
 	const blocks = useSelect(
 		( select ) => {
 			return select( blockEditorStore ).getBlocksByClientId( clientIds );
@@ -21,18 +24,26 @@ export default function BlockVisibilityMenuItem( { clientIds } ) {
 		[ clientIds ]
 	);
 
+	const listViewShortcut = useSelect( ( select ) => {
+		return select( keyboardShortcutsStore ).getShortcutRepresentation(
+			'core/editor/toggle-list-view'
+		);
+	}, [] );
+
 	const hasHiddenBlock = blocks.some(
 		( block ) => block.attributes.metadata?.blockVisibility === false
 	);
 
 	const toggleBlockVisibility = () => {
+		const isHiding = ! hasHiddenBlock;
+
 		const attributesByClientId = Object.fromEntries(
 			blocks?.map( ( { clientId, attributes } ) => [
 				clientId,
 				{
 					metadata: cleanEmptyObject( {
 						...attributes?.metadata,
-						blockVisibility: hasHiddenBlock ? undefined : false,
+						blockVisibility: isHiding ? false : undefined,
 					} ),
 				},
 			] )
@@ -40,6 +51,38 @@ export default function BlockVisibilityMenuItem( { clientIds } ) {
 		updateBlockAttributes( clientIds, attributesByClientId, {
 			uniqueByBlock: true,
 		} );
+
+		if ( isHiding ) {
+			if ( blocks.length > 1 ) {
+				createSuccessNotice(
+					sprintf(
+						// translators: %s: The shortcut key to access the List view.
+						__(
+							'Blocks hidden. You can access them via the List view (%s).'
+						),
+						listViewShortcut
+					),
+					{
+						id: 'block-visibility-hidden',
+						type: 'snackbar',
+					}
+				);
+			} else {
+				createSuccessNotice(
+					sprintf(
+						// translators: %s: The shortcut key to access the List view.
+						__(
+							'Block hidden. You can access it via the List view (%s).'
+						),
+						listViewShortcut
+					),
+					{
+						id: 'block-visibility-hidden',
+						type: 'snackbar',
+					}
+				);
+			}
+		}
 	};
 
 	return (

--- a/packages/block-editor/src/components/block-visibility/menu-item.js
+++ b/packages/block-editor/src/components/block-visibility/menu-item.js
@@ -58,7 +58,7 @@ export default function BlockVisibilityMenuItem( { clientIds } ) {
 					sprintf(
 						// translators: %s: The shortcut key to access the List view.
 						__(
-							'Blocks hidden. You can access them via the List view (%s).'
+							'Blocks hidden. You can access them via the List View (%s).'
 						),
 						listViewShortcut
 					),

--- a/packages/block-editor/src/components/block-visibility/menu-item.js
+++ b/packages/block-editor/src/components/block-visibility/menu-item.js
@@ -56,7 +56,7 @@ export default function BlockVisibilityMenuItem( { clientIds } ) {
 			if ( blocks.length > 1 ) {
 				createSuccessNotice(
 					sprintf(
-						// translators: %s: The shortcut key to access the List view.
+						// translators: %s: The shortcut key to access the List View.
 						__(
 							'Blocks hidden. You can access them via the List View (%s).'
 						),

--- a/packages/block-editor/src/components/block-visibility/menu-item.js
+++ b/packages/block-editor/src/components/block-visibility/menu-item.js
@@ -70,7 +70,7 @@ export default function BlockVisibilityMenuItem( { clientIds } ) {
 			} else {
 				createSuccessNotice(
 					sprintf(
-						// translators: %s: The shortcut key to access the List view.
+						// translators: %s: The shortcut key to access the List View.
 						__(
 							'Block hidden. You can access it via the List View (%s).'
 						),


### PR DESCRIPTION
- Part of #72001
- Addresses: https://github.com/WordPress/gutenberg/pull/71203#issuecomment-3322980887

## What?

Shows a snackbar when hiding the selected block.

Screenshots in Windows OS: The shortcut key should be `⌃⌥O` in MacOS

<img width="408" height="100" alt="image" src="https://github.com/user-attachments/assets/d602b844-8c26-41d8-81f9-06adc3566c6e" />

## Why?

When the Hide button is clicked, the selected block is visually hidden, and users may not know how to enable the block again.

## How?

One problem may be that this snackbar will be displayed even when the block is hidden via the List View. This is because the same options dropdown component is used in both the List View and the block toolbar. I'm a bit hesitant to do this because it would likely require changing the behavior of public components.

## Testing Instructions

Hide a block and confirm the snackbar.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/ba2f76fd-65a6-4ad5-a15e-267ecbe0a1e4