### PR TITLE
Block Bindings: Deduplicate compatible data computation code

### DIFF
--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -319,6 +319,18 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 					sourceName,
 					{ editorUI, getFieldsList, usesContext, label, getValues },
 				] ) => {
+					const allowedAttributeTypes = _bindableAttributes.map(
+						( attribute ) => {
+							const attributeType =
+								getBlockType( blockName ).attributes?.[
+									attribute
+								]?.type;
+							return attributeType === 'rich-text'
+								? 'string'
+								: attributeType;
+						}
+					);
+
 					if ( editorUI ) {
 						// Populate context.
 						const context = {};
@@ -332,18 +344,6 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 							select,
 							context,
 						} );
-
-						const allowedAttributeTypes = _bindableAttributes.map(
-							( attribute ) => {
-								const attributeType =
-									getBlockType( blockName ).attributes?.[
-										attribute
-									]?.type;
-								return attributeType === 'rich-text'
-									? 'string'
-									: attributeType;
-							}
-						);
 
 						const compatibleData = editorUIResult?.data?.filter(
 							( item ) =>

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -332,26 +332,28 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 							select,
 							context,
 						} );
-						const hasCompatibleData = _bindableAttributes.some(
+
+						const allowedAttributeTypes = _bindableAttributes.map(
 							( attribute ) => {
-								const _attributeType =
+								const attributeType =
 									getBlockType( blockName ).attributes?.[
 										attribute
 									]?.type;
-								const attributeType =
-									_attributeType === 'rich-text'
-										? 'string'
-										: _attributeType;
-
-								return editorUIResult.data?.some(
-									( item ) => item?.type === attributeType
-								);
+								return attributeType === 'rich-text'
+									? 'string'
+									: attributeType;
 							}
 						);
 
-						if ( hasCompatibleData ) {
+						const compatibleData = editorUIResult?.data?.filter(
+							( item ) =>
+								allowedAttributeTypes.includes( item?.type )
+						);
+
+						if ( compatibleData?.length > 0 ) {
 							_sources[ sourceName ] = {
 								...editorUIResult,
+								data: compatibleData,
 								label,
 								getValues,
 							};

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -382,27 +382,14 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 								} )
 							);
 
-							const hasCompatibleData = _bindableAttributes.some(
-								( attribute ) => {
-									const _attributeType =
-										getBlockType( blockName ).attributes?.[
-											attribute
-										]?.type;
-									const attributeType =
-										_attributeType === 'rich-text'
-											? 'string'
-											: _attributeType;
-
-									return data.some(
-										( item ) => item?.type === attributeType
-									);
-								}
+							const compatibleData = data?.filter( ( item ) =>
+								allowedAttributeTypes.includes( item?.type )
 							);
 
-							if ( hasCompatibleData ) {
+							if ( compatibleData?.length > 0 ) {
 								_sources[ sourceName ] = {
 									mode: 'dropdown', // Default mode for backward compatibility
-									data,
+									data: compatibleData,
 									label,
 									getValues,
 								};

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -331,15 +331,15 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 						}
 					);
 
-					if ( editorUI ) {
-						// Populate context.
-						const context = {};
-						if ( usesContext?.length ) {
-							for ( const key of usesContext ) {
-								context[ key ] = blockContext[ key ];
-							}
+					// Populate context.
+					const context = {};
+					if ( usesContext?.length ) {
+						for ( const key of usesContext ) {
+							context[ key ] = blockContext[ key ];
 						}
+					}
 
+					if ( editorUI ) {
 						const editorUIResult = editorUI( {
 							select,
 							context,
@@ -360,12 +360,6 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 						}
 					} else if ( getFieldsList ) {
 						// Backward compatibility: Convert getFieldsList to editorUI format
-						const context = {};
-						if ( usesContext?.length ) {
-							for ( const key of usesContext ) {
-								context[ key ] = blockContext[ key ];
-							}
-						}
 
 						const fieldsListResult = getFieldsList( {
 							select,

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -29,7 +29,6 @@ import { useBlockBindingsUtils } from '../utils/block-bindings';
 import { unlock } from '../lock-unlock';
 import InspectorControls from '../components/inspector-controls';
 import BlockContext from '../components/block-context';
-import { useBlockEditContext } from '../components/block-edit';
 import { store as blockEditorStore } from '../store';
 
 const { Menu } = unlock( componentsPrivateApis );
@@ -55,34 +54,19 @@ function BlockBindingsPanelMenuContent( {
 	sources,
 	onOpenModal,
 } ) {
-	const { clientId } = useBlockEditContext();
 	const { updateBlockBindings } = useBlockBindingsUtils();
 	const isMobile = useViewportMatch( 'medium', '<' );
 	const blockContext = useContext( BlockContext );
-	const { attributeType, select } = useSelect(
-		( _select ) => {
-			const { name: blockName } =
-				_select( blockEditorStore ).getBlock( clientId );
-			const _attributeType =
-				getBlockType( blockName ).attributes?.[ attribute ]?.type;
-			return {
-				attributeType:
-					_attributeType === 'rich-text' ? 'string' : _attributeType,
-				select: _select,
-			};
-		},
-		[ clientId, attribute ]
-	);
+	const { select } = useSelect( ( _select ) => {
+		return {
+			select: _select,
+		};
+	}, [] );
 	return (
 		<Menu placement={ isMobile ? 'bottom-start' : 'left-start' }>
 			{ Object.entries( sources ).map( ( [ sourceKey, source ] ) => {
-				// Only show sources that have compatible data for this specific attribute.
-				const sourceDataItems = source.data?.filter(
-					( item ) => item?.type === attributeType
-				);
-
 				const noItemsAvailable =
-					! sourceDataItems || sourceDataItems.length === 0;
+					! source.data || source.data?.length === 0;
 
 				if ( source.mode === 'dropdown' ) {
 					return (
@@ -105,7 +89,7 @@ function BlockBindingsPanelMenuContent( {
 							{ ! noItemsAvailable && (
 								<Menu.Popover gutter={ 8 }>
 									<Menu.Group>
-										{ sourceDataItems.map( ( item ) => {
+										{ source.data.map( ( item ) => {
 											const itemBindings = {
 												source: sourceKey,
 												args: item?.args || {


### PR DESCRIPTION
## What?
In the client-side Block Bindings code, de-duplicate the logic that computes which of a source's data items are compatible with its attribute type.

See https://github.com/WordPress/gutenberg/pull/71542#discussion_r2398834228.

## Why?
To avoid redundant computations and code.

## How?
This logic existed in `BlockBindingsPanel`' `useSelect`, to compute a boolean called `hasCompatibleData`. However, the filtered `data` itself was discarded. It was then re-computed in `BlockBindingsPanelMenuContent`.

This PR changes the code such that `source.data` is set to the filtered data, which allows us avoiding recomputing it later.
Furthermore, we de-duplicate some logic that's shared between the `editorUI` and (legacy) `getFieldsList` branches.

## Testing Instructions
Verify that block bindings still work as before.

Specifically, in a test setting with no custom block bindings sources, verify that:
- A Paragraph block has an "Attributes" panel from which its `content` attribute can be selected, but not bound to any source;
- A Date block has an "Attributes" panel from which its `datatime` attribute can be selected, and bound to the Post Data source's "Publish Date" and "Modified Date" items.

In a test setting with custom sources (e.g. the "Gutenberg Test Block Bindings" plugin included with e2e tests), try connecting the Paragraph block's `content` attribute to various of the provided source data items. 