### PR TITLE
Block Bindings: Have block fields panel reflects bound attribute value

### DIFF
--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -4,6 +4,7 @@
 import {
 	privateApis as blocksPrivateApis,
 	getBlockType,
+	store as blocksStore,
 } from '@wordpress/blocks';
 import {
 	__experimentalHStack as HStack,
@@ -19,6 +20,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
+import BlockContext from '../../components/block-context';
 import BlockIcon from '../../components/block-icon';
 import useBlockDisplayTitle from '../../components/block-title/use-block-display-title';
 import useBlockDisplayInformation from '../../components/use-block-display-information';
@@ -72,9 +74,31 @@ function BlockFields( {
 
 	const blockTypeFields = blockType?.[ fieldsKey ];
 
+	const blockContext = useContext( BlockContext );
+
 	const attributes = useSelect(
-		( select ) => select( blockEditorStore ).getBlockAttributes( clientId ),
-		[ clientId ]
+		( select ) => {
+			const _attributes =
+				select( blockEditorStore ).getBlockAttributes( clientId );
+			if ( ! _attributes?.metadata?.bindings ) {
+				return _attributes;
+			}
+
+			const { getBlockBindingsSource } = unlock( select( blocksStore ) );
+			return Object.entries( _attributes.metadata.bindings ).reduce(
+				( acc, [ attribute, binding ] ) => {
+					const source = getBlockBindingsSource( binding.source );
+					const values = source.getValues( {
+						select,
+						context: blockContext,
+						bindings: { [ attribute ]: binding },
+					} );
+					return { ...acc, ...values };
+				},
+				_attributes
+			);
+		},
+		[ blockContext, clientId ]
 	);
 
 	const computedForm = useMemo( () => {

--- a/packages/block-editor/src/hooks/block-fields/index.js
+++ b/packages/block-editor/src/hooks/block-fields/index.js
@@ -88,6 +88,9 @@ function BlockFields( {
 			return Object.entries( _attributes.metadata.bindings ).reduce(
 				( acc, [ attribute, binding ] ) => {
 					const source = getBlockBindingsSource( binding.source );
+					if ( ! source ) {
+						return acc;
+					}
 					const values = source.getValues( {
 						select,
 						context: blockContext,

--- a/packages/e2e-tests/plugins/block-bindings.php
+++ b/packages/e2e-tests/plugins/block-bindings.php
@@ -46,11 +46,6 @@ function gutenberg_test_block_bindings_registration() {
 		plugins_url( 'block-bindings/index.js', __FILE__ ),
 		array(
 			'wp-blocks',
-			'wp-block-editor',
-			'wp-components',
-			'wp-compose',
-			'wp-element',
-			'wp-hooks',
 		),
 		filemtime( plugin_dir_path( __FILE__ ) . 'block-bindings/index.js' ),
 		true

--- a/packages/e2e-tests/plugins/block-bindings/index.js
+++ b/packages/e2e-tests/plugins/block-bindings/index.js
@@ -1,9 +1,5 @@
 const { registerBlockBindingsSource } = wp.blocks;
-const { InspectorControls } = wp.blockEditor;
-const { PanelBody, TextControl } = wp.components;
-const { createHigherOrderComponent } = wp.compose;
-const { createElement: el, Fragment } = wp.element;
-const { addFilter } = wp.hooks;
+const { createElement: el } = wp.element;
 const { fieldsList } = window.testingBindings || {};
 
 const getValues = ( { bindings } ) => {
@@ -64,42 +60,3 @@ registerBlockBindingsSource( {
 	getValues,
 	canUserEditValue: () => true,
 } );
-
-const withBlockBindingsInspectorControl = createHigherOrderComponent(
-	( BlockEdit ) => {
-		return ( props ) => {
-			if ( ! props.attributes?.metadata?.bindings?.content ) {
-				return el( BlockEdit, props );
-			}
-
-			return el(
-				Fragment,
-				{},
-				el( BlockEdit, props ),
-				el(
-					InspectorControls,
-					{},
-					el(
-						PanelBody,
-						{ title: 'Bindings' },
-						el( TextControl, {
-							__next40pxDefaultSize: true,
-							label: 'Content',
-							value: props.attributes.content,
-							onChange: ( content ) =>
-								props.setAttributes( {
-									content,
-								} ),
-						} )
-					)
-				)
-			);
-		};
-	}
-);
-
-addFilter(
-	'editor.BlockEdit',
-	'testing/bindings-inspector-control',
-	withBlockBindingsInspectorControl
-);

--- a/packages/e2e-tests/plugins/block-bindings/index.js
+++ b/packages/e2e-tests/plugins/block-bindings/index.js
@@ -1,5 +1,4 @@
 const { registerBlockBindingsSource } = wp.blocks;
-const { createElement: el } = wp.element;
 const { fieldsList } = window.testingBindings || {};
 
 const getValues = ( { bindings } ) => {

--- a/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
@@ -369,7 +369,6 @@ test.describe( 'Post Meta source', () => {
 	test.describe( 'Movie CPT post', () => {
 		test.beforeAll( async ( { requestUtils } ) => {
 			await requestUtils.setGutenbergExperiments( [
-				'gutenberg-content-only-pattern-insertion',
 				'gutenberg-content-only-inspector-fields',
 			] );
 		} );
@@ -548,7 +547,7 @@ test.describe( 'Post Meta source', () => {
 			).toHaveText( 'new value' );
 		} );
 
-		test( 'should be possible to edit the value of the connected custom fields in the inspector control registered by contentOnly experiments', async ( {
+		test( 'should be possible to edit the value of the connected custom fields in the inspector control registered by Block Fields experiment', async ( {
 			editor,
 			page,
 		} ) => {

--- a/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
@@ -536,6 +536,46 @@ test.describe( 'Post Meta source', () => {
 			).toHaveText( 'new value' );
 		} );
 
+		test( 'should be possible to edit the value of the connected custom fields in the inspector control registered by the plugin', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: {
+					anchor: 'connected-paragraph',
+					content: 'fallback content',
+					metadata: {
+						bindings: {
+							content: {
+								source: 'core/post-meta',
+								args: {
+									key: 'movie_field',
+								},
+							},
+						},
+					},
+				},
+			} );
+			const contentInput = page.getByRole( 'textbox', {
+				name: 'Content',
+			} );
+			await expect( contentInput ).toHaveValue(
+				'Movie field default value'
+			);
+			await contentInput.fill( 'new value' );
+			// Check that the paragraph content attribute didn't change.
+			const [ paragraphBlockObject ] = await editor.getBlocks();
+			expect( paragraphBlockObject.attributes.content ).toBe(
+				'fallback content'
+			);
+			// Check the value of the custom field is being updated by visiting the frontend.
+			const previewPage = await editor.openPreviewPage();
+			await expect(
+				previewPage.locator( '#connected-paragraph' )
+			).toHaveText( 'new value' );
+		} );
+
 		test( 'should be possible to connect movie fields through the attributes panel', async ( {
 			editor,
 			page,

--- a/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
@@ -568,14 +568,12 @@ test.describe( 'Post Meta source', () => {
 					},
 				},
 			} );
-
 			const contentInput = page.getByRole( 'textbox', {
 				label: 'Content',
 			} );
 			await expect( contentInput ).toHaveText(
 				'Movie field default value'
 			);
-
 			await contentInput.fill( 'new value' );
 			// Check that the paragraph content attribute didn't change.
 			const [ paragraphBlockObject ] = await editor.getBlocks();

--- a/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
@@ -536,46 +536,6 @@ test.describe( 'Post Meta source', () => {
 			).toHaveText( 'new value' );
 		} );
 
-		test( 'should be possible to edit the value of the connected custom fields in the inspector control registered by the plugin', async ( {
-			editor,
-			page,
-		} ) => {
-			await editor.insertBlock( {
-				name: 'core/paragraph',
-				attributes: {
-					anchor: 'connected-paragraph',
-					content: 'fallback content',
-					metadata: {
-						bindings: {
-							content: {
-								source: 'core/post-meta',
-								args: {
-									key: 'movie_field',
-								},
-							},
-						},
-					},
-				},
-			} );
-			const contentInput = page.getByRole( 'textbox', {
-				name: 'Content',
-			} );
-			await expect( contentInput ).toHaveValue(
-				'Movie field default value'
-			);
-			await contentInput.fill( 'new value' );
-			// Check that the paragraph content attribute didn't change.
-			const [ paragraphBlockObject ] = await editor.getBlocks();
-			expect( paragraphBlockObject.attributes.content ).toBe(
-				'fallback content'
-			);
-			// Check the value of the custom field is being updated by visiting the frontend.
-			const previewPage = await editor.openPreviewPage();
-			await expect(
-				previewPage.locator( '#connected-paragraph' )
-			).toHaveText( 'new value' );
-		} );
-
 		test( 'should be possible to connect movie fields through the attributes panel', async ( {
 			editor,
 			page,

--- a/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
@@ -367,12 +367,24 @@ test.describe( 'Post Meta source', () => {
 	} );
 
 	test.describe( 'Movie CPT post', () => {
+		test.beforeAll( async ( { requestUtils } ) => {
+			await requestUtils.setGutenbergExperiments( [
+				'gutenberg-content-only-pattern-insertion',
+				'gutenberg-content-only-inspector-fields',
+			] );
+		} );
+
 		test.beforeEach( async ( { admin } ) => {
 			// CHECK HOW TO CREATE A MOVIE.
 			await admin.createNewPost( {
 				postType: 'movie',
 				title: 'Test bindings',
 			} );
+		} );
+
+		test.afterAll( async ( { requestUtils } ) => {
+			// Ensure experiments are disabled after test.
+			await requestUtils.setGutenbergExperiments( [] );
 		} );
 
 		test( 'should show the custom field value of that specific post', async ( {
@@ -536,7 +548,7 @@ test.describe( 'Post Meta source', () => {
 			).toHaveText( 'new value' );
 		} );
 
-		test( 'should be possible to edit the value of the connected custom fields in the inspector control registered by the plugin', async ( {
+		test( 'should be possible to edit the value of the connected custom fields in the inspector control registered by contentOnly experiments', async ( {
 			editor,
 			page,
 		} ) => {
@@ -557,12 +569,14 @@ test.describe( 'Post Meta source', () => {
 					},
 				},
 			} );
+
 			const contentInput = page.getByRole( 'textbox', {
-				name: 'Content',
+				label: 'Content',
 			} );
-			await expect( contentInput ).toHaveValue(
+			await expect( contentInput ).toHaveText(
 				'Movie field default value'
 			);
+
 			await contentInput.fill( 'new value' );
 			// Check that the paragraph content attribute didn't change.
 			const [ paragraphBlockObject ] = await editor.getBlocks();
@@ -583,6 +597,7 @@ test.describe( 'Post Meta source', () => {
 			await editor.insertBlock( {
 				name: 'core/paragraph',
 			} );
+			await page.getByRole( 'tab', { name: 'Settings' } ).click();
 			await page.getByLabel( 'Attributes options' ).click();
 			await page
 				.getByRole( 'menuitemcheckbox', {
@@ -611,6 +626,7 @@ test.describe( 'Post Meta source', () => {
 			await editor.insertBlock( {
 				name: 'core/paragraph',
 			} );
+			await page.getByRole( 'tab', { name: 'Settings' } ).click();
 			await page.getByLabel( 'Attributes options' ).click();
 			await page
 				.getByRole( 'menuitemcheckbox', {


### PR DESCRIPTION
## What?
Make sure the Block Fields control in the "Content"  tab (added by the 'Block Fields' experiment instead) reflects the value of a bound attribute.

Furthermore, remove the now-obsolete 'Bindings' panel from the Block Bindings e2e test plugin.

_Ignore the misleading branch name; this PR has undergone a few revisions. It’s now a bugfix with added e2e coverage._

## Why?
To fix a [regression](https://github.com/WordPress/gutenberg/pull/75064#issuecomment-3838366927).

Additionally, there is no more need for a dedicated panel to be added by the e2e test, since we can use the one provided by the experiment instead.

## How?
By overriding the attribute with the value provided by the block bindings source that the attribute is connected to. (Code originally from https://github.com/WordPress/gutenberg/pull/75137.)

Furthermore, by updating an existing e2e test to use the Block Fields control, and removing the now-obsolete 'Bindings' panel from the Block Bindings e2e test plugin.

## Testing Instructions

- Preferably, use wp-env's test environment (by default found at `localhost:8889`). (The reason for this is that you'll need a block bindings data source for testing, and the easiest way to get one is to enable a GB test plugin included in the test env.)
- Activate the "Gutenberg Test Block Bindings" plugin.
- In Gutenberg > Experiments, enable the experiment titled _Block fields: Show dataform driven inspector fields on blocks that support them_.
- Create a new post. Select the automatically added Paragraph block.
- In the block inspector, go to the ⚙️ ('Settings') tab. Expand the Attributes panel, and connect the `content` attribute to the "Post Meta" source's `text_custom_field`.
- Verify that the Paragraph block now reflects the source item's value, i.e. "Value of the text custom field".
- Switch to the 📄 ("Content") tab in the block inspector, and verify that it also reflects that value. (This is what this PR fixes; it didn't previously work in `trunk`.)
- Try changing that string -- both in the editor canvas and block inspector "Content" tab -- and verify that both are synced; any edits are carried over immediately.
- Finally, go back to the ⚙️ ('Settings') tab, and verify that the updated value is now also reflected in the "Post Meta" source items list in the `content` attribute dropdown menu.

## Screenshots or screencast

|Before|After|
|-|-|
| ![block-fields-bindings-before](https://github.com/user-attachments/assets/eff0ad89-40d1-4ed9-a871-20ae42f5d64f) | ![block-fields-bindings](https://github.com/user-attachments/assets/40384399-caa3-48ce-b0cd-e195f4ea4071) |
