### PR TITLE
PHP-only blocks: add documentation

### DIFF
--- a/docs/getting-started/fundamentals/registration-of-a-block.md
+++ b/docs/getting-started/fundamentals/registration-of-a-block.md
@@ -91,6 +91,29 @@ registerBlockType( metadata.name, {
 
 _See the [full block example](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/minimal-block-ca6eda) of the [code above](https://github.com/WordPress/block-development-examples/blob/trunk/plugins/minimal-block-ca6eda/src/index.js)_
 
+## PHP-only blocks with auto-registration
+
+For blocks that only need server-side rendering, you can register them exclusively in PHP using the [`auto_register`](/docs/reference-guides/block-api/block-supports.md#auto_register) flag and a `render_callback`. These blocks automatically appear in the editor without requiring any JavaScript code and use [dynamic rendering](/docs/getting-started/fundamentals/static-dynamic-rendering.md).
+
+```php
+register_block_type( 'my-plugin/server-block', array(
+	'render_callback' => function( $attributes ) {
+		$wrapper_attributes = get_block_wrapper_attributes();
+
+		return sprintf(
+			'<div %1$s>Server content</div>',
+			$wrapper_attributes
+		);
+	},
+	'supports' => array(
+		'auto_register' => true,
+		'color' => array(
+			'background' => true,
+		),
+	),
+) );
+```
+
 ## Additional resources
 
 - [`register_block_type` PHP function](https://developer.wordpress.org/reference/functions/register_block_type/)

--- a/docs/getting-started/fundamentals/registration-of-a-block.md
+++ b/docs/getting-started/fundamentals/registration-of-a-block.md
@@ -44,9 +44,32 @@ add_action( 'init', 'minimal_block_ca6eda___register_block' );
 
 _See the [full block example](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/minimal-block-ca6eda) of the  [code above](https://github.com/WordPress/block-development-examples/blob/trunk/plugins/minimal-block-ca6eda/plugin.php)_
 
+### PHP-only blocks with auto-registration
+
+For blocks that only need server-side rendering, you can register them exclusively in PHP using the [`auto_register`](/docs/reference-guides/block-api/block-supports.md#auto_register) flag and a `render_callback`. These blocks automatically appear in the editor without requiring any JavaScript registration or client-side code and use [dynamic rendering](/docs/getting-started/fundamentals/static-dynamic-rendering.md).
+
+```php
+register_block_type( 'my-plugin/server-block', array(
+	'render_callback' => function( $attributes ) {
+		$wrapper_attributes = get_block_wrapper_attributes();
+
+		return sprintf(
+			'<div %1$s>Server content</div>',
+			$wrapper_attributes
+		);
+	},
+	'supports' => array(
+		'auto_register' => true,
+		'color' => array(
+			'background' => true,
+		),
+	),
+) );
+```
+
 ## Registering a block with JavaScript (client-side)
 
-When the block has already been registered on the server, you only need to register the client-side settings in JavaScript using the [`registerBlockType`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-blocks/#registerblocktype) method from the `@wordpress/blocks` package. You just need to make sure you use the same block name as defined in the block's `block.json` file. Here's an example:
+When the block has already been registered on the server and unless using [PHP-only auto-registered blocks](#php-only-blocks-with-auto-registration), you only need to register the client-side settings in JavaScript using the [`registerBlockType`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-blocks/#registerblocktype) method from the `@wordpress/blocks` package. You just need to make sure you use the same block name as defined in the block's `block.json` file. Here's an example:
 
 ```js
 import { registerBlockType } from '@wordpress/blocks';
@@ -90,29 +113,6 @@ registerBlockType( metadata.name, {
 ```
 
 _See the [full block example](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/minimal-block-ca6eda) of the [code above](https://github.com/WordPress/block-development-examples/blob/trunk/plugins/minimal-block-ca6eda/src/index.js)_
-
-## PHP-only blocks with auto-registration
-
-For blocks that only need server-side rendering, you can register them exclusively in PHP using the [`auto_register`](/docs/reference-guides/block-api/block-supports.md#auto_register) flag and a `render_callback`. These blocks automatically appear in the editor without requiring any JavaScript code and use [dynamic rendering](/docs/getting-started/fundamentals/static-dynamic-rendering.md).
-
-```php
-register_block_type( 'my-plugin/server-block', array(
-	'render_callback' => function( $attributes ) {
-		$wrapper_attributes = get_block_wrapper_attributes();
-
-		return sprintf(
-			'<div %1$s>Server content</div>',
-			$wrapper_attributes
-		);
-	},
-	'supports' => array(
-		'auto_register' => true,
-		'color' => array(
-			'background' => true,
-		),
-	),
-) );
-```
 
 ## Additional resources
 

--- a/docs/getting-started/fundamentals/static-dynamic-rendering.md
+++ b/docs/getting-started/fundamentals/static-dynamic-rendering.md
@@ -88,7 +88,7 @@ There are some common use cases for dynamic blocks:
 
 A block can define dynamic rendering in two main ways:
 
-1. Using the `render_callback` argument that can be passed to the [`register_block_type()`](https://developer.wordpress.org/block-editor/getting-started/fundamentals/registration-of-a-block/#registration-of-the-block-with-php-server-side) function.
+1. Using the `render_callback` argument that can be passed to the [`register_block_type()`](https://developer.wordpress.org/block-editor/getting-started/fundamentals/registration-of-a-block/#registration-of-the-block-with-php-server-side) function. This is needed for [PHP-only blocks](/docs/getting-started/fundamentals/registration-of-a-block.md#php-only-blocks-with-auto-registration).
 2. Using a separate PHP file usually named `render.php`. This file's path should be defined using the [`render`](https://developer.wordpress.org/block-editor/getting-started/fundamentals/block-json/#files-for-the-blocks-behavior-output-or-style) property in the `block.json` file.
 
 Both of these methods receive the following data:

--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -61,7 +61,7 @@ supports: {
 -   Type: `boolean`
 -   Default value: `false`
 
-Enables PHP-only blocks to automatically appear in the block editor without requiring JavaScript registration. When set to `true`, blocks registered on the server with a `render_callback` will automatically be registered in the editor and use `ServerSideRender`. These blocks default to block API version 3 and are automatically upgraded if they're using an older version.
+Enables [PHP-only blocks](/docs/getting-started/fundamentals/registration-of-a-block.md#php-only-blocks-with-auto-registration) to automatically appear in the block editor without requiring JavaScript registration. When set to `true`, blocks registered on the server with a `render_callback` will automatically be registered in the editor and use `ServerSideRender`. These blocks default to block API version 3 and are automatically upgraded if they're using an older version.
 
 ```php
 register_block_type( 'my-plugin/server-block', array(

--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -56,6 +56,29 @@ supports: {
 }
 ```
 
+## auto_register
+
+-   Type: `boolean`
+-   Default value: `false`
+
+Enables PHP-only blocks to automatically appear in the block editor without requiring JavaScript registration. When set to `true`, blocks registered on the server with a `render_callback` will automatically be registered in the editor and use `ServerSideRender`. These blocks default to block API version 3 and are automatically upgraded if they're using an older version.
+
+```php
+register_block_type( 'my-plugin/server-block', array(
+	'render_callback' => function( $attributes ) {
+		$wrapper_attributes = get_block_wrapper_attributes();
+
+		return sprintf(
+			'<div %1$s>Server content</div>',
+			$wrapper_attributes
+		);
+	},
+	'supports' => array(
+		'auto_register' => true,
+	),
+) );
+```
+
 ## align
 
 -   Type: `boolean` or `array`


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of #71792. Adds developer documentation about PHP-only blocks and their client-side autoregistration through the `auto_register` block attribute. 

<!-- In a few words, what is the PR actually doing? -->

## Why?
Because new APIs need docs!

## How?
Adding documentation to the block editor handbook.