### PR TITLE
Dataviews: Delete the isDestructive prop from the actions

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - DataForm: Add summary field support for both card and panel layouts. The `summary` property has been moved from the field level to the layout level, and so fields using `summary` at the field level must now configure it within the `layout` object. Additionally, the first children will only be used as summary for the panel if 1) there is no `layout.summary` and 2) the form field ID doesn't match any existing field. See README for details. [#71576](https://github.com/WordPress/gutenberg/pull/71576)
 - Remove `Data< Item >` type, as it is no longer used internally for a long time. [#72051](https://github.com/WordPress/gutenberg/pull/72051)
+- Remove `isDestructive` prop from actions API, as it is not required according to the latest design guidelines. [#72111](https://github.com/WordPress/gutenberg/pull/72111)
 
 ### Features
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - DataForm: Add summary field support for both card and panel layouts. The `summary` property has been moved from the field level to the layout level, and so fields using `summary` at the field level must now configure it within the `layout` object. Additionally, the first children will only be used as summary for the panel if 1) there is no `layout.summary` and 2) the form field ID doesn't match any existing field. See README for details. [#71576](https://github.com/WordPress/gutenberg/pull/71576)
 - Remove `Data< Item >` type, as it is no longer used internally for a long time. [#72051](https://github.com/WordPress/gutenberg/pull/72051)
-- Remove `isDestructive` prop from actions API, as it is not required according to the latest design guidelines. [#72111](https://github.com/WordPress/gutenberg/pull/72111)
+- Remove `isDestructive` prop from actions API. Destructive actions should be communicated via flow (opens modal to confirm) and color should be used in the modal. [#72111](https://github.com/WordPress/gutenberg/pull/72111)
 
 ### Features
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -318,7 +318,6 @@ const actions = [
 	{
 		id: 'delete',
 		label: 'Delete',
-		isDestructive: true,
 		supportsBulk: true,
 		RenderModal: ( { items, closeModal, onActionPerformed } ) => (
 			<div>
@@ -788,13 +787,6 @@ Function that determines whether the action can be performed for a given record.
 	isEligible: ( item ) => item.status === 'published';
 }
 ```
-
-### `isDestructive`
-
-Whether the action can delete data, in which case the UI communicates it via a red color.
-
--   Type: `boolean`
--   Optional
 
 ### `supportsBulk`
 

--- a/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
@@ -171,7 +171,6 @@ function ActionTrigger< Item >( {
 			accessibleWhenDisabled
 			label={ label }
 			icon={ action.icon }
-			isDestructive={ action.isDestructive }
 			size="compact"
 			onClick={ onClick }
 			isBusy={ isBusy }

--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -77,7 +77,6 @@ function ButtonTrigger< Item >( {
 			icon={ action.icon }
 			disabled={ !! action.disabled }
 			accessibleWhenDisabled
-			isDestructive={ action.isDestructive }
 			size="compact"
 			onClick={ onClick }
 		/>

--- a/packages/dataviews/src/components/dataviews-picker/footer.tsx
+++ b/packages/dataviews/src/components/dataviews-picker/footer.tsx
@@ -99,8 +99,7 @@ function ActionButtons< Item >( {
 					return null;
 				}
 
-				const { id, label, icon, isPrimary, isDestructive, callback } =
-					action;
+				const { id, label, icon, isPrimary, callback } = action;
 
 				const _label =
 					typeof label === 'string' ? label : label( items );
@@ -122,7 +121,6 @@ function ActionButtons< Item >( {
 							setActionInProgress( null );
 						} }
 						size="compact"
-						isDestructive={ isDestructive }
 						variant={ variant }
 					>
 						{ _label }

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -108,7 +108,6 @@ function PrimaryActionGridCell< Item >( {
 						disabled={ !! primaryAction.disabled }
 						accessibleWhenDisabled
 						icon={ primaryAction.icon }
-						isDestructive={ primaryAction.isDestructive }
 						size="small"
 						onClick={ () => setIsModalOpen( true ) }
 					/>
@@ -133,7 +132,6 @@ function PrimaryActionGridCell< Item >( {
 						disabled={ !! primaryAction.disabled }
 						accessibleWhenDisabled
 						icon={ primaryAction.icon }
-						isDestructive={ primaryAction.isDestructive }
 						size="small"
 						onClick={ () => {
 							primaryAction.callback( [ item ], { registry } );

--- a/packages/dataviews/src/test/dataviews.tsx
+++ b/packages/dataviews/src/test/dataviews.tsx
@@ -89,7 +89,6 @@ const actions: Action< Data >[] = [
 	{
 		id: 'delete',
 		label: 'Delete',
-		isDestructive: true,
 		supportsBulk: true,
 		RenderModal: () => <div>Modal Content</div>,
 	},

--- a/packages/dataviews/src/types/dataviews.ts
+++ b/packages/dataviews/src/types/dataviews.ts
@@ -287,11 +287,6 @@ interface ActionBase< Item > {
 	disabled?: boolean;
 
 	/**
-	 * Whether the action is destructive.
-	 */
-	isDestructive?: boolean;
-
-	/**
 	 * Whether the action is a primary action.
 	 */
 	isPrimary?: boolean;


### PR DESCRIPTION
## What?

Deletes the `isDestructive` prop from the dataviews Actions API as it is not required.

## Why?

The `isDestructive` prop is used to set a red color to the primary action's icon, but that is not required according to the new design guidelines, as that will be included in the rendered Modal, that is created by the consumer. So that prop is not required anymore.

## How?

Reviewing all the occurrences of the `isDestructive` prop from the code and the docs.

## Testing Instructions

1. Apply the change of this branch
2. Run `npm run storybook:dev` 
3. Go to the dataviews component, and find occurrences of the `isDestructive` prop
4. Find occurrences of that prop in any of the Markdown documentation files
