### PR TITLE
Pages: disable filter for discussion field

### DIFF
--- a/packages/fields/src/fields/discussion/index.tsx
+++ b/packages/fields/src/fields/discussion/index.tsx
@@ -28,6 +28,7 @@ const discussionField: Field< BasePost > = {
 		}
 		return __( 'Closed' );
 	},
+	filterBy: false,
 };
 
 /**


### PR DESCRIPTION
## What?

Disables the filter for the discussion field to prevent this from happening:

https://github.com/user-attachments/assets/32e72ace-3ffa-4cfc-8ae8-951cac655049

## Why?

It is an unintentionally side effect of this PR https://github.com/WordPress/gutenberg/pull/71949

## How?

Use `filterBy: false`.

## Testing Instructions

Visit the Pages screen in the site editor. Verify it no longer has a discussion field.