### PR TITLE
Enqueue non-minified JS files when `SCRIPT_DEBUG` is enabled

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -186,14 +186,15 @@ function gutenberg_register_packages_scripts( $scripts ) {
 	// When in production, use the plugin's version as the default asset version;
 	// else (for development or test) default to use the current time.
 	$default_version = defined( 'GUTENBERG_VERSION' ) && ! SCRIPT_DEBUG ? GUTENBERG_VERSION : time();
+	$file_extension  = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.js' : '.min.js';
 
-	foreach ( glob( gutenberg_dir_path() . 'build/*/index.min.js' ) as $path ) {
+	foreach ( glob( gutenberg_dir_path() . 'build/*/index' . $file_extension ) as $path ) {
 		// Prefix `wp-` to package directory to get script handle.
 		// For example, `…/build/a11y/index.min.js` becomes `wp-a11y`.
 		$handle = 'wp-' . basename( dirname( $path ) );
 
 		// Replace extension with `.asset.php` to find the generated dependencies file.
-		$asset_file   = substr( $path, 0, -( strlen( '.js' ) ) ) . '.asset.php';
+		$asset_file   = substr( $path, 0, -( strlen( $file_extension ) ) ) . '.min.asset.php';
 		$asset        = file_exists( $asset_file )
 			? require $asset_file
 			: null;

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -193,7 +193,14 @@ function gutenberg_register_packages_scripts( $scripts ) {
 		// For example, `…/build/a11y/index.min.js` becomes `wp-a11y`.
 		$handle = 'wp-' . basename( dirname( $path ) );
 
-		// Replace extension with `.asset.php` to find the generated dependencies file.
+		/**
+		 * Find the asset file for each package script by
+		 * replacing the JS file extension '.js' or '.min.js' with '.min.asset.php'.
+		 *
+		 * Example:
+		 * - '.../build/block-library/index.min.js' => '.../build/block-library/index.min.asset.php'
+		 * - '.../build/block-library/index.js'     => '.../build/block-library/index.min.asset.php'
+		 */
 		$asset_file   = substr( $path, 0, -( strlen( $file_extension ) ) ) . '.min.asset.php';
 		$asset        = file_exists( $asset_file )
 			? require $asset_file


### PR DESCRIPTION
## What?
Closes #72479

Enqueue non-minified JS files when `SCRIPT_DEBUG` is enabled.

## Why?
Using non-minified JavaScript files will display readable component names in React Dev Tools, improving debugging efficiency.

## How?
* Enqueue non-minified JS files when `SCIRPT_DEBUG` is set to `true`
* Enqueue minified JS files when `SCIRPT_DEBUG` is set to `false`

## Testing Instructions
1. Set `SCRIPT_DEBUG` to `true`.
2. Build the project.
3. Open the Block Editor in your browser.
4. Install the React Dev Tools extension.
5. Open the `Component` tab in the Browser Dev Tools.
6. Check the component names. 

They should be human-readable names instead of `Rxt`, `Ety`, etc.

## Screenshots

|Before|After|
|-|-|
| <img width="1280" height="710" alt="Screenshot 2025-10-20 at 3 19 17 PM" src="https://github.com/user-attachments/assets/cf6b1a5c-04b9-4bcc-9570-801e0ddd65bb" /> | <img width="1280" height="710" alt="Screenshot 2025-10-20 at 3 19 40 PM" src="https://github.com/user-attachments/assets/97e5e02a-23b7-40e7-ae3f-fd82795f2ea2" /> |
