### PR TITLE
Terms Query: Stabilize the block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -1014,7 +1014,6 @@ Displays the name of a taxonomy term. ([Source](https://github.com/WordPress/gut
 Contains the block elements used to render a taxonomy term, like the name, description, and more. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/term-template))
 
 -	**Name:** core/term-template
--	**Experimental:** true
 -	**Category:** theme
 -	**Ancestor:** core/terms-query
 -	**Supports:** align (full, wide), color (background, gradients, link, text), interactivity (clientNavigation), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
@@ -1024,7 +1023,6 @@ Contains the block elements used to render a taxonomy term, like the name, descr
 An advanced block that allows displaying taxonomy terms based on different query parameters and visual configurations. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/terms-query))
 
 -	**Name:** core/terms-query
--	**Experimental:** true
 -	**Category:** theme
 -	**Supports:** align (full, wide), interactivity, layout, ~~html~~
 -	**Attributes:** tagName, termQuery

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -254,14 +254,11 @@ const getAllBlocks = () => {
 		termCount,
 		termDescription,
 		termName,
+		termsQuery,
+		termTemplate,
 		queryTitle,
 		postAuthorBiography,
 	];
-
-	if ( window?.__experimentalEnableBlockExperiments ) {
-		blocks.push( termsQuery );
-		blocks.push( termTemplate );
-	}
 
 	if ( window?.__experimentalEnableFormBlocks ) {
 		blocks.push( form );

--- a/packages/block-library/src/term-template/block.json
+++ b/packages/block-library/src/term-template/block.json
@@ -1,7 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
-	"__experimental": true,
 	"name": "core/term-template",
 	"title": "Term Template",
 	"category": "theme",

--- a/packages/block-library/src/terms-query/block.json
+++ b/packages/block-library/src/terms-query/block.json
@@ -1,7 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
-	"__experimental": true,
 	"name": "core/terms-query",
 	"title": "Terms Query",
 	"category": "theme",

--- a/test/integration/fixtures/blocks/core__term-template.json
+++ b/test/integration/fixtures/blocks/core__term-template.json
@@ -1,12 +1,8 @@
 [
 	{
-		"name": "core/missing",
+		"name": "core/term-template",
 		"isValid": true,
-		"attributes": {
-			"originalName": "core/term-template",
-			"originalUndelimitedContent": "",
-			"originalContent": "<!-- wp:term-template /-->"
-		},
+		"attributes": {},
 		"innerBlocks": []
 	}
 ]

--- a/test/integration/fixtures/blocks/core__terms-query.json
+++ b/test/integration/fixtures/blocks/core__terms-query.json
@@ -1,11 +1,19 @@
 [
 	{
-		"name": "core/missing",
+		"name": "core/terms-query",
 		"isValid": true,
 		"attributes": {
-			"originalName": "core/terms-query",
-			"originalUndelimitedContent": "<div class=\"wp-block-terms-query\"></div>",
-			"originalContent": "<!-- wp:terms-query -->\n<div class=\"wp-block-terms-query\"></div>\n<!-- /wp:terms-query -->"
+			"termQuery": {
+				"perPage": 10,
+				"taxonomy": "category",
+				"order": "asc",
+				"orderBy": "name",
+				"include": [],
+				"hideEmpty": true,
+				"showNested": false,
+				"inherit": false
+			},
+			"tagName": "div"
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/49094

After lots of iterations and discussions I think this is ready for 6.9. This PR stabilizes Terms Query and Term Template blocks.
