### PR TITLE
Notes: Audit and update translation strings

### DIFF
--- a/lib/experimental/class-gutenberg-rest-comment-controller.php
+++ b/lib/experimental/class-gutenberg-rest-comment-controller.php
@@ -21,7 +21,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 				if ( $post && $is_block_comment && ! $this->check_post_type_supports_block_comments( $post->post_type ) ) {
 					return new WP_Error(
 						'rest_comment_not_supported_post_type',
-						__( 'Sorry, this post type does not support block comments.', 'gutenberg' ),
+						__( 'Sorry, this post type does not support notes.', 'gutenberg' ),
 						array( 'status' => 403 )
 					);
 				}
@@ -229,7 +229,7 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 		if ( $is_block_comment && ! $this->check_post_type_supports_block_comments( $post->post_type ) ) {
 			return new WP_Error(
 				'rest_comment_not_supported_post_type',
-				__( 'Sorry, this post type does not support block comments.', 'gutenberg' ),
+				__( 'Sorry, this post type does not support notes.', 'gutenberg' ),
 				array( 'status' => 403 )
 			);
 		}

--- a/packages/editor/src/components/collab-sidebar/add-comment.js
+++ b/packages/editor/src/components/collab-sidebar/add-comment.js
@@ -73,8 +73,8 @@ export function AddComment( {
 					setShowCommentBoard( false );
 					blockElement?.focus();
 				} }
-				submitButtonText={ _x( 'Comment', 'Add comment button' ) }
-				labelText={ __( 'New Comment' ) }
+				submitButtonText={ _x( 'Note', 'Add note button' ) }
+				labelText={ __( 'New Note' ) }
 			/>
 		</VStack>
 	);

--- a/packages/editor/src/components/collab-sidebar/comment-author-info.js
+++ b/packages/editor/src/components/collab-sidebar/comment-author-info.js
@@ -63,7 +63,7 @@ function CommentAuthorInfo( { avatar, name, date, userId } ) {
 
 	const tooltipText = dateI18n(
 		// translators: Use a non-breaking space between 'g:i' and 'a' if appropriate.
-		_x( 'F j, Y g:i\xa0a', 'Comment date full date format' ),
+		_x( 'F j, Y g:i\xa0a', 'Note date full date format' ),
 		date
 	);
 

--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -64,7 +64,7 @@ function CommentForm( {
 			spacing="4"
 		>
 			<VisuallyHidden as="label" htmlFor={ inputId }>
-				{ labelText ?? __( 'Comment' ) }
+				{ labelText ?? __( 'Note' ) }
 			</VisuallyHidden>
 			<TextareaAutosize
 				id={ inputId }

--- a/packages/editor/src/components/collab-sidebar/comment-indicator-toolbar.js
+++ b/packages/editor/src/components/collab-sidebar/comment-indicator-toolbar.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { ToolbarButton } from '@wordpress/components';
-import { _x, __, _n, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
@@ -98,7 +98,7 @@ const CommentAvatarIndicator = ( { onClick, thread, hasMoreComments } ) => {
 				className={ clsx( 'comment-avatar-indicator', {
 					'has-unresolved': hasUnresolved,
 				} ) }
-				label={ _x( 'View comments', 'View comment thread' ) }
+				label={ __( 'View notes' ) }
 				onClick={ onClick }
 				showTooltip
 			>

--- a/packages/editor/src/components/collab-sidebar/comment-menu-item.js
+++ b/packages/editor/src/components/collab-sidebar/comment-menu-item.js
@@ -26,7 +26,7 @@ const AddCommentMenuItem = ( { onClick } ) => {
 					} }
 					aria-haspopup="dialog"
 				>
-					{ __( 'Comment' ) }
+					{ __( 'Note' ) }
 				</MenuItem>
 			) }
 		</CommentIconSlotFill.Fill>

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -190,7 +190,7 @@ export function Comments( {
 				justify="flex-start"
 				spacing="2"
 			>
-				{ __( 'No notes available' ) }
+				{ __( 'No notes available.' ) }
 			</VStack>
 		);
 	}

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -190,10 +190,7 @@ export function Comments( {
 				justify="flex-start"
 				spacing="2"
 			>
-				{
-					// translators: message displayed when there are no comments available
-					__( 'No comments available' )
-				}
+				{ __( 'No notes available' ) }
 			</VStack>
 		);
 	}
@@ -299,13 +296,13 @@ function Thread( {
 	);
 	const ariaLabel = relatedBlockElement
 		? sprintf(
-				// translators: %s: comment excerpt
-				__( 'Comment: %s' ),
+				// translators: %s: note excerpt
+				__( 'Note: %s' ),
 				commentExcerpt
 		  )
 		: sprintf(
-				// translators: %s: comment excerpt
-				__( 'Original block deleted. Comment: %s' ),
+				// translators: %s: note excerpt
+				__( 'Original block deleted. Note: %s' ),
 				commentExcerpt
 		  );
 
@@ -361,7 +358,7 @@ function Thread( {
 					);
 				} }
 			>
-				{ __( 'Add new comment' ) }
+				{ __( 'Add new note' ) }
 			</Button>
 			{ ! relatedBlockElement && (
 				<Text as="p" weight={ 500 } variant="muted">
@@ -466,7 +463,8 @@ function Thread( {
 								}
 							} }
 							onCancel={ ( event ) => {
-								event.stopPropagation(); // Prevent the parent onClick from being triggered
+								// Prevent the parent onClick from being triggered.
+								event.stopPropagation();
 								unselectThread();
 								focusCommentThread(
 									thread.id,
@@ -480,8 +478,8 @@ function Thread( {
 							}
 							rows={ 'approved' === thread.status ? 2 : 4 }
 							labelText={ sprintf(
-								// translators: %1$s: comment identifier, %2$s: author name
-								__( 'Reply to Comment %1$s by %2$s' ),
+								// translators: %1$s: note identifier, %2$s: author name
+								__( 'Reply to Note %1$s by %2$s' ),
 								thread.id,
 								thread?.author_name || 'Unknown'
 							) }
@@ -537,7 +535,7 @@ const CommentBoard = ( {
 	const actions = [
 		{
 			id: 'edit',
-			title: _x( 'Edit', 'Edit comment' ),
+			title: __( 'Edit' ),
 			isEligible: ( { status } ) => status !== 'approved',
 			onClick: () => {
 				setActionState( 'edit' );
@@ -545,7 +543,7 @@ const CommentBoard = ( {
 		},
 		{
 			id: 'reopen',
-			title: _x( 'Reopen', 'Reopen comment' ),
+			title: _x( 'Reopen', 'Reopen note' ),
 			isEligible: ( { status } ) => status === 'approved',
 			onClick: () => {
 				onEdit( { id: thread.id, status: 'hold' } );
@@ -553,7 +551,7 @@ const CommentBoard = ( {
 		},
 		{
 			id: 'delete',
-			title: _x( 'Delete', 'Delete comment' ),
+			title: __( 'Delete' ),
 			isEligible: () => true,
 			onClick: () => {
 				setActionState( 'delete' );
@@ -590,7 +588,7 @@ const CommentBoard = ( {
 								<Button
 									label={ _x(
 										'Resolve',
-										'Mark comment as resolved'
+										'Mark note as resolved'
 									) }
 									size="small"
 									icon={ published }
@@ -648,8 +646,8 @@ const CommentBoard = ( {
 					thread={ thread }
 					submitButtonText={ _x( 'Update', 'verb' ) }
 					labelText={ sprintf(
-						// translators: %1$s: comment identifier, %2$s: author name.
-						__( 'Edit Comment %1$s by %2$s' ),
+						// translators: %1$s: note identifier, %2$s: author name.
+						__( 'Edit note %1$s by %2$s' ),
 						thread.id,
 						thread?.author_name || 'Unknown'
 					) }
@@ -680,7 +678,7 @@ const CommentBoard = ( {
 									content.trim() !== ''
 								) {
 									return sprintf(
-										// translators: %1$s: action label ("Marked as resolved" or "Reopened"); %2$s: comment text.
+										// translators: %1$s: action label ("Marked as resolved" or "Reopened"); %2$s: note text.
 										__( '%1$s: %2$s' ),
 										actionText,
 										content
@@ -699,7 +697,7 @@ const CommentBoard = ( {
 					onCancel={ handleCancel }
 					confirmButtonText={ __( 'Delete' ) }
 				>
-					{ __( 'Are you sure you want to delete this comment?' ) }
+					{ __( 'Are you sure you want to delete this note?' ) }
 				</ConfirmDialog>
 			) }
 		</>

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -205,7 +205,7 @@ export function useBlockCommentsActions( reflowComments ) {
 				'snackbar',
 				parent
 					? __( 'Reply added successfully.' )
-					: __( 'Comment added successfully.' ),
+					: __( 'Note added successfully.' ),
 				{
 					type: 'snackbar',
 					isDismissible: true,
@@ -222,13 +222,13 @@ export function useBlockCommentsActions( reflowComments ) {
 	const onEdit = async ( { id, content, status } ) => {
 		const messageType = status ? status : 'updated';
 		const messages = {
-			approved: __( 'Comment marked as resolved.' ),
-			hold: __( 'Comment reopened.' ),
-			updated: __( 'Comment updated.' ),
+			approved: __( 'Note marked as resolved.' ),
+			hold: __( 'Note reopened.' ),
+			updated: __( 'Note updated.' ),
 		};
 
 		try {
-			// For resolution or reopen actions, create a new comment with metadata.
+			// For resolution or reopen actions, create a new note with metadata.
 			if ( status === 'approved' || status === 'hold' ) {
 				// First, update the thread status.
 				await saveEntityRecord(
@@ -273,7 +273,7 @@ export function useBlockCommentsActions( reflowComments ) {
 
 			createNotice(
 				'snackbar',
-				messages[ messageType ] ?? __( 'Comment updated.' ),
+				messages[ messageType ] ?? __( 'Note updated.' ),
 				{
 					type: 'snackbar',
 					isDismissible: true,
@@ -309,7 +309,7 @@ export function useBlockCommentsActions( reflowComments ) {
 				} );
 			}
 
-			createNotice( 'snackbar', __( 'Comment deleted successfully.' ), {
+			createNotice( 'snackbar', __( 'Note deleted successfully.' ), {
 				type: 'snackbar',
 				isDismissible: true,
 			} );

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -156,10 +156,9 @@ export default function CollabSidebar() {
 			<AddCommentMenuItem onClick={ openTheSidebar } />
 			<PluginSidebar
 				identifier={ collabHistorySidebarName }
-				// translators: Comments sidebar title
-				title={ __( 'Comments' ) }
+				title={ __( 'Notes' ) }
 				icon={ commentIcon }
-				closeLabel={ __( 'Close Comments' ) }
+				closeLabel={ __( 'Close Notes' ) }
 			>
 				<CollabSidebarContent
 					comments={ resultComments }

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -45,21 +45,21 @@ test.describe( 'Block Comments', () => {
 			name: 'core/paragraph',
 			attributes: { content: 'Testing block comments' },
 		} );
-		await editor.clickBlockOptionsMenuItem( 'Comment' );
+		await editor.clickBlockOptionsMenuItem( 'Note' );
 		await page
 			.getByRole( 'textbox', {
-				name: 'New Comment',
+				name: 'New Note',
 				exact: true,
 			} )
 			.fill( 'A test comment' );
 		await page
 			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'button', { name: 'Comment', exact: true } )
+			.getByRole( 'button', { name: 'Note', exact: true } )
 			.click();
 		const thread = page
 			.getByRole( 'region', { name: 'Editor settings' } )
 			.getByRole( 'listitem', {
-				name: 'Comment: A test comment',
+				name: 'Note: A test comment',
 			} );
 
 		await expect( thread ).toBeVisible();
@@ -102,7 +102,7 @@ test.describe( 'Block Comments', () => {
 		} );
 		await blockCommentUtils.clickBlockCommentActionMenuItem( 'Edit' );
 		await page
-			.getByRole( 'textbox', { name: 'Comment' } )
+			.getByRole( 'textbox', { name: 'Note' } )
 			.first()
 			.fill( 'Test comment after edit.' );
 		await page
@@ -116,7 +116,7 @@ test.describe( 'Block Comments', () => {
 		await expect(
 			page
 				.getByRole( 'button', { name: 'Dismiss this notice' } )
-				.filter( { hasText: 'Comment updated.' } )
+				.filter( { hasText: 'Note updated.' } )
 		).toBeVisible();
 	} );
 
@@ -141,7 +141,7 @@ test.describe( 'Block Comments', () => {
 		await expect(
 			page
 				.getByRole( 'button', { name: 'Dismiss this notice' } )
-				.filter( { hasText: 'Comment deleted successfully.' } )
+				.filter( { hasText: 'Note deleted successfully.' } )
 		).toBeVisible();
 	} );
 
@@ -158,7 +158,7 @@ test.describe( 'Block Comments', () => {
 		const thread = page
 			.getByRole( 'region', { name: 'Editor settings' } )
 			.getByRole( 'listitem', {
-				name: 'Comment: Test comment to resolve.',
+				name: 'Note: Test comment to resolve.',
 			} );
 		await thread.click();
 		await expect( thread ).toHaveAttribute( 'aria-expanded', 'true' );
@@ -168,7 +168,7 @@ test.describe( 'Block Comments', () => {
 		await expect(
 			page
 				.getByRole( 'button', { name: 'Dismiss this notice' } )
-				.filter( { hasText: 'Comment marked as resolved.' } )
+				.filter( { hasText: 'Note marked as resolved.' } )
 		).toBeVisible();
 		await expect( thread ).toBeFocused();
 		await expect( thread ).toHaveAttribute( 'aria-expanded', 'false' );
@@ -181,7 +181,7 @@ test.describe( 'Block Comments', () => {
 		await expect(
 			page
 				.getByRole( 'button', { name: 'Dismiss this notice' } )
-				.filter( { hasText: 'Comment reopened.' } )
+				.filter( { hasText: 'Note reopened.' } )
 		).toBeVisible();
 	} );
 
@@ -200,7 +200,7 @@ test.describe( 'Block Comments', () => {
 		await expect(
 			page
 				.getByRole( 'button', { name: 'Dismiss this notice' } )
-				.filter( { hasText: 'Comment marked as resolved.' } )
+				.filter( { hasText: 'Note marked as resolved.' } )
 		).toBeVisible();
 
 		await page.locator( '.editor-collab-sidebar-panel__thread' ).click();
@@ -216,7 +216,7 @@ test.describe( 'Block Comments', () => {
 		await expect(
 			page
 				.getByRole( 'button', { name: 'Dismiss this notice' } )
-				.filter( { hasText: 'Comment reopened.' } )
+				.filter( { hasText: 'Note reopened.' } )
 		).toBeVisible();
 	} );
 
@@ -292,7 +292,7 @@ test.describe( 'Block Comments', () => {
 					name: 'Editor settings',
 				} )
 				.getByRole( 'listitem', {
-					name: 'Comment: Test comment',
+					name: 'Note: Test comment',
 				} );
 
 			// Expand the comment with Enter key.
@@ -326,7 +326,7 @@ test.describe( 'Block Comments', () => {
 					name: 'Editor settings',
 				} )
 				.getByRole( 'listitem', {
-					name: 'Comment: Test comment escape',
+					name: 'Note: Test comment escape',
 				} );
 
 			await thread.click();
@@ -352,7 +352,7 @@ test.describe( 'Block Comments', () => {
 					name: 'Editor settings',
 				} )
 				.getByRole( 'listitem', {
-					name: 'Comment: Test comment',
+					name: 'Note: Test comment',
 				} );
 
 			await thread.click();
@@ -379,9 +379,7 @@ test.describe( 'Block Comments', () => {
 				.getByRole( 'listitem' );
 
 			await thread.focus();
-			await expect( thread ).toHaveAccessibleName(
-				'Comment: Test comment'
-			);
+			await expect( thread ).toHaveAccessibleName( 'Note: Test comment' );
 		} );
 
 		test( 'should expand and focus the thread after clicking the "x more replies" button', async ( {
@@ -421,7 +419,7 @@ test.describe( 'Block Comments', () => {
 					name: 'Editor settings',
 				} )
 				.getByRole( 'listitem', {
-					name: 'Comment: Test comment',
+					name: 'Note: Test comment',
 				} );
 
 			await thread
@@ -454,17 +452,17 @@ test.describe( 'Block Comments', () => {
 			const firstThread = page
 				.getByRole( 'region', { name: 'Editor settings' } )
 				.getByRole( 'listitem', {
-					name: 'Comment: First block comment',
+					name: 'Note: First block comment',
 				} );
 			const secondThread = page
 				.getByRole( 'region', { name: 'Editor settings' } )
 				.getByRole( 'listitem', {
-					name: 'Comment: Second block comment',
+					name: 'Note: Second block comment',
 				} );
 			const thirdThread = page
 				.getByRole( 'region', { name: 'Editor settings' } )
 				.getByRole( 'listitem', {
-					name: 'Comment: Third block comment',
+					name: 'Note: Third block comment',
 				} );
 
 			await firstThread.click();
@@ -534,7 +532,7 @@ test.describe( 'Block Comments', () => {
 			const thread = page
 				.getByRole( 'region', { name: 'Editor settings' } )
 				.getByRole( 'listitem', {
-					name: 'Comment: Test comment',
+					name: 'Note: Test comment',
 				} );
 
 			await expect( thread ).toBeFocused();
@@ -554,10 +552,10 @@ test.describe( 'Block Comments', () => {
 					name: 'Editor settings',
 				} )
 				.getByRole( 'listitem', {
-					name: 'Comment: Test comment',
+					name: 'Note: Test comment',
 				} );
 			const addNewCommentButton = thread.getByRole( 'button', {
-				name: 'Add new comment',
+				name: 'Add new note',
 			} );
 			await thread.focus();
 			await page.keyboard.press( 'Tab' );
@@ -586,7 +584,7 @@ test.describe( 'Block Comments', () => {
 					name: 'Editor settings',
 				} )
 				.getByRole( 'listitem', {
-					name: 'Comment: Test comment',
+					name: 'Note: Test comment',
 				} );
 			const replyButton = thread.getByRole( 'button', {
 				name: 'Reply',
@@ -624,7 +622,7 @@ class BlockCommentUtils {
 	async openBlockCommentSidebar() {
 		const toggleButton = this.#page
 			.getByRole( 'region', { name: 'Editor top bar' } )
-			.getByRole( 'button', { name: 'Comments', exact: true } );
+			.getByRole( 'button', { name: 'Notes', exact: true } );
 
 		const isClosed =
 			( await toggleButton.getAttribute( 'aria-expanded' ) ) === 'false';
@@ -633,7 +631,7 @@ class BlockCommentUtils {
 			await toggleButton.click();
 			await this.#page
 				.getByRole( 'region', { name: 'Editor settings' } )
-				.getByRole( 'button', { name: 'Close Comments' } )
+				.getByRole( 'button', { name: 'Close Notes' } )
 				.waitFor();
 		}
 
@@ -648,20 +646,20 @@ class BlockCommentUtils {
 					name: type,
 					attributes,
 				} );
-				await this.#editor.clickBlockOptionsMenuItem( 'Comment' );
+				await this.#editor.clickBlockOptionsMenuItem( 'Note' );
 				await this.#page
 					.getByRole( 'textbox', {
-						name: 'New Comment',
+						name: 'New Note',
 						exact: true,
 					} )
 					.fill( comment );
 				await this.#page
 					.getByRole( 'region', { name: 'Editor settings' } )
-					.getByRole( 'button', { name: 'Comment', exact: true } )
+					.getByRole( 'button', { name: 'Note', exact: true } )
 					.click();
 				await this.#page
 					.getByRole( 'button', { name: 'Dismiss this notice' } )
-					.filter( { hasText: 'Comment added successfully.' } )
+					.filter( { hasText: 'Note added successfully.' } )
 					.click();
 			},
 			{ box: true }


### PR DESCRIPTION
## What?
Closes #71964.
Related https://github.com/WordPress/gutenberg/discussions/72014#discussioncomment-14629639.

PR updates all user-facing strings to reflect the new name of the feature.

P.S. I'm guessing we're going to use the same wording for the replies.

## Testing Instructions
1. Smoke test to feature.
2. Confirm all strings reflect the new name.
3. Audit changes, confirm renaming makes sense.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
<img width="282" height="379" alt="CleanShot 2025-10-14 at 10 08 07" src="https://github.com/user-attachments/assets/7f8ec4cf-4825-4bbb-9eb1-801a57028072" />


