### PR TITLE
Notes: Remove unnecessary horizontal scrollbar

### DIFF
--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -21,6 +21,7 @@
 	border-radius: $radius-large;
 	border: $border-width solid $gray-300;
 	background-color: $gray-100;
+	overflow: hidden;
 
 	&.is-selected {
 		background-color: $white;


### PR DESCRIPTION
## What?

Fixed a regression that occurred in https://github.com/WordPress/gutenberg/commit/c48bb6f2f4087daf7f9a45afa66457001ee58096

<img width="764" height="523" alt="comment" src="https://github.com/user-attachments/assets/1e583c18-20d5-4dfd-bb48-f2f7b6a5b9b8" />

## Why?

To improve focus management, we've introduced a skip link button in the header. When not focused, this button will display "right: -9999px;", which will cause an unintended horizontal scrollbar to appear.

## Testing Instructions

Add comments on a block and confirm that the horizontal scrollbar doesn't appear.
