### PR TITLE
Dataviews: Make header table view select all checkbox always visible.

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+- Dataviews: Make header table view select all checkbox always visible. ([#72050](https://github.com/WordPress/gutenberg/pull/72050))
 - Move search icon in search fields to prefix position ([#71984](https://github.com/WordPress/gutenberg/pull/71984)).
 
 ### Breaking changes

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -133,6 +133,12 @@
 			}
 		}
 	}
+	// Header select all checkbox should always be visible.
+	thead tr {
+		.components-checkbox-control__input.components-checkbox-control__input {
+			opacity: 1;
+		}
+	}
 	thead {
 		position: sticky;
 		inset-block-start: 0;

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -133,12 +133,6 @@
 			}
 		}
 	}
-	// Header select all checkbox should always be visible.
-	thead tr {
-		.components-checkbox-control__input.components-checkbox-control__input {
-			opacity: 1;
-		}
-	}
 	thead {
 		position: sticky;
 		inset-block-start: 0;
@@ -146,6 +140,10 @@
 
 		tr {
 			border: 0;
+			// Header select all checkbox should always be visible.
+			.components-checkbox-control__input.components-checkbox-control__input {
+				opacity: 1;
+			}
 		}
 		th {
 			background-color: $white;


### PR DESCRIPTION
Very simple changes which makes the header select all checkbox always visible.
This is a common practice accross similar interfaces like protonmail.


## Screenshot
<img width="1490" height="1116" alt="Screenshot 2025-10-03 at 12 48 54" src="https://github.com/user-attachments/assets/bb8cb1a0-21b6-4fdd-a497-57bf4c29ff79" />
