### PR TITLE
Ensure meta boxes are not hidden when legacy

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -266,7 +266,7 @@ function MetaBoxesMain( { isLegacy } ) {
 		<div
 			// The class name 'edit-post-layout__metaboxes' is retained because some plugins use it.
 			className="edit-post-layout__metaboxes edit-post-meta-boxes-main__liner"
-			hidden={ ! isOpen }
+			hidden={ ! isLegacy && ! isOpen }
 		>
 			<MetaBoxes location="normal" />
 			<MetaBoxes location="advanced" />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Closes #72185

Ensures the preference that persists the open or closed state of the meta box pane does not apply when there's no toggle button.

## Why?
Without this there are scenarios where the meta boxes are inaccessible.

## How?
Adds a conditional.

## Testing Instructions
1. Starting with the prerequisites:
   - a classic theme active
   - a block < v3 registered
   - at least one meta box available in the 'normal' or 'advanced' area
2. Open a post or page
3. Verify the meta boxes are visible
4. Execute the following in the dev console:
   ```js
   wp.data.dispatch('core/preferences').set('core/edit-post', 'metaBoxesMainIsOpen', false)
   ```
5. Verify that the meta boxes remain visible

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
