### PR TITLE
Block Comments: Refactor active sidebar tracking

### DIFF
--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -2,17 +2,19 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useMemo } from '@wordpress/element';
+import { useEffect, useMemo } from '@wordpress/element';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as noticesStore } from '@wordpress/notices';
 import { decodeEntities } from '@wordpress/html-entities';
+import { store as interfaceStore } from '@wordpress/interface';
 
 /**
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
+import { collabSidebarName } from './constants';
 
 export function useBlockComments( postId ) {
 	const queryArgs = {
@@ -248,4 +250,25 @@ export function useBlockCommentsActions() {
 	};
 
 	return { onCreate, onEdit, onDelete };
+}
+
+export function useEnableFloatingSidebar( enabled = false ) {
+	const registry = useRegistry();
+	useEffect( () => {
+		if ( ! enabled ) {
+			return;
+		}
+
+		return registry.subscribe( () => {
+			const activeSidebar = registry
+				.select( interfaceStore )
+				.getActiveComplementaryArea( 'core' );
+
+			if ( ! activeSidebar ) {
+				registry
+					.dispatch( interfaceStore )
+					.enableComplementaryArea( 'core', collabSidebarName );
+			}
+		} );
+	}, [ enabled, registry ] );
 }

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useSelect, useDispatch, subscribe } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useState, useRef } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
@@ -21,7 +21,11 @@ import { store as editorStore } from '../../store';
 import AddCommentMenuItem from './comment-menu-item';
 import CommentAvatarIndicator from './comment-indicator-toolbar';
 import { useGlobalStylesContext } from '../global-styles-provider';
-import { useBlockComments, useBlockCommentsActions } from './hooks';
+import {
+	useBlockComments,
+	useBlockCommentsActions,
+	useEnableFloatingSidebar,
+} from './hooks';
 
 function CollabSidebarContent( {
 	showCommentBoard,
@@ -65,7 +69,6 @@ function CollabSidebarContent( {
 export default function CollabSidebar() {
 	const [ showCommentBoard, setShowCommentBoard ] = useState( false );
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
-	const { getActiveComplementaryArea } = useSelect( interfaceStore );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const commentSidebarRef = useRef( null );
 
@@ -93,23 +96,13 @@ export default function CollabSidebar() {
 
 	const { resultComments, unresolvedSortedThreads, totalPages } =
 		useBlockComments( postId );
+	useEnableFloatingSidebar( resultComments.length > 0 );
 
 	const hasMoreComments = totalPages && totalPages > 1;
 
 	// Get the global styles to set the background color of the sidebar.
 	const { merged: GlobalStyles } = useGlobalStylesContext();
 	const backgroundColor = GlobalStyles?.styles?.color?.background;
-
-	if ( 0 < resultComments.length ) {
-		const unsubscribe = subscribe( () => {
-			const activeSidebar = getActiveComplementaryArea( 'core' );
-
-			if ( ! activeSidebar ) {
-				enableComplementaryArea( 'core', collabSidebarName );
-				unsubscribe();
-			}
-		} );
-	}
 
 	// Find the current thread for the selected block.
 	const currentThread = blockCommentId


### PR DESCRIPTION
## What?
Yet another minor code refactoring. Related https://github.com/WordPress/gutenberg/pull/71856#issuecomment-3379569378.

PR extracts logic for activating the "floating" comments sidebar when no other sidebar is active. The new hook uses recommended methods for store subscriptions.

P.S. I tried using `useSelect` / `useEffect` combo, but it triggers animations when the sidebar is displayed, which I think doesn't match the design specs.

## Testing Instructions
1. Open a post or page.
2. Add a block and comment on it.
3. Close all sidebars from the toolbar.
4. Confirm that the "floating" comments sidebar is displayed as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/bf7dc4fb-2b1a-44a9-8aa7-e07708aac188


