### PR TITLE
Enable block "click through" overlay for Navigation block in contentOnly mode

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -3060,11 +3060,21 @@ export const __unstableGetVisibleBlocks = createSelector(
 );
 
 export function __unstableHasActiveBlockOverlayActive( state, clientId ) {
+	const blockName = getBlockName( state, clientId );
+	const editingMode = getBlockEditingMode( state, clientId );
+
+	// Temporary: Allow Navigation block to have overlay in contentOnly mode
+	// to promote the off-canvas editing experience.
+	// See: https://github.com/WordPress/gutenberg/issues/71757
+	// TODO: Replace with block support mechanism in future iteration.
+	const isNavigationInContentOnly =
+		blockName === 'core/navigation' && editingMode === 'contentOnly';
+
 	// Prevent overlay on blocks with a non-default editing mode. If the mode is
 	// 'disabled' then the overlay is redundant since the block can't be
 	// selected. If the mode is 'contentOnly' then the overlay is redundant
 	// since there will be no controls to interact with once selected.
-	if ( getBlockEditingMode( state, clientId ) !== 'default' ) {
+	if ( editingMode !== 'default' && ! isNavigationInContentOnly ) {
 		return false;
 	}
 


### PR DESCRIPTION
## What?

Fixes #71757

This PR enables overlay click-through behavior for Navigation blocks in `contentOnly` editing mode. This is a short-term fix to ensure Navigation blocks are ready for the Simplified Editing experience in WordPress 6.9.

## Why?

Without the overlay active, clicks on Navigation Link children immediately select those child blocks, bypassing the parent Navigation block selection. 

In trunk this stops users from seeing the `Add page` utility button we've added to the block toolbar.

When the full drill down experience is implemented, it will prevent users from discovering and accessing the off-canvas editing experience, making Navigation editing more confusing in `contentOnly` mode.

We want to guide users towards selecting the Nav block in order that they can see the affordances we have put in place to help them add new links. This is hidden if the first click selects a sub block.

With this change:
- First click anywhere on a Navigation block selects the parent Navigation block (showing the off-canvas editing interface)
- Second click on a child Nav Link selects that specific child for editing

This interaction pattern already works correctly in `default` editing mode, and this PR extends it to `contentOnly` mode specifically for Navigation blocks.

## How?

Modified the `__unstableHasActiveBlockOverlayActive` selector in `packages/block-editor/src/store/selectors.js` to add a targeted exception for Navigation blocks in `contentOnly` mode. The fix:

1. Extracts the block name and editing mode at the start of the function
2. Checks if the block is a Navigation block in `contentOnly` mode
3. Allows the overlay to remain active for this specific case while preserving existing behavior for all other blocks

This is intentionally implemented as a minimal, block-specific conditional to unblock the immediate use case for WP 6.9. The code includes clear comments indicating this is a temporary solution.

## Future Work

Post-6.9, we should refine and stabilize a proper block support API (e.g., `__experimentalBlockOverlay: { contentOnly: true }`) that allows any block to opt into overlay behavior per editing mode. This would make the feature extensible and remove the need for block-specific conditionals in core editor code.

## Testing Instructions

1. Activate the Twenty Twenty Five theme
2. Open the Site Editor and edit a template (e.g., the Home template)
3. Click on the header template part to edit it (this will be in `contentOnly` mode)
4. Click anywhere on the Navigation block within the header:
   - ✅ The Navigation block itself should be selected (not a child Nav Link)
5. Click again on a specific Nav Link:
   - ✅ The Nav Link child block should now be selected
6. Verify that other blocks in `contentOnly` mode maintain their current behavior (no overlay)
7. Test that Navigation blocks in `default` editing mode continue to work as before

### Screenshots / Screencast

https://github.com/user-attachments/assets/1c0ea853-b72e-468b-828e-858d8f677de1


