### PR TITLE
Notes: Avoid losing sidebar reference

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -47,7 +47,10 @@ function CollabSidebarContent( {
 			style={ styles }
 			role="list"
 			spacing="3"
-			ref={ commentSidebarRef }
+			ref={ ( node ) => {
+				// Keeps the ref fresh when switching between floating and pinned sidebar.
+				commentSidebarRef.current = node;
+			} }
 		>
 			{ ! isFloating && (
 				<AddComment


### PR DESCRIPTION
## What?
This is a follow-up to https://github.com/WordPress/gutenberg/pull/72158#issuecomment-3381334706.

PR prevents `commentSidebarRef` from becoming `undefined` when switching between floating and pinned notes sidebars.

## Why?
Both sidebars use the same reference; unmounting one removes it, and it wasn't restored by the other.

## How?
Use a ref callback that keeps the reference "alive".

## Testing Instructions
1. Open a post.
2. Add a block and note for this block.
3. Reload the editor.
4. Select the block and click the note button in the block toolbar.
5. The focus should move the note.
6. Close this pinned sidebar and display floating notes.
7. Click the same button in the block toolbar.
8. The pinned sidebar should open and focus again, and the user should move to the note.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/67b3960d-8246-4eee-957f-8e8a626dade8

