### PR TITLE
Direct focus to meta box content on expansion via keyboarding

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -55,6 +55,7 @@ import {
 	useRefEffect,
 	useViewportMatch,
 } from '@wordpress/compose';
+import { focus } from '@wordpress/dom';
 
 /**
  * Internal dependencies
@@ -258,6 +259,45 @@ function MetaBoxesMain( { isLegacy } ) {
 		}
 	}, [ isShort ] );
 
+	const focusOnExpandRef = useRef( false );
+	const updateLinerTabbabilityRef = useRef();
+	// Makes the pane’s content wrapper tabbable or not per its overflow and
+	// moves focus to either the scrollable liner or its first tabbable element
+	// when expanded if queued by the toggle button. The focus management is
+	// only helpful because the toggle doesn't directly precede the content in
+	// the DOM and should likely be removed if the following issue is resolved:
+	// https://github.com/WordPress/gutenberg/issues/66436
+	const linerTabbableEffect = useRefEffect( ( node ) => {
+		updateLinerTabbabilityRef.current = () => {
+			const hasOverflow = node.scrollHeight > node.clientHeight;
+			if ( hasOverflow ) {
+				node.tabIndex = 0;
+			} else {
+				node.removeAttribute( 'tabindex' );
+			}
+			return hasOverflow;
+		};
+		const markupSpy = new window.MutationObserver( () => {
+			if ( ! node.hasAttribute( 'hidden' ) ) {
+				const hasOverflow = updateLinerTabbabilityRef.current();
+				if ( focusOnExpandRef.current ) {
+					focusOnExpandRef.current = false;
+					( hasOverflow
+						? node
+						: focus.tabbable.findNext( node )
+					)?.focus();
+				}
+			}
+		} );
+		markupSpy.observe( node, {
+			subtree: true,
+			childList: true,
+			// The class attribute catches when individual meta boxes are toggled.
+			attributeFilter: [ 'hidden', 'class' ],
+		} );
+		return () => markupSpy.disconnect();
+	}, [] );
+
 	if ( ! hasAnyVisible ) {
 		return;
 	}
@@ -267,6 +307,7 @@ function MetaBoxesMain( { isLegacy } ) {
 			// The class name 'edit-post-layout__metaboxes' is retained because some plugins use it.
 			className="edit-post-layout__metaboxes edit-post-meta-boxes-main__liner"
 			hidden={ ! isLegacy && ! isOpen }
+			ref={ ! isLegacy && linerTabbableEffect }
 		>
 			<MetaBoxes location="normal" />
 			<MetaBoxes location="advanced" />
@@ -306,11 +347,15 @@ function MetaBoxesMain( { isLegacy } ) {
 			aria-expanded={ isOpen }
 			onClick={ ( { detail } ) => {
 				const { isToggleInferred } = resizeDataRef.current;
-				if ( isShort || ! detail || isToggleInferred ) {
+				const isKeyboard = ! detail;
+				if ( isShort || isKeyboard || isToggleInferred ) {
 					persistIsOpen();
 					const usedOpenHeight = isShort ? 'auto' : openHeight;
 					const usedHeight = isOpen ? min : usedOpenHeight;
 					applyHeight( usedHeight, false, true );
+					if ( ! isOpen && isKeyboard ) {
+						focusOnExpandRef.current = true;
+					}
 				}
 			} }
 			// Prevents resizing in short viewports.
@@ -404,6 +449,7 @@ function MetaBoxesMain( { isLegacy } ) {
 				if ( nextIsOpen ) {
 					applyHeight( height, true );
 				}
+				updateLinerTabbabilityRef.current();
 			}
 		},
 	} );

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -1,4 +1,9 @@
 .edit-post-meta-boxes-main {
+	--wp-edit-post-meta-boxes-main-presenter-height: #{$button-size-compact};
+	// Enlarge the toggle/resizable hit area on touch devices.
+	@media (pointer: coarse) {
+		--wp-edit-post-meta-boxes-main-presenter-height: #{$button-size};
+	}
 	filter: drop-shadow(0 -1px rgba($color: #000, $alpha: 0.133)); // 0.133 = $gray-200 but with alpha.
 	// Windows High Contrast mode will show this outline, but not the shadow.
 	outline: 1px solid transparent;
@@ -6,7 +11,7 @@
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
-	padding-block-start: $button-size-compact;
+	padding-block-start: var(--wp-edit-post-meta-boxes-main-presenter-height);
 }
 
 .edit-post-meta-boxes-main__presenter {
@@ -19,7 +24,7 @@
 	// and this has to appear in front of it or else click events will be blocked on touch devices.
 	z-index: 10000;
 	inset: 0 0 auto;
-	height: $button-size-compact;
+	height: var(--wp-edit-post-meta-boxes-main-presenter-height);
 
 	// Style reset for both toggle and separator buttons.
 	> button {
@@ -83,16 +88,6 @@
 	}
 }
 
-// Enlarge the toggle/resizable hit area on touch devices.
-@media (pointer: coarse) {
-	.edit-post-meta-boxes-main {
-		padding-block-start: $button-size;
-	}
-	.edit-post-meta-boxes-main__presenter {
-		height: $button-size;
-	}
-}
-
 .edit-post-meta-boxes-main__liner {
 	// Enable scrolling only for the split view.
 	.edit-post-meta-boxes-main & {
@@ -100,6 +95,17 @@
 	}
 	// Keep the contents behind the resize handle.
 	isolation: isolate;
+
+	&:focus-visible::after {
+		content: "";
+		position: absolute;
+		inset: calc(1px + var(--wp-edit-post-meta-boxes-main-presenter-height)) 0 0;
+		pointer-events: none;
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		// Windows High Contrast mode will show this outline, but not the box-shadow.
+		outline: 2px solid transparent;
+		outline-offset: -2px;
+	}
 
 	// While resizing override hidden attribute in case starting from closed state.
 	.is-resizing.edit-post-meta-boxes-main & {


### PR DESCRIPTION
## What?
Related #59246 and #66436 

Improves keyboard navigation to the meta boxes from the canvas.

## Why?
To improve a11y in relation to the `aria-expanded` attribute used on the toggle button because the content that becomes expanded should immediately follow the button in the DOM. That's not an option due the the `re-resizable` library we are using so the next best thing is to move focus into the content upon expansion. Without this it's difficult to find the content that was expanded through keyboarding.

## How?
Adds focus management to the toggle button (when keyboard activated) and some logic to make the meta boxes wrapping element tabbable when it has overflow. The latter is done in following the precedent from the Preferences modal. Adds some styling to show focus on the meta boxes wrapping element.

## Testing Instructions
With at least one meta box active:
1. Open a post or page
2. Toggle the meta box pane closed if it's already open
3. Use the <kbd>space</kbd> or <kbd>enter</kbd> to open the meta box pane
4. Verify that focus moves to the wrapping element if it's scrollable or to the first tabbable item in the content

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
| <video src="https://github.com/user-attachments/assets/def9fbc6-b5fe-432f-a00d-860bab7b2a1c"/> | <video src="https://github.com/user-attachments/assets/e1c87c26-01e0-4407-9bf7-e8309a68a749"/> |
