### PR TITLE
Icons: Bundle generated source code

### DIFF
--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 - Remove `edit` and `warning` icons, which were aliases to `pencil` and `cautionFilled`, respectively. Switch to SVG icons as canonical source format, letting the system auto-generate the React elements and index. ([#71878](https://github.com/WordPress/gutenberg/pull/71878)).
+- Ensure both SVG and generated TSX code in `src/` are included in the published package. ([#72299](https://github.com/WordPress/gutenberg/pull/72299))
 
 ### Enhancements
 


### PR DESCRIPTION
## What?

As of #71878, Icons are defined as SVG files under `src/library/`, and an accompanying `build` script will produce their corresponding TSX files and an index at `src/library/index.ts`.

However, this generated source code was not included in the published package. This pull request seeks to include `src/library/*.ts[x]` in `@wordpress/icons` (_cf._ [file browser](https://www.npmjs.com/package/@wordpress/icons?activeTab=code)), for the benefit of its consumers, who thereby no longer need to generate that code themselves.

It does so by adding an empty `.npmignore` file, which overrides `.gitignore`. As a reminder, we deliberately Git-ignore the generated source code because we don't want the duplication of SVG and TSX files, nor the possible synchronisation issues that come with it.

See https://docs.npmjs.com/cli/v11/commands/npm-publish#files-included-in-package

## Testing Instructions

There's not much to systematise here. Please exercise your judgment and find gaps in my thinking, because this is not my _forte_. :)

That said, the following quick test will reveal that, with this PR, the TSX and index.ts files in the library now appear alongside the SVG files in `npm pack`:

```bash
npm run build -w packages/icons
npm pack --dry-run -w packages/icons 2>&1 | grep library/
```

```
…
npm notice 346B src/library/inbox.svg
npm notice 518B src/library/inbox.tsx   # new
npm notice 16.8kB src/library/index.ts  # new
npm notice 258B src/library/info.svg
npm notice 430B src/library/info.tsx    # new
…
```