### PR TITLE
DataForm: stop auto-injecting select placeholder

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -13,6 +13,7 @@
 - DataForm control for `datetime` supports `required` and `custom` validation. [#72060](https://github.com/WordPress/gutenberg/pull/72060).
 
 ### Breaking changes
+- DataForm: Stop auto-injecting an empty "Select" placeholder into `select` controls. Consumers must now explicitly provide an empty element (for example `{ value: '', label: 'Select' }`) in `field.elements` if they want a placeholder. This is an intentional breaking change to move placeholder behavior to the component/consumer level.[#72241](https://github.com/WordPress/gutenberg/pull/#72241)
 
 - DataForm: Add summary field support for both card and panel layouts. The `summary` property has been moved from the field level to the layout level, and so fields using `summary` at the field level must now configure it within the `layout` object. Additionally, the first children will only be used as summary for the panel if 1) there is no `layout.summary` and 2) the form field ID doesn't match any existing field. See README for details. [#71576](https://github.com/WordPress/gutenberg/pull/71576)
 - Remove `Data< Item >` type, as it is no longer used internally for a long time. [#72051](https://github.com/WordPress/gutenberg/pull/72051)

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -13,7 +13,8 @@
 - DataForm control for `datetime` supports `required` and `custom` validation. [#72060](https://github.com/WordPress/gutenberg/pull/72060).
 
 ### Breaking changes
-- DataForm: Stop auto-injecting an empty "Select" placeholder into `select` controls. Consumers must now explicitly provide an empty element (for example `{ value: '', label: 'Select' }`) in `field.elements` if they want a placeholder. This is an intentional breaking change to move placeholder behavior to the component/consumer level.[#72241](https://github.com/WordPress/gutenberg/pull/#72241)
+
+- DataForm no longer injects an empty value into the `select` control. Consumers must now explicitly provide it if they need one. [#72241](https://github.com/WordPress/gutenberg/pull/#72241)
 
 - DataForm: Add summary field support for both card and panel layouts. The `summary` property has been moved from the field level to the layout level, and so fields using `summary` at the field level must now configure it within the `layout` object. Additionally, the first children will only be used as summary for the panel if 1) there is no `layout.summary` and 2) the form field ID doesn't match any existing field. See README for details. [#71576](https://github.com/WordPress/gutenberg/pull/71576)
 - Remove `Data< Item >` type, as it is no longer used internally for a long time. [#72051](https://github.com/WordPress/gutenberg/pull/72051)

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -14,8 +14,7 @@
 
 ### Breaking changes
 
-- DataForm no longer injects an empty value into the `select` control. Consumers must now explicitly provide it if they need one. [#72241](https://github.com/WordPress/gutenberg/pull/#72241)
-
+- DataForm no longer injects an empty value to the `select` control. Consumers must now explicitly provide it if they need one. [#72241](https://github.com/WordPress/gutenberg/pull/#72241)
 - DataForm: Add summary field support for both card and panel layouts. The `summary` property has been moved from the field level to the layout level, and so fields using `summary` at the field level must now configure it within the `layout` object. Additionally, the first children will only be used as summary for the panel if 1) there is no `layout.summary` and 2) the form field ID doesn't match any existing field. See README for details. [#71576](https://github.com/WordPress/gutenberg/pull/71576)
 - Remove `Data< Item >` type, as it is no longer used internally for a long time. [#72051](https://github.com/WordPress/gutenberg/pull/72051)
 - Remove `isDestructive` prop from actions API. Destructive actions should be communicated via flow (opens modal to confirm) and color should be used in the modal. [#72111](https://github.com/WordPress/gutenberg/pull/72111)

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Breaking changes
 
-- DataForm no longer injects an empty value to the `select` control. Consumers must now explicitly provide it if they need one. [#72241](https://github.com/WordPress/gutenberg/pull/#72241)
+- DataForm no longer injects an empty value to the `select` control. Consumers must now explicitly provide it if they need one. [#72241](https://github.com/WordPress/gutenberg/pull/72241)
 - DataForm: Add summary field support for both card and panel layouts. The `summary` property has been moved from the field level to the layout level, and so fields using `summary` at the field level must now configure it within the `layout` object. Additionally, the first children will only be used as summary for the panel if 1) there is no `layout.summary` and 2) the form field ID doesn't match any existing field. See README for details. [#71576](https://github.com/WordPress/gutenberg/pull/71576)
 - Remove `Data< Item >` type, as it is no longer used internally for a long time. [#72051](https://github.com/WordPress/gutenberg/pull/72051)
 - Remove `isDestructive` prop from actions API. Destructive actions should be communicated via flow (opens modal to confirm) and color should be used in the modal. [#72111](https://github.com/WordPress/gutenberg/pull/72111)

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -1371,7 +1371,6 @@ Example:
 }
 ```
 
-The consumer must provide any empty/placeholder element in field.elements (for example { value: '', label: 'Select' }). DataForm will no longer inject a placeholder automatically.
 
 ### `filterBy`
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -1371,7 +1371,7 @@ Example:
 }
 ```
 
-By default, we add an empty value (label: "Select item"). The label can be overriden by providing an empty element (`{ value: '', label: 'Custom label for empty value'}`).
+The consumer must provide any empty/placeholder element in field.elements (for example { value: '', label: 'Select' }). DataForm will no longer inject a placeholder automatically.
 
 ### `filterBy`
 

--- a/packages/dataviews/src/dataform-controls/select.tsx
+++ b/packages/dataviews/src/dataform-controls/select.tsx
@@ -8,7 +8,6 @@ import deepMerge from 'deepmerge';
  */
 import { privateApis } from '@wordpress/components';
 import { useCallback, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -67,25 +66,9 @@ export default function Select< Item >( {
 		[ data, field, setValue ]
 	);
 
-	const fieldElements = field?.elements ?? [];
-	const hasEmptyValue = fieldElements.some(
-		( { value: elementValue } ) => elementValue === ''
-	);
-
-	const elements =
-		hasEmptyValue || isMultiple
-			? fieldElements
-			: [
-					/*
-					 * Value can be undefined when:
-					 *
-					 * - the field is not required
-					 * - in bulk editing
-					 *
-					 */
-					{ label: __( 'Select item' ), value: '' },
-					...fieldElements,
-			  ];
+	// Use field.elements as-is. The DataForm layer no longer injects an
+	// empty/placeholder option. Consumers must provide an empty element if needed.
+	const elements = field?.elements ?? [];
 
 	return (
 		<ValidatedSelectControl

--- a/packages/dataviews/src/dataform-controls/select.tsx
+++ b/packages/dataviews/src/dataform-controls/select.tsx
@@ -66,8 +66,6 @@ export default function Select< Item >( {
 		[ data, field, setValue ]
 	);
 
-	// Use field.elements as-is. The DataForm layer no longer injects an
-	// empty/placeholder option. Consumers must provide an empty element if needed.
 	const elements = field?.elements ?? [];
 
 	return (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow-up to previous work on the DataForm `Select` control.  
This PR removes the automatic injection of the default “Select item” placeholder and relies entirely on the `field.elements` provided by consumers.  

## Why?
Previously, the DataForm component automatically added an empty option (labelled “Select item”) to every `Select` control.  
This made the field’s behavior inconsistent and added unnecessary complexity — especially for required fields where that option shouldn’t be selectable.  

This change makes the behavior clearer and gives full control to consumers, who can now explicitly define empty options when needed.

## How?
- Removed all logic related to injecting an empty “Select item” option inside the component.
- The control now renders only the options defined in `field.elements`.
- Updated `CHANGELOG.md` to mark this as a **breaking change**, since consumers must now define empty options manually if desired.




🟡 **Note:** Apologies for the earlier push noise — a rebase went wrong which temporarily caused unrelated files to appear in the diff.  
This has now been corrected, and the PR only contains the intended changes. Thanks for your patience!