### PR TITLE
Template activation: fix theme field for old REST API endpoint

### DIFF
--- a/backport-changelog/6.9/8063.md
+++ b/backport-changelog/6.9/8063.md
@@ -7,5 +7,6 @@ https://github.com/WordPress/wordpress-develop/pull/8063
 * https://github.com/WordPress/gutenberg/pull/72029
 * https://github.com/WordPress/gutenberg/pull/72049
 * https://github.com/WordPress/gutenberg/pull/72011
+* https://github.com/WordPress/gutenberg/pull/72366
 * https://github.com/WordPress/gutenberg/pull/72141
 * https://github.com/WordPress/gutenberg/pull/72223

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -45,9 +45,8 @@ function gutenberg_maintain_templates_routes() {
 				// templates controller, so we need to check if the id is an
 				// integer to make sure it's the proper post type endpoint.
 				if ( ! is_int( $post_arr['id'] ) ) {
-					// See _build_block_template_result_from_file, registered
-					// templates always set the theme to the active theme.
-					return get_stylesheet();
+					$template = get_block_template( $post_arr['id'], 'wp_template' );
+					return $template ? $template->theme : null;
 				}
 				$terms = get_the_terms( $post_arr['id'], 'wp_theme' );
 				if ( is_wp_error( $terms ) || empty( $terms ) ) {

--- a/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
+++ b/test/e2e/specs/site-editor/save-entity-record-template-compat.spec.js
@@ -64,6 +64,39 @@ test.describe( 'calling saveEntityRecord with a theme template ID', () => {
 		} );
 	} );
 
+	test( 'should work as expected for different theme by calling the API directly', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitSiteEditor();
+		const template = await page.evaluate( async () => {
+			return await window.wp.apiFetch( {
+				path: '/wp/v2/templates',
+				method: 'POST',
+				data: {
+					slug: 'test',
+					title: 'for different theme',
+					content: 'test',
+					theme: 'twentytwentyone',
+				},
+			} );
+		} );
+		expect( template.content.raw ).toEqual( 'test' );
+		expect( template.theme ).toEqual( 'twentytwentyone' );
+		await admin.visitSiteEditor( {
+			postType: 'wp_template',
+			activeView: 'user',
+		} );
+		await expect(
+			page.getByRole( 'button', { name: 'for different theme' } ).first()
+		).toBeVisible();
+		await page.evaluate( async ( _id ) => {
+			return await window.wp.data
+				.dispatch( 'core' )
+				.deleteEntityRecord( 'postType', 'wp_template', _id );
+		}, template.wp_id );
+	} );
+
 	test( 'getEntityRecord should work as expected', async ( {
 		admin,
 		page,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Fixes https://github.com/WordPress/gutenberg/issues/72225.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Old template endpoint should return the same as before.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The problem is that we add an extra field that gets used by both the old and new endpoint. When the template ID is a string, it always returns the active theme. That's not correct for database templates that are returned by the old endpoint (which have a `wp_id` property. The solution is to get the template object and return the theme property (it will figure out if it's a db template or a file).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
