### PR TITLE
Post Date: Add block deprecation to change source arg to field

### DIFF
--- a/packages/block-library/src/post-date/deprecated.js
+++ b/packages/block-library/src/post-date/deprecated.js
@@ -86,6 +86,7 @@ const v3 = {
 		},
 		...otherAttributes
 	} ) {
+		// Change the block bindings source argument name from "key" to "field".
 		return {
 			metadata: {
 				bindings: {

--- a/packages/block-library/src/post-date/deprecated.js
+++ b/packages/block-library/src/post-date/deprecated.js
@@ -8,6 +8,103 @@ import clsx from 'clsx';
  */
 import migrateFontFamily from '../utils/migrate-font-family';
 
+const v3 = {
+	attributes: {
+		datetime: {
+			type: 'string',
+			role: 'content',
+		},
+		textAlign: {
+			type: 'string',
+		},
+		format: {
+			type: 'string',
+		},
+		isLink: {
+			type: 'boolean',
+			default: false,
+			role: 'content',
+		},
+	},
+	supports: {
+		html: false,
+		color: {
+			gradients: true,
+			link: true,
+			__experimentalDefaultControls: {
+				background: true,
+				text: true,
+				link: true,
+			},
+		},
+		spacing: {
+			margin: true,
+			padding: true,
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalFontWeight: true,
+			__experimentalFontStyle: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalLetterSpacing: true,
+			__experimentalDefaultControls: {
+				fontSize: true,
+			},
+		},
+		interactivity: {
+			clientNavigation: true,
+		},
+		__experimentalBorder: {
+			radius: true,
+			color: true,
+			width: true,
+			style: true,
+			__experimentalDefaultControls: {
+				radius: true,
+				color: true,
+				width: true,
+				style: true,
+			},
+		},
+	},
+	save() {
+		return null;
+	},
+	migrate( {
+		metadata: {
+			bindings: {
+				datetime: {
+					source,
+					args: { key, ...otherArgs },
+				},
+				...otherBindings
+			},
+			...otherMetadata
+		},
+		...otherAttributes
+	} ) {
+		return {
+			metadata: {
+				bindings: {
+					datetime: {
+						source,
+						args: { field: key, ...otherArgs },
+					},
+					...otherBindings,
+				},
+				...otherMetadata,
+			},
+			...otherAttributes,
+		};
+	},
+	isEligible( attributes ) {
+		return attributes?.metadata?.bindings?.datetime?.args?.key;
+	},
+};
+
 const v2 = {
 	attributes: {
 		textAlign: {
@@ -152,4 +249,4 @@ const v1 = {
  *
  * See block-deprecation.md
  */
-export default [ v2, v1 ];
+export default [ v3, v2, v1 ];

--- a/packages/block-library/src/post-date/deprecated.js
+++ b/packages/block-library/src/post-date/deprecated.js
@@ -102,7 +102,7 @@ const v3 = {
 		};
 	},
 	isEligible( attributes ) {
-		return attributes?.metadata?.bindings?.datetime?.args?.key;
+		return !! attributes?.metadata?.bindings?.datetime?.args?.key;
 	},
 };
 

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -48,8 +48,7 @@ export default function PostDateEdit( {
 } ) {
 	const displayType =
 		metadata?.bindings?.datetime?.source === 'core/post-data' &&
-		( metadata?.bindings?.datetime?.args?.field ||
-			metadata?.bindings?.datetime?.args?.key );
+		metadata?.bindings?.datetime?.args?.field;
 
 	const blockProps = useBlockProps( {
 		className: clsx( {

--- a/packages/block-library/src/post-date/variations.js
+++ b/packages/block-library/src/post-date/variations.js
@@ -20,15 +20,11 @@ const variations = [
 			},
 		},
 		scope: [ 'block', 'inserter', 'transform' ],
-		isActive: ( blockAttributes ) => {
-			const fieldValue =
-				blockAttributes?.metadata?.bindings?.datetime?.args?.field ||
-				blockAttributes?.metadata?.bindings?.datetime?.args?.key;
-			return (
-				blockAttributes?.metadata?.bindings?.datetime?.source ===
-					'core/post-data' && fieldValue === 'date'
-			);
-		},
+		isActive: ( blockAttributes ) =>
+			blockAttributes?.metadata?.bindings?.datetime?.source ===
+				'core/post-data' &&
+			blockAttributes?.metadata?.bindings?.datetime?.args?.field ===
+				'date',
 		icon: postDate,
 	},
 	{
@@ -47,15 +43,11 @@ const variations = [
 			className: 'wp-block-post-date__modified-date',
 		},
 		scope: [ 'block', 'inserter', 'transform' ],
-		isActive: ( blockAttributes ) => {
-			const fieldValue =
-				blockAttributes?.metadata?.bindings?.datetime?.args?.field ||
-				blockAttributes?.metadata?.bindings?.datetime?.args?.key;
-			return (
-				blockAttributes?.metadata?.bindings?.datetime?.source ===
-					'core/post-data' && fieldValue === 'modified'
-			);
-		},
+		isActive: ( blockAttributes ) =>
+			blockAttributes?.metadata?.bindings?.datetime?.source ===
+				'core/post-data' &&
+			blockAttributes?.metadata?.bindings?.datetime?.args?.field ===
+				'modified',
 		icon: postDate,
 	},
 ];

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -107,9 +107,7 @@ export default {
 		const newValues = {};
 		for ( const [ attributeName, source ] of Object.entries( bindings ) ) {
 			// Use the value, the field label, or the field key.
-			const fieldKey = globalThis.IS_GUTENBERG_PLUGIN
-				? source.args.field || source.args.key
-				: source.args.field;
+			const fieldKey = source.args.field;
 			const { value: fieldValue, label: fieldLabel } =
 				dataFields?.[ fieldKey ] || {};
 			newValues[ attributeName ] = fieldValue ?? fieldLabel ?? fieldKey;

--- a/test/integration/fixtures/blocks/core__post-date__deprecated-v3.html
+++ b/test/integration/fixtures/blocks/core__post-date__deprecated-v3.html
@@ -1,0 +1,1 @@
+<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"key":"date"}}}}} /-->

--- a/test/integration/fixtures/blocks/core__post-date__deprecated-v3.json
+++ b/test/integration/fixtures/blocks/core__post-date__deprecated-v3.json
@@ -1,0 +1,20 @@
+[
+	{
+		"name": "core/post-date",
+		"isValid": true,
+		"attributes": {
+			"metadata": {
+				"bindings": {
+					"datetime": {
+						"source": "core/post-data",
+						"args": {
+							"field": "date"
+						}
+					}
+				}
+			},
+			"isLink": false
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__post-date__deprecated-v3.parsed.json
+++ b/test/integration/fixtures/blocks/core__post-date__deprecated-v3.parsed.json
@@ -1,0 +1,20 @@
+[
+	{
+		"blockName": "core/post-date",
+		"attrs": {
+			"metadata": {
+				"bindings": {
+					"datetime": {
+						"source": "core/post-data",
+						"args": {
+							"key": "date"
+						}
+					}
+				}
+			}
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__post-date__deprecated-v3.serialized.html
+++ b/test/integration/fixtures/blocks/core__post-date__deprecated-v3.serialized.html
@@ -1,0 +1,1 @@
+<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}}} /-->


### PR DESCRIPTION
## What?
Add a block deprecation for the Post Date block to update the block bindings source arg from `key` to `field`.

Follow-up to https://github.com/WordPress/gutenberg/pull/72382.

## Why?
In order to change existing Post Date block markup to use `field` instead of `key` as source arg for the `core/post-data` source.

## How?
By adding a block deprecation.

## Testing Instructions
On `trunk`, create a Post Date block and save it to a post. Inspect it in the Code Editor and verify that it looks like this:

```html
<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"key":"date"}}}}} /-->
```

Switch back to the Visual Editor.
Then, switch to this branch, and reload the post. Make a minor change to the post (e.g. insert a new paragraph) and save it. 
Go to the Code Editor and verify that the arg was changed to `field`:

```html
<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}}} /-->
```

This is also covered by integration tests.