### PR TITLE
Navigation Link: Fix custom links creating empty bindings and severed links retaining bindings

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -553,7 +553,6 @@ export default function NavigationLinkEdit( {
 							anchor={ popoverAnchor }
 							onRemove={ removeLink }
 							onChange={ ( updatedValue ) => {
-								// updateAttributes determines the final state and returns metadata
 								const { isEntityLink } = updateAttributes(
 									updatedValue,
 									setAttributes,

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -553,17 +553,20 @@ export default function NavigationLinkEdit( {
 							anchor={ popoverAnchor }
 							onRemove={ removeLink }
 							onChange={ ( updatedValue ) => {
-								updateAttributes(
+								// updateAttributes determines the final state and returns metadata
+								const { isEntityLink } = updateAttributes(
 									updatedValue,
 									setAttributes,
 									attributes
 								);
 
-								// Handle URL binding
-								if ( ! updatedValue?.id ) {
-									clearBinding();
-								} else {
+								// Handle URL binding based on the final computed state
+								// Only create bindings for entity links (posts, pages, taxonomies)
+								// Never create bindings for custom links (manual URLs)
+								if ( isEntityLink ) {
 									createBinding();
+								} else {
+									clearBinding();
 								}
 							} }
 						/>

--- a/packages/block-library/src/navigation-link/shared/test/update-attributes.test.js
+++ b/packages/block-library/src/navigation-link/shared/test/update-attributes.test.js
@@ -1133,4 +1133,175 @@ describe( 'updateAttributes', () => {
 			);
 		} );
 	} );
+
+	describe( 'Return value metadata', () => {
+		describe( 'isEntityLink', () => {
+			it( 'should return true for entity links with id and non-custom kind', () => {
+				const setAttributes = jest.fn();
+				const linkSuggestion = {
+					id: 123,
+					kind: 'post-type',
+					type: 'page',
+					url: 'https://example.com/page',
+					title: 'Test Page',
+				};
+
+				const result = updateAttributes(
+					linkSuggestion,
+					setAttributes
+				);
+
+				expect( result ).toEqual( {
+					isEntityLink: true,
+				} );
+			} );
+
+			it( 'should return false for custom links even with id', () => {
+				const setAttributes = jest.fn();
+				const linkSuggestion = {
+					id: 123,
+					kind: 'custom',
+					type: 'custom',
+					url: 'https://example.com/custom',
+					title: 'Custom Link',
+				};
+
+				const result = updateAttributes(
+					linkSuggestion,
+					setAttributes
+				);
+
+				expect( result ).toEqual( {
+					isEntityLink: false,
+				} );
+			} );
+
+			it( 'should return false for links without id', () => {
+				const setAttributes = jest.fn();
+				const linkSuggestion = {
+					url: 'https://example.com',
+					title: 'Example',
+				};
+
+				const result = updateAttributes(
+					linkSuggestion,
+					setAttributes
+				);
+
+				expect( result ).toEqual( {
+					isEntityLink: false,
+				} );
+			} );
+
+			it( 'should return false when entity link is severed', () => {
+				const setAttributes = jest.fn();
+				const blockAttributes = {
+					id: 123,
+					type: 'page',
+					kind: 'post-type',
+					url: 'https://example.com/original-page',
+				};
+
+				const updatedValue = {
+					url: 'https://example.com/different-page',
+				};
+
+				const result = updateAttributes(
+					updatedValue,
+					setAttributes,
+					blockAttributes
+				);
+
+				// Should return false because the link was severed and converted to custom
+				expect( result ).toEqual( {
+					isEntityLink: false,
+				} );
+			} );
+
+			it( 'should return true when entity link is preserved through query string change', () => {
+				const setAttributes = jest.fn();
+				const blockAttributes = {
+					id: 123,
+					type: 'page',
+					kind: 'post-type',
+					url: 'https://example.com/page',
+				};
+
+				const updatedValue = {
+					url: 'https://example.com/page?foo=bar',
+				};
+
+				const result = updateAttributes(
+					updatedValue,
+					setAttributes,
+					blockAttributes
+				);
+
+				// Should return true because entity link is preserved
+				expect( result ).toEqual( {
+					isEntityLink: true,
+				} );
+			} );
+
+			it( 'should return false for mailto links', () => {
+				const setAttributes = jest.fn();
+				const linkSuggestion = {
+					id: 'mailto:test@example.com',
+					type: 'mailto',
+					url: 'mailto:test@example.com',
+					title: 'mailto:test@example.com',
+				};
+
+				const result = updateAttributes(
+					linkSuggestion,
+					setAttributes
+				);
+
+				// mailto links have kind: 'custom', so isEntityLink should be false
+				expect( result ).toEqual( {
+					isEntityLink: false,
+				} );
+			} );
+
+			it( 'should return false for tel links', () => {
+				const setAttributes = jest.fn();
+				const linkSuggestion = {
+					id: 'tel:5555555',
+					type: 'tel',
+					url: 'tel:5555555',
+					title: 'tel:5555555',
+				};
+
+				const result = updateAttributes(
+					linkSuggestion,
+					setAttributes
+				);
+
+				// tel links have kind: 'custom', so isEntityLink should be false
+				expect( result ).toEqual( {
+					isEntityLink: false,
+				} );
+			} );
+
+			it( 'should return true for taxonomy links', () => {
+				const setAttributes = jest.fn();
+				const linkSuggestion = {
+					id: 5,
+					kind: 'taxonomy',
+					type: 'category',
+					url: 'https://example.com/category/news',
+					title: 'News',
+				};
+
+				const result = updateAttributes(
+					linkSuggestion,
+					setAttributes
+				);
+
+				expect( result ).toEqual( {
+					isEntityLink: true,
+				} );
+			} );
+		} );
+	} );
 } );

--- a/packages/block-library/src/navigation-link/shared/update-attributes.js
+++ b/packages/block-library/src/navigation-link/shared/update-attributes.js
@@ -208,4 +208,19 @@ export const updateAttributes = (
 	}
 
 	setAttributes( attributes );
+
+	// Return metadata about the final state for binding decisions.
+	// We need to distinguish between:
+	// 1. Property not set in attributes (use blockAttributes fallback)
+	// 2. Property explicitly set to undefined (means "remove this")
+	// Using 'in' operator checks if property exists, even if undefined.
+	// This is critical for severing: attributes.id = undefined means "remove the ID",
+	// not "keep the old ID from blockAttributes".
+	const finalId = 'id' in attributes ? attributes.id : blockAttributes.id;
+	const finalKind =
+		'kind' in attributes ? attributes.kind : blockAttributes.kind;
+
+	return {
+		isEntityLink: !! finalId && finalKind !== 'custom',
+	};
 };

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -435,17 +435,20 @@ export default function NavigationSubmenuEdit( {
 								speak( __( 'Link removed.' ), 'assertive' );
 							} }
 							onChange={ ( updatedValue ) => {
-								updateAttributes(
+								// updateAttributes determines the final state and returns metadata
+								const { isEntityLink } = updateAttributes(
 									updatedValue,
 									setAttributes,
 									attributes
 								);
 
-								// Handle URL binding
-								if ( ! updatedValue?.id ) {
-									clearBinding();
-								} else {
+								// Handle URL binding based on the final computed state
+								// Only create bindings for entity links (posts, pages, taxonomies)
+								// Never create bindings for custom links (manual URLs)
+								if ( isEntityLink ) {
 									createBinding();
+								} else {
+									clearBinding();
 								}
 							} }
 						/>


### PR DESCRIPTION
## What?

Follow-up to #71630 which introduced dynamic URLs for Navigation Link blocks using the Block Bindings API.

This PR fixes two bugs discovered after the original implementation:

1. **Custom links creating empty bindings**: Manually inserting a "Custom Link" variation would incorrectly create an empty block binding
2. **Severed links retaining bindings**: Converting an existing entity link (Page/Post) to a custom URL would fail to clear the binding, causing the original entity link to persist

## Why?

The root cause was **derived state divergence** - binding decisions were made based on input values from `LinkUI` rather than the final computed state from `updateAttributes`.

### Example of the problem:
```javascript
// User converts entity link to custom link
onChange( { url: 'https://example.com' } )

// updateAttributes correctly severs the entity link:
setAttributes({ id: undefined, kind: 'custom' })

// But binding logic checked the INPUT (updatedValue.url exists)
// instead of the FINAL STATE (id was removed)
if ( updatedValue.url ) {
  createBinding() // ❌ Wrong! Should clear binding
}
```

## How?

**Refactored `updateAttributes` to return metadata** about the final computed state:

```javascript
const { isEntityLink } = updateAttributes(updatedValue, setAttributes, attributes);

// Use final state metadata for binding decisions
if ( isEntityLink ) {
  createBinding();
} else {
  clearBinding();
}
```

The `isEntityLink` metadata correctly reflects whether the final state is an entity link by checking if there's an `id` and the `kind` is not `'custom'`. The implementation uses the `in` operator to distinguish between:
- Property explicitly set to `undefined` (means "remove this")
- Property not in the delta (means "keep existing value")

**Updated three locations** to use this pattern consistently:
- `navigation-link/edit.js`
- `navigation-submenu/edit.js`  
- `navigation/edit/menu-inspector-controls.js`

## Testing Instructions

### Test 1: Custom Link Variation Should Not Create Bindings
1. Insert a Navigation block
2. Add a new Navigation Link block
3. Select the **Custom Link** variation from the block inserter
4. Enter a URL (e.g., `https://wordpress.org`)
5. Select the block and check the Code Editor view
6. ✅ **Expected**: No `metadata` or `bindings` attributes should be present
7. ❌ **Bug (before fix)**: Would show empty binding: `"metadata":{"bindings":{}}`

### Test 2: Converting Entity Link to Custom Link Should Clear Binding
1. Insert a Navigation block
2. Add a new Navigation Link and select an existing **Page** or **Post**
3. Verify in Code Editor that it has `"id":123` and `"metadata":{"bindings":{"url":{...}}}`
4. Click the link in the editor to open the Link UI
5. Click **"Unlink"** then type a new custom URL (e.g., `https://example.com`)
6. Press Enter to save
7. Check the Code Editor view
8. ✅ **Expected**: `id` attribute removed, `kind` is `"custom"`, no `metadata.bindings`
9. ❌ **Bug (before fix)**: Binding would remain, causing the original page/post URL to be used instead of the custom URL

### Test 3: Entity Links Should Still Create Bindings
1. Insert a Navigation block
2. Add a Navigation Link and select an existing **Page** or **Post**
3. Check the Code Editor view
4. ✅ **Expected**: Should have `"id":123`, `"kind":"post-type"`, and `"metadata":{"bindings":{"url":{...}}}`

### Test 4: Adding Links via Navigation List View Inspector
1. Insert a Navigation block
2. Open the List View (click the list icon in the toolbar)
3. Click the **"+"** button in the list view to add a new link
4. Select a **Page** → verify binding is created in Code Editor
5. Add another link via **"+"** button
6. Enter a custom URL → verify no binding is created in Code Editor