### PR TITLE
Create block: update DocBlock with exposed variables for render.php t…

### DIFF
--- a/packages/create-block/lib/templates/block/render.php.mustache
+++ b/packages/create-block/lib/templates/block/render.php.mustache
@@ -1,6 +1,13 @@
 {{#isDynamicVariant}}
 <?php
 /**
+ * PHP file to use when rendering the block type on the server to show on the front end.
+ *
+ * The following variables are exposed to the file:
+ *     $attributes (array): The block attributes.
+ *     $content (string): The block default content.
+ *     $block (WP_Block): The block instance.
+ *
  * @see https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render
  */
 ?>

--- a/packages/create-block/lib/templates/es5/render.php.mustache
+++ b/packages/create-block/lib/templates/es5/render.php.mustache
@@ -1,6 +1,13 @@
 {{#isDynamicVariant}}
 <?php
 /**
+ * PHP file to use when rendering the block type on the server to show on the front end.
+ *
+ * The following variables are exposed to the file:
+ *     $attributes (array): The block attributes.
+ *     $content (string): The block default content.
+ *     $block (WP_Block): The block instance.
+ *
  * @see https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render
  */
 ?>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Update DocBlock for the render.php templates of the create-block package.

<!-- In a few words, what is the PR actually doing? -->

## Why?
The exposed variables were not documented in these files.

## How?
This PR uses the same DocBlock that is already used for the create-block-tutorial-template.
https://github.com/WordPress/gutenberg/blob/trunk/packages/create-block-interactive-template/block-templates/render.php.mustache

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Create a new dynamic block with the create-block package
2. See that the render.php file has the expected updated DocBlock