### PR TITLE
Accordion Header: fixes default styling

### DIFF
--- a/packages/block-library/src/accordion-heading/style.scss
+++ b/packages/block-library/src/accordion-heading/style.scss
@@ -1,7 +1,41 @@
+@mixin accordion-inherit-style {
+	background-color: inherit;
+	border-color: inherit;
+	color: inherit;
+}
+
 // The .wp-block-accordion selector is needed to make this CSS stronger
 // than the default heading padding when background color is applied.
+// than the default button background, color and border styles.
 .wp-block-accordion .wp-block-accordion-heading {
+	margin: 0;
 	padding: 0;
+}
+
+.wp-block-accordion {
+	.wp-block {
+		&.wp-block-accordion-heading {
+			margin: 0;
+		}
+	}
+	.wp-block-accordion-item {
+		.wp-block-accordion-heading {
+			width: 100%;
+
+			&.has-text-color,
+			&.has-background {
+				.wp-block-accordion-heading__toggle {
+					text-decoration: none;
+					@include accordion-inherit-style;
+
+					&:hover,
+					&:focus {
+						@include accordion-inherit-style;
+					}
+				}
+			}
+		}
+	}
 }
 
 .wp-block-accordion-heading__toggle {

--- a/packages/block-library/src/accordion-panel/style.scss
+++ b/packages/block-library/src/accordion-panel/style.scss
@@ -1,8 +1,20 @@
+.wp-block-accordion {
+	.wp-block {
+		&.wp-block-accordion-panel {
+			margin: 0;
+		}
+	}
+}
+
 .wp-block-accordion-panel {
 	// Prevent blockGap from Accordion Content block from adding extra margin between accordions.
 	&[inert],
 	&[aria-hidden="true"] {
 		display: none;
 		margin-block-start: 0;
+	}
+
+	p {
+		margin: 0;
 	}
 }


### PR DESCRIPTION
Closes #71529


## Why?
In many themes, which they have applying style to button element, But in accordion block button and also heading elements used. Button and heading elements styles is affects to the accordion block.

## How?
With the use of minimal styling i have applied to accordion block for themes.

## screenshots

### Twenty Twenty Five theme
| Backend  | Frontend                     |
|---------|-------------------------------|
| <img width="1370" height="498" alt="Twentytwenty-five-backend" src="https://github.com/user-attachments/assets/a2d069e8-4c29-49c3-93be-afc9055b13e1" /> |  <img width="1370" height="498" alt="Twentytwenty-five-frontend" src="https://github.com/user-attachments/assets/96150284-3086-4a2c-a951-0a832f3b587f" /> | 

### Twenty Twenty One theme

| Backend  | Frontend                     |
|---------|-------------------------------|
| <img width="1308" height="578" alt="Twentytwenty-one-backend" src="https://github.com/user-attachments/assets/e4b3811e-4e78-478f-92e8-10439e91e48e" /> |  <img width="1384" height="420" alt="Twentytwenty-one-frontend" src="https://github.com/user-attachments/assets/1023e7d0-7b71-4b82-9125-aed98aba4844" /> | 

### Twenty Twenty theme

| Backend  | Frontend                     |
|---------|-------------------------------|
| <img width="1372" height="426" alt="Twentytwenty-backend" src="https://github.com/user-attachments/assets/cc985c44-dafa-4619-97d0-3c399ff94468" /> |  <img width="1246" height="330" alt="Twentytwenty-frontend" src="https://github.com/user-attachments/assets/793fade4-1e59-458a-85f2-fef503bb2b65" /> | 

### Twenty Nineteen theme

| Backend  | Frontend                     |
|---------|-------------------------------|
| <img width="1416" height="588" alt="Twenty-nineteen-backend" src="https://github.com/user-attachments/assets/4f996b91-7d53-4858-9b59-02358105ba28" /> |  <img width="1502" height="392" alt="Twenty-nineteen-frontend" src="https://github.com/user-attachments/assets/5a285474-1491-431d-95b6-5917f0e21e18" /> | 

### Twenty Seventeen theme

| Backend  | Frontend                     |
|---------|-------------------------------|
| <img width="1460" height="368" alt="Twenty-seventeen-backend" src="https://github.com/user-attachments/assets/e98ceada-c7ef-486a-86db-c1e5930c0067" /> | <img width="1136" height="398" alt="Twenty-seventeen-frontend" src="https://github.com/user-attachments/assets/f132e9a5-9367-4518-b0fe-8ec8bb47099a" /> | 
