### PR TITLE
Notes: improve REST API checks for resolution notes

### DIFF
--- a/lib/experimental/block-comments.php
+++ b/lib/experimental/block-comments.php
@@ -130,5 +130,6 @@ function gutenberg_allow_duplicate_note_resolution( $dupe_id, $commentdata ) {
 	if ( isset( $commentdata['meta']['_wp_note_status'] ) && in_array( $commentdata['meta']['_wp_note_status'], array( 'resolved', 'reopen' ), true ) ) {
 		return false;
 	}
+	return $dupe_id;
 }
 add_filter( 'duplicate_comment_id', 'gutenberg_allow_duplicate_note_resolution', 10, 2 );

--- a/lib/experimental/block-comments.php
+++ b/lib/experimental/block-comments.php
@@ -43,8 +43,8 @@ function gutenberg_register_block_comment_metadata() {
 					'enum' => array( 'resolved', 'reopen' ),
 				),
 			),
-			'auth_callback' => function () {
-				return current_user_can( 'edit_posts' );
+			'auth_callback' => function ( $allowed, $meta_key, $object_id ) {
+				return current_user_can( 'edit_comment', $object_id );
 			},
 		)
 	);

--- a/lib/experimental/class-gutenberg-rest-comment-controller.php
+++ b/lib/experimental/class-gutenberg-rest-comment-controller.php
@@ -550,11 +550,12 @@ class Gutenberg_REST_Comment_Controller extends WP_REST_Comments_Controller {
 			return true;
 		}
 
-		// Allow empty block comments with resolution metadata [backport].
+		// Allow empty block comments only when resolution metadata is valid [backport].
 		if (
 			isset( $check['comment_type'] ) &&
 			'note' === $check['comment_type'] &&
-			isset( $check['meta']['_wp_note_status'] )
+			isset( $check['meta']['_wp_note_status'] ) &&
+			in_array( $check['meta']['_wp_note_status'], array( 'resolved', 'reopen' ), true )
 		) {
 			return true;
 		}


### PR DESCRIPTION
Follow-up #71563

## What?

This PR adds REST API unit tests for the resolution notes, and fixes the bugs found by those tests.

## Why?

Code quality.

## How?

- Add unit tests.
- Fixes two bugs that were revealed by adding unit tests:
  - `gutenberg_allow_duplicate_note_resolution()` had no default return statement
  - Empty comments were allowed even if the value of `_wp_note_status` was invalid.

## Testing Instructions

All CIs should be ✅.