### PR TITLE
DataViews: Improve renderItemLink event propagation handling

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - Move search icon in search fields to prefix position ([#71984](https://github.com/WordPress/gutenberg/pull/71984)).
+- DataViews: Improve renderItemLink event propagation handling. ([#72081](https://github.com/WordPress/gutenberg/pull/72081)).
 
 ### Breaking changes
 

--- a/packages/dataviews/src/dataviews-layouts/utils/item-click-wrapper.tsx
+++ b/packages/dataviews/src/dataviews-layouts/utils/item-click-wrapper.tsx
@@ -3,6 +3,11 @@
  */
 import type { ReactNode, ReactElement, ComponentProps } from 'react';
 
+/**
+ * WordPress dependencies
+ */
+import { cloneElement } from '@wordpress/element';
+
 function getClickableItemProps< Item >( {
 	item,
 	isItemClickable,
@@ -69,11 +74,24 @@ export function ItemClickWrapper< Item >( {
 
 	// If we have a renderItemLink, use it
 	if ( renderItemLink ) {
-		return renderItemLink( {
+		const renderedElement = renderItemLink( {
 			item,
 			className: `${ className } ${ className }--clickable`,
 			...extraProps,
 			children,
+		} );
+
+		// Clone the element and enhance onClick to stop propagation
+		return cloneElement( renderedElement, {
+			onClick: ( event: React.MouseEvent ) => {
+				// Always stop propagation to prevent selection
+				event.stopPropagation();
+
+				// If consumer provided an onClick, call it
+				if ( renderedElement.props.onClick ) {
+					renderedElement.props.onClick( event );
+				}
+			},
 		} );
 	}
 

--- a/packages/dataviews/src/dataviews-layouts/utils/item-click-wrapper.tsx
+++ b/packages/dataviews/src/dataviews-layouts/utils/item-click-wrapper.tsx
@@ -92,6 +92,20 @@ export function ItemClickWrapper< Item >( {
 					renderedElement.props.onClick( event );
 				}
 			},
+			onKeyDown: ( event: React.KeyboardEvent ) => {
+				if (
+					event.key === 'Enter' ||
+					event.key === '' ||
+					event.key === ' '
+				) {
+					// Prevents onChangeSelection from triggering.
+					event.stopPropagation();
+					// If consumer provided an onKeyDown, call it
+					if ( renderedElement.props.onKeyDown ) {
+						renderedElement.props.onKeyDown( event );
+					}
+				}
+			},
 		} );
 	}
 

--- a/packages/dataviews/src/stories/dataviews.story.tsx
+++ b/packages/dataviews/src/stories/dataviews.story.tsx
@@ -93,8 +93,7 @@ export const Default = ( { perPageSizes = [ 10, 25, 50, 100 ] } ) => {
 			renderItemLink={ ( { item, ...props }: { item: SpaceObject } ) => (
 				<button
 					style={ { background: 'none', border: 'none', padding: 0 } }
-					onClick={ ( e ) => {
-						e.stopPropagation();
+					onClick={ () => {
 						// eslint-disable-next-line no-alert
 						alert( 'Clicked: ' + item.name.title );
 					} }


### PR DESCRIPTION
When using the `renderItemLink` prop in DataViews, consumers were required to manually call `e.stopPropagation()` in their onClick handlers to prevent the parent row/item selection handlers from triggering. This created an additional burden on consumers and was easy to forget, leading to unexpected behavior where clicking a custom link would also select/deselect the item.

## Solution

Modified `ItemClickWrapper` to automatically handle event propagation for custom links rendered via `renderItemLink`. The component now:

1. Renders the custom link element from `renderItemLink`
2. Uses `React.cloneElement` to enhance the rendered element with an onClick handler that:
   - Stops event propagation to prevent parent selection handlers from firing
   - Preserves and calls any consumer-provided onClick handler

## Implementation Details

- Updated `item-click-wrapper.tsx` to import `cloneElement` from `@wordpress/element`
- Enhanced the `renderItemLink` code path to clone the rendered element with an onClick wrapper
- The wrapper always calls `stopPropagation()` before delegating to the consumer's onClick
- Removed `e.stopPropagation()` from the DataViews story example to demonstrate the new automatic behavior

## Benefits

- **Simpler consumer API**: Consumers no longer need to remember to call `stopPropagation()`
- **Consistent behavior**: Item links behave consistently with the default clickable items (which already stopped propagation)
- **No DOM changes**: Solution uses `cloneElement` rather than wrapper elements, preserving CSS selectors and DOM structure

## Files Changed

- `packages/dataviews/src/dataviews-layouts/utils/item-click-wrapper.tsx`
- `packages/dataviews/src/stories/dataviews.story.tsx`

## Testing
Open the Dataviews test story at http://localhost:50240/?path=/story/dataviews-dataviews--default
Select "Moon", then "Europa" (abova the link), verify an alter is triggered but the selection is kept on the moon.
On trunk remove e.stopPropagation(); from packages/dataviews/src/stories/dataviews.story.tsx as we are doing on this PR repeat the test and verify the selection changes.
