### PR TITLE
Fix dataviews scroll and footer stickiness

### DIFF
--- a/packages/admin-ui/src/page/header.tsx
+++ b/packages/admin-ui/src/page/header.tsx
@@ -40,6 +40,7 @@ export default function Header( {
 				<HStack
 					style={ { width: 'auto', flexShrink: 0 } }
 					spacing={ 2 }
+					className="admin-ui-page__header-actions"
 				>
 					{ actions }
 				</HStack>

--- a/packages/admin-ui/src/page/index.tsx
+++ b/packages/admin-ui/src/page/index.tsx
@@ -17,7 +17,6 @@ function Page( {
 	children,
 	className,
 	actions,
-	hasPadding = true,
 }: {
 	breadcrumbs?: React.ReactNode;
 	badges?: React.ReactNode;
@@ -41,13 +40,7 @@ function Page( {
 					actions={ actions }
 				/>
 			) }
-			<div
-				className={ clsx( 'admin-ui-page__content', {
-					'has-padding': hasPadding,
-				} ) }
-			>
-				{ children }
-			</div>
+			{ children }
 		</NavigableRegion>
 	);
 }

--- a/packages/admin-ui/src/page/index.tsx
+++ b/packages/admin-ui/src/page/index.tsx
@@ -17,6 +17,7 @@ function Page( {
 	children,
 	className,
 	actions,
+	hasPadding = false,
 }: {
 	breadcrumbs?: React.ReactNode;
 	badges?: React.ReactNode;
@@ -40,7 +41,13 @@ function Page( {
 					actions={ actions }
 				/>
 			) }
-			{ children }
+			{ hasPadding ? (
+				<div className="admin-ui-page__content has-padding">
+					{ children }
+				</div>
+			) : (
+				children
+			) }
 		</NavigableRegion>
 	);
 }

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -1,6 +1,8 @@
 .admin-ui-page {
 	display: flex;
 	height: 100%;
+	background: $white;
+	color: $gray-800;
 	position: relative;
 	z-index: 1;
 	flex-flow: column;

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -1,8 +1,9 @@
 .admin-ui-page {
+	display: flex;
 	height: 100%;
-	background: $white;
-	color: $gray-800;
-	container: admin-ui-page / inline-size;
+	position: relative;
+	z-index: 1;
+	flex-flow: column;
 
 	@media not (prefers-reduced-motion) {
 		transition: width ease-out 0.2s;
@@ -28,16 +29,3 @@
 	margin: 0;
 }
 
-.admin-ui-page__content {
-	flex-grow: 1;
-	overflow: auto;
-	display: flex;
-	flex-direction: column;
-
-	&.has-padding {
-		padding: $grid-unit-20 $grid-unit * 2.5;
-		@container (max-width: 430px) {
-			padding: $grid-unit-20 $grid-unit-30;
-		}
-	}
-}

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -32,3 +32,24 @@
 	margin: 0;
 }
 
+// Show button text labels when preference is enabled.
+.show-icon-labels {
+	.admin-ui-page__header-actions {
+		.components-button.has-icon {
+			width: auto;
+			padding: 0 $grid-unit-10;
+
+			// Hide the button icons when labels are set to display...
+			svg {
+				display: none;
+			}
+			// ... and display labels.
+			&::after {
+				content: attr(aria-label);
+				font-size: $helptext-font-size;
+			}
+		}
+
+	}
+}
+

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -32,6 +32,20 @@
 	margin: 0;
 }
 
+.admin-ui-page__content {
+	flex-grow: 1;
+	overflow: auto;
+	display: flex;
+	flex-direction: column;
+
+	&.has-padding {
+		padding: $grid-unit-20 $grid-unit * 2.5;
+		@container (max-width: 430px) {
+			padding: $grid-unit-20 $grid-unit-30;
+		}
+	}
+}
+
 // Show button text labels when preference is enabled.
 .show-icon-labels {
 	.admin-ui-page__header-actions {

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -1,7 +1,7 @@
 .admin-ui-page {
 	display: flex;
 	height: 100%;
-	background: $white;
+	background-color: $white;
 	color: $gray-800;
 	position: relative;
 	z-index: 1;

--- a/packages/admin-ui/src/page/style.scss
+++ b/packages/admin-ui/src/page/style.scss
@@ -6,6 +6,7 @@
 	position: relative;
 	z-index: 1;
 	flex-flow: column;
+	container: admin-ui-page / inline-size;
 
 	@media not (prefers-reduced-motion) {
 		transition: width ease-out 0.2s;

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -217,7 +217,6 @@ export default function DataviewsPatterns() {
 						<PatternsActions />
 					</>
 				}
-				hasPadding={ false }
 			>
 				<DataViews
 					key={ categoryId + postType }

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -254,7 +254,6 @@ export default function PageTemplates() {
 					<AddNewTemplate />
 				</>
 			}
-			hasPadding={ false }
 		>
 			<DataViews
 				key={ activeView }

--- a/packages/edit-site/src/components/post-edit/style.scss
+++ b/packages/edit-site/src/components/post-edit/style.scss
@@ -1,11 +1,5 @@
 .edit-site-post-edit {
 	padding: $grid-unit-30;
-
-	&.is-empty .admin-ui-page__content {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-	}
 }
 
 .dataforms-layouts-panel__field-dropdown {

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -254,7 +254,6 @@ export default function PostList( { postType } ) {
 					) }
 				</>
 			}
-			hasPadding={ false }
 		>
 			<DataViews
 				key={ activeView }

--- a/packages/edit-site/src/components/sidebar-global-styles-wrapper/index.js
+++ b/packages/edit-site/src/components/sidebar-global-styles-wrapper/index.js
@@ -132,7 +132,6 @@ export default function GlobalStylesUIWrapper() {
 			}
 			className="edit-site-styles"
 			title={ __( 'Styles' ) }
-			hasPadding={ false }
 		>
 			<GlobalStylesUI path={ section } onPathChange={ onChangeSection } />
 		</Page>

--- a/packages/edit-site/src/components/sidebar-global-styles-wrapper/style.scss
+++ b/packages/edit-site/src/components/sidebar-global-styles-wrapper/style.scss
@@ -26,24 +26,3 @@
 	}
 }
 
-.show-icon-labels {
-	.edit-site-styles {
-		.edit-site-page-header__actions {
-			.components-button.has-icon {
-				width: auto;
-				padding: 0 $grid-unit-10;
-
-				// Hide the button icons when labels are set to display...
-				svg {
-					display: none;
-				}
-				// ... and display labels.
-				&::after {
-					content: attr(aria-label);
-					font-size: $helptext-font-size;
-				}
-			}
-
-		}
-	}
-}

--- a/packages/edit-site/src/components/sidebar-global-styles-wrapper/style.scss
+++ b/packages/edit-site/src/components/sidebar-global-styles-wrapper/style.scss
@@ -1,4 +1,4 @@
-.edit-site-styles .admin-ui-page__content {
+.edit-site-styles {
 	.edit-site-global-styles-screen-root {
 		box-shadow: none;
 		& > div > hr {
@@ -27,7 +27,7 @@
 }
 
 .show-icon-labels {
-	.edit-site-styles .admin-ui-page__content {
+	.edit-site-styles {
 		.edit-site-page-header__actions {
 			.components-button.has-icon {
 				width: auto;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

Fixes [this issue](https://github.com/WordPress/gutenberg/pull/72106#issuecomment-3379150485)

#72106 introduced an extra wrapper around the `dataviews-wrapper`, but it and some styling discrepancies in its container were disabling the scrollbar in the views. I tried removing the wrapper and it doesn't break anything; the only thing it did was take some optional padding which doesn't seem to be in use anywhere? I think we can find a less disruptive way of doing that if needed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open Site Editor, check Pages, Templates, Patterns screens. Try looking at screens that have enough items to cause scrollbars, and also ones that don't have enough items to fill the screen. In all instances, scrollbars should appear where needed and the footer should always be sticky.

<img width="1337" height="1014" alt="Screenshot 2025-10-08 at 12 06 29 pm" src="https://github.com/user-attachments/assets/718da7a5-b2dd-4f75-988b-1fcf33ae1fb3" />
