### PR TITLE
Breadcrumbs: Add archives support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -93,7 +93,7 @@ Display a breadcrumb trail for hierarchical post types or based on taxonomy term
 -	**Experimental:** true
 -	**Category:** theme
 -	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** postBreadcrumbsType, separator, showHomeLink
+-	**Attributes:** prefersTaxonomy, separator, showHomeLink
 
 ## Button
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -93,7 +93,7 @@ Display a breadcrumb trail for hierarchical post types or based on taxonomy term
 -	**Experimental:** true
 -	**Category:** theme
 -	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** separator, showHomeLink, type
+-	**Attributes:** postBreadcrumbsType, separator, showHomeLink
 
 ## Button
 

--- a/packages/block-library/src/breadcrumbs/block.json
+++ b/packages/block-library/src/breadcrumbs/block.json
@@ -8,10 +8,10 @@
 	"description": "Display a breadcrumb trail for hierarchical post types or based on taxonomy terms.",
 	"textdomain": "default",
 	"attributes": {
-		"type": {
+		"postBreadcrumbsType": {
 			"type": "string",
-			"default": "auto",
-			"enum": [ "auto", "postWithTerms", "postWithAncestors" ]
+			"default": "postWithAncestors",
+			"enum": [ "postWithTerms", "postWithAncestors" ]
 		},
 		"separator": {
 			"type": "string",

--- a/packages/block-library/src/breadcrumbs/block.json
+++ b/packages/block-library/src/breadcrumbs/block.json
@@ -8,10 +8,9 @@
 	"description": "Display a breadcrumb trail for hierarchical post types or based on taxonomy terms.",
 	"textdomain": "default",
 	"attributes": {
-		"postBreadcrumbsType": {
-			"type": "string",
-			"default": "postWithAncestors",
-			"enum": [ "postWithTerms", "postWithAncestors" ]
+		"prefersTaxonomy": {
+			"type": "boolean",
+			"default": false
 		},
 		"separator": {
 			"type": "string",

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -22,23 +22,14 @@ import { useServerSideRender } from '@wordpress/server-side-render';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const separatorDefaultValue = '/';
-const postBreadcrumbsTypeDefaultValue = 'postWithAncestors';
-
-const BREADCRUMB_TYPES = {
-	postWithAncestors: {
-		placeholderItems: [ __( 'Ancestor' ), __( 'Parent' ) ],
-	},
-	postWithTerms: {
-		placeholderItems: [ __( 'Category' ) ],
-	},
-};
+const prefersTaxonomyDefaultValue = false;
 
 export default function BreadcrumbEdit( {
 	attributes,
 	setAttributes,
 	context: { postId, postType, templateSlug },
 } ) {
-	const { separator, showHomeLink, postBreadcrumbsType } = attributes;
+	const { separator, showHomeLink, prefersTaxonomy } = attributes;
 	const {
 		post,
 		isPostTypeHierarchical,
@@ -121,18 +112,15 @@ export default function BreadcrumbEdit( {
 	}
 
 	// Determine breadcrumb type for accurate previews (matching PHP logic).
-	let breadcrumbsType;
+	let _showTerms;
 	if ( ! isPostTypeHierarchical ) {
-		breadcrumbsType = 'postWithTerms';
+		_showTerms = true;
 	} else if ( ! postTypeHasTaxonomies ) {
 		// Hierarchical post type without taxonomies can only use ancestors.
-		breadcrumbsType = 'postWithAncestors';
+		_showTerms = false;
 	} else {
-		// For hierarchical post types with taxonomies, use the attribute if valid.
-		const supportedTypes = [ 'postWithAncestors', 'postWithTerms' ];
-		breadcrumbsType = supportedTypes.includes( postBreadcrumbsType )
-			? postBreadcrumbsType
-			: 'postWithAncestors';
+		// For hierarchical post types with taxonomies, use the attribute.
+		_showTerms = prefersTaxonomy;
 	}
 	let placeholder = null;
 	// This is fragile because this block is server side rendered and we'll have to
@@ -144,17 +132,21 @@ export default function BreadcrumbEdit( {
 		// This is needed because when we are showing the template in post editor we
 		// want to show the real breadcrumbs if we have the post type.
 		( templateSlug && ! postType ) ||
-		( breadcrumbsType === 'postWithAncestors' &&
-			! isPostTypeHierarchical ) ||
-		( breadcrumbsType === 'postWithTerms' && ! hasTermsAssigned );
+		( ! _showTerms && ! isPostTypeHierarchical ) ||
+		( _showTerms && ! hasTermsAssigned );
 	if ( showPlaceholder ) {
-		const placeholderItems = [
-			showHomeLink && __( 'Home' ),
-			// For now if we are adding this in a template show a generic placeholder.
-			...( templateSlug && ! postId
-				? [ __( 'Page' ) ]
-				: BREADCRUMB_TYPES[ breadcrumbsType ]?.placeholderItems || [] ),
-		].filter( Boolean );
+		const placeholderItems = [];
+		if ( showHomeLink ) {
+			placeholderItems.push( __( 'Home' ) );
+		}
+		if ( templateSlug && ! postId ) {
+			placeholderItems.push( __( 'Page' ) );
+		} else {
+			placeholderItems.push(
+				_showTerms ? __( 'Category' ) : __( 'Ancestor' ),
+				__( 'Parent' )
+			);
+		}
 		placeholder = (
 			<nav
 				style={ {
@@ -186,8 +178,7 @@ export default function BreadcrumbEdit( {
 						setAttributes( {
 							separator: separatorDefaultValue,
 							showHomeLink: true,
-							postBreadcrumbsType:
-								postBreadcrumbsTypeDefaultValue,
+							prefersTaxonomy: prefersTaxonomyDefaultValue,
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
@@ -245,13 +236,9 @@ export default function BreadcrumbEdit( {
 				<CheckboxControl
 					__nextHasNoMarginBottom
 					label={ __( 'Prefer taxonomy terms' ) }
-					checked={ postBreadcrumbsType === 'postWithTerms' }
+					checked={ prefersTaxonomy }
 					onChange={ ( value ) =>
-						setAttributes( {
-							postBreadcrumbsType: value
-								? 'postWithTerms'
-								: 'postWithAncestors',
-						} )
+						setAttributes( { prefersTaxonomy: value } )
 					}
 					help={ __(
 						'The exact type of breadcrumbs shown will vary automatically depending on the page in which this block is displayed. In the specific case of a hierarchical post type with taxonomies, the breadcrumbs can either reflect its post hierarchy (default) or the hierarchy of its assigned taxonomy terms.'

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -6,7 +6,8 @@ import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
 	ToggleControl,
 	TextControl,
-	SelectControl,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	Spinner,
@@ -22,24 +23,13 @@ import { useServerSideRender } from '@wordpress/server-side-render';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const separatorDefaultValue = '/';
-const typeDefaultValue = 'auto';
+const postBreadcrumbsTypeDefaultValue = 'postWithAncestors';
 
 const BREADCRUMB_TYPES = {
-	auto: {
-		help: __(
-			'Try to automatically determine the best type of breadcrumb for the template.'
-		),
-	},
 	postWithAncestors: {
-		help: __(
-			'Shows breadcrumbs based on post hierarchy. Only works for hierarchical post types.'
-		),
 		placeholderItems: [ __( 'Ancestor' ), __( 'Parent' ) ],
 	},
 	postWithTerms: {
-		help: __(
-			'Shows breadcrumbs based on taxonomy terms. Chooses the first taxonomy with assigned terms and includes ancestors if the taxonomy is hierarchical.'
-		),
 		placeholderItems: [ __( 'Category' ) ],
 	},
 };
@@ -49,60 +39,66 @@ export default function BreadcrumbEdit( {
 	setAttributes,
 	context: { postId, postType, templateSlug },
 } ) {
-	const { separator, showHomeLink, type } = attributes;
-	const { post, isPostTypeHierarchical, hasTermsAssigned, isLoading } =
-		useSelect(
-			( select ) => {
-				if ( ! postType ) {
-					return {};
-				}
-				const _post = select( coreStore ).getEntityRecord(
-					'postType',
-					postType,
-					postId
-				);
-				const postTypeObject =
-					select( coreStore ).getPostType( postType );
-				const postTypeHasTaxonomies =
-					postTypeObject && postTypeObject.taxonomies.length;
-				let taxonomies;
-				if ( postTypeHasTaxonomies ) {
-					taxonomies = select( coreStore ).getTaxonomies( {
-						type: postType,
-						per_page: -1,
-					} );
-				}
-				return {
-					post: _post,
-					isPostTypeHierarchical: postTypeObject?.hierarchical,
-					hasTermsAssigned:
-						_post &&
-						( taxonomies || [] )
-							.filter(
-								( { visibility } ) =>
-									visibility?.publicly_queryable
-							)
-							.some( ( taxonomy ) => {
-								return !! _post[ taxonomy.rest_base ]?.length;
-							} ),
-					isLoading:
-						! _post ||
-						! postTypeObject ||
-						( postTypeHasTaxonomies && ! taxonomies ),
-				};
-			},
-			[ postType, postId ]
-		);
+	const { separator, showHomeLink, postBreadcrumbsType } = attributes;
+	const {
+		post,
+		isPostTypeHierarchical,
+		postTypeHasTaxonomies,
+		hasTermsAssigned,
+		isLoading,
+	} = useSelect(
+		( select ) => {
+			if ( ! postType ) {
+				return {};
+			}
+			const _post = select( coreStore ).getEntityRecord(
+				'postType',
+				postType,
+				postId
+			);
+			const postTypeObject = select( coreStore ).getPostType( postType );
+			const _postTypeHasTaxonomies =
+				postTypeObject && postTypeObject.taxonomies.length;
+			let taxonomies;
+			if ( _postTypeHasTaxonomies ) {
+				taxonomies = select( coreStore ).getTaxonomies( {
+					type: postType,
+					per_page: -1,
+				} );
+			}
+			return {
+				post: _post,
+				isPostTypeHierarchical: postTypeObject?.hierarchical,
+				postTypeHasTaxonomies: _postTypeHasTaxonomies,
+				hasTermsAssigned:
+					_post &&
+					( taxonomies || [] )
+						.filter(
+							( { visibility } ) => visibility?.publicly_queryable
+						)
+						.some( ( taxonomy ) => {
+							return !! _post[ taxonomy.rest_base ]?.length;
+						} ),
+				isLoading:
+					( postId && ! _post ) ||
+					! postTypeObject ||
+					( _postTypeHasTaxonomies && ! taxonomies ),
+			};
+		},
+		[ postType, postId ]
+	);
 
-	// Counter used to cache-bust `useServerSideRender`
-	//
-	// This is a catch-all signal to re-render the block when a post's title,
-	// parent ID, or terms change.
-	//
-	// This is fundamentally imperfect, because there are other entities which
-	// could change in the meantime (the titles of ancestor posts, or the
-	// labels of taxonomy terms), hence the choice to re-render systematically
-	// upon saving.
+	/**
+	 * Counter used to cache-bust `useServerSideRender`.
+	 *
+	 * This is a catch-all signal to re-render the block when a post's title,
+	 * parent ID, or terms change.
+	 *
+	 * This is fundamentally imperfect, because there are other entities which
+	 * could change in the meantime (the titles of ancestor posts, or the
+	 * labels of taxonomy terms), hence the choice to re-render systematically
+	 * upon saving.
+	 */
 	const [ invalidationKey, setInvalidationKey ] = useState( 0 );
 	useEffect( () => {
 		setInvalidationKey( ( c ) => c + 1 );
@@ -124,18 +120,20 @@ export default function BreadcrumbEdit( {
 			</div>
 		);
 	}
-	// TODO: this should be handled better when we add more types.
+
+	// Determine breadcrumb type for accurate previews (matching PHP logic).
 	let breadcrumbsType;
-	const isSpecificSupportedTypeSet = [
-		'postWithAncestors',
-		'postWithTerms',
-	].includes( type );
-	if ( isSpecificSupportedTypeSet ) {
-		breadcrumbsType = type;
+	if ( ! isPostTypeHierarchical ) {
+		breadcrumbsType = 'postWithTerms';
+	} else if ( ! postTypeHasTaxonomies ) {
+		// Hierarchical post type without taxonomies can only use ancestors.
+		breadcrumbsType = 'postWithAncestors';
 	} else {
-		breadcrumbsType = isPostTypeHierarchical
-			? 'postWithAncestors'
-			: 'postWithTerms';
+		// For hierarchical post types with taxonomies, use the attribute if valid.
+		const supportedTypes = [ 'postWithAncestors', 'postWithTerms' ];
+		breadcrumbsType = supportedTypes.includes( postBreadcrumbsType )
+			? postBreadcrumbsType
+			: 'postWithAncestors';
 	}
 	let placeholder = null;
 	// This is fragile because this block is server side rendered and we'll have to
@@ -154,9 +152,9 @@ export default function BreadcrumbEdit( {
 		const placeholderItems = [
 			showHomeLink && __( 'Home' ),
 			// For now if we are adding this in a template show a generic placeholder.
-			...( templateSlug && ! isSpecificSupportedTypeSet
+			...( templateSlug && ! postId
 				? [ __( 'Page' ) ]
-				: BREADCRUMB_TYPES[ breadcrumbsType ].placeholderItems ),
+				: BREADCRUMB_TYPES[ breadcrumbsType ]?.placeholderItems || [] ),
 		].filter( Boolean );
 		placeholder = (
 			<nav
@@ -189,46 +187,12 @@ export default function BreadcrumbEdit( {
 						setAttributes( {
 							separator: separatorDefaultValue,
 							showHomeLink: true,
-							type: typeDefaultValue,
+							postBreadcrumbsType:
+								postBreadcrumbsTypeDefaultValue,
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
 				>
-					<ToolsPanelItem
-						label={ __( 'Type' ) }
-						isShownByDefault
-						hasValue={ () => type !== typeDefaultValue }
-						onDeselect={ () =>
-							setAttributes( {
-								type: typeDefaultValue,
-							} )
-						}
-					>
-						<SelectControl
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-							label={ __( 'Type' ) }
-							value={ type }
-							onChange={ ( value ) =>
-								setAttributes( { type: value } )
-							}
-							options={ [
-								{
-									label: __( 'Auto' ),
-									value: 'auto',
-								},
-								{
-									label: __( 'Post with ancestors' ),
-									value: 'postWithAncestors',
-								},
-								{
-									label: __( 'Post with terms' ),
-									value: 'postWithTerms',
-								},
-							] }
-							help={ BREADCRUMB_TYPES[ type ].help }
-						/>
-					</ToolsPanelItem>
 					<ToolsPanelItem
 						label={ __( 'Show home link' ) }
 						isShownByDefault
@@ -275,6 +239,43 @@ export default function BreadcrumbEdit( {
 								}
 							} }
 						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						label={ __( 'Post breadcrumbs type' ) }
+						hasValue={ () =>
+							postBreadcrumbsType !==
+							postBreadcrumbsTypeDefaultValue
+						}
+						onDeselect={ () =>
+							setAttributes( {
+								postBreadcrumbsType:
+									postBreadcrumbsTypeDefaultValue,
+							} )
+						}
+						isShownByDefault
+					>
+						<ToggleGroupControl
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+							isBlock
+							label={ __( 'Type' ) }
+							value={ postBreadcrumbsType }
+							onChange={ ( value ) =>
+								setAttributes( { postBreadcrumbsType: value } )
+							}
+							help={ __(
+								'For hierarchical post types with taxonomies, the breadcrumbs trail can consist of either the post ancestors or its assigned terms.'
+							) }
+						>
+							<ToggleGroupControlOption
+								value="postWithAncestors"
+								label={ __( 'With ancestors' ) }
+							/>
+							<ToggleGroupControlOption
+								value="postWithTerms"
+								label={ __( 'With terms' ) }
+							/>
+						</ToggleGroupControl>
 					</ToolsPanelItem>
 				</ToolsPanel>
 			</InspectorControls>

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -6,8 +6,7 @@ import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
 	ToggleControl,
 	TextControl,
-	__experimentalToggleGroupControl as ToggleGroupControl,
-	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	CheckboxControl,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	Spinner,
@@ -240,44 +239,24 @@ export default function BreadcrumbEdit( {
 							} }
 						/>
 					</ToolsPanelItem>
-					<ToolsPanelItem
-						label={ __( 'Post breadcrumbs type' ) }
-						hasValue={ () =>
-							postBreadcrumbsType !==
-							postBreadcrumbsTypeDefaultValue
-						}
-						onDeselect={ () =>
-							setAttributes( {
-								postBreadcrumbsType:
-									postBreadcrumbsTypeDefaultValue,
-							} )
-						}
-						isShownByDefault
-					>
-						<ToggleGroupControl
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-							isBlock
-							label={ __( 'Type' ) }
-							value={ postBreadcrumbsType }
-							onChange={ ( value ) =>
-								setAttributes( { postBreadcrumbsType: value } )
-							}
-							help={ __(
-								'For hierarchical post types with taxonomies, the breadcrumbs trail can consist of either the post ancestors or its assigned terms.'
-							) }
-						>
-							<ToggleGroupControlOption
-								value="postWithAncestors"
-								label={ __( 'With ancestors' ) }
-							/>
-							<ToggleGroupControlOption
-								value="postWithTerms"
-								label={ __( 'With terms' ) }
-							/>
-						</ToggleGroupControl>
-					</ToolsPanelItem>
 				</ToolsPanel>
+			</InspectorControls>
+			<InspectorControls group="advanced">
+				<CheckboxControl
+					__nextHasNoMarginBottom
+					label={ __( 'Prefer taxonomy terms' ) }
+					checked={ postBreadcrumbsType === 'postWithTerms' }
+					onChange={ ( value ) =>
+						setAttributes( {
+							postBreadcrumbsType: value
+								? 'postWithTerms'
+								: 'postWithAncestors',
+						} )
+					}
+					help={ __(
+						'The exact type of breadcrumbs shown will vary automatically depending on the page in which this block is displayed. In the specific case of a hierarchical post type with taxonomies, the breadcrumbs can either reflect its post hierarchy (default) or the hierarchy of its assigned taxonomy terms.'
+					) }
+				/>
 			</InspectorControls>
 			<div { ...blockProps }>
 				{ showPlaceholder ? (

--- a/packages/block-library/src/breadcrumbs/edit.js
+++ b/packages/block-library/src/breadcrumbs/edit.js
@@ -22,7 +22,6 @@ import { useServerSideRender } from '@wordpress/server-side-render';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const separatorDefaultValue = '/';
-const prefersTaxonomyDefaultValue = false;
 
 export default function BreadcrumbEdit( {
 	attributes,
@@ -141,11 +140,10 @@ export default function BreadcrumbEdit( {
 		}
 		if ( templateSlug && ! postId ) {
 			placeholderItems.push( __( 'Page' ) );
+		} else if ( _showTerms ) {
+			placeholderItems.push( __( 'Category' ) );
 		} else {
-			placeholderItems.push(
-				_showTerms ? __( 'Category' ) : __( 'Ancestor' ),
-				__( 'Parent' )
-			);
+			placeholderItems.push( __( 'Ancestor' ), __( 'Parent' ) );
 		}
 		placeholder = (
 			<nav
@@ -178,7 +176,6 @@ export default function BreadcrumbEdit( {
 						setAttributes( {
 							separator: separatorDefaultValue,
 							showHomeLink: true,
-							prefersTaxonomy: prefersTaxonomyDefaultValue,
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -53,8 +53,19 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 			return '';
 		}
 
-		$breadcrumbs_type = block_core_breadcrumbs_get_breadcrumbs_type( $post_type, $attributes );
-		if ( 'postWithAncestors' === $breadcrumbs_type ) {
+		// Determine breadcrumb type for accurate rendering (matching JavaScript logic).
+		$show_terms = false;
+		if ( ! is_post_type_hierarchical( $post_type ) ) {
+			$show_terms = true;
+		} elseif ( empty( get_object_taxonomies( $post_type, 'objects' ) ) ) {
+			// Hierarchical post type without taxonomies can only use ancestors.
+			$show_terms = false;
+		} else {
+			// For hierarchical post types with taxonomies, use the attribute.
+			$show_terms = $attributes['prefersTaxonomy'];
+		}
+
+		if ( ! $show_terms ) {
 			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id ) );
 		} else {
 			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) );
@@ -92,33 +103,6 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 }
 
 /**
- * Determines the breadcrumb type based on the block's default heuristics.
- *
- * @since 6.9.0
- *
- * @param string $post_type The post type name.
- *
- * @return string The breadcrumb type.
- */
-function block_core_breadcrumbs_get_breadcrumbs_type( $post_type, $attributes ) {
-	// Breadcrumbs type for posts can be either 'postWithAncestors' or 'postWithTerms'.
-	// If the post type is not hierarchical, default to 'postWithTerms'.
-	if ( ! is_post_type_hierarchical( $post_type ) ) {
-		return 'postWithTerms';
-	}
-
-	// Hierarchical post type without taxonomies can only use ancestors.
-	if ( empty( get_object_taxonomies( $post_type, 'objects' ) ) ) {
-		return 'postWithAncestors';
-	}
-
-	// For hierarchical post types with taxonomies, use the attribute if valid.
-	$supported_types = array( 'postWithAncestors', 'postWithTerms' );
-	$type            = $attributes['postBreadcrumbsType'];
-	return in_array( $type, $supported_types, true ) ? $type : 'postWithAncestors';
-}
-
-/**
  * Generates breadcrumb items from hierarchical post type ancestors.
  *
  * @since 6.9.0
@@ -142,6 +126,39 @@ function block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id
 	return $breadcrumb_items;
 }
 
+/**
+ * Generates breadcrumb items for hierarchical term ancestors.
+ *
+ * For hierarchical taxonomies, retrieves and formats ancestor terms as breadcrumb links.
+ *
+ * @since 6.9.0
+ *
+ * @param int    $term_id  The term ID.
+ * @param string $taxonomy The taxonomy name.
+ *
+ * @return array Array of breadcrumb HTML items for ancestors.
+ */
+function block_core_breadcrumbs_get_term_ancestors_items( $term_id, $taxonomy ) {
+	$breadcrumb_items = array();
+
+	// Check if taxonomy is hierarchical and add ancestor term links.
+	if ( is_taxonomy_hierarchical( $taxonomy ) ) {
+		$term_ancestors = get_ancestors( $term_id, $taxonomy, 'taxonomy' );
+		$term_ancestors = array_reverse( $term_ancestors );
+		foreach ( $term_ancestors as $ancestor_id ) {
+			$ancestor_term = get_term( $ancestor_id, $taxonomy );
+			if ( $ancestor_term && ! is_wp_error( $ancestor_term ) ) {
+				$breadcrumb_items[] = sprintf(
+					'<a href="%s">%s</a>',
+					esc_url( get_term_link( $ancestor_term ) ),
+					esc_html( $ancestor_term->name )
+				);
+			}
+		}
+	}
+
+	return $breadcrumb_items;
+}
 
 /**
  * Generates breadcrumb items for archive pages.
@@ -176,7 +193,7 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 					$breadcrumb_items[] = sprintf(
 						'<a href="%s">%s</a>',
 						esc_url( get_month_link( $year, $month ) ),
-						esc_html( date_i18n( 'F', mktime( 0, 0, 0, $month, 1 ) ) )
+						esc_html( date_i18n( 'F', mktime( 0, 0, 0, $month, 1, $year ) ) )
 					);
 					// Current day.
 					$breadcrumb_items[] = sprintf(
@@ -187,7 +204,7 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 					// Current month.
 					$breadcrumb_items[] = sprintf(
 						'<span aria-current="page">%s</span>',
-						esc_html( date_i18n( 'F', mktime( 0, 0, 0, $month, 1 ) ) )
+						esc_html( date_i18n( 'F', mktime( 0, 0, 0, $month, 1, $year ) ) )
 					);
 				}
 			} else {
@@ -215,20 +232,10 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 		$taxonomy = $term->taxonomy;
 
 		// Add hierarchical term ancestors if applicable.
-		if ( is_taxonomy_hierarchical( $taxonomy ) ) {
-			$term_ancestors = get_ancestors( $term->term_id, $taxonomy, 'taxonomy' );
-			$term_ancestors = array_reverse( $term_ancestors );
-			foreach ( $term_ancestors as $ancestor_id ) {
-				$ancestor_term = get_term( $ancestor_id, $taxonomy );
-				if ( $ancestor_term && ! is_wp_error( $ancestor_term ) ) {
-					$breadcrumb_items[] = sprintf(
-						'<a href="%s">%s</a>',
-						esc_url( get_term_link( $ancestor_term ) ),
-						esc_html( $ancestor_term->name )
-					);
-				}
-			}
-		}
+		$breadcrumb_items = array_merge(
+			$breadcrumb_items,
+			block_core_breadcrumbs_get_term_ancestors_items( $term->term_id, $taxonomy )
+		);
 
 		// Add current term.
 		$breadcrumb_items[] = sprintf(
@@ -251,12 +258,10 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 	} elseif ( is_author() ) {
 		// Author archive.
 		$author = $queried_object;
-		if ( $author instanceof WP_User ) {
-			$breadcrumb_items[] = sprintf(
-				'<span aria-current="page">%s</span>',
-				esc_html( $author->display_name )
-			);
-		}
+		$breadcrumb_items[] = sprintf(
+			'<span aria-current="page">%s</span>',
+			esc_html( $author->display_name )
+		);
 	}
 
 	return $breadcrumb_items;
@@ -305,21 +310,11 @@ function block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) {
 	if ( ! empty( $terms ) ) {
 		// Use the first term (if multiple are assigned).
 		$term = reset( $terms );
-		// Check if taxonomy is hierarchical also add ancestor term links
-		if ( is_taxonomy_hierarchical( $taxonomy_name ) ) {
-			$term_ancestors = get_ancestors( $term->term_id, $taxonomy_name, 'taxonomy' );
-			$term_ancestors = array_reverse( $term_ancestors );
-			foreach ( $term_ancestors as $ancestor_id ) {
-				$ancestor_term = get_term( $ancestor_id, $taxonomy_name );
-				if ( $ancestor_term && ! is_wp_error( $ancestor_term ) ) {
-					$breadcrumb_items[] = sprintf(
-						'<a href="%s">%s</a>',
-						esc_url( get_term_link( $ancestor_term ) ),
-						esc_html( $ancestor_term->name )
-					);
-				}
-			}
-		}
+		// Add hierarchical term ancestors if applicable.
+		$breadcrumb_items = array_merge(
+			$breadcrumb_items,
+			block_core_breadcrumbs_get_term_ancestors_items( $term->term_id, $taxonomy_name )
+		);
 		$breadcrumb_items[] = sprintf(
 			'<a href="%s">%s</a>',
 			esc_url( get_term_link( $term ) ),

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -257,7 +257,7 @@ function block_core_breadcrumbs_get_archive_breadcrumbs() {
 		}
 	} elseif ( is_author() ) {
 		// Author archive.
-		$author = $queried_object;
+		$author             = $queried_object;
 		$breadcrumb_items[] = sprintf(
 			'<span aria-current="page">%s</span>',
 			esc_html( $author->display_name )
@@ -311,7 +311,7 @@ function block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) {
 		// Use the first term (if multiple are assigned).
 		$term = reset( $terms );
 		// Add hierarchical term ancestors if applicable.
-		$breadcrumb_items = array_merge(
+		$breadcrumb_items   = array_merge(
 			$breadcrumb_items,
 			block_core_breadcrumbs_get_term_ancestors_items( $term->term_id, $taxonomy_name )
 		);

--- a/packages/block-library/src/breadcrumbs/index.php
+++ b/packages/block-library/src/breadcrumbs/index.php
@@ -17,25 +17,14 @@
  * @return string Returns the post breadcrumb for hierarchical post types.
  */
 function render_block_core_breadcrumbs( $attributes, $content, $block ) {
-	// Exclude breadcrumbs from special contexts like archives, search, 404, etc.
+	// Exclude breadcrumbs from special contexts like search, 404, etc.
 	// until they are explicitly supported.
-	if ( is_archive() || is_search() || is_404() || is_home() || is_front_page() ) {
-		return '';
-	}
-	if ( ! isset( $block->context['postId'] ) || ! isset( $block->context['postType'] ) ) {
+	if ( is_search() || is_404() || is_home() || is_front_page() ) {
 		return '';
 	}
 
-	$post_id   = $block->context['postId'];
-	$post_type = $block->context['postType'];
-
-	$post = get_post( $post_id );
-	if ( ! $post ) {
-		return '';
-	}
-
-	$type             = $attributes['type'];
 	$breadcrumb_items = array();
+
 	if ( $attributes['showHomeLink'] ) {
 		$breadcrumb_items[] = sprintf(
 			'<a href="%s">%s</a>',
@@ -43,16 +32,41 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
 			esc_html__( 'Home' )
 		);
 	}
-	$supported_types = array( 'postWithAncestors', 'postWithTerms' );
-	// If `type` is not set to a specific breadcrumb type, determine it based on the block's default heuristics.
-	$breadcrumbs_type = in_array( $type, $supported_types, true ) ? $type : block_core_breadcrumbs_get_breadcrumbs_type( $post_type );
-	if ( 'postWithAncestors' === $breadcrumbs_type ) {
-		$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id ) );
+
+	// Handle archive pages (taxonomy, post type, date, author archives).
+	if ( is_archive() ) {
+		$archive_breadcrumbs = block_core_breadcrumbs_get_archive_breadcrumbs();
+		if ( ! empty( $archive_breadcrumbs ) ) {
+			$breadcrumb_items = array_merge( $breadcrumb_items, $archive_breadcrumbs );
+		}
 	} else {
-		$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) );
+		// Handle single post/page breadcrumbs.
+		if ( ! isset( $block->context['postId'] ) || ! isset( $block->context['postType'] ) ) {
+			return '';
+		}
+
+		$post_id   = $block->context['postId'];
+		$post_type = $block->context['postType'];
+
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return '';
+		}
+
+		$breadcrumbs_type = block_core_breadcrumbs_get_breadcrumbs_type( $post_type, $attributes );
+		if ( 'postWithAncestors' === $breadcrumbs_type ) {
+			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id ) );
+		} else {
+			$breadcrumb_items = array_merge( $breadcrumb_items, block_core_breadcrumbs_get_terms_breadcrumbs( $post_id, $post_type ) );
+		}
+		// Add current post title (not linked).
+		$breadcrumb_items[] = sprintf( '<span aria-current="page">%s</span>', get_the_title( $post ) );
 	}
-	// Add current post title (not linked).
-	$breadcrumb_items[] = sprintf( '<span aria-current="page">%s</span>', get_the_title( $post ) );
+
+	if ( empty( $breadcrumb_items ) ) {
+		return '';
+	}
+
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
 			'style'      => '--separator: "' . addcslashes( $attributes['separator'], '\\"' ) . '";',
@@ -86,8 +100,22 @@ function render_block_core_breadcrumbs( $attributes, $content, $block ) {
  *
  * @return string The breadcrumb type.
  */
-function block_core_breadcrumbs_get_breadcrumbs_type( $post_type ) {
-	return is_post_type_hierarchical( $post_type ) ? 'postWithAncestors' : 'postWithTerms';
+function block_core_breadcrumbs_get_breadcrumbs_type( $post_type, $attributes ) {
+	// Breadcrumbs type for posts can be either 'postWithAncestors' or 'postWithTerms'.
+	// If the post type is not hierarchical, default to 'postWithTerms'.
+	if ( ! is_post_type_hierarchical( $post_type ) ) {
+		return 'postWithTerms';
+	}
+
+	// Hierarchical post type without taxonomies can only use ancestors.
+	if ( empty( get_object_taxonomies( $post_type, 'objects' ) ) ) {
+		return 'postWithAncestors';
+	}
+
+	// For hierarchical post types with taxonomies, use the attribute if valid.
+	$supported_types = array( 'postWithAncestors', 'postWithTerms' );
+	$type            = $attributes['postBreadcrumbsType'];
+	return in_array( $type, $supported_types, true ) ? $type : 'postWithAncestors';
 }
 
 /**
@@ -114,6 +142,125 @@ function block_core_breadcrumbs_get_hierarchical_post_type_breadcrumbs( $post_id
 	return $breadcrumb_items;
 }
 
+
+/**
+ * Generates breadcrumb items for archive pages.
+ *
+ * Handles taxonomy archives, post type archives, date archives, and author archives.
+ * For hierarchical taxonomies, includes ancestor terms in the breadcrumb trail.
+ *
+ * @since 6.9.0
+ *
+ * @return array Array of breadcrumb HTML items.
+ */
+function block_core_breadcrumbs_get_archive_breadcrumbs() {
+	$breadcrumb_items = array();
+
+	// Date archive (check first since it doesn't have a queried object).
+	if ( is_date() ) {
+		$year  = get_query_var( 'year' );
+		$month = get_query_var( 'monthnum' );
+		$day   = get_query_var( 'day' );
+
+		if ( $year ) {
+			if ( $month ) {
+				// Year is linked if we have month.
+				$breadcrumb_items[] = sprintf(
+					'<a href="%s">%s</a>',
+					esc_url( get_year_link( $year ) ),
+					esc_html( $year )
+				);
+
+				if ( $day ) {
+					// Month is linked if we have day.
+					$breadcrumb_items[] = sprintf(
+						'<a href="%s">%s</a>',
+						esc_url( get_month_link( $year, $month ) ),
+						esc_html( date_i18n( 'F', mktime( 0, 0, 0, $month, 1 ) ) )
+					);
+					// Current day.
+					$breadcrumb_items[] = sprintf(
+						'<span aria-current="page">%s</span>',
+						esc_html( $day )
+					);
+				} else {
+					// Current month.
+					$breadcrumb_items[] = sprintf(
+						'<span aria-current="page">%s</span>',
+						esc_html( date_i18n( 'F', mktime( 0, 0, 0, $month, 1 ) ) )
+					);
+				}
+			} else {
+				// Current year only.
+				$breadcrumb_items[] = sprintf(
+					'<span aria-current="page">%s</span>',
+					esc_html( $year )
+				);
+			}
+		}
+
+		return $breadcrumb_items;
+	}
+
+	// For other archive types, we need a queried object.
+	$queried_object = get_queried_object();
+
+	if ( ! $queried_object ) {
+		return array();
+	}
+
+	// Taxonomy archive (category, tag, custom taxonomy).
+	if ( $queried_object instanceof WP_Term ) {
+		$term     = $queried_object;
+		$taxonomy = $term->taxonomy;
+
+		// Add hierarchical term ancestors if applicable.
+		if ( is_taxonomy_hierarchical( $taxonomy ) ) {
+			$term_ancestors = get_ancestors( $term->term_id, $taxonomy, 'taxonomy' );
+			$term_ancestors = array_reverse( $term_ancestors );
+			foreach ( $term_ancestors as $ancestor_id ) {
+				$ancestor_term = get_term( $ancestor_id, $taxonomy );
+				if ( $ancestor_term && ! is_wp_error( $ancestor_term ) ) {
+					$breadcrumb_items[] = sprintf(
+						'<a href="%s">%s</a>',
+						esc_url( get_term_link( $ancestor_term ) ),
+						esc_html( $ancestor_term->name )
+					);
+				}
+			}
+		}
+
+		// Add current term.
+		$breadcrumb_items[] = sprintf(
+			'<span aria-current="page">%s</span>',
+			esc_html( $term->name )
+		);
+	} elseif ( is_post_type_archive() ) {
+		// Post type archive.
+		$post_type = get_query_var( 'post_type' );
+		if ( is_array( $post_type ) ) {
+			$post_type = reset( $post_type );
+		}
+		$post_type_object = get_post_type_object( $post_type );
+		if ( $post_type_object ) {
+			$breadcrumb_items[] = sprintf(
+				'<span aria-current="page">%s</span>',
+				esc_html( $post_type_object->labels->name )
+			);
+		}
+	} elseif ( is_author() ) {
+		// Author archive.
+		$author = $queried_object;
+		if ( $author instanceof WP_User ) {
+			$breadcrumb_items[] = sprintf(
+				'<span aria-current="page">%s</span>',
+				esc_html( $author->display_name )
+			);
+		}
+	}
+
+	return $breadcrumb_items;
+}
 
 /**
  * Generates breadcrumb items from taxonomy terms.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/72498

This PR adds `archives` support for Breadcrumbs block. 

The goal for this block is to be used in possibly a single page (for example header of the site) and work seamlessly in any page. I've tried to think of any use case where the breadcrumb trail could should alternative trails based on any condition but couldn't, besides the case of hierarchical post types with taxonomies (`postWithAncestors|postWithTerms). 

For the above reasons it doesn't make any sense to keep the `type:auto` flag, as we're going to handle this internally. We just need a specific block setting to just handle the user's preference in that case (hierarchical post types with taxonomies ), which also has a default value to show the ancestors.

For this PR, I don't believe the position of control matters much, but in a follow up we'll also add whether to show the breadcrumbs in the `home page`. Both of these settings are `template` specific logic, which can be even grouped in a separate `panel`.
<img width="282" height="312" alt="Screenshot 2025-10-20 at 12 04 03 PM" src="https://github.com/user-attachments/assets/d6865d15-bcc3-4671-b56c-2d1cdf9c3acd" />




## Testing Instructions
1. Have the GB blocks experiment enabled
2. Insert the `Breadcrumbs` block in various contexts (pages, templates, etc..)
3. All posts/pages, and archives should work as expected.
4. It might be easier to just add the block in the main `Header` of the site and visit different pages/categories, etc..


## Screenshots or screencast <!-- if applicable -->
Below I'm sharing some screenshots in a site that I've added @justintadlock's [plugin](https://wordpress.org/plugins/x3p0-breadcrumbs/) and the core block in the main header. 
Above is `x3p0-breadcrumbs/` and below is the `core block`.

### Date archive (identical)
<img width="665" height="154" alt="date-archive" src="https://github.com/user-attachments/assets/41eea7ae-f11b-46fa-849c-0e660ef1b529" />

### Author archive (identical)
<img width="665" height="154" alt="author-archive" src="https://github.com/user-attachments/assets/ac76c9c4-0961-471f-ae3d-1015ce96a23f" />

### Custom CPT archive (identical)
<img width="665" height="154" alt="customCPT-archive" src="https://github.com/user-attachments/assets/0c42caef-149b-43d7-af10-cca4da1254b4" />

### Tag archives (identical)
<img width="665" height="154" alt="tag-archive" src="https://github.com/user-attachments/assets/d32d4c5c-9a8e-445b-900b-dbbb894daaa7" />

### Custom taxonomy (identical)
<img width="665" height="154" alt="custom-taxonomy" src="https://github.com/user-attachments/assets/72791277-913e-43e0-bb81-419d9b5afcc9" />

### Woo category 
Justin's block also shows the `products archive` - is this special handling for Woo @justintadlock ? 🤔 
<img width="665" height="154" alt="woo-category-archive" src="https://github.com/user-attachments/assets/5c0d035d-e40d-4a10-841a-7e6aa318076e" />

### Nested post categories (2 levels)
<img width="665" height="154" alt="category-archive" src="https://github.com/user-attachments/assets/7adcd686-b694-4bf6-851c-db2d1d5c506f" />

### Nested post categories (3 levels)
Core block displays **all nested levels**.
<img width="665" height="154" alt="post-with-nested-hiearchical-terms" src="https://github.com/user-attachments/assets/44e09ae0-6332-40d3-8d46-db6287ca948b" />

### Custom CPT with terms assigned
Core shows the term link and Justin's block the CPT archive.
<img width="665" height="154" alt="customCPT-with-terms-assigned" src="https://github.com/user-attachments/assets/463dccb9-3a1b-4d7a-8d02-a84847c2d956" />


### Custom CPT **without** terms assigned
Justin's block shows the CPT archive link.
<img width="665" height="154" alt="customCPT-without-terms-assigned" src="https://github.com/user-attachments/assets/2ea82d83-9657-48c1-998b-4331d47e4155" />



