### PR TITLE
Notes: Update button labels

### DIFF
--- a/packages/editor/src/components/collab-sidebar/add-comment.js
+++ b/packages/editor/src/components/collab-sidebar/add-comment.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import {
 	__experimentalHStack as HStack,
@@ -73,7 +73,7 @@ export function AddComment( {
 					setShowCommentBoard( false );
 					blockElement?.focus();
 				} }
-				submitButtonText={ _x( 'Note', 'Add note button' ) }
+				submitButtonText={ __( 'Add note' ) }
 				labelText={ __( 'New Note' ) }
 			/>
 		</VStack>

--- a/packages/editor/src/components/collab-sidebar/comment-menu-item.js
+++ b/packages/editor/src/components/collab-sidebar/comment-menu-item.js
@@ -26,7 +26,7 @@ const AddCommentMenuItem = ( { onClick } ) => {
 					} }
 					aria-haspopup="dialog"
 				>
-					{ __( 'Note' ) }
+					{ __( 'Add note' ) }
 				</MenuItem>
 			) }
 		</CommentIconSlotFill.Fill>

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -476,9 +476,9 @@ function Thread( {
 							rows={ 'approved' === thread.status ? 2 : 4 }
 							labelText={ sprintf(
 								// translators: %1$s: note identifier, %2$s: author name
-								__( 'Reply to Note %1$s by %2$s' ),
+								__( 'Reply to note %1$s by %2$s' ),
 								thread.id,
-								thread?.author_name || 'Unknown'
+								thread.author_name
 							) }
 							reflowComments={ reflowComments }
 						/>
@@ -646,7 +646,7 @@ const CommentBoard = ( {
 						// translators: %1$s: note identifier, %2$s: author name.
 						__( 'Edit note %1$s by %2$s' ),
 						thread.id,
-						thread?.author_name || 'Unknown'
+						thread.author_name
 					) }
 					reflowComments={ reflowComments }
 				/>

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -36,7 +36,7 @@ test.describe( 'Block Comments', () => {
 			name: 'core/paragraph',
 			attributes: { content: 'Testing block comments' },
 		} );
-		await editor.clickBlockOptionsMenuItem( 'Note' );
+		await editor.clickBlockOptionsMenuItem( 'Add note' );
 		await page
 			.getByRole( 'textbox', {
 				name: 'New Note',
@@ -45,7 +45,7 @@ test.describe( 'Block Comments', () => {
 			.fill( 'A test comment' );
 		await page
 			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'button', { name: 'Note', exact: true } )
+			.getByRole( 'button', { name: 'Add note', exact: true } )
 			.click();
 		const thread = page
 			.getByRole( 'region', { name: 'Editor settings' } )
@@ -642,7 +642,7 @@ class BlockCommentUtils {
 					name: type,
 					attributes,
 				} );
-				await this.#editor.clickBlockOptionsMenuItem( 'Note' );
+				await this.#editor.clickBlockOptionsMenuItem( 'Add note' );
 				await this.#page
 					.getByRole( 'textbox', {
 						name: 'New Note',
@@ -651,7 +651,7 @@ class BlockCommentUtils {
 					.fill( comment );
 				await this.#page
 					.getByRole( 'region', { name: 'Editor settings' } )
-					.getByRole( 'button', { name: 'Note', exact: true } )
+					.getByRole( 'button', { name: 'Add note', exact: true } )
 					.click();
 				await this.#page
 					.getByRole( 'button', { name: 'Dismiss this notice' } )


### PR DESCRIPTION
## What?
This is a follow-up to https://github.com/WordPress/gutenberg/pull/72311#issuecomment-3402816099.

PR changes "Note" submit button label to "Add note". I've also updated the label for the block options menu item.

## Testing Instructions
1. Open post or page.
2. Add blocks.
3. Add notes for these blocks.
4. Confirm the mentioned labels are updated.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
<img width="1249" height="564" alt="CleanShot 2025-10-15 at 11 48 25" src="https://github.com/user-attachments/assets/15e81cee-3d4d-4021-a2fc-01553664e23c" />