### PR TITLE
Notes: Hide block settings menu items for mulit-selection

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -334,9 +334,11 @@ export function BlockSettingsDropdown( {
 											</MenuItem>
 										</>
 									) }
-									<CommentIconSlotFill.Slot
-										fillProps={ { onClose } }
-									/>
+									{ count === 1 && (
+										<CommentIconSlotFill.Slot
+											fillProps={ { onClose } }
+										/>
+									) }
 								</MenuGroup>
 								{ canCopyStyles && ! isContentOnly && (
 									<MenuGroup>


### PR DESCRIPTION
## What?
Part of #66377.

PR updates the block settings dropdown to render `CommentIconSlotFill` only when a single block is selected.

## Why?
Currently, the feature doesn't support adding notes to multiple blocks.

## Testing Instructions
1. Open a post or page.
2. Insert two paragraphs.
3. Select both and open the "Options" dropdown.
4. Confirm that the "Comment" menu item isn't displayed.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="804" height="599" alt="CleanShot 2025-10-09 at 14 45 11" src="https://github.com/user-attachments/assets/3f536ccf-7c18-4b00-8d5a-a4066de5a910" />
