### PR TITLE
DataForm: row layout can control field width

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -7,6 +7,10 @@
 - DataForm: Add summary field support for both card and panel layouts. The `summary` property has been moved from the field level to the layout level, and so fields using `summary` at the field level must now configure it within the `layout` object. Additionally, the first children will only be used as summary for the panel if 1) there is no `layout.summary` and 2) the form field ID doesn't match any existing field. See README for details. [#71576](https://github.com/WordPress/gutenberg/pull/71576)
 - Remove `Data< Item >` type, as it is no longer used internally for a long time. [#72051](https://github.com/WordPress/gutenberg/pull/72051)
 
+### Features
+
+- DataForm: add a style prop to set the width of elements in the row layout. [#72066](https://github.com/WordPress/gutenberg/pull/72066)
+
 ### Code Quality
 
 - Reorganizes normalize-form-fields and renames `dataforms-layouts/` to `dataform-layout/` to follow the naming schema of any other folder in the package. [#72056](https://github.com/WordPress/gutenberg/pull/72056)

--- a/packages/dataviews/src/dataform-layouts/normalize-form-fields.ts
+++ b/packages/dataviews/src/dataform-layouts/normalize-form-fields.ts
@@ -90,6 +90,7 @@ export function normalizeLayout( layout?: Layout ): NormalizedLayout {
 		normalizedLayout = {
 			type: 'row',
 			alignment: layout?.alignment ?? 'center',
+			styles: layout?.styles ?? {},
 		} satisfies NormalizedRowLayout;
 	}
 

--- a/packages/dataviews/src/dataform-layouts/row/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/row/index.tsx
@@ -75,6 +75,7 @@ export default function FormRowField< Item >( {
 							<div
 								key={ nestedField.id }
 								className="dataforms-layouts-row__field-control"
+								style={ layout.styles[ nestedField.id ] }
 							>
 								<FieldLayout
 									data={ data }

--- a/packages/dataviews/src/stories/dataform.story.tsx
+++ b/packages/dataviews/src/stories/dataform.story.tsx
@@ -1330,13 +1330,10 @@ const LayoutRowComponent = ( {
 			id: 'cost',
 			label: 'Cost',
 			type: 'integer',
-			readOnly: true,
-		},
-		{
-			id: 'tax',
-			label: 'Tax',
-			type: 'integer',
-			readOnly: true,
+			setValue: ( { item, value } ) => ( {
+				cost: value,
+				total: Number( value ) * item.quantity,
+			} ),
 		},
 		{
 			id: 'quantity',
@@ -1354,11 +1351,16 @@ const LayoutRowComponent = ( {
 				{ value: 9, label: '9' },
 				{ value: 10, label: '10' },
 			],
+			setValue: ( { item, value } ) => ( {
+				quantity: Number( value ),
+				total: Number( value ) * item.cost,
+			} ),
 		},
 		{
 			id: 'total',
 			label: 'Total',
 			type: 'integer',
+			readOnly: true,
 		},
 	];
 
@@ -1500,13 +1502,12 @@ const LayoutRowComponent = ( {
 								type: 'row',
 								alignment: 'end',
 								styles: {
-									cost: { flex: 1 },
-									tax: { flex: 1 },
-									quantity: { flex: 2 },
-									total: { flex: 2 },
+									total: { flex: 1 },
+									cost: { flex: 3 },
+									quantity: { flex: 3 },
 								},
 							},
-							children: [ 'cost', 'tax', 'quantity', 'total' ],
+							children: [ 'total', 'cost', 'quantity' ],
 						},
 					],
 				} }

--- a/packages/dataviews/src/stories/dataform.story.tsx
+++ b/packages/dataviews/src/stories/dataform.story.tsx
@@ -1232,6 +1232,10 @@ const LayoutRowComponent = ( {
 		hasDiscount: boolean;
 		vat: number;
 		commission: number;
+		cost: number;
+		tax: number;
+		quantity: number;
+		total: number;
 	};
 
 	const customerFields: Field< Customer >[] = [
@@ -1322,6 +1326,40 @@ const LayoutRowComponent = ( {
 				{ value: 'yearly', label: 'Yearly' },
 			],
 		},
+		{
+			id: 'cost',
+			label: 'Cost',
+			type: 'integer',
+			readOnly: true,
+		},
+		{
+			id: 'tax',
+			label: 'Tax',
+			type: 'integer',
+			readOnly: true,
+		},
+		{
+			id: 'quantity',
+			label: 'Quantity',
+			type: 'integer',
+			elements: [
+				{ value: 1, label: '1' },
+				{ value: 2, label: '2' },
+				{ value: 3, label: '3' },
+				{ value: 4, label: '4' },
+				{ value: 5, label: '5' },
+				{ value: 6, label: '6' },
+				{ value: 7, label: '7' },
+				{ value: 8, label: '8' },
+				{ value: 9, label: '9' },
+				{ value: 10, label: '10' },
+			],
+		},
+		{
+			id: 'total',
+			label: 'Total',
+			type: 'integer',
+		},
 	];
 
 	const [ customer, setCustomer ] = useState< Customer >( {
@@ -1343,6 +1381,10 @@ const LayoutRowComponent = ( {
 		vat: 10,
 		commission: 5,
 		hasDiscount: true,
+		cost: 100,
+		tax: 20,
+		quantity: 5,
+		total: 600,
 	} );
 
 	const form: Form = useMemo(
@@ -1438,6 +1480,36 @@ const LayoutRowComponent = ( {
 				data={ customer }
 				fields={ customerFields }
 				form={ form }
+				onChange={ ( edits ) =>
+					setCustomer( ( prev ) => ( {
+						...prev,
+						...edits,
+					} ) )
+				}
+			/>
+			<h2>Field widths</h2>
+			<DataForm
+				data={ customer }
+				fields={ customerFields }
+				form={ {
+					fields: [
+						{
+							id: 'product',
+							label: 'Product',
+							layout: {
+								type: 'row',
+								alignment: 'end',
+								styles: {
+									cost: { flex: 1 },
+									tax: { flex: 1 },
+									quantity: { flex: 2 },
+									total: { flex: 2 },
+								},
+							},
+							children: [ 'cost', 'tax', 'quantity', 'total' ],
+						},
+					],
+				} }
 				onChange={ ( edits ) =>
 					setCustomer( ( prev ) => ( {
 						...prev,

--- a/packages/dataviews/src/types/dataform.ts
+++ b/packages/dataviews/src/types/dataform.ts
@@ -83,10 +83,12 @@ export type NormalizedCardLayout =
 export type RowLayout = {
 	type: 'row';
 	alignment?: 'start' | 'center' | 'end';
+	styles?: Record< string, { flex?: React.CSSProperties[ 'flex' ] } >;
 };
 export type NormalizedRowLayout = {
 	type: 'row';
 	alignment: 'start' | 'center' | 'end';
+	styles: Record< string, { flex?: React.CSSProperties[ 'flex' ] } >;
 };
 
 export type Layout = RegularLayout | PanelLayout | CardLayout | RowLayout;


### PR DESCRIPTION
This PR adds a styles option on the row layout (for now supporting only flex), this allows to control the relative width of each field on the same row.
It also implements a story to demonstrate this functionality.


## Screenshot
<img width="1261" height="687" alt="Screenshot 2025-10-03 at 17 31 59" src="https://github.com/user-attachments/assets/14489bb5-16d3-4c35-87f6-7482299282ef" />



## Testing Instructions
Open http://localhost:50240/?path=/story/dataviews-dataform--layout-row.
Verify the story look as the image.
Test different flex values by changing the story and verify things look correct.
