### PR TITLE
Notes: Add skip link button to back to block

### DIFF
--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -53,10 +53,7 @@ import TabbedSidebar from './components/tabbed-sidebar';
 import CommentIconSlotFill from './components/collab/block-comment-icon-slot';
 import CommentIconToolbarSlotFill from './components/collab/block-comment-icon-toolbar-slot';
 import HTMLElementControl from './components/html-element-control';
-import {
-	useBlockElement,
-	useBlockElementRef,
-} from './components/block-list/use-block-props/use-block-refs';
+import { useBlockElement } from './components/block-list/use-block-props/use-block-refs';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -109,5 +106,4 @@ lock( privateApis, {
 	mediaEditKey,
 	essentialFormatKey,
 	useBlockElement,
-	useBlockElementRef,
 } );

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -53,7 +53,11 @@ import TabbedSidebar from './components/tabbed-sidebar';
 import CommentIconSlotFill from './components/collab/block-comment-icon-slot';
 import CommentIconToolbarSlotFill from './components/collab/block-comment-icon-toolbar-slot';
 import HTMLElementControl from './components/html-element-control';
-import { useBlockElement } from './components/block-list/use-block-props/use-block-refs';
+import {
+	useBlockElement,
+	useBlockElementRef,
+} from './components/block-list/use-block-props/use-block-refs';
+
 /**
  * Private @wordpress/block-editor APIs.
  */
@@ -105,4 +109,5 @@ lock( privateApis, {
 	mediaEditKey,
 	essentialFormatKey,
 	useBlockElement,
+	useBlockElementRef,
 } );

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -236,7 +236,7 @@ function Thread( {
 			aria-expanded={ isSelected }
 		>
 			<Button
-				className="editor-collab-sidebar-panel__skip-link"
+				className="editor-collab-sidebar-panel__skip-to-comment"
 				variant="secondary"
 				size="compact"
 				onClick={ () => {
@@ -248,17 +248,6 @@ function Thread( {
 				} }
 			>
 				{ __( 'Add new comment' ) }
-			</Button>
-			<Button
-				className="editor-collab-sidebar-panel__skip-link"
-				variant="secondary"
-				size="compact"
-				onClick={ ( event ) => {
-					event.stopPropagation();
-					blockRef.current?.focus();
-				} }
-			>
-				{ __( 'Back to block' ) }
 			</Button>
 			{ ! relatedBlockElement && (
 				<Text as="p" weight={ 500 } variant="muted">
@@ -379,6 +368,17 @@ function Thread( {
 					</VStack>
 				</VStack>
 			) }
+			<Button
+				className="editor-collab-sidebar-panel__skip-to-block"
+				variant="secondary"
+				size="compact"
+				onClick={ ( event ) => {
+					event.stopPropagation();
+					blockRef.current?.focus();
+				} }
+			>
+				{ __( 'Back to block' ) }
+			</Button>
 		</VStack>
 	);
 }

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -69,8 +69,8 @@ export function Comments( {
 			selectedBlockClientId: clientId,
 		};
 	}, [] );
-	const { selectBlock } = useDispatch( blockEditorStore );
 	const [ selectedThread = blockCommentId, setSelectedThread ] = useState();
+	const relatedBlockElement = useBlockElement( selectedBlockClientId );
 
 	const handleDelete = async ( comment ) => {
 		const currentIndex = threads.findIndex( ( t ) => t.id === comment.id );
@@ -90,7 +90,7 @@ export function Comments( {
 			setSelectedThread( null );
 			setShowCommentBoard( false );
 			// Focus the parent block instead of just scrolling into view.
-			selectBlock( selectedBlockClientId );
+			relatedBlockElement?.focus();
 		}
 	};
 

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useState, RawHTML, useEffect } from '@wordpress/element';
+import { useState, RawHTML, useEffect, useRef } from '@wordpress/element';
 import {
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
@@ -35,7 +35,9 @@ import CommentAuthorInfo from './comment-author-info';
 import CommentForm from './comment-form';
 import { getCommentExcerpt, focusCommentThread } from './utils';
 
-const { useBlockElement } = unlock( blockEditorPrivateApis );
+const { useBlockElement, useBlockElementRef } = unlock(
+	blockEditorPrivateApis
+);
 const { Menu } = unlock( componentsPrivateApis );
 
 /**
@@ -144,6 +146,8 @@ function Thread( {
 	const { toggleBlockHighlight, selectBlock, toggleBlockSpotlight } = unlock(
 		useDispatch( blockEditorStore )
 	);
+	const blockRef = useRef();
+	useBlockElementRef( thread.blockClientId, blockRef );
 	const relatedBlockElement = useBlockElement( thread.blockClientId );
 	const debouncedToggleBlockHighlight = useDebounce(
 		toggleBlockHighlight,
@@ -243,7 +247,18 @@ function Thread( {
 					);
 				} }
 			>
-				{ __( 'Add New Comment' ) }
+				{ __( 'Add new comment' ) }
+			</Button>
+			<Button
+				className="editor-collab-sidebar-panel__skip-link"
+				variant="secondary"
+				size="compact"
+				onClick={ ( event ) => {
+					event.stopPropagation();
+					blockRef.current?.focus();
+				} }
+			>
+				{ __( 'Back to block' ) }
 			</Button>
 			{ ! relatedBlockElement && (
 				<Text as="p" weight={ 500 } variant="muted">

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useState, RawHTML, useEffect, useRef } from '@wordpress/element';
+import { useState, RawHTML, useEffect } from '@wordpress/element';
 import {
 	__experimentalText as Text,
 	__experimentalHStack as HStack,
@@ -35,9 +35,7 @@ import CommentAuthorInfo from './comment-author-info';
 import CommentForm from './comment-form';
 import { getCommentExcerpt, focusCommentThread } from './utils';
 
-const { useBlockElement, useBlockElementRef } = unlock(
-	blockEditorPrivateApis
-);
+const { useBlockElement } = unlock( blockEditorPrivateApis );
 const { Menu } = unlock( componentsPrivateApis );
 
 /**
@@ -146,8 +144,6 @@ function Thread( {
 	const { toggleBlockHighlight, selectBlock, toggleBlockSpotlight } = unlock(
 		useDispatch( blockEditorStore )
 	);
-	const blockRef = useRef();
-	useBlockElementRef( thread.blockClientId, blockRef );
 	const relatedBlockElement = useBlockElement( thread.blockClientId );
 	const debouncedToggleBlockHighlight = useDebounce(
 		toggleBlockHighlight,
@@ -374,7 +370,7 @@ function Thread( {
 				size="compact"
 				onClick={ ( event ) => {
 					event.stopPropagation();
-					blockRef.current?.focus();
+					relatedBlockElement?.focus();
 				} }
 			>
 				{ __( 'Back to block' ) }

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -156,11 +156,9 @@
 }
 .editor-collab-sidebar-panel__skip-to-comment:focus {
 	top: $grid-unit-10;
-	right: $grid-unit-10;
 }
 .editor-collab-sidebar-panel__skip-to-block:focus {
 	top: auto;
-	right: $grid-unit-10;
 	bottom: $grid-unit-10;
 }
 

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -137,7 +137,8 @@
 }
 
 // Visually hidden until focused (skip link pattern)
-.editor-collab-sidebar-panel__skip-link {
+.editor-collab-sidebar-panel__skip-to-comment,
+.editor-collab-sidebar-panel__skip-to-block {
 	position: absolute;
 	top: -9999px;
 	right: -9999px;
@@ -147,12 +148,20 @@
 	z-index: -1;
 
 	&:focus {
-		top: $grid-unit-10;
-		right: $grid-unit-10;
 		overflow: visible;
 		clip-path: none;
 		z-index: 1;
+		right: $grid-unit-10;
 	}
+}
+.editor-collab-sidebar-panel__skip-to-comment:focus {
+	top: $grid-unit-10;
+	right: $grid-unit-10;
+}
+.editor-collab-sidebar-panel__skip-to-block:focus {
+	top: auto;
+	right: $grid-unit-10;
+	bottom: $grid-unit-10;
 }
 
 // Comment avatar indicators.

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -479,11 +479,13 @@ test.describe( 'Block Comments', () => {
 				.getByRole( 'listitem', {
 					name: 'Comment: Test comment',
 				} );
+			const replyButton = thread.getByRole( 'button', {
+				name: 'Reply',
+			} );
 			const backToBlockButton = thread.getByRole( 'button', {
 				name: 'Back to block',
 			} );
-			await thread.focus();
-			await page.keyboard.press( 'Tab' );
+			await replyButton.focus();
 			await page.keyboard.press( 'Tab' );
 
 			await expect( backToBlockButton ).toBeFocused();

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -430,6 +430,72 @@ test.describe( 'Block Comments', () => {
 			await expect( thread ).toHaveAttribute( 'aria-expanded', 'true' );
 			await expect( thread ).toBeFocused();
 		} );
+
+		test( 'should focus comment form after clicking "Add new comment" skip link button', async ( {
+			page,
+			blockCommentUtils,
+		} ) => {
+			await blockCommentUtils.addBlockWithComment( {
+				type: 'core/paragraph',
+				attributes: { content: 'Testing block comments' },
+				comment: 'Test comment',
+			} );
+			const thread = page
+				.getByRole( 'region', {
+					name: 'Editor settings',
+				} )
+				.getByRole( 'listitem', {
+					name: 'Comment: Test comment',
+				} );
+			const addNewCommentButton = thread.getByRole( 'button', {
+				name: 'Add new comment',
+			} );
+			await thread.focus();
+			await page.keyboard.press( 'Tab' );
+
+			await expect( addNewCommentButton ).toBeFocused();
+
+			await page.keyboard.press( 'Enter' );
+
+			await expect(
+				page.getByRole( 'textbox', { name: 'Reply to' } )
+			).toBeFocused();
+		} );
+
+		test( 'should focus block after clicking "Back to block" skip link button', async ( {
+			editor,
+			page,
+			blockCommentUtils,
+		} ) => {
+			await blockCommentUtils.addBlockWithComment( {
+				type: 'core/paragraph',
+				attributes: { content: 'Testing block comments' },
+				comment: 'Test comment',
+			} );
+			const thread = page
+				.getByRole( 'region', {
+					name: 'Editor settings',
+				} )
+				.getByRole( 'listitem', {
+					name: 'Comment: Test comment',
+				} );
+			const backToBlockButton = thread.getByRole( 'button', {
+				name: 'Back to block',
+			} );
+			await thread.focus();
+			await page.keyboard.press( 'Tab' );
+			await page.keyboard.press( 'Tab' );
+
+			await expect( backToBlockButton ).toBeFocused();
+
+			await page.keyboard.press( 'Enter' );
+
+			await expect(
+				editor.canvas.getByRole( 'document', {
+					name: 'Block: Paragraph',
+				} )
+			).toBeFocused();
+		} );
 	} );
 } );
 


### PR DESCRIPTION
Closes #71676

See: https://github.com/WordPress/gutenberg/issues/71676#issuecomment-3335950725

> There's no mechanism to navigate back to the block you commented on.
There should be a link in the comment area where you can return to the selected block. Otherwise, it's going to be very labor intensive for a keyboard user to review comments.

## What?

This PR adds a skip-link button inside a comment thread to go back to the block.

## Why?

Accessibility.

## How?

At first, I thought I could just run selectBlock. However, `selectBlock` doesn't focus a block if it's already focused. Instead, I imitated the implementation of [the `SkipToSelectedBlock` component](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/skip-to-selected-block/index.js#L18).

<img width="286" height="110" alt="image" src="https://github.com/user-attachments/assets/90e006e2-8a6b-4c4d-8c1e-a46a536d2f61" />


That is, I exported the useBlockElementRef as a private API and use it to explicitly move focus.

## Testing Instructions

### Testing Instructions for Keyboard

- Launch your screen reader.
- Move the focus to any of the comment threads.
- Press the `Tab` key twice.
- Confirm that the skip-link button is visible.
- Click the `Enter` key.
- Confirm that the block itself gets focused, and your screen reader announces it.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/9d0f8eea-f5b7-48c4-ac0e-719d907d4b48