### PR TITLE
BlockRenameModal: Fix Rename `cleanEmptyObject` attributes

### DIFF
--- a/packages/block-editor/src/components/block-rename/modal.js
+++ b/packages/block-editor/src/components/block-rename/modal.js
@@ -19,6 +19,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '../../store';
 import { useBlockDisplayInformation } from '..';
 import isEmptyString from './is-empty-string';
+import { cleanEmptyObject } from '../../hooks/utils';
 
 export default function BlockRenameModal( { clientId, onClose } ) {
 	const [ editedBlockName, setEditedBlockName ] = useState();
@@ -75,10 +76,10 @@ export default function BlockRenameModal( { clientId, onClose } ) {
 		// Must be assertive to immediately announce change.
 		speak( message, 'assertive' );
 		updateBlockAttributes( [ clientId ], {
-			metadata: {
+			metadata: cleanEmptyObject( {
 				...metadata,
 				name: newName,
-			},
+			} ),
 		} );
 
 		// Immediate close avoids ability to hit save multiple times.

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -146,11 +146,6 @@ test.describe( 'Block Renaming', () => {
 			await expect.poll( editor.getBlocks ).toMatchObject( [
 				{
 					name: 'core/group',
-					attributes: {
-						metadata: {
-							name: undefined,
-						},
-					},
 				},
 			] );
 		} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Fix Rename `cleanEmptyObject` attributes

similar #71151 #72369

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Removing the name leaves behind an unnecessary attribute.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
As with other block support, use cleanEmptyObject to remove unnecessary attributes.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert some blocks.
3. Set and clear Rename.
4. Set the name change and set it to an empty string.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

https://github.com/user-attachments/assets/c92a45c6-6e8f-419d-bf37-ec5bfd3a9317

### After

https://github.com/user-attachments/assets/deff3828-cdde-4392-a2dd-1bbf3c747cfa


