### PR TITLE
Real-time collaboration: Add typings in `core-data` for `@wordpress__blocks`

### DIFF
--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -7,11 +7,9 @@ import fastDeepEqual from 'fast-deep-equal/es6';
 /**
  * WordPress dependencies
  */
+import { getBlockTypes } from '@wordpress/blocks';
 import { RichTextData } from '@wordpress/rich-text';
 import { Y } from '@wordpress/sync';
-
-// @ts-expect-error No exported types.
-import { getBlockTypes } from '@wordpress/blocks';
 
 /**
  * Internal dependencies

--- a/packages/core-data/tsconfig.json
+++ b/packages/core-data/tsconfig.json
@@ -5,6 +5,7 @@
 		"checkJs": false,
 		"noImplicitAny": false
 	},
+	"include": [ "src", "typings" ],
 	"references": [
 		{ "path": "../api-fetch" },
 		{ "path": "../compose" },

--- a/packages/core-data/typings/wordpress__blocks.d.ts
+++ b/packages/core-data/typings/wordpress__blocks.d.ts
@@ -1,0 +1,8 @@
+declare module '@wordpress/blocks' {
+	interface BlockType {
+		name: string;
+		attributes?: Record< string, { type?: string } >;
+	}
+
+	function getBlockTypes(): BlockType[];
+}


### PR DESCRIPTION
See wordpress/wordpress-develop#10282
See wordpress/wordpress-develop#10283

## What?

Add typings in `core-data` for `@wordpress__blocks`.


## Why?

These hard-coded typings avoid the use of `@ts-expect-error`, which generates a TypeScript error in build environments where typings for `@wordpress/blocks` might be incidentally available or inferred. One prominent example is when Gutenberg is built inside `wordpress-develop` ([example build log](https://github.com/WordPress/wordpress-develop/actions/runs/18493174617/job/52753473503)).

## How?

- Add type declarations for `@wordpress/blocks` inside of `packages/core-data`.
   - Define only what is used by TypeScript files.
- Including these type declarations in `tsconfig.json`.

Once `@wordpress/blocks` defines and provides its own types, this change can be reverted.

## Testing Instructions

```sh
$ git clone git@github.com:WordPress/wordpress-develop.git
$ cd wordpress-develop
$ npm install
$ cd src/wp-content/plugins
$ git clone git@github.com:WordPress/gutenberg.git
$ cd gutenberg
$ npm install
$ npm run build
```

### Testing Instructions for Keyboard

n/a
