### PR TITLE
Dataforms: Add validation to date time field.

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
-- DataForm control for `datetime` supports `required` and `custom` validation. [#72048](https://github.com/WordPress/gutenberg/pull/72048/)
+- DataForm control for `datetime` supports `required` and `custom` validation. [#72060](https://github.com/WordPress/gutenberg/pull/72060/)
 - Dataviews: Make header table view select all checkbox always visible. ([#72050](https://github.com/WordPress/gutenberg/pull/72050))
 - Move search icon in search fields to prefix position ([#71984](https://github.com/WordPress/gutenberg/pull/71984)).
 - Flip search icons depending on placement ([#72070](https://github.com/WordPress/gutenberg/pull/72070)).

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -10,7 +10,7 @@
 - DataViews: Improve renderItemLink event propagation handling. ([#72081](https://github.com/WordPress/gutenberg/pull/72081)).
 - Normalize search field styles ([#72072](https://github.com/WordPress/gutenberg/pull/72072)).
 - DataForm control for `date` supports `required` and `custom` validation [#72048](https://github.com/WordPress/gutenberg/pull/72048).
-- DataForm control for `datetime` supports `required` and `custom` validation. [#72060](https://github.com/WordPress/gutenberg/pull/72060/).
+- DataForm control for `datetime` supports `required` and `custom` validation. [#72060](https://github.com/WordPress/gutenberg/pull/72060).
 
 ### Breaking changes
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+- DataForm control for `datetime` supports `required` and `custom` validation. [#72048](https://github.com/WordPress/gutenberg/pull/72048/)
 - Dataviews: Make header table view select all checkbox always visible. ([#72050](https://github.com/WordPress/gutenberg/pull/72050))
 - Move search icon in search fields to prefix position ([#71984](https://github.com/WordPress/gutenberg/pull/71984)).
 - Flip search icons depending on placement ([#72070](https://github.com/WordPress/gutenberg/pull/72070)).

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
-- DataForm control for `datetime` supports `required` and `custom` validation. [#72060](https://github.com/WordPress/gutenberg/pull/72060/)
+- DataForm control for `datetime` supports `required` and `custom` validation. ([#72060](https://github.com/WordPress/gutenberg/pull/72060/))
 - Dataviews: Make header table view select all checkbox always visible. ([#72050](https://github.com/WordPress/gutenberg/pull/72050))
 - Move search icon in search fields to prefix position ([#71984](https://github.com/WordPress/gutenberg/pull/71984)).
 - Flip search icons depending on placement ([#72070](https://github.com/WordPress/gutenberg/pull/72070)).

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### Enhancements
 
-- DataForm control for `datetime` supports `required` and `custom` validation. ([#72060](https://github.com/WordPress/gutenberg/pull/72060/))
 - Dataviews: Make header table view select all checkbox always visible. ([#72050](https://github.com/WordPress/gutenberg/pull/72050))
 - Move search icon in search fields to prefix position ([#71984](https://github.com/WordPress/gutenberg/pull/71984)).
 - Flip search icons depending on placement ([#72070](https://github.com/WordPress/gutenberg/pull/72070)).
 - DataViews: Improve renderItemLink event propagation handling. ([#72081](https://github.com/WordPress/gutenberg/pull/72081)).
 - Normalize search field styles ([#72072](https://github.com/WordPress/gutenberg/pull/72072)).
 - DataForm control for `date` supports `required` and `custom` validation [#72048](https://github.com/WordPress/gutenberg/pull/72048).
+- DataForm control for `datetime` supports `required` and `custom` validation. [#72060](https://github.com/WordPress/gutenberg/pull/72060/).
 
 ### Breaking changes
 

--- a/packages/dataviews/src/dataform-controls/datetime.tsx
+++ b/packages/dataviews/src/dataform-controls/datetime.tsx
@@ -156,7 +156,8 @@ function CalendarDateTimeControl< Item >( {
 				inputControlRef.current &&
 				inputControlRef.current.ownerDocument.activeElement;
 
-			// Trigger validation display by simulating focus and blur and changes
+			// Trigger validation display by simulating focus, blur, and changes.
+			// Use a timeout to ensure it runs after the value update.
 			validationTimeoutRef.current = setTimeout( () => {
 				if ( inputControlRef.current ) {
 					inputControlRef.current.focus();
@@ -201,11 +202,16 @@ function CalendarDateTimeControl< Item >( {
 		l10n: { startOfWeek },
 	} = getSettings();
 
+	const displayLabel =
+		field.isValid?.required && ! hideLabelFromVision
+			? `${ label } (${ __( 'Required' ) })`
+			: label;
+
 	return (
 		<BaseControl
 			__nextHasNoMarginBottom
 			id={ id }
-			label={ label }
+			label={ displayLabel }
 			help={ description }
 			hideLabelFromVision={ hideLabelFromVision }
 		>

--- a/packages/dataviews/src/dataform-controls/datetime.tsx
+++ b/packages/dataviews/src/dataform-controls/datetime.tsx
@@ -12,7 +12,7 @@ import {
 	privateApis as componentsPrivateApis,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getDate, getSettings } from '@wordpress/date';
 
@@ -81,6 +81,8 @@ function CalendarDateTimeControl< Item >( {
 			>[ 'customValidity' ]
 		>( undefined );
 
+	const baseControlRef = useRef< HTMLDivElement >( null );
+
 	const onValidateControl = useCallback(
 		( newValue: any ) => {
 			const message = field.isValid?.custom?.(
@@ -128,6 +130,22 @@ function CalendarDateTimeControl< Item >( {
 				const dateTimeValue = finalDateTime.toISOString();
 				onChange( dateTimeValue );
 				onValidateControl( dateTimeValue );
+
+				setTimeout( () => {
+					if ( baseControlRef.current ) {
+						const input = baseControlRef.current.querySelector(
+							'input[type="datetime-local"]'
+						) as HTMLInputElement;
+						if ( input ) {
+							input.focus();
+							input.blur();
+							onChange( dateTimeValue );
+							onValidateControl( dateTimeValue );
+						}
+					}
+				}, 10 );
+
+				// Trigger validation display by simulating focus and blur
 			} else {
 				onChange( undefined );
 				onValidateControl( undefined );
@@ -161,46 +179,50 @@ function CalendarDateTimeControl< Item >( {
 	} = getSettings();
 
 	return (
-		<BaseControl
-			__nextHasNoMarginBottom
-			id={ id }
-			label={ label }
-			help={ description }
-			hideLabelFromVision={ hideLabelFromVision }
-		>
-			<VStack spacing={ 4 }>
-				{ /* Calendar widget */ }
-				<DateCalendar
-					style={ { width: '100%' } }
-					selected={
-						value ? parseDateTime( value ) || undefined : undefined
-					}
-					onSelect={ onSelectDate }
-					month={ calendarMonth }
-					onMonthChange={ setCalendarMonth }
-					timeZone={ timezoneString || undefined }
-					weekStartsOn={ startOfWeek }
-				/>
-				{ /* Manual datetime input */ }
-				<ValidatedInputControl
-					__next40pxDefaultSize
-					required={ !! field.isValid?.required }
-					onValidate={ onValidateControl }
-					customValidity={ customValidity }
-					type="datetime-local"
-					label={ __( 'Date time' ) }
-					hideLabelFromVision
-					value={
-						value
-							? formatDateTime(
-									parseDateTime( value ) || undefined
-							  )
-							: ''
-					}
-					onChange={ handleManualDateTimeChange }
-				/>
-			</VStack>
-		</BaseControl>
+		<div ref={ baseControlRef }>
+			<BaseControl
+				__nextHasNoMarginBottom
+				id={ id }
+				label={ label }
+				help={ description }
+				hideLabelFromVision={ hideLabelFromVision }
+			>
+				<VStack spacing={ 4 }>
+					{ /* Calendar widget */ }
+					<DateCalendar
+						style={ { width: '100%' } }
+						selected={
+							value
+								? parseDateTime( value ) || undefined
+								: undefined
+						}
+						onSelect={ onSelectDate }
+						month={ calendarMonth }
+						onMonthChange={ setCalendarMonth }
+						timeZone={ timezoneString || undefined }
+						weekStartsOn={ startOfWeek }
+					/>
+					{ /* Manual datetime input */ }
+					<ValidatedInputControl
+						__next40pxDefaultSize
+						required={ !! field.isValid?.required }
+						onValidate={ onValidateControl }
+						customValidity={ customValidity }
+						type="datetime-local"
+						label={ __( 'Date time' ) }
+						hideLabelFromVision
+						value={
+							value
+								? formatDateTime(
+										parseDateTime( value ) || undefined
+								  )
+								: ''
+						}
+						onChange={ handleManualDateTimeChange }
+					/>
+				</VStack>
+			</BaseControl>
+		</div>
 	);
 }
 

--- a/packages/dataviews/src/dataform-controls/datetime.tsx
+++ b/packages/dataviews/src/dataform-controls/datetime.tsx
@@ -122,6 +122,7 @@ function CalendarDateTimeControl< Item >( {
 
 	const onSelectDate = useCallback(
 		( newDate: Date | undefined | null ) => {
+			let dateTimeValue: string | undefined;
 			if ( newDate ) {
 				// Preserve time if it exists in current value, otherwise use current time
 				let finalDateTime = newDate;
@@ -138,7 +139,7 @@ function CalendarDateTimeControl< Item >( {
 					}
 				}
 
-				const dateTimeValue = finalDateTime.toISOString();
+				dateTimeValue = finalDateTime.toISOString();
 				onChange( dateTimeValue );
 				onValidateControl( dateTimeValue );
 
@@ -146,38 +147,37 @@ function CalendarDateTimeControl< Item >( {
 				if ( validationTimeoutRef.current ) {
 					clearTimeout( validationTimeoutRef.current );
 				}
-
-				// Save the currently focused element
-				previousFocusRef.current =
-					baseControlRef.current &&
-					baseControlRef.current.ownerDocument.activeElement;
-
-				// Trigger validation display by simulating focus and blur
-				validationTimeoutRef.current = setTimeout( () => {
-					if ( baseControlRef.current ) {
-						const input = baseControlRef.current.querySelector(
-							'input[type="datetime-local"]'
-						) as HTMLInputElement;
-						if ( input ) {
-							input.focus();
-							input.blur();
-							onChange( dateTimeValue );
-							onValidateControl( dateTimeValue );
-
-							// Restore focus to the previously focused element
-							if (
-								previousFocusRef.current &&
-								previousFocusRef.current instanceof HTMLElement
-							) {
-								previousFocusRef.current.focus();
-							}
-						}
-					}
-				}, 0 );
 			} else {
 				onChange( undefined );
 				onValidateControl( undefined );
 			}
+			// Save the currently focused element
+			previousFocusRef.current =
+				baseControlRef.current &&
+				baseControlRef.current.ownerDocument.activeElement;
+
+			// Trigger validation display by simulating focus and blur and changes
+			validationTimeoutRef.current = setTimeout( () => {
+				if ( baseControlRef.current ) {
+					const input = baseControlRef.current.querySelector(
+						'input[type="datetime-local"]'
+					) as HTMLInputElement;
+					if ( input ) {
+						input.focus();
+						input.blur();
+						onChange( dateTimeValue );
+						onValidateControl( dateTimeValue );
+
+						// Restore focus to the previously focused element
+						if (
+							previousFocusRef.current &&
+							previousFocusRef.current instanceof HTMLElement
+						) {
+							previousFocusRef.current.focus();
+						}
+					}
+				}
+			}, 0 );
 		},
 		[ onChange, value, onValidateControl ]
 	);

--- a/packages/dataviews/src/dataform-controls/datetime.tsx
+++ b/packages/dataviews/src/dataform-controls/datetime.tsx
@@ -1,20 +1,20 @@
 /**
+ * External dependencies
+ */
+import deepMerge from 'deepmerge';
+import { format, isValid } from 'date-fns';
+
+/**
  * WordPress dependencies
  */
 import {
 	BaseControl,
 	privateApis as componentsPrivateApis,
-	__experimentalInputControl as InputControl,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getDate, getSettings } from '@wordpress/date';
-
-/**
- * External dependencies
- */
-import { format, isValid } from 'date-fns';
 
 /**
  * Internal dependencies
@@ -27,7 +27,7 @@ import RelativeDateControl, {
 } from './relative-date-control';
 import { unlock } from '../lock-unlock';
 
-const { DateCalendar } = unlock( componentsPrivateApis );
+const { DateCalendar, ValidatedInputControl } = unlock( componentsPrivateApis );
 
 const parseDateTime = ( dateTimeString?: string ): Date | null => {
 	if ( ! dateTimeString ) {
@@ -48,13 +48,16 @@ const formatDateTime = ( date?: Date | string ): string => {
 	return format( date, "yyyy-MM-dd'T'HH:mm" );
 };
 
-function CalendarDateTimeControl( {
+function CalendarDateTimeControl< Item >( {
 	id,
 	value,
 	onChange,
 	label,
 	description,
 	hideLabelFromVision,
+	data,
+	field,
+	setValue,
 }: {
 	id: string;
 	value: string | undefined;
@@ -62,11 +65,47 @@ function CalendarDateTimeControl( {
 	label: string;
 	description?: string;
 	hideLabelFromVision?: boolean;
+	data: Item;
+	field: any;
+	setValue: any;
 } ) {
 	const [ calendarMonth, setCalendarMonth ] = useState< Date >( () => {
 		const parsedDate = parseDateTime( value );
 		return parsedDate || new Date(); // Default to current month
 	} );
+
+	const [ customValidity, setCustomValidity ] =
+		useState<
+			React.ComponentProps<
+				typeof ValidatedInputControl
+			>[ 'customValidity' ]
+		>( undefined );
+
+	const onValidateControl = useCallback(
+		( newValue: any ) => {
+			const message = field.isValid?.custom?.(
+				deepMerge(
+					data,
+					setValue( {
+						item: data,
+						value: newValue,
+					} ) as Partial< Item >
+				),
+				field
+			);
+
+			if ( message ) {
+				setCustomValidity( {
+					type: 'invalid',
+					message,
+				} );
+				return;
+			}
+
+			setCustomValidity( undefined );
+		},
+		[ data, field, setValue ]
+	);
 
 	const onSelectDate = useCallback(
 		( newDate: Date | undefined | null ) => {
@@ -88,11 +127,13 @@ function CalendarDateTimeControl( {
 
 				const dateTimeValue = finalDateTime.toISOString();
 				onChange( dateTimeValue );
+				onValidateControl( dateTimeValue );
 			} else {
 				onChange( undefined );
+				onValidateControl( undefined );
 			}
 		},
-		[ onChange, value ]
+		[ onChange, value, onValidateControl ]
 	);
 
 	const handleManualDateTimeChange = useCallback(
@@ -141,8 +182,11 @@ function CalendarDateTimeControl( {
 					weekStartsOn={ startOfWeek }
 				/>
 				{ /* Manual datetime input */ }
-				<InputControl
+				<ValidatedInputControl
 					__next40pxDefaultSize
+					required={ !! field.isValid?.required }
+					onValidate={ onValidateControl }
+					customValidity={ customValidity }
 					type="datetime-local"
 					label={ __( 'Date time' ) }
 					hideLabelFromVision
@@ -204,6 +248,9 @@ export default function DateTime< Item >( {
 			label={ label }
 			description={ description }
 			hideLabelFromVision={ hideLabelFromVision }
+			data={ data }
+			field={ field }
+			setValue={ setValue }
 		/>
 	);
 }

--- a/packages/dataviews/src/dataform-controls/datetime.tsx
+++ b/packages/dataviews/src/dataform-controls/datetime.tsx
@@ -12,7 +12,7 @@ import {
 	privateApis as componentsPrivateApis,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { useCallback, useRef, useState } from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getDate, getSettings } from '@wordpress/date';
 
@@ -82,6 +82,17 @@ function CalendarDateTimeControl< Item >( {
 		>( undefined );
 
 	const baseControlRef = useRef< HTMLDivElement >( null );
+	const validationTimeoutRef = useRef< ReturnType< typeof setTimeout > >();
+	const previousFocusRef = useRef< Element | null >( null );
+
+	// Cleanup timeout on unmount
+	useEffect( () => {
+		return () => {
+			if ( validationTimeoutRef.current ) {
+				clearTimeout( validationTimeoutRef.current );
+			}
+		};
+	}, [] );
 
 	const onValidateControl = useCallback(
 		( newValue: any ) => {
@@ -131,7 +142,18 @@ function CalendarDateTimeControl< Item >( {
 				onChange( dateTimeValue );
 				onValidateControl( dateTimeValue );
 
-				setTimeout( () => {
+				// Clear any existing timeout
+				if ( validationTimeoutRef.current ) {
+					clearTimeout( validationTimeoutRef.current );
+				}
+
+				// Save the currently focused element
+				previousFocusRef.current =
+					baseControlRef.current &&
+					baseControlRef.current.ownerDocument.activeElement;
+
+				// Trigger validation display by simulating focus and blur
+				validationTimeoutRef.current = setTimeout( () => {
 					if ( baseControlRef.current ) {
 						const input = baseControlRef.current.querySelector(
 							'input[type="datetime-local"]'
@@ -141,11 +163,17 @@ function CalendarDateTimeControl< Item >( {
 							input.blur();
 							onChange( dateTimeValue );
 							onValidateControl( dateTimeValue );
+
+							// Restore focus to the previously focused element
+							if (
+								previousFocusRef.current &&
+								previousFocusRef.current instanceof HTMLElement
+							) {
+								previousFocusRef.current.focus();
+							}
 						}
 					}
-				}, 10 );
-
-				// Trigger validation display by simulating focus and blur
+				}, 0 );
 			} else {
 				onChange( undefined );
 				onValidateControl( undefined );

--- a/packages/dataviews/src/dataform-controls/datetime.tsx
+++ b/packages/dataviews/src/dataform-controls/datetime.tsx
@@ -81,7 +81,7 @@ function CalendarDateTimeControl< Item >( {
 			>[ 'customValidity' ]
 		>( undefined );
 
-	const baseControlRef = useRef< HTMLDivElement >( null );
+	const inputControlRef = useRef< HTMLInputElement >( null );
 	const validationTimeoutRef = useRef< ReturnType< typeof setTimeout > >();
 	const previousFocusRef = useRef< Element | null >( null );
 
@@ -153,28 +153,23 @@ function CalendarDateTimeControl< Item >( {
 			}
 			// Save the currently focused element
 			previousFocusRef.current =
-				baseControlRef.current &&
-				baseControlRef.current.ownerDocument.activeElement;
+				inputControlRef.current &&
+				inputControlRef.current.ownerDocument.activeElement;
 
 			// Trigger validation display by simulating focus and blur and changes
 			validationTimeoutRef.current = setTimeout( () => {
-				if ( baseControlRef.current ) {
-					const input = baseControlRef.current.querySelector(
-						'input[type="datetime-local"]'
-					) as HTMLInputElement;
-					if ( input ) {
-						input.focus();
-						input.blur();
-						onChange( dateTimeValue );
-						onValidateControl( dateTimeValue );
+				if ( inputControlRef.current ) {
+					inputControlRef.current.focus();
+					inputControlRef.current.blur();
+					onChange( dateTimeValue );
+					onValidateControl( dateTimeValue );
 
-						// Restore focus to the previously focused element
-						if (
-							previousFocusRef.current &&
-							previousFocusRef.current instanceof HTMLElement
-						) {
-							previousFocusRef.current.focus();
-						}
+					// Restore focus to the previously focused element
+					if (
+						previousFocusRef.current &&
+						previousFocusRef.current instanceof HTMLElement
+					) {
+						previousFocusRef.current.focus();
 					}
 				}
 			}, 0 );
@@ -207,50 +202,47 @@ function CalendarDateTimeControl< Item >( {
 	} = getSettings();
 
 	return (
-		<div ref={ baseControlRef }>
-			<BaseControl
-				__nextHasNoMarginBottom
-				id={ id }
-				label={ label }
-				help={ description }
-				hideLabelFromVision={ hideLabelFromVision }
-			>
-				<VStack spacing={ 4 }>
-					{ /* Calendar widget */ }
-					<DateCalendar
-						style={ { width: '100%' } }
-						selected={
-							value
-								? parseDateTime( value ) || undefined
-								: undefined
-						}
-						onSelect={ onSelectDate }
-						month={ calendarMonth }
-						onMonthChange={ setCalendarMonth }
-						timeZone={ timezoneString || undefined }
-						weekStartsOn={ startOfWeek }
-					/>
-					{ /* Manual datetime input */ }
-					<ValidatedInputControl
-						__next40pxDefaultSize
-						required={ !! field.isValid?.required }
-						onValidate={ onValidateControl }
-						customValidity={ customValidity }
-						type="datetime-local"
-						label={ __( 'Date time' ) }
-						hideLabelFromVision
-						value={
-							value
-								? formatDateTime(
-										parseDateTime( value ) || undefined
-								  )
-								: ''
-						}
-						onChange={ handleManualDateTimeChange }
-					/>
-				</VStack>
-			</BaseControl>
-		</div>
+		<BaseControl
+			__nextHasNoMarginBottom
+			id={ id }
+			label={ label }
+			help={ description }
+			hideLabelFromVision={ hideLabelFromVision }
+		>
+			<VStack spacing={ 4 }>
+				{ /* Calendar widget */ }
+				<DateCalendar
+					style={ { width: '100%' } }
+					selected={
+						value ? parseDateTime( value ) || undefined : undefined
+					}
+					onSelect={ onSelectDate }
+					month={ calendarMonth }
+					onMonthChange={ setCalendarMonth }
+					timeZone={ timezoneString || undefined }
+					weekStartsOn={ startOfWeek }
+				/>
+				{ /* Manual datetime input */ }
+				<ValidatedInputControl
+					ref={ inputControlRef }
+					__next40pxDefaultSize
+					required={ !! field.isValid?.required }
+					onValidate={ onValidateControl }
+					customValidity={ customValidity }
+					type="datetime-local"
+					label={ __( 'Date time' ) }
+					hideLabelFromVision
+					value={
+						value
+							? formatDateTime(
+									parseDateTime( value ) || undefined
+							  )
+							: ''
+					}
+					onChange={ handleManualDateTimeChange }
+				/>
+			</VStack>
+		</BaseControl>
 	);
 }
 

--- a/packages/dataviews/src/dataform-controls/datetime.tsx
+++ b/packages/dataviews/src/dataform-controls/datetime.tsx
@@ -49,26 +49,15 @@ const formatDateTime = ( date?: Date | string ): string => {
 };
 
 function CalendarDateTimeControl< Item >( {
-	id,
-	value,
-	onChange,
-	label,
-	description,
-	hideLabelFromVision,
 	data,
 	field,
-	setValue,
-}: {
-	id: string;
-	value: string | undefined;
-	onChange: ( value: string | undefined ) => void;
-	label: string;
-	description?: string;
-	hideLabelFromVision?: boolean;
-	data: Item;
-	field: any;
-	setValue: any;
-} ) {
+	onChange,
+	hideLabelFromVision,
+}: DataFormControlProps< Item > ) {
+	const { id, label, description, setValue, getValue } = field;
+	const fieldValue = getValue( { item: data } );
+	const value = typeof fieldValue === 'string' ? fieldValue : undefined;
+
 	const [ calendarMonth, setCalendarMonth ] = useState< Date >( () => {
 		const parsedDate = parseDateTime( value );
 		return parsedDate || new Date(); // Default to current month
@@ -84,6 +73,12 @@ function CalendarDateTimeControl< Item >( {
 	const inputControlRef = useRef< HTMLInputElement >( null );
 	const validationTimeoutRef = useRef< ReturnType< typeof setTimeout > >();
 	const previousFocusRef = useRef< Element | null >( null );
+
+	const onChangeCallback = useCallback(
+		( newValue: string | undefined ) =>
+			onChange( setValue( { item: data, value: newValue } ) ),
+		[ data, onChange, setValue ]
+	);
 
 	// Cleanup timeout on unmount
 	useEffect( () => {
@@ -140,7 +135,7 @@ function CalendarDateTimeControl< Item >( {
 				}
 
 				dateTimeValue = finalDateTime.toISOString();
-				onChange( dateTimeValue );
+				onChangeCallback( dateTimeValue );
 				onValidateControl( dateTimeValue );
 
 				// Clear any existing timeout
@@ -148,7 +143,7 @@ function CalendarDateTimeControl< Item >( {
 					clearTimeout( validationTimeoutRef.current );
 				}
 			} else {
-				onChange( undefined );
+				onChangeCallback( undefined );
 				onValidateControl( undefined );
 			}
 			// Save the currently focused element
@@ -162,7 +157,7 @@ function CalendarDateTimeControl< Item >( {
 				if ( inputControlRef.current ) {
 					inputControlRef.current.focus();
 					inputControlRef.current.blur();
-					onChange( dateTimeValue );
+					onChangeCallback( dateTimeValue );
 					onValidateControl( dateTimeValue );
 
 					// Restore focus to the previously focused element
@@ -175,7 +170,7 @@ function CalendarDateTimeControl< Item >( {
 				}
 			}, 0 );
 		},
-		[ onChange, value, onValidateControl ]
+		[ onChangeCallback, value, onValidateControl ]
 	);
 
 	const handleManualDateTimeChange = useCallback(
@@ -183,7 +178,7 @@ function CalendarDateTimeControl< Item >( {
 			if ( newValue ) {
 				// Convert from datetime-local format to ISO string
 				const dateTime = new Date( newValue );
-				onChange( dateTime.toISOString() );
+				onChangeCallback( dateTime.toISOString() );
 
 				// Update calendar month to match
 				const parsedDate = parseDateTime( dateTime.toISOString() );
@@ -191,10 +186,10 @@ function CalendarDateTimeControl< Item >( {
 					setCalendarMonth( parsedDate );
 				}
 			} else {
-				onChange( undefined );
+				onChangeCallback( undefined );
 			}
 		},
-		[ onChange ]
+		[ onChangeCallback ]
 	);
 
 	const {
@@ -259,17 +254,11 @@ export default function DateTime< Item >( {
 	hideLabelFromVision,
 	operator,
 }: DataFormControlProps< Item > ) {
-	const { id, label, description, getValue, setValue } = field;
+	const { id, label, getValue, setValue } = field;
 	const value = getValue( { item: data } );
 
 	const onChangeRelativeDateControl = useCallback(
 		( newValue: DateRelative ) =>
-			onChange( setValue( { item: data, value: newValue } ) ),
-		[ data, onChange, setValue ]
-	);
-
-	const onChangeCalendarDateTimeControl = useCallback(
-		( newValue: string | undefined ) =>
 			onChange( setValue( { item: data, value: newValue } ) ),
 		[ data, onChange, setValue ]
 	);
@@ -290,15 +279,10 @@ export default function DateTime< Item >( {
 
 	return (
 		<CalendarDateTimeControl
-			id={ id }
-			value={ typeof value === 'string' ? value : undefined }
-			onChange={ onChangeCalendarDateTimeControl }
-			label={ label }
-			description={ description }
-			hideLabelFromVision={ hideLabelFromVision }
 			data={ data }
 			field={ field }
-			setValue={ setValue }
+			onChange={ onChange }
+			hideLabelFromVision={ hideLabelFromVision }
 		/>
 	);
 }

--- a/packages/dataviews/src/stories/dataform.story.tsx
+++ b/packages/dataviews/src/stories/dataform.story.tsx
@@ -18,6 +18,7 @@ import {
  */
 import DataForm from '../components/dataform';
 import isItemValid from '../utils/is-item-valid';
+
 import type {
 	Field,
 	Form,

--- a/packages/dataviews/src/stories/dataform.story.tsx
+++ b/packages/dataviews/src/stories/dataform.story.tsx
@@ -511,32 +511,6 @@ function CustomEditControl< Item >( {
 	);
 }
 
-type ValidatedItem = {
-	text: string;
-	select?: string;
-	textWithRadio?: string;
-	textarea: string;
-	email: string;
-	telephone: string;
-	url: string;
-	color: string;
-	integer: number;
-	number: number;
-	boolean: boolean;
-	customEdit: string;
-	categories: string[];
-	countries: string[];
-	password: string;
-	toggle?: boolean;
-	toggleGroup?: string;
-	date?: string;
-	dateRange?: [ string, string ];
-};
-
-const DateRangeEdit = ( props: DataFormControlProps< ValidatedItem > ) => {
-	return <DateControl { ...props } operator="between" />;
-};
-
 const ValidationComponent = ( {
 	required,
 	type,
@@ -567,6 +541,10 @@ const ValidationComponent = ( {
 		date?: string;
 		dateRange?: string;
 		datetime?: string;
+	};
+
+	const DateRangeEdit = ( props: DataFormControlProps< ValidatedItem > ) => {
+		return <DateControl { ...props } operator="between" />;
 	};
 
 	const [ post, setPost ] = useState< ValidatedItem >( {

--- a/packages/dataviews/src/stories/dataform.story.tsx
+++ b/packages/dataviews/src/stories/dataform.story.tsx
@@ -545,6 +545,27 @@ const ValidationComponent = ( {
 	custom: boolean;
 	type: 'regular' | 'panel';
 } ) => {
+	type ValidatedItem = {
+		text: string;
+		select?: string;
+		textWithRadio?: string;
+		textarea: string;
+		email: string;
+		telephone: string;
+		url: string;
+		color: string;
+		integer: number;
+		number: number;
+		boolean: boolean;
+		customEdit: string;
+		categories: string[];
+		countries: string[];
+		password: string;
+		toggle?: boolean;
+		toggleGroup?: string;
+		datetime?: string;
+	};
+
 	const [ post, setPost ] = useState< ValidatedItem >( {
 		text: 'Can have letters and spaces',
 		select: undefined,
@@ -565,6 +586,7 @@ const ValidationComponent = ( {
 		toggleGroup: undefined,
 		date: undefined,
 		dateRange: undefined,
+		datetime: undefined,
 	} );
 
 	const customTextRule = ( value: ValidatedItem ) => {
@@ -684,6 +706,18 @@ const ValidationComponent = ( {
 		today.setHours( 0, 0, 0, 0 );
 		if ( selectedDate < today ) {
 			return 'Date must not be in the past.';
+		}
+
+		return null;
+	};
+	const customDateTimeRule = ( value: ValidatedItem ) => {
+		if ( ! value.datetime ) {
+			return null;
+		}
+		const selectedDateTime = new Date( value.datetime );
+		const now = new Date();
+		if ( selectedDateTime < now ) {
+			return 'Date and time must not be in the past.';
 		}
 
 		return null;
@@ -920,6 +954,15 @@ const ValidationComponent = ( {
 				custom: maybeCustomRule( customDateRangeRule ),
 			},
 		},
+		{
+			id: 'datetime',
+			type: 'datetime',
+			label: 'Date Time',
+			isValid: {
+				required,
+				custom: maybeCustomRule( customDateTimeRule ),
+			},
+		},
 	];
 
 	const form = {
@@ -944,6 +987,7 @@ const ValidationComponent = ( {
 			'customEdit',
 			'date',
 			'dateRange',
+			'datetime',
 		],
 	};
 

--- a/packages/dataviews/src/stories/dataform.story.tsx
+++ b/packages/dataviews/src/stories/dataform.story.tsx
@@ -564,6 +564,8 @@ const ValidationComponent = ( {
 		password: string;
 		toggle?: boolean;
 		toggleGroup?: string;
+		date?: string;
+		dateRange?: string;
 		datetime?: string;
 	};
 


### PR DESCRIPTION
This PR implements validation on the datetime field. I changes the input control to a ValidatedInputControl, and reuses all the validation provided by this component.
Given that date time includes a date time input control and a calendar in order to trigger validation when the user interacts with the calendar  we do some events on the input so the field is marked as touched and the validation runs. This allows us to reuse all the validation provided by html5 and the custom validation as implemented on ValidatedInputControl. It looks hacky but works well without downsides.


##Screenshots
<img width="283" height="345" alt="Screenshot 2025-10-03 at 16 27 03" src="https://github.com/user-attachments/assets/a3bf2652-a875-4fe1-9cac-e4226fb9616f" />


## Testing Instructions
Open the story http://localhost:50240/?path=/story/dataviews-dataform--validation.
Press some value on the calendar e.g: in the past, verify the correct validation message appears.
Use tab + arrow keys + enter to select a different day on the calendar, verify everything works and focus is not lost.
Remove the value from the calendar by clicking on the select day, verify the required field message appears.
Use the input field and verify the correct error messages also appear there.