### PR TITLE
Components: Fix color scale functions

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -201,15 +201,15 @@
 	 */
 	&.is-destructive {
 		--wp-components-color-accent: #{$alert-red};
-		--wp-components-color-accent-darker-10: #{color.scale($alert-red, $lightness: -10%)};
-		--wp-components-color-accent-darker-20: #{color.scale($alert-red, $lightness: -20%)};
+		--wp-components-color-accent-darker-10: #{color.adjust($alert-red, $lightness: -10%)};
+		--wp-components-color-accent-darker-20: #{color.adjust($alert-red, $lightness: -20%)};
 
 		// Only the default variant is styled differently from the non-destructive counterparts.
 		&:not(.is-primary):not(.is-secondary):not(.is-tertiary):not(.is-link) {
 			color: $alert-red;
 
 			&:hover:not(:disabled, [aria-disabled="true"]) {
-				color: color.scale($alert-red, $lightness: -20%);
+				color: color.adjust($alert-red, $lightness: -20%);
 			}
 
 			&:focus {
@@ -294,10 +294,10 @@
 		background-image: linear-gradient(
 			-45deg,
 			// TODO: Prepare for theming (https://github.com/WordPress/gutenberg/pull/45466/files#r1030872724)
-			color.scale($white, $lightness: -2%) 33%,
-			color.scale($white, $lightness: -12%) 33%,
-			color.scale($white, $lightness: -12%) 70%,
-			color.scale($white, $lightness: -2%) 70%
+			color.adjust($white, $lightness: -2%) 33%,
+			color.adjust($white, $lightness: -12%) 33%,
+			color.adjust($white, $lightness: -12%) 70%,
+			color.adjust($white, $lightness: -2%) 70%
 		);
 		/* stylelint-enable */
 	}

--- a/packages/components/src/notice/style.scss
+++ b/packages/components/src/notice/style.scss
@@ -19,17 +19,17 @@
 
 	&.is-success {
 		border-left-color: $alert-green;
-		background-color: color.scale($alert-green, $lightness: +45%);
+		background-color: color.adjust($alert-green, $lightness: +45%);
 	}
 
 	&.is-warning {
 		border-left-color: $alert-yellow;
-		background-color: color.scale($alert-yellow, $lightness: +35%);
+		background-color: color.adjust($alert-yellow, $lightness: +35%);
 	}
 
 	&.is-error {
 		border-left-color: $alert-red;
-		background-color: color.scale($alert-red, $lightness: +35%);
+		background-color: color.adjust($alert-red, $lightness: +35%);
 	}
 }
 


### PR DESCRIPTION
Follow-up to #72242

## What?

Changes the color functions changed in #72242 from `color.scale()` to `color.adjust()`.

## Why?

The [equivalent](https://sass-lang.com/documentation/modules/color/#lighten) of the Sass `lighten()` function is `color.adjust()`. We should maintain the previous colors, at least for the time being, to ensure consistency within the project.

## Testing Instructions

On a commit before the changes in #72242, check the affected colors in the built CSS file (`packages/components/build-style/style.css`). On this PR branch, check that the affected colors in the built CSS file are the same. (They are now expressed in `rgb()` style now, but should be the equivalent of the original hex colors.)
