### PR TITLE
Breadcrumbs: Do not allow empty separator

### DIFF
--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -69,7 +69,7 @@ export default function BreadcrumbEdit( {
 						</li>
 					) ) }
 					<li>
-						<span>{ __( 'Current' ) }</span>
+						<span aria-current="page">{ __( 'Current' ) }</span>
 					</li>
 				</ol>
 			</nav>
@@ -126,6 +126,13 @@ export default function BreadcrumbEdit( {
 							onChange={ ( value ) =>
 								setAttributes( { separator: value } )
 							}
+							onBlur={ () => {
+								if ( ! separator ) {
+									setAttributes( {
+										separator: separatorDefaultValue,
+									} );
+								}
+							} }
 						/>
 					</ToolsPanelItem>
 				</ToolsPanel>

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -34,11 +34,8 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$separator        = isset( $attributes['separator'] ) ? $attributes['separator'] : '/';
-	$show_home_link   = isset( $attributes['showHomeLink'] ) ? $attributes['showHomeLink'] : true;
 	$breadcrumb_items = array();
-
-	if ( $show_home_link ) {
+	if ( $attributes['showHomeLink'] ) {
 		$breadcrumb_items[] = sprintf(
 			'<a href="%s">%s</a>',
 			esc_url( home_url() ),
@@ -58,10 +55,10 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 	}
 
 	// Add current post title (not linked).
-	$breadcrumb_items[] = sprintf( '<span>%s</span>', get_the_title( $post ) );
+	$breadcrumb_items[] = sprintf( '<span aria-current="page">%s</span>', get_the_title( $post ) );
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
-			'style'      => '--separator: "' . addcslashes( $separator, '\\"' ) . '";',
+			'style'      => '--separator: "' . addcslashes( $attributes['separator'], '\\"' ) . '";',
 			'aria-label' => __( 'Breadcrumbs' ),
 		)
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/72122

This PR doesn't allow the user to save an `empty` separator value because it was deemed vital for making the breadcrumb trail clear. Additionally it adds the `aria-current="page"` to the last item for a11y reasons.

## Testing Instructions
1. Insert Breadcrumbs block and verify that everything works as expected and that you cannot save an empty value.
