### PR TITLE
Remove manual focus tracking for navigation link blocks

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -192,10 +192,10 @@ export default function NavigationLinkEdit( {
 	const isNewLink = useRef( ! url );
 
 	// On mount, if this is a new link without a URL and it's selected,
-	// select the parent navigation block instead to keep the appender visible.
+	// select the parent block (submenu or navigation) instead to keep the appender visible.
 	useEffect( () => {
 		if ( isNewLink.current && isSelected && ! url ) {
-			selectBlock( rootNavigationClientId );
+			selectBlock( parentBlockClientId );
 		}
 	}, [] );
 
@@ -231,7 +231,7 @@ export default function NavigationLinkEdit( {
 		isParentOfSelectedBlock,
 		hasChildren,
 		validateLinkStatus,
-		rootNavigationClientId,
+		parentBlockClientId,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -243,8 +243,8 @@ export default function NavigationLinkEdit( {
 				getSelectedBlockClientId,
 			} = select( blockEditorStore );
 			const rootClientId = getBlockRootClientId( clientId );
-			const isTopLevel =
-				getBlockName( rootClientId ) === 'core/navigation';
+			const parentBlockName = getBlockName( rootClientId );
+			const isTopLevel = parentBlockName === 'core/navigation';
 			const selectedBlockClientId = getSelectedBlockClientId();
 			const rootNavClientId = isTopLevel
 				? rootClientId
@@ -252,6 +252,12 @@ export default function NavigationLinkEdit( {
 						clientId,
 						'core/navigation'
 				  )[ 0 ];
+
+			// Get the immediate parent - if it's a submenu, use it; otherwise use the navigation block
+			const parentBlockId =
+				parentBlockName === 'core/navigation-submenu'
+					? rootClientId
+					: rootNavClientId;
 
 			// Enable when the root Navigation block is selected or any of its inner blocks.
 			const enableLinkStatusValidation =
@@ -269,7 +275,7 @@ export default function NavigationLinkEdit( {
 				),
 				hasChildren: !! getBlockCount( clientId ),
 				validateLinkStatus: enableLinkStatusValidation,
-				rootNavigationClientId: rootNavClientId,
+				parentBlockClientId: parentBlockId,
 			};
 		},
 		[ clientId, maxNestingLevel ]

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -192,6 +192,9 @@ export default function NavigationLinkEdit( {
 
 	// On mount, if this is a new link without a URL and it's selected,
 	// select the parent block (submenu or navigation) instead to keep the appender visible.
+	// This helps us return focus to the appender if the user closes the link ui without creating a link.
+	// If we leave focus on this block, then when we close the link without creating a link, focus will
+	// be lost during the new block selection process.
 	useEffect( () => {
 		if ( isNewLink.current && isSelected && ! url ) {
 			selectBlock( parentBlockClientId );

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -190,7 +190,8 @@ export default function NavigationLinkEdit( {
 	const linkUIref = useRef();
 	const prevUrl = usePrevious( url );
 	const closedByEscapeRef = useRef( false );
-	const isNewLink = useRef( ! url );
+	// If the link isSelected when mounted, it was just added via an appender
+	const isNewLink = isSelected;
 
 	// Listen for Escape key at document level when LinkUI is open
 	useEffect( () => {
@@ -541,7 +542,7 @@ export default function NavigationLinkEdit( {
 							onClose={ () => {
 								// If there is no link then remove the auto-inserted block.
 								// This avoids empty blocks which can provide a poor UX.
-								if ( ! url && isNewLink.current ) {
+								if ( ! url && isNewLink ) {
 									if ( closedByEscapeRef.current ) {
 										// User pressed Escape or closed intentionally
 										// Select the previous block so the appender remains visible.
@@ -557,7 +558,7 @@ export default function NavigationLinkEdit( {
 
 								if (
 									closedByEscapeRef.current &&
-									isNewLink.current &&
+									isNewLink &&
 									ref.current
 								) {
 									ref.current.focus();

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -190,6 +190,7 @@ export default function NavigationLinkEdit( {
 	const linkUIref = useRef();
 	const prevUrl = usePrevious( url );
 	const closedByEscapeRef = useRef( false );
+	const isNewLink = useRef( ! url );
 
 	// Listen for Escape key at document level when LinkUI is open
 	useEffect( () => {
@@ -540,7 +541,7 @@ export default function NavigationLinkEdit( {
 							onClose={ () => {
 								// If there is no link then remove the auto-inserted block.
 								// This avoids empty blocks which can provide a poor UX.
-								if ( ! url ) {
+								if ( ! url && isNewLink.current ) {
 									if ( closedByEscapeRef.current ) {
 										// User pressed Escape or closed intentionally
 										// Select the previous block so the appender remains visible.
@@ -556,6 +557,7 @@ export default function NavigationLinkEdit( {
 
 								if (
 									closedByEscapeRef.current &&
+									isNewLink.current &&
 									ref.current
 								) {
 									ref.current.focus();

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -190,8 +190,6 @@ export default function NavigationLinkEdit( {
 	const linkUIref = useRef();
 	const prevUrl = usePrevious( url );
 	const closedByEscapeRef = useRef( false );
-	// If the link isSelected when mounted, it was just added via an appender
-	const isNewLink = isSelected;
 
 	// Listen for Escape key at document level when LinkUI is open
 	useEffect( () => {
@@ -542,7 +540,7 @@ export default function NavigationLinkEdit( {
 							onClose={ () => {
 								// If there is no link then remove the auto-inserted block.
 								// This avoids empty blocks which can provide a poor UX.
-								if ( ! url && isNewLink ) {
+								if ( ! url ) {
 									if ( closedByEscapeRef.current ) {
 										// User pressed Escape or closed intentionally
 										// Select the previous block so the appender remains visible.
@@ -555,14 +553,6 @@ export default function NavigationLinkEdit( {
 								}
 
 								setIsLinkOpen( false );
-
-								if (
-									closedByEscapeRef.current &&
-									isNewLink &&
-									ref.current
-								) {
-									ref.current.focus();
-								}
 							} }
 							anchor={ popoverAnchor }
 							onRemove={ removeLink }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -176,7 +176,6 @@ export default function NavigationLinkEdit( {
 		replaceBlock,
 		__unstableMarkNextChangeAsNotPersistent,
 		selectBlock,
-		selectPreviousBlock,
 	} = useDispatch( blockEditorStore );
 	// Have the link editing ui open on mount when lacking a url and selected.
 	const [ isLinkOpen, setIsLinkOpen ] = useState( isSelected && ! url );
@@ -190,6 +189,15 @@ export default function NavigationLinkEdit( {
 	const linkUIref = useRef();
 	const prevUrl = usePrevious( url );
 	const closedByEscapeRef = useRef( false );
+	const isNewLink = useRef( ! url );
+
+	// On mount, if this is a new link without a URL and it's selected,
+	// select the parent navigation block instead to keep the appender visible.
+	useEffect( () => {
+		if ( isNewLink.current && isSelected && ! url ) {
+			selectBlock( rootNavigationClientId );
+		}
+	}, [] );
 
 	// Listen for Escape key at document level when LinkUI is open
 	useEffect( () => {
@@ -223,6 +231,7 @@ export default function NavigationLinkEdit( {
 		isParentOfSelectedBlock,
 		hasChildren,
 		validateLinkStatus,
+		rootNavigationClientId,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -237,7 +246,7 @@ export default function NavigationLinkEdit( {
 			const isTopLevel =
 				getBlockName( rootClientId ) === 'core/navigation';
 			const selectedBlockClientId = getSelectedBlockClientId();
-			const rootNavigationClientId = isTopLevel
+			const rootNavClientId = isTopLevel
 				? rootClientId
 				: getBlockParentsByBlockName(
 						clientId,
@@ -246,8 +255,8 @@ export default function NavigationLinkEdit( {
 
 			// Enable when the root Navigation block is selected or any of its inner blocks.
 			const enableLinkStatusValidation =
-				selectedBlockClientId === rootNavigationClientId ||
-				hasSelectedInnerBlock( rootNavigationClientId, true );
+				selectedBlockClientId === rootNavClientId ||
+				hasSelectedInnerBlock( rootNavClientId, true );
 
 			return {
 				isAtMaxNesting:
@@ -260,6 +269,7 @@ export default function NavigationLinkEdit( {
 				),
 				hasChildren: !! getBlockCount( clientId ),
 				validateLinkStatus: enableLinkStatusValidation,
+				rootNavigationClientId: rootNavClientId,
 			};
 		},
 		[ clientId, maxNestingLevel ]
@@ -538,21 +548,13 @@ export default function NavigationLinkEdit( {
 							clientId={ clientId }
 							link={ attributes }
 							onClose={ () => {
+								setIsLinkOpen( false );
+
 								// If there is no link then remove the auto-inserted block.
 								// This avoids empty blocks which can provide a poor UX.
 								if ( ! url ) {
-									if ( closedByEscapeRef.current ) {
-										// User pressed Escape or closed intentionally
-										// Select the previous block so the appender remains visible.
-										// Ideally this would focus the appender instead.
-										selectPreviousBlock( clientId );
-									}
-
-									// Then remove this block
 									onReplace( [] );
 								}
-
-								setIsLinkOpen( false );
 							} }
 							anchor={ popoverAnchor }
 							onRemove={ removeLink }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -180,8 +180,6 @@ export default function NavigationLinkEdit( {
 	} = useDispatch( blockEditorStore );
 	// Have the link editing ui open on mount when lacking a url and selected.
 	const [ isLinkOpen, setIsLinkOpen ] = useState( isSelected && ! url );
-	// Store what element opened the popover, so we know where to return focus to (toolbar button vs navigation link text)
-	const [ openedBy, setOpenedBy ] = useState( null );
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
@@ -191,6 +189,33 @@ export default function NavigationLinkEdit( {
 	const ref = useRef();
 	const linkUIref = useRef();
 	const prevUrl = usePrevious( url );
+	const closedByEscapeRef = useRef( false );
+
+	// Listen for Escape key at document level when LinkUI is open
+	useEffect( () => {
+		if ( ! isLinkOpen ) {
+			return;
+		}
+
+		const handleEscapeKey = ( event ) => {
+			if ( event.key === 'Escape' ) {
+				closedByEscapeRef.current = true;
+			}
+		};
+
+		// Use capture phase to catch Escape before Popover handles it
+		// Attach to document to ensure we catch it
+		document.addEventListener( 'keydown', handleEscapeKey, {
+			capture: true,
+		} );
+		return () => {
+			document.removeEventListener( 'keydown', handleEscapeKey, {
+				capture: true,
+			} );
+			// Reset the flag when the LinkUI closes
+			closedByEscapeRef.current = false;
+		};
+	}, [ isLinkOpen ] );
 
 	const {
 		isAtMaxNesting,
@@ -353,7 +378,6 @@ export default function NavigationLinkEdit( {
 			// If this link is a child of a parent submenu item, the parent submenu item event will also open, closing this popover
 			event.stopPropagation();
 			setIsLinkOpen( true );
-			setOpenedBy( ref.current );
 		}
 	}
 
@@ -392,7 +416,6 @@ export default function NavigationLinkEdit( {
 	if ( ! url || isInvalid || isDraft ) {
 		blockProps.onClick = () => {
 			setIsLinkOpen( true );
-			setOpenedBy( ref.current );
 		};
 	}
 
@@ -415,9 +438,8 @@ export default function NavigationLinkEdit( {
 						icon={ linkIcon }
 						title={ __( 'Link' ) }
 						shortcut={ displayShortcut.primary( 'k' ) }
-						onClick={ ( event ) => {
+						onClick={ () => {
 							setIsLinkOpen( true );
-							setOpenedBy( event.currentTarget );
 						} }
 					/>
 					{ ! isAtMaxNesting && (
@@ -517,37 +539,26 @@ export default function NavigationLinkEdit( {
 							link={ attributes }
 							onClose={ () => {
 								// If there is no link then remove the auto-inserted block.
-								// This avoids empty blocks which can provided a poor UX.
+								// This avoids empty blocks which can provide a poor UX.
 								if ( ! url ) {
-									// Fixes https://github.com/WordPress/gutenberg/issues/61361
-									// There's a chance we're closing due to the user selecting the browse all button.
-									// Only move focus if the focus is still within the popover ui. If it's not within
-									// the popover, it's because something has taken the focus from the popover, and
-									// we don't want to steal it back.
-									if (
-										linkUIref.current.contains(
-											window.document.activeElement
-										)
-									) {
-										// Select the previous block to keep focus nearby
-										selectPreviousBlock( clientId, true );
+									if ( closedByEscapeRef.current ) {
+										// User pressed Escape or closed intentionally
+										// Select the previous block so the appender remains visible.
+										// Ideally this would focus the appender instead.
+										selectPreviousBlock( clientId );
 									}
 
-									// Remove the link.
+									// Then remove this block
 									onReplace( [] );
-									return;
 								}
 
 								setIsLinkOpen( false );
-								if ( openedBy ) {
-									openedBy.focus();
-									setOpenedBy( null );
-								} else if ( ref.current ) {
-									// select the ref when adding a new link
+
+								if (
+									closedByEscapeRef.current &&
+									ref.current
+								) {
 									ref.current.focus();
-								} else {
-									// Fallback
-									selectPreviousBlock( clientId, true );
 								}
 							} }
 							anchor={ popoverAnchor }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -560,6 +560,9 @@ export default function NavigationLinkEdit( {
 								// This avoids empty blocks which can provide a poor UX.
 								if ( ! url ) {
 									onReplace( [] );
+								} else if ( isNewLink.current ) {
+									// If we just created a new link, select it
+									selectBlock( clientId );
 								}
 							} }
 							anchor={ popoverAnchor }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -188,7 +188,6 @@ export default function NavigationLinkEdit( {
 	const ref = useRef();
 	const linkUIref = useRef();
 	const prevUrl = usePrevious( url );
-	const closedByEscapeRef = useRef( false );
 	const isNewLink = useRef( ! url );
 
 	// On mount, if this is a new link without a URL and it's selected,
@@ -198,32 +197,6 @@ export default function NavigationLinkEdit( {
 			selectBlock( parentBlockClientId );
 		}
 	}, [] );
-
-	// Listen for Escape key at document level when LinkUI is open
-	useEffect( () => {
-		if ( ! isLinkOpen ) {
-			return;
-		}
-
-		const handleEscapeKey = ( event ) => {
-			if ( event.key === 'Escape' ) {
-				closedByEscapeRef.current = true;
-			}
-		};
-
-		// Use capture phase to catch Escape before Popover handles it
-		// Attach to document to ensure we catch it
-		document.addEventListener( 'keydown', handleEscapeKey, {
-			capture: true,
-		} );
-		return () => {
-			document.removeEventListener( 'keydown', handleEscapeKey, {
-				capture: true,
-			} );
-			// Reset the flag when the LinkUI closes
-			closedByEscapeRef.current = false;
-		};
-	}, [ isLinkOpen ] );
 
 	const {
 		isAtMaxNesting,

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -151,7 +151,8 @@ export default function NavigationSubmenuEdit( {
 	const itemLabelPlaceholder = __( 'Add text…' );
 	const ref = useRef();
 	const closedByEscapeRef = useRef( false );
-	const isNewLink = useRef( ! url );
+	// If the link isSelected when mounted, it was just added via an appender
+	const isNewLink = isSelected;
 	const hasInitialized = useRef( false );
 
 	const {
@@ -451,7 +452,7 @@ export default function NavigationSubmenuEdit( {
 							link={ attributes }
 							onClose={ () => {
 								// If there is no link then remove the auto-inserted block.
-								if ( ! url && isNewLink.current ) {
+								if ( ! url && isNewLink ) {
 									if ( closedByEscapeRef.current ) {
 										// User pressed Escape - select previous block so appender remains visible
 										selectPreviousBlock( clientId );
@@ -464,7 +465,7 @@ export default function NavigationSubmenuEdit( {
 
 								if (
 									closedByEscapeRef.current &&
-									isNewLink.current &&
+									isNewLink &&
 									ref.current
 								) {
 									ref.current.focus();

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -21,7 +21,7 @@ import {
 	getColorClassName,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
-import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 import { link as linkIcon, removeSubmenu } from '@wordpress/icons';
 import { speak } from '@wordpress/a11y';
 import { createBlock } from '@wordpress/blocks';
@@ -95,7 +95,7 @@ const useIsDraggingWithin = ( elementRef ) => {
 			ownerDocument.removeEventListener( 'dragend', handleDragEnd );
 			ownerDocument.removeEventListener( 'dragenter', handleDragEnter );
 		};
-	}, [ elementRef ] );
+	}, [] );
 
 	return isDraggingWithin;
 };
@@ -147,7 +147,6 @@ export default function NavigationSubmenuEdit( {
 	const isDraggingWithin = useIsDraggingWithin( listItemRef );
 	const itemLabelPlaceholder = __( 'Add text…' );
 	const ref = useRef();
-	const hasInitialized = useRef( false );
 
 	const {
 		parentCount,
@@ -212,11 +211,10 @@ export default function NavigationSubmenuEdit( {
 	// This can't be done in the useState call because it conflicts
 	// with the autofocus behavior of the BlockListBlock component.
 	useEffect( () => {
-		if ( ! hasInitialized.current && ! openSubmenusOnClick && ! url ) {
+		if ( ! openSubmenusOnClick && ! url ) {
 			setIsLinkOpen( true );
-			hasInitialized.current = true;
 		}
-	}, [ openSubmenusOnClick, url ] );
+	}, [] );
 
 	/**
 	 * The hook shouldn't be necessary but due to a focus loss happening
@@ -240,7 +238,7 @@ export default function NavigationSubmenuEdit( {
 				selectLabelText();
 			}
 		}
-	}, [ url, isLinkOpen, label ] );
+	}, [ url ] );
 
 	/**
 	 * Focus the Link label text and select it.
@@ -331,10 +329,10 @@ export default function NavigationSubmenuEdit( {
 
 	const ParentElement = openSubmenusOnClick ? 'button' : 'a';
 
-	const transformToLink = useCallback( () => {
+	function transformToLink() {
 		const newLinkBlock = createBlock( 'core/navigation-link', attributes );
 		replaceBlock( clientId, newLinkBlock );
-	}, [ attributes, replaceBlock, clientId ] );
+	}
 
 	useEffect( () => {
 		// If block becomes empty, transform to Navigation Link.
@@ -344,12 +342,7 @@ export default function NavigationSubmenuEdit( {
 			__unstableMarkNextChangeAsNotPersistent();
 			transformToLink();
 		}
-	}, [
-		hasChildren,
-		prevHasChildren,
-		__unstableMarkNextChangeAsNotPersistent,
-		transformToLink,
-	] );
+	}, [ hasChildren, prevHasChildren ] );
 
 	const canConvertToLink =
 		! selectedBlockHasChildren || onlyDescendantIsEmptyLink;

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -151,8 +151,6 @@ export default function NavigationSubmenuEdit( {
 	const itemLabelPlaceholder = __( 'Add text…' );
 	const ref = useRef();
 	const closedByEscapeRef = useRef( false );
-	// If the link isSelected when mounted, it was just added via an appender
-	const isNewLink = isSelected;
 	const hasInitialized = useRef( false );
 
 	const {
@@ -452,7 +450,7 @@ export default function NavigationSubmenuEdit( {
 							link={ attributes }
 							onClose={ () => {
 								// If there is no link then remove the auto-inserted block.
-								if ( ! url && isNewLink ) {
+								if ( ! url ) {
 									if ( closedByEscapeRef.current ) {
 										// User pressed Escape - select previous block so appender remains visible
 										selectPreviousBlock( clientId );
@@ -462,14 +460,6 @@ export default function NavigationSubmenuEdit( {
 								}
 
 								setIsLinkOpen( false );
-
-								if (
-									closedByEscapeRef.current &&
-									isNewLink &&
-									ref.current
-								) {
-									ref.current.focus();
-								}
 							} }
 							anchor={ popoverAnchor }
 							onRemove={ () => {

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -21,7 +21,7 @@ import {
 	getColorClassName,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
-import { useState, useEffect, useRef } from '@wordpress/element';
+import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
 import { link as linkIcon, removeSubmenu } from '@wordpress/icons';
 import { speak } from '@wordpress/a11y';
 import { createBlock } from '@wordpress/blocks';
@@ -95,7 +95,7 @@ const useIsDraggingWithin = ( elementRef ) => {
 			ownerDocument.removeEventListener( 'dragend', handleDragEnd );
 			ownerDocument.removeEventListener( 'dragenter', handleDragEnter );
 		};
-	}, [] );
+	}, [ elementRef ] );
 
 	return isDraggingWithin;
 };
@@ -140,11 +140,9 @@ export default function NavigationSubmenuEdit( {
 	const {
 		__unstableMarkNextChangeAsNotPersistent,
 		replaceBlock,
-		selectBlock,
+		selectPreviousBlock,
 	} = useDispatch( blockEditorStore );
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
-	// Store what element opened the popover, so we know where to return focus to (toolbar button vs navigation link text)
-	const [ openedBy, setOpenedBy ] = useState( null );
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
@@ -152,6 +150,9 @@ export default function NavigationSubmenuEdit( {
 	const isDraggingWithin = useIsDraggingWithin( listItemRef );
 	const itemLabelPlaceholder = __( 'Add text…' );
 	const ref = useRef();
+	const closedByEscapeRef = useRef( false );
+	const isNewLink = useRef( ! url );
+	const hasInitialized = useRef( false );
 
 	const {
 		parentCount,
@@ -216,10 +217,36 @@ export default function NavigationSubmenuEdit( {
 	// This can't be done in the useState call because it conflicts
 	// with the autofocus behavior of the BlockListBlock component.
 	useEffect( () => {
-		if ( ! openSubmenusOnClick && ! url ) {
+		if ( ! hasInitialized.current && ! openSubmenusOnClick && ! url ) {
 			setIsLinkOpen( true );
+			hasInitialized.current = true;
 		}
-	}, [] );
+	}, [ openSubmenusOnClick, url ] );
+
+	// Listen for Escape key at document level when LinkUI is open
+	useEffect( () => {
+		if ( ! isLinkOpen ) {
+			return;
+		}
+
+		const handleEscapeKey = ( event ) => {
+			if ( event.key === 'Escape' ) {
+				closedByEscapeRef.current = true;
+			}
+		};
+
+		// Use capture phase to catch Escape before Popover handles it
+		document.addEventListener( 'keydown', handleEscapeKey, {
+			capture: true,
+		} );
+		return () => {
+			document.removeEventListener( 'keydown', handleEscapeKey, {
+				capture: true,
+			} );
+			// Reset the flag when the LinkUI closes
+			closedByEscapeRef.current = false;
+		};
+	}, [ isLinkOpen ] );
 
 	/**
 	 * The hook shouldn't be necessary but due to a focus loss happening
@@ -243,7 +270,7 @@ export default function NavigationSubmenuEdit( {
 				selectLabelText();
 			}
 		}
-	}, [ url ] );
+	}, [ url, isLinkOpen, label ] );
 
 	/**
 	 * Focus the Link label text and select it.
@@ -276,7 +303,6 @@ export default function NavigationSubmenuEdit( {
 			// If we don't stop propagation, this event bubbles up to the parent submenu item
 			event.stopPropagation();
 			setIsLinkOpen( true );
-			setOpenedBy( ref.current );
 		}
 	}
 
@@ -335,10 +361,10 @@ export default function NavigationSubmenuEdit( {
 
 	const ParentElement = openSubmenusOnClick ? 'button' : 'a';
 
-	function transformToLink() {
+	const transformToLink = useCallback( () => {
 		const newLinkBlock = createBlock( 'core/navigation-link', attributes );
 		replaceBlock( clientId, newLinkBlock );
-	}
+	}, [ attributes, replaceBlock, clientId ] );
 
 	useEffect( () => {
 		// If block becomes empty, transform to Navigation Link.
@@ -348,7 +374,12 @@ export default function NavigationSubmenuEdit( {
 			__unstableMarkNextChangeAsNotPersistent();
 			transformToLink();
 		}
-	}, [ hasChildren, prevHasChildren ] );
+	}, [
+		hasChildren,
+		prevHasChildren,
+		__unstableMarkNextChangeAsNotPersistent,
+		transformToLink,
+	] );
 
 	const canConvertToLink =
 		! selectedBlockHasChildren || onlyDescendantIsEmptyLink;
@@ -363,9 +394,8 @@ export default function NavigationSubmenuEdit( {
 							icon={ linkIcon }
 							title={ __( 'Link' ) }
 							shortcut={ displayShortcut.primary( 'k' ) }
-							onClick={ ( event ) => {
+							onClick={ () => {
 								setIsLinkOpen( true );
-								setOpenedBy( event.currentTarget );
 							} }
 						/>
 					) }
@@ -407,7 +437,6 @@ export default function NavigationSubmenuEdit( {
 						onClick={ () => {
 							if ( ! openSubmenusOnClick && ! url ) {
 								setIsLinkOpen( true );
-								setOpenedBy( ref.current );
 							}
 						} }
 					/>
@@ -421,12 +450,24 @@ export default function NavigationSubmenuEdit( {
 							clientId={ clientId }
 							link={ attributes }
 							onClose={ () => {
+								// If there is no link then remove the auto-inserted block.
+								if ( ! url && isNewLink.current ) {
+									if ( closedByEscapeRef.current ) {
+										// User pressed Escape - select previous block so appender remains visible
+										selectPreviousBlock( clientId );
+									}
+									// Then remove this block
+									onReplace( [] );
+								}
+
 								setIsLinkOpen( false );
-								if ( openedBy ) {
-									openedBy.focus();
-									setOpenedBy( null );
-								} else {
-									selectBlock( clientId );
+
+								if (
+									closedByEscapeRef.current &&
+									isNewLink.current &&
+									ref.current
+								) {
+									ref.current.focus();
 								}
 							} }
 							anchor={ popoverAnchor }

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -147,7 +147,6 @@ export default function NavigationSubmenuEdit( {
 	const isDraggingWithin = useIsDraggingWithin( listItemRef );
 	const itemLabelPlaceholder = __( 'Add text…' );
 	const ref = useRef();
-	const closedByEscapeRef = useRef( false );
 	const hasInitialized = useRef( false );
 
 	const {
@@ -218,31 +217,6 @@ export default function NavigationSubmenuEdit( {
 			hasInitialized.current = true;
 		}
 	}, [ openSubmenusOnClick, url ] );
-
-	// Listen for Escape key at document level when LinkUI is open
-	useEffect( () => {
-		if ( ! isLinkOpen ) {
-			return;
-		}
-
-		const handleEscapeKey = ( event ) => {
-			if ( event.key === 'Escape' ) {
-				closedByEscapeRef.current = true;
-			}
-		};
-
-		// Use capture phase to catch Escape before Popover handles it
-		document.addEventListener( 'keydown', handleEscapeKey, {
-			capture: true,
-		} );
-		return () => {
-			document.removeEventListener( 'keydown', handleEscapeKey, {
-				capture: true,
-			} );
-			// Reset the flag when the LinkUI closes
-			closedByEscapeRef.current = false;
-		};
-	}, [ isLinkOpen ] );
 
 	/**
 	 * The hook shouldn't be necessary but due to a focus loss happening
@@ -447,11 +421,6 @@ export default function NavigationSubmenuEdit( {
 							link={ attributes }
 							onClose={ () => {
 								setIsLinkOpen( false );
-
-								// If there is no link then remove the auto-inserted block.
-								if ( ! url ) {
-									onReplace( [] );
-								}
 							} }
 							anchor={ popoverAnchor }
 							onRemove={ () => {

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -137,11 +137,8 @@ export default function NavigationSubmenuEdit( {
 		attributes,
 	} );
 
-	const {
-		__unstableMarkNextChangeAsNotPersistent,
-		replaceBlock,
-		selectPreviousBlock,
-	} = useDispatch( blockEditorStore );
+	const { __unstableMarkNextChangeAsNotPersistent, replaceBlock } =
+		useDispatch( blockEditorStore );
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
@@ -449,17 +446,12 @@ export default function NavigationSubmenuEdit( {
 							clientId={ clientId }
 							link={ attributes }
 							onClose={ () => {
+								setIsLinkOpen( false );
+
 								// If there is no link then remove the auto-inserted block.
 								if ( ! url ) {
-									if ( closedByEscapeRef.current ) {
-										// User pressed Escape - select previous block so appender remains visible
-										selectPreviousBlock( clientId );
-									}
-									// Then remove this block
 									onReplace( [] );
 								}
-
-								setIsLinkOpen( false );
 							} }
 							anchor={ popoverAnchor }
 							onRemove={ () => {

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -336,73 +336,58 @@ test.describe( 'Navigation block', () => {
 		test( 'Focus management when using the navigation link appender', async ( {
 			pageUtils,
 			navigation,
-		} ) => {
-			const navBlock = navigation.getNavBlock();
-
-			/**
-			 * Test: We don't lose focus when using the navigation link appender
-			 */
-			await pageUtils.pressKeys( 'ArrowDown' );
-			await navigation.useBlockInserter();
-			await navigation.addLinkClose();
-
-			/**
-			 * TODO: This is not desired behavior. Ideally the
-			 * Appender should be focused again since it opened
-			 * the link control.
-			 * IMPORTANT: This check is not to enforce this behavior,
-			 * but to make sure focus is kept nearby until we are able
-			 * to send focus to the appender.
-			 */
-			await expect( navBlock ).toBeFocused();
-		} );
-
-		// eslint-disable-next-line playwright/expect-expect
-		test( 'Focus management when creating navigation links', async ( {
 			page,
-			pageUtils,
-			navigation,
 		} ) => {
-			/**
-			 * Test: Creating a link sends focus to the newly created navigation link item
-			 */
-			await pageUtils.pressKeys( 'ArrowDown' );
-			await navigation.useBlockInserter();
-			await navigation.addPage( 'Cat' );
+			const navBlockInserter = navigation.getNavBlockInserter();
 
-			/**
-			 * Test: We can open and close the preview with the keyboard and escape
-			 *       buttons from a top-level nav item using both the shortcut and toolbar
-			 */
-			await navigation.useLinkShortcut();
-			await navigation.previewIsOpenAndCloses();
-			await navigation.checkLabelFocus( 'Cat' );
+			await test.step( 'with no links, focus returns to the top level navigation link appender if we close the Link UI without creating a link', async () => {
+				await pageUtils.pressKeys( 'ArrowDown' );
+				await navigation.useBlockInserter();
+				await navigation.addLinkClose();
 
-			await navigation.canUseToolbarLink();
+				await expect( navBlockInserter ).toBeVisible();
+				await expect( navBlockInserter ).toBeFocused();
+			} );
 
-			/**
-			 * Test: Creating a link from a url-string (https://www.example.com) returns
-			 *       focus to the newly created link with the text selected
-			 */
-			await page.keyboard.press( 'Escape' );
-			await pageUtils.pressKeys( 'ArrowDown' );
-			await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
+			await test.step( 'creating a link sends focus to the newly created navigation link item', async () => {
+				await pageUtils.pressKeys( 'ArrowDown' );
+				await navigation.useBlockInserter();
+				await navigation.addPage( 'Cat' );
+			} );
 
-			await navigation.useBlockInserter();
-			await navigation.addCustomURL( 'https://example.com' );
-			await navigation.expectToHaveTextSelected( 'example.com' );
+			await test.step( 'we can open and close the preview with the keyboard and escape buttons from a top-level nav item using both the shortcut and toolbar', async () => {
+				await navigation.useLinkShortcut();
+				await navigation.previewIsOpenAndCloses();
+				await navigation.checkLabelFocus( 'Cat' );
 
-			/**
-			 * Test: We can open and close the preview with the keyboard and escape
-			 *       buttons from a top-level nav link with a url-like label using
-			 *       both the shortcut and toolbar
-			 */
-			await pageUtils.pressKeys( 'ArrowLeft' );
-			await navigation.useLinkShortcut();
-			await navigation.previewIsOpenAndCloses();
-			await navigation.checkLabelFocus( 'example.com' );
+				await navigation.canUseToolbarLink();
 
-			await navigation.canUseToolbarLink();
+				await page.keyboard.press( 'Escape' );
+				await pageUtils.pressKeys( 'ArrowDown' );
+				await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
+			} );
+
+			await test.step( 'focus returns to the navigation link appender if we close the Link UI without creating a link', async () => {
+				await navigation.useBlockInserter();
+				await navigation.addLinkClose();
+				await expect( navBlockInserter ).toBeVisible();
+				await expect( navBlockInserter ).toBeFocused();
+			} );
+
+			await test.step( 'creating a link from a url-string (https://www.example.com) returns focus to the newly created link with the text selected', async () => {
+				await navigation.useBlockInserter();
+				await navigation.addCustomURL( 'https://example.com' );
+				await navigation.expectToHaveTextSelected( 'example.com' );
+			} );
+
+			await test.step( 'we can open and close the preview with the keyboard and escape buttons from a top-level nav link with a url-like label using both the shortcut and toolbar', async () => {
+				await pageUtils.pressKeys( 'ArrowLeft' );
+				await navigation.useLinkShortcut();
+				await navigation.previewIsOpenAndCloses();
+				await navigation.checkLabelFocus( 'example.com' );
+
+				await navigation.canUseToolbarLink();
+			} );
 		} );
 
 		test( 'Can add submenu item using the keyboard', async ( {
@@ -916,7 +901,7 @@ class Navigation {
 
 		await expect( linkControlSearch ).toBeFocused();
 
-		await this.page.keyboard.type( label, { delay: 50 } );
+		await this.page.keyboard.type( label, { delay: 200 } );
 
 		// Wait for the search results to be visible
 		await expect(
@@ -930,7 +915,7 @@ class Navigation {
 		await this.page.keyboard.press( 'Enter' );
 
 		const linkControlLink = await this.getLinkControlLink( label );
-		await expect( linkControlLink ).toBeFocused();
+		await expect( linkControlLink ).toBeVisible();
 
 		await this.page.keyboard.press( 'Escape' );
 

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -355,17 +355,20 @@ test.describe( 'Navigation block', () => {
 				await navigation.addPage( 'Cat' );
 			} );
 
-			await test.step( 'we can open and close the preview with the keyboard and escape buttons from a top-level nav item using both the shortcut and toolbar', async () => {
+			await test.step( 'can use the shortcut to open the preview with the keyboard and escape keypress sends focus back to the navigation link block', async () => {
 				await navigation.useLinkShortcut();
 				await navigation.previewIsOpenAndCloses();
 				await navigation.checkLabelFocus( 'Cat' );
+			} );
 
+			await test.step( 'can use the toolbar link to open the preview and escape keypress sends focus back to the toolbar link button', async () => {
 				await navigation.canUseToolbarLink();
 
 				await page.keyboard.press( 'Escape' );
-				await pageUtils.pressKeys( 'ArrowDown' );
-				await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
 			} );
+
+			await pageUtils.pressKeys( 'ArrowDown' );
+			await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
 
 			await test.step( 'focus returns to the navigation link appender if we close the Link UI without creating a link', async () => {
 				await navigation.useBlockInserter();
@@ -396,69 +399,71 @@ test.describe( 'Navigation block', () => {
 			navigation,
 			page,
 		} ) => {
-			await pageUtils.pressKeys( 'ArrowDown' );
-			await navigation.useBlockInserter();
-			await navigation.addPage( 'Cat' );
-
-			/**
-			 * Test: Can add submenu item using the keyboard
-			 */
-			navigation.useToolbarButton( 'Add submenu' );
-
-			// Expect the submenu Add link to be present
-			await expect(
-				editor.canvas.locator( 'a' ).filter( { hasText: 'Add link' } )
-			).toBeVisible();
-
-			await pageUtils.pressKeys( 'ArrowDown' );
-			// There is a bug that won't allow us to press Enter to add the link: https://github.com/WordPress/gutenberg/issues/60051
-			// TODO: Use Enter after that bug is resolved
-			await navigation.useLinkShortcut();
-
-			await navigation.addPage( 'Dog' );
-
-			/**
-			 * Test: We can open and close the preview with the keyboard and escape
-			 *       buttons from a submenu nav item using both the shortcut and toolbar
-			 */
-			await navigation.useLinkShortcut();
-			await navigation.previewIsOpenAndCloses();
-			await navigation.checkLabelFocus( 'Dog' );
-
-			await navigation.canUseToolbarLink();
-
-			// Return to nav label from toolbar
-			await page.keyboard.press( 'Escape' );
-
-			// We should be at the first position on the label
-			await navigation.checkLabelFocus( 'Dog' );
-
-			/**
-			 * Test: We don't lose focus when closing the submenu appender
-			 */
-
-			// Move focus to the submenu navigation appender
-			await page.keyboard.press( 'End' );
-			await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
-
-			// Use the submenu block inserter
-			const navBlock = navigation.getNavBlock();
-			const submenuBlock = navBlock.getByRole( 'document', {
-				name: 'Block: Submenu',
+			await test.step( 'create a top level navigation link', async () => {
+				await pageUtils.pressKeys( 'ArrowDown' );
+				await navigation.useBlockInserter();
+				await navigation.addPage( 'Cat' );
 			} );
-			const submenuBlockInserter = submenuBlock.getByLabel( 'Add block' );
-			await submenuBlockInserter.click();
 
-			await navigation.addLinkClose();
-			/**
-			 * TODO: This is not desired behavior. Ideally the
-			 * Appender should be focused again since it opened
-			 * the link control.
-			 * IMPORTANT: This check is not to enforce this behavior,
-			 * but to make sure focus is kept nearby until we are able
-			 * to send focus to the appender. It is falling back to the previous sibling.
-			 */
-			await navigation.checkLabelFocus( 'Dog' );
+			await test.step( 'can add submenu item using the keyboard', async () => {
+				navigation.useToolbarButton( 'Add submenu' );
+
+				// Expect the submenu Add link to be present
+				await expect(
+					editor.canvas
+						.locator( 'a' )
+						.filter( { hasText: 'Add link' } )
+				).toBeVisible();
+
+				await pageUtils.pressKeys( 'ArrowDown' );
+				// There is a bug that won't allow us to press Enter to add the link: https://github.com/WordPress/gutenberg/issues/60051
+				// TODO: Use Enter after that bug is resolved
+				await navigation.useLinkShortcut();
+
+				await navigation.addPage( 'Dog' );
+			} );
+
+			await test.step( 'can use the shortcut to open the preview with the keyboard and escape keypress sends focus back to the navigation link block in the submenu', async () => {
+				await navigation.useLinkShortcut();
+				await navigation.previewIsOpenAndCloses();
+				await navigation.checkLabelFocus( 'Dog' );
+			} );
+
+			await test.step( 'can use the toolbar link to open the preview and escape keypress sends focus back to the toolbar link button', async () => {
+				await navigation.canUseToolbarLink();
+
+				// Return to nav label from toolbar
+				await page.keyboard.press( 'Escape' );
+
+				// We should be at the first position on the label
+				await navigation.checkLabelFocus( 'Dog' );
+			} );
+
+			await test.step( 'focus returns to the submenu appender when exiting the submenu link creation without creating a link', async () => {
+				// Move focus to the submenu navigation appender
+				await page.keyboard.press( 'End' );
+				await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
+
+				await pageUtils.pressKeys( 'ArrowDown' );
+
+				// Use the submenu block inserter
+				const navBlock = navigation.getNavBlock();
+				const submenuBlock = navBlock.getByRole( 'document', {
+					name: 'Block: Submenu',
+				} );
+
+				const submenuBlockInserter =
+					submenuBlock.getByLabel( 'Add block' );
+				await expect( submenuBlockInserter ).toBeVisible();
+				await expect( submenuBlockInserter ).toBeFocused();
+
+				await page.keyboard.press( 'Enter' );
+
+				await navigation.addLinkClose();
+
+				await expect( submenuBlockInserter ).toBeVisible();
+				await expect( submenuBlockInserter ).toBeFocused();
+			} );
 		} );
 
 		test( 'Can add submenu item(custom-link) using the keyboard', async ( {


### PR DESCRIPTION
## What? 
Fixes and simplifies focus management issues in Navigation Link and Navigation Submenu blocks when closing link popovers. Fixes https://github.com/WordPress/gutenberg/issues/68035

Fixes https://github.com/WordPress/gutenberg/issues/65962 by moving block selection to the parent block so the sidebar editing isn't available during this step.

Flaky test fixes: Closes <!-- #ISSUE-NUMBER or URL --> https://github.com/WordPress/gutenberg/issues/71966, https://github.com/WordPress/gutenberg/issues/72064, https://github.com/WordPress/gutenberg/issues/72065 and https://github.com/WordPress/gutenberg/issues/71108


## Why? 
After adding a new navigation link and clicking anywhere (inspector, header, etc.), the popover would aggressively steal focus back to the canvas, preventing interaction with other UI elements, instead of letting the click naturally place focus. 

## How? 
Removed the openedBy state that was tracking which element opened the link popover, as it's no longer needed for focus management since https://github.com/WordPress/gutenberg/pull/68060 and https://github.com/WordPress/gutenberg/pull/71252/ were merged.

- Keep selection on parent block
- This allows the appender that opened the link ui to remain visible
- Modified onClose handler to: 
    - Only handle focus when adding a new link by selecting the newly added block.
    - If the link does not get created, remove the empty link
    - Focus is naturally handled by the useFocusOutside on the popover
- Broke navigation tests into steps and updated them to have focus go to the appender instead of previous block
- Added polling to fix flakey link ui check

Additional Changes
 - Applied the same fixes to both navigation-link and navigation-submenu blocks for consistency
 - Fixed React hook linting

Test Focus Behavior for New Links 
1. Add a Navigation block 
2. Click the appender to add a new Navigation Link (popover opens) 
3. Type a URL and press Enter (link is created) 
4. Click on an inspector control field in the sidebar 
5. ✅ Focus should stay in the inspector field you clicked 


Test Escape Key Behavior for New Links 
1. Add a Navigation block 
2. Click the appender to add a new Navigation Link (popover opens) 
3. Press Escape without entering a URL 
4. ✅ The empty block should be removed 
5. ✅ The previous block should be selected 
6. ✅ The appender should remain visible

Test Escape Key Behavior for Existing Links 
- From rich text element, press command + k to open the popover
- Press Escape
- ✅  Focus should go back to the rich text field
- Shift + tab to the toolbar
- Tab to the link edit button
- Enter
- Escape
- ✅ Focus should be on the toolbar link edit button

Test Navigation Submenu Repeat all the above tests with Navigation Submenu blocks to ensure they behave identically.

**Before**

https://github.com/user-attachments/assets/63c67475-6ce9-4e0c-953e-93d3a8edd697



**After**

https://github.com/user-attachments/assets/87d400ba-4277-46e9-9638-18102cf283d8

