### PR TITLE
Add end to end tests for Fit Text

### DIFF
--- a/test/e2e/specs/editor/blocks/fit-text.spec.js
+++ b/test/e2e/specs/editor/blocks/fit-text.spec.js
@@ -176,7 +176,6 @@ test.describe( 'Fit Text', () => {
 
 		test( 'should apply much larger font size with fit text compared to without fit text for a short text', async ( {
 			editor,
-			page,
 		} ) => {
 			// Insert two paragraphs with same content for comparison
 			await editor.insertBlock( {
@@ -245,7 +244,6 @@ test.describe( 'Fit Text', () => {
 			);
 
 			await page.goto( postUrl );
-			await page.waitForLoadState( 'networkidle' );
 
 			const heading = page.locator( 'h2.has-fit-text' );
 
@@ -283,7 +281,6 @@ test.describe( 'Fit Text', () => {
 			);
 
 			await page.goto( postUrl );
-			await page.waitForLoadState( 'networkidle' );
 
 			const heading = page.locator( 'h2.has-fit-text' );
 
@@ -298,12 +295,12 @@ test.describe( 'Fit Text', () => {
 				return window.getComputedStyle( el ).fontSize;
 			} );
 
+			await page.setViewportSize( { width: 440, height: 720 } );
+			await heading.waitFor( { state: 'attached' } );
+
 			// Wait for fit text to recalculate (temporary solution while implementation uses 1000ms setTimeout)
 			// eslint-disable-next-line playwright/no-wait-for-timeout, no-restricted-syntax
 			await page.waitForTimeout( 1100 );
-
-			await page.setViewportSize( { width: 640, height: 720 } );
-			await heading.waitFor( { state: 'attached' } );
 
 			const newFontSize = await heading.evaluate( ( el ) => {
 				return window.getComputedStyle( el ).fontSize;
@@ -343,7 +340,6 @@ test.describe( 'Fit Text', () => {
 			);
 
 			await page.goto( postUrl );
-			await page.waitForLoadState( 'networkidle' );
 
 			const fitTextParagraph = page.locator( 'p.has-fit-text' );
 

--- a/test/e2e/specs/editor/blocks/fit-text.spec.js
+++ b/test/e2e/specs/editor/blocks/fit-text.spec.js
@@ -254,18 +254,24 @@ test.describe( 'Fit Text', () => {
 			const fitTextId = await heading.getAttribute( 'data-fit-text-id' );
 			expect( fitTextId ).toBeTruthy();
 
-			// Verify style element exists for this fit text instance
+			// Verify style element exists for this fit text instance.
 			const styleElement = page.locator(
 				`style#fit-text-${ fitTextId }`
 			);
 			await expect( styleElement ).toBeAttached();
 
-			const fontSize = await heading.evaluate( ( el ) => {
+			const computedFontSize = await heading.evaluate( ( el ) => {
 				return window.getComputedStyle( el ).fontSize;
 			} );
 
-			expect( fontSize ).toBeTruthy();
-			expect( parseFloat( fontSize ) ).toBeGreaterThan( 0 );
+			const styleContent = await styleElement.textContent();
+			const fontSizeMatch = styleContent.match(
+				/font-size:\s*(\d+(?:\.\d+)?)px/
+			);
+			expect( fontSizeMatch ).toBeTruthy();
+			const expectedFontSize = parseFloat( fontSizeMatch[ 1 ] );
+
+			expect( parseFloat( computedFontSize ) ).toBe( expectedFontSize );
 		} );
 
 		test( 'should resize text on window resize on the frontend', async ( {

--- a/test/e2e/specs/editor/blocks/fit-text.spec.js
+++ b/test/e2e/specs/editor/blocks/fit-text.spec.js
@@ -23,6 +23,16 @@ test.describe( 'Fit Text', () => {
 
 			await editor.openDocumentSettingsSidebar();
 
+			// Enable Fit text control via Typography options menu
+			await page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Typography options' } )
+				.click();
+			await page
+				.getByRole( 'menu', { name: 'Typography options' } )
+				.getByRole( 'menuitemcheckbox', { name: 'Show Fit text' } )
+				.click();
+
 			const fitTextToggle = page.getByRole( 'checkbox', {
 				name: 'Fit text',
 			} );
@@ -40,9 +50,9 @@ test.describe( 'Fit Text', () => {
 				},
 			] );
 
-			const headingBlock = editor.canvas.getByRole( 'document', {
-				name: 'Block: Heading',
-			} );
+			const headingBlock = editor.canvas.locator(
+				'[data-type="core/heading"]'
+			);
 
 			await expect( headingBlock ).toHaveClass( /has-fit-text/ );
 		} );
@@ -85,6 +95,16 @@ test.describe( 'Fit Text', () => {
 
 			await editor.openDocumentSettingsSidebar();
 
+			// Enable Fit text control via Typography options menu
+			await page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Typography options' } )
+				.click();
+			await page
+				.getByRole( 'menu', { name: 'Typography options' } )
+				.getByRole( 'menuitemcheckbox', { name: 'Show Fit text' } )
+				.click();
+
 			const fitTextToggle = page.getByRole( 'checkbox', {
 				name: 'Fit text',
 			} );
@@ -101,9 +121,9 @@ test.describe( 'Fit Text', () => {
 				},
 			] );
 
-			const paragraphBlock = editor.canvas.getByRole( 'document', {
-				name: 'Block: Paragraph',
-			} );
+			const paragraphBlock = editor.canvas.locator(
+				'[data-type="core/paragraph"]'
+			);
 
 			await expect( paragraphBlock ).toHaveClass( /has-fit-text/ );
 		} );

--- a/test/e2e/specs/editor/blocks/fit-text.spec.js
+++ b/test/e2e/specs/editor/blocks/fit-text.spec.js
@@ -1,0 +1,376 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Fit Text', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test.describe( 'Editor functionality', () => {
+		test( 'should enable fit text on a heading block', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/heading',
+				attributes: {
+					content: 'Test Heading',
+					level: 2,
+				},
+			} );
+
+			await editor.openDocumentSettingsSidebar();
+
+			// Open typography panel
+			const typographyButton = page
+				.getByRole( 'region', {
+					name: 'Editor settings',
+				} )
+				.getByRole( 'button', { name: 'Typography', exact: true } );
+
+			await typographyButton.click();
+
+			const fitTextToggle = page.getByRole( 'checkbox', {
+				name: 'Fit text',
+			} );
+
+			await fitTextToggle.click();
+
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/heading',
+					attributes: {
+						content: 'Test Heading',
+						level: 2,
+						fitText: true,
+					},
+				},
+			] );
+
+			const headingBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Heading',
+			} );
+
+			await expect( headingBlock ).toHaveClass( /has-fit-text/ );
+		} );
+
+		test( 'should disable fit text when toggled off', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/heading',
+				attributes: {
+					content: 'Test Heading',
+					level: 2,
+					fitText: true,
+				},
+			} );
+
+			await editor.openDocumentSettingsSidebar();
+
+			// Open typography panel
+			const typographyButton = page
+				.getByRole( 'region', {
+					name: 'Editor settings',
+				} )
+				.getByRole( 'button', { name: 'Typography', exact: true } );
+
+			await typographyButton.click();
+
+			const fitTextToggle = page.getByRole( 'checkbox', {
+				name: 'Fit text',
+			} );
+
+			await fitTextToggle.click();
+
+			const blocks = await editor.getBlocks();
+			expect( blocks[ 0 ].attributes.fitText ).toBeUndefined();
+		} );
+
+		test( 'should enable fit text on a paragraph block', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: {
+					content: 'Test paragraph with fit text enabled',
+				},
+			} );
+
+			await editor.openDocumentSettingsSidebar();
+
+			// Open typography panel
+			const typographyButton = page
+				.getByRole( 'region', {
+					name: 'Editor settings',
+				} )
+				.getByRole( 'button', { name: 'Typography', exact: true } );
+
+			await typographyButton.click();
+
+			const fitTextToggle = page.getByRole( 'checkbox', {
+				name: 'Fit text',
+			} );
+
+			await fitTextToggle.click();
+
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/paragraph',
+					attributes: {
+						content: 'Test paragraph with fit text enabled',
+						fitText: true,
+					},
+				},
+			] );
+
+			const paragraphBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Paragraph',
+			} );
+
+			await expect( paragraphBlock ).toHaveClass( /has-fit-text/ );
+		} );
+
+		test( 'should apply font size dynamically based on container width in editor', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/heading',
+				attributes: {
+					content: 'Resizable Text',
+					level: 2,
+					fitText: true,
+				},
+			} );
+
+			const headingBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Heading',
+			} );
+
+			// Wait for fit text to apply
+			await page.waitForTimeout( 500 );
+
+			const initialFontSize = await headingBlock.evaluate( ( el ) => {
+				return window.getComputedStyle( el ).fontSize;
+			} );
+
+			// Add more text to force smaller font size
+			await headingBlock.click();
+			await page.keyboard.press( 'End' );
+			await page.keyboard.type(
+				' that is much longer and should have smaller font'
+			);
+
+			// Wait for resize to apply
+			await page.waitForTimeout( 500 );
+
+			const newFontSize = await headingBlock.evaluate( ( el ) => {
+				return window.getComputedStyle( el ).fontSize;
+			} );
+
+			const initialSize = parseFloat( initialFontSize );
+			const newSize = parseFloat( newFontSize );
+
+			// Font size should decrease with more content
+			expect( newSize ).toBeLessThan( initialSize );
+		} );
+
+		test( 'should apply much larger font size with fit text compared to without fit text for a short text', async ( {
+			editor,
+			page,
+		} ) => {
+			// Insert two paragraphs with same content for comparison
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: {
+					content: 'Hello',
+				},
+			} );
+
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: {
+					content: 'Hello',
+					fitText: true,
+				},
+			} );
+
+			// Wait for fit text to apply
+			await page.waitForTimeout( 500 );
+
+			const paragraphBlocks = editor.canvas.getByRole( 'document', {
+				name: 'Block: Paragraph',
+			} );
+
+			const normalFontSize = await paragraphBlocks
+				.first()
+				.evaluate( ( el ) => {
+					return window.getComputedStyle( el ).fontSize;
+				} );
+
+			const fitTextFontSize = await paragraphBlocks
+				.last()
+				.evaluate( ( el ) => {
+					return window.getComputedStyle( el ).fontSize;
+				} );
+
+			const normalSize = parseFloat( normalFontSize );
+			const fitTextSize = parseFloat( fitTextFontSize );
+
+			// Fit text should scale up significantly for short content
+			expect( fitTextSize ).toBeGreaterThan( normalSize * 2 );
+		} );
+	} );
+
+	test.describe( 'Frontend functionality', () => {
+		test( 'should render fit text correctly on the frontend', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/heading',
+				attributes: {
+					content: 'Frontend Test',
+					level: 2,
+					fitText: true,
+				},
+			} );
+
+			await editor.publishPost();
+
+			const postUrl = await page.evaluate( () =>
+				window.wp.data
+					.select( 'core/editor' )
+					.getPermalink()
+			);
+
+			await page.goto( postUrl );
+			await page.waitForLoadState( 'networkidle' );
+
+			const heading = page.locator( 'h2.has-fit-text' );
+
+			await expect( heading ).toBeVisible();
+			await expect( heading ).toHaveClass( /has-fit-text/ );
+
+			// Verify data attribute is set (added by frontend script)
+			await expect( heading ).toHaveAttribute(
+				'data-fit-text-id',
+				/.+/
+			);
+
+			const fontSize = await heading.evaluate( ( el ) => {
+				return window.getComputedStyle( el ).fontSize;
+			} );
+
+			expect( fontSize ).toBeTruthy();
+			expect( parseFloat( fontSize ) ).toBeGreaterThan( 0 );
+		} );
+
+		test( 'should resize text on window resize on the frontend', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/heading',
+				attributes: {
+					content: 'Resize Me',
+					level: 2,
+					fitText: true,
+				},
+			} );
+
+			await editor.publishPost();
+
+			const postUrl = await page.evaluate( () =>
+				window.wp.data
+					.select( 'core/editor' )
+					.getPermalink()
+			);
+
+			await page.goto( postUrl );
+			await page.waitForLoadState( 'networkidle' );
+
+			const heading = page.locator( 'h2.has-fit-text' );
+
+			// Wait for fit text to initialize
+			await page.waitForTimeout( 500 );
+
+			await page.setViewportSize( { width: 1280, height: 720 } );
+			await page.waitForTimeout( 500 );
+
+			const initialFontSize = await heading.evaluate( ( el ) => {
+				return window.getComputedStyle( el ).fontSize;
+			} );
+
+			await page.setViewportSize( { width: 640, height: 720 } );
+			await page.waitForTimeout( 500 );
+
+			const newFontSize = await heading.evaluate( ( el ) => {
+				return window.getComputedStyle( el ).fontSize;
+			} );
+
+			const initialSize = parseFloat( initialFontSize );
+			const newSize = parseFloat( newFontSize );
+
+			// Font size should adapt to narrower viewport
+			expect( newSize ).toBeLessThan( initialSize );
+		} );
+
+		test( 'should apply much larger font size with fit text compared to without fit text on frontend for a short text', async ( {
+			editor,
+			page,
+		} ) => {
+			// Insert two paragraphs with same content for comparison
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: {
+					content: 'Hello',
+				},
+			} );
+
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: {
+					content: 'Hello',
+					fitText: true,
+				},
+			} );
+
+			await editor.publishPost();
+
+			const postUrl = await page.evaluate( () =>
+				window.wp.data
+					.select( 'core/editor' )
+					.getPermalink()
+			);
+
+			await page.goto( postUrl );
+			await page.waitForLoadState( 'networkidle' );
+
+			// Wait for fit text to initialize
+			await page.waitForTimeout( 500 );
+
+			const paragraphs = page.locator( 'p' );
+
+			const normalFontSize = await paragraphs.first().evaluate( ( el ) => {
+				return window.getComputedStyle( el ).fontSize;
+			} );
+
+			const fitTextParagraph = page.locator( 'p.has-fit-text' );
+			const fitTextFontSize = await fitTextParagraph.evaluate( ( el ) => {
+				return window.getComputedStyle( el ).fontSize;
+			} );
+
+			const normalSize = parseFloat( normalFontSize );
+			const fitTextSize = parseFloat( fitTextFontSize );
+
+			// Fit text should scale up significantly for short content
+			expect( fitTextSize ).toBeGreaterThan( normalSize * 2 );
+		} );
+	} );
+} );

--- a/test/e2e/specs/editor/blocks/fit-text.spec.js
+++ b/test/e2e/specs/editor/blocks/fit-text.spec.js
@@ -251,7 +251,14 @@ test.describe( 'Fit Text', () => {
 			await expect( heading ).toHaveClass( /has-fit-text/ );
 
 			// Verify data attribute is set (added by frontend script)
-			await expect( heading ).toHaveAttribute( 'data-fit-text-id', /.+/ );
+			const fitTextId = await heading.getAttribute( 'data-fit-text-id' );
+			expect( fitTextId ).toBeTruthy();
+
+			// Verify style element exists for this fit text instance
+			const styleElement = page.locator(
+				`style#fit-text-${ fitTextId }`
+			);
+			await expect( styleElement ).toBeAttached();
 
 			const fontSize = await heading.evaluate( ( el ) => {
 				return window.getComputedStyle( el ).fontSize;
@@ -286,21 +293,55 @@ test.describe( 'Fit Text', () => {
 
 			// Wait for fit text to initialize (verify frontend script ran)
 			await heading.waitFor( { state: 'attached' } );
-			await expect( heading ).toHaveAttribute( 'data-fit-text-id', /.+/ );
+			const fitTextId = await heading.getAttribute( 'data-fit-text-id' );
+			expect( fitTextId ).toBeTruthy();
 
-			await page.setViewportSize( { width: 1280, height: 720 } );
-			await heading.waitFor( { state: 'attached' } );
+			// Verify style element exists for this fit text instance
+			const styleElement = page.locator(
+				`style#fit-text-${ fitTextId }`
+			);
+			await styleElement.waitFor( { state: 'attached' } );
+
+			// Wait for fit text to calculate initially
+			await page.waitForFunction(
+				( styleId ) => {
+					const style = document.getElementById( styleId );
+					return style && style.textContent.trim().length > 0;
+				},
+				`fit-text-${ fitTextId }`,
+				{ timeout: 5000 }
+			);
 
 			const initialFontSize = await heading.evaluate( ( el ) => {
 				return window.getComputedStyle( el ).fontSize;
 			} );
 
-			await page.setViewportSize( { width: 440, height: 720 } );
-			await heading.waitFor( { state: 'attached' } );
+			// Capture style content before resize
+			const styleBeforeResize = await styleElement.textContent();
 
-			// Wait for fit text to recalculate (temporary solution while implementation uses 1000ms setTimeout)
-			// eslint-disable-next-line playwright/no-wait-for-timeout, no-restricted-syntax
-			await page.waitForTimeout( 1100 );
+			await page.setViewportSize( { width: 440, height: 720 } );
+
+			// Wait for fit text to recalculate (style content changes)
+			await page.waitForFunction(
+				( { styleId, previousContent } ) => {
+					const style = document.getElementById( styleId );
+					return (
+						style &&
+						style.textContent !== previousContent &&
+						style.textContent.trim().length > 0
+					);
+				},
+				{
+					styleId: `fit-text-${ fitTextId }`,
+					previousContent: styleBeforeResize,
+				},
+				{ timeout: 5000 }
+			);
+
+			// Verify the same element instance is maintained (ID unchanged)
+			const fitTextIdAfterResize =
+				await heading.getAttribute( 'data-fit-text-id' );
+			expect( fitTextIdAfterResize ).toBe( fitTextId );
 
 			const newFontSize = await heading.evaluate( ( el ) => {
 				return window.getComputedStyle( el ).fontSize;
@@ -345,10 +386,15 @@ test.describe( 'Fit Text', () => {
 
 			// Wait for fit text to initialize (verify frontend script ran)
 			await fitTextParagraph.waitFor( { state: 'visible' } );
-			await expect( fitTextParagraph ).toHaveAttribute(
-				'data-fit-text-id',
-				/.+/
+			const fitTextId =
+				await fitTextParagraph.getAttribute( 'data-fit-text-id' );
+			expect( fitTextId ).toBeTruthy();
+
+			// Verify style element exists for this fit text instance
+			const styleElement = page.locator(
+				`style#fit-text-${ fitTextId }`
 			);
+			await expect( styleElement ).toBeAttached();
 
 			const paragraphs = page.locator( 'p' );
 

--- a/test/e2e/specs/editor/blocks/fit-text.spec.js
+++ b/test/e2e/specs/editor/blocks/fit-text.spec.js
@@ -298,6 +298,10 @@ test.describe( 'Fit Text', () => {
 				return window.getComputedStyle( el ).fontSize;
 			} );
 
+			// Wait for fit text to recalculate (temporary solution while implementation uses 1000ms setTimeout)
+			// eslint-disable-next-line playwright/no-wait-for-timeout, no-restricted-syntax
+			await page.waitForTimeout( 1100 );
+
 			await page.setViewportSize( { width: 640, height: 720 } );
 			await heading.waitFor( { state: 'attached' } );
 

--- a/test/e2e/specs/editor/blocks/fit-text.spec.js
+++ b/test/e2e/specs/editor/blocks/fit-text.spec.js
@@ -308,16 +308,6 @@ test.describe( 'Fit Text', () => {
 			);
 			await styleElement.waitFor( { state: 'attached' } );
 
-			// Wait for fit text to calculate initially
-			await page.waitForFunction(
-				( styleId ) => {
-					const style = document.getElementById( styleId );
-					return style && style.textContent.trim().length > 0;
-				},
-				`fit-text-${ fitTextId }`,
-				{ timeout: 5000 }
-			);
-
 			const initialFontSize = await heading.evaluate( ( el ) => {
 				return window.getComputedStyle( el ).fontSize;
 			} );

--- a/test/e2e/specs/editor/blocks/fit-text.spec.js
+++ b/test/e2e/specs/editor/blocks/fit-text.spec.js
@@ -23,15 +23,6 @@ test.describe( 'Fit Text', () => {
 
 			await editor.openDocumentSettingsSidebar();
 
-			// Open typography panel
-			const typographyButton = page
-				.getByRole( 'region', {
-					name: 'Editor settings',
-				} )
-				.getByRole( 'button', { name: 'Typography', exact: true } );
-
-			await typographyButton.click();
-
 			const fitTextToggle = page.getByRole( 'checkbox', {
 				name: 'Fit text',
 			} );
@@ -71,15 +62,6 @@ test.describe( 'Fit Text', () => {
 
 			await editor.openDocumentSettingsSidebar();
 
-			// Open typography panel
-			const typographyButton = page
-				.getByRole( 'region', {
-					name: 'Editor settings',
-				} )
-				.getByRole( 'button', { name: 'Typography', exact: true } );
-
-			await typographyButton.click();
-
 			const fitTextToggle = page.getByRole( 'checkbox', {
 				name: 'Fit text',
 			} );
@@ -102,15 +84,6 @@ test.describe( 'Fit Text', () => {
 			} );
 
 			await editor.openDocumentSettingsSidebar();
-
-			// Open typography panel
-			const typographyButton = page
-				.getByRole( 'region', {
-					name: 'Editor settings',
-				} )
-				.getByRole( 'button', { name: 'Typography', exact: true } );
-
-			await typographyButton.click();
 
 			const fitTextToggle = page.getByRole( 'checkbox', {
 				name: 'Fit text',
@@ -148,12 +121,12 @@ test.describe( 'Fit Text', () => {
 				},
 			} );
 
-			const headingBlock = editor.canvas.getByRole( 'document', {
-				name: 'Block: Heading',
-			} );
-
 			// Wait for fit text to apply
 			await page.waitForTimeout( 500 );
+
+			const headingBlock = editor.canvas.locator(
+				'[data-type="core/heading"]'
+			);
 
 			const initialFontSize = await headingBlock.evaluate( ( el ) => {
 				return window.getComputedStyle( el ).fontSize;
@@ -203,18 +176,18 @@ test.describe( 'Fit Text', () => {
 			// Wait for fit text to apply
 			await page.waitForTimeout( 500 );
 
-			const paragraphBlocks = editor.canvas.getByRole( 'document', {
-				name: 'Block: Paragraph',
-			} );
+			const paragraphBlocks = editor.canvas.locator(
+				'[data-type="core/paragraph"]'
+			);
 
 			const normalFontSize = await paragraphBlocks
-				.first()
+				.nth( 0 )
 				.evaluate( ( el ) => {
 					return window.getComputedStyle( el ).fontSize;
 				} );
 
 			const fitTextFontSize = await paragraphBlocks
-				.last()
+				.nth( 1 )
 				.evaluate( ( el ) => {
 					return window.getComputedStyle( el ).fontSize;
 				} );
@@ -244,9 +217,7 @@ test.describe( 'Fit Text', () => {
 			await editor.publishPost();
 
 			const postUrl = await page.evaluate( () =>
-				window.wp.data
-					.select( 'core/editor' )
-					.getPermalink()
+				window.wp.data.select( 'core/editor' ).getPermalink()
 			);
 
 			await page.goto( postUrl );
@@ -258,10 +229,7 @@ test.describe( 'Fit Text', () => {
 			await expect( heading ).toHaveClass( /has-fit-text/ );
 
 			// Verify data attribute is set (added by frontend script)
-			await expect( heading ).toHaveAttribute(
-				'data-fit-text-id',
-				/.+/
-			);
+			await expect( heading ).toHaveAttribute( 'data-fit-text-id', /.+/ );
 
 			const fontSize = await heading.evaluate( ( el ) => {
 				return window.getComputedStyle( el ).fontSize;
@@ -287,9 +255,7 @@ test.describe( 'Fit Text', () => {
 			await editor.publishPost();
 
 			const postUrl = await page.evaluate( () =>
-				window.wp.data
-					.select( 'core/editor' )
-					.getPermalink()
+				window.wp.data.select( 'core/editor' ).getPermalink()
 			);
 
 			await page.goto( postUrl );
@@ -344,9 +310,7 @@ test.describe( 'Fit Text', () => {
 			await editor.publishPost();
 
 			const postUrl = await page.evaluate( () =>
-				window.wp.data
-					.select( 'core/editor' )
-					.getPermalink()
+				window.wp.data.select( 'core/editor' ).getPermalink()
 			);
 
 			await page.goto( postUrl );
@@ -357,9 +321,11 @@ test.describe( 'Fit Text', () => {
 
 			const paragraphs = page.locator( 'p' );
 
-			const normalFontSize = await paragraphs.first().evaluate( ( el ) => {
-				return window.getComputedStyle( el ).fontSize;
-			} );
+			const normalFontSize = await paragraphs
+				.first()
+				.evaluate( ( el ) => {
+					return window.getComputedStyle( el ).fontSize;
+				} );
 
 			const fitTextParagraph = page.locator( 'p.has-fit-text' );
 			const fitTextFontSize = await fitTextParagraph.evaluate( ( el ) => {

--- a/test/e2e/specs/editor/blocks/fit-text.spec.js
+++ b/test/e2e/specs/editor/blocks/fit-text.spec.js
@@ -141,12 +141,13 @@ test.describe( 'Fit Text', () => {
 				},
 			} );
 
-			// Wait for fit text to apply
-			await page.waitForTimeout( 500 );
-
 			const headingBlock = editor.canvas.locator(
 				'[data-type="core/heading"]'
 			);
+
+			// Wait for fit text to apply
+			await headingBlock.waitFor( { state: 'attached' } );
+			await expect( headingBlock ).toHaveClass( /has-fit-text/ );
 
 			const initialFontSize = await headingBlock.evaluate( ( el ) => {
 				return window.getComputedStyle( el ).fontSize;
@@ -159,8 +160,8 @@ test.describe( 'Fit Text', () => {
 				' that is much longer and should have smaller font'
 			);
 
-			// Wait for resize to apply
-			await page.waitForTimeout( 500 );
+			// Wait for DOM to update and fit text to recalculate
+			await headingBlock.waitFor( { state: 'attached' } );
 
 			const newFontSize = await headingBlock.evaluate( ( el ) => {
 				return window.getComputedStyle( el ).fontSize;
@@ -193,11 +194,14 @@ test.describe( 'Fit Text', () => {
 				},
 			} );
 
-			// Wait for fit text to apply
-			await page.waitForTimeout( 500 );
-
 			const paragraphBlocks = editor.canvas.locator(
 				'[data-type="core/paragraph"]'
+			);
+
+			// Wait for fit text to apply
+			await paragraphBlocks.nth( 1 ).waitFor( { state: 'attached' } );
+			await expect( paragraphBlocks.nth( 1 ) ).toHaveClass(
+				/has-fit-text/
 			);
 
 			const normalFontSize = await paragraphBlocks
@@ -283,18 +287,19 @@ test.describe( 'Fit Text', () => {
 
 			const heading = page.locator( 'h2.has-fit-text' );
 
-			// Wait for fit text to initialize
-			await page.waitForTimeout( 500 );
+			// Wait for fit text to initialize (verify frontend script ran)
+			await heading.waitFor( { state: 'attached' } );
+			await expect( heading ).toHaveAttribute( 'data-fit-text-id', /.+/ );
 
 			await page.setViewportSize( { width: 1280, height: 720 } );
-			await page.waitForTimeout( 500 );
+			await heading.waitFor( { state: 'attached' } );
 
 			const initialFontSize = await heading.evaluate( ( el ) => {
 				return window.getComputedStyle( el ).fontSize;
 			} );
 
 			await page.setViewportSize( { width: 640, height: 720 } );
-			await page.waitForTimeout( 500 );
+			await heading.waitFor( { state: 'attached' } );
 
 			const newFontSize = await heading.evaluate( ( el ) => {
 				return window.getComputedStyle( el ).fontSize;
@@ -336,8 +341,14 @@ test.describe( 'Fit Text', () => {
 			await page.goto( postUrl );
 			await page.waitForLoadState( 'networkidle' );
 
-			// Wait for fit text to initialize
-			await page.waitForTimeout( 500 );
+			const fitTextParagraph = page.locator( 'p.has-fit-text' );
+
+			// Wait for fit text to initialize (verify frontend script ran)
+			await fitTextParagraph.waitFor( { state: 'visible' } );
+			await expect( fitTextParagraph ).toHaveAttribute(
+				'data-fit-text-id',
+				/.+/
+			);
 
 			const paragraphs = page.locator( 'p' );
 
@@ -347,7 +358,6 @@ test.describe( 'Fit Text', () => {
 					return window.getComputedStyle( el ).fontSize;
 				} );
 
-			const fitTextParagraph = page.locator( 'p.has-fit-text' );
 			const fitTextFontSize = await fitTextParagraph.evaluate( ( el ) => {
 				return window.getComputedStyle( el ).fontSize;
 			} );


### PR DESCRIPTION
Implements end to end tests for Fit Text.

## Testing
Verify the end to end test is passing `npm run test:e2e -- fit-text`

Apply this patch:
```
diff --git a/lib/block-supports/typography.php b/lib/block-supports/typography.php
index 3e21b1555c..fd59db7ce5 100644
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -244,9 +244,9 @@ function gutenberg_typography_get_preset_inline_style_value( $style_value, $css_
  * @return string                Filtered block content.
  */
 function gutenberg_render_typography_support( $block_content, $block ) {
 	if ( ! empty( $block['attrs']['fitText'] ) ) {
-		wp_enqueue_script_module( '@wordpress/block-editor/utils/fit-text-frontend' );
+		//wp_enqueue_script_module( '@wordpress/block-editor/utils/fit-text-frontend' );
 	}
 
 	if ( ! isset( $block['attrs']['style']['typography']['fontSize'] ) ) {
 		return $block_content;
```

Rerun the end to end test `npm run test:e2e -- fit-text` verify all the front end tests fail.

Apply this patch:
```
diff --git a/packages/block-editor/src/hooks/fit-text.js b/packages/block-editor/src/hooks/fit-text.js
index aa6a923483..960d4aaea7 100644
--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -186,8 +186,9 @@ export function FitTextControl( {
 	fitText = false,
 	setAttributes,
 	name,
 } ) {
+	return null;
 	if ( ! hasBlockSupport( name, FIT_TEXT_SUPPORT_KEY ) ) {
 		return null;
 	}
 	return (
@@ -255,8 +256,9 @@ function addSaveProps( props, blockType, attributes ) {
  * @param {string}  props.clientId Block client ID.
  * @return {Object} Filtered props applied to the block element.
  */
 function useBlockProps( { name, fitText, clientId } ) {
+	return {};
 	useFitText( { fitText, name, clientId } );
 	if ( ! fitText || ! hasBlockSupport( name, FIT_TEXT_SUPPORT_KEY ) ) {
 		return {};
 	}

```
Rerun the end to end test `npm run test:e2e -- fit-text` verify all the editor tests fail.