### PR TITLE
Template activation: reduce templates listed as options for post/page

### DIFF
--- a/backport-changelog/6.9/8063.md
+++ b/backport-changelog/6.9/8063.md
@@ -5,3 +5,4 @@ https://github.com/WordPress/wordpress-develop/pull/8063
 * https://github.com/WordPress/gutenberg/pull/72029
 * https://github.com/WordPress/gutenberg/pull/72049
 * https://github.com/WordPress/gutenberg/pull/72011
+* https://github.com/WordPress/gutenberg/pull/72141

--- a/packages/edit-site/src/components/add-new-template/index.js
+++ b/packages/edit-site/src/components/add-new-template/index.js
@@ -211,7 +211,9 @@ function NewTemplateModal( { onClose } ) {
 					status: 'publish',
 					title,
 					// This adds a post meta field in template that is part of `is_custom` value calculation.
-					is_wp_suggestion: isWPSuggestion,
+					meta: {
+						is_wp_suggestion: isWPSuggestion,
+					},
 				},
 				{ throwOnError: true }
 			);

--- a/packages/editor/src/components/post-template/hooks.js
+++ b/packages/editor/src/components/post-template/hooks.js
@@ -66,7 +66,7 @@ function useTemplates( postType ) {
 			const userTemplates = select( coreStore ).getEntityRecords(
 				'postType',
 				'wp_template',
-				{ per_page: -1, post_type: postType }
+				{ per_page: -1 }
 			);
 			if ( ! currentTheme || ! registeredTemplates || ! userTemplates ) {
 				return [];

--- a/packages/editor/src/components/post-template/hooks.js
+++ b/packages/editor/src/components/post-template/hooks.js
@@ -55,26 +55,40 @@ function useTemplates( postType ) {
 	// To do: create a new selector to checks if templates exist at all instead
 	// of and unbound request. In the modal, the user templates should be
 	// paginated and we should not make an unbound request.
-	const { staticTemplates, templates } = useSelect(
+	return useSelect(
 		( select ) => {
-			return {
-				staticTemplates: select( coreStore ).getEntityRecords(
-					'postType',
-					'wp_registered_template',
-					{ per_page: -1, post_type: postType }
+			const currentTheme = select( coreStore ).getCurrentTheme();
+			const registeredTemplates = select( coreStore ).getEntityRecords(
+				'postType',
+				'wp_registered_template',
+				{ per_page: -1, post_type: postType }
+			);
+			const userTemplates = select( coreStore ).getEntityRecords(
+				'postType',
+				'wp_template',
+				{ per_page: -1, post_type: postType }
+			);
+			if ( ! currentTheme || ! registeredTemplates || ! userTemplates ) {
+				return [];
+			}
+
+			const defaultTemplateTypes = currentTheme.default_template_types;
+			return [
+				...registeredTemplates,
+				...userTemplates.filter(
+					( template ) =>
+						// Only give "custom" templates as an option, which
+						// means the is_wp_suggestion meta field is not set and
+						// the slug is not found in the default template types.
+						// https://github.com/WordPress/wordpress-develop/blob/97382397b2bd7c85aef6d4cd1c10bafd397957fc/src/wp-includes/block-template-utils.php#L858-L867
+						! template.meta.is_wp_suggestion &&
+						! defaultTemplateTypes.find(
+							( type ) => type.slug === template.slug
+						)
 				),
-				templates: select( coreStore ).getEntityRecords(
-					'postType',
-					'wp_template',
-					{ per_page: -1, post_type: postType }
-				),
-			};
+			];
 		},
 		[ postType ]
-	);
-	return useMemo(
-		() => [ ...( staticTemplates || [] ), ...( templates || [] ) ],
-		[ staticTemplates, templates ]
 	);
 }
 

--- a/packages/editor/src/components/post-template/hooks.js
+++ b/packages/editor/src/components/post-template/hooks.js
@@ -55,41 +55,54 @@ function useTemplates( postType ) {
 	// To do: create a new selector to checks if templates exist at all instead
 	// of and unbound request. In the modal, the user templates should be
 	// paginated and we should not make an unbound request.
-	return useSelect(
-		( select ) => {
-			const currentTheme = select( coreStore ).getCurrentTheme();
-			const registeredTemplates = select( coreStore ).getEntityRecords(
-				'postType',
-				'wp_registered_template',
-				{ per_page: -1, post_type: postType }
-			);
-			const userTemplates = select( coreStore ).getEntityRecords(
-				'postType',
-				'wp_template',
-				{ per_page: -1 }
-			);
-			if ( ! currentTheme || ! registeredTemplates || ! userTemplates ) {
-				return [];
-			}
+	const { defaultTemplateTypes, registeredTemplates, userTemplates } =
+		useSelect(
+			( select ) => {
+				return {
+					defaultTemplateTypes:
+						select( coreStore ).getCurrentTheme()
+							?.default_template_types,
+					registeredTemplates: select( coreStore ).getEntityRecords(
+						'postType',
+						'wp_registered_template',
+						{
+							per_page: -1,
+							post_type: postType,
+						}
+					),
+					userTemplates: select( coreStore ).getEntityRecords(
+						'postType',
+						'wp_template',
+						{ per_page: -1 }
+					),
+				};
+			},
+			[ postType ]
+		);
 
-			const defaultTemplateTypes = currentTheme.default_template_types;
-			return [
-				...registeredTemplates,
-				...userTemplates.filter(
-					( template ) =>
-						// Only give "custom" templates as an option, which
-						// means the is_wp_suggestion meta field is not set and
-						// the slug is not found in the default template types.
-						// https://github.com/WordPress/wordpress-develop/blob/97382397b2bd7c85aef6d4cd1c10bafd397957fc/src/wp-includes/block-template-utils.php#L858-L867
-						! template.meta.is_wp_suggestion &&
-						! defaultTemplateTypes.find(
-							( type ) => type.slug === template.slug
-						)
-				),
-			];
-		},
-		[ postType ]
-	);
+	return useMemo( () => {
+		if (
+			! defaultTemplateTypes ||
+			! registeredTemplates ||
+			! userTemplates
+		) {
+			return [];
+		}
+		return [
+			...registeredTemplates,
+			...userTemplates.filter(
+				( template ) =>
+					// Only give "custom" templates as an option, which
+					// means the is_wp_suggestion meta field is not set and
+					// the slug is not found in the default template types.
+					// https://github.com/WordPress/wordpress-develop/blob/97382397b2bd7c85aef6d4cd1c10bafd397957fc/src/wp-includes/block-template-utils.php#L858-L867
+					! template.meta.is_wp_suggestion &&
+					! defaultTemplateTypes.find(
+						( type ) => type.slug === template.slug
+					)
+			),
+		];
+	}, [ registeredTemplates, userTemplates, defaultTemplateTypes ] );
 }
 
 export function useAvailableTemplates( postType ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

<!-- In a few words, what is the PR actually doing? -->

Restores the behaviour from WP 6.8: only actual _custom_ templates should be listed in the template modal for specific posts/pages.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is the current WP behavior: when you make edits to a theme template file, the old template or the edit is not visible as an option. Only templates that are "custom" according to the hierarchy can be picked. This is not ideal, but it's a currently limitation because the template property of a post has to be a slug instead of the template ID.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

There's actually an error in the changes I made before: the new templates endpoint doesn't have a `post_type` query option because it's a normal post endpoint. That's why I have to expose the `is_wp_suggestion` meta (which was not correctly set anymore after the rewrite), which seems to be used currently to determine if a template is custom.

A template is custom if `is_wp_suggestion` is not set and if the template slug does not appear in the default template types.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Create a specific template for a certain post, this template should not appear in the template options for other posts.
Duplicate the page template for the theme (or any other template). These user templates should also not appear in the options in the post/page editors.
Now create a "custom" templates (last option) after clicking "Add template". This one _should_ appear in the options!

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
