### PR TITLE
Notes: Change metadata key

### DIFF
--- a/packages/block-library/src/utils/get-transformed-metadata.js
+++ b/packages/block-library/src/utils/get-transformed-metadata.js
@@ -23,7 +23,7 @@ export function getTransformedMetadata(
 	const { supports } = getBlockType( newBlockName );
 
 	// The metadata properties that should be preserved after the transform.
-	const transformSupportedProps = [ 'commentId' ];
+	const transformSupportedProps = [ 'noteId' ];
 	// If there is a transform bindings callback, add the `id` and `bindings` properties.
 	if ( bindingsCallback ) {
 		transformSupportedProps.push( 'id', 'bindings' );

--- a/packages/editor/src/components/collab-sidebar/add-comment.js
+++ b/packages/editor/src/components/collab-sidebar/add-comment.js
@@ -35,7 +35,7 @@ export function AddComment( {
 			const selectedBlock = getSelectedBlock();
 			return {
 				clientId: selectedBlock?.clientId,
-				blockCommentId: selectedBlock?.attributes?.metadata?.commentId,
+				blockCommentId: selectedBlock?.attributes?.metadata?.noteId,
 				isEmptyDefaultBlock: selectedBlock
 					? isUnmodifiedDefaultBlock( selectedBlock )
 					: false,

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -80,7 +80,7 @@ export function Comments( {
 			const clientId = getSelectedBlockClientId();
 			return {
 				blockCommentId: clientId
-					? getBlockAttributes( clientId )?.metadata?.commentId
+					? getBlockAttributes( clientId )?.metadata?.noteId
 					: null,
 				selectedBlockClientId: clientId,
 				blockIds: getBlockOrder(),

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -71,8 +71,7 @@ export function useBlockComments( postId ) {
 	// Process comments to build the tree structure.
 	const { resultComments, unresolvedSortedThreads } = useMemo( () => {
 		const blocksWithComments = clientIds.reduce( ( results, clientId ) => {
-			const commentId =
-				getBlockAttributes( clientId )?.metadata?.commentId;
+			const commentId = getBlockAttributes( clientId )?.metadata?.noteId;
 			if ( commentId ) {
 				results[ clientId ] = commentId;
 			}
@@ -198,7 +197,7 @@ export function useBlockCommentsActions( reflowComments = noop ) {
 				updateBlockAttributes( clientId, {
 					metadata: {
 						...metadata,
-						commentId: savedRecord.id,
+						noteId: savedRecord.id,
 					},
 				} );
 			}
@@ -304,7 +303,7 @@ export function useBlockCommentsActions( reflowComments = noop ) {
 				updateBlockAttributes( clientId, {
 					metadata: cleanEmptyObject( {
 						...metadata,
-						commentId: undefined,
+						noteId: undefined,
 					} ),
 				} );
 			}

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -99,7 +99,7 @@ export default function CollabSidebar() {
 			select( blockEditorStore );
 		const clientId = getSelectedBlockClientId();
 		return clientId
-			? getBlockAttributes( clientId )?.metadata?.commentId
+			? getBlockAttributes( clientId )?.metadata?.noteId
 			: null;
 	}, [] );
 


### PR DESCRIPTION
See:

- https://github.com/WordPress/gutenberg/issues/66377#issuecomment-3413478422
- https://github.com/WordPress/gutenberg/discussions/72014#discussioncomment-14629639

## What? Why? 
The feature for leaving comments on blocks has been decided to be "Notes". Accordingly, I changed the internal metadata key from `commentId` to `noteId`.

## How?

Note that I have only modified the parts that affect the actual functionality, and have not changed variable names, etc.

## Testing Instructions

- Everything works as before.
- All Cis should be ✅

Note: The Notes feature will first be stabilized in Gutenberg 21.9. Since Gutenberg 21.9 is not yet released, this breaking change should be acceptable.