### PR TITLE
Block Bindings: Make `getFielsList` only available in Gutenberg plugin.

### DIFF
--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -349,10 +349,132 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 			}
 
 			const registeredSources = getBlockBindingsSources();
+			if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+				Object.entries( registeredSources ).forEach(
+					( [
+						sourceName,
+						{
+							editorUI,
+							getFieldsList,
+							usesContext,
+							label,
+							getValues,
+						},
+					] ) => {
+						if ( editorUI ) {
+							// Populate context.
+							const context = {};
+							if ( usesContext?.length ) {
+								for ( const key of usesContext ) {
+									context[ key ] = blockContext[ key ];
+								}
+							}
+
+							const editorUIResult = editorUI( {
+								select,
+								context,
+							} );
+							const hasCompatibleData = _bindableAttributes.some(
+								( attribute ) => {
+									const _attributeType =
+										getBlockType( blockName ).attributes?.[
+											attribute
+										]?.type;
+									const attributeType =
+										_attributeType === 'rich-text'
+											? 'string'
+											: _attributeType;
+
+									return editorUIResult.data?.some(
+										( item ) => item?.type === attributeType
+									);
+								}
+							);
+
+							if ( hasCompatibleData ) {
+								_sources[ sourceName ] = {
+									...editorUIResult,
+									label,
+									getValues,
+								};
+							}
+						} else if ( getFieldsList ) {
+							// Backward compatibility: Convert getFieldsList to editorUI format
+							const context = {};
+							if ( usesContext?.length ) {
+								for ( const key of usesContext ) {
+									context[ key ] = blockContext[ key ];
+								}
+							}
+
+							const fieldsListResult = getFieldsList( {
+								select,
+								context,
+							} );
+
+							if ( fieldsListResult ) {
+								// Convert getFieldsList format to editorUI format
+								const data = Object.entries(
+									fieldsListResult
+								).map( ( [ key, field ] ) => ( {
+									label: field.label || key,
+									type: field.type || 'string',
+									args: { key },
+								} ) );
+
+								const hasCompatibleData =
+									_bindableAttributes.some( ( attribute ) => {
+										const _attributeType =
+											getBlockType( blockName )
+												.attributes?.[ attribute ]
+												?.type;
+										const attributeType =
+											_attributeType === 'rich-text'
+												? 'string'
+												: _attributeType;
+
+										return data.some(
+											( item ) =>
+												item?.type === attributeType
+										);
+									} );
+
+								if ( hasCompatibleData ) {
+									_sources[ sourceName ] = {
+										mode: 'dropdown', // Default mode for backward compatibility
+										data,
+										label,
+										getValues,
+									};
+								}
+							}
+						} else {
+							/*
+							 * Include sources without editorUI if they are introduced
+							 * by other means (e.g. code editor).
+							 */
+							_sources[ sourceName ] = {
+								label,
+								getValues,
+							};
+						}
+					}
+				);
+				return {
+					sources:
+						Object.values( _sources ).length > 0
+							? _sources
+							: EMPTY_OBJECT,
+					canUpdateBlockBindings:
+						select( blockEditorStore ).getSettings()
+							.canUpdateBlockBindings,
+					bindableAttributes: _bindableAttributes,
+				};
+			}
 			Object.entries( registeredSources ).forEach(
 				( [
 					sourceName,
-					{ editorUI, getFieldsList, usesContext, label, getValues },
+					{ editorUI, usesContext, label, getValues },
 				] ) => {
 					// Populate context.
 					const context = {};
@@ -373,29 +495,6 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 							label,
 							getValues,
 						};
-					} else if ( getFieldsList ) {
-						// Backward compatibility: Convert getFieldsList to editorUI format.
-						const fieldsListResult = getFieldsList( {
-							select,
-							context,
-						} );
-
-						if ( fieldsListResult ) {
-							const data = Object.entries( fieldsListResult ).map(
-								( [ key, field ] ) => ( {
-									label: field.label || key,
-									type: field.type || 'string',
-									args: { key },
-								} )
-							);
-
-							_sources[ sourceName ] = {
-								mode: 'dropdown', // Default mode for backward compatibility.
-								data,
-								label,
-								getValues,
-							};
-						}
 					} else {
 						/*
 						 * Include sources without editorUI if they are already used in a binding.
@@ -409,7 +508,6 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 					}
 				}
 			);
-
 			return {
 				sources:
 					Object.values( _sources ).length > 0

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -830,9 +830,24 @@ export const registerBlockBindingsSource = ( source ) => {
 		getValues,
 		setValues,
 		canUserEditValue,
-		getFieldsList,
 		editorUI,
 	} = source;
+	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+		const { getFieldsList } = source;
+		if ( getFieldsList ) {
+			warning(
+				'The getFieldsList function only works on Gutenberg and will be removed in a future release.Please use the editorUI property instead.'
+			);
+		}
+		// Check the `getFieldsList` property is correct.
+		if ( getFieldsList && typeof getFieldsList !== 'function' ) {
+			// eslint-disable-next-line no-console
+			warning(
+				'Block bindings source getFieldsList must be a function.'
+			);
+			return;
+		}
+	}
 
 	const existingSource = unlock(
 		select( blocksStore )
@@ -921,13 +936,6 @@ export const registerBlockBindingsSource = ( source ) => {
 	// Check the `canUserEditValue` property is correct.
 	if ( canUserEditValue && typeof canUserEditValue !== 'function' ) {
 		warning( 'Block bindings source canUserEditValue must be a function.' );
-		return;
-	}
-
-	// Check the `getFieldsList` property is correct.
-	if ( getFieldsList && typeof getFieldsList !== 'function' ) {
-		// eslint-disable-next-line no-console
-		warning( 'Block bindings source getFieldsList must be a function.' );
 		return;
 	}
 

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { select, dispatch } from '@wordpress/data';
+import deprecated from '@wordpress/deprecated';
 import { _x } from '@wordpress/i18n';
 import warning from '@wordpress/warning';
 
@@ -835,9 +836,12 @@ export const registerBlockBindingsSource = ( source ) => {
 	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
 		const { getFieldsList } = source;
 		if ( getFieldsList ) {
-			warning(
-				'The getFieldsList function only works on Gutenberg and will be removed in a future release.Please use the editorUI property instead.'
-			);
+			deprecated( 'getFieldsList', {
+				since: '21.9.0',
+				version: '22.5.0',
+				alternative: 'editorUI',
+				plugin: 'Gutenberg',
+			} );
 		}
 		// Check the `getFieldsList` property is correct.
 		if ( getFieldsList && typeof getFieldsList !== 'function' ) {

--- a/packages/blocks/src/store/private-actions.js
+++ b/packages/blocks/src/store/private-actions.js
@@ -47,6 +47,19 @@ export function addUnprocessedBlockType( name, blockType ) {
  * @param {string} source Name of the source to register.
  */
 export function addBlockBindingsSource( source ) {
+	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+		return {
+			type: 'ADD_BLOCK_BINDINGS_SOURCE',
+			name: source.name,
+			label: source.label,
+			usesContext: source.usesContext,
+			getValues: source.getValues,
+			setValues: source.setValues,
+			canUserEditValue: source.canUserEditValue,
+			getFieldsList: source.getFieldsList,
+			editorUI: source.editorUI,
+		};
+	}
 	return {
 		type: 'ADD_BLOCK_BINDINGS_SOURCE',
 		name: source.name,
@@ -55,7 +68,6 @@ export function addBlockBindingsSource( source ) {
 		getValues: source.getValues,
 		setValues: source.setValues,
 		canUserEditValue: source.canUserEditValue,
-		getFieldsList: source.getFieldsList,
 		editorUI: source.editorUI,
 	};
 }

--- a/packages/blocks/src/store/private-actions.js
+++ b/packages/blocks/src/store/private-actions.js
@@ -47,20 +47,7 @@ export function addUnprocessedBlockType( name, blockType ) {
  * @param {string} source Name of the source to register.
  */
 export function addBlockBindingsSource( source ) {
-	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-		return {
-			type: 'ADD_BLOCK_BINDINGS_SOURCE',
-			name: source.name,
-			label: source.label,
-			usesContext: source.usesContext,
-			getValues: source.getValues,
-			setValues: source.setValues,
-			canUserEditValue: source.canUserEditValue,
-			getFieldsList: source.getFieldsList,
-			editorUI: source.editorUI,
-		};
-	}
-	return {
+	const action = {
 		type: 'ADD_BLOCK_BINDINGS_SOURCE',
 		name: source.name,
 		label: source.label,
@@ -70,6 +57,12 @@ export function addBlockBindingsSource( source ) {
 		canUserEditValue: source.canUserEditValue,
 		editorUI: source.editorUI,
 	};
+	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+		return {
+			...action,
+			getFieldsList: source.getFieldsList,
+		};
+	}
 }
 
 /**

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -393,11 +393,9 @@ function getMergedUsesContext( existingUsesContext = [], newUsesContext = [] ) {
 export function blockBindingsSources( state = {}, action ) {
 	switch ( action.type ) {
 		case 'ADD_BLOCK_BINDINGS_SOURCE':
-			// Only open this API in Gutenberg and for `core/post-meta` for the moment.
+			// Only open this API in Gutenberg, will be removed in about 3 months after 6.9.
 			let getFieldsList;
 			if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-				getFieldsList = action.getFieldsList;
-			} else if ( action.name === 'core/post-meta' ) {
 				getFieldsList = action.getFieldsList;
 			}
 			return {

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -122,10 +122,6 @@ export default {
 
 		return true;
 	},
-	getFieldsList( { select, context } ) {
-		// Deprecated, will be removed after 6.9.
-		return getPostDataFields( select, context );
-	},
 	editorUI( { select, context } ) {
 		const selectedBlock = select( 'core/block-editor' ).getSelectedBlock();
 		if ( selectedBlock?.name !== 'core/post-date' ) {

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -141,10 +141,6 @@ export default {
 
 		return true;
 	},
-	getFieldsList( { select, context } ) {
-		// Deprecated, will be removed after 6.9.
-		return getPostMetaFields( select, context );
-	},
 	editorUI( { select, context } ) {
 		const metaFields = Object.entries(
 			getPostMetaFields( select, context ) || {}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
According to the code. `getFieldsList` was only available for `post-meta` source and the Gutenberg plugin. As it has never been in Core, extenders without Gutenberg plugin could not use it.

We are "deprecating" ( it was never public or documented ) in favor of the new `editorUI`, so let's give a couple of months after the WordPress release for any extender who used it, to update to the new `editorUI`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

- Create a custom source, register on the editor with getFieldsList.
- Check that fields are appearing on the UI with Gutenberg enabled, check console for a warning.
- Disable Gutenberg, the field should not appear on Core.
