### PR TITLE
Terms Query: rename "hierarchical" to "showNested"

### DIFF
--- a/packages/block-library/src/term-template/edit.js
+++ b/packages/block-library/src/term-template/edit.js
@@ -96,7 +96,7 @@ export default function TermTemplateEdit( {
 			order,
 			orderBy,
 			hideEmpty,
-			hierarchical = false,
+			showNested = false,
 			parent = 0,
 			perPage = 10,
 		} = {},
@@ -111,14 +111,14 @@ export default function TermTemplateEdit( {
 		order,
 		orderby: orderBy,
 		// To preview the data the closest to the frontend, we fetch the largest number of terms
-		// and limit them during rendering. This is because WP_Term_Query fetches data in hierarchical manner,
-		// while in editor we build the hierarchy manually. It also allows us to avoid re-fetching data when max terms changes.
+		// and limit them during rendering. This allows us to avoid re-fetching data when max
+		// terms changes.
 		per_page: 100,
 	};
 
 	// Nested terms are returned by default from REST API as long as parent is not set.
 	// If we want to show nested terms, we must not set parent at all.
-	if ( parent || ! hierarchical ) {
+	if ( parent || ! showNested ) {
 		queryArgs.parent = parent || 0;
 	}
 

--- a/packages/block-library/src/term-template/index.php
+++ b/packages/block-library/src/term-template/index.php
@@ -52,7 +52,7 @@ function render_block_core_term_template( $attributes, $content, $block ) {
 		// Get the current term ID from the queried object.
 		$current_term_id      = get_queried_object_id();
 		$query_args['parent'] = $current_term_id;
-	} elseif ( empty( $query['hierarchical'] ) ) {
+	} elseif ( empty( $query['showNested'] ) ) {
 		$query_args['parent'] = 0;
 	}
 

--- a/packages/block-library/src/terms-query/block.json
+++ b/packages/block-library/src/terms-query/block.json
@@ -18,7 +18,7 @@
 				"orderBy": "name",
 				"hideEmpty": true,
 				"parent": false,
-				"hierarchical": false,
+				"showNested": false,
 				"inherit": false
 			}
 		},

--- a/packages/block-library/src/terms-query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/terms-query/edit/inspector-controls/index.js
@@ -35,7 +35,7 @@ export default function TermsQueryInspectorControls( {
 		order,
 		hideEmpty,
 		inherit,
-		hierarchical,
+		showNested,
 		perPage,
 	} = termQuery;
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
@@ -66,8 +66,8 @@ export default function TermsQueryInspectorControls( {
 	const displayInheritControl =
 		isTaxonomyHierarchical && isTaxonomyMatchingTemplate;
 
-	// Only display the hierarchical control if the taxonomy is hierarchical and not inheriting.
-	const displayHierarchicalControl =
+	// Only display the showNested control if the taxonomy is hierarchical and not inheriting.
+	const displayShowNestedControl =
 		isTaxonomyHierarchical && ! termQuery.inherit;
 
 	// Labels shared between ToolsPanelItem and its child control.
@@ -90,7 +90,7 @@ export default function TermsQueryInspectorControls( {
 								order: 'asc',
 								orderBy: 'name',
 								hideEmpty: true,
-								hierarchical: false,
+								showNested: false,
 								parent: false,
 								perPage: 10,
 							},
@@ -161,20 +161,20 @@ export default function TermsQueryInspectorControls( {
 							/>
 						</ToolsPanelItem>
 					) }
-					{ displayHierarchicalControl && (
+					{ displayShowNestedControl && (
 						<ToolsPanelItem
-							hasValue={ () => hierarchical !== false }
+							hasValue={ () => showNested !== false }
 							label={ nestedTermsControlLabel }
 							onDeselect={ () =>
-								setQuery( { hierarchical: false } )
+								setQuery( { showNested: false } )
 							}
 							isShownByDefault
 						>
 							<NestedTermsControl
 								label={ nestedTermsControlLabel }
-								value={ hierarchical }
+								value={ showNested }
 								onChange={ ( value ) =>
-									setQuery( { hierarchical: value } )
+									setQuery( { showNested: value } )
 								}
 							/>
 						</ToolsPanelItem>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Relates to this comment in the main Terms Query block issue: https://github.com/WordPress/gutenberg/issues/49094#issuecomment-3381641181

<!-- In a few words, what is the PR actually doing? -->
Renames the `hierarchical` property of the `termQuery` attribute to `showNested`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The `hierarchical` property is a vestige of when the block was rendering child terms in a nested layout, and the `hierarchical` argument of `WP_Term_Query` means something very specific:

> Whether to include terms that have non-empty descendants (even if $hide_empty is set to true). **Default true**.

This is _not_ what our `hierarchical` argument is doing, and furthermore the REST API does not support a `hierarchical` argument.

Instead, this argument is a way to display either all terms regardless of nesting or only the top-level terms.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Renames the property.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Block should work exactly the same as before.