### PR TITLE
Update Terms Query block variation names and icons

### DIFF
--- a/packages/block-library/src/terms-query/variations.js
+++ b/packages/block-library/src/terms-query/variations.js
@@ -18,19 +18,19 @@ export const titleExcerpt = (
 
 const variations = [
 	{
-		name: 'title',
-		title: __( 'Title' ),
-		description: __( "Display the terms' titles." ),
+		name: 'name',
+		title: __( 'Name' ),
+		description: __( "Display the terms' names." ),
 		attributes: {},
 		icon: titleDate,
 		scope: [ 'block' ],
 		innerBlocks: [ [ 'core/term-template', {}, [ [ 'core/term-name' ] ] ] ],
 	},
 	{
-		name: 'title-count',
-		title: __( 'Title & Count' ),
+		name: 'name-count',
+		title: __( 'Name & Count' ),
 		description: __(
-			"Display the terms' titles and number of posts assigned to each term."
+			"Display the terms' names and number of posts assigned to each term."
 		),
 		attributes: {},
 		icon: titleExcerpt,

--- a/packages/block-library/src/terms-query/variations.js
+++ b/packages/block-library/src/terms-query/variations.js
@@ -6,13 +6,13 @@ import { Path, SVG } from '@wordpress/components';
 
 export const titleDate = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
-		<Path d="M41 9H7v3h34V9zm-22 5H7v1h12v-1zM7 26h12v1H7v-1zm34-5H7v3h34v-3zM7 38h12v1H7v-1zm34-5H7v3h34v-3z" />
+		<Path d="M 41,9 H 7 v 3 h 34 z m 0,9 H 7 v 3 h 34 z m 0,18 H 7 v 3 h 34 z m 0,-9 H 7 v 3 h 34 z" />
 	</SVG>
 );
 
 export const titleExcerpt = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
-		<Path d="M41 9H7v3h34V9zm-4 5H7v1h30v-1zm4 3H7v1h34v-1zM7 20h30v1H7v-1zm0 12h30v1H7v-1zm34 3H7v1h34v-1zM7 38h30v1H7v-1zm34-11H7v3h34v-3z" />
+		<Path d="m 36,36 h 5 v 3 h -5 z m 0,-9 h 5 v 3 h -5 z m 0,-9 h 5 v 3 h -5 z m 0,-9 h 5 v 3 H 36 Z M 31,9 H 7 v 3 h 24 z m 0,9 H 7 v 3 h 24 z m 0,18 H 7 v 3 h 24 z m 0,-9 H 7 v 3 h 24 z" />
 	</SVG>
 );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

<!-- In a few words, what is the PR actually doing? -->
Updates the Terms Query block variation names and icons to reflect the layout and blocks used.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The current variations are misnamed ("title" instead of "name") and the icons do not represent the actual layouts.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Updates variation names/descriptions and adds new icon SVGs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

**You must enable "Experimental blocks" in the Gutenberg plugin settings!**

1. Add the Terms Query block to a page.
2. Confirm that 2 variation choices are presented with icons that match their respective outputs.
3. Confirm that the variation choices use "name" instead of "title".

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<img width="1200" height="768" alt="Screen Shot 2025-10-13 at 10 30 15" src="https://github.com/user-attachments/assets/fad9264d-2009-402c-bf30-6fff6107e5eb" />

<img width="1200" height="768" alt="Screen Shot 2025-10-13 at 10 30 28" src="https://github.com/user-attachments/assets/688621a3-9032-4032-b601-c4d1fa1713f0" />

