### PR TITLE
Build: Support watching SVG icons to generate TSX

### DIFF
--- a/bin/packages/build-worker.js
+++ b/bin/packages/build-worker.js
@@ -8,10 +8,12 @@ const babel = require( '@babel/core' );
 const makeDir = require( 'make-dir' );
 const sass = require( 'sass' );
 const postcss = require( 'postcss' );
+
 /**
  * Internal dependencies
  */
 const getBabelConfig = require( './get-babel-config' );
+const iconsBuildUtils = require( '../../packages/icons/lib/build-worker-utils' );
 
 const isDev = process.env.NODE_ENV === 'development';
 
@@ -179,6 +181,14 @@ async function buildJS( file ) {
 	}
 }
 
+// This build task is only meant for regenerating icons in the icons library at
+// packages/icons/src/library. Let it delegate to that package's own handler.
+async function buildSVG( file ) {
+	if ( ! ( await iconsBuildUtils.buildSVG( file ) ) ) {
+		throw new Error( `No handler for SVG file: ${ file }` );
+	}
+}
+
 /**
  * Object of build tasks per file extension.
  *
@@ -189,6 +199,7 @@ const BUILD_TASK_BY_EXTENSION = {
 	'.js': buildJS,
 	'.ts': buildJS,
 	'.tsx': buildJS,
+	'.svg': buildSVG,
 };
 
 module.exports = async ( file, callback ) => {

--- a/bin/packages/watch.js
+++ b/bin/packages/watch.js
@@ -64,7 +64,8 @@ function isSourceFile( filename ) {
 		.replace( /\\/g, '/' );
 
 	return (
-		/\/src\/.+\.(js|json|scss|ts|tsx)$/.test( relativePath ) &&
+		// Include .svg for automatic generation of icons in packages/icons
+		/\/src\/.+\.(js|json|scss|ts|tsx|svg)$/.test( relativePath ) &&
 		! [
 			/\/(benchmark|__mocks__|__tests__|test|storybook|stories|e2e-test-utils-playwright)\/.+/,
 			/.\.(spec|test)\.js$/,

--- a/packages/icons/lib/build-worker-utils.js
+++ b/packages/icons/lib/build-worker-utils.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+const { promisify } = require( 'util' );
+const execFile = promisify( require( 'child_process' ).execFile );
+
+/**
+ * Internal dependencies
+ */
+const { generateTsxFiles } = require( './generate-library' );
+
+const ICON_LIBRARY_DIR = path.join( __dirname, '..', 'src', 'library' );
+
+/**
+ * A build-worker task to be used by the monorepo's watcher-builder.
+ *
+ * @see bin/packages/build-worker.js
+ *
+ * @param {string} file File to build.
+ */
+async function buildSVG( file ) {
+	if ( path.dirname( file ) !== ICON_LIBRARY_DIR ) {
+		return false;
+	}
+
+	try {
+		await execFile( 'git', [ 'ls-files', '--error-unmatch', file ] );
+	} catch {
+		throw new Error(
+			`Cannot generate icon from untracked SVG file '${ path.basename(
+				file
+			) }'.
+Please add it to Git, then restart:
+
+	git add ${ path.relative( '', file ) }
+	npm run dev
+`
+		);
+	}
+
+	await generateTsxFiles( [ path.basename( file ) ] );
+	return true;
+}
+
+module.exports = { buildSVG };

--- a/packages/icons/lib/build-worker-utils.js
+++ b/packages/icons/lib/build-worker-utils.js
@@ -24,17 +24,20 @@ async function buildSVG( file ) {
 		return false;
 	}
 
+	const FgRed = '\x1b[31m';
+	const Reset = '\x1b[0m';
+
 	try {
 		await execFile( 'git', [ 'ls-files', '--error-unmatch', file ] );
 	} catch {
 		throw new Error(
-			`Cannot generate icon from untracked SVG file '${ path.basename(
+			`${ FgRed }Cannot generate icon from untracked SVG file '${ path.basename(
 				file
-			) }'.
-Please add it to Git, then restart:
+			) }'.${ Reset }
+${ FgRed }Please add it to Git, then restart:${ Reset }
 
-	git add ${ path.relative( '', file ) }
-	npm run dev
+${ FgRed }	git add ${ path.relative( '', file ) }${ Reset }
+${ FgRed }	npm run dev${ Reset }
 `
 		);
 	}

--- a/packages/icons/lib/generate-library.js
+++ b/packages/icons/lib/generate-library.js
@@ -70,12 +70,16 @@ async function cleanup() {
 }
 
 // Generate src/library/*.tsx based on the available SVG files.
-async function generateTsxFiles() {
-	const svgFiles = ( await readdir( ICON_LIBRARY_DIR ) ).filter( ( file ) =>
-		// Stricter than just checking for SVG suffix, thereby avoiding hidden
-		// files and characters that would get in the way of camel-casing.
-		file.match( /^[a-z0-9--]+\.svg$/ )
-	);
+async function generateTsxFiles( svgFiles ) {
+	if ( svgFiles ) {
+		// Argument passed by caller at ./build-worker-utils.js
+	} else {
+		svgFiles = ( await readdir( ICON_LIBRARY_DIR ) ).filter( ( file ) =>
+			// Stricter than just checking for SVG suffix, thereby avoiding hidden
+			// files and characters that would get in the way of camel-casing.
+			file.match( /^[a-z0-9--]+\.svg$/ )
+		);
+	}
 
 	await Promise.all(
 		svgFiles.map( async ( svgFile ) => {
@@ -189,4 +193,10 @@ ${ jsxContent }
 `;
 }
 
-main();
+if ( module === require.main ) {
+	main();
+}
+
+module.exports = {
+	generateTsxFiles,
+};

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -39,6 +39,6 @@
 	},
 	"scripts": {
 		"prelint": "npm run build",
-		"build": "node bin/generate-library"
+		"build": "node lib/generate-library"
 	}
 }


### PR DESCRIPTION
## What?

Follow-up of #71878

As of #71878, the library of icons in the Icons package consists of plain SVG files, from which a build step generates TSX files and an index.ts.

However, this generation _only happened once_ upon invoking `npm run dev` (and `npm run build`). This pull request adds support for watching changes to those SVG files and regenerating accordingly.

## Why?

Better developer experience whenever an icon is being actively tweaked.

## How?

- In Gutenberg's build tooling (`bin/packages/`):
  * Add `src/**/*.svg` as a possible match for source files
  * Add a build task for SVG files
    * Let this task delegate to the Icons package's own implementation
- In the Icons package:
  * Implement a build task (`buildSVG`) specifically for icons which calls the preexisting generation functions
  * Let it reject SVG files that aren't Git-tracked (same rationale as for #71878, to avoid user mistakes)

### To do

- [ ] Decide what to do when, after starting the watcher, an SVG file is added to Git. Re-index everything? That can be noisy.

## Testing Instructions

* Run `npm run dev`. Once it settles:
  * Modify an existing SVG at `packages/icons/src/library/*.svg`. Ensure that the watcher-builder sees this change and generates the corresponding TSX file. Ensure that the icon has changed in the UI.
  * Add a new SVG at `packages/icons/src/library/*.svg`. Ensure that the watcher-builder reports this as an error.
  * Follow that error's instructions (`git add`, then restart `dev`) and ensure that a TSX file is now generated.
* Run `npm run build`. It should work just as described in #71878.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/b963b4b1-5fcf-43d2-a187-79814afb0d5e

