### PR TITLE
Fix: Automatically build docs in CI and commit to Branch

### DIFF
--- a/.github/workflows/auto-generate-docs.yml
+++ b/.github/workflows/auto-generate-docs.yml
@@ -1,0 +1,56 @@
+name: Auto-generate Documentation
+
+on:
+    pull_request:
+        branches:
+            - trunk
+            - 'release/**'
+            - 'wp/**'
+
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+    # The concurrency group contains the workflow name and the branch name for pull requests
+    # or the commit hash for any other events.
+    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
+jobs:
+    generate-docs:
+        name: Generate Documentation
+        runs-on: 'ubuntu-24.04'
+        permissions:
+            contents: write
+            pull-requests: write
+        if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+              with:
+                  ref: ${{ github.event.pull_request.head.ref }}
+                  repository: ${{ github.event.pull_request.head.repo.full_name }}
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+                  persist-credentials: true
+
+            - name: Setup Node.js and install dependencies
+              uses: ./.github/setup-node
+
+            - name: Generate documentation
+              run: npm run docs:build
+
+            - name: Commit documentation changes
+              uses: stefanzweifel/git-auto-commit-action@8621497c8c39c72f3e2a999a26b4ca1b5058a842 # v5.0.1
+              with:
+                  commit_message: 'chore: Auto-generate documentation'
+                  commit_user_name: 'Gutenberg Repository Automation'
+                  commit_user_email: 'gutenberg@wordpress.org'
+                  commit_author: 'Gutenberg Repository Automation <gutenberg@wordpress.org>'
+                  file_pattern: 'docs/**/*.md packages/**/*.md'
+                  skip_dirty_check: false
+                  skip_fetch: false
+                  skip_checkout: true


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #42375

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's always a pain having to checkout the full codebase with local env etc for a simple docs change. We get so manny PR's for simple typos somewhere that we need to ask to pull down the codebase and manually run `npm run build:docs` for.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adding a new action that automatically does this.
