### PR TITLE
Fix contentOnly insertion, removal, and moving

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -184,7 +184,7 @@ function Items( {
 				getTemplateLock,
 				getBlockEditingMode,
 				isSectionBlock,
-				isContainerInsertableToInWriteMode,
+				isContainerInsertableToInContentOnlyMode,
 				getBlockName,
 				isZoomOut: _isZoomOut,
 				canInsertBlockType,
@@ -223,7 +223,7 @@ function Items( {
 				isZoomOut: _isZoomOut(),
 				shouldRenderAppender:
 					( ! isSectionBlock( rootClientId ) ||
-						isContainerInsertableToInWriteMode(
+						isContainerInsertableToInContentOnlyMode(
 							getBlockName( selectedBlockClientId ),
 							rootClientId
 						) ) &&

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -95,7 +95,7 @@ export const isBlockSubtreeDisabled = ( state, clientId ) => {
  * @param {string} rootClientId The client ID of the root container block.
  * @return {boolean} Whether the container allows insertion.
  */
-export function isContainerInsertableToInWriteMode(
+export function isContainerInsertableToInContentOnlyMode(
 	state,
 	blockName,
 	rootClientId
@@ -105,7 +105,7 @@ export function isContainerInsertableToInWriteMode(
 	const isContainerContentBlock = isContentBlock( rootBlockName );
 	const isRootBlockMain = getSectionRootClientId( state ) === rootClientId;
 
-	// In write mode, containers shouldn't be inserted into unless:
+	// In contentOnly mode, containers shouldn't be inserted into unless:
 	// 1. they are a section root;
 	// 2. they are a content block and the block to be inserted is also content.
 	return (

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1866,21 +1866,22 @@ export function canRemoveBlock( state, clientId ) {
 		return false;
 	}
 
-	const blockEditingMode = getBlockEditingMode( state, rootClientId );
+	const blockEditingMode = getBlockEditingMode( state, clientId );
 
 	// Check if the parent container allows insertion/removal in write mode
 	if (
 		blockEditingMode === 'contentOnly' &&
 		! isContainerInsertableToInWriteMode(
 			state,
-			getBlockName( state, rootClientId ),
+			getBlockName( state, clientId ),
 			rootClientId
 		)
 	) {
 		return false;
 	}
 
-	return blockEditingMode !== 'disabled';
+	const rootBlockEditingMode = getBlockEditingMode( state, rootClientId );
+	return rootBlockEditingMode !== 'disabled';
 }
 
 /**

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1918,7 +1918,8 @@ export function canMoveBlock( state, clientId ) {
 	}
 
 	const rootClientId = getBlockRootClientId( state, clientId );
-	if ( getTemplateLock( state, rootClientId ) === 'all' ) {
+	const templateLock = getTemplateLock( state, rootClientId );
+	if ( templateLock === 'all' || templateLock === 'contentOnly' ) {
 		return false;
 	}
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1917,6 +1917,19 @@ export function canMoveBlock( state, clientId ) {
 	if ( getTemplateLock( state, rootClientId ) === 'all' ) {
 		return false;
 	}
+
+	const blockEditingMode = getBlockEditingMode( state, clientId );
+	if (
+		blockEditingMode === 'contentOnly' &&
+		! isContainerInsertableToInWriteMode(
+			state,
+			getBlockName( state, clientId ),
+			rootClientId
+		)
+	) {
+		return false;
+	}
+
 	return getBlockEditingMode( state, rootClientId ) !== 'disabled';
 }
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1682,15 +1682,7 @@ const canInsertBlockTypeUnmemoized = (
 		blockType = getBlockType( blockName );
 	}
 
-	const isLocked = !! getTemplateLock( state, rootClientId );
-	if ( isLocked ) {
-		return false;
-	}
-	const isContentRoleBlock = isContentBlock( blockName );
-	const isParentSectionBlock = !! isSectionBlock( state, rootClientId );
-	// It shouldn't be possible to insert inside a section block unless in
-	// some cases when the block is a content block.
-	if ( isParentSectionBlock && ! isContentRoleBlock ) {
+	if ( getTemplateLock( state, rootClientId ) ) {
 		return false;
 	}
 
@@ -1704,6 +1696,21 @@ const canInsertBlockTypeUnmemoized = (
 	// The parent block doesn't have settings indicating it doesn't support
 	// inner blocks, return false.
 	if ( rootClientId && parentBlockListSettings === undefined ) {
+		return false;
+	}
+
+	// It shouldn't be possible to insert inside a section block unless in
+	// some cases when the block is a content block.
+	const isContentRoleBlock = isContentBlock( blockName );
+	const isParentSectionBlock = !! isSectionBlock( state, rootClientId );
+	const isBlockWithinSection = !! getParentSectionBlock(
+		state,
+		rootClientId
+	);
+	if (
+		( isParentSectionBlock || isBlockWithinSection ) &&
+		! isContentRoleBlock
+	) {
 		return false;
 	}
 
@@ -1862,6 +1869,8 @@ export function canRemoveBlock( state, clientId ) {
 		return false;
 	}
 
+	// It shouldn't be possible to move in a section block unless in
+	// some cases when the block is a content block.
 	const isBlockWithinSection = !! getParentSectionBlock( state, clientId );
 	const isContentRoleBlock = isContentBlock(
 		getBlockName( state, clientId )
@@ -1870,11 +1879,11 @@ export function canRemoveBlock( state, clientId ) {
 		return false;
 	}
 
-	const blockEditingMode = getBlockEditingMode( state, clientId );
-
+	const isParentSectionBlock = !! isSectionBlock( state, rootClientId );
+	const rootBlockEditingMode = getBlockEditingMode( state, rootClientId );
 	// Check if the parent container allows insertion/removal in contentOnly mode
 	if (
-		blockEditingMode === 'contentOnly' &&
+		( isParentSectionBlock || rootBlockEditingMode === 'contentOnly' ) &&
 		! isContainerInsertableToInContentOnlyMode(
 			state,
 			getBlockName( state, clientId ),
@@ -1884,7 +1893,6 @@ export function canRemoveBlock( state, clientId ) {
 		return false;
 	}
 
-	const rootBlockEditingMode = getBlockEditingMode( state, rootClientId );
 	return rootBlockEditingMode !== 'disabled';
 }
 
@@ -1918,14 +1926,24 @@ export function canMoveBlock( state, clientId ) {
 	}
 
 	const rootClientId = getBlockRootClientId( state, clientId );
-	const templateLock = getTemplateLock( state, rootClientId );
-	if ( templateLock === 'all' || templateLock === 'contentOnly' ) {
+	if ( getTemplateLock( state, rootClientId ) ) {
 		return false;
 	}
 
-	const blockEditingMode = getBlockEditingMode( state, clientId );
+	const isBlockWithinSection = !! getParentSectionBlock( state, clientId );
+	const isContentRoleBlock = isContentBlock(
+		getBlockName( state, clientId )
+	);
+	if ( isBlockWithinSection && ! isContentRoleBlock ) {
+		return false;
+	}
+
+	// If the parent is a section or is `contentOnly`, then check is the inner block
+	// should be allowed to move.
+	const isParentSectionBlock = !! isSectionBlock( state, rootClientId );
+	const rootBlockEditingMode = getBlockEditingMode( state, rootClientId );
 	if (
-		blockEditingMode === 'contentOnly' &&
+		( isParentSectionBlock || rootBlockEditingMode === 'contentOnly' ) &&
 		! isContainerInsertableToInContentOnlyMode(
 			state,
 			getBlockName( state, clientId ),

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1926,7 +1926,8 @@ export function canMoveBlock( state, clientId ) {
 	}
 
 	const rootClientId = getBlockRootClientId( state, clientId );
-	if ( getTemplateLock( state, rootClientId ) ) {
+	const templateLock = getTemplateLock( state, rootClientId );
+	if ( templateLock === 'all' || templateLock === 'contentOnly' ) {
 		return false;
 	}
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -43,7 +43,7 @@ import {
 	isSectionBlock,
 	getParentSectionBlock,
 	isZoomOut,
-	isContainerInsertableToInWriteMode,
+	isContainerInsertableToInContentOnlyMode,
 } from './private-selectors';
 
 const { isContentBlock } = unlock( blocksPrivateApis );
@@ -1707,10 +1707,14 @@ const canInsertBlockTypeUnmemoized = (
 		return false;
 	}
 
-	// In write mode, check if this container allows insertion.
+	// In content only mode, check if this container allows insertion.
 	if (
 		( isParentSectionBlock || blockEditingMode === 'contentOnly' ) &&
-		! isContainerInsertableToInWriteMode( state, blockName, rootClientId )
+		! isContainerInsertableToInContentOnlyMode(
+			state,
+			blockName,
+			rootClientId
+		)
 	) {
 		return false;
 	}
@@ -1868,10 +1872,10 @@ export function canRemoveBlock( state, clientId ) {
 
 	const blockEditingMode = getBlockEditingMode( state, clientId );
 
-	// Check if the parent container allows insertion/removal in write mode
+	// Check if the parent container allows insertion/removal in contentOnly mode
 	if (
 		blockEditingMode === 'contentOnly' &&
-		! isContainerInsertableToInWriteMode(
+		! isContainerInsertableToInContentOnlyMode(
 			state,
 			getBlockName( state, clientId ),
 			rootClientId
@@ -1921,7 +1925,7 @@ export function canMoveBlock( state, clientId ) {
 	const blockEditingMode = getBlockEditingMode( state, clientId );
 	if (
 		blockEditingMode === 'contentOnly' &&
-		! isContainerInsertableToInWriteMode(
+		! isContainerInsertableToInContentOnlyMode(
 			state,
 			getBlockName( state, clientId ),
 			rootClientId

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1709,7 +1709,7 @@ const canInsertBlockTypeUnmemoized = (
 
 	// In write mode, check if this container allows insertion.
 	if (
-		blockEditingMode === 'contentOnly' &&
+		( isParentSectionBlock || blockEditingMode === 'contentOnly' ) &&
 		! isContainerInsertableToInWriteMode( state, blockName, rootClientId )
 	) {
 		return false;

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -3081,7 +3081,7 @@ describe( 'selectors', () => {
 					byClientId: new Map(
 						Object.entries( {
 							block1: { name: 'core/test-block-ancestor' },
-							block2: { name: 'core/block' },
+							block2: { name: 'core/group' },
 							block3: { name: 'core/test-block-parent' },
 						} )
 					),

--- a/packages/block-editor/src/store/utils.js
+++ b/packages/block-editor/src/store/utils.js
@@ -10,7 +10,7 @@ import { parse as grammarParse } from '@wordpress/block-serialization-default-pa
 import { selectBlockPatternsKey } from './private-keys';
 import { unlock } from '../lock-unlock';
 import { STORE_NAME } from './constants';
-import { getSectionRootClientId } from './private-selectors';
+import { getSectionRootClientId, isSectionBlock } from './private-selectors';
 import { getBlockEditingMode } from './selectors';
 import { INSERTER_PATTERN_TYPES } from '../components/inserter/block-patterns-tab/utils';
 
@@ -140,5 +140,6 @@ export const getInsertBlockTypeDependants = () => ( state, rootClientId ) => {
 		state.settings.templateLock,
 		getBlockEditingMode( state, rootClientId ),
 		getSectionRootClientId( state ),
+		isSectionBlock( state, rootClientId ),
 	];
 };

--- a/packages/block-library/src/home-link/block.json
+++ b/packages/block-library/src/home-link/block.json
@@ -9,7 +9,8 @@
 	"textdomain": "default",
 	"attributes": {
 		"label": {
-			"type": "string"
+			"type": "string",
+			"role": "content"
 		}
 	},
 	"usesContext": [

--- a/test/e2e/specs/editor/various/content-only-lock.spec.js
+++ b/test/e2e/specs/editor/various/content-only-lock.spec.js
@@ -180,39 +180,7 @@ test.describe( 'Content-only lock', () => {
 
 		// Select the content-locked group block.
 		await editor.selectBlocks( groupBlock );
-		await test.step( 'Blocks cannot be duplicated', async () => {
-			// Test paragraph.
-			await editor.selectBlocks( paragraph );
-			await editor.showBlockToolbar();
-
-			await expect(
-				page
-					.getByRole( 'toolbar', { name: 'Block tools' } )
-					.getByRole( 'button', { name: 'Options' } )
-			).toBeHidden();
-
-			// Test first list item.
-			await editor.selectBlocks( firstListItem );
-			await editor.showBlockToolbar();
-
-			await expect(
-				page
-					.getByRole( 'toolbar', { name: 'Block tools' } )
-					.getByRole( 'button', { name: 'Options' } )
-			).toBeHidden();
-
-			// Test second list item.
-			await editor.selectBlocks( secondListItem );
-			await editor.showBlockToolbar();
-
-			await expect(
-				page
-					.getByRole( 'toolbar', { name: 'Block tools' } )
-					.getByRole( 'button', { name: 'Options' } )
-			).toBeHidden();
-		} );
-
-		await test.step( 'Blocks cannot be inserted before/after', async () => {
+		await test.step( 'Blocks cannot be inserted before/after or duplicated', async () => {
 			// Test paragraph.
 			await editor.selectBlocks( paragraph );
 			await editor.showBlockToolbar();

--- a/test/e2e/specs/editor/various/content-only-lock.spec.js
+++ b/test/e2e/specs/editor/various/content-only-lock.spec.js
@@ -90,12 +90,12 @@ test.describe( 'Content-only lock', () => {
 			<div class="wp-block-group"><!-- wp:paragraph -->
 			<p>Locked block a</p>
 			<!-- /wp:paragraph -->
-			
+
 			<!-- wp:paragraph -->
 			<p>Locked block b</p>
 			<!-- /wp:paragraph --></div>
 			<!-- /wp:group -->
-			
+
 			<!-- wp:heading -->
 			<h2 class="wp-block-heading"><strong>outside block</strong></h2>
 			<!-- /wp:heading -->` );
@@ -127,5 +127,171 @@ test.describe( 'Content-only lock', () => {
 		await expect(
 			page.locator( '.color-block-support-panel' )
 		).not.toBeAttached();
+	} );
+
+	test( 'blocks within content-only locked container cannot be duplicated, inserted before/after, or moved', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		// Add content only locked block with paragraph and list
+		await pageUtils.pressKeys( 'secondary+M' );
+
+		await page.getByPlaceholder( 'Start writing with text or HTML' )
+			.fill( `<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>First paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>List item one</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>List item two</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></div>
+<!-- /wp:group -->` );
+
+		await pageUtils.pressKeys( 'secondary+M' );
+
+		const groupBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Group',
+		} );
+		const paragraph = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Paragraph',
+				includeHidden: true,
+			} )
+			.filter( { hasText: 'First paragraph' } );
+		const firstListItem = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: List item',
+				includeHidden: true,
+			} )
+			.filter( { hasText: 'List item one' } );
+		const secondListItem = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: List item',
+				includeHidden: true,
+			} )
+			.filter( { hasText: 'List item two' } );
+
+		// Select the content-locked group block.
+		await editor.selectBlocks( groupBlock );
+		await test.step( 'Blocks cannot be duplicated', async () => {
+			// Test paragraph.
+			await editor.selectBlocks( paragraph );
+			await editor.showBlockToolbar();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Options' } )
+			).toBeHidden();
+
+			// Test first list item.
+			await editor.selectBlocks( firstListItem );
+			await editor.showBlockToolbar();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Options' } )
+			).toBeHidden();
+
+			// Test second list item.
+			await editor.selectBlocks( secondListItem );
+			await editor.showBlockToolbar();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Options' } )
+			).toBeHidden();
+		} );
+
+		await test.step( 'Blocks cannot be inserted before/after', async () => {
+			// Test paragraph.
+			await editor.selectBlocks( paragraph );
+			await editor.showBlockToolbar();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Options' } )
+			).toBeHidden();
+
+			// Test first list item.
+			await editor.selectBlocks( firstListItem );
+			await editor.showBlockToolbar();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Options' } )
+			).toBeHidden();
+
+			// Test second list item.
+			await editor.selectBlocks( secondListItem );
+			await editor.showBlockToolbar();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Options' } )
+			).toBeHidden();
+		} );
+
+		await test.step( 'Blocks cannot be moved', async () => {
+			// Test paragraph.
+			await editor.selectBlocks( paragraph );
+			await editor.showBlockToolbar();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Move up' } )
+			).toBeHidden();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Move down' } )
+			).toBeHidden();
+
+			// Test first list item.
+			await editor.selectBlocks( firstListItem );
+			await editor.showBlockToolbar();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Move up' } )
+			).toBeHidden();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Move down' } )
+			).toBeHidden();
+
+			// Test second list item.
+			await editor.selectBlocks( secondListItem );
+			await editor.showBlockToolbar();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Move up' } )
+			).toBeHidden();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Move down' } )
+			).toBeHidden();
+		} );
 	} );
 } );

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -224,6 +224,132 @@ test.describe( 'Pattern Overrides', () => {
 		} );
 	} );
 
+	test( 'blocks within a synced pattern cannot be duplicated, inserted before/after, or moved', async ( {
+		admin,
+		editor,
+		page,
+		requestUtils,
+	} ) => {
+		const content = `
+		<!-- wp:paragraph {"metadata":{"name":"Pattern Overrides","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
+		<p>Block with pattern overrides</p>
+		<!-- /wp:paragraph -->
+		<!-- wp:paragraph {"metadata":{"name":"No Overrides"}} -->
+		<p>Block without overrides</p>
+		<!-- /wp:paragraph -->
+		`;
+
+		const { id } = await requestUtils.createBlock( {
+			title: 'Test Pattern',
+			content,
+			status: 'publish',
+		} );
+
+		await admin.createNewPost();
+
+		await editor.insertBlock( {
+			name: 'core/block',
+			attributes: { ref: id },
+		} );
+
+		const patternBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Pattern',
+		} );
+		const blockWithOverrides = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Paragraph',
+				includeHidden: true,
+			} )
+			.filter( { hasText: 'Block with pattern overrides' } );
+		const blockWithoutOverrides = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Paragraph',
+				includeHidden: true,
+			} )
+			.filter( { hasText: 'Block without overrides' } );
+
+		// Select the pattern to make blocks accessible.
+		await editor.selectBlocks( patternBlock );
+
+		await test.step( 'Blocks cannot be duplicated', async () => {
+			// Test block with overrides.
+			await editor.selectBlocks( blockWithOverrides );
+			await editor.showBlockToolbar();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Options' } )
+			).toBeHidden();
+
+			// Test block without overrides.
+			await editor.selectBlocks( blockWithoutOverrides );
+			await editor.showBlockToolbar();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Options' } )
+			).toBeHidden();
+		} );
+
+		await test.step( 'Blocks cannot be inserted before/after', async () => {
+			// Test block with overrides.
+			await editor.selectBlocks( blockWithOverrides );
+			await editor.showBlockToolbar();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Options' } )
+			).toBeHidden();
+
+			// Test block without overrides.
+			await editor.selectBlocks( blockWithoutOverrides );
+			await editor.showBlockToolbar();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Options' } )
+			).toBeHidden();
+		} );
+
+		await test.step( 'Blocks cannot be moved', async () => {
+			// Test block with overrides.
+			await editor.selectBlocks( blockWithOverrides );
+			await editor.showBlockToolbar();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Move up' } )
+			).toBeHidden();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Move down' } )
+			).toBeHidden();
+
+			// Test block without overrides.
+			await editor.selectBlocks( blockWithoutOverrides );
+			await editor.showBlockToolbar();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Move up' } )
+			).toBeHidden();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Move down' } )
+			).toBeHidden();
+		} );
+	} );
+
 	test.describe( 'block editing modes', () => {
 		test( 'blocks with bindings in a synced pattern are editable, and all other blocks are disabled', async ( {
 			admin,

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -294,49 +294,7 @@ test.describe( 'Pattern Overrides', () => {
 		// Select the pattern to make blocks accessible.
 		await editor.selectBlocks( patternBlock );
 
-		await test.step( 'Blocks cannot be duplicated', async () => {
-			// Test block with overrides.
-			await editor.selectBlocks( blockWithOverrides );
-			await editor.showBlockToolbar();
-
-			await expect(
-				page
-					.getByRole( 'toolbar', { name: 'Block tools' } )
-					.getByRole( 'button', { name: 'Options' } )
-			).toBeHidden();
-
-			// Test block without overrides.
-			await editor.selectBlocks( blockWithoutOverrides );
-			await editor.showBlockToolbar();
-
-			await expect(
-				page
-					.getByRole( 'toolbar', { name: 'Block tools' } )
-					.getByRole( 'button', { name: 'Options' } )
-			).toBeHidden();
-
-			// Test first button.
-			await editor.selectBlocks( firstButton );
-			await editor.showBlockToolbar();
-
-			await expect(
-				page
-					.getByRole( 'toolbar', { name: 'Block tools' } )
-					.getByRole( 'button', { name: 'Options' } )
-			).toBeHidden();
-
-			// Test second button.
-			await editor.selectBlocks( secondButton );
-			await editor.showBlockToolbar();
-
-			await expect(
-				page
-					.getByRole( 'toolbar', { name: 'Block tools' } )
-					.getByRole( 'button', { name: 'Options' } )
-			).toBeHidden();
-		} );
-
-		await test.step( 'Blocks cannot be inserted before/after', async () => {
+		await test.step( 'Blocks cannot be inserted before/after or duplicated', async () => {
 			// Test block with overrides.
 			await editor.selectBlocks( blockWithOverrides );
 			await editor.showBlockToolbar();

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -237,6 +237,15 @@ test.describe( 'Pattern Overrides', () => {
 		<!-- wp:paragraph {"metadata":{"name":"No Overrides"}} -->
 		<p>Block without overrides</p>
 		<!-- /wp:paragraph -->
+		<!-- wp:buttons -->
+		<div class="wp-block-buttons"><!-- wp:button {"metadata":{"name":"First Button","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
+		<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">First button</a></div>
+		<!-- /wp:button -->
+
+		<!-- wp:button {"metadata":{"name":"Second Button","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
+		<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Second button</a></div>
+		<!-- /wp:button --></div>
+		<!-- /wp:buttons -->
 		`;
 
 		const { id } = await requestUtils.createBlock( {
@@ -267,6 +276,20 @@ test.describe( 'Pattern Overrides', () => {
 				includeHidden: true,
 			} )
 			.filter( { hasText: 'Block without overrides' } );
+		const firstButton = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Button',
+				exact: true,
+				includeHidden: true,
+			} )
+			.filter( { hasText: 'First button' } );
+		const secondButton = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Button',
+				exact: true,
+				includeHidden: true,
+			} )
+			.filter( { hasText: 'Second button' } );
 
 		// Select the pattern to make blocks accessible.
 		await editor.selectBlocks( patternBlock );
@@ -284,6 +307,26 @@ test.describe( 'Pattern Overrides', () => {
 
 			// Test block without overrides.
 			await editor.selectBlocks( blockWithoutOverrides );
+			await editor.showBlockToolbar();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Options' } )
+			).toBeHidden();
+
+			// Test first button.
+			await editor.selectBlocks( firstButton );
+			await editor.showBlockToolbar();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Options' } )
+			).toBeHidden();
+
+			// Test second button.
+			await editor.selectBlocks( secondButton );
 			await editor.showBlockToolbar();
 
 			await expect(
@@ -313,6 +356,26 @@ test.describe( 'Pattern Overrides', () => {
 					.getByRole( 'toolbar', { name: 'Block tools' } )
 					.getByRole( 'button', { name: 'Options' } )
 			).toBeHidden();
+
+			// Test first button.
+			await editor.selectBlocks( firstButton );
+			await editor.showBlockToolbar();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Options' } )
+			).toBeHidden();
+
+			// Test second button.
+			await editor.selectBlocks( secondButton );
+			await editor.showBlockToolbar();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Options' } )
+			).toBeHidden();
 		} );
 
 		await test.step( 'Blocks cannot be moved', async () => {
@@ -334,6 +397,38 @@ test.describe( 'Pattern Overrides', () => {
 
 			// Test block without overrides.
 			await editor.selectBlocks( blockWithoutOverrides );
+			await editor.showBlockToolbar();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Move up' } )
+			).toBeHidden();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Move down' } )
+			).toBeHidden();
+
+			// Test first button.
+			await editor.selectBlocks( firstButton );
+			await editor.showBlockToolbar();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Move up' } )
+			).toBeHidden();
+
+			await expect(
+				page
+					.getByRole( 'toolbar', { name: 'Block tools' } )
+					.getByRole( 'button', { name: 'Move down' } )
+			).toBeHidden();
+
+			// Test second button.
+			await editor.selectBlocks( secondButton );
 			await editor.showBlockToolbar();
 
 			await expect(


### PR DESCRIPTION
## What?
I've noticed lately some cases where in contentOnly mode, certain block features are available that shouldn't be:
- Movers, block insertion and block removal being allowed in synced patterns
- Paragraphs being insertable/removable when at the root of an unsynced pattern (with the unsynced contentOnly patterns experiment active)
- Movers available for paragraphs, list items and possibly other blocks inside `templateLock: "contentOnly"` groups. I think the expectation right now is that this shouldn't be possible, but I might need confirmation on that.

This PR should fix these issues, but still maintain the desired behavior from #71232

## How?
Adjusts some logic in the relevant selectors. I've left some PR comments about the exact changes.

## Testing Instructions
### Synced patterns
1. Create a synced pattern with the following markup:
```html
<!-- wp:heading {"metadata":{"name":"Title","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
<h2 class="wp-block-heading">test</h2>
<!-- /wp:heading -->
<!-- wp:paragraph {"metadata":{"name":"Body text","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
<p>test</p>
<!-- /wp:paragraph -->
<!-- wp:image {"metadata":{"name":"Image","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
<figure class="wp-block-image"><img alt=""/><figcaption class="wp-element-caption"></figcaption></figure>
<!-- /wp:image -->
<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"metadata":{"name":"CTA","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="https://bbc.com">test</a></div>
<!-- /wp:button -->
<!-- wp:button {"metadata":{"name":"test","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">test 2</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->
<!-- wp:verse -->
<pre class="wp-block-verse">verse text here</pre>
<!-- /wp:verse -->
```
2. Insert an instance of the pattern in a post
3. Note that in trunk for the heading, paragraph, image you can Add before/after, Duplicate, and Delete, which should not be possible. In this branch it's fixed.
4. In trunk you can also drag the paragraph to a new position, but that's no longer possible in this PR.

### Unsynced patterns
(test with the contentOnly unsynced patterns experiment active).
1. Create an unsynced pattern with the following markup:
```html
<!-- wp:group {"metadata":{"patternName":"core/block/124","name":"test2"},"className":"is-style-section-2","layout":{"type":"constrained"}} -->
<div class="wp-block-group is-style-section-2"><!-- wp:paragraph -->
<p>test</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>test</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:list -->
<ul class="wp-block-list"><!-- wp:list-item -->
<li>1</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>test<!-- wp:list -->
<ul class="wp-block-list"><!-- wp:list-item -->
<li>2</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>3</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></li>
<!-- /wp:list-item --></ul>
<!-- /wp:list -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">test</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">test</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```
2. Insert an instance of the unsynced pattern
3. Note that in trunk the paragraphs can be added/removed/duplicated etc. In this PR they cannot.
4. Test that list items and buttons can still be inserted and removed.

### templateLock: contentOnly
1. Insert the following block markup:
```html
<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>Locked block a</p>
<!-- /wp:paragraph -->
<!-- wp:paragraph -->
<p>Locked block b</p>
<!-- /wp:paragraph -->
<!-- wp:list -->
<ul class="wp-block-list"><!-- wp:list-item -->
<li>1</li>
<!-- /wp:list-item -->
<!-- wp:list-item -->
<li>2</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></div>
<!-- /wp:group -->
```
2. Check that all the blocks cannot be added/removed or moved. (I think that's how it's supposed to work 😅 )

### Also worth testing
- 'Show Template' mode, blocks within Post content should be freely insertable, removable etc. Blocks that are part of the template shouldn't be.

## Screenshots or screencast <!-- if applicable -->
### Content Only Template Lock
#### Before
<img width="292" height="258" alt="Screenshot 2025-10-20 at 12 39 07 pm" src="https://github.com/user-attachments/assets/4bd95e8a-419f-424f-b6ff-ecb556c47770" />

#### After
<img width="281" height="258" alt="Screenshot 2025-10-20 at 12 39 27 pm" src="https://github.com/user-attachments/assets/baad5af7-06a6-4e7e-8714-dbb9c69fc4a2" />

### Synced Patterns
#### Before
<img width="703" height="488" alt="Screenshot 2025-10-20 at 12 41 46 pm" src="https://github.com/user-attachments/assets/e6f3c569-14e6-48cf-a3ff-386e1ae6bc61" />

#### After
<img width="692" height="497" alt="Screenshot 2025-10-20 at 12 41 25 pm" src="https://github.com/user-attachments/assets/95368672-303e-44f4-a3a6-43a5fd66630b" />

### Unsynced Patterns
#### Before
<img width="540" height="339" alt="Screenshot 2025-10-20 at 12 48 38 pm" src="https://github.com/user-attachments/assets/1d071f17-ab06-4ef6-9277-21a9387eece8" />

#### After
<img width="262" height="209" alt="Screenshot 2025-10-20 at 12 48 18 pm" src="https://github.com/user-attachments/assets/75b59f43-0fcc-4cfc-8161-cefd52764518" />
