### PR TITLE
[PoC] Add infrastracture to register icons

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -431,6 +431,12 @@ Add custom HTML code and preview it as you edit. ([Source](https://github.com/Wo
 -	**Supports:** interactivity (clientNavigation), ~~className~~, ~~customClassName~~, ~~html~~
 -	**Attributes:** content
 
+## Icon
+
+undefined ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/icon))
+
+-	**Name:** core/icon
+
 ## Image
 
 Insert an image to make a visual statement. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/image))

--- a/lib/experimental/class-wp-icons-registry.php
+++ b/lib/experimental/class-wp-icons-registry.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Icons API: WP_Icons_Registry class
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Class used for interacting with icons.
+ */
+if ( ! class_exists( 'WP_Icons_Registry' ) ) {
+	class WP_Icons_Registry {
+		/**
+		 * Registered icons array.
+		 *
+		 * @var array[]
+		 */
+		private $registered_icons = array();
+
+
+		/**
+		 * Container for the main instance of the class.
+		 *
+		 * @var WP_Icons_Registry|null
+		 */
+		private static $instance = null;
+
+		/**
+		 * Registers an icon.
+		 *
+		 *
+		 * @param string $icon_name       Icon name including namespace.
+		 * @param array  $icon_properties {
+		 *     List of properties for the icon.
+		 *
+		 *     @type string $title    Required. A human-readable title for the icon.
+		 *     @type string $content  Optional. SVG markup for the icon.
+		 *                            If not provided, the content will be retrieved from the `filePath` if set.
+		 *                            If both `content` and `filePath` are not set, the icon will not be registered.
+		 *     @type string $filePath Optional. The full path to the file containing the icon content.
+		 * }
+		 * @return bool True if the icon was registered with success and false otherwise.
+		 */
+		public function register( $icon_name, $icon_properties ) {
+			if ( ! isset( $icon_name ) || ! is_string( $icon_name ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'Icon name must be a string.', 'gutenberg' ),
+					''
+				);
+				return false;
+			}
+
+			if ( ! isset( $icon_properties['title'] ) || ! is_string( $icon_properties['title'] ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'Icon title must be a string.', 'gutenberg' ),
+					''
+				);
+				return false;
+			}
+
+			if ( ! isset( $icon_properties['filePath'] ) ) {
+				if ( ! isset( $icon_properties['content'] ) || ! is_string( $icon_properties['content'] ) ) {
+					_doing_it_wrong(
+						__METHOD__,
+						__( 'Icon content must be a string.', 'gutenberg' ),
+						''
+					);
+					return false;
+				}
+			}
+
+			$icon = array_merge(
+				$icon_properties,
+				array( 'name' => $icon_name )
+			);
+
+			$this->registered_icons[ $icon_name ] = $icon;
+
+			return true;
+		}
+
+		/**
+		 * Unregisters an icon.
+		 *
+		 *
+		 * @param string $icon_name Icon name including namespace.
+		 * @return bool True if the icon was unregistered with success and false otherwise.
+		 */
+		public function unregister( $icon_name ) {
+			if ( ! $this->is_registered( $icon_name ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					/* translators: %s: Icon name. */
+					sprintf( __( 'Icon "%s" not found.', 'gutenberg' ), $icon_name ),
+					''
+				);
+				return false;
+			}
+
+			unset( $this->registered_icons[ $icon_name ] );
+
+			return true;
+		}
+
+		/**
+		 * Retrieves the content of a registered icon.
+		 *
+		 * @param string $icon_name Icon name including namespace.
+		 * @return string The content of the icon.
+		 * @since 6.9.0
+		 */
+		private function get_content( $icon_name ) {
+			if ( ! isset( $this->registered_icons[ $icon_name ]['content'] ) && isset( $this->registered_icons[ $icon_name ]['filePath'] ) ) {
+				ob_start();
+				include $this->registered_icons[ $icon_name ]['filePath'];
+				$this->registered_icons[ $icon_name ]['content'] = ob_get_clean();
+				unset( $this->registered_icons[ $icon_name ]['filePath'] );
+			}
+			return $this->registered_icons[ $icon_name ]['content'];
+		}
+
+		/**
+		 * Retrieves an array containing the properties of a registered icon.
+		 *
+		 *
+		 * @param string $icon_name Icon name including namespace.
+		 * @return array|null Registered icon properties or `null` if the icon is not registered.
+		 */
+		public function get_registered( $icon_name ) {
+			if ( ! $this->is_registered( $icon_name ) ) {
+				return null;
+			}
+
+			$icon            = $this->registered_icons[ $icon_name ];
+			$content         = $this->get_content( $icon_name );
+			$icon['content'] = $content;
+
+			return $icon;
+		}
+
+		/**
+		 * Retrieves all registered icons.
+		 *
+		 * @return array[] Array of arrays containing the registered icon properties.
+		 */
+		public function get_all_registered() {
+			$icons = $this->registered_icons;
+
+			foreach ( $icons as $index => $icon ) {
+				$content                    = $this->get_content( $icon['name'] );
+				$icons[ $index ]['content'] = $content;
+			}
+
+			return array_values( $icons );
+		}
+
+		/**
+		 * Checks if an icon is registered.
+		 *
+		 *
+		 * @param string $icon_name Icon name including namespace.
+		 * @return bool True if the icon is registered, false otherwise.
+		 */
+		public function is_registered( $icon_name ) {
+			return isset( $this->registered_icons[ $icon_name ] );
+		}
+
+		/**
+		 * Magic method for object serialization.
+		 *
+		 */
+		public function __wakeup() {
+			if ( ! $this->registered_icons ) {
+				return;
+			}
+			if ( ! is_array( $this->registered_icons ) ) {
+				throw new UnexpectedValueException();
+			}
+			foreach ( $this->registered_icons as $value ) {
+				if ( ! is_array( $value ) ) {
+					throw new UnexpectedValueException();
+				}
+			}
+		}
+
+		/**
+		 * Utility method to retrieve the main instance of the class.
+		 *
+		 * The instance will be created if it does not exist yet.
+		 *
+		 *
+		 * @return WP_Icons_Registry The main instance.
+		 */
+		public static function get_instance() {
+			if ( null === self::$instance ) {
+				self::$instance = new self();
+			}
+
+			return self::$instance;
+		}
+	}
+}

--- a/lib/experimental/class-wp-rest-icons-controller.php
+++ b/lib/experimental/class-wp-rest-icons-controller.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * REST API: WP_REST_Icons_Controller class
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Core class used to access icons via the REST API.
+ */
+if ( ! class_exists( 'WP_REST_Icons_Controller' ) ) {
+	class WP_REST_Icons_Controller extends WP_REST_Controller {
+
+		/**
+		 * Constructs the controller.
+		 */
+		public function __construct() {
+			$this->namespace = 'wp/v2';
+			$this->rest_base = 'icons';
+		}
+
+		/**
+		 * Registers the routes for the objects of the controller.
+		 */
+		public function register_routes() {
+			register_rest_route(
+				$this->namespace,
+				'/' . $this->rest_base,
+				array(
+					array(
+						'methods'             => WP_REST_Server::READABLE,
+						'callback'            => array( $this, 'get_items' ),
+						'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					),
+					'schema' => array( $this, 'get_public_item_schema' ),
+				)
+			);
+		}
+
+		/**
+		 * Checks whether a given request has permission to read icons.
+		 *
+		 * @param WP_REST_Request $_request Full details about the request.
+		 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+		 */
+		public function get_items_permissions_check(
+			// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			$request
+		) {
+			if ( current_user_can( 'edit_posts' ) ) {
+				return true;
+			}
+
+			foreach ( get_post_types( array( 'show_in_rest' => true ), 'objects' ) as $post_type ) {
+				if ( current_user_can( $post_type->cap->edit_posts ) ) {
+					return true;
+				}
+			}
+
+			return new WP_Error(
+				'rest_cannot_view',
+				__( 'Sorry, you are not allowed to view the registered icons.', 'gutenberg' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		/**
+		 * Retrieves all icons.
+		 *
+		 * @param WP_REST_Request $request Full details about the request.
+		 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+		 */
+		public function get_items( $request ) {
+			$response = array();
+			$icons    = WP_Icons_Registry::get_instance()->get_all_registered();
+			foreach ( $icons as $icon ) {
+				$prepared_icon = $this->prepare_item_for_response( $icon, $request );
+				$response[]    = $this->prepare_response_for_collection( $prepared_icon );
+			}
+			return rest_ensure_response( $response );
+		}
+
+		/**
+		 * Prepare a raw icon before it gets output in a REST API response.
+		 *
+		 * @param array           $item    Raw icon as registered, before any changes.
+		 * @param WP_REST_Request $request Request object.
+		 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+		 */
+		public function prepare_item_for_response( $item, $request ) {
+			$fields = $this->get_fields_for_response( $request );
+			$keys   = array(
+				'name'    => 'name',
+				'title'   => 'title',
+				'content' => 'content',
+			);
+			$data   = array();
+			foreach ( $keys as $item_key => $rest_key ) {
+				if ( isset( $item[ $item_key ] ) && rest_is_field_included( $rest_key, $fields ) ) {
+					$data[ $rest_key ] = $item[ $item_key ];
+				}
+			}
+
+			$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+			$data    = $this->add_additional_fields_to_object( $data, $request );
+			$data    = $this->filter_response_by_context( $data, $context );
+			return rest_ensure_response( $data );
+		}
+
+		/**
+		 * Retrieves the icon schema, conforming to JSON Schema.
+		 *
+		 * @return array Item schema data.
+		 */
+		public function get_item_schema() {
+			if ( $this->schema ) {
+				return $this->add_additional_fields_schema( $this->schema );
+			}
+
+			$schema = array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'icon',
+				'type'       => 'object',
+				'properties' => array(
+					'name'    => array(
+						'description' => __( 'The icon name.', 'gutenberg' ),
+						'type'        => 'string',
+						'readonly'    => true,
+						'context'     => array( 'view', 'edit', 'embed' ),
+					),
+					'title'   => array(
+						'description' => __( 'The icon title, in human readable format.', 'gutenberg' ),
+						'type'        => 'string',
+						'readonly'    => true,
+						'context'     => array( 'view', 'edit', 'embed' ),
+					),
+					'content' => array(
+						'description' => __( 'The icon content (SVG markup).', 'gutenberg' ),
+						'type'        => 'string',
+						'readonly'    => true,
+						'context'     => array( 'view', 'edit', 'embed' ),
+					),
+				),
+			);
+
+			$this->schema = $schema;
+
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+	}
+}

--- a/lib/experimental/class-wp-rest-icons-controller.php
+++ b/lib/experimental/class-wp-rest-icons-controller.php
@@ -31,6 +31,29 @@ if ( ! class_exists( 'WP_REST_Icons_Controller' ) ) {
 						'methods'             => WP_REST_Server::READABLE,
 						'callback'            => array( $this, 'get_items' ),
 						'permission_callback' => array( $this, 'get_items_permissions_check' ),
+						'args'                => $this->get_collection_params(),
+					),
+					'schema' => array( $this, 'get_public_item_schema' ),
+				)
+			);
+
+			register_rest_route(
+				$this->namespace,
+				'/' . $this->rest_base . '/(?P<name>[a-z][a-z0-9-]*/[a-z][a-z0-9-]*)',
+				array(
+					'args'   => array(
+						'name' => array(
+							'description' => __( 'Icon name.', 'gutenberg' ),
+							'type'        => 'string',
+						),
+					),
+					array(
+						'methods'             => WP_REST_Server::READABLE,
+						'callback'            => array( $this, 'get_item' ),
+						'permission_callback' => array( $this, 'get_item_permissions_check' ),
+						'args'                => array(
+							'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+						),
 					),
 					'schema' => array( $this, 'get_public_item_schema' ),
 				)
@@ -73,7 +96,14 @@ if ( ! class_exists( 'WP_REST_Icons_Controller' ) ) {
 		public function get_items( $request ) {
 			$response = array();
 			$icons    = WP_Icons_Registry::get_instance()->get_all_registered();
+			$search   = $request->get_param( 'search' );
+
 			foreach ( $icons as $icon ) {
+				// Filter by search query if provided
+				if ( ! empty( $search ) && false === stripos( $icon['name'], $search ) ) {
+					continue;
+				}
+
 				$prepared_icon = $this->prepare_item_for_response( $icon, $request );
 				$response[]    = $this->prepare_response_for_collection( $prepared_icon );
 			}
@@ -146,6 +176,74 @@ if ( ! class_exists( 'WP_REST_Icons_Controller' ) ) {
 			$this->schema = $schema;
 
 			return $this->add_additional_fields_schema( $this->schema );
+		}
+
+		/**
+		 * Checks if a given request has access to read a specific icon.
+		 *
+		 * @param WP_REST_Request $request Full details about the request.
+		 * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
+		 */
+		public function get_item_permissions_check( $request ) {
+			$check = $this->get_items_permissions_check( $request );
+			if ( is_wp_error( $check ) ) {
+				return $check;
+			}
+
+			$icon = $this->get_icon( $request['name'] );
+			if ( is_wp_error( $icon ) ) {
+				return $icon;
+			}
+
+			return true;
+		}
+
+		/**
+		 * Retrieves a specific icon.
+		 *
+		 * @param WP_REST_Request $request Full details about the request.
+		 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+		 */
+		public function get_item( $request ) {
+			$icon = $this->get_icon( $request['name'] );
+			if ( is_wp_error( $icon ) ) {
+				return $icon;
+			}
+
+			$data = $this->prepare_item_for_response( $icon, $request );
+			return rest_ensure_response( $data );
+		}
+
+		/**
+		 * Retrieves a specific icon from the registry.
+		 *
+		 * @param string $name Icon name.
+		 * @return array|WP_Error Icon data on success, or WP_Error object on failure.
+		 */
+		public function get_icon( $name ) {
+			$registry = WP_Icons_Registry::get_instance();
+			$icon     = $registry->get_registered( $name );
+
+			if ( null === $icon ) {
+				return new WP_Error(
+					'rest_icon_invalid_name',
+					__( 'Invalid icon name.', 'gutenberg' ),
+					array( 'status' => 404 )
+				);
+			}
+
+			return $icon;
+		}
+
+		/**
+		 * Retrieves the query params for the icons collection.
+		 *
+		 * @return array Collection parameters.
+		 */
+		public function get_collection_params() {
+			$query_params                       = parent::get_collection_params();
+			$query_params['context']['default'] = 'view';
+			return $query_params;
 		}
 	}
 }

--- a/lib/experimental/icon.php
+++ b/lib/experimental/icon.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Icon registration examples using WP_Icons_Registry.
+ *
+ * @package Gutenberg
+ */
+
+/**
+ * Example: Register icons from a directory.
+ */
+function gutenberg_register_icons_from_directory() {
+	if ( ! class_exists( 'WP_Icons_Registry' ) ) {
+		return;
+	}
+
+	$registry        = WP_Icons_Registry::get_instance();
+	$icons_directory = __DIR__ . '/../../packages/icons/src/library/';
+
+	if ( ! is_dir( $icons_directory ) ) {
+		return;
+	}
+
+	// Get all SVG files from the directory
+	$svg_files = glob( $icons_directory . '*.svg' );
+
+	foreach ( $svg_files as $svg_file ) {
+		$icon_name   = basename( $svg_file, '.svg' );
+		$svg_content = file_get_contents( $svg_file );
+
+		if ( false === $svg_content ) {
+			continue;
+		}
+
+		// Create a human-readable title from the filename
+		$title = ucwords( str_replace( array( '-', '_' ), ' ', $icon_name ) );
+
+		$registry->register(
+			$icon_name,
+			array(
+				'title'   => $title,
+				'content' => $svg_content,
+			)
+		);
+	}
+}
+add_action( 'rest_api_init', 'gutenberg_register_icons_from_directory' );
+
+/**
+ * Example to register custom icons.
+ */
+function gutenberg_register_custom_icons() {
+	if ( ! class_exists( 'WP_Icons_Registry' ) ) {
+		return;
+	}
+	$registry = WP_Icons_Registry::get_instance();
+	$registry->register(
+		'my-custom-icon',
+		array(
+			'title'   => 'Custom Icon',
+			'content' => '<svg fill="red" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="10"/></svg>',
+		)
+	);
+}
+add_action( 'rest_api_init', 'gutenberg_register_custom_icons' );

--- a/lib/experimental/icon.php
+++ b/lib/experimental/icon.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * Icon registration examples using WP_Icons_Registry.
+ * Icon registration using WP_Icons_Registry.
  *
  * @package Gutenberg
  */
 
 /**
- * Example: Register icons from a directory.
+ * Register core icons from the `@wordpress/icons` package.
  */
-function gutenberg_register_icons_from_directory() {
+function gutenberg_register_core_icons() {
 	if ( ! class_exists( 'WP_Icons_Registry' ) ) {
 		return;
 	}
@@ -20,7 +20,6 @@ function gutenberg_register_icons_from_directory() {
 		return;
 	}
 
-	// Get all SVG files from the directory
 	$svg_files = glob( $icons_directory . '*.svg' );
 
 	foreach ( $svg_files as $svg_file ) {
@@ -31,11 +30,10 @@ function gutenberg_register_icons_from_directory() {
 			continue;
 		}
 
-		// Create a human-readable title from the filename
 		$title = ucwords( str_replace( array( '-', '_' ), ' ', $icon_name ) );
 
 		$registry->register(
-			$icon_name,
+			'core/' . $icon_name,
 			array(
 				'title'   => $title,
 				'content' => $svg_content,
@@ -43,22 +41,22 @@ function gutenberg_register_icons_from_directory() {
 		);
 	}
 }
-add_action( 'rest_api_init', 'gutenberg_register_icons_from_directory' );
+add_action( 'rest_api_init', 'gutenberg_register_core_icons' );
 
 /**
  * Example to register custom icons.
  */
-function gutenberg_register_custom_icons() {
+function gutenberg_custom_register_custom_icons() {
 	if ( ! class_exists( 'WP_Icons_Registry' ) ) {
 		return;
 	}
 	$registry = WP_Icons_Registry::get_instance();
 	$registry->register(
-		'my-custom-icon',
+		'custom/my-custom-icon',
 		array(
 			'title'   => 'Custom Icon',
 			'content' => '<svg fill="red" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="10"/></svg>',
 		)
 	);
 }
-add_action( 'rest_api_init', 'gutenberg_register_custom_icons' );
+add_action( 'rest_api_init', 'gutenberg_custom_register_custom_icons' );

--- a/lib/experimental/rest-api.php
+++ b/lib/experimental/rest-api.php
@@ -92,3 +92,48 @@ function gutenberg_auto_draft_get_sample_permalink( $permalink, $id, $title, $na
 	return $permalink;
 }
 add_filter( 'get_sample_permalink', 'gutenberg_auto_draft_get_sample_permalink', 10, 5 );
+/**
+ * Registers the Icons REST API routes.
+ */
+function gutenberg_register_icons_controller() {
+	$icons_controller = new WP_REST_Icons_Controller();
+	$icons_controller->register_routes();
+}
+add_action( 'rest_api_init', 'gutenberg_register_icons_controller' );
+
+/**
+ * Loads all SVG icons from the icons package and registers them with WP_Icons_Registry.
+ */
+function gutenberg_load_icons_from_package() {
+	if ( ! class_exists( 'WP_Icons_Registry' ) ) {
+		return;
+	}
+	$icons_directory = __DIR__ . '/../../packages/icons/src/library/';
+
+	if ( ! is_dir( $icons_directory ) ) {
+		return;
+	}
+
+	$svg_files = glob( $icons_directory . '*.svg' );
+	$registry  = WP_Icons_Registry::get_instance();
+
+	foreach ( $svg_files as $svg_file ) {
+		$icon_name   = basename( $svg_file, '.svg' );
+		$svg_content = file_get_contents( $svg_file );
+
+		if ( false === $svg_content ) {
+			continue;
+		}
+
+		$title = ucwords( str_replace( array( '-', '_' ), ' ', $icon_name ) );
+
+		$registry->register(
+			$icon_name,
+			array(
+				'title'   => $title,
+				'content' => $svg_content,
+			)
+		);
+	}
+}
+add_action( 'rest_api_init', 'gutenberg_load_icons_from_package' );

--- a/lib/experimental/rest-api.php
+++ b/lib/experimental/rest-api.php
@@ -92,6 +92,7 @@ function gutenberg_auto_draft_get_sample_permalink( $permalink, $id, $title, $na
 	return $permalink;
 }
 add_filter( 'get_sample_permalink', 'gutenberg_auto_draft_get_sample_permalink', 10, 5 );
+
 /**
  * Registers the Icons REST API routes.
  */
@@ -100,40 +101,3 @@ function gutenberg_register_icons_controller() {
 	$icons_controller->register_routes();
 }
 add_action( 'rest_api_init', 'gutenberg_register_icons_controller' );
-
-/**
- * Loads all SVG icons from the icons package and registers them with WP_Icons_Registry.
- */
-function gutenberg_load_icons_from_package() {
-	if ( ! class_exists( 'WP_Icons_Registry' ) ) {
-		return;
-	}
-	$icons_directory = __DIR__ . '/../../packages/icons/src/library/';
-
-	if ( ! is_dir( $icons_directory ) ) {
-		return;
-	}
-
-	$svg_files = glob( $icons_directory . '*.svg' );
-	$registry  = WP_Icons_Registry::get_instance();
-
-	foreach ( $svg_files as $svg_file ) {
-		$icon_name   = basename( $svg_file, '.svg' );
-		$svg_content = file_get_contents( $svg_file );
-
-		if ( false === $svg_content ) {
-			continue;
-		}
-
-		$title = ucwords( str_replace( array( '-', '_' ), ' ', $icon_name ) );
-
-		$registry->register(
-			$icon_name,
-			array(
-				'title'   => $title,
-				'content' => $svg_content,
-			)
-		);
-	}
-}
-add_action( 'rest_api_init', 'gutenberg_load_icons_from_package' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -54,14 +54,20 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require_once __DIR__ . '/class-wp-rest-edit-site-export-controller-gutenberg.php';
 	require_once __DIR__ . '/rest-api.php';
 
+	// PoC: Infrastructure to register icons and expose them via the REST API.
 	require_once __DIR__ . '/experimental/rest-api.php';
 	require_once __DIR__ . '/experimental/kses-allowed-html.php';
+	require_once __DIR__ . '/experimental/icon.php';
 
 	// Block Comments.
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-block-comment' ) ) {
 		require __DIR__ . '/experimental/block-comments.php';
 		require __DIR__ . '/experimental/class-gutenberg-rest-comment-controller.php';
 	}
+
+	// Icons.
+	require_once __DIR__ . '/experimental/class-wp-icons-registry.php';
+	require_once __DIR__ . '/experimental/class-wp-rest-icons-controller.php';
 }
 
 // Experimental signaling server.

--- a/lib/load.php
+++ b/lib/load.php
@@ -54,10 +54,8 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require_once __DIR__ . '/class-wp-rest-edit-site-export-controller-gutenberg.php';
 	require_once __DIR__ . '/rest-api.php';
 
-	// PoC: Infrastructure to register icons and expose them via the REST API.
 	require_once __DIR__ . '/experimental/rest-api.php';
 	require_once __DIR__ . '/experimental/kses-allowed-html.php';
-	require_once __DIR__ . '/experimental/icon.php';
 
 	// Block Comments.
 	if ( gutenberg_is_experiment_enabled( 'gutenberg-block-comment' ) ) {
@@ -65,7 +63,8 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		require __DIR__ . '/experimental/class-gutenberg-rest-comment-controller.php';
 	}
 
-	// Icons.
+	// PoC: Infrastructure to register icons and expose them via the REST API.
+	require_once __DIR__ . '/experimental/icon.php';
 	require_once __DIR__ . '/experimental/class-wp-icons-registry.php';
 	require_once __DIR__ . '/experimental/class-wp-rest-icons-controller.php';
 }

--- a/packages/block-library/src/icon/block.json
+++ b/packages/block-library/src/icon/block.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "core/icon",
+	"title": "Icon",
+	"textdomain": "default"
+}

--- a/packages/block-library/src/icon/edit.js
+++ b/packages/block-library/src/icon/edit.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+import { useEntityRecords } from '@wordpress/core-data';
+import { __experimentalGrid as Grid } from '@wordpress/components';
+
+export default function Edit() {
+	const blockProps = useBlockProps();
+
+	const { records: icons, hasResolved } = useEntityRecords( 'root', 'icon', {
+		per_page: -1,
+	} );
+
+	if ( ! hasResolved ) {
+		return <div { ...blockProps }>Loading...</div>;
+	}
+
+	if ( ! icons || icons.length === 0 ) {
+		return <div { ...blockProps }>No icons found</div>;
+	}
+
+	return (
+		<div { ...blockProps }>
+			<Grid columns={ 10 } gap={ 1 } justify="center">
+				{ icons.map( ( icon ) => (
+					<div
+						key={ icon.name }
+						dangerouslySetInnerHTML={ { __html: icon.content } }
+						style={ {
+							width: '24px',
+							height: '24px',
+						} }
+					/>
+				) ) }
+			</Grid>
+		</div>
+	);
+}

--- a/packages/block-library/src/icon/index.js
+++ b/packages/block-library/src/icon/index.js
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import initBlock from '../utils/init-block';
+import edit from './edit';
+import metadata from './block.json';
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	edit,
+};
+
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -68,6 +68,7 @@ import * as group from './group';
 import * as heading from './heading';
 import * as homeLink from './home-link';
 import * as html from './html';
+import * as icon from './icon';
 import * as image from './image';
 import * as latestComments from './latest-comments';
 import * as latestPosts from './latest-posts';
@@ -176,6 +177,7 @@ const getAllBlocks = () => {
 		file,
 		group,
 		html,
+		icon,
 		latestComments,
 		latestPosts,
 		mediaText,

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -201,6 +201,15 @@ export const rootEntitiesConfig = [
 		plural: 'statuses',
 		key: 'slug',
 	},
+	{
+		name: 'icon',
+		kind: 'root',
+		baseURL: '/wp/v2/icons',
+		baseURLParams: { context: 'edit' },
+		plural: 'icons',
+		label: __( 'Icons' ),
+		key: 'name',
+	},
 ];
 
 export const deprecatedEntities = {


### PR DESCRIPTION
Related:

- #71227
- #71878

This is a test PR to verify the construction of the infrastructure for icon registration.

### WP_Icons_Registry

This class is very similar to `WP_Block_Patterns_Registry`. For now, I registered all SVG icons that exist in `@wordpress/icons` package.

Consumers can also register custom SVG icons like this:

```
$registry = WP_Icons_Registry::get_instance();
$registry->register(
	'my-custom-icon',
	array(
		'title'   => 'Custom Icon',
		'content' => '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="10"/></svg>',
	)
);
```

Although not implemented in this PR, we might expose a utility function like the following:

```php
wp_register_icon(
	'my-custom-icon',
	array(
		'title'   => 'Custom Icon',
		'content' => '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="10"/></svg>',
	)
);
```

### WP_REST_Icons_Controller

Expose a list of icons registered via the icon registry.

### Icon block

This is a block to test that the above two classes work and that the icon list can be referenced.

<img width="1295" height="515" alt="image" src="https://github.com/user-attachments/assets/a79b9bfb-9fe4-4fe2-ab54-c6d2493ad7b1" />

