### PR TITLE
Icons: Make tracked file checker work in more environments

### DIFF
--- a/packages/icons/lib/generate-library.js
+++ b/packages/icons/lib/generate-library.js
@@ -35,12 +35,18 @@ async function ensureSvgFilesTracked() {
 	try {
 		// Avoid invoking `ls-files` with a wildcard (`*.svg`) due to the
 		// variability of wildcard behaviour across shells.
-		const { stdout } = await execFileAsync( 'git', [
-			'ls-files',
-			'-o',
-			'--full-name',
-			ICON_LIBRARY_DIR,
-		] );
+		const { stdout } = await execFileAsync(
+			'git',
+			[ 'ls-files', '-o', '--full-name', ICON_LIBRARY_DIR ],
+			{
+				// Unset GIT_WORK_TREE to avoid path resolution issues
+				// in commit hook environments (e.g. GUI git clients)
+				env: {
+					...process.env,
+					GIT_WORK_TREE: undefined,
+				},
+			}
+		);
 
 		// Filtering with `grep` in a single `exec` call was tempting, but this
 		// manual filtering avoids any shell escaping weirdness.
@@ -66,7 +72,12 @@ async function ensureSvgFilesTracked() {
 }
 
 async function cleanup() {
-	await execFileAsync( 'git', [ 'clean', '-Xfq', ICON_LIBRARY_DIR ] );
+	await execFileAsync( 'git', [ 'clean', '-Xfq', ICON_LIBRARY_DIR ], {
+		env: {
+			...process.env,
+			GIT_WORK_TREE: undefined,
+		},
+	} );
 }
 
 // Generate src/library/*.tsx based on the available SVG files.


### PR DESCRIPTION
## What?

Prevents the `ensureSvgFilesTracked()` script from making git commit hooks fail on every commit, in certain git client apps.

## Why?

Since this script was introduced to the prelint process, every commit I try to make in my GUI git app fails, because the script incorrectly thinks that all the svg files in the `ICON_LIBRARY_DIR` are untracked. At least in my environment, I've narrowed down the cause to my git app environment setting `GIT_WORK_TREE` to `"."` by default.

I could perhaps work around this problem in my local environment, but the fact that my git app sets it by default suggests that other apps may be doing so as well. Making the script itself more defensive may prevent others from having to hit this issue.

## How?

Unset `GIT_WORK_TREE` when running the relevant git commands.

## Testing Instructions

Test that the `npm run build` of the `icons` package still does what it's intended to do. (I assume it's supposed to error when you run `npm run build` with untracked svg files in `ICON_LIBRARY_DIR`. Judging from the behavior on trunk, the error won't trigger on git commit hooks though, presumably due to lint-staged. @mcsf Please confirm 🙏)