### PR TITLE
DataViews: create top-level `utils/` folder

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Reorganizes normalize-form-fields and renames `dataforms-layouts/` to `dataform-layout/` to follow the naming schema of any other folder in the package. [#72056](https://github.com/WordPress/gutenberg/pull/72056)
 - Moves `utils.ts` to `field-types/utils/render-from-elements.ts`, so it's collocated where it is used. [#72058](https://github.com/WordPress/gutenberg/pull/72058)
+- Centralize all top-level utilities in a `utils/` folder, sets a name that reflects on the function name, and uses the default exports. [#72063](https://github.com/WordPress/gutenberg/pull/72063)
 
 ## 9.1.0 (2025-10-01)
 

--- a/packages/dataviews/src/components/dataform/index.tsx
+++ b/packages/dataviews/src/components/dataform/index.tsx
@@ -8,7 +8,7 @@ import { useMemo } from '@wordpress/element';
  */
 import type { DataFormProps } from '../../types';
 import { DataFormProvider } from '../dataform-context';
-import { normalizeFields } from '../../normalize-fields';
+import normalizeFields from '../../utils/normalize-fields';
 import { DataFormLayout } from '../../dataform-layouts/data-form-layout';
 
 export default function DataForm< Item >( {

--- a/packages/dataviews/src/components/dataviews-picker/index.tsx
+++ b/packages/dataviews/src/components/dataviews-picker/index.tsx
@@ -29,7 +29,7 @@ import DataViewsViewConfig, {
 	DataviewsViewConfigDropdown,
 	ViewTypeMenu,
 } from '../dataviews-view-config';
-import { normalizeFields } from '../../normalize-fields';
+import normalizeFields from '../../utils/normalize-fields';
 import type { ActionButton, Field, View, SupportedLayouts } from '../../types';
 import type { SelectionOrUpdater } from '../../types/private';
 type ItemWithId = { id: string };

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -30,7 +30,7 @@ import DataViewsViewConfig, {
 	DataviewsViewConfigDropdown,
 	ViewTypeMenu,
 } from '../dataviews-view-config';
-import { normalizeFields } from '../../normalize-fields';
+import normalizeFields from '../../utils/normalize-fields';
 import type { Action, Field, View, SupportedLayouts } from '../../types';
 import type { SelectionOrUpdater } from '../../types/private';
 type ItemWithId = { id: string };

--- a/packages/dataviews/src/index.ts
+++ b/packages/dataviews/src/index.ts
@@ -2,6 +2,6 @@ export { default as DataViews } from './components/dataviews';
 export { default as DataViewsPicker } from './components/dataviews-picker';
 export { default as DataForm } from './components/dataform';
 export { default as filterSortAndPaginate } from './utils/filter-sort-and-paginate';
+export { default as isItemValid } from './utils/is-item-valid';
 export { VIEW_LAYOUTS } from './dataviews-layouts';
 export type * from './types';
-export { isItemValid } from './validation';

--- a/packages/dataviews/src/index.ts
+++ b/packages/dataviews/src/index.ts
@@ -1,7 +1,7 @@
 export { default as DataViews } from './components/dataviews';
 export { default as DataViewsPicker } from './components/dataviews-picker';
 export { default as DataForm } from './components/dataform';
+export { default as filterSortAndPaginate } from './utils/filter-sort-and-paginate';
 export { VIEW_LAYOUTS } from './dataviews-layouts';
-export { filterSortAndPaginate } from './filter-and-sort-data-view';
 export type * from './types';
 export { isItemValid } from './validation';

--- a/packages/dataviews/src/stories/dataform.story.tsx
+++ b/packages/dataviews/src/stories/dataform.story.tsx
@@ -17,7 +17,7 @@ import {
  * Internal dependencies
  */
 import DataForm from '../components/dataform';
-import { isItemValid } from '../validation';
+import isItemValid from '../utils/is-item-valid';
 import type {
 	Field,
 	Form,

--- a/packages/dataviews/src/stories/dataviews-picker.story.tsx
+++ b/packages/dataviews/src/stories/dataviews-picker.story.tsx
@@ -13,7 +13,7 @@ import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
  */
 import DataViewsPicker from '../components/dataviews-picker/index';
 import { LAYOUT_PICKER_GRID } from '../constants';
-import { filterSortAndPaginate } from '../filter-and-sort-data-view';
+import filterSortAndPaginate from '../utils/filter-sort-and-paginate';
 import type { ActionButton, View } from '../types';
 import { data, fields, type SpaceObject } from './dataviews.fixtures';
 

--- a/packages/dataviews/src/stories/dataviews.story.tsx
+++ b/packages/dataviews/src/stories/dataviews.story.tsx
@@ -31,7 +31,7 @@ import { __, _n } from '@wordpress/i18n';
  */
 import DataViews from '../components/dataviews/index';
 import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../constants';
-import { filterSortAndPaginate } from '../filter-and-sort-data-view';
+import filterSortAndPaginate from '../utils/filter-sort-and-paginate';
 import type { Field, View } from '../types';
 import {
 	DEFAULT_VIEW,

--- a/packages/dataviews/src/stories/field-types.story.tsx
+++ b/packages/dataviews/src/stories/field-types.story.tsx
@@ -16,7 +16,7 @@ import { starFilled } from '@wordpress/icons';
  */
 import DataViews from '../components/dataviews/index';
 import DataForm from '../components/dataform/index';
-import { filterSortAndPaginate } from '../filter-and-sort-data-view';
+import filterSortAndPaginate from '../utils/filter-sort-and-paginate';
 import type { View, Form, Field } from '../types';
 
 const meta = {

--- a/packages/dataviews/src/test/dataviews-picker.tsx
+++ b/packages/dataviews/src/test/dataviews-picker.tsx
@@ -15,7 +15,7 @@ import { useMemo, useState } from '@wordpress/element';
 import DataViewsPicker from '../components/dataviews-picker';
 import { LAYOUT_PICKER_GRID } from '../constants';
 import type { ActionButton, View, ViewPickerGrid } from '../types';
-import { filterSortAndPaginate } from '../filter-and-sort-data-view';
+import filterSortAndPaginate from '../utils/filter-sort-and-paginate';
 
 type Data = {
 	id: number;

--- a/packages/dataviews/src/test/dataviews.tsx
+++ b/packages/dataviews/src/test/dataviews.tsx
@@ -15,7 +15,7 @@ import { useMemo, useState } from '@wordpress/element';
 import DataViews from '../components/dataviews';
 import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../constants';
 import type { Action, View } from '../types';
-import { filterSortAndPaginate } from '../filter-and-sort-data-view';
+import filterSortAndPaginate from '../utils/filter-sort-and-paginate';
 
 type Data = {
 	id: number;

--- a/packages/dataviews/src/test/filter-sort-and-paginate.js
+++ b/packages/dataviews/src/test/filter-sort-and-paginate.js
@@ -6,7 +6,7 @@ import { subDays, subYears } from 'date-fns';
 /**
  * Internal dependencies
  */
-import { filterSortAndPaginate } from '../filter-and-sort-data-view';
+import filterSortAndPaginate from '../utils/filter-sort-and-paginate';
 import { data, fields } from '../stories/dataviews.fixtures';
 
 describe( 'filters', () => {

--- a/packages/dataviews/src/test/normalize-fields.ts
+++ b/packages/dataviews/src/test/normalize-fields.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { normalizeFields } from '../normalize-fields';
+import normalizeFields from '../utils/normalize-fields';
 import type { Field } from '../types';
 
 describe( 'normalizeFields: default getValue', () => {

--- a/packages/dataviews/src/test/validation.ts
+++ b/packages/dataviews/src/test/validation.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { isItemValid } from '../validation';
+import isItemValid from '../utils/is-item-valid';
 import type { Field } from '../types';
 
 describe( 'validation', () => {

--- a/packages/dataviews/src/utils/filter-sort-and-paginate.ts
+++ b/packages/dataviews/src/utils/filter-sort-and-paginate.ts
@@ -35,9 +35,9 @@ import {
 	OPERATOR_NOT_ON,
 	OPERATOR_IN_THE_PAST,
 	OPERATOR_OVER,
-} from './constants';
-import { normalizeFields } from './normalize-fields';
-import type { Field, View } from './types';
+} from '../constants';
+import { normalizeFields } from '../normalize-fields';
+import type { Field, View } from '../types';
 
 function normalizeSearchInput( input = '' ) {
 	return removeAccents( input.trim().toLowerCase() );
@@ -76,7 +76,7 @@ function getRelativeDate( value: number, unit: string ): Date {
  *
  * @return Filtered, sorted and paginated data.
  */
-export function filterSortAndPaginate< Item >(
+export default function filterSortAndPaginate< Item >(
 	data: Item[],
 	view: View,
 	fields: Field< Item >[]

--- a/packages/dataviews/src/utils/filter-sort-and-paginate.ts
+++ b/packages/dataviews/src/utils/filter-sort-and-paginate.ts
@@ -36,7 +36,7 @@ import {
 	OPERATOR_IN_THE_PAST,
 	OPERATOR_OVER,
 } from '../constants';
-import { normalizeFields } from '../normalize-fields';
+import normalizeFields from './normalize-fields';
 import type { Field, View } from '../types';
 
 function normalizeSearchInput( input = '' ) {

--- a/packages/dataviews/src/utils/is-item-valid.ts
+++ b/packages/dataviews/src/utils/is-item-valid.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { normalizeFields } from '../normalize-fields';
+import normalizeFields from './normalize-fields';
 import type { Field, Form } from '../types';
 
 /**

--- a/packages/dataviews/src/utils/is-item-valid.ts
+++ b/packages/dataviews/src/utils/is-item-valid.ts
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import { normalizeFields } from './normalize-fields';
-import type { Field, Form } from './types';
+import { normalizeFields } from '../normalize-fields';
+import type { Field, Form } from '../types';
 
 /**
  * Whether or not the given item's value is valid according to the fields and form config.
@@ -13,7 +13,7 @@ import type { Field, Form } from './types';
  *
  * @return A boolean indicating if the item is valid (true) or not (false).
  */
-export function isItemValid< Item >(
+export default function isItemValid< Item >(
 	item: Item,
 	fields: Field< Item >[],
 	form: Form

--- a/packages/dataviews/src/utils/normalize-fields.ts
+++ b/packages/dataviews/src/utils/normalize-fields.ts
@@ -37,7 +37,7 @@ const getValueFromId =
 		return value;
 	};
 
-export const setValueFromId =
+const setValueFromId =
 	( id: string ) =>
 	( { value }: { value: any } ) => {
 		const path = id.split( '.' );

--- a/packages/dataviews/src/utils/normalize-fields.ts
+++ b/packages/dataviews/src/utils/normalize-fields.ts
@@ -6,20 +6,20 @@ import type { FunctionComponent } from 'react';
 /**
  * Internal dependencies
  */
-import getFieldTypeDefinition from './field-types';
+import getFieldTypeDefinition from '../field-types';
 import type {
 	DataViewRenderFieldProps,
 	Field,
 	FieldTypeDefinition,
 	NormalizedFilterByConfig,
 	NormalizedField,
-} from './types';
-import { getControl } from './dataform-controls';
+} from '../types';
+import { getControl } from '../dataform-controls';
 import {
 	ALL_OPERATORS,
 	OPERATOR_BETWEEN,
 	SINGLE_SELECTION_OPERATORS,
-} from './constants';
+} from '../constants';
 
 const getValueFromId =
 	( id: string ) =>
@@ -136,7 +136,7 @@ function getFilterBy< Item >(
  * @param fields Fields config.
  * @return Normalized fields config.
  */
-export function normalizeFields< Item >(
+export default function normalizeFields< Item >(
 	fields: Field< Item >[]
 ): NormalizedField< Item >[] {
 	return fields.map( ( field ) => {


### PR DESCRIPTION
## What?

This is a code-quality PR. It centralizes all top-level utilities in a `utils/` folder, sets a name that reflects on the function name, and uses the default exports.

## Why?

For consistency and readability.

## How?

- Moves `filter-and-sort-dataviews.ts` to `utils/filter-sort-and-paginate.ts`.
- Moves `normalize-fields.ts` to `utils/normalize-fields.ts`.
- Moves `validation.ts` to `utils/is-item-valid.ts`.

## Testing Instructions

Smoke test by running the storybook or wp-env.