### PR TITLE
Accordion Item and Panel: Remove layout from the block supports

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -39,7 +39,7 @@ Displays a section of content in an accordion, including a heading and expandabl
 -	**Category:** design
 -	**Parent:** core/accordion
 -	**Allowed Blocks:** core/accordion-heading, core/accordion-panel
--	**Supports:** color (background, gradients, text), interactivity, shadow, spacing (blockGap, margin), typography (fontSize, lineHeight), ~~layout~~
+-	**Supports:** color (background, gradients, text), interactivity, shadow, spacing (blockGap, margin), typography (fontSize, lineHeight)
 -	**Attributes:** openByDefault
 
 ## Accordion Panel
@@ -50,7 +50,7 @@ Displays an accordion panel. ([Source](https://github.com/WordPress/gutenberg/tr
 -	**Experimental:** true
 -	**Category:** design
 -	**Parent:** core/accordion-item
--	**Supports:** color (background, gradients, text), interactivity, shadow, spacing (blockGap, padding), typography (fontSize, lineHeight), ~~blockVisibility~~, ~~layout~~
+-	**Supports:** color (background, gradients, text), interactivity, shadow, spacing (blockGap, padding), typography (fontSize, lineHeight), ~~blockVisibility~~
 -	**Attributes:** allowedBlocks, isSelected, openByDefault, templateLock
 
 ## Archives

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -39,7 +39,7 @@ Displays a section of content in an accordion, including a heading and expandabl
 -	**Category:** design
 -	**Parent:** core/accordion
 -	**Allowed Blocks:** core/accordion-heading, core/accordion-panel
--	**Supports:** color (background, gradients, text), interactivity, layout, shadow, spacing (blockGap, margin), typography (fontSize, lineHeight)
+-	**Supports:** color (background, gradients, text), interactivity, shadow, spacing (blockGap, margin), typography (fontSize, lineHeight), ~~layout~~
 -	**Attributes:** openByDefault
 
 ## Accordion Panel
@@ -50,7 +50,7 @@ Displays an accordion panel. ([Source](https://github.com/WordPress/gutenberg/tr
 -	**Experimental:** true
 -	**Category:** design
 -	**Parent:** core/accordion-item
--	**Supports:** color (background, gradients, text), interactivity, layout, shadow, spacing (blockGap, padding), typography (fontSize, lineHeight), ~~blockVisibility~~
+-	**Supports:** color (background, gradients, text), interactivity, shadow, spacing (blockGap, padding), typography (fontSize, lineHeight), ~~blockVisibility~~, ~~layout~~
 -	**Attributes:** allowedBlocks, isSelected, openByDefault, templateLock
 
 ## Archives

--- a/packages/block-library/src/accordion-item/block.json
+++ b/packages/block-library/src/accordion-item/block.json
@@ -31,7 +31,7 @@
 			}
 		},
 		"shadow": true,
-		"layout": true,
+		"layout": false,
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,

--- a/packages/block-library/src/accordion-item/block.json
+++ b/packages/block-library/src/accordion-item/block.json
@@ -31,7 +31,6 @@
 			}
 		},
 		"shadow": true,
-		"layout": false,
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,

--- a/packages/block-library/src/accordion-panel/block.json
+++ b/packages/block-library/src/accordion-panel/block.json
@@ -47,7 +47,7 @@
 			}
 		},
 		"shadow": true,
-		"layout": true,
+		"layout": false,
 		"blockVisibility": false
 	},
 	"attributes": {

--- a/packages/block-library/src/accordion-panel/block.json
+++ b/packages/block-library/src/accordion-panel/block.json
@@ -47,7 +47,6 @@
 			}
 		},
 		"shadow": true,
-		"layout": false,
 		"blockVisibility": false
 	},
 	"attributes": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Removes layout support from the Accordion Item and Accordion panel blocks, since its probably only really useful on the Accordion block itself.

<!-- In a few words, what is the PR actually doing? -->

## Why?
These supports add complexity without adding value.

## How?
Just remove from the block.json

## Testing Instructions
1. Add an accordion block and some content to it
2. Check that there is no`Inner blocks use content width` setting on the Accordion item or Accordion panel blocks

## Screenshots or screencast <!-- if applicable -->
<img width="1726" height="961" alt="Screenshot 2025-10-03 at 11 14 42" src="https://github.com/user-attachments/assets/0604735b-abe1-4bac-a20d-3ce903af8053" />
<img width="1728" height="959" alt="Screenshot 2025-10-03 at 11 14 35" src="https://github.com/user-attachments/assets/a356242b-faa2-4bb5-ab79-0c285fc6e420" />
