### PR TITLE
Build V2: Fix DataViews export file

### DIFF
--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -32,7 +32,7 @@
 		},
 		"./wp": {
 			"types": "./build-types/index.d.ts",
-			"require": "./build-wp/index.js"
+			"default": "./build-wp/index.js"
 		},
 		"./package.json": {
 			"default": "./package.json"


### PR DESCRIPTION
The "wp" build in the DataViews package is not exposed properly in the package.json file after the build v2 migration. This means that for folks doing `import something from '@wordpress/dataviews/wp'`, things might break depending on the bundler.