### PR TITLE
Block Bindings: Refactor UI, improve consistency, add more info about source status.

### DIFF
--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -428,7 +428,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 	if ( ! bindableAttributes || bindableAttributes.length === 0 ) {
 		return null;
 	}
-	// Filter bindings to only show bindable attributes.
+
 	const { bindings } = metadata || {};
 
 	// Check if all sources have empty data arrays

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -95,7 +95,6 @@ function BlockBindingsPanelMenuContent( {
 				const noItemsAvailable =
 					! sourceDataItems || sourceDataItems.length === 0;
 
-				// Skip sources with no compatible items for this attribute
 				if ( noItemsAvailable ) {
 					return null;
 				}
@@ -213,7 +212,7 @@ function BlockBindingsAttribute( { attribute, binding, sources, blockName } ) {
 	const isNotBound = binding === undefined;
 
 	if ( isNotBound ) {
-		// Check if there are any compatible sources for this attribute type
+		// Check if there are any compatible sources for this attribute type.
 		const attributeType = getAttributeType( blockName, attribute );
 
 		const hasCompatibleSources = Object.values( sources ).some( ( src ) =>
@@ -375,14 +374,13 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 							getValues,
 						};
 					} else if ( getFieldsList ) {
-						// Backward compatibility: Convert getFieldsList to editorUI format
+						// Backward compatibility: Convert getFieldsList to editorUI format.
 						const fieldsListResult = getFieldsList( {
 							select,
 							context,
 						} );
 
 						if ( fieldsListResult ) {
-							// Convert getFieldsList format to editorUI format
 							const data = Object.entries( fieldsListResult ).map(
 								( [ key, field ] ) => ( {
 									label: field.label || key,
@@ -392,7 +390,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 							);
 
 							_sources[ sourceName ] = {
-								mode: 'dropdown', // Default mode for backward compatibility
+								mode: 'dropdown', // Default mode for backward compatibility.
 								data,
 								label,
 								getValues,
@@ -424,14 +422,15 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 			};
 		},
 		[ blockContext, blockName ]
-	); // Return early if there are no bindable attributes.
+	);
+	// Return early if there are no bindable attributes.
 	if ( ! bindableAttributes || bindableAttributes.length === 0 ) {
 		return null;
 	}
 
 	const { bindings } = metadata || {};
 
-	// Check if all sources have empty data arrays
+	// Check if all sources have empty data arrays.
 	const hasCompatibleData = Object.values( sources ).some(
 		( source ) => source.data && source.data.length > 0
 	);
@@ -460,7 +459,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 					{ bindableAttributes.map( ( attribute ) => {
 						const binding = bindings?.[ attribute ];
 
-						// Check if this specific attribute has compatible data from any source
+						// Check if this specific attribute has compatible data from any source.
 						const attributeType = getAttributeType(
 							blockName,
 							attribute

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -274,16 +274,20 @@ function ReadOnlyBlockBindingsPanelItem( {
 	sources,
 	blockName,
 } ) {
+	const isMobile = useViewportMatch( 'medium', '<' );
+
 	return (
 		<ToolsPanelItem hasValue={ () => !! binding } label={ attribute }>
-			<Item>
-				<BlockBindingsAttribute
-					attribute={ attribute }
-					binding={ binding }
-					sources={ sources }
-					blockName={ blockName }
-				/>
-			</Item>
+			<Menu placement={ isMobile ? 'bottom-start' : 'left-start' }>
+				<Menu.TriggerButton render={ <Item /> } disabled>
+					<BlockBindingsAttribute
+						attribute={ attribute }
+						binding={ binding }
+						sources={ sources }
+						blockName={ blockName }
+					/>
+				</Menu.TriggerButton>
+			</Menu>
 		</ToolsPanelItem>
 	);
 }

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -113,89 +113,76 @@ function BlockBindingsPanelMenuContent( {
 									{ source.label }
 								</Menu.ItemLabel>
 							</Menu.SubmenuTriggerItem>
-							{ ! noItemsAvailable && (
-								<Menu.Popover gutter={ 8 }>
-									<Menu.Group>
-										{ sourceDataItems.map( ( item ) => {
-											const itemBindings = {
-												source: sourceKey,
-												args: item?.args || {
-													key: item.key,
-												},
-											};
-											const values = source.getValues( {
-												select,
-												context: blockContext,
-												bindings: {
-													[ attribute ]: itemBindings,
-												},
-											} );
-											return (
-												<Menu.CheckboxItem
-													key={
-														sourceKey +
-															JSON.stringify(
-																item.args
-															) || item.key
-													}
-													onChange={ () => {
-														const isCurrentlySelected =
-															fastDeepEqual(
-																binding?.args,
-																item.args
-															) ??
-															// Deprecate key dependency in 7.0.
-															item.key ===
-																binding?.args
-																	?.key;
-
-														if (
-															isCurrentlySelected
-														) {
-															// Unset if the same item is selected again.
-															updateBlockBindings(
-																{
-																	[ attribute ]:
-																		undefined,
-																}
-															);
-														} else {
-															updateBlockBindings(
-																{
-																	[ attribute ]:
-																		itemBindings,
-																}
-															);
-														}
-													} }
-													name={
-														attribute + '-binding'
-													}
-													value={
-														values[ attribute ]
-													}
-													checked={
+							<Menu.Popover gutter={ 8 }>
+								<Menu.Group>
+									{ sourceDataItems.map( ( item ) => {
+										const itemBindings = {
+											source: sourceKey,
+											args: item?.args || {
+												key: item.key,
+											},
+										};
+										const values = source.getValues( {
+											select,
+											context: blockContext,
+											bindings: {
+												[ attribute ]: itemBindings,
+											},
+										} );
+										return (
+											<Menu.CheckboxItem
+												key={
+													sourceKey +
+														JSON.stringify(
+															item.args
+														) || item.key
+												}
+												onChange={ () => {
+													const isCurrentlySelected =
 														fastDeepEqual(
 															binding?.args,
 															item.args
 														) ??
 														// Deprecate key dependency in 7.0.
 														item.key ===
-															binding?.args?.key
+															binding?.args?.key;
+
+													if ( isCurrentlySelected ) {
+														// Unset if the same item is selected again.
+														updateBlockBindings( {
+															[ attribute ]:
+																undefined,
+														} );
+													} else {
+														updateBlockBindings( {
+															[ attribute ]:
+																itemBindings,
+														} );
 													}
-												>
-													<Menu.ItemLabel>
-														{ item?.label }
-													</Menu.ItemLabel>
-													<Menu.ItemHelpText>
-														{ values[ attribute ] }
-													</Menu.ItemHelpText>
-												</Menu.CheckboxItem>
-											);
-										} ) }
-									</Menu.Group>
-								</Menu.Popover>
-							) }
+												} }
+												name={ attribute + '-binding' }
+												value={ values[ attribute ] }
+												checked={
+													fastDeepEqual(
+														binding?.args,
+														item.args
+													) ??
+													// Deprecate key dependency in 7.0.
+													item.key ===
+														binding?.args?.key
+												}
+											>
+												<Menu.ItemLabel>
+													{ item?.label }
+												</Menu.ItemLabel>
+												<Menu.ItemHelpText>
+													{ values[ attribute ] }
+												</Menu.ItemHelpText>
+											</Menu.CheckboxItem>
+										);
+									} ) }
+								</Menu.Group>
+							</Menu.Popover>
 						</Menu>
 					);
 				}

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -438,20 +438,10 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 	}
 	// Filter bindings to only show bindable attributes.
 	const { bindings } = metadata || {};
-	const filteredBindings = { ...bindings };
-	Object.keys( filteredBindings ).forEach( ( key ) => {
-		if ( ! bindableAttributes.includes( key ) ) {
-			delete filteredBindings[ key ];
-		}
-	} );
 
 	// Lock the UI when the user can't update bindings or there are no fields to connect to.
 	const readOnly =
 		! canUpdateBlockBindings || ! Object.keys( sources ).length;
-
-	if ( readOnly && Object.keys( filteredBindings ).length === 0 ) {
-		return null;
-	}
 
 	const RenderModalContent =
 		sources[ modalState?.sourceKey ]?.renderModalContent;
@@ -468,7 +458,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 			>
 				<ItemGroup isBordered isSeparated>
 					{ bindableAttributes.map( ( attribute ) => {
-						const binding = filteredBindings[ attribute ];
+						const binding = bindings?.[ attribute ];
 						const hasCompatibleData = Object.values( sources ).some(
 							( source ) => source.data
 						);

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -423,7 +423,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 				bindableAttributes: _bindableAttributes,
 			};
 		},
-		[ blockContext, blockName, metadata ]
+		[ blockContext, blockName ]
 	); // Return early if there are no bindable attributes.
 	if ( ! bindableAttributes || bindableAttributes.length === 0 ) {
 		return null;

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -208,7 +208,7 @@ function BlockBindingsPanelMenuContent( {
 
 function BlockBindingsAttribute( { attribute, binding, source } ) {
 	const { source: sourceName, args } = binding || {};
-	const isSourceInvalid = ! source;
+	const isSourceInvalid = ! sourceName;
 	return (
 		<VStack className="block-editor-bindings__item" spacing={ 0 }>
 			<Text truncate>{ attribute }</Text>
@@ -412,6 +412,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 						 * by other means (e.g. code editor).
 						 */
 						_sources[ sourceName ] = {
+							data: [],
 							label,
 							getValues,
 						};
@@ -439,9 +440,13 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 	// Filter bindings to only show bindable attributes.
 	const { bindings } = metadata || {};
 
+	// Check if all sources have empty data arrays
+	const hasCompatibleData = Object.values( sources ).some(
+		( source ) => source.data && source.data.length > 0
+	);
+
 	// Lock the UI when the user can't update bindings or there are no fields to connect to.
-	const readOnly =
-		! canUpdateBlockBindings || ! Object.keys( sources ).length;
+	const readOnly = ! canUpdateBlockBindings || ! hasCompatibleData;
 
 	const RenderModalContent =
 		sources[ modalState?.sourceKey ]?.renderModalContent;
@@ -459,11 +464,8 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 				<ItemGroup isBordered isSeparated>
 					{ bindableAttributes.map( ( attribute ) => {
 						const binding = bindings?.[ attribute ];
-						const hasCompatibleData = Object.values( sources ).some(
-							( source ) => source.data
-						);
 
-						return readOnly || ! hasCompatibleData ? (
+						return readOnly ? (
 							<ReadOnlyBlockBindingsPanelItem
 								key={ attribute }
 								attribute={ attribute }

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -36,6 +36,20 @@ const { Menu } = unlock( componentsPrivateApis );
 
 const EMPTY_OBJECT = {};
 
+/**
+ * Get the normalized attribute type for block bindings.
+ * Converts 'rich-text' to 'string' since rich-text is stored as string.
+ *
+ * @param {string} blockName The block name.
+ * @param {string} attribute The attribute name.
+ * @return {string} The normalized attribute type.
+ */
+const getAttributeType = ( blockName, attribute ) => {
+	const _attributeType =
+		getBlockType( blockName ).attributes?.[ attribute ]?.type;
+	return _attributeType === 'rich-text' ? 'string' : _attributeType;
+};
+
 const useToolsPanelDropdownMenuProps = () => {
 	const isMobile = useViewportMatch( 'medium', '<' );
 	return ! isMobile
@@ -63,11 +77,8 @@ function BlockBindingsPanelMenuContent( {
 		( _select ) => {
 			const { name: blockName } =
 				_select( blockEditorStore ).getBlock( clientId );
-			const _attributeType =
-				getBlockType( blockName ).attributes?.[ attribute ]?.type;
 			return {
-				attributeType:
-					_attributeType === 'rich-text' ? 'string' : _attributeType,
+				attributeType: getAttributeType( blockName, attribute ),
 				select: _select,
 			};
 		},
@@ -206,7 +217,7 @@ function BlockBindingsPanelMenuContent( {
 	);
 }
 
-function BlockBindingsAttribute( { attribute, binding, sources } ) {
+function BlockBindingsAttribute( { attribute, binding, sources, blockName } ) {
 	const { source: sourceName, args } = binding || {};
 	const source = sources?.[ sourceName ];
 
@@ -215,7 +226,18 @@ function BlockBindingsAttribute( { attribute, binding, sources } ) {
 	const isNotBound = binding === undefined;
 
 	if ( isNotBound ) {
-		displayText = __( 'Not connected' );
+		// Check if there are any compatible sources for this attribute type
+		const attributeType = getAttributeType( blockName, attribute );
+
+		const hasCompatibleSources = Object.values( sources ).some( ( src ) =>
+			src.data?.some( ( item ) => item?.type === attributeType )
+		);
+
+		if ( ! hasCompatibleSources ) {
+			displayText = __( 'No sources available' );
+		} else {
+			displayText = __( 'Not connected' );
+		}
 		isValid = true;
 	} else if ( ! source ) {
 		// If there's a binding but the source is not found, it's invalid.
@@ -246,7 +268,12 @@ function BlockBindingsAttribute( { attribute, binding, sources } ) {
 	);
 }
 
-function ReadOnlyBlockBindingsPanelItem( { attribute, binding, sources } ) {
+function ReadOnlyBlockBindingsPanelItem( {
+	attribute,
+	binding,
+	sources,
+	blockName,
+} ) {
 	return (
 		<ToolsPanelItem hasValue={ () => !! binding } label={ attribute }>
 			<Item>
@@ -254,6 +281,7 @@ function ReadOnlyBlockBindingsPanelItem( { attribute, binding, sources } ) {
 					attribute={ attribute }
 					binding={ binding }
 					sources={ sources }
+					blockName={ blockName }
 				/>
 			</Item>
 		</ToolsPanelItem>
@@ -265,6 +293,7 @@ function EditableBlockBindingsPanelItem( {
 	binding,
 	sources,
 	setModalState,
+	blockName,
 } ) {
 	const { updateBlockBindings } = useBlockBindingsUtils();
 	const isMobile = useViewportMatch( 'medium', '<' );
@@ -289,6 +318,7 @@ function EditableBlockBindingsPanelItem( {
 						attribute={ attribute }
 						binding={ binding }
 						sources={ sources }
+						blockName={ blockName }
 					/>
 				</Menu.TriggerButton>
 				<Menu.Popover gutter={ isMobile ? 8 : 36 }>
@@ -329,72 +359,32 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 			}
 
 			const registeredSources = getBlockBindingsSources();
-			const { bindings } = metadata || {};
-			const usedSources = new Set(
-				Object.values( bindings || {} ).map(
-					( binding ) => binding?.source
-				)
-			);
 			Object.entries( registeredSources ).forEach(
 				( [
 					sourceName,
 					{ editorUI, getFieldsList, usesContext, label, getValues },
 				] ) => {
-					if ( editorUI ) {
-						// Populate context.
-						const context = {};
-						if ( usesContext?.length ) {
-							for ( const key of usesContext ) {
-								context[ key ] = blockContext[ key ];
-							}
+					// Populate context.
+					const context = {};
+					if ( usesContext?.length ) {
+						for ( const key of usesContext ) {
+							context[ key ] = blockContext[ key ];
 						}
+					}
 
+					if ( editorUI ) {
 						const editorUIResult = editorUI( {
 							select,
 							context,
 						} );
-						const hasCompatibleData = _bindableAttributes.some(
-							( attribute ) => {
-								const _attributeType =
-									getBlockType( blockName ).attributes?.[
-										attribute
-									]?.type;
-								const attributeType =
-									_attributeType === 'rich-text'
-										? 'string'
-										: _attributeType;
 
-								return editorUIResult.data?.some(
-									( item ) => item?.type === attributeType
-								);
-							}
-						);
-
-						if ( hasCompatibleData ) {
-							_sources[ sourceName ] = {
-								...editorUIResult,
-								label,
-								getValues,
-							};
-						} else if ( usedSources.has( sourceName ) ) {
-							// If there's no compatible data but the source is already used in a binding,
-							// still add it with empty data so it can be displayed in read-only mode.
-							_sources[ sourceName ] = {
-								...editorUIResult,
-								data: [],
-								label,
-								getValues,
-							};
-						}
+						_sources[ sourceName ] = {
+							...editorUIResult,
+							label,
+							getValues,
+						};
 					} else if ( getFieldsList ) {
 						// Backward compatibility: Convert getFieldsList to editorUI format
-						const context = {};
-						if ( usesContext?.length ) {
-							for ( const key of usesContext ) {
-								context[ key ] = blockContext[ key ];
-							}
-						}
-
 						const fieldsListResult = getFieldsList( {
 							select,
 							context,
@@ -410,42 +400,14 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 								} )
 							);
 
-							const hasCompatibleData = _bindableAttributes.some(
-								( attribute ) => {
-									const _attributeType =
-										getBlockType( blockName ).attributes?.[
-											attribute
-										]?.type;
-									const attributeType =
-										_attributeType === 'rich-text'
-											? 'string'
-											: _attributeType;
-
-									return data.some(
-										( item ) => item?.type === attributeType
-									);
-								}
-							);
-
-							if ( hasCompatibleData ) {
-								_sources[ sourceName ] = {
-									mode: 'dropdown', // Default mode for backward compatibility
-									data,
-									label,
-									getValues,
-								};
-							} else if ( usedSources.has( sourceName ) ) {
-								// If there's no compatible data but the source is already used in a binding,
-								// still add it with empty data so it can be displayed in read-only mode.
-								_sources[ sourceName ] = {
-									mode: 'dropdown', // Default mode for backward compatibility
-									data: [],
-									label,
-									getValues,
-								};
-							}
+							_sources[ sourceName ] = {
+								mode: 'dropdown', // Default mode for backward compatibility
+								data,
+								label,
+								getValues,
+							};
 						}
-					} else if ( usedSources.has( sourceName ) ) {
+					} else {
 						/*
 						 * Include sources without editorUI if they are already used in a binding.
 						 * This allows them to be displayed in read-only mode.
@@ -507,12 +469,30 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 					{ bindableAttributes.map( ( attribute ) => {
 						const binding = bindings?.[ attribute ];
 
-						return readOnly ? (
+						// Check if this specific attribute has compatible data from any source
+						const attributeType = getAttributeType(
+							blockName,
+							attribute
+						);
+
+						const hasCompatibleDataForAttribute = Object.values(
+							sources
+						).some( ( source ) =>
+							source.data?.some(
+								( item ) => item?.type === attributeType
+							)
+						);
+
+						const isAttributeReadOnly =
+							readOnly || ! hasCompatibleDataForAttribute;
+
+						return isAttributeReadOnly ? (
 							<ReadOnlyBlockBindingsPanelItem
 								key={ attribute }
 								attribute={ attribute }
 								binding={ binding }
 								sources={ sources }
+								blockName={ blockName }
 							/>
 						) : (
 							<EditableBlockBindingsPanelItem
@@ -521,6 +501,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 								binding={ binding }
 								sources={ sources }
 								setModalState={ setModalState }
+								blockName={ blockName }
 							/>
 						);
 					} ) }

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -84,6 +84,11 @@ function BlockBindingsPanelMenuContent( {
 				const noItemsAvailable =
 					! sourceDataItems || sourceDataItems.length === 0;
 
+				// Skip sources with no compatible items for this attribute
+				if ( noItemsAvailable ) {
+					return null;
+				}
+
 				if ( source.mode === 'dropdown' ) {
 					return (
 						<Menu
@@ -92,16 +97,11 @@ function BlockBindingsPanelMenuContent( {
 								isMobile ? 'bottom-start' : 'left-start'
 							}
 						>
-							{ noItemsAvailable ? (
-								<Menu.Item disabled>{ source.label }</Menu.Item>
-							) : (
-								<Menu.SubmenuTriggerItem>
-									<Menu.ItemLabel>
-										{ source.label }
-									</Menu.ItemLabel>
-								</Menu.SubmenuTriggerItem>
-							) }
-
+							<Menu.SubmenuTriggerItem>
+								<Menu.ItemLabel>
+									{ source.label }
+								</Menu.ItemLabel>
+							</Menu.SubmenuTriggerItem>
 							{ ! noItemsAvailable && (
 								<Menu.Popover gutter={ 8 }>
 									<Menu.Group>
@@ -206,39 +206,54 @@ function BlockBindingsPanelMenuContent( {
 	);
 }
 
-function BlockBindingsAttribute( { attribute, binding, source } ) {
+function BlockBindingsAttribute( { attribute, binding, sources } ) {
 	const { source: sourceName, args } = binding || {};
-	const isSourceInvalid = ! sourceName;
+	const source = sources?.[ sourceName ];
+
+	let displayText;
+	let isValid = true;
+	const isNotBound = binding === undefined;
+
+	if ( isNotBound ) {
+		displayText = __( 'Not connected' );
+		isValid = true;
+	} else if ( ! source ) {
+		// If there's a binding but the source is not found, it's invalid.
+		isValid = false;
+		displayText = __( 'Source not registered' );
+		if ( Object.keys( sources ).length === 0 ) {
+			displayText = __( 'No sources available' );
+		}
+	} else {
+		displayText =
+			source.data?.find( ( item ) => fastDeepEqual( item.args, args ) )
+				?.label ||
+			source.label ||
+			sourceName;
+	}
+
 	return (
 		<VStack className="block-editor-bindings__item" spacing={ 0 }>
 			<Text truncate>{ attribute }</Text>
-			{ !! binding && (
-				<Text
-					truncate
-					variant={ ! isSourceInvalid && 'muted' }
-					isDestructive={ isSourceInvalid }
-				>
-					{ isSourceInvalid
-						? __( 'Invalid source' )
-						: source?.data?.find( ( item ) =>
-								fastDeepEqual( item.args, args )
-						  )?.label ||
-						  source?.label ||
-						  sourceName }
-				</Text>
-			) }
+			<Text
+				truncate
+				variant={ isValid ? 'muted' : undefined }
+				isDestructive={ ! isValid }
+			>
+				{ displayText }
+			</Text>
 		</VStack>
 	);
 }
 
-function ReadOnlyBlockBindingsPanelItem( { attribute, binding, source } ) {
+function ReadOnlyBlockBindingsPanelItem( { attribute, binding, sources } ) {
 	return (
 		<ToolsPanelItem hasValue={ () => !! binding } label={ attribute }>
 			<Item>
 				<BlockBindingsAttribute
 					attribute={ attribute }
 					binding={ binding }
-					source={ source }
+					sources={ sources }
 				/>
 			</Item>
 		</ToolsPanelItem>
@@ -273,7 +288,7 @@ function EditableBlockBindingsPanelItem( {
 					<BlockBindingsAttribute
 						attribute={ attribute }
 						binding={ binding }
-						source={ sources?.[ binding?.source ] }
+						sources={ sources }
 					/>
 				</Menu.TriggerButton>
 				<Menu.Popover gutter={ isMobile ? 8 : 36 }>
@@ -314,6 +329,12 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 			}
 
 			const registeredSources = getBlockBindingsSources();
+			const { bindings } = metadata || {};
+			const usedSources = new Set(
+				Object.values( bindings || {} ).map(
+					( binding ) => binding?.source
+				)
+			);
 			Object.entries( registeredSources ).forEach(
 				( [
 					sourceName,
@@ -352,6 +373,15 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 						if ( hasCompatibleData ) {
 							_sources[ sourceName ] = {
 								...editorUIResult,
+								label,
+								getValues,
+							};
+						} else if ( usedSources.has( sourceName ) ) {
+							// If there's no compatible data but the source is already used in a binding,
+							// still add it with empty data so it can be displayed in read-only mode.
+							_sources[ sourceName ] = {
+								...editorUIResult,
+								data: [],
 								label,
 								getValues,
 							};
@@ -404,12 +434,21 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 									label,
 									getValues,
 								};
+							} else if ( usedSources.has( sourceName ) ) {
+								// If there's no compatible data but the source is already used in a binding,
+								// still add it with empty data so it can be displayed in read-only mode.
+								_sources[ sourceName ] = {
+									mode: 'dropdown', // Default mode for backward compatibility
+									data: [],
+									label,
+									getValues,
+								};
 							}
 						}
-					} else {
+					} else if ( usedSources.has( sourceName ) ) {
 						/*
-						 * Include sources without editorUI if they are introduced
-						 * by other means (e.g. code editor).
+						 * Include sources without editorUI if they are already used in a binding.
+						 * This allows them to be displayed in read-only mode.
 						 */
 						_sources[ sourceName ] = {
 							data: [],
@@ -431,9 +470,8 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 				bindableAttributes: _bindableAttributes,
 			};
 		},
-		[ blockContext, blockName ]
-	);
-	// Return early if there are no bindable attributes.
+		[ blockContext, blockName, metadata ]
+	); // Return early if there are no bindable attributes.
 	if ( ! bindableAttributes || bindableAttributes.length === 0 ) {
 		return null;
 	}
@@ -450,6 +488,10 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 
 	const RenderModalContent =
 		sources[ modalState?.sourceKey ]?.renderModalContent;
+
+	if ( bindings === undefined && ! hasCompatibleData ) {
+		return null;
+	}
 
 	return (
 		<InspectorControls group="bindings">
@@ -470,7 +512,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 								key={ attribute }
 								attribute={ attribute }
 								binding={ binding }
-								source={ sources?.[ binding?.source ] }
+								sources={ sources }
 							/>
 						) : (
 							<EditableBlockBindingsPanelItem

--- a/packages/e2e-tests/plugins/block-bindings.php
+++ b/packages/e2e-tests/plugins/block-bindings.php
@@ -18,20 +18,25 @@ function gutenberg_test_block_bindings_registration() {
 	$upload_dir  = wp_upload_dir();
 	$testing_url = $upload_dir['url'] . '/1024x768_e2e_test_image_size.jpeg';
 	$fields_list = array(
-		'text_field'  => array(
+		'text_field'          => array(
 			'label' => 'Text Field Label',
 			'value' => 'Text Field Value',
 			'type'  => 'string',
 		),
-		'url_field'   => array(
+		'url_field'           => array(
 			'label' => 'URL Field Label',
 			'value' => $testing_url,
 			'type'  => 'string',
 		),
-		'empty_field' => array(
+		'empty_field'         => array(
 			'label' => 'Empty Field Label',
 			'value' => '',
 			'type'  => 'string',
+		),
+		'number_custom_field' => array(
+			'label' => 'Number Custom Field Label',
+			'value' => 10.5,
+			'type'  => 'number',
 		),
 	);
 

--- a/packages/e2e-tests/plugins/block-bindings.php
+++ b/packages/e2e-tests/plugins/block-bindings.php
@@ -166,7 +166,7 @@ function gutenberg_test_block_bindings_registration() {
 	);
 	register_meta(
 		'post',
-		'number',
+		'number_custom_field',
 		array(
 			'label'        => 'Number custom field',
 			'type'         => 'number',

--- a/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
@@ -44,6 +44,68 @@ test.describe( 'Registered sources', () => {
 		await requestUtils.deactivatePlugin( 'gutenberg-test-block-bindings' );
 	} );
 
+	test.describe( 'Default WP installation', () => {
+		test.beforeEach( async ( { admin, requestUtils } ) => {
+			await requestUtils.deactivatePlugin(
+				'gutenberg-test-block-bindings'
+			);
+			await admin.createNewPost( { title: 'Test bindings' } );
+		} );
+
+		test.afterEach( async ( { requestUtils } ) => {
+			await requestUtils.activatePlugin(
+				'gutenberg-test-block-bindings'
+			);
+		} );
+
+		test( 'It should not show the attributes panel if there are no sources registered.', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+			} );
+			await expect(
+				page.getByLabel( 'Attributes options' )
+			).toBeHidden();
+		} );
+		test( 'It should show the attributes panel, no sources registered, readOnlyAttributes.', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/image',
+				attributes: {
+					metadata: {
+						bindings: {
+							alt: {
+								source: 'testing/server-only-source',
+							},
+						},
+					},
+				},
+			} );
+			await page.getByLabel( 'Attributes options' ).click();
+			await page
+				.getByRole( 'menuitemcheckbox', { name: 'Show id' } )
+				.click();
+			const idAttribute = page.getByRole( 'button', {
+				name: 'id',
+			} );
+			await expect( idAttribute ).toBeVisible();
+			await expect( idAttribute ).toBeDisabled();
+			await expect( idAttribute ).toContainText( 'No sources available' );
+			const altAttribute = page.getByRole( 'button', {
+				name: 'alt',
+			} );
+			await expect( altAttribute ).toBeVisible();
+			await expect( altAttribute ).toBeDisabled();
+			await expect( altAttribute ).toContainText(
+				'Source not registered'
+			);
+		} );
+	} );
+
 	test.describe( 'getValues', () => {
 		test( 'should show the returned value in paragraph content', async ( {
 			editor,

--- a/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
@@ -1197,7 +1197,7 @@ test.describe( 'Registered sources', () => {
 		} );
 		await expect( contentButton ).toContainText( 'Server Source' );
 	} );
-	test( 'should show an "Invalid source" warning for not registered sources', async ( {
+	test( 'should show an "Source not registered" warning for not registered sources', async ( {
 		editor,
 		page,
 	} ) => {
@@ -1217,7 +1217,7 @@ test.describe( 'Registered sources', () => {
 		const contentButton = page.getByRole( 'button', {
 			name: 'content',
 		} );
-		await expect( contentButton ).toContainText( 'Invalid source' );
+		await expect( contentButton ).toContainText( 'Source not registered' );
 	} );
 
 	test.describe( 'Modal source', () => {
@@ -1314,22 +1314,23 @@ test.describe( 'Registered sources', () => {
 			editor,
 			page,
 		} ) => {
-			// Test string attribute - paragraph content
-			await editor.insertBlock( { name: 'core/image' } );
+			await editor.insertBlock( {
+				name: 'core/image',
+			} );
+
+			// Open the bindings panel
 			await page.getByLabel( 'Attributes options' ).click();
 			await page
-				.getByRole( 'menuitemcheckbox', { name: 'Show id' } )
+				.getByRole( 'menuitemcheckbox', {
+					name: 'Show id',
+				} )
 				.click();
-			await page.getByRole( 'button', { name: 'id' } ).click();
 
-			// String sources enabled, number source disabled for string attribute
-			await expect(
-				page.getByRole( 'menuitem', { name: 'Complete Source' } )
-			).toBeDisabled();
-
-			await expect(
-				page.getByRole( 'menuitem', { name: 'Modal Source' } )
-			).toBeEnabled();
+			// Click on the content binding button
+			const idButton = page.getByRole( 'button', {
+				name: 'id',
+			} );
+			await expect( idButton ).toContainText( 'Not connected' );
 		} );
 	} );
 } );

--- a/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
@@ -1310,27 +1310,31 @@ test.describe( 'Registered sources', () => {
 	} );
 
 	test.describe( 'Source compatibility filtering', () => {
-		test( 'should show compatible sources enabled and incompatible sources disabled', async ( {
+		test( 'should show only compatible sources.', async ( {
 			editor,
 			page,
 		} ) => {
-			await editor.insertBlock( {
-				name: 'core/image',
-			} );
-
-			// Open the bindings panel
+			await editor.insertBlock( { name: 'core/image' } );
 			await page.getByLabel( 'Attributes options' ).click();
 			await page
-				.getByRole( 'menuitemcheckbox', {
-					name: 'Show id',
-				} )
+				.getByRole( 'menuitemcheckbox', { name: 'Show id' } )
 				.click();
+			await page.getByRole( 'button', { name: 'id' } ).click();
 
-			// Click on the content binding button
-			const idButton = page.getByRole( 'button', {
-				name: 'id',
+			const idMenuItem = page.getByRole( 'menuitem', {
+				name: 'Complete Source',
 			} );
-			await expect( idButton ).toContainText( 'Not connected' );
+			await expect( idMenuItem ).toBeEnabled();
+			await idMenuItem.click();
+			const numberField = page.getByRole( 'menuitemcheckbox', {
+				name: 'Number Custom Field Label',
+			} );
+			await expect( numberField ).toBeEnabled();
+			await expect(
+				page.getByRole( 'menuitemcheckbox', {
+					name: 'Text Field Label',
+				} )
+			).toBeHidden();
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
The new Bindings UI open tons of possibilities, which are included in this screenshot.

This PR:
  - Sets readOnly items with the same button structure, instead of a div one.
  - Sets new information about the sources status, including compatibility and availability.
  - Do not display the attributes panel if there are no sources to bind. This happens on a default WordPress installation for blocks like paragraphs.
  - Confirms that we don't have to filter by source name, now is handled with EditorUI.
  - Shows the attributes panel if blocks have been bound by hardcoding the HTML markup.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Now that the UI landed, is time to polish and debug it, as we opened several use cases.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
E2E everywhere.

## Screenshots or screencast <!-- if applicable -->
<img width="1335" height="738" alt="Screenshot 2025-10-14 at 15 58 50" src="https://github.com/user-attachments/assets/96508977-315d-4f26-8b3b-4bea5b92e16f" />

<img width="263" height="393" alt="Screenshot 2025-10-14 at 16 18 48" src="https://github.com/user-attachments/assets/8a04712c-e1a2-4e5f-a106-7b87674cf403" />
