### PR TITLE
Notes: Add privacy info text

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -14,11 +14,12 @@ import {
 	__experimentalConfirmDialog as ConfirmDialog,
 	Button,
 	FlexItem,
+	Icon,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useDebounce } from '@wordpress/compose';
 
-import { published, moreVertical } from '@wordpress/icons';
+import { published, moreVertical, seen } from '@wordpress/icons';
 import { __, _x, sprintf, _n } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
@@ -108,6 +109,7 @@ export function Comments( {
 				justify="flex-start"
 				spacing="2"
 			>
+				<PrivacyInfoText />
 				{
 					// translators: message displayed when there are no comments available
 					__( 'No comments available' )
@@ -116,19 +118,24 @@ export function Comments( {
 		);
 	}
 
-	return threads.map( ( thread ) => (
-		<Thread
-			key={ thread.id }
-			thread={ thread }
-			onAddReply={ onAddReply }
-			onCommentDelete={ handleDelete }
-			onEditComment={ onEditComment }
-			isSelected={ selectedThread === thread.id }
-			setSelectedThread={ setSelectedThread }
-			setShowCommentBoard={ setShowCommentBoard }
-			commentSidebarRef={ commentSidebarRef }
-		/>
-	) );
+	return (
+		<VStack spacing="3">
+			<PrivacyInfoText />
+			{ threads.map( ( thread ) => (
+				<Thread
+					key={ thread.id }
+					thread={ thread }
+					onAddReply={ onAddReply }
+					onCommentDelete={ handleDelete }
+					onEditComment={ onEditComment }
+					isSelected={ selectedThread === thread.id }
+					setSelectedThread={ setSelectedThread }
+					setShowCommentBoard={ setShowCommentBoard }
+					commentSidebarRef={ commentSidebarRef }
+				/>
+			) ) }
+		</VStack>
+	);
 }
 
 function Thread( {
@@ -521,3 +528,23 @@ const CommentBoard = ( { thread, parent, isExpanded, onEdit, onDelete } ) => {
 		</>
 	);
 };
+
+/**
+ * Privacy info text component that displays information about notes visibility.
+ *
+ * @return {React.ReactNode} The rendered PrivacyInfoText component.
+ */
+function PrivacyInfoText() {
+	return (
+		<HStack
+			alignment="left"
+			spacing="2"
+			className="editor-collab-sidebar-panel__privacy-info"
+		>
+			<Icon icon={ seen } size={ 26 } />
+			<Text as="span" variant="muted" size="small">
+				{ __( 'Only logged in users can see Notes' ) }
+			</Text>
+		</HStack>
+	);
+}

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -14,12 +14,11 @@ import {
 	__experimentalConfirmDialog as ConfirmDialog,
 	Button,
 	FlexItem,
-	Icon,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useDebounce } from '@wordpress/compose';
 
-import { published, moreVertical, seen } from '@wordpress/icons';
+import { published, moreVertical } from '@wordpress/icons';
 import { __, _x, sprintf, _n } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
@@ -109,7 +108,7 @@ export function Comments( {
 				justify="flex-start"
 				spacing="2"
 			>
-				<PrivacyInfoText />
+				<Text>{ __( 'Only logged in users can see Notes' ) }</Text>
 				{
 					// translators: message displayed when there are no comments available
 					__( 'No comments available' )
@@ -120,7 +119,7 @@ export function Comments( {
 
 	return (
 		<VStack spacing="3">
-			<PrivacyInfoText />
+			<Text>{ __( 'Only logged in users can see Notes' ) }</Text>
 			{ threads.map( ( thread ) => (
 				<Thread
 					key={ thread.id }
@@ -528,23 +527,3 @@ const CommentBoard = ( { thread, parent, isExpanded, onEdit, onDelete } ) => {
 		</>
 	);
 };
-
-/**
- * Privacy info text component that displays information about notes visibility.
- *
- * @return {React.ReactNode} The rendered PrivacyInfoText component.
- */
-function PrivacyInfoText() {
-	return (
-		<HStack
-			alignment="left"
-			spacing="2"
-			className="editor-collab-sidebar-panel__privacy-info"
-		>
-			<Icon icon={ seen } size={ 26 } />
-			<Text as="span" variant="muted" size="small">
-				{ __( 'Only logged in users can see Notes' ) }
-			</Text>
-		</HStack>
-	);
-}

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -108,7 +108,6 @@ export function Comments( {
 				justify="flex-start"
 				spacing="2"
 			>
-				<Text>{ __( 'Only logged in users can see Notes' ) }</Text>
 				{
 					// translators: message displayed when there are no comments available
 					__( 'No comments available' )
@@ -119,7 +118,9 @@ export function Comments( {
 
 	return (
 		<VStack spacing="3">
-			<Text>{ __( 'Only logged in users can see Notes' ) }</Text>
+			<Text as="p" variant="muted">
+				{ __( 'Only logged in users can see Notes' ) }
+			</Text>
 			{ threads.map( ( thread ) => (
 				<Thread
 					key={ thread.id }

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -15,6 +15,15 @@
 	height: 100%;
 }
 
+.editor-collab-sidebar-panel__privacy-info {
+	text-wrap: pretty;
+
+	.components-icon {
+		color: $gray-600;
+		flex-shrink: 0;
+	}
+}
+
 .editor-collab-sidebar-panel__thread {
 	position: relative;
 	padding: $grid-unit-20;

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -15,15 +15,6 @@
 	height: 100%;
 }
 
-.editor-collab-sidebar-panel__privacy-info {
-	text-wrap: pretty;
-
-	.components-icon {
-		color: $gray-600;
-		flex-shrink: 0;
-	}
-}
-
 .editor-collab-sidebar-panel__thread {
 	position: relative;
 	padding: $grid-unit-20;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #72077

<!-- In a few words, what is the PR actually doing? -->
Adds a privacy info text to the block comments sidebar to clarify that comments are only visible to logged-in users.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Block comments are internal only and never front-end facing, but this isn't clear to editors who might not understand who can see their comments. This creates confusion about the visibility scope of comments and could lead to inappropriate content being added to comments.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Added a simple privacy info text that displays "Only logged in users can see Notes" at the top of the comments list
- Used the WordPress `Text` component directly with `variant="muted"` for appropriate styling

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page in the WordPress editor
2. Select any block
3. Open the Comments sidebar (either via the sidebar panel or the floating sidebar)
4. Verify that the privacy info text appears at the top with a visibility icon
5. Check that the text reads "Only logged in users can see Notes"



## Screenshots or screencast <!-- if applicable -->

<img width="302" height="498" alt="image" src="https://github.com/user-attachments/assets/2d28b978-6077-4f5f-b022-da1936125247" />

