### PR TITLE
Notes: Don't change 'type' schema

### DIFF
--- a/backport-changelog/6.9/10280.md
+++ b/backport-changelog/6.9/10280.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/10280
 
 * https://github.com/WordPress/gutenberg/pull/72344
+* https://github.com/WordPress/gutenberg/pull/72357

--- a/phpunit/experimental/rest-api-comment-permissions-test.php
+++ b/phpunit/experimental/rest-api-comment-permissions-test.php
@@ -202,8 +202,10 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 
 	public function test_cannot_create_with_non_valid_comment_type() {
 		wp_set_current_user( self::$user_ids['administrator'] );
+		$post_id = $this->factory->post->create();
 
 		$params = array(
+			'post'         => $post_id,
 			'author_name'  => 'Ishmael',
 			'author_email' => 'herman-melville@earthlink.net',
 			'author_url'   => 'https://en.wikipedia.org/wiki/Herman_Melville',
@@ -217,7 +219,7 @@ class WP_Test_REST_Block_Comment_Permissions extends WP_Test_REST_TestCase {
 		$request->set_body( wp_json_encode( $params ) );
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+		$this->assertErrorResponse( 'rest_invalid_comment_type', $response, 400 );
 	}
 
 	public function test_create_assigns_default_type() {


### PR DESCRIPTION
## What?
Related https://github.com/WordPress/wordpress-develop/pull/10280#discussion_r2432329836.

Updates comments endpoint modifications and avoids changing `type` property schema.

## Testing Instructions
CI checks are green.
