### PR TITLE
Template activation: add meta to all newly created templates

### DIFF
--- a/backport-changelog/6.9/8063.md
+++ b/backport-changelog/6.9/8063.md
@@ -2,6 +2,7 @@ https://github.com/WordPress/wordpress-develop/pull/8063
 
 * https://github.com/WordPress/gutenberg/pull/67125
 * https://github.com/WordPress/gutenberg/pull/71840
+* https://github.com/WordPress/gutenberg/pull/72156
 * https://github.com/WordPress/gutenberg/pull/71811
 * https://github.com/WordPress/gutenberg/pull/72003
 * https://github.com/WordPress/gutenberg/pull/72029

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -484,10 +484,15 @@ function gutenberg_migrate_existing_templates() {
 		),
 		// Only get templates that are not inactive by default.
 		'meta_query'          => array(
+			'relation' => 'OR',
 			array(
 				'key'     => 'is_inactive_by_default',
-				'value'   => true,
-				'compare' => '!=',
+				'compare' => 'NOT EXISTS',
+			),
+			array(
+				'key'     => 'is_inactive_by_default',
+				'value'   => false,
+				'compare' => '=',
 			),
 		),
 	);

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -450,6 +450,11 @@ function gutenberg_set_active_template_theme( $changes, $request ) {
 	$changes->tax_input = array(
 		'wp_theme' => isset( $request['theme'] ) ? $request['theme'] : get_stylesheet(),
 	);
+	// All new templates saved will receive meta so we can distinguish between
+	// templates created the old way as edits and templates created the new way.
+	$changes->meta_input = array(
+		'is_inactive_by_default' => true,
+	);
 	return $changes;
 }
 
@@ -475,6 +480,14 @@ function gutenberg_migrate_existing_templates() {
 				'taxonomy' => 'wp_theme',
 				'field'    => 'name',
 				'terms'    => get_stylesheet(),
+			),
+		),
+		// Only get templates that are not inactive by default.
+		'meta_query'          => array(
+			array(
+				'key'     => 'is_inactive_by_default',
+				'value'   => true,
+				'compare' => '!=',
 			),
 		),
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Adds meta to any templates created from this point forward, so we can easily distinguish between templates created the old way and new way. 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

1) This makes the migrate function more stable: if the `active_templates` option is ever removed, any new templates created will not suddenly become activated due to this migration, only the old templates will.
2) It gives us a bit more room to fix migrations in case of a revert of the whole feature.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds the meta any time a template is created from now on. In the migration function, check that the templates do not have this meta.

To do: when you de-activate one of the old templates, ideally we should add the meta to them.

Idea: perhaps there is a way we can avoid the migration entirely: if a template doesn't have the `inactive_by_default` meta, then it should just be considered active regardless of the option. It makes the checks for activation a bit more complex though.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Create a new template. Delete the `active_templates` option.  This new templates should not be activated due to the migration function.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
