### PR TITLE
Changelog automation: change "Block Commenting" to "Notes"

### DIFF
--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -97,7 +97,7 @@ const LABEL_TYPE_MAPPING = {
  */
 const LABEL_FEATURE_MAPPING = {
 	'[Feature] Real-time Collaboration': 'Collaboration',
-	'[Feature] Block Commenting': 'Collaboration',
+	'[Feature] Notes': 'Collaboration',
 	'[Feature] Widgets Screen': 'Widgets Editor',
 	'[Feature] Widgets Customizer': 'Widgets Editor',
 	'[Feature] Design Tools': 'Design Tools',


### PR DESCRIPTION
- Follow up: #72075
- See this discussion: https://github.com/WordPress/gutenberg/discussions/72014#discussioncomment-14629639

## What?

When we're releasing Gutenberg, the PRs that belong to that milestone will be grouped based on labels and recorded in a changelog.

As part of this, PRs with the [\[Feature\] Block Commenting](https://github.com/WordPress/gutenberg/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22%5BFeature%5D%20Block%20Commenting%22) label are automatically added under the Collaboration section in the changelog.

<details><summary>Screenshot</summary>

```
npm run other:changelog -- --milestone="Gutenberg 21.8"
```

<img width="1611" height="940" alt="screenshot" src="https://github.com/user-attachments/assets/8f2729eb-7ffc-460b-ab48-252c07068c6f" />

</details> 

As per [this discussion](https://github.com/WordPress/gutenberg/discussions/72014#discussioncomment-14629639), the name of this feature has been decided to be "Notes",  so I will update the mapping definition.

> [!NOTE]
> After this PR is merged, I'd like to rename the `[Feature] Block Commenting` label to `[Feature] Notes` label.


cc @jeffpaul @annezazu 