### PR TITLE
Remove manual focus tracking for navigation link blocks

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -176,12 +176,9 @@ export default function NavigationLinkEdit( {
 		replaceBlock,
 		__unstableMarkNextChangeAsNotPersistent,
 		selectBlock,
-		selectPreviousBlock,
 	} = useDispatch( blockEditorStore );
 	// Have the link editing ui open on mount when lacking a url and selected.
 	const [ isLinkOpen, setIsLinkOpen ] = useState( isSelected && ! url );
-	// Store what element opened the popover, so we know where to return focus to (toolbar button vs navigation link text)
-	const [ openedBy, setOpenedBy ] = useState( null );
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
@@ -191,6 +188,7 @@ export default function NavigationLinkEdit( {
 	const ref = useRef();
 	const linkUIref = useRef();
 	const prevUrl = usePrevious( url );
+	const isNewLink = useRef( ! url );
 
 	const {
 		isAtMaxNesting,
@@ -198,6 +196,7 @@ export default function NavigationLinkEdit( {
 		isParentOfSelectedBlock,
 		hasChildren,
 		validateLinkStatus,
+		parentBlockClientId,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -209,8 +208,8 @@ export default function NavigationLinkEdit( {
 				getSelectedBlockClientId,
 			} = select( blockEditorStore );
 			const rootClientId = getBlockRootClientId( clientId );
-			const isTopLevel =
-				getBlockName( rootClientId ) === 'core/navigation';
+			const parentBlockName = getBlockName( rootClientId );
+			const isTopLevel = parentBlockName === 'core/navigation';
 			const selectedBlockClientId = getSelectedBlockClientId();
 			const rootNavigationClientId = isTopLevel
 				? rootClientId
@@ -218,6 +217,12 @@ export default function NavigationLinkEdit( {
 						clientId,
 						'core/navigation'
 				  )[ 0 ];
+
+			// Get the immediate parent - if it's a submenu, use it; otherwise use the navigation block
+			const parentBlockId =
+				parentBlockName === 'core/navigation-submenu'
+					? rootClientId
+					: rootNavigationClientId;
 
 			// Enable when the root Navigation block is selected or any of its inner blocks.
 			const enableLinkStatusValidation =
@@ -235,6 +240,7 @@ export default function NavigationLinkEdit( {
 				),
 				hasChildren: !! getBlockCount( clientId ),
 				validateLinkStatus: enableLinkStatusValidation,
+				parentBlockClientId: parentBlockId,
 			};
 		},
 		[ clientId, maxNestingLevel ]
@@ -270,6 +276,17 @@ export default function NavigationLinkEdit( {
 		);
 		replaceBlock( clientId, newSubmenu );
 	}, [ getBlocks, clientId, selectBlock, replaceBlock, attributes ] );
+
+	// On mount, if this is a new link without a URL and it's selected,
+	// select the parent block (submenu or navigation) instead to keep the appender visible.
+	// This helps us return focus to the appender if the user closes the link ui without creating a link.
+	// If we leave focus on this block, then when we close the link without creating a link, focus will
+	// be lost during the new block selection process.
+	useEffect( () => {
+		if ( isNewLink.current && isSelected && ! url ) {
+			selectBlock( parentBlockClientId );
+		}
+	}, [] );
 
 	useEffect( () => {
 		// If block has inner blocks, transform to Submenu.
@@ -353,7 +370,6 @@ export default function NavigationLinkEdit( {
 			// If this link is a child of a parent submenu item, the parent submenu item event will also open, closing this popover
 			event.stopPropagation();
 			setIsLinkOpen( true );
-			setOpenedBy( ref.current );
 		}
 	}
 
@@ -392,7 +408,6 @@ export default function NavigationLinkEdit( {
 	if ( ! url || isInvalid || isDraft ) {
 		blockProps.onClick = () => {
 			setIsLinkOpen( true );
-			setOpenedBy( ref.current );
 		};
 	}
 
@@ -415,9 +430,8 @@ export default function NavigationLinkEdit( {
 						icon={ linkIcon }
 						title={ __( 'Link' ) }
 						shortcut={ displayShortcut.primary( 'k' ) }
-						onClick={ ( event ) => {
+						onClick={ () => {
 							setIsLinkOpen( true );
-							setOpenedBy( event.currentTarget );
 						} }
 					/>
 					{ ! isAtMaxNesting && (
@@ -516,38 +530,14 @@ export default function NavigationLinkEdit( {
 							clientId={ clientId }
 							link={ attributes }
 							onClose={ () => {
+								setIsLinkOpen( false );
 								// If there is no link then remove the auto-inserted block.
 								// This avoids empty blocks which can provided a poor UX.
 								if ( ! url ) {
-									// Fixes https://github.com/WordPress/gutenberg/issues/61361
-									// There's a chance we're closing due to the user selecting the browse all button.
-									// Only move focus if the focus is still within the popover ui. If it's not within
-									// the popover, it's because something has taken the focus from the popover, and
-									// we don't want to steal it back.
-									if (
-										linkUIref.current.contains(
-											window.document.activeElement
-										)
-									) {
-										// Select the previous block to keep focus nearby
-										selectPreviousBlock( clientId, true );
-									}
-
-									// Remove the link.
 									onReplace( [] );
-									return;
-								}
-
-								setIsLinkOpen( false );
-								if ( openedBy ) {
-									openedBy.focus();
-									setOpenedBy( null );
-								} else if ( ref.current ) {
-									// select the ref when adding a new link
-									ref.current.focus();
-								} else {
-									// Fallback
-									selectPreviousBlock( clientId, true );
+								} else if ( isNewLink.current ) {
+									// If we just created a new link, select it
+									selectBlock( clientId );
 								}
 							} }
 							anchor={ popoverAnchor }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -286,7 +286,7 @@ export default function NavigationLinkEdit( {
 		if ( isNewLink.current && isSelected && ! url ) {
 			selectBlock( parentBlockClientId );
 		}
-	}, [] );
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	useEffect( () => {
 		// If block has inner blocks, transform to Submenu.

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -137,14 +137,9 @@ export default function NavigationSubmenuEdit( {
 		attributes,
 	} );
 
-	const {
-		__unstableMarkNextChangeAsNotPersistent,
-		replaceBlock,
-		selectBlock,
-	} = useDispatch( blockEditorStore );
+	const { __unstableMarkNextChangeAsNotPersistent, replaceBlock } =
+		useDispatch( blockEditorStore );
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
-	// Store what element opened the popover, so we know where to return focus to (toolbar button vs navigation link text)
-	const [ openedBy, setOpenedBy ] = useState( null );
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
@@ -276,7 +271,6 @@ export default function NavigationSubmenuEdit( {
 			// If we don't stop propagation, this event bubbles up to the parent submenu item
 			event.stopPropagation();
 			setIsLinkOpen( true );
-			setOpenedBy( ref.current );
 		}
 	}
 
@@ -363,9 +357,8 @@ export default function NavigationSubmenuEdit( {
 							icon={ linkIcon }
 							title={ __( 'Link' ) }
 							shortcut={ displayShortcut.primary( 'k' ) }
-							onClick={ ( event ) => {
+							onClick={ () => {
 								setIsLinkOpen( true );
-								setOpenedBy( event.currentTarget );
 							} }
 						/>
 					) }
@@ -407,7 +400,6 @@ export default function NavigationSubmenuEdit( {
 						onClick={ () => {
 							if ( ! openSubmenusOnClick && ! url ) {
 								setIsLinkOpen( true );
-								setOpenedBy( ref.current );
 							}
 						} }
 					/>
@@ -422,12 +414,6 @@ export default function NavigationSubmenuEdit( {
 							link={ attributes }
 							onClose={ () => {
 								setIsLinkOpen( false );
-								if ( openedBy ) {
-									openedBy.focus();
-									setOpenedBy( null );
-								} else {
-									selectBlock( clientId );
-								}
 							} }
 							anchor={ popoverAnchor }
 							onRemove={ () => {

--- a/test/e2e/specs/editor/blocks/search.spec.js
+++ b/test/e2e/specs/editor/blocks/search.spec.js
@@ -44,7 +44,11 @@ test.describe( 'Search', () => {
 		} );
 		await navBlockInserter.click();
 
-		await page.getByRole( 'button', { name: 'Add block' } ).click();
+		await page
+			.getByRole( 'button', { name: 'Add block' } )
+			.filter( { hasText: 'Add block' } )
+			.first()
+			.click();
 
 		// Click on the Search block option.
 		await page.getByRole( 'option', { name: 'Search' } ).click();


### PR DESCRIPTION
## What? 
Fixes and simplifies focus management issues in Navigation Link and Navigation Submenu blocks when closing link popovers. Fixes https://github.com/WordPress/gutenberg/issues/68035

Fixes https://github.com/WordPress/gutenberg/issues/65962 by moving block selection to the parent block so the sidebar editing isn't available during this step.

Flaky test fixes: Closes <!-- #ISSUE-NUMBER or URL --> https://github.com/WordPress/gutenberg/issues/71966, https://github.com/WordPress/gutenberg/issues/72064, https://github.com/WordPress/gutenberg/issues/72065 and https://github.com/WordPress/gutenberg/issues/71108


## Why? 
After adding a new navigation link and clicking anywhere (inspector, header, etc.), the popover would aggressively steal focus back to the canvas, preventing interaction with other UI elements, instead of letting the click naturally place focus. 

## How? 
Removed the `openedBy` state that was tracking which element opened the link popover, as it's no longer needed for focus management since https://github.com/WordPress/gutenberg/pull/68060 and https://github.com/WordPress/gutenberg/pull/71252/ were merged.

- **Enhancement**: Keep selection on parent block. This allows for significant simplification of focus management by allowing the appender that opened the link ui to remain a stable ref.
- Modified `onClose` handler to: 
    - Only handle focus when adding a new link by selecting the newly added block.
    - If the link does not get created, remove the empty link (same as before, but this no longer causes focus loss as the parent block remains selected)
    - Focus is naturally handled by the `useFocusOutside` via the popover
- **Enhancement**: Broke navigation tests into steps and updated them to have focus go to the appender instead of previous block

Additional Changes
 - Applied the same fixes to both navigation-link and navigation-submenu blocks for consistency

Test Focus Behavior for New Links 
1. Add a Navigation block 
2. Click the appender to add a new Navigation Link (popover opens) 
3. Type a URL and press Enter (link is created) 
4. Click on an inspector control field in the sidebar 
5. ✅ Focus should stay in the inspector field you clicked 


Test Escape Key Behavior for New Links 
1. Add a Navigation block 
2. Click the appender to add a new Navigation Link (popover opens) 
3. Press Escape without entering a URL 
4. ✅ The empty block should be removed 
5. ✅ The previous block should be selected 
6. ✅ The appender should remain visible

Test Escape Key Behavior for Existing Links 
- From rich text element, press command + k to open the popover
- Press Escape
- ✅  Focus should go back to the rich text field
- Shift + tab to the toolbar
- Tab to the link edit button
- Enter
- Escape
- ✅ Focus should be on the toolbar link edit button

Test Navigation Submenu Repeat all the above tests with Navigation Submenu blocks to ensure they behave identically.

**Before**

https://github.com/user-attachments/assets/63c67475-6ce9-4e0c-953e-93d3a8edd697



**After**

https://github.com/user-attachments/assets/87d400ba-4277-46e9-9638-18102cf283d8

