### PR TITLE
Template activation: fix /lookup endpoint to use custom resolve fn

### DIFF
--- a/backport-changelog/6.9/8063.md
+++ b/backport-changelog/6.9/8063.md
@@ -3,3 +3,4 @@ https://github.com/WordPress/wordpress-develop/pull/8063
 * https://github.com/WordPress/gutenberg/pull/67125
 * https://github.com/WordPress/gutenberg/pull/71811
 * https://github.com/WordPress/gutenberg/pull/72029
+* https://github.com/WordPress/gutenberg/pull/72049

--- a/lib/compat/wordpress-6.9/class-gutenberg-rest-old-templates-controller.php
+++ b/lib/compat/wordpress-6.9/class-gutenberg-rest-old-templates-controller.php
@@ -1,0 +1,17 @@
+<?php
+
+class Gutenberg_REST_Old_Templates_Controller extends WP_REST_Templates_Controller {
+	public function get_template_fallback( $request ) {
+		$hierarchy = get_template_hierarchy( $request['slug'], $request['is_custom'], $request['template_prefix'] );
+
+		do {
+			$fallback_template = gutenberg_resolve_block_template( $request['slug'], $hierarchy, '' );
+			array_shift( $hierarchy );
+		} while ( ! empty( $hierarchy ) && empty( $fallback_template->content ) );
+
+		// To maintain original behavior, return an empty object rather than a 404 error when no template is found.
+		$response = $fallback_template ? $this->prepare_item_for_response( $fallback_template, $request ) : new stdClass();
+
+		return rest_ensure_response( $response );
+	}
+}

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__ . '/class-gutenberg-rest-old-templates-controller.php';
+
 // How does this work?
 // 1. For wp_template, we remove the custom templates controller, so it becomes
 //    a normal posts endpoint, modified slightly to allow auto-drafts.
@@ -28,7 +30,7 @@ function gutenberg_maintain_templates_routes() {
 	// WP_REST_Templates_Controller with a post type.
 	global $wp_post_types;
 	$wp_post_types['wp_template']->rest_base = 'templates';
-	$controller                              = new WP_REST_Templates_Controller( 'wp_template' );
+	$controller                              = new Gutenberg_REST_Old_Templates_Controller( 'wp_template' );
 	$wp_post_types['wp_template']->rest_base = 'wp_template';
 	$controller->register_routes();
 

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -206,7 +206,7 @@ function gutenberg_resolve_block_template( $template_type, $template_hierarchy, 
 	//////////////////////////////
 
 	$object            = get_queried_object();
-	$specific_template = get_page_template_slug( $object );
+	$specific_template = $object ? get_page_template_slug( $object ) : null;
 	$active_templates  = (array) get_option( 'active_templates', array() );
 
 	// Remove templates slugs that are deactivated, except if it's the specific

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -240,13 +240,11 @@ export const getTemplateId = createRegistrySelector(
 		// First see if the post/page has an assigned template and fetch it.
 		const currentTemplateSlug = editedEntity.template;
 		if ( currentTemplateSlug ) {
-			const currentTemplate = select( STORE_NAME )
-				.getEntityRecords( 'postType', 'wp_template', {
-					per_page: -1,
-				} )
-				?.find( ( { slug } ) => slug === currentTemplateSlug );
+			const currentTemplate = select( STORE_NAME ).getDefaultTemplateId( {
+				slug: currentTemplateSlug,
+			} );
 			if ( currentTemplate ) {
-				return currentTemplate.id;
+				return currentTemplate;
 			}
 		}
 		// If no template is assigned, use the default template.

--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -89,24 +89,20 @@ test.describe( 'Post Editor Template mode', () => {
 		await postEditorTemplateMode.disableTemplateWelcomeGuide();
 		await postEditorTemplateMode.openTemplatePopover();
 		// Change to a custom template, save and reload.
-		await page
-			.getByRole( 'menuitem', {
-				name: 'Change template',
-			} )
-			.click();
-		await page
-			.getByRole( 'option', {
-				name: 'Custom',
-			} )
-			.click();
+		await page.getByRole( 'menuitem', { name: 'Change template' } ).click();
+		await page.getByRole( 'option', { name: 'Custom' } ).click();
+		await expect(
+			page.getByRole( 'button', { name: 'Template options' } )
+		).toHaveText( 'Custom' );
 		await editor.saveDraft();
 		await page.reload();
+		await expect(
+			page.getByRole( 'button', { name: 'Template options' } )
+		).toHaveText( 'Custom' );
 		// Change to the default template.
 		await postEditorTemplateMode.openTemplatePopover();
 		await page
-			.getByRole( 'menuitem', {
-				name: 'Use default template',
-			} )
+			.getByRole( 'menuitem', { name: 'Use default template' } )
 			.click();
 		await expect(
 			page.getByRole( 'button', { name: 'Template options' } )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

The rewrite (#71811) adjusting template resolution use an earlier filter instead of `get_block_templates` should have also adjusted the `/lookup` endpoint, which is still using the core `resolve_block_template` function. It should use modified version instead.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently when you create a new page template and edit a page, that inactive page template will be shown instead of the active theme one. That's because the old resolve template function is still called, and WP thinks that edit should be active.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We override the endpoint callback.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Duplicate and edit a page template. Do not activate it. Then create a new page. Use the "show template" preview button. You should see the theme template, not the newly created inactive template.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
