### PR TITLE
Categories block: Improve and harden JavaScript used when displayed as dropdown

### DIFF
--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -112,7 +112,7 @@ function build_dropdown_script_block_core_categories( $dropdown_id ) {
 				location.href = url.href;
 			}
 		} );
-	})( <?php echo wp_json_encode( $exports, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?> );
+	} )( <?php echo wp_json_encode( $exports, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?> );
 	</script>
 	<?php
 	return wp_get_inline_script_tag(

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -115,7 +115,10 @@ function build_dropdown_script_block_core_categories( $dropdown_id ) {
 	})( <?php echo wp_json_encode( $exports, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?> );
 	</script>
 	<?php
-	return wp_get_inline_script_tag( str_replace( array( '<script>', '</script>' ), '', ob_get_clean() ) );
+	return wp_get_inline_script_tag(
+		trim( str_replace( array( '<script>', '</script>' ), '', ob_get_clean() ) ) .
+		"\n//# sourceURL=" . rawurlencode( __FUNCTION__ )
+	);
 }
 
 /**

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -99,17 +99,20 @@ function render_block_core_categories( $attributes, $content, $block ) {
  */
 function build_dropdown_script_block_core_categories( $dropdown_id ) {
 	ob_start();
+
+	$exports = array( $dropdown_id, home_url() );
 	?>
 	<script>
-	( function() {
-		var dropdown = document.getElementById( '<?php echo esc_js( $dropdown_id ); ?>' );
-		function onCatChange() {
-			if ( dropdown.options[ dropdown.selectedIndex ].value !== -1 ) {
-				location.href = "<?php echo esc_url( home_url() ); ?>/?" + dropdown.name + '=' + dropdown.options[ dropdown.selectedIndex ].value;
+	( ( [ dropdownId, homeUrl ] ) => {
+		document.getElementById( dropdownId ).addEventListener( 'change', ( event ) => {
+			const dropdown = /** @type {HTMLSelectElement} */ ( event.target );
+			if ( dropdown.selectedIndex >= 0 && dropdown.options[ dropdown.selectedIndex ].value !== '-1' ) {
+				const url = new URL( homeUrl );
+				url.searchParams.set( dropdown.name, dropdown.options[ dropdown.selectedIndex ].value );
+				location.href = url.href;
 			}
-		}
-		dropdown.onchange = onCatChange;
-	})();
+		} );
+	})( <?php echo wp_json_encode( $exports, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?> );
 	</script>
 	<?php
 	return wp_get_inline_script_tag( str_replace( array( '<script>', '</script>' ), '', ob_get_clean() ) );

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -106,9 +106,9 @@ function build_dropdown_script_block_core_categories( $dropdown_id ) {
 	( ( [ dropdownId, homeUrl ] ) => {
 		document.getElementById( dropdownId ).addEventListener( 'change', ( event ) => {
 			const dropdown = /** @type {HTMLSelectElement} */ ( event.target );
-			if ( dropdown.selectedIndex >= 0 && dropdown.options[ dropdown.selectedIndex ].value !== '-1' ) {
+			if ( dropdown.value && dropdown.value !== '-1' ) {
 				const url = new URL( homeUrl );
-				url.searchParams.set( dropdown.name, dropdown.options[ dropdown.selectedIndex ].value );
+				url.searchParams.set( dropdown.name, dropdown.value );
 				location.href = url.href;
 			}
 		} );


### PR DESCRIPTION
This is upstream the relevant change from https://github.com/WordPress/wordpress-develop/pull/9955 for Core-63887. It adds a new `sourceURL` comment to the end of the JS in the Categories block when the dropdown option is enabled. This allows for the source of the inline JS to be exposed in places like console errors or when running code coverage in Chrome DevTools:

<img width="1096" height="62" alt="image" src="https://github.com/user-attachments/assets/75c4a32a-b394-49d0-b9a3-9a4afdac070a" />

This also fixes/improves the JS logic in the following ways:

* Data from PHP is exported to JS via `json_encode()` with the proper flags per Core-63851.
* `addEventListener()` is used instead of assigning a function to the dropdown's `onchange` attribute.
* The previous condition `dropdown.options[ dropdown.selectedIndex ].value !== -1` would never evaluate to true since `value` is a string. The first option has the value of `"-1"`. So this is now accounted for.
* The [`HTMLSelectElement.value` property](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement/value) is used instead of `HTMLSelectElement.selectedIndex` plus `HTMLSelectElement.options`. Note that if `selectedIndex` was set to `-1` then `value` is an empty string, so the condition now checks for the value being non-falsy and not "-1" (the value of the first option). This property is in [Baseline, Widely available since 2015](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement/value#browser_compatibility).
* The URL that the user is being redirected to is now constructed via the [`URL` API](https://caniuse.com/url), ensuring that any existing query parameters that may be present when `home_url()` are retained (e.g. parameters for localized sites).