### PR TITLE
Feature/word wrap toggle 39421

### DIFF
--- a/packages/block-library/src/code/edit.js
+++ b/packages/block-library/src/code/edit.js
@@ -4,6 +4,12 @@
 import { __ } from '@wordpress/i18n';
 import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { CodeCopyButton } from '@wordpress/components';
 
 export default function CodeEdit( {
 	attributes,
@@ -12,24 +18,51 @@ export default function CodeEdit( {
 	insertBlocksAfter,
 	mergeBlocks,
 } ) {
-	const blockProps = useBlockProps();
+	const [ isWordWrapped, setIsWordWrapped ] = useState( false );
+	const blockProps = useBlockProps( {
+		style: {
+			position: 'relative',
+		},
+	} );
+
+	const preStyle = {
+		whiteSpace: isWordWrapped ? 'pre-wrap' : 'pre',
+		overflowX: isWordWrapped ? 'visible' : 'auto',
+	};
+
 	return (
-		<pre { ...blockProps }>
-			<RichText
-				tagName="code"
-				identifier="content"
-				value={ attributes.content }
-				onChange={ ( content ) => setAttributes( { content } ) }
-				onRemove={ onRemove }
-				onMerge={ mergeBlocks }
-				placeholder={ __( 'Write code…' ) }
-				aria-label={ __( 'Code' ) }
-				preserveWhiteSpace
-				__unstablePastePlainText
-				__unstableOnSplitAtDoubleLineEnd={ () =>
-					insertBlocksAfter( createBlock( getDefaultBlockName() ) )
-				}
-			/>
-		</pre>
+		<div { ...blockProps }>
+			<div
+				style={ {
+					position: 'absolute',
+					top: '8px',
+					right: '8px',
+					zIndex: 1,
+				} }
+			>
+				<CodeCopyButton
+					text={ attributes.content || '' }
+					onWordWrapToggle={ setIsWordWrapped }
+					isWordWrapped={ isWordWrapped }
+				/>
+			</div>
+			<pre style={ preStyle }>
+				<RichText
+					tagName="code"
+					identifier="content"
+					value={ attributes.content }
+					onChange={ ( content ) => setAttributes( { content } ) }
+					onRemove={ onRemove }
+					onMerge={ mergeBlocks }
+					placeholder={ __( 'Write code…' ) }
+					aria-label={ __( 'Code' ) }
+					preserveWhiteSpace
+					__unstablePastePlainText
+					__unstableOnSplitAtDoubleLineEnd={ () =>
+						insertBlocksAfter( createBlock( getDefaultBlockName() ) )
+					}
+				/>
+			</pre>
+		</div>
 	);
 }

--- a/packages/components/src/code-copy-button/index.tsx
+++ b/packages/components/src/code-copy-button/index.tsx
@@ -1,0 +1,85 @@
+/**
+ * WordPress dependencies
+ */
+import { useCopyToClipboard } from '@wordpress/compose';
+import { useState, useEffect, useRef } from '@wordpress/element';
+import { copy, check, textWrap } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '../button';
+import Tooltip from '../tooltip';
+
+interface CodeCopyButtonProps {
+	text: string;
+	onWordWrapToggle?: ( isWrapped: boolean ) => void;
+	isWordWrapped?: boolean;
+}
+
+export const CodeCopyButton = ( {
+	text,
+	onWordWrapToggle,
+	isWordWrapped = false,
+}: CodeCopyButtonProps ) => {
+	const [ isCopied, setIsCopied ] = useState( false );
+	const copyTimerRef = useRef< ReturnType< typeof setTimeout > >();
+
+	const copyRef = useCopyToClipboard(
+		text,
+		() => {
+			if ( copyTimerRef.current ) {
+				clearTimeout( copyTimerRef.current );
+			}
+			setIsCopied( true );
+			copyTimerRef.current = setTimeout( () => {
+				setIsCopied( false );
+				copyTimerRef.current = undefined;
+			}, 3000 );
+		}
+	);
+
+	useEffect( () => {
+		return () => {
+			if ( copyTimerRef.current ) {
+				clearTimeout( copyTimerRef.current );
+			}
+		};
+	}, [] );
+
+	const handleWordWrapToggle = () => {
+		if ( onWordWrapToggle ) {
+			onWordWrapToggle( ! isWordWrapped );
+		}
+	};
+
+	const copyLabel = isCopied ? __( 'Copied!' ) : __( 'Copy' );
+	const wrapLabel = isWordWrapped ? __( 'Unwrap text' ) : __( 'Wrap text' );
+
+	return (
+		<div style={ { display: 'flex', gap: '4px' } }>
+			{ onWordWrapToggle && (
+				<Tooltip delay={ 0 } hideOnClick={ false } text={ wrapLabel }>
+					<Button
+						size="compact"
+						aria-label={ wrapLabel }
+						onClick={ handleWordWrapToggle }
+						icon={ textWrap }
+						showTooltip={ false }
+						variant={ isWordWrapped ? 'primary' : 'secondary' }
+					/>
+				</Tooltip>
+			) }
+			<Tooltip delay={ 0 } hideOnClick={ false } text={ copyLabel }>
+				<Button
+					size="compact"
+					aria-label={ copyLabel }
+					ref={ copyRef }
+					icon={ isCopied ? check : copy }
+					showTooltip={ false }
+				/>
+			</Tooltip>
+		</div>
+	);
+};

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -59,6 +59,7 @@ export {
 } from './card';
 export { default as CheckboxControl } from './checkbox-control';
 export { default as ClipboardButton } from './clipboard-button';
+export { CodeCopyButton } from './code-copy-button';
 export { default as __experimentalPaletteEdit } from './palette-edit';
 export { default as ColorIndicator } from './color-indicator';
 export { default as ColorPalette } from './color-palette';

--- a/packages/icons/src/library/text-wrap.svg
+++ b/packages/icons/src/library/text-wrap.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+	<path d="M4 7h16v1.5H4V7zm0 4.5h16v1.5H4v-1.5zM4 16h10v1.5H4V16zm14.5 1.5V16H20v1.5h-1.5zm0-3V13H20v1.5h-1.5z"/>
+	<path d="m16.5 18.5-2-2 2-2v1.25h3v1.5h-3v1.25z"/>
+</svg>


### PR DESCRIPTION
## What?
Adds a word wrap toggle icon next to the copy icon in code block sections to improve readability of long commands.

## Why?
- Long commands in code blocks require horizontal scrolling on smaller screens
- Difficult to read and copy commands efficiently
- Enhances accessibility and user experience

## How?
- Added `text-wrap.svg` icon to WordPress icons library
- Created `CodeCopyButton` component combining copy + word wrap toggle functionality
- Integrated into code block editor with toggle between `pre` and `pre-wrap` modes
- Positioned buttons in top-right corner of code blocks

## Testing
- [ ] Code block displays copy and wrap toggle buttons
- [ ] Word wrap toggle switches between wrapped/unwrapped view
- [ ] Copy functionality works correctly
- [ ] Buttons are accessible via keyboard navigation
- [ ] Works on mobile/smaller screens

Closes #39421
