### PR TITLE
Fix ColorPalette to respect clearable property when deselecting colors

### DIFF
--- a/packages/components/src/color-palette/index.tsx
+++ b/packages/components/src/color-palette/index.tsx
@@ -193,7 +193,10 @@ function UnforwardedColorPalette(
 	} = props;
 	const [ normalizedColorValue, setNormalizedColorValue ] = useState( value );
 
-	const clearColor = useCallback( () => onChange( undefined ), [ onChange ] );
+	const clearColor = useCallback(
+		() => clearable && onChange( undefined ),
+		[ clearable, onChange ]
+	);
 
 	const customColorPaletteCallbackRef = useCallback(
 		( node: HTMLElement | null ) => {


### PR DESCRIPTION
### What?
Closes #71725

Fixes the behavior of the ColorPalette component when clearable={false}. Previously, deselecting a color would still trigger the clearColor function even when clearing was disabled.

### Why?
The clearable property is intended to prevent a user from clearing a selected color. Without this fix, the behavior was inconsistent and did not respect the clearable setting.

See #71725 for more details.

### How?

Updated the clearColor function to check the clearable value before clearing a color.

Ensured that clearing a color is only possible when clearable is set to true.

### Testing

Setting clearable={false} now prevents deselecting a color.

Setting clearable={true} still allows clearing the selected color.

Existing usages of ColorPalette with clearable={true} or default behavior continue to work without issues.