### PR TITLE
ENHANCEMENT OF SUMMARY BLOCK

### DIFF
--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -1,81 +1,93 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 3,
-	"name": "core/paragraph",
-	"title": "Paragraph",
-	"category": "text",
-	"description": "Start with the basic building block of all narrative.",
-	"keywords": [ "text" ],
-	"textdomain": "default",
-	"attributes": {
-		"align": {
-			"type": "string"
-		},
-		"content": {
-			"type": "rich-text",
-			"source": "rich-text",
-			"selector": "p",
-			"role": "content"
-		},
-		"dropCap": {
-			"type": "boolean",
-			"default": false
-		},
-		"placeholder": {
-			"type": "string"
-		},
-		"direction": {
-			"type": "string",
-			"enum": [ "ltr", "rtl" ]
-		}
-	},
-	"supports": {
-		"splitting": true,
-		"anchor": true,
-		"className": false,
-		"__experimentalBorder": {
-			"color": true,
-			"radius": true,
-			"style": true,
-			"width": true
-		},
-		"color": {
-			"gradients": true,
-			"link": true,
-			"__experimentalDefaultControls": {
-				"background": true,
-				"text": true
-			}
-		},
-		"spacing": {
-			"margin": true,
-			"padding": true,
-			"__experimentalDefaultControls": {
-				"margin": false,
-				"padding": false
-			}
-		},
-		"typography": {
-			"fontSize": true,
-			"lineHeight": true,
-			"__experimentalFontFamily": true,
-			"__experimentalTextDecoration": true,
-			"__experimentalFontStyle": true,
-			"__experimentalFontWeight": true,
-			"__experimentalLetterSpacing": true,
-			"__experimentalTextTransform": true,
-			"__experimentalWritingMode": true,
-			"fitText": true,
-			"__experimentalDefaultControls": {
-				"fontSize": true
-			}
-		},
-		"__experimentalSelector": "p",
-		"__unstablePasteTextInline": true,
-		"interactivity": {
-			"clientNavigation": true
-		}
-	},
-	"editorStyle": "wp-block-paragraph-editor",
-	"style": "wp-block-paragraph"
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 3,
+  "name": "core/details",
+  "title": "Details",
+  "category": "text",
+  "description": "Hide and show additional content.",
+  "keywords": [ "summary", "toggle", "disclosure" ],
+  "textdomain": "default",
+  "attributes": {
+    "showContent": {
+      "type": "boolean",
+      "default": false
+    },
+    "summary": {
+      "type": "rich-text",
+      "source": "rich-text",
+      "selector": "summary",
+      "role": "content"
+    },
+    "name": {
+      "type": "string",
+      "source": "attribute",
+      "attribute": "name",
+      "selector": ".wp-block-details"
+    },
+    "placeholder": {
+      "type": "string"
+    },
+    "summaryLevel": {
+      "type": "string",
+      "default": ""
+    },
+    "summaryId": {
+      "type": "string"
+    },
+    "contentId": {
+      "type": "string"
+    }
+  },
+  "supports": {
+    "__experimentalOnEnter": true,
+    "align": [ "wide", "full" ],
+    "anchor": true,
+    "color": {
+      "gradients": true,
+      "link": true,
+      "__experimentalDefaultControls": {
+        "background": true,
+        "text": true
+      }
+    },
+    "__experimentalBorder": {
+      "color": true,
+      "width": true,
+      "style": true
+    },
+    "html": false,
+    "spacing": {
+      "margin": true,
+      "padding": true,
+      "blockGap": true,
+      "__experimentalDefaultControls": {
+        "margin": false,
+        "padding": false
+      }
+    },
+    "typography": {
+      "fontSize": true,
+      "lineHeight": true,
+      "__experimentalFontFamily": true,
+      "__experimentalFontWeight": true,
+      "__experimentalFontStyle": true,
+      "__experimentalTextTransform": true,
+      "__experimentalTextDecoration": true,
+      "__experimentalLetterSpacing": true,
+      "__experimentalDefaultControls": {
+        "fontSize": true
+      }
+    },
+    "layout": {
+      "allowEditing": false
+    },
+    "interactivity": {
+      "clientNavigation": true
+    },
+    "allowedBlocks": true
+  },
+  "editorStyle": "wp-block-details-editor",
+  "style": "wp-block-details"
 }
+
+

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -1,4 +1,8 @@
 /**
+ * edit.js — Details block editor
+ */
+
+/**
  * External dependencies
  */
 import clsx from 'clsx';
@@ -6,176 +10,121 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { __, _x, isRTL } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
-	ToolbarButton,
-	ToggleControl,
-	__experimentalToolsPanelItem as ToolsPanelItem,
+    PanelBody,
+    SelectControl,
 } from '@wordpress/components';
 import {
-	AlignmentControl,
-	BlockControls,
-	InspectorControls,
-	RichText,
-	useBlockProps,
-	useSettings,
-	useBlockEditingMode,
+    BlockControls,
+    InspectorControls,
+    RichText,
+    useBlockProps,
+    InnerBlocks,
+    useBlockEditingMode,
 } from '@wordpress/block-editor';
-import { getBlockSupport } from '@wordpress/blocks';
-import { formatLtr } from '@wordpress/icons';
+import { useInstanceId } from '@wordpress/compose';
+
 /**
  * Internal dependencies
  */
-import { useOnEnter } from './use-enter';
+import {useOnEnter} from './use-enter';
 
-function ParagraphRTLControl( { direction, setDirection } ) {
-	return (
-		isRTL() && (
-			<ToolbarButton
-				icon={ formatLtr }
-				title={ _x( 'Left to right', 'editor button' ) }
-				isActive={ direction === 'ltr' }
-				onClick={ () => {
-					setDirection( direction === 'ltr' ? undefined : 'ltr' );
-				} }
-			/>
-		)
-	);
-}
+const HEADING_OPTIONS = [
+    { label: __( 'Plain text (no heading)', 'default' ), value: '' },
+    { label: 'H1', value: 'h1' },
+    { label: 'H2', value: 'h2' },
+    { label: 'H3', value: 'h3' },
+    { label: 'H4', value: 'h4' },
+    { label: 'H5', value: 'h5' },
+    { label: 'H6', value: 'h6' },
+];
 
-function hasDropCapDisabled( align ) {
-	return align === ( isRTL() ? 'left' : 'right' ) || align === 'center';
-}
-
-function DropCapControl( { clientId, attributes, setAttributes, name } ) {
-	// Please do not add a useSelect call to the paragraph block unconditionally.
-	// Every useSelect added to a (frequently used) block will degrade load
-	// and type performance. By moving it within InspectorControls, the subscription is
-	// now only added for the selected block(s).
-	const [ isDropCapFeatureEnabled ] = useSettings( 'typography.dropCap' );
-
-	if ( ! isDropCapFeatureEnabled ) {
-		return null;
-	}
-
-	const { align, dropCap } = attributes;
-
-	let helpText;
-	if ( hasDropCapDisabled( align ) ) {
-		helpText = __( 'Not available for aligned text.' );
-	} else if ( dropCap ) {
-		helpText = __( 'Showing large initial letter.' );
-	} else {
-		helpText = __( 'Show a large initial letter.' );
-	}
-
-	const isDropCapControlEnabledByDefault = getBlockSupport(
-		name,
-		'typography.defaultControls.dropCap',
-		false
-	);
-
-	return (
-		<InspectorControls group="typography">
-			<ToolsPanelItem
-				hasValue={ () => !! dropCap }
-				label={ __( 'Drop cap' ) }
-				isShownByDefault={ isDropCapControlEnabledByDefault }
-				onDeselect={ () => setAttributes( { dropCap: false } ) }
-				resetAllFilter={ () => ( { dropCap: false } ) }
-				panelId={ clientId }
-			>
-				<ToggleControl
-					__nextHasNoMarginBottom
-					label={ __( 'Drop cap' ) }
-					checked={ !! dropCap }
-					onChange={ () => setAttributes( { dropCap: ! dropCap } ) }
-					help={ helpText }
-					disabled={ hasDropCapDisabled( align ) }
-				/>
-			</ToolsPanelItem>
-		</InspectorControls>
-	);
-}
-
-function ParagraphBlock( {
-	attributes,
-	mergeBlocks,
-	onReplace,
-	onRemove,
-	setAttributes,
-	clientId,
-	isSelected: isSingleSelected,
-	name,
+function DetailsEdit( {
+    attributes,
+    setAttributes,
+    clientId,
 } ) {
-	const { align, content, direction, dropCap, placeholder } = attributes;
-	const blockProps = useBlockProps( {
-		ref: useOnEnter( { clientId, content } ),
-		className: clsx( {
-			'has-drop-cap': hasDropCapDisabled( align ) ? false : dropCap,
-			[ `has-text-align-${ align }` ]: align,
-		} ),
-		style: { direction },
-	} );
-	const blockEditingMode = useBlockEditingMode();
+    const {
+        summary,
+        summaryLevel,
+        summaryId,
+        contentId,
+        showContent,
+        placeholder,
+    } = attributes;
 
-	return (
-		<>
-			{ blockEditingMode === 'default' && (
-				<BlockControls group="block">
-					<AlignmentControl
-						value={ align }
-						onChange={ ( newAlign ) =>
-							setAttributes( {
-								align: newAlign,
-								dropCap: hasDropCapDisabled( newAlign )
-									? false
-									: dropCap,
-							} )
-						}
-					/>
-					<ParagraphRTLControl
-						direction={ direction }
-						setDirection={ ( newDirection ) =>
-							setAttributes( { direction: newDirection } )
-						}
-					/>
-				</BlockControls>
-			) }
-			{ isSingleSelected && (
-				<DropCapControl
-					name={ name }
-					clientId={ clientId }
-					attributes={ attributes }
-					setAttributes={ setAttributes }
-				/>
-			) }
-			<RichText
-				identifier="content"
-				tagName="p"
-				{ ...blockProps }
-				value={ content }
-				onChange={ ( newContent ) =>
-					setAttributes( { content: newContent } )
-				}
-				onMerge={ mergeBlocks }
-				onReplace={ onReplace }
-				onRemove={ onRemove }
-				aria-label={
-					RichText.isEmpty( content )
-						? __(
-								'Empty block; start writing or type forward slash to choose a block'
-						  )
-						: __( 'Block: Paragraph' )
-				}
-				data-empty={ RichText.isEmpty( content ) }
-				placeholder={ placeholder || __( 'Type / to choose a block' ) }
-				data-custom-placeholder={ placeholder ? true : undefined }
-				__unstableEmbedURLOnPaste
-				__unstableAllowPrefixTransformations
-			/>
-		</>
-	);
+    const blockProps = useBlockProps( {
+        ref: useOnEnter( { clientId, content: summary } ),
+        className: clsx( 'wp-block-details' ),
+    } );
+
+    const blockEditingMode = useBlockEditingMode();
+    const instance = useInstanceId( DetailsEdit, 'details' );
+
+    // Generate stable ids on mount if missing
+    // (no dependency array items to avoid re-run)
+    if ( ( ! summaryId || ! contentId ) && typeof instance !== 'undefined' ) {
+        const base = typeof instance === 'number' ? String( instance ) : String( Date.now() );
+        setAttributes( {
+            summaryId: summaryId || `details-summary-${ base }`,
+            contentId: contentId || `details-content-${ base }`,
+        } );
+    }
+
+    return (
+        <>
+            {blockEditingMode === 'default' && (
+                <BlockControls group="block">
+                    {/* you can add block-level toolbar buttons here if needed */}
+                </BlockControls>
+            )}
+
+            <InspectorControls>
+                <PanelBody title={ __( 'Summary heading settings', 'default' ) } initialOpen>
+                    <SelectControl
+                        label={ __( 'Summary heading level', 'default' ) }
+                        value={ summaryLevel }
+                        options={ HEADING_OPTIONS }
+                        onChange={ ( v ) => setAttributes( { summaryLevel: v } ) }
+                    />
+                    <p style={ { marginTop: 8, color: '#666' } }>
+                        { __( 'Wrap the summary text in a heading (H1–H6) for improved structure and accessibility.', 'default' ) }
+                    </p>
+                </PanelBody>
+            </InspectorControls>
+
+            <div { ...blockProps }>
+                <details open={ !! showContent }>
+                    {/* summary: render chosen heading inside summary for WYSIWYG */}
+                    <summary id={ summaryId } aria-controls={ contentId }>
+                        { summaryLevel ? (
+                            <RichText
+                                identifier="summary"
+                                tagName={ summaryLevel }
+                                className="wp-block-details-summary-heading"
+                                value={ summary }
+                                onChange={ ( value ) => setAttributes( { summary: value } ) }
+                                placeholder={ placeholder || __( 'Summary text…', 'default' ) }
+                            />
+                        ) : (
+                            <RichText
+                                identifier="summary"
+                                tagName="span"
+                                value={ summary }
+                                onChange={ ( value ) => setAttributes( { summary: value } ) }
+                                placeholder={ placeholder || __( 'Summary text…', 'default' ) }
+                            />
+                        ) }
+                    </summary>
+
+                    <div id={ contentId } role="region" aria-labelledby={ summaryId } style={ { paddingLeft: '1rem' } }>
+                        <InnerBlocks />
+                    </div>
+                </details>
+            </div>
+        </>
+    );
 }
 
-export default ParagraphBlock;
+export default DetailsEdit;

--- a/packages/block-library/src/paragraph/save.js
+++ b/packages/block-library/src/paragraph/save.js
@@ -1,4 +1,8 @@
 /**
+ * 
+ */
+
+/**
  * External dependencies
  */
 import clsx from 'clsx';
@@ -6,22 +10,41 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { RichText, useBlockProps } from '@wordpress/block-editor';
-import { isRTL } from '@wordpress/i18n';
+import { RichText, useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { align, content, dropCap, direction } = attributes;
-	const className = clsx( {
-		'has-drop-cap':
-			align === ( isRTL() ? 'left' : 'right' ) || align === 'center'
-				? false
-				: dropCap,
-		[ `has-text-align-${ align }` ]: align,
-	} );
+    const {
+        summary,
+        summaryLevel,
+        summaryId,
+        contentId,
+        showContent,
+    } = attributes;
 
-	return (
-		<p { ...useBlockProps.save( { className, dir: direction } ) }>
-			<RichText.Content value={ content } />
-		</p>
-	);
+     const className = clsx( 'wp-block-details', {
+        'is-open': !! showContent,
+    } );
+
+    const blockProps = useBlockProps.save( { className } );
+
+     const TagName = summaryLevel ? summaryLevel : 'span';
+
+    return (
+        <div { ...blockProps }>
+            <details open={ !! showContent }>
+                <summary id={ summaryId } aria-controls={ contentId }>
+                    <RichText.Content
+                        tagName={ TagName }
+                        className={ summaryLevel ? 'wp-block-details-summary-heading' : undefined }
+                        value={ summary }
+                    />
+                </summary>
+
+                <div id={ contentId } role="region" aria-labelledby={ summaryId }>
+                    <InnerBlocks.Content />
+                </div>
+            </details>
+        </div>
+    );
 }
+

--- a/packages/block-library/src/paragraph/style.scss
+++ b/packages/block-library/src/paragraph/style.scss
@@ -55,3 +55,8 @@ p.has-text-align-right[style*="writing-mode:vertical-rl"],
 p.has-text-align-left[style*="writing-mode:vertical-lr"] {
 	rotate: 180deg;
 }
+.wp-block-details-summary-heading {
+  display: inline;
+  margin: 0;
+  line-height: inherit;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #71942 

Add optional heading-level support for the Details block summary.

This PR introduces:
- a `summaryLevel` attribute (string; `""` or `"h1"`–`"h6"`) that stores the chosen heading level for the `<summary>` text.
- `summaryId` and `contentId` attributes (stable IDs) used for `id` / `aria-labelledby` pairing.
- an Inspector control (select) so authors can pick Plain text / H1–H6 in the block sidebar.
- editor preview rendering that shows the chosen heading tag inside `<summary>` (using `RichText`).
- save output that emits `<summary><hX class="wp-block-details-summary-heading">…</hX></summary>` when a level is selected, and falls back to `<summary><span>…</span></summary>` when not.
- a small CSS helper to keep heading visuals inline inside `<summary>` by default.

Files changed (summary):
- `block.json` — add `summaryLevel`, `summaryId`, `contentId` attributes.
- `edit.js` — Inspector SelectControl, stable id generation, RichText preview using chosen heading tag.
- `save.js` — render chosen heading tag in saved HTML, `aria-controls`, `role="region"`, `aria-labelledby`.
- `editor.css` / `style.css` — `.wp-block-details-summary-heading { display: inline; margin:0; line-height:inherit; }`

## Why?
The `<summary>` content is often used as the visible title for a collapsible section. When authors use it as a semantic heading (section title), screen readers and document outline tools do not treat plain `<summary>` text as a heading, which harms:
- Accessibility: keyboard/assistive-tech users cannot navigate the document by headings.
- Document semantics/structure: authors cannot build a proper outline using Details blocks.
- SEO: meaningful headings contribute to document structure metadata.

Allowing authors to wrap the summary in a real heading element (H1–H6) inside `<summary>` provides semantic structure without breaking existing behavior.

## How?
Implementation details:
- `block.json` adds three attributes:
  - `summaryLevel` (string) — stores the chosen tag (e.g., `"h3"`). Default `""` for plain text.
  - `summaryId`, `contentId` (string) — stable IDs generated in editor for `aria-labelledby` / `aria-controls`.
- `edit.js`:
  - Adds an Inspector `SelectControl` with options: Plain text (no heading), H1–H6.
  - Uses `useInstanceId` (or fallback) to create stable `summaryId` / `contentId` (only generated when missing).
  - Renders `RichText` with `tagName={ summaryLevel }` in preview (or `span` when empty).
  - Keeps `showContent` editor preview via `open={ !! showContent }`.
- `save.js`:
  - When `summaryLevel` is non-empty, outputs `<summary><hX class="wp-block-details-summary-heading">…</hX></summary>`.
  - Otherwise falls back to `<summary><span>…</span></summary>`.
  - Adds `id`, `aria-controls` on `<summary>` and `role="region" aria-labelledby` on the content wrapper.
- CSS:
  - `.wp-block-details-summary-heading` defaults to `display: inline; margin: 0; line-height: inherit;` to avoid forced block breaks inside `<summary>`. Theme authors can override.

Backwards compatibility:
- Existing posts remain unchanged (default `summaryLevel === ""`).
- The change is opt-in: authors must pick a heading level.

## Testing Instructions
1. Open the editor (post or page).
2. Insert a **Details** block.
3. In the block inspector, set the Summary text to `"Module Overview"` (or any text).
4. Change the **Summary heading level** to **H2**.
5. Save / Preview the post.
6. Inspect the frontend DOM:
   - Expect: `<details> <summary id="details-summary-..."> <h2 class="wp-block-details-summary-heading">Module Overview</h2> </summary> <div id="details-content-..." role="region" aria-labelledby="details-summary-..."> ... </div> </details>`
7. Change the inspector back to **Plain text (no heading)**, save, and confirm the frontend output is `<summary><span>…</span></summary>` (no heading tags).
8. Create several Details blocks with differing heading levels (H2, H3, etc.) and confirm the document outline (browser dev tools + screen reader) reflects these headings.


https://github.com/user-attachments/assets/6c2f39ae-1257-4128-810f-755ad0540d89





