### PR TITLE
Notes: Allow creating duplicate comments for all notes

### DIFF
--- a/lib/experimental/block-comments.php
+++ b/lib/experimental/block-comments.php
@@ -117,17 +117,17 @@ function gutenberg_filter_comment_count_query_exclude_block_comments( $query ) {
 add_filter( 'query', 'gutenberg_filter_comment_count_query_exclude_block_comments' );
 
 /**
- * Allows duplicate block comment resolution messages.
+ * Allows duplicate block comment.
  *
  * @since 6.9.0
  *
  * @param int $dupe_id The duplicate comment ID.
  * @param array $commentdata The comment data.
  *
- * @return bool True if the comment can be duplicated, false otherwise.
+ * @return int ID of the comment identified as a duplicate.
  */
 function gutenberg_allow_duplicate_note_resolution( $dupe_id, $commentdata ) {
-	if ( isset( $commentdata['meta']['_wp_note_status'] ) && in_array( $commentdata['meta']['_wp_note_status'], array( 'resolved', 'reopen' ), true ) ) {
+	if ( isset( $commentdata['comment_type'] ) && 'note' === $commentdata['comment_type'] ) {
 		return false;
 	}
 	return $dupe_id;

--- a/phpunit/experimental/rest-api-comment-permissions-test.php
+++ b/phpunit/experimental/rest-api-comment-permissions-test.php
@@ -324,7 +324,7 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 	/**
 	 * Test that duplicate block comments with resolution metadata are allowed.
 	 */
-	public function test_create_duplicate_block_comment_with_resolution_metadata() {
+	public function test_create_duplicate_block_comment() {
 		wp_set_current_user( self::$user_ids['editor'] );
 		$post_id = $this->factory->post->create();
 
@@ -337,9 +337,6 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 				'author'       => self::$user_ids['editor'],
 				'type'         => 'note',
 				'content'      => 'Doplicated comment',
-				'meta'         => array(
-					'_wp_note_status' => 'resolved',
-				),
 			);
 			$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
 			$request->add_header( 'Content-Type', 'application/json' );
@@ -347,34 +344,6 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 			$response = rest_get_server()->dispatch( $request );
 			$this->assertSame( 201, $response->get_status() );
 		}
-	}
-
-	/**
-	 * Test that duplicate block comments without resolution metadata are not allowed.
-	 */
-	public function test_cannot_create_duplicate_block_comment_without_resolution_meta() {
-		wp_set_current_user( self::$user_ids['editor'] );
-		$post_id = $this->factory->post->create();
-		$params  = array(
-			'post'         => $post_id,
-			'author_name'  => 'Editor',
-			'author_email' => 'editor@example.com',
-			'author_url'   => 'https://example.com',
-			'author'       => self::$user_ids['editor'],
-			'type'         => 'note',
-			'content'      => 'Doplicated comment',
-		);
-		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
-		$request->add_header( 'Content-Type', 'application/json' );
-		$request->set_body( wp_json_encode( $params ) );
-		$response = rest_get_server()->dispatch( $request );
-		$this->assertSame( 201, $response->get_status() );
-
-		$request = new WP_REST_Request( 'POST', '/wp/v2/comments' );
-		$request->add_header( 'Content-Type', 'application/json' );
-		$request->set_body( wp_json_encode( $params ) );
-		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'comment_duplicate', $response, 409 );
 	}
 
 	/**


### PR DESCRIPTION
Closes #72288

## What?

Currently, duplicate comments are only allowed in resolution notes, but duplicate comments should always be allowed in notes.

## How?

Update the `gutenberg_allow_duplicate_note_resolution()` function and unit tests.

## Testing Instructions

Confirm that you submit duplicate notes and replies with the same comment text.