### PR TITLE
Notes: Update snackbar text

### DIFF
--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -205,9 +205,7 @@ export function useBlockCommentsActions( reflowComments = noop ) {
 
 			createNotice(
 				'snackbar',
-				parent
-					? __( 'Reply added successfully.' )
-					: __( 'Note added successfully.' ),
+				parent ? __( 'Reply added.' ) : __( 'Note added.' ),
 				{
 					type: 'snackbar',
 					isDismissible: true,
@@ -311,7 +309,7 @@ export function useBlockCommentsActions( reflowComments = noop ) {
 				} );
 			}
 
-			createNotice( 'snackbar', __( 'Note deleted successfully.' ), {
+			createNotice( 'snackbar', __( 'Note deleted.' ), {
 				type: 'snackbar',
 				isDismissible: true,
 			} );

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -81,7 +81,7 @@ test.describe( 'Block Comments', () => {
 		await expect(
 			page
 				.getByRole( 'button', { name: 'Dismiss this notice' } )
-				.filter( { hasText: 'Reply added successfully.' } )
+				.filter( { hasText: 'Reply added.' } )
 		).toBeVisible();
 	} );
 
@@ -132,7 +132,7 @@ test.describe( 'Block Comments', () => {
 		await expect(
 			page
 				.getByRole( 'button', { name: 'Dismiss this notice' } )
-				.filter( { hasText: 'Note deleted successfully.' } )
+				.filter( { hasText: 'Note deleted.' } )
 		).toBeVisible();
 	} );
 
@@ -393,11 +393,11 @@ test.describe( 'Block Comments', () => {
 			await replyForm.fill( 'Second reply' );
 			await replyButton.click();
 
-			// Check that two replies were added successfully.
+			// Check that two replies were added.
 			await expect(
 				page
 					.getByRole( 'button', { name: 'Dismiss this notice' } )
-					.filter( { hasText: 'Reply added successfully.' } )
+					.filter( { hasText: 'Reply added.' } )
 			).toHaveCount( 2 );
 
 			// Click on the title field to deselect the block and the comment.
@@ -655,7 +655,7 @@ class BlockCommentUtils {
 					.click();
 				await this.#page
 					.getByRole( 'button', { name: 'Dismiss this notice' } )
-					.filter( { hasText: 'Note added successfully.' } )
+					.filter( { hasText: 'Note added.' } )
 					.click();
 			},
 			{ box: true }


### PR DESCRIPTION
## What?

Remove "successfully" from the snackbar when adding or replying to a note.

<img width="241" height="93" alt="snackbar" src="https://github.com/user-attachments/assets/6af32303-8f38-4019-9ca2-0eb51f6148a6" />


## Why?

Gutenbrerg rarely uses "successfully" for the text displayed as the result of an action. It's only used when performing some kind of batch or complex operation, such as installing fonts or importing a classic navigation menu.

## Testing Instructions

Add a note to a block and confirm the snackbar message.