### PR TITLE
Accordion heading:remove toggle icon typography

### DIFF
--- a/packages/block-library/src/accordion-heading/block.json
+++ b/packages/block-library/src/accordion-heading/block.json
@@ -60,13 +60,9 @@
 		"blockVisibility": false
 	},
 	"selectors": {
-		"root": ".wp-block-accordion-heading",
 		"typography": {
-			"fontSize": ".wp-block-accordion-heading",
-			"__experimentalFontFamily": ".wp-block-accordion-heading",
-			"__experimentalFontWeight": ".wp-block-accordion-heading",
-			"__experimentalFontStyle": ".wp-block-accordion-heading",
-			"__experimentalTextTransform": ".wp-block-accordion-heading"
+			"letterSpacing": ".wp-block-accordion-heading .wp-block-accordion-heading__toggle-title",
+			"textDecoration": ".wp-block-accordion-heading .wp-block-accordion-heading__toggle-title"
 		}
 	},
 	"attributes": {

--- a/packages/block-library/src/accordion-heading/block.json
+++ b/packages/block-library/src/accordion-heading/block.json
@@ -40,6 +40,10 @@
 			}
 		},
 		"typography": {
+			"__experimentalSkipSerialization": [
+				"textDecoration",
+				"letterSpacing"
+			],
 			"fontSize": true,
 			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
@@ -54,6 +58,16 @@
 		},
 		"shadow": true,
 		"blockVisibility": false
+	},
+	"selectors": {
+		"root": ".wp-block-accordion-heading",
+		"typography": {
+			"fontSize": ".wp-block-accordion-heading",
+			"__experimentalFontFamily": ".wp-block-accordion-heading",
+			"__experimentalFontWeight": ".wp-block-accordion-heading",
+			"__experimentalFontStyle": ".wp-block-accordion-heading",
+			"__experimentalTextTransform": ".wp-block-accordion-heading"
+		}
 	},
 	"attributes": {
 		"openByDefault": {

--- a/packages/block-library/src/accordion-heading/deprecated.js
+++ b/packages/block-library/src/accordion-heading/deprecated.js
@@ -1,0 +1,119 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	useBlockProps,
+	__experimentalGetSpacingClassesAndStyles as getSpacingClassesAndStyles,
+	RichText,
+} from '@wordpress/block-editor';
+
+const v1 = {
+	attributes: {
+		openByDefault: {
+			type: 'boolean',
+			default: false,
+		},
+		title: {
+			type: 'rich-text',
+			source: 'rich-text',
+			selector: '.wp-block-accordion-heading__toggle-title',
+			role: 'content',
+		},
+		level: {
+			type: 'number',
+		},
+		iconPosition: {
+			type: 'string',
+			enum: [ 'left', 'right' ],
+			default: 'right',
+		},
+		showIcon: {
+			type: 'boolean',
+			default: true,
+		},
+	},
+	supports: {
+		anchor: true,
+		color: {
+			background: true,
+			gradients: true,
+		},
+		align: false,
+		interactivity: true,
+		spacing: {
+			padding: true,
+			__experimentalDefaultControls: {
+				padding: true,
+			},
+			__experimentalSkipSerialization: true,
+			__experimentalSelector: '.wp-block-accordion-heading__toggle',
+		},
+		__experimentalBorder: {
+			color: true,
+			radius: true,
+			style: true,
+			width: true,
+			__experimentalDefaultControls: {
+				color: true,
+				radius: true,
+				style: true,
+				width: true,
+			},
+		},
+		typography: {
+			fontSize: true,
+			__experimentalFontFamily: true,
+			__experimentalFontWeight: true,
+			__experimentalFontStyle: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalLetterSpacing: true,
+			__experimentalDefaultControls: {
+				fontSize: true,
+				fontFamily: true,
+			},
+		},
+		shadow: true,
+		blockVisibility: false,
+	},
+	save( { attributes } ) {
+		const { level, title, iconPosition, showIcon } = attributes;
+		const TagName = 'h' + ( level || 3 );
+
+		const blockProps = useBlockProps.save();
+		const spacingProps = getSpacingClassesAndStyles( attributes );
+
+		return (
+			<TagName { ...blockProps }>
+				<button
+					className="wp-block-accordion-heading__toggle"
+					style={ spacingProps.style }
+				>
+					{ showIcon && iconPosition === 'left' && (
+						<span
+							className="wp-block-accordion-heading__toggle-icon"
+							aria-hidden="true"
+						>
+							+
+						</span>
+					) }
+					<RichText.Content
+						className="wp-block-accordion-heading__toggle-title"
+						tagName="span"
+						value={ title }
+					/>
+					{ showIcon && iconPosition === 'right' && (
+						<span
+							className="wp-block-accordion-heading__toggle-icon"
+							aria-hidden="true"
+						>
+							+
+						</span>
+					) }
+				</button>
+			</TagName>
+		);
+	},
+};
+
+export default [ v1 ];

--- a/packages/block-library/src/accordion-heading/edit.js
+++ b/packages/block-library/src/accordion-heading/edit.js
@@ -7,6 +7,8 @@ import {
 	useBlockProps,
 	__experimentalGetSpacingClassesAndStyles as useSpacingProps,
 	RichText,
+	getTypographyClassesAndStyles as useTypographyProps,
+	useSettings,
 } from '@wordpress/block-editor';
 
 export default function Edit( { attributes, setAttributes, context } ) {
@@ -27,6 +29,19 @@ export default function Edit( { attributes, setAttributes, context } ) {
 			} );
 		}
 	}, [ iconPosition, showIcon, setAttributes ] );
+
+	const [ fluidTypographySettings, layout ] = useSettings(
+		'typography.fluid',
+		'layout'
+	);
+	const typographyProps = useTypographyProps( attributes, {
+		typography: {
+			fluid: fluidTypographySettings,
+		},
+		layout: {
+			wideSize: layout?.wideSize,
+		},
+	} );
 
 	const blockProps = useBlockProps();
 	const spacingProps = useSpacingProps( attributes );
@@ -56,6 +71,10 @@ export default function Edit( { attributes, setAttributes, context } ) {
 					}
 					placeholder={ __( 'Accordion title' ) }
 					className="wp-block-accordion-heading__toggle-title"
+					style={ {
+						letterSpacing: typographyProps.style.letterSpacing,
+						textDecoration: typographyProps.style.textDecoration,
+					} }
 				/>
 				{ showIcon && iconPosition === 'right' && (
 					<span

--- a/packages/block-library/src/accordion-heading/index.js
+++ b/packages/block-library/src/accordion-heading/index.js
@@ -6,6 +6,7 @@ import save from './save';
 import metadata from './block.json';
 import initBlock from '../utils/init-block';
 import icon from './icon';
+import deprecated from './deprecated';
 
 const { name } = metadata;
 
@@ -15,6 +16,7 @@ export const settings = {
 	icon,
 	edit,
 	save,
+	deprecated,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/accordion-heading/save.js
+++ b/packages/block-library/src/accordion-heading/save.js
@@ -5,11 +5,13 @@ import {
 	useBlockProps,
 	__experimentalGetSpacingClassesAndStyles as getSpacingClassesAndStyles,
 	RichText,
+	getTypographyClassesAndStyles,
 } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const { level, title, iconPosition, showIcon } = attributes;
 	const TagName = 'h' + ( level || 3 );
+	const typographyProps = getTypographyClassesAndStyles( attributes );
 
 	const blockProps = useBlockProps.save();
 	const spacingProps = getSpacingClassesAndStyles( attributes );
@@ -32,6 +34,10 @@ export default function save( { attributes } ) {
 					className="wp-block-accordion-heading__toggle-title"
 					tagName="span"
 					value={ title }
+					style={ {
+						letterSpacing: typographyProps.style.letterSpacing,
+						textDecoration: typographyProps.style.textDecoration,
+					} }
 				/>
 				{ showIcon && iconPosition === 'right' && (
 					<span

--- a/test/integration/fixtures/blocks/core__accordion-heading__deprecated-v1.html
+++ b/test/integration/fixtures/blocks/core__accordion-heading__deprecated-v1.html
@@ -1,0 +1,8 @@
+<!-- wp:accordion-heading {"style":{"typography":{"letterSpacing":"39px","textDecoration":"underline","fontStyle":"normal","fontWeight":"100","fontSize":"3.19rem"}}} -->
+<h3 class="wp-block-accordion-heading" style="font-size:3.19rem;font-style:normal;font-weight:100;letter-spacing:39px;text-decoration:underline">
+	<button class="wp-block-accordion-heading__toggle">
+		<span class="wp-block-accordion-heading__toggle-title">title</span>
+		<span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span>
+	</button>
+</h3>
+<!-- /wp:accordion-heading -->

--- a/test/integration/fixtures/blocks/core__accordion-heading__deprecated-v1.json
+++ b/test/integration/fixtures/blocks/core__accordion-heading__deprecated-v1.json
@@ -1,0 +1,22 @@
+[
+	{
+		"name": "core/accordion-heading",
+		"isValid": true,
+		"attributes": {
+			"openByDefault": false,
+			"title": "title",
+			"iconPosition": "right",
+			"showIcon": true,
+			"style": {
+				"typography": {
+					"letterSpacing": "39px",
+					"textDecoration": "underline",
+					"fontStyle": "normal",
+					"fontWeight": "100",
+					"fontSize": "3.19rem"
+				}
+			}
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__accordion-heading__deprecated-v1.parsed.json
+++ b/test/integration/fixtures/blocks/core__accordion-heading__deprecated-v1.parsed.json
@@ -1,0 +1,21 @@
+[
+	{
+		"blockName": "core/accordion-heading",
+		"attrs": {
+			"style": {
+				"typography": {
+					"letterSpacing": "39px",
+					"textDecoration": "underline",
+					"fontStyle": "normal",
+					"fontWeight": "100",
+					"fontSize": "3.19rem"
+				}
+			}
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<h3 class=\"wp-block-accordion-heading\" style=\"font-size:3.19rem;font-style:normal;font-weight:100;letter-spacing:39px;text-decoration:underline\">\n\t<button class=\"wp-block-accordion-heading__toggle\">\n\t\t<span class=\"wp-block-accordion-heading__toggle-title\">title</span>\n\t\t<span class=\"wp-block-accordion-heading__toggle-icon\" aria-hidden=\"true\">+</span>\n\t</button>\n</h3>\n",
+		"innerContent": [
+			"\n<h3 class=\"wp-block-accordion-heading\" style=\"font-size:3.19rem;font-style:normal;font-weight:100;letter-spacing:39px;text-decoration:underline\">\n\t<button class=\"wp-block-accordion-heading__toggle\">\n\t\t<span class=\"wp-block-accordion-heading__toggle-title\">title</span>\n\t\t<span class=\"wp-block-accordion-heading__toggle-icon\" aria-hidden=\"true\">+</span>\n\t</button>\n</h3>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__accordion-heading__deprecated-v1.serialized.html
+++ b/test/integration/fixtures/blocks/core__accordion-heading__deprecated-v1.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:accordion-heading {"style":{"typography":{"letterSpacing":"39px","textDecoration":"underline","fontStyle":"normal","fontWeight":"100","fontSize":"3.19rem"}}} -->
+<h3 class="wp-block-accordion-heading" style="font-size:3.19rem;font-style:normal;font-weight:100"><button class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title" style="letter-spacing:39px;text-decoration:underline">title</span><span class="wp-block-accordion-heading__toggle-icon" aria-hidden="true">+</span></button></h3>
+<!-- /wp:accordion-heading -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #72130

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Prevents the textDecoration and letterSpacing styles from being affected by the Accordion Heading toggle icon.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a Accordion block.
3. You can see that the Accordion Heading's textDecoration and letterSpacing styles do not affect the toggle icon.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/fa7db369-81e8-41e3-b393-44fba221747e


