### PR TITLE
Template activation: improve back compat

### DIFF
--- a/backport-changelog/6.9/8063.md
+++ b/backport-changelog/6.9/8063.md
@@ -9,3 +9,4 @@ https://github.com/WordPress/wordpress-develop/pull/8063
 * https://github.com/WordPress/gutenberg/pull/72049
 * https://github.com/WordPress/gutenberg/pull/72011
 * https://github.com/WordPress/gutenberg/pull/72141
+* https://github.com/WordPress/gutenberg/pull/72223

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -524,3 +524,50 @@ function gutenberg_migrate_existing_templates() {
 
 	update_option( 'active_templates', $active_templates );
 }
+
+add_action( 'save_post_wp_template', 'gutenberg_maybe_update_active_templates' );
+function gutenberg_maybe_update_active_templates( $post_id ) {
+	$post = get_post( $post_id );
+	$is_inactive_by_default = get_post_meta( $post_id, 'is_inactive_by_default', true );
+	if ( $is_inactive_by_default ) {
+		return;
+	}
+	$active_templates = get_option( 'active_templates', array() );
+	$active_templates[ $post->post_name ] = $post->ID;
+	update_option( 'active_templates', $active_templates );
+}
+
+add_action( 'pre_get_block_template', 'gutenberg_get_block_template', 10, 3 );
+
+function gutenberg_get_block_template( $output, $id, $template_type ) {
+	$parts = explode( '//', $id, 2 );
+	if ( count( $parts ) < 2 ) {
+		return null;
+	}
+	list( $theme, $slug ) = $parts;
+	$active_templates = get_option( 'active_templates', array() );
+
+	if ( ! empty( $active_templates[ $slug ] ) ) {
+		$post = get_post( $active_templates[ $slug ] );
+		if ( $post && 'publish' === $post->post_status ) {
+			$template = _build_block_template_result_from_post( $post );
+
+			if ( ! is_wp_error( $template ) ) {
+				return $template;
+			}
+		}
+	}
+
+	$block_template = get_block_file_template( $id, $template_type );
+
+	/**
+	 * Filters the queried block template object after it's been fetched.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @param WP_Block_Template|null $block_template The found block template, or null if there isn't one.
+	 * @param string                 $id             Template unique identifier (example: 'theme_slug//template_slug').
+	 * @param string                 $template_type  Template type. Either 'wp_template' or 'wp_template_part'.
+	 */
+	return apply_filters( 'get_block_template', $block_template, $id, $template_type );
+}

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -694,8 +694,9 @@ function gutenberg_get_block_templates( $output, $query = array(), $template_typ
 		//////////////////////////////
 		// START CORE MODIFICATIONS //
 		//////////////////////////////
-		if ( $template->is_custom ) {
+		if ( $template->is_custom || isset( $query['wp_id'] ) ) {
 			// Custom templates don't need to be activated, leave them be.
+			// Also don't filter out templates when querying by wp_id.
 			$query_result[] = $template;
 		} elseif ( isset( $active_templates[ $template->slug ] ) && $active_templates[ $template->slug ] === $post->ID ) {
 			// Only include active templates.

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -45,7 +45,9 @@ function gutenberg_maintain_templates_routes() {
 				// templates controller, so we need to check if the id is an
 				// integer to make sure it's the proper post type endpoint.
 				if ( ! is_int( $post_arr['id'] ) ) {
-					return null;
+					// See _build_block_template_result_from_file, registered
+					// templates always set the theme to the active theme.
+					return get_stylesheet();
 				}
 				$terms = get_the_terms( $post_arr['id'], 'wp_theme' );
 				if ( is_wp_error( $terms ) || empty( $terms ) ) {

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -557,7 +557,7 @@ function gutenberg_get_block_template( $output, $id, $template_type ) {
 	//////////////////////////////
 	// START CORE MODIFICATIONS //
 	//////////////////////////////
-	$active_templates     = get_option( 'active_templates', array() );
+	$active_templates = get_option( 'active_templates', array() );
 
 	if ( ! empty( $active_templates[ $slug ] ) ) {
 		if ( is_int( $active_templates[ $slug ] ) ) {
@@ -569,7 +569,7 @@ function gutenberg_get_block_template( $output, $id, $template_type ) {
 					return $template;
 				}
 			}
-		} else if ( $active_templates[ $slug ] === false ) {
+		} elseif ( false === $active_templates[ $slug ] ) {
 			return null;
 		}
 	}
@@ -577,7 +577,7 @@ function gutenberg_get_block_template( $output, $id, $template_type ) {
 	// END CORE MODIFICATIONS //
 	////////////////////////////
 
-	$wp_query_args        = array(
+	$wp_query_args  = array(
 		'post_name__in'  => array( $slug ),
 		'post_type'      => $template_type,
 		'post_status'    => array( 'auto-draft', 'draft', 'publish', 'trash' ),
@@ -591,8 +591,8 @@ function gutenberg_get_block_template( $output, $id, $template_type ) {
 			),
 		),
 	);
-	$template_query       = new WP_Query( $wp_query_args );
-	$posts                = $template_query->posts;
+	$template_query = new WP_Query( $wp_query_args );
+	$posts          = $template_query->posts;
 
 	if ( count( $posts ) > 0 ) {
 		$template = _build_block_template_result_from_post( $posts[0] );
@@ -665,7 +665,7 @@ function gutenberg_get_block_templates( $output, $query = array(), $template_typ
 	//////////////////////////////
 	// START CORE MODIFICATIONS //
 	//////////////////////////////
-	$active_templates     = get_option( 'active_templates', array() );
+	$active_templates = get_option( 'active_templates', array() );
 	////////////////////////////
 	// END CORE MODIFICATIONS //
 	////////////////////////////
@@ -697,7 +697,7 @@ function gutenberg_get_block_templates( $output, $query = array(), $template_typ
 		if ( $template->is_custom ) {
 			// Custom templates don't need to be activated, leave them be.
 			$query_result[] = $template;
-		} else if ( isset( $active_templates[ $template->slug ] ) && $active_templates[ $template->slug ] === $post->ID ) {
+		} elseif ( isset( $active_templates[ $template->slug ] ) && $active_templates[ $template->slug ] === $post->ID ) {
 			// Only include active templates.
 			$query_result[] = $template;
 		}

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -541,6 +541,9 @@ function gutenberg_maybe_update_active_templates( $post_id ) {
 
 add_action( 'pre_get_block_template', 'gutenberg_get_block_template', 10, 3 );
 
+///////////////////////////////////////////////////////////////////////
+// This function is a copy of core's, except for the marked section. //
+///////////////////////////////////////////////////////////////////////
 function gutenberg_get_block_template( $output, $id, $template_type ) {
 	if ( 'wp_template' !== $template_type ) {
 		return $output;
@@ -550,17 +553,61 @@ function gutenberg_get_block_template( $output, $id, $template_type ) {
 		return null;
 	}
 	list( $theme, $slug ) = $parts;
+
+	//////////////////////////////
+	// START CORE MODIFICATIONS //
+	//////////////////////////////
 	$active_templates     = get_option( 'active_templates', array() );
 
 	if ( ! empty( $active_templates[ $slug ] ) ) {
-		$post = get_post( $active_templates[ $slug ] );
-		if ( $post && 'publish' === $post->post_status ) {
-			$template = _build_block_template_result_from_post( $post );
+		if ( is_int( $active_templates[ $slug ] ) ) {
+			$post = get_post( $active_templates[ $slug ] );
+			if ( $post && 'publish' === $post->post_status ) {
+				$template = _build_block_template_result_from_post( $post );
 
-			if ( ! is_wp_error( $template ) && $theme === $template->theme ) {
-				return $template;
+				if ( ! is_wp_error( $template ) && $theme === $template->theme ) {
+					return $template;
+				}
 			}
+		} else if ( $active_templates[ $slug ] === false ) {
+			return null;
 		}
+	}
+	////////////////////////////
+	// END CORE MODIFICATIONS //
+	////////////////////////////
+
+	$wp_query_args        = array(
+		'post_name__in'  => array( $slug ),
+		'post_type'      => $template_type,
+		'post_status'    => array( 'auto-draft', 'draft', 'publish', 'trash' ),
+		'posts_per_page' => 1,
+		'no_found_rows'  => true,
+		'tax_query'      => array(
+			array(
+				'taxonomy' => 'wp_theme',
+				'field'    => 'name',
+				'terms'    => $theme,
+			),
+		),
+	);
+	$template_query       = new WP_Query( $wp_query_args );
+	$posts                = $template_query->posts;
+
+	if ( count( $posts ) > 0 ) {
+		$template = _build_block_template_result_from_post( $posts[0] );
+
+		//////////////////////////////
+		// START CORE MODIFICATIONS //
+		//////////////////////////////
+		// Custom templates don't need to be activated, so if it's a custom
+		// template, return it.
+		if ( ! is_wp_error( $template ) && $template->is_custom ) {
+			return $template;
+		}
+		////////////////////////////
+		// END CORE MODIFICATIONS //
+		////////////////////////////
 	}
 
 	$block_template = get_block_file_template( $id, $template_type );
@@ -575,4 +622,173 @@ function gutenberg_get_block_template( $output, $id, $template_type ) {
 	 * @param string                 $template_type  Template type. Either 'wp_template' or 'wp_template_part'.
 	 */
 	return apply_filters( 'get_block_template', $block_template, $id, $template_type );
+}
+
+add_action( 'pre_get_block_templates', 'gutenberg_get_block_templates', 10, 3 );
+
+///////////////////////////////////////////////////////////////////////
+// This function is a copy of core's, except for the marked section. //
+///////////////////////////////////////////////////////////////////////
+function gutenberg_get_block_templates( $output, $query = array(), $template_type = 'wp_template' ) {
+	if ( 'wp_template' !== $template_type ) {
+		return $output;
+	}
+
+	$post_type     = isset( $query['post_type'] ) ? $query['post_type'] : '';
+	$wp_query_args = array(
+		'post_status'         => array( 'auto-draft', 'draft', 'publish' ),
+		'post_type'           => $template_type,
+		'posts_per_page'      => -1,
+		'no_found_rows'       => true,
+		'lazy_load_term_meta' => false,
+		'tax_query'           => array(
+			array(
+				'taxonomy' => 'wp_theme',
+				'field'    => 'name',
+				'terms'    => get_stylesheet(),
+			),
+		),
+	);
+
+	if ( ! empty( $query['slug__in'] ) ) {
+		$wp_query_args['post_name__in']  = $query['slug__in'];
+		$wp_query_args['posts_per_page'] = count( array_unique( $query['slug__in'] ) );
+	}
+
+	// This is only needed for the regular templates/template parts post type listing and editor.
+	if ( isset( $query['wp_id'] ) ) {
+		$wp_query_args['p'] = $query['wp_id'];
+	} else {
+		$wp_query_args['post_status'] = 'publish';
+	}
+
+	//////////////////////////////
+	// START CORE MODIFICATIONS //
+	//////////////////////////////
+	$active_templates     = get_option( 'active_templates', array() );
+	////////////////////////////
+	// END CORE MODIFICATIONS //
+	////////////////////////////
+
+	$template_query = new WP_Query( $wp_query_args );
+	$query_result   = array();
+	foreach ( $template_query->posts as $post ) {
+		$template = _build_block_template_result_from_post( $post );
+
+		if ( is_wp_error( $template ) ) {
+			continue;
+		}
+
+		if ( $post_type && ! $template->is_custom ) {
+			continue;
+		}
+
+		if (
+			$post_type &&
+			isset( $template->post_types ) &&
+			! in_array( $post_type, $template->post_types, true )
+		) {
+			continue;
+		}
+
+		//////////////////////////////
+		// START CORE MODIFICATIONS //
+		//////////////////////////////
+		if ( $template->is_custom ) {
+			// Custom templates don't need to be activated, leave them be.
+			$query_result[] = $template;
+		} else if ( isset( $active_templates[ $template->slug ] ) && $active_templates[ $template->slug ] === $post->ID ) {
+			// Only include active templates.
+			$query_result[] = $template;
+		}
+		////////////////////////////
+		// END CORE MODIFICATIONS //
+		////////////////////////////
+	}
+
+	if ( ! isset( $query['wp_id'] ) ) {
+		/*
+		 * If the query has found some user templates, those have priority
+		 * over the theme-provided ones, so we skip querying and building them.
+		 */
+		$query['slug__not_in'] = wp_list_pluck( $query_result, 'slug' );
+		/*
+		 * We need to unset the post_type query param because some templates
+		 * would be excluded otherwise, like `page.html` when looking for
+		 * `page` templates. We need all templates so we can exclude duplicates
+		 * from plugin-registered templates.
+		 * See: https://github.com/WordPress/gutenberg/issues/65584
+		 */
+		$template_files_query = $query;
+		unset( $template_files_query['post_type'] );
+		$template_files = _get_block_templates_files( $template_type, $template_files_query );
+		foreach ( $template_files as $template_file ) {
+			// If the query doesn't specify a post type, or it does and the template matches the post type, add it.
+			if (
+				! isset( $query['post_type'] ) ||
+				(
+					isset( $template_file['postTypes'] ) &&
+					in_array( $query['post_type'], $template_file['postTypes'], true )
+				)
+			) {
+				$query_result[] = _build_block_template_result_from_file( $template_file, $template_type );
+			} elseif ( ! isset( $template_file['postTypes'] ) ) {
+				// The custom templates with no associated post types are available for all post types as long
+				// as they are not default templates.
+				$candidate              = _build_block_template_result_from_file( $template_file, $template_type );
+				$default_template_types = get_default_block_template_types();
+				if ( ! isset( $default_template_types[ $candidate->slug ] ) ) {
+					$query_result[] = $candidate;
+				}
+			}
+		}
+
+		if ( 'wp_template' === $template_type ) {
+			// Add templates registered in the template registry. Filtering out the ones which have a theme file.
+			$registered_templates          = WP_Block_Templates_Registry::get_instance()->get_by_query( $query );
+			$matching_registered_templates = array_filter(
+				$registered_templates,
+				function ( $registered_template ) use ( $template_files ) {
+					foreach ( $template_files as $template_file ) {
+						if ( $template_file['slug'] === $registered_template->slug ) {
+							return false;
+						}
+					}
+					return true;
+				}
+			);
+
+			$matching_registered_templates = array_map(
+				function ( $template ) {
+					$template->content = apply_block_hooks_to_content(
+						$template->content,
+						$template,
+						'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata'
+					);
+					return $template;
+				},
+				$matching_registered_templates
+			);
+
+			$query_result = array_merge( $query_result, $matching_registered_templates );
+		}
+	}
+
+	/**
+	 * Filters the array of queried block templates array after they've been fetched.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @param WP_Block_Template[] $query_result Array of found block templates.
+	 * @param array               $query {
+	 *     Arguments to retrieve templates. All arguments are optional.
+	 *
+	 *     @type string[] $slug__in  List of slugs to include.
+	 *     @type int      $wp_id     Post ID of customized template.
+	 *     @type string   $area      A 'wp_template_part_area' taxonomy value to filter by (for 'wp_template_part' template type only).
+	 *     @type string   $post_type Post type to get the templates for.
+	 * }
+	 * @param string              $template_type wp_template or wp_template_part.
+	 */
+	return apply_filters( 'get_block_templates', $query_result, $query, $template_type );
 }

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -540,6 +540,9 @@ function gutenberg_maybe_update_active_templates( $post_id ) {
 add_action( 'pre_get_block_template', 'gutenberg_get_block_template', 10, 3 );
 
 function gutenberg_get_block_template( $output, $id, $template_type ) {
+	if ( 'wp_template' !== $template_type ) {
+		return $output;
+	}
 	$parts = explode( '//', $id, 2 );
 	if ( count( $parts ) < 2 ) {
 		return null;

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -527,12 +527,12 @@ function gutenberg_migrate_existing_templates() {
 
 add_action( 'save_post_wp_template', 'gutenberg_maybe_update_active_templates' );
 function gutenberg_maybe_update_active_templates( $post_id ) {
-	$post = get_post( $post_id );
+	$post                   = get_post( $post_id );
 	$is_inactive_by_default = get_post_meta( $post_id, 'is_inactive_by_default', true );
 	if ( $is_inactive_by_default ) {
 		return;
 	}
-	$active_templates = get_option( 'active_templates', array() );
+	$active_templates                     = get_option( 'active_templates', array() );
 	$active_templates[ $post->post_name ] = $post->ID;
 	update_option( 'active_templates', $active_templates );
 }
@@ -545,14 +545,14 @@ function gutenberg_get_block_template( $output, $id, $template_type ) {
 		return null;
 	}
 	list( $theme, $slug ) = $parts;
-	$active_templates = get_option( 'active_templates', array() );
+	$active_templates     = get_option( 'active_templates', array() );
 
 	if ( ! empty( $active_templates[ $slug ] ) ) {
 		$post = get_post( $active_templates[ $slug ] );
 		if ( $post && 'publish' === $post->post_status ) {
 			$template = _build_block_template_result_from_post( $post );
 
-			if ( ! is_wp_error( $template ) ) {
+			if ( ! is_wp_error( $template ) && $theme === $template->theme ) {
 				return $template;
 			}
 		}

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -323,16 +323,20 @@ export const deleteEntityRecord =
 			} );
 
 			let hasError = false;
+			let { baseURL } = entityConfig;
+			if (
+				kind === 'postType' &&
+				name === 'wp_template' &&
+				recordId &&
+				typeof recordId === 'string' &&
+				! /^\d+$/.test( recordId )
+			) {
+				baseURL =
+					baseURL.slice( 0, baseURL.lastIndexOf( '/' ) ) +
+					'/templates';
+			}
 			try {
-				let path = `${
-					kind === 'postType' &&
-					name === 'wp_template' &&
-					recordId &&
-					typeof recordId === 'string' &&
-					! /^\d+$/.test( recordId )
-						? '/wp/v2/templates'
-						: entityConfig.baseURL
-				}/${ recordId }`;
+				let path = `${ baseURL }/${ recordId }`;
 
 				if ( query ) {
 					path = addQueryArgs( path, query );
@@ -566,16 +570,21 @@ export const saveEntityRecord =
 			let updatedRecord;
 			let error;
 			let hasError = false;
+			let { baseURL } = entityConfig;
+			// For "string" IDs, use the old templates endpoint.
+			if (
+				kind === 'postType' &&
+				name === 'wp_template' &&
+				recordId &&
+				typeof recordId === 'string' &&
+				! /^\d+$/.test( recordId )
+			) {
+				baseURL =
+					baseURL.slice( 0, baseURL.lastIndexOf( '/' ) ) +
+					'/templates';
+			}
 			try {
-				const path = `${
-					kind === 'postType' &&
-					name === 'wp_template' &&
-					recordId &&
-					typeof recordId === 'string' &&
-					! /^\d+$/.test( recordId )
-						? '/wp/v2/templates'
-						: entityConfig.baseURL
-				}${ recordId ? '/' + recordId : '' }`;
+				const path = `${ baseURL }${ recordId ? '/' + recordId : '' }`;
 				const persistedRecord = select.getRawEntityRecord(
 					kind,
 					name,

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -324,7 +324,14 @@ export const deleteEntityRecord =
 
 			let hasError = false;
 			try {
-				let path = `${ entityConfig.baseURL }/${ recordId }`;
+				let path = `${
+					kind === 'postType' &&
+					name === 'wp_template' &&
+					typeof recordId === 'string' &&
+					! /^\d+$/.test( recordId )
+						? '/wp/v2/templates'
+						: entityConfig.baseURL
+				}/${ recordId }`;
 
 				if ( query ) {
 					path = addQueryArgs( path, query );
@@ -521,46 +528,6 @@ export const saveEntityRecord =
 		const entityIdKey = entityConfig.key || DEFAULT_ENTITY_KEY;
 		const recordId = record[ entityIdKey ];
 
-		// When called with a theme template ID, trigger the compatibility
-		// logic.
-		if (
-			kind === 'postType' &&
-			name === 'wp_template' &&
-			typeof recordId === 'string' &&
-			! /^\d+$/.test( recordId )
-		) {
-			// Get the theme template.
-			const template = await select.getEntityRecord(
-				'postType',
-				'wp_registered_template',
-				recordId
-			);
-			// Duplicate the theme template and make the edit.
-			const newTemplate = await dispatch.saveEntityRecord(
-				'postType',
-				'wp_template',
-				{
-					...template,
-					...record,
-					id: undefined,
-					type: 'wp_template',
-					status: 'publish',
-				}
-			);
-			// Make the new template active.
-			const activeTemplates = await select.getEntityRecord(
-				'root',
-				'site'
-			);
-			await dispatch.saveEntityRecord( 'root', 'site', {
-				active_templates: {
-					...activeTemplates.active_templates,
-					[ newTemplate.slug ]: newTemplate.id,
-				},
-			} );
-			return newTemplate;
-		}
-
 		const lock = await dispatch.__unstableAcquireStoreLock(
 			STORE_NAME,
 			[ 'entities', 'records', kind, name, recordId || uuid() ],
@@ -599,9 +566,14 @@ export const saveEntityRecord =
 			let error;
 			let hasError = false;
 			try {
-				const path = `${ entityConfig.baseURL }${
-					recordId ? '/' + recordId : ''
-				}`;
+				const path = `${
+					kind === 'postType' &&
+					name === 'wp_template' &&
+					typeof recordId === 'string' &&
+					! /^\d+$/.test( recordId )
+						? '/wp/v2/templates'
+						: entityConfig.baseURL
+				}${ recordId ? '/' + recordId : '' }`;
 				const persistedRecord = select.getRawEntityRecord(
 					kind,
 					name,

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -327,6 +327,7 @@ export const deleteEntityRecord =
 				let path = `${
 					kind === 'postType' &&
 					name === 'wp_template' &&
+					recordId &&
 					typeof recordId === 'string' &&
 					! /^\d+$/.test( recordId )
 						? '/wp/v2/templates'
@@ -569,6 +570,7 @@ export const saveEntityRecord =
 				const path = `${
 					kind === 'postType' &&
 					name === 'wp_template' &&
+					recordId &&
 					typeof recordId === 'string' &&
 					! /^\d+$/.test( recordId )
 						? '/wp/v2/templates'

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -112,21 +112,25 @@ export const getEntityRecord =
 				}
 			}
 
-			const path = addQueryArgs(
-				( kind === 'postType' &&
+			let { baseURL } = entityConfig;
+
+			// For "string" IDs, use the old templates endpoint.
+			if (
+				kind === 'postType' &&
 				name === 'wp_template' &&
 				key &&
 				typeof key === 'string' &&
-				// __experimentalGetDirtyEntityRecords always calls getEntityRecord
-				// with a string key, so we need that it's not a numeric ID.
 				! /^\d+$/.test( key )
-					? '/wp/v2/templates'
-					: entityConfig.baseURL ) + ( key ? '/' + key : '' ),
-				{
-					...entityConfig.baseURLParams,
-					...query,
-				}
-			);
+			) {
+				baseURL =
+					baseURL.slice( 0, baseURL.lastIndexOf( '/' ) ) +
+					'/templates';
+			}
+
+			const path = addQueryArgs( baseURL + ( key ? '/' + key : '' ), {
+				...entityConfig.baseURLParams,
+				...query,
+			} );
 			const response = await apiFetch( { path, parse: false } );
 			const record = await response.json();
 			const permissions = getUserPermissionsFromAllowHeader(

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -216,13 +216,18 @@ export const getEntityRecord =
 		}
 	};
 
+// Whenever a template is saved, the active templates might be updated, so
+// invalidate the site settings when a template is updated or deleted.
 getEntityRecord.shouldInvalidate = ( action, kind, name ) => {
 	return (
 		kind === 'root' &&
 		name === 'site' &&
-		// Unfortunately there's no way to distinguish between updating and
-		// receiving.
-		( action.type === 'RECEIVE_ITEMS' || action.type === 'REMOVE_ITEMS' ) &&
+		( ( action.type === 'RECEIVE_ITEMS' &&
+			// Makeing sure persistedEdits is set seems to be the only way of
+			// knowing if it's an update or fetch.
+			action.persistedEdits &&
+			action.persistedEdits.status !== 'auto-draft' ) ||
+			action.type === 'REMOVE_ITEMS' ) &&
 		action.kind === 'postType' &&
 		action.name === 'wp_template'
 	);

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -336,7 +336,20 @@ export const getEntityRecords =
 				};
 			}
 
-			const path = addQueryArgs( entityConfig.baseURL, {
+			let { baseURL } = entityConfig;
+			const { combinedTemplates = true } = query;
+
+			if (
+				kind === 'postType' &&
+				name === 'wp_template' &&
+				combinedTemplates
+			) {
+				baseURL =
+					baseURL.slice( 0, baseURL.lastIndexOf( '/' ) ) +
+					'/templates';
+			}
+
+			const path = addQueryArgs( baseURL, {
 				...entityConfig.baseURLParams,
 				...query,
 			} );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -115,6 +115,7 @@ export const getEntityRecord =
 			const path = addQueryArgs(
 				( kind === 'postType' &&
 				name === 'wp_template' &&
+				key &&
 				typeof key === 'string' &&
 				// __experimentalGetDirtyEntityRecords always calls getEntityRecord
 				// with a string key, so we need that it's not a numeric ID.

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -340,7 +340,7 @@ export const getEntityRecords =
 			let { baseURL } = entityConfig;
 			// `combinedTemplates` means that we fetch templates from the "old"
 			// /templates endpoint, which combines active user templates with
-			// the registered templates rewrites IDs in the form of
+			// the registered templates and rewrites IDs in the form of
 			// `theme-slug/template-slug`. When turned off, we only fetch
 			// database templates (posts). To fetch registered templates without
 			// edits applied, use the `wp_registered_template` entity.

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -228,7 +228,8 @@ getEntityRecord.shouldInvalidate = ( action, kind, name ) => {
 		name === 'site' &&
 		( ( action.type === 'RECEIVE_ITEMS' &&
 			// Making sure persistedEdits is set seems to be the only way of
-			// knowing whether it's an update or fetch.
+			// knowing whether it's an update or fetch. Only an update would
+			// have persistedEdits.
 			action.persistedEdits &&
 			action.persistedEdits.status !== 'auto-draft' ) ||
 			action.type === 'REMOVE_ITEMS' ) &&
@@ -337,6 +338,12 @@ export const getEntityRecords =
 			}
 
 			let { baseURL } = entityConfig;
+			// `combinedTemplates` means that we fetch templates from the "old"
+			// /templates endpoint, which combines active user templates with
+			// the registered templates rewrites IDs in the form of
+			// `theme-slug/template-slug`. When turned off, we only fetch
+			// database templates (posts). To fetch registered templates without
+			// edits applied, use the `wp_registered_template` entity.
 			const { combinedTemplates = true } = query;
 
 			if (

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -216,6 +216,18 @@ export const getEntityRecord =
 		}
 	};
 
+getEntityRecord.shouldInvalidate = ( action, kind, name ) => {
+	return (
+		kind === 'root' &&
+		name === 'site' &&
+		// Unfortunately there's no way to distinguish between updating and
+		// receiving.
+		( action.type === 'RECEIVE_ITEMS' || action.type === 'REMOVE_ITEMS' ) &&
+		action.kind === 'postType' &&
+		action.name === 'wp_template'
+	);
+};
+
 export const getTemplateAutoDraftId =
 	( staticTemplateId ) =>
 	async ( { resolveSelect, dispatch } ) => {
@@ -893,7 +905,7 @@ export const getDefaultTemplateId =
 
 getDefaultTemplateId.shouldInvalidate = ( action ) => {
 	return (
-		action.type === 'EDIT_ENTITY_RECORD' &&
+		action.type === 'RECEIVE_ITEMS' &&
 		action.kind === 'root' &&
 		action.name === 'site'
 	);

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -66,18 +66,6 @@ export const getCurrentUser =
 export const getEntityRecord =
 	( kind, name, key = '', query ) =>
 	async ( { select, dispatch, registry, resolveSelect } ) => {
-		// For back-compat, we allow querying for static templates through
-		// wp_template.
-		if (
-			kind === 'postType' &&
-			name === 'wp_template' &&
-			typeof key === 'string' &&
-			// __experimentalGetDirtyEntityRecords always calls getEntityRecord
-			// with a string key, so we need that it's not a numeric ID.
-			! /^\d+$/.test( key )
-		) {
-			name = 'wp_registered_template';
-		}
 		const configs = await resolveSelect.getEntitiesConfig( kind );
 		const entityConfig = configs.find(
 			( config ) => config.name === name && config.kind === kind
@@ -125,7 +113,14 @@ export const getEntityRecord =
 			}
 
 			const path = addQueryArgs(
-				entityConfig.baseURL + ( key ? '/' + key : '' ),
+				( kind === 'postType' &&
+				name === 'wp_template' &&
+				typeof key === 'string' &&
+				// __experimentalGetDirtyEntityRecords always calls getEntityRecord
+				// with a string key, so we need that it's not a numeric ID.
+				! /^\d+$/.test( key )
+					? '/wp/v2/templates'
+					: entityConfig.baseURL ) + ( key ? '/' + key : '' ),
 				{
 					...entityConfig.baseURLParams,
 					...query,

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -227,8 +227,8 @@ getEntityRecord.shouldInvalidate = ( action, kind, name ) => {
 		kind === 'root' &&
 		name === 'site' &&
 		( ( action.type === 'RECEIVE_ITEMS' &&
-			// Makeing sure persistedEdits is set seems to be the only way of
-			// knowing if it's an update or fetch.
+			// Making sure persistedEdits is set seems to be the only way of
+			// knowing whether it's an update or fetch.
 			action.persistedEdits &&
 			action.persistedEdits.status !== 'auto-draft' ) ||
 			action.type === 'REMOVE_ITEMS' ) &&

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -358,19 +358,6 @@ export const getEntityRecord = createSelector(
 		query?: GetRecordsHttpQuery
 	): EntityRecord | undefined => {
 		logEntityDeprecation( kind, name, 'getEntityRecord' );
-
-		// For back-compat, we allow querying for static templates through
-		// wp_template.
-		if (
-			kind === 'postType' &&
-			name === 'wp_template' &&
-			typeof key === 'string' &&
-			// __experimentalGetDirtyEntityRecords always calls getEntityRecord
-			// with a string key, so we need that it's not a numeric ID.
-			! /^\d+$/.test( key )
-		) {
-			name = 'wp_registered_template';
-		}
 		const queriedState =
 			state.entities.records?.[ kind ]?.[ name ]?.queriedData;
 		if ( ! queriedState ) {

--- a/packages/e2e-test-utils-playwright/src/request-utils/templates.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/templates.ts
@@ -18,7 +18,7 @@ interface CreateTemplatePayload {
 }
 
 const PATH_MAPPING = {
-	wp_template: '/wp/v2/templates',
+	wp_template: '/wp/v2/wp_template',
 	wp_template_part: '/wp/v2/template-parts',
 };
 

--- a/packages/e2e-test-utils-playwright/src/request-utils/templates.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/templates.ts
@@ -18,7 +18,7 @@ interface CreateTemplatePayload {
 }
 
 const PATH_MAPPING = {
-	wp_template: '/wp/v2/wp_template',
+	wp_template: '/wp/v2/templates',
 	wp_template_part: '/wp/v2/template-parts',
 };
 

--- a/packages/edit-site/src/components/editor/use-resolve-edited-entity.js
+++ b/packages/edit-site/src/components/editor/use-resolve-edited-entity.js
@@ -30,7 +30,7 @@ const postTypesWithoutParentTemplate = [
 
 const authorizedPostTypes = [ 'page', 'post' ];
 
-function getPostType( name, postId ) {
+function getPostType( name ) {
 	let postType;
 	if ( name === 'navigation-item' ) {
 		postType = NAVIGATION_POST_TYPE;
@@ -39,9 +39,7 @@ function getPostType( name, postId ) {
 	} else if ( name === 'template-part-item' ) {
 		postType = TEMPLATE_PART_POST_TYPE;
 	} else if ( name === 'templates' ) {
-		postType = /^\d+$/.test( postId )
-			? TEMPLATE_POST_TYPE
-			: 'wp_registered_template';
+		postType = TEMPLATE_POST_TYPE;
 	} else if ( name === 'template-item' ) {
 		postType = TEMPLATE_POST_TYPE;
 	} else if ( name === 'static-template-item' ) {
@@ -126,18 +124,6 @@ export function useResolveEditedEntity() {
 		[ homePage, postId, postType ]
 	);
 
-	const editableResolvedTemplateId = useSelect(
-		( select ) => {
-			if ( typeof resolvedTemplateId !== 'string' ) {
-				return resolvedTemplateId;
-			}
-			return unlock( select( coreDataStore ) ).getTemplateAutoDraftId(
-				resolvedTemplateId
-			);
-		},
-		[ resolvedTemplateId ]
-	);
-
 	const context = useMemo( () => {
 		if ( postTypesWithoutParentTemplate.includes( postType ) && postId ) {
 			return {};
@@ -161,9 +147,9 @@ export function useResolveEditedEntity() {
 
 	if ( !! homePage ) {
 		return {
-			isReady: editableResolvedTemplateId !== undefined,
+			isReady: resolvedTemplateId !== undefined,
 			postType: TEMPLATE_POST_TYPE,
-			postId: editableResolvedTemplateId,
+			postId: resolvedTemplateId,
 			context,
 		};
 	}

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -82,6 +82,7 @@ export default function PageTemplates() {
 	const { records: userRecords, isResolving: isLoadingUserRecords } =
 		useEntityRecordsWithPermissions( 'postType', TEMPLATE_POST_TYPE, {
 			per_page: -1,
+			combinedTemplates: false,
 		} );
 	const { records: staticRecords, isResolving: isLoadingStaticData } =
 		useEntityRecordsWithPermissions( 'postType', 'wp_registered_template', {

--- a/packages/editor/src/components/post-template/hooks.js
+++ b/packages/editor/src/components/post-template/hooks.js
@@ -73,7 +73,7 @@ function useTemplates( postType ) {
 					userTemplates: select( coreStore ).getEntityRecords(
 						'postType',
 						'wp_template',
-						{ per_page: -1 }
+						{ per_page: -1, combinedTemplates: false }
 					),
 				};
 			},

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -273,7 +273,12 @@ export const savePost =
 		}
 		dispatch( { type: 'REQUEST_POST_UPDATE_FINISH', options } );
 
-		if ( ! options.isAutosave && previousRecord.type === 'wp_template' ) {
+		if (
+			! options.isAutosave &&
+			previousRecord.type === 'wp_template' &&
+			( typeof previousRecord.id === 'number' ||
+				/^\d+$/.test( previousRecord.id ) )
+		) {
 			templateActivationNotice( { select, dispatch, registry } );
 		}
 

--- a/test/e2e/specs/site-editor/preload.spec.js
+++ b/test/e2e/specs/site-editor/preload.spec.js
@@ -46,12 +46,9 @@ test.describe( 'Preload', () => {
 
 		// To do: these should all be removed or preloaded.
 		expect( requests ).toEqual( [
-			'/wp/v2/wp_template',
-			'/wp/v2/wp_template?context=edit',
+			'/wp/v2/templates/emptytheme//index?context=edit',
 			// Seems to be coming from `enableComplementaryArea`.
 			'/wp/v2/users/me',
-			// This is the auto-draft template.
-			expect.stringMatching( /\/wp\/v2\/wp_template\/\d+\?context=edit/ ),
 			// There are two separate settings OPTIONS requests. We should fix
 			// so the one for canUser and getEntityRecord are reused.
 			'/wp/v2/settings',

--- a/test/e2e/specs/site-editor/preload.spec.js
+++ b/test/e2e/specs/site-editor/preload.spec.js
@@ -47,6 +47,7 @@ test.describe( 'Preload', () => {
 		// To do: these should all be removed or preloaded.
 		expect( requests ).toEqual( [
 			'/wp/v2/wp_template',
+			'/wp/v2/wp_template?context=edit',
 			// Seems to be coming from `enableComplementaryArea`.
 			'/wp/v2/users/me',
 			// This is the auto-draft template.

--- a/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
+++ b/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
@@ -42,6 +42,7 @@ test.describe( 'calling saveEntityRecord with a theme template ID', () => {
 				);
 		} );
 		expect( template.content.raw ).toEqual( 'test' );
+		expect( template.theme ).toEqual( 'emptytheme' );
 		await admin.visitSiteEditor( {
 			postType: 'wp_template',
 			activeView: 'user',
@@ -82,6 +83,7 @@ test.describe( 'calling saveEntityRecord with a theme template ID', () => {
 		expect( template.status ).toEqual( 'publish' );
 		expect( template.wp_id ).toEqual( 0 );
 		expect( template.is_custom ).toEqual( false );
+		expect( template.theme ).toEqual( 'emptytheme' );
 	} );
 
 	test( 'getEditedEntityRecord should work as expected', async ( {
@@ -103,5 +105,6 @@ test.describe( 'calling saveEntityRecord with a theme template ID', () => {
 		expect( template.status ).toEqual( 'publish' );
 		expect( template.wp_id ).toEqual( 0 );
 		expect( template.is_custom ).toEqual( false );
+		expect( template.theme ).toEqual( 'emptytheme' );
 	} );
 } );

--- a/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
+++ b/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
@@ -6,13 +6,17 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 test.describe( 'calling saveEntityRecord with a theme template ID', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+	test.beforeEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
 	} );
-	test.afterAll( async ( { requestUtils } ) => {
+	test.afterEach( async ( { requestUtils } ) => {
 		await requestUtils.deleteAllTemplates( 'wp_template' );
 		await requestUtils.deleteAllTemplates( 'wp_template_part' );
-		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 	test( 'should work as expected', async ( { admin, page } ) => {
 		await admin.visitSiteEditor();
@@ -28,6 +32,16 @@ test.describe( 'calling saveEntityRecord with a theme template ID', () => {
 				{ throwOnError: true }
 			);
 		} );
+		const template = await page.evaluate( async () => {
+			return await window.wp.data
+				.select( 'core' )
+				.getEntityRecord(
+					'postType',
+					'wp_template',
+					'emptytheme//index'
+				);
+		} );
+		expect( template.content.raw ).toEqual( 'test' );
 		await admin.visitSiteEditor( {
 			postType: 'wp_template',
 			activeView: 'user',
@@ -38,5 +52,56 @@ test.describe( 'calling saveEntityRecord with a theme template ID', () => {
 				.first()
 		).toBeVisible();
 		await expect( page.getByText( 'Template typeIndex' ) ).toBeVisible();
+		await page.evaluate( async () => {
+			return await window.wp.data
+				.dispatch( 'core' )
+				.deleteEntityRecord(
+					'postType',
+					'wp_template',
+					'emptytheme//index'
+				);
+		} );
+	} );
+
+	test( 'getEntityRecord should work as expected', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitSiteEditor();
+		const template = await page.evaluate( async () => {
+			return await window.wp.data
+				.resolveSelect( 'core' )
+				.getEntityRecord(
+					'postType',
+					'wp_template',
+					'emptytheme//index'
+				);
+		} );
+		expect( template.slug ).toEqual( 'index' );
+		expect( template.type ).toEqual( 'wp_template' );
+		expect( template.status ).toEqual( 'publish' );
+		expect( template.wp_id ).toEqual( 0 );
+		expect( template.is_custom ).toEqual( false );
+	} );
+
+	test( 'getEditedEntityRecord should work as expected', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitSiteEditor();
+		const template = await page.evaluate( async () => {
+			return await window.wp.data
+				.resolveSelect( 'core' )
+				.getEditedEntityRecord(
+					'postType',
+					'wp_template',
+					'emptytheme//index'
+				);
+		} );
+		expect( template.slug ).toEqual( 'index' );
+		expect( template.type ).toEqual( 'wp_template' );
+		expect( template.status ).toEqual( 'publish' );
+		expect( template.wp_id ).toEqual( 0 );
+		expect( template.is_custom ).toEqual( false );
 	} );
 } );

--- a/test/e2e/specs/site-editor/template-activate.spec.js
+++ b/test/e2e/specs/site-editor/template-activate.spec.js
@@ -63,7 +63,7 @@ test.describe( 'Template Activate', () => {
 		await activateButton.click();
 
 		await page.waitForSelector(
-			'.dataviews-view-grid__field-value .is-success'
+			'.dataviews-view-grid__field-value .is-success:has-text("Active")'
 		);
 
 		await page

--- a/test/e2e/specs/site-editor/template-registration.spec.js
+++ b/test/e2e/specs/site-editor/template-registration.spec.js
@@ -378,5 +378,8 @@ class BlockTemplateRegistrationUtils {
 		await expect
 			.poll( async () => await searchResults.count() )
 			.toBeLessThanOrEqual( initialSearchResultsCount );
+		await expect
+			.poll( async () => this.page.url() )
+			.toContain( `search=${ encodeURIComponent( searchTerm ) }` );
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Fixes #72225.
Fixes Woo CYS.
Fixes Woo email editor.
Fixes MailPoet email editor.
Fixes Woo Checkout customization.

We need to restore the `wp_template` entities to work as much as possible as it was before. That's why in this PR, instead of patching things up client-side, I'm switching calls with "string" IDs to use the old endpoint so they work 100% as before. The exception for now is collection queries. In order to achieve that, any time a template is "updated" through the old API, the template must be automatically activated to preserve the old behavior. We do this by checking if the new meta key is _not_ present. This means we only don't activate templates when templates are created or updated through the new endpoint. It also gives us a mechanism to activate templates through the new endpoint without having to ask the user in a notice (remove the meta key from the post).

To make sure things work in reality, I've switched the root of the site editor back to use the old entity/endpoint. When you now edit the root template, it will always activate immediately as well.

~~To do: if we're keeping the old entities, perhaps we can just use them for the site editor root and get rid of the auto-draft templates.~~ ✅  Also remove editing theme templates in the templates list and force duplication cause it's anyway too confusing. Following up with that in #72285.
~~To do: invalidate the site settings entity when templates are saved.~~ ✅
~~To do: get_block_templates should also be adjusted to only list active  and custom templates.~~ ✅

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For backward compatibility. One major user of these entities is Woo.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Adjust the `/templates` to take into account activation, by adjusting the `get_block_template` and `get_block_templates` function.
* Whenever templates are created without the meta flag (for example through `/templates`), activate the template automatically.
* When an entity is requested by a "string" ID like `twentytwentyone//home`, use the `/templates` endpoint, restoring previous behavior. The new way of requesting `wp_template` entities is anyway by numeric ID.
* When an entity collection is requested, also use the `/templates` endpoint, restoring previous behavior.  To query actual `wp_template` posts in the db, you now have to add the query property `combinedTemplates: false`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Test "Customise your store" in Woo. Install Woo. Skip setup. Go to the Woo page and click "Customize store" (first item in the list). Then click "design your own theme". Make some edits, such as to the home page, and save. There should be no errors.
* Test editing the home template in the site editor, which now uses the old endpoint. Edits here should be immediately active without having to active it.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
