### PR TITLE
Surface 'Posts per page' setting in more templates

### DIFF
--- a/packages/block-library/src/query/edit/query-content.js
+++ b/packages/block-library/src/query/edit/query-content.js
@@ -14,6 +14,7 @@ import {
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -55,18 +56,15 @@ export default function QueryContent( {
 	} );
 	const { postsPerPage } = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
-		const {
-			getEntityRecord,
-			getEntityRecords,
-			getEntityRecordEdits,
-			canUser,
-		} = select( coreStore );
+		const { getEntityRecord, getEntityRecordEdits, canUser } =
+			select( coreStore );
 		const settingPerPage = canUser( 'read', {
 			kind: 'root',
 			name: 'site',
 		} )
 			? +getEntityRecord( 'root', 'site' )?.posts_per_page
 			: +getSettings().postsPerPage;
+		const { getCurrentPostId } = select( editorStore );
 
 		// Gets changes made via the template area posts per page setting. These won't be saved
 		// until the page is saved, but we should reflect this setting within the query loops
@@ -74,19 +72,23 @@ export default function QueryContent( {
 		const editedSettingPerPage = +getEntityRecordEdits( 'root', 'site' )
 			?.posts_per_page;
 
-		const template = getEntityRecords( 'postType', 'wp_template' )?.find(
-			( record ) => record.slug === templateSlug
-		);
-		const templatePostsPerPage = template?.posts_per_page;
-		const editedTemplatePostsPerPage = getEntityRecordEdits(
+		const templateId = getCurrentPostId();
+		const templatePerPage = getEntityRecord(
 			'postType',
 			'wp_template',
-			template?.id
+			templateId,
+			{ combinedTemplates: false }
 		)?.posts_per_page;
+		const editedTemplatePerPage = getEntityRecordEdits(
+			'postType',
+			'wp_template',
+			templateId
+		)?.posts_per_page;
+
 		return {
 			postsPerPage:
-				editedTemplatePostsPerPage ||
-				templatePostsPerPage ||
+				editedTemplatePerPage ||
+				templatePerPage ||
 				editedSettingPerPage ||
 				settingPerPage ||
 				DEFAULTS_POSTS_PER_PAGE,

--- a/packages/block-library/src/query/edit/query-content.js
+++ b/packages/block-library/src/query/edit/query-content.js
@@ -55,8 +55,12 @@ export default function QueryContent( {
 	} );
 	const { postsPerPage } = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
-		const { getEntityRecord, getEntityRecordEdits, canUser } =
-			select( coreStore );
+		const {
+			getEntityRecord,
+			getEntityRecords,
+			getEntityRecordEdits,
+			canUser,
+		} = select( coreStore );
 		const settingPerPage = canUser( 'read', {
 			kind: 'root',
 			name: 'site',
@@ -70,8 +74,19 @@ export default function QueryContent( {
 		const editedSettingPerPage = +getEntityRecordEdits( 'root', 'site' )
 			?.posts_per_page;
 
+		const template = getEntityRecords( 'postType', 'wp_template' )?.find(
+			( record ) => record.slug === templateSlug
+		);
+		const templatePostsPerPage = template?.posts_per_page;
+		const editedTemplatePostsPerPage = getEntityRecordEdits(
+			'postType',
+			'wp_template',
+			template?.id
+		)?.posts_per_page;
 		return {
 			postsPerPage:
+				editedTemplatePostsPerPage ||
+				templatePostsPerPage ||
 				editedSettingPerPage ||
 				settingPerPage ||
 				DEFAULTS_POSTS_PER_PAGE,

--- a/packages/core-data/src/entity-types/wp-template.ts
+++ b/packages/core-data/src/entity-types/wp-template.ts
@@ -93,6 +93,10 @@ declare module './base-entity-records' {
 			 * The date the template was last modified, in the site's timezone.
 			 */
 			modified: ContextualField< string, 'view' | 'edit', C >;
+			/**
+			 * Blog pages show at most.
+			 */
+			posts_per_page: number;
 		}
 	}
 }

--- a/packages/editor/src/components/posts-per-page/index.js
+++ b/packages/editor/src/components/posts-per-page/index.js
@@ -2,8 +2,8 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
-import { store as coreStore, useEntityProp } from '@wordpress/core-data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 import {
 	Button,
 	Dropdown,
@@ -20,37 +20,51 @@ import { store as editorStore } from '../../store';
 import PostPanelRow from '../post-panel-row';
 
 export default function PostsPerPage() {
-	const { isTemplate, postSlug, templateId, globalPostsPerPage } = useSelect(
-		( select ) => {
-			const { getEditedPostAttribute, getCurrentPostType } =
-				select( editorStore );
-			const { getEntityRecords, getEditedEntityRecord, canUser } =
-				select( coreStore );
-			const siteSettings = canUser( 'read', {
-				kind: 'root',
-				name: 'site',
-			} )
-				? getEditedEntityRecord( 'root', 'site' )
-				: undefined;
-			const slug = getEditedPostAttribute( 'slug' );
-			return {
-				isTemplate: getCurrentPostType() === TEMPLATE_POST_TYPE,
-				postSlug: slug,
-				templateId: getEntityRecords(
-					'postType',
-					TEMPLATE_POST_TYPE
-				)?.find( ( record ) => record.slug === slug )?.id,
-				globalPostsPerPage: siteSettings?.posts_per_page || 1,
-			};
-		},
-		[]
-	);
-	const [ postsPerPage, setPostsPerPage ] = useEntityProp(
-		'postType',
-		TEMPLATE_POST_TYPE,
-		'posts_per_page',
-		templateId
-	);
+	const { editEntityRecord } = useDispatch( coreStore );
+	const {
+		isTemplate,
+		postSlug,
+		templateId,
+		postsPerPage,
+		globalPostsPerPage,
+	} = useSelect( ( select ) => {
+		const { getEditedPostAttribute, getCurrentPostId, getCurrentPostType } =
+			select( editorStore );
+		const {
+			getEntityRecord,
+			getEntityRecordEdits,
+			getEditedEntityRecord,
+			canUser,
+		} = select( coreStore );
+		const siteSettings = canUser( 'read', {
+			kind: 'root',
+			name: 'site',
+		} )
+			? getEditedEntityRecord( 'root', 'site' )
+			: undefined;
+		const slug = getEditedPostAttribute( 'slug' );
+
+		const id = getCurrentPostId();
+		const perPage = getEntityRecord(
+			'postType',
+			TEMPLATE_POST_TYPE,
+			id,
+			{ combinedTemplates: false }
+		)?.posts_per_page;
+		const editedPerPage = getEntityRecordEdits(
+			'postType',
+			TEMPLATE_POST_TYPE,
+			id
+		)?.posts_per_page;
+
+		return {
+			isTemplate: getCurrentPostType() === TEMPLATE_POST_TYPE,
+			postSlug: slug,
+			templateId: id,
+			postsPerPage: editedPerPage || perPage,
+			globalPostsPerPage: siteSettings?.posts_per_page || 1,
+		};
+	}, [] );
 
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
@@ -91,7 +105,9 @@ export default function PostsPerPage() {
 		if ( newPostsPerPage ) {
 			newPostsPerPage = Number( newPostsPerPage );
 		}
-		setPostsPerPage( newPostsPerPage );
+		editEntityRecord( 'postType', TEMPLATE_POST_TYPE, templateId, {
+			posts_per_page: newPostsPerPage,
+		} );
 	};
 	return (
 		<PostPanelRow label={ __( 'Posts per page' ) } ref={ setPopoverAnchor }>

--- a/packages/editor/src/components/posts-per-page/index.js
+++ b/packages/editor/src/components/posts-per-page/index.js
@@ -56,7 +56,8 @@ export default function PostsPerPage() {
 		[ popoverAnchor ]
 	);
 
-	if ( ! isTemplate || ! [ 'home', 'index' ].includes( postSlug ) ) {
+	if ( ! isTemplate || ! [ 'home', 'index', 'author', 'category', 'tag', 'taxonomy', 'date', 'search', 'archive' ]
+		.some( slug => postSlug === slug || postSlug?.startsWith(slug + '-') ) ) {
 		return null;
 	}
 

--- a/packages/editor/src/components/posts-per-page/index.js
+++ b/packages/editor/src/components/posts-per-page/index.js
@@ -20,25 +20,37 @@ import { store as editorStore } from '../../store';
 import PostPanelRow from '../post-panel-row';
 
 export default function PostsPerPage() {
-	const { isTemplate, postSlug, templateId, globalPostsPerPage } = useSelect( ( select ) => {
-		const { getEditedPostAttribute, getCurrentPostType } =
-			select( editorStore );
-		const { getEntityRecords, getEditedEntityRecord, canUser } = select( coreStore );
-		const siteSettings = canUser( 'read', {
-			kind: 'root',
-			name: 'site',
-		} )
-			? getEditedEntityRecord( 'root', 'site' )
-			: undefined;
-		const slug = getEditedPostAttribute( 'slug' );
-		return {
-			isTemplate: getCurrentPostType() === TEMPLATE_POST_TYPE,
-			postSlug: slug,
-			templateId: getEntityRecords( 'postType', TEMPLATE_POST_TYPE)?.find( record => record.slug === slug )?.id,
-			globalPostsPerPage: siteSettings?.posts_per_page || 1,
-		};
-	}, [] );
-	const [ postsPerPage, setPostsPerPage ] = useEntityProp( 'postType', TEMPLATE_POST_TYPE, 'posts_per_page', templateId );
+	const { isTemplate, postSlug, templateId, globalPostsPerPage } = useSelect(
+		( select ) => {
+			const { getEditedPostAttribute, getCurrentPostType } =
+				select( editorStore );
+			const { getEntityRecords, getEditedEntityRecord, canUser } =
+				select( coreStore );
+			const siteSettings = canUser( 'read', {
+				kind: 'root',
+				name: 'site',
+			} )
+				? getEditedEntityRecord( 'root', 'site' )
+				: undefined;
+			const slug = getEditedPostAttribute( 'slug' );
+			return {
+				isTemplate: getCurrentPostType() === TEMPLATE_POST_TYPE,
+				postSlug: slug,
+				templateId: getEntityRecords(
+					'postType',
+					TEMPLATE_POST_TYPE
+				)?.find( ( record ) => record.slug === slug )?.id,
+				globalPostsPerPage: siteSettings?.posts_per_page || 1,
+			};
+		},
+		[]
+	);
+	const [ postsPerPage, setPostsPerPage ] = useEntityProp(
+		'postType',
+		TEMPLATE_POST_TYPE,
+		'posts_per_page',
+		templateId
+	);
 
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
@@ -56,16 +68,30 @@ export default function PostsPerPage() {
 		[ popoverAnchor ]
 	);
 
-	if ( ! isTemplate || ! [ 'home', 'index', 'author', 'category', 'tag', 'taxonomy', 'date', 'search', 'archive' ]
-		.some( slug => postSlug === slug || postSlug?.startsWith(slug + '-') ) ) {
+	if (
+		! isTemplate ||
+		! [
+			'home',
+			'index',
+			'author',
+			'category',
+			'tag',
+			'taxonomy',
+			'date',
+			'search',
+			'archive',
+		].some(
+			( slug ) => postSlug === slug || postSlug?.startsWith( slug + '-' )
+		)
+	) {
 		return null;
 	}
 
 	const handleSetPostsPerPage = ( newPostsPerPage ) => {
 		if ( newPostsPerPage ) {
-			newPostsPerPage = Number( newPostsPerPage )
+			newPostsPerPage = Number( newPostsPerPage );
 		}
-		setPostsPerPage(newPostsPerPage);
+		setPostsPerPage( newPostsPerPage );
 	};
 	return (
 		<PostPanelRow label={ __( 'Posts per page' ) } ref={ setPopoverAnchor }>
@@ -81,7 +107,7 @@ export default function PostsPerPage() {
 						aria-label={ __( 'Change posts per page' ) }
 						onClick={ onToggle }
 					>
-						{ postsPerPage || `Default ${globalPostsPerPage}` }
+						{ postsPerPage || `Default ${ globalPostsPerPage }` }
 					</Button>
 				) }
 				renderContent={ ( { onClose } ) => (
@@ -91,7 +117,7 @@ export default function PostsPerPage() {
 							onClose={ onClose }
 						/>
 						<NumberControl
-							placeholder={ `Default ${globalPostsPerPage}` }
+							placeholder={ `Default ${ globalPostsPerPage }` }
 							value={ postsPerPage }
 							size="__unstable-large"
 							spinControls="custom"

--- a/packages/editor/src/components/posts-per-page/index.js
+++ b/packages/editor/src/components/posts-per-page/index.js
@@ -2,8 +2,8 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore, useEntityProp } from '@wordpress/core-data';
 import {
 	Button,
 	Dropdown,
@@ -20,23 +20,26 @@ import { store as editorStore } from '../../store';
 import PostPanelRow from '../post-panel-row';
 
 export default function PostsPerPage() {
-	const { editEntityRecord } = useDispatch( coreStore );
-	const { postsPerPage, isTemplate, postSlug } = useSelect( ( select ) => {
+	const { isTemplate, postSlug, templateId, globalPostsPerPage } = useSelect( ( select ) => {
 		const { getEditedPostAttribute, getCurrentPostType } =
 			select( editorStore );
-		const { getEditedEntityRecord, canUser } = select( coreStore );
+		const { getEntityRecords, getEditedEntityRecord, canUser } = select( coreStore );
 		const siteSettings = canUser( 'read', {
 			kind: 'root',
 			name: 'site',
 		} )
 			? getEditedEntityRecord( 'root', 'site' )
 			: undefined;
+		const slug = getEditedPostAttribute( 'slug' );
 		return {
 			isTemplate: getCurrentPostType() === TEMPLATE_POST_TYPE,
-			postSlug: getEditedPostAttribute( 'slug' ),
-			postsPerPage: siteSettings?.posts_per_page || 1,
+			postSlug: slug,
+			templateId: getEntityRecords( 'postType', TEMPLATE_POST_TYPE)?.find( record => record.slug === slug )?.id,
+			globalPostsPerPage: siteSettings?.posts_per_page || 1,
 		};
 	}, [] );
+	const [ postsPerPage, setPostsPerPage ] = useEntityProp( 'postType', TEMPLATE_POST_TYPE, 'posts_per_page', templateId );
+
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
@@ -56,10 +59,12 @@ export default function PostsPerPage() {
 	if ( ! isTemplate || ! [ 'home', 'index' ].includes( postSlug ) ) {
 		return null;
 	}
-	const setPostsPerPage = ( newValue ) => {
-		editEntityRecord( 'root', 'site', undefined, {
-			posts_per_page: newValue,
-		} );
+
+	const handleSetPostsPerPage = ( newPostsPerPage ) => {
+		if ( newPostsPerPage ) {
+			newPostsPerPage = Number( newPostsPerPage )
+		}
+		setPostsPerPage(newPostsPerPage);
 	};
 	return (
 		<PostPanelRow label={ __( 'Posts per page' ) } ref={ setPopoverAnchor }>
@@ -75,7 +80,7 @@ export default function PostsPerPage() {
 						aria-label={ __( 'Change posts per page' ) }
 						onClick={ onToggle }
 					>
-						{ postsPerPage }
+						{ postsPerPage || `Default ${globalPostsPerPage}` }
 					</Button>
 				) }
 				renderContent={ ( { onClose } ) => (
@@ -85,16 +90,16 @@ export default function PostsPerPage() {
 							onClose={ onClose }
 						/>
 						<NumberControl
-							placeholder={ 0 }
+							placeholder={ `Default ${globalPostsPerPage}` }
 							value={ postsPerPage }
 							size="__unstable-large"
 							spinControls="custom"
 							step="1"
-							min="1"
-							onChange={ setPostsPerPage }
+							min="0"
+							onChange={ handleSetPostsPerPage }
 							label={ __( 'Posts per page' ) }
 							help={ __(
-								'Set the default number of posts to display on blog pages, including categories and tags. Some templates may override this setting.'
+								'Set the number of posts to display per page. Leave empty to use the site default.'
 							) }
 							hideLabelFromVision
 						/>

--- a/packages/editor/src/components/posts-per-page/index.js
+++ b/packages/editor/src/components/posts-per-page/index.js
@@ -45,12 +45,9 @@ export default function PostsPerPage() {
 		const slug = getEditedPostAttribute( 'slug' );
 
 		const id = getCurrentPostId();
-		const perPage = getEntityRecord(
-			'postType',
-			TEMPLATE_POST_TYPE,
-			id,
-			{ combinedTemplates: false }
-		)?.posts_per_page;
+		const perPage = getEntityRecord( 'postType', TEMPLATE_POST_TYPE, id, {
+			combinedTemplates: false,
+		} )?.posts_per_page;
 		const editedPerPage = getEntityRecordEdits(
 			'postType',
 			TEMPLATE_POST_TYPE,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/gutenberg/issues/63660

## Questions

- This PR adds a “Posts per page” setting for archival templates, as suggested in the issue.
Should we also provide this setting for custom templates? Or would it make sense to expose it for all templates in general?

## Notes

I ignored the following Git hook errors since they don’t seem related to this PR:
```
✖ node found some errors. Please fix them and try committing again.
packages/editor/src/dataviews/fields/content-preview/content-preview-view.tsx(6,2): error TS2305: Module '"@wordpress/block-editor"' has no exported member 'BlockPreview'.
packages/editor/src/dataviews/fields/content-preview/content-preview-view.tsx(7,2): error TS2305: Module '"@wordpress/block-editor"' has no exported member 'privateApis'.
husky - pre-commit hook exited with code 1 (error)
```

## Screenshots or screencast <!-- if applicable -->
<img width="632" height="335" alt="image" src="https://github.com/user-attachments/assets/ad7637d6-3bd3-4f91-a260-d0819ae3b4a5" />
<img width="622" height="338" alt="image" src="https://github.com/user-attachments/assets/40f7e57b-7ad5-4169-ac1b-6796accbddae" />

# Problem

Encountered problem that was difficult to solve☹️. Isn’t this the correct way to modify the template data? May I ask how to modify the template data?
```
editEntityRecord( 'postType', TEMPLATE_POST_TYPE, templateId, {
	posts_per_page: newPostsPerPage,
} );
```
