### PR TITLE
Fix Navigation Link Focus Loss

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -192,11 +192,6 @@ export default function NavigationLinkEdit( {
 	const linkUIref = useRef();
 	const prevUrl = usePrevious( url );
 
-	// Change the `label` and `url` using inspector causes RichText to change focus.
-	// This is a workaround to keep the focus on the field when it's focused we don't render the RichText.
-	// See: https://github.com/WordPress/gutenberg/pull/61374.
-	const [ isEditingControl, setIsEditingControl ] = useState( false );
-
 	const {
 		isAtMaxNesting,
 		isTopLevelLink,
@@ -439,7 +434,6 @@ export default function NavigationLinkEdit( {
 				<Controls
 					attributes={ attributes }
 					setAttributes={ setAttributes }
-					setIsEditingControl={ setIsEditingControl }
 					clientId={ clientId }
 				/>
 			</InspectorControls>
@@ -447,51 +441,47 @@ export default function NavigationLinkEdit( {
 				{ /* eslint-disable jsx-a11y/anchor-is-valid */ }
 				<a className={ classes }>
 					{ /* eslint-enable */ }
-					{ ! url &&
-					! isEditingControl &&
-					! metadata?.bindings?.url ? (
+					{ ! url && ! metadata?.bindings?.url ? (
 						<div className="wp-block-navigation-link__placeholder-text">
 							<span>{ missingText }</span>
 						</div>
 					) : (
 						<>
-							{ ! isInvalid &&
-								! isDraft &&
-								! isEditingControl && (
-									<>
-										<RichText
-											ref={ ref }
-											identifier="label"
-											className="wp-block-navigation-item__label"
-											value={ label }
-											onChange={ ( labelValue ) =>
-												setAttributes( {
-													label: labelValue,
-												} )
-											}
-											onMerge={ mergeBlocks }
-											onReplace={ onReplace }
-											__unstableOnSplitAtEnd={ () =>
-												insertBlocksAfter(
-													createBlock(
-														'core/navigation-link'
-													)
+							{ ! isInvalid && ! isDraft && (
+								<>
+									<RichText
+										ref={ ref }
+										identifier="label"
+										className="wp-block-navigation-item__label"
+										value={ label }
+										onChange={ ( labelValue ) =>
+											setAttributes( {
+												label: labelValue,
+											} )
+										}
+										onMerge={ mergeBlocks }
+										onReplace={ onReplace }
+										__unstableOnSplitAtEnd={ () =>
+											insertBlocksAfter(
+												createBlock(
+													'core/navigation-link'
 												)
-											}
-											aria-label={ __(
-												'Navigation link text'
-											) }
-											placeholder={ itemLabelPlaceholder }
-											withoutInteractiveFormatting
-										/>
-										{ description && (
-											<span className="wp-block-navigation-item__description">
-												{ description }
-											</span>
+											)
+										}
+										aria-label={ __(
+											'Navigation link text'
 										) }
-									</>
-								) }
-							{ ( isInvalid || isDraft || isEditingControl ) && (
+										placeholder={ itemLabelPlaceholder }
+										withoutInteractiveFormatting
+									/>
+									{ description && (
+										<span className="wp-block-navigation-item__description">
+											{ description }
+										</span>
+									) }
+								</>
+							) }
+							{ ( isInvalid || isDraft ) && (
 								<div
 									className={ clsx(
 										'wp-block-navigation-link__placeholder-text',

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -61,10 +61,10 @@ function getEntityTypeName( type, kind ) {
  * This component provides the inspector controls (ToolsPanel) that are identical
  * between both navigation blocks.
  *
- * @param {Object}   props                     - Component props
- * @param {Object}   props.attributes          - Block attributes
- * @param {Function} props.setAttributes       - Function to update block attributes
- * @param {string}   props.clientId            - Block client ID
+ * @param {Object}   props               - Component props
+ * @param {Object}   props.attributes    - Block attributes
+ * @param {Function} props.setAttributes - Function to update block attributes
+ * @param {string}   props.clientId      - Block client ID
  */
 export function Controls( { attributes, setAttributes, clientId } ) {
 	const { label, url, description, rel, opensInNewTab } = attributes;

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -64,15 +64,9 @@ function getEntityTypeName( type, kind ) {
  * @param {Object}   props                     - Component props
  * @param {Object}   props.attributes          - Block attributes
  * @param {Function} props.setAttributes       - Function to update block attributes
- * @param {Function} props.setIsEditingControl - Function to set editing state (optional)
  * @param {string}   props.clientId            - Block client ID
  */
-export function Controls( {
-	attributes,
-	setAttributes,
-	setIsEditingControl = () => {},
-	clientId,
-} ) {
+export function Controls( { attributes, setAttributes, clientId } ) {
 	const { label, url, description, rel, opensInNewTab } = attributes;
 	const lastURLRef = useRef( url );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
@@ -122,8 +116,6 @@ export function Controls( {
 						setAttributes( { label: labelValue } );
 					} }
 					autoComplete="off"
-					onFocus={ () => setIsEditingControl( true ) }
-					onBlur={ () => setIsEditingControl( false ) }
 				/>
 			</ToolsPanelItem>
 
@@ -155,7 +147,6 @@ export function Controls( {
 							return;
 						}
 						lastURLRef.current = url;
-						setIsEditingControl( true );
 					} }
 					onBlur={ () => {
 						if ( hasUrlBinding ) {
@@ -167,7 +158,6 @@ export function Controls( {
 							setAttributes,
 							{ ...attributes, url: lastURLRef.current }
 						);
-						setIsEditingControl( false );
 					} }
 					help={
 						hasUrlBinding && (

--- a/packages/block-library/src/navigation-link/shared/test/controls.js
+++ b/packages/block-library/src/navigation-link/shared/test/controls.js
@@ -156,31 +156,6 @@ describe( 'Controls', () => {
 		);
 	} );
 
-	it( 'calls setIsEditingControl on focus and blur for all inputs', () => {
-		render( <Controls { ...defaultProps } /> );
-
-		const textInput = screen.getByLabelText( 'Text' );
-		const urlInput = screen.getByLabelText( 'Link' );
-
-		// Test text input
-		fireEvent.focus( textInput );
-		expect( defaultProps.setIsEditingControl ).toHaveBeenCalledWith( true );
-
-		fireEvent.blur( textInput );
-		expect( defaultProps.setIsEditingControl ).toHaveBeenCalledWith(
-			false
-		);
-
-		// Test URL input
-		fireEvent.focus( urlInput );
-		expect( defaultProps.setIsEditingControl ).toHaveBeenCalledWith( true );
-
-		fireEvent.blur( urlInput );
-		expect( defaultProps.setIsEditingControl ).toHaveBeenCalledWith(
-			false
-		);
-	} );
-
 	it( 'handles all form field changes correctly', () => {
 		render( <Controls { ...defaultProps } /> );
 


### PR DESCRIPTION
## What?

Fixes Tab key navigation in the Navigation Link block's inspector controls. Previously, pressing Tab from the second text field would incorrectly return focus to the block canvas instead of advancing to the "Open in new tab" checkbox.

## Why?

The block used an isEditingControl state to conditionally unmount RichText while editing inspector fields, which was a workaround for an old focus-stealing issue (PR #61374). This workaround is no longer necessary and caused RichText to remount when tabbing between fields, stealing focus back to the canvas.

## How?

  - Removed isEditingControl state and all related logic from edit.js
  - Removed setIsEditingControl prop and calls from shared/controls.js
  - Removed conditional rendering of RichText based on isEditingControl
  - Kept the updateAttributes call on blur for the Link field (needed for entity connection logic)

 ## Testing Instructions

  1. Add a Navigation block and create a navigation link
  2. Select the link and open the inspector sidebar (Settings panel)
  3. Focus the "Text" field and press Tab
  4. Verify focus moves to the "Link" field
  5. Press Tab again
  6. Verify focus moves to the "Open in new tab" checkbox (not back to the canvas)
  7. Continue pressing Tab to verify navigation through remaining fields works correctly
  8. Test typing in both Text and Link fields to verify no focus stealing occurs