### PR TITLE
Build v2: Fix scss watching

### DIFF
--- a/bin/packages/build-v2.mjs
+++ b/bin/packages/build-v2.mjs
@@ -745,7 +745,7 @@ function isV2SourceFile( filename ) {
 		path.relative( process.cwd(), filename )
 	);
 
-	if ( ! /\/src\/.+\.(js|ts|tsx)$/.test( relativePath ) ) {
+	if ( ! /\/src\/.+\.(js|ts|tsx|scss)$/.test( relativePath ) ) {
 		return false;
 	}
 
@@ -841,6 +841,7 @@ async function watchMode() {
 				const startTime = Date.now();
 
 				await transpilePackage( packageName );
+				await compileStyles( packageName );
 				await bundlePackage( packageName );
 
 				const buildTime = Date.now() - startTime;

--- a/bin/packages/build-v2.mjs
+++ b/bin/packages/build-v2.mjs
@@ -841,7 +841,6 @@ async function watchMode() {
 				const startTime = Date.now();
 
 				await transpilePackage( packageName );
-				await compileStyles( packageName );
 				await bundlePackage( packageName );
 
 				const buildTime = Date.now() - startTime;


### PR DESCRIPTION
Follow-up to #72242

## What?

Makes sure that `.scss` file changes are watched as expected in dev mode.

## Why?

When running `npm run dev`, the CSS build wasn't retriggered after changes to stylesheets.

## Testing Instructions

1. `npm run dev`
2. Make a change to a scss file in the components package.
3. See that the change is reflected in `packages/components/build-style/style.css`.

This doesn't work on trunk, but should be fixed in this PR branch.

Also fixes the issue for `npm run storybook:dev`.
