### PR TITLE
Notes: Tweak thead style

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -188,7 +188,7 @@ export function Comments( {
 				alignment="left"
 				className="editor-collab-sidebar-panel__thread"
 				justify="flex-start"
-				spacing="2"
+				spacing="3"
 			>
 				{
 					// translators: message displayed when there are no comments available
@@ -318,7 +318,7 @@ function Thread( {
 				'is-floating': isFloating,
 			} ) }
 			id={ `comment-thread-${ thread.id }` }
-			spacing={ isFloating ? '0' : '2' }
+			spacing="3"
 			onClick={ handleCommentSelect }
 			onMouseEnter={ onMouseEnter }
 			onMouseLeave={ onMouseLeave }
@@ -387,21 +387,15 @@ function Thread( {
 			/>
 			{ isSelected &&
 				replies.map( ( reply ) => (
-					<VStack
+					<CommentBoard
 						key={ reply.id }
-						className="editor-collab-sidebar-panel__child-thread"
-						id={ reply.id }
-						spacing="2"
-					>
-						<CommentBoard
-							thread={ reply }
-							parent={ thread }
-							isExpanded={ isSelected }
-							onEdit={ onEditComment }
-							onDelete={ onCommentDelete }
-							reflowComments={ reflowComments }
-						/>
-					</VStack>
+						thread={ reply }
+						parent={ thread }
+						isExpanded={ isSelected }
+						onEdit={ onEditComment }
+						onDelete={ onCommentDelete }
+						reflowComments={ reflowComments }
+					/>
 				) ) }
 			{ ! isSelected && restReplies.length > 0 && (
 				<HStack className="editor-collab-sidebar-panel__more-reply-separator">
@@ -440,10 +434,7 @@ function Thread( {
 				/>
 			) }
 			{ isSelected && (
-				<VStack
-					className="editor-collab-sidebar-panel__child-thread"
-					spacing="2"
-				>
+				<VStack spacing="2">
 					<HStack alignment="left" spacing="3" justify="flex-start">
 						<CommentAuthorInfo />
 					</HStack>
@@ -558,7 +549,7 @@ const CommentBoard = ( {
 			: [];
 
 	return (
-		<>
+		<VStack spacing="2" id={ thread.id }>
 			<HStack alignment="left" spacing="3" justify="flex-start">
 				<CommentAuthorInfo
 					avatar={ thread?.author_avatar_urls?.[ 48 ] }
@@ -659,6 +650,6 @@ const CommentBoard = ( {
 					{ __( 'Are you sure you want to delete this comment?' ) }
 				</ConfirmDialog>
 			) }
-		</>
+		</VStack>
 	);
 };

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -560,7 +560,7 @@ const CommentBoard = ( {
 			: [];
 
 	return (
-		<VStack spacing="2" id={ thread.id }>
+		<VStack spacing="2">
 			<HStack alignment="left" spacing="3" justify="flex-start">
 				<CommentAuthorInfo
 					avatar={ thread?.author_avatar_urls?.[ 48 ] }

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -37,16 +37,11 @@
 	}
 
 	&.is-floating {
-		padding: 16px;
-		border: none;
+		left: $grid-unit-20;
+		right: $grid-unit-20;
 		position: absolute;
-		width: 250px;
-		margin-top: 16px;
+		margin-top: $grid-unit-20;
 	}
-}
-
-.editor-collab-sidebar-panel__child-thread {
-	margin-top: 15px;
 }
 
 .editor-collab-sidebar-panel__user-name {
@@ -78,29 +73,6 @@
 	border-width: var(--wp-admin-border-width-focus);
 	border-style: solid;
 	padding: var(--wp-admin-border-width-focus);
-}
-
-.editor-collab-sidebar-panel__thread-overlay {
-	background-color: rgba(0, 0, 0, 0.7);
-	width: 100%;
-	height: 100%;
-	text-align: center;
-	position: absolute;
-	top: 0;
-	left: 0;
-	z-index: 1;
-	padding: 15px;
-	border-radius: $radius-large;
-	color: $white;
-
-	p {
-		margin-bottom: 15px;
-	}
-
-	button {
-		padding: 4px 10px;
-		color: $white;
-	}
 }
 
 .editor-collab-sidebar-panel__comment-status {


### PR DESCRIPTION
## What?

This PR improves the style of Note.

### How?

- Add a border to floating threads
- Avoid using a hardcoded CSS value
- Apply consistent spacing, whether it's a floating toolbar or not

## Screenshots or screencast <!-- if applicable -->

| State | Before | After |
|--------|--------|--------|
| Floating, Collapsed | <img width="273" height="194" alt="image" src="https://github.com/user-attachments/assets/0c911045-6c6d-4e8e-91a6-c1eb946803dd" /> | <img width="270" height="229" alt="image" src="https://github.com/user-attachments/assets/e31537b9-de4b-4e65-9f6a-755eb506641a" /> |
| Floating, Expanded | <img width="275" height="360" alt="image" src="https://github.com/user-attachments/assets/4b5bdf62-a1ae-4939-8e36-5569f2be61e7" /> | <img width="266" height="370" alt="image" src="https://github.com/user-attachments/assets/1a605b68-a7a7-445e-a937-01eaaee93243" /> |
| Floating, Editing Comment | <img width="274" height="435" alt="image" src="https://github.com/user-attachments/assets/7affec1a-1ebc-4bd1-a252-0c2b3d06a880" />| <img width="271" height="444" alt="image" src="https://github.com/user-attachments/assets/8aae391d-c365-44f5-9e90-b3460feec8c0" /> |
| History, Collapsed | <img width="269" height="256" alt="image" src="https://github.com/user-attachments/assets/f514ca35-8a78-4fb5-8fd6-ddb9fb32056f" /> | <img width="267" height="255" alt="image" src="https://github.com/user-attachments/assets/14a4c620-05b4-4410-9502-2d57dd0852ee" /> |
| History, Expanded | <img width="266" height="420" alt="image" src="https://github.com/user-attachments/assets/f4386b7c-7b0e-48c0-b7e4-cf7f26887786" />| <img width="267" height="391" alt="image" src="https://github.com/user-attachments/assets/23dfec67-d03c-446d-942a-390a3d701791" /> |
