### PR TITLE
Try: Fix flaky router styles e2e tests

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/render.php
@@ -84,6 +84,16 @@ $wrapper_attributes = get_block_wrapper_attributes();
 		<?php echo $content; ?>
 	</div>
 
+	<!-- Flag to check whether hydration has occurred. -->
+	<div
+		data-testid="hydrated"
+		data-wp-interactive="test/router-styles"
+		data-wp-bind--hidden="state.undefined"
+		hidden
+	>
+		Hydrated
+	</div>
+
 	<!-- Text to check whether a navigation was client-side. -->
 	<div
 		data-testid="client-side navigation"

--- a/test/e2e/specs/interactivity/router-styles.spec.ts
+++ b/test/e2e/specs/interactivity/router-styles.spec.ts
@@ -305,7 +305,7 @@ test.describe( 'Router styles', () => {
 		const linkPattern = '**/router-styles-red/style-from-link.css*';
 		await page.route( linkPattern, async ( route ) => {
 			await route.abort( 'failed' );
-			await page.unroute( linkPattern );
+			await page.unrouteAll( { behavior: 'ignoreErrors' } );
 		} );
 
 		// Navigate to the page with the Red block

--- a/test/e2e/specs/interactivity/router-styles.spec.ts
+++ b/test/e2e/specs/interactivity/router-styles.spec.ts
@@ -53,6 +53,7 @@ test.describe( 'Router styles', () => {
 
 	test.beforeEach( async ( { page, interactivityUtils: utils } ) => {
 		await page.goto( utils.getLink( 'none' ) );
+		await expect( page.getByTestId( 'hydrated' ) ).toBeVisible();
 	} );
 
 	test.afterAll( async ( { interactivityUtils: utils } ) => {


### PR DESCRIPTION
## What?
Closes #71722.

PR tries to fix the flaky "should refresh the page when stylesheet loading fails" e2e test.

## Testing Instructions
```
npm run test:e2e -- test/e2e/specs/interactivity/router-styles.spec.ts --grep "should refresh the page when stylesheet loading fails" --repeat-each 20
```
