### PR TITLE
iAPI: Add missing changelog entries for #71870 and #71635 PRs

### DIFF
--- a/packages/interactivity-router/CHANGELOG.md
+++ b/packages/interactivity-router/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 2.32.0 (2025-10-01)
 
+-   Update router regions inside elements with `data-wp-interactive`. ([#71635](https://github.com/WordPress/gutenberg/pull/71635))
+
 ## 2.31.0 (2025-09-17)
 
 ## 2.30.0 (2025-09-03)

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## 6.32.0 (2025-10-01)
 
+-   Update router regions inside elements with `data-wp-interactive`. ([#71635](https://github.com/WordPress/gutenberg/pull/71635))
+-   Fix nested `data-wp-each` directives using the same items key. ([#71870](https://github.com/WordPress/gutenberg/pull/71870))
+
 ## 6.31.0 (2025-09-17)
 
 ## 6.30.0 (2025-09-03)


### PR DESCRIPTION
## What?

Adds missing changelog entries for the changes made in #71870 and #71635, which were released in versions 6.32.0 and 2.32.0 of the `@wordpress/interactivity` and `@wordpress/interactivity-router` packages, respectively.

## Why?

It was forgotten to add these entries to their respective PRs.
