### PR TITLE
Block Comments: Fix the canvas re-ordering synchronization

### DIFF
--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -21,11 +21,17 @@ export function useBlockComments( postId ) {
 		{ enabled: !! postId && typeof postId === 'number' }
 	);
 
-	const blocksWithComments = useSelect( ( select ) => {
-		const { getBlockAttributes, getClientIdsWithDescendants } =
-			select( blockEditorStore );
+	const { getBlockAttributes } = useSelect( blockEditorStore );
+	const { clientIds } = useSelect( ( select ) => {
+		const { getClientIdsWithDescendants } = select( blockEditorStore );
+		return {
+			clientIds: getClientIdsWithDescendants(),
+		};
+	}, [] );
 
-		return getClientIdsWithDescendants().reduce( ( results, clientId ) => {
+	// Process comments to build the tree structure.
+	const { resultComments, unresolvedSortedThreads } = useMemo( () => {
+		const blocksWithComments = clientIds.reduce( ( results, clientId ) => {
 			const commentId =
 				getBlockAttributes( clientId )?.metadata?.commentId;
 			if ( commentId ) {
@@ -33,10 +39,7 @@ export function useBlockComments( postId ) {
 			}
 			return results;
 		}, {} );
-	}, [] );
 
-	// Process comments to build the tree structure.
-	const { resultComments, unresolvedSortedThreads } = useMemo( () => {
 		// Create a compare to store the references to all objects by id.
 		const compare = {};
 		const result = [];
@@ -104,7 +107,7 @@ export function useBlockComments( postId ) {
 			resultComments: allSortedComments,
 			unresolvedSortedThreads: unresolvedSortedComments,
 		};
-	}, [ threads, blocksWithComments ] );
+	}, [ clientIds, threads, getBlockAttributes ] );
 
 	return { resultComments, unresolvedSortedThreads, totalPages };
 }


### PR DESCRIPTION
## What?
A quick follow-up to https://github.com/WordPress/gutenberg/pull/72069#discussion_r2407549067.

PR updates the derived block editor and comments states in `useBlockComments`, ensuring their order is always in sync.

## Why?
Fixes a bug where re-ordering a block in the canvas didn't change the order of the threads in the sidebar.

## Testing Instructions
1. Create a post.
2. Add a couple of blocks and comments for each of them.
3. Confirm that moving blocks also changes the corresponding comment's position in the sidebar.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/2747de3f-bb47-4a9e-94ff-fe7aeb0fa5d9

