### PR TITLE
Template activation: clear notice on post change

### DIFF
--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -285,7 +285,8 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			setEditedPost,
 			setRenderingMode,
 		} = unlock( useDispatch( editorStore ) );
-		const { createWarningNotice } = useDispatch( noticesStore );
+		const { createWarningNotice, removeNotice } =
+			useDispatch( noticesStore );
 
 		// Ideally this should be synced on each change and not just something you do once.
 		useLayoutEffect( () => {
@@ -321,7 +322,9 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		// Synchronizes the active post with the state
 		useEffect( () => {
 			setEditedPost( post.type, post.id );
-		}, [ post.type, post.id, setEditedPost ] );
+			// Clear any notices dependent and the post context.
+			removeNotice( 'template-activate-notice' );
+		}, [ post.type, post.id, setEditedPost, removeNotice ] );
 
 		// Synchronize the editor settings as they change.
 		useEffect( () => {

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -322,7 +322,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		// Synchronizes the active post with the state
 		useEffect( () => {
 			setEditedPost( post.type, post.id );
-			// Clear any notices dependent and the post context.
+			// Clear any notices dependent on the post context.
 			removeNotice( 'template-activate-notice' );
 		}, [ post.type, post.id, setEditedPost, removeNotice ] );
 

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -349,15 +349,10 @@ async function templateActivationNotice( { select, registry } ) {
 					onClick: async () => {
 						await registry
 							.dispatch( noticesStore )
-							.removeNotice( 'template-activate-notice' );
-						await registry
-							.dispatch( noticesStore )
 							.createNotice(
 								'info',
 								__( 'Activating template…' ),
-								{
-									id: 'template-activating-notice',
-								}
+								{ id: 'template-activate-notice' }
 							);
 						try {
 							const currentSite = await registry
@@ -378,20 +373,16 @@ async function templateActivationNotice( { select, registry } ) {
 								);
 							await registry
 								.dispatch( noticesStore )
-								.removeNotice( 'template-activating-notice' );
-							await registry
-								.dispatch( noticesStore )
 								.createSuccessNotice(
-									__( 'Template activated.' )
+									__( 'Template activated.' ),
+									{ id: 'template-activate-notice' }
 								);
 						} catch ( error ) {
 							await registry
 								.dispatch( noticesStore )
-								.removeNotice( 'template-activating-notice' );
-							await registry
-								.dispatch( noticesStore )
 								.createErrorNotice(
-									__( 'Template activation failed.' )
+									__( 'Template activation failed.' ),
+									{ id: 'template-activate-notice' }
 								);
 							// Rethrow for debugging.
 							throw error;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

See https://github.com/WordPress/gutenberg/pull/72285#issuecomment-3411774201

Remove the template activation notice when the post in the editor changes.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The notice currently lingers: when you open another template the notice is still there.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I'm not sure if it's the best solution tbh. Alternatively we could remove the notice when `EditorNotices` unmounts. 🤔 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Edit an inactive template. Save. Observe the notice, optionally activate. Now go back to the list and activate editor another template. The notice shouldn't be there.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
