### PR TITLE
Bundled packages should expose their styles in exports

### DIFF
--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -30,7 +30,8 @@
 			"import": "./build-module/index.js",
 			"require": "./build/index.js"
 		},
-		"./package.json": "./package.json"
+		"./package.json": "./package.json",
+		"./build-style/": "./build-style/"
 	},
 	"react-native": "src/index",
 	"types": "build-types",

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -30,7 +30,8 @@
 			"import": "./build-module/index.js",
 			"require": "./build/index.js"
 		},
-		"./package.json": "./package.json"
+		"./package.json": "./package.json",
+		"./build-style/": "./build-style/"
 	},
 	"react-native": "src/index",
 	"sideEffects": [


### PR DESCRIPTION
Related #72032 

This allow third-parties to "import" these styles directly and not be prevented by the "exports"