### PR TITLE
Block Inserter: Don't show back button in inserter preview when a navigation block child is selected

### DIFF
--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -46,14 +46,15 @@ const { Badge } = unlock( componentsPrivateApis );
  * }
  * ```
  *
- * @param {Object}        props             Component props.
- * @param {string}        props.title       The title of the block.
- * @param {string|Object} props.icon        The icon of the block. This can be any of [WordPress' Dashicons](https://developer.wordpress.org/resource/dashicons/), or a custom `svg` element.
- * @param {string}        props.description The description of the block.
- * @param {Object}        [props.blockType] Deprecated: Object containing block type data.
- * @param {string}        [props.className] Additional classes to apply to the card.
- * @param {string}        [props.name]      Custom block name to display before the title.
- * @param {Element}       [props.children]  Children.
+ * @param {Object}        props                         Component props.
+ * @param {string}        props.title                   The title of the block.
+ * @param {string|Object} props.icon                    The icon of the block. This can be any of [WordPress' Dashicons](https://developer.wordpress.org/resource/dashicons/), or a custom `svg` element.
+ * @param {string}        props.description             The description of the block.
+ * @param {Object}        [props.blockType]             Deprecated: Object containing block type data.
+ * @param {string}        [props.className]             Additional classes to apply to the card.
+ * @param {string}        [props.name]                  Custom block name to display before the title.
+ * @param {string}        [props.allowParentNavigation] Show a back arrow to the parent block in some situations.
+ * @param {Element}       [props.children]              Children.
  * @return {Element}                        Block card component.
  */
 function BlockCard( {
@@ -63,6 +64,7 @@ function BlockCard( {
 	blockType,
 	className,
 	name,
+	allowParentNavigation,
 	children,
 } ) {
 	if ( blockType ) {
@@ -73,38 +75,43 @@ function BlockCard( {
 		( { title, icon, description } = blockType );
 	}
 
-	const { parentNavBlockClientId } = useSelect( ( select ) => {
-		const { getSelectedBlockClientId, getBlockParentsByBlockName } =
-			select( blockEditorStore );
+	const parentNavBlockClientId = useSelect(
+		( select ) => {
+			if ( ! allowParentNavigation ) {
+				return;
+			}
+			const { getSelectedBlockClientId, getBlockParentsByBlockName } =
+				select( blockEditorStore );
 
-		const _selectedBlockClientId = getSelectedBlockClientId();
+			const _selectedBlockClientId = getSelectedBlockClientId();
 
-		return {
-			parentNavBlockClientId: getBlockParentsByBlockName(
+			return getBlockParentsByBlockName(
 				_selectedBlockClientId,
 				'core/navigation',
 				true
-			)[ 0 ],
-		};
-	}, [] );
+			)[ 0 ];
+		},
+		[ allowParentNavigation ]
+	);
 
 	const { selectBlock } = useDispatch( blockEditorStore );
 
 	return (
 		<div className={ clsx( 'block-editor-block-card', className ) }>
-			{ parentNavBlockClientId && ( // This is only used by the Navigation block for now. It's not ideal having Navigation block specific code here.
-				<Button
-					onClick={ () => selectBlock( parentNavBlockClientId ) }
-					label={ __( 'Go to parent Navigation block' ) }
-					style={
-						// TODO: This style override is also used in ToolsPanelHeader.
-						// It should be supported out-of-the-box by Button.
-						{ minWidth: 24, padding: 0 }
-					}
-					icon={ isRTL() ? chevronRight : chevronLeft }
-					size="small"
-				/>
-			) }
+			{ allowParentNavigation &&
+				parentNavBlockClientId && ( // This is only used by the Navigation block for now. It's not ideal having Navigation block specific code here.
+					<Button
+						onClick={ () => selectBlock( parentNavBlockClientId ) }
+						label={ __( 'Go to parent Navigation block' ) }
+						style={
+							// TODO: This style override is also used in ToolsPanelHeader.
+							// It should be supported out-of-the-box by Button.
+							{ minWidth: 24, padding: 0 }
+						}
+						icon={ isRTL() ? chevronRight : chevronLeft }
+						size="small"
+					/>
+				) }
 			<BlockIcon icon={ icon } showColors />
 			<VStack spacing={ 1 }>
 				<h2 className="block-editor-block-card__title">

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -301,6 +301,7 @@ const BlockInspectorSingleBlock = ( {
 			<BlockCard
 				{ ...blockInformation }
 				className={ isBlockSynced && 'is-synced' }
+				allowParentNavigation
 			>
 				{ window?.__experimentalContentOnlyPatternInsertion && (
 					<EditContentsButton clientId={ clientId } />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
When a child block of the navigation block is selected, the block inspector shows a handy little back arrow button that when clicked allows selecting the parent navigation block, this is implemented in the BlockCard component:
<img width="275" height="132" alt="Screenshot 2025-10-09 at 4 06 34 pm" src="https://github.com/user-attachments/assets/1a0f6daa-95b7-40fb-8192-409b52dbcde3" />

That same BlockCard component is also used in the inserter menu, when hovering a block there's a small preview popover. There's a bug in that the same back arrow is present in the popover if a child of the navigation block is currently selected:
<img width="553" height="308" alt="Screenshot 2025-10-09 at 3 52 49 pm" src="https://github.com/user-attachments/assets/342ab602-103a-4423-a9e0-13b050b609dd" />

## How?
To fix this I've added an extra prop to the BlockCard component to control when the back arrow should be shown. The component isn't exported, so adding props isn't a huge concern.

## Testing Instructions
1. Open an editor and insert a navigation block
2. Select one of the inner blocks of the navigation block
3. Open the main block inserter sidebar and hover over a block
4. Note that in trunk, the popover that appears has a back arrow, while in this PR it doesn't
5. Open the block inspector, not that the back arrow is still present

## Screenshots or screencast <!-- if applicable -->
|Before|After|
|-|-|
| <img width="553" height="308" alt="Screenshot 2025-10-09 at 3 52 49 pm" src="https://github.com/user-attachments/assets/d8998993-d01e-49cf-a609-9326b29c9055" /> | <img width="560" height="293" alt="Screenshot 2025-10-09 at 4 03 42 pm" src="https://github.com/user-attachments/assets/fdbfe42f-eaf6-4e53-a07a-a108bb3d7d6d" /> |
