### PR TITLE
Fix Classic Menu to Navigation Link conversion with entity bindings

### DIFF
--- a/packages/block-library/src/navigation/menu-items-to-blocks.js
+++ b/packages/block-library/src/navigation/menu-items-to-blocks.js
@@ -5,6 +5,26 @@ import { createBlock, parse } from '@wordpress/blocks';
 import { applyFilters } from '@wordpress/hooks';
 
 /**
+ * Builds entity binding configuration for navigation link URLs.
+ * This function generates the structure used to bind navigation link URLs to their entity sources.
+ *
+ * Using a function instead of a constant allows for future enhancements where the binding
+ * might need dynamic data (e.g., entity ID, context-specific arguments).
+ *
+ * @return {Object} Entity binding configuration object
+ */
+function buildNavigationLinkEntityBinding() {
+	return {
+		url: {
+			source: 'core/entity',
+			args: {
+				key: 'url',
+			},
+		},
+	};
+}
+
+/**
  * Convert a flat menu item structure to a nested blocks structure.
  *
  * @param {Object[]} menuItems An array of menu items.
@@ -167,6 +187,9 @@ function menuItemToBlockAttributes(
 		...( object_id &&
 			'custom' !== object && {
 				id: object_id,
+				metadata: {
+					bindings: buildNavigationLinkEntityBinding(),
+				},
 			} ),
 		/* eslint-enable camelcase */
 		...( description?.length && {

--- a/packages/block-library/src/navigation/menu-items-to-blocks.js
+++ b/packages/block-library/src/navigation/menu-items-to-blocks.js
@@ -5,24 +5,9 @@ import { createBlock, parse } from '@wordpress/blocks';
 import { applyFilters } from '@wordpress/hooks';
 
 /**
- * Builds entity binding configuration for navigation link URLs.
- * This function generates the structure used to bind navigation link URLs to their entity sources.
- *
- * Using a function instead of a constant allows for future enhancements where the binding
- * might need dynamic data (e.g., entity ID, context-specific arguments).
- *
- * @return {Object} Entity binding configuration object
+ * Internal dependencies
  */
-function buildNavigationLinkEntityBinding() {
-	return {
-		url: {
-			source: 'core/entity',
-			args: {
-				key: 'url',
-			},
-		},
-	};
-}
+import { buildNavigationLinkEntityBinding } from '../navigation-link/shared/use-entity-binding';
 
 /**
  * Convert a flat menu item structure to a nested blocks structure.
@@ -165,12 +150,14 @@ function menuItemToBlockAttributes(
 		object = 'tag';
 	}
 
+	const inferredKind = menuItemTypeField?.replace( '_', '-' ) || 'custom';
+
 	return {
 		label: menuItemTitleField?.rendered || '',
 		...( object?.length && {
 			type: object,
 		} ),
-		kind: menuItemTypeField?.replace( '_', '-' ) || 'custom',
+		kind: inferredKind,
 		url: url || '',
 		...( xfn?.length &&
 			xfn.join( ' ' ).trim() && {
@@ -185,10 +172,10 @@ function menuItemToBlockAttributes(
 			title: attr_title,
 		} ),
 		...( object_id &&
-			'custom' !== object && {
+			( inferredKind === 'post-type' || inferredKind === 'taxonomy' ) && {
 				id: object_id,
 				metadata: {
-					bindings: buildNavigationLinkEntityBinding(),
+					bindings: buildNavigationLinkEntityBinding( inferredKind ),
 				},
 			} ),
 		/* eslint-enable camelcase */

--- a/packages/block-library/src/navigation/test/menu-items-to-blocks.js
+++ b/packages/block-library/src/navigation/test/menu-items-to-blocks.js
@@ -441,9 +441,9 @@ describe( 'converting menu items to blocks', () => {
 					metadata: {
 						bindings: {
 							url: {
-								source: 'core/entity',
+								source: 'core/post-data',
 								args: {
-									key: 'url',
+									field: 'link',
 								},
 							},
 						},
@@ -459,9 +459,9 @@ describe( 'converting menu items to blocks', () => {
 					metadata: {
 						bindings: {
 							url: {
-								source: 'core/entity',
+								source: 'core/term-data',
 								args: {
-									key: 'url',
+									field: 'link',
 								},
 							},
 						},

--- a/packages/block-library/src/navigation/test/menu-items-to-blocks.js
+++ b/packages/block-library/src/navigation/test/menu-items-to-blocks.js
@@ -371,4 +371,116 @@ describe( 'converting menu items to blocks', () => {
 		const { innerBlocks: actual } = menuItemsToBlocks( [] );
 		expect( actual ).toEqual( [] );
 	} );
+
+	it( 'adds entity bindings for non-custom menu items', () => {
+		const { innerBlocks: actual } = menuItemsToBlocks( [
+			{
+				id: 1,
+				title: {
+					raw: 'Page Item',
+					rendered: 'Page Item',
+				},
+				url: 'http://localhost:8889/page-item/',
+				attr_title: '',
+				description: '',
+				type: 'post_type',
+				type_label: 'Page',
+				object: 'page',
+				object_id: 123,
+				parent: 0,
+				menu_order: 1,
+				target: '',
+				classes: [ '' ],
+				xfn: [ '' ],
+			},
+			{
+				id: 2,
+				title: {
+					raw: 'Category Item',
+					rendered: 'Category Item',
+				},
+				url: 'http://localhost:8889/category/category-item/',
+				attr_title: '',
+				description: '',
+				type: 'taxonomy',
+				type_label: 'Category',
+				object: 'category',
+				object_id: 456,
+				parent: 0,
+				menu_order: 2,
+				target: '',
+				classes: [ '' ],
+				xfn: [ '' ],
+			},
+			{
+				id: 3,
+				title: {
+					raw: 'Custom Item',
+					rendered: 'Custom Item',
+				},
+				url: 'http://localhost:8889/custom-link/',
+				attr_title: '',
+				description: '',
+				type: 'custom',
+				type_label: 'Custom Link',
+				object: 'custom',
+				parent: 0,
+				menu_order: 3,
+				target: '',
+				classes: [ '' ],
+				xfn: [ '' ],
+			},
+		] );
+
+		expect( actual ).toEqual( [
+			expect.objectContaining( {
+				name: 'core/navigation-link',
+				attributes: expect.objectContaining( {
+					label: 'Page Item',
+					id: 123,
+					metadata: {
+						bindings: {
+							url: {
+								source: 'core/entity',
+								args: {
+									key: 'url',
+								},
+							},
+						},
+					},
+				} ),
+				innerBlocks: [],
+			} ),
+			expect.objectContaining( {
+				name: 'core/navigation-link',
+				attributes: expect.objectContaining( {
+					label: 'Category Item',
+					id: 456,
+					metadata: {
+						bindings: {
+							url: {
+								source: 'core/entity',
+								args: {
+									key: 'url',
+								},
+							},
+						},
+					},
+				} ),
+				innerBlocks: [],
+			} ),
+			expect.objectContaining( {
+				name: 'core/navigation-link',
+				attributes: expect.objectContaining( {
+					label: 'Custom Item',
+					// Custom items should NOT have id, metadata, or bindings
+				} ),
+				innerBlocks: [],
+			} ),
+		] );
+
+		// Verify custom item does NOT have bindings
+		expect( actual[ 2 ].attributes ).not.toHaveProperty( 'id' );
+		expect( actual[ 2 ].attributes ).not.toHaveProperty( 'metadata' );
+	} );
 } );

--- a/packages/block-library/src/navigation/test/menu-items-to-blocks.js
+++ b/packages/block-library/src/navigation/test/menu-items-to-blocks.js
@@ -483,4 +483,36 @@ describe( 'converting menu items to blocks', () => {
 		expect( actual[ 2 ].attributes ).not.toHaveProperty( 'id' );
 		expect( actual[ 2 ].attributes ).not.toHaveProperty( 'metadata' );
 	} );
+
+	it( 'does not add bindings for invalid kinds even when object_id is present', () => {
+		const { innerBlocks: actual } = menuItemsToBlocks( [
+			{
+				id: 10,
+				title: {
+					raw: 'Invalid Kind Item',
+					rendered: 'Invalid Kind Item',
+				},
+				url: 'http://localhost:8889/invalid-kind-item/',
+				attr_title: '',
+				description: '',
+				type: 'invalid', // becomes inferred kind 'invalid'
+				type_label: 'Invalid',
+				object: 'page',
+				object_id: 999,
+				parent: 0,
+				menu_order: 1,
+				target: '',
+				classes: [ '' ],
+				xfn: [ '' ],
+			},
+		] );
+
+		expect( actual ).toHaveLength( 1 );
+		expect( actual[ 0 ].name ).toBe( 'core/navigation-link' );
+		// Should not set id or metadata when kind is not supported
+		expect( actual[ 0 ].attributes ).not.toHaveProperty( 'id' );
+		expect( actual[ 0 ].attributes ).not.toHaveProperty( 'metadata' );
+		// Label should still be set correctly
+		expect( actual[ 0 ].attributes.label ).toBe( 'Invalid Kind Item' );
+	} );
 } );


### PR DESCRIPTION

> **Important Note**: This PR copies the `buildNavigationLinkEntityBinding` function implementation from PR #72287 since that PR is not yet merged. When PR #72287 merges, this branch should be rebased to use the shared function from `../navigation-link/shared` instead of the local copy.

## What

Fixes the Classic Menu to Navigation Link conversion to automatically create entity bindings for dynamic URLs, ensuring converted links maintain their connection to the underlying page entities. This addresses the issue where Classic Menu items converted to Navigation Links were missing the required entity bindings for dynamic URL resolution.

## Why

When a Classic Menu is converted to Navigation blocks, the conversion creates Navigation Link blocks but doesn't add the required entity bindings. This means the links don't have dynamic URLs as per #71630, causing them to lose their connection to the underlying page entities.

## How

-   **Added entity binding logic**: Modified `menuItemToBlockAttributes` function to automatically include `metadata.bindings` when converting classic menu items that have entity relationships (`object_id` exists and `object` is not `'custom'`)
-   **Preserved existing behavior**: Custom menu items (external links) continue to work as before without entity bindings since they don't have underlying entities
-   **Reused proven pattern**: Applied the same entity binding structure from PR #72287 to ensure consistency across all conversion processes

## Testing Instructions

### Automated Testing

```bash
# Run the navigation tests
npm run test:unit -- packages/block-library/src/navigation/test/menu-items-to-blocks.js

# Run all navigation-related tests
npm run test:unit -- packages/block-library/src/navigation/
```

### Manual Testing with WP-CLI

1. **Create test content**:

```bash
# Create test pages and posts
npm run wp-env run cli -- wp post create --post_type=page --post_title="Test Page 1" --post_status=publish
npm run wp-env run cli -- wp post create --post_type=page --post_title="Test Page 2" --post_status=publish
npm run wp-env run cli -- wp post create --post_title="Test Post 1" --post_status=publish

# Create test categories and tags
npm run wp-env run cli -- wp term create category "Test Category 1"
npm run wp-env run cli -- wp term create post_tag "Test Tag 1"
```

2. **Create Classic Menu with mixed item types**:

```bash
# Create the menu
npm run wp-env run cli -- wp menu create "Test Classic Menu"

# Add custom link (should NOT get entity bindings)
npm run wp-env run cli -- wp menu item add-custom "Test Classic Menu" "Custom Link" "https://example.com"

# Get page IDs and add them (replace with actual IDs from the list command)
npm run wp-env run cli -- wp post list --post_type=page --field=ID --format=ids
npm run wp-env run cli -- wp menu item add-post "Test Classic Menu" [PAGE_ID_1]
npm run wp-env run cli -- wp menu item add-post "Test Classic Menu" [PAGE_ID_2]

# Get category IDs and add them (replace with actual IDs from the list command)
npm run wp-env run cli -- wp term list category --field=term_id --format=ids
npm run wp-env run cli -- wp menu item add-term "Test Classic Menu" category [CATEGORY_ID]
```

**Note**: Run the list commands first to get the actual IDs, then use those IDs in the add commands.

3. **Convert in Site Editor**:

    - Navigate to Site Editor → Navigation
    - Import from Classic Menu → Select "Test Classic Menu"
    - Convert to Navigation Menu

4. **Verify Entity Bindings**:

    - Open browser developer tools
    - Inspect converted Navigation Link blocks
    - **Expected**: Pages, posts, categories should have `metadata.bindings.url.source: 'core/entity'`
    - **Expected**: Custom links should NOT have `metadata.bindings`

5. **Test Dynamic URL Updates**:
    - Change a page slug via WP-CLI
    - Verify navigation links automatically update to reflect new URLs

### Expected Results

-   ✅ **Entity-linked items** (pages, posts, categories, tags) get entity bindings for dynamic URL resolution
-   ✅ **Custom links** remain unchanged (no bindings) as they don't have entity relationships
-   ✅ **Dynamic URL updates** work correctly when page URLs change
-   ✅ **Backward compatibility** maintained for existing functionality

## Screenshots

The conversion process now ensures that classic menu items maintain their entity relationships, providing the same dynamic URL capabilities as the Page List conversion from PR #72287.

## Related Issues

This addresses the same underlying issue as PR #72287 but for Classic Menu conversions instead of Page List conversions. Both ensure that Navigation Links maintain dynamic URL resolution through entity bindings.

## Notes

-   The condition `object_id && 'custom' !== object` already existed in the code, making this a natural extension
-   All entity types (posts, pages, taxonomies) receive bindings since they all benefit from dynamic URL resolution
