### PR TITLE
Template activation: adjust saveEntityRecord compat

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -537,6 +537,25 @@ export const saveEntityRecord =
 				'wp_registered_template',
 				recordId
 			);
+			// Evaluate optimized edits.
+			// (Function edits that should be evaluated on save to avoid expensive computations on every edit.)
+			for ( const [ key, value ] of Object.entries( record ) ) {
+				if ( typeof value === 'function' ) {
+					const evaluatedValue = value(
+						select.getEditedEntityRecord( kind, name, recordId )
+					);
+					dispatch.editEntityRecord(
+						kind,
+						name,
+						recordId,
+						{
+							[ key ]: evaluatedValue,
+						},
+						{ undoIgnore: true }
+					);
+					record[ key ] = evaluatedValue;
+				}
+			}
 			// Duplicate the theme template and make the edit.
 			const newTemplate = await dispatch.saveEntityRecord(
 				'postType',

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -523,6 +523,26 @@ export const saveEntityRecord =
 		const entityIdKey = entityConfig.key || DEFAULT_ENTITY_KEY;
 		const recordId = record[ entityIdKey ];
 
+		// Evaluate optimized edits.
+		// (Function edits that should be evaluated on save to avoid expensive computations on every edit.)
+		for ( const [ key, value ] of Object.entries( record ) ) {
+			if ( typeof value === 'function' ) {
+				const evaluatedValue = value(
+					select.getEditedEntityRecord( kind, name, recordId )
+				);
+				dispatch.editEntityRecord(
+					kind,
+					name,
+					recordId,
+					{
+						[ key ]: evaluatedValue,
+					},
+					{ undoIgnore: true }
+				);
+				record[ key ] = evaluatedValue;
+			}
+		}
+
 		// When called with a theme template ID, trigger the compatibility
 		// logic.
 		if (
@@ -537,25 +557,6 @@ export const saveEntityRecord =
 				'wp_registered_template',
 				recordId
 			);
-			// Evaluate optimized edits.
-			// (Function edits that should be evaluated on save to avoid expensive computations on every edit.)
-			for ( const [ key, value ] of Object.entries( record ) ) {
-				if ( typeof value === 'function' ) {
-					const evaluatedValue = value(
-						select.getEditedEntityRecord( kind, name, recordId )
-					);
-					dispatch.editEntityRecord(
-						kind,
-						name,
-						recordId,
-						{
-							[ key ]: evaluatedValue,
-						},
-						{ undoIgnore: true }
-					);
-					record[ key ] = evaluatedValue;
-				}
-			}
 			// Duplicate the theme template and make the edit.
 			const newTemplate = await dispatch.saveEntityRecord(
 				'postType',
@@ -589,26 +590,6 @@ export const saveEntityRecord =
 		);
 
 		try {
-			// Evaluate optimized edits.
-			// (Function edits that should be evaluated on save to avoid expensive computations on every edit.)
-			for ( const [ key, value ] of Object.entries( record ) ) {
-				if ( typeof value === 'function' ) {
-					const evaluatedValue = value(
-						select.getEditedEntityRecord( kind, name, recordId )
-					);
-					dispatch.editEntityRecord(
-						kind,
-						name,
-						recordId,
-						{
-							[ key ]: evaluatedValue,
-						},
-						{ undoIgnore: true }
-					);
-					record[ key ] = evaluatedValue;
-				}
-			}
-
 			dispatch( {
 				type: 'SAVE_ENTITY_RECORD_START',
 				kind,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

saveEntityRecord might be called with content properties that have a function. In that case, we need to fetch the current edited entity and call the function with the edited entity as an argument.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
