### PR TITLE
Notes/Block Comments: Use arguments from the schema for creation

### DIFF
--- a/lib/experimental/block-comments.php
+++ b/lib/experimental/block-comments.php
@@ -27,28 +27,6 @@ function gutenberg_block_comment_add_post_type_support() {
 add_action( 'init', 'gutenberg_block_comment_add_post_type_support' );
 
 /**
- * Updates the comment type in the REST API.
- *
- * This function is used as a filter callback for the 'rest_pre_insert_comment' hook.
- * It checks if the 'comment_type' parameter is set to 'block_comment' in the REST API request,
- * and if so, updates the 'comment_type' and 'comment_approved' properties of the prepared comment.
- *
- * @param array $prepared_comment The prepared comment data.
- * @param WP_REST_Request $request The REST API request object.
- * @return array The updated prepared comment data.
- */
-if ( ! function_exists( 'update_comment_type_in_rest_api_6_8' ) ) {
-	function update_comment_type_in_rest_api_6_8( $prepared_comment, $request ) {
-		if ( ! empty( $request['comment_type'] ) && 'block_comment' === $request['comment_type'] ) {
-			$prepared_comment['comment_type']     = $request['comment_type'];
-		}
-
-		return $prepared_comment;
-	}
-	add_filter( 'rest_pre_insert_comment', 'update_comment_type_in_rest_api_6_8', 10, 2 );
-}
-
-/**
  * Updates the comment type for avatars in the WordPress REST API.
  *
  * This function adds the 'block_comment' type to the list of comment types

--- a/lib/experimental/block-comments.php
+++ b/lib/experimental/block-comments.php
@@ -41,7 +41,6 @@ if ( ! function_exists( 'update_comment_type_in_rest_api_6_8' ) ) {
 	function update_comment_type_in_rest_api_6_8( $prepared_comment, $request ) {
 		if ( ! empty( $request['comment_type'] ) && 'block_comment' === $request['comment_type'] ) {
 			$prepared_comment['comment_type']     = $request['comment_type'];
-			$prepared_comment['comment_approved'] = $request['comment_approved'];
 		}
 
 		return $prepared_comment;

--- a/lib/experimental/class-gutenberg-rest-comment-controller.php
+++ b/lib/experimental/class-gutenberg-rest-comment-controller.php
@@ -188,7 +188,8 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 			}
 		}
 
-		if ( isset( $request['status'] ) && ! current_user_can( 'moderate_comments' ) ) {
+		// Note: This is only relevant change for the backport.
+		if ( isset( $request['status'] ) && ! $is_block_comment && ! current_user_can( 'moderate_comments' ) ) {
 			return new WP_Error(
 				'rest_comment_invalid_status',
 				/* translators: %s: Request parameter. */

--- a/lib/experimental/class-gutenberg-rest-comment-controller.php
+++ b/lib/experimental/class-gutenberg-rest-comment-controller.php
@@ -132,7 +132,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 	}
 
 	public function create_item_permissions_check( $request ) {
-		$is_block_comment = ! empty( $request['comment_type'] ) && 'block_comment' === $request['comment_type'];
+		$is_block_comment = ! empty( $request['type'] ) && 'block_comment' === $request['type'];
 
 		// Note: This is only relevant change for the backport.
 		if ( ! is_user_logged_in() && ! $is_block_comment ) {
@@ -263,6 +263,211 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 	}
 
 	/**
+	 * Creates a comment.
+	 *
+	 * @since 4.7.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or error object on failure.
+	 */
+	public function create_item( $request ) {
+		// This code is copied exactly from (core file name) except for sectioned marked with the comment.
+		// '// Note: This is only relevant change for the backport.'
+		if ( ! empty( $request['id'] ) ) {
+			return new WP_Error(
+				'rest_comment_exists',
+				__( 'Cannot create existing comment.', 'gutenberg' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Note: Removes non-default comment type check for the backport.
+
+		$prepared_comment = $this->prepare_item_for_database( $request );
+		if ( is_wp_error( $prepared_comment ) ) {
+			return $prepared_comment;
+		}
+
+		$prepared_comment['comment_type'] = $request['type'];
+
+		if ( ! isset( $prepared_comment['comment_content'] ) ) {
+			$prepared_comment['comment_content'] = '';
+		}
+
+		if ( ! $this->check_is_comment_content_allowed( $prepared_comment ) ) {
+			return new WP_Error(
+				'rest_comment_content_invalid',
+				__( 'Invalid comment content.', 'gutenberg' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Setting remaining values before wp_insert_comment so we can use wp_allow_comment().
+		if ( ! isset( $prepared_comment['comment_date_gmt'] ) ) {
+			$prepared_comment['comment_date_gmt'] = current_time( 'mysql', true );
+		}
+
+		// Set author data if the user's logged in.
+		$missing_author = empty( $prepared_comment['user_id'] )
+			&& empty( $prepared_comment['comment_author'] )
+			&& empty( $prepared_comment['comment_author_email'] )
+			&& empty( $prepared_comment['comment_author_url'] );
+
+		if ( is_user_logged_in() && $missing_author ) {
+			$user = wp_get_current_user();
+
+			$prepared_comment['user_id']              = $user->ID;
+			$prepared_comment['comment_author']       = $user->display_name;
+			$prepared_comment['comment_author_email'] = $user->user_email;
+			$prepared_comment['comment_author_url']   = $user->user_url;
+		}
+
+		// Honor the discussion setting that requires a name and email address of the comment author.
+		if ( get_option( 'require_name_email' ) ) {
+			if ( empty( $prepared_comment['comment_author'] ) || empty( $prepared_comment['comment_author_email'] ) ) {
+				return new WP_Error(
+					'rest_comment_author_data_required',
+					__( 'Creating a comment requires valid author name and email values.', 'gutenberg' ),
+					array( 'status' => 400 )
+				);
+			}
+		}
+
+		if ( ! isset( $prepared_comment['comment_author_email'] ) ) {
+			$prepared_comment['comment_author_email'] = '';
+		}
+
+		if ( ! isset( $prepared_comment['comment_author_url'] ) ) {
+			$prepared_comment['comment_author_url'] = '';
+		}
+
+		if ( ! isset( $prepared_comment['comment_agent'] ) ) {
+			$prepared_comment['comment_agent'] = '';
+		}
+
+		$check_comment_lengths = wp_check_comment_data_max_lengths( $prepared_comment );
+
+		if ( is_wp_error( $check_comment_lengths ) ) {
+			$error_code = $check_comment_lengths->get_error_code();
+			return new WP_Error(
+				$error_code,
+				__( 'Comment field exceeds maximum length allowed.', 'gutenberg' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$prepared_comment['comment_approved'] = wp_allow_comment( $prepared_comment, true );
+
+		if ( is_wp_error( $prepared_comment['comment_approved'] ) ) {
+			$error_code    = $prepared_comment['comment_approved']->get_error_code();
+			$error_message = $prepared_comment['comment_approved']->get_error_message();
+
+			if ( 'comment_duplicate' === $error_code ) {
+				return new WP_Error(
+					$error_code,
+					$error_message,
+					array( 'status' => 409 )
+				);
+			}
+
+			if ( 'comment_flood' === $error_code ) {
+				return new WP_Error(
+					$error_code,
+					$error_message,
+					array( 'status' => 400 )
+				);
+			}
+
+			return $prepared_comment['comment_approved'];
+		}
+
+		/**
+		 * Filters a comment before it is inserted via the REST API.
+		 *
+		 * Allows modification of the comment right before it is inserted via wp_insert_comment().
+		 * Returning a WP_Error value from the filter will short-circuit insertion and allow
+		 * skipping further processing.
+		 *
+		 * @since 4.7.0
+		 * @since 4.8.0 `$prepared_comment` can now be a WP_Error to short-circuit insertion.
+		 *
+		 * @param array|WP_Error  $prepared_comment The prepared comment data for wp_insert_comment().
+		 * @param WP_REST_Request $request          Request used to insert the comment.
+		 */
+		$prepared_comment = apply_filters( 'rest_pre_insert_comment', $prepared_comment, $request );
+		if ( is_wp_error( $prepared_comment ) ) {
+			return $prepared_comment;
+		}
+
+		$comment_id = wp_insert_comment( wp_filter_comment( wp_slash( (array) $prepared_comment ) ) );
+
+		if ( ! $comment_id ) {
+			return new WP_Error(
+				'rest_comment_failed_create',
+				__( 'Creating comment failed.', 'gutenberg' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		if ( isset( $request['status'] ) ) {
+			$this->handle_status_param( $request['status'], $comment_id );
+		}
+
+		$comment = get_comment( $comment_id );
+
+		/**
+		 * Fires after a comment is created or updated via the REST API.
+		 *
+		 * @since 4.7.0
+		 *
+		 * @param WP_Comment      $comment  Inserted or updated comment object.
+		 * @param WP_REST_Request $request  Request object.
+		 * @param bool            $creating True when creating a comment, false
+		 *                                  when updating.
+		 */
+		do_action( 'rest_insert_comment', $comment, $request, true );
+
+		$schema = $this->get_item_schema();
+
+		if ( ! empty( $schema['properties']['meta'] ) && isset( $request['meta'] ) ) {
+			$meta_update = $this->meta->update_value( $request['meta'], $comment_id );
+
+			if ( is_wp_error( $meta_update ) ) {
+				return $meta_update;
+			}
+		}
+
+		$fields_update = $this->update_additional_fields_for_object( $comment, $request );
+
+		if ( is_wp_error( $fields_update ) ) {
+			return $fields_update;
+		}
+
+		$context = current_user_can( 'moderate_comments' ) ? 'edit' : 'view';
+		$request->set_param( 'context', $context );
+
+		/**
+		 * Fires completely after a comment is created or updated via the REST API.
+		 *
+		 * @since 5.0.0
+		 *
+		 * @param WP_Comment      $comment  Inserted or updated comment object.
+		 * @param WP_REST_Request $request  Request object.
+		 * @param bool            $creating True when creating a comment, false
+		 *                                  when updating.
+		 */
+		do_action( 'rest_after_insert_comment', $comment, $request, true );
+
+		$response = $this->prepare_item_for_response( $comment, $request );
+		$response = rest_ensure_response( $response );
+
+		$response->set_status( 201 );
+		$response->header( 'Location', rest_url( sprintf( '%s/%s/%d', $this->namespace, $this->rest_base, $comment_id ) ) );
+
+		return $response;
+	}
+
+	/**
 	 * Check if post type supports block comments.
 	 *
 	 * @param string $post_type Post type name.
@@ -294,11 +499,10 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		$schema['properties']['type'] = array(
 			'description' => __( 'Type of the comment.', 'gutenberg' ),
 			'type'        => 'string',
-			'context'     => array( 'view', 'edit', 'embed' ),
 			// Note: This is only relevant change for the backport.
-			'arg_options' => array(
-				'sanitize_callback' => 'sanitize_key',
-			),
+			'enum'        => array( 'comment', 'block_comment' ),
+			'default'     => 'comment',
+			'context'     => array( 'view', 'edit', 'embed' ),
 		);
 
 		return $schema;

--- a/lib/experimental/class-gutenberg-rest-comment-controller.php
+++ b/lib/experimental/class-gutenberg-rest-comment-controller.php
@@ -197,7 +197,8 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		}
 
 		// Note: This is only relevant change for the backport.
-		if ( isset( $request['status'] ) && ! $is_block_comment && ! current_user_can( 'moderate_comments' ) ) {
+		$edit_cap = $is_block_comment ? array( 'edit_post', (int) $request['post'] ) : array( 'moderate_comments' );
+		if ( isset( $request['status'] ) && ! current_user_can( ...$edit_cap ) ) {
 			return new WP_Error(
 				'rest_comment_invalid_status',
 				/* translators: %s: Request parameter. */

--- a/lib/experimental/class-gutenberg-rest-comment-controller.php
+++ b/lib/experimental/class-gutenberg-rest-comment-controller.php
@@ -135,7 +135,15 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		$is_block_comment = ! empty( $request['type'] ) && 'block_comment' === $request['type'];
 
 		// Note: This is only relevant change for the backport.
-		if ( ! is_user_logged_in() && ! $is_block_comment ) {
+		if ( ! is_user_logged_in() && $is_block_comment ) {
+			return new WP_Error(
+				'rest_comment_login_required',
+				__( 'Sorry, you must be logged in to comment.', 'gutenberg' ),
+				array( 'status' => 401 )
+			);
+		}
+
+		if ( ! is_user_logged_in() ) {
 			if ( get_option( 'comment_registration' ) ) {
 				return new WP_Error(
 					'rest_comment_login_required',

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -150,7 +150,7 @@ export function useBlockCommentsActions() {
 					post: getCurrentPostId(),
 					content,
 					status: 'hold',
-					comment_type: 'block_comment',
+					type: 'block_comment',
 					parent: parent || 0,
 				},
 				{ throwOnError: true }

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -149,8 +149,8 @@ export function useBlockCommentsActions() {
 				{
 					post: getCurrentPostId(),
 					content,
+					status: 'hold',
 					comment_type: 'block_comment',
-					comment_approved: 0,
 					parent: parent || 0,
 				},
 				{ throwOnError: true }

--- a/phpunit/experimental/rest-api-comment-permissions-test.php
+++ b/phpunit/experimental/rest-api-comment-permissions-test.php
@@ -175,7 +175,7 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 
 	public function test_create_block_comment_status() {
 		wp_set_current_user( self::$user_ids['author'] );
-		$post_id = $this->factory->post->create();
+		$post_id = $this->factory->post->create( array( 'post_author' => self::$user_ids['author'] ) );
 
 		$params = array(
 			'post'         => $post_id,

--- a/phpunit/experimental/rest-api-comment-permissions-test.php
+++ b/phpunit/experimental/rest-api-comment-permissions-test.php
@@ -124,7 +124,7 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 			'author_url'   => 'https://en.wikipedia.org/wiki/Herman_Melville',
 			'content'      => 'Call me Ishmael.',
 			'author'       => self::$user_ids['administrator'],
-			'comment_type' => 'block_comment',
+			'type'         => 'block_comment',
 		);
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
@@ -148,7 +148,7 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 			'author_url'   => 'https://en.wikipedia.org/wiki/Herman_Melville',
 			'content'      => 'Call me Ishmael.',
 			'author'       => self::$user_ids['editor'],
-			'comment_type' => 'block_comment',
+			'type'         => 'block_comment',
 		);
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
@@ -159,20 +159,21 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 		$data        = $response->get_data();
 		$new_comment = get_comment( $data['id'] );
 		$this->assertSame( 'Call me Ishmael.', $new_comment->comment_content );
+		$this->assertSame( 'block_comment', $new_comment->comment_type );
 	}
 
 	public function test_create_block_comment_status() {
 		wp_set_current_user( self::$user_ids['author'] );
 		$post_id = $this->factory->post->create();
 
-		$params   = array(
+		$params = array(
 			'post'         => $post_id,
 			'author_name'  => 'Ishmael',
 			'author_email' => 'herman-melville@earthlink.net',
 			'author_url'   => 'https://en.wikipedia.org/wiki/Herman_Melville',
 			'content'      => 'Comic Book Guy',
 			'author'       => self::$user_ids['author'],
-			'comment_type' => 'block_comment',
+			'type'         => 'block_comment',
 			'status'       => 'hold',
 		);
 
@@ -185,7 +186,53 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 		$new_comment = get_comment( $data['id'] );
 
 		$this->assertSame( '0', $new_comment->comment_approved );
+		$this->assertSame( 'block_comment', $new_comment->comment_type );
 	}
+
+	public function test_cannot_create_with_non_valid_comment_type() {
+		wp_set_current_user( self::$user_ids['administrator'] );
+
+		$params = array(
+			'author_name'  => 'Ishmael',
+			'author_email' => 'herman-melville@earthlink.net',
+			'author_url'   => 'https://en.wikipedia.org/wiki/Herman_Melville',
+			'content'      => 'Comic Book Guy',
+			'author'       => self::$user_ids['administrator'],
+			'type'         => 'review',
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( $params ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+	}
+
+	public function test_create_assigns_default_type() {
+		wp_set_current_user( self::$user_ids['editor'] );
+		$post_id = $this->factory->post->create();
+
+		$params = array(
+			'post'         => $post_id,
+			'author_name'  => 'Ishmael',
+			'author_email' => 'herman-melville@earthlink.net',
+			'author_url'   => 'https://en.wikipedia.org/wiki/Herman_Melville',
+			'content'      => 'Comic Book Guy',
+			'author'       => self::$user_ids['editor'],
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( $params ) );
+
+		$response    = rest_get_server()->dispatch( $request );
+		$data        = $response->get_data();
+		$new_comment = get_comment( $data['id'] );
+
+		$this->assertSame( 'comment', $new_comment->comment_type );
+	}
+
 
 	/**
 	 * Test that for each user role, the permissions are correct when accessing comments.

--- a/phpunit/experimental/rest-api-comment-permissions-test.php
+++ b/phpunit/experimental/rest-api-comment-permissions-test.php
@@ -161,6 +161,32 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 		$this->assertSame( 'Call me Ishmael.', $new_comment->comment_content );
 	}
 
+	public function test_create_block_comment_status() {
+		wp_set_current_user( self::$user_ids['author'] );
+		$post_id = $this->factory->post->create();
+
+		$params   = array(
+			'post'         => $post_id,
+			'author_name'  => 'Ishmael',
+			'author_email' => 'herman-melville@earthlink.net',
+			'author_url'   => 'https://en.wikipedia.org/wiki/Herman_Melville',
+			'content'      => 'Comic Book Guy',
+			'author'       => self::$user_ids['author'],
+			'comment_type' => 'block_comment',
+			'status'       => 'hold',
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( $params ) );
+
+		$response    = rest_get_server()->dispatch( $request );
+		$data        = $response->get_data();
+		$new_comment = get_comment( $data['id'] );
+
+		$this->assertSame( '0', $new_comment->comment_approved );
+	}
+
 	/**
 	 * Test that for each user role, the permissions are correct when accessing comments.
 	 *

--- a/phpunit/experimental/rest-api-comment-permissions-test.php
+++ b/phpunit/experimental/rest-api-comment-permissions-test.php
@@ -104,6 +104,17 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 		$this->assertErrorResponse( 'rest_comment_not_supported_post_type', $response, 403 );
 	}
 
+	public function test_create_block_comment_require_login() {
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
+		$request->set_param( 'post', self::$post_id );
+		$request->set_param( 'type', 'block_comment' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_comment_login_required', $response, 401 );
+	}
+
 	public function test_cannot_create_block_comment_without_post_type_support() {
 		register_post_type(
 			'no-block-comments',
@@ -232,7 +243,6 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 
 		$this->assertSame( 'comment', $new_comment->comment_type );
 	}
-
 
 	/**
 	 * Test that for each user role, the permissions are correct when accessing comments.


### PR DESCRIPTION
## What?
Related #71919.

PR updates the Comments REST API controller to allow setting the status for `block_comment` type and allowing type specification when creating a comment.

The comment `type` validation now happens via schema, instead of custom error handling. I had to duplicate the `::create_item` method, but the changes are minimal.

## Why?
This should make it easier to backport changes and align the experiment's code with core.

## Testing Instructions
I've added new PHPUnit tests that should cover the changes in this PR. The feature also has good e2e test coverage.

1. Smoke test the block commenting feature.

```
npm run test:unit:php:base -- --filter WP_Test_REST_Block_Comment_Permissions

npm run test:e2e -- test/e2e/specs/editor/various/block-comments.spec.js
```

### Testing Instructions for Keyboard
Same.
