### PR TITLE
Fix entity binding not cleared when unsyncing and entering custom URL in Nav block

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -362,7 +362,7 @@ function LinkControl( {
 			id: undefined,
 			kind: undefined,
 			type: undefined,
-			url: '',
+			url: undefined,
 		} );
 
 		// Request focus after the component re-renders with the cleared state

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -352,9 +352,18 @@ function LinkControl( {
 
 	const handleUnlink = () => {
 		// Clear the internal state to remove the ID and re-enable the field
-		// The user will need to submit to commit this change
-		const { id, ...restValue } = internalControlValue;
-		setInternalControlValue( { ...restValue, url: '' } );
+		// Explicitly set id, kind, and type to undefined so they override
+		// the original values when spread in handleSubmit. This ensures that
+		// when the user types a custom URL and submits, the entity link is
+		// properly severed (not just when selecting a different entity from suggestions).
+		const { id, kind, type, ...restValue } = internalControlValue;
+		setInternalControlValue( {
+			...restValue,
+			id: undefined,
+			kind: undefined,
+			type: undefined,
+			url: '',
+		} );
 
 		// Request focus after the component re-renders with the cleared state
 		// We can't focus immediately because the input might still be disabled

--- a/packages/block-editor/src/components/link-control/test/index.js
+++ b/packages/block-editor/src/components/link-control/test/index.js
@@ -2747,6 +2747,70 @@ describe( 'Entity handling', () => {
 		} );
 	} );
 
+	it( 'should allow unlinking and entering a custom URL', async () => {
+		const user = userEvent.setup();
+
+		const entityLink = {
+			id: 123,
+			url: 'https://example.com/page',
+			title: 'Test Page',
+			type: 'page',
+			kind: 'post-type',
+		};
+
+		const onChange = jest.fn();
+
+		render(
+			<LinkControl
+				value={ entityLink }
+				handleEntities
+				forceIsEditingLink
+				onChange={ onChange }
+			/>
+		);
+
+		const searchInput = screen.getByRole( 'combobox', {
+			name: 'Search or type URL',
+		} );
+
+		// Initially should be disabled because it's an entity
+		expect( searchInput ).toBeDisabled();
+
+		// Click the unsync button
+		const unlinkButton = screen.getByRole( 'button', {
+			name: 'Unsync and edit',
+		} );
+		await user.click( unlinkButton );
+
+		// Input should now be enabled and value should be cleared
+		expect( searchInput ).toBeEnabled();
+		expect( searchInput ).toHaveValue( '' );
+
+		// Type a custom URL (not selecting from suggestions)
+		const customUrl = 'www.wordpress.org';
+		await user.type( searchInput, customUrl );
+
+		// Wait for the URL suggestion to appear
+		await screen.findByRole( 'listbox' );
+
+		// Click the Apply button to submit
+		const applyButton = screen.getByRole( 'button', {
+			name: 'Apply',
+		} );
+		await user.click( applyButton );
+
+		// Verify that onChange was called with the entity link severed
+		// id, kind, and type should be undefined to indicate it's no longer an entity
+		expect( onChange ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				url: customUrl,
+				id: undefined,
+				kind: undefined,
+				type: undefined,
+			} )
+		);
+	} );
+
 	describe( 'Accessibility association for entity links', () => {
 		it( 'should associate unlink button with help text via aria-describedby', () => {
 			const entityLink = {


### PR DESCRIPTION
## What

Fixes #72203

This PR fixes a bug where the entity binding was not properly cleared when a user clicks "Unsync" on an entity link and enters a custom URL.

## Why

When a navigation link is bound to an entity (post, page, taxonomy), users can click the "Unsync" button to unlock the URL field and change it. However, when typing a custom URL (not selecting from suggestions) and submitting, the entity binding was not being cleared. This caused:

1. The `metadata.bindings.url` to remain intact
2. The `id`, `kind`, and `type` attributes to persist
3. The URL to not update to the expected custom value

The root cause was in `LinkControl`'s `handleUnlink()` function. It destructured `id` out of `internalControlValue` but didn't explicitly set it to `undefined`. When `handleSubmit()` spread the values (`...value, ...internalControlValue`), the original entity properties from the `value` prop persisted through the spread, preventing the severing logic in `update-attributes.js` from detecting the change.

## How

Modified the `handleUnlink()` function in `LinkControl` to explicitly set `id`, `kind`, and `type` to `undefined`:

```javascript
const { id, kind, type, ...restValue } = internalControlValue;
setInternalControlValue( {
    ...restValue,
    id: undefined,
    kind: undefined,
    type: undefined,
    url: undefined
} );
```

This ensures these properties override the original entity values when spread in `handleSubmit()`, allowing the severing logic to work correctly.

Added comprehensive test coverage for this specific scenario: "should allow unlinking and entering a custom URL".

## Testing Instructions

### Manual Testing

1. **Create an entity link:**
   - Add a Navigation block to a post/page
   - Add a Navigation Link item
   - Link it to an entity (e.g., select a Page from the suggestions)
   - Save and verify the link has `id`, `kind`, and `type` attributes in block markup

2. **Reproduce the original bug (before fix):**
   - Select the Navigation Link block
   - Open the Link UI (click to edit the link)
   - Click the "Unsync" button (unlink icon) to unlock the URL field
   - Type a custom URL: `www.wordpress.org`
   - Click "Apply" to submit
   - **Expected (with fix):** The URL updates to `www.wordpress.org`, and the entity binding (`metadata.bindings.url`) is removed, along with `id`, `kind`, and `type` attributes
   - **Previous behavior (bug):** The URL would not update, and the entity binding would remain

3. **Verify the existing use case still works:**
   - Create another entity link (link to a Page)
   - Click "Unsync" 
   - Select a **different entity** from the suggestions list
   - Verify the link updates to the new entity with correct `id`, `kind`, and `type`

### Automated Testing

Run the LinkControl unit tests:
```bash
npm run test:unit -- packages/block-editor/src/components/link-control/test/index.js
```

All 115 tests should pass, including the new test: "should allow unlinking and entering a custom URL"

## Screenshots


https://github.com/user-attachments/assets/cc126e2c-3b76-4d3c-8ee0-19eeaa4fa2a4

