### PR TITLE
Fit text: update help text to clarify override of font-size

### DIFF
--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -193,7 +193,9 @@ export function FitTextControl( {
 					help={
 						fitText
 							? __( 'Text will resize to fit its container.' )
-							: __('The text will resize to fit its container, resetting other font size settings.')
+							: __(
+									'The text will resize to fit its container, resetting other font size settings.'
+							  )
 					}
 				/>
 			</ToolsPanelItem>

--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -193,9 +193,7 @@ export function FitTextControl( {
 					help={
 						fitText
 							? __( 'Text will resize to fit its container.' )
-							: __(
-									'Resize text to fit its container. When enabled, font size settings are ignored.'
-							  )
+							: __('The text will resize to fit its container, resetting other font size settings.')
 					}
 				/>
 			</ToolsPanelItem>

--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -193,7 +193,9 @@ export function FitTextControl( {
 					help={
 						fitText
 							? __( 'Text will resize to fit its container.' )
-							: __( 'Resize text to fit its container.' )
+							: __(
+									'Font size setting is overriden when enabled'
+							  )
 					}
 				/>
 			</ToolsPanelItem>

--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -194,7 +194,7 @@ export function FitTextControl( {
 						fitText
 							? __( 'Text will resize to fit its container.' )
 							: __(
-									'Font size setting is overriden when enabled'
+									'Resize text to fit its container. When enabled, font size settings are ignored.'
 							  )
 					}
 				/>


### PR DESCRIPTION
closes:-#72219.

What?
Adds clarification to the Fit text control’s help text, explaining that when enabled, it overrides the Font Size setting.

Why?
To prevent confusion for users who might think the Font Size control isn’t working when Fit text is active.
This implements the reviewer’s suggestion to clarify behavior without connecting the two controls in code.

How?
Updated the help text in fit-text.js → FitTextControl component to state that Font Size settings are ignored when Fit text is enabled.

Before:

“Text will resize to fit its container.”

After:

“Text will resize to fit its container and override font size settings.”

Related Issue / PR:
Fixes minor UX feedback from reviewer on #72219.