### PR TITLE
Provide "collaborative-editing" post type support

### DIFF
--- a/lib/experimental/synchronization.php
+++ b/lib/experimental/synchronization.php
@@ -22,3 +22,20 @@ function gutenberg_rest_api_init_collaborative_editing() {
 	wp_add_inline_script( 'wp-sync', 'window.__experimentalCollaborativeEditingSecret = "' . $collaborative_editing_secret . '";', 'before' );
 }
 add_action( 'admin_init', 'gutenberg_rest_api_init_collaborative_editing' );
+
+/**
+ * Add support for collaborative editing to some built-in post types.
+ */
+function gutenberg_add_collaborative_editing_post_type_support() {
+	$gutenberg_experiments = get_option( 'gutenberg-experiments' );
+	if ( ! $gutenberg_experiments || ! array_key_exists( 'gutenberg-sync-collaboration', $gutenberg_experiments ) ) {
+		return;
+	}
+
+	foreach ( array( 'page', 'post' ) as $post_type ) {
+		if ( post_type_exists( $post_type ) ) {
+			add_post_type_support( $post_type, 'collaborative-editing' );
+		}
+	}
+}
+add_action( 'init', 'gutenberg_add_collaborative_editing_post_type_support', 10, 0 );

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -286,9 +286,10 @@ function makeBlocksSerializable( blocks ) {
  */
 async function loadPostTypeEntities() {
 	const postTypes = await apiFetch( {
-		path: '/wp/v2/types?context=view',
+		path: '/wp/v2/types?context=edit',
 	} );
 	return Object.entries( postTypes ?? {} ).map( ( [ name, postType ] ) => {
+		const isSyncEnabled = postType.supports?.[ 'collaborative-editing' ];
 		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
 			name
 		);
@@ -314,58 +315,71 @@ async function loadPostTypeEntities() {
 					: String( record.id ) ),
 			__unstablePrePersist: isTemplate ? undefined : prePersistPostType,
 			__unstable_rest_base: postType.rest_base,
-			syncConfig: {
-				/**
-				 * Apply changes from the local editor to the local CRDT document so
-				 * that those changes can be synced to other peers (via the provider).
-				 *
-				 * @param {import('@wordpress/sync').CRDTDoc}               crdtDoc
-				 * @param {Partial< import('@wordpress/sync').ObjectData >} changes
-				 * @return {void}
-				 */
-				applyChangesToCRDTDoc: ( crdtDoc, changes ) => {
-					const document = crdtDoc.getMap( 'document' );
+			syncConfig: isSyncEnabled
+				? {
+						/**
+						 * Apply changes from the local editor to the local CRDT document so
+						 * that those changes can be synced to other peers (via the provider).
+						 *
+						 * @param {import('@wordpress/sync').CRDTDoc}               crdtDoc
+						 * @param {Partial< import('@wordpress/sync').ObjectData >} changes
+						 * @return {void}
+						 */
+						applyChangesToCRDTDoc: ( crdtDoc, changes ) => {
+							const document = crdtDoc.getMap( 'document' );
 
-					Object.entries( changes ).forEach( ( [ key, value ] ) => {
-						if ( ! syncedProperties.has( key ) ) {
-							return;
-						}
+							Object.entries( changes ).forEach(
+								( [ key, value ] ) => {
+									if ( ! syncedProperties.has( key ) ) {
+										return;
+									}
 
-						if ( typeof value !== 'function' ) {
-							if ( key === 'blocks' ) {
-								if ( ! serialisableBlocksCache.has( value ) ) {
-									serialisableBlocksCache.set(
-										value,
-										makeBlocksSerializable( value )
-									);
+									if ( typeof value !== 'function' ) {
+										if ( key === 'blocks' ) {
+											if (
+												! serialisableBlocksCache.has(
+													value
+												)
+											) {
+												serialisableBlocksCache.set(
+													value,
+													makeBlocksSerializable(
+														value
+													)
+												);
+											}
+
+											value =
+												serialisableBlocksCache.get(
+													value
+												);
+										}
+
+										if ( document.get( key ) !== value ) {
+											document.set( key, value );
+										}
+									}
 								}
+							);
+						},
 
-								value = serialisableBlocksCache.get( value );
-							}
+						/**
+						 * Extract changes from a CRDT document that can be used to update the
+						 * local editor state.
+						 *
+						 * @param {import('@wordpress/sync').CRDTDoc} crdtDoc
+						 * @return {Partial< import('@wordpress/sync').ObjectData >} Changes to record
+						 */
+						getChangesFromCRDTDoc: defaultGetChangesFromCRDTDoc,
 
-							if ( document.get( key ) !== value ) {
-								document.set( key, value );
-							}
-						}
-					} );
-				},
-
-				/**
-				 * Extract changes from a CRDT document that can be used to update the
-				 * local editor state.
-				 *
-				 * @param {import('@wordpress/sync').CRDTDoc} crdtDoc
-				 * @return {Partial< import('@wordpress/sync').ObjectData >} Changes to record
-				 */
-				getChangesFromCRDTDoc: defaultGetChangesFromCRDTDoc,
-
-				/**
-				 * Sync features supported by the entity.
-				 *
-				 * @type {Record< string, boolean >}
-				 */
-				supports: {},
-			},
+						/**
+						 * Sync features supported by the entity.
+						 *
+						 * @type {Record< string, boolean >}
+						 */
+						supports: {},
+				  }
+				: undefined,
 			supportsPagination: true,
 			getRevisionsUrl: ( parentId, revisionId ) =>
 				`/${ namespace }/${


### PR DESCRIPTION

## What?

Provide a new "collaborative-editing" post type support.

## Why?

A new post type support adds support for collaborative editing to posts and pages by default and allows custom post types to opt in to collaborative editing.

## How?

Use the `enabled` flag on the entity sync config to signal whether an entity supports collaborative editing.

## Testing Instructions

1. Check out this branch.
1. Enable the real-time collaboration experiment: Gutenberg > Experiments.
1. Open a post or page for editing in two different browser environments.
1. Use your browser's development tools to remove the post editor lock (see screencast in the next section).
1. Add a code snippet to register a custom post type and enable collaborative editing support.
1. Repeat steps 3 and 4 to confirm that the custom post type supports collaborative editing.

```php
$args = array(
        'label' => 'recipes',
        'public' => true,
        'show_ui' => true,
        'show_in_menu' => true,
        'supports' => array( 'title', 'editor', 'author', 'thumbnail', 'collaborative-editing' ),
        'show_in_rest' => true,
);     
register_post_type( 'Recipe', $args );
```

### Testing Instructions for Keyboard

Note: This provider uses requests to admin-ajax.php for signaling and the initial connection is delayed.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/40d3c34b-ca2a-4e82-aee6-6e644d67e1b3