### PR TITLE
Create Block: Enable `alias` package installation

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## Enhancement 
-- created block support alias ([#72079](https://github.com/WordPress/gutenberg/pull/72079)).
+- Enable `alias` package installation ([#72079](https://github.com/WordPress/gutenberg/pull/72079)).
 
 ## 4.75.0 (2025-10-01)
 

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -9,7 +9,7 @@
 ## 4.73.0 (2025-09-03)
 
 ### Enhancement
-
+- created block support alias ([#72079](https://github.com/WordPress/gutenberg/pull/72079)).
 -   Add lifecycle script execution support during npm packages installation ([#71072](https://github.com/WordPress/gutenberg/pull/71072)).
 
 ## 4.72.0 (2025-08-20)

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## Enhancement 
+- created block support alias ([#72079](https://github.com/WordPress/gutenberg/pull/72079)).
+
 ## 4.75.0 (2025-10-01)
 
 ## 4.74.0 (2025-09-17)
@@ -9,7 +12,6 @@
 ## 4.73.0 (2025-09-03)
 
 ### Enhancement
-- created block support alias ([#72079](https://github.com/WordPress/gutenberg/pull/72079)).
 -   Add lifecycle script execution support during npm packages installation ([#71072](https://github.com/WordPress/gutenberg/pull/71072)).
 
 ## 4.72.0 (2025-08-20)

--- a/packages/create-block/lib/init-package-json.js
+++ b/packages/create-block/lib/init-package-json.js
@@ -46,8 +46,6 @@ module.exports = async ( {
 			);
 		}
 	}
-
-
 	const dependencies = {};
 	const devDependencies = {};
 

--- a/packages/create-block/lib/init-package-json.js
+++ b/packages/create-block/lib/init-package-json.js
@@ -35,17 +35,17 @@ module.exports = async ( {
 	 * @param {string} packageArg The package to install.
 	 */
 	function checkDependency( packageArg ) {
-        const { type } = npmPackageArg( packageArg );
-        if (
-            ! [ 'git', 'tag', 'version', 'range', 'remote', 'alias' ].includes(
-                type
-            ) 
-        ) {
-            throw new Error(
-                `Provided package type "${ type }" is not supported.`
-            );
-        }
-    }
+		const { type } = npmPackageArg( packageArg );
+		if (
+			! [ 'git', 'tag', 'version', 'range', 'remote', 'alias' ].includes(
+				type
+			)
+		) {
+			throw new Error(
+				`Provided package type "${ type }" is not supported.`
+			);
+		}
+	}
 
 
 	const dependencies = {};

--- a/packages/create-block/lib/init-package-json.js
+++ b/packages/create-block/lib/init-package-json.js
@@ -35,15 +35,18 @@ module.exports = async ( {
 	 * @param {string} packageArg The package to install.
 	 */
 	function checkDependency( packageArg ) {
-		const { type } = npmPackageArg( packageArg );
-		if (
-			! [ 'git', 'tag', 'version', 'range', 'remote' ].includes( type )
-		) {
-			throw new Error(
-				`Provided package type "${ type }" is not supported.`
-			);
-		}
-	}
+        const { type } = npmPackageArg( packageArg );
+        if (
+            ! [ 'git', 'tag', 'version', 'range', 'remote', 'alias' ].includes(
+                type
+            ) 
+        ) {
+            throw new Error(
+                `Provided package type "${ type }" is not supported.`
+            );
+        }
+    }
+
 
 	const dependencies = {};
 	const devDependencies = {};


### PR DESCRIPTION
old pr--> #72074 

What?

Closes

Add support for npm alias package type in the @wordpress/create-block template dependency checker.

Specifically, this PR updates the checkDependency logic so the alias type is accepted when parsing dependency strings (e.g. prettier@npm:wp-prettier@2.8.5).

Changed file:

packages/create-block/lib/init-package-json.js

Why?

Currently, @wordpress/create-block rejects aliased dependencies declared in custom templates with the error:

Provided package type "alias" is not supported.

This prevents template authors from using npm package aliases (for example, pointing to a fork or a workspace package under a different name). Allowing alias improves flexibility for template authors and makes it easier to reference alternative package sources (e.g. prettier@npm:wp-prettier@latest) without renaming or forking packages in templates.

How?

The PR updates the checkDependency function to include alias among the supported npm package argument types returned by npmPackageArg(...).

Example change:

function checkDependency(packageArg) {
const { type } = npmPackageArg(packageArg);
if (
!['git', 'tag', 'version', 'range', 'remote', 'alias'].includes(type) // added 'alias'
) {
throw new Error(
Provided package type "${type}" is not supported.
);
}
}

No other behavior is changed. The change is intentionally minimal — it only permits the alias type to pass the existing validation so downstream installation/resolve flows can proceed as normal.