### PR TITLE
Icons: Document breaking changes and fix issues from #71878

### DIFF
--- a/package.json
+++ b/package.json
@@ -296,6 +296,9 @@
 			"node ./bin/api-docs/are-api-docs-unstaged.js",
 			"node ./bin/packages/lint-staged-typecheck.js"
 		],
+		"packages/icons/src/library/*": [
+			"npm run -w packages/icons build"
+		],
 		"**/tsconfig.json": [
 			"npm run lint:tsconfig"
 		]

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -14,7 +14,14 @@ import {
 } from '@wordpress/components';
 import { useCopyToClipboard } from '@wordpress/compose';
 import { filterURLForDisplay, safeDecodeURI } from '@wordpress/url';
-import { Icon, globe, info, linkOff, edit, copySmall } from '@wordpress/icons';
+import {
+	Icon,
+	globe,
+	info,
+	linkOff,
+	pencil,
+	copySmall,
+} from '@wordpress/icons';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
@@ -153,7 +160,7 @@ export default function LinkPreview( {
 					</span>
 				</span>
 				<Button
-					icon={ edit }
+					icon={ pencil }
 					label={ __( 'Edit link' ) }
 					onClick={ onEditClick }
 					size="compact"

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -12,7 +12,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { forwardRef } from '@wordpress/element';
-import { Icon, edit as editIcon } from '@wordpress/icons';
+import { Icon, pencil as editIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies

--- a/packages/block-editor/src/components/url-popover/link-viewer.js
+++ b/packages/block-editor/src/components/url-popover/link-viewer.js
@@ -8,7 +8,7 @@ import clsx from 'clsx';
  */
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { edit } from '@wordpress/icons';
+import { pencil } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -38,7 +38,7 @@ export default function LinkViewer( {
 			/>
 			{ onEditLinkClick && (
 				<Button
-					icon={ edit }
+					icon={ pencil }
 					label={ __( 'Edit' ) }
 					onClick={ onEditLinkClick }
 					size="compact"

--- a/packages/block-library/src/embed/embed-controls.js
+++ b/packages/block-library/src/embed/embed-controls.js
@@ -10,7 +10,7 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
-import { edit } from '@wordpress/icons';
+import { pencil } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -45,7 +45,7 @@ const EmbedControls = ( {
 						<ToolbarButton
 							className="components-toolbar__control"
 							label={ __( 'Edit URL' ) }
-							icon={ edit }
+							icon={ pencil }
 							onClick={ switchBackToURLInput }
 						/>
 					) }

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -39,7 +39,7 @@ import {
 	button,
 	external,
 	link,
-	warning,
+	cautionFilled,
 } from '@wordpress/icons';
 import { Component } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
@@ -477,7 +477,7 @@ export class FileEdit extends Component {
 									{ isUploadFailed && (
 										<View style={ styles.errorContainer }>
 											<Icon
-												icon={ warning }
+												icon={ cautionFilled }
 												style={ errorIconStyle }
 											/>
 											<PlainText

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -32,7 +32,7 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { __, _x, sprintf } from '@wordpress/i18n';
-import { edit } from '@wordpress/icons';
+import { pencil } from '@wordpress/icons';
 import { DOWN } from '@wordpress/keycodes';
 import { useSelect, useDispatch } from '@wordpress/data';
 
@@ -174,7 +174,7 @@ export default function PostDateEdit( {
 										return (
 											<ToolbarButton
 												aria-expanded={ isOpen }
-												icon={ edit }
+												icon={ pencil }
 												title={ __( 'Change Date' ) }
 												onClick={ onToggle }
 												onKeyDown={ openOnArrowDown }

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -20,7 +20,7 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { createInterpolateElement, useState } from '@wordpress/element';
-import { grid, list, edit, rss } from '@wordpress/icons';
+import { grid, list, pencil, rss } from '@wordpress/icons';
 import { __, _x } from '@wordpress/i18n';
 import { prependHTTP } from '@wordpress/url';
 import ServerSideRender from '@wordpress/server-side-render';
@@ -113,7 +113,7 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 
 	const toolbarControls = [
 		{
-			icon: edit,
+			icon: pencil,
 			title: __( 'Edit RSS URL' ),
 			onClick: () => setIsEditing( true ),
 		},

--- a/packages/commands/README.md
+++ b/packages/commands/README.md
@@ -196,7 +196,7 @@ _Usage_
 
 ```js
 import { useCommands } from '@wordpress/commands';
-import { plus, edit } from '@wordpress/icons';
+import { plus, pencil } from '@wordpress/icons';
 
 useCommands( [
 	{
@@ -211,7 +211,7 @@ useCommands( [
 	{
 		name: 'myplugin/edit-posts',
 		label: __( 'Edit posts' ),
-		icon: edit,
+		icon: pencil,
 		callback: ( { close } ) => {
 			document.location.href = 'edit.php';
 			close();

--- a/packages/commands/src/hooks/use-command.js
+++ b/packages/commands/src/hooks/use-command.js
@@ -74,7 +74,7 @@ export function useCommand( command ) {
  * @example
  * ```js
  * import { useCommands } from '@wordpress/commands';
- * import { plus, edit } from '@wordpress/icons';
+ * import { plus, pencil } from '@wordpress/icons';
  *
  * useCommands( [
  *     {
@@ -89,7 +89,7 @@ export function useCommand( command ) {
  *     {
  *         name: 'myplugin/edit-posts',
  *         label: __( 'Edit posts' ),
- *         icon: edit,
+ *         icon: pencil,
  *         callback: ({ close }) => {
  *             document.location.href = 'edit.php';
  *             close();

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   `SearchControl`: Move search icon to prefix position ([#71984](https://github.com/WordPress/gutenberg/pull/71984)).
 
+### Internal
+
+-   Replace usage of extinct icons `edit` and `warning` with `pencil` and `cautionFilled`, respectively ([#72105](https://github.com/WordPress/gutenberg/pull/72105)).
+
 ## 30.5.0 (2025-10-01)
 
 ### Enhancements

--- a/packages/components/src/toolbar/toolbar-button/README.md
+++ b/packages/components/src/toolbar/toolbar-button/README.md
@@ -10,13 +10,13 @@ To create general interfaces, you'll want to render ToolbarButton in a [Toolbar]
 
 ```jsx
 import { Toolbar, ToolbarButton } from '@wordpress/components';
-import { edit } from '@wordpress/icons';
+import { pencil } from '@wordpress/icons';
 
 function MyToolbar() {
 	return (
 		<Toolbar label="Options">
 			<ToolbarButton
-				icon={ edit }
+				icon={ pencil }
 				label="Edit"
 				onClick={ () => alert( 'Editing' ) }
 			/>
@@ -32,14 +32,14 @@ If you're working on a custom block and you want to add controls to the block to
 ```jsx
 import { BlockControls } from '@wordpress/block-editor';
 import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
-import { edit } from '@wordpress/icons';
+import { pencil } from '@wordpress/icons';
 
 function Edit() {
 	return (
 		<BlockControls>
 			<ToolbarGroup>
 				<ToolbarButton
-					icon={ edit }
+					icon={ pencil }
 					label="Edit"
 					onClick={ () => alert( 'Editing' ) }
 				/>

--- a/packages/components/src/toolbar/toolbar-button/index.tsx
+++ b/packages/components/src/toolbar/toolbar-button/index.tsx
@@ -116,13 +116,13 @@ function UnforwardedToolbarButton(
  *
  * ```jsx
  * import { Toolbar, ToolbarButton } from '@wordpress/components';
- * import { edit } from '@wordpress/icons';
+ * import { pencil } from '@wordpress/icons';
  *
  * function MyToolbar() {
  *   return (
  *		<Toolbar label="Options">
  *			<ToolbarButton
- *				icon={ edit }
+ *				icon={ pencil }
  *				label="Edit"
  *				onClick={ () => alert( 'Editing' ) }
  *			/>

--- a/packages/edit-site/src/components/add-new-template/index.js
+++ b/packages/edit-site/src/components/add-new-template/index.js
@@ -26,7 +26,7 @@ import {
 	calendar,
 	category,
 	commentAuthorAvatar,
-	edit,
+	pencil,
 	home,
 	layout,
 	list,
@@ -315,7 +315,7 @@ function NewTemplateModal( { onClose } ) {
 						title={ __( 'Custom template' ) }
 						direction="row"
 						className="edit-site-add-new-template__custom-template-button"
-						icon={ edit }
+						icon={ pencil }
 						onClick={ () =>
 							setModalContent(
 								modalContentMap.customGenericTemplate

--- a/packages/edit-site/src/components/dataviews-actions/index.js
+++ b/packages/edit-site/src/components/dataviews-actions/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { edit } from '@wordpress/icons';
+import { pencil } from '@wordpress/icons';
 import { useMemo } from '@wordpress/element';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -32,7 +32,7 @@ export const useSetActiveTemplateAction = () => {
 					: __( 'Activate' );
 			},
 			isPrimary: true,
-			icon: edit,
+			icon: pencil,
 			isEligible( item ) {
 				return (
 					! ( item.slug === 'index' && item.source === 'theme' ) &&
@@ -83,7 +83,7 @@ export const useEditPostAction = () => {
 			id: 'edit-post',
 			label: __( 'Edit' ),
 			isPrimary: true,
-			icon: edit,
+			icon: pencil,
 			isEligible( post ) {
 				if ( post.status === 'trash' ) {
 					return false;

--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -8,7 +8,7 @@ import {
 	code,
 	drawerLeft,
 	drawerRight,
-	edit,
+	pencil,
 	formatListBullets,
 	listView,
 	external,
@@ -293,7 +293,7 @@ const getEditedEntityContextualCommands = () =>
 			commands.push( {
 				name: 'core/rename-pattern',
 				label: __( 'Rename pattern' ),
-				icon: edit,
+				icon: pencil,
 				callback: ( { close } ) => {
 					openModal( patternRenameModalName );
 					close();

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-- Non-breaking, but major change: Switch to SVG icons as canonical source format, letting the system auto-generate the React elements and index. ([#71878](https://github.com/WordPress/gutenberg/pull/71878))
+### Breaking Changes
+
+- Remove `edit` and `warning` icons, which were aliases to `pencil` and `cautionFilled`, respectively. Switch to SVG icons as canonical source format, letting the system auto-generate the React elements and index. ([#71878](https://github.com/WordPress/gutenberg/pull/71878)).
 
 ## 10.32.0 (2025-10-01)
 

--- a/packages/icons/src/library/edit.svg
+++ b/packages/icons/src/library/edit.svg
@@ -1,1 +1,0 @@
-pencil.svg


### PR DESCRIPTION
## What?

Follow-up of #71878
Reported in https://github.com/WordPress/gutenberg/pull/71878#issuecomment-3369118981 by @t-hamano 

* Remove icon symlink from `edit.svg` to `pencil.svg`
* Document removal of `edit` and `warning` icons (removed in aforementioned PR)
* Also add a specific rule in `lint-staged` to (re)generate icons any time the icons library is modified, thereby catching generation errors even in commits that don't modify JS/TS files. (Before this commit, the only way to catch errors was to commit JS/TS files, which would trigger the NPM `prelint` script, which would then call the icon generator.)