### PR TITLE
Build V2: Fix emotion transpiling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -94,6 +94,7 @@
 				"deep-freeze": "0.0.1",
 				"equivalent-key-map": "0.2.2",
 				"esbuild": "0.25.10",
+				"esbuild-plugin-babel": "0.2.3",
 				"esbuild-sass-plugin": "3.3.1",
 				"escape-html": "1.0.3",
 				"eslint-import-resolver-node": "0.3.4",
@@ -24286,6 +24287,16 @@
 				"@esbuild/win32-arm64": "0.25.10",
 				"@esbuild/win32-ia32": "0.25.10",
 				"@esbuild/win32-x64": "0.25.10"
+			}
+		},
+		"node_modules/esbuild-plugin-babel": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/esbuild-plugin-babel/-/esbuild-plugin-babel-0.2.3.tgz",
+			"integrity": "sha512-hGLL31n+GvBhkHUpPCt1sU4ynzOH7I1IUkKhera66jigi4mHFPL6dfJo44L6/1rfcZudXx+wGdf9VOifzDPqYQ==",
+			"dev": true,
+			"license": "ISC",
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
 			}
 		},
 		"node_modules/esbuild-register": {

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
 		"deep-freeze": "0.0.1",
 		"equivalent-key-map": "0.2.2",
 		"esbuild": "0.25.10",
+		"esbuild-plugin-babel": "0.2.3",
 		"esbuild-sass-plugin": "3.3.1",
 		"escape-html": "1.0.3",
 		"eslint-import-resolver-node": "0.3.4",


### PR DESCRIPTION
## What?

Related https://github.com/WordPress/gutenberg/issues/72032
Fix small regression. See https://github.com/WordPress/gutenberg/pull/72242#issuecomment-3393249581

Our use of emotion in the components package require a special babel plugin to transform the `emotion.css` usage properly. Unfortunately, no equivalent esbuild plugin exists so this forces us to use babel in esbuild pipeline which makes things slower. For the moment, I added an exception for the components package to do that. Ideally, we should find a way to move away from motion in the components package or some other solution long term.
 
## Testing Instructions

- Open the editor
- Check that the border control looks properly (and not like the screenshot on the link above).