### PR TITLE
Primitives: Add missing type export

### DIFF
--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -28,7 +28,8 @@
 	"exports": {
 		".": {
 			"import": "./build-module/index.js",
-			"require": "./build/index.js"
+			"require": "./build/index.js",
+			"types": "./build-types/index.d.ts"
 		},
 		"./package.json": "./package.json"
 	},


### PR DESCRIPTION
## What?

Add missing type export to allow types to be inferred.

## Why?

Using:

```ts
import { SVG } from '@wordpress/primitives';
```

will result in

```
There are types at '/project-path/node_modules/@wordpress/primitives/build-types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@wordpress/primitives' library may need to update its package.json or typings.ts(7016)
```

## How?

By adding a type export.

## Testing Instructions

Use the above import and make sure there's no typescript error.
