### PR TITLE
Real-time collaboration: Add Yjs awareness

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -382,7 +382,6 @@ async function loadPostTypeEntities() {
 					 * @type {Record< string, boolean >}
 					 */
 					supports: {
-						awareness: true,
 						crdtPersistence: true,
 					},
 				};

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -382,6 +382,7 @@ async function loadPostTypeEntities() {
 					 * @type {Record< string, boolean >}
 					 */
 					supports: {
+						awareness: true,
 						crdtPersistence: true,
 					},
 				};

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -111,13 +111,9 @@ export function createSyncManager(): SyncManager {
 
 		// Create providers for the given entity and its Yjs document.
 		const providerResults = await Promise.all(
-			providerCreators.map( ( create ) => {
-				const awareness = syncConfig.supports?.awareness
-					? new Awareness( ydoc )
-					: undefined;
-
-				return create( objectType, objectId, ydoc, awareness );
-			} )
+			providerCreators.map( ( create ) =>
+				create( objectType, objectId, ydoc, new Awareness( ydoc ) )
+			)
 		);
 
 		// Attach observers.

--- a/packages/sync/src/manager.ts
+++ b/packages/sync/src/manager.ts
@@ -24,6 +24,7 @@ import type {
 	SyncManager,
 } from './types';
 import { createYjsDoc } from './utils';
+import { Awareness } from 'y-protocols/awareness';
 
 interface EntityState {
 	handlers: RecordHandlers;
@@ -110,9 +111,13 @@ export function createSyncManager(): SyncManager {
 
 		// Create providers for the given entity and its Yjs document.
 		const providerResults = await Promise.all(
-			providerCreators.map( ( create ) =>
-				create( objectType, objectId, ydoc )
-			)
+			providerCreators.map( ( create ) => {
+				const awareness = syncConfig.supports?.awareness
+					? new Awareness( ydoc )
+					: undefined;
+
+				return create( objectType, objectId, ydoc, awareness );
+			} )
 		);
 
 		// Attach observers.

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import * as Y from 'yjs';
+import { Awareness } from 'y-protocols/awareness';
 import * as fun from 'lib0/function';
 import {
 	describe,
@@ -136,7 +137,28 @@ describe( 'SyncManager', () => {
 			expect( mockProviderCreator ).toHaveBeenCalledWith(
 				'post',
 				'123',
-				expect.any( Y.Doc )
+				expect.any( Y.Doc ),
+				undefined
+			);
+		} );
+
+		it( 'creates providers with awareness when supported', async () => {
+			const manager = createSyncManager();
+
+			await manager.load(
+				{ ...mockSyncConfig, supports: { awareness: true } },
+				'post',
+				'123',
+				mockRecord,
+				mockHandlers
+			);
+
+			expect( mockProviderCreator ).toHaveBeenCalledTimes( 1 );
+			expect( mockProviderCreator ).toHaveBeenCalledWith(
+				'post',
+				'123',
+				expect.any( Y.Doc ),
+				expect.any( Awareness )
 			);
 		} );
 

--- a/packages/sync/src/test/manager.ts
+++ b/packages/sync/src/test/manager.ts
@@ -138,26 +138,6 @@ describe( 'SyncManager', () => {
 				'post',
 				'123',
 				expect.any( Y.Doc ),
-				undefined
-			);
-		} );
-
-		it( 'creates providers with awareness when supported', async () => {
-			const manager = createSyncManager();
-
-			await manager.load(
-				{ ...mockSyncConfig, supports: { awareness: true } },
-				'post',
-				'123',
-				mockRecord,
-				mockHandlers
-			);
-
-			expect( mockProviderCreator ).toHaveBeenCalledTimes( 1 );
-			expect( mockProviderCreator ).toHaveBeenCalledWith(
-				'post',
-				'123',
-				expect.any( Y.Doc ),
 				expect.any( Awareness )
 			);
 		} );

--- a/packages/sync/src/types.ts
+++ b/packages/sync/src/types.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type * as Y from 'yjs';
+import type { Awareness } from 'y-protocols/awareness';
 
 /**
  * Internal dependencies
@@ -50,7 +51,8 @@ export interface ProviderCreatorResult {
 export type ProviderCreator = (
 	objectType: ObjectType,
 	objectId: ObjectID,
-	ydoc: Y.Doc
+	ydoc: Y.Doc,
+	awareness?: Awareness
 ) => Promise< ProviderCreatorResult >;
 
 export interface RecordHandlers {


### PR DESCRIPTION

## What?
Instantiate and pass a Yjs `Awareness` instance to the connection creator.

## Why?

An `Awareness` instance allows for the implementation of [awareness / presence indicators](https://docs.yjs.dev/getting-started/adding-awareness) in the UI. These indicators can be provided by Gutenberg in future PRs. Plugins can also provide an implementation by accessing the `Awareness` instance passed to the connection creator function.


## How?

- Add a `supports.awareness` flag to indicate awareness support. It is assumed that some entities will always be edited together and will not need a separate `Awareness` instance.
- Pass the `Awareness` instance to the connection creator.

## Testing Instructions

The `Awareness` instance is unused. Refer the instructions in [this PR](https://github.com/WordPress/gutenberg/pull/72183) for general testing.

### Testing Instructions for Keyboard

No UI changes in this PR
