### PR TITLE
Fit-Text: Resize immediately, but limit max size when block is selected

### DIFF
--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -62,14 +62,17 @@ function useFitText( { fitText, name, clientId } ) {
 	const hasFitTextSupport = hasBlockSupport( name, FIT_TEXT_SUPPORT_KEY );
 	const blockElement = useBlockElement( clientId );
 
-	// Monitor block attribute changes
+	// Monitor block attribute changes and selection state
 	// Any attribute may change the available space.
-	const blockAttributes = useSelect(
+	const { blockAttributes, isSelected } = useSelect(
 		( select ) => {
 			if ( ! clientId ) {
-				return;
+				return { blockAttributes: undefined, isSelected: false };
 			}
-			return select( blockEditorStore ).getBlockAttributes( clientId );
+			return {
+				blockAttributes: select( blockEditorStore ).getBlockAttributes( clientId ),
+				isSelected: select( blockEditorStore ).isBlockSelected( clientId ),
+			};
 		},
 		[ clientId ]
 	);
@@ -94,8 +97,11 @@ function useFitText( { fitText, name, clientId } ) {
 			styleElement.textContent = css;
 		};
 
-		optimizeFitText( blockElement, blockSelector, applyStylesFn );
-	}, [ blockElement, clientId, hasFitTextSupport, fitText ] );
+		// Limit font size to 200px when block is selected
+		const maxSize = isSelected ? 200 : 600;
+
+		optimizeFitText( blockElement, blockSelector, applyStylesFn, maxSize );
+	}, [ blockElement, clientId, hasFitTextSupport, fitText, isSelected ] );
 
 	useEffect( () => {
 		if (
@@ -138,14 +144,14 @@ function useFitText( { fitText, name, clientId } ) {
 	// Trigger fit text recalculation when content changes
 	useEffect( () => {
 		if ( fitText && blockElement && hasFitTextSupport ) {
-			// Small delay to ensure DOM has updated after content changes
-			const timer = setTimeout( () => {
+			// Wait for next frame to ensure DOM has updated after content changes
+			const frameId = requestAnimationFrame( () => {
 				if ( blockElement ) {
 					applyFitText();
 				}
-			}, 1000 );
+			} );
 
-			return () => clearTimeout( timer );
+			return () => cancelAnimationFrame( frameId );
 		}
 	}, [
 		blockAttributes,

--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -107,7 +107,7 @@ function useFitText( { fitText, name, clientId } ) {
 		// Avoid very jarring resizes when a user is actively editing the
 		// block. Placing a ceiling on how much the block can grow curbs the
 		// effect of the first few keypresses.
-		const maxSize = isSelectedRef.current ? 200 : 600;
+		const maxSize = isSelectedRef.current ? 200 : undefined;
 
 		optimizeFitText( blockElement, blockSelector, applyStylesFn, maxSize );
 	}, [ blockElement, clientId, hasFitTextSupport, fitText, isSelectedRef ] );

--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -3,7 +3,7 @@
  */
 import { addFilter } from '@wordpress/hooks';
 import { hasBlockSupport } from '@wordpress/blocks';
-import { useEffect, useCallback } from '@wordpress/element';
+import { useEffect, useCallback, useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import {
@@ -70,12 +70,19 @@ function useFitText( { fitText, name, clientId } ) {
 				return { blockAttributes: undefined, isSelected: false };
 			}
 			return {
-				blockAttributes: select( blockEditorStore ).getBlockAttributes( clientId ),
-				isSelected: select( blockEditorStore ).isBlockSelected( clientId ),
+				blockAttributes:
+					select( blockEditorStore ).getBlockAttributes( clientId ),
+				isSelected:
+					select( blockEditorStore ).isBlockSelected( clientId ),
 			};
 		},
 		[ clientId ]
 	);
+
+	const isSelectedRef = useRef();
+	useEffect( () => {
+		isSelectedRef.current = isSelected;
+	}, [ isSelected ] );
 
 	const applyFitText = useCallback( () => {
 		if ( ! blockElement || ! hasFitTextSupport || ! fitText ) {
@@ -97,11 +104,13 @@ function useFitText( { fitText, name, clientId } ) {
 			styleElement.textContent = css;
 		};
 
-		// Limit font size to 200px when block is selected
-		const maxSize = isSelected ? 200 : 600;
+		// Avoid very jarring resizes when a user is actively editing the
+		// block. Placing a ceiling on how much the block can grow curbs the
+		// effect of the first few keypresses.
+		const maxSize = isSelectedRef.current ? 200 : 600;
 
 		optimizeFitText( blockElement, blockSelector, applyStylesFn, maxSize );
-	}, [ blockElement, clientId, hasFitTextSupport, fitText, isSelected ] );
+	}, [ blockElement, clientId, hasFitTextSupport, fitText, isSelectedRef ] );
 
 	useEffect( () => {
 		if (
@@ -145,16 +154,17 @@ function useFitText( { fitText, name, clientId } ) {
 	useEffect( () => {
 		if ( fitText && blockElement && hasFitTextSupport ) {
 			// Wait for next frame to ensure DOM has updated after content changes
-			const frameId = requestAnimationFrame( () => {
+			const frameId = window.requestAnimationFrame( () => {
 				if ( blockElement ) {
 					applyFitText();
 				}
 			} );
 
-			return () => cancelAnimationFrame( frameId );
+			return () => window.cancelAnimationFrame( frameId );
 		}
 	}, [
 		blockAttributes,
+		isSelected,
 		fitText,
 		applyFitText,
 		blockElement,

--- a/packages/block-editor/src/utils/fit-text-utils.js
+++ b/packages/block-editor/src/utils/fit-text-utils.js
@@ -20,13 +20,13 @@ function generateCSSRule( elementSelector, fontSize ) {
  * @param {HTMLElement} textElement     The text element
  * @param {string}      elementSelector CSS selector for the text element
  * @param {Function}    applyStylesFn   Function to apply test styles
+ * @param {number}      maxSize         Maximum font size in pixels (default: 600)
  * @return {number} Optimal font size
  */
-function findOptimalFontSize( textElement, elementSelector, applyStylesFn ) {
+function findOptimalFontSize( textElement, elementSelector, applyStylesFn, maxSize = 600 ) {
 	const alreadyHasScrollableHeight =
 		textElement.scrollHeight > textElement.clientHeight;
 	let minSize = 5;
-	let maxSize = 600;
 	let bestSize = minSize;
 
 	while ( minSize <= maxSize ) {
@@ -56,8 +56,9 @@ function findOptimalFontSize( textElement, elementSelector, applyStylesFn ) {
  * @param {HTMLElement} textElement     The text element (paragraph, heading, etc.)
  * @param {string}      elementSelector CSS selector for the text element
  * @param {Function}    applyStylesFn   Function to apply CSS styles (pass empty string to clear)
+ * @param {number}      maxSize         Maximum font size in pixels (default: 600)
  */
-export function optimizeFitText( textElement, elementSelector, applyStylesFn ) {
+export function optimizeFitText( textElement, elementSelector, applyStylesFn, maxSize = 600 ) {
 	if ( ! textElement ) {
 		return;
 	}
@@ -67,7 +68,8 @@ export function optimizeFitText( textElement, elementSelector, applyStylesFn ) {
 	const optimalSize = findOptimalFontSize(
 		textElement,
 		elementSelector,
-		applyStylesFn
+		applyStylesFn,
+		maxSize
 	);
 
 	const cssRule = generateCSSRule( elementSelector, optimalSize );

--- a/packages/block-editor/src/utils/fit-text-utils.js
+++ b/packages/block-editor/src/utils/fit-text-utils.js
@@ -23,7 +23,12 @@ function generateCSSRule( elementSelector, fontSize ) {
  * @param {number}      maxSize         Maximum font size in pixels (default: 600)
  * @return {number} Optimal font size
  */
-function findOptimalFontSize( textElement, elementSelector, applyStylesFn, maxSize = 600 ) {
+function findOptimalFontSize(
+	textElement,
+	elementSelector,
+	applyStylesFn,
+	maxSize = 600
+) {
 	const alreadyHasScrollableHeight =
 		textElement.scrollHeight > textElement.clientHeight;
 	let minSize = 5;
@@ -58,7 +63,12 @@ function findOptimalFontSize( textElement, elementSelector, applyStylesFn, maxSi
  * @param {Function}    applyStylesFn   Function to apply CSS styles (pass empty string to clear)
  * @param {number}      maxSize         Maximum font size in pixels (default: 600)
  */
-export function optimizeFitText( textElement, elementSelector, applyStylesFn, maxSize = 600 ) {
+export function optimizeFitText(
+	textElement,
+	elementSelector,
+	applyStylesFn,
+	maxSize
+) {
 	if ( ! textElement ) {
 		return;
 	}

--- a/packages/block-editor/src/utils/fit-text-utils.js
+++ b/packages/block-editor/src/utils/fit-text-utils.js
@@ -61,7 +61,7 @@ function findOptimalFontSize(
  * @param {HTMLElement} textElement     The text element (paragraph, heading, etc.)
  * @param {string}      elementSelector CSS selector for the text element
  * @param {Function}    applyStylesFn   Function to apply CSS styles (pass empty string to clear)
- * @param {number}      maxSize         Maximum font size in pixels (default: 600)
+ * @param {number}      maxSize         Maximum font size in pixels.
  */
 export function optimizeFitText(
 	textElement,


### PR DESCRIPTION
## Summary

Improves the fit-text feature by limiting the maximum font size to 200px when a block is selected, avoiding a very big change on the font size when the user just started typing on a fit text block, and also the initial potential very big font size makes the typing experience worse.

It also removes the previously timeout we had and uses requestAnimation frame, so the text is now fitting in an instantaneous way.


## Testing

1. Enable fit-text on a heading or paragraph block
2. Select the block type just one letter and verify font size doesn't exceed 200px
3. Deselect the block and verify it can scale up to 600px
4. Verify fit-text still correctly responds to content changes and container resizing
5. Verify now fit text instantaneously updates the size while you type.
