### PR TITLE
Block Bindings: Move support for Navigation blocks url attribute to correct place

### DIFF
--- a/backport-changelog/6.9/10322.md
+++ b/backport-changelog/6.9/10322.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10322
+
+- https://github.com/WordPress/gutenberg/pull/72418

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -18,6 +18,12 @@ add_filter(
 		if ( 'core/post-date' === $block_type && ! in_array( 'datetime', $attributes, true ) ) {
 			$attributes[] = 'datetime';
 		}
+		if (
+			in_array( $block_type, array( 'core/navigation-link', 'core/navigation-submenu' ), true ) &&
+			! in_array( 'url', $attributes, true )
+		) {
+			$attributes[] = 'url';
+		}
 		return $attributes;
 	},
 	10,
@@ -110,14 +116,17 @@ add_filter( 'render_block', 'gutenberg_block_bindings_render_block', 10, 3 );
  * @return array The list of block attributes that are supported by block bindings.
  */
 function gutenberg_get_block_bindings_supported_attributes( $block_type ) {
-	// List of block attributes supported by Block Bindings in WP 6.8.
+	/*
+	 * List of block attributes supported by Block Bindings in WP 6.8.
+	 * DO NOT MODIFY THIS ARRAY. It's a snapshot of what Core supports in 6.8.
+	 * Use the `block_bindings_supported_attributes` filter instead to add support
+	 * for new block attributes.
+	 */
 	$block_bindings_supported_attributes_6_8 = array(
 		'core/paragraph'          => array( 'content' ),
 		'core/heading'            => array( 'content' ),
 		'core/image'              => array( 'id', 'url', 'title', 'alt' ),
 		'core/button'             => array( 'url', 'text', 'linkTarget', 'rel' ),
-		'core/navigation-link'    => array( 'url' ),
-		'core/navigation-submenu' => array( 'url' ),
 	);
 
 	$supported_block_attributes =

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -123,10 +123,10 @@ function gutenberg_get_block_bindings_supported_attributes( $block_type ) {
 	 * for new block attributes.
 	 */
 	$block_bindings_supported_attributes_6_8 = array(
-		'core/paragraph'          => array( 'content' ),
-		'core/heading'            => array( 'content' ),
-		'core/image'              => array( 'id', 'url', 'title', 'alt' ),
-		'core/button'             => array( 'url', 'text', 'linkTarget', 'rel' ),
+		'core/paragraph' => array( 'content' ),
+		'core/heading'   => array( 'content' ),
+		'core/image'     => array( 'id', 'url', 'title', 'alt' ),
+		'core/button'    => array( 'url', 'text', 'linkTarget', 'rel' ),
 	);
 
 	$supported_block_attributes =

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -202,20 +202,6 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		return '';
 	}
 
-	// Resolve URL binding if present
-	$url = $attributes['url'] ?? '';
-	if ( isset( $attributes['metadata']['bindings']['url']['source'] ) ) {
-		$binding = $attributes['metadata']['bindings']['url'];
-		$source  = get_block_bindings_source( $binding['source'] );
-		if ( $source ) {
-			$source_args  = $binding['args'] ?? array();
-			$resolved_url = $source->get_value( $source_args, $block, 'url' );
-			if ( $resolved_url ) {
-				$url = $resolved_url;
-			}
-		}
-	}
-
 	$font_sizes      = block_core_navigation_link_build_css_font_sizes( $block->context );
 	$classes         = array_merge(
 		$font_sizes['css_classes']
@@ -227,9 +213,9 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	$kind        = empty( $attributes['kind'] ) ? 'post_type' : str_replace( '-', '_', $attributes['kind'] );
 	$is_active   = ! empty( $attributes['id'] ) && get_queried_object_id() === (int) $attributes['id'] && ! empty( get_queried_object()->$kind );
 
-	if ( is_post_type_archive() && ! empty( $url ) ) {
+	if ( is_post_type_archive() && ! empty( $attributes['url'] ) ) {
 		$queried_archive_link = get_post_type_archive_link( get_queried_object()->name );
-		if ( $url === $queried_archive_link ) {
+		if ( $attributes['url'] === $queried_archive_link ) {
 			$is_active = true;
 		}
 	}
@@ -245,8 +231,8 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 		'<a class="wp-block-navigation-item__content" ';
 
 	// Start appending HTML attributes to anchor tag.
-	if ( ! empty( $url ) ) {
-		$html .= ' href="' . esc_url( block_core_navigation_link_maybe_urldecode( $url ) ) . '"';
+	if ( isset( $attributes['url'] ) ) {
+		$html .= ' href="' . esc_url( block_core_navigation_link_maybe_urldecode( $attributes['url'] ) ) . '"';
 	}
 
 	if ( $is_active ) {

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -79,20 +79,6 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		return '';
 	}
 
-	// Resolve URL binding if present
-	$url = $attributes['url'] ?? '';
-	if ( isset( $attributes['metadata']['bindings']['url']['source'] ) ) {
-		$binding = $attributes['metadata']['bindings']['url'];
-		$source  = get_block_bindings_source( $binding['source'] );
-		if ( $source ) {
-			$source_args  = $binding['args'] ?? array();
-			$resolved_url = $source->get_value( $source_args, $block, 'url' );
-			if ( $resolved_url ) {
-				$url = $resolved_url;
-			}
-		}
-	}
-
 	$font_sizes      = block_core_navigation_submenu_build_css_font_sizes( $block->context );
 	$style_attribute = $font_sizes['inline_styles'];
 
@@ -100,9 +86,9 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	$kind        = empty( $attributes['kind'] ) ? 'post_type' : str_replace( '-', '_', $attributes['kind'] );
 	$is_active   = ! empty( $attributes['id'] ) && get_queried_object_id() === (int) $attributes['id'] && ! empty( get_queried_object()->$kind );
 
-	if ( is_post_type_archive() && ! empty( $url ) ) {
+	if ( is_post_type_archive() && ! empty( $attributes['url'] ) ) {
 		$queried_archive_link = get_post_type_archive_link( get_queried_object()->name );
-		if ( $url === $queried_archive_link ) {
+		if ( $attributes['url'] === $queried_archive_link ) {
 			$is_active = true;
 		}
 	}
@@ -156,7 +142,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	// If Submenus open on hover, we render an anchor tag with attributes.
 	// If submenu icons are set to show, we also render a submenu button, so the submenu can be opened on click.
 	if ( ! $open_on_click ) {
-		$item_url = $url;
+		$item_url = isset( $attributes['url'] ) ? $attributes['url'] : '';
 		// Start appending HTML attributes to anchor tag.
 		$html .= '<a class="wp-block-navigation-item__content"';
 


### PR DESCRIPTION
## What?
Fix block bindings support for the Navigation Link and Navigation Submenu blocks' `url` attribute.

Props @getdave for pointing this out. Discovered while working on https://github.com/WordPress/gutenberg/pull/72165.

## Why?
Those blocks and attributes were previously added to an array that contains block attributes supported by block bindings as of WP 6.8 -- effectively skipping them from the Gutenberg-side polyfill that processes them.

## How?
By using the `block_bindings_supported_attributes` filter instead. Furthermore, we're removing the now-obsolete logic that manually invoked block bindings from inside each block's code. (The latter is achieved by reverting https://github.com/WordPress/gutenberg/pull/72169.)

## Testing Instructions
Refer to testing instructions of https://github.com/WordPress/gutenberg/pull/72169.