### PR TITLE
Remove specific logger in test environments

### DIFF
--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -19,7 +19,6 @@ import {
 	validateBlock,
 	isClosedByToken,
 } from '../validation';
-import { createLogger } from '../validation/logger';
 import {
 	registerBlockType,
 	unregisterBlockType,
@@ -758,14 +757,6 @@ describe( 'validation', () => {
 			} );
 
 			expect( isValid ).toBe( true );
-		} );
-	} );
-
-	describe( 'createLogger()', () => {
-		it( 'creates logger that pre-processes string substitutions', () => {
-			createLogger().warning( '%o', { foo: 'bar' } );
-
-			expect( console ).toHaveWarnedWith( "{ foo: 'bar' }" );
 		} );
 	} );
 } );

--- a/packages/blocks/src/api/validation/logger.js
+++ b/packages/blocks/src/api/validation/logger.js
@@ -13,18 +13,8 @@ export function createLogger() {
 	 * @return {Function} Augmented logger function.
 	 */
 	function createLogHandler( logger ) {
-		let log = ( message, ...args ) =>
+		return ( message, ...args ) =>
 			logger( 'Block validation: ' + message, ...args );
-
-		// In test environments, pre-process string substitutions to improve
-		// readability of error messages. We'd prefer to avoid pulling in this
-		// dependency in runtime environments, and it can be dropped by a combo
-		// of Webpack env substitution + UglifyJS dead code elimination.
-		if ( process.env.NODE_ENV === 'test' ) {
-			log = ( ...args ) => logger( require( 'util' ).format( ...args ) );
-		}
-
-		return log;
 	}
 
 	return {


### PR DESCRIPTION
Refs #72032 

This removes the last warning (with #72456) in the output of the build tool. I think this is some very old code that doesn't really add much value to our tests to be honest.

