### PR TITLE
Notes: Fix logic for opening feature sidebar areas

### DIFF
--- a/packages/editor/src/components/collab-sidebar/constants.js
+++ b/packages/editor/src/components/collab-sidebar/constants.js
@@ -1,2 +1,3 @@
 export const collabHistorySidebarName = 'edit-post/collab-history-sidebar';
 export const collabSidebarName = 'edit-post/collab-sidebar';
+export const SIDEBARS = [ collabHistorySidebarName, collabSidebarName ];

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -86,8 +86,7 @@ function CollabSidebarContent( {
 export default function CollabSidebar() {
 	const [ showCommentBoard, setShowCommentBoard ] = useState( false );
 	const { getActiveComplementaryArea } = useSelect( interfaceStore );
-	const { enableComplementaryArea, disableComplementaryArea } =
-		useDispatch( interfaceStore );
+	const { enableComplementaryArea } = useDispatch( interfaceStore );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const commentSidebarRef = useRef( null );
 
@@ -132,28 +131,19 @@ export default function CollabSidebar() {
 		return null;
 	}
 
-	async function openTheSidebar( newNotesArea ) {
-		const currentActiveArea = await getActiveComplementaryArea( 'core' );
+	async function openTheSidebar() {
+		const prevArea = await getActiveComplementaryArea( 'core' );
+		const activeNotesArea = SIDEBARS.find( ( name ) => name === prevArea );
 
-		const activeNotesArea = SIDEBARS.find(
-			( name ) => name === currentActiveArea
-		);
-
+		// If the notes sidebar is not already active, enable the pinned sidebar.
 		if ( ! activeNotesArea ) {
-			// If the notes sidebar is not already active, enable the notes sidebar.
-			// Default to the floating notes sidebar.
-			enableComplementaryArea(
-				'core',
-				newNotesArea || collabSidebarName
-			);
-		} else if (
-			activeNotesArea &&
-			newNotesArea &&
-			activeNotesArea !== newNotesArea
-		) {
-			// If the current notes sidebar is not the one we want to open, disable it and enable the new one.
-			disableComplementaryArea( 'core', activeNotesArea );
-			enableComplementaryArea( 'core', newNotesArea );
+			enableComplementaryArea( 'core', collabSidebarName );
+		}
+
+		const currentArea = await getActiveComplementaryArea( 'core' );
+		// Bail out if the current active area is not one of note sidebars.
+		if ( ! SIDEBARS.includes( currentArea ) ) {
+			return;
 		}
 
 		setShowCommentBoard( ! blockCommentId );
@@ -171,10 +161,10 @@ export default function CollabSidebar() {
 				<CommentAvatarIndicator
 					thread={ currentThread }
 					hasMoreComments={ hasMoreComments }
-					onClick={ () => openTheSidebar() }
+					onClick={ openTheSidebar }
 				/>
 			) }
-			<AddCommentMenuItem onClick={ () => openTheSidebar() } />
+			<AddCommentMenuItem onClick={ openTheSidebar } />
 			<PluginSidebar
 				identifier={ collabHistorySidebarName }
 				title={ __( 'Notes' ) }
@@ -216,7 +206,9 @@ export default function CollabSidebar() {
 				) }
 			<PluginMoreMenuItem
 				icon={ commentIcon }
-				onClick={ () => openTheSidebar( collabHistorySidebarName ) }
+				onClick={ () =>
+					enableComplementaryArea( 'core', collabHistorySidebarName )
+				}
 			>
 				{ __( 'Notes' ) }
 			</PluginMoreMenuItem>

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -86,7 +86,8 @@ function CollabSidebarContent( {
 export default function CollabSidebar() {
 	const [ showCommentBoard, setShowCommentBoard ] = useState( false );
 	const { getActiveComplementaryArea } = useSelect( interfaceStore );
-	const { enableComplementaryArea } = useDispatch( interfaceStore );
+	const { enableComplementaryArea, disableComplementaryArea } =
+		useDispatch( interfaceStore );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const commentSidebarRef = useRef( null );
 
@@ -131,19 +132,28 @@ export default function CollabSidebar() {
 		return null;
 	}
 
-	async function openTheSidebar() {
-		const prevArea = await getActiveComplementaryArea( 'core' );
-		const activeNotesArea = SIDEBARS.find( ( name ) => name === prevArea );
+	async function openTheSidebar( newNotesArea ) {
+		const currentActiveArea = await getActiveComplementaryArea( 'core' );
 
-		// If the notes sidebar is not already active, enable floating sidebar.
+		const activeNotesArea = SIDEBARS.find(
+			( name ) => name === currentActiveArea
+		);
+
 		if ( ! activeNotesArea ) {
-			enableComplementaryArea( 'core', collabSidebarName );
-		}
-
-		const currentArea = await getActiveComplementaryArea( 'core' );
-		// Bail out if the current active area is not one of note sidebars.
-		if ( ! SIDEBARS.includes( currentArea ) ) {
-			return;
+			// If the notes sidebar is not already active, enable the notes sidebar.
+			// Default to the floating notes sidebar.
+			enableComplementaryArea(
+				'core',
+				newNotesArea || collabSidebarName
+			);
+		} else if (
+			activeNotesArea &&
+			newNotesArea &&
+			activeNotesArea !== newNotesArea
+		) {
+			// If the current notes sidebar is not the one we want to open, disable it and enable the new one.
+			disableComplementaryArea( 'core', activeNotesArea );
+			enableComplementaryArea( 'core', newNotesArea );
 		}
 
 		setShowCommentBoard( ! blockCommentId );
@@ -161,10 +171,10 @@ export default function CollabSidebar() {
 				<CommentAvatarIndicator
 					thread={ currentThread }
 					hasMoreComments={ hasMoreComments }
-					onClick={ openTheSidebar }
+					onClick={ () => openTheSidebar() }
 				/>
 			) }
-			<AddCommentMenuItem onClick={ openTheSidebar } />
+			<AddCommentMenuItem onClick={ () => openTheSidebar() } />
 			<PluginSidebar
 				identifier={ collabHistorySidebarName }
 				title={ __( 'Notes' ) }
@@ -204,7 +214,10 @@ export default function CollabSidebar() {
 						/>
 					</PluginSidebar>
 				) }
-			<PluginMoreMenuItem icon={ commentIcon } onClick={ openTheSidebar }>
+			<PluginMoreMenuItem
+				icon={ commentIcon }
+				onClick={ () => openTheSidebar( collabHistorySidebarName ) }
+			>
 				{ __( 'Notes' ) }
 			</PluginMoreMenuItem>
 		</>

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -14,7 +14,11 @@ import { store as interfaceStore } from '@wordpress/interface';
  * Internal dependencies
  */
 import PluginSidebar from '../plugin-sidebar';
-import { collabHistorySidebarName, collabSidebarName } from './constants';
+import {
+	collabHistorySidebarName,
+	collabSidebarName,
+	SIDEBARS,
+} from './constants';
 import { Comments } from './comments';
 import { AddComment } from './add-comment';
 import { store as editorStore } from '../../store';
@@ -54,14 +58,12 @@ function CollabSidebarContent( {
 				commentSidebarRef.current = node;
 			} }
 		>
-			{ ( ! isFloating || ( isFloating && showCommentBoard ) ) && (
-				<AddComment
-					onSubmit={ onCreate }
-					showCommentBoard={ showCommentBoard }
-					setShowCommentBoard={ setShowCommentBoard }
-					commentSidebarRef={ commentSidebarRef }
-				/>
-			) }
+			<AddComment
+				onSubmit={ onCreate }
+				showCommentBoard={ showCommentBoard }
+				setShowCommentBoard={ setShowCommentBoard }
+				commentSidebarRef={ commentSidebarRef }
+			/>
 			<Comments
 				threads={ comments }
 				onEditComment={ onEdit }
@@ -84,8 +86,7 @@ function CollabSidebarContent( {
 export default function CollabSidebar() {
 	const [ showCommentBoard, setShowCommentBoard ] = useState( false );
 	const { getActiveComplementaryArea } = useSelect( interfaceStore );
-	const { enableComplementaryArea, disableComplementaryArea } =
-		useDispatch( interfaceStore );
+	const { enableComplementaryArea } = useDispatch( interfaceStore );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const commentSidebarRef = useRef( null );
 
@@ -131,31 +132,27 @@ export default function CollabSidebar() {
 	}
 
 	async function openTheSidebar() {
-		const activeArea = await getActiveComplementaryArea( 'core' );
+		const prevArea = await getActiveComplementaryArea( 'core' );
+		const activeNotesArea = SIDEBARS.find( ( name ) => name === prevArea );
 
-		// If adding a new comment, handle sidebar logic based on what's currently open.
-		if ( ! blockCommentId ) {
-			setShowCommentBoard( true );
+		// If the notes sidebar is not already active, enable floating sidebar.
+		if ( ! activeNotesArea ) {
+			enableComplementaryArea( 'core', collabSidebarName );
+		}
 
-			// If Notes sidebar is already open, keep it open.
-			if ( activeArea === collabHistorySidebarName ) {
-				// Notes sidebar is open, keep it open and show floating form.
-				return;
-			}
-
-			// If any other sidebar is open (like Page sidebar), close it to make room for floating sidebar.
-			if ( activeArea && activeArea !== collabHistorySidebarName ) {
-				disableComplementaryArea( 'core' );
-				enableComplementaryArea( 'core', collabSidebarName );
-			}
-
+		const currentArea = await getActiveComplementaryArea( 'core' );
+		// Bail out if the current active area is not one of note sidebars.
+		if ( ! SIDEBARS.includes( currentArea ) ) {
 			return;
 		}
 
-		// Otherwise, open the sidebar as usual.
-		enableComplementaryArea( 'core', collabHistorySidebarName );
-		setShowCommentBoard( false );
-		focusCommentThread( blockCommentId, commentSidebarRef.current );
+		setShowCommentBoard( ! blockCommentId );
+		focusCommentThread(
+			blockCommentId,
+			commentSidebarRef.current,
+			// Focus a comment thread when there's a selected block with a comment.
+			! blockCommentId ? 'textarea' : undefined
+		);
 	}
 
 	return (

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -48,12 +48,13 @@ function CollabSidebarContent( {
 			style={ styles }
 			role="list"
 			spacing="3"
+			justify="flex-start"
 			ref={ ( node ) => {
 				// Keeps the ref fresh when switching between floating and pinned sidebar.
 				commentSidebarRef.current = node;
 			} }
 		>
-			{ ! isFloating && (
+			{ ( ! isFloating || ( isFloating && showCommentBoard ) ) && (
 				<AddComment
 					onSubmit={ onCreate }
 					showCommentBoard={ showCommentBoard }
@@ -83,7 +84,8 @@ function CollabSidebarContent( {
 export default function CollabSidebar() {
 	const [ showCommentBoard, setShowCommentBoard ] = useState( false );
 	const { getActiveComplementaryArea } = useSelect( interfaceStore );
-	const { enableComplementaryArea } = useDispatch( interfaceStore );
+	const { enableComplementaryArea, disableComplementaryArea } =
+		useDispatch( interfaceStore );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const commentSidebarRef = useRef( null );
 
@@ -129,23 +131,31 @@ export default function CollabSidebar() {
 	}
 
 	async function openTheSidebar() {
-		enableComplementaryArea( 'core', collabHistorySidebarName );
 		const activeArea = await getActiveComplementaryArea( 'core' );
 
-		// Move focus to the target element after the sidebar has opened.
-		if (
-			[ collabHistorySidebarName, collabSidebarName ].includes(
-				activeArea
-			)
-		) {
-			setShowCommentBoard( ! blockCommentId );
-			focusCommentThread(
-				blockCommentId,
-				commentSidebarRef.current,
-				// Focus a comment thread when there's a selected block with a comment.
-				! blockCommentId ? 'textarea' : undefined
-			);
+		// If adding a new comment, handle sidebar logic based on what's currently open.
+		if ( ! blockCommentId ) {
+			setShowCommentBoard( true );
+
+			// If Notes sidebar is already open, keep it open.
+			if ( activeArea === collabHistorySidebarName ) {
+				// Notes sidebar is open, keep it open and show floating form.
+				return;
+			}
+
+			// If any other sidebar is open (like Page sidebar), close it to make room for floating sidebar.
+			if ( activeArea && activeArea !== collabHistorySidebarName ) {
+				disableComplementaryArea( 'core' );
+				enableComplementaryArea( 'core', collabSidebarName );
+			}
+
+			return;
 		}
+
+		// Otherwise, open the sidebar as usual.
+		enableComplementaryArea( 'core', collabHistorySidebarName );
+		setShowCommentBoard( false );
+		focusCommentThread( blockCommentId, commentSidebarRef.current );
 	}
 
 	return (
@@ -173,29 +183,30 @@ export default function CollabSidebar() {
 					commentLastUpdated={ commentLastUpdated }
 				/>
 			</PluginSidebar>
-			{ isLargeViewport && unresolvedSortedThreads.length > 0 && (
-				<PluginSidebar
-					isPinnable={ false }
-					header={ false }
-					identifier={ collabSidebarName }
-					className="editor-collab-sidebar"
-					headerClassName="editor-collab-sidebar__header"
-					backgroundColor={ backgroundColor }
-				>
-					<CollabSidebarContent
-						comments={ unresolvedSortedThreads }
-						showCommentBoard={ showCommentBoard }
-						setShowCommentBoard={ setShowCommentBoard }
-						commentSidebarRef={ commentSidebarRef }
-						reflowComments={ reflowComments }
-						commentLastUpdated={ commentLastUpdated }
-						styles={ {
-							backgroundColor,
-						} }
-						isFloating
-					/>
-				</PluginSidebar>
-			) }
+			{ isLargeViewport &&
+				( unresolvedSortedThreads.length > 0 || showCommentBoard ) && (
+					<PluginSidebar
+						isPinnable={ false }
+						header={ false }
+						identifier={ collabSidebarName }
+						className="editor-collab-sidebar"
+						headerClassName="editor-collab-sidebar__header"
+						backgroundColor={ backgroundColor }
+					>
+						<CollabSidebarContent
+							comments={ unresolvedSortedThreads }
+							showCommentBoard={ showCommentBoard }
+							setShowCommentBoard={ setShowCommentBoard }
+							commentSidebarRef={ commentSidebarRef }
+							reflowComments={ reflowComments }
+							commentLastUpdated={ commentLastUpdated }
+							styles={ {
+								backgroundColor,
+							} }
+							isFloating
+						/>
+					</PluginSidebar>
+				) }
 			<PluginMoreMenuItem icon={ commentIcon } onClick={ openTheSidebar }>
 				{ __( 'Notes' ) }
 			</PluginMoreMenuItem>

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -33,6 +33,7 @@
 	&.is-selected {
 		background-color: $white;
 		box-shadow: $elevation-medium;
+		z-index: 1;
 	}
 
 	&:focus {

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -10,8 +10,9 @@ test.use( {
 } );
 
 test.describe( 'Block Comments', () => {
-	test.beforeEach( async ( { admin } ) => {
+	test.beforeEach( async ( { admin, blockCommentUtils } ) => {
 		await admin.createNewPost();
+		await blockCommentUtils.openBlockCommentSidebar();
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes part of #72157 **( Since we have comments in the canvas, don't open the block comments sidebar when adding one. The sidebar should be thought of as a historical archive of comments, one you open to see previous or resolved comments, not the primary interface for engaging with comments.)**

<!-- In a few words, what is the PR actually doing? -->
Improves block comment UX by preventing sidebar from opening when adding comments.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The block comments sidebar opens when adding a new comment, but it should be thought of as a historical archive for existing comments, not the primary interface for engaging with comments.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
**Changes made:**

1. **Modified `CollabSidebarContent` in `index.js`**: Added conditional rendering to only show the `Comments` component when not in "add comment" mode (`!showCommentBoard`). This ensures only the comment form is visible when adding comments, not existing comments.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page in the editor.
2. Select a block and add a comment using the comment functionality.
3. **Verify**: Only the comment form is visible in the canvas, not existing comments.
4. Submit the comment.
5. Now the whole comment canvas will be shown.

## Video <!-- if applicable -->


https://github.com/user-attachments/assets/b74debae-be54-4bf4-a44e-a9b8de6fefaa

cc @Mamaduka 
