### PR TITLE
Dataviews Filter: Showing error when sort-by filter changes to Status

### DIFF
--- a/packages/dataviews/src/field-types/email.tsx
+++ b/packages/dataviews/src/field-types/email.tsx
@@ -26,9 +26,10 @@ import {
 } from '../constants';
 
 function sort( valueA: any, valueB: any, direction: SortDirection ) {
-	return direction === 'asc'
-		? valueA.localeCompare( valueB )
-		: valueB.localeCompare( valueA );
+	const a = valueA === null || valueA === undefined ? '' : String( valueA );
+	const b = valueB === null || valueB === undefined ? '' : String( valueB );
+
+	return direction === 'asc' ? a.localeCompare( b ) : b.localeCompare( a );
 }
 
 // Email validation regex based on HTML5 spec

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -98,9 +98,13 @@ export default function getFieldTypeDefinition< Item >(
 				return direction === 'asc' ? a - b : b - a;
 			}
 
+			// Coerce values to strings before calling localeCompare.
+			const stringA = a === null || a === undefined ? '' : String( a );
+			const stringB = b === null || b === undefined ? '' : String( b );
+
 			return direction === 'asc'
-				? a.localeCompare( b )
-				: b.localeCompare( a );
+				? stringA.localeCompare( stringB )
+				: stringB.localeCompare( stringA );
 		},
 		isValid: {
 			custom: ( item: any, field: NormalizedField< any > ) => {

--- a/packages/dataviews/src/field-types/text.tsx
+++ b/packages/dataviews/src/field-types/text.tsx
@@ -25,10 +25,13 @@ import {
 	OPERATOR_STARTS_WITH,
 } from '../constants';
 
+// Coerce values to strings to avoid calling localeCompare on
+// undefined/null or non-string values which would throw.
 function sort( valueA: any, valueB: any, direction: SortDirection ) {
-	return direction === 'asc'
-		? valueA.localeCompare( valueB )
-		: valueB.localeCompare( valueA );
+	const a = valueA === null || valueA === undefined ? '' : String( valueA );
+	const b = valueB === null || valueB === undefined ? '' : String( valueB );
+
+	return direction === 'asc' ? a.localeCompare( b ) : b.localeCompare( a );
 }
 
 export default {

--- a/packages/dataviews/src/field-types/url.tsx
+++ b/packages/dataviews/src/field-types/url.tsx
@@ -26,9 +26,10 @@ import {
 } from '../constants';
 
 function sort( valueA: any, valueB: any, direction: SortDirection ) {
-	return direction === 'asc'
-		? valueA.localeCompare( valueB )
-		: valueB.localeCompare( valueA );
+	const a = valueA === null || valueA === undefined ? '' : String( valueA );
+	const b = valueB === null || valueB === undefined ? '' : String( valueB );
+
+	return direction === 'asc' ? a.localeCompare( b ) : b.localeCompare( a );
 }
 
 export default {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix a runtime TypeError when sorting DataViews by fields that can produce non-string or missing values. Specifically: prevent "TypeError: a.localeCompare is not a function" by hardening the comparators used for sorting in dataviews field types and the fallback comparator.



<!-- In a few words, what is the PR actually doing? -->

## Why?
When sorting, some comparators called `localCompare` directly on values that could be undefined, null, or non-string. Calling `localCompare` on a non-string throws a TypeError and breaks the UI when users change sort settings (reported when sorting by Status in dataviews). This PR makes the sorting comparators robust so they never call `localeCompare` on a non-string.

## How?
For field types that can reasonably return non-strings or undefined (text, email, url, and the fallback field-type), comparator code now coerces values to strings before calling` localeCompare`:

- null/undefined -> '' (empty string)
- else -> String(value)

## Testing Instructions

1. Go to the Templates --- Appearance->Editor->Templates
2. Change the filter-> "Sort by" option to `Status` or any other fields.
3. Observe the console: there should be no "TypeError: a.localeCompare is not a function". -- No UI breaks.
4. Confirm sorting behaves sensibly: Ascending vs descending order toggles as expected.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/49793f6a-3048-4471-98bb-dde88f9cf633




|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
