### PR TITLE
Pattern Overrides: Infer partial syncing supported blocks from the server

### DIFF
--- a/docs/private-apis.md
+++ b/docs/private-apis.md
@@ -225,7 +225,6 @@ Private exports:
 - `CreatePatternModalContents`
 - `DuplicatePatternModal`
 - `isOverridableBlock`
-- `hasOverridableBlocks`
 - `useDuplicatePatternProps`
 - `RenamePatternModal`
 - `PatternsMenuItems`
@@ -239,7 +238,6 @@ Private exports:
 - `PATTERN_USER_CATEGORY`
 - `EXCLUDED_PATTERN_SOURCES`
 - `PATTERN_SYNC_TYPES`
-- `PARTIAL_SYNCING_SUPPORTED_BLOCKS`
 
 ### `core/patterns` store
 

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -40,7 +40,7 @@ import { getBlockBindingsSource } from '@wordpress/blocks';
 import { unlock } from '../lock-unlock';
 
 const { useLayoutClasses } = unlock( blockEditorPrivateApis );
-const { hasOverridableBlocks } = unlock( patternsPrivateApis );
+const { isOverridableBlock } = unlock( patternsPrivateApis );
 
 const fullAlignments = [ 'full', 'wide', 'left', 'right' ];
 
@@ -168,24 +168,39 @@ function ReusableBlockEdit( {
 	const { __unstableMarkLastChangeAsPersistent } =
 		useDispatch( blockEditorStore );
 
-	const { onNavigateToEntityRecord, hasPatternOverridesSource } = useSelect(
-		( select ) => {
-			const { getSettings } = select( blockEditorStore );
-			// For editing link to the site editor if the theme and user permissions support it.
-			return {
-				onNavigateToEntityRecord:
-					getSettings().onNavigateToEntityRecord,
-				hasPatternOverridesSource: !! getBlockBindingsSource(
-					'core/pattern-overrides'
-				),
-			};
-		},
-		[]
-	);
+	const {
+		onNavigateToEntityRecord,
+		hasPatternOverridesSource,
+		supportedBlockTypes,
+	} = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		// For editing link to the site editor if the theme and user permissions support it.
+		return {
+			onNavigateToEntityRecord: getSettings().onNavigateToEntityRecord,
+			hasPatternOverridesSource: !! getBlockBindingsSource(
+				'core/pattern-overrides'
+			),
+			supportedBlockTypes: Object.keys(
+				getSettings().__experimentalBlockBindingsSupportedAttributes ||
+					{}
+			),
+		};
+	}, [] );
+
+	const hasOverridableBlocks = ( _blocks ) =>
+		_blocks.some( ( block ) => {
+			if (
+				supportedBlockTypes.includes( block.name ) &&
+				isOverridableBlock( block )
+			) {
+				return true;
+			}
+			return hasOverridableBlocks( block.innerBlocks );
+		} );
 
 	const canOverrideBlocks = useMemo(
 		() => hasPatternOverridesSource && hasOverridableBlocks( blocks ),
-		[ hasPatternOverridesSource, blocks ]
+		[ hasPatternOverridesSource, hasOverridableBlocks, blocks ]
 	);
 
 	const { alignment, layout } = useInferredLayout( blocks, parentLayout );

--- a/packages/editor/src/hooks/pattern-overrides.js
+++ b/packages/editor/src/hooks/pattern-overrides.js
@@ -4,7 +4,10 @@
 import { addFilter } from '@wordpress/hooks';
 import { privateApis as patternsPrivateApis } from '@wordpress/patterns';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { useBlockEditingMode } from '@wordpress/block-editor';
+import {
+	store as blockEditorStore,
+	useBlockEditingMode,
+} from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { getBlockBindingsSource } from '@wordpress/blocks';
 
@@ -21,7 +24,6 @@ const {
 	ResetOverridesControl,
 	PatternOverridesBlockControls,
 	PATTERN_TYPES,
-	PARTIAL_SYNCING_SUPPORTED_BLOCKS,
 	PATTERN_SYNC_TYPES,
 } = unlock( patternsPrivateApis );
 
@@ -36,8 +38,14 @@ const {
  */
 const withPatternOverrideControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
-		const isSupportedBlock =
-			!! PARTIAL_SYNCING_SUPPORTED_BLOCKS[ props.name ];
+		const isSupportedBlock = useSelect(
+			( select ) => {
+				const { __experimentalBlockBindingsSupportedAttributes } =
+					select( blockEditorStore ).getSettings();
+				return !! __experimentalBlockBindingsSupportedAttributes?.[ props.name ];
+			},
+			[ props.name ]
+		);
 
 		return (
 			<>

--- a/packages/editor/src/hooks/pattern-overrides.js
+++ b/packages/editor/src/hooks/pattern-overrides.js
@@ -41,7 +41,9 @@ const withPatternOverrideControls = createHigherOrderComponent(
 			( select ) => {
 				const { __experimentalBlockBindingsSupportedAttributes } =
 					select( blockEditorStore ).getSettings();
-				return !! __experimentalBlockBindingsSupportedAttributes?.[ props.name ];
+				return !! __experimentalBlockBindingsSupportedAttributes?.[
+					props.name
+				];
 			},
 			[ props.name ]
 		);

--- a/packages/editor/src/hooks/pattern-overrides.js
+++ b/packages/editor/src/hooks/pattern-overrides.js
@@ -30,7 +30,6 @@ const {
 /**
  * Override the default edit UI to include a new block inspector control for
  * assigning a partial syncing controls to supported blocks in the pattern editor.
- * Currently, only the `core/paragraph` block is supported.
  *
  * @param {Component} BlockEdit Original component.
  *

--- a/packages/patterns/src/api/index.js
+++ b/packages/patterns/src/api/index.js
@@ -1,9 +1,4 @@
 /**
- * Internal dependencies
- */
-import { PARTIAL_SYNCING_SUPPORTED_BLOCKS } from '../constants';
-
-/**
  * Determines whether a block is overridable.
  *
  * @param {WPBlock} block The block to test.
@@ -12,29 +7,10 @@ import { PARTIAL_SYNCING_SUPPORTED_BLOCKS } from '../constants';
  */
 export function isOverridableBlock( block ) {
 	return (
-		Object.keys( PARTIAL_SYNCING_SUPPORTED_BLOCKS ).includes(
-			block.name
-		) &&
 		!! block.attributes.metadata?.name &&
 		!! block.attributes.metadata?.bindings &&
 		Object.values( block.attributes.metadata.bindings ).some(
 			( binding ) => binding.source === 'core/pattern-overrides'
 		)
 	);
-}
-
-/**
- * Determines whether the blocks list has overridable blocks.
- *
- * @param {WPBlock[]} blocks The blocks list.
- *
- * @return {boolean} `true` if the list has overridable blocks, `false` otherwise.
- */
-export function hasOverridableBlocks( blocks ) {
-	return blocks.some( ( block ) => {
-		if ( isOverridableBlock( block ) ) {
-			return true;
-		}
-		return hasOverridableBlocks( block.innerBlocks );
-	} );
 }

--- a/packages/patterns/src/components/overrides-panel.js
+++ b/packages/patterns/src/components/overrides-panel.js
@@ -19,8 +19,15 @@ import { unlock } from '../lock-unlock';
 const { BlockQuickNavigation } = unlock( blockEditorPrivateApis );
 
 export default function OverridesPanel() {
-	const allClientIds = useSelect(
-		( select ) => select( blockEditorStore ).getClientIdsWithDescendants(),
+	const { allClientIds, supportedBlockTypes } = useSelect(
+		( select ) => ( {
+			allClientIds:
+				select( blockEditorStore ).getClientIdsWithDescendants(),
+			supportedBlockTypes: Object.keys(
+				select( blockEditorStore ).getSettings()
+					?.__experimentalBlockBindingsSupportedAttributes || {}
+			),
+		} ),
 		[]
 	);
 	const { getBlock } = useSelect( blockEditorStore );
@@ -28,9 +35,12 @@ export default function OverridesPanel() {
 		() =>
 			allClientIds.filter( ( clientId ) => {
 				const block = getBlock( clientId );
-				return isOverridableBlock( block );
+				return (
+					supportedBlockTypes.includes( block.name ) &&
+					isOverridableBlock( block )
+				);
 			} ),
-		[ allClientIds, getBlock ]
+		[ allClientIds, getBlock, supportedBlockTypes ]
 	);
 
 	if ( ! clientIdsWithOverrides?.length ) {

--- a/packages/patterns/src/constants.js
+++ b/packages/patterns/src/constants.js
@@ -15,12 +15,4 @@ export const PATTERN_SYNC_TYPES = {
 	unsynced: 'unsynced',
 };
 
-// TODO: This should not be hardcoded. Maybe there should be a config and/or an UI.
-export const PARTIAL_SYNCING_SUPPORTED_BLOCKS = {
-	'core/paragraph': [ 'content' ],
-	'core/heading': [ 'content' ],
-	'core/button': [ 'text', 'url', 'linkTarget', 'rel' ],
-	'core/image': [ 'id', 'url', 'title', 'alt' ],
-};
-
 export const PATTERN_OVERRIDES_BINDING_SOURCE = 'core/pattern-overrides';

--- a/packages/patterns/src/private-apis.js
+++ b/packages/patterns/src/private-apis.js
@@ -11,7 +11,7 @@ import {
 	default as DuplicatePatternModal,
 	useDuplicatePatternProps,
 } from './components/duplicate-pattern-modal';
-import { isOverridableBlock, hasOverridableBlocks } from './api';
+import { isOverridableBlock } from './api';
 import RenamePatternModal from './components/rename-pattern-modal';
 import PatternsMenuItems from './components';
 import RenamePatternCategoryModal from './components/rename-pattern-category-modal';
@@ -25,7 +25,6 @@ import {
 	PATTERN_USER_CATEGORY,
 	EXCLUDED_PATTERN_SOURCES,
 	PATTERN_SYNC_TYPES,
-	PARTIAL_SYNCING_SUPPORTED_BLOCKS,
 } from './constants';
 
 export const privateApis = {};
@@ -35,7 +34,6 @@ lock( privateApis, {
 	CreatePatternModalContents,
 	DuplicatePatternModal,
 	isOverridableBlock,
-	hasOverridableBlocks,
 	useDuplicatePatternProps,
 	RenamePatternModal,
 	PatternsMenuItems,
@@ -49,5 +47,4 @@ lock( privateApis, {
 	PATTERN_USER_CATEGORY,
 	EXCLUDED_PATTERN_SOURCES,
 	PATTERN_SYNC_TYPES,
-	PARTIAL_SYNCING_SUPPORTED_BLOCKS,
 } );


### PR DESCRIPTION
## What?
In Patterns code, infer the list of blocks supported by pattern overrides from the server (instead of a hardcoded array).

Follow-up to https://github.com/WordPress/gutenberg/pull/71820.

## Why?
This is one of the instances where we were still keeping a separate, hard-coded list of blocks supported by block bindings on the client side, and it has been outdated for a while (`core/post-date` is missing).

Starting with https://github.com/WordPress/gutenberg/pull/71820, we've been using the server side as the source of truth for the list of blocks (and block attributes) supported by block bindings; it is also exposed on the client side via private block context (see https://github.com/WordPress/gutenberg/pull/72351).

## How?
- Remove the check against `PARTIAL_SYNCING_SUPPORTED_BLOCKS` from `isOverridableBlock`, and instead check against `Object.keys( select( blockEditorStore ).getSettings()?.__experimentalBlockBindingsSupportedAttributes || {} )` from the callsites of `isOverridableBlock`.
- Remove `hasOverridableBlocks` (as that depended on `isOverridableBlock` and additionally worked recursively), and also perform the relevant checks inline.

## Testing Instructions
Verify that pattern overrides still work. For example,

> 1. Create a synced pattern with two paragraphs
> 2. Enable overrides for the two paragraphs and use the same block names for both
> 3. Save the pattern
> 4. Create a new post and insert the pattern
> 5. Try typing in one of the paragraphs
>
> Expected: The two paragraphs can be synchronized.

(from https://github.com/WordPress/gutenberg/pull/60721)
