### PR TITLE
Terms Query: Fix display all terms in editor

### DIFF
--- a/packages/block-library/src/term-template/edit.js
+++ b/packages/block-library/src/term-template/edit.js
@@ -93,7 +93,10 @@ export default function TermTemplateEdit( {
 		hide_empty: hideEmpty,
 		order,
 		orderby: orderBy,
-		per_page: perPage,
+		// There is a mismatch between `WP_Term_Query` and the REST API parameter default
+		// values to fetch all items. In `WP_Term_Query`, the default is `''|0` and in
+		// the REST API is `-1`.
+		per_page: perPage || -1,
 	};
 
 	// Nested terms are returned by default from REST API as long as parent is not set.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/72415

There is a mismatch between `WP_Term_Query` and the REST API parameter default values to fetch all items. In `WP_Term_Query`, the default is `''|0` and in the REST API is `-1`.




## Testing Instructions
1. Insert Terms Query and enter `0` (zero)  in `max terms` inspector control setting.
2. Observe that it works as expected in the editor and front end.
