### PR TITLE
Editor Canvas: Fix background color caused by invalid Sass value

### DIFF
--- a/packages/base-styles/_default-custom-properties.scss
+++ b/packages/base-styles/_default-custom-properties.scss
@@ -11,6 +11,6 @@
 	// This CSS variable is not used in Gutenberg project,
 	// but is maintained for backwards compatibility.
 	--wp-bound-block-color: var(--wp-block-synced-color);
-	--wp-editor-canvas-background: colors.$gray-300;
+	--wp-editor-canvas-background: #{colors.$gray-300};
 	@include mixins.admin-scheme(#007cba);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Fixes a regression caused by #72037

The background color for the editor canvas was the literal string `colors . $gray-300` instead of the actual color value, so the background appears white on `trunk` when it should be gray.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

According to ChatGPT: Sass does not interpolate variables in custom property values automatically when they are namespaced, so it outputs the value literally, rather than looking up `colors.$gray-300`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Wrap in `#{}` so that Sass knows to interpolate the variable

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Open up the site editor and go into zoom out mode. The background should be gray
* Go to edit a header template part, and the background should be gray

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

<img width="1500" height="1148" alt="image" src="https://github.com/user-attachments/assets/6ef00405-6fb9-489e-8dae-e1d8dcbc3a62" />

### After

<img width="1500" height="1221" alt="image" src="https://github.com/user-attachments/assets/8edf68e1-2426-4966-b0b1-160fbeecd16a" />
