### PR TITLE
Terms Query: use linked term names in variations

### DIFF
--- a/packages/block-library/src/terms-query/variations.js
+++ b/packages/block-library/src/terms-query/variations.js
@@ -16,6 +16,13 @@ export const titleExcerpt = (
 	</SVG>
 );
 
+const termName = [
+	'core/term-name',
+	{
+		isLink: true,
+	},
+];
+
 const variations = [
 	{
 		name: 'name',
@@ -24,7 +31,7 @@ const variations = [
 		attributes: {},
 		icon: titleDate,
 		scope: [ 'block' ],
-		innerBlocks: [ [ 'core/term-template', {}, [ [ 'core/term-name' ] ] ] ],
+		innerBlocks: [ [ 'core/term-template', {}, [ termName ] ] ],
 	},
 	{
 		name: 'name-count',
@@ -43,7 +50,7 @@ const variations = [
 					[
 						'core/group',
 						{ layout: { type: 'flex', flexWrap: 'nowrap' } },
-						[ [ 'core/term-name' ], [ 'core/term-count' ] ],
+						[ termName, [ 'core/term-count' ] ],
 					],
 				],
 			],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

<!-- In a few words, what is the PR actually doing? -->
Updates Term Query variations to contain Term Name blocks with links.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
These variations provide the default experience for the Terms Query block and should be useful at the outset. A list of unlinked terms is unlikely to be what most people are looking for.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Sets `isLink` to `true` for the Term Name blocks in variations.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

**You must enable "Experimental blocks" in the Gutenberg plugin settings!**

1. Edit a page/post and add the Terms Query block
2. Choose a variation and confirm that the Term Name blocks are linked by default
