### PR TITLE
Fix empty url value from unbinding entity from inspector sidebar

### DIFF
--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -99,6 +99,8 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 	};
 
 	useEffect( () => {
+		// Checking for ! hasUrlBinding is a defensive check, as we would
+		// only want to focus the input if the url is not bound to an entity.
 		if ( ! hasUrlBinding && shouldFocusURLInputRef.current ) {
 			urlInputRef.current?.focus();
 		}

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -104,7 +104,7 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 		// processes attributes through the binding system.
 		// See: packages/block-editor/src/components/block-edit/edit.js
 		updateBlockAttributes( clientId, {
-			url: lastURLRef.current,
+			url: lastURLRef.current, // set the lastURLRef as the new editable value so we avoid bugs from empty link states
 			id: undefined,
 		} );
 	};
@@ -173,9 +173,9 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 							return;
 						}
 
-						// Don't update the actual url attribute yet, defer to onBlur so we
-						// don't end up with the canvas thinking the url is empty, which causes
-						// the label to be replaced by the placeholder text.
+						// Defer updating the url attribute until onBlur to prevent the canvas from
+						// treating a temporary empty value as a committed value, which replaces the
+						// label with placeholder text.
 						setInputValue( newValue );
 					} }
 					onFocus={ () => {

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -83,6 +83,7 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 	// Sync local state when url prop changes (e.g., from undo/redo or external updates)
 	useEffect( () => {
 		setInputValue( url );
+		lastURLRef.current = url;
 	}, [ url ] );
 
 	// Use the entity binding hook internally

--- a/packages/block-library/src/navigation-link/shared/controls.js
+++ b/packages/block-library/src/navigation-link/shared/controls.js
@@ -11,7 +11,7 @@ import {
 	TextareaControl,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { useRef, useEffect } from '@wordpress/element';
+import { useRef, useEffect, useState } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
 import { safeDecodeURI } from '@wordpress/url';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
@@ -77,6 +77,14 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 	const inputId = useInstanceId( Controls, 'link-input' );
 	const helpTextId = `${ inputId }__help`;
 
+	// Local state to control the input value
+	const [ inputValue, setInputValue ] = useState( url );
+
+	// Sync local state when url prop changes (e.g., from undo/redo or external updates)
+	useEffect( () => {
+		setInputValue( url );
+	}, [ url ] );
+
 	// Use the entity binding hook internally
 	const { hasUrlBinding, clearBinding } = useEntityBinding( {
 		clientId,
@@ -95,14 +103,19 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 		// setAttributes is actually setBoundAttributes, a wrapper function that
 		// processes attributes through the binding system.
 		// See: packages/block-editor/src/components/block-edit/edit.js
-		updateBlockAttributes( clientId, { url: '', id: undefined } );
+		updateBlockAttributes( clientId, {
+			url: lastURLRef.current,
+			id: undefined,
+		} );
 	};
 
 	useEffect( () => {
 		// Checking for ! hasUrlBinding is a defensive check, as we would
 		// only want to focus the input if the url is not bound to an entity.
 		if ( ! hasUrlBinding && shouldFocusURLInputRef.current ) {
-			urlInputRef.current?.focus();
+			// focuses and highlights the url input value, giving the user
+			// the ability to delete the value quickly or edit it.
+			urlInputRef.current?.select();
 		}
 		shouldFocusURLInputRef.current = false;
 	}, [ hasUrlBinding ] );
@@ -151,18 +164,20 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 					__next40pxDefaultSize
 					id={ inputId }
 					label={ __( 'Link' ) }
-					value={ url ? safeDecodeURI( url ) : '' }
-					onChange={ ( urlValue ) => {
-						if ( hasUrlBinding ) {
-							return; // Prevent editing when URL is bound
-						}
-						setAttributes( {
-							url: encodeURI( safeDecodeURI( urlValue ) ),
-						} );
-					} }
+					value={ inputValue ? safeDecodeURI( inputValue ) : '' }
 					autoComplete="off"
 					type="url"
 					disabled={ hasUrlBinding }
+					onChange={ ( newValue ) => {
+						if ( hasUrlBinding ) {
+							return;
+						}
+
+						// Don't update the actual url attribute yet, defer to onBlur so we
+						// don't end up with the canvas thinking the url is empty, which causes
+						// the label to be replaced by the placeholder text.
+						setInputValue( newValue );
+					} }
 					onFocus={ () => {
 						if ( hasUrlBinding ) {
 							return;
@@ -173,12 +188,19 @@ export function Controls( { attributes, setAttributes, clientId } ) {
 						if ( hasUrlBinding ) {
 							return;
 						}
+
+						const finalValue = ! inputValue
+							? lastURLRef.current
+							: inputValue;
+
+						// Update local state immediately so input reflects the reverted value if the value was cleared
+						setInputValue( finalValue );
+
 						// Defer the updateAttributes call to ensure entity connection isn't severed by accident.
-						updateAttributes(
-							{ url: ! url ? lastURLRef.current : url },
-							setAttributes,
-							{ ...attributes, url: lastURLRef.current }
-						);
+						updateAttributes( { url: finalValue }, setAttributes, {
+							...attributes,
+							url: lastURLRef.current,
+						} );
 					} }
 					help={
 						hasUrlBinding && (

--- a/packages/block-library/src/navigation-link/shared/test/controls.js
+++ b/packages/block-library/src/navigation-link/shared/test/controls.js
@@ -6,6 +6,7 @@
  * External dependencies
  */
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
@@ -95,16 +96,16 @@ describe( 'Controls', () => {
 		expect( urlInput.value ).toBe( 'https://example.com/test page' );
 	} );
 
-	it( 'calls updateAttributes with new URL on blur', () => {
+	it( 'calls updateAttributes with new URL on blur', async () => {
+		const user = userEvent.setup();
 		render( <Controls { ...defaultProps } /> );
 
 		const urlInput = screen.getByLabelText( 'Link' );
 
-		fireEvent.focus( urlInput );
-		fireEvent.change( urlInput, {
-			target: { value: 'https://example.com/test page' },
-		} );
-		fireEvent.blur( urlInput );
+		await user.click( urlInput );
+		await user.clear( urlInput );
+		await user.type( urlInput, 'https://example.com/test page' );
+		await user.tab();
 
 		expect( mockUpdateAttributes ).toHaveBeenCalledWith(
 			{ url: 'https://example.com/test page' },

--- a/packages/block-library/src/navigation-link/shared/test/controls.js
+++ b/packages/block-library/src/navigation-link/shared/test/controls.js
@@ -95,18 +95,22 @@ describe( 'Controls', () => {
 		expect( urlInput.value ).toBe( 'https://example.com/test page' );
 	} );
 
-	it( 'encodes URL values when changed', () => {
+	it( 'calls updateAttributes with new URL on blur', () => {
 		render( <Controls { ...defaultProps } /> );
 
 		const urlInput = screen.getByLabelText( 'Link' );
 
+		fireEvent.focus( urlInput );
 		fireEvent.change( urlInput, {
 			target: { value: 'https://example.com/test page' },
 		} );
+		fireEvent.blur( urlInput );
 
-		expect( defaultProps.setAttributes ).toHaveBeenCalledWith( {
-			url: 'https://example.com/test%20page',
-		} );
+		expect( mockUpdateAttributes ).toHaveBeenCalledWith(
+			{ url: 'https://example.com/test page' },
+			defaultProps.setAttributes,
+			{ ...defaultProps.attributes, url: 'https://example.com' }
+		);
 	} );
 
 	it( 'calls updateAttributes on URL blur', () => {
@@ -143,11 +147,11 @@ describe( 'Controls', () => {
 			target: { value: 'https://new.com' },
 		} );
 
-		// Blur should call updateAttributes with the current URL (since url exists)
+		// Blur should call updateAttributes with the new URL value from the input
 		fireEvent.blur( urlInput );
 
 		expect( mockUpdateAttributes ).toHaveBeenCalledWith(
-			{ url: 'https://different.com' }, // Current URL from attributes (not input value)
+			{ url: 'https://new.com' }, // New URL from input value
 			defaultProps.setAttributes,
 			{
 				...propsWithDifferentUrl.attributes,

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -1069,7 +1069,7 @@ test.describe( 'Navigation block', () => {
 				} );
 				await unlinkButton.click();
 				await expect( linkInput ).toBeEnabled();
-				await expect( linkInput ).toHaveValue( '' );
+				await expect( linkInput ).toHaveValue( updatedPage.link );
 				await expect( linkInput ).toBeFocused();
 			} );
 		} );


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/72481

Unbinding the navigation link entity from the sidebar updates the url value to be '', which causes the canvas to go into its empty URL state, which removes the label. Then, when you start typing in the url link input, it would steal focus back to the canvas. This changes the flow when unbinding to set the url as the previously linked url, which avoids an empty link issue. However, you can still get to the messed up state by deleting the url value. To fix this, instead of updating the attribute onChange, update it onBlur so we can restore the last known url.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
When unsyncing the entity of a navigation link from the inspector sidebar:
1. the on-canvas label becomes the placeholder (select page) even though the text field in the sidebar still preserves the page name
2. When you start typing in the link url field the first time, focus is stolen to the canvas after the first keypress

<!-- In a few words, what is the PR actually doing? -->
This PR fixes the issue by filling the url field with the existing entity link url so it doesn't get an empty value, which means the placeholder on the canvas does not show.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The current flow is clearly not the ideal behavior. It's a bug.

## How?
This does not need to be the final solution, as I think integrating the link control with this field will ultimately be better. However, the behavior on trunk is very buggy, and this PR does not feel buggy.
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Instead of clearing the URL, set it as the entity url that was just unsynced
- Don't update the url value onChange, wait until the blur event. Otherwise, if they delete their URL while still focused on the input, the canvas will show the label placeholder again
- Update the url onBlur (it already is anyways). If the value is empty onBlur, revert to the previous link value instead.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- From an entity bound navigation link
- Go to its inspector sidebar
- Click the Unsync and edit button
- The link text should be whatever the previously bound url is
- The link text should be selected so you can easily delete it
- Update the link
- Move focus away from the link.
- Check it works as expected

- From an entity bound navigation link
- Go to its inspector sidebar
- Click the Unsync and edit button
- Delete the url
- The on canvas text label should remain
- Tab away from the field
- The url link input should revert to the value it was before editing began

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

**Before**

https://github.com/user-attachments/assets/f06028de-a122-4d34-bf2c-6478df8d8ca6 

**After**

https://github.com/user-attachments/assets/19ec6720-d2b2-451c-9950-a11a569a5e8f 




