### PR TITLE
Wait for transpilation of all JS files before compiling styles

### DIFF
--- a/bin/packages/build.mjs
+++ b/bin/packages/build.mjs
@@ -878,9 +878,9 @@ async function transpilePackage( packageName ) {
 		}
 	}
 
-	await compileStyles( packageName );
-
 	await Promise.all( builds );
+
+	await compileStyles( packageName );
 
 	return Date.now() - startTime;
 }


### PR DESCRIPTION
## What?
Closes #72390

Waiting for transpilation of all JS/JSX/TS/TSX files before compiling styles.

## Why?
It prevents dev build process from crashing in watch mode due to incorrect syntax.

## How?
Changing the order solves the issue, but root cause is still the mystery.

## Testing Instructions
1. Run `npm run dev`
2. Add partial syntax like `<` in any file.
3. Observe the terminal.
4. The build process should not crash and continue rebuilding the project on subsequent code change.

