### PR TITLE
Fix Dataviews ItemClickable when set to false.

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - DataViews: keep non-hideable fields out of the hidden-fields list when they’re already invisible. [#71729](https://github.com/WordPress/gutenberg/pull/71729/)
 - DataViewsPicker: Hide the space reserved for the title when the title is hidden. [#71865](https://github.com/WordPress/gutenberg/pull/71865)
+- Always render a wrapper for media field (prevents layout break when 'itemClickable' is false). [#72078](https://github.com/WordPress/gutenberg/pull/72078).
 
 ### Enhancements
 

--- a/packages/dataviews/src/dataviews-layouts/utils/item-click-wrapper.tsx
+++ b/packages/dataviews/src/dataviews-layouts/utils/item-click-wrapper.tsx
@@ -63,8 +63,14 @@ export function ItemClickWrapper< Item >( {
 	className?: string;
 	children: ReactNode;
 } ) {
+	// Always render a wrapper element so layout and styling relying on the wrapper
+	// still works even if the item is not clickable.
 	if ( ! isItemClickable( item ) ) {
-		return children;
+		return (
+			<div className={ className } { ...extraProps }>
+				{ children }
+			</div>
+		);
 	}
 
 	// If we have a renderItemLink, use it


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes: https://github.com/WordPress/gutenberg/issues/71220

<!-- In a few words, what is the PR actually doing? -->
Always render the wrapper element for data-view items, even when the item is not clickable. Concretely, ItemClickWrapper now returns a simple <div className={className} {...extraProps}>…</div> for non-clickable items instead of omitting the wrapper or returning nothing.

## Why?
Some Dataview layouts and their CSS assume a wrapper element exists around each item. When an item was not clickable the wrapper was previously omitted and layout/styling could break (items collapsing, mis-aligned grids/lists). This caused visual regressions when itemClickable is false (or an item is individually non-clickable).

## How?
Updated ItemClickWrapper so that it always renders a wrapper element.

## Testing Instructions

1. Run npm run storybook:dev
2. When the storybook opens go to the Default DataViews story
3. Change this line in the story from` true` to `false`.
[gutenberg/packages/dataviews/src/components/dataviews/stories/index.story.tsx](https://github.com/WordPress/gutenberg/blob/c6d9267ec5570cb2fb1ece740c611784652f0b5e/packages/dataviews/src/components/dataviews/stories/index.story.tsx#L90)
5. Observe the images are now same sizes and aspect ratios. Switch to Grid layout and see the same.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
