### PR TITLE
Block Bindings: Remove spurious attributes from supported-by-6.8 list

### DIFF
--- a/backport-changelog/6.9/10322.md
+++ b/backport-changelog/6.9/10322.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/10322
 
 - https://github.com/WordPress/gutenberg/pull/72418
+- https://github.com/WordPress/gutenberg/pull/72442

--- a/lib/compat/wordpress-6.9/block-bindings.php
+++ b/lib/compat/wordpress-6.9/block-bindings.php
@@ -211,14 +211,17 @@ function gutenberg_process_block_bindings( $instance ) {
 	$parsed_block        = $instance->parsed_block;
 	$computed_attributes = array();
 
-	// List of block attributes supported by Block Bindings in WP 6.8.
+	/*
+	 * List of block attributes supported by Block Bindings in WP 6.8.
+	 * DO NOT MODIFY THIS ARRAY. It's a snapshot of what Core supports in 6.8.
+	 * Use the `block_bindings_supported_attributes` filter instead to add support
+	 * for new block attributes.
+	 */
 	$block_bindings_supported_attributes_6_8 = array(
-		'core/paragraph'          => array( 'content' ),
-		'core/heading'            => array( 'content' ),
-		'core/image'              => array( 'id', 'url', 'title', 'alt' ),
-		'core/button'             => array( 'url', 'text', 'linkTarget', 'rel' ),
-		'core/navigation-link'    => array( 'url' ),
-		'core/navigation-submenu' => array( 'url' ),
+		'core/paragraph' => array( 'content' ),
+		'core/heading'   => array( 'content' ),
+		'core/image'     => array( 'id', 'url', 'title', 'alt' ),
+		'core/button'    => array( 'url', 'text', 'linkTarget', 'rel' ),
 	);
 
 	$supported_block_attributes = gutenberg_get_block_bindings_supported_attributes( $block_type );


### PR DESCRIPTION
## What?
Oversight when working on https://github.com/WordPress/gutenberg/pull/72418. See [here](https://github.com/WordPress/gutenberg/pull/72418#issuecomment-3415895772) for more information.

[Found](https://github.com/WordPress/gutenberg/pull/72287#issuecomment-3415314779) by @getdave while working on https://github.com/WordPress/gutenberg/pull/72287.

## Why?
Block Bindings for Nav Link and Nav Submenu blocks are still broken otherwise.

## How?
By removing two stray lines.

## Testing Instructions
Refer to testing instructions of https://github.com/WordPress/gutenberg/pull/72169.