### PR TITLE
Alt Fix: Prevent focus loss in Firefox when typing in sidebar inputs

### DIFF
--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -171,9 +171,11 @@ export function useRichText( {
 			return;
 		}
 
-		if ( ref.current.ownerDocument.activeElement !== ref.current ) {
-			ref.current.focus();
-		}
+		// Always call focus() to force browsers to re-synchronize the visual caret
+		// with the selection range after DOM mutations. Without this, the caret may
+		// appear at the wrong position or not appear at all (Firefox), even though
+		// the Selection API reports the correct position.
+		ref.current.focus();
 
 		applyRecord( recordRef.current );
 		hadSelectionUpdateRef.current = false;

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -300,7 +300,18 @@ export function applySelection( { startPath, endPath }, current ) {
 		//
 		// See: https://github.com/Microsoft/TypeScript/issues/5901#issuecomment-431649653
 		if ( activeElement instanceof defaultView.HTMLElement ) {
-			activeElement.focus();
+			// Don't restore focus to BODY or HTML elements, as this can cause
+			// unwanted focus changes. In Firefox, focusing BODY inside an iframe
+			// can cause the parent document to focus the iframe itself.
+			// Only restore focus to meaningful focusable elements.
+			const tagName = activeElement.tagName;
+			const isContentEditable = activeElement.isContentEditable;
+			const isMeaningfulElement =
+				tagName !== 'BODY' && tagName !== 'HTML' && tagName !== 'DIV';
+
+			if ( isContentEditable || isMeaningfulElement ) {
+				activeElement.focus();
+			}
 		}
 	}
 }

--- a/packages/rich-text/src/to-dom.js
+++ b/packages/rich-text/src/to-dom.js
@@ -299,19 +299,15 @@ export function applySelection( { startPath, endPath }, current ) {
 		// or `blur` property).
 		//
 		// See: https://github.com/Microsoft/TypeScript/issues/5901#issuecomment-431649653
-		if ( activeElement instanceof defaultView.HTMLElement ) {
+		if (
+			activeElement instanceof defaultView.HTMLElement &&
+			activeElement.tagName !== 'BODY'
+		) {
 			// Don't restore focus to BODY or HTML elements, as this can cause
 			// unwanted focus changes. In Firefox, focusing BODY inside an iframe
 			// can cause the parent document to focus the iframe itself.
 			// Only restore focus to meaningful focusable elements.
-			const tagName = activeElement.tagName;
-			const isContentEditable = activeElement.isContentEditable;
-			const isMeaningfulElement =
-				tagName !== 'BODY' && tagName !== 'HTML' && tagName !== 'DIV';
-
-			if ( isContentEditable || isMeaningfulElement ) {
-				activeElement.focus();
-			}
+			activeElement.focus();
 		}
 	}
 }

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -830,6 +830,127 @@ test.describe( 'Navigation block', () => {
 			await expect( linkInput ).toHaveValue( '' );
 		} );
 	} );
+
+	test.describe( 'Focus management', () => {
+		test.beforeEach( async ( { admin, requestUtils } ) => {
+			await requestUtils.deleteAllMenus();
+			await admin.createNewPost();
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await Promise.all( [
+				requestUtils.deleteAllPosts(),
+				requestUtils.deleteAllMenus(),
+			] );
+		} );
+
+		test( 'should preserve focus in sidebar text input when typing (@firefox)', async ( {
+			page,
+			editor,
+			requestUtils,
+			pageUtils,
+			navigation,
+		} ) => {
+			// Create a navigation menu with one link
+			const createdMenu = await requestUtils.createNavigationMenu( {
+				title: 'Test Menu',
+				content: `<!-- wp:navigation-link {"label":"Home","url":"https://example.com"} /-->`,
+			} );
+
+			// Insert the navigation block
+			await editor.insertBlock( {
+				name: 'core/navigation',
+				attributes: {
+					ref: createdMenu?.id,
+				},
+			} );
+
+			// Click on the navigation link label in the canvas to edit it
+			const linkLabel = editor.canvas.getByRole( 'textbox', {
+				name: 'Navigation link text',
+			} );
+			await linkLabel.click();
+			await pageUtils.pressKeys( 'primary+a' );
+			await page.keyboard.type( 'Updated Home' );
+
+			// Open the document settings sidebar
+			await editor.openDocumentSettingsSidebar();
+
+			// Tab to the sidebar settings panel
+			// First tab should go to the settings sidebar
+			await page.keyboard.press( 'Tab' );
+
+			// Find the text input in the sidebar
+			const textInput = page.getByRole( 'textbox', {
+				name: 'Text',
+			} );
+
+			// Tab until we reach the Text field in the sidebar
+			// This may take multiple tabs depending on other controls
+			for ( let i = 0; i < 10; i++ ) {
+				const focusedElement = await page.evaluate( () => {
+					const el = document.activeElement;
+					return {
+						tagName: el?.tagName,
+						label:
+							el?.getAttribute( 'aria-label' ) ||
+							el?.labels?.[ 0 ]?.textContent,
+						id: el?.id,
+					};
+				} );
+
+				if (
+					focusedElement.label?.includes( 'Text' ) &&
+					focusedElement.tagName === 'INPUT'
+				) {
+					break;
+				}
+
+				await page.keyboard.press( 'Tab' );
+			}
+
+			await expect( textInput ).toBeFocused();
+			await pageUtils.pressKeys( 'ArrowRight' );
+			// Type in the sidebar text input
+			await page.keyboard.type( ' Extra' );
+
+			// Verify the text was actually typed (change happened)
+			await expect( textInput ).toHaveValue( 'Updated Home Extra' );
+
+			// Tab again to move to the next field
+			await page.keyboard.press( 'Tab' );
+
+			// Check that focus is still within the document sidebar
+			const focusIsInSidebar = await page.evaluate( () => {
+				const activeEl = document.activeElement;
+				const sidebar = document.querySelector(
+					'.interface-interface-skeleton__sidebar'
+				);
+				return sidebar?.contains( activeEl );
+			} );
+
+			expect( focusIsInSidebar ).toBe( true );
+
+			// Tab until the Skip to Selected Block link is focused
+			for ( let i = 0; i < 10; i++ ) {
+				await page.keyboard.press( 'Tab' );
+				if (
+					( await page.evaluate(
+						() => document.activeElement?.textContent
+					) ) === 'Skip to the selected block'
+				) {
+					break;
+				}
+			}
+
+			await page.keyboard.press( 'Enter' );
+
+			// Check that focus is on the canvas and the text is updated
+			await pageUtils.pressKeys( 'ArrowDown' );
+			await pageUtils.pressKeys( 'primary+a' );
+			await navigation.expectToHaveTextSelected( 'Updated Home Extra' );
+		} );
+	} );
 } );
 
 class Navigation {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/72168
Alternative to https://github.com/WordPress/gutenberg/pull/61374 and https://github.com/WordPress/gutenberg/pull/72174/

<!-- In a few words, what is the PR actually doing? -->
In Firefox, when typing in a navigation link's canvas label and then switching to the sidebar Text input, focus would jump to the iframe after each keystroke.

The issue occurred with `selection.addRange()`, as this causes that element to receive focus in Firefox. In Chrome, no focus shift happens. 

In some instances, we want `selection.addRange()` to move focus, such as when restoring focus to the same location when indenting a block item.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We should be able to use the text input in the sidebar to update the label text without focus being stolen.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
When focus is outside the canvas iframe (such as editing a sidebar inspector text field), the iframe will say focus is on the body. If focus is on the body, we _don't_ want to steal focus from outside the iframe _unless_ focus outside the iframe is also on its body element. In this instance, the user was likely interacting with the toolbar, and their interaction caused a focus loss, and we'd _want_ to restore focus to the active canvas element. This scenario happens when indenting a list item from the toolbar, for example. The item is indented and focus moves to the list item.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- IN FIREFOX
- Click a navigation link block
- In the sidebar, click or Tab to the Text input to update the label
- Type in the sidebar input
- Focus should remain in the text field and update the on-canvas element

- Add a list block with two list items
- Indent the second list item from the toolbar
- The list item you indented should receive focus


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
