### PR TITLE
Allow Post Content when "Force Page Reload" is disable in the Query Loop

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -664,7 +664,7 @@ Displays the contents of a post or page. ([Source](https://github.com/WordPress/
 
 -	**Name:** core/post-content
 -	**Category:** theme
--	**Supports:** align (full, wide), background (backgroundImage, backgroundSize), color (background, gradients, heading, link, text), dimensions (minHeight), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), background (backgroundImage, backgroundSize), color (background, gradients, heading, link, text), dimensions (minHeight), interactivity (clientNavigation), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** tagName
 
 ## Date

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Enable the Query Loop "Force Page Reload" setting to be false when the Post Content block is used. ([#72160](https://github.com/WordPress/gutenberg/pull/72160))
+
 ## 9.32.0 (2025-10-01)
 
 ## 9.31.0 (2025-09-17)

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -61,6 +61,9 @@
 				"fontSize": true
 			}
 		},
+		"interactivity": {
+			"clientNavigation": true
+		},
 		"__experimentalBorder": {
 			"radius": true,
 			"color": true,

--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -23,8 +23,7 @@ export default function EnhancedPaginationModal( {
 	setAttributes,
 } ) {
 	const [ isOpen, setOpen ] = useState( false );
-	const { hasBlocksFromPlugins, hasPostContentBlock, hasUnsupportedBlocks } =
-		useUnsupportedBlocks( clientId );
+	const hasUnsupportedBlocks = useUnsupportedBlocks( clientId );
 
 	useEffect( () => {
 		if ( enhancedPagination && hasUnsupportedBlocks ) {
@@ -37,24 +36,14 @@ export default function EnhancedPaginationModal( {
 		setOpen( false );
 	};
 
-	let notice = __(
-		'If you still want to prevent full page reloads, remove that block, then disable "Reload full page" again in the Query Block settings.'
-	);
-	if ( hasBlocksFromPlugins ) {
-		notice =
-			__(
-				'Currently, avoiding full page reloads is not possible when non-interactive or non-client Navigation compatible blocks from plugins are present inside the Query block.'
-			) +
-			' ' +
-			notice;
-	} else if ( hasPostContentBlock ) {
-		notice =
-			__(
-				'Currently, avoiding full page reloads is not possible when a Content block is present inside the Query block.'
-			) +
-			' ' +
-			notice;
-	}
+	const notice =
+		__(
+			'If you still want to prevent full page reloads, remove that block, then disable "Reload full page" again in the Query Block settings.'
+		) +
+		' ' +
+		__(
+			'Currently, avoiding full page reloads is not possible when non-interactive or non-client Navigation compatible blocks from plugins are present inside the Query block.'
+		);
 
 	return (
 		isOpen && (

--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -38,11 +38,11 @@ export default function EnhancedPaginationModal( {
 
 	const notice =
 		__(
-			'If you still want to prevent full page reloads, remove that block, then disable "Reload full page" again in the Query Block settings.'
+			'Currently, avoiding full page reloads is not possible when non-interactive or non-client Navigation compatible blocks from plugins are present inside the Query block.'
 		) +
 		' ' +
 		__(
-			'Currently, avoiding full page reloads is not possible when non-interactive or non-client Navigation compatible blocks from plugins are present inside the Query block.'
+			'If you still want to prevent full page reloads, remove that block, then disable "Reload full page" again in the Query Block settings.'
 		);
 
 	return (

--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -14,7 +14,7 @@ export default function EnhancedPaginationControl( {
 	setAttributes,
 	clientId,
 } ) {
-	const { hasUnsupportedBlocks } = useUnsupportedBlocks( clientId );
+	const hasUnsupportedBlocks = useUnsupportedBlocks( clientId );
 
 	let help = __(
 		'Reload the full page—instead of just the posts list—when visitors navigate between pages.'

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -434,31 +434,17 @@ export const usePatterns = ( clientId, name ) => {
 };
 
 /**
- * The object returned by useUnsupportedBlocks with info about the type of
- * unsupported blocks present inside the Query block.
- *
- * @typedef  {Object}  UnsupportedBlocksInfo
- * @property {boolean} hasBlocksFromPlugins True if blocks from plugins are present.
- * @property {boolean} hasPostContentBlock  True if a 'core/post-content' block is present.
- * @property {boolean} hasUnsupportedBlocks True if there are any unsupported blocks.
- */
-
-/**
- * Hook that returns an object with information about the unsupported blocks
- * present inside a Query Loop with the given `clientId`. The returned object
- * contains props that are true when a certain type of unsupported block is
- * present.
+ * Hook that, given a block clientId, determines if it has unsupported blocks or not.
  *
  * @param {string} clientId The block's client ID.
- * @return {UnsupportedBlocksInfo} The object containing the information.
+ * @return {boolean} True if there are any unsupported blocks.
  */
 export const useUnsupportedBlocks = ( clientId ) => {
 	return useSelect(
 		( select ) => {
 			const { getClientIdsOfDescendants, getBlockName } =
 				select( blockEditorStore );
-			const blocks = {};
-			getClientIdsOfDescendants( clientId ).forEach(
+			return getClientIdsOfDescendants( clientId ).some(
 				( descendantClientId ) => {
 					const blockName = getBlockName( descendantClientId );
 					/*
@@ -475,19 +461,13 @@ export const useUnsupportedBlocks = ( clientId ) => {
 							blockName,
 							'interactivity.clientNavigation'
 						);
-					const blockInteractivity =
-						blockSupportsInteractivity ||
-						blockSupportsInteractivityClientNavigation;
-					if ( ! blockInteractivity ) {
-						blocks.hasBlocksFromPlugins = true;
-					} else if ( blockName === 'core/post-content' ) {
-						blocks.hasPostContentBlock = true;
-					}
+
+					return (
+						! blockSupportsInteractivity &&
+						! blockSupportsInteractivityClientNavigation
+					);
 				}
 			);
-			blocks.hasUnsupportedBlocks =
-				blocks.hasBlocksFromPlugins || blocks.hasPostContentBlock;
-			return blocks;
 		},
 		[ clientId ]
 	);

--- a/phpunit/blocks/render-query-test.php
+++ b/phpunit/blocks/render-query-test.php
@@ -215,7 +215,7 @@ HTML;
 		$content = <<<HTML
 		<!-- wp:query {"queryId":0,"query":{"inherit":true},"enhancedPagination":true} -->
 		<div class="wp-block-query">
-			<!-- wp:post-content {"align":"wide"} --><!-- /wp:post-content -->
+			<!-- wp:test/plugin-block /-->
 		</div>
 		<!-- /wp:query -->
 HTML;

--- a/phpunit/blocks/render-query-test.php
+++ b/phpunit/blocks/render-query-test.php
@@ -203,40 +203,4 @@ HTML;
 		$router_config = wp_interactivity_config( 'core/router' );
 		$this->assertTrue( $router_config['clientNavigationDisabled'] );
 	}
-
-	/**
-	 * Tests that the `core/query` block sets the option
-	 * `clientNavigationDisabled` to `true` in the `core/router` store config
-	 * when a plugin that does not define clientNavigation is found inside.
-	 */
-	public function test_rendering_query_with_enhanced_pagination_auto_disabled_when_there_is_a_non_compatible_block() {
-		global $wp_query, $wp_the_query;
-
-		$content = <<<HTML
-		<!-- wp:query {"queryId":0,"query":{"inherit":true},"enhancedPagination":true} -->
-		<div class="wp-block-query">
-			<!-- wp:test/plugin-block /-->
-		</div>
-		<!-- /wp:query -->
-HTML;
-
-		// Set main query to single post.
-		$wp_query = new WP_Query(
-			array(
-				'posts_per_page' => 1,
-			)
-		);
-
-		$wp_the_query = $wp_query;
-
-		$output = do_blocks( $content );
-
-		$p = new WP_HTML_Tag_Processor( $output );
-
-		$p->next_tag( array( 'class_name' => 'wp-block-query' ) );
-		$this->assertSame( 'query-0', $p->get_attribute( 'data-wp-router-region' ) );
-
-		$router_config = wp_interactivity_config( 'core/router' );
-		$this->assertTrue( $router_config['clientNavigationDisabled'] );
-	}
 }

--- a/phpunit/blocks/render-query-test.php
+++ b/phpunit/blocks/render-query-test.php
@@ -146,43 +146,6 @@ HTML;
 	}
 
 	/**
-	 * Tests that the `core/query` block sets the option
-	 * `clientNavigationDisabled` to `true` in the `core/router` store config
-	 * when a post content block is found inside.
-	 */
-	public function test_rendering_query_with_enhanced_pagination_auto_disabled_when_post_content_block_is_found() {
-		global $wp_query, $wp_the_query;
-
-		$content = <<<HTML
-		<!-- wp:query {"queryId":0,"query":{"inherit":true},"enhancedPagination":true} -->
-		<div class="wp-block-query">
-			<!-- wp:post-template {"align":"wide"} -->
-				<!-- wp:post-content /-->
-			<!-- /wp:post-template -->
-		</div>
-		<!-- /wp:query -->
-HTML;
-
-		// Set main query to single post.
-		$wp_query = new WP_Query(
-			array(
-				'posts_per_page' => 1,
-			)
-		);
-
-		$wp_the_query = $wp_query;
-
-		$output = do_blocks( $content );
-
-		$p = new WP_HTML_Tag_Processor( $output );
-
-		$p->next_tag( array( 'class_name' => 'wp-block-query' ) );
-		$this->assertSame( 'query-0', $p->get_attribute( 'data-wp-router-region' ) );
-		$router_config = wp_interactivity_config( 'core/router' );
-		$this->assertTrue( $router_config['clientNavigationDisabled'] );
-	}
-
-	/**
 	 * Tests that, whenever a `core/query` contains a descendant that is not
 	 * supported (i.e., a plugin block), the option `clientNavigationDisabled`
 	 * is set to `true` in the `core/router` store config.

--- a/phpunit/blocks/render-query-test.php
+++ b/phpunit/blocks/render-query-test.php
@@ -15,8 +15,6 @@ class Tests_Blocks_RenderQueryBlock extends WP_UnitTestCase {
 	private $original_wp_interactivity;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		self::$posts = $factory->post->create_many( 3 );
-
 		register_block_type(
 			'test/plugin-block',
 			array(
@@ -25,9 +23,41 @@ class Tests_Blocks_RenderQueryBlock extends WP_UnitTestCase {
 				},
 			)
 		);
+
+		self::$posts[] = $factory->post->create(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_name'   => 'empty_post',
+				'post_title'  => 'Empty post',
+			)
+		);
+
+		self::$posts[] = $factory->post->create(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_name'    => 'compatible_post',
+				'post_title'   => 'Compatible post',
+				'post_content' => '<!-- wp:paragraph --><p>Compatible</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		self::$posts[] = $factory->post->create(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_name'    => 'incompatible_post',
+				'post_title'   => 'Incompatible post',
+				'post_content' => '<!-- wp:test/plugin-block /-->',
+			)
+		);
 	}
 
 	public static function wpTearDownAfterClass() {
+		foreach ( self::$posts as $post_to_delete ) {
+			wp_delete_post( $post_to_delete, true );
+		}
 		unregister_block_type( 'test/plugin-block' );
 	}
 
@@ -202,5 +232,75 @@ HTML;
 
 		$router_config = wp_interactivity_config( 'core/router' );
 		$this->assertTrue( $router_config['clientNavigationDisabled'] );
+	}
+
+	/**
+	 * Tests that `clientNavigationDisabled` is enabled when
+	 * there is an incompatible block in post content.
+	 */
+	public function test_rendering_query_with_enhanced_pagination_is_disabled_with_incompatible_block_inside_post_content() {
+		global $wp_query, $wp_the_query;
+
+		$content      = <<<HTML
+		<!-- wp:query {"queryId":0,"query":{"inherit":true},"enhancedPagination":true} -->
+		<div class="wp-block-query">
+			<!-- wp:post-template {"align":"wide"} -->
+				<!-- wp:post-content /-->
+			<!-- /wp:post-template -->
+		</div>
+		<!-- /wp:query -->
+HTML;
+		$wp_query     = new WP_Query(
+			array(
+				'posts_per_page' => 1,
+				'paged'          => 1,
+			)
+		);
+		$wp_the_query = $wp_query;
+
+		$output = do_blocks( $content );
+
+		$p = new WP_HTML_Tag_Processor( $output );
+		$p->next_tag( array( 'class_name' => 'wp-block-query' ) );
+		$this->assertSame( 'query-0', $p->get_attribute( 'data-wp-router-region' ) );
+		$router_config = wp_interactivity_config( 'core/router' );
+		$this->assertTrue( $router_config['clientNavigationDisabled'] );
+	}
+
+	/**
+	 * Tests that `clientNavigationDisabled` doesn't exist when
+	 * there all blocks inside post content are compatible.
+	 */
+	public function test_rendering_query_with_enhanced_pagination_with_compatible_blocks_inside_post_content() {
+		global $wp_query, $wp_the_query, $paged;
+
+		$content      = <<<HTML
+		<!-- wp:query {"queryId":0,"query":{"inherit":true},"enhancedPagination":true} -->
+		<div class="wp-block-query">
+			<!-- wp:post-template {"align":"wide"} -->
+				<!-- wp:post-content /-->
+			<!-- /wp:post-template -->
+		</div>
+		<!-- /wp:query -->
+HTML;
+		$wp_query     = new WP_Query(
+			array(
+				'posts_per_page' => 1,
+				'paged'          => 2,
+			)
+		);
+		$prev_paged   = $paged;
+		$paged        = 2;
+		$wp_the_query = $wp_query;
+
+		$output = do_blocks( $content );
+
+		$paged = $prev_paged;
+
+		$p = new WP_HTML_Tag_Processor( $output );
+		$p->next_tag( array( 'class_name' => 'wp-block-query' ) );
+		$this->assertSame( 'query-0', $p->get_attribute( 'data-wp-router-region' ) );
+		$router_config = wp_interactivity_config( 'core/router' );
+		$this->assertArrayNotHasKey( 'clientNavigationDisabled', $router_config );
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #70871

As explained in the issue, now that [the logic that enables/disables client-side navigation automatically](https://github.com/WordPress/gutenberg/blob/491d0ac0334352eda456d285415b331eb2072856/packages/block-library/src/query/index.php#L73-L152) is already in place, it is safe to mark the Post Content block as compatible with client-side navigation. Which allows the Query Loop "Force Page Reload" setting to be false when this block is used.

## How?
I'm just setting `supports.interactivity.clientNavigation` to identify it is compatible. Additionally, I changed the editor logic a bit because it was differentiating between Post Content block vs external blocks and I believe it is not needed anymore.

## Testing Instructions
1. Go to a page and add query loop of posts.
2. Include the Post Content block inside the template.
3. Check that you can turn to false the "Force Page Reload" setting of the Query Loop in the Advanced section.
4. Go to the frontend and check that it works fine without reloading the page (Ensure that there is pagination to test it).

You can also check that changing the `supports.interactivity` to false still disable the setting in the editor and it triggers the popup when added to the Query Loop.