### PR TITLE
Button: Ensure that icons don't shrink

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,10 @@
 -   `Button`: Update font weight to `500` ([#70787](https://github.com/WordPress/gutenberg/pull/70787)).
 -   `TabPanel`: Update tab font weight ([#72455](https://github.com/WordPress/gutenberg/pull/72455)).
 
+### Bug Fixes
+
+-   `Button`: Ensure that icons don't shrink ([#72474](https://github.com/WordPress/gutenberg/pull/72474)).
+
 ## 30.6.0 (2025-10-17)
 
 ### Enhancements

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -390,6 +390,7 @@
 	svg {
 		fill: currentColor;
 		outline: none;
+		flex-shrink: 0;
 
 		// Optimize for high contrast modes.
 		// See also https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Prevents icon buttons from shrinking their icons when the button content wants to overflow their containers.

## Why?

We don't want icons to be shrunken down, especially if a subtle shrink causes a developer to not notice an overflow.

## How?

Add a `flex-shrink: 0` to the icon element.

## Testing Instructions

You can either use this story for testing, or simply change the width of a `<Button icon={ foo } text="foo" />` in dev tools.

<details><summary>Story for testing</summary>
<p>

```diff
diff --git a/packages/components/src/button/stories/index.story.tsx b/packages/components/src/button/stories/index.story.tsx
index 605b56686c..d9d24f7eef 100644
--- a/packages/components/src/button/stories/index.story.tsx
+++ b/packages/components/src/button/stories/index.story.tsx
@@ -121,14 +121,14 @@ Icon.args = {
 
 export const GroupedIcons = () => {
 	const GroupContainer = ( { children }: { children: ReactNode } ) => (
-		<div style={ { display: 'inline-flex' } }>{ children }</div>
+		<div style={ { display: 'inline-flex', width: 200 } }>{ children }</div>
 	);
 
 	return (
 		<GroupContainer>
-			<Button icon={ formatBold } label="Bold" />
-			<Button icon={ formatItalic } label="Italic" />
-			<Button icon={ link } label="Link" />
+			<Button icon={ formatBold } text="Bold" variant="secondary" />
+			<Button icon={ formatItalic } text="Italic" variant="secondary" />
+			<Button icon={ link } text="Link" variant="secondary" />
 		</GroupContainer>
 	);
 };
```
</p>
</details> 

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img width="446" height="106" alt="Flex shrinking buttons, before" src="https://github.com/user-attachments/assets/6eaa60ae-74aa-4f72-9ad9-cf1c7e77ba93" />|<img width="446" height="106" alt="Flex shrinking buttons, after" src="https://github.com/user-attachments/assets/21b7dd1b-9b2f-49dd-a1ab-80e2e0c1f293" />|
