### PR TITLE
Block Comments: Use better locators

### DIFF
--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -65,7 +65,7 @@ test.describe( 'Block Comments', () => {
 			attributes: { content: 'Testing block comments' },
 			comment: 'Test comment',
 		} );
-		const commentForm = page.getByRole( 'textbox', { name: 'Comment' } );
+		const commentForm = page.getByRole( 'textbox', { name: 'Reply to' } );
 		const commentText = page
 			.locator( '.editor-collab-sidebar-panel__user-comment' )
 			.last();
@@ -192,7 +192,7 @@ test.describe( 'Block Comments', () => {
 		).toBeVisible();
 
 		await page.locator( '.editor-collab-sidebar-panel__thread' ).click();
-		const commentForm = page.getByRole( 'textbox', { name: 'Comment' } );
+		const commentForm = page.getByRole( 'textbox', { name: 'Reply to' } );
 		await commentForm.fill( 'Test reply that reopens the comment.' );
 		await page
 			.getByRole( 'region', { name: 'Editor settings' } )
@@ -460,7 +460,10 @@ class BlockCommentUtils {
 				} );
 				await this.#editor.clickBlockOptionsMenuItem( 'Comment' );
 				await this.#page
-					.getByRole( 'textbox', { name: 'Comment' } )
+					.getByRole( 'textbox', {
+						name: 'New Comment',
+						exact: true,
+					} )
 					.fill( comment );
 				await this.#page
 					.getByRole( 'region', { name: 'Editor settings' } )


### PR DESCRIPTION
## What?
PR improves block comments textarea locators to avoid conflicts. Discovered an issue while working on a different problem.

## Testing Instructions
None. CI checks are still passing.