### PR TITLE
Remove the 'no comments available' message 

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -101,19 +101,7 @@ export function Comments( {
 
 	const hasThreads = Array.isArray( threads ) && threads.length > 0;
 	if ( ! hasThreads ) {
-		return (
-			<VStack
-				alignment="left"
-				className="editor-collab-sidebar-panel__thread"
-				justify="flex-start"
-				spacing="2"
-			>
-				{
-					// translators: message displayed when there are no comments available
-					__( 'No comments available' )
-				}
-			</VStack>
-		);
+		return <></>;
 	}
 
 	return threads.map( ( thread ) => (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of https://github.com/WordPress/gutenberg/issues/72157

Before
<img width="198" height="184" alt="before1" src="https://github.com/user-attachments/assets/7e3fb420-2cc0-45e3-8f55-d4026ad909ef" />


After
<img width="190" height="168" alt="after1" src="https://github.com/user-attachments/assets/37ac59ef-e387-46e5-96a3-1a3ba6c8a01d" />

