### PR TITLE
PHP-only blocks: Auto-register blocks with block API version 3 by default

### DIFF
--- a/lib/compat/wordpress-7.0/php-only-blocks.php
+++ b/lib/compat/wordpress-7.0/php-only-blocks.php
@@ -20,7 +20,10 @@ function gutenberg_register_auto_register_blocks() {
 		$has_render_callback    = ! empty( $block_type->render_callback );
 
 		if ( $has_auto_register_flag && $has_render_callback ) {
-			$auto_register_blocks[] = $block_name;
+			$auto_register_blocks[] = array(
+				'name'       => $block_name,
+				'apiVersion' => max( 3, $block_type->api_version ),
+			);
 		}
 	}
 

--- a/lib/compat/wordpress-7.0/php-only-blocks.php
+++ b/lib/compat/wordpress-7.0/php-only-blocks.php
@@ -20,10 +20,7 @@ function gutenberg_register_auto_register_blocks() {
 		$has_render_callback    = ! empty( $block_type->render_callback );
 
 		if ( $has_auto_register_flag && $has_render_callback ) {
-			$auto_register_blocks[] = array(
-				'name'       => $block_name,
-				'apiVersion' => max( 3, $block_type->api_version ),
-			);
+			$auto_register_blocks[] = $block_name;
 		}
 	}
 

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -315,8 +315,16 @@ export const registerCoreBlocks = (
 	// Auto-register PHP-only blocks with ServerSideRender
 	if ( window.__unstableAutoRegisterBlocks ) {
 		window.__unstableAutoRegisterBlocks.forEach( ( blockName ) => {
+			const existingBlockType =
+				window.wp.blocks.getBlockType( blockName );
+			const apiVersion =
+				existingBlockType && existingBlockType.apiVersion >= 3
+					? existingBlockType.apiVersion
+					: 3;
+
 			registerBlockType( blockName, {
 				title: blockName,
+				apiVersion,
 				edit: ( { attributes } ) => {
 					return createElement( ServerSideRender, {
 						block: blockName,

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -7,7 +7,9 @@ import {
 	setUnregisteredTypeHandlerName,
 	setGroupingBlockName,
 	registerBlockType,
+	store as blocksStore,
 } from '@wordpress/blocks';
+import { select } from '@wordpress/data';
 import { createElement } from '@wordpress/element';
 import ServerSideRender from '@wordpress/server-side-render';
 
@@ -133,6 +135,7 @@ import * as video from './video';
 import * as footnotes from './footnotes';
 
 import isBlockMetadataExperimental from './utils/is-block-metadata-experimental';
+import { unlock } from './lock-unlock';
 
 /**
  * Function to get all the block-library blocks in an array
@@ -314,14 +317,18 @@ export const registerCoreBlocks = (
 
 	// Auto-register PHP-only blocks with ServerSideRender
 	if ( window.__unstableAutoRegisterBlocks ) {
-		window.__unstableAutoRegisterBlocks.forEach( ( blockData ) => {
-			const { name, apiVersion } = blockData;
-			registerBlockType( name, {
-				title: name,
-				apiVersion,
+		window.__unstableAutoRegisterBlocks.forEach( ( blockName ) => {
+			const bootstrappedBlockType = unlock(
+				select( blocksStore )
+			).getBootstrappedBlockType( blockName );
+			const bootstrappedApiVersion = bootstrappedBlockType.apiVersion;
+
+			registerBlockType( blockName, {
+				title: blockName,
+				...( bootstrappedApiVersion < 3 && { apiVersion: 3 } ),
 				edit: ( { attributes } ) => {
 					return createElement( ServerSideRender, {
-						block: name,
+						block: blockName,
 						attributes,
 					} );
 				},

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -314,20 +314,14 @@ export const registerCoreBlocks = (
 
 	// Auto-register PHP-only blocks with ServerSideRender
 	if ( window.__unstableAutoRegisterBlocks ) {
-		window.__unstableAutoRegisterBlocks.forEach( ( blockName ) => {
-			const existingBlockType =
-				window.wp.blocks.getBlockType( blockName );
-			const apiVersion =
-				existingBlockType && existingBlockType.apiVersion >= 3
-					? existingBlockType.apiVersion
-					: 3;
-
-			registerBlockType( blockName, {
-				title: blockName,
+		window.__unstableAutoRegisterBlocks.forEach( ( blockData ) => {
+			const { name, apiVersion } = blockData;
+			registerBlockType( name, {
+				title: name,
 				apiVersion,
 				edit: ( { attributes } ) => {
 					return createElement( ServerSideRender, {
-						block: blockName,
+						block: name,
 						attributes,
 					} );
 				},

--- a/packages/e2e-tests/plugins/server-side-rendered-block.php
+++ b/packages/e2e-tests/plugins/server-side-rendered-block.php
@@ -48,7 +48,6 @@ add_action(
 		register_block_type(
 			'test/auto-register-block',
 			array(
-				// Explicitly avoid setting API version, it will be set to 3 by default
 				'render_callback' => static function () {
 					return '<div>Auto-register block content</div>';
 				},

--- a/packages/e2e-tests/plugins/server-side-rendered-block.php
+++ b/packages/e2e-tests/plugins/server-side-rendered-block.php
@@ -48,7 +48,7 @@ add_action(
 		register_block_type(
 			'test/auto-register-block',
 			array(
-				'api_version'     => 3,
+				// Explicitly avoid setting API version, it will be set to 3 by default
 				'render_callback' => static function () {
 					return '<div>Auto-register block content</div>';
 				},

--- a/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
+++ b/test/e2e/specs/editor/plugins/server-side-rendered-block.spec.js
@@ -122,7 +122,7 @@ test.describe( 'PHP-only auto-register blocks', () => {
 		await admin.createNewPost();
 	} );
 
-	test( 'should only register blocks with auto_register flag', async ( {
+	test( 'should register blocks with auto_register flag', async ( {
 		editor,
 	} ) => {
 		// Block with auto_register flag should be insertable
@@ -130,6 +130,13 @@ test.describe( 'PHP-only auto-register blocks', () => {
 
 		const block = editor.canvas.getByText( 'Auto-register block content' );
 		await expect( block ).toBeVisible();
+
+		// Verify the auto-registered block uses API version 3
+		// (minimum version set if not specified or registered with version < 3)
+		const blockType = await editor.page.evaluate( () => {
+			return window.wp.blocks.getBlockType( 'test/auto-register-block' );
+		} );
+		expect( blockType.apiVersion ).toBe( 3 );
 
 		// Block without auto_register flag should NOT exist in registry
 		const blockExists = await editor.page.evaluate( () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow-up to #71794, sets the default block API version of PHP-only auto-registered blocks to 3.

<!-- In a few words, what is the PR actually doing? -->

## Why?
Since PHP-only blocks are a new thing, it doesn't make sense to allow this registration method to register new blocks with older api versions, especially since they can throw console warnings (see https://github.com/WordPress/gutenberg/pull/70783)

## How?
- During the client-side registration, bump the received `apiVersion` to 3.
- Note that if no `api_version` is set during the PHP registration, it would have defaulted to 1, so with this, we are basically making `api_version` optional during the PHP registration.

## Testing Instructions
1. Register a PHP-only block with no `api_version` set, or set it to one:
```
function my_php_only_block_render( $attributes )
{
  return '<div>
    <h3>🚀 PHP-only Block</h3>
      <p>This block was created with only PHP!</p>
  </div>';
}

register_block_type( 'my-plugin/php-only-test-block',
  array(
    'title' => 'My PHP-only Block',
    'render_callback' => 'my_php_only_block_render',
     'supports' => array(
          'auto_ssr' => true,
      ),
) );
```
2. Go to the editor
3. In the console, check the block's `apiVersion` with `wp.data.select('core/blocks').getBlockTypes().find(b => b.name === 'my-plugin/php-only-test-block').apiVersion`, it should be set to `3`.