### PR TITLE
Accordion Item block: add layout support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -36,7 +36,7 @@ Displays a section of content in an accordion, including a heading and expandabl
 -	**Category:** design
 -	**Parent:** core/accordion
 -	**Allowed Blocks:** core/accordion-heading, core/accordion-panel
--	**Supports:** color (background, gradients, text), contentRole, interactivity, shadow, spacing (blockGap, margin), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** color (background, gradients, text), contentRole, interactivity, layout (~~allowEditing~~), shadow, spacing (blockGap, margin), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** openByDefault
 
 ## Accordion Panel

--- a/packages/block-library/src/accordion-item/block.json
+++ b/packages/block-library/src/accordion-item/block.json
@@ -31,6 +31,9 @@
 			}
 		},
 		"shadow": true,
+		"layout": {
+			"allowEditing": false
+			},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,


### PR DESCRIPTION
## What?
Closes#72116

This PR enables the block layout engine for the accordion child / items blocks so spacing and layout tokens resolve correctly:

## Why?
The Block Spacing control was not producing visible spacing for accordion items 
## How?
- Modify `packages/block-library/src/accordion-item/block.json`: