### PR TITLE
Notes: Rename comment type

### DIFF
--- a/lib/experimental/block-comments.php
+++ b/lib/experimental/block-comments.php
@@ -14,7 +14,7 @@ function gutenberg_block_comment_add_post_type_support() {
 		}
 
 		$supports        = get_all_post_type_supports( $post_type );
-		$editor_supports = array( 'block-comments' => true );
+		$editor_supports = array( 'notes' => true );
 
 		// `add_post_type_support()` doesn't merge support sub-properties, so we explicitly merge it here.
 		if ( is_array( $supports['editor'] ) && isset( $supports['editor'][0] ) && is_array( $supports['editor'][0] ) ) {

--- a/lib/experimental/block-comments.php
+++ b/lib/experimental/block-comments.php
@@ -32,10 +32,10 @@ add_action( 'init', 'gutenberg_block_comment_add_post_type_support' );
 function gutenberg_register_block_comment_metadata() {
 	register_meta(
 		'comment',
-		'_wp_block_comment_status',
+		'_wp_note_status',
 		array(
 			'type'          => 'string',
-			'description'   => __( 'Block comment resolution status', 'gutenberg' ),
+			'description'   => __( 'Note resolution status', 'gutenberg' ),
 			'single'        => true,
 			'show_in_rest'  => array(
 				'schema' => array(
@@ -54,7 +54,7 @@ add_action( 'init', 'gutenberg_register_block_comment_metadata' );
 /**
  * Updates the comment type for avatars in the WordPress REST API.
  *
- * This function adds the 'block_comment' type to the list of comment types
+ * This function adds the 'note' type to the list of comment types
  * for which avatars should be retrieved in the WordPress REST API.
  *
  * @param array $comment_type The array of comment types.
@@ -62,7 +62,7 @@ add_action( 'init', 'gutenberg_register_block_comment_metadata' );
  */
 if ( ! function_exists( 'update_get_avatar_comment_type' ) ) {
 	function update_get_avatar_comment_type( $comment_type ) {
-		$comment_type[] = 'block_comment';
+		$comment_type[] = 'note';
 		return $comment_type;
 	}
 	add_filter( 'get_avatar_comment_types', 'update_get_avatar_comment_type' );
@@ -71,7 +71,7 @@ if ( ! function_exists( 'update_get_avatar_comment_type' ) ) {
 /**
  * Excludes block comments from the admin comments query.
  *
- * This function modifies the comments query to exclude comments of type 'block_comment'
+ * This function modifies the comments query to exclude comments of type 'note'
  * when the query is for comments in the WordPress admin.
  *
  * @global wpdb $wpdb WordPress database abstraction object.
@@ -88,7 +88,7 @@ if ( ! function_exists( 'exclude_block_comments_from_admin' ) ) {
 			$query->set( 'type', '' );
 
 			global $wpdb;
-			$clauses['where'] .= " AND {$wpdb->comments}.comment_type != 'block_comment'";
+			$clauses['where'] .= " AND {$wpdb->comments}.comment_type != 'note'";
 		}
 
 		return $clauses;
@@ -108,8 +108,8 @@ if ( ! function_exists( 'exclude_block_comments_from_admin' ) ) {
 function gutenberg_filter_comment_count_query_exclude_block_comments( $query ) {
 	// Adjust the query if it is a comment count query.
 	if ( str_starts_with( $query, 'SELECT comment_post_ID, COUNT(comment_ID) as num_comments FROM' ) && str_contains( $query, 'comment_approved' ) ) {
-		if ( ! str_contains( $query, "comment_type != 'block_comment'" ) ) {
-			$query = str_replace( 'comment_approved', "comment_type != 'block_comment' AND comment_approved", $query );
+		if ( ! str_contains( $query, "comment_type != 'note'" ) ) {
+			$query = str_replace( 'comment_approved', "comment_type != 'note' AND comment_approved", $query );
 		}
 	}
 	return $query;
@@ -126,10 +126,9 @@ add_filter( 'query', 'gutenberg_filter_comment_count_query_exclude_block_comment
  *
  * @return bool True if the comment can be duplicated, false otherwise.
  */
-function gutenberg_allow_duplicate_block_comment_resolution( $dupe_id, $commentdata ) {
-	if ( isset( $commentdata['meta']['_wp_block_comment_status'] ) && in_array( $commentdata['meta']['_wp_block_comment_status'], array( 'resolved', 'reopen' ), true ) ) {
+function gutenberg_allow_duplicate_note_resolution( $dupe_id, $commentdata ) {
+	if ( isset( $commentdata['meta']['_wp_note_status'] ) && in_array( $commentdata['meta']['_wp_note_status'], array( 'resolved', 'reopen' ), true ) ) {
 		return false;
 	}
 }
-
-add_filter( 'duplicate_comment_id', 'gutenberg_allow_duplicate_block_comment_resolution', 10, 2 );
+add_filter( 'duplicate_comment_id', 'gutenberg_allow_duplicate_note_resolution', 10, 2 );

--- a/lib/experimental/class-gutenberg-rest-comment-controller.php
+++ b/lib/experimental/class-gutenberg-rest-comment-controller.php
@@ -10,8 +10,8 @@
 class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 
 	public function get_items_permissions_check( $request ) {
-		$is_note = ! empty( $request['type'] ) && 'note' === $request['type'];
-		$is_edit_context  = ! empty( $request['context'] ) && 'edit' === $request['context'];
+		$is_note         = ! empty( $request['type'] ) && 'note' === $request['type'];
+		$is_edit_context = ! empty( $request['context'] ) && 'edit' === $request['context'];
 
 		if ( ! empty( $request['post'] ) ) {
 			foreach ( (array) $request['post'] as $post_id ) {

--- a/lib/experimental/class-gutenberg-rest-comment-controller.php
+++ b/lib/experimental/class-gutenberg-rest-comment-controller.php
@@ -18,7 +18,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 				$post = get_post( $post_id );
 
 				// Note: This is only relevant change for the backport.
-				if ( $post && $is_note && ! $this->check_post_type_supports_block_comments( $post->post_type ) ) {
+				if ( $post && $is_note && ! $this->check_post_type_supports_notes( $post->post_type ) ) {
 					return new WP_Error(
 						'rest_comment_not_supported_post_type',
 						__( 'Sorry, this post type does not support block comments.', 'gutenberg' ),
@@ -226,7 +226,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		}
 
 		// Note: This is only relevant change for the backport.
-		if ( $is_note && ! $this->check_post_type_supports_block_comments( $post->post_type ) ) {
+		if ( $is_note && ! $this->check_post_type_supports_notes( $post->post_type ) ) {
 			return new WP_Error(
 				'rest_comment_not_supported_post_type',
 				__( 'Sorry, this post type does not support block comments.', 'gutenberg' ),
@@ -487,7 +487,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 	 * @param string $post_type Post type name.
 	 * @return bool True if post type supports block comments, false otherwise.
 	 */
-	private function check_post_type_supports_block_comments( $post_type ) {
+	private function check_post_type_supports_notes( $post_type ) {
 		$supports = get_all_post_type_supports( $post_type );
 		if ( ! isset( $supports['editor'] ) ) {
 			return false;
@@ -496,7 +496,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 			return false;
 		}
 		foreach ( $supports['editor'] as $item ) {
-			if ( is_array( $item ) && isset( $item['block-comments'] ) && true === $item['block-comments'] ) {
+			if ( is_array( $item ) && isset( $item['notes'] ) && true === $item['notes'] ) {
 				return true;
 			}
 		}

--- a/lib/experimental/class-gutenberg-rest-comment-controller.php
+++ b/lib/experimental/class-gutenberg-rest-comment-controller.php
@@ -10,7 +10,7 @@
 class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 
 	public function get_items_permissions_check( $request ) {
-		$is_block_comment = ! empty( $request['type'] ) && 'block_comment' === $request['type'];
+		$is_note = ! empty( $request['type'] ) && 'note' === $request['type'];
 		$is_edit_context  = ! empty( $request['context'] ) && 'edit' === $request['context'];
 
 		if ( ! empty( $request['post'] ) ) {
@@ -18,7 +18,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 				$post = get_post( $post_id );
 
 				// Note: This is only relevant change for the backport.
-				if ( $post && $is_block_comment && ! $this->check_post_type_supports_block_comments( $post->post_type ) ) {
+				if ( $post && $is_note && ! $this->check_post_type_supports_block_comments( $post->post_type ) ) {
 					return new WP_Error(
 						'rest_comment_not_supported_post_type',
 						__( 'Sorry, this post type does not support block comments.', 'gutenberg' ),
@@ -42,9 +42,9 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 			}
 		}
 
-		// Re-map edit context capabilities when requesting `block_comment` for a post.
+		// Re-map edit context capabilities when requesting `note` for a post.
 		// Note: This is only relevant change for the backport.
-		if ( $is_edit_context && $is_block_comment && ! empty( $request['post'] ) ) {
+		if ( $is_edit_context && $is_note && ! empty( $request['post'] ) ) {
 			foreach ( (array) $request['post'] as $post_id ) {
 				if ( ! current_user_can( 'edit_post', $post_id ) ) {
 					return new WP_Error(
@@ -99,9 +99,9 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 			return $comment;
 		}
 
-		// Re-map edit context capabilities when requesting `block_comment` type.
+		// Re-map edit context capabilities when requesting `note` type.
 		// Note: This is only relevant change for the backport.
-		$edit_cap = 'block_comment' === $comment->comment_type ? array( 'edit_comment', $comment->comment_ID ) : array( 'moderate_comments' );
+		$edit_cap = 'note' === $comment->comment_type ? array( 'edit_comment', $comment->comment_ID ) : array( 'moderate_comments' );
 		if ( ! empty( $request['context'] ) && 'edit' === $request['context'] && ! current_user_can( ...$edit_cap ) ) {
 			return new WP_Error(
 				'rest_forbidden_context',
@@ -132,10 +132,10 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 	}
 
 	public function create_item_permissions_check( $request ) {
-		$is_block_comment = ! empty( $request['type'] ) && 'block_comment' === $request['type'];
+		$is_note = ! empty( $request['type'] ) && 'note' === $request['type'];
 
 		// Note: This is only relevant change for the backport.
-		if ( ! is_user_logged_in() && $is_block_comment ) {
+		if ( ! is_user_logged_in() && $is_note ) {
 			return new WP_Error(
 				'rest_comment_login_required',
 				__( 'Sorry, you must be logged in to comment.', 'gutenberg' ),
@@ -197,7 +197,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		}
 
 		// Note: This is only relevant change for the backport.
-		$edit_cap = $is_block_comment ? array( 'edit_post', (int) $request['post'] ) : array( 'moderate_comments' );
+		$edit_cap = $is_note ? array( 'edit_post', (int) $request['post'] ) : array( 'moderate_comments' );
 		if ( isset( $request['status'] ) && ! current_user_can( ...$edit_cap ) ) {
 			return new WP_Error(
 				'rest_comment_invalid_status',
@@ -226,7 +226,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		}
 
 		// Note: This is only relevant change for the backport.
-		if ( $is_block_comment && ! $this->check_post_type_supports_block_comments( $post->post_type ) ) {
+		if ( $is_note && ! $this->check_post_type_supports_block_comments( $post->post_type ) ) {
 			return new WP_Error(
 				'rest_comment_not_supported_post_type',
 				__( 'Sorry, this post type does not support block comments.', 'gutenberg' ),
@@ -235,7 +235,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		}
 
 		// Note: This is only relevant change for the backport.
-		if ( 'draft' === $post->post_status && ! $is_block_comment ) {
+		if ( 'draft' === $post->post_status && ! $is_note ) {
 			return new WP_Error(
 				'rest_comment_draft_post',
 				__( 'Sorry, you are not allowed to create a comment on this post.', 'gutenberg' ),
@@ -260,7 +260,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		}
 
 		// Note: This is only relevant change for the backport.
-		if ( ! comments_open( $post->ID ) && ! $is_block_comment ) {
+		if ( ! comments_open( $post->ID ) && ! $is_note ) {
 			return new WP_Error(
 				'rest_comment_closed',
 				__( 'Sorry, comments are closed for this item.', 'gutenberg' ),
@@ -303,9 +303,9 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 			$prepared_comment['comment_content'] = '';
 		}
 
-		// Include block comment metadata into check_is_comment_content_allowed [backport].
-		if ( isset( $request['meta']['_wp_block_comment_status'] ) ) {
-			$prepared_comment['meta']['_wp_block_comment_status'] = $request['meta']['_wp_block_comment_status'];
+		// Include note metadata into check_is_comment_content_allowed [backport].
+		if ( isset( $request['meta']['_wp_note_status'] ) ) {
+			$prepared_comment['meta']['_wp_note_status'] = $request['meta']['_wp_note_status'];
 		}
 
 		if ( ! $this->check_is_comment_content_allowed( $prepared_comment ) ) {
@@ -514,7 +514,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 			'description' => __( 'Type of the comment.', 'gutenberg' ),
 			'type'        => 'string',
 			// Note: This is only relevant change for the backport.
-			'enum'        => array( 'comment', 'block_comment' ),
+			'enum'        => array( 'comment', 'note' ),
 			'default'     => 'comment',
 			'context'     => array( 'view', 'edit', 'embed' ),
 		);
@@ -553,8 +553,8 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		// Allow empty block comments with resolution metadata [backport].
 		if (
 			isset( $check['comment_type'] ) &&
-			'block_comment' === $check['comment_type'] &&
-			isset( $check['meta']['_wp_block_comment_status'] )
+			'note' === $check['comment_type'] &&
+			isset( $check['meta']['_wp_note_status'] )
 		) {
 			return true;
 		}

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -529,10 +529,10 @@ const CommentBoard = ( {
 
 	// Check if this is a resolution comment by checking metadata.
 	const isResolutionComment =
-		thread.type === 'block_comment' &&
+		thread.type === 'note' &&
 		thread.meta &&
-		( thread.meta._wp_block_comment_status === 'resolved' ||
-			thread.meta._wp_block_comment_status === 'reopen' );
+		( thread.meta._wp_note_status === 'resolved' ||
+			thread.meta._wp_note_status === 'reopen' );
 
 	const actions = [
 		{
@@ -668,8 +668,7 @@ const CommentBoard = ( {
 					{ isResolutionComment
 						? ( () => {
 								const actionText =
-									thread.meta._wp_block_comment_status ===
-									'resolved'
+									thread.meta._wp_note_status === 'resolved'
 										? __( 'Marked as resolved' )
 										: __( 'Reopened' );
 								const content = thread?.content?.raw;

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -46,7 +46,7 @@ export function useBlockComments( postId ) {
 
 	const queryArgs = {
 		post: postId,
-		type: 'block_comment',
+		type: 'note',
 		status: 'all',
 		per_page: 100,
 	};
@@ -183,7 +183,7 @@ export function useBlockCommentsActions( reflowComments ) {
 					post: getCurrentPostId(),
 					content,
 					status: 'hold',
-					type: 'block_comment',
+					type: 'note',
 					parent: parent || 0,
 				},
 				{ throwOnError: true }
@@ -247,11 +247,11 @@ export function useBlockCommentsActions( reflowComments ) {
 				const newCommentData = {
 					post: getCurrentPostId(),
 					content: content || '', // Empty content for resolve, content for reopen.
-					type: 'block_comment',
+					type: 'note',
 					status,
 					parent: id,
 					meta: {
-						_wp_block_comment_status:
+						_wp_note_status:
 							status === 'approved' ? 'resolved' : 'reopen',
 					},
 				};

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -198,7 +198,7 @@ function Header( {
 				) }
 
 				{ isBlockCommentExperimentEnabled && (
-					<PostTypeSupportCheck supportKeys="editor.block-comments">
+					<PostTypeSupportCheck supportKeys="editor.notes">
 						<CollabSidebar />
 					</PostTypeSupportCheck>
 				) }

--- a/phpunit/experimental/rest-api-comment-permissions-test.php
+++ b/phpunit/experimental/rest-api-comment-permissions-test.php
@@ -68,7 +68,7 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 			$this->factory->comment->create(
 				array(
 					'comment_post_ID'  => $post_id,
-					'comment_type'     => 'block_comment',
+					'comment_type'     => 'note',
 					'comment_approved' => 0 === $i % 2 ? 1 : 0,
 				)
 			);
@@ -97,7 +97,7 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 		$post_id = self::factory()->post->create( array( 'post_type' => 'no-block-comments' ) );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 		$request->set_param( 'post', $post_id );
-		$request->set_param( 'type', 'block_comment' );
+		$request->set_param( 'type', 'note' );
 		$request->set_param( 'context', 'edit' );
 
 		$response = rest_get_server()->dispatch( $request );
@@ -109,7 +109,7 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
 		$request->set_param( 'post', self::$post_id );
-		$request->set_param( 'type', 'block_comment' );
+		$request->set_param( 'type', 'note' );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_comment_login_required', $response, 401 );
@@ -135,7 +135,7 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 			'author_url'   => 'https://en.wikipedia.org/wiki/Herman_Melville',
 			'content'      => 'Call me Ishmael.',
 			'author'       => self::$user_ids['administrator'],
-			'type'         => 'block_comment',
+			'type'         => 'note',
 		);
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
@@ -159,7 +159,7 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 			'author_url'   => 'https://en.wikipedia.org/wiki/Herman_Melville',
 			'content'      => 'Call me Ishmael.',
 			'author'       => self::$user_ids['editor'],
-			'type'         => 'block_comment',
+			'type'         => 'note',
 		);
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
@@ -170,7 +170,7 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 		$data        = $response->get_data();
 		$new_comment = get_comment( $data['id'] );
 		$this->assertSame( 'Call me Ishmael.', $new_comment->comment_content );
-		$this->assertSame( 'block_comment', $new_comment->comment_type );
+		$this->assertSame( 'note', $new_comment->comment_type );
 	}
 
 	public function test_create_block_comment_status() {
@@ -184,7 +184,7 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 			'author_url'   => 'https://en.wikipedia.org/wiki/Herman_Melville',
 			'content'      => 'Comic Book Guy',
 			'author'       => self::$user_ids['author'],
-			'type'         => 'block_comment',
+			'type'         => 'note',
 			'status'       => 'hold',
 		);
 
@@ -197,7 +197,7 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 		$new_comment = get_comment( $data['id'] );
 
 		$this->assertSame( '0', $new_comment->comment_approved );
-		$this->assertSame( 'block_comment', $new_comment->comment_type );
+		$this->assertSame( 'note', $new_comment->comment_type );
 	}
 
 	public function test_cannot_create_with_non_valid_comment_type() {
@@ -259,7 +259,7 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 		$request->set_param( 'post', $post_id );
-		$request->set_param( 'type', 'block_comment' );
+		$request->set_param( 'type', 'note' );
 		$request->set_param( 'status', 'all' );
 		$request->set_param( 'per_page', 100 );
 		$request->set_param( 'context', 'edit' );
@@ -288,7 +288,7 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 		$request->set_param( 'post', array( $author_post_id, $editor_post_id ) );
-		$request->set_param( 'type', 'block_comment' );
+		$request->set_param( 'type', 'note' );
 		$request->set_param( 'status', 'all' );
 		$request->set_param( 'per_page', 100 );
 		$request->set_param( 'context', 'edit' );
@@ -324,7 +324,7 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 		$comment_id = $this->factory->comment->create(
 			array(
 				'comment_post_ID'  => $post_id,
-				'comment_type'     => 'block_comment',
+				'comment_type'     => 'note',
 				// Test with unapproved comment, which is more restrictive.
 				'comment_approved' => 0,
 				'user_id'          => self::$user_ids[ $post_author_role ],

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -22,7 +22,7 @@ test.describe( 'Block Comments', () => {
 
 	test.afterAll( async ( { requestUtils } ) => {
 		await Promise.all( [
-			requestUtils.deleteAllComments( 'block_comment' ),
+			requestUtils.deleteAllComments( 'note' ),
 			requestUtils.setGutenbergExperiments( [] ),
 		] );
 	} );


### PR DESCRIPTION
## What?
Part of #66377.
Related https://github.com/WordPress/gutenberg/discussions/72014#discussioncomment-14629639.

Now that the feature has a final name, PR changes internal references stored in the DB to reflect this new name.

Included changes:

* Rename comment type from `block_comment` to `note`. Considering that WP doesn't have an API for [registering custom comment types](https://core.trac.wordpress.org/ticket/35214), I don't expect a name clash.
* Rename status meta from `_wp_block_comment_status` to `_wp_note_status`.
* Rename post type support key from `block-comments` to `notes`.

P.S. I tried to keep changes to function names to a minimum. Internals can be renamed as we work on them.

### Migrate existing comments for testing

```
wp comment update $(wp comment list --status=all --comment_type=block_comment --format=ids) --comment_type=note
```

## Testing Instructions
The feature has good test coverage. All CI checks should pass as before.
