### PR TITLE
Build V2: Handle externals properly, do not bundle them

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -23,6 +23,7 @@ on:
             - 'webpack.config.js'
             # Changes to this workflow file should always verify the changes are successful.
             - '.github/workflows/bundle-size.yml'
+            - bin/packages
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:

--- a/bin/packages/build-v2.mjs
+++ b/bin/packages/build-v2.mjs
@@ -67,6 +67,50 @@ function wordpressExternalsPlugin() {
 		setup( build ) {
 			const dependencies = new Set();
 
+			// Map of vendor packages to their global variables and handles
+			const vendorExternals = {
+				react: { global: 'React', handle: 'react' },
+				'react-dom': { global: 'ReactDOM', handle: 'react-dom' },
+				'react/jsx-runtime': {
+					global: 'ReactJSXRuntime',
+					handle: 'react-jsx-runtime',
+				},
+				'react/jsx-dev-runtime': {
+					global: 'ReactJSXRuntime',
+					handle: 'react-jsx-runtime',
+				},
+				moment: { global: 'moment', handle: 'moment' },
+				lodash: { global: 'lodash', handle: 'lodash' },
+				'lodash-es': { global: 'lodash', handle: 'lodash' },
+				jquery: { global: 'jQuery', handle: 'jquery' },
+			};
+
+			// Handle vendor packages
+			for ( const [ packageName, config ] of Object.entries(
+				vendorExternals
+			) ) {
+				build.onResolve(
+					{
+						filter: new RegExp(
+							`^${ packageName.replace(
+								/[.*+?^${}()|[\]\\]/g,
+								'\\$&'
+							) }$`
+						),
+					},
+					( args ) => {
+						// Track dependency for asset file
+						dependencies.add( config.handle );
+
+						return {
+							path: args.path,
+							namespace: 'vendor-external',
+							pluginData: { global: config.global },
+						};
+					}
+				);
+			}
+
 			// Handle all @wordpress/* packages
 			build.onResolve( { filter: /^@wordpress\// }, ( args ) => {
 				// Track dependency for asset file
@@ -78,6 +122,18 @@ function wordpressExternalsPlugin() {
 					namespace: 'wordpress-external',
 				};
 			} );
+
+			build.onLoad(
+				{ filter: /.*/, namespace: 'vendor-external' },
+				( args ) => {
+					const global = args.pluginData.global;
+
+					return {
+						contents: `module.exports = window.${ global };`,
+						loader: 'js',
+					};
+				}
+			);
 
 			build.onLoad(
 				{ filter: /.*/, namespace: 'wordpress-external' },

--- a/bin/packages/build-v2.mjs
+++ b/bin/packages/build-v2.mjs
@@ -207,6 +207,12 @@ async function bundlePackage( packageName ) {
 			target,
 			platform: 'browser',
 			globalName,
+			alias: {
+				'moment-timezone/moment-timezone':
+					'moment-timezone/builds/moment-timezone-with-data-1970-2030',
+				'moment-timezone/moment-timezone-utils':
+					'moment-timezone/builds/moment-timezone-with-data-1970-2030',
+			},
 		};
 
 		// For packages with default exports, add a footer to properly expose the default

--- a/bin/packages/build-v2.mjs
+++ b/bin/packages/build-v2.mjs
@@ -56,6 +56,60 @@ function kebabToCamelCase( str ) {
 }
 
 /**
+ * Plugin to handle moment-timezone aliases.
+ * Redirects moment-timezone imports to use pre-built bundles with limited data.
+ *
+ * @return {Object} esbuild plugin.
+ */
+function momentTimezoneAliasPlugin() {
+	return {
+		name: 'moment-timezone-alias',
+		async setup( build ) {
+			// Resolve paths at plugin creation time
+			const { createRequire } = await import( 'module' );
+			const require = createRequire( import.meta.url );
+
+			const preBuiltBundlePath = require.resolve(
+				'moment-timezone/builds/moment-timezone-with-data-1970-2030'
+			);
+			const momentTimezoneUtilsPath = require.resolve(
+				'moment-timezone/moment-timezone-utils.js'
+			);
+
+			// Redirect main moment-timezone files to pre-built bundle
+			build.onResolve(
+				{ filter: /^moment-timezone\/moment-timezone$/ },
+				() => {
+					return { path: preBuiltBundlePath };
+				}
+			);
+
+			// For utils, we need to load it but ensure it works with the pre-built bundle
+			// The utils file tries to require('./') which would load index.js
+			// We need to make sure it gets the pre-built bundle instead
+			build.onResolve(
+				{ filter: /^moment-timezone\/moment-timezone-utils$/ },
+				() => {
+					return { path: momentTimezoneUtilsPath };
+				}
+			);
+
+			// Intercept the require('./') call inside moment-timezone-utils
+			// and redirect it to the pre-built bundle
+			build.onResolve( { filter: /^\.\/$/ }, ( args ) => {
+				// Only intercept if this is coming from moment-timezone-utils
+				if (
+					args.importer &&
+					args.importer.includes( 'moment-timezone-utils' )
+				) {
+					return { path: preBuiltBundlePath };
+				}
+			} );
+		},
+	};
+}
+
+/**
  * WordPress externals and asset plugin.
  * Inspired by wp-build's wordpressExternalsAndAssetPlugin.
  *
@@ -207,12 +261,6 @@ async function bundlePackage( packageName ) {
 			target,
 			platform: 'browser',
 			globalName,
-			alias: {
-				'moment-timezone/moment-timezone':
-					'moment-timezone/builds/moment-timezone-with-data-1970-2030',
-				'moment-timezone/moment-timezone-utils':
-					'moment-timezone/builds/moment-timezone-with-data-1970-2030',
-			},
 		};
 
 		// For packages with default exports, add a footer to properly expose the default
@@ -227,12 +275,16 @@ async function bundlePackage( packageName ) {
 				...baseConfig,
 				outfile: path.join( outputDir, 'index.min.js' ),
 				minify: true,
-				plugins: [ wordpressExternalsPlugin() ],
+				plugins: [
+					momentTimezoneAliasPlugin(),
+					wordpressExternalsPlugin(),
+				],
 			} ),
 			esbuild.build( {
 				...baseConfig,
 				outfile: path.join( outputDir, 'index.js' ),
 				minify: false,
+				plugins: [ momentTimezoneAliasPlugin() ],
 			} )
 		);
 	}


### PR DESCRIPTION
## What?

Related #72032

@mcsf [spotted](https://github.com/WordPress/gutenberg/pull/72163#issuecomment-3382507023) that the date bundle size increased a lot. I think it's due to the vendor externals not being treated as externals and bundled within the built file. This PR should solve it.

