### PR TITLE
Block Editor: Hide Navigation block children from Content sidebar in contentOnly mode

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -142,29 +142,37 @@ function BlockInspector() {
 				getClientIdsOfDescendants,
 				getBlockName,
 				getBlockEditingMode,
-				getBlockParentsByBlockName,
 			} = unlock( select( blockEditorStore ) );
 
 			const descendants = getClientIdsOfDescendants(
 				selectedBlockClientId
 			);
+
+			// Temporary workaround for issue #71991
+			// Exclude Navigation block children from Content sidebar until proper
+			// drill-down experience is implemented (see #65699)
+			// This prevents a poor UX where all Nav block sub-items are shown
+			// when the parent block is in contentOnly mode.
+			// Build a Set of all navigation block descendants for efficient lookup
+			const navigationDescendants = new Set();
+			descendants.forEach( ( clientId ) => {
+				if ( getBlockName( clientId ) === 'core/navigation' ) {
+					const navChildren = getClientIdsOfDescendants( clientId );
+					navChildren.forEach( ( childId ) =>
+						navigationDescendants.add( childId )
+					);
+				}
+			} );
+
 			return descendants.filter( ( current ) => {
-				// Temporary workaround for issue #71991
-				// Exclude Navigation block children from Content sidebar until proper
-				// drill-down experience is implemented (see #65699)
-				// This prevents a poor UX where all Nav block sub-items are shown
-				// when the parent block is in contentOnly mode.
-				const navigationAncestors = getBlockParentsByBlockName(
-					current,
-					'core/navigation',
-					true
-				);
-				const isNavigationDescendant = navigationAncestors.length > 0;
+				// Exclude navigation block children
+				if ( navigationDescendants.has( current ) ) {
+					return false;
+				}
 
 				return (
 					getBlockName( current ) !== 'core/list-item' &&
-					getBlockEditingMode( current ) === 'contentOnly' &&
-					! isNavigationDescendant
+					getBlockEditingMode( current ) === 'contentOnly'
 				);
 			} );
 		},

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -142,16 +142,31 @@ function BlockInspector() {
 				getClientIdsOfDescendants,
 				getBlockName,
 				getBlockEditingMode,
+				getBlockParentsByBlockName,
 			} = unlock( select( blockEditorStore ) );
 
 			const descendants = getClientIdsOfDescendants(
 				selectedBlockClientId
 			);
-			return descendants.filter(
-				( current ) =>
+			return descendants.filter( ( current ) => {
+				// Temporary workaround for issue #71991
+				// Exclude Navigation block children from Content sidebar until proper
+				// drill-down experience is implemented (see #65699)
+				// This prevents a poor UX where all Nav block sub-items are shown
+				// when the parent block is in contentOnly mode.
+				const navigationAncestors = getBlockParentsByBlockName(
+					current,
+					'core/navigation',
+					true
+				);
+				const isNavigationDescendant = navigationAncestors.length > 0;
+
+				return (
 					getBlockName( current ) !== 'core/list-item' &&
-					getBlockEditingMode( current ) === 'contentOnly'
-			);
+					getBlockEditingMode( current ) === 'contentOnly' &&
+					! isNavigationDescendant
+				);
+			} );
 		},
 		[ isSectionBlock, selectedBlockClientId ]
 	);


### PR DESCRIPTION
## What

Fixes #71991

Adds a temporary **stopgap solution** to exclude Navigation block children from appearing in the Content sidebar when the parent block is in contentOnly mode.

This ensures a stable version of the Navigation block is ready for Simplified Editing landing in WP 6.9.

This is part of the broader work to develop a content-only representation for the Navigation block tracked in #65699.

## Why

When a template part is in contentOnly mode, the Content sidebar currently displays all sub-items of the Navigation block. This creates a poor user experience as users are overwhelmed with navigation link items that aren't helpful in this context.

**This is a stopgap solution to ensure the Navigation block is stable for WP 6.9's Simplified Editing feature.** A better UI with a proper drill-down experience will be implemented in the future to allow access to child blocks as required (see #65699).

## How

Modified the `contentClientIds` computation in the Block Inspector to filter out any blocks that are descendants of a `core/navigation` block. The implementation:

- Checks each descendant block to see if it has a Navigation block ancestor using `getBlockParentsByBlockName`
- Excludes those blocks from the Content sidebar
- Includes clear comments explaining this is a temporary workaround

## Testing Instructions

1. Enable the contentOnly experiment
2. Open the Site Editor
3. Click on a Template Part that contains a Navigation block
4. Open the sidebar
5. Check the "Content" section
6. **Expected**: The Navigation block itself should appear, but its child blocks (navigation links) should NOT be shown
7. **Previous behavior**: All child blocks of the Nav block were visible