### PR TITLE
Notes: Relocate privacy info text

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -247,24 +247,17 @@ export function Comments( {
 	const hasThreads = Array.isArray( threads ) && threads.length > 0;
 	if ( ! hasThreads ) {
 		return (
-			<VStack
-				alignment="left"
-				className="editor-collab-sidebar-panel__thread"
-				justify="flex-start"
-				spacing="3"
-			>
-				{ __( 'No notes available.' ) }
+			<VStack alignment="left" justify="flex-start" spacing="2">
+				<Text as="p">{ __( 'No notes available.' ) }</Text>
+				<Text as="p" variant="muted">
+					{ __( 'Only logged in users can see Notes.' ) }
+				</Text>
 			</VStack>
 		);
 	}
 
 	return (
 		<VStack spacing="3">
-			{ ! isFloating && (
-				<Text as="p" variant="muted">
-					{ __( 'Only logged in users can see Notes' ) }
-				</Text>
-			) }
 			{ threads.map( ( thread ) => (
 				<Thread
 					key={ thread.id }


### PR DESCRIPTION
## What?
This is a follow-up to #72077.
Closes #72393.

PR moves "Only logged in users can see Notes." info text next inside the "no results" area. I've also removed the "thread" like styling for this text wrapper element.

## Why?
Makes text less prominent.

## Testing Instructions
1. Create a post or page.
2. Open the Notes sidebar.
3. Confirm that privacy text is displayed correctly.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="282" height="353" alt="CleanShot 2025-10-17 at 13 07 34" src="https://github.com/user-attachments/assets/624b6d5b-389a-408e-83f6-45c13a986332" />|<img width="278" height="316" alt="CleanShot 2025-10-17 at 13 05 53" src="https://github.com/user-attachments/assets/f819a126-8f0d-4b58-9982-4220c73997df" />|

