### PR TITLE
Fix flaky Template Activate e2e test

### DIFF
--- a/test/e2e/specs/site-editor/template-activate.spec.js
+++ b/test/e2e/specs/site-editor/template-activate.spec.js
@@ -50,7 +50,7 @@ test.describe( 'Template Activate', () => {
 			'.dataviews-view-grid__card:has-text("Index (Copy)")'
 		);
 
-		expect( await indexCopy.textContent() ).toContain( 'Inactive' );
+		await expect( indexCopy ).toContainText( 'Inactive' );
 
 		actionsButton = indexCopy.getByRole( 'button', {
 			name: 'Actions',


### PR DESCRIPTION
## What?
Closes #71988.

PR fixes flaky `site-editor/template-activate.spec.js` e2e test.

## Why?
> If you need to assert text on the page, prefer [expect(locator).toHaveText()](https://playwright.dev/docs/api/class-locatorassertions#locator-assertions-to-have-text) to avoid flakiness. See [assertions guide](https://playwright.dev/docs/test-assertions) for more details.

See: https://playwright.dev/docs/api/class-locator#locator-text-content

## Testing Instructions
```
npm run test:e2e -- test/e2e/specs/site-editor/template-activate.spec.js
```

## Screenshot
<img width="1150" height="437" alt="CleanShot 2025-10-06 at 15 11 33" src="https://github.com/user-attachments/assets/72db9cbf-3224-497c-9a71-05a5900f61dd" />
