### PR TITLE
Perf: Avoid busting the memo cache for `useDebounce` options

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -43,6 +43,9 @@ export const IntersectionObserver = createContext();
 IntersectionObserver.displayName = 'IntersectionObserverContext';
 
 const pendingBlockVisibilityUpdatesPerRegistry = new WeakMap();
+const delayedBlockVisibilityDebounceOptions = {
+	trailing: true,
+};
 
 function Root( { className, ...settings } ) {
 	const { isOutlineMode, isFocusMode, temporarilyEditingAsBlocks } =
@@ -74,9 +77,7 @@ function Root( { className, ...settings } ) {
 			setBlockVisibility( updates );
 		}, [ registry ] ),
 		300,
-		{
-			trailing: true,
-		}
+		delayedBlockVisibilityDebounceOptions
 	);
 	const intersectionObserver = useMemo( () => {
 		const { IntersectionObserver: Observer } = window;

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -43,9 +43,6 @@ export const IntersectionObserver = createContext();
 IntersectionObserver.displayName = 'IntersectionObserverContext';
 
 const pendingBlockVisibilityUpdatesPerRegistry = new WeakMap();
-const blockVisibilityDebounceOptions = {
-	trailing: true,
-};
 
 function Root( { className, ...settings } ) {
 	const { isOutlineMode, isFocusMode, temporarilyEditingAsBlocks } =
@@ -77,7 +74,9 @@ function Root( { className, ...settings } ) {
 			setBlockVisibility( updates );
 		}, [ registry ] ),
 		300,
-		blockVisibilityDebounceOptions
+		{
+			trailing: true,
+		}
 	);
 	const intersectionObserver = useMemo( () => {
 		const { IntersectionObserver: Observer } = window;

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -43,6 +43,9 @@ export const IntersectionObserver = createContext();
 IntersectionObserver.displayName = 'IntersectionObserverContext';
 
 const pendingBlockVisibilityUpdatesPerRegistry = new WeakMap();
+const blockVisibilityDebounceOptions = {
+	trailing: true,
+};
 
 function Root( { className, ...settings } ) {
 	const { isOutlineMode, isFocusMode, temporarilyEditingAsBlocks } =
@@ -74,9 +77,7 @@ function Root( { className, ...settings } ) {
 			setBlockVisibility( updates );
 		}, [ registry ] ),
 		300,
-		{
-			trailing: true,
-		}
+		blockVisibilityDebounceOptions
 	);
 	const intersectionObserver = useMemo( () => {
 		const { IntersectionObserver: Observer } = window;

--- a/packages/compose/src/hooks/use-debounce/index.js
+++ b/packages/compose/src/hooks/use-debounce/index.js
@@ -31,7 +31,7 @@ import { debounce } from '../../utils/debounce';
 export default function useDebounce( fn, wait, options ) {
 	const debounced = useMemoOne(
 		() => debounce( fn, wait ?? 0, options ),
-		[ fn, wait, options ]
+		[ fn, wait, options?.leading, options?.trailing, options?.maxWait ]
 	);
 	useEffect( () => () => debounced.cancel(), [ debounced ] );
 	return debounced;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Not sure if this PR will make a whole load of difference, but I noticed while editing some nearby code that the `useDebounce` for `delayedBlockVisibilityUpdates` will create a new cache entry on every render because the `options` are passed as a new object reference on every render:
https://github.com/WordPress/gutenberg/blob/c5024f11ade160b8f760d328b799a9b89e5b0618/packages/block-editor/src/components/block-list/index.js#L66-L80

In the `useDebounce` implementation `options` is passed straight into the dependency array:
https://github.com/WordPress/gutenberg/blob/c5024f11ade160b8f760d328b799a9b89e5b0618/packages/compose/src/hooks/use-debounce/index.js#L31-L38

I expect this is not optimal for `useMemoOne` (vs. `useMemo`) as it never forgets cached values, so the cache will get incrementally bigger. At least that's my understanding, I only read the README on the repo (https://github.com/alexreardon/use-memo-one).

In this PR I'm resolving that issue. Initially I thought I'd do that by fixing `delayedBlockVisibilityUpdates` so that it passes a stable options value, but I think it might be better to instead fix `useDebounce` at its core. If we pass each of the options in the dependency array that should ensure stable dependencies, as they're all of primitive types.

## Testing Instructions
To test this, I added some logging in `useDebounce` to see how often it was re-creating the memoization function. It's a bit tricky to do so as `useDebounce` is used all over the place. To limit to just the `delayedBlockVisibilityUpdates` usage, I passed a `name` in the options, and this is what I logged that out (the name can also be added to the dependencies).

I then loaded up the demo post and clicked around on various blocks and observed the console.

In this PR the debounce function is only created once when the editor first loads (it might show up twice in debug mode). In trunk the debounce function is created more times, but not a massive number - it might happen more regularly for certain actions that cause `BlockList` to re-render, or when more blocks lists are in a post.