### PR TITLE
Block API: Add block visibility control in the command center

### DIFF
--- a/packages/block-editor/src/components/use-block-commands/index.js
+++ b/packages/block-editor/src/components/use-block-commands/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	hasBlockSupport,
 	store as blocksStore,
@@ -297,21 +297,10 @@ const getQuickActionsCommands = () =>
 				( block ) =>
 					block.attributes.metadata?.blockVisibility === false
 			);
-			const blockVisibilityLabel = hasHiddenBlock
-				? _n(
-						'Show selected block',
-						'Show selected blocks',
-						blocks.length
-				  )
-				: _n(
-						'Hide selected block',
-						'Hide selected blocks',
-						blocks.length
-				  );
 
 			commands.push( {
 				name: 'core/toggle-block-visibility',
-				label: blockVisibilityLabel,
+				label: hasHiddenBlock ? __( 'Show' ) : __( 'Hide' ),
 				callback: () => {
 					const attributesByClientId = Object.fromEntries(
 						blocks?.map( ( { clientId, attributes } ) => [

--- a/packages/block-editor/src/components/use-block-commands/index.js
+++ b/packages/block-editor/src/components/use-block-commands/index.js
@@ -319,7 +319,7 @@ const getQuickActionsCommands = () =>
 						uniqueByBlock: true,
 					} );
 				},
-				icon: hasHiddenBlock ? unseen : seen,
+				icon: hasHiddenBlock ? seen : unseen,
 			} );
 		}
 

--- a/packages/block-editor/src/components/use-block-commands/index.js
+++ b/packages/block-editor/src/components/use-block-commands/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import {
 	hasBlockSupport,
 	store as blocksStore,
@@ -16,6 +16,8 @@ import {
 	plus as add,
 	group,
 	ungroup,
+	seen,
+	unseen,
 } from '@wordpress/icons';
 
 /**
@@ -23,6 +25,7 @@ import {
  */
 import BlockIcon from '../block-icon';
 import { store as blockEditorStore } from '../../store';
+import { cleanEmptyObject } from '../../hooks/utils';
 
 const getTransformCommands = () =>
 	function useTransformCommands() {
@@ -157,6 +160,7 @@ const getQuickActionsCommands = () =>
 			getBlockRootClientId,
 			getBlocksByClientId,
 			canRemoveBlocks,
+			getBlockName,
 		} = useSelect( blockEditorStore );
 		const { getDefaultBlockName, getGroupingBlockName } =
 			useSelect( blocksStore );
@@ -169,6 +173,7 @@ const getQuickActionsCommands = () =>
 			duplicateBlocks,
 			insertAfterBlock,
 			insertBeforeBlock,
+			updateBlockAttributes,
 		} = useDispatch( blockEditorStore );
 
 		const onGroup = () => {
@@ -217,6 +222,10 @@ const getQuickActionsCommands = () =>
 			);
 		} );
 		const canRemove = canRemoveBlocks( clientIds );
+
+		const canToggleBlockVisibility = blocks.every( ( { clientId } ) =>
+			hasBlockSupport( getBlockName( clientId ), 'blockVisibility', true )
+		);
 
 		const commands = [];
 
@@ -280,6 +289,48 @@ const getQuickActionsCommands = () =>
 				label: __( 'Delete' ),
 				callback: () => removeBlocks( clientIds, true ),
 				icon: remove,
+			} );
+		}
+
+		if ( canToggleBlockVisibility ) {
+			const hasHiddenBlock = blocks.some(
+				( block ) =>
+					block.attributes.metadata?.blockVisibility === false
+			);
+			const blockVisibilityLabel = hasHiddenBlock
+				? _n(
+						'Show selected block',
+						'Show selected blocks',
+						blocks.length
+				  )
+				: _n(
+						'Hide selected block',
+						'Hide selected blocks',
+						blocks.length
+				  );
+
+			commands.push( {
+				name: 'core/toggle-block-visibility',
+				label: blockVisibilityLabel,
+				callback: () => {
+					const attributesByClientId = Object.fromEntries(
+						blocks?.map( ( { clientId, attributes } ) => [
+							clientId,
+							{
+								metadata: cleanEmptyObject( {
+									...attributes?.metadata,
+									blockVisibility: hasHiddenBlock
+										? undefined
+										: false,
+								} ),
+							},
+						] )
+					);
+					updateBlockAttributes( clientIds, attributesByClientId, {
+						uniqueByBlock: true,
+					} );
+				},
+				icon: hasHiddenBlock ? unseen : seen,
 			} );
 		}
 


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Follow up to https://github.com/WordPress/gutenberg/pull/71203

Part of 

- https://github.com/WordPress/gutenberg/issues/72001

This PR adds support for toggling block visibility based on block attributes in the command centre.


## Why?

To make the show/hide function available in the command centre.


## Testing Instructions

Similar to the testing instructions in https://github.com/WordPress/gutenberg/pull/71203 but for the command centre

1. Select one or more blocks or template parts. 
2. Hit `Cmd/Ctrl + k` to open the command center, and observe the `"Hide"` command.
3. Select that command. Check that the blocks are hidden.
4. Now select the blocks again, and open the command centre. Now `"Show"` them.
5. They should be there again!

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/1bd4d14e-2fe8-4ed7-97b3-113df6989fe2


