### PR TITLE
Build v2: Fix transpilation warnings

### DIFF
--- a/packages/e2e-test-utils-playwright/src/lighthouse/index.ts
+++ b/packages/e2e-test-utils-playwright/src/lighthouse/index.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import type { Page } from '@playwright/test';
-import * as lighthouse from 'lighthouse/core/index.cjs';
+import lighthouse from 'lighthouse/core/index.cjs';
 
 type LighthouseConstructorProps = {
 	page: Page;

--- a/packages/e2e-test-utils-playwright/src/test.ts
+++ b/packages/e2e-test-utils-playwright/src/test.ts
@@ -4,7 +4,7 @@
 import * as path from 'path';
 import { test as base, expect, chromium } from '@playwright/test';
 import type { ConsoleMessage } from '@playwright/test';
-import * as getPort from 'get-port';
+import getPort from 'get-port';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
## What?
See #72294

Fixing transpilation warnings

## Why?
It's good to have a warning-free build process.

## How?
Import modules the correct way

## Testing Instructions
1. Run `npm run build:packages:v2`
2. Check the output logs. It shouldn't contain any import-related warnings except one which is related to dynamically importing the `util` module using require.
