### PR TITLE
CheckboxControl, RadioControl, ToggleControl: Ensure focus on click

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,11 @@
 -   `SearchControl`: Move search icon to prefix position ([#71984](https://github.com/WordPress/gutenberg/pull/71984)).
 -   `SearchControl`: Flip search icon depending on placement ([#72070](https://github.com/WordPress/gutenberg/pull/72070)).
 -   `SearchControl`: Normalize styles ([#72072](https://github.com/WordPress/gutenberg/pull/72072)).
+-   `CheckboxControl`, `RadioControl`: Ensure elements are focused when clicked in Safari ([#72115](https://github.com/WordPress/gutenberg/pull/72115)).
+
+### Bug Fixes
+
+-   `ValidatedCheckboxControl`, `ValidatedRadioControl`: Fix issue where validation may not be triggered in Safari when elements are toggled by clicking ([#72115](https://github.com/WordPress/gutenberg/pull/72115)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,11 +7,11 @@
 -   `SearchControl`: Move search icon to prefix position ([#71984](https://github.com/WordPress/gutenberg/pull/71984)).
 -   `SearchControl`: Flip search icon depending on placement ([#72070](https://github.com/WordPress/gutenberg/pull/72070)).
 -   `SearchControl`: Normalize styles ([#72072](https://github.com/WordPress/gutenberg/pull/72072)).
--   `CheckboxControl`, `RadioControl`: Ensure elements are focused when clicked in Safari ([#72115](https://github.com/WordPress/gutenberg/pull/72115)).
+-   `CheckboxControl`, `RadioControl`, `ToggleControl` (`FormToggle`): Ensure elements are focused when clicked in Safari ([#72115](https://github.com/WordPress/gutenberg/pull/72115)).
 
 ### Bug Fixes
 
--   `ValidatedCheckboxControl`, `ValidatedRadioControl`: Fix issue where validation may not be triggered in Safari when elements are toggled by clicking ([#72115](https://github.com/WordPress/gutenberg/pull/72115)).
+-   `ValidatedCheckboxControl`, `ValidatedRadioControl`, `ValidatedToggleControl`: Fix issue where validation may not be triggered in Safari when elements are toggled by clicking ([#72115](https://github.com/WordPress/gutenberg/pull/72115)).
 
 ### Internal
 

--- a/packages/components/src/checkbox-control/index.tsx
+++ b/packages/components/src/checkbox-control/index.tsx
@@ -54,6 +54,7 @@ export function CheckboxControl(
 		help,
 		id: idProp,
 		onChange,
+		onClick,
 		...additionalProps
 	} = props;
 
@@ -118,6 +119,12 @@ export function CheckboxControl(
 						onChange={ onChangeValue }
 						checked={ checked }
 						aria-describedby={ !! help ? id + '__help' : undefined }
+						onClick={ ( event ) => {
+							// Compat code for Safari to ensure that the checkbox is focused when clicked.
+							event.currentTarget.focus();
+
+							onClick?.( event );
+						} }
 						{ ...additionalProps }
 					/>
 					{ showIndeterminateIcon ? (

--- a/packages/components/src/form-toggle/index.tsx
+++ b/packages/components/src/form-toggle/index.tsx
@@ -27,6 +27,7 @@ function UnforwardedFormToggle(
 		id,
 		disabled,
 		onChange = noop,
+		onClick,
 		...additionalProps
 	} = props;
 	const wrapperClasses = clsx( 'components-form-toggle', className, {
@@ -43,6 +44,12 @@ function UnforwardedFormToggle(
 				checked={ checked }
 				onChange={ onChange }
 				disabled={ disabled }
+				onClick={ ( event ) => {
+					// Compat code for Safari to ensure that the toggle is focused when clicked.
+					event.currentTarget.focus();
+
+					onClick?.( event );
+				} }
 				{ ...additionalProps }
 				ref={ ref }
 			/>

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -65,6 +65,7 @@ export function RadioControl(
 		selected,
 		help,
 		onChange,
+		onClick,
 		hideLabelFromVision,
 		options = [],
 		id: preferredId,
@@ -121,6 +122,12 @@ export function RadioControl(
 									? generateOptionDescriptionId( id, index )
 									: undefined
 							}
+							onClick={ ( event ) => {
+								// Compat code for Safari to ensure that the radio is focused when clicked.
+								event.currentTarget.focus();
+
+								onClick?.( event );
+							} }
 							{ ...additionalProps }
 						/>
 						<label


### PR DESCRIPTION
## What?

Ensures that radios, checkboxes, and toggles get focused when clicked in Safari.

This is also fixes an issue in `ValidatedCheckboxControl`, `ValidatedRadioControl`, and `ValidatedToggleControl` where validation may not run in Safari.

## Why?
 
Safari has a quirk in its [click-to-focus behavior](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#clicking_and_focus), where it will not focus a button or input element when clicked by mouse.

This led to a validation issue in `ValidatedCheckboxControl`, `ValidatedRadioControl`, and `ValidatedToggleControl`, because the component could not accurately detect when the checkboxes or radios were blurred, if they were never focused when interacted with.

I first considered patching it at the validated components level, but I noticed that it's not uncommon for component libraries to patch this Safari quirk on their Checkbox and Radio components. Base UI and Ariakit both have compat code to ensure the elements are focused when clicked. So I think we can also probably patch it directly on the `CheckboxControl`, `RadioControl`, and `ToggleControl` (`FormToggle`) components. This way, other consumers can also depend on focus/blur events as expected.

## How?

Adds a click handler to focus the current target.

## Testing Instructions

Interact with the `ValidatedRadioControl` with a mouse on Mac Safari. Select "Option B" before submitting. [On trunk](https://wordpress.github.io/gutenberg/?path=/docs/components-validatedradiocontrol--docs), the form will not catch the error. In this PR, the error will be caught.

https://github.com/user-attachments/assets/3815bc5a-4a7b-4d5c-b61e-aab6848a9ba4

You can also see in the stories for `CheckboxControl`, `RadioControl`, and `ToggleControl` that the checkboxes and radios are properly focused when clicked with a mouse.