### PR TITLE
Block Comments: Add a11y related e2e tests

### DIFF
--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -144,6 +144,14 @@ test.describe( 'Block Comments', () => {
 			comment: 'Test comment to resolve.',
 		} );
 
+		const thread = page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'listitem', {
+				name: 'Comment: Test comment to resolve.',
+			} );
+		await thread.click();
+		await expect( thread ).toHaveAttribute( 'aria-expanded', 'true' );
+
 		const resolveButton = page.getByRole( 'button', { name: 'Resolve' } );
 		await resolveButton.click();
 		await expect( resolveButton ).toBeDisabled();
@@ -152,6 +160,8 @@ test.describe( 'Block Comments', () => {
 				.getByRole( 'button', { name: 'Dismiss this notice' } )
 				.filter( { hasText: 'Comment marked as resolved.' } )
 		).toBeVisible();
+		await expect( thread ).toBeFocused();
+		await expect( thread ).toHaveAttribute( 'aria-expanded', 'false' );
 
 		await blockCommentUtils.clickBlockCommentActionMenuItem( 'Reopen' );
 		await expect( resolveButton ).toBeEnabled();
@@ -283,6 +293,79 @@ test.describe( 'Block Comments', () => {
 			// Collapse the comment with Enter key.
 			await page.keyboard.press( 'Enter' );
 			await expect( thread ).toHaveAttribute( 'aria-expanded', 'false' );
+		} );
+
+		test( 'should collapse a comment with Escape key', async ( {
+			page,
+			blockCommentUtils,
+		} ) => {
+			await blockCommentUtils.addBlockWithComment( {
+				type: 'core/heading',
+				attributes: { content: 'Testing block comments' },
+				comment: 'Test comment escape',
+			} );
+
+			const thread = page
+				.getByRole( 'region', {
+					name: 'Editor settings',
+				} )
+				.getByRole( 'listitem', {
+					name: 'Comment: Test comment escape',
+				} );
+
+			await thread.click();
+			await expect( thread ).toHaveAttribute( 'aria-expanded', 'true' );
+
+			// Collapse the comment with Escape key.
+			await page.keyboard.press( 'Escape' );
+			await expect( thread ).toHaveAttribute( 'aria-expanded', 'false' );
+		} );
+
+		test( 'should collapse a comment after canceling comment form', async ( {
+			page,
+			blockCommentUtils,
+		} ) => {
+			await blockCommentUtils.addBlockWithComment( {
+				type: 'core/heading',
+				attributes: { content: 'Testing block comments' },
+				comment: 'Test comment',
+			} );
+
+			const thread = page
+				.getByRole( 'region', {
+					name: 'Editor settings',
+				} )
+				.getByRole( 'listitem', {
+					name: 'Comment: Test comment',
+				} );
+
+			await thread.click();
+			await expect( thread ).toHaveAttribute( 'aria-expanded', 'true' );
+			await thread.getByRole( 'button', { name: 'Cancel' } ).click();
+			await expect( thread ).toHaveAttribute( 'aria-expanded', 'false' );
+			await expect( thread ).toBeFocused();
+		} );
+
+		test( 'should have accessible name for the comment threads', async ( {
+			page,
+			blockCommentUtils,
+		} ) => {
+			await blockCommentUtils.addBlockWithComment( {
+				type: 'core/heading',
+				attributes: { content: 'Testing block comments' },
+				comment: 'Test comment',
+			} );
+
+			const thread = page
+				.getByRole( 'region', {
+					name: 'Editor settings',
+				} )
+				.getByRole( 'listitem' );
+
+			await thread.focus();
+			await expect( thread ).toHaveAccessibleName(
+				'Comment: Test comment'
+			);
 		} );
 	} );
 } );

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -370,6 +370,53 @@ test.describe( 'Block Comments', () => {
 				'Comment: Test comment'
 			);
 		} );
+
+		test( 'should expand and focus the thread after clicking the "x more replies" button', async ( {
+			editor,
+			page,
+			blockCommentUtils,
+		} ) => {
+			await blockCommentUtils.addBlockWithComment( {
+				type: 'core/paragraph',
+				attributes: { content: 'Testing block comments' },
+				comment: 'Test comment',
+			} );
+			const replyForm = page.getByRole( 'textbox', { name: 'Reply to' } );
+			const replyButton = page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Reply', exact: true } );
+
+			await replyForm.fill( 'First reply' );
+			await replyButton.click();
+			await replyForm.fill( 'Second reply' );
+			await replyButton.click();
+
+			// Check that two replies were added successfully.
+			await expect(
+				page
+					.getByRole( 'button', { name: 'Dismiss this notice' } )
+					.filter( { hasText: 'Reply added successfully.' } )
+			).toHaveCount( 2 );
+
+			// Click on the title field to deselect the block and the comment.
+			await editor.canvas
+				.getByRole( 'textbox', { name: 'Add title' } )
+				.focus();
+
+			const thread = page
+				.getByRole( 'region', {
+					name: 'Editor settings',
+				} )
+				.getByRole( 'listitem', {
+					name: 'Comment: Test comment',
+				} );
+
+			await thread
+				.getByRole( 'button', { name: '1 more reply' } )
+				.click();
+			await expect( thread ).toHaveAttribute( 'aria-expanded', 'true' );
+			await expect( thread ).toBeFocused();
+		} );
 	} );
 } );
 

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -229,12 +229,15 @@ test.describe( 'Block Comments', () => {
 			comment: 'Third block comment',
 		} );
 
-		const threads = page.locator( '.editor-collab-sidebar-panel__thread' );
-		const activeThread = page.locator(
-			'.editor-collab-sidebar-panel__thread.is-selected'
-		);
+		const threadsContainer = page
+			.getByRole( 'region', {
+				name: 'Editor settings',
+			} )
+			.getByRole( 'list' );
+		const threads = threadsContainer.getByRole( 'listitem' );
+		const activeThread = threadsContainer.locator( '.is-selected' );
 		const replyTextbox = activeThread.getByRole( 'textbox', {
-			name: 'Comment',
+			name: 'Reply to',
 		} );
 
 		// Comment and reply textbox should active for last inserter block.


### PR DESCRIPTION
## What?
Closes #71962.

PRs add more e2e tests for the Block Comments feature to cover a11y-related improvements.

## Testing Instructions
```
npm run test:e2e -- test/e2e/specs/editor/various/block-comments.spec.js
```

### Testing Instructions for Keyboard
Same.
