### PR TITLE
Pages: use embedded info for feature media

### DIFF
--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -134,7 +134,7 @@ export default function PostList( { postType } ) {
 		return {
 			per_page: view.perPage,
 			page: view.page,
-			_embed: 'author',
+			_embed: 'author,wp:featuredmedia',
 			order: view.sort?.direction,
 			orderby: view.sort?.field,
 			orderby_hierarchy: !! view.showLevels,

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -69,7 +69,7 @@ Export action as JSON for Pattern.
 
 ### featuredImageField
 
-Featured Image field for BasePost.
+Featured Image field for BasePostWithEmbeddedFeaturedMedia.
 
 ### orderField
 

--- a/packages/fields/src/fields/featured-image/featured-image-edit.tsx
+++ b/packages/fields/src/fields/featured-image/featured-image-edit.tsx
@@ -2,37 +2,24 @@
  * WordPress dependencies
  */
 import { Button, __experimentalGrid as Grid } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 import { useCallback, useRef } from '@wordpress/element';
 // @ts-ignore
 import { MediaUpload } from '@wordpress/media-utils';
 import { lineSolid } from '@wordpress/icons';
-import { store as coreStore } from '@wordpress/core-data';
 import type { DataFormControlProps } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import type { BasePost } from '../../types';
+import type { BasePostWithEmbeddedFeaturedMedia } from '../../types';
 
 export const FeaturedImageEdit = ( {
 	data,
 	field,
 	onChange,
-}: DataFormControlProps< BasePost > ) => {
+}: DataFormControlProps< BasePostWithEmbeddedFeaturedMedia > ) => {
 	const { id } = field;
-
-	const value = field.getValue( { item: data } );
-
-	const media = useSelect(
-		( select ) => {
-			const { getEntityRecord } = select( coreStore );
-			return getEntityRecord( 'postType', 'attachment', value );
-		},
-		[ value ]
-	);
-
 	const onChangeControl = useCallback(
 		( newValue: number ) =>
 			onChange( {
@@ -41,6 +28,7 @@ export const FeaturedImageEdit = ( {
 		[ id, onChange ]
 	);
 
+	const media = data?._embedded?.[ 'wp:featuredmedia' ]?.[ 0 ];
 	const url = media?.source_url;
 	const title = media?.title?.rendered;
 	const ref = useRef( null );

--- a/packages/fields/src/fields/featured-image/featured-image-edit.tsx
+++ b/packages/fields/src/fields/featured-image/featured-image-edit.tsx
@@ -2,10 +2,12 @@
  * WordPress dependencies
  */
 import { Button, __experimentalGrid as Grid } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { useCallback, useRef } from '@wordpress/element';
 // @ts-ignore
 import { MediaUpload } from '@wordpress/media-utils';
 import { lineSolid } from '@wordpress/icons';
+import { store as coreStore } from '@wordpress/core-data';
 import type { DataFormControlProps } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 
@@ -20,6 +22,17 @@ export const FeaturedImageEdit = ( {
 	onChange,
 }: DataFormControlProps< BasePostWithEmbeddedFeaturedMedia > ) => {
 	const { id } = field;
+
+	const value = field.getValue( { item: data } );
+
+	const media = useSelect(
+		( select ) => {
+			const { getEntityRecord } = select( coreStore );
+			return getEntityRecord( 'postType', 'attachment', value );
+		},
+		[ value ]
+	);
+
 	const onChangeControl = useCallback(
 		( newValue: number ) =>
 			onChange( {
@@ -28,7 +41,6 @@ export const FeaturedImageEdit = ( {
 		[ id, onChange ]
 	);
 
-	const media = data?._embedded?.[ 'wp:featuredmedia' ]?.[ 0 ];
 	const url = media?.source_url;
 	const title = media?.title?.rendered;
 	const ref = useRef( null );

--- a/packages/fields/src/fields/featured-image/featured-image-view.tsx
+++ b/packages/fields/src/fields/featured-image/featured-image-view.tsx
@@ -1,30 +1,18 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
 import type { DataViewRenderFieldProps } from '@wordpress/dataviews';
 
 /**
  * Internal dependencies
  */
-import type { BasePost } from '../../types';
+import type { BasePostWithEmbeddedFeaturedMedia } from '../../types';
 
 export const FeaturedImageView = ( {
 	item,
 	config,
-}: DataViewRenderFieldProps< BasePost > ) => {
-	const mediaId = item.featured_media;
-
-	const media = useSelect(
-		( select ) => {
-			const { getEntityRecord } = select( coreStore );
-			return mediaId
-				? getEntityRecord( 'postType', 'attachment', mediaId )
-				: null;
-		},
-		[ mediaId ]
-	);
+}: DataViewRenderFieldProps< BasePostWithEmbeddedFeaturedMedia > ) => {
+	const media = item?._embedded?.[ 'wp:featuredmedia' ]?.[ 0 ];
 	const url = media?.source_url;
 
 	if ( url ) {

--- a/packages/fields/src/fields/featured-image/index.ts
+++ b/packages/fields/src/fields/featured-image/index.ts
@@ -7,11 +7,11 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import type { BasePost } from '../../types';
+import type { BasePostWithEmbeddedFeaturedMedia } from '../../types';
 import { FeaturedImageEdit } from './featured-image-edit';
 import { FeaturedImageView } from './featured-image-view';
 
-const featuredImageField: Field< BasePost > = {
+const featuredImageField: Field< BasePostWithEmbeddedFeaturedMedia > = {
 	id: 'featured_media',
 	type: 'media',
 	label: __( 'Featured Image' ),
@@ -22,6 +22,6 @@ const featuredImageField: Field< BasePost > = {
 };
 
 /**
- * Featured Image field for BasePost.
+ * Featured Image field for BasePostWithEmbeddedFeaturedMedia.
  */
 export default featuredImageField;

--- a/packages/fields/src/types.ts
+++ b/packages/fields/src/types.ts
@@ -58,6 +58,24 @@ export interface BasePostWithEmbeddedAuthor extends BasePost {
 	_embedded: EmbeddedAuthor;
 }
 
+interface FeaturedMedia {
+	title: {
+		rendered: string;
+	};
+	source_url: string;
+	media_details: {
+		sizes: Record< string, { width: number; source_url: string } >;
+	};
+}
+
+interface EmbeddedFeaturedMedia {
+	'wp:featuredmedia': FeaturedMedia[];
+}
+
+export interface BasePostWithEmbeddedFeaturedMedia extends BasePost {
+	_embedded: EmbeddedFeaturedMedia;
+}
+
 export interface Template extends CommonPost {
 	type: 'wp_template';
 	is_custom: boolean;


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/pull/72200

## What?

This PR prevents 20 network requests from being triggered.

Before: there was a new network request to retrieve the feature media of each item.

https://github.com/user-attachments/assets/1242c06a-23fd-42ff-b3b0-4e716555a7b5

After: no extra network request.

https://github.com/user-attachments/assets/e01c7256-ff83-4b2e-8b7a-c5a04055a2b4


## Why?

To minimize unnecessary requests.

## How?

By leveraging the `wp:featuredmedia` embed.

## Testing Instructions

Go to the Pages screen in the site editor. Verify the featured media loads but no extra requests is triggered.
