### PR TITLE
Accordion Panel Block: Add layout support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -46,7 +46,7 @@ Displays an accordion panel. ([Source](https://github.com/WordPress/gutenberg/tr
 -	**Name:** core/accordion-panel
 -	**Category:** design
 -	**Parent:** core/accordion-item
--	**Supports:** allowedBlocks, color (background, gradients, text), contentRole, interactivity, shadow, spacing (blockGap, padding), typography (fontSize, lineHeight), ~~blockVisibility~~, ~~html~~
+-	**Supports:** allowedBlocks, color (background, gradients, text), contentRole, interactivity, layout (~~allowEditing~~), shadow, spacing (blockGap, padding), typography (fontSize, lineHeight), ~~blockVisibility~~, ~~html~~
 -	**Attributes:** isSelected, openByDefault, templateLock
 
 ## Archives

--- a/packages/block-library/src/accordion-panel/block.json
+++ b/packages/block-library/src/accordion-panel/block.json
@@ -47,6 +47,9 @@
 			}
 		},
 		"shadow": true,
+		"layout": {
+			"allowEditing": false
+		},
 		"blockVisibility": false,
 		"contentRole": true,
 		"allowedBlocks": true


### PR DESCRIPTION
## What?  Why?  How?

This PR adds `layout` support to the Accordion Panel block. Otherwise, the block gap setting doesn't work properly.

## Testing Instructions

- Insert an Accordion block and select the Accordion Panel block inside it.
- Make sure that the block gap setting works as expected.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/a1fc0f74-7f26-43f5-a913-9316c8fee3fc

