### PR TITLE
Notes: Don't render 'no results' message for floating sidebar

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -245,7 +245,7 @@ export function Comments( {
 	}, [ heights, blockRefs, isFloating, threads, selectedThread ] );
 
 	const hasThreads = Array.isArray( threads ) && threads.length > 0;
-	if ( ! hasThreads ) {
+	if ( ! hasThreads && ! isFloating ) {
 		return (
 			<VStack alignment="left" justify="flex-start" spacing="2">
 				<Text as="p">{ __( 'No notes available.' ) }</Text>


### PR DESCRIPTION
## What?
This is a follow-up to https://github.com/WordPress/gutenberg/issues/72157#issuecomment-3421349597.

PR removes "no results" message when adding a comment via floating sidebar, which regressed at some point.

## Testing Instructions
1. Create a post.
2. Add a block and click on the "Add note" options dropdown button.
3. Confirm the "no results" message isn't rendered below the form.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
<img width="280" height="354" alt="CleanShot 2025-10-20 at 14 36 57" src="https://github.com/user-attachments/assets/48b1f4c5-abdf-4e23-b7b3-cd067e7e70d6" />
