### PR TITLE
Notes: Remove 'isDefaultEmptyBlock' condition

### DIFF
--- a/packages/editor/src/components/collab-sidebar/add-comment.js
+++ b/packages/editor/src/components/collab-sidebar/add-comment.js
@@ -11,7 +11,6 @@ import {
 	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
-import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -29,28 +28,17 @@ export function AddComment( {
 	setShowCommentBoard,
 	commentSidebarRef,
 } ) {
-	const { clientId, blockCommentId, isEmptyDefaultBlock } = useSelect(
-		( select ) => {
-			const { getSelectedBlock } = select( blockEditorStore );
-			const selectedBlock = getSelectedBlock();
-			return {
-				clientId: selectedBlock?.clientId,
-				blockCommentId: selectedBlock?.attributes?.metadata?.noteId,
-				isEmptyDefaultBlock: selectedBlock
-					? isUnmodifiedDefaultBlock( selectedBlock )
-					: false,
-			};
-		},
-		[]
-	);
+	const { clientId, blockCommentId } = useSelect( ( select ) => {
+		const { getSelectedBlock } = select( blockEditorStore );
+		const selectedBlock = getSelectedBlock();
+		return {
+			clientId: selectedBlock?.clientId,
+			blockCommentId: selectedBlock?.attributes?.metadata?.noteId,
+		};
+	}, [] );
 	const blockElement = useBlockElement( clientId );
 
-	if (
-		! showCommentBoard ||
-		! clientId ||
-		undefined !== blockCommentId ||
-		isEmptyDefaultBlock
-	) {
+	if ( ! showCommentBoard || ! clientId || undefined !== blockCommentId ) {
 		return null;
 	}
 
@@ -68,6 +56,7 @@ export function AddComment( {
 				onSubmit={ async ( inputComment ) => {
 					const { id } = await onSubmit( { content: inputComment } );
 					focusCommentThread( id, commentSidebarRef.current );
+					setShowCommentBoard( false );
 				} }
 				onCancel={ () => {
 					setShowCommentBoard( false );


### PR DESCRIPTION
## What?
Reverts #71497.
Closes #72394.

PR removes the check that prevents rendering the "Add new note" form for empty default blocks (paragraphs). Instead, let the users decide when they want to add the notes.

This also fixes the consistency described in #72394.

## Testing Instructions
CI checks are passing.

### Testing Instructions for Keyboard
Same.
