### PR TITLE
Templates DataViews: Support persistence

### DIFF
--- a/packages/edit-site/src/components/page-patterns/header.js
+++ b/packages/edit-site/src/components/page-patterns/header.js
@@ -79,7 +79,7 @@ export default function PatternsHeader( {
 				<HStack expanded={ false }>
 					{ isModifiedView && (
 						<Button __next40pxDefaultSize onClick={ resetView }>
-							{ __( 'Reset View' ) }
+							{ __( 'Reset view' ) }
 						</Button>
 					) }
 					<AddNewPattern />

--- a/packages/edit-site/src/components/page-templates/view-utils.js
+++ b/packages/edit-site/src/components/page-templates/view-utils.js
@@ -1,0 +1,44 @@
+export const defaultLayouts = {
+	table: {
+		showMedia: false,
+	},
+	grid: {
+		showMedia: true,
+	},
+	list: {
+		showMedia: false,
+	},
+};
+
+const DEFAULT_VIEW = {
+	type: 'grid',
+	search: '',
+	page: 1,
+	perPage: 20,
+	sort: {
+		field: 'title',
+		direction: 'asc',
+	},
+	titleField: 'title',
+	descriptionField: 'description',
+	mediaField: 'preview',
+	fields: [ 'author', 'active', 'slug', 'theme' ],
+	filters: [],
+	...defaultLayouts.grid,
+};
+
+export function getDefaultView( activeView ) {
+	return {
+		...DEFAULT_VIEW,
+		filters: ! [ 'active', 'user' ].includes( activeView )
+			? [
+					{
+						field: 'author',
+						operator: 'isAny',
+						value: [ activeView ],
+					},
+			  ]
+			: [],
+		...defaultLayouts[ DEFAULT_VIEW.type ],
+	};
+}

--- a/packages/edit-site/src/components/page-templates/view-utils.js
+++ b/packages/edit-site/src/components/page-templates/view-utils.js
@@ -39,6 +39,5 @@ export function getDefaultView( activeView ) {
 					},
 			  ]
 			: [],
-		...defaultLayouts[ DEFAULT_VIEW.type ],
 	};
 }

--- a/packages/edit-site/src/components/site-editor-routes/templates.js
+++ b/packages/edit-site/src/components/site-editor-routes/templates.js
@@ -1,10 +1,27 @@
 /**
+ * WordPress dependencies
+ */
+import { loadView } from '@wordpress/views';
+
+/**
  * Internal dependencies
  */
 import Editor from '../editor';
 import SidebarNavigationScreenTemplatesBrowse from '../sidebar-navigation-screen-templates-browse';
 import SidebarNavigationScreenUnsupported from '../sidebar-navigation-screen-unsupported';
 import PageTemplates from '../page-templates';
+import { getDefaultView } from '../page-templates/view-utils';
+
+async function isTemplateListView( query ) {
+	const { activeView = 'active' } = query;
+	const view = await loadView( {
+		kind: 'postType',
+		name: 'wp_template',
+		slug: activeView,
+		defaultView: getDefaultView( activeView ),
+	} );
+	return view.type === 'list';
+}
 
 export const templatesRoute = {
 	name: 'templates',
@@ -22,12 +39,12 @@ export const templatesRoute = {
 			const isBlockTheme = siteData.currentTheme?.is_block_theme;
 			return isBlockTheme ? <PageTemplates /> : undefined;
 		},
-		preview( { query, siteData } ) {
+		async preview( { query, siteData } ) {
 			const isBlockTheme = siteData.currentTheme?.is_block_theme;
 			if ( ! isBlockTheme ) {
 				return undefined;
 			}
-			const isListView = query.layout === 'list';
+			const isListView = await isTemplateListView( query );
 			return isListView ? <Editor /> : undefined;
 		},
 		mobile( { siteData } ) {
@@ -40,8 +57,8 @@ export const templatesRoute = {
 		},
 	},
 	widths: {
-		content( { query } ) {
-			const isListView = query.layout === 'list';
+		async content( { query } ) {
+			const isListView = await isTemplateListView( query );
 			return isListView ? 380 : undefined;
 		},
 	},


### PR DESCRIPTION
Refs #57669
Follow-up to #72102

## What?

This PR adds view persistence support to the templates route. That said, this route allows switching between "list" and "grid" which has an impact on which router areas should be rendered. Previously, this was handled by having the "layout" in the url, which was admittedly a hack. Now we have a slightly better solution for it:

 - Route areas can be async functions. (Just like loaders in routers like tanstack or react router)
 - Route are can use the `loadView` utility to retrieve the persisted view.
 - Using that information we know whether canvas needed to be rendered or not.
 - In addition to that and since switching a layout doesn't change the url but need to trigger the router areas resolution, we added a `history.invalidate` function to be able to do that.

## Testing Instructions

- Test the templates dataviews
- Notice the "reset view" button when you tweak the config
- Notice that pagination and search are persisted in the url instead.
