### PR TITLE
Cleanup clearBinding usage

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -558,7 +558,7 @@ export default function NavigationLinkEdit( {
 								if ( isEntityLink ) {
 									createBinding( updatedAttributes );
 								} else {
-									clearBinding( updatedAttributes );
+									clearBinding();
 								}
 							} }
 						/>

--- a/packages/block-library/src/navigation-link/shared/use-entity-binding.js
+++ b/packages/block-library/src/navigation-link/shared/use-entity-binding.js
@@ -29,7 +29,7 @@ export function useEntityBinding( { clientId, attributes } ) {
 		if ( hasUrlBinding ) {
 			updateBlockBindings( { url: undefined } );
 		}
-	}, [ updateBlockBindings, hasUrlBinding, metadata, id ] );
+	}, [ updateBlockBindings, hasUrlBinding ] );
 
 	const createBinding = useCallback(
 		( updatedAttributes ) => {

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -447,7 +447,7 @@ export default function NavigationSubmenuEdit( {
 								if ( isEntityLink ) {
 									createBinding( updatedAttributes );
 								} else {
-									clearBinding( updatedAttributes );
+									clearBinding();
 								}
 							} }
 						/>

--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -124,7 +124,7 @@ function AdditionalBlockContent( { block, insertedBlock, setInsertedBlock } ) {
 				if ( isEntityLink ) {
 					createBinding( updatedAttributes );
 				} else {
-					clearBinding( updatedAttributes );
+					clearBinding();
 				}
 
 				setInsertedBlock( null );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->


## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Follow-up to https://github.com/WordPress/gutenberg/pull/72165

<!-- In a few words, what is the PR actually doing? -->
Cleans up the clearBinding usage. clearBinding doesn't accept any params, yet it was receiving them. Also, it had things in its useEffect dependency array that were not used.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Code quality

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Remove params passed in clearBinding
- Remove unused params from dependency array

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
