### PR TITLE
Real-time collaboration: Allow post-locked-modal to be overridden when `collaborative-editing` is enabled

### DIFF
--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -155,7 +155,7 @@ function PostLockedModal() {
 	}
 
 	// Avoid sending the modal if sync is supported, but retain functionality around locks etc.
-	if ( window.__experimentalEnableSync && supportsSync ) {
+	if ( supportsSync ) {
 		if ( globalThis.IS_GUTENBERG_PLUGIN ) {
 			return null;
 		}

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -41,13 +41,14 @@ function PostLockedModal() {
 			isPostLockTakeover,
 			getPostLockUser,
 			getCurrentPostId,
+			getCurrentPostType,
 			getActivePostLock,
 			getEditedPostAttribute,
 			getEditedPostPreviewLink,
 			getEditorSettings,
 		} = select( editorStore );
 		const { getPostType, getEntityConfig } = select( coreStore );
-		const entityName = getEditedPostAttribute( 'type' );
+		const currentPostType = getCurrentPostType();
 		return {
 			isLocked: isPostLocked(),
 			isTakeover: isPostLockTakeover(),
@@ -57,7 +58,7 @@ function PostLockedModal() {
 			activePostLock: getActivePostLock(),
 			postType: getPostType( getEditedPostAttribute( 'type' ) ),
 			previewLink: getEditedPostPreviewLink(),
-			supportsSync: getEntityConfig( 'postType', entityName )?.syncConfig?.enabled,
+			supportsSync: getEntityConfig( 'postType', currentPostType )?.syncConfig?.enabled,
 		};
 	}, [] );
 

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -57,7 +57,7 @@ function PostLockedModal() {
 			activePostLock: getActivePostLock(),
 			postType: getPostType( getEditedPostAttribute( 'type' ) ),
 			previewLink: getEditedPostPreviewLink(),
-			supportsSync: getEntityConfig( 'postType', entityName )?.syncConfig?.enabled,
+			supportsSync: Boolean( getEntityConfig( 'postType', entityName )?.syncConfig ),
 		};
 	}, [] );
 

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -58,7 +58,9 @@ function PostLockedModal() {
 			activePostLock: getActivePostLock(),
 			postType: getPostType( getEditedPostAttribute( 'type' ) ),
 			previewLink: getEditedPostPreviewLink(),
-			supportsSync: Boolean( getEntityConfig( 'postType', currentPostType )?.syncConfig ),
+			supportsSync: Boolean(
+				getEntityConfig( 'postType', currentPostType )?.syncConfig
+			),
 		};
 	}, [] );
 

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -34,6 +34,7 @@ function PostLockedModal() {
 		activePostLock,
 		postType,
 		previewLink,
+		supportsSync,
 	} = useSelect( ( select ) => {
 		const {
 			isPostLocked,
@@ -45,7 +46,8 @@ function PostLockedModal() {
 			getEditedPostPreviewLink,
 			getEditorSettings,
 		} = select( editorStore );
-		const { getPostType } = select( coreStore );
+		const { getPostType, getEntityConfig } = select( coreStore );
+		const entityName = getEditedPostAttribute( 'type' );
 		return {
 			isLocked: isPostLocked(),
 			isTakeover: isPostLockTakeover(),
@@ -55,6 +57,7 @@ function PostLockedModal() {
 			activePostLock: getActivePostLock(),
 			postType: getPostType( getEditedPostAttribute( 'type' ) ),
 			previewLink: getEditedPostPreviewLink(),
+			supportsSync: getEntityConfig( 'postType', entityName )?.syncConfig?.enabled,
 		};
 	}, [] );
 
@@ -146,6 +149,13 @@ function PostLockedModal() {
 
 	if ( ! isLocked ) {
 		return null;
+	}
+
+	// Avoid sending the modal if sync is supported, but retain functionality around locks etc.
+	if ( window.__experimentalEnableSync && supportsSync ) {
+		if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+			return null;
+		}
 	}
 
 	const userDisplayName = user.name;


### PR DESCRIPTION
## What?

Pulled from: https://github.com/WordPress/gutenberg/pull/72040, this allows the post lock to be configured based on the sync enabled entity.

## Why?

In order to maintain the post lock functionality, we need to return when sync config is enabled during a real-time collaboration session where it is enabled for a post type.

## How?

Checks that the post type has `collaborative-editing` enabled via `post_type_supports` and disabled the lock modal based on it.

## Testing Instructions
1. By default `post` and `page` post types have this enabled within the Gutenberg plugin.
2. Visit a `post` with more than 1 user present and note there is no pock lock modal for either user.

