### PR TITLE
Build: Fix primitives package warning

### DIFF
--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -27,9 +27,9 @@
 	"module": "build-module/index.js",
 	"exports": {
 		".": {
+			"types": "./build-types/index.d.ts",
 			"import": "./build-module/index.js",
-			"require": "./build/index.js",
-			"types": "./build-types/index.d.ts"
+			"require": "./build/index.js"
 		},
 		"./package.json": "./package.json"
 	},


### PR DESCRIPTION
Follow-up to #72428 

The issue is that the order of exports is actually important :) TIL