### PR TITLE
Term Name: Decode HTML entities

### DIFF
--- a/packages/block-library/src/term-name/edit.js
+++ b/packages/block-library/src/term-name/edit.js
@@ -19,6 +19,7 @@ import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -34,7 +35,9 @@ export default function TermNameEdit( {
 	const { textAlign, level = 0, isLink } = attributes;
 	const { term } = useTermName( termId, taxonomy );
 
-	const termName = term?.name || __( 'Term Name' );
+	const termName = term?.name
+		? decodeEntities( term.name )
+		: __( 'Term Name' );
 
 	const blockProps = useBlockProps( {
 		className: clsx( {


### PR DESCRIPTION
## What?

This PR decodes HTML entities in term names in the editor.

## Testing Instructions

- Create terms that contains a`<`and `&`.
- Insert a Terms Query block and confirm the term name text.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
| <img width="274" height="290" alt="image" src="https://github.com/user-attachments/assets/1924fa55-6e58-488d-9704-a6afaa3cf158" /> | <img width="272" height="301" alt="image" src="https://github.com/user-attachments/assets/88de0be3-f7b8-4e3b-82bc-dfe93c7ec616" /> |

cc @cr0ybot
