### PR TITLE
Block Bindings: Migrate post-data and term-data source to use `field` instead of `key` args.

### DIFF
--- a/backport-changelog/6.9/10304.md
+++ b/backport-changelog/6.9/10304.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10304
+
+* https://github.com/WordPress/gutenberg/pull/72382

--- a/lib/compat/wordpress-6.9/post-data-block-bindings.php
+++ b/lib/compat/wordpress-6.9/post-data-block-bindings.php
@@ -72,7 +72,7 @@ function gutenberg_block_bindings_post_data_get_value( array $source_args, $bloc
 		}
 	}
 
-	if ( 'link' === $source_args['key'] ) {
+	if ( 'link' === $field ) {
 		$permalink = get_permalink( $post_id );
 		return false === $permalink ? null : esc_url( $permalink );
 	}

--- a/lib/compat/wordpress-6.9/post-data-block-bindings.php
+++ b/lib/compat/wordpress-6.9/post-data-block-bindings.php
@@ -19,14 +19,14 @@
  * @return mixed The value computed for the source.
  */
 function gutenberg_block_bindings_post_data_get_value( array $source_args, $block_instance ) {
-	$field = isset( $source_args['field'] ) ? $source_args['field'] : null;
-
-	// Backward compatibility for when the source argument was called `key` in Gutenberg plugin.
-	if ( empty( $field ) && defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-		$field = $source_args['key'];
-		if ( empty( $field ) ) {
+	if ( empty( $source_args['field'] ) ) {
+		// Backward compatibility for when the source argument was called `key` in Gutenberg plugin.
+		if ( empty( $source_args['key'] ) ) {
 			return null;
 		}
+		$field = $source_args['key'];
+	} else {
+		$field = $source_args['field'];
 	}
 
 	/*

--- a/lib/compat/wordpress-6.9/post-data-block-bindings.php
+++ b/lib/compat/wordpress-6.9/post-data-block-bindings.php
@@ -14,13 +14,19 @@
  * @access private
  *
  * @param array    $source_args    Array containing source arguments used to look up the override value.
- *                                 Example: array( "key" => "foo" ).
+ *                                 Example: array( "field" => "foo" ).
  * @param WP_Block $block_instance The block instance.
  * @return mixed The value computed for the source.
  */
 function gutenberg_block_bindings_post_data_get_value( array $source_args, $block_instance ) {
-	if ( empty( $source_args['key'] ) ) {
-		return null;
+	$field = isset( $source_args['field'] ) ? $source_args['field'] : null;
+
+	// Backward compatibility for when the source argument was called `key` in Gutenberg plugin.
+	if ( empty( $field ) && defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
+		$field = $source_args['key'];
+		if ( empty( $field ) ) {
+			return null;
+		}
 	}
 
 	/*
@@ -53,11 +59,11 @@ function gutenberg_block_bindings_post_data_get_value( array $source_args, $bloc
 		return null;
 	}
 
-	if ( 'date' === $source_args['key'] ) {
+	if ( 'date' === $field ) {
 		return esc_attr( get_the_date( 'c', $post_id ) );
 	}
 
-	if ( 'modified' === $source_args['key'] ) {
+	if ( 'modified' === $field ) {
 		// Only return the modified date if it is later than the publishing date.
 		if ( get_the_modified_date( 'U', $post_id ) > get_the_date( 'U', $post_id ) ) {
 			return esc_attr( get_the_modified_date( 'c', $post_id ) );

--- a/lib/compat/wordpress-6.9/term-data-block-bindings.php
+++ b/lib/compat/wordpress-6.9/term-data-block-bindings.php
@@ -14,12 +14,12 @@
  * @access private
  *
  * @param array    $source_args    Array containing source arguments used to look up the override value.
- *                                 Example: array( "key" => "name" ).
+ *                                 Example: array( "field" => "name" ).
  * @param WP_Block $block_instance The block instance.
  * @return mixed The value computed for the source.
  */
 function gutenberg_block_bindings_term_data_get_value( array $source_args, $block_instance ) {
-	if ( empty( $source_args['key'] ) ) {
+	if ( empty( $source_args['field'] ) ) {
 		return null;
 	}
 
@@ -65,7 +65,7 @@ function gutenberg_block_bindings_term_data_get_value( array $source_args, $bloc
 		}
 	}
 
-	switch ( $source_args['key'] ) {
+	switch ( $source_args['field'] ) {
 		case 'id':
 			return esc_html( (string) $term_id );
 

--- a/packages/block-library/src/navigation-link/shared/test/use-entity-binding.js
+++ b/packages/block-library/src/navigation-link/shared/test/use-entity-binding.js
@@ -58,7 +58,7 @@ describe( 'useEntityBinding', () => {
 					bindings: {
 						url: {
 							source: 'core/post-data',
-							args: { key: 'link' },
+							args: { field: 'link' },
 						},
 					},
 				},
@@ -82,7 +82,7 @@ describe( 'useEntityBinding', () => {
 					bindings: {
 						url: {
 							source: 'core/term-data',
-							args: { key: 'link' },
+							args: { field: 'link' },
 						},
 					},
 				},
@@ -106,7 +106,7 @@ describe( 'useEntityBinding', () => {
 					bindings: {
 						url: {
 							source: 'some-other-source',
-							args: { key: 'url' },
+							args: { field: 'url' },
 						},
 					},
 				},
@@ -130,7 +130,7 @@ describe( 'useEntityBinding', () => {
 					bindings: {
 						url: {
 							source: 'core/post-data',
-							args: { key: 'link' },
+							args: { field: 'link' },
 						},
 					},
 				},
@@ -178,7 +178,7 @@ describe( 'useEntityBinding', () => {
 				bindings: {
 					url: {
 						source: 'core/post-data',
-						args: { key: 'link' },
+						args: { field: 'link' },
 					},
 				},
 			},
@@ -273,7 +273,7 @@ describe( 'useEntityBinding', () => {
 			url: {
 				source: 'core/post-data',
 				args: {
-					key: 'link',
+					field: 'link',
 				},
 			},
 		} );
@@ -285,7 +285,7 @@ describe( 'useEntityBinding', () => {
 			expect( binding ).toEqual( {
 				url: {
 					source: 'core/post-data',
-					args: { key: 'link' },
+					args: { field: 'link' },
 				},
 			} );
 		} );
@@ -295,7 +295,7 @@ describe( 'useEntityBinding', () => {
 			expect( binding ).toEqual( {
 				url: {
 					source: 'core/term-data',
-					args: { key: 'link' },
+					args: { field: 'link' },
 				},
 			} );
 		} );

--- a/packages/block-library/src/navigation-link/shared/use-entity-binding.js
+++ b/packages/block-library/src/navigation-link/shared/use-entity-binding.js
@@ -38,7 +38,7 @@ export function buildNavigationLinkEntityBinding( kind ) {
 		url: {
 			source,
 			args: {
-				key: 'link',
+				field: 'link',
 			},
 		},
 	};

--- a/packages/block-library/src/page-list/test/convert-to-navigation-links.js
+++ b/packages/block-library/src/page-list/test/convert-to-navigation-links.js
@@ -9,7 +9,7 @@ const EXPECTED_ENTITY_BINDING = {
 	url: {
 		source: 'core/post-data',
 		args: {
-			key: 'link',
+			field: 'link',
 		},
 	},
 };

--- a/packages/block-library/src/post-date/deprecated.js
+++ b/packages/block-library/src/post-date/deprecated.js
@@ -90,7 +90,7 @@ const v2 = {
 					bindings: {
 						datetime: {
 							source: 'core/post-data',
-							args: { key: displayType },
+							args: { field: displayType },
 						},
 					},
 				},

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -48,10 +48,8 @@ export default function PostDateEdit( {
 } ) {
 	const displayType =
 		metadata?.bindings?.datetime?.source === 'core/post-data' &&
-		( globalThis.IS_GUTENBERG_PLUGIN
-			? metadata?.bindings?.datetime?.args?.field ||
-			  metadata?.bindings?.datetime?.args?.key
-			: metadata?.bindings?.datetime?.args?.field );
+		( metadata?.bindings?.datetime?.args?.field ||
+			metadata?.bindings?.datetime?.args?.key );
 
 	const blockProps = useBlockProps( {
 		className: clsx( {

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -48,7 +48,10 @@ export default function PostDateEdit( {
 } ) {
 	const displayType =
 		metadata?.bindings?.datetime?.source === 'core/post-data' &&
-		metadata?.bindings?.datetime?.args?.key;
+		( globalThis.IS_GUTENBERG_PLUGIN
+			? metadata?.bindings?.datetime?.args?.field ||
+			  metadata?.bindings?.datetime?.args?.key
+			: metadata?.bindings?.datetime?.args?.field );
 
 	const blockProps = useBlockProps( {
 		className: clsx( {

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -32,17 +32,17 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 		$source = get_block_bindings_source( 'core/post-data' );
 		if ( isset( $attributes['displayType'] ) && 'modified' === $attributes['displayType'] ) {
 			$source_args = array(
-				'key' => 'modified',
+				'field' => 'modified',
 			);
 		} else {
 			$source_args = array(
-				'key' => 'date',
+				'field' => 'date',
 			);
 		}
 		$attributes['datetime'] = $source->get_value( $source_args, $block, 'datetime' );
 	}
 
-	if ( isset( $source_args['key'] ) && 'modified' === $source_args['key'] ) {
+	if ( isset( $source_args['field'] ) && 'modified' === $source_args['field'] ) {
 		$classes[] = 'wp-block-post-date__modified-date';
 	}
 

--- a/packages/block-library/src/post-date/variations.js
+++ b/packages/block-library/src/post-date/variations.js
@@ -21,10 +21,9 @@ const variations = [
 		},
 		scope: [ 'block', 'inserter', 'transform' ],
 		isActive: ( blockAttributes ) => {
-			const fieldValue = globalThis.IS_GUTENBERG_PLUGIN
-				? blockAttributes?.metadata?.bindings?.datetime?.args?.field ||
-				  blockAttributes?.metadata?.bindings?.datetime?.args?.key
-				: blockAttributes?.metadata?.bindings?.datetime?.args?.field;
+			const fieldValue =
+				blockAttributes?.metadata?.bindings?.datetime?.args?.field ||
+				blockAttributes?.metadata?.bindings?.datetime?.args?.key;
 			return (
 				blockAttributes?.metadata?.bindings?.datetime?.source ===
 					'core/post-data' && fieldValue === 'date'
@@ -49,10 +48,9 @@ const variations = [
 		},
 		scope: [ 'block', 'inserter', 'transform' ],
 		isActive: ( blockAttributes ) => {
-			const fieldValue = globalThis.IS_GUTENBERG_PLUGIN
-				? blockAttributes?.metadata?.bindings?.datetime?.args?.field ||
-				  blockAttributes?.metadata?.bindings?.datetime?.args?.key
-				: blockAttributes?.metadata?.bindings?.datetime?.args?.field;
+			const fieldValue =
+				blockAttributes?.metadata?.bindings?.datetime?.args?.field ||
+				blockAttributes?.metadata?.bindings?.datetime?.args?.key;
 			return (
 				blockAttributes?.metadata?.bindings?.datetime?.source ===
 					'core/post-data' && fieldValue === 'modified'

--- a/packages/block-library/src/post-date/variations.js
+++ b/packages/block-library/src/post-date/variations.js
@@ -14,16 +14,22 @@ const variations = [
 				bindings: {
 					datetime: {
 						source: 'core/post-data',
-						args: { key: 'date' },
+						args: { field: 'date' },
 					},
 				},
 			},
 		},
 		scope: [ 'block', 'inserter', 'transform' ],
-		isActive: ( blockAttributes ) =>
-			blockAttributes?.metadata?.bindings?.datetime?.source ===
-				'core/post-data' &&
-			blockAttributes?.metadata?.bindings?.datetime?.args?.key === 'date',
+		isActive: ( blockAttributes ) => {
+			const fieldValue = globalThis.IS_GUTENBERG_PLUGIN
+				? blockAttributes?.metadata?.bindings?.datetime?.args?.field ||
+				  blockAttributes?.metadata?.bindings?.datetime?.args?.key
+				: blockAttributes?.metadata?.bindings?.datetime?.args?.field;
+			return (
+				blockAttributes?.metadata?.bindings?.datetime?.source ===
+					'core/post-data' && fieldValue === 'date'
+			);
+		},
 		icon: postDate,
 	},
 	{
@@ -35,18 +41,23 @@ const variations = [
 				bindings: {
 					datetime: {
 						source: 'core/post-data',
-						args: { key: 'modified' },
+						args: { field: 'modified' },
 					},
 				},
 			},
 			className: 'wp-block-post-date__modified-date',
 		},
 		scope: [ 'block', 'inserter', 'transform' ],
-		isActive: ( blockAttributes ) =>
-			blockAttributes?.metadata?.bindings?.datetime?.source ===
-				'core/post-data' &&
-			blockAttributes?.metadata?.bindings?.datetime?.args?.key ===
-				'modified',
+		isActive: ( blockAttributes ) => {
+			const fieldValue = globalThis.IS_GUTENBERG_PLUGIN
+				? blockAttributes?.metadata?.bindings?.datetime?.args?.field ||
+				  blockAttributes?.metadata?.bindings?.datetime?.args?.key
+				: blockAttributes?.metadata?.bindings?.datetime?.args?.field;
+			return (
+				blockAttributes?.metadata?.bindings?.datetime?.source ===
+					'core/post-data' && fieldValue === 'modified'
+			);
+		},
 		icon: postDate,
 	},
 ];

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -107,7 +107,9 @@ export default {
 		const newValues = {};
 		for ( const [ attributeName, source ] of Object.entries( bindings ) ) {
 			// Use the value, the field label, or the field key.
-			const fieldKey = source.args.key;
+			const fieldKey = globalThis.IS_GUTENBERG_PLUGIN
+				? source.args.field || source.args.key
+				: source.args.field;
 			const { value: fieldValue, label: fieldLabel } =
 				dataFields?.[ fieldKey ] || {};
 			newValues[ attributeName ] = fieldValue ?? fieldLabel ?? fieldKey;
@@ -126,7 +128,7 @@ export default {
 		}
 		const newData = {};
 		Object.values( bindings ).forEach( ( { args, newValue } ) => {
-			newData[ args.key ] = newValue;
+			newData[ args.field ] = newValue;
 		} );
 
 		dispatch( coreDataStore ).editEntityRecord(
@@ -159,7 +161,7 @@ export default {
 		}
 
 		const fieldValue = getPostDataFields( select, context, undefined )?.[
-			args.key
+			args.field
 		]?.value;
 		// Empty string or `false` could be a valid value, so we need to check if the field value is undefined.
 		if ( fieldValue === undefined ) {
@@ -197,7 +199,7 @@ export default {
 		).map( ( [ key, field ] ) => ( {
 			label: field.label,
 			args: {
-				key,
+				field: key,
 			},
 			type: field.type,
 		} ) );

--- a/packages/editor/src/bindings/term-data.js
+++ b/packages/editor/src/bindings/term-data.js
@@ -149,7 +149,7 @@ export default {
 		const newValues = {};
 		for ( const [ attributeName, source ] of Object.entries( bindings ) ) {
 			// Use the value, the field label, or the field key.
-			const fieldKey = source.args.key;
+			const fieldKey = source.args.field;
 			const { value: fieldValue, label: fieldLabel } =
 				dataFields?.[ fieldKey ] || {};
 			newValues[ attributeName ] = fieldValue ?? fieldLabel ?? fieldKey;
@@ -185,7 +185,7 @@ export default {
 		}
 
 		const fieldValue = getTermDataFields( select, context, undefined )?.[
-			args.key
+			args.field
 		]?.value;
 		// Empty string or `false` could be a valid value, so we need to check if the field value is undefined.
 		if ( fieldValue === undefined ) {
@@ -210,7 +210,7 @@ export default {
 			label: field.label,
 			type: field.type,
 			args: {
-				key,
+				field: key,
 			},
 		} ) );
 		/*

--- a/phpunit/blocks/render-block-core-post-date.php
+++ b/phpunit/blocks/render-block-core-post-date.php
@@ -70,7 +70,7 @@ class Test_Render_Block_Core_Post_Date extends WP_UnitTestCase {
 				'bindings' => array(
 					'datetime' => array(
 						'source' => 'core/post-data',
-						'args'   => array( 'field' => $field ),
+						'args'   => array( 'key' => $field ),
 					),
 				),
 			),
@@ -138,7 +138,7 @@ class Test_Render_Block_Core_Post_Date extends WP_UnitTestCase {
 				'bindings' => array(
 					'datetime' => array(
 						'source' => 'core/post-data',
-						'args'   => array( 'field' => 'modified' ),
+						'args'   => array( 'key' => 'modified' ),
 					),
 				),
 			),

--- a/phpunit/blocks/render-block-core-post-date.php
+++ b/phpunit/blocks/render-block-core-post-date.php
@@ -70,7 +70,7 @@ class Test_Render_Block_Core_Post_Date extends WP_UnitTestCase {
 				'bindings' => array(
 					'datetime' => array(
 						'source' => 'core/post-data',
-						'args'   => array( 'key' => $field ),
+						'args'   => array( 'field' => $field ),
 					),
 				),
 			),
@@ -138,7 +138,7 @@ class Test_Render_Block_Core_Post_Date extends WP_UnitTestCase {
 				'bindings' => array(
 					'datetime' => array(
 						'source' => 'core/post-data',
-						'args'   => array( 'key' => 'modified' ),
+						'args'   => array( 'field' => 'modified' ),
 					),
 				),
 			),

--- a/test/e2e/specs/editor/various/__snapshots__/Inserting-blocks-firefox-webkit-inserts-p-59603-ragging-and-dropping-from-the-global-inserter-1-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Inserting-blocks-firefox-webkit-inserts-p-59603-ragging-and-dropping-from-the-global-inserter-1-chromium.txt
@@ -14,6 +14,6 @@
 <hr class="wp-block-separator has-css-opacity"/>
 <!-- /wp:separator -->
 
-<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"key":"date"}}}}} /-->
+<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}}} /-->
 <!-- /wp:post-template --></div>
 <!-- /wp:query -->

--- a/test/e2e/specs/editor/various/__snapshots__/Inserting-blocks-firefox-webkit-inserts-p-59603-ragging-and-dropping-from-the-global-inserter-1-webkit.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Inserting-blocks-firefox-webkit-inserts-p-59603-ragging-and-dropping-from-the-global-inserter-1-webkit.txt
@@ -14,6 +14,6 @@
 <hr class="wp-block-separator has-css-opacity"/>
 <!-- /wp:separator -->
 
-<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"key":"date"}}}}} /-->
+<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}}} /-->
 <!-- /wp:post-template --></div>
 <!-- /wp:query -->

--- a/test/e2e/specs/editor/various/block-bindings/post-data.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-data.spec.js
@@ -41,7 +41,7 @@ test.describe( 'Post Data source', () => {
 							content: {
 								source: 'core/post-data',
 								args: {
-									key: 'modified',
+									field: 'modified',
 								},
 							},
 						},
@@ -71,7 +71,7 @@ test.describe( 'Post Data source', () => {
 						bindings: {
 							datetime: {
 								source: 'core/post-data',
-								args: { key: 'date' },
+								args: { field: 'date' },
 							},
 						},
 					},

--- a/test/integration/fixtures/blocks/core__image__caption-block-bindings.html
+++ b/test/integration/fixtures/blocks/core__image__caption-block-bindings.html
@@ -1,3 +1,3 @@
-<!-- wp:image {"metadata":{"bindings":{"caption":{"source":"core/post-data","args":{"key":"date"}}}}} -->
+<!-- wp:image {"metadata":{"bindings":{"caption":{"source":"core/post-data","args":{"field":"date"}}}}} -->
 <figure class="wp-block-image"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" /><figcaption class="wp-element-caption"></figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__caption-block-bindings.json
+++ b/test/integration/fixtures/blocks/core__image__caption-block-bindings.json
@@ -11,7 +11,7 @@
 					"caption": {
 						"source": "core/post-data",
 						"args": {
-							"key": "date"
+							"field": "date"
 						}
 					}
 				}

--- a/test/integration/fixtures/blocks/core__image__caption-block-bindings.parsed.json
+++ b/test/integration/fixtures/blocks/core__image__caption-block-bindings.parsed.json
@@ -7,7 +7,7 @@
 					"caption": {
 						"source": "core/post-data",
 						"args": {
-							"key": "date"
+							"field": "date"
 						}
 					}
 				}

--- a/test/integration/fixtures/blocks/core__image__caption-block-bindings.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__caption-block-bindings.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:image {"metadata":{"bindings":{"caption":{"source":"core/post-data","args":{"key":"date"}}}}} -->
+<!-- wp:image {"metadata":{"bindings":{"caption":{"source":"core/post-data","args":{"field":"date"}}}}} -->
 <figure class="wp-block-image"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt=""/><figcaption class="wp-element-caption"></figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__post-date.json
+++ b/test/integration/fixtures/blocks/core__post-date.json
@@ -9,7 +9,7 @@
 					"datetime": {
 						"source": "core/post-data",
 						"args": {
-							"key": "date"
+							"field": "date"
 						}
 					}
 				}

--- a/test/integration/fixtures/blocks/core__post-date.serialized.html
+++ b/test/integration/fixtures/blocks/core__post-date.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"key":"date"}}}}} /-->
+<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}}} /-->

--- a/test/integration/fixtures/blocks/core__post-date__deprecated-v2.json
+++ b/test/integration/fixtures/blocks/core__post-date__deprecated-v2.json
@@ -10,7 +10,7 @@
 					"datetime": {
 						"source": "core/post-data",
 						"args": {
-							"key": "modified"
+							"field": "modified"
 						}
 					}
 				}

--- a/test/integration/fixtures/blocks/core__post-date__deprecated-v2.serialized.html
+++ b/test/integration/fixtures/blocks/core__post-date__deprecated-v2.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:post-date {"className":"wp-block-post-date__modified-date","metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"key":"modified"}}}}} /-->
+<!-- wp:post-date {"className":"wp-block-post-date__modified-date","metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"modified"}}}}} /-->

--- a/test/integration/fixtures/blocks/core__query__deprecated-3.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-3.json
@@ -73,7 +73,7 @@
 											"datetime": {
 												"source": "core/post-data",
 												"args": {
-													"key": "date"
+													"field": "date"
 												}
 											}
 										}

--- a/test/integration/fixtures/blocks/core__query__deprecated-3.serialized.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-3.serialized.html
@@ -3,7 +3,7 @@
 <div class="wp-block-group has-pale-cyan-blue-color has-text-color has-background has-link-color" style="background-color:#284d5f"><!-- wp:post-template {"fontSize":"large","layout":{"type":"grid","columnCount":3}} -->
 <!-- wp:post-title /-->
 
-<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"key":"date"}}}}} /-->
+<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}}} /-->
 
 <!-- wp:post-excerpt /-->
 <!-- /wp:post-template -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
The first use case for block bindings was `post-meta` source. This one keeps a `key` - `value` relation, which makes totally sense. But all examples for Block Bindings have been done with this `key` argument, and the UI was pretty `key` dependant.

After the UI refactor, `args` can contain anything, and using whatever fits better for each source is encouraged.

For `post-meta` and `term-data`, `key` may not be the best argument, as it will connect in a future to different fields. 
<!-- In a few words, what is the PR actually doing? -->

The source has been introduced during 6.9 cycle, but for a couple of Gutenberg versions, so I added backward compatibility with `key` only for the Gutenberg plugin, that way we cover:
 - WP 6.8.X and 6.7.X versions that used the new `post-date` approach with Gutenberg enabled.
 - WP 6.9 without GB will use the migration to the new `post-date` with `field`.
 - WP 6.9 with GB enabled.



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
```
<!-- wp:post-date {"datetime":"2025-10-15T17:51:51.749Z","metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"key":"date"}}}},"className":"wp-block-post-date__modified-date"} /-->

<!-- wp:post-date {"datetime":"2025-10-15T17:51:51.749Z","metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"key":"modified"}}}},"className":"wp-block-post-date__modified-date"} /-->
```

- These blocks should work with Gutenberg enabled and WP trunk.
- These blocks should work with Gutenberg enabled and WP 6.8.
