### PR TITLE
Accordion Block: Added anchor support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -15,7 +15,7 @@ Displays a group of accordion headings and associated expandable content. ([Sour
 -	**Name:** core/accordion
 -	**Category:** design
 -	**Allowed Blocks:** core/accordion-item
--	**Supports:** align (full, wide), ariaLabel, background (backgroundImage, backgroundSize), color (background, gradients, text), interactivity, layout, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), anchor, ariaLabel, background (backgroundImage, backgroundSize), color (background, gradients, text), interactivity, layout, shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** autoclose, headingLevel, iconPosition, levelOptions, showIcon
 
 ## Accordion Heading

--- a/packages/block-library/src/accordion/block.json
+++ b/packages/block-library/src/accordion/block.json
@@ -7,6 +7,7 @@
 	"description": "Displays a group of accordion headings and associated expandable content.",
 	"example": {},
 	"supports": {
+		"anchor": true,
 		"html": false,
 		"align": [ "wide", "full" ],
 		"background": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Adds anchor support to the Accordion block.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Anchors should be customizable with as many blocks as possible.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add anchor support `true`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a accordion block. 
3. You can set the anchor from the Advanced panel

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="276" height="756" alt="anchor" src="https://github.com/user-attachments/assets/fee31edb-7f1c-410d-ae34-600086cf435c" />

