### PR TITLE
Block bindings: Fix PHP 8.5 array offset deprecation warning

### DIFF
--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -121,8 +121,9 @@ function gutenberg_get_block_bindings_supported_attributes( $block_type ) {
 	);
 
 	$supported_block_attributes =
-		$block_bindings_supported_attributes_6_8[ $block_type ] ??
-		array();
+		isset( $block_type, $block_bindings_supported_attributes_6_8[ $block_type ] ) ?
+			$block_bindings_supported_attributes_6_8[ $block_type ] :
+			array();
 
 	/**
 	 * Filters the supported block attributes for block bindings.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Addresses `Using null as the key parameter for array_key_exists() is deprecated, use an empty string instead` in PHP 8.5

See https://wiki.php.net/rfc/deprecations_php_8_5

Follow-up to #71654

See core change in https://core.trac.wordpress.org/changeset/60809

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
