### PR TITLE
Terms Query: Add `include` specific terms support

### DIFF
--- a/packages/block-library/src/term-template/edit.js
+++ b/packages/block-library/src/term-template/edit.js
@@ -80,8 +80,8 @@ export default function TermTemplateEdit( {
 			orderBy,
 			hideEmpty,
 			showNested = false,
-			parent = 0,
 			perPage,
+			include,
 		} = {},
 	},
 	__unstableLayoutClassNames,
@@ -98,8 +98,15 @@ export default function TermTemplateEdit( {
 
 	// Nested terms are returned by default from REST API as long as parent is not set.
 	// If we want to show nested terms, we must not set parent at all.
-	if ( parent || ! showNested ) {
-		queryArgs.parent = parent || 0;
+	if ( ! showNested && ! include?.length ) {
+		queryArgs.parent = 0;
+	}
+
+	if ( include?.length ) {
+		queryArgs.include = include;
+		// If we are using `include` update the `order` and `orderby` arguments to preserve the order.
+		queryArgs.orderby = 'include';
+		queryArgs.order = 'asc';
 	}
 
 	const { records: terms } = useEntityRecords(

--- a/packages/block-library/src/terms-query/block.json
+++ b/packages/block-library/src/terms-query/block.json
@@ -16,8 +16,8 @@
 				"taxonomy": "category",
 				"order": "asc",
 				"orderBy": "name",
+				"include": [],
 				"hideEmpty": true,
-				"parent": false,
 				"showNested": false,
 				"inherit": false
 			}

--- a/packages/block-library/src/terms-query/edit/inspector-controls/include-control.js
+++ b/packages/block-library/src/terms-query/edit/inspector-controls/include-control.js
@@ -1,0 +1,147 @@
+/**
+ * WordPress dependencies
+ */
+import { FormTokenField } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { useState, useEffect, useMemo } from '@wordpress/element';
+import { useDebounce } from '@wordpress/compose';
+
+const EMPTY_ARRAY = [];
+const BASE_QUERY = {
+	order: 'asc',
+	_fields: 'id,name',
+	context: 'view',
+};
+
+export default function IncludeControl( {
+	value: include,
+	taxonomy,
+	onChange,
+	...props
+} ) {
+	const [ search, setSearch ] = useState( '' );
+	const [ value, setValue ] = useState( EMPTY_ARRAY );
+	const [ suggestions, setSuggestions ] = useState( EMPTY_ARRAY );
+	const debouncedSearch = useDebounce( setSearch, 250 );
+
+	const { searchResults, searchHasResolved } = useSelect(
+		( select ) => {
+			if ( ! search ) {
+				return { searchResults: EMPTY_ARRAY, searchHasResolved: true };
+			}
+			const { getEntityRecords, hasFinishedResolution } =
+				select( coreStore );
+			const selectorArgs = [
+				'taxonomy',
+				taxonomy,
+				{
+					...BASE_QUERY,
+					search,
+					orderby: 'name',
+					exclude: include,
+					per_page: 20,
+				},
+			];
+			return {
+				searchResults: getEntityRecords( ...selectorArgs ),
+				searchHasResolved: hasFinishedResolution(
+					'getEntityRecords',
+					selectorArgs
+				),
+			};
+		},
+		[ search, taxonomy, include ]
+	);
+
+	const currentTerms = useSelect(
+		( select ) => {
+			if ( ! include?.length ) {
+				return EMPTY_ARRAY;
+			}
+			const { getEntityRecords } = select( coreStore );
+			return getEntityRecords( 'taxonomy', taxonomy, {
+				...BASE_QUERY,
+				include,
+				per_page: include.length,
+			} );
+		},
+		[ include, taxonomy ]
+	);
+
+	// Update the `value` state only after the selectors are resolved
+	// to avoid emptying the input when we're changing terms.
+	useEffect( () => {
+		if ( ! include?.length ) {
+			setValue( EMPTY_ARRAY );
+		}
+		if ( ! currentTerms?.length ) {
+			return;
+		}
+		// Returns only the existing entity ids. This prevents the component
+		// from crashing in the editor, when non existing ids are provided.
+		const sanitizedValue = include.reduce( ( accumulator, id ) => {
+			const entity = currentTerms.find( ( term ) => term.id === id );
+			if ( entity ) {
+				accumulator.push( {
+					id,
+					value: entity.name,
+				} );
+			}
+			return accumulator;
+		}, [] );
+		setValue( sanitizedValue );
+	}, [ include, currentTerms ] );
+
+	const entitiesInfo = useMemo( () => {
+		if ( ! searchResults?.length ) {
+			return { names: EMPTY_ARRAY, mapByName: {} };
+		}
+		const names = [];
+		const mapByName = {};
+		searchResults.forEach( ( result ) => {
+			names.push( result.name );
+			mapByName[ result.name ] = result;
+		} );
+		return { names, mapByName };
+	}, [ searchResults ] );
+
+	// Update suggestions only when the query has resolved.
+	useEffect( () => {
+		if ( ! searchHasResolved ) {
+			return;
+		}
+		setSuggestions( entitiesInfo.names );
+	}, [ entitiesInfo.names, searchHasResolved ] );
+
+	const getIdByValue = ( entitiesMappedByName, entity ) =>
+		entity?.id || entitiesMappedByName?.[ entity ]?.id;
+
+	const onTermChange = ( newValue ) => {
+		const ids = Array.from(
+			newValue.reduce( ( accumulator, entity ) => {
+				// Verify that new values point to existing entities.
+				const id = getIdByValue( entitiesInfo.mapByName, entity );
+				if ( id ) {
+					accumulator.add( id );
+				}
+				return accumulator;
+			}, new Set() )
+		);
+		setSuggestions( EMPTY_ARRAY );
+		onChange( ids );
+	};
+
+	return (
+		<FormTokenField
+			__next40pxDefaultSize
+			value={ value }
+			onInputChange={ debouncedSearch }
+			suggestions={ suggestions }
+			onChange={ onTermChange }
+			__experimentalShowHowTo={ false }
+			__nextHasNoMarginBottom
+			{ ...props }
+		/>
+	);
+}

--- a/packages/block-library/src/terms-query/edit/inspector-controls/include-control.js
+++ b/packages/block-library/src/terms-query/edit/inspector-controls/include-control.js
@@ -6,6 +6,7 @@ import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { useState, useEffect, useMemo } from '@wordpress/element';
 import { useDebounce } from '@wordpress/compose';
+import { decodeEntities } from '@wordpress/html-entities';
 
 const EMPTY_ARRAY = [];
 const BASE_QUERY = {
@@ -85,7 +86,7 @@ export default function IncludeControl( {
 			if ( entity ) {
 				accumulator.push( {
 					id,
-					value: entity.name,
+					value: decodeEntities( entity.name ),
 				} );
 			}
 			return accumulator;
@@ -100,8 +101,9 @@ export default function IncludeControl( {
 		const names = [];
 		const mapByName = {};
 		searchResults.forEach( ( result ) => {
-			names.push( result.name );
-			mapByName[ result.name ] = result;
+			const decodedName = decodeEntities( result.name );
+			names.push( decodedName );
+			mapByName[ decodedName ] = result;
 		} );
 		return { names, mapByName };
 	}, [ searchResults ] );

--- a/packages/block-library/src/terms-query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/terms-query/edit/inspector-controls/index.js
@@ -47,7 +47,7 @@ export default function TermsQueryInspectorControls( {
 	const isTaxonomyHierarchical = taxonomies.find(
 		( _taxonomy ) => _taxonomy.slug === taxonomy
 	)?.hierarchical;
-
+	const inheritQuery = !! inherit;
 	// Display the inherit control when we're in a taxonomy-related
 	// template (category, tag, or custom taxonomy).
 	const displayInheritControl =
@@ -56,10 +56,7 @@ export default function TermsQueryInspectorControls( {
 		templateSlug?.startsWith( 'category-' ) ||
 		templateSlug?.startsWith( 'tag-' );
 	// Only display the showNested control if the taxonomy is hierarchical and not inheriting.
-	const displayShowNestedControl =
-		isTaxonomyHierarchical && ! termQuery.inherit;
-	// Only display the taxonomy control when not inheriting (custom query type).
-	const displayTaxonomyControl = ! termQuery.inherit;
+	const displayShowNestedControl = isTaxonomyHierarchical && ! inheritQuery;
 	const hasIncludeFilter = !! include?.length;
 
 	// Labels shared between ToolsPanelItem and its child control.
@@ -69,7 +66,7 @@ export default function TermsQueryInspectorControls( {
 	const emptyTermsControlLabel = __( 'Show empty terms' );
 	const nestedTermsControlLabel = __( 'Show nested terms' );
 	const maxTermsControlLabel = __( 'Max terms' );
-	const includeControlLabel = __( 'Include terms' );
+	const includeControlLabel = __( 'Selected terms' );
 
 	return (
 		<>
@@ -106,7 +103,7 @@ export default function TermsQueryInspectorControls( {
 							/>
 						</ToolsPanelItem>
 					) }
-					{ displayTaxonomyControl && (
+					{ ! inheritQuery && (
 						<ToolsPanelItem
 							hasValue={ () => taxonomy !== 'category' }
 							label={ taxonomyControlLabel }
@@ -152,27 +149,29 @@ export default function TermsQueryInspectorControls( {
 							}
 						/>
 					</ToolsPanelItem>
-					<ToolsPanelItem
-						hasValue={ () => !! include?.length }
-						label={ includeControlLabel }
-						onDeselect={ () =>
-							setQuery( {
-								include: [],
-								orderBy: 'name',
-								order: 'asc',
-							} )
-						}
-						isShownByDefault
-					>
-						<IncludeControl
+					{ ! inheritQuery && (
+						<ToolsPanelItem
+							hasValue={ () => !! include?.length }
 							label={ includeControlLabel }
-							taxonomy={ taxonomy }
-							value={ include }
-							onChange={ ( value ) =>
-								setQuery( { include: value } )
+							onDeselect={ () =>
+								setQuery( {
+									include: [],
+									orderBy: 'name',
+									order: 'asc',
+								} )
 							}
-						/>
-					</ToolsPanelItem>
+							isShownByDefault
+						>
+							<IncludeControl
+								label={ includeControlLabel }
+								taxonomy={ taxonomy }
+								value={ include }
+								onChange={ ( value ) =>
+									setQuery( { include: value } )
+								}
+							/>
+						</ToolsPanelItem>
+					) }
 					<ToolsPanelItem
 						hasValue={ () => hideEmpty !== true }
 						label={ emptyTermsControlLabel }

--- a/packages/block-library/src/terms-query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/terms-query/edit/inspector-controls/index.js
@@ -146,7 +146,7 @@ export default function TermsQueryInspectorControls( {
 							help={
 								hasIncludeFilter
 									? __(
-											'When specific terms are included, the order is based on their inclusion order.'
+											'When specific terms are selected, the order is based on their selection order.'
 									  )
 									: undefined
 							}
@@ -206,7 +206,7 @@ export default function TermsQueryInspectorControls( {
 								help={
 									hasIncludeFilter
 										? __(
-												'When specific terms are included strictly display those terms.'
+												'When specific terms are selected, only those are displayed.'
 										  )
 										: undefined
 								}

--- a/packages/block-library/src/terms-query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/terms-query/edit/inspector-controls/index.js
@@ -20,6 +20,7 @@ import NestedTermsControl from './nested-terms-control';
 import InheritControl from './inherit-control';
 import MaxTermsControl from './max-terms-control';
 import AdvancedControls from './advanced-controls';
+import IncludeControl from './include-control';
 
 export default function TermsQueryInspectorControls( {
 	attributes,
@@ -37,6 +38,7 @@ export default function TermsQueryInspectorControls( {
 		inherit,
 		showNested,
 		perPage,
+		include,
 	} = termQuery;
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
@@ -53,13 +55,12 @@ export default function TermsQueryInspectorControls( {
 		templateSlug?.startsWith( 'taxonomy-' ) ||
 		templateSlug?.startsWith( 'category-' ) ||
 		templateSlug?.startsWith( 'tag-' );
-
 	// Only display the showNested control if the taxonomy is hierarchical and not inheriting.
 	const displayShowNestedControl =
 		isTaxonomyHierarchical && ! termQuery.inherit;
-
 	// Only display the taxonomy control when not inheriting (custom query type).
 	const displayTaxonomyControl = ! termQuery.inherit;
+	const hasIncludeFilter = !! include?.length;
 
 	// Labels shared between ToolsPanelItem and its child control.
 	const queryTypeControlLabel = __( 'Query type' );
@@ -68,6 +69,7 @@ export default function TermsQueryInspectorControls( {
 	const emptyTermsControlLabel = __( 'Show empty terms' );
 	const nestedTermsControlLabel = __( 'Show nested terms' );
 	const maxTermsControlLabel = __( 'Max terms' );
+	const includeControlLabel = __( 'Include terms' );
 
 	return (
 		<>
@@ -80,10 +82,10 @@ export default function TermsQueryInspectorControls( {
 								taxonomy: 'category',
 								order: 'asc',
 								orderBy: 'name',
+								include: [],
 								hideEmpty: true,
 								showNested: false,
 								inherit: false,
-								parent: false,
 								perPage: 10,
 							},
 						} );
@@ -117,7 +119,8 @@ export default function TermsQueryInspectorControls( {
 								label={ taxonomyControlLabel }
 								value={ taxonomy }
 								onChange={ ( value ) =>
-									setQuery( { taxonomy: value } )
+									// We also need to reset the include filter when changing taxonomy.
+									setQuery( { taxonomy: value, include: [] } )
 								}
 							/>
 						</ToolsPanelItem>
@@ -139,6 +142,35 @@ export default function TermsQueryInspectorControls( {
 									order: newOrder,
 								} );
 							} }
+							disabled={ hasIncludeFilter }
+							help={
+								hasIncludeFilter
+									? __(
+											'When specific terms are included, the order is based on their inclusion order.'
+									  )
+									: undefined
+							}
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						hasValue={ () => !! include?.length }
+						label={ includeControlLabel }
+						onDeselect={ () =>
+							setQuery( {
+								include: [],
+								orderBy: 'name',
+								order: 'asc',
+							} )
+						}
+						isShownByDefault
+					>
+						<IncludeControl
+							label={ includeControlLabel }
+							taxonomy={ taxonomy }
+							value={ include }
+							onChange={ ( value ) =>
+								setQuery( { include: value } )
+							}
 						/>
 					</ToolsPanelItem>
 					<ToolsPanelItem
@@ -169,6 +201,14 @@ export default function TermsQueryInspectorControls( {
 								value={ showNested }
 								onChange={ ( value ) =>
 									setQuery( { showNested: value } )
+								}
+								disabled={ hasIncludeFilter }
+								help={
+									hasIncludeFilter
+										? __(
+												'When specific terms are included strictly display those terms.'
+										  )
+										: undefined
 								}
 							/>
 						</ToolsPanelItem>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/71443

This PR adds an `include` attribute and handling in `Terms Query` block.

When we include specific terms we disable the `sorting and show nested terms` controls. `Sorting` is because we need to explicitly order by `include` and `show nested terms` because we need to allow users to handpick either top level terms or nested ones. 

I think this makes sense and is easy to reason with.

### Notes
1. I've removed the `parent` attribute from `block.json` because there is no UI to that and we explicitly set a value if needed internally.
2. The `include` control is very similar to Query Loop's one which has undergone iterations and handles cases like validating existence of term ids, debouncing, etc..
3. For now the order of insertion is respected and I believe it's going to be enough for first iteration. It's not great that if we want to reorder items we need to remove and re-enter all values accordingly, but having a better UI/control that supports reordering will definitely need way more time, as I don't think there is any similar control in GB and core.

## Testing Instructions
1. Terms Query block should work as expected in various settings. Just play around with the new `include` control and the combination of existing settings.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/a17226ba-5950-4eae-9b1a-49eddc2643e7

