### PR TITLE
Block Bindings: In source definitions, turn editorUI into component

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -100,6 +100,10 @@ _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/block-alignment-control/README.md>
 
+### BlockBindingsDropdown
+
+Undocumented declaration.
+
 ### BlockBreadcrumb
 
 Block breadcrumb component, displaying the hierarchy of the current block selection as a breadcrumb.

--- a/packages/block-editor/src/components/block-bindings/index.js
+++ b/packages/block-editor/src/components/block-bindings/index.js
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import fastDeepEqual from 'fast-deep-equal/es6';
+
+/**
+ * WordPress dependencies
+ */
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import { useBlockBindingsUtils } from '../../utils/block-bindings';
+
+const { Menu } = unlock( componentsPrivateApis );
+
+function BlockBindingsDropdown( {
+	attribute,
+	binding,
+	data,
+	source,
+	sourceKey,
+} ) {
+	const { updateBlockBindings } = useBlockBindingsUtils();
+	const { isMobile } = useViewportMatch( 'medium', '<' );
+
+	const noItemsAvailable = ! data || data.length === 0;
+
+	return (
+		<Menu placement={ isMobile ? 'bottom-start' : 'left-start' }>
+			{ noItemsAvailable ? (
+				<Menu.Item disabled>{ source.label }</Menu.Item>
+			) : (
+				<Menu.SubmenuTriggerItem>
+					<Menu.ItemLabel>{ source.label }</Menu.ItemLabel>
+				</Menu.SubmenuTriggerItem>
+			) }
+
+			{ ! noItemsAvailable && (
+				<Menu.Popover gutter={ 8 }>
+					<Menu.Group>
+						{ data.map( ( item ) => {
+							const itemBindings = {
+								source: sourceKey,
+								args: item?.args || {
+									key: item.key,
+								},
+							};
+
+							return (
+								<Menu.CheckboxItem
+									key={
+										sourceKey +
+											JSON.stringify( item.args ) ||
+										item.key
+									}
+									onChange={ () => {
+										const isCurrentlySelected =
+											fastDeepEqual(
+												binding?.args,
+												item.args
+											) ??
+											// Deprecate key dependency in 7.0.
+											item.key === binding?.args?.key;
+
+										if ( isCurrentlySelected ) {
+											// Unset if the same item is selected again.
+											updateBlockBindings( {
+												[ attribute ]: undefined,
+											} );
+										} else {
+											updateBlockBindings( {
+												[ attribute ]: itemBindings,
+											} );
+										}
+									} }
+									name={ attribute + '-binding' }
+									value={ item.value }
+									checked={
+										fastDeepEqual(
+											binding?.args,
+											item.args
+										) ??
+										// Deprecate key dependency in 7.0.
+										item.key === binding?.args?.key
+									}
+								>
+									<Menu.ItemLabel>
+										{ item?.label }
+									</Menu.ItemLabel>
+									<Menu.ItemHelpText>
+										{ item.value }
+									</Menu.ItemHelpText>
+								</Menu.CheckboxItem>
+							);
+						} ) }
+					</Menu.Group>
+				</Menu.Popover>
+			) }
+		</Menu>
+	);
+}
+
+export { BlockBindingsDropdown };

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -13,6 +13,7 @@ export {
 } from './block-alignment-control';
 export { default as __experimentalBlockFullHeightAligmentControl } from './block-full-height-alignment-control';
 export { default as __experimentalBlockAlignmentMatrixControl } from './block-alignment-matrix-control';
+export { BlockBindingsDropdown } from './block-bindings';
 export { default as BlockBreadcrumb } from './block-breadcrumb';
 export { default as __experimentalUseBlockOverlayActive } from './block-content-overlay';
 export { BlockContextProvider } from './block-context';

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -7,7 +7,11 @@ import fastDeepEqual from 'fast-deep-equal/es6';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { getBlockBindingsSources, getBlockType } from '@wordpress/blocks';
+import {
+	getBlockBindingsSource,
+	getBlockBindingsSources,
+	getBlockType,
+} from '@wordpress/blocks';
 import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
@@ -28,8 +32,8 @@ import { useViewportMatch } from '@wordpress/compose';
 import { useBlockBindingsUtils } from '../utils/block-bindings';
 import { unlock } from '../lock-unlock';
 import InspectorControls from '../components/inspector-controls';
+import { BlockBindingsDropdown } from '../components/block-bindings';
 import BlockContext from '../components/block-context';
-import { useBlockEditContext } from '../components/block-edit';
 import { store as blockEditorStore } from '../store';
 
 const { Menu } = unlock( componentsPrivateApis );
@@ -63,14 +67,8 @@ const useToolsPanelDropdownMenuProps = () => {
 		: {};
 };
 
-function BlockBindingsPanelMenuContent( {
-	attribute,
-	binding,
-	sources,
-	onOpenModal,
-} ) {
-	const { clientId } = useBlockEditContext();
-	const { updateBlockBindings } = useBlockBindingsUtils();
+function BlockBindingsPanelMenuContent( { attribute, binding } ) {
+	const sources = getBlockBindingsSources();
 	const isMobile = useViewportMatch( 'medium', '<' );
 	const blockContext = useContext( BlockContext );
 	const { attributeType, select } = useSelect(
@@ -87,123 +85,54 @@ function BlockBindingsPanelMenuContent( {
 	return (
 		<Menu placement={ isMobile ? 'bottom-start' : 'left-start' }>
 			{ Object.entries( sources ).map( ( [ sourceKey, source ] ) => {
-				// Only show sources that have compatible data for this specific attribute.
-				const sourceDataItems = source.data?.filter(
-					( item ) => item?.type === attributeType
-				);
+				if ( sourceKey === 'core/post-data' ) {
+					const context = {};
+					if ( source.usesContext?.length ) {
+						for ( const key of source.usesContext ) {
+							context[ key ] = blockContext[ key ];
+						}
+					}
+					const EditorUI = source.editorUI;
+
+					return (
+						<EditorUI
+							key={ sourceKey }
+							attribute={ attribute }
+							binding={ binding }
+							source={ source }
+							sourceKey={ sourceKey }
+							context={ context }
+						/>
+					);
+				}
 
 				const noItemsAvailable =
-					! sourceDataItems || sourceDataItems.length === 0;
+					! source.data || source.data.length === 0;
 
 				if ( noItemsAvailable ) {
 					return null;
 				}
 
-				if ( source.mode === 'dropdown' ) {
-					return (
-						<Menu
-							key={ sourceKey }
-							placement={
-								isMobile ? 'bottom-start' : 'left-start'
-							}
-						>
-							<Menu.SubmenuTriggerItem>
-								<Menu.ItemLabel>
-									{ source.label }
-								</Menu.ItemLabel>
-							</Menu.SubmenuTriggerItem>
-							<Menu.Popover gutter={ 8 }>
-								<Menu.Group>
-									{ sourceDataItems.map( ( item ) => {
-										const itemBindings = {
-											source: sourceKey,
-											args: item?.args || {
-												key: item.key,
-											},
-										};
-										const values = source.getValues( {
-											select,
-											context: blockContext,
-											bindings: {
-												[ attribute ]: itemBindings,
-											},
-										} );
-										return (
-											<Menu.CheckboxItem
-												key={
-													sourceKey +
-														JSON.stringify(
-															item.args
-														) || item.key
-												}
-												onChange={ () => {
-													const isCurrentlySelected =
-														fastDeepEqual(
-															binding?.args,
-															item.args
-														) ??
-														// Deprecate key dependency in 7.0.
-														item.key ===
-															binding?.args?.key;
-
-													if ( isCurrentlySelected ) {
-														// Unset if the same item is selected again.
-														updateBlockBindings( {
-															[ attribute ]:
-																undefined,
-														} );
-													} else {
-														updateBlockBindings( {
-															[ attribute ]:
-																itemBindings,
-														} );
-													}
-												} }
-												name={ attribute + '-binding' }
-												value={ values[ attribute ] }
-												checked={
-													fastDeepEqual(
-														binding?.args,
-														item.args
-													) ??
-													// Deprecate key dependency in 7.0.
-													item.key ===
-														binding?.args?.key
-												}
-											>
-												<Menu.ItemLabel>
-													{ item?.label }
-												</Menu.ItemLabel>
-												<Menu.ItemHelpText>
-													{ values[ attribute ] }
-												</Menu.ItemHelpText>
-											</Menu.CheckboxItem>
-										);
-									} ) }
-								</Menu.Group>
-							</Menu.Popover>
-						</Menu>
-					);
-				}
-
-				if ( source.mode === 'modal' ) {
-					return (
-						<Menu.Item
-							key={ sourceKey }
-							onClick={ () => onOpenModal( { sourceKey } ) }
-						>
-							<Menu.ItemLabel>{ source.label }</Menu.ItemLabel>
-						</Menu.Item>
-					);
-				}
-
-				return null;
+				// FIXME: This is only here for now to avoid breaking other sources.
+				// Remove once other sources are updated to the new format.
+				return (
+					<BlockBindingsDropdown
+						key={ sourceKey }
+						attribute={ attribute }
+						binding={ binding }
+						source={ source }
+						sourceKey={ sourceKey }
+					/>
+				);
 			} ) }
 		</Menu>
 	);
 }
 
 function BlockBindingsAttribute( { attribute, binding, sources, blockName } ) {
+	// const source = getBlockBindingsSource( sourceName );
+	// const isSourceInvalid = ! source;
+
 	const { source: sourceName, args } = binding || {};
 	const source = sources?.[ sourceName ];
 
@@ -281,7 +210,6 @@ function ReadOnlyBlockBindingsPanelItem( {
 function EditableBlockBindingsPanelItem( {
 	attribute,
 	binding,
-	sources,
 	setModalState,
 	blockName,
 } ) {
@@ -315,7 +243,6 @@ function EditableBlockBindingsPanelItem( {
 					<BlockBindingsPanelMenuContent
 						attribute={ attribute }
 						binding={ binding }
-						sources={ sources }
 						onOpenModal={ handleOpenModal }
 					/>
 				</Menu.Popover>
@@ -334,21 +261,27 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 		setModalState( null );
 	};
 
-	// Use useSelect to ensure sources are updated whenever there are updates in block context
-	// or when underlying data changes.
-	// Still needs a fix regarding _sources scope.
-	const _sources = {};
-	const { sources, canUpdateBlockBindings, bindableAttributes } = useSelect(
+	const registeredSources = getBlockBindingsSources();
+
+	const { bindableAttributes } = useSelect(
 		( select ) => {
 			const { __experimentalBlockBindingsSupportedAttributes } =
 				select( blockEditorStore ).getSettings();
-			const _bindableAttributes =
-				__experimentalBlockBindingsSupportedAttributes?.[ blockName ];
-			if ( ! _bindableAttributes || _bindableAttributes.length === 0 ) {
-				return EMPTY_OBJECT;
-			}
+			return {
+				bindableAttributes:
+					__experimentalBlockBindingsSupportedAttributes?.[
+						blockName
+					] ?? [],
+			};
+		},
+		[ blockName ]
+	);
 
-			const registeredSources = getBlockBindingsSources();
+	// Use useSelect to ensure sources are updated whenever there are updates in block context
+	// or when underlying data changes.
+	const { canUpdateBlockBindings } = useSelect(
+		( select ) => {
+			const _sources = {};
 			Object.entries( registeredSources ).forEach(
 				( [
 					sourceName,
@@ -362,7 +295,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 						}
 					}
 
-					if ( editorUI ) {
+					if ( editorUI && sourceName !== 'core/post-data' ) {
 						const editorUIResult = editorUI( {
 							select,
 							context,
@@ -411,18 +344,14 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 			);
 
 			return {
-				sources:
-					Object.values( _sources ).length > 0
-						? _sources
-						: EMPTY_OBJECT,
 				canUpdateBlockBindings:
 					select( blockEditorStore ).getSettings()
 						.canUpdateBlockBindings,
-				bindableAttributes: _bindableAttributes,
 			};
 		},
-		[ blockContext, blockName ]
+		[ blockContext, blockName, registeredSources, bindableAttributes ]
 	);
+
 	// Return early if there are no bindable attributes.
 	if ( ! bindableAttributes || bindableAttributes.length === 0 ) {
 		return null;
@@ -438,8 +367,9 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 	// Lock the UI when the user can't update bindings or there are no fields to connect to.
 	const readOnly = ! canUpdateBlockBindings || ! hasCompatibleData;
 
-	const RenderModalContent =
-		sources[ modalState?.sourceKey ]?.renderModalContent;
+	const RenderModalContent = getBlockBindingsSource(
+		modalState?.sourceKey
+	)?.renderModalContent;
 
 	if ( bindings === undefined && ! hasCompatibleData ) {
 		return null;
@@ -489,7 +419,6 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 								key={ attribute }
 								attribute={ attribute }
 								binding={ binding }
-								sources={ sources }
 								setModalState={ setModalState }
 								blockName={ blockName }
 							/>

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -71,17 +71,7 @@ function BlockBindingsPanelMenuContent( { attribute, binding } ) {
 	const sources = getBlockBindingsSources();
 	const isMobile = useViewportMatch( 'medium', '<' );
 	const blockContext = useContext( BlockContext );
-	const { attributeType, select } = useSelect(
-		( _select ) => {
-			const { name: blockName } =
-				_select( blockEditorStore ).getBlock( clientId );
-			return {
-				attributeType: getAttributeType( blockName, attribute ),
-				select: _select,
-			};
-		},
-		[ clientId, attribute ]
-	);
+
 	return (
 		<Menu placement={ isMobile ? 'bottom-start' : 'left-start' }>
 			{ Object.entries( sources ).map( ( [ sourceKey, source ] ) => {
@@ -129,38 +119,37 @@ function BlockBindingsPanelMenuContent( { attribute, binding } ) {
 	);
 }
 
-function BlockBindingsAttribute( { attribute, binding, sources, blockName } ) {
-	// const source = getBlockBindingsSource( sourceName );
-	// const isSourceInvalid = ! source;
-
+function BlockBindingsAttribute( { attribute, binding } ) {
 	const { source: sourceName, args } = binding || {};
-	const source = sources?.[ sourceName ];
+	const source = getBlockBindingsSource( sourceName );
 
 	let displayText;
 	let isValid = true;
 	const isNotBound = binding === undefined;
 
 	if ( isNotBound ) {
+		// FIXME: Re-enable
 		// Check if there are any compatible sources for this attribute type.
-		const attributeType = getAttributeType( blockName, attribute );
+		// const attributeType = getAttributeType( blockName, attribute );
 
-		const hasCompatibleSources = Object.values( sources ).some( ( src ) =>
-			src.data?.some( ( item ) => item?.type === attributeType )
-		);
+		// const hasCompatibleSources = Object.values( sources ).some( ( src ) =>
+		// 	src.data?.some( ( item ) => item?.type === attributeType )
+		// );
 
-		if ( ! hasCompatibleSources ) {
-			displayText = __( 'No sources available' );
-		} else {
-			displayText = __( 'Not connected' );
-		}
+		// if ( ! hasCompatibleSources ) {
+		// 	displayText = __( 'No sources available' );
+		// } else {
+		// 	displayText = __( 'Not connected' );
+		// }
 		isValid = true;
 	} else if ( ! source ) {
 		// If there's a binding but the source is not found, it's invalid.
 		isValid = false;
 		displayText = __( 'Source not registered' );
-		if ( Object.keys( sources ).length === 0 ) {
-			displayText = __( 'No sources available' );
-		}
+		// FIXME: Re-enable
+		// if ( Object.keys( sources ).length === 0 ) {
+		// 	displayText = __( 'No sources available' );
+		// }
 	} else {
 		displayText =
 			source.data?.find( ( item ) => fastDeepEqual( item.args, args ) )
@@ -183,12 +172,7 @@ function BlockBindingsAttribute( { attribute, binding, sources, blockName } ) {
 	);
 }
 
-function ReadOnlyBlockBindingsPanelItem( {
-	attribute,
-	binding,
-	sources,
-	blockName,
-} ) {
+function ReadOnlyBlockBindingsPanelItem( { attribute, binding } ) {
 	const isMobile = useViewportMatch( 'medium', '<' );
 
 	return (
@@ -198,8 +182,6 @@ function ReadOnlyBlockBindingsPanelItem( {
 					<BlockBindingsAttribute
 						attribute={ attribute }
 						binding={ binding }
-						sources={ sources }
-						blockName={ blockName }
 					/>
 				</Menu.TriggerButton>
 			</Menu>
@@ -211,7 +193,6 @@ function EditableBlockBindingsPanelItem( {
 	attribute,
 	binding,
 	setModalState,
-	blockName,
 } ) {
 	const { updateBlockBindings } = useBlockBindingsUtils();
 	const isMobile = useViewportMatch( 'medium', '<' );
@@ -235,8 +216,6 @@ function EditableBlockBindingsPanelItem( {
 					<BlockBindingsAttribute
 						attribute={ attribute }
 						binding={ binding }
-						sources={ sources }
-						blockName={ blockName }
 					/>
 				</Menu.TriggerButton>
 				<Menu.Popover gutter={ isMobile ? 8 : 36 }>
@@ -279,7 +258,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 
 	// Use useSelect to ensure sources are updated whenever there are updates in block context
 	// or when underlying data changes.
-	const { canUpdateBlockBindings } = useSelect(
+	const { canUpdateBlockBindings, sources } = useSelect(
 		( select ) => {
 			const _sources = {};
 			Object.entries( registeredSources ).forEach(
@@ -347,9 +326,10 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 				canUpdateBlockBindings:
 					select( blockEditorStore ).getSettings()
 						.canUpdateBlockBindings,
+				sources: _sources || EMPTY_OBJECT,
 			};
 		},
-		[ blockContext, blockName, registeredSources, bindableAttributes ]
+		[ blockContext, registeredSources ]
 	);
 
 	// Return early if there are no bindable attributes.
@@ -411,8 +391,6 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 								key={ attribute }
 								attribute={ attribute }
 								binding={ binding }
-								sources={ sources }
-								blockName={ blockName }
 							/>
 						) : (
 							<EditableBlockBindingsPanelItem
@@ -420,7 +398,6 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 								attribute={ attribute }
 								binding={ binding }
 								setModalState={ setModalState }
-								blockName={ blockName }
 							/>
 						);
 					} ) }

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -9,6 +9,12 @@ import {
 import { store as coreDataStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
+// Navigation block types that use special handling for backwards compatibility
+const NAVIGATION_BLOCK_TYPES = [
+	'core/navigation-link',
+	'core/navigation-submenu',
+];
+
 /**
  * Gets a list of post data fields with their values and labels
  * to be consumed in the needed callbacks.

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -2,14 +2,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import {
+	BlockBindingsDropdown,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { store as coreDataStore } from '@wordpress/core-data';
-import { store as blockEditorStore } from '@wordpress/block-editor';
-
-// Navigation block types that use special handling for backwards compatibility
-const NAVIGATION_BLOCK_TYPES = [
-	'core/navigation-link',
-	'core/navigation-submenu',
-];
+import { useSelect } from '@wordpress/data';
 
 /**
  * Gets a list of post data fields with their values and labels
@@ -94,6 +92,59 @@ function getPostDataFields( select, context, clientId ) {
 	}
 
 	return dataFields;
+}
+
+function EditorUI( { attribute, binding, source, sourceKey, context } ) {
+	// FIXME: Pass blockName as prop instead?
+
+	const { postId, postType } = context;
+	const { date, modified, selectedBlock } = useSelect(
+		( select ) => {
+			const { getEditedEntityRecord } = select( coreDataStore );
+
+			const entityDataValues = getEditedEntityRecord(
+				'postType',
+				postType,
+				postId
+			);
+
+			return {
+				selectedBlock: select( blockEditorStore ).getSelectedBlock(),
+				date: entityDataValues?.date,
+				modified: entityDataValues?.modified,
+			};
+		},
+		[ postId, postType ]
+	);
+
+	if ( selectedBlock?.name !== 'core/post-date' ) {
+		return null;
+	}
+
+	const data = [
+		{
+			label: __( 'Post Date' ),
+			value: date,
+			args: { key: 'date' },
+			type: 'string',
+		},
+		{
+			label: __( 'Post Modified Date' ),
+			value: modified,
+			args: { key: 'modified' },
+			type: 'string',
+		},
+	];
+
+	return (
+		<BlockBindingsDropdown
+			attribute={ attribute }
+			binding={ binding }
+			data={ data }
+			source={ source }
+			sourceKey={ sourceKey }
+		/>
+	);
 }
 
 /**
@@ -183,30 +234,5 @@ export default {
 		// Deprecated, will be removed after 6.9.
 		return getPostDataFields( select, context, clientId );
 	},
-	editorUI( { select, context } ) {
-		const selectedBlock = select( blockEditorStore ).getSelectedBlock();
-		if ( selectedBlock?.name !== 'core/post-date' ) {
-			return {};
-		}
-		// Exit early for navigation blocks (read-only)
-		if ( NAVIGATION_BLOCK_TYPES.includes( selectedBlock?.name ) ) {
-			return {};
-		}
-		const postDataFields = Object.entries(
-			getPostDataFields( select, context ) || {}
-		).map( ( [ key, field ] ) => ( {
-			label: field.label,
-			args: {
-				field: key,
-			},
-			type: field.type,
-		} ) );
-		/*
-		 * We need to define the data as [{ label: string, value: any, type: https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#type-validation }]
-		 */
-		return {
-			mode: 'dropdown',
-			data: postDataFields,
-		};
-	},
+	editorUI: EditorUI,
 };


### PR DESCRIPTION
## What?

Supersedes https://github.com/WordPress/gutenberg/pull/72109. See https://github.com/WordPress/gutenberg/pull/72109#issuecomment-3380362766 for the rationale.

More details to follow.

## Why?
TBD

## How?
TBD

## Testing Instructions
TBD

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

## TODO

- [ ] Add back `link` item to `core/post-data` source.
- [ ] Add back check that makes the Attributes panel control read-only for Navigation blocks ([see](https://github.com/WordPress/gutenberg/pull/72165/files#diff-131cf978a390cb2c40909c7ca120bd618455accc478c5334e35d7d798800b811)).
