### PR TITLE
Fix Nav Block Link UI regression for blocks with id but no binding - make UI opt in

### DIFF
--- a/packages/block-library/src/navigation-link/link-ui/index.js
+++ b/packages/block-library/src/navigation-link/link-ui/index.js
@@ -66,7 +66,7 @@ export function getSuggestionsQuery( type, kind ) {
 }
 
 function UnforwardedLinkUI( props, ref ) {
-	const { label, url, opensInNewTab, type, kind, id } = props.link;
+	const { label, url, opensInNewTab, type, kind, id, metadata } = props.link;
 	const postType = type || 'page';
 
 	const [ addingBlock, setAddingBlock ] = useState( false );
@@ -77,6 +77,11 @@ function UnforwardedLinkUI( props, ref ) {
 		kind: 'postType',
 		name: postType,
 	} );
+
+	// Check if there's a URL binding with the core/entity source
+	// Only enable handleEntities when there's actually a binding present
+	const hasUrlBinding =
+		metadata?.bindings?.url?.source === 'core/entity' && !! id;
 
 	// Memoize link value to avoid overriding the LinkControl's internal state.
 	// This is a temporary fix. See https://github.com/WordPress/gutenberg/issues/50976#issuecomment-1568226407.
@@ -145,7 +150,7 @@ function UnforwardedLinkUI( props, ref ) {
 						onChange={ props.onChange }
 						onRemove={ props.onRemove }
 						onCancel={ props.onCancel }
-						handleEntities
+						handleEntities={ hasUrlBinding }
 						renderControlBottom={ () => {
 							// Don't show the tools when there is submitted link (preview state).
 							if ( link?.url?.length ) {

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -829,6 +829,59 @@ test.describe( 'Navigation block', () => {
 			await expect( linkInput ).toBeEnabled();
 			await expect( linkInput ).toHaveValue( '' );
 		} );
+
+		test( 'existing links with id but no binding remain editable', async ( {
+			editor,
+			page,
+			admin,
+			navigation,
+			requestUtils,
+		} ) => {
+			await admin.createNewPost();
+
+			// Create a menu with an existing link that has id but no binding
+			// This simulates existing sites before the binding feature
+			const menu = await requestUtils.createNavigationMenu( {
+				title: 'Test Menu',
+				content: `<!-- wp:navigation-link {"label":"Support","type":"page","id":${ testPage1.id },"url":"${ testPage1.link }","kind":"post-type"} /-->`,
+			} );
+
+			await editor.insertBlock( {
+				name: 'core/navigation',
+				attributes: {
+					ref: menu.id,
+				},
+			} );
+
+			// Select the Navigation Link block
+			const navBlock = navigation.getNavBlock();
+			await editor.selectBlocks( navBlock );
+
+			const navLinkBlock = navBlock
+				.getByRole( 'document', {
+					name: 'Block: Page Link',
+				} )
+				.first();
+
+			await editor.selectBlocks( navLinkBlock );
+
+			// Check the Inspector controls for the Nav Link block
+			// to verify the Link field is enabled (not locked in entity mode)
+			await editor.openDocumentSettingsSidebar();
+			const settingsControls = page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'tabpanel', { name: 'Settings' } );
+
+			await expect( settingsControls ).toBeVisible();
+
+			const linkInput = settingsControls.getByRole( 'textbox', {
+				name: 'Link',
+			} );
+
+			// For existing links with id but no binding, the input should be enabled
+			await expect( linkInput ).toBeEnabled();
+			await expect( linkInput ).toHaveValue( testPage1.link );
+		} );
 	} );
 } );
 


### PR DESCRIPTION
## What

Fixes regression where existing navigation links with `id` but no binding were incorrectly showing locked entity UI.

## Why

The recent dynamic URL binding changes introduced a regression where existing WordPress sites with navigation links containing an `id` attribute (but no actual binding) would show the locked entity UI, making them appear non-editable. This affects existing sites that have navigation links like:

```html
<!-- wp:navigation-link {"label":"Support","type":"page","id":26,"url":"XXXXXX","kind":"post-type"} /-->
```

These links have an `id` but no `metadata.bindings`, so they should remain editable.

## How

- Made `handleEntities` conditional on actual binding presence in LinkUI component
- Only links with both `id` AND `metadata.bindings.url.source === 'core/entity'` get locked entity UI
- Existing links with `id` but no binding remain editable
- New links with proper bindings get the locked entity UI as intended
- Added E2E test to verify the fix

## Testing

Please test with Link and Submenu:

1. Existing sites: Links with `id` but no binding remain editable ✅
2. New bound links: Links with `id` and binding show locked UI ✅  
3. Custom links: Links without `id` remain editable ✅
4. E2E test: `existing links with id but no binding remain editable` passes ✅

## Breaking Changes

None - this is a regression fix that maintains backward compatibility.

## Screenshots

[Screenshots to be added]