### PR TITLE
Terms Query: Use `perPage` attribute to fetch only required terms

### DIFF
--- a/packages/block-library/src/term-template/index.php
+++ b/packages/block-library/src/term-template/index.php
@@ -30,11 +30,11 @@ function render_block_core_term_template( $attributes, $content, $block ) {
 	$query = $query_block_context['termQuery'];
 
 	$query_args = array(
-		'taxonomy'   => $query['taxonomy'] ?? 'category',
-		'number'     => $query['perPage'] ?? 10,
-		'order'      => $query['order'] ?? 'asc',
-		'orderby'    => $query['orderBy'] ?? 'name',
-		'hide_empty' => $query['hideEmpty'] ?? true,
+		'taxonomy'   => $query['taxonomy'],
+		'number'     => $query['perPage'],
+		'order'      => $query['order'],
+		'orderby'    => $query['orderBy'],
+		'hide_empty' => $query['hideEmpty'],
 	);
 
 	// We set parent only when inheriting from the taxonomy archive context or not


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR utilizes the `perPage` attribute to fetch only the required terms. Additionally it removes some extra checks in php that were trying to set some attributes' defaults again.

## Testing Instructions
1. Everything should work as before


--cc @cr0ybot 
