### PR TITLE
Block Bindings: Move bindable attributes to privateContext.

### DIFF
--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -25,8 +25,8 @@ import {
 	hasPatternOverridesDefaultBinding,
 	replacePatternOverridesDefaultBinding,
 } from '../../utils/block-bindings';
-import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
+import { PrivateBlockContext } from '../block-list/private-block-context';
 
 /**
  * Default value used for blocks which do not define their own context needs,
@@ -56,8 +56,6 @@ const Edit = ( props ) => {
 
 const EditWithFilters = withFilters( 'editor.BlockEdit' )( Edit );
 
-const EMPTY_ARRAY = [];
-
 const EditWithGeneratedProps = ( props ) => {
 	const { name, clientId, attributes, setAttributes } = props;
 	const registry = useRegistry();
@@ -68,17 +66,7 @@ const EditWithGeneratedProps = ( props ) => {
 			unlock( select( blocksStore ) ).getAllBlockBindingsSources(),
 		[]
 	);
-	const bindableAttributes = useSelect(
-		( select ) => {
-			const { __experimentalBlockBindingsSupportedAttributes } =
-				select( blockEditorStore ).getSettings();
-			return (
-				__experimentalBlockBindingsSupportedAttributes?.[ name ] ||
-				EMPTY_ARRAY
-			);
-		},
-		[ name ]
-	);
+	const { bindableAttributes } = useContext( PrivateBlockContext );
 
 	const { blockBindings, context, hasPatternOverrides } = useMemo( () => {
 		// Assign context values using the block type's declared context needs.

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -606,7 +606,16 @@ function BlockListBlockProvider( props ) {
 			const attributes = getBlockAttributes( clientId );
 			const { name: blockName, isValid } = blockWithoutAttributes;
 			const blockType = getBlockType( blockName );
-			const { supportsLayout, isPreviewMode } = getSettings();
+			const {
+				supportsLayout,
+				isPreviewMode,
+				__experimentalBlockBindingsSupportedAttributes,
+			} = getSettings();
+
+			const bindableAttributes =
+				__experimentalBlockBindingsSupportedAttributes?.[ blockName ] ||
+				[];
+
 			const hasLightBlockWrapper = blockType?.apiVersion > 1;
 			const previewContext = {
 				isPreviewMode,
@@ -710,6 +719,7 @@ function BlockListBlockProvider( props ) {
 					? blocksWithSameName[ 0 ]
 					: false,
 				isBlockHidden: _isBlockHidden( clientId ),
+				bindableAttributes,
 			};
 		},
 		[ clientId, rootClientId ]
@@ -753,6 +763,7 @@ function BlockListBlockProvider( props ) {
 		defaultClassName,
 		originalBlockClientId,
 		isBlockHidden,
+		bindableAttributes,
 	} = selectedProps;
 
 	// Users of the editor.BlockListBlock filter used to be able to
@@ -802,6 +813,7 @@ function BlockListBlockProvider( props ) {
 		themeSupportsLayout,
 		canMove,
 		isBlockHidden,
+		bindableAttributes,
 	};
 
 	if (

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -613,8 +613,7 @@ function BlockListBlockProvider( props ) {
 			} = getSettings();
 
 			const bindableAttributes =
-				__experimentalBlockBindingsSupportedAttributes?.[ blockName ] ||
-				[];
+				__experimentalBlockBindingsSupportedAttributes?.[ blockName ];
 
 			const hasLightBlockWrapper = blockType?.apiVersion > 1;
 			const previewContext = {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
https://github.com/WordPress/gutenberg/pull/71820 introduced a performance regression.

Following recommendations by @youknowriad  and @talldan, this PR removes a useSelect call by using privateContext instead. 

This is the performance test results watched in the previous PR
<img width="1068" height="630" alt="Screenshot 2025-10-15 at 14 33 25" src="https://github.com/user-attachments/assets/1841971d-1e54-47ac-87d6-235322badee9" />

<img width="1083" height="471" alt="Screenshot 2025-10-15 at 14 35 38" src="https://github.com/user-attachments/assets/a9ca4ba4-b53b-4937-9f0e-57335ef9bdd6" />

