### PR TITLE
Terms Query: Update `inherit` control and functionality

### DIFF
--- a/packages/block-library/src/terms-query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/terms-query/edit/inspector-controls/index.js
@@ -46,24 +46,26 @@ export default function TermsQueryInspectorControls( {
 		( _taxonomy ) => _taxonomy.slug === taxonomy
 	)?.hierarchical;
 
-	const isTaxonomyMatchingTemplate = templateSlug?.startsWith(
-		// `Tags` are a special case in WP template hierarchy.
-		taxonomy === 'post_tag' ? 'tag' : taxonomy
-	);
-
-	// Only display the inherit control if the taxonomy is hierarchical and matches the current template.
+	// Display the inherit control when we're in a taxonomy-related
+	// template (category, tag, or custom taxonomy).
 	const displayInheritControl =
-		isTaxonomyHierarchical && isTaxonomyMatchingTemplate;
+		templateSlug?.startsWith( 'taxonomy' ) ||
+		templateSlug?.startsWith( 'category' ) ||
+		templateSlug?.startsWith( 'tag' ) ||
+		templateSlug === 'archive';
 
 	// Only display the showNested control if the taxonomy is hierarchical and not inheriting.
 	const displayShowNestedControl =
 		isTaxonomyHierarchical && ! termQuery.inherit;
 
+	// Only display the taxonomy control when not inheriting (custom query type).
+	const displayTaxonomyControl = ! termQuery.inherit;
+
 	// Labels shared between ToolsPanelItem and its child control.
+	const queryTypeControlLabel = __( 'Query type' );
 	const taxonomyControlLabel = __( 'Taxonomy' );
 	const orderByControlLabel = __( 'Order by' );
 	const emptyTermsControlLabel = __( 'Show empty terms' );
-	const inheritControlLabel = __( 'Inherit parent term from archive' );
 	const nestedTermsControlLabel = __( 'Show nested terms' );
 	const maxTermsControlLabel = __( 'Max terms' );
 
@@ -80,6 +82,7 @@ export default function TermsQueryInspectorControls( {
 								orderBy: 'name',
 								hideEmpty: true,
 								showNested: false,
+								inherit: false,
 								parent: false,
 								perPage: 10,
 							},
@@ -87,22 +90,38 @@ export default function TermsQueryInspectorControls( {
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
 				>
-					<ToolsPanelItem
-						hasValue={ () => taxonomy !== 'category' }
-						label={ taxonomyControlLabel }
-						onDeselect={ () => {
-							setQuery( { taxonomy: 'category' } );
-						} }
-						isShownByDefault
-					>
-						<TaxonomyControl
+					{ displayInheritControl && (
+						<ToolsPanelItem
+							hasValue={ () => inherit !== false }
+							label={ queryTypeControlLabel }
+							onDeselect={ () => setQuery( { inherit: false } ) }
+							isShownByDefault
+						>
+							<InheritControl
+								label={ queryTypeControlLabel }
+								value={ inherit }
+								onChange={ setQuery }
+							/>
+						</ToolsPanelItem>
+					) }
+					{ displayTaxonomyControl && (
+						<ToolsPanelItem
+							hasValue={ () => taxonomy !== 'category' }
 							label={ taxonomyControlLabel }
-							value={ taxonomy }
-							onChange={ ( value ) =>
-								setQuery( { taxonomy: value } )
-							}
-						/>
-					</ToolsPanelItem>
+							onDeselect={ () => {
+								setQuery( { taxonomy: 'category' } );
+							} }
+							isShownByDefault
+						>
+							<TaxonomyControl
+								label={ taxonomyControlLabel }
+								value={ taxonomy }
+								onChange={ ( value ) =>
+									setQuery( { taxonomy: value } )
+								}
+							/>
+						</ToolsPanelItem>
+					) }
 					<ToolsPanelItem
 						hasValue={ () => orderBy !== 'name' || order !== 'asc' }
 						label={ orderByControlLabel }
@@ -136,20 +155,6 @@ export default function TermsQueryInspectorControls( {
 							}
 						/>
 					</ToolsPanelItem>
-					{ displayInheritControl && (
-						<ToolsPanelItem
-							hasValue={ () => inherit !== false }
-							label={ inheritControlLabel }
-							onDeselect={ () => setQuery( { inherit: false } ) }
-							isShownByDefault
-						>
-							<InheritControl
-								label={ inheritControlLabel }
-								value={ inherit }
-								onChange={ setQuery }
-							/>
-						</ToolsPanelItem>
-					) }
 					{ displayShowNestedControl && (
 						<ToolsPanelItem
 							hasValue={ () => showNested !== false }

--- a/packages/block-library/src/terms-query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/terms-query/edit/inspector-controls/index.js
@@ -49,10 +49,10 @@ export default function TermsQueryInspectorControls( {
 	// Display the inherit control when we're in a taxonomy-related
 	// template (category, tag, or custom taxonomy).
 	const displayInheritControl =
-		templateSlug?.startsWith( 'taxonomy' ) ||
-		templateSlug?.startsWith( 'category' ) ||
-		templateSlug?.startsWith( 'tag' ) ||
-		templateSlug === 'archive';
+		[ 'taxonomy', 'category', 'tag', 'archive' ].includes( templateSlug ) ||
+		templateSlug?.startsWith( 'taxonomy-' ) ||
+		templateSlug?.startsWith( 'category-' ) ||
+		templateSlug?.startsWith( 'tag-' );
 
 	// Only display the showNested control if the taxonomy is hierarchical and not inheriting.
 	const displayShowNestedControl =

--- a/packages/block-library/src/terms-query/edit/inspector-controls/inherit-control.js
+++ b/packages/block-library/src/terms-query/edit/inspector-controls/inherit-control.js
@@ -1,21 +1,40 @@
 /**
  * WordPress dependencies
  */
-import { ToggleControl } from '@wordpress/components';
+import {
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
-export default function InheritControl( { value, onChange, ...props } ) {
+export default function InheritControl( { value, onChange, label } ) {
 	return (
-		<ToggleControl
+		<ToggleGroupControl
+			__next40pxDefaultSize
 			__nextHasNoMarginBottom
-			checked={ value }
-			onChange={ ( inherit ) =>
+			label={ label }
+			isBlock
+			onChange={ ( newValue ) => {
 				onChange( {
-					inherit,
+					inherit: newValue === 'default',
 					// When enabling inherit, hierarchical is not supported.
-					...( inherit ? { hierarchical: false } : {} ),
-				} )
+					...( newValue === 'default' ? { showNested: false } : {} ),
+				} );
+			} }
+			help={
+				value
+					? __(
+							'Display terms based on the current taxonomy archive. For hierarchical taxonomies, shows direct children of the current term. For non-hierarchical taxonomies, shows all terms.'
+					  )
+					: __( 'Display terms based on specific criteria.' )
 			}
-			{ ...props }
-		/>
+			value={ value ? 'default' : 'custom' }
+		>
+			<ToggleGroupControlOption
+				value="default"
+				label={ __( 'Default' ) }
+			/>
+			<ToggleGroupControlOption value="custom" label={ __( 'Custom' ) } />
+		</ToggleGroupControl>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR updates how Terms Query block handles the `inherit` from template query, the control used and when to show that control.

Currently there is a `Inherit parent term from archive` that is shown only when some checks about trying to match the current template with the block's selected taxonomy.  This is limiting and requires the user to insert the block in various templates and select the respective taxonomy in block attributes, and then set to `inherit`.

This PR updates the logic to show the control when there is a category/taxonomy template and even checks for the `archive` fallback template, in order to show the control.

If a user selects the `default` Query type (`inherit:true`) then the block's `taxonomy` attribute is not taken into account and the one from the queried object is used. This way users can insert the same block with just selecting the `default` query type even in `archive` template and it should just work.

1. For hierarchical taxonomies -> show the child terms of current term.
2. For non-hierarchical taxonomies -> show all the terms

In both cases we respect the other settings that affect the query, like `perPage`.

The updated `query type (inherit)` control matches the design of Query loop for familiarity and there are help messages per use case and I moved it on the top of the settings. That would need some design feedback from @WordPress/gutenberg-design though.



## Testing Instructions
1. Ensure the block works in a post/page as before
2. In site editor test the block in various templates and ensure it works as expected in all these cases

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/ced32149-a2d2-4d85-952d-7e2469d7ffd3

