### PR TITLE
Notes: Add More Menu Item

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -27,6 +27,7 @@ import {
 	useEnableFloatingSidebar,
 } from './hooks';
 import { focusCommentThread } from './utils';
+import PluginMoreMenuItem from '../plugin-more-menu-item';
 
 function CollabSidebarContent( {
 	showCommentBoard,
@@ -195,6 +196,9 @@ export default function CollabSidebar() {
 					/>
 				</PluginSidebar>
 			) }
+			<PluginMoreMenuItem icon={ commentIcon } onClick={ openTheSidebar }>
+				{ __( 'Notes' ) }
+			</PluginMoreMenuItem>
 		</>
 	);
 }


### PR DESCRIPTION
## What? Why?

When the note sidebar is unpinned, there is no way to access the note archive. The user has to click on a block and then on the comment button.

This PR will make the note archive accessible from the options menu even when the sidebar is unpinned.

## Testing Instructions

- Insert a block and add a note to it.
- Open the note sidebar.
- Click the 'Unpin from toolbar' button and close the sidebar.
- Open the Options menu > Notes

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/b4e461fe-e858-4f65-985c-0801d95ad73f