### PR TITLE
Block Comments: Extract CRUD actions into a separate hook

### DIFF
--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -1,10 +1,18 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
-import { useEntityRecords } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
+import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as noticesStore } from '@wordpress/notices';
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
 
 export function useBlockComments( postId ) {
 	const queryArgs = {
@@ -110,4 +118,127 @@ export function useBlockComments( postId ) {
 	}, [ clientIds, threads, getBlockAttributes ] );
 
 	return { resultComments, unresolvedSortedThreads, totalPages };
+}
+
+export function useBlockCommentsActions() {
+	const { createNotice } = useDispatch( noticesStore );
+	const { saveEntityRecord, deleteEntityRecord } = useDispatch( coreStore );
+	const { getCurrentPostId } = useSelect( editorStore );
+	const { getBlockAttributes, getSelectedBlockClientId } =
+		useSelect( blockEditorStore );
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	const onError = ( error ) => {
+		const errorMessage =
+			error.message && error.code !== 'unknown_error'
+				? decodeEntities( error.message )
+				: __( 'An error occurred while performing an update.' );
+		createNotice( 'error', errorMessage, {
+			type: 'snackbar',
+			isDismissible: true,
+		} );
+	};
+
+	const onCreate = async ( { content, parent } ) => {
+		try {
+			const savedRecord = await saveEntityRecord(
+				'root',
+				'comment',
+				{
+					post: getCurrentPostId(),
+					content,
+					comment_type: 'block_comment',
+					comment_approved: 0,
+					parent: parent || 0,
+				},
+				{ throwOnError: true }
+			);
+
+			// If it's a main comment, update the block attributes with the comment id.
+			if ( ! parent && savedRecord?.id ) {
+				const clientId = getSelectedBlockClientId();
+				const metadata = getBlockAttributes( clientId )?.metadata;
+				updateBlockAttributes( clientId, {
+					metadata: {
+						...metadata,
+						commentId: savedRecord.id,
+					},
+				} );
+			}
+
+			createNotice(
+				'snackbar',
+				parent
+					? __( 'Reply added successfully.' )
+					: __( 'Comment added successfully.' ),
+				{
+					type: 'snackbar',
+					isDismissible: true,
+				}
+			);
+		} catch ( error ) {
+			onError( error );
+		}
+	};
+
+	const onEdit = async ( { id, content, status } ) => {
+		const messageType = status ? status : 'updated';
+		const messages = {
+			approved: __( 'Comment marked as resolved.' ),
+			hold: __( 'Comment reopened.' ),
+			updated: __( 'Comment updated.' ),
+		};
+
+		try {
+			await saveEntityRecord(
+				'root',
+				'comment',
+				{
+					id,
+					content,
+					status,
+				},
+				{ throwOnError: true }
+			);
+			createNotice(
+				'snackbar',
+				messages[ messageType ] ?? __( 'Comment updated.' ),
+				{
+					type: 'snackbar',
+					isDismissible: true,
+				}
+			);
+		} catch ( error ) {
+			onError( error );
+		}
+	};
+
+	const onDelete = async ( comment ) => {
+		try {
+			await deleteEntityRecord(
+				'root',
+				'comment',
+				comment.id,
+				undefined,
+				{
+					throwOnError: true,
+				}
+			);
+
+			if ( ! comment.parent ) {
+				updateBlockAttributes( getSelectedBlockClientId(), {
+					blockCommentId: undefined,
+				} );
+			}
+
+			createNotice( 'snackbar', __( 'Comment deleted successfully.' ), {
+				type: 'snackbar',
+				isDismissible: true,
+			} );
+		} catch ( error ) {
+			onError( error );
+		}
+	};
+
+	return { onCreate, onEdit, onDelete };
 }

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -176,6 +176,8 @@ export function useBlockCommentsActions() {
 					isDismissible: true,
 				}
 			);
+
+			return savedRecord;
 		} catch ( error ) {
 			onError( error );
 		}

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -228,8 +228,13 @@ export function useBlockCommentsActions() {
 			);
 
 			if ( ! comment.parent ) {
-				updateBlockAttributes( getSelectedBlockClientId(), {
-					blockCommentId: undefined,
+				const clientId = getSelectedBlockClientId();
+				const metadata = getBlockAttributes( clientId )?.metadata;
+				updateBlockAttributes( clientId, {
+					metadata: {
+						...metadata,
+						commentId: undefined,
+					},
 				} );
 			}
 

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -7,11 +7,8 @@ import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useState, useRef } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 import { comment as commentIcon } from '@wordpress/icons';
-import { store as noticesStore } from '@wordpress/notices';
-import { store as coreStore } from '@wordpress/core-data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as interfaceStore } from '@wordpress/interface';
-import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -24,7 +21,7 @@ import { store as editorStore } from '../../store';
 import AddCommentButton from './comment-button';
 import CommentAvatarIndicator from './comment-indicator-toolbar';
 import { useGlobalStylesContext } from '../global-styles-provider';
-import { useBlockComments } from './hooks';
+import { useBlockComments, useBlockCommentsActions } from './hooks';
 
 function CollabSidebarContent( {
 	showCommentBoard,
@@ -33,141 +30,7 @@ function CollabSidebarContent( {
 	comments,
 	commentSidebarRef,
 } ) {
-	const { createNotice } = useDispatch( noticesStore );
-	const { saveEntityRecord, deleteEntityRecord } = useDispatch( coreStore );
-	const { updateBlockAttributes } = useDispatch( blockEditorStore );
-	const { currentPostId, getSelectedBlockClientId, getBlockAttributes } =
-		useSelect( ( select ) => {
-			const { getCurrentPostId } = select( editorStore );
-			return {
-				getSelectedBlockClientId:
-					select( blockEditorStore ).getSelectedBlockClientId,
-				getBlockAttributes:
-					select( blockEditorStore ).getBlockAttributes,
-				currentPostId: getCurrentPostId(),
-			};
-		}, [] );
-
-	const onError = ( error ) => {
-		const errorMessage =
-			error.message && error.code !== 'unknown_error'
-				? decodeEntities( error.message )
-				: __( 'An error occurred while performing an update.' );
-		createNotice( 'error', errorMessage, {
-			type: 'snackbar',
-			isDismissible: true,
-		} );
-	};
-
-	const addNewComment = async ( { content, parent } ) => {
-		try {
-			const savedRecord = await saveEntityRecord(
-				'root',
-				'comment',
-				{
-					post: currentPostId,
-					content,
-					comment_type: 'block_comment',
-					comment_approved: 0,
-					parent: parent || 0,
-				},
-				{ throwOnError: true }
-			);
-
-			// If it's a main comment, update the block attributes with the comment id.
-			if ( ! parent && savedRecord?.id ) {
-				const metadata = getBlockAttributes(
-					getSelectedBlockClientId()
-				)?.metadata;
-				updateBlockAttributes( getSelectedBlockClientId(), {
-					metadata: {
-						...metadata,
-						commentId: savedRecord.id,
-					},
-				} );
-			}
-
-			createNotice(
-				'snackbar',
-				parent
-					? __( 'Reply added successfully.' )
-					: __( 'Comment added successfully.' ),
-				{
-					type: 'snackbar',
-					isDismissible: true,
-				}
-			);
-
-			return savedRecord;
-		} catch ( error ) {
-			onError( error );
-		}
-	};
-
-	const onEditComment = async ( { id, content, status } ) => {
-		const messageType = status ? status : 'updated';
-		const messages = {
-			approved: __( 'Comment marked as resolved.' ),
-			hold: __( 'Comment reopened.' ),
-			updated: __( 'Comment updated.' ),
-		};
-
-		try {
-			await saveEntityRecord(
-				'root',
-				'comment',
-				{
-					id,
-					content,
-					status,
-				},
-				{ throwOnError: true }
-			);
-			createNotice(
-				'snackbar',
-				messages[ messageType ] ?? __( 'Comment updated.' ),
-				{
-					type: 'snackbar',
-					isDismissible: true,
-				}
-			);
-		} catch ( error ) {
-			onError( error );
-		}
-	};
-
-	const onCommentDelete = async ( comment ) => {
-		try {
-			await deleteEntityRecord(
-				'root',
-				'comment',
-				comment.id,
-				undefined,
-				{
-					throwOnError: true,
-				}
-			);
-
-			if ( ! comment.parent ) {
-				const metadata = getBlockAttributes(
-					getSelectedBlockClientId()
-				)?.metadata;
-				updateBlockAttributes( getSelectedBlockClientId(), {
-					metadata: {
-						...metadata,
-						commentId: undefined,
-					},
-				} );
-			}
-
-			createNotice( 'snackbar', __( 'Comment deleted successfully.' ), {
-				type: 'snackbar',
-				isDismissible: true,
-			} );
-		} catch ( error ) {
-			onError( error );
-		}
-	};
+	const { onCreate, onEdit, onDelete } = useBlockCommentsActions();
 
 	return (
 		<div
@@ -177,16 +40,16 @@ function CollabSidebarContent( {
 		>
 			<VStack role="list" spacing="3">
 				<AddComment
-					onSubmit={ addNewComment }
+					onSubmit={ onCreate }
 					showCommentBoard={ showCommentBoard }
 					setShowCommentBoard={ setShowCommentBoard }
 					commentSidebarRef={ commentSidebarRef }
 				/>
 				<Comments
 					threads={ comments }
-					onEditComment={ onEditComment }
-					onAddReply={ addNewComment }
-					onCommentDelete={ onCommentDelete }
+					onEditComment={ onEdit }
+					onAddReply={ onCreate }
+					onCommentDelete={ onDelete }
 					showCommentBoard={ showCommentBoard }
 					setShowCommentBoard={ setShowCommentBoard }
 					commentSidebarRef={ commentSidebarRef }


### PR DESCRIPTION
## What?
Related https://github.com/WordPress/gutenberg/pull/71856#issuecomment-3379569378.

PR extracts core data methods into a custom hook for easier maintainability. This is a preparation for larger refactoring before the Block Comments feature is stabilized.

P.S. I hope this will make conflict resolution easier.

## Testing Instructions
CI checks are passing:

```
npm run test:e2e -- test/e2e/specs/editor/various/block-comments.spec.js
```
