### PR TITLE
Update Terms Query block to inherit from post context

### DIFF
--- a/packages/block-library/src/term-template/block.json
+++ b/packages/block-library/src/term-template/block.json
@@ -8,7 +8,7 @@
 	"ancestor": [ "core/terms-query" ],
 	"description": "Contains the block elements used to render a taxonomy term, like the name, description, and more.",
 	"textdomain": "default",
-	"usesContext": [ "termQuery", "termId" ],
+	"usesContext": [ "termQuery", "postId" ],
 	"supports": {
 		"reusable": false,
 		"html": false,

--- a/packages/block-library/src/term-template/block.json
+++ b/packages/block-library/src/term-template/block.json
@@ -8,7 +8,7 @@
 	"ancestor": [ "core/terms-query" ],
 	"description": "Contains the block elements used to render a taxonomy term, like the name, description, and more.",
 	"textdomain": "default",
-	"usesContext": [ "termQuery" ],
+	"usesContext": [ "termQuery", "termId" ],
 	"supports": {
 		"reusable": false,
 		"html": false,

--- a/packages/block-library/src/term-template/edit.js
+++ b/packages/block-library/src/term-template/edit.js
@@ -80,9 +80,10 @@ export default function TermTemplateEdit( {
 			orderBy,
 			hideEmpty,
 			showNested = false,
-			parent = 0,
-			perPage,
+			parent = false,
+			perPage = 10,
 		} = {},
+		termId,
 	},
 	__unstableLayoutClassNames,
 } ) {
@@ -96,9 +97,16 @@ export default function TermTemplateEdit( {
 		per_page: perPage,
 	};
 
-	// Nested terms are returned by default from REST API as long as parent is not set.
-	// If we want to show nested terms, we must not set parent at all.
-	if ( parent || ! showNested ) {
+	if ( parent === 'inherit' ) {
+		if ( termId ) {
+			queryArgs.parent = termId;
+		} else {
+			// If there is no termId in context, we can't inherit, so we fall back to 0.
+			queryArgs.parent = 0;
+		}
+	} else if ( parent !== false || ! showNested ) {
+		// Nested terms are returned by default from REST API as long as parent is not set.
+		// If we want to show nested terms, we must not set parent at all.
 		queryArgs.parent = parent || 0;
 	}
 

--- a/packages/block-library/src/term-template/edit.js
+++ b/packages/block-library/src/term-template/edit.js
@@ -80,7 +80,7 @@ export default function TermTemplateEdit( {
 			orderBy,
 			hideEmpty,
 			showNested = false,
-			perPage = 10,
+			perPage,
 			inherit = false,
 		} = {},
 		postId,

--- a/packages/block-library/src/term-template/edit.js
+++ b/packages/block-library/src/term-template/edit.js
@@ -80,10 +80,10 @@ export default function TermTemplateEdit( {
 			orderBy,
 			hideEmpty,
 			showNested = false,
-			parent = false,
 			perPage = 10,
+			inherit = false,
 		} = {},
-		termId,
+		postId,
 	},
 	__unstableLayoutClassNames,
 } ) {
@@ -97,17 +97,16 @@ export default function TermTemplateEdit( {
 		per_page: perPage,
 	};
 
-	if ( parent === 'inherit' ) {
-		if ( termId ) {
-			queryArgs.parent = termId;
-		} else {
-			// If there is no termId in context, we can't inherit, so we fall back to 0.
-			queryArgs.parent = 0;
+	if ( inherit ) {
+		if ( postId ) {
+			queryArgs.post = postId;
 		}
-	} else if ( parent !== false || ! showNested ) {
-		// Nested terms are returned by default from REST API as long as parent is not set.
-		// If we want to show nested terms, we must not set parent at all.
-		queryArgs.parent = parent || 0;
+	}
+
+	// Nested terms are returned by default from REST API as long as parent is not set.
+	// If we want to show nested terms, we must not set parent at all.
+	if ( ! showNested && ! inherit ) {
+		queryArgs.parent = 0;
 	}
 
 	const { records: terms } = useEntityRecords(

--- a/packages/block-library/src/term-template/index.php
+++ b/packages/block-library/src/term-template/index.php
@@ -39,13 +39,13 @@ function render_block_core_term_template( $attributes, $content, $block ) {
 
 	// We set parent only when inheriting from the taxonomy archive context or not
 	// showing nested terms, otherwise nested terms are not displayed.
-	$parent = $query['parent'] ?? false;
 	if (
-		'inherit' === $parent
+		isset( $query['inherit'] )
+		&& $query['inherit']
 	) {
-		if ( isset( $query_block_context['termId'] ) ) {
-			// Get the current term ID from context.
-			$query_args['parent'] = $query_block_context['termId'];
+		// Check for post context to get terms attached to that post.
+		if ( isset( $block->context['postId'] ) ) {
+			$query_args['object_ids'] = $block->context['postId'];
 		} elseif (
 			is_tax( $query_args['taxonomy'] )
 			// is_tax() does not detect built-in category or tag archives, only custom taxonomies.
@@ -56,8 +56,8 @@ function render_block_core_term_template( $attributes, $content, $block ) {
 			$current_term_id      = get_queried_object_id();
 			$query_args['parent'] = $current_term_id;
 		}
-	} elseif ( false !== $parent || empty( $query['showNested'] ) ) {
-		$query_args['parent'] = $parent ? $parent : 0;
+	} elseif ( empty( $query['showNested'] ) && empty( $query['include'] ) ) {
+		$query_args['parent'] = 0;
 	}
 
 	$terms_query = new WP_Term_Query( $query_args );

--- a/packages/block-library/src/term-template/index.php
+++ b/packages/block-library/src/term-template/index.php
@@ -39,21 +39,25 @@ function render_block_core_term_template( $attributes, $content, $block ) {
 
 	// We set parent only when inheriting from the taxonomy archive context or not
 	// showing nested terms, otherwise nested terms are not displayed.
+	$parent = $query['parent'] ?? false;
 	if (
-		isset( $query['inherit'] )
-		&& $query['inherit']
-		&& (
+		'inherit' === $parent
+	) {
+		if ( isset( $query_block_context['termId'] ) ) {
+			// Get the current term ID from context.
+			$query_args['parent'] = $query_block_context['termId'];
+		} elseif (
 			is_tax( $query_args['taxonomy'] )
 			// is_tax() does not detect built-in category or tag archives, only custom taxonomies.
 			|| ( 'category' === $query_args['taxonomy'] && is_category() )
 			|| ( 'post_tag' === $query_args['taxonomy'] && is_tag() )
-		)
-	) {
-		// Get the current term ID from the queried object.
-		$current_term_id      = get_queried_object_id();
-		$query_args['parent'] = $current_term_id;
-	} elseif ( empty( $query['showNested'] ) ) {
-		$query_args['parent'] = 0;
+		) {
+			// Get the current term ID from the queried object.
+			$current_term_id      = get_queried_object_id();
+			$query_args['parent'] = $current_term_id;
+		}
+	} elseif ( false !== $parent || empty( $query['showNested'] ) ) {
+		$query_args['parent'] = $parent ? $parent : 0;
 	}
 
 	$terms_query = new WP_Term_Query( $query_args );

--- a/packages/block-library/src/terms-query/block.json
+++ b/packages/block-library/src/terms-query/block.json
@@ -6,13 +6,7 @@
 	"title": "Terms Query",
 	"category": "theme",
 	"description": "An advanced block that allows displaying taxonomy terms based on different query parameters and visual configurations.",
-	"keywords": [
-		"terms",
-		"taxonomy",
-		"categories",
-		"tags",
-		"list"
-	],
+	"keywords": [ "terms", "taxonomy", "categories", "tags", "list" ],
 	"textdomain": "default",
 	"attributes": {
 		"termQuery": {
@@ -33,20 +27,12 @@
 			"default": "div"
 		}
 	},
-	"usesContext": [
-		"templateSlug"
-	],
+	"usesContext": [ "templateSlug" ],
 	"providesContext": {
 		"termQuery": "termQuery"
 	},
-	"usesContext": [
-		"termId"
-	],
 	"supports": {
-		"align": [
-			"wide",
-			"full"
-		],
+		"align": [ "wide", "full" ],
 		"html": false,
 		"layout": true,
 		"interactivity": true

--- a/packages/block-library/src/terms-query/block.json
+++ b/packages/block-library/src/terms-query/block.json
@@ -17,7 +17,6 @@
 				"order": "asc",
 				"orderBy": "name",
 				"hideEmpty": true,
-				"parent": false,
 				"showNested": false,
 				"inherit": false
 			}
@@ -27,7 +26,7 @@
 			"default": "div"
 		}
 	},
-	"usesContext": [ "templateSlug" ],
+	"usesContext": [ "postId", "templateSlug" ],
 	"providesContext": {
 		"termQuery": "termQuery"
 	},

--- a/packages/block-library/src/terms-query/block.json
+++ b/packages/block-library/src/terms-query/block.json
@@ -6,7 +6,13 @@
 	"title": "Terms Query",
 	"category": "theme",
 	"description": "An advanced block that allows displaying taxonomy terms based on different query parameters and visual configurations.",
-	"keywords": [ "terms", "taxonomy", "categories", "tags", "list" ],
+	"keywords": [
+		"terms",
+		"taxonomy",
+		"categories",
+		"tags",
+		"list"
+	],
 	"textdomain": "default",
 	"attributes": {
 		"termQuery": {
@@ -27,12 +33,20 @@
 			"default": "div"
 		}
 	},
-	"usesContext": [ "templateSlug" ],
+	"usesContext": [
+		"templateSlug"
+	],
 	"providesContext": {
 		"termQuery": "termQuery"
 	},
+	"usesContext": [
+		"termId"
+	],
 	"supports": {
-		"align": [ "wide", "full" ],
+		"align": [
+			"wide",
+			"full"
+		],
 		"html": false,
 		"layout": true,
 		"interactivity": true

--- a/packages/block-library/src/terms-query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/terms-query/edit/inspector-controls/index.js
@@ -52,15 +52,19 @@ export default function TermsQueryInspectorControls( {
 		taxonomy === 'post_tag' ? 'tag' : taxonomy
 	);
 
+	const isSinglePostContext =
+		!! postId || templateSlug?.startsWith( 'single' );
+
 	// Only display the inherit control if the taxonomy is hierarchical and matches the current template or a post is available.
 	const displayInheritControl =
-		isTaxonomyHierarchical && ( isTaxonomyMatchingTemplate || postId );
+		( isTaxonomyHierarchical && isTaxonomyMatchingTemplate ) ||
+		isSinglePostContext;
 
 	// Only display the show nested control if the taxonomy is hierarchical and not inheriting.
 	const displayShowNestedControl =
 		isTaxonomyHierarchical && termQuery.parent === false;
 
-	const inheritingFromPost = inherit && postId;
+	const inheritingFromPost = inherit && isSinglePostContext;
 
 	// Labels shared between ToolsPanelItem and its child control.
 	const taxonomyControlLabel = __( 'Taxonomy' );
@@ -69,7 +73,7 @@ export default function TermsQueryInspectorControls( {
 	const inheritControlLabel = sprintf(
 		/* translators: %s: either "post" or "archive" */
 		__( 'Inherit parent term from %s' ),
-		postId ? __( 'post' ) : __( 'archive' )
+		isSinglePostContext ? __( 'post' ) : __( 'archive' )
 	);
 	const nestedTermsControlLabel = __( 'Show nested terms' );
 	const maxTermsControlLabel = __( 'Max terms' );
@@ -166,10 +170,13 @@ export default function TermsQueryInspectorControls( {
 										inherit: value,
 										// When enabling inherit, showNested is not supported for posts.
 										...( value
-											? { showNested: ! postId }
+											? {
+													showNested:
+														! isSinglePostContext,
+											  }
 											: {} ),
 										// If inheriting from a post, hideEmpty is irrelevant but UI should reflect that no empty terms should be shown.
-										...( value && postId
+										...( value && isSinglePostContext
 											? { hideEmpty: true }
 											: {} ),
 									} );

--- a/packages/block-library/src/terms-query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/terms-query/edit/inspector-controls/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
@@ -70,11 +70,9 @@ export default function TermsQueryInspectorControls( {
 	const taxonomyControlLabel = __( 'Taxonomy' );
 	const orderByControlLabel = __( 'Order by' );
 	const emptyTermsControlLabel = __( 'Show empty terms' );
-	const inheritControlLabel = sprintf(
-		/* translators: %s: either "post" or "archive" */
-		__( 'Inherit parent term from %s' ),
-		isSinglePostContext ? __( 'post' ) : __( 'archive' )
-	);
+	const inheritControlLabel = isSinglePostContext
+		? __( 'Inherit terms from post' )
+		: __( 'Inherit parent term from archive' );
 	const nestedTermsControlLabel = __( 'Show nested terms' );
 	const maxTermsControlLabel = __( 'Max terms' );
 

--- a/packages/block-library/src/terms-query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/terms-query/edit/inspector-controls/index.js
@@ -142,6 +142,13 @@ export default function TermsQueryInspectorControls( {
 								setQuery( { hideEmpty: value } )
 							}
 							disabled={ inheritingFromPost }
+							help={
+								inheritingFromPost
+									? __(
+											'When inheriting terms from a post, empty terms are not shown.'
+									  )
+									: undefined
+							}
 						/>
 					</ToolsPanelItem>
 					{ displayInheritControl && (

--- a/packages/block-library/src/terms-query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/terms-query/edit/inspector-controls/index.js
@@ -34,11 +34,11 @@ export default function TermsQueryInspectorControls( {
 		orderBy,
 		order,
 		hideEmpty,
-		parent = false,
 		showNested,
 		perPage,
+		inherit,
 	} = termQuery;
-	const { termId, templateSlug } = context;
+	const { postId, templateSlug } = context;
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	const taxonomies = usePublicTaxonomies();
@@ -52,22 +52,24 @@ export default function TermsQueryInspectorControls( {
 		taxonomy === 'post_tag' ? 'tag' : taxonomy
 	);
 
-	// Only display the inherit control if the taxonomy is hierarchical and matches the current template.
+	// Only display the inherit control if the taxonomy is hierarchical and matches the current template or a post is available.
 	const displayInheritControl =
-		isTaxonomyHierarchical && ( isTaxonomyMatchingTemplate || termId );
+		isTaxonomyHierarchical && ( isTaxonomyMatchingTemplate || postId );
 
 	// Only display the show nested control if the taxonomy is hierarchical and not inheriting.
 	const displayShowNestedControl =
 		isTaxonomyHierarchical && termQuery.parent === false;
+
+	const inheritingFromPost = inherit && postId;
 
 	// Labels shared between ToolsPanelItem and its child control.
 	const taxonomyControlLabel = __( 'Taxonomy' );
 	const orderByControlLabel = __( 'Order by' );
 	const emptyTermsControlLabel = __( 'Show empty terms' );
 	const inheritControlLabel = sprintf(
-		/* translators: %s: either "parent block" or "archive" */
+		/* translators: %s: either "post" or "archive" */
 		__( 'Inherit parent term from %s' ),
-		termId ? __( 'parent block' ) : __( 'archive' )
+		postId ? __( 'post' ) : __( 'archive' )
 	);
 	const nestedTermsControlLabel = __( 'Show nested terms' );
 	const maxTermsControlLabel = __( 'Max terms' );
@@ -139,19 +141,32 @@ export default function TermsQueryInspectorControls( {
 							onChange={ ( value ) =>
 								setQuery( { hideEmpty: value } )
 							}
+							disabled={ inheritingFromPost }
 						/>
 					</ToolsPanelItem>
 					{ displayInheritControl && (
 						<ToolsPanelItem
-							hasValue={ () => parent !== false }
+							hasValue={ () => inherit !== false }
 							label={ inheritControlLabel }
-							onDeselect={ () => setQuery( { parent: false } ) }
+							onDeselect={ () => setQuery( { inherit: false } ) }
 							isShownByDefault
 						>
 							<InheritControl
 								label={ inheritControlLabel }
-								value={ parent === 'inherit' }
-								onChange={ setQuery }
+								value={ inherit }
+								onChange={ ( value ) => {
+									setQuery( {
+										inherit: value,
+										// When enabling inherit, showNested is not supported for posts.
+										...( value
+											? { showNested: ! postId }
+											: {} ),
+										// If inheriting from a post, hideEmpty is irrelevant but UI should reflect that no empty terms should be shown.
+										...( value && postId
+											? { hideEmpty: true }
+											: {} ),
+									} );
+								} }
 							/>
 						</ToolsPanelItem>
 					) }

--- a/packages/block-library/src/terms-query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/terms-query/edit/inspector-controls/index.js
@@ -23,10 +23,10 @@ import AdvancedControls from './advanced-controls';
 
 export default function TermsQueryInspectorControls( {
 	attributes,
-	setQuery,
 	setAttributes,
 	clientId,
-	templateSlug,
+	context,
+	setQuery,
 } ) {
 	const { termQuery, tagName: TagName } = attributes;
 	const {
@@ -34,10 +34,11 @@ export default function TermsQueryInspectorControls( {
 		orderBy,
 		order,
 		hideEmpty,
-		inherit,
+		parent = false,
 		showNested,
 		perPage,
 	} = termQuery;
+	const { termId, templateSlug } = context;
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	const taxonomies = usePublicTaxonomies();
@@ -53,11 +54,11 @@ export default function TermsQueryInspectorControls( {
 
 	// Only display the inherit control if the taxonomy is hierarchical and matches the current template.
 	const displayInheritControl =
-		isTaxonomyHierarchical && isTaxonomyMatchingTemplate;
+		isTaxonomyHierarchical && ( isTaxonomyMatchingTemplate || termId );
 
-	// Only display the showNested control if the taxonomy is hierarchical and not inheriting.
+	// Only display the show nested control if the taxonomy is hierarchical and not inheriting.
 	const displayShowNestedControl =
-		isTaxonomyHierarchical && ! termQuery.inherit;
+		isTaxonomyHierarchical && termQuery.parent === false;
 
 	// Labels shared between ToolsPanelItem and its child control.
 	const taxonomyControlLabel = __( 'Taxonomy' );
@@ -138,14 +139,14 @@ export default function TermsQueryInspectorControls( {
 					</ToolsPanelItem>
 					{ displayInheritControl && (
 						<ToolsPanelItem
-							hasValue={ () => inherit !== false }
+							hasValue={ () => parent !== false }
 							label={ inheritControlLabel }
-							onDeselect={ () => setQuery( { inherit: false } ) }
+							onDeselect={ () => setQuery( { parent: false } ) }
 							isShownByDefault
 						>
 							<InheritControl
 								label={ inheritControlLabel }
-								value={ inherit }
+								value={ parent === 'inherit' }
 								onChange={ setQuery }
 							/>
 						</ToolsPanelItem>

--- a/packages/block-library/src/terms-query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/terms-query/edit/inspector-controls/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
@@ -64,7 +64,11 @@ export default function TermsQueryInspectorControls( {
 	const taxonomyControlLabel = __( 'Taxonomy' );
 	const orderByControlLabel = __( 'Order by' );
 	const emptyTermsControlLabel = __( 'Show empty terms' );
-	const inheritControlLabel = __( 'Inherit parent term from archive' );
+	const inheritControlLabel = sprintf(
+		/* translators: %s: either "parent block" or "archive" */
+		__( 'Inherit parent term from %s' ),
+		termId ? __( 'parent block' ) : __( 'archive' )
+	);
 	const nestedTermsControlLabel = __( 'Show nested terms' );
 	const maxTermsControlLabel = __( 'Max terms' );
 

--- a/packages/block-library/src/terms-query/edit/inspector-controls/inherit-control.js
+++ b/packages/block-library/src/terms-query/edit/inspector-controls/inherit-control.js
@@ -10,9 +10,9 @@ export default function InheritControl( { value, onChange, ...props } ) {
 			checked={ value }
 			onChange={ ( inherit ) =>
 				onChange( {
-					inherit,
-					// When enabling inherit, hierarchical is not supported.
-					...( inherit ? { hierarchical: false } : {} ),
+					parent: inherit ? 'inherit' : false,
+					// When enabling inherit, showNested is not supported.
+					...( inherit ? { showNested: false } : {} ),
 				} )
 			}
 			{ ...props }

--- a/packages/block-library/src/terms-query/edit/inspector-controls/inherit-control.js
+++ b/packages/block-library/src/terms-query/edit/inspector-controls/inherit-control.js
@@ -8,13 +8,7 @@ export default function InheritControl( { value, onChange, ...props } ) {
 		<ToggleControl
 			__nextHasNoMarginBottom
 			checked={ value }
-			onChange={ ( inherit ) =>
-				onChange( {
-					parent: inherit ? 'inherit' : false,
-					// When enabling inherit, showNested is not supported.
-					...( inherit ? { showNested: false } : {} ),
-				} )
-			}
+			onChange={ onChange }
 			{ ...props }
 		/>
 	);

--- a/packages/block-library/src/terms-query/edit/terms-query-content.js
+++ b/packages/block-library/src/terms-query/edit/terms-query-content.js
@@ -11,12 +11,8 @@ import TermsQueryInspectorControls from './inspector-controls';
 
 const TEMPLATE = [ [ 'core/term-template' ] ];
 
-export default function TermsQueryContent( {
-	attributes,
-	setAttributes,
-	clientId,
-	context,
-} ) {
+export default function TermsQueryContent( props ) {
+	const { attributes, setAttributes } = props;
 	const { tagName: TagName } = attributes;
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
@@ -31,13 +27,7 @@ export default function TermsQueryContent( {
 	);
 	return (
 		<>
-			<TermsQueryInspectorControls
-				attributes={ attributes }
-				setQuery={ setQuery }
-				setAttributes={ setAttributes }
-				clientId={ clientId }
-				templateSlug={ context?.templateSlug }
-			/>
+			<TermsQueryInspectorControls { ...props } setQuery={ setQuery } />
 			<TagName { ...innerBlocksProps } />
 		</>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Related to #71911

<!-- In a few words, what is the PR actually doing? -->
We currently support inheriting the parent term from a taxonomy archive context, but there is no mechanism in place for inheriting from a post.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We have blocks that display a post's terms as comma-separated lists or button-like links (but not actually buttons), but the in-editor layout and design tools are very limited and users must rely on block styles provided by the theme.

If we still had term data block bindings and full layout controls in place, this would enable a wide variety of customizations for how terms are displayed in single post templates.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR extends the meaning of `inherit = true` to inherit the terms of a post in context by checking if `postId` is set or if editing a `single` template.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

**You must enable "Experimental blocks" in the Gutenberg plugin settings!**

Post inheritance from a single post:

1. Create or edit a post and add the Terms Query block
2. Ensure the post has terms applied and select the same taxonomy for the Terms Query block
3. Set the "inherit terms from post" setting to true
4. Confirm that the terms displayed are the same as the ones selected for the post both in the editor and on the front end

Post inheritance within a Query Loop:

1. Create or edit a page and add a Query Loop, setting the query type to "custom"
2. Ensure that the post type selected is the same as the test posts with terms applied
3. Add a Terms Query block into the Post Template, select the taxonomy you're testing, and set "inherit terms from post" to true
4. Confirm that the terms displayed are the same as the ones selected for the post both in the editor and on the front end

Post inheritance in a single template:

1. Create or edit the single template in the Site Editor and add the Terms Query block
2. Select the taxonomy you're testing, and set "inherit terms from post" to true
3. Since there is no post to get terms from in the editor, the default set of terms will be displayed
4. Confirm that the terms displayed for a post on the front end are the same as the ones selected for the post

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

To do

## Issues

Inheritance from the current post works, but the post must have been previously saved with the terms for them to show up—they do not dynamically change when updating the terms on the post.
