### PR TITLE
DataForm: refactor RelativeDateControl to use DataFormControl props

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Reorganizes normalize-form-fields and renames `dataforms-layouts/` to `dataform-layout/` to follow the naming schema of any other folder in the package. [#72056](https://github.com/WordPress/gutenberg/pull/72056)
 - Moves `utils.ts` to `field-types/utils/render-from-elements.ts`, so it's collocated where it is used. [#72058](https://github.com/WordPress/gutenberg/pull/72058)
 - Centralize all top-level utilities in a `utils/` folder, sets a name that reflects on the function name, and uses the default exports. [#72063](https://github.com/WordPress/gutenberg/pull/72063)
+- DataForm: refactor RelativeDateControl to use DataFormControl props. [#72361](https://github.com/WordPress/gutenberg/pull/72361)
 
 ## 9.1.0 (2025-10-01)
 

--- a/packages/dataviews/src/dataform-controls/date.tsx
+++ b/packages/dataviews/src/dataform-controls/date.tsx
@@ -40,7 +40,6 @@ import deepMerge from 'deepmerge';
  * Internal dependencies
  */
 import RelativeDateControl, {
-	TIME_UNITS_OPTIONS,
 	type DateRelative,
 } from './relative-date-control';
 import {
@@ -662,7 +661,7 @@ export default function DateControl< Item >( {
 				onChange={ onChangeRelativeDateControl }
 				label={ label }
 				hideLabelFromVision={ hideLabelFromVision }
-				options={ TIME_UNITS_OPTIONS[ operator ] }
+				operator={ operator }
 			/>
 		);
 	}

--- a/packages/dataviews/src/dataform-controls/date.tsx
+++ b/packages/dataviews/src/dataform-controls/date.tsx
@@ -39,7 +39,7 @@ import deepMerge from 'deepmerge';
 /**
  * Internal dependencies
  */
-import RelativeDateControl from './relative-date-control';
+import RelativeDateControl from './utils/relative-date-control';
 import {
 	OPERATOR_IN_THE_PAST,
 	OPERATOR_OVER,

--- a/packages/dataviews/src/dataform-controls/date.tsx
+++ b/packages/dataviews/src/dataform-controls/date.tsx
@@ -642,8 +642,7 @@ export default function DateControl< Item >( {
 	hideLabelFromVision,
 	operator,
 }: DataFormControlProps< Item > ) {
-	const { id, label, getValue, setValue } = field;
-	const value = getValue( { item: data } );
+	const { setValue } = field;
 
 	const onChangeRelativeDateControl = useCallback(
 		( newValue: DateRelative ) => {
@@ -656,10 +655,9 @@ export default function DateControl< Item >( {
 		return (
 			<RelativeDateControl
 				className="dataviews-controls__date"
-				id={ id }
-				value={ value && typeof value === 'object' ? value : {} }
+				data={ data }
+				field={ field }
 				onChange={ onChangeRelativeDateControl }
-				label={ label }
 				hideLabelFromVision={ hideLabelFromVision }
 				operator={ operator }
 			/>

--- a/packages/dataviews/src/dataform-controls/date.tsx
+++ b/packages/dataviews/src/dataform-controls/date.tsx
@@ -39,9 +39,7 @@ import deepMerge from 'deepmerge';
 /**
  * Internal dependencies
  */
-import RelativeDateControl, {
-	type DateRelative,
-} from './relative-date-control';
+import RelativeDateControl from './relative-date-control';
 import {
 	OPERATOR_IN_THE_PAST,
 	OPERATOR_OVER,
@@ -642,22 +640,13 @@ export default function DateControl< Item >( {
 	hideLabelFromVision,
 	operator,
 }: DataFormControlProps< Item > ) {
-	const { setValue } = field;
-
-	const onChangeRelativeDateControl = useCallback(
-		( newValue: DateRelative ) => {
-			onChange( setValue( { item: data, value: newValue } ) );
-		},
-		[ data, onChange, setValue ]
-	);
-
 	if ( operator === OPERATOR_IN_THE_PAST || operator === OPERATOR_OVER ) {
 		return (
 			<RelativeDateControl
 				className="dataviews-controls__date"
 				data={ data }
 				field={ field }
-				onChange={ onChangeRelativeDateControl }
+				onChange={ onChange }
 				hideLabelFromVision={ hideLabelFromVision }
 				operator={ operator }
 			/>

--- a/packages/dataviews/src/dataform-controls/datetime.tsx
+++ b/packages/dataviews/src/dataform-controls/datetime.tsx
@@ -21,7 +21,7 @@ import { getDate, getSettings } from '@wordpress/date';
  */
 import type { DataFormControlProps } from '../types';
 import { OPERATOR_IN_THE_PAST, OPERATOR_OVER } from '../constants';
-import RelativeDateControl from './relative-date-control';
+import RelativeDateControl from './utils/relative-date-control';
 import { unlock } from '../lock-unlock';
 
 const { DateCalendar, ValidatedInputControl } = unlock( componentsPrivateApis );

--- a/packages/dataviews/src/dataform-controls/datetime.tsx
+++ b/packages/dataviews/src/dataform-controls/datetime.tsx
@@ -253,8 +253,7 @@ export default function DateTime< Item >( {
 	hideLabelFromVision,
 	operator,
 }: DataFormControlProps< Item > ) {
-	const { id, label, getValue, setValue } = field;
-	const value = getValue( { item: data } );
+	const { setValue } = field;
 
 	const onChangeRelativeDateControl = useCallback(
 		( newValue: DateRelative ) =>
@@ -266,10 +265,9 @@ export default function DateTime< Item >( {
 		return (
 			<RelativeDateControl
 				className="dataviews-controls__datetime"
-				id={ id }
-				value={ value && typeof value === 'object' ? value : {} }
+				data={ data }
+				field={ field }
 				onChange={ onChangeRelativeDateControl }
-				label={ label }
 				hideLabelFromVision={ hideLabelFromVision }
 				operator={ operator }
 			/>

--- a/packages/dataviews/src/dataform-controls/datetime.tsx
+++ b/packages/dataviews/src/dataform-controls/datetime.tsx
@@ -22,7 +22,6 @@ import { getDate, getSettings } from '@wordpress/date';
 import type { DataFormControlProps } from '../types';
 import { OPERATOR_IN_THE_PAST, OPERATOR_OVER } from '../constants';
 import RelativeDateControl, {
-	TIME_UNITS_OPTIONS,
 	type DateRelative,
 } from './relative-date-control';
 import { unlock } from '../lock-unlock';
@@ -272,7 +271,7 @@ export default function DateTime< Item >( {
 				onChange={ onChangeRelativeDateControl }
 				label={ label }
 				hideLabelFromVision={ hideLabelFromVision }
-				options={ TIME_UNITS_OPTIONS[ operator ] }
+				operator={ operator }
 			/>
 		);
 	}

--- a/packages/dataviews/src/dataform-controls/datetime.tsx
+++ b/packages/dataviews/src/dataform-controls/datetime.tsx
@@ -21,9 +21,7 @@ import { getDate, getSettings } from '@wordpress/date';
  */
 import type { DataFormControlProps } from '../types';
 import { OPERATOR_IN_THE_PAST, OPERATOR_OVER } from '../constants';
-import RelativeDateControl, {
-	type DateRelative,
-} from './relative-date-control';
+import RelativeDateControl from './relative-date-control';
 import { unlock } from '../lock-unlock';
 
 const { DateCalendar, ValidatedInputControl } = unlock( componentsPrivateApis );
@@ -253,21 +251,13 @@ export default function DateTime< Item >( {
 	hideLabelFromVision,
 	operator,
 }: DataFormControlProps< Item > ) {
-	const { setValue } = field;
-
-	const onChangeRelativeDateControl = useCallback(
-		( newValue: DateRelative ) =>
-			onChange( setValue( { item: data, value: newValue } ) ),
-		[ data, onChange, setValue ]
-	);
-
 	if ( operator === OPERATOR_IN_THE_PAST || operator === OPERATOR_OVER ) {
 		return (
 			<RelativeDateControl
 				className="dataviews-controls__datetime"
 				data={ data }
 				field={ field }
-				onChange={ onChangeRelativeDateControl }
+				onChange={ onChange }
 				hideLabelFromVision={ hideLabelFromVision }
 				operator={ operator }
 			/>

--- a/packages/dataviews/src/dataform-controls/relative-date-control.tsx
+++ b/packages/dataviews/src/dataform-controls/relative-date-control.tsx
@@ -25,17 +25,24 @@ export type DateRelative = {
 	unit?: string;
 };
 
+type VALID_OPERATORS = 'inThePast' | 'over';
+
 interface RelativeDateControlProps {
 	id: string;
 	value: DateRelative;
 	onChange: ( args: DateRelative ) => void;
 	label: string;
 	hideLabelFromVision?: boolean;
-	options: { value: string; label: string }[];
 	className?: string;
+	operator: VALID_OPERATORS;
 }
 
-export const TIME_UNITS_OPTIONS = {
+interface TimeUnitOption {
+	value: string;
+	label: string;
+}
+
+const TIME_UNITS_OPTIONS: Record< VALID_OPERATORS, TimeUnitOption[] > = {
 	[ OPERATOR_IN_THE_PAST ]: [
 		{ value: 'days', label: __( 'Days' ) },
 		{ value: 'weeks', label: __( 'Weeks' ) },
@@ -56,9 +63,10 @@ export default function RelativeDateControl( {
 	onChange,
 	label,
 	hideLabelFromVision,
-	options,
+	operator,
 	className,
 }: RelativeDateControlProps ) {
+	const options: TimeUnitOption[] = TIME_UNITS_OPTIONS[ operator ];
 	const { value: relValue = '', unit = options[ 0 ].value } = value;
 
 	const onChangeValue = useCallback(

--- a/packages/dataviews/src/dataform-controls/relative-date-control.tsx
+++ b/packages/dataviews/src/dataform-controls/relative-date-control.tsx
@@ -19,23 +19,9 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { OPERATOR_IN_THE_PAST, OPERATOR_OVER } from '../constants';
-import type { NormalizedField } from '../types';
-
-export type DateRelative = {
-	value?: string | number;
-	unit?: string;
-};
+import type { DataFormControlProps } from '../types';
 
 type VALID_OPERATORS = 'inThePast' | 'over';
-
-interface RelativeDateControlProps< Item > {
-	className?: string;
-	data: Item;
-	field: NormalizedField< Item >;
-	onChange: ( args: DateRelative ) => void;
-	hideLabelFromVision?: boolean;
-	operator: VALID_OPERATORS;
-}
 
 interface TimeUnitOption {
 	value: string;
@@ -64,24 +50,39 @@ export default function RelativeDateControl< Item >( {
 	onChange,
 	hideLabelFromVision,
 	operator,
-}: RelativeDateControlProps< Item > ) {
-	const options: TimeUnitOption[] = TIME_UNITS_OPTIONS[ operator ];
+}: DataFormControlProps< Item > & {
+	className: string;
+} ) {
+	const options: TimeUnitOption[] =
+		TIME_UNITS_OPTIONS[
+			operator === OPERATOR_IN_THE_PAST ? 'inThePast' : 'over'
+		];
 
-	const { id, label, getValue } = field;
+	const { id, label, getValue, setValue } = field;
 	const fieldValue = getValue( { item: data } );
 	const { value: relValue = '', unit = options[ 0 ].value } =
 		fieldValue && typeof fieldValue === 'object' ? fieldValue : {};
 
 	const onChangeValue = useCallback(
 		( newValue: string | undefined ) =>
-			onChange( { value: Number( newValue ), unit } ),
-		[ onChange, unit ]
+			onChange(
+				setValue( {
+					item: data,
+					value: { value: Number( newValue ), unit },
+				} )
+			),
+		[ onChange, setValue, data, unit ]
 	);
 
 	const onChangeUnit = useCallback(
 		( newUnit: string | undefined ) =>
-			onChange( { value: relValue, unit: newUnit } ),
-		[ onChange, relValue ]
+			onChange(
+				setValue( {
+					item: data,
+					value: { value: relValue, unit: newUnit },
+				} )
+			),
+		[ onChange, setValue, data, relValue ]
 	);
 
 	return (

--- a/packages/dataviews/src/dataform-controls/relative-date-control.tsx
+++ b/packages/dataviews/src/dataform-controls/relative-date-control.tsx
@@ -19,6 +19,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { OPERATOR_IN_THE_PAST, OPERATOR_OVER } from '../constants';
+import type { NormalizedField } from '../types';
 
 export type DateRelative = {
 	value?: string | number;
@@ -27,13 +28,12 @@ export type DateRelative = {
 
 type VALID_OPERATORS = 'inThePast' | 'over';
 
-interface RelativeDateControlProps {
-	id: string;
-	value: DateRelative;
-	onChange: ( args: DateRelative ) => void;
-	label: string;
-	hideLabelFromVision?: boolean;
+interface RelativeDateControlProps< Item > {
 	className?: string;
+	data: Item;
+	field: NormalizedField< Item >;
+	onChange: ( args: DateRelative ) => void;
+	hideLabelFromVision?: boolean;
 	operator: VALID_OPERATORS;
 }
 
@@ -57,17 +57,20 @@ const TIME_UNITS_OPTIONS: Record< VALID_OPERATORS, TimeUnitOption[] > = {
 	],
 };
 
-export default function RelativeDateControl( {
-	id,
-	value,
+export default function RelativeDateControl< Item >( {
+	className,
+	data,
+	field,
 	onChange,
-	label,
 	hideLabelFromVision,
 	operator,
-	className,
-}: RelativeDateControlProps ) {
+}: RelativeDateControlProps< Item > ) {
 	const options: TimeUnitOption[] = TIME_UNITS_OPTIONS[ operator ];
-	const { value: relValue = '', unit = options[ 0 ].value } = value;
+
+	const { id, label, getValue } = field;
+	const fieldValue = getValue( { item: data } );
+	const { value: relValue = '', unit = options[ 0 ].value } =
+		fieldValue && typeof fieldValue === 'object' ? fieldValue : {};
 
 	const onChangeValue = useCallback(
 		( newValue: string | undefined ) =>

--- a/packages/dataviews/src/dataform-controls/utils/relative-date-control.tsx
+++ b/packages/dataviews/src/dataform-controls/utils/relative-date-control.tsx
@@ -18,8 +18,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { OPERATOR_IN_THE_PAST, OPERATOR_OVER } from '../constants';
-import type { DataFormControlProps } from '../types';
+import { OPERATOR_IN_THE_PAST, OPERATOR_OVER } from '../../constants';
+import type { DataFormControlProps } from '../../types';
 
 type VALID_OPERATORS = 'inThePast' | 'over';
 


### PR DESCRIPTION
## What?

Refactors the internal `RelativeDateControl` to use `DataFormControl` props.

## Why?

To improve code maintainability.

## How?

Change the props that are passed to the control. Inline as much logic as possible within.

## Testing Instructions

- Open the storybook, go to "DataViews > Default".
- Use the date filter, and select "in the past" or "over" operator.
- Use it to filter the data.
