### PR TITLE
Accordion Heading: Remove the padding from the heading when it has a background color

### DIFF
--- a/packages/block-library/src/accordion-heading/block.json
+++ b/packages/block-library/src/accordion-heading/block.json
@@ -25,7 +25,8 @@
 			"__experimentalDefaultControls": {
 				"padding": true
 			},
-			"__experimentalSkipSerialization": true
+			"__experimentalSkipSerialization": true,
+			"__experimentalSelector": ".wp-block-accordion-heading__toggle"
 		},
 		"__experimentalBorder": {
 			"color": true,

--- a/packages/block-library/src/accordion-heading/style.scss
+++ b/packages/block-library/src/accordion-heading/style.scss
@@ -1,3 +1,9 @@
+// The .wp-block-accordion selector is needed to make this CSS stronger
+// than the default heading padding when background color is applied.
+.wp-block-accordion .wp-block-accordion-heading {
+	padding: 0;
+}
+
 .wp-block-accordion-heading__toggle {
 	font-family: inherit;
 	font-size: inherit;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Remove the padding from the Accordion heading block.
<!-- In a few words, what is the PR actually doing? -->

## Why?
When the block has a background color, a padding applied from the heading element. We don't want that in the case as it is impossible override with the padding for this block.

## How?
Using a stronger CSS selector to override the default padding

## Testing Instructions
1. Add an accordion block with content
2. Apply a background color the Accordion heading block
3. Check that no padding is applied
4. Check that the padding controls for the block work correctly.

## Screenshots or screencast <!-- if applicable -->
<img width="737" height="653" alt="Screenshot 2025-10-03 at 11 34 41" src="https://github.com/user-attachments/assets/1a457c71-6f93-4670-8bb6-7637bd82ebeb" />
<img width="744" height="667" alt="Screenshot 2025-10-03 at 11 34 32" src="https://github.com/user-attachments/assets/c0d21190-d7b9-4cc0-b1a2-1da190b82a14" />
