### PR TITLE
Add polling to fix flaky test condition

### DIFF
--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -1005,16 +1005,26 @@ class Navigation {
 	async previewIsOpenAndCloses() {
 		const linkPopover = this.getLinkPopover();
 		await expect( linkPopover ).toBeVisible();
-		// Expect focus to be within the link control. We could be more exact here, but it would be more brittle that way. We really care if focus is within it or not.
-		expect(
-			await this.page.evaluate( () => {
-				const { activeElement } =
-					document.activeElement?.contentDocument ?? document;
-				return !! activeElement.closest(
-					'.components-popover__content .block-editor-link-control'
-				);
-			} )
-		).toBe( true );
+
+		// Wait for focus to be within the link control
+		// We could be more exact here, but it would be more brittle that way. We really care if focus is within it or not.
+		await expect
+			.poll(
+				async () => {
+					return await this.page.evaluate( () => {
+						const { activeElement } =
+							document.activeElement?.contentDocument ?? document;
+						return !! activeElement.closest(
+							'.components-popover__content .block-editor-link-control'
+						);
+					} );
+				},
+				{
+					message: 'Focus should be within the link control',
+					timeout: 500,
+				}
+			)
+			.toBe( true );
 
 		await this.page.keyboard.press( 'Escape' );
 

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -4,36 +4,8 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Navigation block', () => {
-	test.beforeEach( async ( { requestUtils } ) => {
-		await requestUtils.deleteAllMenus();
-	} );
-
-	test.beforeAll( async ( { requestUtils } ) => {
-		// We need pages to be published so the Link Control can return pages
-		await requestUtils.createPage( {
-			title: 'Cat',
-			status: 'publish',
-		} );
-		await requestUtils.createPage( {
-			title: 'Dog',
-			status: 'publish',
-		} );
-		await requestUtils.createPage( {
-			title: 'Walrus',
-			status: 'publish',
-		} );
-	} );
-
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllMenus();
-	} );
-
-	test.afterEach( async ( { requestUtils } ) => {
-		await Promise.all( [
-			requestUtils.deleteAllPosts(),
-			requestUtils.deleteAllPages(),
-			requestUtils.deleteAllMenus(),
-		] );
 	} );
 
 	test.use( {
@@ -43,6 +15,14 @@ test.describe( 'Navigation block', () => {
 	} );
 
 	test.describe( 'As a user I want the navigation block to fallback to the best possible default', () => {
+		test.afterEach( async ( { requestUtils } ) => {
+			await Promise.all( [
+				requestUtils.deleteAllPosts(),
+				requestUtils.deleteAllPages(),
+				requestUtils.deleteAllMenus(),
+			] );
+		} );
+
 		test( 'default to a list of pages if there are no menus', async ( {
 			admin,
 			editor,
@@ -316,6 +296,22 @@ test.describe( 'Navigation block', () => {
 	} );
 
 	test.describe( 'Focus management', () => {
+		test.beforeAll( async ( { requestUtils } ) => {
+			// We need pages to be published so the Link Control can return pages
+			await requestUtils.createPage( {
+				title: 'Cat',
+				status: 'publish',
+			} );
+			await requestUtils.createPage( {
+				title: 'Dog',
+				status: 'publish',
+			} );
+			await requestUtils.createPage( {
+				title: 'Walrus',
+				status: 'publish',
+			} );
+		} );
+
 		test.beforeEach(
 			async ( { admin, editor, requestUtils, navigation } ) => {
 				await admin.createNewPost();
@@ -332,6 +328,10 @@ test.describe( 'Navigation block', () => {
 				await expect( navBlockInserter ).toBeVisible();
 			}
 		);
+
+		test.afterAll( async ( { requestUtils } ) => {
+			await requestUtils.deleteAllMenus();
+		} );
 
 		test( 'Focus management when using the navigation link appender', async ( {
 			pageUtils,


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL --> https://github.com/WordPress/gutenberg/issues/71966, https://github.com/WordPress/gutenberg/issues/72064, https://github.com/WordPress/gutenberg/issues/72065 and https://github.com/WordPress/gutenberg/issues/71108

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Flaky tests make for slower progress. The check to see if focus landed in the popover became flaky. Focus would resolve to the right place, but sometimes playwright checked before it had fully resolved.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adding polling resolves the flaky tests.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Run the tests 5x and make sure everything passes
npm run test:e2e -- test/e2e/specs/editor/blocks/navigation.spec.js

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="808" height="354" alt="14 navigation tests all passing" src="https://github.com/user-attachments/assets/9d717ea3-8a1d-4893-8189-beeb65c14e18" />
<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|


