### PR TITLE
Revert "Block Bindings: Move bindable attributes to privateContext.

### DIFF
--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -25,8 +25,8 @@ import {
 	hasPatternOverridesDefaultBinding,
 	replacePatternOverridesDefaultBinding,
 } from '../../utils/block-bindings';
+import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
-import { PrivateBlockContext } from '../block-list/private-block-context';
 
 /**
  * Default value used for blocks which do not define their own context needs,
@@ -56,6 +56,8 @@ const Edit = ( props ) => {
 
 const EditWithFilters = withFilters( 'editor.BlockEdit' )( Edit );
 
+const EMPTY_ARRAY = [];
+
 const EditWithGeneratedProps = ( props ) => {
 	const { name, clientId, attributes, setAttributes } = props;
 	const registry = useRegistry();
@@ -66,7 +68,17 @@ const EditWithGeneratedProps = ( props ) => {
 			unlock( select( blocksStore ) ).getAllBlockBindingsSources(),
 		[]
 	);
-	const { bindableAttributes } = useContext( PrivateBlockContext );
+	const bindableAttributes = useSelect(
+		( select ) => {
+			const { __experimentalBlockBindingsSupportedAttributes } =
+				select( blockEditorStore ).getSettings();
+			return (
+				__experimentalBlockBindingsSupportedAttributes?.[ name ] ||
+				EMPTY_ARRAY
+			);
+		},
+		[ name ]
+	);
 
 	const { blockBindings, context, hasPatternOverrides } = useMemo( () => {
 		// Assign context values using the block type's declared context needs.

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -606,15 +606,7 @@ function BlockListBlockProvider( props ) {
 			const attributes = getBlockAttributes( clientId );
 			const { name: blockName, isValid } = blockWithoutAttributes;
 			const blockType = getBlockType( blockName );
-			const {
-				supportsLayout,
-				isPreviewMode,
-				__experimentalBlockBindingsSupportedAttributes,
-			} = getSettings();
-
-			const bindableAttributes =
-				__experimentalBlockBindingsSupportedAttributes?.[ blockName ];
-
+			const { supportsLayout, isPreviewMode } = getSettings();
 			const hasLightBlockWrapper = blockType?.apiVersion > 1;
 			const previewContext = {
 				isPreviewMode,
@@ -718,7 +710,6 @@ function BlockListBlockProvider( props ) {
 					? blocksWithSameName[ 0 ]
 					: false,
 				isBlockHidden: _isBlockHidden( clientId ),
-				bindableAttributes,
 			};
 		},
 		[ clientId, rootClientId ]
@@ -762,7 +753,6 @@ function BlockListBlockProvider( props ) {
 		defaultClassName,
 		originalBlockClientId,
 		isBlockHidden,
-		bindableAttributes,
 	} = selectedProps;
 
 	// Users of the editor.BlockListBlock filter used to be able to
@@ -812,7 +802,6 @@ function BlockListBlockProvider( props ) {
 		themeSupportsLayout,
 		canMove,
 		isBlockHidden,
-		bindableAttributes,
 	};
 
 	if (


### PR DESCRIPTION
⚠️ Do not merge. Can be fixed in https://github.com/WordPress/gutenberg/pull/72401

This reverts commit 3ca7316bfe87eab3d58484d7a20a851c282bf6ee from https://github.com/WordPress/gutenberg/pull/72351.

`bindableAttributes.includes`  crashes on the site editor.

While I prepare a bugfix and its correspondant e2e, is better to have this reverted.

Thanks @scruffian for pinging. ([link](https://github.com/WordPress/gutenberg/pull/72351#issuecomment-3411262191))



