### PR TITLE
Workflows: Performance: Fix RegExp for wpVersion option

### DIFF
--- a/bin/plugin/commands/performance.js
+++ b/bin/plugin/commands/performance.js
@@ -359,7 +359,7 @@ async function runPerformanceTests( branches, options ) {
 		//     5.7   -> 5.7   (unchanged)
 		//     5.7.0 -> 5.7   (changed)
 		//     5.7.2 -> 5.7.2 (unchanged)
-		const zipVersion = options.wpVersion.replace( /^(\d+\.\d+).0/, '$1' );
+		const zipVersion = options.wpVersion.replace( /^(\d+\.\d+)\.0$/, '$1' );
 		wpZipUrl = `https://wordpress.org/wordpress-${ zipVersion }.zip`;
 	}
 


### PR DESCRIPTION
## What?

Follow-up of #32244 (4½ years later!)

Fix a regular expression used in `runPerformanceTests` when parsing the `wpVersion` option. This option denotes the WordPress version to be used when running the performance benchmarks. For versions with format `x.y.0` (i.e. versions whose patch count is 0), the corresponding WordPress ZIP file should be found by dropping the `.0` suffix. The regular expression is meant to identify those cases only.

The original regular expression was missing a backslash to match a literal period (\.), and thus it could match any character.

In practice, this should never matter because of WordPress's versioning conventions. However, if we ever reach a x.100 minor release, the CI performance tests could fail. ;)