### PR TITLE
Icons: Add `prepare` script to generate source; don't bundle

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -45,6 +45,7 @@
 	},
 	"scripts": {
 		"prelint": "npm run build",
+		"prepare": "npm run build",
 		"build": "node lib/generate-library"
 	}
 }


### PR DESCRIPTION
## What?

Alternative to (and revert of) #72299 (e82f6687e6)

As of #71878 (8dff7def7d), Icons are defined as SVG files under `src/library/`, and an accompanying `build` script will produce their corresponding TSX files and an index at `src/library/index.ts`.

This patch reverts the addition of `.npmignore` in #72299. With this revert, we return to the guarantee that any generated source code WILL NOT be included in the published NPM package.

## How?

Instead, this patch adds a `prepare` script for @wordpress/icons to trigger the code generation. This script is part of several NPM life cycles, including installation (`install`, `ci`) and packing (`publish`, `pack`), and runs in the background:

https://docs.npmjs.com/cli/v11/using-npm/scripts#life-cycle-scripts

## Why?

This change is motivated by the fact that Gutenberg's [workflow for releasing NPM packages](https://github.com/WordPress/gutenberg/blob/fca898bcd0a7825950dc3d50a957512a164f3ef0/.github/workflows/publish-npm-packages.yml#L97-L99) involves [calling `npm version`](https://github.com/WordPress/gutenberg/blob/fca898bcd0a7825950dc3d50a957512a164f3ef0/bin/plugin/commands/packages.js#L377) (via Lerna) on a fresh repository clone. Since `npm version` involves creating new commits, the clone needs to be prepared to run pre-commit hooks. Concretely, linting will fail if import paths to the icon library cannot be resolved.

See [example of failed workflow run](https://github.com/WordPress/gutenberg/actions/runs/18523468981/job/52788643881#step:8:9).

A more localised fix would have been to explicitly invoke a build of the icons package during the package-release workflow (after `ci` and before `version`), but with this approach based on `prepare` we guarantee the availability of the generation code in (probably) all situations. In particular, it eliminates the need to bundle the generated code in the package (as previously mentioned).

## Testing Instructions

The real test will be to run the [publish-npm-packages](https://github.com/WordPress/gutenberg/actions/workflows/publish-npm-packages.yml) workflow once this in trunk.

Until then, try emulating what `./bin/plugin/cli.js npm-next --ci --repository-path ../publish` does (`bin/plugin/commands/packages.js`). If my investigation of that tool is right, this means checking out a fresh copy at `wp/next`, running `npm ci`, and then verifying that the generated icon files (`packages/icons/src/library/*.tsx`) are present before the invocation of `npx lerna version`.