### PR TITLE
Avoid notes cut off by overflowing bottom border

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -157,12 +157,23 @@ export function Comments( {
 			const selectedThreadTop = blockRect?.top || 0;
 			const selectedThreadHeight = heights[ selectedThreadData.id ] || 0;
 
-			offsets[ selectedThreadData.id ] = -16;
+			// Ensure the selected thread is not overlapping the sidebar bottom border,
+			// otherwise the user may not be able to add a reply.
+			let threadBottom = selectedThreadTop + selectedThreadHeight;
+			const sidebarHeight =
+				commentSidebarRef.current?.getBoundingClientRect().height || 0;
+			if ( threadBottom > sidebarHeight ) {
+				const offset = sidebarHeight - threadBottom - 36;
+				offsets[ selectedThreadData.id ] = offset;
+			} else {
+				offsets[ selectedThreadData.id ] = -16;
+			}
 
-			let previousThreadData = {
-				threadTop: selectedThreadTop - 16,
+			const selectedThreadPreviousData = {
+				threadTop: selectedThreadTop + offsets[ selectedThreadData.id ],
 				threadHeight: selectedThreadHeight,
 			};
+			let previousThreadData = { ...selectedThreadPreviousData };
 
 			// Process threads after the selected thread, offsetting any overlapping
 			// threads downward.
@@ -199,9 +210,7 @@ export function Comments( {
 
 			// Process threads before the selected thread, offsetting any overlapping
 			// threads upward.
-			let nextThreadData = {
-				threadTop: selectedThreadTop - 16,
-			};
+			let nextThreadData = { ...selectedThreadPreviousData };
 
 			for ( let i = selectedThreadIndex - 1; i >= 0; i-- ) {
 				const thread = threads[ i ];
@@ -217,7 +226,7 @@ export function Comments( {
 				let additionalOffset = -16;
 
 				// Calculate the bottom position of this thread with default offset.
-				const threadBottom = threadTop + threadHeight;
+				threadBottom = threadTop + threadHeight;
 
 				// Check if this thread's bottom would overlap with the next thread's top.
 				if ( threadBottom > nextThreadData.threadTop ) {


### PR DESCRIPTION
## What?
Fix a bug where under certain conditions the comment reply form became inaccessible/cur off at the bottom of the screen

<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/72440
[<!-- #ISSUE-NUMBER or URL -->](https://github.com/WordPress/gutenberg/issues/72440)

<!-- In a few words, what is the PR actually doing? -->

## Why?
With very long comments that do not fit in the viewport, users should still be able to enter a new reply.

Considerations:
* The thread can easily get pushed off the top now, making the top of the thread hard to access for very long threads (in floating mode)
* Another approach would be to grow the main editor area to accommodate the floating note height, that way a scrollbar would appear. Can someone suggest how/where to do that?

## How?
The current PR
* Checks the bottom of the active thread against the bottom of the sidebar container
* If there is an overlap shift the active thread up to avoid
* Ensure other threads are also shifted up.



## Testing Instructions
See issue


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
Adjusting while typing

https://github.com/user-attachments/assets/2eacdce4-f67e-4ce4-a6de-2769032c515e

