### PR TITLE
Add aspect ratio control for gallery block (#71116)

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -392,7 +392,7 @@ Display multiple images in a rich gallery. ([Source](https://github.com/WordPres
 -	**Category:** media
 -	**Allowed Blocks:** core/image
 -	**Supports:** align, anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), spacing (blockGap, margin, padding), units (em, px, rem, vh, vw), ~~html~~
--	**Attributes:** allowResize, caption, columns, fixedHeight, ids, imageCrop, images, linkTarget, linkTo, randomOrder, shortCodeTransforms, sizeSlug
+-	**Attributes:** allowResize, aspectRatio, caption, columns, fixedHeight, ids, imageCrop, images, linkTarget, linkTo, randomOrder, shortCodeTransforms, sizeSlug
 
 ## Group
 

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -103,6 +103,10 @@
 		"allowResize": {
 			"type": "boolean",
 			"default": false
+		},
+		"aspectRatio": {
+			"type": "string",
+			"default": "auto"
 		}
 	},
 	"providesContext": {

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -215,7 +215,7 @@ export default function GalleryEdit( props ) {
 	} ) );
 	const aspectRatioOptions = [
 		{
-			label: _x( 'Original', 'Aspect ratio option for Gallery images' ),
+			label: _x( 'Original', 'Aspect ratio option for dimensions control' ),
 			value: 'auto',
 		},
 		...( showDefaultRatios ? defaultOptions || [] : [] ),

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -119,7 +119,13 @@ export default function GalleryEdit( props ) {
 		onFocus,
 	} = props;
 
-	const [ lightboxSetting ] = useSettings( 'blocks.core/image.lightbox' );
+	const [ lightboxSetting, defaultRatios, themeRatios, showDefaultRatios ] =
+		useSettings(
+			'blocks.core/image.lightbox',
+			'dimensions.aspectRatios.default',
+			'dimensions.aspectRatios.theme',
+			'dimensions.defaultAspectRatios'
+		);
 
 	const linkOptions = ! lightboxSetting?.allowEditing
 		? LINK_OPTIONS.filter(
@@ -127,8 +133,15 @@ export default function GalleryEdit( props ) {
 		  )
 		: LINK_OPTIONS;
 
-	const { columns, imageCrop, randomOrder, linkTarget, linkTo, sizeSlug } =
-		attributes;
+	const {
+		columns,
+		imageCrop,
+		randomOrder,
+		linkTarget,
+		linkTo,
+		sizeSlug,
+		aspectRatio,
+	} = attributes;
 
 	const {
 		__unstableMarkNextChangeAsNotPersistent,
@@ -191,6 +204,23 @@ export default function GalleryEdit( props ) {
 	const imageData = useGetMedia( innerBlockImages );
 
 	const newImages = useGetNewImages( images, imageData );
+
+	const themeOptions = themeRatios?.map( ( { name, ratio } ) => ( {
+		label: name,
+		value: ratio,
+	} ) );
+	const defaultOptions = defaultRatios?.map( ( { name, ratio } ) => ( {
+		label: name,
+		value: ratio,
+	} ) );
+	const aspectRatioOptions = [
+		{
+			label: _x( 'Original', 'Aspect ratio option for Gallery images' ),
+			value: 'auto',
+		},
+		...( showDefaultRatios ? defaultOptions || [] : [] ),
+		...( themeOptions || [] ),
+	];
 
 	useEffect( () => {
 		newImages?.forEach( ( newImage ) => {
@@ -259,6 +289,7 @@ export default function GalleryEdit( props ) {
 			sizeSlug,
 			caption: imageAttributes.caption || image.caption?.raw,
 			alt: imageAttributes.alt || image.alt_text,
+			aspectRatio: aspectRatio === 'auto' ? undefined : aspectRatio,
 		};
 	}
 
@@ -482,6 +513,39 @@ export default function GalleryEdit( props ) {
 		);
 	}
 
+	function setAspectRatio( value ) {
+		setAttributes( { aspectRatio: value } );
+
+		// Update all inner image blocks with the new aspect ratio
+		const changedAttributes = {};
+		const blocks = [];
+
+		getBlock( clientId ).innerBlocks.forEach( ( block ) => {
+			blocks.push( block.clientId );
+			changedAttributes[ block.clientId ] = {
+				aspectRatio: value === 'auto' ? undefined : value,
+			};
+		} );
+
+		updateBlockAttributes( blocks, changedAttributes, true );
+
+		const aspectRatioText = aspectRatioOptions.find(
+			( option ) => option.value === value
+		);
+
+		createSuccessNotice(
+			sprintf(
+				/* translators: %s: aspect ratio setting */
+				__( 'All gallery images updated to aspect ratio: %s' ),
+				aspectRatioText?.label || value
+			),
+			{
+				id: 'gallery-attributes-aspectRatio',
+				type: 'snackbar',
+			}
+		);
+	}
+
 	useEffect( () => {
 		// linkTo attribute must be saved so blocks don't break when changing image_default_link_type in options.php.
 		if ( ! linkTo ) {
@@ -579,6 +643,8 @@ export default function GalleryEdit( props ) {
 								imageCrop: true,
 								randomOrder: false,
 							} );
+
+							setAspectRatio( 'auto' );
 
 							if ( sizeSlug !== DEFAULT_MEDIA_SIZE_SLUG ) {
 								updateImagesSize( DEFAULT_MEDIA_SIZE_SLUG );
@@ -692,6 +758,28 @@ export default function GalleryEdit( props ) {
 								/>
 							</ToolsPanelItem>
 						) }
+						{ aspectRatioOptions.length > 1 && (
+							<ToolsPanelItem
+								hasValue={ () =>
+									!! aspectRatio && aspectRatio !== 'auto'
+								}
+								label={ __( 'Aspect ratio' ) }
+								onDeselect={ () => setAspectRatio( 'auto' ) }
+								isShownByDefault
+							>
+								<SelectControl
+									__next40pxDefaultSize
+									__nextHasNoMarginBottom
+									label={ __( 'Aspect ratio' ) }
+									help={ __(
+										'Set a consistent aspect ratio for all images in the gallery.'
+									) }
+									value={ aspectRatio }
+									options={ aspectRatioOptions }
+									onChange={ setAspectRatio }
+								/>
+							</ToolsPanelItem>
+						) }
 					</ToolsPanel>
 				) }
 				{ Platform.isNative && (
@@ -754,6 +842,20 @@ export default function GalleryEdit( props ) {
 								label={ __( 'Open images in new tab' ) }
 								checked={ linkTarget === '_blank' }
 								onChange={ toggleOpenInNewTab }
+							/>
+						) }
+						{ aspectRatioOptions.length > 1 && (
+							<SelectControl
+								__nextHasNoMarginBottom
+								label={ __( 'Aspect Ratio' ) }
+								help={ __(
+									'Set a consistent aspect ratio for all images in the gallery.'
+								) }
+								value={ aspectRatio }
+								options={ aspectRatioOptions }
+								onChange={ setAspectRatio }
+								hideCancelButton
+								size="__unstable-large"
 							/>
 						) }
 					</PanelBody>

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -215,7 +215,10 @@ export default function GalleryEdit( props ) {
 	} ) );
 	const aspectRatioOptions = [
 		{
-			label: _x( 'Original', 'Aspect ratio option for dimensions control' ),
+			label: _x(
+				'Original',
+				'Aspect ratio option for dimensions control'
+			),
 			value: 'auto',
 		},
 		...( showDefaultRatios ? defaultOptions || [] : [] ),

--- a/test/integration/fixtures/blocks/core__gallery-with-caption.json
+++ b/test/integration/fixtures/blocks/core__gallery-with-caption.json
@@ -13,6 +13,7 @@
 			"linkTo": "none",
 			"sizeSlug": "large",
 			"allowResize": false,
+			"aspectRatio": "auto",
 			"className": "columns-2"
 		},
 		"innerBlocks": [

--- a/test/integration/fixtures/blocks/core__gallery.json
+++ b/test/integration/fixtures/blocks/core__gallery.json
@@ -13,6 +13,7 @@
 			"linkTo": "none",
 			"sizeSlug": "large",
 			"allowResize": false,
+			"aspectRatio": "auto",
 			"className": "columns-2"
 		},
 		"innerBlocks": [

--- a/test/integration/fixtures/blocks/core__gallery__columns.json
+++ b/test/integration/fixtures/blocks/core__gallery__columns.json
@@ -13,7 +13,8 @@
 			"fixedHeight": true,
 			"linkTo": "none",
 			"sizeSlug": "large",
-			"allowResize": false
+			"allowResize": false,
+			"aspectRatio": "auto"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-7.json
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-7.json
@@ -12,7 +12,8 @@
 			"fixedHeight": true,
 			"linkTo": "media",
 			"sizeSlug": "large",
-			"allowResize": false
+			"allowResize": false,
+			"aspectRatio": "auto"
 		},
 		"innerBlocks": [
 			{


### PR DESCRIPTION
Bringing in the changes from https://github.com/WordPress/gutenberg/pull/71116 so I can fix the tests.