### PR TITLE
Pattern Overrides: Add support for Image caption attribute

### DIFF
--- a/packages/patterns/src/components/pattern-overrides-controls.js
+++ b/packages/patterns/src/components/pattern-overrides-controls.js
@@ -61,8 +61,7 @@ function PatternOverridesControls( {
 	}
 
 	const hasUnsupportedImageAttributes =
-		blockName === 'core/image' &&
-		( !! attributes.caption?.length || !! attributes.href?.length );
+		blockName === 'core/image' && !! attributes.href?.length;
 
 	const helpText =
 		! hasOverrides && hasUnsupportedImageAttributes

--- a/packages/patterns/src/components/pattern-overrides-controls.js
+++ b/packages/patterns/src/components/pattern-overrides-controls.js
@@ -67,7 +67,7 @@ function PatternOverridesControls( {
 	const helpText =
 		! hasOverrides && hasUnsupportedImageAttributes
 			? __(
-					`Overrides currently don't support image captions or links. Remove the caption or link first before enabling overrides.`
+					`Overrides currently don't support image links. Remove the link first before enabling overrides.`
 			  )
 			: __(
 					'Allow changes to this block throughout instances of this pattern.'

--- a/packages/patterns/src/constants.js
+++ b/packages/patterns/src/constants.js
@@ -20,7 +20,7 @@ export const PARTIAL_SYNCING_SUPPORTED_BLOCKS = {
 	'core/paragraph': [ 'content' ],
 	'core/heading': [ 'content' ],
 	'core/button': [ 'text', 'url', 'linkTarget', 'rel' ],
-	'core/image': [ 'id', 'url', 'title', 'alt' ],
+	'core/image': [ 'id', 'url', 'title', 'alt', 'caption' ],
 };
 
 export const PATTERN_OVERRIDES_BINDING_SOURCE = 'core/pattern-overrides';


### PR DESCRIPTION
## What?
Add Pattern Overrides support for the Image block's `caption` attribute.

## Why?
Block Bindings support has been added for the `caption` attribute, which means it should also be made available for Pattern Overrides.

## How?
By adding it to the `PARTIAL_SYNCING_SUPPORTED_BLOCKS` array.

We [previously considered inferring the list of block attributes supported by pattern overrides from the list of block attributes supported by block bindings from the server](https://github.com/WordPress/gutenberg/pull/72391). However, we found that those lists aren't necessarily identical -- e.g. the Nav Link and Submenu blocks' `url` attribute is now supported by block bindings, but shouldn't be supported by pattern overrides. We thus decided to keep the separate `PARTIAL_SYNCING_SUPPORTED_BLOCKS` const for now.

## Testing Instructions

- In the post editor, add a paragraph block and an image block. Select an image for the latter to display.
- Add a caption to the image block.
- Highlight the paragraph and image blocks, and open the vertical ... menu from the block toolbar.
- Select "Create pattern". Assign a name, and make sure it's a synced pattern.
- Click on the newly created pattern. In the block toolbar, click "Edit original".
- In the pattern editor, select the image. Open the block inspector, and expand the "Advanced" panel.
- Verify that the "Enable overrides" button is enabled. (Compare this to `trunk`, where it isn't -- see screencasts below.)
- Click the "Enable overrides" button. Then, save the pattern and return to the post you were editing previously.
- In the post, change the block caption. Publish the post and verify on the frontend that the updated caption is shown.

## Screenshots or screencast

|Before|After|
|-|-|
| ![img-caption-overrides-before](https://github.com/user-attachments/assets/00e86604-2709-4d01-8d43-d6b522114d98) | ![img-caption-overrides-after](https://github.com/user-attachments/assets/06c80198-5ebc-4f26-8826-c50b3fff54b3) |
