### PR TITLE
Block Comments: Always show comment menu item

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comment-menu-item.js
+++ b/packages/editor/src/components/collab-sidebar/comment-menu-item.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { MenuItem } from '@wordpress/components';
-import { _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { comment as commentIcon } from '@wordpress/icons';
 
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
@@ -14,7 +14,7 @@ import { unlock } from '../../lock-unlock';
 
 const { CommentIconSlotFill } = unlock( blockEditorPrivateApis );
 
-const AddCommentButton = ( { onClick } ) => {
+const AddCommentMenuItem = ( { onClick } ) => {
 	return (
 		<CommentIconSlotFill.Fill>
 			{ ( { onClose } ) => (
@@ -26,11 +26,11 @@ const AddCommentButton = ( { onClick } ) => {
 					} }
 					aria-haspopup="dialog"
 				>
-					{ _x( 'Comment', 'Add comment button' ) }
+					{ __( 'Comment' ) }
 				</MenuItem>
 			) }
 		</CommentIconSlotFill.Fill>
 	);
 };
 
-export default AddCommentButton;
+export default AddCommentMenuItem;

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -21,7 +21,7 @@ import { collabHistorySidebarName, collabSidebarName } from './constants';
 import { Comments } from './comments';
 import { AddComment } from './add-comment';
 import { store as editorStore } from '../../store';
-import AddCommentButton from './comment-button';
+import AddCommentMenuItem from './comment-menu-item';
 import CommentAvatarIndicator from './comment-indicator-toolbar';
 import { useGlobalStylesContext } from '../global-styles-provider';
 import { useBlockComments } from './hooks';
@@ -248,10 +248,6 @@ export default function CollabSidebar() {
 		} );
 	}
 
-	const AddCommentComponent = blockCommentId
-		? CommentAvatarIndicator
-		: AddCommentButton;
-
 	// Find the current thread for the selected block.
 	const currentThread = blockCommentId
 		? resultComments.find( ( thread ) => thread.id === blockCommentId )
@@ -264,11 +260,13 @@ export default function CollabSidebar() {
 
 	return (
 		<>
-			<AddCommentComponent
-				onClick={ openCollabBoard }
-				thread={ currentThread }
-				hasMoreComments={ hasMoreComments }
-			/>
+			{ blockCommentId && (
+				<CommentAvatarIndicator
+					thread={ currentThread }
+					hasMoreComments={ hasMoreComments }
+				/>
+			) }
+			<AddCommentMenuItem onClick={ openCollabBoard } />
 			<PluginSidebar
 				identifier={ collabHistorySidebarName }
 				// translators: Comments sidebar title


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #71906

**Note**: This PR doesn't fix the a11y issues mentioned in #71906. The issues related to a11y should be addressed in https://github.com/WordPress/gutenberg/pull/71814 separately.


## Why?

A conditionally rendered menu item can be confusing.

## How?

Renders the comment menu item, whether or not it has a blockCommentId. As a small refactor, I renamed the component.

## Testing Instructions

- Open a post, insert a block, and comment on it.
- Confirm that the block has the Comment menu item inside the Options dropdown.

## Screenshots or screencast <!-- if applicable -->

<img width="717" height="327" alt="comment" src="https://github.com/user-attachments/assets/221e1aaf-ece5-47ef-abf1-3031e9c3ddd2" />

