### PR TITLE
Block Transforms: In metadata transform, remove check for block bindings.

### DIFF
--- a/packages/block-library/src/utils/get-transformed-metadata.js
+++ b/packages/block-library/src/utils/get-transformed-metadata.js
@@ -21,20 +21,11 @@ export function getTransformedMetadata(
 		return;
 	}
 	const { supports } = getBlockType( newBlockName );
-	// Fixed until an opt-in mechanism is implemented.
-	const BLOCK_BINDINGS_SUPPORTED_BLOCKS = [
-		'core/paragraph',
-		'core/heading',
-		'core/image',
-		'core/button',
-	];
+
 	// The metadata properties that should be preserved after the transform.
 	const transformSupportedProps = [ 'commentId' ];
-	// If it support bindings, and there is a transform bindings callback, add the `id` and `bindings` properties.
-	if (
-		BLOCK_BINDINGS_SUPPORTED_BLOCKS.includes( newBlockName ) &&
-		bindingsCallback
-	) {
+	// If there is a transform bindings callback, add the `id` and `bindings` properties.
+	if ( bindingsCallback ) {
 		transformSupportedProps.push( 'id', 'bindings' );
 	}
 	// If it support block naming (true by default), add the `name` property.


### PR DESCRIPTION
## What?
In the `getTransformedMetadata()` method, remove check if the type of block being transformed is supported by block bindings.

Follow-up to https://github.com/WordPress/gutenberg/pull/71820.

## Why?
This is one of the instances where we were still keeping a separate, hard-coded list of blocks supported by block bindings on the client side, and it has been outdated for a while (`core/post-date` is missing).

Starting with https://github.com/WordPress/gutenberg/pull/71820, we've been using the server side as the source of truth for the list of blocks (and block attributes) supported by block bindings; it is also exposed on the client side via private block context (see https://github.com/WordPress/gutenberg/pull/72351).

## How?
In `getTransformedMetadata()`, the hardcoded list was used as one criterion to determine if `id` and `bindings` properties should be added. The other criterion is whether a `bindingsCallback` argument was passed to `getTransformedMetadata()`. It's probably fine to solely rely on that criterion (and trust that in the unlikely case that such a callback argument is provided, adding `id` and `bindings` properties won't do any harm).

The alternative would be to read the list from private block context. However, that would require either exposing that context across package boundaries, or using `select( blockEditorStore ).getSettings()`. In any case, it would create a dependency of `getTransformedMetadata()` (which is part of `@wordpress/block-library`) on the `@wordpress/block-editor` package. That seems suboptimal, which is why I chose the solution found in this PR.

## Testing Instructions

Refer to testing instructions in https://github.com/WordPress/gutenberg/pull/59179.

Additionally, this seems to be covered by e2e tests (also added by the aforementioned PR).