### PR TITLE
Fix: don’t allow unlocking accordion item and panel blocks

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -25,7 +25,7 @@ Displays an accordion heading. ([Source](https://github.com/WordPress/gutenberg/
 -	**Name:** core/accordion-heading
 -	**Category:** design
 -	**Parent:** core/accordion-item
--	**Supports:** anchor, color (background, gradients, text), interactivity, shadow, spacing (padding), typography (fontSize), ~~align~~, ~~blockVisibility~~
+-	**Supports:** anchor, color (background, gradients, text), interactivity, shadow, spacing (padding), typography (fontSize), ~~align~~, ~~blockVisibility~~, ~~lock~~
 -	**Attributes:** iconPosition, level, openByDefault, showIcon, title
 
 ## Accordion Item
@@ -46,7 +46,7 @@ Displays an accordion panel. ([Source](https://github.com/WordPress/gutenberg/tr
 -	**Name:** core/accordion-panel
 -	**Category:** design
 -	**Parent:** core/accordion-item
--	**Supports:** allowedBlocks, color (background, gradients, text), contentRole, interactivity, layout (~~allowEditing~~), shadow, spacing (blockGap, padding), typography (fontSize, lineHeight), ~~blockVisibility~~, ~~html~~
+-	**Supports:** allowedBlocks, color (background, gradients, text), contentRole, interactivity, layout (~~allowEditing~~), shadow, spacing (blockGap, padding), typography (fontSize, lineHeight), ~~blockVisibility~~, ~~html~~, ~~lock~~
 -	**Attributes:** isSelected, openByDefault, templateLock
 
 ## Archives

--- a/packages/block-library/src/accordion-heading/block.json
+++ b/packages/block-library/src/accordion-heading/block.json
@@ -57,7 +57,8 @@
 			}
 		},
 		"shadow": true,
-		"blockVisibility": false
+		"blockVisibility": false,
+		"lock": false
 	},
 	"selectors": {
 		"typography": {

--- a/packages/block-library/src/accordion-panel/block.json
+++ b/packages/block-library/src/accordion-panel/block.json
@@ -52,7 +52,8 @@
 		},
 		"blockVisibility": false,
 		"contentRole": true,
-		"allowedBlocks": true
+		"allowedBlocks": true,
+		"lock": false
 	},
 	"attributes": {
 		"templateLock": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Removes the ability to unlock the Accordion Title / Accordion Panel block through the UI. 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

These inner blocks are locked for a reason. The Accordion simply doesn't work when they are not present. And once you have removed them there is no way (through the UI) of getting them back. So this makes it a little more robust for users.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Leveraging the "lock" block support

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Insert an Accordion block and see that you can no longer unlock the inner Accordion Title / Accordion Panel blocks through the block toolbar. The lock icon is greyed out. 