### PR TITLE
Block Bindings: fix bindableAttributes.includes render error.

### DIFF
--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -123,7 +123,7 @@ const EditWithGeneratedProps = ( props ) => {
 				const source = registeredSources[ sourceName ];
 				if (
 					! source ||
-					! bindableAttributes.includes( attributeName )
+					! bindableAttributes?.includes( attributeName )
 				) {
 					continue;
 				}
@@ -202,7 +202,7 @@ const EditWithGeneratedProps = ( props ) => {
 				) ) {
 					if (
 						! blockBindings[ attributeName ] ||
-						! bindableAttributes.includes( attributeName )
+						! bindableAttributes?.includes( attributeName )
 					) {
 						continue;
 					}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
https://github.com/WordPress/gutenberg/pull/72351 introduces a bug, as we are removing the default binding attributes array. We did that to prevent the useSelect warning that returns different values for the same inputs (as it creates a new array on each select).

For that reason, bindableAttributes can be `undefined` now. And calling a `includes` function to a non array prototype is causing a rendering error.

This should fix it, but please, @scruffian , confirm it as I couldn't reproduce the error on my local (I only had the console error, but not the broken block one).

Otherwise we can just merge and revert this one (https://github.com/WordPress/gutenberg/pull/72400), but the performance improve should be good to go.
