### PR TITLE
Breadcrumbs: Add `post with terms` breadcrumbs support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -87,13 +87,13 @@ Reuse this design across your site. ([Source](https://github.com/WordPress/guten
 
 ## Breadcrumbs
 
-Display a breadcrumb trail only for Pages, or for hierarchical post types. The block is useful to insert in the Pages template. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/breadcrumbs))
+Display a breadcrumb trail for hierarchical post types or based on taxonomy terms. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/breadcrumbs))
 
 -	**Name:** core/breadcrumbs
 -	**Experimental:** true
 -	**Category:** theme
 -	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** separator, showHomeLink
+-	**Attributes:** separator, showHomeLink, type
 
 ## Button
 

--- a/packages/block-library/src/breadcrumbs/block.json
+++ b/packages/block-library/src/breadcrumbs/block.json
@@ -5,9 +5,14 @@
 	"title": "Breadcrumbs",
 	"__experimental": true,
 	"category": "theme",
-	"description": "Display a breadcrumb trail only for Pages, or for hierarchical post types. The block is useful to insert in the Pages template.",
+	"description": "Display a breadcrumb trail for hierarchical post types or based on taxonomy terms.",
 	"textdomain": "default",
 	"attributes": {
+		"type": {
+			"type": "string",
+			"default": "auto",
+			"enum": [ "auto", "terms", "hierarchical" ]
+		},
 		"separator": {
 			"type": "string",
 			"default": "/"
@@ -17,7 +22,7 @@
 			"default": true
 		}
 	},
-	"usesContext": [ "postId", "postType" ],
+	"usesContext": [ "postId", "postType", "templateSlug" ],
 	"supports": {
 		"html": false,
 		"spacing": {

--- a/packages/block-library/src/breadcrumbs/block.json
+++ b/packages/block-library/src/breadcrumbs/block.json
@@ -11,7 +11,7 @@
 		"type": {
 			"type": "string",
 			"default": "auto",
-			"enum": [ "auto", "terms", "hierarchical" ]
+			"enum": [ "auto", "postWithTerms", "postWithAncestors" ]
 		},
 		"separator": {
 			"type": "string",

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -29,13 +29,13 @@ const BREADCRUMB_TYPES = {
 			'Try to automatically determine the best type of breadcrumb for the template.'
 		),
 	},
-	hierarchical: {
+	postWithAncestors: {
 		help: __(
 			'Shows breadcrumbs based on post hierarchy. Only works for hierarchical post types.'
 		),
 		placeholderItems: [ __( 'Ancestor' ), __( 'Parent' ) ],
 	},
-	terms: {
+	postWithTerms: {
 		help: __(
 			'Shows breadcrumbs based on taxonomy terms. Chooses the first taxonomy with assigned terms and includes ancestors if the taxonomy is hierarchical.'
 		),
@@ -89,13 +89,16 @@ export default function BreadcrumbEdit( {
 	} );
 	// TODO: this should be handled better when we add more types.
 	let breadcrumbsType;
-	const isSpecificSupportedTypeSet = [ 'hierarchical', 'terms' ].includes(
-		type
-	);
+	const isSpecificSupportedTypeSet = [
+		'postWithAncestors',
+		'postWithTerms',
+	].includes( type );
 	if ( isSpecificSupportedTypeSet ) {
 		breadcrumbsType = type;
 	} else {
-		breadcrumbsType = isPostTypeHierarchical ? 'hierarchical' : 'terms';
+		breadcrumbsType = isPostTypeHierarchical
+			? 'postWithAncestors'
+			: 'postWithTerms';
 	}
 	let placeholder = null;
 	// This is fragile because this block is server side rendered and we'll have to
@@ -107,8 +110,9 @@ export default function BreadcrumbEdit( {
 		// This is needed because when we are showing the template in post editor we
 		// want to show the real breadcrumbs if we have the post type.
 		( templateSlug && ! postType ) ||
-		( breadcrumbsType === 'hierarchical' && ! isPostTypeHierarchical ) ||
-		( breadcrumbsType === 'terms' && ! hasTermsAssigned );
+		( breadcrumbsType === 'postWithAncestors' &&
+			! isPostTypeHierarchical ) ||
+		( breadcrumbsType === 'postWithTerms' && ! hasTermsAssigned );
 	if ( showPlaceholder ) {
 		const placeholderItems = [
 			showHomeLink && __( 'Home' ),
@@ -177,12 +181,12 @@ export default function BreadcrumbEdit( {
 									value: 'auto',
 								},
 								{
-									label: __( 'Hierarchical' ),
-									value: 'hierarchical',
+									label: __( 'Post with ancestors' ),
+									value: 'postWithAncestors',
 								},
 								{
-									label: __( 'Terms' ),
-									value: 'terms',
+									label: __( 'Post with terms' ),
+									value: 'postWithTerms',
 								},
 							] }
 							help={ BREADCRUMB_TYPES[ type ].help }

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -12,7 +12,7 @@ import {
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { RawHTML } from '@wordpress/element';
+import { useEffect, useState, RawHTML } from '@wordpress/element';
 import { useServerSideRender } from '@wordpress/server-side-render';
 
 /**
@@ -49,12 +49,12 @@ export default function BreadcrumbEdit( {
 	context: { postId, postType, templateSlug },
 } ) {
 	const { separator, showHomeLink, type } = attributes;
-	const { isPostTypeHierarchical, hasTermsAssigned } = useSelect(
+	const { post, isPostTypeHierarchical, hasTermsAssigned } = useSelect(
 		( select ) => {
 			if ( ! postType ) {
 				return {};
 			}
-			const post = select( coreStore ).getEntityRecord(
+			const _post = select( coreStore ).getEntityRecord(
 				'postType',
 				postType,
 				postId
@@ -64,28 +64,44 @@ export default function BreadcrumbEdit( {
 				per_page: -1,
 			} );
 			return {
+				post: _post,
 				isPostTypeHierarchical:
 					select( coreStore ).getPostType( postType )?.hierarchical,
 				hasTermsAssigned:
-					post &&
+					_post &&
 					( taxonomies || [] )
 						.filter(
 							( { visibility } ) => visibility?.publicly_queryable
 						)
 						.some( ( taxonomy ) => {
-							return !! post[ taxonomy.rest_base ]?.length;
+							return !! _post[ taxonomy.rest_base ]?.length;
 						} ),
 			};
 		},
 		[ postType, postId ]
 	);
+
+	// Counter used to cache-bust `useServerSideRender`
+	//
+	// This is a catch-all signal to re-render the block when a post's title,
+	// parent ID, or terms change.
+	//
+	// This is fundamentally imperfect, because there are other entities which
+	// could change in the meantime (the titles of ancestor posts, or the
+	// labels of taxonomy terms), hence the choice to re-render systematically
+	// upon saving.
+	const [ invalidationKey, setInvalidationKey ] = useState( 0 );
+	useEffect( () => {
+		setInvalidationKey( ( c ) => c + 1 );
+	}, [ post ] );
+
 	const blockProps = useBlockProps();
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const { content } = useServerSideRender( {
 		attributes,
 		skipBlockSupportAttributes: true,
 		block: 'core/breadcrumbs',
-		urlQueryArgs: { post_id: postId },
+		urlQueryArgs: { post_id: postId, invalidationKey },
 	} );
 	// TODO: this should be handled better when we add more types.
 	let breadcrumbsType;

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -26,7 +26,7 @@ const typeDefaultValue = 'auto';
 const BREADCRUMB_TYPES = {
 	auto: {
 		help: __(
-			'Uses heuristics to automatically choose between hierarchical or terms based on the post type.'
+			'Try to automatically determine the best type of breadcrumb for the template.'
 		),
 	},
 	hierarchical: {

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -6,6 +6,7 @@ import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
 	ToggleControl,
 	TextControl,
+	SelectControl,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
@@ -18,22 +19,65 @@ import { useServerSideRender } from '@wordpress/server-side-render';
  * Internal dependencies
  */
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+
 const separatorDefaultValue = '/';
+const typeDefaultValue = 'auto';
+
+const BREADCRUMB_TYPES = {
+	auto: {
+		help: __(
+			'Uses heuristics to automatically choose between hierarchical or terms based on the post type.'
+		),
+	},
+	hierarchical: {
+		help: __(
+			'Shows breadcrumbs based on post hierarchy. Only works for hierarchical post types.'
+		),
+		placeholderItems: [ __( 'Ancestor' ), __( 'Parent' ) ],
+	},
+	terms: {
+		help: __(
+			'Shows breadcrumbs based on taxonomy terms. Chooses the first taxonomy with assigned terms and includes ancestors if the taxonomy is hierarchical.'
+		),
+		placeholderItems: [ __( 'Category' ) ],
+	},
+};
 
 export default function BreadcrumbEdit( {
 	attributes,
 	setAttributes,
-	context: { postId, postType },
+	context: { postId, postType, templateSlug },
 } ) {
-	const { separator, showHomeLink } = attributes;
-	const isPostTypeHierarchical = useSelect(
+	const { separator, showHomeLink, type } = attributes;
+	const { isPostTypeHierarchical, hasTermsAssigned } = useSelect(
 		( select ) => {
 			if ( ! postType ) {
-				return null;
+				return {};
 			}
-			return select( coreStore ).getPostType( postType )?.hierarchical;
+			const post = select( coreStore ).getEntityRecord(
+				'postType',
+				postType,
+				postId
+			);
+			const taxonomies = select( coreStore ).getTaxonomies( {
+				type: postType,
+				per_page: -1,
+			} );
+			return {
+				isPostTypeHierarchical:
+					select( coreStore ).getPostType( postType )?.hierarchical,
+				hasTermsAssigned:
+					post &&
+					( taxonomies || [] )
+						.filter(
+							( { visibility } ) => visibility?.publicly_queryable
+						)
+						.some( ( taxonomy ) => {
+							return !! post[ taxonomy.rest_base ]?.length;
+						} ),
+			};
 		},
-		[ postType ]
+		[ postType, postId ]
 	);
 	const blockProps = useBlockProps();
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
@@ -43,15 +87,35 @@ export default function BreadcrumbEdit( {
 		block: 'core/breadcrumbs',
 		urlQueryArgs: { post_id: postId },
 	} );
+	// TODO: this should be handled better when we add more types.
+	let breadcrumbsType;
+	const isSpecificSupportedTypeSet = [ 'hierarchical', 'terms' ].includes(
+		type
+	);
+	if ( isSpecificSupportedTypeSet ) {
+		breadcrumbsType = type;
+	} else {
+		breadcrumbsType = isPostTypeHierarchical ? 'hierarchical' : 'terms';
+	}
 	let placeholder = null;
-	// If no post context or the post type is not hierarchical, show placeholder.
 	// This is fragile because this block is server side rendered and we'll have to
 	// update the placeholder html if the server side rendering output changes.
-	if ( ! postId || ! postType || ! isPostTypeHierarchical ) {
+	const showPlaceholder =
+		! postId ||
+		! postType ||
+		// When `templateSlug` is set only show placeholder if the post type is not.
+		// This is needed because when we are showing the template in post editor we
+		// want to show the real breadcrumbs if we have the post type.
+		( templateSlug && ! postType ) ||
+		( breadcrumbsType === 'hierarchical' && ! isPostTypeHierarchical ) ||
+		( breadcrumbsType === 'terms' && ! hasTermsAssigned );
+	if ( showPlaceholder ) {
 		const placeholderItems = [
 			showHomeLink && __( 'Home' ),
-			__( 'Ancestor' ),
-			__( 'Parent' ),
+			// For now if we are adding this in a template show a generic placeholder.
+			...( templateSlug && ! isSpecificSupportedTypeSet
+				? [ __( 'Page' ) ]
+				: BREADCRUMB_TYPES[ breadcrumbsType ].placeholderItems ),
 		].filter( Boolean );
 		placeholder = (
 			<nav
@@ -84,10 +148,46 @@ export default function BreadcrumbEdit( {
 						setAttributes( {
 							separator: separatorDefaultValue,
 							showHomeLink: true,
+							type: typeDefaultValue,
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
 				>
+					<ToolsPanelItem
+						label={ __( 'Type' ) }
+						isShownByDefault
+						hasValue={ () => type !== typeDefaultValue }
+						onDeselect={ () =>
+							setAttributes( {
+								type: typeDefaultValue,
+							} )
+						}
+					>
+						<SelectControl
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+							label={ __( 'Type' ) }
+							value={ type }
+							onChange={ ( value ) =>
+								setAttributes( { type: value } )
+							}
+							options={ [
+								{
+									label: __( 'Auto' ),
+									value: 'auto',
+								},
+								{
+									label: __( 'Hierarchical' ),
+									value: 'hierarchical',
+								},
+								{
+									label: __( 'Terms' ),
+									value: 'terms',
+								},
+							] }
+							help={ BREADCRUMB_TYPES[ type ].help }
+						/>
+					</ToolsPanelItem>
 					<ToolsPanelItem
 						label={ __( 'Show home link' ) }
 						isShownByDefault
@@ -138,7 +238,11 @@ export default function BreadcrumbEdit( {
 				</ToolsPanel>
 			</InspectorControls>
 			<div { ...blockProps }>
-				{ placeholder || <RawHTML inert="true">{ content }</RawHTML> }
+				{ showPlaceholder ? (
+					placeholder
+				) : (
+					<RawHTML inert="true">{ content }</RawHTML>
+				) }
 			</div>
 		</>
 	);

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -9,6 +9,7 @@ import {
 	SelectControl,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	Spinner,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -49,37 +50,49 @@ export default function BreadcrumbEdit( {
 	context: { postId, postType, templateSlug },
 } ) {
 	const { separator, showHomeLink, type } = attributes;
-	const { post, isPostTypeHierarchical, hasTermsAssigned } = useSelect(
-		( select ) => {
-			if ( ! postType ) {
-				return {};
-			}
-			const _post = select( coreStore ).getEntityRecord(
-				'postType',
-				postType,
-				postId
-			);
-			const taxonomies = select( coreStore ).getTaxonomies( {
-				type: postType,
-				per_page: -1,
-			} );
-			return {
-				post: _post,
-				isPostTypeHierarchical:
-					select( coreStore ).getPostType( postType )?.hierarchical,
-				hasTermsAssigned:
-					_post &&
-					( taxonomies || [] )
-						.filter(
-							( { visibility } ) => visibility?.publicly_queryable
-						)
-						.some( ( taxonomy ) => {
-							return !! _post[ taxonomy.rest_base ]?.length;
-						} ),
-			};
-		},
-		[ postType, postId ]
-	);
+	const { post, isPostTypeHierarchical, hasTermsAssigned, isLoading } =
+		useSelect(
+			( select ) => {
+				if ( ! postType ) {
+					return {};
+				}
+				const _post = select( coreStore ).getEntityRecord(
+					'postType',
+					postType,
+					postId
+				);
+				const postTypeObject =
+					select( coreStore ).getPostType( postType );
+				const postTypeHasTaxonomies =
+					postTypeObject && postTypeObject.taxonomies.length;
+				let taxonomies;
+				if ( postTypeHasTaxonomies ) {
+					taxonomies = select( coreStore ).getTaxonomies( {
+						type: postType,
+						per_page: -1,
+					} );
+				}
+				return {
+					post: _post,
+					isPostTypeHierarchical: postTypeObject?.hierarchical,
+					hasTermsAssigned:
+						_post &&
+						( taxonomies || [] )
+							.filter(
+								( { visibility } ) =>
+									visibility?.publicly_queryable
+							)
+							.some( ( taxonomy ) => {
+								return !! _post[ taxonomy.rest_base ]?.length;
+							} ),
+					isLoading:
+						! _post ||
+						! postTypeObject ||
+						( postTypeHasTaxonomies && ! taxonomies ),
+				};
+			},
+			[ postType, postId ]
+		);
 
 	// Counter used to cache-bust `useServerSideRender`
 	//
@@ -103,6 +116,14 @@ export default function BreadcrumbEdit( {
 		block: 'core/breadcrumbs',
 		urlQueryArgs: { post_id: postId, invalidationKey },
 	} );
+
+	if ( isLoading ) {
+		return (
+			<div { ...blockProps }>
+				<Spinner />
+			</div>
+		);
+	}
 	// TODO: this should be handled better when we add more types.
 	let breadcrumbsType;
 	const isSpecificSupportedTypeSet = [

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -24,16 +24,14 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 	$post_id   = $block->context['postId'];
 	$post_type = $block->context['postType'];
 
-	// Only render for hierarchical post types.
-	if ( ! is_post_type_hierarchical( $post_type ) ) {
-		return '';
-	}
-
 	$post = get_post( $post_id );
-	if ( ! $post ) {
+	// Exclude breadcrumbs from special contexts like archives, search, 404, etc.
+	// until they are explicitly supported.
+	if ( ! $post || is_archive() || is_search() || is_404() || is_home() ) {
 		return '';
 	}
 
+	$type             = $attributes['type'];
 	$breadcrumb_items = array();
 	if ( $attributes['showHomeLink'] ) {
 		$breadcrumb_items[] = sprintf(
@@ -43,16 +41,14 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 		);
 	}
 
-	$ancestors = get_post_ancestors( $post_id );
-	$ancestors = array_reverse( $ancestors );
-
-	foreach ( $ancestors as $ancestor_id ) {
-		$breadcrumb_items[] = sprintf(
-			'<a href="%s">%s</a>',
-			esc_url( get_permalink( $ancestor_id ) ),
-			get_the_title( $ancestor_id )
-		);
-	}
+	// Map breadcrumb types to their corresponding functions.
+	$breadcrumb_type_map = array(
+		'hierarchical' => 'get_hierarchical_post_type_breadcrumbs',
+		'terms'        => 'get_terms_breadcrumbs',
+	);
+	// If `type` is not set to a specific breadcrumb type, determine it based on the block's default heuristics.
+	$breadcrumbs_type = isset( $breadcrumb_type_map[ $type ] ) ? $type : get_breadcrumbs_type( $post_type );
+	$breadcrumb_items = array_merge( $breadcrumb_items, call_user_func( $breadcrumb_type_map[ $breadcrumbs_type ], $post_id, $post_type ) );
 
 	// Add current post title (not linked).
 	$breadcrumb_items[] = sprintf( '<span aria-current="page">%s</span>', get_the_title( $post ) );
@@ -78,6 +74,112 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 	);
 
 	return $breadcrumb_html;
+}
+
+/**
+ * Determines the breadcrumb type based on the block's default heuristics.
+ *
+ * @since 6.9.0
+ *
+ * @param string $post_type The post type name.
+ *
+ * @return string The breadcrumb type..
+ */
+function get_breadcrumbs_type( $post_type ) {
+	return is_post_type_hierarchical( $post_type ) ? 'hierarchical' : 'terms';
+}
+
+/**
+ * Generates breadcrumb items from hierarchical post type ancestors.
+ *
+ * @since 6.9.0
+ *
+ * @param int    $post_id   The post ID.
+ * @param string $post_type The post type name.
+ *
+ * @return array Array of breadcrumb HTML items.
+ */
+function get_hierarchical_post_type_breadcrumbs( $post_id, $post_type ) {
+	$breadcrumb_items = array();
+	$ancestors = get_post_ancestors( $post_id );
+	$ancestors = array_reverse( $ancestors );
+
+	foreach ( $ancestors as $ancestor_id ) {
+		$breadcrumb_items[] = sprintf(
+			'<a href="%s">%s</a>',
+			esc_url( get_permalink( $ancestor_id ) ),
+			esc_html( get_the_title( $ancestor_id ) )
+		);
+	}
+	return $breadcrumb_items;
+}
+
+
+/**
+ * Generates breadcrumb items from taxonomy terms.
+ *
+ * Finds the first publicly queryable taxonomy with terms assigned to the post
+ * and generates breadcrumb links, including hierarchical term ancestors if applicable.
+ *
+ * @since 6.9.0
+ *
+ * @param int    $post_id   The post ID.
+ * @param string $post_type The post type name.
+ *
+ * @return array Array of breadcrumb HTML items.
+ */
+function get_terms_breadcrumbs( $post_id, $post_type ) {
+	$breadcrumb_items = array();
+	// Get public taxonomies for this post type.
+	$taxonomies = wp_filter_object_list(
+		get_object_taxonomies( $post_type, 'objects' ),
+		array(
+			'publicly_queryable' => true,
+			'show_in_rest'       => true,
+		)
+	);
+
+	if ( empty( $taxonomies ) ) {
+		return array();
+	}
+
+	// Find the first taxonomy that has terms assigned to this post.
+	$taxonomy_name = null;
+	$terms         = array();
+	foreach ( $taxonomies as $taxonomy ) {
+		$post_terms = get_the_terms( $post_id, $taxonomy->name );
+		if ( ! empty( $post_terms ) && ! is_wp_error( $post_terms ) ) {
+			$taxonomy_name = $taxonomy->name;
+			$terms         = $post_terms;
+			break;
+		}
+	}
+
+	if ( ! empty( $terms ) ) {
+		// Use the first term (if multiple are assigned).
+		$term = reset( $terms );
+		// Check if taxonomy is hierarchical also add ancestor term links
+		if ( is_taxonomy_hierarchical( $taxonomy_name ) ) {
+			$term_ancestors = get_ancestors( $term->term_id, $taxonomy_name, 'taxonomy' );
+			$term_ancestors = array_reverse( $term_ancestors );
+			foreach ( $term_ancestors as $ancestor_id ) {
+				$ancestor_term = get_term( $ancestor_id, $taxonomy_name );
+				if ( $ancestor_term && ! is_wp_error( $ancestor_term ) ) {
+					$breadcrumb_items[] = sprintf(
+						'<a href="%s">%s</a>',
+						esc_url( get_term_link( $ancestor_term ) ),
+						esc_html( $ancestor_term->name )
+					);
+				}
+			}
+		}
+		$breadcrumb_items[] = sprintf(
+			'<a href="%s">%s</a>',
+			esc_url( get_term_link( $term ) ),
+			esc_html( $term->name )
+		);
+	}
+	return $breadcrumb_items;
 }
 
 /**

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -108,7 +108,7 @@ function block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id
 		$breadcrumb_items[] = sprintf(
 			'<a href="%s">%s</a>',
 			esc_url( get_permalink( $ancestor_id ) ),
-			esc_html( get_the_title( $ancestor_id ) )
+			get_the_title( $ancestor_id )
 		);
 	}
 	return $breadcrumb_items;

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -27,7 +27,7 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 	$post = get_post( $post_id );
 	// Exclude breadcrumbs from special contexts like archives, search, 404, etc.
 	// until they are explicitly supported.
-	if ( ! $post || is_archive() || is_search() || is_404() || is_home() ) {
+	if ( ! $post || is_archive() || is_search() || is_404() || is_home() || is_front_page() ) {
 		return '';
 	}
 

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -40,16 +40,14 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 			esc_html__( 'Home' )
 		);
 	}
-
-	// Map breadcrumb types to their corresponding functions.
-	$breadcrumb_type_map = array(
-		'hierarchical' => 'get_hierarchical_post_type_breadcrumbs',
-		'terms'        => 'get_terms_breadcrumbs',
-	);
+	$supported_types = array( 'hierarchical', 'terms' );
 	// If `type` is not set to a specific breadcrumb type, determine it based on the block's default heuristics.
-	$breadcrumbs_type = isset( $breadcrumb_type_map[ $type ] ) ? $type : get_breadcrumbs_type( $post_type );
-	$breadcrumb_items = array_merge( $breadcrumb_items, call_user_func( $breadcrumb_type_map[ $breadcrumbs_type ], $post_id, $post_type ) );
-
+	$breadcrumbs_type = in_array( $type, $supported_types, true ) ? $type : block_core_breadcrumbs_get_breadcrumbs_type( $post_type );
+	if ( 'hierarchical' === $breadcrumbs_type ) {
+		$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id ) );
+	} else {
+		$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) );
+	}
 	// Add current post title (not linked).
 	$breadcrumb_items[] = sprintf( '<span aria-current="page">%s</span>', get_the_title( $post ) );
 	$wrapper_attributes = get_block_wrapper_attributes(
@@ -85,7 +83,7 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
  *
  * @return string The breadcrumb type..
  */
-function get_breadcrumbs_type( $post_type ) {
+function block_core_breadcrumbs_get_breadcrumbs_type( $post_type ) {
 	return is_post_type_hierarchical( $post_type ) ? 'hierarchical' : 'terms';
 }
 
@@ -95,14 +93,13 @@ function get_breadcrumbs_type( $post_type ) {
  * @since 6.9.0
  *
  * @param int    $post_id   The post ID.
- * @param string $post_type The post type name.
  *
  * @return array Array of breadcrumb HTML items.
  */
-function get_hierarchical_post_type_breadcrumbs( $post_id, $post_type ) {
+function block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id ) {
 	$breadcrumb_items = array();
-	$ancestors = get_post_ancestors( $post_id );
-	$ancestors = array_reverse( $ancestors );
+	$ancestors        = get_post_ancestors( $post_id );
+	$ancestors        = array_reverse( $ancestors );
 
 	foreach ( $ancestors as $ancestor_id ) {
 		$breadcrumb_items[] = sprintf(
@@ -128,7 +125,7 @@ function get_hierarchical_post_type_breadcrumbs( $post_id, $post_type ) {
  *
  * @return array Array of breadcrumb HTML items.
  */
-function get_terms_breadcrumbs( $post_id, $post_type ) {
+function block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) {
 	$breadcrumb_items = array();
 	// Get public taxonomies for this post type.
 	$taxonomies = wp_filter_object_list(

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -17,6 +17,11 @@
  * @return string Returns the post breadcrumb for hierarchical post types.
  */
 function render_block_core_breadcrumbs( $attributes, $content, $block ) {
+	// Exclude breadcrumbs from special contexts like archives, search, 404, etc.
+	// until they are explicitly supported.
+	if ( is_archive() || is_search() || is_404() || is_home() || is_front_page() ) {
+		return '';
+	}
 	if ( ! isset( $block->context['postId'] ) || ! isset( $block->context['postType'] ) ) {
 		return '';
 	}
@@ -25,9 +30,7 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 	$post_type = $block->context['postType'];
 
 	$post = get_post( $post_id );
-	// Exclude breadcrumbs from special contexts like archives, search, 404, etc.
-	// until they are explicitly supported.
-	if ( ! $post || is_archive() || is_search() || is_404() || is_home() || is_front_page() ) {
+	if ( ! $post ) {
 		return '';
 	}
 
@@ -40,10 +43,10 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 			esc_html__( 'Home' )
 		);
 	}
-	$supported_types = array( 'hierarchical', 'terms' );
+	$supported_types = array( 'postWithAncestors', 'postWithTerms' );
 	// If `type` is not set to a specific breadcrumb type, determine it based on the block's default heuristics.
 	$breadcrumbs_type = in_array( $type, $supported_types, true ) ? $type : block_core_breadcrumbs_get_breadcrumbs_type( $post_type );
-	if ( 'hierarchical' === $breadcrumbs_type ) {
+	if ( 'postWithAncestors' === $breadcrumbs_type ) {
 		$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id ) );
 	} else {
 		$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) );
@@ -81,10 +84,10 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
  *
  * @param string $post_type The post type name.
  *
- * @return string The breadcrumb type..
+ * @return string The breadcrumb type.
  */
 function block_core_breadcrumbs_get_breadcrumbs_type( $post_type ) {
-	return is_post_type_hierarchical( $post_type ) ? 'hierarchical' : 'terms';
+	return is_post_type_hierarchical( $post_type ) ? 'postWithAncestors' : 'postWithTerms';
 }
 
 /**

--- a/packages/editor/src/components/provider/use-hide-blocks-from-inserter.js
+++ b/packages/editor/src/components/provider/use-hide-blocks-from-inserter.js
@@ -3,13 +3,11 @@
  */
 import { useEffect } from '@wordpress/element';
 import { addFilter, removeFilter } from '@wordpress/hooks';
-import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
 
 // These post types are "structural" block lists.
-// We should be allowed to use the post content,
-// template parts and breadcrumbs blocks within them.
-const POST_TYPES_ALLOWING_POST_CONTENT_TEMPLATE_PART_BREADCRUMBS = [
+// We should be allowed to use
+// the post content and template parts blocks within them.
+const POST_TYPES_ALLOWING_POST_CONTENT_TEMPLATE_PART = [
 	'wp_block',
 	'wp_template',
 	'wp_template_part',
@@ -23,10 +21,6 @@ const POST_TYPES_ALLOWING_POST_CONTENT_TEMPLATE_PART_BREADCRUMBS = [
  * @param {string} mode     Rendering mode
  */
 export function useHideBlocksFromInserter( postType, mode ) {
-	const isHierarchicalPostType = useSelect(
-		( select ) => select( coreStore ).getPostType( postType )?.hierarchical,
-		[ postType ]
-	);
 	useEffect( () => {
 		/*
 		 * Prevent adding template part in the editor.
@@ -36,7 +30,7 @@ export function useHideBlocksFromInserter( postType, mode ) {
 			'removeTemplatePartsFromInserter',
 			( canInsert, blockType ) => {
 				if (
-					! POST_TYPES_ALLOWING_POST_CONTENT_TEMPLATE_PART_BREADCRUMBS.includes(
+					! POST_TYPES_ALLOWING_POST_CONTENT_TEMPLATE_PART.includes(
 						postType
 					) &&
 					blockType.name === 'core/template-part' &&
@@ -61,7 +55,7 @@ export function useHideBlocksFromInserter( postType, mode ) {
 				{ getBlockParentsByBlockName }
 			) => {
 				if (
-					! POST_TYPES_ALLOWING_POST_CONTENT_TEMPLATE_PART_BREADCRUMBS.includes(
+					! POST_TYPES_ALLOWING_POST_CONTENT_TEMPLATE_PART.includes(
 						postType
 					) &&
 					blockType.name === 'core/post-content'
@@ -70,27 +64,6 @@ export function useHideBlocksFromInserter( postType, mode ) {
 						getBlockParentsByBlockName( rootClientId, 'core/query' )
 							.length > 0
 					);
-				}
-				return canInsert;
-			}
-		);
-
-		/*
-		 * Prevent adding breadcrumbs block to non-hierarchical post types.
-		 */
-		addFilter(
-			'blockEditor.__unstableCanInsertBlockType',
-			'removeBreadcrumbsFromInserter',
-			( canInsert, blockType ) => {
-				if (
-					! POST_TYPES_ALLOWING_POST_CONTENT_TEMPLATE_PART_BREADCRUMBS.includes(
-						postType
-					) &&
-					! isHierarchicalPostType &&
-					blockType.name === 'core/breadcrumbs' &&
-					mode === 'post-only'
-				) {
-					return false;
 				}
 				return canInsert;
 			}
@@ -105,10 +78,6 @@ export function useHideBlocksFromInserter( postType, mode ) {
 				'blockEditor.__unstableCanInsertBlockType',
 				'removePostContentFromInserter'
 			);
-			removeFilter(
-				'blockEditor.__unstableCanInsertBlockType',
-				'removeBreadcrumbsFromInserter'
-			);
 		};
-	}, [ postType, isHierarchicalPostType, mode ] );
+	}, [ postType, mode ] );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is a follow up of: https://github.com/WordPress/gutenberg/pull/71793 and adds `terms breadcrumbs` support to Breadcrumbs block.

The block has a new `type` attribute that defaults to `auto` and the block use sensible defaults to handle different use cases. For now it only supports the `postWithAncestors` type for post types that support this and `postWithTerms` for posts with taxonomies and assigned terms.

Users can change explicitly the `type` in inspector controls and a different `help` message is shown.

In front-end if the type of breadcrumbs is not supported yet, it will not render anything (like `search, archive, etc..).

In the editor there are cases where we show a placeholder using similar heuristics with back end. If we add this block in a template in site editor, we use a generic placeholder for now.
If we are showing the template in post editor and the block exists in that template, it tries to use the proper content that will be the same with the front end.

### Notes
Some breadcrumb types will need some extra config to work better. For example `postWithTerms` breadcrumbs would work best if the user could choose the `main` taxonomy for the breadcrumbs (in case multiple taxonomies exist) I think it's better to handle that in a follow up to reduce the scope of this PR. Currently it chooses the first taxonomy found with terms assigned.

## Testing Instructions
1. Insert the block in different post types which are either hierarchical or have taxonomies and terms and test its behavior. When making changes also check the front end for the expected results
2. In post editor also check how the block behaves when we show the template (from page inspector controls in `Template` field) and that template includes the Breadcrumbs block
3. In site editor in various templates.


## Screenshots or screencast <!-- if applicable -->
In the below recording I'm showing:
1. `Page` editing in post editor with `auto` and the front-end.
4. Same `page` in post editor by explicitly changing the `type` to `postWithTerms` and the front-end
5. `Post` editing in post editor with terms and the front-end
6. `Template` editing in site editor


https://github.com/user-attachments/assets/4470fd57-5be3-4eb8-a411-021c37d3daf0


