### PR TITLE
Editor post featured image: Ensure hidden text is hidden when common CSS is not loaded

### DIFF
--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -1,6 +1,10 @@
 .editor-post-featured-image {
 	padding: 0;
 
+	.hidden {
+		display: none;
+	}
+
 	.components-spinner {
 		position: absolute;
 		top: 50%;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Update the editor post featured image component to ensure hidden text is hidden when common CSS is not loaded.

This is a similar kind of PR to some of my earlier ones that have been looking into removing our overall dependency on `common.css` resets (see: https://github.com/WordPress/gutenberg/pull/71217 and https://github.com/WordPress/gutenberg/pull/70685 for examples)

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently the post and site editors expect common.css to be loaded, however the editor can be used outside of a Gutenberg context where common.css might not be loaded (i.e. for plugins and custom editors). This PR ensures that the featured image doesn't accidentally display the describedby text in such a case, by ensuring that the component is responsible for its own `hidden` behaviour.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add a `display: none` rule to the `hidden` class for this component. This follows the same rule used in `common.css`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

***Note: in normal usage this PR will appear to make no change vs trunk, so you'll need to follow the below instructions to see any difference***

To replicate an environment that does not use common.css, load up the post editor and run the following from the console:

```
document.querySelector( 'link#common-css' ).remove()
```

Then, add a featured image. With this PR applied, the describedby text should not display visually.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="600" height="696" alt="image" src="https://github.com/user-attachments/assets/d1096599-6a2a-4b5f-809d-437ae53c8dea" /> | <img width="600" height="638" alt="image" src="https://github.com/user-attachments/assets/d26a4cbe-da0f-402b-8880-a5112ba25ec2" /> |