### PR TITLE
Resolving Comments hide reserved space for comments

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -155,7 +155,7 @@ export default function CollabSidebar() {
 					commentSidebarRef={ commentSidebarRef }
 				/>
 			</PluginSidebar>
-			{ isLargeViewport && (
+			{ isLargeViewport && unresolvedSortedThreads.length > 0 && (
 				<PluginSidebar
 					isPinnable={ false }
 					header={ false }


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes part of #72157 **(**When resolving a comment in the canvas, don't show the "No comments available" message if you're resolving the last comment, just hide the reserved space for comments entirely.**)**

<!-- In a few words, what is the PR actually doing? -->
Hide the canvas comment sidebar entirely when there are no unresolved comments, instead of showing "No comments available" message.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When resolving the last comment in the canvas, the "No comments available" message was still being displayed instead of hiding the reserved space for comments entirely. This creates unnecessary visual clutter and doesn't provide a clean user experience when all comments are resolved.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Modified the condition for rendering the canvas sidebar in `CollabSidebar` component to only show when there are unresolved comments (`unresolvedSortedThreads.length > 0`). This ensures the entire canvas comment space is hidden when the last comment is resolved, rather than showing an empty space with a "No comments available" message.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page in the editor.
2. Add a comment to a block by selecting the block and using the comment functionality.
3. Verify the canvas comment sidebar appears with the comment.
4. Resolve the comment by clicking the resolve button.
5. Verify that the canvas comment sidebar disappears entirely (no reserved space or "No comments available" message).
6. Add another comment and verify the sidebar reappears.
7. Resolve this comment as well and verify the sidebar disappears again.

## Video 


https://github.com/user-attachments/assets/e1f990ae-7780-4d90-a696-81ad181ea8ed

