### PR TITLE
Pattern overrides: Remove old back compat code and update tests

### DIFF
--- a/packages/blocks/src/api/parser/convert-legacy-block.js
+++ b/packages/blocks/src/api/parser/convert-legacy-block.js
@@ -114,53 +114,5 @@ export function convertLegacyBlockNameAndAttributes( name, attributes ) {
 		};
 	}
 
-	// The following code is only relevant for the Gutenberg plugin.
-	// It's a stand-alone if statement for dead-code elimination.
-	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-		// Convert pattern overrides added during experimental phase.
-		// Only four blocks were supported initially.
-		// These checks can be removed in WordPress 6.6.
-		if (
-			newAttributes.metadata?.bindings &&
-			( name === 'core/paragraph' ||
-				name === 'core/heading' ||
-				name === 'core/image' ||
-				name === 'core/button' ) &&
-			newAttributes.metadata.bindings.__default?.source !==
-				'core/pattern-overrides'
-		) {
-			const bindings = [
-				'content',
-				'url',
-				'title',
-				'id',
-				'alt',
-				'text',
-				'linkTarget',
-			];
-			// Delete any existing individual bindings and add a default binding.
-			// It was only possible to add all the default attributes through the UI,
-			// So as soon as we find an attribute, we can assume all default attributes are overridable.
-			let hasPatternOverrides = false;
-			bindings.forEach( ( binding ) => {
-				if (
-					newAttributes.metadata.bindings[ binding ]?.source ===
-					'core/pattern-overrides'
-				) {
-					hasPatternOverrides = true;
-					newAttributes.metadata = {
-						...newAttributes.metadata,
-						bindings: { ...newAttributes.metadata.bindings },
-					};
-					delete newAttributes.metadata.bindings[ binding ];
-				}
-			} );
-			if ( hasPatternOverrides ) {
-				newAttributes.metadata.bindings.__default = {
-					source: 'core/pattern-overrides',
-				};
-			}
-		}
-	}
 	return [ name, newAttributes ];
 }

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -986,7 +986,7 @@ test.describe( 'Pattern Overrides', () => {
 		const paragraphName = 'Editable paragraph';
 		const { id } = await requestUtils.createBlock( {
 			title: 'Pattern',
-			content: `<!-- wp:paragraph {"metadata":{"name":"${ paragraphName }","bindings":{"content":{"source":"core/pattern-overrides"}}}} -->
+			content: `<!-- wp:paragraph {"metadata":{"name":"${ paragraphName }","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
 <p>Paragraph</p>
 <!-- /wp:paragraph -->`,
 			status: 'publish',
@@ -1301,13 +1301,13 @@ test.describe( 'Pattern Overrides', () => {
 		await test.step( 'create a pattern with synced blocks with the same name', async () => {
 			const { id } = await requestUtils.createBlock( {
 				title: 'Blocks with the same name',
-				content: `<!-- wp:heading {"metadata":{"name":"${ sharedName }","bindings":{"content":{"source":"core/pattern-overrides"}}}} -->
+				content: `<!-- wp:heading {"metadata":{"name":"${ sharedName }","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
 			<h2>default name</h2>
 			<!-- /wp:heading -->
-			<!-- wp:paragraph {"metadata":{"name":"${ sharedName }","bindings":{"content":{"source":"core/pattern-overrides"}}}} -->
+			<!-- wp:paragraph {"metadata":{"name":"${ sharedName }","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
 			<p>default content</p>
 			<!-- /wp:paragraph -->
-			<!-- wp:paragraph {"metadata":{"name":"${ sharedName }","bindings":{"content":{"source":"core/pattern-overrides"}}}} -->
+			<!-- wp:paragraph {"metadata":{"name":"${ sharedName }","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
 			<p>default content</p>
 			<!-- /wp:paragraph -->`,
 				status: 'publish',
@@ -1428,86 +1428,5 @@ test.describe( 'Pattern Overrides', () => {
 		await expect(
 			editorSettings.getByRole( 'button', { name: 'Enable overrides' } )
 		).toBeHidden();
-	} );
-
-	// @see https://github.com/WordPress/gutenberg/pull/60694
-	test( 'handles back-compat from individual attributes to __default', async ( {
-		page,
-		admin,
-		requestUtils,
-		editor,
-	} ) => {
-		const imageName = 'Editable image';
-		const TEST_IMAGE_FILE_PATH = path.resolve(
-			__dirname,
-			'../../../assets/10x10_e2e_test_image_z9T8jK.png'
-		);
-		const { id } = await requestUtils.createBlock( {
-			title: 'Pattern',
-			content: `<!-- wp:image {"metadata":{"name":"${ imageName }","bindings":{"id":{"source":"core/pattern-overrides"},"url":{"source":"core/pattern-overrides"},"title":{"source":"core/pattern-overrides"},"alt":{"source":"core/pattern-overrides"}}}} -->
-<figure class="wp-block-image"><img alt=""/></figure>
-<!-- /wp:image -->`,
-			status: 'publish',
-		} );
-
-		await admin.createNewPost();
-
-		await editor.insertBlock( {
-			name: 'core/block',
-			attributes: { ref: id },
-		} );
-
-		const blocks = await editor.getBlocks( { full: true } );
-		expect( blocks ).toMatchObject( [
-			{
-				name: 'core/block',
-				attributes: { ref: id },
-			},
-		] );
-		expect(
-			await editor.getBlocks( { clientId: blocks[ 0 ].clientId } )
-		).toMatchObject( [
-			{
-				name: 'core/image',
-				attributes: {
-					metadata: {
-						name: imageName,
-						bindings: {
-							__default: {
-								source: 'core/pattern-overrides',
-							},
-						},
-					},
-				},
-			},
-		] );
-
-		const imageBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Image',
-		} );
-		await editor.selectBlocks( imageBlock );
-		await imageBlock
-			.getByTestId( 'form-file-upload-input' )
-			.setInputFiles( TEST_IMAGE_FILE_PATH );
-		await expect( imageBlock.getByRole( 'img' ) ).toHaveCount( 1 );
-		await expect( imageBlock.getByRole( 'img' ) ).toHaveAttribute(
-			'src',
-			/\/wp-content\/uploads\//
-		);
-		await editor.showBlockToolbar();
-		await editor.clickBlockToolbarButton( 'More' );
-		await page
-			.getByRole( 'menuitem', { name: 'Alternative text' } )
-			.click();
-		await page
-			.getByRole( 'textbox', { name: 'alternative text' } )
-			.fill( 'Test Image' );
-
-		const postId = await editor.publishPost();
-
-		await page.goto( `/?p=${ postId }` );
-		await expect(
-			page.getByRole( 'img', { name: 'Test Image' } )
-		).toHaveAttribute( 'src', /\/wp-content\/uploads\// );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Related: https://github.com/WordPress/gutenberg/pull/72202#issuecomment-3388290438

## What?
When pattern overrides was first being developed, it supported bindings being set on individual attributes.

At some point during development this was changed to binding all attributes using a special `__default` binding.

Because the first iteration had already been released in the gutenberg plugin (though never in WP core), some back compat code was added to convert those old overrides to the `__default` format.

It should have been removed some time ago (after a couple of plugin releases), but has been forgotten about and kept in the plugin. I'm removing it now in this PR!

In this PR I also update a couple of tests that for some reason using the old individual bindings, and remove one test that checks the back compat code is running.

## Testing Instructions
Everything should be as it is in trunk, here's some steps to test pattern overrides:
1. Open an editor and add a few blocks (paragraph, heading, image)
2. Select the blocks and create a synced pattern from them
3. Check that you can't edit the blocks in the pattern
4. Edit the pattern by clicking 'Edit original' on the toolbar
5. Select each of the blocks in the pattern, and from the block inspector > advanced area click 'Enable Bindings', giving the blocks a name
6. Go back to the original post being edited and check that you can now edit the blocks in the pattern
7. Save everything and view the frontend
8. Check that the values you entered in step 6 are present on the frontend
