### PR TITLE
Notes: Move focus to the parent thread when a reply was deleted

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -98,7 +98,13 @@ export function Comments( {
 
 		await onCommentDelete( comment );
 
-		// Focus logic after deletion completes.
+		if ( comment.parent !== 0 ) {
+			// Move focus to the parent thread when a reply was deleted.
+			setSelectedThread( comment.parent );
+			focusCommentThread( comment.parent, commentSidebarRef.current );
+			return;
+		}
+
 		if ( nextThread ) {
 			setSelectedThread( nextThread.id );
 			focusCommentThread( nextThread.id, commentSidebarRef.current );
@@ -108,7 +114,7 @@ export function Comments( {
 		} else {
 			setSelectedThread( null );
 			setShowCommentBoard( false );
-			// Focus the parent block instead of just scrolling into view.
+			// Move focus to the related block.
 			relatedBlockElement?.focus();
 		}
 	};

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -511,6 +511,11 @@ test.describe( 'Block Comments', () => {
 			await blockCommentUtils.addBlockWithComment( {
 				type: 'core/paragraph',
 				attributes: { content: 'Testing block comments' },
+				comment: 'Test note',
+			} );
+			await blockCommentUtils.addBlockWithComment( {
+				type: 'core/paragraph',
+				attributes: { content: 'Testing block comments' },
 				comment: 'Test comment',
 			} );
 			const commentForm = page.getByRole( 'textbox', {


### PR DESCRIPTION
## What?
This is a follow-up to #71974.

PR fixes the focus after deletion logic when deleting replies, ensuring focus always returns to the parent thread. It would move to the previous thread if you've more than one on trunk.

I've adjusted the e2e test to showcase the bug. Check out the [c7e68e5](https://github.com/WordPress/gutenberg/pull/72341/commits/c7e68e5e43509d178d441e6d491c6e88f077f72f), which demonstrates the problem.

## Testing Instructions
1. Create a post.
2. Add multiple blocks and notes for each.
3. Select the last block and add a reply.
4. Delete the reply.
5. Confirm that focus moves to the paren note.

### Testing Instructions for Keyboard
Same.