### PR TITLE
Build v2: Fix block-editor default colors

### DIFF
--- a/packages/block-editor/src/content.scss
+++ b/packages/block-editor/src/content.scss
@@ -1,3 +1,4 @@
+@use "@wordpress/base-styles/default-custom-properties";
 @use "@wordpress/base-styles/mixins" as *;
 @use "./components/block-icon/content.scss" as *;
 @use "./components/block-list/content.scss" as *;

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -1,3 +1,4 @@
+@use "@wordpress/base-styles/default-custom-properties";
 @use "@wordpress/base-styles/mixins" as *;
 @use "./autocompleters/style.scss" as *;
 @use "./components/background-image-control/style.scss" as *;


### PR DESCRIPTION
## What?
Closes #72343

Small regression from #72259 where I forgot to include the default colors to the style.scss since we know moved to explicit dependencies over implicit ones.

## Testing Instructions

1- Open the post editor
2- Insert a placeholder block
3- The colors of the buttons in the placeholder should be the default WP colors.