### PR TITLE
Hooks Package: Build using esbuild

### DIFF
--- a/bin/packages/build-worker-esbuild.js
+++ b/bin/packages/build-worker-esbuild.js
@@ -1,0 +1,121 @@
+/**
+ * External dependencies
+ */
+const { promisify } = require( 'util' );
+const fs = require( 'fs' );
+const path = require( 'path' );
+const esbuild = require( 'esbuild' );
+const makeDir = require( 'make-dir' );
+
+/**
+ * Path to packages directory.
+ *
+ * @type {string}
+ */
+const PACKAGES_DIR = path
+	.resolve( __dirname, '../../packages' )
+	.replace( /\\/g, '/' );
+
+/**
+ * Promisified fs.writeFile.
+ *
+ * @type {Function}
+ */
+const writeFile = promisify( fs.writeFile );
+
+/**
+ * Get the package name for a specified file
+ *
+ * @param {string} file File name.
+ *
+ * @return {string} Package name.
+ */
+function getPackageName( file ) {
+	return path.relative( PACKAGES_DIR, file ).split( path.sep )[ 0 ];
+}
+
+/**
+ * Get Build Path for a specified file.
+ *
+ * @param {string} file        File to build.
+ * @param {string} buildFolder Output folder.
+ *
+ * @return {string} Build path.
+ */
+function getBuildPath( file, buildFolder ) {
+	const pkgName = getPackageName( file );
+	const pkgSrcPath = path.resolve( PACKAGES_DIR, pkgName, 'src' );
+	const pkgBuildPath = path.resolve( PACKAGES_DIR, pkgName, buildFolder );
+	const relativeToSrcPath = path.relative( pkgSrcPath, file );
+	return path.resolve( pkgBuildPath, relativeToSrcPath );
+}
+
+/**
+ * Build a JavaScript/TypeScript file using esbuild.
+ *
+ * @param {string} file File to build.
+ */
+async function buildJS( file ) {
+	// Build for CommonJS (main)
+	const destPathCJS = getBuildPath(
+		file.replace( /\.tsx?$/, '.js' ),
+		'build'
+	);
+
+	// Build for ESM (module)
+	const destPathESM = getBuildPath(
+		file.replace( /\.tsx?$/, '.js' ),
+		'build-module'
+	);
+
+	// Create output directories
+	await Promise.all( [
+		makeDir( path.dirname( destPathCJS ) ),
+		makeDir( path.dirname( destPathESM ) ),
+	] );
+
+	// Get target from browserslist config
+	const { default: browserslistToEsbuild } = await import(
+		// eslint-disable-next-line import/no-unresolved
+		'browserslist-to-esbuild'
+	);
+	const target = browserslistToEsbuild();
+
+	// Build CommonJS version
+	const resultCJS = await esbuild.build( {
+		entryPoints: [ file ],
+		outfile: destPathCJS,
+		bundle: false,
+		platform: 'node',
+		format: 'cjs',
+		sourcemap: true,
+		target,
+		write: false,
+	} );
+
+	// Build ESM version
+	const resultESM = await esbuild.build( {
+		entryPoints: [ file ],
+		outfile: destPathESM,
+		bundle: false,
+		platform: 'neutral',
+		format: 'esm',
+		sourcemap: true,
+		target,
+		write: false,
+	} );
+
+	// Write CJS output
+	await Promise.all( [
+		writeFile( destPathCJS, resultCJS.outputFiles[ 1 ].text ),
+		writeFile( destPathCJS + '.map', resultCJS.outputFiles[ 0 ].text ),
+	] );
+
+	// Write ESM output
+	await Promise.all( [
+		writeFile( destPathESM, resultESM.outputFiles[ 1 ].text ),
+		writeFile( destPathESM + '.map', resultESM.outputFiles[ 0 ].text ),
+	] );
+}
+
+module.exports = buildJS;

--- a/bin/packages/build-worker-esbuild.js
+++ b/bin/packages/build-worker-esbuild.js
@@ -81,29 +81,29 @@ async function buildJS( file ) {
 	);
 	const target = browserslistToEsbuild();
 
-	// Build CommonJS version
-	const resultCJS = await esbuild.build( {
-		entryPoints: [ file ],
-		outfile: destPathCJS,
-		bundle: false,
-		platform: 'node',
-		format: 'cjs',
-		sourcemap: true,
-		target,
-		write: false,
-	} );
-
-	// Build ESM version
-	const resultESM = await esbuild.build( {
-		entryPoints: [ file ],
-		outfile: destPathESM,
-		bundle: false,
-		platform: 'neutral',
-		format: 'esm',
-		sourcemap: true,
-		target,
-		write: false,
-	} );
+	// Build both CJS and ESM in parallel
+	const [ resultCJS, resultESM ] = await Promise.all( [
+		esbuild.build( {
+			entryPoints: [ file ],
+			outfile: destPathCJS,
+			bundle: false,
+			platform: 'node',
+			format: 'cjs',
+			sourcemap: true,
+			target,
+			write: false,
+		} ),
+		esbuild.build( {
+			entryPoints: [ file ],
+			outfile: destPathESM,
+			bundle: false,
+			platform: 'neutral',
+			format: 'esm',
+			sourcemap: true,
+			target,
+			write: false,
+		} ),
+	] );
 
 	// Write CJS output
 	await Promise.all( [

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,7 @@
 				"babel-plugin-transform-remove-console": "6.9.4",
 				"benchmark": "2.1.4",
 				"browserslist": "4.25.1",
+				"browserslist-to-esbuild": "2.1.1",
 				"caniuse-lite": "1.0.30001731",
 				"chalk": "4.1.1",
 				"change-case": "4.1.2",
@@ -18628,6 +18629,38 @@
 			},
 			"engines": {
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+			}
+		},
+		"node_modules/browserslist-to-esbuild": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/browserslist-to-esbuild/-/browserslist-to-esbuild-2.1.1.tgz",
+			"integrity": "sha512-KN+mty6C3e9AN8Z5dI1xeN15ExcRNeISoC3g7V0Kax/MMF9MSoYA2G7lkTTcVUFntiEjkpI0HNgqJC1NjdyNUw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"meow": "^13.0.0"
+			},
+			"bin": {
+				"browserslist-to-esbuild": "cli/index.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"browserslist": "*"
+			}
+		},
+		"node_modules/browserslist-to-esbuild/node_modules/meow": {
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+			"integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/bser": {
@@ -51014,9 +51047,6 @@
 			"name": "@wordpress/hooks",
 			"version": "4.32.0",
 			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
 		"babel-plugin-transform-remove-console": "6.9.4",
 		"benchmark": "2.1.4",
 		"browserslist": "4.25.1",
+		"browserslist-to-esbuild": "2.1.1",
 		"caniuse-lite": "1.0.30001731",
 		"chalk": "4.1.1",
 		"change-case": "4.1.2",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -24,12 +24,17 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"exports": {
+		".": {
+			"types": "./build-types/index.d.ts",
+			"import": "./build-module/index.js",
+			"require": "./build/index.js"
+		},
+		"./package.json": "./package.json"
+	},
 	"react-native": "src/index",
 	"wpScript": true,
 	"types": "build-types",
-	"dependencies": {
-		"@babel/runtime": "7.25.7"
-	},
 	"publishConfig": {
 		"access": "public"
 	}


### PR DESCRIPTION
## What?

This is a first small step towards the vision outlined here #72032
In this first step, I'm adding a new build script for packages based on esbuild. In the following step, I'll add a separate script that auto-discovers packages (a whitelist initially).

Noting that this PR brings performance improvement as well:

 - Building hooks package using the babel based tooling: `5.33s user 0.88s system 426% cpu 1.457 total`
 - Building hooks package using the new script: ` 2.08s user 0.32s system 354% cpu 0.678 total`

Once we migrate more packages to this new tooling, it will have a very significant impact on the packages build time.

## Testing instructions

- I don't expect any impact, you can try loading the editor.
- What would be good would be to check the built files and the import maps.