### PR TITLE
Stabilize Accordion block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -13,7 +13,6 @@ This page lists the blocks included in the block-library package.
 Displays a group of accordion headings and associated expandable content. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/accordion))
 
 -	**Name:** core/accordion
--	**Experimental:** true
 -	**Category:** design
 -	**Allowed Blocks:** core/accordion-item
 -	**Supports:** align (full, wide), ariaLabel, background (backgroundImage, backgroundSize), color (background, gradients, text), interactivity, layout, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
@@ -24,7 +23,6 @@ Displays a group of accordion headings and associated expandable content. ([Sour
 Displays an accordion heading. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/accordion-heading))
 
 -	**Name:** core/accordion-heading
--	**Experimental:** true
 -	**Category:** design
 -	**Parent:** core/accordion-item
 -	**Supports:** anchor, color (background, gradients, text), interactivity, shadow, spacing (padding), typography (fontSize), ~~align~~, ~~blockVisibility~~
@@ -35,7 +33,6 @@ Displays an accordion heading. ([Source](https://github.com/WordPress/gutenberg/
 Displays a section of content in an accordion, including a heading and expandable content. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/accordion-item))
 
 -	**Name:** core/accordion-item
--	**Experimental:** true
 -	**Category:** design
 -	**Parent:** core/accordion
 -	**Allowed Blocks:** core/accordion-heading, core/accordion-panel
@@ -47,7 +44,6 @@ Displays a section of content in an accordion, including a heading and expandabl
 Displays an accordion panel. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/accordion-panel))
 
 -	**Name:** core/accordion-panel
--	**Experimental:** true
 -	**Category:** design
 -	**Parent:** core/accordion-item
 -	**Supports:** color (background, gradients, text), interactivity, layout, shadow, spacing (blockGap, padding), typography (fontSize, lineHeight), ~~blockVisibility~~

--- a/packages/block-library/src/accordion-heading/block.json
+++ b/packages/block-library/src/accordion-heading/block.json
@@ -5,7 +5,6 @@
 	"title": "Accordion Heading",
 	"category": "design",
 	"description": "Displays an accordion heading.",
-	"__experimental": true,
 	"parent": [ "core/accordion-item" ],
 	"usesContext": [
 		"core/accordion-icon-position",

--- a/packages/block-library/src/accordion-item/block.json
+++ b/packages/block-library/src/accordion-item/block.json
@@ -5,7 +5,6 @@
 	"title": "Accordion Item",
 	"category": "design",
 	"description": "Displays a section of content in an accordion, including a heading and expandable content.",
-	"__experimental": true,
 	"parent": [ "core/accordion" ],
 	"allowedBlocks": [ "core/accordion-heading", "core/accordion-panel" ],
 	"supports": {

--- a/packages/block-library/src/accordion-item/index.php
+++ b/packages/block-library/src/accordion-item/index.php
@@ -4,7 +4,7 @@
  * Server-side rendering of the `core/accordion-item` block.
  *
  * @package WordPress
- * @since 6.6.0
+ * @since 6.9.0
  *
  * @param array $attributes The block attributes.
  * @param string $content The block content.
@@ -61,7 +61,7 @@ function block_core_accordion_item_render( $attributes, $content ) {
 /**
  * Registers the `core/accordion-item` block on server.
  *
- * @since 6.6.0
+ * @since 6.9.0
  */
 function register_block_core_accordion_item() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/accordion-panel/block.json
+++ b/packages/block-library/src/accordion-panel/block.json
@@ -5,7 +5,6 @@
 	"title": "Accordion Panel",
 	"category": "design",
 	"description": "Displays an accordion panel.",
-	"__experimental": true,
 	"parent": [ "core/accordion-item" ],
 	"supports": {
 		"color": {

--- a/packages/block-library/src/accordion/block.json
+++ b/packages/block-library/src/accordion/block.json
@@ -6,7 +6,6 @@
 	"category": "design",
 	"description": "Displays a group of accordion headings and associated expandable content.",
 	"example": {},
-	"__experimental": true,
 	"supports": {
 		"html": false,
 		"align": [ "wide", "full" ],

--- a/packages/block-library/src/accordion/index.php
+++ b/packages/block-library/src/accordion/index.php
@@ -3,7 +3,7 @@
  * Server-side rendering of the `core/accordion` block.
  *
  * @package WordPress
- * @since 6.6.0
+ * @since 6.9.0
  *
  * @param array $attributes The block attributes.
  * @param string $content The block content.
@@ -32,7 +32,7 @@ function render_block_core_accordion( $attributes, $content ) {
 /**
  * Registers the `core/accordion` block on server.
  *
- * @since 6.6.0
+ * @since 6.9.0
  */
 function register_block_core_accordion() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -150,6 +150,10 @@ const getAllBlocks = () => {
 		quote,
 
 		// Register all remaining core blocks.
+		accordion,
+		accordionItem,
+		accordionHeading,
+		accordionPanel,
 		archives,
 		audio,
 		button,
@@ -245,10 +249,6 @@ const getAllBlocks = () => {
 	];
 
 	if ( window?.__experimentalEnableBlockExperiments ) {
-		blocks.push( accordion );
-		blocks.push( accordionItem );
-		blocks.push( accordionHeading );
-		blocks.push( accordionPanel );
 		blocks.push( termsQuery );
 		blocks.push( termTemplate );
 	}

--- a/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
+++ b/test/e2e/specs/editor/various/autocomplete-and-mentions.spec.js
@@ -571,7 +571,7 @@ test.describe( 'Autocomplete (@firefox, @webkit)', () => {
 		// Get the assertive live region screen reader announcement.
 		await expect(
 			page.getByText(
-				'2 results found, use up and down arrow keys to navigate.'
+				'3 results found, use up and down arrow keys to navigate.'
 			)
 		).toBeVisible();
 	} );

--- a/test/e2e/specs/site-editor/push-to-global-styles.spec.js
+++ b/test/e2e/specs/site-editor/push-to-global-styles.spec.js
@@ -36,7 +36,9 @@ test.describe( 'Push to Global Styles button', () => {
 		// Navigate to Styles -> Blocks -> Heading -> Typography
 		await topBar.getByRole( 'button', { name: 'Styles' } ).click();
 		await settingsPanel.getByRole( 'button', { name: 'Blocks' } ).click();
-		await settingsPanel.getByRole( 'button', { name: 'Heading' } ).click();
+		await settingsPanel
+			.getByRole( 'button', { name: 'Heading', exact: true } )
+			.click();
 
 		// Headings should not have uppercase
 		await expect(

--- a/test/integration/fixtures/blocks/core__accordion-heading.html
+++ b/test/integration/fixtures/blocks/core__accordion-heading.html
@@ -1,0 +1,5 @@
+<!-- wp:accordion-heading -->
+<h3 class="wp-block-accordion-heading">
+	<button class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title">Accordion Title</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button>
+</h3>
+<!-- /wp:accordion-heading -->

--- a/test/integration/fixtures/blocks/core__accordion-heading.json
+++ b/test/integration/fixtures/blocks/core__accordion-heading.json
@@ -1,0 +1,13 @@
+[
+	{
+		"name": "core/accordion-heading",
+		"isValid": true,
+		"attributes": {
+			"openByDefault": false,
+			"title": "Accordion Title",
+			"iconPosition": "right",
+			"showIcon": true
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__accordion-heading.parsed.json
+++ b/test/integration/fixtures/blocks/core__accordion-heading.parsed.json
@@ -1,0 +1,11 @@
+[
+	{
+		"blockName": "core/accordion-heading",
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n<h3 class=\"wp-block-accordion-heading\">\n\t<button class=\"wp-block-accordion-heading__toggle\"><span class=\"wp-block-accordion-heading__toggle-title\">Accordion Title</span><span class=\"wp-block-accordion-heading__toggle-icon\" aria-hidden=\"true\">+</span></button>\n</h3>\n",
+		"innerContent": [
+			"\n<h3 class=\"wp-block-accordion-heading\">\n\t<button class=\"wp-block-accordion-heading__toggle\"><span class=\"wp-block-accordion-heading__toggle-title\">Accordion Title</span><span class=\"wp-block-accordion-heading__toggle-icon\" aria-hidden=\"true\">+</span></button>\n</h3>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__accordion-heading.serialized.html
+++ b/test/integration/fixtures/blocks/core__accordion-heading.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:accordion-heading -->
+<h3 class="wp-block-accordion-heading"><button class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title">Accordion Title</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h3>
+<!-- /wp:accordion-heading -->

--- a/test/integration/fixtures/blocks/core__accordion-item.html
+++ b/test/integration/fixtures/blocks/core__accordion-item.html
@@ -8,7 +8,7 @@
 	<!-- wp:accordion-panel -->
 	<div role="region" class="wp-block-accordion-panel">
 		<!-- wp:paragraph -->
-		<p>Accoridion Panel Content</p>
+		<p>Accordion  Panel Content</p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:accordion-panel -->

--- a/test/integration/fixtures/blocks/core__accordion-item.html
+++ b/test/integration/fixtures/blocks/core__accordion-item.html
@@ -1,0 +1,16 @@
+<!-- wp:accordion-item -->
+<div class="wp-block-accordion-item">
+	<!-- wp:accordion-heading -->
+	<h3 class="wp-block-accordion-heading">
+		<button class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title">Accordion Title</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button>
+	</h3>
+	<!-- /wp:accordion-heading -->
+	<!-- wp:accordion-panel -->
+	<div role="region" class="wp-block-accordion-panel">
+		<!-- wp:paragraph -->
+		<p>Accoridion Panel Content</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:accordion-panel -->
+</div>
+<!-- /wp:accordion-item -->

--- a/test/integration/fixtures/blocks/core__accordion-item.json
+++ b/test/integration/fixtures/blocks/core__accordion-item.json
@@ -30,7 +30,7 @@
 						"name": "core/paragraph",
 						"isValid": true,
 						"attributes": {
-							"content": "Accoridion Panel Content",
+							"content": "Accordion  Panel Content",
 							"dropCap": false
 						},
 						"innerBlocks": []

--- a/test/integration/fixtures/blocks/core__accordion-item.json
+++ b/test/integration/fixtures/blocks/core__accordion-item.json
@@ -1,0 +1,42 @@
+[
+	{
+		"name": "core/accordion-item",
+		"isValid": true,
+		"attributes": {
+			"openByDefault": false
+		},
+		"innerBlocks": [
+			{
+				"name": "core/accordion-heading",
+				"isValid": true,
+				"attributes": {
+					"openByDefault": false,
+					"title": "Accordion Title",
+					"iconPosition": "right",
+					"showIcon": true
+				},
+				"innerBlocks": []
+			},
+			{
+				"name": "core/accordion-panel",
+				"isValid": true,
+				"attributes": {
+					"templateLock": false,
+					"openByDefault": false,
+					"isSelected": false
+				},
+				"innerBlocks": [
+					{
+						"name": "core/paragraph",
+						"isValid": true,
+						"attributes": {
+							"content": "Accoridion Panel Content",
+							"dropCap": false
+						},
+						"innerBlocks": []
+					}
+				]
+			}
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__accordion-item.parsed.json
+++ b/test/integration/fixtures/blocks/core__accordion-item.parsed.json
@@ -20,9 +20,9 @@
 						"blockName": "core/paragraph",
 						"attrs": {},
 						"innerBlocks": [],
-						"innerHTML": "\n\t\t<p>Accoridion Panel Content</p>\n\t\t",
+						"innerHTML": "\n\t\t<p>Accordion  Panel Content</p>\n\t\t",
 						"innerContent": [
-							"\n\t\t<p>Accoridion Panel Content</p>\n\t\t"
+							"\n\t\t<p>Accordion  Panel Content</p>\n\t\t"
 						]
 					}
 				],

--- a/test/integration/fixtures/blocks/core__accordion-item.parsed.json
+++ b/test/integration/fixtures/blocks/core__accordion-item.parsed.json
@@ -1,0 +1,46 @@
+[
+	{
+		"blockName": "core/accordion-item",
+		"attrs": {},
+		"innerBlocks": [
+			{
+				"blockName": "core/accordion-heading",
+				"attrs": {},
+				"innerBlocks": [],
+				"innerHTML": "\n\t<h3 class=\"wp-block-accordion-heading\">\n\t\t<button class=\"wp-block-accordion-heading__toggle\"><span class=\"wp-block-accordion-heading__toggle-title\">Accordion Title</span><span class=\"wp-block-accordion-heading__toggle-icon\" aria-hidden=\"true\">+</span></button>\n\t</h3>\n\t",
+				"innerContent": [
+					"\n\t<h3 class=\"wp-block-accordion-heading\">\n\t\t<button class=\"wp-block-accordion-heading__toggle\"><span class=\"wp-block-accordion-heading__toggle-title\">Accordion Title</span><span class=\"wp-block-accordion-heading__toggle-icon\" aria-hidden=\"true\">+</span></button>\n\t</h3>\n\t"
+				]
+			},
+			{
+				"blockName": "core/accordion-panel",
+				"attrs": {},
+				"innerBlocks": [
+					{
+						"blockName": "core/paragraph",
+						"attrs": {},
+						"innerBlocks": [],
+						"innerHTML": "\n\t\t<p>Accoridion Panel Content</p>\n\t\t",
+						"innerContent": [
+							"\n\t\t<p>Accoridion Panel Content</p>\n\t\t"
+						]
+					}
+				],
+				"innerHTML": "\n\t<div role=\"region\" class=\"wp-block-accordion-panel\">\n\t\t\n\t</div>\n\t",
+				"innerContent": [
+					"\n\t<div role=\"region\" class=\"wp-block-accordion-panel\">\n\t\t",
+					null,
+					"\n\t</div>\n\t"
+				]
+			}
+		],
+		"innerHTML": "\n<div class=\"wp-block-accordion-item\">\n\t\n\t\n</div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-accordion-item\">\n\t",
+			null,
+			"\n\t",
+			null,
+			"\n</div>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__accordion-item.serialized.html
+++ b/test/integration/fixtures/blocks/core__accordion-item.serialized.html
@@ -1,0 +1,11 @@
+<!-- wp:accordion-item -->
+<div class="wp-block-accordion-item"><!-- wp:accordion-heading -->
+<h3 class="wp-block-accordion-heading"><button class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title">Accordion Title</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h3>
+<!-- /wp:accordion-heading -->
+
+<!-- wp:accordion-panel -->
+<div role="region" class="wp-block-accordion-panel"><!-- wp:paragraph -->
+<p>Accoridion Panel Content</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:accordion-panel --></div>
+<!-- /wp:accordion-item -->

--- a/test/integration/fixtures/blocks/core__accordion-item.serialized.html
+++ b/test/integration/fixtures/blocks/core__accordion-item.serialized.html
@@ -5,7 +5,7 @@
 
 <!-- wp:accordion-panel -->
 <div role="region" class="wp-block-accordion-panel"><!-- wp:paragraph -->
-<p>Accoridion Panel Content</p>
+<p>Accordion  Panel Content</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:accordion-panel --></div>
 <!-- /wp:accordion-item -->

--- a/test/integration/fixtures/blocks/core__accordion-panel.html
+++ b/test/integration/fixtures/blocks/core__accordion-panel.html
@@ -1,0 +1,7 @@
+<!-- wp:accordion-panel -->
+<div role="region" class="wp-block-accordion-panel">
+	<!-- wp:paragraph -->
+	<p>Accoridion Panel Content</p>
+	<!-- /wp:paragraph -->
+</div>
+<!-- /wp:accordion-panel -->

--- a/test/integration/fixtures/blocks/core__accordion-panel.html
+++ b/test/integration/fixtures/blocks/core__accordion-panel.html
@@ -1,7 +1,7 @@
 <!-- wp:accordion-panel -->
 <div role="region" class="wp-block-accordion-panel">
 	<!-- wp:paragraph -->
-	<p>Accoridion Panel Content</p>
+	<p>Accordion  Panel Content</p>
 	<!-- /wp:paragraph -->
 </div>
 <!-- /wp:accordion-panel -->

--- a/test/integration/fixtures/blocks/core__accordion-panel.json
+++ b/test/integration/fixtures/blocks/core__accordion-panel.json
@@ -1,0 +1,22 @@
+[
+	{
+		"name": "core/accordion-panel",
+		"isValid": true,
+		"attributes": {
+			"templateLock": false,
+			"openByDefault": false,
+			"isSelected": false
+		},
+		"innerBlocks": [
+			{
+				"name": "core/paragraph",
+				"isValid": true,
+				"attributes": {
+					"content": "Accoridion Panel Content",
+					"dropCap": false
+				},
+				"innerBlocks": []
+			}
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__accordion-panel.json
+++ b/test/integration/fixtures/blocks/core__accordion-panel.json
@@ -12,7 +12,7 @@
 				"name": "core/paragraph",
 				"isValid": true,
 				"attributes": {
-					"content": "Accoridion Panel Content",
+					"content": "Accordion  Panel Content",
 					"dropCap": false
 				},
 				"innerBlocks": []

--- a/test/integration/fixtures/blocks/core__accordion-panel.parsed.json
+++ b/test/integration/fixtures/blocks/core__accordion-panel.parsed.json
@@ -1,0 +1,21 @@
+[
+	{
+		"blockName": "core/accordion-panel",
+		"attrs": {},
+		"innerBlocks": [
+			{
+				"blockName": "core/paragraph",
+				"attrs": {},
+				"innerBlocks": [],
+				"innerHTML": "\n\t<p>Accoridion Panel Content</p>\n\t",
+				"innerContent": [ "\n\t<p>Accoridion Panel Content</p>\n\t" ]
+			}
+		],
+		"innerHTML": "\n<div role=\"region\" class=\"wp-block-accordion-panel\">\n\t\n</div>\n",
+		"innerContent": [
+			"\n<div role=\"region\" class=\"wp-block-accordion-panel\">\n\t",
+			null,
+			"\n</div>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__accordion-panel.parsed.json
+++ b/test/integration/fixtures/blocks/core__accordion-panel.parsed.json
@@ -7,8 +7,8 @@
 				"blockName": "core/paragraph",
 				"attrs": {},
 				"innerBlocks": [],
-				"innerHTML": "\n\t<p>Accoridion Panel Content</p>\n\t",
-				"innerContent": [ "\n\t<p>Accoridion Panel Content</p>\n\t" ]
+				"innerHTML": "\n\t<p>Accordion  Panel Content</p>\n\t",
+				"innerContent": [ "\n\t<p>Accordion  Panel Content</p>\n\t" ]
 			}
 		],
 		"innerHTML": "\n<div role=\"region\" class=\"wp-block-accordion-panel\">\n\t\n</div>\n",

--- a/test/integration/fixtures/blocks/core__accordion-panel.serialized.html
+++ b/test/integration/fixtures/blocks/core__accordion-panel.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:accordion-panel -->
 <div role="region" class="wp-block-accordion-panel"><!-- wp:paragraph -->
-<p>Accoridion Panel Content</p>
+<p>Accordion  Panel Content</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:accordion-panel -->

--- a/test/integration/fixtures/blocks/core__accordion-panel.serialized.html
+++ b/test/integration/fixtures/blocks/core__accordion-panel.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:accordion-panel -->
+<div role="region" class="wp-block-accordion-panel"><!-- wp:paragraph -->
+<p>Accoridion Panel Content</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:accordion-panel -->

--- a/test/integration/fixtures/blocks/core__accordion.html
+++ b/test/integration/fixtures/blocks/core__accordion.html
@@ -1,0 +1,20 @@
+<!-- wp:accordion -->
+<div role="group" class="wp-block-accordion">
+	<!-- wp:accordion-item -->
+	<div class="wp-block-accordion-item">
+		<!-- wp:accordion-heading -->
+		<h3 class="wp-block-accordion-heading">
+			<button class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title">Accordion Title</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button>
+		</h3>
+		<!-- /wp:accordion-heading -->
+		<!-- wp:accordion-panel -->
+		<div role="region" class="wp-block-accordion-panel">
+			<!-- wp:paragraph -->
+			<p>Accoridion Panel Content</p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:accordion-panel -->
+	</div>
+	<!-- /wp:accordion-item -->
+</div>
+<!-- /wp:accordion -->

--- a/test/integration/fixtures/blocks/core__accordion.html
+++ b/test/integration/fixtures/blocks/core__accordion.html
@@ -10,7 +10,7 @@
 		<!-- wp:accordion-panel -->
 		<div role="region" class="wp-block-accordion-panel">
 			<!-- wp:paragraph -->
-			<p>Accoridion Panel Content</p>
+			<p>Accordion  Panel Content</p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:accordion-panel -->

--- a/test/integration/fixtures/blocks/core__accordion.json
+++ b/test/integration/fixtures/blocks/core__accordion.json
@@ -40,7 +40,7 @@
 								"name": "core/paragraph",
 								"isValid": true,
 								"attributes": {
-									"content": "Accoridion Panel Content",
+									"content": "Accordion  Panel Content",
 									"dropCap": false
 								},
 								"innerBlocks": []

--- a/test/integration/fixtures/blocks/core__accordion.json
+++ b/test/integration/fixtures/blocks/core__accordion.json
@@ -1,0 +1,54 @@
+[
+	{
+		"name": "core/accordion",
+		"isValid": true,
+		"attributes": {
+			"iconPosition": "right",
+			"showIcon": true,
+			"autoclose": false,
+			"headingLevel": 3
+		},
+		"innerBlocks": [
+			{
+				"name": "core/accordion-item",
+				"isValid": true,
+				"attributes": {
+					"openByDefault": false
+				},
+				"innerBlocks": [
+					{
+						"name": "core/accordion-heading",
+						"isValid": true,
+						"attributes": {
+							"openByDefault": false,
+							"title": "Accordion Title",
+							"iconPosition": "right",
+							"showIcon": true
+						},
+						"innerBlocks": []
+					},
+					{
+						"name": "core/accordion-panel",
+						"isValid": true,
+						"attributes": {
+							"templateLock": false,
+							"openByDefault": false,
+							"isSelected": false
+						},
+						"innerBlocks": [
+							{
+								"name": "core/paragraph",
+								"isValid": true,
+								"attributes": {
+									"content": "Accoridion Panel Content",
+									"dropCap": false
+								},
+								"innerBlocks": []
+							}
+						]
+					}
+				]
+			}
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__accordion.parsed.json
+++ b/test/integration/fixtures/blocks/core__accordion.parsed.json
@@ -24,9 +24,9 @@
 								"blockName": "core/paragraph",
 								"attrs": {},
 								"innerBlocks": [],
-								"innerHTML": "\n\t\t\t<p>Accoridion Panel Content</p>\n\t\t\t",
+								"innerHTML": "\n\t\t\t<p>Accordion  Panel Content</p>\n\t\t\t",
 								"innerContent": [
-									"\n\t\t\t<p>Accoridion Panel Content</p>\n\t\t\t"
+									"\n\t\t\t<p>Accordion  Panel Content</p>\n\t\t\t"
 								]
 							}
 						],

--- a/test/integration/fixtures/blocks/core__accordion.parsed.json
+++ b/test/integration/fixtures/blocks/core__accordion.parsed.json
@@ -1,0 +1,58 @@
+[
+	{
+		"blockName": "core/accordion",
+		"attrs": {},
+		"innerBlocks": [
+			{
+				"blockName": "core/accordion-item",
+				"attrs": {},
+				"innerBlocks": [
+					{
+						"blockName": "core/accordion-heading",
+						"attrs": {},
+						"innerBlocks": [],
+						"innerHTML": "\n\t\t<h3 class=\"wp-block-accordion-heading\">\n\t\t\t<button class=\"wp-block-accordion-heading__toggle\"><span class=\"wp-block-accordion-heading__toggle-title\">Accordion Title</span><span class=\"wp-block-accordion-heading__toggle-icon\" aria-hidden=\"true\">+</span></button>\n\t\t</h3>\n\t\t",
+						"innerContent": [
+							"\n\t\t<h3 class=\"wp-block-accordion-heading\">\n\t\t\t<button class=\"wp-block-accordion-heading__toggle\"><span class=\"wp-block-accordion-heading__toggle-title\">Accordion Title</span><span class=\"wp-block-accordion-heading__toggle-icon\" aria-hidden=\"true\">+</span></button>\n\t\t</h3>\n\t\t"
+						]
+					},
+					{
+						"blockName": "core/accordion-panel",
+						"attrs": {},
+						"innerBlocks": [
+							{
+								"blockName": "core/paragraph",
+								"attrs": {},
+								"innerBlocks": [],
+								"innerHTML": "\n\t\t\t<p>Accoridion Panel Content</p>\n\t\t\t",
+								"innerContent": [
+									"\n\t\t\t<p>Accoridion Panel Content</p>\n\t\t\t"
+								]
+							}
+						],
+						"innerHTML": "\n\t\t<div role=\"region\" class=\"wp-block-accordion-panel\">\n\t\t\t\n\t\t</div>\n\t\t",
+						"innerContent": [
+							"\n\t\t<div role=\"region\" class=\"wp-block-accordion-panel\">\n\t\t\t",
+							null,
+							"\n\t\t</div>\n\t\t"
+						]
+					}
+				],
+				"innerHTML": "\n\t<div class=\"wp-block-accordion-item\">\n\t\t\n\t\t\n\t</div>\n\t",
+				"innerContent": [
+					"\n\t<div class=\"wp-block-accordion-item\">\n\t\t",
+					null,
+					"\n\t\t",
+					null,
+					"\n\t</div>\n\t"
+				]
+			}
+		],
+		"innerHTML": "\n<div role=\"group\" class=\"wp-block-accordion\">\n\t\n</div>\n",
+		"innerContent": [
+			"\n<div role=\"group\" class=\"wp-block-accordion\">\n\t",
+			null,
+			"\n</div>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__accordion.serialized.html
+++ b/test/integration/fixtures/blocks/core__accordion.serialized.html
@@ -1,0 +1,13 @@
+<!-- wp:accordion -->
+<div role="group" class="wp-block-accordion"><!-- wp:accordion-item -->
+<div class="wp-block-accordion-item"><!-- wp:accordion-heading -->
+<h3 class="wp-block-accordion-heading"><button class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title">Accordion Title</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h3>
+<!-- /wp:accordion-heading -->
+
+<!-- wp:accordion-panel -->
+<div role="region" class="wp-block-accordion-panel"><!-- wp:paragraph -->
+<p>Accoridion Panel Content</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:accordion-panel --></div>
+<!-- /wp:accordion-item --></div>
+<!-- /wp:accordion -->

--- a/test/integration/fixtures/blocks/core__accordion.serialized.html
+++ b/test/integration/fixtures/blocks/core__accordion.serialized.html
@@ -6,7 +6,7 @@
 
 <!-- wp:accordion-panel -->
 <div role="region" class="wp-block-accordion-panel"><!-- wp:paragraph -->
-<p>Accoridion Panel Content</p>
+<p>Accordion  Panel Content</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:accordion-panel --></div>
 <!-- /wp:accordion-item --></div>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Closes #71732

Stabilize Accordion Block for the 6.9 release.

## Why?

We've identified and resolved the tasks that need to be resolved before stabilizing this block. There are a few open sub-issues, but we believe they're all minor bugs that will be resolved in the 6.9 release.

I hope you'll take a fresh look at this block and see if it's worth stabilizing. We look forward to your feedback!

cc @mikachan @hanneslsm @joedolson @WordPress/gutenberg-core 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

- Confirm that the "Blocks: add experimental blocks" experimental setting is NOT enabled.
- Smoke test the Accordion block:
  - Do all toolbars, sidebars, and UI elements work as expected?
  - Accessibility ready?
  - Does the block HTML contain unnecessary elements?
  - Is the block.json definition correct?
  - Do all block supports work correctly?