### PR TITLE
Fix React Hook dependency warnings in Navigation Submenu

### DIFF
--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -160,6 +160,7 @@ export default function NavigationSubmenuEdit( {
 		hasChildren,
 		selectedBlockHasChildren,
 		onlyDescendantIsEmptyLink,
+		getBlockAttributes,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -169,6 +170,7 @@ export default function NavigationSubmenuEdit( {
 				getBlock,
 				getBlockCount,
 				getBlockOrder,
+				getBlockAttributes: _getBlockAttributes,
 			} = select( blockEditorStore );
 
 			let _onlyDescendantIsEmptyLink;
@@ -204,6 +206,7 @@ export default function NavigationSubmenuEdit( {
 				hasChildren: !! getBlockCount( clientId ),
 				selectedBlockHasChildren: !! selectedBlockChildren?.length,
 				onlyDescendantIsEmptyLink: _onlyDescendantIsEmptyLink,
+				getBlockAttributes: _getBlockAttributes,
 			};
 		},
 		[ clientId ]
@@ -336,9 +339,13 @@ export default function NavigationSubmenuEdit( {
 	const ParentElement = openSubmenusOnClick ? 'button' : 'a';
 
 	const transformToLink = useCallback( () => {
-		const newLinkBlock = createBlock( 'core/navigation-link', attributes );
+		const currentAttributes = getBlockAttributes( clientId );
+		const newLinkBlock = createBlock(
+			'core/navigation-link',
+			currentAttributes
+		);
 		replaceBlock( clientId, newLinkBlock );
-	}, [ attributes, replaceBlock, clientId ] );
+	}, [ replaceBlock, clientId, getBlockAttributes ] );
 
 	useEffect( () => {
 		// If block becomes empty, transform to Navigation Link.

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -21,7 +21,7 @@ import {
 	getColorClassName,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP } from '@wordpress/url';
-import { useState, useEffect, useRef } from '@wordpress/element';
+import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
 import { link as linkIcon, removeSubmenu } from '@wordpress/icons';
 import { speak } from '@wordpress/a11y';
 import { createBlock } from '@wordpress/blocks';
@@ -95,7 +95,7 @@ const useIsDraggingWithin = ( elementRef ) => {
 			ownerDocument.removeEventListener( 'dragend', handleDragEnd );
 			ownerDocument.removeEventListener( 'dragenter', handleDragEnter );
 		};
-	}, [] );
+	}, [ elementRef ] );
 
 	return isDraggingWithin;
 };
@@ -219,7 +219,7 @@ export default function NavigationSubmenuEdit( {
 		if ( ! openSubmenusOnClick && ! url ) {
 			setIsLinkOpen( true );
 		}
-	}, [] );
+	}, [ openSubmenusOnClick, url ] );
 
 	/**
 	 * The hook shouldn't be necessary but due to a focus loss happening
@@ -243,7 +243,7 @@ export default function NavigationSubmenuEdit( {
 				selectLabelText();
 			}
 		}
-	}, [ url ] );
+	}, [ isLinkOpen, url, label ] );
 
 	/**
 	 * Focus the Link label text and select it.
@@ -335,10 +335,10 @@ export default function NavigationSubmenuEdit( {
 
 	const ParentElement = openSubmenusOnClick ? 'button' : 'a';
 
-	function transformToLink() {
+	const transformToLink = useCallback( () => {
 		const newLinkBlock = createBlock( 'core/navigation-link', attributes );
 		replaceBlock( clientId, newLinkBlock );
-	}
+	}, [ attributes, replaceBlock, clientId ] );
 
 	useEffect( () => {
 		// If block becomes empty, transform to Navigation Link.
@@ -348,7 +348,12 @@ export default function NavigationSubmenuEdit( {
 			__unstableMarkNextChangeAsNotPersistent();
 			transformToLink();
 		}
-	}, [ hasChildren, prevHasChildren ] );
+	}, [
+		hasChildren,
+		prevHasChildren,
+		__unstableMarkNextChangeAsNotPersistent,
+		transformToLink,
+	] );
 
 	const canConvertToLink =
 		! selectedBlockHasChildren || onlyDescendantIsEmptyLink;


### PR DESCRIPTION
## What

Fixes React Hook dependency warnings in Navigation Submenu block edit component

```
/home/runner/work/gutenberg/gutenberg/packages/block-library/src/navigation-submenu/edit.js
[2]    98:5  warning  React Hook useEffect has a missing dependency: 'elementRef'. Either include it or remove the dependency array                                                       react-hooks/exhaustive-deps
[2]   222:5  warning  React Hook useEffect has missing dependencies: 'openSubmenusOnClick' and 'url'. Either include them or remove the dependency array                                  react-hooks/exhaustive-deps
[2]   246:5  warning  React Hook useEffect has missing dependencies: 'isLinkOpen' and 'label'. Either include them or remove the dependency array                                         react-hooks/exhaustive-deps
[2]   351:5  warning  React Hook useEffect has missing dependencies: '__unstableMarkNextChangeAsNotPersistent' and 'transformToLink'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
```

## Why

The Navigation Submenu block had 4 ESLint warnings about missing dependencies in `useEffect` hooks, which could lead to stale closures and unexpected behavior. These warnings were preventing clean CI builds and indicated potential bugs where effects might not re-run when their dependencies change.

## How

Added missing dependencies to all `useEffect` hooks and wrapped `transformToLink` function in `useCallback` where necessary to prevent unnecessary re-renders.

## Testing

1. Verify Navigation Submenu block still functions correctly in the editor
2. Test drag and drop functionality within submenu items
3. Test LinkControl opening/closing behavior
4. Test submenu to link transformation when empty
5. Run `npx eslint packages/block-library/src/navigation-submenu/edit.js` to confirm no warnings

## Screenshots

[Screenshots to be added]
