### PR TITLE
Don't applySelection change for off-canvas text length changes

### DIFF
--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -151,14 +151,17 @@ export function useRichText( {
 	}
 
 	function applyFromProps() {
-		const previousRecord = recordRef.current;
+		// Get previous value before updating
+		const previousValue = _valueRef.current;
+
 		setRecordFromProps();
-		const newRecord = recordRef.current;
 
 		// Check if content length changed (text was added/removed, not just formatted)
 		const contentLengthChanged =
-			previousRecord &&
-			previousRecord.text?.length !== newRecord.text?.length;
+			previousValue &&
+			typeof previousValue === 'string' &&
+			typeof value === 'string' &&
+			previousValue.length !== value.length;
 
 		// Check if focus is on this element
 		const hasFocus = ref.current?.contains(
@@ -169,7 +172,7 @@ export function useRichText( {
 		// (e.g., typing in sidebar input changes canvas text)
 		const skipSelection = contentLengthChanged && ! hasFocus;
 
-		applyRecord( newRecord, { domOnly: skipSelection } );
+		applyRecord( recordRef.current, { domOnly: skipSelection } );
 	}
 
 	const didMountRef = useRef( false );

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -151,8 +151,25 @@ export function useRichText( {
 	}
 
 	function applyFromProps() {
+		const previousRecord = recordRef.current;
 		setRecordFromProps();
-		applyRecord( recordRef.current );
+		const newRecord = recordRef.current;
+
+		// Check if content length changed (text was added/removed, not just formatted)
+		const contentLengthChanged =
+			previousRecord &&
+			previousRecord.text?.length !== newRecord.text?.length;
+
+		// Check if focus is on this element
+		const hasFocus = ref.current?.contains(
+			ref.current.ownerDocument.activeElement
+		);
+
+		// Only skip selection if content changed AND focus is elsewhere
+		// (e.g., typing in sidebar input)
+		const shouldApplySelection = ! ( contentLengthChanged && ! hasFocus );
+
+		applyRecord( newRecord, { domOnly: ! shouldApplySelection } );
 	}
 
 	const didMountRef = useRef( false );

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -165,11 +165,11 @@ export function useRichText( {
 			ref.current.ownerDocument.activeElement
 		);
 
-		// Only skip selection if content changed AND focus is elsewhere
-		// (e.g., typing in sidebar input)
-		const shouldApplySelection = ! ( contentLengthChanged && ! hasFocus );
+		// Skip re-applying the selection state when content changed from external source
+		// (e.g., typing in sidebar input changes canvas text)
+		const skipSelection = contentLengthChanged && ! hasFocus;
 
-		applyRecord( newRecord, { domOnly: ! shouldApplySelection } );
+		applyRecord( newRecord, { domOnly: skipSelection } );
 	}
 
 	const didMountRef = useRef( false );

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -606,6 +606,93 @@ test.describe( 'Navigation block', () => {
 			await pageUtils.pressKeys( 'ArrowDown' );
 			await expect( navigation.getNavBlockInserter() ).toBeFocused();
 		} );
+
+		test( 'should preserve focus in sidebar text input when typing (@firefox)', async ( {
+			page,
+			editor,
+			requestUtils,
+			pageUtils,
+		} ) => {
+			// Create a navigation menu with one link
+			const createdMenu = await requestUtils.createNavigationMenu( {
+				title: 'Test Menu',
+				content: `<!-- wp:navigation-link {"label":"Home","url":"https://example.com"} /-->`,
+			} );
+
+			// Insert the navigation block
+			await editor.insertBlock( {
+				name: 'core/navigation',
+				attributes: {
+					ref: createdMenu?.id,
+				},
+			} );
+
+			// Click on the navigation link label in the canvas to edit it
+			const linkLabel = editor.canvas.getByRole( 'textbox', {
+				name: 'Navigation link text',
+			} );
+			await linkLabel.click();
+			await pageUtils.pressKeys( 'primary+a' );
+			await page.keyboard.type( 'Updated Home' );
+
+			// Open the document settings sidebar
+			await editor.openDocumentSettingsSidebar();
+
+			// Tab to the sidebar settings panel
+			// First tab should go to the settings sidebar
+			await page.keyboard.press( 'Tab' );
+
+			// Find the text input in the sidebar
+			const textInput = page.getByRole( 'textbox', {
+				name: 'Text',
+			} );
+
+			// Tab until we reach the Text field in the sidebar
+			// This may take multiple tabs depending on other controls
+			for ( let i = 0; i < 10; i++ ) {
+				const focusedElement = await page.evaluate( () => {
+					const el = document.activeElement;
+					return {
+						tagName: el?.tagName,
+						label:
+							el?.getAttribute( 'aria-label' ) ||
+							el?.labels?.[ 0 ]?.textContent,
+						id: el?.id,
+					};
+				} );
+
+				if (
+					focusedElement.label?.includes( 'Text' ) &&
+					focusedElement.tagName === 'INPUT'
+				) {
+					break;
+				}
+
+				await page.keyboard.press( 'Tab' );
+			}
+
+			await expect( textInput ).toBeFocused();
+			await pageUtils.pressKeys( 'ArrowRight' );
+			// Type in the sidebar text input
+			await page.keyboard.type( ' Extra' );
+
+			// Verify the text was actually typed (change happened)
+			await expect( textInput ).toHaveValue( 'Updated Home Extra' );
+
+			// Tab again to move to the next field
+			await page.keyboard.press( 'Tab' );
+
+			// Check that focus is still within the document sidebar
+			const focusIsInSidebar = await page.evaluate( () => {
+				const activeEl = document.activeElement;
+				const sidebar = document.querySelector(
+					'.interface-interface-skeleton__sidebar'
+				);
+				return sidebar?.contains( activeEl );
+			} );
+
+			expect( focusIsInSidebar ).toBe( true );
+		} );
 	} );
 
 	test( 'Adding new links to a navigation block with existing inner blocks triggers creation of a single Navigation Menu', async ( {


### PR DESCRIPTION
The attempt to keep track of caret position ([applySelection](https://github.com/WordPress/gutenberg/blob/trunk/packages/rich-text/src/to-dom.js#L198-L200)) when applying changes to the on-canvas elements via props, was stealing focus back to the canvas. In most cases, we want prop changes to retain the current selection. For example, making text bold should preserve selection. However, when changing the length of the text, we likely don't want to keep track of the selection. 

For example, when we change the text label of a navigation item from an off canvas input (inspector sidebar), we likely don't want to preserve this selection range. In these cases, it's better to not keep track of that focus. Here's a video of `trunk` behavior retaining this selection. 

https://github.com/user-attachments/assets/d086a46d-b711-4a6f-9f2b-3639ddd44e42

We have a sort of "ghost" selection. The previously highlighted range is preserved, even though the text has changed underneath it. Worse, this attempt to apply selection causes a focus shift from the off-canvas element to the on canvas element in firefox (https://github.com/WordPress/gutenberg/issues/72168).

So, if text length changes are coming from props and the current focus is off-canvas, let's NOT apply the selection again. This results in clearing the selection when text is changed off canvas:

https://github.com/user-attachments/assets/44cf76e2-2b9f-4274-b400-bdb35ac7c2ea

And it also prevents the focus shift.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL --> https://github.com/WordPress/gutenberg/issues/72168
Alternative to https://github.com/WordPress/gutenberg/pull/61374, https://github.com/WordPress/gutenberg/pull/72174 and https://github.com/WordPress/gutenberg/pull/72217. 

<!-- In a few words, what is the PR actually doing? -->
Don't applySelection when updating rich text elements via props if they are text length changes that are coming from off canvas.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
1. It's weird. If you change all the text via the input, your on canvas selection will remain. It's odd to have this "ghost" selection memory in some instances.
2. applySelection steals focus in firefox, as firefox focuses the element that receives the selection change. https://github.com/WordPress/gutenberg/issues/72168

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
In `rich-text` component's `applyFromProps()`, make the record application `domOnly` if the prop change is a text-length change and the canvas does not have focus (change coming from off canvas)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
**In Firefox**

**Navigation Block**

- Click a navigation link block
- In the sidebar, click or Tab to the Text input to update the label
- Type in the sidebar input
- Focus should remain in the text field and update the on-canvas element

**List Block**

- Add a list block with two list items
- On the second list item, place the cursor one position in from the edge. i.e. t[caret here]wo
- Indent the second list item from the toolbar
- The list item you indented should have the caret in the same position it was before the indention
- You should be able to type and add text from this caret position

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
