### PR TITLE
Pages: reuse embedded info for authors

### DIFF
--- a/packages/fields/src/fields/author/author-view.tsx
+++ b/packages/fields/src/fields/author/author-view.tsx
@@ -10,9 +10,6 @@ import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { commentAuthorAvatar as authorIcon } from '@wordpress/icons';
 import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
-import type { User } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -20,20 +17,9 @@ import type { User } from '@wordpress/core-data';
 import type { BasePostWithEmbeddedAuthor } from '../../types';
 
 function AuthorView( { item }: { item: BasePostWithEmbeddedAuthor } ) {
-	const { text, imageUrl } = useSelect(
-		( select ) => {
-			const { getEntityRecord } = select( coreStore );
-			let user: User | undefined;
-			if ( !! item.author ) {
-				user = getEntityRecord( 'root', 'user', item.author );
-			}
-			return {
-				imageUrl: user?.avatar_urls?.[ 48 ],
-				text: user?.name,
-			};
-		},
-		[ item ]
-	);
+	const text = item?._embedded?.author?.[ 0 ]?.name;
+	const imageUrl = item?._embedded?.author?.[ 0 ]?.avatar_urls?.[ 48 ];
+
 	const [ isImageLoaded, setIsImageLoaded ] = useState( false );
 	return (
 		<HStack alignment="left" spacing={ 0 }>


### PR DESCRIPTION
## What?

This PR prevents 20 network requests from being triggered.

Before

- There was a new network request for each author to get their name and avatar.
- The author field rendered as an empty field and only when the info was received would they display the text/avatar.

https://github.com/user-attachments/assets/44610ce0-6756-44e7-a561-e949c58fd905

After:

- No extra network request.
- The author field immediately renders.

https://github.com/user-attachments/assets/ee643d20-eb0e-4196-b5d3-9ae852b08619


## Why?

To minimize unnecessary requests.

## How?

By reusing the info already available in the pages item: it comes with the embedded author.

## Testing Instructions

- Throttle down the network request to observe how the author field is displayed.
- Go to the Pages screen in the site editor and interact with it.
