### PR TITLE
Block Comments: Select block when comment is selected

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -132,6 +132,7 @@ function Thread( {
 	const handleCommentSelect = () => {
 		setShowCommentBoard( false );
 		setSelectedThread( thread.id );
+		// pass `null` as the second parameter to prevent focusing the block.
 		selectBlock( thread.blockClientId, null );
 	};
 

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -129,10 +129,10 @@ function Thread( {
 		debouncedToggleBlockHighlight( thread.blockClientId, false );
 	};
 
-	const handleCommentSelect = ( { blockClientId } ) => {
+	const handleCommentSelect = () => {
 		setShowCommentBoard( false );
 		setSelectedThread( thread.id );
-		selectBlock( blockClientId, null );
+		selectBlock( thread.blockClientId, null );
 	};
 
 	const focusThread = () => {
@@ -175,7 +175,7 @@ function Thread( {
 			} ) }
 			id={ `thread-${ thread.id }` }
 			spacing="2"
-			onClick={ () => handleCommentSelect( thread ) }
+			onClick={ handleCommentSelect }
 			onMouseEnter={ onMouseEnter }
 			onMouseLeave={ onMouseLeave }
 			onFocus={ onMouseEnter }
@@ -189,7 +189,7 @@ function Thread( {
 					if ( isSelected ) {
 						unselectThread();
 					} else {
-						handleCommentSelect( thread );
+						handleCommentSelect();
 					}
 				}
 				// Collapse thread and focus the thread.

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useState, RawHTML, useRef } from '@wordpress/element';
+import { useState, RawHTML, useRef, useEffect } from '@wordpress/element';
 import {
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
@@ -56,6 +56,8 @@ export function Comments( {
 	onCommentDelete,
 	setShowCommentBoard,
 } ) {
+	const [ selectedThread, setSelectedThread ] = useState();
+
 	const blockCommentId = useSelect( ( select ) => {
 		const { getBlockAttributes, getSelectedBlockClientId } =
 			select( blockEditorStore );
@@ -64,7 +66,11 @@ export function Comments( {
 			? getBlockAttributes( clientId )?.metadata?.commentId
 			: null;
 	}, [] );
-	const [ selectedThread = blockCommentId, setSelectedThread ] = useState();
+
+	// Auto-select the related comment thread when a block is selected.
+	useEffect( () => {
+		setSelectedThread( blockCommentId ?? undefined );
+	}, [ blockCommentId ] );
 
 	const hasThreads = Array.isArray( threads ) && threads.length > 0;
 	if ( ! hasThreads ) {
@@ -107,7 +113,8 @@ function Thread( {
 	setShowCommentBoard,
 } ) {
 	const threadRef = useRef( null );
-	const { toggleBlockHighlight } = useDispatch( blockEditorStore );
+	const { toggleBlockHighlight, selectBlock } =
+		useDispatch( blockEditorStore );
 	const relatedBlockElement = useBlockElement( thread.blockClientId );
 	const debouncedToggleBlockHighlight = useDebounce(
 		toggleBlockHighlight,
@@ -122,15 +129,10 @@ function Thread( {
 		debouncedToggleBlockHighlight( thread.blockClientId, false );
 	};
 
-	const handleCommentSelect = ( { id, blockClientId } ) => {
+	const handleCommentSelect = ( { blockClientId } ) => {
 		setShowCommentBoard( false );
-		setSelectedThread( id );
-		if ( blockClientId && relatedBlockElement ) {
-			relatedBlockElement.scrollIntoView( {
-				behavior: 'instant',
-				block: 'center',
-			} );
-		}
+		setSelectedThread( thread.id );
+		selectBlock( blockClientId, null );
 	};
 
 	const focusThread = () => {

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -175,7 +175,6 @@ function CollabSidebarContent( {
 					setShowCommentBoard={ setShowCommentBoard }
 				/>
 				<Comments
-					key={ getSelectedBlockClientId() }
 					threads={ comments }
 					onEditComment={ onEditComment }
 					onAddReply={ addNewComment }

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -243,6 +243,48 @@ test.describe( 'Block Comments', () => {
 		await expect( activeThread ).toContainText( 'Second block comment' );
 		await expect( replyTextbox ).toBeVisible();
 	} );
+
+	test.describe( 'Keyboard navigation', () => {
+		test( 'should expand or collapse a comment with Enter key', async ( {
+			editor,
+			page,
+			blockCommentUtils,
+		} ) => {
+			await blockCommentUtils.addBlockWithComment( {
+				type: 'core/heading',
+				attributes: { content: 'Testing block comments' },
+				comment: 'Test comment',
+			} );
+
+			// Click on the title field to deselect the block and the comment.
+			await editor.canvas
+				.getByRole( 'textbox', { name: 'Add title' } )
+				.focus();
+
+			const thread = page
+				.getByRole( 'region', {
+					name: 'Editor settings',
+				} )
+				.getByRole( 'listitem', {
+					name: 'Comment: Test comment',
+				} );
+
+			// Expand the comment with Enter key.
+			await thread.focus();
+			await page.keyboard.press( 'Enter' );
+			await expect( thread ).toHaveAttribute( 'aria-expanded', 'true' );
+
+			// The related block should be selected, but the focus should remain on the comment.
+			await expect(
+				editor.canvas.getByText( 'Testing block comments' )
+			).toHaveClass( /is-selected/ );
+			await expect( thread ).toBeFocused();
+
+			// Collapse the comment with Enter key.
+			await page.keyboard.press( 'Enter' );
+			await expect( thread ).toHaveAttribute( 'aria-expanded', 'false' );
+		} );
+	} );
 } );
 
 class BlockCommentUtils {


### PR DESCRIPTION
- Follow-up:
  -  https://github.com/WordPress/gutenberg/pull/71308
  - https://github.com/WordPress/gutenberg/pull/71932
- Preparing for https://github.com/WordPress/gutenberg/issues/71891

## What?

This PR actually "selects" the block when a comment is selected, but the focus remains on the comment.

This allows comment selection to work properly in Spotlight mode.

## Why?

When a comment is selected, `scrollIntoView + toggleHighlight` is performed to visually indicate which block the comment relates to. The reason we didn't use the `selectBlock` is that we didn't want the focus to move to the block when a comment was clicked.

However, this behaviour is problematic when the spotlight mode is enabled. When a comment is selected, the related block is visually highlighted, but the block remains semi-transparent because it is not actually selected.

## How?

I realized that we can prevent the focus from being moved to the block by passing `null` as the second parameter of the `selectBlock`. This allows us to completely replace `scrollIntoView + toggleBlockHighlight` with just `selectBlock`.

However, this introduced an unintended issue. In the current implementation, the Comments component has [a key prop](https://github.com/WordPress/gutenberg/pull/72082/files#diff-596246f230398d3ea9ef49fcb3fe535feaa005ee244e2c7dca881b774e5a574bL178) to force a re-rendering of associated comments when a block is selected. This means that:

- Selecting a comment
- A block is selected
- `getSelectedBlockClientId()` is updated
- The Comments component is remounted
- Focus is lost from the comment

Instead, I've added a new effect [here](https://github.com/WordPress/gutenberg/pull/72082/files#diff-75adb16312a98cd771571dc3a24d08470e2ed7be595314e2f5f0176b2ba09a16R70-R73). This prevents the focus from being lost when a comment is selected and a block is selected.

## Testing Instructions

- Enable Spotlight mode.
- Insert multiple blocks and comment on them.
- Click on one of the comments.
- The comment will remain in focus (a blue outline will appear around it)
- The associated block will be spotlighted.
- Click on one of the blocks. The associated comment will be expanded.

### Testing Instructions for Keyboard

 - Press the Tab key repeatedly to move the focus to one of the comments.
 - Press the Enter key. The comment is expanded, the related block is selected, but the focus should remain on the comment.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/2d52ca3d-66f2-49c3-97bf-a15af26ea682

