### PR TITLE
Eslint: Ignore `build-wp`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,6 +2,7 @@
 build
 build-module
 build-types
+build-wp
 node_modules
 packages/block-serialization-spec-parser/parser.js
 packages/react-native-editor/bundle


### PR DESCRIPTION
## What?

Ignore `build-wp` folders when running eslint.

## Why?

Running `npm run lint:js` locally takes forever because the `packages/dataviews/build-wp` folder is not ignored. It logs this message and seems to hang (I've never been able to see it return):

```
[BABEL] Note: The code generator has deoptimised the styling of /Users/lena/Documents/Work/gutenberg/packages/dataviews/build-wp/index.js as it exceeds the max of 500KB.
```

## Testing Instructions

Run `npm run lint:js`. The Babel message should not appear, and you should be able to see the lint process complete (~115 secs in my environment).