### PR TITLE
Build: Fix script_debug modules and scripts

### DIFF
--- a/bin/packages/build.mjs
+++ b/bin/packages/build.mjs
@@ -56,18 +56,18 @@ function getAllPackages() {
 
 const PACKAGES = getAllPackages();
 
-// Define global variables for feature flagging, matching webpack's DefinePlugin behavior
-const define = {
+const baseDefine = {
 	'globalThis.IS_GUTENBERG_PLUGIN': JSON.stringify(
 		Boolean( process.env.npm_package_config_IS_GUTENBERG_PLUGIN )
 	),
 	'globalThis.IS_WORDPRESS_CORE': JSON.stringify(
 		Boolean( process.env.npm_package_config_IS_WORDPRESS_CORE )
 	),
-	'globalThis.SCRIPT_DEBUG': JSON.stringify(
-		process.env.NODE_ENV === 'development'
-	),
 };
+const getDefine = ( scriptDebug ) => ( {
+	...baseDefine,
+	'globalThis.SCRIPT_DEBUG': JSON.stringify( ! scriptDebug ),
+} );
 
 /**
  * Create emotion babel plugin for esbuild.
@@ -560,14 +560,14 @@ async function bundlePackage( packageName ) {
 				...baseConfig,
 				outfile: path.join( outputDir, 'index.min.js' ),
 				minify: true,
-				define,
+				define: getDefine( true ),
 				plugins: bundlePlugins,
 			} ),
 			esbuild.build( {
 				...baseConfig,
 				outfile: path.join( outputDir, 'index.js' ),
 				minify: false,
-				define,
+				define: getDefine( false ),
 				plugins: bundlePlugins,
 			} )
 		);
@@ -595,7 +595,6 @@ async function bundlePackage( packageName ) {
 					: exportName.replace( /^\.\//, '' );
 			const entryPoint = path.join( packageDir, exportPath );
 			const baseFileName = path.basename( fileName );
-
 			const modulePlugins = [
 				wordpressExternalsPlugin( `${ baseFileName }.min`, 'esm' ),
 			];
@@ -613,7 +612,22 @@ async function bundlePackage( packageName ) {
 					target,
 					platform: 'browser',
 					minify: true,
-					define,
+					define: getDefine( true ),
+					plugins: modulePlugins,
+				} ),
+				esbuild.build( {
+					entryPoints: [ entryPoint ],
+					outfile: path.join(
+						rootBuildModuleDir,
+						`${ fileName }.js`
+					),
+					bundle: true,
+					sourcemap: true,
+					format: 'esm',
+					target,
+					platform: 'browser',
+					minify: false,
+					define: getDefine( false ),
 					plugins: modulePlugins,
 				} )
 			);
@@ -1046,7 +1060,9 @@ async function buildAll() {
 			const isBundled = await bundlePackage( packageName );
 			const buildTime = Date.now() - startBundleTime;
 			if ( isBundled ) {
-				console.log( `   ✔ Bundled ${ packageName } (${ buildTime }ms)` );
+				console.log(
+					`   ✔ Bundled ${ packageName } (${ buildTime }ms)`
+				);
 			}
 		} )
 	);

--- a/bin/packages/build.mjs
+++ b/bin/packages/build.mjs
@@ -66,7 +66,7 @@ const baseDefine = {
 };
 const getDefine = ( scriptDebug ) => ( {
 	...baseDefine,
-	'globalThis.SCRIPT_DEBUG': JSON.stringify( ! scriptDebug ),
+	'globalThis.SCRIPT_DEBUG': JSON.stringify( scriptDebug ),
 } );
 
 /**
@@ -560,14 +560,14 @@ async function bundlePackage( packageName ) {
 				...baseConfig,
 				outfile: path.join( outputDir, 'index.min.js' ),
 				minify: true,
-				define: getDefine( true ),
+				define: getDefine( false ),
 				plugins: bundlePlugins,
 			} ),
 			esbuild.build( {
 				...baseConfig,
 				outfile: path.join( outputDir, 'index.js' ),
 				minify: false,
-				define: getDefine( false ),
+				define: getDefine( true ),
 				plugins: bundlePlugins,
 			} )
 		);
@@ -612,7 +612,7 @@ async function bundlePackage( packageName ) {
 					target,
 					platform: 'browser',
 					minify: true,
-					define: getDefine( true ),
+					define: getDefine( false ),
 					plugins: modulePlugins,
 				} ),
 				esbuild.build( {
@@ -627,7 +627,7 @@ async function bundlePackage( packageName ) {
 					target,
 					platform: 'browser',
 					minify: false,
-					define: getDefine( false ),
+					define: getDefine( true ),
 					plugins: modulePlugins,
 				} )
 			);

--- a/packages/interactivity/package.json
+++ b/packages/interactivity/package.json
@@ -22,13 +22,11 @@
 		"node": ">=18.12.0",
 		"npm": ">=8.19.2"
 	},
-	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"exports": {
 		".": {
 			"types": "./build-types/index.d.ts",
-			"import": "./build-module/index.js",
-			"require": "./build/index.js"
+			"import": "./build-module/index.js"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/interactivity/package.json
+++ b/packages/interactivity/package.json
@@ -33,10 +33,7 @@
 		"./package.json": "./package.json"
 	},
 	"react-native": "src/index",
-	"wpScriptModuleExports": {
-		".": "./build-module/index.js",
-		"./debug": "./build-module/debug.js"
-	},
+	"wpScriptModuleExports": "./build-module/index.js",
 	"types": "build-types",
 	"dependencies": {
 		"@preact/signals": "^1.3.0",

--- a/packages/interactivity/src/debug.ts
+++ b/packages/interactivity/src/debug.ts
@@ -1,6 +1,0 @@
-/**
- * External dependencies
- */
-import 'preact/debug';
-
-export * from './index';

--- a/packages/interactivity/src/index.ts
+++ b/packages/interactivity/src/index.ts
@@ -1,3 +1,7 @@
+if ( globalThis.SCRIPT_DEBUG ) {
+	await import( 'preact/debug' );
+}
+
 /**
  * External dependencies
  */
@@ -37,10 +41,6 @@ export {
 } from './utils';
 
 export { useState, useRef } from 'preact/hooks';
-
-if ( globalThis.SCRIPT_DEBUG ) {
-	import( 'preact/debug' );
-}
 
 const requiredConsent =
 	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.';

--- a/packages/interactivity/src/index.ts
+++ b/packages/interactivity/src/index.ts
@@ -38,6 +38,10 @@ export {
 
 export { useState, useRef } from 'preact/hooks';
 
+if ( globalThis.SCRIPT_DEBUG ) {
+	import( 'preact/debug' );
+}
+
 const requiredConsent =
 	'I acknowledge that using private APIs means my theme or plugin will inevitably break in the next version of WordPress.';
 


### PR DESCRIPTION
Related #72032

### What

Update the build system to generate both minified and non-minified versions of script modules, matching the pattern used for regular scripts. Also fixes the scripts injection of `globalThis.SCRIPT_DEBUG`

###  Why?

  Script modules were only generating .min.js files, while regular scripts generate both .js and .min.js. This inconsistency meant that:
  - SCRIPT_DEBUG couldn't control which version was loaded for modules
  - globalThis.SCRIPT_DEBUG was incorrectly tied to NODE_ENV instead of the minification state

This also allows us to remove the special case we had for interactivity API.

### How?

  Build system (bin/packages/build.mjs):
  - Generate both *.js (non-minified) and *.min.js (minified) for script modules
  - Set globalThis.SCRIPT_DEBUG based on minification state (true for non-minified, false for minified)
  - Both versions share the same .min.asset.php file (like regular scripts)

  PHP registration (lib/client-assets.php):
  - Use SCRIPT_DEBUG to select between .js and .min.js extensions
  - Remove special Interactivity API debug entry point handling
  - Fix asset file path construction bug (incorrect substr() usage)

  Interactivity package cleanup:
  - Remove /debug entry point from package.json
  - Delete src/debug.ts file
  - Non-minified builds now automatically include appropriate debug features via SCRIPT_DEBUG

 ### Testing

  - Set SCRIPT_DEBUG = true → loads .js files with debug features
  - Set SCRIPT_DEBUG = false → loads .min.js optimized files
  - Interactive blocks work correctly in both modes