### PR TITLE
Note: Fix the error when creating a new note

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comment-form.js
+++ b/packages/editor/src/components/collab-sidebar/comment-form.js
@@ -20,27 +20,15 @@ import { useInstanceId, useDebounce } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { sanitizeCommentString } from './utils';
+import { sanitizeCommentString, noop } from './utils';
 
-/**
- * EditComment component.
- *
- * @param {Object}   props                  - The component props.
- * @param {Function} props.onSubmit         - The function to call when updating the comment.
- * @param {Function} props.onCancel         - The function to call when canceling the comment update.
- * @param {Object}   props.thread           - The comment thread object.
- * @param {string}   props.submitButtonText - The text to display on the submit button.
- * @param {string?}  props.labelText        - The label text for the comment input.
- * @param {Function} props.reflowComments   - The function to call when the comment is updated.
- * @return {React.ReactNode} The CommentForm component.
- */
 function CommentForm( {
 	onSubmit,
 	onCancel,
 	thread,
 	submitButtonText,
 	labelText,
-	reflowComments,
+	reflowComments = noop,
 } ) {
 	const [ inputComment, setInputComment ] = useState(
 		thread?.content?.raw ?? ''

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -15,8 +15,8 @@ import {
 	useEffect,
 	useMemo,
 	useRef,
-	useState,
 	useCallback,
+	useReducer,
 } from '@wordpress/element';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
@@ -39,11 +39,10 @@ import { noop } from './utils';
 const { useBlockElementRef } = unlock( blockEditorPrivateApis );
 
 export function useBlockComments( postId ) {
-	const [ commentLastUpdated, setCommentLastUpdated ] = useState( null );
-
-	const reflowComments = () => {
-		setCommentLastUpdated( Date.now() );
-	};
+	const [ commentLastUpdated, reflowComments ] = useReducer(
+		() => Date.now(),
+		0
+	);
 
 	const queryArgs = {
 		post: postId,

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -34,6 +34,7 @@ import { store as interfaceStore } from '@wordpress/interface';
 import { store as editorStore } from '../../store';
 import { collabSidebarName } from './constants';
 import { unlock } from '../../lock-unlock';
+import { noop } from './utils';
 
 const { useBlockElementRef } = unlock( blockEditorPrivateApis );
 
@@ -155,7 +156,7 @@ export function useBlockComments( postId ) {
 	};
 }
 
-export function useBlockCommentsActions( reflowComments ) {
+export function useBlockCommentsActions( reflowComments = noop ) {
 	const { createNotice } = useDispatch( noticesStore );
 	const { saveEntityRecord, deleteEntityRecord } = useDispatch( coreStore );
 	const { getCurrentPostId } = useSelect( editorStore );

--- a/packages/editor/src/components/collab-sidebar/utils.js
+++ b/packages/editor/src/components/collab-sidebar/utils.js
@@ -14,6 +14,11 @@ export function sanitizeCommentString( str ) {
 }
 
 /**
+ * A no-operation function that does nothing.
+ */
+export function noop() {}
+
+/**
  * These colors are picked from the WordPress.org design library.
  * @see https://www.figma.com/design/HOJTpCFfa3tR0EccUlu0CM/WordPress.org-Design-Library?node-id=1-2193&t=M6WdRvTpt0mh8n6T-1
  */


### PR DESCRIPTION
## What?
PR fixes JS error when creating a new note, caused by `undefined` `reflowComments` method.

I've also updated `reflowComments` to ensure it always has a stable reference. This is a requirement for hooks like `useDebounce`.

## How?
* Default `reflowComments` to `noop` when needed.
* Update `commentLastUpdated` state to use a reducer.

## Testing Instructions
1. Open post or page.
2. Add blocks and notes for them.
3. Confirm there are no JS errors when typing new notes.
4. Ensure floating notes work as before.

### Testing Instructions for Keyboard
<img width="621" height="405" alt="CleanShot 2025-10-14 at 10 34 39" src="https://github.com/user-attachments/assets/7a6a5431-049b-4ccd-a4f1-257b4097886a" />
