### PR TITLE
Fix navigation link URL binding resolution on frontend

### DIFF
--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -202,6 +202,20 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		return '';
 	}
 
+	// Resolve URL binding if present
+	$url = $attributes['url'] ?? '';
+	if ( isset( $attributes['metadata']['bindings']['url']['source'] ) ) {
+		$binding = $attributes['metadata']['bindings']['url'];
+		$source = get_block_bindings_source( $binding['source'] );
+		if ( $source ) {
+			$source_args = $binding['args'] ?? array();
+			$resolved_url = $source->get_value( $source_args, $block, 'url' );
+			if ( $resolved_url ) {
+				$url = $resolved_url;
+			}
+		}
+	}
+
 	$font_sizes      = block_core_navigation_link_build_css_font_sizes( $block->context );
 	$classes         = array_merge(
 		$font_sizes['css_classes']
@@ -213,9 +227,9 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	$kind        = empty( $attributes['kind'] ) ? 'post_type' : str_replace( '-', '_', $attributes['kind'] );
 	$is_active   = ! empty( $attributes['id'] ) && get_queried_object_id() === (int) $attributes['id'] && ! empty( get_queried_object()->$kind );
 
-	if ( is_post_type_archive() && ! empty( $attributes['url'] ) ) {
+	if ( is_post_type_archive() && ! empty( $url ) ) {
 		$queried_archive_link = get_post_type_archive_link( get_queried_object()->name );
-		if ( $attributes['url'] === $queried_archive_link ) {
+		if ( $url === $queried_archive_link ) {
 			$is_active = true;
 		}
 	}
@@ -231,8 +245,8 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		'<a class="wp-block-navigation-item__content" ';
 
 	// Start appending HTML attributes to anchor tag.
-	if ( isset( $attributes['url'] ) ) {
-		$html .= ' href="' . esc_url( block_core_navigation_link_maybe_urldecode( $attributes['url'] ) ) . '"';
+	if ( ! empty( $url ) ) {
+		$html .= ' href="' . esc_url( block_core_navigation_link_maybe_urldecode( $url ) ) . '"';
 	}
 
 	if ( $is_active ) {

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -206,9 +206,9 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	$url = $attributes['url'] ?? '';
 	if ( isset( $attributes['metadata']['bindings']['url']['source'] ) ) {
 		$binding = $attributes['metadata']['bindings']['url'];
-		$source = get_block_bindings_source( $binding['source'] );
+		$source  = get_block_bindings_source( $binding['source'] );
 		if ( $source ) {
-			$source_args = $binding['args'] ?? array();
+			$source_args  = $binding['args'] ?? array();
 			$resolved_url = $source->get_value( $source_args, $block, 'url' );
 			if ( $resolved_url ) {
 				$url = $resolved_url;

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -83,9 +83,9 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	$url = $attributes['url'] ?? '';
 	if ( isset( $attributes['metadata']['bindings']['url']['source'] ) ) {
 		$binding = $attributes['metadata']['bindings']['url'];
-		$source = get_block_bindings_source( $binding['source'] );
+		$source  = get_block_bindings_source( $binding['source'] );
 		if ( $source ) {
-			$source_args = $binding['args'] ?? array();
+			$source_args  = $binding['args'] ?? array();
 			$resolved_url = $source->get_value( $source_args, $block, 'url' );
 			if ( $resolved_url ) {
 				$url = $resolved_url;

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -79,6 +79,20 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		return '';
 	}
 
+	// Resolve URL binding if present
+	$url = $attributes['url'] ?? '';
+	if ( isset( $attributes['metadata']['bindings']['url']['source'] ) ) {
+		$binding = $attributes['metadata']['bindings']['url'];
+		$source = get_block_bindings_source( $binding['source'] );
+		if ( $source ) {
+			$source_args = $binding['args'] ?? array();
+			$resolved_url = $source->get_value( $source_args, $block, 'url' );
+			if ( $resolved_url ) {
+				$url = $resolved_url;
+			}
+		}
+	}
+
 	$font_sizes      = block_core_navigation_submenu_build_css_font_sizes( $block->context );
 	$style_attribute = $font_sizes['inline_styles'];
 
@@ -86,9 +100,9 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	$kind        = empty( $attributes['kind'] ) ? 'post_type' : str_replace( '-', '_', $attributes['kind'] );
 	$is_active   = ! empty( $attributes['id'] ) && get_queried_object_id() === (int) $attributes['id'] && ! empty( get_queried_object()->$kind );
 
-	if ( is_post_type_archive() && ! empty( $attributes['url'] ) ) {
+	if ( is_post_type_archive() && ! empty( $url ) ) {
 		$queried_archive_link = get_post_type_archive_link( get_queried_object()->name );
-		if ( $attributes['url'] === $queried_archive_link ) {
+		if ( $url === $queried_archive_link ) {
 			$is_active = true;
 		}
 	}
@@ -142,7 +156,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	// If Submenus open on hover, we render an anchor tag with attributes.
 	// If submenu icons are set to show, we also render a submenu button, so the submenu can be opened on click.
 	if ( ! $open_on_click ) {
-		$item_url = isset( $attributes['url'] ) ? $attributes['url'] : '';
+		$item_url = $url;
 		// Start appending HTML attributes to anchor tag.
 		$html .= '<a class="wp-block-navigation-item__content"';
 


### PR DESCRIPTION
## What

Fixes navigation link and navigation submenu blocks to properly resolve URL bindings on the frontend. Previously, these blocks were outputting stored URL attributes instead of resolving bound values from sources like `core/entity`.

Follow up to https://github.com/WordPress/gutenberg/pull/71630

## Why

Navigation blocks with URL bindings (e.g., bound to post permalinks via `core/entity` source) were not displaying the correct URLs on the frontend. The blocks were using the stored `url` attribute directly instead of resolving the binding, making the binding functionality ineffective for navigation links.

This bug was particularly insidious because as a consumer, it wasn't immediately clear that bindings weren't being auto-resolved on the frontend - the binding system appeared to work in the editor, but the actual rendered output was using the stored attribute values instead of the resolved binding values.

## How

Added manual binding resolution to both `core/navigation-link` and `core/navigation-submenu` render functions, following the same pattern used in `core/post-date` block:

1. Check for URL binding metadata
2. Get the binding source (e.g., `core/entity`)
3. Call the source's `get_value()` method with binding args
4. Use resolved URL instead of stored attribute

Uses a separate `$url` variable to avoid modifying the original `$attributes` array.

## Testing

**Navigation Link Block:**
1. Delete all items from menu (important)
2. Create a new entity link to a Page
3. Open black 'W' sidebar
4. Click Navigation - select your Navigation Menu
5. Find 3 dots settings menu and click "Edit"
6. Click into the canvas
7. Switch to code view
8. Change the URL attribute to "XXXXXX" or something
9. Save
10. Switch to front of site
11. Validate that `href` of link resolves to the bound entity and not the random URL
12. Also try removing the `url` attribute entirely

**Navigation Submenu Block:**
Repeat the above steps for the Submenu block as well.

- All existing navigation E2E tests pass (14/14)
- No regression in existing functionality

## Screenshots

[Screenshots to be added]