### PR TITLE
[WIP] Adds missing alt visual indication, adds checkbox to declare decorative img

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -18,6 +18,7 @@ import {
 	ToolbarItem,
 	DropdownMenu,
 	Popover,
+	CheckboxControl,
 } from '@wordpress/components';
 import {
 	useMergeRefs,
@@ -289,6 +290,7 @@ export default function Image( {
 	const [ resizeDelta, setResizeDelta ] = useState( null );
 	const [ pixelSize, setPixelSize ] = useState( {} );
 	const [ offsetTop, setOffsetTop ] = useState( 0 );
+	const [ isDecorativeImage, setIsDecorativeImage ] = useState( false );
 	const setResizeObserved = useResizeObserver( ( [ entry ] ) => {
 		if ( ! resizeDelta ) {
 			const [ box ] = entry.borderBoxSize;
@@ -425,6 +427,11 @@ export default function Image( {
 
 	function onSetHref( props ) {
 		setAttributes( props );
+	}
+
+	function onSetDecorativeImage( props ) {
+		setIsDecorativeImage(props)
+		alt && updateAlt('')
 	}
 
 	function onSetLightbox( enable ) {
@@ -829,12 +836,17 @@ export default function Image( {
 											</ExternalLink>
 											<br />
 											{ __(
-												'Leave empty if decorative.'
+												'Leave empty and check below if decorative.'
 											) }
 										</>
 									)
 								}
 								__nextHasNoMarginBottom
+							/>
+							<CheckboxControl
+								label= { __('This is a decorative image.') }
+								checked={ isDecorativeImage }
+								onChange={ onSetDecorativeImage }
 							/>
 						</ToolsPanelItem>
 					) }
@@ -936,6 +948,7 @@ export default function Image( {
 						objectFit: scale,
 						...borderProps.style,
 						...shadowProps.style,
+						border: !isDecorativeImage && !alt && '5px solid red',
 					} }
 				/>
 				{ temporaryURL && <Spinner /> }


### PR DESCRIPTION
Starting 

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL --> #16909

<!-- In a few words, what is the PR actually doing? -->
Improves author awareness of accessibility by visually surfacing images without alt text

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
(the lack of accessible alt text is a known issue in accessibility circles, will dig up research, tickers)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Adds a checkbox to declare an image as Decorative
- Adds a visual indicator to the image block when it is missing alt text, and not declared as Decorative

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
![alt-insertion](https://github.com/user-attachments/assets/18618f6d-5cde-40d9-9178-106b83a25918)
