### PR TITLE
DataViews: Use Text-Based Links for Primary Actions

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- Dataviews: Use text based buttons for actions instead of text. [#72417](https://github.com/WordPress/gutenberg/pull/72417)
+
 ## 10.0.0 (2025-10-17)
 
 ### Bug Fixes
@@ -20,7 +24,6 @@
 - Standardise DataForm typography. [#72284](https://github.com/WordPress/gutenberg/pull/72284).
 - Dataviews: Add support for dynamic modal headers. [#72384](https://github.com/WordPress/gutenberg/pull/72384)
 - Field API: support async loading elements. [#72254](https://github.com/WordPress/gutenberg/pull/72254)
-- Dataviews: Use text based buttons for actions instead of text. [#72417](https://github.com/WordPress/gutenberg/pull/72417)
 
 ### Breaking changes
 

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Standardise DataForm typography. [#72284](https://github.com/WordPress/gutenberg/pull/72284).
 - Dataviews: Add support for dynamic modal headers. [#72384](https://github.com/WordPress/gutenberg/pull/72384)
 - Field API: support async loading elements. [#72254](https://github.com/WordPress/gutenberg/pull/72254)
+- Dataviews: Use text based buttons for actions instead of text. [#72417](https://github.com/WordPress/gutenberg/pull/72417)
 
 ### Breaking changes
 

--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -77,7 +77,6 @@ function ButtonTrigger< Item >( {
 			accessibleWhenDisabled
 			size="compact"
 			onClick={ onClick }
-			variant="link"
 		>
 			{ label }
 		</Button>
@@ -186,7 +185,7 @@ export default function ItemActions< Item >( {
 
 	return (
 		<HStack
-			spacing={ 5 }
+			spacing={ 0 }
 			justify="flex-end"
 			className="dataviews-item-actions"
 			style={ {

--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -186,7 +186,7 @@ export default function ItemActions< Item >( {
 
 	return (
 		<HStack
-			spacing={ 1 }
+			spacing={ 5 }
 			justify="flex-end"
 			className="dataviews-item-actions"
 			style={ {

--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -73,13 +73,14 @@ function ButtonTrigger< Item >( {
 		typeof action.label === 'string' ? action.label : action.label( items );
 	return (
 		<Button
-			label={ label }
-			icon={ action.icon }
 			disabled={ !! action.disabled }
 			accessibleWhenDisabled
 			size="compact"
 			onClick={ onClick }
-		/>
+			variant="link"
+		>
+			{ label }
+		</Button>
 	);
 }
 
@@ -164,7 +165,7 @@ export default function ItemActions< Item >( {
 			( action ) => ! action.isEligible || action.isEligible( item )
 		);
 		const _primaryActions = _eligibleActions.filter(
-			( action ) => action.isPrimary && !! action.icon
+			( action ) => action.isPrimary
 		);
 		return {
 			primaryActions: _primaryActions,

--- a/packages/dataviews/src/components/dataviews-item-actions/style.scss
+++ b/packages/dataviews/src/components/dataviews-item-actions/style.scss
@@ -1,4 +1,5 @@
 @use "@wordpress/base-styles/variables" as *;
+@use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/z-index" as *;
 
 .dataviews-action-modal {
@@ -7,6 +8,15 @@
 
 .dataviews-item-actions {
 	.components-button.is-link {
+		text-decoration: none;
+		font-weight: 600;
+		color: $gray-700;
 		white-space: nowrap;
+		&:hover:not(:disabled) {
+			color: var(--wp-admin-theme-color);
+		}
+		&:active:not(:disabled) {
+			color: $gray-900;
+		}
 	}
 }

--- a/packages/dataviews/src/components/dataviews-item-actions/style.scss
+++ b/packages/dataviews/src/components/dataviews-item-actions/style.scss
@@ -8,6 +8,8 @@
 
 .dataviews-item-actions {
 	.components-button.is-link {
+		padding-left: $grid-unit-10;
+		padding-right: $grid-unit-10;
 		text-decoration: none;
 		font-weight: 600;
 		color: $gray-700;

--- a/packages/dataviews/src/components/dataviews-item-actions/style.scss
+++ b/packages/dataviews/src/components/dataviews-item-actions/style.scss
@@ -5,20 +5,3 @@
 .dataviews-action-modal {
 	z-index: z-index(".dataviews-action-modal");
 }
-
-.dataviews-item-actions {
-	.components-button.is-link {
-		padding-left: $grid-unit-10;
-		padding-right: $grid-unit-10;
-		text-decoration: none;
-		font-weight: 600;
-		color: $gray-700;
-		white-space: nowrap;
-		&:hover:not(:disabled) {
-			color: var(--wp-admin-theme-color);
-		}
-		&:active:not(:disabled) {
-			color: $gray-900;
-		}
-	}
-}

--- a/packages/dataviews/src/components/dataviews-item-actions/style.scss
+++ b/packages/dataviews/src/components/dataviews-item-actions/style.scss
@@ -4,3 +4,9 @@
 .dataviews-action-modal {
 	z-index: z-index(".dataviews-action-modal");
 }
+
+.dataviews-item-actions {
+	.components-button.is-link {
+		white-space: nowrap;
+	}
+}

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -104,13 +104,14 @@ function PrimaryActionGridCell< Item >( {
 				id={ compositeItemId }
 				render={
 					<Button
-						label={ label }
 						disabled={ !! primaryAction.disabled }
 						accessibleWhenDisabled
-						icon={ primaryAction.icon }
 						size="small"
 						onClick={ () => setIsModalOpen( true ) }
-					/>
+						variant="link"
+					>
+						{ label }
+					</Button>
 				}
 			>
 				{ isModalOpen && (
@@ -128,15 +129,16 @@ function PrimaryActionGridCell< Item >( {
 				id={ compositeItemId }
 				render={
 					<Button
-						label={ label }
 						disabled={ !! primaryAction.disabled }
 						accessibleWhenDisabled
-						icon={ primaryAction.icon }
 						size="small"
 						onClick={ () => {
 							primaryAction.callback( [ item ], { registry } );
 						} }
-					/>
+						variant="link"
+					>
+						{ label }
+					</Button>
 				}
 			/>
 		</div>
@@ -195,7 +197,7 @@ function ListItem< Item >( {
 			( action ) => ! action.isEligible || action.isEligible( item )
 		);
 		const _primaryActions = _eligibleActions.filter(
-			( action ) => action.isPrimary && !! action.icon
+			( action ) => action.isPrimary
 		);
 		return {
 			primaryAction: _primaryActions[ 0 ],

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -210,9 +210,8 @@
 	}
 
 	.dataviews-view-table__actions-column {
-		width: 1%;
-		max-width: inherit;
-		min-width: inherit;
+		width: auto;
+		white-space: nowrap;
 	}
 
 	&:has(tr.is-selected) {

--- a/test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
+++ b/test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
@@ -136,7 +136,7 @@ test.describe( 'Dataviews List Layout', () => {
 		await expect(
 			page
 				.getByRole( 'row', { name: 'Privacy Policy Edit Actions' } )
-				.getByLabel( 'Edit' )
+				.getByRole( 'button', { name: 'Edit' } )
 		).toBeFocused();
 
 		await page.keyboard.press( 'ArrowRight' );
@@ -150,7 +150,7 @@ test.describe( 'Dataviews List Layout', () => {
 		await expect(
 			page
 				.getByRole( 'row', { name: 'Privacy Policy Edit Actions' } )
-				.getByLabel( 'Edit' )
+				.getByRole( 'button', { name: 'Edit' } )
 		).toBeFocused();
 
 		await page.keyboard.press( 'ArrowLeft' );
@@ -178,14 +178,14 @@ test.describe( 'Dataviews List Layout', () => {
 		await expect(
 			page
 				.getByRole( 'row', { name: 'Sample Page Edit Actions' } )
-				.getByLabel( 'Edit' )
+				.getByRole( 'button', { name: 'Edit' } )
 		).toBeFocused();
 
 		await page.keyboard.press( 'ArrowUp' );
 		await expect(
 			page
 				.getByRole( 'row', { name: 'Privacy Policy Edit Actions' } )
-				.getByLabel( 'Edit' )
+				.getByRole( 'button', { name: 'Edit' } )
 		).toBeFocused();
 
 		// Use arrow up/down to move through the list from the all actions button.


### PR DESCRIPTION
Replaces icon-only buttons with text-based links for primary actions in DataViews table and list layouts. Not all actions can possibly be represented as an icon so forcing an icon use at the framework level was an hard constraint. This also improves the accessibility of the application.


## Testing
- Went to site editor pages, and verified the primary actions render as a text based link.
- Repeted the text for the template section, and patterns and verified there was nothing obviously broken. 


## Screenshots
<img width="1214" height="768" alt="Screenshot 2025-10-17 at 10 03 52" src="https://github.com/user-attachments/assets/82877053-5717-4677-987d-6b9a0801f1ae" />
<img width="1193" height="61" alt="Screenshot 2025-10-17 at 10 02 37" src="https://github.com/user-attachments/assets/1450beea-1fd3-439f-ab50-f24421ded6a3" />
<img width="1197" height="59" alt="Screenshot 2025-10-17 at 10 02 04" src="https://github.com/user-attachments/assets/9cbc97fc-db0c-4375-914d-94cfe431240f" />
<img width="1193" height="60" alt="Screenshot 2025-10-17 at 09 59 51" src="https://github.com/user-attachments/assets/85acca8e-2c80-4bb7-9110-2da6183e5704" />




