### PR TITLE
Fix focus loss from unsync and edit button in navigation link inspector sidebar

### DIFF
--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -11,7 +11,7 @@ import {
 	TextareaControl,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { useRef } from '@wordpress/element';
+import { useRef, useEffect } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
 import { safeDecodeURI } from '@wordpress/url';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
@@ -72,6 +72,8 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 	const { label, url, description, rel, opensInNewTab } = attributes;
 	const lastURLRef = useRef( url );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+	const urlInputRef = useRef();
+	const shouldFocusURLInputRef = useRef( false );
 	const inputId = useInstanceId( Controls, 'link-input' );
 	const helpTextId = `${ inputId }__help`;
 
@@ -84,7 +86,7 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 	// Get direct store dispatch to bypass setBoundAttributes wrapper
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
-	const editBoundLink = () => {
+	const unsyncBoundLink = () => {
 		// Clear the binding first
 		clearBinding();
 
@@ -95,6 +97,13 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 		// See: packages/block-editor/src/components/block-edit/edit.js
 		updateBlockAttributes( clientId, { url: '', id: undefined } );
 	};
+
+	useEffect( () => {
+		if ( shouldFocusURLInputRef.current ) {
+			urlInputRef.current?.focus();
+			shouldFocusURLInputRef.current = false;
+		}
+	}, [ hasUrlBinding ] );
 
 	return (
 		<ToolsPanel
@@ -135,6 +144,7 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 				isShownByDefault
 			>
 				<InputControl
+					ref={ urlInputRef }
 					__nextHasNoMarginBottom
 					__next40pxDefaultSize
 					id={ inputId }
@@ -180,7 +190,12 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 						hasUrlBinding && (
 							<Button
 								icon={ unlinkIcon }
-								onClick={ editBoundLink }
+								onClick={ () => {
+									unsyncBoundLink();
+									// focus management to send focus to the URL input
+									// on next render after disabled state is removed
+									shouldFocusURLInputRef.current = true;
+								} }
 								aria-describedby={ helpTextId }
 								showTooltip
 								label={ __( 'Unsync and edit' ) }

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -192,8 +192,8 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 								icon={ unlinkIcon }
 								onClick={ () => {
 									unsyncBoundLink();
-									// focus management to send focus to the URL input
-									// on next render after disabled state is removed
+									// Focus management to send focus to the URL input
+									// on next render after disabled state is removed.
 									shouldFocusURLInputRef.current = true;
 								} }
 								aria-describedby={ helpTextId }

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -99,10 +99,10 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 	};
 
 	useEffect( () => {
-		if ( shouldFocusURLInputRef.current ) {
+		if ( ! hasUrlBinding && shouldFocusURLInputRef.current ) {
 			urlInputRef.current?.focus();
-			shouldFocusURLInputRef.current = false;
 		}
+		shouldFocusURLInputRef.current = false;
 	}, [ hasUrlBinding ] );
 
 	return (

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -1070,6 +1070,7 @@ test.describe( 'Navigation block', () => {
 				await unlinkButton.click();
 				await expect( linkInput ).toBeEnabled();
 				await expect( linkInput ).toHaveValue( '' );
+				await expect( linkInput ).toBeFocused();
 			} );
 		} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Fixes a focus loss from the inspector sidebar on navigation links when pressing the unsync and edit button

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The unsync and edit button enables the disabled input and removes the button that was focused. This causes a focus loss. We need to manage focus to meet accessibility standards. 


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Add urlInputRef for the input
- Add shouldFocusURLInputRef for knowing if we should focus on next render (we can't focus immediately, as the input is disabled and cannot receive focus)
- useEffect to check if we should send focus to the input when hasUrlBinding changes
- Defensively check for if we should send focus:
   - Only focus if hasUrlBinding is false
   - ALWAYS reset the shouldFocusURLInputRef to false
- Added test to check for focus after the unsync and edit button is clicked

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- With an entity bound navigation link selected
- Open the inspector sidebar
- Click "unsync and edit" button from the disabled url input field
- Url input should be focused

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
