### PR TITLE
Fix PHP tests

### DIFF
--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -83,6 +83,9 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 	 * @param string $wrapper             Existing markup for the block wrapper.
 	 */
 	public function test_background_block_support( $theme_name, $block_name, $background_settings, $background_style, $expected_wrapper, $wrapper ) {
+		// Replace the placeholder with the actual apostrophe encoding based on WP version.
+		$expected_wrapper = str_replace( '{{APOS}}', $this->get_apostrophe_entity(), $expected_wrapper );
+
 		switch_theme( $theme_name );
 		$this->test_block_name = $block_name;
 
@@ -125,7 +128,9 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function data_background_block_support() {
-		$apos = $this->get_apostrophe_entity();
+		// Use a placeholder that will be replaced in the test method
+		// when WordPress is fully loaded and get_bloginfo() is available.
+		$apos = '{{APOS}}';
 
 		return array(
 			'background image style is applied' => array(

--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -65,7 +65,9 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 	}
 
 	private function get_apostrophe_entity() {
-		return version_compare( get_bloginfo( 'version' ), '6.9', '>=' ) ? '&apos;' : '&#039;';
+		// WP 6.9+ has get_block_bindings_supported_attributes() and uses &apos;
+		// WP 6.8 and earlier use &#039;
+		return function_exists( 'get_block_bindings_supported_attributes' ) ? '&apos;' : '&#039;';
 	}
 
 	/**
@@ -83,9 +85,6 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 	 * @param string $wrapper             Existing markup for the block wrapper.
 	 */
 	public function test_background_block_support( $theme_name, $block_name, $background_settings, $background_style, $expected_wrapper, $wrapper ) {
-		// Replace the placeholder with the actual apostrophe encoding based on WP version.
-		$expected_wrapper = str_replace( '{{APOS}}', $this->get_apostrophe_entity(), $expected_wrapper );
-
 		switch_theme( $theme_name );
 		$this->test_block_name = $block_name;
 
@@ -128,9 +127,9 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function data_background_block_support() {
-		// Use a placeholder that will be replaced in the test method
-		// when WordPress is fully loaded and get_bloginfo() is available.
-		$apos = '{{APOS}}';
+		// Get the appropriate apostrophe encoding based on WordPress version.
+		// function_exists() works in data providers, unlike get_bloginfo().
+		$apos = $this->get_apostrophe_entity();
 
 		return array(
 			'background image style is applied' => array(

--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -64,6 +64,10 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 		return $this->theme_root;
 	}
 
+	private function get_apostrophe_entity() {
+		return version_compare( get_bloginfo( 'version' ), '6.9', '>=' ) ? '&apos;' : '&#039;';
+	}
+
 	/**
 	 * Tests that background image block support works as expected.
 	 *
@@ -121,6 +125,8 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function data_background_block_support() {
+		$apos = $this->get_apostrophe_entity();
+
 		return array(
 			'background image style is applied' => array(
 				'theme_name'          => 'block-theme-child-with-fluid-typography',
@@ -133,7 +139,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 						'url' => 'https://example.com/image.jpg',
 					),
 				),
-				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
+				'expected_wrapper'    => '<div class="has-background" style="background-image:url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
 			'background image style is applied when backgroundImage is a string' => array(
@@ -145,7 +151,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 				'background_style'    => array(
 					'backgroundImage' => "url('https://example.com/image.jpg')",
 				),
-				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
+				'expected_wrapper'    => '<div class="has-background" style="background-image:url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
 			'background image style with contain, position, attachment, and repeat is applied' => array(
@@ -162,7 +168,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 					'backgroundSize'       => 'contain',
 					'backgroundAttachment' => 'fixed',
 				),
-				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-position:50% 50%;background-repeat:no-repeat;background-size:contain;background-attachment:fixed;">Content</div>',
+				'expected_wrapper'    => '<div class="has-background" style="background-image:url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-position:50% 50%;background-repeat:no-repeat;background-size:contain;background-attachment:fixed;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
 			'background image style is appended if a style attribute already exists' => array(
@@ -176,7 +182,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 						'url' => 'https://example.com/image.jpg',
 					),
 				),
-				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
+				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;background-image:url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover;">Content</div>',
 				'wrapper'             => '<div class="wp-block-test" style="color: red">Content</div>',
 			),
 			'background image style is appended if a style attribute containing multiple styles already exists' => array(
@@ -190,7 +196,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 						'url' => 'https://example.com/image.jpg',
 					),
 				),
-				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;font-size: 15px;background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
+				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;font-size: 15px;background-image:url(' . $apos . 'https://example.com/image.jpg' . $apos . ');background-size:cover;">Content</div>',
 				'wrapper'             => '<div class="wp-block-test" style="color: red;font-size: 15px;">Content</div>',
 			),
 			'background image style is not applied if the block does not support background image' => array(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A core change (https://github.com/WordPress/wordpress-develop/pull/10143) have resulted in some PHP unit tests failing. This PR updates the tests based on the WP version because we have CI jobs that also check the previous WP version.

After a few tries checking for a function that was introduced in 6.9 seem to did it. The choice of `get_block_bindings_supported_attributes` it's kind of arbitrary and felt a good candidate to me when looking what was introduced in 6.9.
