### PR TITLE
Build: Move packages that output script modules to v2 pipeline

### DIFF
--- a/bin/packages/v2-packages.js
+++ b/bin/packages/v2-packages.js
@@ -6,6 +6,7 @@
  * @type {string[]}
  */
 const V2_PACKAGES = [
+	'a11y',
 	'api-fetch',
 	'autop',
 	'blob',

--- a/package-lock.json
+++ b/package-lock.json
@@ -48808,7 +48808,6 @@
 			"version": "4.32.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/runtime": "7.25.7",
 				"@wordpress/dom-ready": "file:../dom-ready",
 				"@wordpress/i18n": "file:../i18n"
 			},

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -26,12 +26,19 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"exports": {
+		".": {
+			"types": "./build-types/index.d.ts",
+			"import": "./build-module/index.js",
+			"require": "./build/index.js"
+		},
+		"./package.json": "./package.json"
+	},
 	"react-native": "src/index",
 	"wpScript": true,
 	"wpScriptModuleExports": "./build-module/module/index.js",
 	"types": "build-types",
 	"dependencies": {
-		"@babel/runtime": "7.25.7",
 		"@wordpress/dom-ready": "file:../dom-ready",
 		"@wordpress/i18n": "file:../i18n"
 	},

--- a/tools/webpack/script-modules.js
+++ b/tools/webpack/script-modules.js
@@ -13,6 +13,7 @@ const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extrac
  * Internal dependencies
  */
 const { baseConfig, plugins } = require( './shared' );
+const { V2_PACKAGES } = require( '../../bin/packages/v2-packages' );
 
 const WORDPRESS_NAMESPACE = '@wordpress/';
 
@@ -26,6 +27,11 @@ const packageDirs = readdirSync(
 /** @type {Map<string, string>} */
 const gutenbergScriptModules = new Map();
 for ( const packageDir of packageDirs ) {
+	// Skip v2 packages - they're built with build-v2.mjs
+	if ( V2_PACKAGES.includes( packageDir ) ) {
+		continue;
+	}
+
 	const packageJson = require( `@wordpress/${ packageDir }/package.json` );
 
 	if ( ! Object.hasOwn( packageJson, 'wpScriptModuleExports' ) ) {


### PR DESCRIPTION
Related #72032

## What?

This continues the work on the v2 build pipeline and expands the number of packages built by the v2 pipeline. 
The current PR focus on packages like "a11y" that use the "wpScriptModuleExports" flag to generate script modules to be registered in WordPress.

## Testing instructions

 - you can run `npm run dev` locally, changes some files in the said packages.
 - Everything should continue to work as normal. (especially the a11y module)