### PR TITLE
Properly position color panel popover

### DIFF
--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -155,6 +155,8 @@ const popoverProps = {
 	placement: 'left-start',
 	offset: 36,
 	shift: true,
+	flip: true,
+	resize: false,
 };
 
 const { Tabs } = unlock( componentsPrivateApis );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
When the color popover was triggered from the sidebar near the bottom of the page, it could be very squished - only showing the titles.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The area was very tiny. There's plenty of room. We should always show the full popover.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add the `flip: true` and `resize: false` to the color popover settings.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to a group bock
- Change colors for the block in the sidebar style inspector
- Color panel should be fully visible in all scenarios

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here --><img width="627" height="355" alt="Color panel only showing headings" src="https://github.com/user-attachments/assets/eca1308c-464c-498a-95fa-85d2bcc63209" />|<!-- After screenshot here --><img width="705" height="491" alt="Full color panel visible" src="https://github.com/user-attachments/assets/61538d5d-8704-4de9-8925-d138a57020f9" />
|
