### PR TITLE
Fix api doc generation for module re-exports

### DIFF
--- a/packages/docgen/lib/get-export-entries.js
+++ b/packages/docgen/lib/get-export-entries.js
@@ -54,10 +54,10 @@ module.exports = ( token ) => {
 	}
 
 	const name = [];
-	if ( token.declaration === null ) {
+	if ( ! token.declaration ) {
 		token.specifiers.forEach( ( specifier ) =>
 			name.push( {
-				localName: specifier.local.name,
+				localName: specifier.local?.name,
 				exportName: specifier.exported.name,
 				module: token.source?.value ?? null,
 				lineStart: specifier.loc.start.line,

--- a/packages/docgen/test/get-export-entries.js
+++ b/packages/docgen/test/get-export-entries.js
@@ -502,4 +502,30 @@ describe( 'Export entries', () => {
 			} ),
 		] );
 	} );
+
+	it( 're-exporting node module for external use', () => {
+		expect(
+			firstExport(
+				`
+				export * as Y from 'yjs';
+			`,
+				`
+				/**
+				 * Exports the entire API of Yjs.
+				 *
+				 * @module yjs
+				 */
+				export { Doc, Transaction, YArray as Array, YMap as Map, YText as Text, YXmlText as XmlText, YXmlHook as XmlHook, YXmlElement as XmlElement, YXmlFragment as XmlFragment, YXmlEvent, YMapEvent, YArrayEvent, YTextEvent, YEvent, Item, AbstractStruct, GC, Skip, ContentBinary, ContentDeleted, ContentDoc, ContentEmbed, ContentFormat, ContentJSON, ContentAny, ContentString, ContentType, AbstractType, getTypeChildren, createRelativePositionFromTypeIndex, createRelativePositionFromJSON, createAbsolutePositionFromRelativePosition, compareRelativePositions, AbsolutePosition, RelativePosition, ID, createID, compareIDs, getState, Snapshot, createSnapshot, createDeleteSet, createDeleteSetFromStructStore, cleanupYTextFormatting, snapshot, emptySnapshot, findRootTypeKey, findIndexSS, getItem, getItemCleanStart, getItemCleanEnd, typeListToArraySnapshot, typeMapGetSnapshot, typeMapGetAllSnapshot, createDocFromSnapshot, iterateDeletedStructs, applyUpdate, applyUpdateV2, readUpdate, readUpdateV2, encodeStateAsUpdate, encodeStateAsUpdateV2, encodeStateVector, UndoManager, decodeSnapshot, encodeSnapshot, decodeSnapshotV2, encodeSnapshotV2, decodeStateVector, logUpdate, logUpdateV2, decodeUpdate, decodeUpdateV2, relativePositionToJSON, isDeleted, isParentOf, equalSnapshots, PermanentUserData, tryGc, transact, AbstractConnector, logType, mergeUpdates, mergeUpdatesV2, parseUpdateMeta, parseUpdateMetaV2, encodeStateVectorFromUpdate, encodeStateVectorFromUpdateV2, encodeRelativePosition, decodeRelativePosition, diffUpdate, diffUpdateV2, convertUpdateFormatV1ToV2, convertUpdateFormatV2ToV1, obfuscateUpdate, obfuscateUpdateV2, UpdateEncoderV1, UpdateEncoderV2, UpdateDecoderV1, UpdateDecoderV2, equalDeleteSets, mergeDeleteSets, snapshotContainsUpdate } from "./internals.js";
+			`
+			)
+		).toEqual( [
+			expect.objectContaining( {
+				lineStart: 1,
+				lineEnd: 1,
+				localName: undefined,
+				exportName: 'Y',
+				module: 'yjs',
+			} ),
+		] );
+	} );
 } );


### PR DESCRIPTION
## What?

Instead of being unable to generate API docs for exports that re-export an NPM package, this change now allows that to succeed.

This error came up during our real time collaboration work, and is part of the ongoing merges into core like #72114.

## Why?

Take [this index.ts](https://github.com/Automattic/gutenberg/blob/vip-rtc/packages/sync/src/index.ts#L15) found within the sync package of our fork, as an example. Yjs is being re-exported as Y, so that it can be used outside the sync package. This is critical to do because Yjs does not allow double instantiation. Before this change, the doc generation command would fail as it wouldn't be able to correctly parse out the tokens necessary to populate the README.md from this re-export.

## How?

First and foremost, the token declaration's null check is expanded to include undefined as well. Previously, undefined would skip that check due to the quirks of Javascript when in fact it should not.

Next, the local name is changed to be optional because it's likely only the exported name would be present.

Together, this ensures the API Docs are generated no matter the export pattern used.

## Testing Instructions

- Introduce Yjs into the sync package's package.json
- Within sync/src/index.js, introduce `export * as Y from 'yjs';`
- Rebuild the docs, and ensure they don't fail.
- Without this change, the doc generation should fail with the error shown in the screenshot below.

Alternately, simply run the test in trunk and in this branch to see the difference.

## Screenshots or screencast

The error

<img width="1944" height="937" alt="CleanShot 2025-10-10 at 10 26 54" src="https://github.com/user-attachments/assets/27cd460b-54e7-42c4-b9fd-17491edea700" />

The problematic tokens

```
Node {
  type: 'ExportNamedDeclaration',
  start: 233,
  end: 258,
  loc: SourceLocation {
    start: Position { line: 12, column: 0, index: 233 },
    end: Position { line: 12, column: 25, index: 258 },
    filename: undefined,
    identifierName: undefined
  },
  exportKind: 'value',
  specifiers: [
    Node {
      type: 'ExportNamespaceSpecifier',
      start: 240,
      end: 246,
      loc: [SourceLocation],
      exported: [Node]
    }
  ],
  source: Node {
    type: 'StringLiteral',
    start: 252,
    end: 257,
    loc: SourceLocation {
      start: [Position],
      end: [Position],
      filename: undefined,
      identifierName: undefined
    },
    extra: { rawValue: 'yjs', raw: "'yjs'" },
    value: 'yjs'
  }
}
```
