### PR TITLE
Block Comments: Avoid focus loss after creating a comment

### DIFF
--- a/packages/editor/src/components/collab-sidebar/add-comment.js
+++ b/packages/editor/src/components/collab-sidebar/add-comment.js
@@ -15,6 +15,7 @@ import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
  */
 import CommentAuthorInfo from './comment-author-info';
 import CommentForm from './comment-form';
+import { focusCommentThread } from './utils';
 
 /**
  * Renders the UI for adding a comment in the Gutenberg editor's collaboration sidebar.
@@ -23,12 +24,14 @@ import CommentForm from './comment-form';
  * @param {Function} props.onSubmit            - A callback function to be called when the user submits a comment.
  * @param {boolean}  props.showCommentBoard    - The function to edit the comment.
  * @param {Function} props.setShowCommentBoard - The function to delete the comment.
+ * @param {Ref}      props.commentSidebarRef   - The ref to the comment sidebar.
  * @return {React.ReactNode} The rendered comment input UI.
  */
 export function AddComment( {
 	onSubmit,
 	showCommentBoard,
 	setShowCommentBoard,
+	commentSidebarRef,
 } ) {
 	const { clientId, blockCommentId, isEmptyDefaultBlock } = useSelect(
 		( select ) => {
@@ -66,8 +69,9 @@ export function AddComment( {
 				<CommentAuthorInfo />
 			</HStack>
 			<CommentForm
-				onSubmit={ ( inputComment ) => {
-					onSubmit( { content: inputComment } );
+				onSubmit={ async ( inputComment ) => {
+					const { id } = await onSubmit( { content: inputComment } );
+					focusCommentThread( id, commentSidebarRef.current );
 				} }
 				onCancel={ () => {
 					setShowCommentBoard( false );

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -97,6 +97,8 @@ function CollabSidebarContent( {
 					isDismissible: true,
 				}
 			);
+
+			return savedRecord;
 		} catch ( error ) {
 			onError( error );
 		}
@@ -178,6 +180,7 @@ function CollabSidebarContent( {
 					onSubmit={ addNewComment }
 					showCommentBoard={ showCommentBoard }
 					setShowCommentBoard={ setShowCommentBoard }
+					commentSidebarRef={ commentSidebarRef }
 				/>
 				<Comments
 					threads={ comments }

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -40,20 +40,31 @@ test.describe( 'Block Comments', () => {
 		await expect( topBarButton ).toBeVisible();
 	} );
 
-	test( 'can add a comment to a block', async ( {
-		page,
-		blockCommentUtils,
-	} ) => {
-		await blockCommentUtils.addBlockWithComment( {
-			type: 'core/paragraph',
+	test( 'can add a comment to a block', async ( { editor, page } ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
 			attributes: { content: 'Testing block comments' },
-			comment: 'Test comment',
 		} );
+		await editor.clickBlockOptionsMenuItem( 'Comment' );
+		await page
+			.getByRole( 'textbox', {
+				name: 'New Comment',
+				exact: true,
+			} )
+			.fill( 'A test comment' );
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'button', { name: 'Comment', exact: true } )
+			.click();
+		const thread = page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'listitem', {
+				name: 'Comment: A test comment',
+			} );
 
-		// Currently, the class locator is the easiest way to find the comment text.
-		await expect(
-			page.locator( '.editor-collab-sidebar-panel__user-comment' )
-		).toHaveText( 'Test comment' );
+		await expect( thread ).toBeVisible();
+		// Should focus the newly added comment thread.
+		await expect( thread ).toBeFocused();
 	} );
 
 	test( 'can reply to a block comment', async ( {


### PR DESCRIPTION
## What?
Closes #71677.
Related #72024.

PR ensures the focus is moved to the newly created comment. I've also adjusted e2e tests to assert for focus.

## Why?
When a new comment is created, focus is lost or returns to the page body, rather than remaining on the newly created comment.

## Testing Instructions
1. Open a post.
2. Add a block.
3. Add a comment.
4. Confirm that focus is moved to the newly created comment.


### Testing Instructions for Keyboard
Same.