### PR TITLE
DataForm: set spacing for regular and card layouts

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Consistently use font-weight 499 instead of 500 ([#72473](https://github.com/WordPress/gutenberg/pull/72473)).
 - Dataviews: Use text based buttons for actions instead of text. [#72417](https://github.com/WordPress/gutenberg/pull/72417)
-- DataForm: make layout spacing customizable. [#72249](https://github.com/WordPress/gutenberg/pull/72249).
+- DataForm: update spacing for regular and card layouts. [#72249](https://github.com/WordPress/gutenberg/pull/72249).
 
 ## 10.0.0 (2025-10-17)
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Consistently use font-weight 499 instead of 500 ([#72473](https://github.com/WordPress/gutenberg/pull/72473)).
 - Dataviews: Use text based buttons for actions instead of text. [#72417](https://github.com/WordPress/gutenberg/pull/72417)
+- DataForm: make layout spacing customizable. [#72249](https://github.com/WordPress/gutenberg/pull/72249).
 
 ## 10.0.0 (2025-10-17)
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 ## Unreleased
 
+### Enhancements
+
+- DataForm: update spacing for regular and card layouts. [#72249](https://github.com/WordPress/gutenberg/pull/72249).
+
 ## 10.1.0 (2025-10-21)
 
 ### Enhancements
 
 - Consistently use font-weight 499 instead of 500 ([#72473](https://github.com/WordPress/gutenberg/pull/72473)).
 - Dataviews: Use text based buttons for actions instead of text. [#72417](https://github.com/WordPress/gutenberg/pull/72417)
-- DataForm: update spacing for regular and card layouts. [#72249](https://github.com/WordPress/gutenberg/pull/72249).
 
 ## 10.0.0 (2025-10-17)
 

--- a/packages/dataviews/src/dataform-layouts/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/index.tsx
@@ -21,15 +21,11 @@ const FORM_FIELD_LAYOUTS = [
 		component: FormRegularField,
 		wrapper: ( {
 			children,
-			layout,
 		}: {
 			children: React.ReactNode;
 			layout: Layout;
 		} ) => (
-			<VStack
-				className="dataforms-layouts__wrapper"
-				spacing={ ( layout as any )?.spacing ?? 4 }
-			>
+			<VStack className="dataforms-layouts__wrapper" spacing={ 4 }>
 				{ children }
 			</VStack>
 		),
@@ -48,19 +44,14 @@ const FORM_FIELD_LAYOUTS = [
 		component: FormCardField,
 		wrapper: ( {
 			children,
-			layout,
 		}: {
 			children: React.ReactNode;
 			layout: Layout;
 		} ) => (
-<<<<<<< HEAD
 			<VStack
 				className="dataforms-layouts__wrapper"
 				spacing={ ( layout as any )?.spacing ?? 6 }
 			>
-=======
-			<VStack spacing={ ( layout as any ).spacing ?? 4 }>
->>>>>>> 5da5e9b1f9 (Make DataFormLayout spacing customisable)
 				{ children }
 			</VStack>
 		),

--- a/packages/dataviews/src/dataform-layouts/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/index.tsx
@@ -48,10 +48,7 @@ const FORM_FIELD_LAYOUTS = [
 			children: React.ReactNode;
 			layout: Layout;
 		} ) => (
-			<VStack
-				className="dataforms-layouts__wrapper"
-				spacing={ ( layout as any )?.spacing ?? 6 }
-			>
+			<VStack className="dataforms-layouts__wrapper" spacing={ 6 }>
 				{ children }
 			</VStack>
 		),

--- a/packages/dataviews/src/dataform-layouts/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/index.tsx
@@ -53,10 +53,14 @@ const FORM_FIELD_LAYOUTS = [
 			children: React.ReactNode;
 			layout: Layout;
 		} ) => (
+<<<<<<< HEAD
 			<VStack
 				className="dataforms-layouts__wrapper"
 				spacing={ ( layout as any )?.spacing ?? 6 }
 			>
+=======
+			<VStack spacing={ ( layout as any ).spacing ?? 4 }>
+>>>>>>> 5da5e9b1f9 (Make DataFormLayout spacing customisable)
 				{ children }
 			</VStack>
 		),

--- a/packages/dataviews/src/dataform-layouts/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/index.tsx
@@ -19,12 +19,7 @@ const FORM_FIELD_LAYOUTS = [
 	{
 		type: 'regular',
 		component: FormRegularField,
-		wrapper: ( {
-			children,
-		}: {
-			children: React.ReactNode;
-			layout: Layout;
-		} ) => (
+		wrapper: ( { children }: { children: React.ReactNode } ) => (
 			<VStack className="dataforms-layouts__wrapper" spacing={ 4 }>
 				{ children }
 			</VStack>
@@ -42,12 +37,7 @@ const FORM_FIELD_LAYOUTS = [
 	{
 		type: 'card',
 		component: FormCardField,
-		wrapper: ( {
-			children,
-		}: {
-			children: React.ReactNode;
-			layout: Layout;
-		} ) => (
+		wrapper: ( { children }: { children: React.ReactNode } ) => (
 			<VStack className="dataforms-layouts__wrapper" spacing={ 6 }>
 				{ children }
 			</VStack>

--- a/packages/dataviews/src/dataform-layouts/normalize-form-fields.ts
+++ b/packages/dataviews/src/dataform-layouts/normalize-form-fields.ts
@@ -21,7 +21,6 @@ interface NormalizedFormField {
 export const DEFAULT_LAYOUT: NormalizedLayout = {
 	type: 'regular',
 	labelPosition: 'top',
-	spacing: 4,
 } as NormalizedRegularLayout;
 
 const normalizeCardSummaryField = (
@@ -51,8 +50,6 @@ export function normalizeLayout( layout?: Layout ): NormalizedLayout {
 		normalizedLayout = {
 			type: 'regular',
 			labelPosition: layout?.labelPosition ?? 'top',
-			// Spacing is fixed for regular layout.
-			spacing: 4,
 		} satisfies NormalizedRegularLayout;
 	} else if ( layout?.type === 'panel' ) {
 		const summary = layout.summary ?? [];
@@ -75,8 +72,6 @@ export function normalizeLayout( layout?: Layout ): NormalizedLayout {
 				withHeader: false,
 				isOpened: true,
 				summary: [],
-				// Spacing is fixed for card layout.
-				spacing: 6,
 			} satisfies NormalizedCardLayout;
 		} else {
 			const summary = layout.summary ?? [];
@@ -89,8 +84,6 @@ export function normalizeLayout( layout?: Layout ): NormalizedLayout {
 						? layout.isOpened
 						: true,
 				summary: normalizeCardSummaryField( summary ),
-				// Spacing is fixed for card layout.
-				spacing: 6,
 			} satisfies NormalizedCardLayout;
 		}
 	} else if ( layout?.type === 'row' ) {

--- a/packages/dataviews/src/dataform-layouts/normalize-form-fields.ts
+++ b/packages/dataviews/src/dataform-layouts/normalize-form-fields.ts
@@ -51,7 +51,8 @@ export function normalizeLayout( layout?: Layout ): NormalizedLayout {
 		normalizedLayout = {
 			type: 'regular',
 			labelPosition: layout?.labelPosition ?? 'top',
-			spacing: ( layout as any )?.spacing ?? 4,
+			// Spacing is fixed for regular layout.
+			spacing: 4,
 		} satisfies NormalizedRegularLayout;
 	} else if ( layout?.type === 'panel' ) {
 		const summary = layout.summary ?? [];
@@ -74,7 +75,8 @@ export function normalizeLayout( layout?: Layout ): NormalizedLayout {
 				withHeader: false,
 				isOpened: true,
 				summary: [],
-				spacing: ( layout as any )?.spacing ?? 6,
+				// Spacing is fixed for card layout.
+				spacing: 6,
 			} satisfies NormalizedCardLayout;
 		} else {
 			const summary = layout.summary ?? [];
@@ -87,7 +89,8 @@ export function normalizeLayout( layout?: Layout ): NormalizedLayout {
 						? layout.isOpened
 						: true,
 				summary: normalizeCardSummaryField( summary ),
-				spacing: ( layout as any )?.spacing ?? 6,
+				// Spacing is fixed for card layout.
+				spacing: 6,
 			} satisfies NormalizedCardLayout;
 		}
 	} else if ( layout?.type === 'row' ) {

--- a/packages/dataviews/src/dataform-layouts/normalize-form-fields.ts
+++ b/packages/dataviews/src/dataform-layouts/normalize-form-fields.ts
@@ -21,7 +21,8 @@ interface NormalizedFormField {
 export const DEFAULT_LAYOUT: NormalizedLayout = {
 	type: 'regular',
 	labelPosition: 'top',
-};
+	spacing: 4,
+} as NormalizedRegularLayout;
 
 const normalizeCardSummaryField = (
 	sum: CardSummaryField
@@ -50,6 +51,7 @@ export function normalizeLayout( layout?: Layout ): NormalizedLayout {
 		normalizedLayout = {
 			type: 'regular',
 			labelPosition: layout?.labelPosition ?? 'top',
+			spacing: ( layout as any )?.spacing ?? 4,
 		} satisfies NormalizedRegularLayout;
 	} else if ( layout?.type === 'panel' ) {
 		const summary = layout.summary ?? [];
@@ -72,6 +74,7 @@ export function normalizeLayout( layout?: Layout ): NormalizedLayout {
 				withHeader: false,
 				isOpened: true,
 				summary: [],
+				spacing: ( layout as any )?.spacing ?? 6,
 			} satisfies NormalizedCardLayout;
 		} else {
 			const summary = layout.summary ?? [];
@@ -84,6 +87,7 @@ export function normalizeLayout( layout?: Layout ): NormalizedLayout {
 						? layout.isOpened
 						: true,
 				summary: normalizeCardSummaryField( summary ),
+				spacing: ( layout as any )?.spacing ?? 6,
 			} satisfies NormalizedCardLayout;
 		}
 	} else if ( layout?.type === 'row' ) {

--- a/packages/dataviews/src/stories/dataform.story.tsx
+++ b/packages/dataviews/src/stories/dataform.story.tsx
@@ -1799,6 +1799,7 @@ const LayoutMixedComponent = () => {
 	} );
 
 	const form: Form = {
+		layout: { type: 'card', spacing: 6 },
 		fields: [
 			{
 				id: 'title-and-status',

--- a/packages/dataviews/src/stories/dataform.story.tsx
+++ b/packages/dataviews/src/stories/dataform.story.tsx
@@ -1799,7 +1799,7 @@ const LayoutMixedComponent = () => {
 	} );
 
 	const form: Form = {
-		layout: { type: 'card', spacing: 6 },
+		layout: { type: 'card' },
 		fields: [
 			{
 				id: 'title-and-status',

--- a/packages/dataviews/src/test/normalize-form-fields.ts
+++ b/packages/dataviews/src/test/normalize-form-fields.ts
@@ -31,7 +31,6 @@ describe( 'normalizeFormFields', () => {
 					layout: {
 						type: 'regular',
 						labelPosition: 'top',
-						spacing: 4,
 					},
 				},
 				{
@@ -39,7 +38,6 @@ describe( 'normalizeFormFields', () => {
 					layout: {
 						type: 'regular',
 						labelPosition: 'top',
-						spacing: 4,
 					},
 				},
 			] );
@@ -62,7 +60,6 @@ describe( 'normalizeFormFields', () => {
 					layout: {
 						type: 'regular',
 						labelPosition: 'top',
-						spacing: 4,
 					},
 				},
 				{
@@ -71,7 +68,6 @@ describe( 'normalizeFormFields', () => {
 					layout: {
 						type: 'regular',
 						labelPosition: 'top',
-						spacing: 4,
 					},
 				},
 			] );
@@ -91,7 +87,6 @@ describe( 'normalizeFormFields', () => {
 					layout: {
 						type: 'regular',
 						labelPosition: 'top',
-						spacing: 4,
 					},
 				},
 			] );
@@ -109,7 +104,6 @@ describe( 'normalizeFormFields', () => {
 					layout: {
 						type: 'regular',
 						labelPosition: 'side',
-						spacing: 4,
 					},
 				},
 			] );
@@ -167,7 +161,6 @@ describe( 'normalizeFormFields', () => {
 						withHeader: true,
 						isOpened: true,
 						summary: [],
-						spacing: 6,
 					},
 				},
 			] );
@@ -194,7 +187,6 @@ describe( 'normalizeFormFields', () => {
 						withHeader: false,
 						isOpened: true,
 						summary: [],
-						spacing: 6,
 					},
 				},
 			] );
@@ -219,7 +211,6 @@ describe( 'normalizeFormFields', () => {
 						withHeader: true,
 						isOpened: false,
 						summary: [ { id: 'field1', visibility: 'always' } ],
-						spacing: 6,
 					},
 				},
 			] );
@@ -250,7 +241,6 @@ describe( 'normalizeFormFields', () => {
 							{ id: 'field2', visibility: 'when-collapsed' },
 							{ id: 'field1', visibility: 'always' },
 						],
-						spacing: 6,
 					},
 				},
 			] );
@@ -276,7 +266,6 @@ describe( 'normalizeFormFields', () => {
 					layout: {
 						type: 'regular',
 						labelPosition: 'top',
-						spacing: 4,
 					},
 				},
 				{
@@ -311,7 +300,6 @@ describe( 'normalizeFormFields', () => {
 						withHeader: false,
 						isOpened: true,
 						summary: [],
-						spacing: 6,
 					},
 				},
 				{
@@ -321,7 +309,6 @@ describe( 'normalizeFormFields', () => {
 						withHeader: true,
 						isOpened: false,
 						summary: [],
-						spacing: 6,
 					},
 				},
 			] );

--- a/packages/dataviews/src/test/normalize-form-fields.ts
+++ b/packages/dataviews/src/test/normalize-form-fields.ts
@@ -28,11 +28,19 @@ describe( 'normalizeFormFields', () => {
 			expect( result ).toEqual( [
 				{
 					id: 'field1',
-					layout: { type: 'regular', labelPosition: 'top' },
+					layout: {
+						type: 'regular',
+						labelPosition: 'top',
+						spacing: 4,
+					},
 				},
 				{
 					id: 'field2',
-					layout: { type: 'regular', labelPosition: 'top' },
+					layout: {
+						type: 'regular',
+						labelPosition: 'top',
+						spacing: 4,
+					},
 				},
 			] );
 		} );
@@ -51,12 +59,20 @@ describe( 'normalizeFormFields', () => {
 			expect( result ).toEqual( [
 				{
 					id: 'field1',
-					layout: { type: 'regular', labelPosition: 'top' },
+					layout: {
+						type: 'regular',
+						labelPosition: 'top',
+						spacing: 4,
+					},
 				},
 				{
 					id: 'field2',
 					label: 'Field 2',
-					layout: { type: 'regular', labelPosition: 'top' },
+					layout: {
+						type: 'regular',
+						labelPosition: 'top',
+						spacing: 4,
+					},
 				},
 			] );
 		} );
@@ -72,7 +88,11 @@ describe( 'normalizeFormFields', () => {
 			expect( result ).toEqual( [
 				{
 					id: 'field1',
-					layout: { type: 'regular', labelPosition: 'top' },
+					layout: {
+						type: 'regular',
+						labelPosition: 'top',
+						spacing: 4,
+					},
 				},
 			] );
 		} );
@@ -86,7 +106,11 @@ describe( 'normalizeFormFields', () => {
 			expect( result ).toEqual( [
 				{
 					id: 'field1',
-					layout: { type: 'regular', labelPosition: 'side' },
+					layout: {
+						type: 'regular',
+						labelPosition: 'side',
+						spacing: 4,
+					},
 				},
 			] );
 		} );
@@ -143,6 +167,7 @@ describe( 'normalizeFormFields', () => {
 						withHeader: true,
 						isOpened: true,
 						summary: [],
+						spacing: 6,
 					},
 				},
 			] );
@@ -169,6 +194,7 @@ describe( 'normalizeFormFields', () => {
 						withHeader: false,
 						isOpened: true,
 						summary: [],
+						spacing: 6,
 					},
 				},
 			] );
@@ -193,6 +219,7 @@ describe( 'normalizeFormFields', () => {
 						withHeader: true,
 						isOpened: false,
 						summary: [ { id: 'field1', visibility: 'always' } ],
+						spacing: 6,
 					},
 				},
 			] );
@@ -223,6 +250,7 @@ describe( 'normalizeFormFields', () => {
 							{ id: 'field2', visibility: 'when-collapsed' },
 							{ id: 'field1', visibility: 'always' },
 						],
+						spacing: 6,
 					},
 				},
 			] );
@@ -245,7 +273,11 @@ describe( 'normalizeFormFields', () => {
 			expect( result ).toEqual( [
 				{
 					id: 'field1',
-					layout: { type: 'regular', labelPosition: 'top' },
+					layout: {
+						type: 'regular',
+						labelPosition: 'top',
+						spacing: 4,
+					},
 				},
 				{
 					id: 'field2',
@@ -279,6 +311,7 @@ describe( 'normalizeFormFields', () => {
 						withHeader: false,
 						isOpened: true,
 						summary: [],
+						spacing: 6,
 					},
 				},
 				{
@@ -288,6 +321,7 @@ describe( 'normalizeFormFields', () => {
 						withHeader: true,
 						isOpened: false,
 						summary: [],
+						spacing: 6,
 					},
 				},
 			] );

--- a/packages/dataviews/src/types/dataform.ts
+++ b/packages/dataviews/src/types/dataform.ts
@@ -19,7 +19,6 @@ export type RegularLayout = {
 export type NormalizedRegularLayout = {
 	type: 'regular';
 	labelPosition: LabelPosition;
-	spacing: number;
 };
 
 export type PanelLayout = {
@@ -73,14 +72,12 @@ export type NormalizedCardLayout =
 			isOpened: true;
 			// Summary is an empty array
 			summary: [];
-			spacing: number;
 	  }
 	| {
 			type: 'card';
 			withHeader: true;
 			isOpened: boolean;
 			summary: NormalizedCardSummaryField;
-			spacing: number;
 	  };
 
 export type RowLayout = {

--- a/packages/dataviews/src/types/dataform.ts
+++ b/packages/dataviews/src/types/dataform.ts
@@ -15,11 +15,6 @@ export type NormalizedPanelSummaryField = string[];
 export type RegularLayout = {
 	type: 'regular';
 	labelPosition?: LabelPosition;
-	/**
-	 * Spacing between individual fields when using the regular layout.
-	 * Defaults to 4.
-	 */
-	spacing?: number;
 };
 export type NormalizedRegularLayout = {
 	type: 'regular';
@@ -62,22 +57,12 @@ export type CardLayout =
 			// isOpened cannot be false if withHeader is false as well.
 			// Otherwise, the card would not be visible.
 			isOpened?: true;
-			/**
-			 * Spacing between separate cards when using the card layout.
-			 * Defaults to 4.
-			 */
-			spacing?: number;
 	  }
 	| {
 			type: 'card';
 			withHeader?: true | undefined;
 			isOpened?: boolean;
 			summary?: CardSummaryField;
-			/**
-			 * Spacing between separate cards when using the card layout.
-			 * Defaults to 4.
-			 */
-			spacing?: number;
 	  };
 export type NormalizedCardLayout =
 	| {

--- a/packages/dataviews/src/types/dataform.ts
+++ b/packages/dataviews/src/types/dataform.ts
@@ -15,10 +15,16 @@ export type NormalizedPanelSummaryField = string[];
 export type RegularLayout = {
 	type: 'regular';
 	labelPosition?: LabelPosition;
+	/**
+	 * Spacing between individual fields when using the regular layout.
+	 * Defaults to 4.
+	 */
+	spacing?: number;
 };
 export type NormalizedRegularLayout = {
 	type: 'regular';
 	labelPosition: LabelPosition;
+	spacing: number;
 };
 
 export type PanelLayout = {
@@ -56,12 +62,22 @@ export type CardLayout =
 			// isOpened cannot be false if withHeader is false as well.
 			// Otherwise, the card would not be visible.
 			isOpened?: true;
+			/**
+			 * Spacing between separate cards when using the card layout.
+			 * Defaults to 4.
+			 */
+			spacing?: number;
 	  }
 	| {
 			type: 'card';
 			withHeader?: true | undefined;
 			isOpened?: boolean;
 			summary?: CardSummaryField;
+			/**
+			 * Spacing between separate cards when using the card layout.
+			 * Defaults to 4.
+			 */
+			spacing?: number;
 	  };
 export type NormalizedCardLayout =
 	| {
@@ -72,12 +88,14 @@ export type NormalizedCardLayout =
 			isOpened: true;
 			// Summary is an empty array
 			summary: [];
+			spacing: number;
 	  }
 	| {
 			type: 'card';
 			withHeader: true;
 			isOpened: boolean;
 			summary: NormalizedCardSummaryField;
+			spacing: number;
 	  };
 
 export type RowLayout = {


### PR DESCRIPTION
## What?
* Introduces independent spacing controls for DataForm layouts:
  * Regular layout: spacing between individual fields (default 4).
  * Card layout: spacing between consecutive cards (default 6).
* Added `spacing` to `RegularLayout`, `CardLayout`, and their normalized types.
* Applied layout-specific wrappers so each layout’s spacing is respected.
* Updated `LayoutMixed` story to use `layout: { type: 'card', spacing: 6 }`.

<!-- In a few words, what is the PR actually doing? -->

## Why?
* Previously, one spacing setting controlled both field spacing and card spacing, preventing independent tuning.
* Enables tighter spacing inside cards while keeping larger gaps between cards (or vice versa) per design needs.

## How?
* **Types**
  * Updated packages/dataviews/src/types/dataform.ts to add spacing to RegularLayout and CardLayout, and to normalized variants.
* **Normalization**
  * Updated packages/dataviews/src/dataform-layouts/normalize-form-fields.ts to:
    * Default regular spacing to 4.
    * Default card spacing to 6.
    * Preserve user-supplied spacing.
* **Rendering**
  * packages/dataviews/src/dataform-layouts/index.tsx: Added wrappers for regular and card that render a VStack with layout.spacing.
  * packages/dataviews/src/dataform-layouts/data-form-layout.tsx: Default wrapper now respects layout.spacing.
* **Stories**
  * packages/dataviews/src/stories/dataform.story.tsx: LayoutMixedComponent now sets layout: { type: 'card', spacing: 6 }.

## Testing

- `npm run storybook`.
- Compare http://localhost:50240/?path=/story/dataviews-dataform--layout-card with https://wordpress.github.io/gutenberg/?path=/story/dataviews-dataform--layout-card.
- In the former the gap between cards should be 24px compared to 16px in the latter.

> [!NOTE]  
> I had assistance from AI preparing this PR. Apologies if anything was butchered, but hopefully it communicates the idea and can serve as a starting point.
