### PR TITLE
Notes: Show orphaned notes in archive sidebar

### DIFF
--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -121,6 +121,11 @@ export function useBlockComments( postId ) {
 			updatedResult.map( ( thread ) => [ String( thread.id ), thread ] )
 		);
 
+		// Prepare sets to determine which threads are linked to existing blocks.
+		const mappedIds = new Set(
+			Object.values( blocksWithComments ).map( ( id ) => String( id ) )
+		);
+
 		// Get comments by block order, first unresolved, then resolved.
 		const unresolvedSortedComments = Object.values( blocksWithComments )
 			.map( ( commentId ) => threadIdMap.get( String( commentId ) ) )
@@ -135,10 +140,23 @@ export function useBlockComments( postId ) {
 					thread !== undefined && thread.status === 'approved'
 			);
 
-		// Combine unresolved comments in block order with resolved comments at the end.
+		// Append orphan notes (whose related block was deleted or missing).
+		const orphanUnresolvedComments = updatedResult.filter(
+			( thread ) =>
+				! mappedIds.has( String( thread.id ) ) &&
+				thread.status === 'hold'
+		);
+		const orphanResolvedComments = updatedResult.filter(
+			( thread ) =>
+				! mappedIds.has( String( thread.id ) ) &&
+				thread.status === 'approved'
+		);
+
 		const allSortedComments = [
 			...unresolvedSortedComments,
 			...resolvedSortedComments,
+			...orphanUnresolvedComments,
+			...orphanResolvedComments,
 		];
 
 		return {

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -141,22 +141,14 @@ export function useBlockComments( postId ) {
 			);
 
 		// Append orphan notes (whose related block was deleted or missing).
-		const orphanUnresolvedComments = updatedResult.filter(
-			( thread ) =>
-				! mappedIds.has( String( thread.id ) ) &&
-				thread.status === 'hold'
-		);
-		const orphanResolvedComments = updatedResult.filter(
-			( thread ) =>
-				! mappedIds.has( String( thread.id ) ) &&
-				thread.status === 'approved'
+		const orphanComments = updatedResult.filter(
+			( thread ) => ! mappedIds.has( String( thread.id ) )
 		);
 
 		const allSortedComments = [
 			...unresolvedSortedComments,
 			...resolvedSortedComments,
-			...orphanUnresolvedComments,
-			...orphanResolvedComments,
+			...orphanComments,
 		];
 
 		return {

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -140,15 +140,15 @@ export function useBlockComments( postId ) {
 					thread !== undefined && thread.status === 'approved'
 			);
 
-		// Append orphan notes (whose related block was deleted or missing).
-		const orphanComments = updatedResult.filter(
+		// Append orphaned notes (whose related block was deleted or missing).
+		const orphanedComments = updatedResult.filter(
 			( thread ) => ! mappedIds.has( String( thread.id ) )
 		);
 
 		const allSortedComments = [
 			...unresolvedSortedComments,
 			...resolvedSortedComments,
-			...orphanComments,
+			...orphanedComments,
 		];
 
 		return {


### PR DESCRIPTION
## What? Why?

I noticed that orphaned notes, i.e. notes whose block has been deleted, do not appear in the Archives sidebar. I was unable to identify the exact PR where the issue occurred, but it is not a recent issue.

## How?

Update the `useBlockComments` to include orhpaned notes.

## Testing Instructions

- Insert blocks and comment on them.
- Resolve some of those notes.
- Delete some blocks.
- In the archive sidebar, make sure the notes remain.
- In the floating sidebar, make sure no orphaned comments are displayed.


## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/abe1ce97-b2b4-4532-acc4-7130d582a30a


