### PR TITLE
Changelogs: Fix example to match standard format

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -192,7 +192,7 @@ _Example:_
 
 ## Unreleased
 
-### Bug Fix
+### Bug Fixes
 
 -   Fixed an off-by-one error with the `sum` function.
 ```


### PR DESCRIPTION
## What?

Just a slight change in the example under the [Maintaining Changelogs](https://github.com/WordPress/gutenberg/blob/trunk/packages/README.md#maintaining-changelogs) section to match the current standard introduced in https://github.com/WordPress/gutenberg/pull/58268.

## Why?

I noticed that there is logic to support various ways of labeling bug fixes ([here](https://github.com/WordPress/gutenberg/blob/trunk/bin/plugin/commands/changelog.js#L172-L174)), so this change is not particularly important. This is to prevent contributors from using a non-standard form.