### PR TITLE
Add --wp-editor-canvas-background css var

### DIFF
--- a/packages/base-styles/_default-custom-properties.scss
+++ b/packages/base-styles/_default-custom-properties.scss
@@ -10,5 +10,6 @@
 	// This CSS variable is not used in Gutenberg project,
 	// but is maintained for backwards compatibility.
 	--wp-bound-block-color: var(--wp-block-synced-color);
+	--wp-editor-canvas-background: #ddd;
 	@include mixins.admin-scheme(#007cba);
 }

--- a/packages/base-styles/_default-custom-properties.scss
+++ b/packages/base-styles/_default-custom-properties.scss
@@ -1,5 +1,6 @@
 @use "./mixins";
 @use "./functions";
+@use "./colors";
 
 // It is important to include these styles in all built stylesheets.
 // This allows to CSS variables post CSS plugin to generate fallbacks.
@@ -10,6 +11,6 @@
 	// This CSS variable is not used in Gutenberg project,
 	// but is maintained for backwards compatibility.
 	--wp-bound-block-color: var(--wp-block-synced-color);
-	--wp-editor-canvas-background: #ddd;
+	--wp-editor-canvas-background: colors.$gray-300;
 	@include mixins.admin-scheme(#007cba);
 }

--- a/packages/block-editor/src/components/block-canvas/style.scss
+++ b/packages/block-editor/src/components/block-canvas/style.scss
@@ -7,5 +7,5 @@ iframe[name="editor-canvas"] {
 	@media not ( prefers-reduced-motion ) {
 		transition: all 400ms cubic-bezier(0.46, 0.03, 0.52, 0.96);
 	}
-	background-color: $gray-300;
+	background-color: var(--wp-editor-canvas-background);
 }

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -35,7 +35,7 @@
 		// Apply an X translation to center the scaled content within the available space.
 		transform: translateX(calc((#{$scale-container-width} - #{$container-width}) / 2 / #{$scale}));
 		scale: $scale;
-		background-color: $gray-300;
+		background-color: var(--wp-editor-canvas-background);
 
 		// Chrome seems to respect that transform scale shouldn't affect the layout size of the element,
 		// so we need to adjust the height of the content to match the scale by using negative margins.

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -6,7 +6,6 @@ import { Menu } from './menu';
 import { ComponentsContext } from './context/context-system-provider';
 import Theme from './theme';
 import { Tabs } from './tabs';
-import { COLORS } from './utils';
 import { kebabCase, normalizeTextString } from './utils/strings';
 import { withIgnoreIMEEvents } from './utils/with-ignore-ime-events';
 import { lock } from './lock-unlock';
@@ -52,5 +51,4 @@ lock( privateApis, {
 	ValidatedToggleControl,
 	ValidatedToggleGroupControl,
 	ValidatedFormTokenField,
-	COLORS,
 } );

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -6,6 +6,7 @@ import { Menu } from './menu';
 import { ComponentsContext } from './context/context-system-provider';
 import Theme from './theme';
 import { Tabs } from './tabs';
+import { COLORS } from './utils';
 import { kebabCase, normalizeTextString } from './utils/strings';
 import { withIgnoreIMEEvents } from './utils/with-ignore-ime-events';
 import { lock } from './lock-unlock';
@@ -51,4 +52,5 @@ lock( privateApis, {
 	ValidatedToggleControl,
 	ValidatedToggleGroupControl,
 	ValidatedFormTokenField,
+	COLORS,
 } );

--- a/packages/edit-site/src/components/editor-canvas-container/style.scss
+++ b/packages/edit-site/src/components/editor-canvas-container/style.scss
@@ -3,7 +3,7 @@
 
 	// This is the gray background color that's applied behind "isolation mode".
 	// The color normally comes from .editor-visual-editor, but that class is missing here.
-	background-color: $gray-300;
+	background-color: var(--wp-editor-canvas-background);
 
 	// Controls height of editor and editor canvas container (style book, global styles revisions previews etc.)
 	iframe {

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -345,12 +345,11 @@ function VisualEditor( {
 				}}
 				${
 					enableResizing
-						? '.block-editor-iframe__html{background:#ddd;display:flex;align-items:center;justify-content:center;min-height:100vh;}.block-editor-iframe__body{width:100%;}'
+						? '.block-editor-iframe__html{background:var(--wp-editor-canvas-background);display:flex;align-items:center;justify-content:center;min-height:100vh;}.block-editor-iframe__body{width:100%;}'
 						: ''
 				}`,
 				// The CSS above centers the body content vertically when resizing is enabled and applies a background
 				// color to the iframe HTML element to match the background color of the editor canvas.
-				// TODO: Move the #ddd somewhere else or use a variable.
 			},
 		];
 	}, [ styles, enableResizing ] );

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -21,7 +21,6 @@ import { useSelect } from '@wordpress/data';
 import { parse } from '@wordpress/blocks';
 import { store as coreStore } from '@wordpress/core-data';
 import { useMergeRefs, useViewportMatch } from '@wordpress/compose';
-import { privateApis as componentsPrivateApis } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -47,8 +46,6 @@ const {
 	ExperimentalBlockCanvas: BlockCanvas,
 	useFlashEditableBlocks,
 } = unlock( blockEditorPrivateApis );
-
-const { COLORS } = unlock( componentsPrivateApis );
 
 /**
  * These post types have a special editor where they don't allow you to fill the title
@@ -348,11 +345,12 @@ function VisualEditor( {
 				}}
 				${
 					enableResizing
-						? `.block-editor-iframe__html{background:${ COLORS.theme.gray[ 300 ] };display:flex;align-items:center;justify-content:center;min-height:100vh;}.block-editor-iframe__body{width:100%;}`
+						? '.block-editor-iframe__html{background:#ddd;display:flex;align-items:center;justify-content:center;min-height:100vh;}.block-editor-iframe__body{width:100%;}'
 						: ''
 				}`,
 				// The CSS above centers the body content vertically when resizing is enabled and applies a background
 				// color to the iframe HTML element to match the background color of the editor canvas.
+				// TODO: Move the #ddd somewhere else or use a variable.
 			},
 		];
 	}, [ styles, enableResizing ] );

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -21,6 +21,7 @@ import { useSelect } from '@wordpress/data';
 import { parse } from '@wordpress/blocks';
 import { store as coreStore } from '@wordpress/core-data';
 import { useMergeRefs, useViewportMatch } from '@wordpress/compose';
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -46,6 +47,8 @@ const {
 	ExperimentalBlockCanvas: BlockCanvas,
 	useFlashEditableBlocks,
 } = unlock( blockEditorPrivateApis );
+
+const { COLORS } = unlock( componentsPrivateApis );
 
 /**
  * These post types have a special editor where they don't allow you to fill the title
@@ -345,12 +348,11 @@ function VisualEditor( {
 				}}
 				${
 					enableResizing
-						? '.block-editor-iframe__html{background:#ddd;display:flex;align-items:center;justify-content:center;min-height:100vh;}.block-editor-iframe__body{width:100%;}'
+						? `.block-editor-iframe__html{background:${ COLORS.theme.gray[ 300 ] };display:flex;align-items:center;justify-content:center;min-height:100vh;}.block-editor-iframe__body{width:100%;}`
 						: ''
 				}`,
 				// The CSS above centers the body content vertically when resizing is enabled and applies a background
 				// color to the iframe HTML element to match the background color of the editor canvas.
-				// TODO: Move the #ddd somewhere else or use a variable.
 			},
 		];
 	}, [ styles, enableResizing ] );

--- a/packages/editor/src/components/visual-editor/style.scss
+++ b/packages/editor/src/components/visual-editor/style.scss
@@ -5,7 +5,7 @@
 	// This duplicates the iframe background but it's necessary in some situations
 	// when the iframe doesn't cover the whole canvas
 	// like the "focused entities".
-	background-color: $gray-300;
+	background-color: var(--wp-editor-canvas-background);
 
 	// This overrides the iframe background since it's applied again here
 	// It also prevents some style glitches if `editor-visual-editor`


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Follow up to https://github.com/WordPress/gutenberg/pull/72013
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Consolidate background colors for editor canvas to one area.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
These are spread throughout the codebase outside the editor iframe, inside the editor iframe, and in the javascript. Refactoring this to one CSS variable that can be applied everywhere is better.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add one CSS variable named `--wp-editor-canvas-background` and put it in the same area as the `--wp-block-synced-color` CSS var which is also used to share across the iframe boundary.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Edit a template part, such a header to get to the focused editor mode
- The editor background should appear a seamless #ddd color

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
<img width="1269" height="1114" alt="Screenshot 2025-10-02 at 1 10 51 PM" src="https://github.com/user-attachments/assets/bfbb7ed9-8987-42fe-9fd4-043b316cfa71" />
