### PR TITLE
Build: Cross-package style dependencies should use built files and not src

### DIFF
--- a/bin/packages/build-v2.mjs
+++ b/bin/packages/build-v2.mjs
@@ -24,6 +24,7 @@ import babel from 'esbuild-plugin-babel';
  * Internal dependencies
  */
 import { V2_PACKAGES } from './v2-packages.js';
+import { groupByDepth } from './dependency-graph.js';
 
 const __dirname = path.dirname( fileURLToPath( import.meta.url ) );
 
@@ -891,14 +892,23 @@ async function buildAll() {
 
 	const startTime = Date.now();
 
-	// Phase 1: Transpile all packages in parallel
+	// Group packages by dependency depth
+	const levels = groupByDepth( V2_PACKAGES );
+
+	// Phase 1: Transpile packages level by level (respecting dependencies)
 	console.log( '📝 Phase 1: Transpiling packages...\n' );
-	await Promise.all(
-		V2_PACKAGES.map( async ( packageName ) => {
-			const buildTime = await transpilePackage( packageName );
-			console.log( `✔ Transpiled ${ packageName } (${ buildTime }ms)` );
-		} )
-	);
+
+	for ( let i = 0; i < levels.length; i++ ) {
+		const level = levels[ i ];
+		await Promise.all(
+			level.map( async ( packageName ) => {
+				const buildTime = await transpilePackage( packageName );
+				console.log(
+					`   ✔ Transpiled ${ packageName } (${ buildTime }ms)`
+				);
+			} )
+		);
+	}
 
 	// Phase 2: Bundle packages with wpScript in parallel
 	console.log( '\n📦 Phase 2: Bundling packages...\n' );

--- a/bin/packages/dependency-graph.js
+++ b/bin/packages/dependency-graph.js
@@ -1,0 +1,180 @@
+/**
+ * Dependency graph utilities for WordPress packages.
+ *
+ * This module provides functions to analyze dependencies between @wordpress/* packages
+ * and determine the correct build order using topological sorting.
+ */
+
+/**
+ * External dependencies
+ */
+const fs = require( 'fs' );
+const path = require( 'path' );
+const toposort = require( 'toposort' );
+
+const PACKAGES_DIR = path.resolve( __dirname, '../../packages' );
+
+/**
+ * Get WordPress package dependencies from a package.json file.
+ *
+ * @param {string} packageName The name of the package.
+ * @return {string[]} Array of WordPress package names this package depends on.
+ */
+function getWordPressDependencies( packageName ) {
+	const packageJsonPath = path.join(
+		PACKAGES_DIR,
+		packageName,
+		'package.json'
+	);
+
+	try {
+		const packageJson = JSON.parse(
+			fs.readFileSync( packageJsonPath, 'utf8' )
+		);
+		const deps = packageJson.dependencies || {};
+
+		// Extract @wordpress/* package names (without @wordpress/ prefix)
+		return Object.keys( deps )
+			.filter( ( dep ) => dep.startsWith( '@wordpress/' ) )
+			.map( ( dep ) => dep.replace( '@wordpress/', '' ) );
+	} catch ( error ) {
+		// If package.json doesn't exist or can't be read, return empty array
+		return [];
+	}
+}
+
+/**
+ * Build a dependency graph for the given packages.
+ *
+ * @param {string[]} packages Array of package names to analyze.
+ * @return {Array<[string, string]>} Array of [dependent, dependency] edges.
+ */
+function buildDependencyGraph( packages ) {
+	const edges = [];
+	const packagesSet = new Set( packages );
+
+	for ( const packageName of packages ) {
+		const deps = getWordPressDependencies( packageName );
+
+		// Only include edges where both packages are in our list
+		for ( const dep of deps ) {
+			if ( packagesSet.has( dep ) ) {
+				edges.push( [ packageName, dep ] );
+			}
+		}
+
+		// If package has no dependencies in our list, add a self-reference
+		// This ensures it appears in the sorted output
+		if ( deps.filter( ( dep ) => packagesSet.has( dep ) ).length === 0 ) {
+			edges.push( [ packageName, packageName ] );
+		}
+	}
+
+	return edges;
+}
+
+/**
+ * Sort packages in topological order based on their dependencies.
+ *
+ * @param {string[]} packages Array of package names to sort.
+ * @return {string[]} Sorted array where dependencies come before dependents.
+ */
+function topologicalSort( packages ) {
+	const edges = buildDependencyGraph( packages );
+
+	try {
+		// toposort returns dependencies first, then dependents
+		const sorted = toposort( edges );
+
+		// Filter to only include packages in our input list
+		// (toposort might include extra nodes)
+		const packagesSet = new Set( packages );
+		return sorted.filter( ( pkg ) => packagesSet.has( pkg ) );
+	} catch ( error ) {
+		if ( error.message.includes( 'cyclic' ) ) {
+			console.error(
+				'❌ Cyclic dependency detected in packages:',
+				error.message
+			);
+			throw new Error(
+				'Cannot build packages due to cyclic dependencies'
+			);
+		}
+		throw error;
+	}
+}
+
+/**
+ * Group packages by dependency depth level.
+ * Packages at the same depth level can be built in parallel.
+ *
+ * @param {string[]} packages Array of package names to group.
+ * @return {string[][]} Array of arrays, where each inner array is a depth level.
+ */
+function groupByDepth( packages ) {
+	const packagesSet = new Set( packages );
+	const depths = new Map();
+	const visited = new Set();
+
+	/**
+	 * Calculate depth for a package recursively.
+	 *
+	 * @param {string} packageName Package name to calculate depth for.
+	 * @return {number} Depth level (0 = no dependencies).
+	 */
+	function calculateDepth( packageName ) {
+		if ( depths.has( packageName ) ) {
+			return depths.get( packageName );
+		}
+
+		// Prevent infinite loops in case of circular dependencies
+		if ( visited.has( packageName ) ) {
+			return 0;
+		}
+
+		visited.add( packageName );
+
+		const deps = getWordPressDependencies( packageName );
+		const relevantDeps = deps.filter( ( dep ) => packagesSet.has( dep ) );
+
+		if ( relevantDeps.length === 0 ) {
+			depths.set( packageName, 0 );
+			return 0;
+		}
+
+		const maxDepth = Math.max(
+			...relevantDeps.map( ( dep ) => calculateDepth( dep ) )
+		);
+		const depth = maxDepth + 1;
+		depths.set( packageName, depth );
+
+		return depth;
+	}
+
+	// Calculate depth for all packages
+	for ( const packageName of packages ) {
+		calculateDepth( packageName );
+	}
+
+	// Group by depth
+	const levels = [];
+	const maxDepth = Math.max( ...depths.values() );
+
+	for ( let depth = 0; depth <= maxDepth; depth++ ) {
+		const packagesAtDepth = packages.filter(
+			( pkg ) => depths.get( pkg ) === depth
+		);
+		if ( packagesAtDepth.length > 0 ) {
+			levels.push( packagesAtDepth );
+		}
+	}
+
+	return levels;
+}
+
+module.exports = {
+	getWordPressDependencies,
+	buildDependencyGraph,
+	topologicalSort,
+	groupByDepth,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -39145,6 +39145,29 @@
 				"postcss": "^8.2.15"
 			}
 		},
+		"node_modules/postcss-import": {
+			"version": "16.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.1.1.tgz",
+			"integrity": "sha512-2xVS1NCZAfjtVdvXiyegxzJ447GyqCeEI5V7ApgQVOWnros1p5lGNovJNapwPpMombyFBfqDwt7AD3n2l0KOfQ==",
+			"license": "MIT",
+			"dependencies": {
+				"postcss-value-parser": "^4.0.0",
+				"read-cache": "^1.0.0",
+				"resolve": "^1.1.7"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.0.0"
+			}
+		},
+		"node_modules/postcss-import/node_modules/postcss-value-parser": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+			"license": "MIT"
+		},
 		"node_modules/postcss-loader": {
 			"version": "6.2.1",
 			"resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-6.2.1.tgz",
@@ -41326,6 +41349,24 @@
 			},
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/read-cache": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+			"integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+			"license": "MIT",
+			"dependencies": {
+				"pify": "^2.3.0"
+			}
+		},
+		"node_modules/read-cache/node_modules/pify": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/read-cmd-shim": {
@@ -52444,7 +52485,8 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/base-styles": "file:../base-styles",
-				"autoprefixer": "^10.4.20"
+				"autoprefixer": "^10.4.20",
+				"postcss-import": "^16.1.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -162,6 +162,7 @@
 				"style-loader": "3.2.1",
 				"terser": "5.32.0",
 				"terser-webpack-plugin": "5.3.10",
+				"toposort": "2.0.2",
 				"typescript": "5.7.2",
 				"uuid": "9.0.1",
 				"webdriverio": "8.16.20",
@@ -45972,6 +45973,13 @@
 			"engines": {
 				"node": ">=0.6"
 			}
+		},
+		"node_modules/toposort": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+			"integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/totalist": {
 			"version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
 		"style-loader": "3.2.1",
 		"terser": "5.32.0",
 		"terser-webpack-plugin": "5.3.10",
+		"toposort": "2.0.2",
 		"typescript": "5.7.2",
 		"uuid": "9.0.1",
 		"webdriverio": "8.16.20",

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -1,4 +1,4 @@
-@import "../../admin-ui/src/style.scss";
+@import "@wordpress/admin-ui/build-style/style.css";
 @import "./components/back-button/style.scss";
 @import "./components/layout/style.scss";
 @import "./components/meta-boxes/meta-boxes-area/style.scss";

--- a/packages/edit-site/src/posts.scss
+++ b/packages/edit-site/src/posts.scss
@@ -1,5 +1,5 @@
-@import "../../admin-ui/src/style.scss";
-@import "../../dataviews/src/style.scss";
+@import "@wordpress/admin-ui/build-style/style.css";
+@import "@wordpress/dataviews/build-style/style.css";
 @import "./components/layout/style.scss";
 @import "./components/save-hub/style.scss";
 @import "./components/save-panel/style.scss";

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -1,5 +1,5 @@
-@import "../../admin-ui/src/style.scss";
-@import "../../dataviews/src/style.scss";
+@import "@wordpress/admin-ui/build-style/style.css";
+@import "@wordpress/dataviews/build-style/style.css";
 @import "../../fields/src/style.scss";
 @import "./components/add-new-template/style.scss";
 @import "./components/block-editor/style.scss";

--- a/packages/edit-widgets/src/style.scss
+++ b/packages/edit-widgets/src/style.scss
@@ -1,4 +1,4 @@
-@import "../../interface/src/style.scss";
+@import "@wordpress/interface/build-style/style.css";
 
 @import "./blocks/widget-area/editor.scss";
 @import "./components/error-boundary/style.scss";

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -1,4 +1,4 @@
-@import "../../interface/src/style.scss";
+@import "@wordpress/interface/build-style/style.css";
 
 @import "./components/autocompleters/style.scss";
 @import "./components/collab-sidebar/style.scss";

--- a/packages/interface/src/style.scss
+++ b/packages/interface/src/style.scss
@@ -1,4 +1,4 @@
-@import "../../admin-ui/src/style.scss";
+@import "@wordpress/admin-ui/build-style/style.css";
 @import "./components/complementary-area-header/style.scss";
 @import "./components/complementary-area/style.scss";
 @import "./components/fullscreen-mode/style.scss";

--- a/packages/postcss-plugins-preset/lib/index.js
+++ b/packages/postcss-plugins-preset/lib/index.js
@@ -1,1 +1,4 @@
-module.exports = [ require( 'autoprefixer' )( { grid: true } ) ];
+module.exports = [
+	require( 'postcss-import' )(),
+	require( 'autoprefixer' )( { grid: true } ),
+];

--- a/packages/postcss-plugins-preset/package.json
+++ b/packages/postcss-plugins-preset/package.json
@@ -31,7 +31,8 @@
 	"main": "lib/index.js",
 	"dependencies": {
 		"@wordpress/base-styles": "file:../base-styles",
-		"autoprefixer": "^10.4.20"
+		"autoprefixer": "^10.4.20",
+		"postcss-import": "^16.1.1"
 	},
 	"peerDependencies": {
 		"postcss": "^8.0.0"


### PR DESCRIPTION
Related #72032

The way we write CSS in a given package shouldn't impact the way you have to write CSS in a package that depend on it. The dependency should expose a regular CSS file that gets consumed by the higher-level package.

Conceptually, this is more correct but it also makes migration to v2 pipeline easier as we're not forced to migrate these packages at the same time.

## Testing instructions

No behavior change, just ensure the site editor looks correct. (It would look very broken if this PR fails)