### PR TITLE
Block Bindings: Fix useSelect()

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -100,6 +100,10 @@ _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/block-alignment-control/README.md>
 
+### BlockBindingsDropdown
+
+Undocumented declaration.
+
 ### BlockBreadcrumb
 
 Block breadcrumb component, displaying the hierarchy of the current block selection as a breadcrumb.

--- a/packages/block-editor/src/components/block-bindings/index.js
+++ b/packages/block-editor/src/components/block-bindings/index.js
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import fastDeepEqual from 'fast-deep-equal/es6';
+
+/**
+ * WordPress dependencies
+ */
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import { useBlockBindingsUtils } from '../../utils/block-bindings';
+
+const { Menu } = unlock( componentsPrivateApis );
+
+function BlockBindingsDropdown( {
+	attribute,
+	binding,
+	data,
+	source,
+	sourceKey,
+} ) {
+	const { updateBlockBindings } = useBlockBindingsUtils();
+	const { isMobile } = useViewportMatch( 'medium', '<' );
+
+	const noItemsAvailable = ! data || data.length === 0;
+
+	return (
+		<Menu placement={ isMobile ? 'bottom-start' : 'left-start' }>
+			{ noItemsAvailable ? (
+				<Menu.Item disabled>{ source.label }</Menu.Item>
+			) : (
+				<Menu.SubmenuTriggerItem>
+					<Menu.ItemLabel>{ source.label }</Menu.ItemLabel>
+				</Menu.SubmenuTriggerItem>
+			) }
+
+			{ ! noItemsAvailable && (
+				<Menu.Popover gutter={ 8 }>
+					<Menu.Group>
+						{ data.map( ( item ) => {
+							const itemBindings = {
+								source: sourceKey,
+								args: item?.args || {
+									key: item.key,
+								},
+							};
+
+							return (
+								<Menu.CheckboxItem
+									key={
+										sourceKey +
+											JSON.stringify( item.args ) ||
+										item.key
+									}
+									onChange={ () => {
+										const isCurrentlySelected =
+											fastDeepEqual(
+												binding?.args,
+												item.args
+											) ??
+											// Deprecate key dependency in 7.0.
+											item.key === binding?.args?.key;
+
+										if ( isCurrentlySelected ) {
+											// Unset if the same item is selected again.
+											updateBlockBindings( {
+												[ attribute ]: undefined,
+											} );
+										} else {
+											updateBlockBindings( {
+												[ attribute ]: itemBindings,
+											} );
+										}
+									} }
+									name={ attribute + '-binding' }
+									value={ item.value }
+									checked={
+										fastDeepEqual(
+											binding?.args,
+											item.args
+										) ??
+										// Deprecate key dependency in 7.0.
+										item.key === binding?.args?.key
+									}
+								>
+									<Menu.ItemLabel>
+										{ item?.label }
+									</Menu.ItemLabel>
+									<Menu.ItemHelpText>
+										{ item.value }
+									</Menu.ItemHelpText>
+								</Menu.CheckboxItem>
+							);
+						} ) }
+					</Menu.Group>
+				</Menu.Popover>
+			) }
+		</Menu>
+	);
+}
+
+export { BlockBindingsDropdown };

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -13,6 +13,7 @@ export {
 } from './block-alignment-control';
 export { default as __experimentalBlockFullHeightAligmentControl } from './block-full-height-alignment-control';
 export { default as __experimentalBlockAlignmentMatrixControl } from './block-alignment-matrix-control';
+export { BlockBindingsDropdown } from './block-bindings';
 export { default as BlockBreadcrumb } from './block-breadcrumb';
 export { default as __experimentalUseBlockOverlayActive } from './block-content-overlay';
 export { BlockContextProvider } from './block-context';

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -325,15 +325,15 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 					sourceName,
 					{ editorUI, getFieldsList, usesContext, label, getValues },
 				] ) => {
-					if ( editorUI ) {
-						// Populate context.
-						const context = {};
-						if ( usesContext?.length ) {
-							for ( const key of usesContext ) {
-								context[ key ] = blockContext[ key ];
-							}
+					// Populate context.
+					const context = {};
+					if ( usesContext?.length ) {
+						for ( const key of usesContext ) {
+							context[ key ] = blockContext[ key ];
 						}
+					}
 
+					if ( editorUI ) {
 						const editorUIResult = editorUI( {
 							select,
 							context,
@@ -364,13 +364,6 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 						}
 					} else if ( getFieldsList ) {
 						// Backward compatibility: Convert getFieldsList to editorUI format
-						const context = {};
-						if ( usesContext?.length ) {
-							for ( const key of usesContext ) {
-								context[ key ] = blockContext[ key ];
-							}
-						}
-
 						const fieldsListResult = getFieldsList( {
 							select,
 							context,

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -7,7 +7,11 @@ import fastDeepEqual from 'fast-deep-equal/es6';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { getBlockBindingsSources, getBlockType } from '@wordpress/blocks';
+import {
+	getBlockBindingsSource,
+	getBlockBindingsSources,
+	getBlockType,
+} from '@wordpress/blocks';
 import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
@@ -206,8 +210,9 @@ function BlockBindingsPanelMenuContent( {
 	);
 }
 
-function BlockBindingsAttribute( { attribute, binding, source } ) {
+function BlockBindingsAttribute( { attribute, binding } ) {
 	const { source: sourceName, args } = binding || {};
+	const source = getBlockBindingsSource( sourceName );
 	const isSourceInvalid = ! source;
 	return (
 		<VStack className="block-editor-bindings__item" spacing={ 0 }>
@@ -231,14 +236,13 @@ function BlockBindingsAttribute( { attribute, binding, source } ) {
 	);
 }
 
-function ReadOnlyBlockBindingsPanelItem( { attribute, binding, source } ) {
+function ReadOnlyBlockBindingsPanelItem( { attribute, binding } ) {
 	return (
 		<ToolsPanelItem hasValue={ () => !! binding } label={ attribute }>
 			<Item>
 				<BlockBindingsAttribute
 					attribute={ attribute }
 					binding={ binding }
-					source={ source }
 				/>
 			</Item>
 		</ToolsPanelItem>
@@ -273,7 +277,6 @@ function EditableBlockBindingsPanelItem( {
 					<BlockBindingsAttribute
 						attribute={ attribute }
 						binding={ binding }
-						source={ sources?.[ binding?.source ] }
 					/>
 				</Menu.TriggerButton>
 				<Menu.Popover gutter={ isMobile ? 8 : 36 }>
@@ -477,7 +480,6 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 								key={ attribute }
 								attribute={ attribute }
 								binding={ binding }
-								source={ sources?.[ binding?.source ] }
 							/>
 						) : (
 							<EditableBlockBindingsPanelItem

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -301,18 +301,24 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 
 	const registeredSources = getBlockBindingsSources();
 
-	// Use useSelect to ensure sources are updated whenever there are updates in block context
-	// or when underlying data changes.
-	const { sources, canUpdateBlockBindings, bindableAttributes } = useSelect(
+	const { bindableAttributes } = useSelect(
 		( select ) => {
 			const { __experimentalBlockBindingsSupportedAttributes } =
 				select( blockEditorStore ).getSettings();
-			const _bindableAttributes =
-				__experimentalBlockBindingsSupportedAttributes?.[ blockName ];
-			if ( ! _bindableAttributes || _bindableAttributes.length === 0 ) {
-				return EMPTY_OBJECT;
-			}
+			return {
+				bindableAttributes:
+					__experimentalBlockBindingsSupportedAttributes?.[
+						blockName
+					] ?? [],
+			};
+		},
+		[ blockName ]
+	);
 
+	// Use useSelect to ensure sources are updated whenever there are updates in block context
+	// or when underlying data changes.
+	const { sources, canUpdateBlockBindings } = useSelect(
+		( select ) => {
 			const _sources = {};
 			Object.entries( registeredSources ).forEach(
 				( [
@@ -332,7 +338,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 							select,
 							context,
 						} );
-						const hasCompatibleData = _bindableAttributes.some(
+						const hasCompatibleData = bindableAttributes.some(
 							( attribute ) => {
 								const _attributeType =
 									getBlockType( blockName ).attributes?.[
@@ -380,7 +386,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 								} )
 							);
 
-							const hasCompatibleData = _bindableAttributes.some(
+							const hasCompatibleData = bindableAttributes.some(
 								( attribute ) => {
 									const _attributeType =
 										getBlockType( blockName ).attributes?.[
@@ -427,10 +433,9 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 				canUpdateBlockBindings:
 					select( blockEditorStore ).getSettings()
 						.canUpdateBlockBindings,
-				bindableAttributes: _bindableAttributes,
 			};
 		},
-		[ blockContext, blockName, registeredSources ]
+		[ blockContext, blockName, registeredSources, bindableAttributes ]
 	);
 
 	// Return early if there are no bindable attributes.

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -32,13 +32,11 @@ import { useViewportMatch } from '@wordpress/compose';
 import { useBlockBindingsUtils } from '../utils/block-bindings';
 import { unlock } from '../lock-unlock';
 import InspectorControls from '../components/inspector-controls';
+import { BlockBindingsDropdown } from '../components/block-bindings';
 import BlockContext from '../components/block-context';
-import { useBlockEditContext } from '../components/block-edit';
 import { store as blockEditorStore } from '../store';
 
 const { Menu } = unlock( componentsPrivateApis );
-
-const EMPTY_OBJECT = {};
 
 const useToolsPanelDropdownMenuProps = () => {
 	const isMobile = useViewportMatch( 'medium', '<' );
@@ -53,158 +51,46 @@ const useToolsPanelDropdownMenuProps = () => {
 		: {};
 };
 
-function BlockBindingsPanelMenuContent( {
-	attribute,
-	binding,
-	sources,
-	onOpenModal,
-} ) {
-	const { clientId } = useBlockEditContext();
-	const { updateBlockBindings } = useBlockBindingsUtils();
+function BlockBindingsPanelMenuContent( { attribute, binding } ) {
+	const sources = getBlockBindingsSources();
 	const isMobile = useViewportMatch( 'medium', '<' );
 	const blockContext = useContext( BlockContext );
-	const { attributeType, select } = useSelect(
-		( _select ) => {
-			const { name: blockName } =
-				_select( blockEditorStore ).getBlock( clientId );
-			const _attributeType =
-				getBlockType( blockName ).attributes?.[ attribute ]?.type;
-			return {
-				attributeType:
-					_attributeType === 'rich-text' ? 'string' : _attributeType,
-				select: _select,
-			};
-		},
-		[ clientId, attribute ]
-	);
+
 	return (
 		<Menu placement={ isMobile ? 'bottom-start' : 'left-start' }>
 			{ Object.entries( sources ).map( ( [ sourceKey, source ] ) => {
-				// Only show sources that have compatible data for this specific attribute.
-				const sourceDataItems = source.data?.filter(
-					( item ) => item?.type === attributeType
+				if ( sourceKey === 'core/post-data' ) {
+					const context = {};
+					if ( source.usesContext?.length ) {
+						for ( const key of source.usesContext ) {
+							context[ key ] = blockContext[ key ];
+						}
+					}
+					const EditorUI = source.editorUI;
+
+					return (
+						<EditorUI
+							key={ sourceKey }
+							attribute={ attribute }
+							binding={ binding }
+							source={ source }
+							sourceKey={ sourceKey }
+							context={ context }
+						/>
+					);
+				}
+
+				// FIXME: This is only here for now to avoid breaking other sources.
+				// Remove once other sources are updated to the new format.
+				return (
+					<BlockBindingsDropdown
+						key={ sourceKey }
+						attribute={ attribute }
+						binding={ binding }
+						source={ source }
+						sourceKey={ sourceKey }
+					/>
 				);
-
-				const noItemsAvailable =
-					! sourceDataItems || sourceDataItems.length === 0;
-
-				if ( source.mode === 'dropdown' ) {
-					return (
-						<Menu
-							key={ sourceKey }
-							placement={
-								isMobile ? 'bottom-start' : 'left-start'
-							}
-						>
-							{ noItemsAvailable ? (
-								<Menu.Item disabled>{ source.label }</Menu.Item>
-							) : (
-								<Menu.SubmenuTriggerItem>
-									<Menu.ItemLabel>
-										{ source.label }
-									</Menu.ItemLabel>
-								</Menu.SubmenuTriggerItem>
-							) }
-
-							{ ! noItemsAvailable && (
-								<Menu.Popover gutter={ 8 }>
-									<Menu.Group>
-										{ sourceDataItems.map( ( item ) => {
-											const itemBindings = {
-												source: sourceKey,
-												args: item?.args || {
-													key: item.key,
-												},
-											};
-											const values = source.getValues( {
-												select,
-												context: blockContext,
-												bindings: {
-													[ attribute ]: itemBindings,
-												},
-											} );
-											return (
-												<Menu.CheckboxItem
-													key={
-														sourceKey +
-															JSON.stringify(
-																item.args
-															) || item.key
-													}
-													onChange={ () => {
-														const isCurrentlySelected =
-															fastDeepEqual(
-																binding?.args,
-																item.args
-															) ??
-															// Deprecate key dependency in 7.0.
-															item.key ===
-																binding?.args
-																	?.key;
-
-														if (
-															isCurrentlySelected
-														) {
-															// Unset if the same item is selected again.
-															updateBlockBindings(
-																{
-																	[ attribute ]:
-																		undefined,
-																}
-															);
-														} else {
-															updateBlockBindings(
-																{
-																	[ attribute ]:
-																		itemBindings,
-																}
-															);
-														}
-													} }
-													name={
-														attribute + '-binding'
-													}
-													value={
-														values[ attribute ]
-													}
-													checked={
-														fastDeepEqual(
-															binding?.args,
-															item.args
-														) ??
-														// Deprecate key dependency in 7.0.
-														item.key ===
-															binding?.args?.key
-													}
-												>
-													<Menu.ItemLabel>
-														{ item?.label }
-													</Menu.ItemLabel>
-													<Menu.ItemHelpText>
-														{ values[ attribute ] }
-													</Menu.ItemHelpText>
-												</Menu.CheckboxItem>
-											);
-										} ) }
-									</Menu.Group>
-								</Menu.Popover>
-							) }
-						</Menu>
-					);
-				}
-
-				if ( source.mode === 'modal' ) {
-					return (
-						<Menu.Item
-							key={ sourceKey }
-							onClick={ () => onOpenModal( { sourceKey } ) }
-						>
-							<Menu.ItemLabel>{ source.label }</Menu.ItemLabel>
-						</Menu.Item>
-					);
-				}
-
-				return null;
 			} ) }
 		</Menu>
 	);
@@ -252,7 +138,6 @@ function ReadOnlyBlockBindingsPanelItem( { attribute, binding } ) {
 function EditableBlockBindingsPanelItem( {
 	attribute,
 	binding,
-	sources,
 	setModalState,
 } ) {
 	const { updateBlockBindings } = useBlockBindingsUtils();
@@ -283,7 +168,6 @@ function EditableBlockBindingsPanelItem( {
 					<BlockBindingsPanelMenuContent
 						attribute={ attribute }
 						binding={ binding }
-						sources={ sources }
 						onOpenModal={ handleOpenModal }
 					/>
 				</Menu.Popover>
@@ -320,7 +204,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 
 	// Use useSelect to ensure sources are updated whenever there are updates in block context
 	// or when underlying data changes.
-	const { sources, canUpdateBlockBindings } = useSelect(
+	const { canUpdateBlockBindings } = useSelect(
 		( select ) => {
 			const _sources = {};
 			Object.entries( registeredSources ).forEach(
@@ -336,7 +220,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 						}
 					}
 
-					if ( editorUI ) {
+					if ( editorUI && sourceName !== 'core/post-data' ) {
 						const editorUIResult = editorUI( {
 							select,
 							context,
@@ -422,10 +306,6 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 			);
 
 			return {
-				sources:
-					Object.values( _sources ).length > 0
-						? _sources
-						: EMPTY_OBJECT,
 				canUpdateBlockBindings:
 					select( blockEditorStore ).getSettings()
 						.canUpdateBlockBindings,
@@ -448,15 +328,15 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 	} );
 
 	// Lock the UI when the user can't update bindings or there are no fields to connect to.
-	const readOnly =
-		! canUpdateBlockBindings || ! Object.keys( sources ).length;
+	const readOnly = ! canUpdateBlockBindings; // || ! Object.keys( sources ).length; // FIXME
 
 	if ( readOnly && Object.keys( filteredBindings ).length === 0 ) {
 		return null;
 	}
 
-	const RenderModalContent =
-		sources[ modalState?.sourceKey ]?.renderModalContent;
+	const RenderModalContent = getBlockBindingsSource(
+		modalState?.sourceKey
+	)?.renderModalContent;
 
 	return (
 		<InspectorControls group="bindings">
@@ -471,9 +351,10 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 				<ItemGroup isBordered isSeparated>
 					{ bindableAttributes.map( ( attribute ) => {
 						const binding = filteredBindings[ attribute ];
-						const hasCompatibleData = Object.values( sources ).some(
-							( source ) => source.data
-						);
+						const hasCompatibleData = true;
+						// Object.values( sources ).some(
+						// 	( source ) => source.data
+						// );
 
 						return readOnly || ! hasCompatibleData ? (
 							<ReadOnlyBlockBindingsPanelItem
@@ -486,7 +367,6 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 								key={ attribute }
 								attribute={ attribute }
 								binding={ binding }
-								sources={ sources }
 								setModalState={ setModalState }
 							/>
 						);

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -299,10 +299,10 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 		setModalState( null );
 	};
 
+	const registeredSources = getBlockBindingsSources();
+
 	// Use useSelect to ensure sources are updated whenever there are updates in block context
 	// or when underlying data changes.
-	// Still needs a fix regarding _sources scope.
-	const _sources = {};
 	const { sources, canUpdateBlockBindings, bindableAttributes } = useSelect(
 		( select ) => {
 			const { __experimentalBlockBindingsSupportedAttributes } =
@@ -313,7 +313,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 				return EMPTY_OBJECT;
 			}
 
-			const registeredSources = getBlockBindingsSources();
+			const _sources = {};
 			Object.entries( registeredSources ).forEach(
 				( [
 					sourceName,
@@ -430,8 +430,9 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 				bindableAttributes: _bindableAttributes,
 			};
 		},
-		[ blockContext, blockName ]
+		[ blockContext, blockName, registeredSources ]
 	);
+
 	// Return early if there are no bindable attributes.
 	if ( ! bindableAttributes || bindableAttributes.length === 0 ) {
 		return null;

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -2,7 +2,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import {
+	BlockBindingsDropdown,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { store as coreDataStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Gets a list of post data fields with their values and labels
@@ -59,6 +64,45 @@ function getPostDataFields( select, context ) {
 	}
 
 	return dataFields;
+}
+
+function EditorUI( { attribute, binding, source, sourceKey, context } ) {
+	// FIXME: Pass blockName as prop instead?
+	// FIXME: Compute context here? Might be needed to avoid the `useSelect` warning.
+	const { data, selectedBlock } = useSelect(
+		( select ) => {
+			return {
+				selectedBlock: select( blockEditorStore ).getSelectedBlock(),
+				data: getPostDataFields( select, context ), // FIXME: Inline code; otherwise, we'll continue to face the `useSelect` warning.
+			};
+		},
+		[ context ]
+	);
+
+	if ( selectedBlock?.name !== 'core/post-date' ) {
+		return null;
+	}
+
+	const dataArray = Object.entries( data || {} ).map(
+		( [ key, field ] ) => ( {
+			label: field.label,
+			args: {
+				key,
+			},
+			value: field.value, // Or compute via getValues()?
+			type: field.type,
+		} )
+	);
+
+	return (
+		<BlockBindingsDropdown
+			attribute={ attribute }
+			binding={ binding }
+			data={ dataArray }
+			source={ source }
+			sourceKey={ sourceKey }
+		/>
+	);
 }
 
 /**
@@ -126,26 +170,5 @@ export default {
 		// Deprecated, will be removed after 6.9.
 		return getPostDataFields( select, context );
 	},
-	editorUI( { select, context } ) {
-		const selectedBlock = select( 'core/block-editor' ).getSelectedBlock();
-		if ( selectedBlock?.name !== 'core/post-date' ) {
-			return {};
-		}
-		const postDataFields = Object.entries(
-			getPostDataFields( select, context ) || {}
-		).map( ( [ key, field ] ) => ( {
-			label: field.label,
-			args: {
-				key,
-			},
-			type: field.type,
-		} ) );
-		/*
-		 * We need to define the data as [{ label: string, value: any, type: https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#type-validation }]
-		 */
-		return {
-			mode: 'dropdown',
-			data: postDataFields,
-		};
-	},
+	editorUI: EditorUI,
 };

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -69,14 +69,39 @@ function getPostDataFields( select, context ) {
 function EditorUI( { attribute, binding, source, sourceKey, context } ) {
 	// FIXME: Pass blockName as prop instead?
 	// FIXME: Compute context here? Might be needed to avoid the `useSelect` warning.
+
+	const { postId, postType } = context;
 	const { data, selectedBlock } = useSelect(
 		( select ) => {
+			const { getEditedEntityRecord } = select( coreDataStore );
+
+			let dataFields;
+			if ( postType && postId ) {
+				const entityDataValues = getEditedEntityRecord(
+					'postType',
+					postType,
+					postId
+				);
+				dataFields = {
+					date: {
+						label: __( 'Post Date' ),
+						value: entityDataValues?.date,
+						type: 'string',
+					},
+					modified: {
+						label: __( 'Post Modified Date' ),
+						value: entityDataValues?.modified,
+						type: 'string',
+					},
+				};
+			}
+
 			return {
 				selectedBlock: select( blockEditorStore ).getSelectedBlock(),
-				data: getPostDataFields( select, context ), // FIXME: Inline code; otherwise, we'll continue to face the `useSelect` warning.
+				data: dataFields,
 			};
 		},
-		[ context ]
+		[ postId, postType ]
 	);
 
 	if ( selectedBlock?.name !== 'core/post-date' ) {

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -93,35 +93,26 @@ function EditorUI( { attribute, binding, source, sourceKey, context } ) {
 		return null;
 	}
 
-	const data = {
-		date: {
+	const data = [
+		{
 			label: __( 'Post Date' ),
 			value: date,
+			args: { key: 'date' },
 			type: 'string',
 		},
-		modified: {
+		{
 			label: __( 'Post Modified Date' ),
 			value: modified,
+			args: { key: 'modified' },
 			type: 'string',
 		},
-	};
-
-	const dataArray = Object.entries( data ).map(
-		( [ key, field ] ) => ( {
-			label: field.label,
-			args: {
-				key,
-			},
-			value: field.value, // Or compute via getValues()?
-			type: field.type,
-		} )
-	);
+	];
 
 	return (
 		<BlockBindingsDropdown
 			attribute={ attribute }
 			binding={ binding }
-			data={ dataArray }
+			data={ data }
 			source={ source }
 			sourceKey={ sourceKey }
 		/>

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -68,37 +68,22 @@ function getPostDataFields( select, context ) {
 
 function EditorUI( { attribute, binding, source, sourceKey, context } ) {
 	// FIXME: Pass blockName as prop instead?
-	// FIXME: Compute context here? Might be needed to avoid the `useSelect` warning.
 
 	const { postId, postType } = context;
-	const { data, selectedBlock } = useSelect(
+	const { date, modified, selectedBlock } = useSelect(
 		( select ) => {
 			const { getEditedEntityRecord } = select( coreDataStore );
 
-			let dataFields;
-			if ( postType && postId ) {
-				const entityDataValues = getEditedEntityRecord(
-					'postType',
-					postType,
-					postId
-				);
-				dataFields = {
-					date: {
-						label: __( 'Post Date' ),
-						value: entityDataValues?.date,
-						type: 'string',
-					},
-					modified: {
-						label: __( 'Post Modified Date' ),
-						value: entityDataValues?.modified,
-						type: 'string',
-					},
-				};
-			}
+			const entityDataValues = getEditedEntityRecord(
+				'postType',
+				postType,
+				postId
+			);
 
 			return {
 				selectedBlock: select( blockEditorStore ).getSelectedBlock(),
-				data: dataFields,
+				date: entityDataValues?.date,
+				modified: entityDataValues?.modified,
 			};
 		},
 		[ postId, postType ]
@@ -108,7 +93,20 @@ function EditorUI( { attribute, binding, source, sourceKey, context } ) {
 		return null;
 	}
 
-	const dataArray = Object.entries( data || {} ).map(
+	const data = {
+		date: {
+			label: __( 'Post Date' ),
+			value: date,
+			type: 'string',
+		},
+		modified: {
+			label: __( 'Post Modified Date' ),
+			value: modified,
+			type: 'string',
+		},
+	};
+
+	const dataArray = Object.entries( data ).map(
 		( [ key, field ] ) => ( {
 			label: field.label,
 			args: {


### PR DESCRIPTION
## What?
WIP. See https://github.com/WordPress/gutenberg/pull/71542/files#r2378222245 and https://github.com/WordPress/gutenberg/pull/65604.

## Why?
We were previously defining an object prior to `useSelect` that was then modified and returned from `useSelect`. Due to referential equality, this could lead to problems where return values are assumed to be identical when they're actually different.

## How?
Largely by following best practices, see e.g. https://developer.wordpress.org/news/2024/03/how-to-work-effectively-with-the-useselect-hook/#be-careful-about-transforming-data-inside-the-callback.

## Testing Instructions
TBD

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
