### PR TITLE
[WIP] Fix: iOS Safari anchor link navigation in mobile Navigation overlay

### DIFF
--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -23,6 +23,41 @@ const focusableSelectors = [
 // capture the clicks, instead of relying on the focusout event.
 document.addEventListener( 'click', () => {} );
 
+/**
+ * Checks if a link element is a same-page anchor link.
+ *
+ * @param {HTMLElement} linkElement - The anchor element to check.
+ * @return {boolean} True if the link is a same-page anchor link, false otherwise.
+ */
+function isSamePageAnchorLink( linkElement ) {
+	if ( ! linkElement || linkElement.tagName !== 'A' ) {
+		return false;
+	}
+
+	const href = linkElement.getAttribute( 'href' );
+	if ( ! href ) {
+		return false;
+	}
+
+	// Check if it's a simple anchor link (starts with #)
+	if ( href.startsWith( '#' ) ) {
+		return true;
+	}
+
+	// Check if it's a full URL pointing to the same page with an anchor
+	try {
+		const linkUrl = new URL( linkElement.href );
+		return (
+			linkUrl.hash &&
+			linkUrl.pathname === window.location.pathname &&
+			linkUrl.search === window.location.search
+		);
+	} catch ( e ) {
+		// Invalid URL
+		return false;
+	}
+}
+
 const { state, actions } = store(
 	'core/navigation',
 	{
@@ -151,6 +186,26 @@ const { state, actions } = store(
 				// event.relatedTarget === The element receiving focus (if any)
 				// When focusout is outside the document,
 				// `window.document.activeElement` doesn't change.
+
+				// Check if the event target is an anchor link with a hash (same-page anchor)
+				const clickedLink = event.target.closest( 'a' );
+				if (
+					clickedLink &&
+					type === 'overlay' &&
+					isSamePageAnchorLink( clickedLink )
+				) {
+					// Remove has-modal-open immediately to allow scrolling
+					document.documentElement.classList.remove(
+						'has-modal-open'
+					);
+
+					// Close menu after a short delay to allow anchor navigation
+					setTimeout( () => {
+						actions.closeMenu( 'click' );
+						actions.closeMenu( 'focus' );
+					}, 50 );
+					return;
+				}
 
 				// The event.relatedTarget is null when something outside the navigation menu is clicked. This is only necessary for Safari.
 				if (


### PR DESCRIPTION
## What

Fixes anchor link navigation on iOS Safari in the Navigation block's mobile overlay menu.

Closes https://github.com/WordPress/gutenberg/issues/71322

## Why

When users click same-page anchor links (e.g., `#section` or `https://example.com/#section`) within the mobile navigation overlay on iOS Safari, the browser fails to scroll to the target anchor. 

The root cause is the `has-modal-open` class applied to the `<html>` element, which prevents page scrolling while the mobile menu is open. When an anchor link is clicked, iOS Safari attempts to navigate to the anchor but is blocked because scrolling is disabled, resulting in no visible navigation occurring.

## How

This PR adds intelligent detection for same-page anchor links in the `handleMenuFocusout` action and implements special handling:

1. **Added `isSamePageAnchorLink()` helper function** - A reusable utility that detects whether a link element is a same-page anchor link by checking:
   - Simple hash links (`#section`)
   - Full URLs with hashes pointing to the same page (`https://example.com/page#section`)

2. **Modified `handleMenuFocusout()` action** - When an anchor link is clicked in the mobile overlay:
   - The `has-modal-open` class is immediately removed from the document element, re-enabling page scrolling
   - Menu closing is delayed by 50ms to give the browser time to complete the anchor navigation
   - Normal focusout behavior is prevented from interfering with the anchor navigation

This ensures anchor links work as expected on iOS Safari while maintaining the existing menu behavior for all other click scenarios.

## Testing

1. **Setup**: Create a page with multiple sections that have IDs (e.g., `<section id="about">`)
2. **Add Navigation Block**: Configure the mobile navigation with anchor links to those sections
3. **Test on iOS Safari**:
   - Open the mobile navigation overlay
   - Click an anchor link (e.g., `#about` or full URL with hash)
   - Verify the page scrolls to the target section
   - Verify the menu closes after navigation
4. **Test other scenarios**:
   - Click regular (non-anchor) links - should work normally
   - Click outside the menu - should close normally
   - Tap the close button - should close normally

## Screenshots

Testing screenshots would demonstrate anchor navigation working on iOS Safari.