### PR TITLE
CustomSelectControl: Use key to determine the selected item instead of name

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `TextareaControl`: Add `min-height` to the textarea element ([#72867](https://github.com/WordPress/gutenberg/pull/72867)).
 -   `Card`, `CardHeader`, `CardBody` and `CardFooter`: Add support for directional padding through object-based size prop, allowing independent control of padding for each side ([#72511](https://github.com/WordPress/gutenberg/pull/72511)).
+-   `CustomSelectControl`: Fix the options with the same name are shown as the selected option ([#72189](https://github.com/WordPress/gutenberg/pull/72189)).
 
 ## 30.7.0 (2025-10-29)
 

--- a/packages/components/src/custom-select-control/index.tsx
+++ b/packages/components/src/custom-select-control/index.tsx
@@ -157,6 +157,10 @@ function CustomSelectControl< T extends CustomSelectOption >(
 			?.find( ( { key } ) => currentValue === key ) ?? options[ 0 ];
 
 	const renderSelectedValue = () => {
+		if ( ! showSelectedHint || ! selectedOption.hint ) {
+			return selectedOption.name;
+		}
+
 		return (
 			<Styled.SelectedExperimentalHintWrapper>
 				{ selectedOption.name }

--- a/packages/components/src/custom-select-control/index.tsx
+++ b/packages/components/src/custom-select-control/index.tsx
@@ -84,7 +84,7 @@ function CustomSelectControl< T extends CustomSelectOption >(
 	const store = Ariakit.useSelectStore< string >( {
 		async setValue( nextValue ) {
 			const nextOption = options.find(
-				( item ) => item.name === nextValue
+				( item ) => item.key === nextValue
 			);
 
 			if ( ! onChange || ! nextOption ) {
@@ -108,12 +108,12 @@ function CustomSelectControl< T extends CustomSelectOption >(
 			};
 			onChange( changeObject );
 		},
-		value: value?.name,
+		value: value?.key,
 		// Setting the first option as a default value when no value is provided
 		// is already done natively by the underlying Ariakit component,
 		// but doing this explicitly avoids the `onChange` callback from firing
 		// on initial render, thus making this implementation closer to the v1.
-		defaultValue: options[ 0 ]?.name,
+		defaultValue: options[ 0 ]?.key,
 	} );
 
 	const children = options
@@ -134,7 +134,7 @@ function CustomSelectControl< T extends CustomSelectOption >(
 			return (
 				<CustomSelectItem
 					key={ key }
-					value={ name }
+					value={ key }
 					children={ hint ? withHint : name }
 					style={ style }
 					className={ clsx(
@@ -151,20 +151,21 @@ function CustomSelectControl< T extends CustomSelectOption >(
 
 	const currentValue = Ariakit.useStoreState( store, 'value' );
 
-	const renderSelectedValueHint = () => {
-		const selectedOptionHint = options
+	const selectedOption =
+		options
 			?.map( applyOptionDeprecations )
-			?.find( ( { name } ) => currentValue === name )?.hint;
+			?.find( ( { key } ) => currentValue === key ) ?? options[ 0 ];
 
+	const renderSelectedValue = () => {
 		return (
 			<Styled.SelectedExperimentalHintWrapper>
-				{ currentValue }
-				{ selectedOptionHint && (
+				{ selectedOption.name }
+				{ showSelectedHint && selectedOption.hint && (
 					<Styled.SelectedExperimentalHintItem
 						// Keeping the classname for legacy reasons
 						className="components-custom-select-control__hint"
 					>
-						{ selectedOptionHint }
+						{ selectedOption.hint }
 					</Styled.SelectedExperimentalHintItem>
 				) }
 			</Styled.SelectedExperimentalHintWrapper>
@@ -188,9 +189,7 @@ function CustomSelectControl< T extends CustomSelectOption >(
 		<>
 			<_CustomSelect
 				aria-describedby={ descriptionId }
-				renderSelectedValue={
-					showSelectedHint ? renderSelectedValueHint : undefined
-				}
+				renderSelectedValue={ renderSelectedValue }
 				size={ translatedSize }
 				store={ store }
 				className={ clsx(
@@ -205,7 +204,7 @@ function CustomSelectControl< T extends CustomSelectOption >(
 			</_CustomSelect>
 			<VisuallyHidden>
 				<span id={ descriptionId }>
-					{ getDescribedBy( currentValue, describedBy ) }
+					{ getDescribedBy( selectedOption.name, describedBy ) }
 				</span>
 			</VisuallyHidden>
 		</>

--- a/packages/components/src/custom-select-control/index.tsx
+++ b/packages/components/src/custom-select-control/index.tsx
@@ -164,14 +164,12 @@ function CustomSelectControl< T extends CustomSelectOption >(
 		return (
 			<Styled.SelectedExperimentalHintWrapper>
 				{ selectedOption.name }
-				{ showSelectedHint && selectedOption.hint && (
-					<Styled.SelectedExperimentalHintItem
-						// Keeping the classname for legacy reasons
-						className="components-custom-select-control__hint"
-					>
-						{ selectedOption.hint }
-					</Styled.SelectedExperimentalHintItem>
-				) }
+				<Styled.SelectedExperimentalHintItem
+					// Keeping the classname for legacy reasons
+					className="components-custom-select-control__hint"
+				>
+					{ selectedOption.hint }
+				</Styled.SelectedExperimentalHintItem>
 			</Styled.SelectedExperimentalHintWrapper>
 		);
 	};

--- a/packages/components/src/custom-select-control/index.tsx
+++ b/packages/components/src/custom-select-control/index.tsx
@@ -43,13 +43,13 @@ function applyOptionDeprecations( {
 	};
 }
 
-function getDescribedBy( currentValue: string, describedBy?: string ) {
+function getDescribedBy( currentName: string, describedBy?: string ) {
 	if ( describedBy ) {
 		return describedBy;
 	}
 
 	// translators: %s: The selected option.
-	return sprintf( __( 'Currently selected: %s' ), currentValue );
+	return sprintf( __( 'Currently selected: %s' ), currentName );
 }
 
 function CustomSelectControl< T extends CustomSelectOption >(

--- a/packages/components/src/custom-select-control/index.tsx
+++ b/packages/components/src/custom-select-control/index.tsx
@@ -158,17 +158,17 @@ function CustomSelectControl< T extends CustomSelectOption >(
 
 	const renderSelectedValue = () => {
 		if ( ! showSelectedHint || ! selectedOption.hint ) {
-			return selectedOption.name;
+			return selectedOption?.name;
 		}
 
 		return (
 			<Styled.SelectedExperimentalHintWrapper>
-				{ selectedOption.name }
+				{ selectedOption?.name }
 				<Styled.SelectedExperimentalHintItem
 					// Keeping the classname for legacy reasons
 					className="components-custom-select-control__hint"
 				>
-					{ selectedOption.hint }
+					{ selectedOption?.hint }
 				</Styled.SelectedExperimentalHintItem>
 			</Styled.SelectedExperimentalHintWrapper>
 		);
@@ -206,7 +206,7 @@ function CustomSelectControl< T extends CustomSelectOption >(
 			</_CustomSelect>
 			<VisuallyHidden>
 				<span id={ descriptionId }>
-					{ getDescribedBy( selectedOption.name, describedBy ) }
+					{ getDescribedBy( selectedOption?.name, describedBy ) }
 				</span>
 			</VisuallyHidden>
 		</>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
If the options have duplicate name, then all of them will be shown as the selected item when any of them is selected. For example, if you have a list of the pages as below, and you want to use the `CustomSelectControl`, then it makes the result becomes weird.

```js
const options = [
  {
    key: 0, // page.id
    name: 'Home', // page.title
  },
  {
    key: 1, // page.id
    name: 'Home', // page.title
  },
];
```

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The "key" property should be the unique value in the options. As a result, we should use "key" to determine whether the item is selected to ensure there is only one selected item. Otherwise, if a list has options with the same name, all of them will  be shown as selected item.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replace any condition that checks the selected item using its `name` property so that it instead uses the `key` property. The onChange event now passes the entire selectedItem, ensuring backward compatibility with no breaking changes

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Storybook
* Navigate to CustomSelectControl
* Select different item
* Ensure it works as before

Editor
* Open a post
* Select any block
* Change the font
* Ensure it works as before

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="735" height="275" alt="image" src="https://github.com/user-attachments/assets/120cb0a5-d837-4e94-b839-113f4d875720" />|<img width="1102" height="274" alt="image" src="https://github.com/user-attachments/assets/f23f3c8c-fca6-42c7-83b7-a3aac025286a" />|
