### PR TITLE
Template activation: ignore templates not associated with active theme

### DIFF
--- a/backport-changelog/6.9/8063.md
+++ b/backport-changelog/6.9/8063.md
@@ -2,3 +2,4 @@ https://github.com/WordPress/wordpress-develop/pull/8063
 
 * https://github.com/WordPress/gutenberg/pull/67125
 * https://github.com/WordPress/gutenberg/pull/71811
+* https://github.com/WordPress/gutenberg/pull/72029

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -231,7 +231,7 @@ function gutenberg_resolve_block_template( $template_type, $template_hierarchy, 
 
 		// Ensure the active templates are associated with the active theme.
 		// See _build_block_template_object_from_post_object.
-		if ( $template->theme !== get_stylesheet() ) {
+		if ( get_stylesheet() !== $template->theme ) {
 			$remaining_slugs[] = $slug;
 			continue;
 		}

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -27,6 +27,22 @@ function gutenberg_maintain_templates_routes() {
 	$controller                              = new WP_REST_Templates_Controller( 'wp_template' );
 	$wp_post_types['wp_template']->rest_base = 'wp_template';
 	$controller->register_routes();
+
+	// Add the same field as wp_registered_template.
+	register_rest_field(
+		'wp_template',
+		'theme',
+		array(
+			'get_callback' => function ( $post_arr ) {
+				$terms = get_the_terms( $post_arr['id'], 'wp_theme' );
+				if ( is_wp_error( $terms ) || empty( $terms ) ) {
+					return null;
+				}
+
+				return $terms[0]->slug;
+			},
+		)
+	);
 }
 
 // 3. We need a route to get that raw static templates from themes and plugins.

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -227,7 +227,16 @@ function gutenberg_resolve_block_template( $template_type, $template_hierarchy, 
 			continue;
 		}
 
-		$templates[] = _build_block_template_result_from_post( $post );
+		$template = _build_block_template_result_from_post( $post );
+
+		// Ensure the active templates are associated with the active theme.
+		// See _build_block_template_object_from_post_object.
+		if ( $template->theme !== get_stylesheet() ) {
+			$remaining_slugs[] = $slug;
+			continue;
+		}
+
+		$templates[] = $template;
 	}
 
 	// For any remaining slugs, use the static template.

--- a/packages/edit-site/src/components/dataviews-actions/index.js
+++ b/packages/edit-site/src/components/dataviews-actions/index.js
@@ -17,6 +17,9 @@ import { unlock } from '../../lock-unlock';
 const { useHistory } = unlock( routerPrivateApis );
 
 export const useSetActiveTemplateAction = () => {
+	const activeTheme = useSelect( ( select ) =>
+		select( coreStore ).getCurrentTheme()
+	);
 	const { getEntityRecord } = useSelect( coreStore );
 	const { editEntityRecord, saveEditedEntityRecord } =
 		useDispatch( coreStore );
@@ -31,7 +34,10 @@ export const useSetActiveTemplateAction = () => {
 			isPrimary: true,
 			icon: edit,
 			isEligible( item ) {
-				return ! ( item.slug === 'index' && item.source === 'theme' );
+				return (
+					! ( item.slug === 'index' && item.source === 'theme' ) &&
+					item.theme === activeTheme.stylesheet
+				);
 			},
 			async callback( items ) {
 				const deactivate = items.some( ( item ) => item._isActive );
@@ -61,7 +67,12 @@ export const useSetActiveTemplateAction = () => {
 				await saveEditedEntityRecord( 'root', 'site' );
 			},
 		} ),
-		[ editEntityRecord, saveEditedEntityRecord, getEntityRecord ]
+		[
+			editEntityRecord,
+			saveEditedEntityRecord,
+			getEntityRecord,
+			activeTheme,
+		]
 	);
 };
 

--- a/packages/edit-site/src/components/page-templates/fields.js
+++ b/packages/edit-site/src/components/page-templates/fields.js
@@ -20,7 +20,11 @@ import {
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { EditorProvider } from '@wordpress/editor';
-import { privateApis as corePrivateApis } from '@wordpress/core-data';
+import {
+	privateApis as corePrivateApis,
+	store as coreStore,
+} from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -158,6 +162,23 @@ export const activeField = {
 			</Badge>
 		);
 	},
+};
+
+export const useThemeField = () => {
+	const activeTheme = useSelect( ( select ) =>
+		select( coreStore ).getCurrentTheme()
+	);
+	return {
+		label: __( 'Compatible Theme' ),
+		id: 'theme',
+		getValue: ( { item } ) => item.theme,
+		render: function Render( { item } ) {
+			if ( item.theme === activeTheme.stylesheet ) {
+				return <Badge intent="success">{ item.theme }</Badge>;
+			}
+			return <Badge intent="error">{ item.theme }</Badge>;
+		},
+	};
 };
 
 export const slugField = {

--- a/test/e2e/specs/site-editor/template-activate.spec.js
+++ b/test/e2e/specs/site-editor/template-activate.spec.js
@@ -126,4 +126,34 @@ test.describe( 'Template Activate', () => {
 			'Copied from Index.'
 		);
 	} );
+
+	test( 'should deactivate after theme change', async ( {
+		admin,
+		page,
+		requestUtils,
+		editor,
+	} ) => {
+		await admin.visitSiteEditor( { postType: 'wp_template' } );
+		await page.getByRole( 'button', { name: 'Add Template' } ).click();
+		await page.getByRole( 'button', { name: 'Blog Home' } ).click();
+		await page.waitForSelector( 'iframe[name="editor-canvas"]' );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'My home template test.' },
+		} );
+		await page.getByRole( 'button', { name: 'Save', exact: true } ).click();
+		await page.getByRole( 'button', { name: 'Activate' } ).click();
+		await expect( page.locator( '.components-notice' ) ).toContainText(
+			'Template activated.'
+		);
+		await page.goto( '/' );
+		await expect( page.locator( 'body' ) ).toContainText(
+			'My home template test.'
+		);
+		await requestUtils.activateTheme( 'twentytwentyfive' );
+		await page.reload();
+		await expect( page.locator( 'body' ) ).not.toContainText(
+			'My home template test.'
+		);
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

See #71735.

Addressing feedback from @justintadlock. When the user switches themes, any active templates that are associated with the previous theme should be ignored.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently templates are often heavily dependent on styles and patterns from the current theme.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Whenever new templates are created, we already save information to the database that associates it with the current theme. Fixing the issue is just a matter of using that data:

* On the front-end, check that the active templated set for a slug is associated with the current theme, otherwise ignore it.
* In the site editor, also make sure the template is no longer marked as active. For now, I've opted to also disable the "activate" action. Users can still choose to duplicate the template, which will update the association, and maybe it available to activate. I've also added an extra field to indicate the lack of compatibility.

Please note: when you switched themes previously in WP, theme template edits would completely disappear.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Duplicate the Home template for 2025 (for example), make some changes, and activate it.
* Switch to 2024. The Home page should now use the 2024 template, and the custom template should be inactive.

<img width="1464" height="955" alt="image" src="https://github.com/user-attachments/assets/c1ef46bc-0ab7-464b-819e-d90140904ff0" />


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
