### PR TITLE
Fix: Prevent focus loss in Firefox when typing in sidebar inputs

### DIFF
--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -290,28 +290,58 @@ export function applySelection( { startPath, endPath }, current ) {
 
 	selection.addRange( range );
 
-	// This function is not intended to cause a shift in focus. Since the above
-	// selection manipulations may shift focus, ensure that focus is restored to
-	// its previous state.
-	if ( activeElement !== ownerDocument.activeElement ) {
-		// The `instanceof` checks protect against edge cases where the focused
-		// element is not of the interface HTMLElement (does not have a `focus`
-		// or `blur` property).
-		//
-		// See: https://github.com/Microsoft/TypeScript/issues/5901#issuecomment-431649653
-		if ( activeElement instanceof defaultView.HTMLElement ) {
-			// In Firefox, when you click off the canvas, the BODY becomes the active element.
-			// 1. User types in canvas → switches to sidebar input
-			// 2. Inside the iframe, activeElement is now BODY (default when nothing specific is focused)
-			// 3. RichText updates from typing in sidebar → calls selection.addRange(range)
-			// 4. addRange() moves focus from BODY to the contentEditable DIV
-			// 5. Code detects focus changed, tries to restore by calling body.focus()
-			// 6. In Firefox: calling focus() on BODY inside an iframe focuses the iframe itself in the parent document
-			// 7. Sidebar input loses focus → cursor jumps to iframe
-			// By checking to see if the active element is BODY, we prevent firefox from stealing focus to the canvas.
-			if ( activeElement.tagName !== 'BODY' ) {
+	// Restore activeElement to make selection.addRange() behavior consistent across browsers.
+	// In Firefox, addRange() can change activeElement (e.g., BODY → contentEditable DIV).
+	// In Chrome, addRange() does not change activeElement.
+	// We restore activeElement to match Chrome's behavior and avoid focus management issues.
+	if (
+		activeElement !== ownerDocument.activeElement &&
+		activeElement instanceof defaultView.HTMLElement
+	) {
+		// In Firefox, calling focus() on BODY inside an iframe focuses the iframe
+		// in the parent document, stealing focus from inputs/textareas in the parent.
+		// Check parent document to avoid stealing focus.
+		if ( activeElement.tagName === 'BODY' ) {
+			let shouldRestoreFocus = true;
+			let parentActiveElement = null;
+			try {
+				if (
+					defaultView.parent &&
+					defaultView.parent !== defaultView
+				) {
+					parentActiveElement =
+						defaultView.parent.document.activeElement;
+					// Don't restore BODY focus if parent has an interactive element focused
+					// (INPUT, TEXTAREA, etc.). This prevents stealing focus from sidebar inputs.
+					// Restore BODY when parent has BODY or IFRAME focused (normal editing flow).
+					const isInteractiveElement =
+						parentActiveElement &&
+						parentActiveElement.tagName !== 'BODY' &&
+						parentActiveElement.tagName !== 'IFRAME';
+					shouldRestoreFocus = ! isInteractiveElement;
+				}
+			} catch ( e ) {
+				// Cross-origin iframe, can't access parent - assume safe to restore
+				shouldRestoreFocus = true;
+			}
+
+			console.log( '[to-dom] BODY restoration check', {
+				shouldRestoreFocus,
+				parentActiveElement: parentActiveElement?.tagName,
+				parentActiveElementClass: parentActiveElement?.className,
+				currentActiveElement: ownerDocument.activeElement?.tagName,
+			} );
+
+			if ( shouldRestoreFocus ) {
 				activeElement.focus();
 			}
+		} else {
+			console.log(
+				'[to-dom] Restoring non-BODY element:',
+				activeElement.tagName
+			);
+			// Always restore focus to non-BODY elements
+			activeElement.focus();
 		}
 	}
 }

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -290,44 +290,52 @@ export function applySelection( { startPath, endPath }, current ) {
 
 	selection.addRange( range );
 
-	// Restore activeElement to make selection.addRange() behavior consistent across browsers.
+	// This function is not intended to cause a shift in focus. Since the above
+	// selection manipulations may shift focus, ensure that focus is restored to
+	// its previous state.
+	//
 	// In Firefox, addRange() can change activeElement (e.g., BODY → contentEditable DIV).
 	// In Chrome, addRange() does not change activeElement.
 	// We restore activeElement to match Chrome's behavior and avoid focus management issues.
+	//
+	// In Firefox, when you click off the canvas, the BODY becomes the active element.
+	// 1. User types in canvas → switches to sidebar input
+	// 2. Inside the iframe, activeElement is now BODY (default when nothing specific is focused)
+	// 3. RichText updates from typing in sidebar → calls selection.addRange(range)
+	// 4. addRange() (within this function) moves focus from BODY to the contentEditable DIV
+	// 5. (where we're at in the code now) Code detects focus changed, and determines if we should restore focus
+	// 6. If a non-body item is focused, we restore focus to the canvas. That means they were working in
+	//   the canvas, and we should honor that focus placement.
+	// 7. If the body is focused, that means we're outside of the editing canvas. This normally means we want to
+	//   to preserve focus outside the canvas, such as when editing the navigation block text field from the inspector
+	//   (see https://github.com/WordPress/gutenberg/pull/72071)
+	// 8. If the parent document ALSO has no focused element, then we restore focus to the canvas. This happens when
+	//   we do a block transformation, split block content, indent a list item from the toolbar, etc. In those cases,
+	//   we want to restore focus to the canvas since the parent document also has no intentionally focused element.
 	if (
 		activeElement !== ownerDocument.activeElement &&
 		activeElement instanceof defaultView.HTMLElement
 	) {
-		// In Firefox, when you click off the canvas, the BODY becomes the active element.
-		// 1. User types in canvas → switches to sidebar input
-		// 2. Inside the iframe, activeElement is now BODY (default when nothing specific is focused)
-		// 3. RichText updates from typing in sidebar → calls selection.addRange(range)
-		// 4. addRange() moves focus from BODY to the contentEditable DIV
-		// 5. Code detects focus changed, tries to restore by calling body.focus()
-		// 6. In Firefox: calling focus() on BODY inside an iframe focuses the iframe itself in the parent document
-		// 7. Sidebar input loses focus → cursor jumps to iframe
-		// By checking to see if the active element is BODY and
 		if ( activeElement.tagName === 'BODY' ) {
 			let shouldRestoreFocus;
 			try {
+				// Check if the parent document has an active element. If the body is focused from the parent frame,
+				// then we assume it's due to a focus loss or because they're working intentionally in the canvas and
+				// we should restore focus to the canvas.
 				if (
 					defaultView.parent &&
 					defaultView.parent !== defaultView
 				) {
 					const parentActiveElement =
 						defaultView.parent.document.activeElement;
-					// If nothing is currently focused on the parent, then we assume the user
-					// is in normal editing flow within the canvas and we should restore focus
-					// to the canvas.
-					// If the parent has an element focused (such as input, div, etc.), then we assume
-					// the user has intended to place focus there.
+
 					shouldRestoreFocus =
 						parentActiveElement &&
-						( parentActiveElement.tagName === 'BODY' ||
-							parentActiveElement.tagName === 'IFRAME' );
+						parentActiveElement.tagName === 'BODY';
 				}
 			} catch ( e ) {
-				// Cross-origin iframe, can't access parent - assume safe to restore
+				// Cross-origin iframe, we can't access parent - assume it is safe to
+				// restore as we likely don't want the BODY element to be focused
 				shouldRestoreFocus = true;
 			}
 

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -298,48 +298,43 @@ export function applySelection( { startPath, endPath }, current ) {
 		activeElement !== ownerDocument.activeElement &&
 		activeElement instanceof defaultView.HTMLElement
 	) {
-		// In Firefox, calling focus() on BODY inside an iframe focuses the iframe
-		// in the parent document, stealing focus from inputs/textareas in the parent.
-		// Check parent document to avoid stealing focus.
+		// In Firefox, when you click off the canvas, the BODY becomes the active element.
+		// 1. User types in canvas → switches to sidebar input
+		// 2. Inside the iframe, activeElement is now BODY (default when nothing specific is focused)
+		// 3. RichText updates from typing in sidebar → calls selection.addRange(range)
+		// 4. addRange() moves focus from BODY to the contentEditable DIV
+		// 5. Code detects focus changed, tries to restore by calling body.focus()
+		// 6. In Firefox: calling focus() on BODY inside an iframe focuses the iframe itself in the parent document
+		// 7. Sidebar input loses focus → cursor jumps to iframe
+		// By checking to see if the active element is BODY and
 		if ( activeElement.tagName === 'BODY' ) {
-			let shouldRestoreFocus = true;
-			let parentActiveElement = null;
+			let shouldRestoreFocus;
 			try {
 				if (
 					defaultView.parent &&
 					defaultView.parent !== defaultView
 				) {
-					parentActiveElement =
+					const parentActiveElement =
 						defaultView.parent.document.activeElement;
-					// Don't restore BODY focus if parent has an interactive element focused
-					// (INPUT, TEXTAREA, etc.). This prevents stealing focus from sidebar inputs.
-					// Restore BODY when parent has BODY or IFRAME focused (normal editing flow).
-					const isInteractiveElement =
+					// If nothing is currently focused on the parent, then we assume the user
+					// is in normal editing flow within the canvas and we should restore focus
+					// to the canvas.
+					// If the parent has an element focused (such as input, div, etc.), then we assume
+					// the user has intended to place focus there.
+					shouldRestoreFocus =
 						parentActiveElement &&
-						parentActiveElement.tagName !== 'BODY' &&
-						parentActiveElement.tagName !== 'IFRAME';
-					shouldRestoreFocus = ! isInteractiveElement;
+						( parentActiveElement.tagName === 'BODY' ||
+							parentActiveElement.tagName === 'IFRAME' );
 				}
 			} catch ( e ) {
 				// Cross-origin iframe, can't access parent - assume safe to restore
 				shouldRestoreFocus = true;
 			}
 
-			console.log( '[to-dom] BODY restoration check', {
-				shouldRestoreFocus,
-				parentActiveElement: parentActiveElement?.tagName,
-				parentActiveElementClass: parentActiveElement?.className,
-				currentActiveElement: ownerDocument.activeElement?.tagName,
-			} );
-
 			if ( shouldRestoreFocus ) {
 				activeElement.focus();
 			}
 		} else {
-			console.log(
-				'[to-dom] Restoring non-BODY element:',
-				activeElement.tagName
-			);
 			// Always restore focus to non-BODY elements
 			activeElement.focus();
 		}

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -300,16 +300,16 @@ export function applySelection( { startPath, endPath }, current ) {
 		//
 		// See: https://github.com/Microsoft/TypeScript/issues/5901#issuecomment-431649653
 		if ( activeElement instanceof defaultView.HTMLElement ) {
-			// Don't restore focus to BODY or HTML elements, as this can cause
-			// unwanted focus changes. In Firefox, focusing BODY inside an iframe
-			// can cause the parent document to focus the iframe itself.
-			// Only restore focus to meaningful focusable elements.
-			const tagName = activeElement.tagName;
-			const isContentEditable = activeElement.isContentEditable;
-			const isMeaningfulElement =
-				tagName !== 'BODY' && tagName !== 'HTML' && tagName !== 'DIV';
-
-			if ( isContentEditable || isMeaningfulElement ) {
+			// In Firefox, when you click off the canvas, the BODY becomes the active element.
+			// 1. User types in canvas → switches to sidebar input
+			// 2. Inside the iframe, activeElement is now BODY (default when nothing specific is focused)
+			// 3. RichText updates from typing in sidebar → calls selection.addRange(range)
+			// 4. addRange() moves focus from BODY to the contentEditable DIV
+			// 5. Code detects focus changed, tries to restore by calling body.focus()
+			// 6. In Firefox: calling focus() on BODY inside an iframe focuses the iframe itself in the parent document
+			// 7. Sidebar input loses focus → cursor jumps to iframe
+			// By checking to see if the active element is BODY, we prevent firefox from stealing focus to the canvas.
+			if ( activeElement.tagName !== 'BODY' ) {
 				activeElement.focus();
 			}
 		}

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -300,7 +300,18 @@ export function applySelection( { startPath, endPath }, current ) {
 		//
 		// See: https://github.com/Microsoft/TypeScript/issues/5901#issuecomment-431649653
 		if ( activeElement instanceof defaultView.HTMLElement ) {
-			activeElement.focus();
+			// Don't restore focus to BODY or HTML elements, as this can cause
+			// unwanted focus changes. In Firefox, focusing BODY inside an iframe
+			// can cause the parent document to focus the iframe itself.
+			// Only restore focus to meaningful focusable elements.
+			const tagName = activeElement.tagName;
+			const isContentEditable = activeElement.isContentEditable;
+			const isMeaningfulElement =
+				tagName !== 'BODY' && tagName !== 'HTML' && tagName !== 'DIV';
+
+			if ( isContentEditable || isMeaningfulElement ) {
+				activeElement.focus();
+			}
 		}
 	}
 }

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -606,6 +606,113 @@ test.describe( 'Navigation block', () => {
 			await pageUtils.pressKeys( 'ArrowDown' );
 			await expect( navigation.getNavBlockInserter() ).toBeFocused();
 		} );
+
+		test( 'should preserve focus in sidebar text input when typing (@firefox)', async ( {
+			page,
+			editor,
+			requestUtils,
+			pageUtils,
+			navigation,
+		} ) => {
+			// Create a navigation menu with one link
+			const createdMenu = await requestUtils.createNavigationMenu( {
+				title: 'Test Menu',
+				content: `<!-- wp:navigation-link {"label":"Home","url":"https://example.com"} /-->`,
+			} );
+
+			// Insert the navigation block
+			await editor.insertBlock( {
+				name: 'core/navigation',
+				attributes: {
+					ref: createdMenu?.id,
+				},
+			} );
+
+			// Click on the navigation link label in the canvas to edit it
+			const linkLabel = editor.canvas.getByRole( 'textbox', {
+				name: 'Navigation link text',
+			} );
+			await linkLabel.click();
+			await pageUtils.pressKeys( 'primary+a' );
+			await page.keyboard.type( 'Updated Home' );
+
+			// Open the document settings sidebar
+			await editor.openDocumentSettingsSidebar();
+
+			// Tab to the sidebar settings panel
+			// First tab should go to the settings sidebar
+			await page.keyboard.press( 'Tab' );
+
+			// Find the text input in the sidebar
+			const textInput = page.getByRole( 'textbox', {
+				name: 'Text',
+			} );
+
+			// Tab until we reach the Text field in the sidebar
+			// This may take multiple tabs depending on other controls
+			for ( let i = 0; i < 10; i++ ) {
+				const focusedElement = await page.evaluate( () => {
+					const el = document.activeElement;
+					return {
+						tagName: el?.tagName,
+						label:
+							el?.getAttribute( 'aria-label' ) ||
+							el?.labels?.[ 0 ]?.textContent,
+						id: el?.id,
+					};
+				} );
+
+				if (
+					focusedElement.label?.includes( 'Text' ) &&
+					focusedElement.tagName === 'INPUT'
+				) {
+					break;
+				}
+
+				await page.keyboard.press( 'Tab' );
+			}
+
+			await expect( textInput ).toBeFocused();
+			await pageUtils.pressKeys( 'ArrowRight' );
+			// Type in the sidebar text input
+			await page.keyboard.type( ' Extra' );
+
+			// Verify the text was actually typed (change happened)
+			await expect( textInput ).toHaveValue( 'Updated Home Extra' );
+
+			// Tab again to move to the next field
+			await page.keyboard.press( 'Tab' );
+
+			// Check that focus is still within the document sidebar
+			const focusIsInSidebar = await page.evaluate( () => {
+				const activeEl = document.activeElement;
+				const sidebar = document.querySelector(
+					'.interface-interface-skeleton__sidebar'
+				);
+				return sidebar?.contains( activeEl );
+			} );
+
+			expect( focusIsInSidebar ).toBe( true );
+
+			// Tab until the Skip to Selected Block link is focused
+			for ( let i = 0; i < 10; i++ ) {
+				await page.keyboard.press( 'Tab' );
+				if (
+					( await page.evaluate(
+						() => document.activeElement?.textContent
+					) ) === 'Skip to the selected block'
+				) {
+					break;
+				}
+			}
+
+			await page.keyboard.press( 'Enter' );
+
+			// Check that focus is on the canvas and the text is updated
+			await pageUtils.pressKeys( 'ArrowDown' );
+			await pageUtils.pressKeys( 'primary+a' );
+			await navigation.expectToHaveTextSelected( 'Updated Home Extra' );
+		} );
 	} );
 
 	test( 'Adding new links to a navigation block with existing inner blocks triggers creation of a single Navigation Menu', async ( {
@@ -828,127 +935,6 @@ test.describe( 'Navigation block', () => {
 			await unlinkButton.click();
 			await expect( linkInput ).toBeEnabled();
 			await expect( linkInput ).toHaveValue( '' );
-		} );
-	} );
-
-	test.describe( 'Focus management', () => {
-		test.beforeEach( async ( { admin, requestUtils } ) => {
-			await requestUtils.deleteAllMenus();
-			await admin.createNewPost();
-		} );
-
-		test.afterEach( async ( { requestUtils } ) => {
-			await Promise.all( [
-				requestUtils.deleteAllPosts(),
-				requestUtils.deleteAllMenus(),
-			] );
-		} );
-
-		test( 'should preserve focus in sidebar text input when typing (@firefox)', async ( {
-			page,
-			editor,
-			requestUtils,
-			pageUtils,
-			navigation,
-		} ) => {
-			// Create a navigation menu with one link
-			const createdMenu = await requestUtils.createNavigationMenu( {
-				title: 'Test Menu',
-				content: `<!-- wp:navigation-link {"label":"Home","url":"https://example.com"} /-->`,
-			} );
-
-			// Insert the navigation block
-			await editor.insertBlock( {
-				name: 'core/navigation',
-				attributes: {
-					ref: createdMenu?.id,
-				},
-			} );
-
-			// Click on the navigation link label in the canvas to edit it
-			const linkLabel = editor.canvas.getByRole( 'textbox', {
-				name: 'Navigation link text',
-			} );
-			await linkLabel.click();
-			await pageUtils.pressKeys( 'primary+a' );
-			await page.keyboard.type( 'Updated Home' );
-
-			// Open the document settings sidebar
-			await editor.openDocumentSettingsSidebar();
-
-			// Tab to the sidebar settings panel
-			// First tab should go to the settings sidebar
-			await page.keyboard.press( 'Tab' );
-
-			// Find the text input in the sidebar
-			const textInput = page.getByRole( 'textbox', {
-				name: 'Text',
-			} );
-
-			// Tab until we reach the Text field in the sidebar
-			// This may take multiple tabs depending on other controls
-			for ( let i = 0; i < 10; i++ ) {
-				const focusedElement = await page.evaluate( () => {
-					const el = document.activeElement;
-					return {
-						tagName: el?.tagName,
-						label:
-							el?.getAttribute( 'aria-label' ) ||
-							el?.labels?.[ 0 ]?.textContent,
-						id: el?.id,
-					};
-				} );
-
-				if (
-					focusedElement.label?.includes( 'Text' ) &&
-					focusedElement.tagName === 'INPUT'
-				) {
-					break;
-				}
-
-				await page.keyboard.press( 'Tab' );
-			}
-
-			await expect( textInput ).toBeFocused();
-			await pageUtils.pressKeys( 'ArrowRight' );
-			// Type in the sidebar text input
-			await page.keyboard.type( ' Extra' );
-
-			// Verify the text was actually typed (change happened)
-			await expect( textInput ).toHaveValue( 'Updated Home Extra' );
-
-			// Tab again to move to the next field
-			await page.keyboard.press( 'Tab' );
-
-			// Check that focus is still within the document sidebar
-			const focusIsInSidebar = await page.evaluate( () => {
-				const activeEl = document.activeElement;
-				const sidebar = document.querySelector(
-					'.interface-interface-skeleton__sidebar'
-				);
-				return sidebar?.contains( activeEl );
-			} );
-
-			expect( focusIsInSidebar ).toBe( true );
-
-			// Tab until the Skip to Selected Block link is focused
-			for ( let i = 0; i < 10; i++ ) {
-				await page.keyboard.press( 'Tab' );
-				if (
-					( await page.evaluate(
-						() => document.activeElement?.textContent
-					) ) === 'Skip to the selected block'
-				) {
-					break;
-				}
-			}
-
-			await page.keyboard.press( 'Enter' );
-
-			// Check that focus is on the canvas and the text is updated
-			await pageUtils.pressKeys( 'ArrowDown' );
-			await pageUtils.pressKeys( 'primary+a' );
-			await navigation.expectToHaveTextSelected( 'Updated Home Extra' );
 		} );
 	} );
 } );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -830,6 +830,127 @@ test.describe( 'Navigation block', () => {
 			await expect( linkInput ).toHaveValue( '' );
 		} );
 	} );
+
+	test.describe( 'Focus management', () => {
+		test.beforeEach( async ( { admin, requestUtils } ) => {
+			await requestUtils.deleteAllMenus();
+			await admin.createNewPost();
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await Promise.all( [
+				requestUtils.deleteAllPosts(),
+				requestUtils.deleteAllMenus(),
+			] );
+		} );
+
+		test( 'should preserve focus in sidebar text input when typing (@firefox)', async ( {
+			page,
+			editor,
+			requestUtils,
+			pageUtils,
+			navigation,
+		} ) => {
+			// Create a navigation menu with one link
+			const createdMenu = await requestUtils.createNavigationMenu( {
+				title: 'Test Menu',
+				content: `<!-- wp:navigation-link {"label":"Home","url":"https://example.com"} /-->`,
+			} );
+
+			// Insert the navigation block
+			await editor.insertBlock( {
+				name: 'core/navigation',
+				attributes: {
+					ref: createdMenu?.id,
+				},
+			} );
+
+			// Click on the navigation link label in the canvas to edit it
+			const linkLabel = editor.canvas.getByRole( 'textbox', {
+				name: 'Navigation link text',
+			} );
+			await linkLabel.click();
+			await pageUtils.pressKeys( 'primary+a' );
+			await page.keyboard.type( 'Updated Home' );
+
+			// Open the document settings sidebar
+			await editor.openDocumentSettingsSidebar();
+
+			// Tab to the sidebar settings panel
+			// First tab should go to the settings sidebar
+			await page.keyboard.press( 'Tab' );
+
+			// Find the text input in the sidebar
+			const textInput = page.getByRole( 'textbox', {
+				name: 'Text',
+			} );
+
+			// Tab until we reach the Text field in the sidebar
+			// This may take multiple tabs depending on other controls
+			for ( let i = 0; i < 10; i++ ) {
+				const focusedElement = await page.evaluate( () => {
+					const el = document.activeElement;
+					return {
+						tagName: el?.tagName,
+						label:
+							el?.getAttribute( 'aria-label' ) ||
+							el?.labels?.[ 0 ]?.textContent,
+						id: el?.id,
+					};
+				} );
+
+				if (
+					focusedElement.label?.includes( 'Text' ) &&
+					focusedElement.tagName === 'INPUT'
+				) {
+					break;
+				}
+
+				await page.keyboard.press( 'Tab' );
+			}
+
+			await expect( textInput ).toBeFocused();
+			await pageUtils.pressKeys( 'ArrowRight' );
+			// Type in the sidebar text input
+			await page.keyboard.type( ' Extra' );
+
+			// Verify the text was actually typed (change happened)
+			await expect( textInput ).toHaveValue( 'Updated Home Extra' );
+
+			// Tab again to move to the next field
+			await page.keyboard.press( 'Tab' );
+
+			// Check that focus is still within the document sidebar
+			const focusIsInSidebar = await page.evaluate( () => {
+				const activeEl = document.activeElement;
+				const sidebar = document.querySelector(
+					'.interface-interface-skeleton__sidebar'
+				);
+				return sidebar?.contains( activeEl );
+			} );
+
+			expect( focusIsInSidebar ).toBe( true );
+
+			// Tab until the Skip to Selected Block link is focused
+			for ( let i = 0; i < 10; i++ ) {
+				await page.keyboard.press( 'Tab' );
+				if (
+					( await page.evaluate(
+						() => document.activeElement?.textContent
+					) ) === 'Skip to the selected block'
+				) {
+					break;
+				}
+			}
+
+			await page.keyboard.press( 'Enter' );
+
+			// Check that focus is on the canvas and the text is updated
+			await pageUtils.pressKeys( 'ArrowDown' );
+			await pageUtils.pressKeys( 'primary+a' );
+			await navigation.expectToHaveTextSelected( 'Updated Home Extra' );
+		} );
+	} );
 } );
 
 class Navigation {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/72168
Alternative to https://github.com/WordPress/gutenberg/pull/61374

<!-- In a few words, what is the PR actually doing? -->
In Firefox, when typing in a navigation link's canvas label and then switching to the sidebar Text input, focus would jump to the iframe after each keystroke.

The issue occurred with `selection.addRange()`, as this causes that element to receive focus in Firefox. In Chrome, no focus shift happens. This code attempts to normalize the behavior by not stealing focus from the user if they are attempting to edit something outside the iframe.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We should be able to use the text input in the sidebar to update the label text without focus being stolen.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
When focus is outside the canvas iframe (such as editing a sidebar inspector text field), the iframe will say focus is on the body. If focus is on the body, we _don't_ want to steal focus from outside the iframe _unless_ focus outside the iframe is also on its body element. In this instance, the user was likely interacting with the toolbar, and their interaction caused a focus loss, and we'd _want_ to restore focus to the active canvas element. This scenario happens when indenting a list item from the toolbar, for example. The item is indented and focus moves to the list item.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
**In Firefox**

**Navigation Block**

- Click a navigation link block
- In the sidebar, click or Tab to the Text input to update the label
- Type in the sidebar input
- Focus should remain in the text field and update the on-canvas element

**List Block**

- Add a list block with two list items
- On the second list item, place the cursor one position in from the edge. i.e. t[caret here]wo
- Indent the second list item from the toolbar
- The list item you indented should have the caret in the same position it was before the indention
- You should be able to type and add text from this caret position


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
