### PR TITLE
Add keyboard shortcut toggle block visibility

### DIFF
--- a/packages/block-editor/src/components/keyboard-shortcuts/index.js
+++ b/packages/block-editor/src/components/keyboard-shortcuts/index.js
@@ -197,6 +197,16 @@ function KeyboardShortcutsRegister() {
 				character: 'g',
 			},
 		} );
+
+		registerShortcut( {
+			name: 'core/block-editor/toggle-block-visibility',
+			category: 'block',
+			description: __( 'Show or hide the selected block(s).' ),
+			keyCombination: {
+				modifier: 'primaryShift',
+				character: 'h',
+			},
+		} );
 	}, [ registerShortcut ] );
 
 	return null;


### PR DESCRIPTION
Part of #72001

## What?

This PR adds a keyboard shortcut to toggle the `metadata.blockVisibility` attribute.

## Why?

Like in any design tool, there should be a shortcut to change the visibility of a block.

## How?

Adds the following shortcut. This is the same as the shortcut for switching layer visibility in Figma.

- Mac: Command+Shift+H (⌘+⇧+H)
- Windows: Control+Shift+H (Ctrl+⇧+H)

Also, note that this shortcut overrides any browser or OS shortcuts. As far as I can tell, it overrides the following shortcuts:

- Mac:
  - Apple macOS: Open the Home folder of the current macOS user account
  - Firefox (macOS): History sidebar
- Windows:
  - Firefox: Library window (history)

That said, this shortcut is a contextual command that is only valid when a block is selected, so I personally find it acceptable.

- [What does the Cmd + Shift + H keyboard shortcut? ‒ DefKey](https://defkey.com/what-means/command-shift-h)
- [What does the Ctrl + Shift + H keyboard shortcut? ‒ DefKey](https://defkey.com/what-means/ctrl-shift-h)

## Testing Instructions

- In the block editor, select multiple blocks and run the shortcut.
- Shortcuts should also work in List View.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/27e22829-242c-41bf-a813-2da6f2d67a23