### PR TITLE
Remove redundant max percentage from download progress

### DIFF
--- a/packages/env/lib/download-sources.js
+++ b/packages/env/lib/download-sources.js
@@ -37,7 +37,7 @@ module.exports = function downloadSources( config, spinner ) {
 			Object.entries( progresses )
 				.map(
 					( [ key, value ] ) =>
-						`  - ${ key }: ${ ( value * 100 ).toFixed( 0 ) }/100%`
+						`  - ${ key }: ${ ( value * 100 ).toFixed( 0 ) }%`
 				)
 				.join( '\n' );
 	};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #72281 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is a minor issue and functionality is in no way affected. When wp-env is downloading sources, it displays output such as "Downloading WordPress - 50/100%", and the 100 is redundant since 100% is an implied maximum, and "50%" means the same thing and is clearer and more concise.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removing the `/100` from `download-sources.js` is all that is needed to resolve this issue.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

`wp-env start` will display the plain percentage during downloading.
