### PR TITLE
Badge: Fix styles

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,7 +7,7 @@
 -   `SearchControl`: Move search icon to prefix position ([#71984](https://github.com/WordPress/gutenberg/pull/71984)).
 -   `SearchControl`: Flip search icon depending on placement ([#72070](https://github.com/WordPress/gutenberg/pull/72070)).
 -   `SearchControl`: Normalize styles ([#72072](https://github.com/WordPress/gutenberg/pull/72072)).
--   `Badge`: Avoid propagating text-decoration styles from ancestors into the component ([#72097](https://github.com/WordPress/gutenberg/pull/72097)).
+-   `Badge`: Avoid propagating text-decoration styles from ancestors into the component ([#72097](https://github.com/WordPress/gutenberg/pull/72097), [#72302](https://github.com/WordPress/gutenberg/pull/72302)).
 -   `CheckboxControl`, `RadioControl`, `ToggleControl` (`FormToggle`): Ensure elements are focused when clicked in Safari ([#72115](https://github.com/WordPress/gutenberg/pull/72115)).
 
 ### Bug Fixes

--- a/packages/components/src/badge/styles.scss
+++ b/packages/components/src/badge/styles.scss
@@ -17,6 +17,10 @@ $badge-colors: (
 	padding: 2px $grid-unit-10;
 	min-height: $grid-unit-30;
 	border-radius: $radius-small;
+	line-height: 0;
+
+	// Prevents anchor text-decoration styles from being applied through a parent.
+	display: inline-block;
 
 	&:where(.is-default) {
 		background-color: $gray-100;


### PR DESCRIPTION
Follow-up to #72097

## What?

Fixes the missing styles in the `Badge` component.

## Why?

Some of the [intended styles](https://github.com/WordPress/gutenberg/pull/72097#discussion_r2407031459) were not applied, resulting in misaligned text in the component.

## Testing Instructions

See the `Badge` stories.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img width="986" height="1530" alt="Badge styles, before" src="https://github.com/user-attachments/assets/a84d6ca7-2461-4fed-aab1-9e1b71d39d3a" />|<img width="986" height="1530" alt="Badge styles, after" src="https://github.com/user-attachments/assets/75075649-d8f7-4175-811d-a5c65d15c589" />|
