### PR TITLE
Collaborative editing: Make syncing a side-concern instead of a replacement for local state

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -417,32 +417,28 @@ export const editEntityRecord =
 					edit.edits
 				);
 			}
-		} else {
-			if ( ! options.undoIgnore ) {
-				select.getUndoManager().addRecord(
-					[
-						{
-							id: { kind, name, recordId },
-							changes: Object.keys( edits ).reduce(
-								( acc, key ) => {
-									acc[ key ] = {
-										from: editedRecord[ key ],
-										to: edits[ key ],
-									};
-									return acc;
-								},
-								{}
-							),
-						},
-					],
-					options.isCached
-				);
-			}
-			dispatch( {
-				type: 'EDIT_ENTITY_RECORD',
-				...edit,
-			} );
 		}
+		if ( ! options.undoIgnore ) {
+			select.getUndoManager().addRecord(
+				[
+					{
+						id: { kind, name, recordId },
+						changes: Object.keys( edits ).reduce( ( acc, key ) => {
+							acc[ key ] = {
+								from: editedRecord[ key ],
+								to: edits[ key ],
+							};
+							return acc;
+						}, {} ),
+					},
+				],
+				options.isCached
+			);
+		}
+		dispatch( {
+			type: 'EDIT_ENTITY_RECORD',
+			...edit,
+		} );
 	};
 
 /**

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -313,6 +313,7 @@ async function loadPostTypeEntities() {
 			name
 		);
 		const namespace = postType?.rest_namespace ?? 'wp/v2';
+		const syncedProperties = new Set( [ 'blocks' ] );
 		return {
 			kind: 'postType',
 			baseURL: `/${ namespace }/${ postType.rest_base }`,
@@ -343,6 +344,10 @@ async function loadPostTypeEntities() {
 					const document = doc.getMap( 'document' );
 
 					Object.entries( changes ).forEach( ( [ key, value ] ) => {
+						if ( ! syncedProperties.has( key ) ) {
+							return;
+						}
+
 						if ( typeof value !== 'function' ) {
 							if ( key === 'blocks' ) {
 								if ( ! serialisableBlocksCache.has( value ) ) {

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -163,21 +163,12 @@ export const getEntityRecord =
 				if ( globalThis.IS_GUTENBERG_PLUGIN ) {
 					const objectId = entityConfig.getSyncObjectId( key );
 
-					// Loads the persisted document.
-					await getSyncProvider().bootstrap(
-						entityConfig.syncObjectType,
-						objectId,
-						( rawRecord ) => {
-							dispatch.receiveEntityRecords(
-								kind,
-								name,
-								rawRecord,
-								query
-							);
-						}
+					getSyncProvider().register(
+						entityConfig.syncObjectType + '--edit',
+						entityConfig.syncConfig
 					);
 
-					// Bootstraps the edited document as well (and load from peers).
+					// Bootstraps the edited document (and load from peers).
 					await getSyncProvider().bootstrap(
 						entityConfig.syncObjectType + '--edit',
 						objectId,

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -93,8 +93,68 @@ export const getEntityRecord =
 		);
 
 		try {
-			// Entity supports configs,
-			// use the sync algorithm instead of the old fetch behavior.
+			if ( query !== undefined && query._fields ) {
+				// If requesting specific fields, items and query association to said
+				// records are stored by ID reference. Thus, fields must always include
+				// the ID.
+				query = {
+					...query,
+					_fields: [
+						...new Set( [
+							...( getNormalizedCommaSeparable( query._fields ) ||
+								[] ),
+							entityConfig.key || DEFAULT_ENTITY_KEY,
+						] ),
+					].join(),
+				};
+			}
+
+			if ( query !== undefined && query._fields ) {
+				// The resolution cache won't consider query as reusable based on the
+				// fields, so it's tested here, prior to initiating the REST request,
+				// and without causing `getEntityRecord` resolution to occur.
+				const hasRecord = select.hasEntityRecord(
+					kind,
+					name,
+					key,
+					query
+				);
+				if ( hasRecord ) {
+					return;
+				}
+			}
+
+			const path = addQueryArgs(
+				entityConfig.baseURL + ( key ? '/' + key : '' ),
+				{
+					...entityConfig.baseURLParams,
+					...query,
+				}
+			);
+			const response = await apiFetch( { path, parse: false } );
+			const record = await response.json();
+			const permissions = getUserPermissionsFromAllowHeader(
+				response.headers?.get( 'allow' )
+			);
+
+			const canUserResolutionsArgs = [];
+			const receiveUserPermissionArgs = {};
+			for ( const action of ALLOWED_RESOURCE_ACTIONS ) {
+				receiveUserPermissionArgs[
+					getUserPermissionCacheKey( action, {
+						kind,
+						name,
+						id: key,
+					} )
+				] = permissions[ action ];
+
+				canUserResolutionsArgs.push( [
+					action,
+					{ kind, name, id: key },
+				] );
+			}
+
+			// Entity supports syncing.
 			if (
 				window.__experimentalEnableSync &&
 				entityConfig.syncConfig &&
@@ -107,11 +167,11 @@ export const getEntityRecord =
 					await getSyncProvider().bootstrap(
 						entityConfig.syncObjectType,
 						objectId,
-						( record ) => {
+						( rawRecord ) => {
 							dispatch.receiveEntityRecords(
 								kind,
 								name,
-								record,
+								rawRecord,
 								query
 							);
 						}
@@ -121,13 +181,13 @@ export const getEntityRecord =
 					await getSyncProvider().bootstrap(
 						entityConfig.syncObjectType + '--edit',
 						objectId,
-						( record ) => {
+						( edits ) => {
 							dispatch( {
 								type: 'EDIT_ENTITY_RECORD',
 								kind,
 								name,
 								recordId: key,
-								edits: record,
+								edits,
 								meta: {
 									undo: undefined,
 								},
@@ -135,80 +195,13 @@ export const getEntityRecord =
 						}
 					);
 				}
-			} else {
-				if ( query !== undefined && query._fields ) {
-					// If requesting specific fields, items and query association to said
-					// records are stored by ID reference. Thus, fields must always include
-					// the ID.
-					query = {
-						...query,
-						_fields: [
-							...new Set( [
-								...( getNormalizedCommaSeparable(
-									query._fields
-								) || [] ),
-								entityConfig.key || DEFAULT_ENTITY_KEY,
-							] ),
-						].join(),
-					};
-				}
-
-				if ( query !== undefined && query._fields ) {
-					// The resolution cache won't consider query as reusable based on the
-					// fields, so it's tested here, prior to initiating the REST request,
-					// and without causing `getEntityRecord` resolution to occur.
-					const hasRecord = select.hasEntityRecord(
-						kind,
-						name,
-						key,
-						query
-					);
-					if ( hasRecord ) {
-						return;
-					}
-				}
-
-				const path = addQueryArgs(
-					entityConfig.baseURL + ( key ? '/' + key : '' ),
-					{
-						...entityConfig.baseURLParams,
-						...query,
-					}
-				);
-				const response = await apiFetch( { path, parse: false } );
-				const record = await response.json();
-				const permissions = getUserPermissionsFromAllowHeader(
-					response.headers?.get( 'allow' )
-				);
-
-				const canUserResolutionsArgs = [];
-				const receiveUserPermissionArgs = {};
-				for ( const action of ALLOWED_RESOURCE_ACTIONS ) {
-					receiveUserPermissionArgs[
-						getUserPermissionCacheKey( action, {
-							kind,
-							name,
-							id: key,
-						} )
-					] = permissions[ action ];
-
-					canUserResolutionsArgs.push( [
-						action,
-						{ kind, name, id: key },
-					] );
-				}
-
-				registry.batch( () => {
-					dispatch.receiveEntityRecords( kind, name, record, query );
-					dispatch.receiveUserPermissions(
-						receiveUserPermissionArgs
-					);
-					dispatch.finishResolutions(
-						'canUser',
-						canUserResolutionsArgs
-					);
-				} );
 			}
+
+			registry.batch( () => {
+				dispatch.receiveEntityRecords( kind, name, record, query );
+				dispatch.receiveUserPermissions( receiveUserPermissionArgs );
+				dispatch.finishResolutions( 'canUser', canUserResolutionsArgs );
+			} );
 		} finally {
 			dispatch.__unstableReleaseStoreLock( lock );
 		}

--- a/phpunit/script-dependencies-test.php
+++ b/phpunit/script-dependencies-test.php
@@ -45,7 +45,6 @@ class Test_Script_Dependencies extends WP_UnitTestCase {
 			'wp-core-data',
 			'wp-editor',
 			'wp-router',
-			'wp-sync',
 			'wp-url',
 			'wp-widgets',
 		);

--- a/phpunit/script-dependencies-test.php
+++ b/phpunit/script-dependencies-test.php
@@ -45,6 +45,7 @@ class Test_Script_Dependencies extends WP_UnitTestCase {
 			'wp-core-data',
 			'wp-editor',
 			'wp-router',
+			'wp-sync',
 			'wp-url',
 			'wp-widgets',
 		);


### PR DESCRIPTION
## What?

Instead of effectively replacing the core-data store with a "database" Yjs provider (IndexedDB), this change makes syncing a side-effect of the `core-data` store, without changing how the entity records are represented and treated within it.

> [!NOTE]  
> This is the first of a series of modular PRs related to collaborative editing derived from the work in https://github.com/WordPress/gutenberg/pull/72040. Not all PRs result in a fully functional editing experience.

## Why?

- The primary motivation for this change is that **not all entity record properties should be synced**. When all properties are not synced, the simplest path is to continue to represent the entity in the local store.
   - Properties like `guid`, `_links`, and `modified` should not be synced because we want the local codebase to remain authoritative over their values.
   - Properties like `content` should not be synced because we prefer to sync a derivative property (`blocks`) instead.
- A secondary motivation is architectural simplicity. The `core-data` store continues to function as it does now, and the sync package interacts with it as a (privileged) client.
- A database Yjs provider (IndexedDB) _can_ be a vehicle for offline editing, but this is not easily implemented when a separate database (WordPress's relational database) is considered the source of truth.

## How?


- In `editEntityRecord` (`core-data` actions), do not skip dispatching edits and adding undo records for entities with syncing enabled.
  - Kevin's PR [took the same approach](https://github.com/WordPress/gutenberg/pull/68483/files#diff 
- In `getEntityRecord` (`core-data` resolvers), do not conditionally load the entity record into the store, and invert the order so that the entity is loaded before "bootstrapping."
  - This code change is minor (unwrapping an if/else), but produces a large diff due to the changed indentation.
963b9796c15a1a44431b3386775e7fe05e5bfd1f96293a8e20f5debae3478bc8). 
- Make sure to call the "register" method on the sync provider.
- In the entity sync config, introduce a set of synced properties. This set is currently limited to `blocks` to help navigate syncing errors, but it will be expanded in future PRs.


## Testing Instructions

1. Check out this branch.
2. Enable the real-time collaboration experiment: Gutenberg > Experiments.
3. Open a post for editing in two different browser environments.
4. Use your browser's development tools to remove the post editor lock (see screencast in the next section).

Note: This provider uses requests to `admin-ajax.php` for signaling and the initial connection is delayed.

### Testing Instructions for Keyboard

No UI changes in this pull request.

## Screenshots or screencast 

https://github.com/user-attachments/assets/40d3c34b-ca2a-4e82-aee6-6e644d67e1b3

