### PR TITLE
Changelog automation: add "Collaboration" mapping

### DIFF
--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -96,6 +96,8 @@ const LABEL_TYPE_MAPPING = {
  * @type {Record<string,string>}
  */
 const LABEL_FEATURE_MAPPING = {
+	'[Feature] Real-time Collaboration': 'Collaboration',
+	'[Feature] Block Commenting': 'Collaboration',
 	'[Feature] Widgets Screen': 'Widgets Editor',
 	'[Feature] Widgets Customizer': 'Widgets Editor',
 	'[Feature] Design Tools': 'Design Tools',


### PR DESCRIPTION
Related resources:

- [Update on Phase 3: Collaboration efforts](https://make.wordpress.org/core/2024/11/21/update-on-phase-3-collaboration-efforts/)
- https://github.com/WordPress/gutenberg/discussions/72014

## Why?

When we're releasing Gutenberg, the PRs that belong to that milestone will be grouped based on labels and recorded in a changelog.

As far as I know, there are only two labels related to Phase 3, `Collaborative Workflows` and `[Feature] Real-time Collaboration]`, and these are not referenced when generating the changelog. As a result, when generating the changelog, PRs with those labels are placed right below the `Enhancements` and `Bug Fixes` section, which makes it very difficult to see:

<img width="1622" height="631" alt="block-comments" src="https://github.com/user-attachments/assets/4e1a8c8e-4f3e-4cc4-8163-bbb12c3430b7" />

## How?

Group PRs with the following two labels into a "Collaboration" section:

- `[Feature] Real-time Collaboration`
- `[Feature] Block Commenting`

This will generate a changelog like this:

```
## Changelog

### Enhancements

#### Collaboration
- Block Comments: Improve...
- Improve Block Commenting...
- Real Time Collaboration: Improve...

### Bug Fixes

#### Collaboration
- Fix: Block Commenting ...
- Block Comments: Fix...
- Real Time Collaboration: Fix...
```

If this PR is merged, I will do the following:

- Evaluate issues and PRs with the `Collaborative Workflows` label and add either label `[Feature] Real-time Collaboration` or `[Feature] Block Commenting` to each.
- Then, remove the `Collaborative Workflows` label.