### PR TITLE
Notes: Fix the focus transfer issue when switching the sidebars

### DIFF
--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -336,6 +336,9 @@ export function useEnableFloatingSidebar( enabled = false ) {
 	const registry = useRegistry();
 	useEffect( () => {
 		if ( ! enabled ) {
+			registry
+				.dispatch( interfaceStore )
+				.disableComplementaryArea( 'core', collabSidebarName );
 			return;
 		}
 

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -336,24 +336,27 @@ export function useEnableFloatingSidebar( enabled = false ) {
 	const registry = useRegistry();
 	useEffect( () => {
 		if ( ! enabled ) {
-			registry
-				.dispatch( interfaceStore )
-				.disableComplementaryArea( 'core', collabSidebarName );
 			return;
 		}
 
-		return registry.subscribe( () => {
-			const activeSidebar = registry
-				.select( interfaceStore )
-				.getActiveComplementaryArea( 'core' );
+		const { getActiveComplementaryArea } =
+			registry.select( interfaceStore );
+		const { disableComplementaryArea, enableComplementaryArea } =
+			registry.dispatch( interfaceStore );
 
+		const unsubscribe = registry.subscribe( () => {
 			// Return `null` to indicate the user hid the complementary area.
-			if ( activeSidebar === null ) {
-				registry
-					.dispatch( interfaceStore )
-					.enableComplementaryArea( 'core', collabSidebarName );
+			if ( getActiveComplementaryArea( 'core' ) === null ) {
+				enableComplementaryArea( 'core', collabSidebarName );
 			}
 		} );
+
+		return () => {
+			unsubscribe();
+			if ( getActiveComplementaryArea( 'core' ) === collabSidebarName ) {
+				disableComplementaryArea( 'core', collabSidebarName );
+			}
+		};
 	}, [ enabled, registry ] );
 }
 

--- a/packages/editor/src/components/collab-sidebar/hooks.js
+++ b/packages/editor/src/components/collab-sidebar/hooks.js
@@ -347,7 +347,8 @@ export function useEnableFloatingSidebar( enabled = false ) {
 				.select( interfaceStore )
 				.getActiveComplementaryArea( 'core' );
 
-			if ( ! activeSidebar ) {
+			// Return `null` to indicate the user hid the complementary area.
+			if ( activeSidebar === null ) {
 				registry
 					.dispatch( interfaceStore )
 					.enableComplementaryArea( 'core', collabSidebarName );

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -54,8 +54,11 @@ function CollabSidebarContent( {
 			spacing="3"
 			justify="flex-start"
 			ref={ ( node ) => {
-				// Keeps the ref fresh when switching between floating and pinned sidebar.
-				commentSidebarRef.current = node;
+				// Sometimes previous sidebar unmounts after the new one mounts.
+				// This ensures we always have the latest reference.
+				if ( node ) {
+					commentSidebarRef.current = node;
+				}
 			} }
 		>
 			<AddComment

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -116,7 +116,9 @@ export default function CollabSidebar() {
 		reflowComments,
 		commentLastUpdated,
 	} = useBlockComments( postId );
-	useEnableFloatingSidebar( resultComments.length > 0 );
+	useEnableFloatingSidebar(
+		unresolvedSortedThreads.length > 0 || showCommentBoard
+	);
 
 	const hasMoreComments = totalPages && totalPages > 1;
 
@@ -138,7 +140,7 @@ export default function CollabSidebar() {
 		const prevArea = await getActiveComplementaryArea( 'core' );
 		const activeNotesArea = SIDEBARS.find( ( name ) => name === prevArea );
 
-		// If the notes sidebar is not already active, enable the pinned sidebar.
+		// If the notes sidebar is not already active, enable the floating sidebar.
 		if ( ! activeNotesArea ) {
 			enableComplementaryArea( 'core', collabSidebarName );
 		}
@@ -183,30 +185,29 @@ export default function CollabSidebar() {
 					commentLastUpdated={ commentLastUpdated }
 				/>
 			</PluginSidebar>
-			{ isLargeViewport &&
-				( unresolvedSortedThreads.length > 0 || showCommentBoard ) && (
-					<PluginSidebar
-						isPinnable={ false }
-						header={ false }
-						identifier={ collabSidebarName }
-						className="editor-collab-sidebar"
-						headerClassName="editor-collab-sidebar__header"
-						backgroundColor={ backgroundColor }
-					>
-						<CollabSidebarContent
-							comments={ unresolvedSortedThreads }
-							showCommentBoard={ showCommentBoard }
-							setShowCommentBoard={ setShowCommentBoard }
-							commentSidebarRef={ commentSidebarRef }
-							reflowComments={ reflowComments }
-							commentLastUpdated={ commentLastUpdated }
-							styles={ {
-								backgroundColor,
-							} }
-							isFloating
-						/>
-					</PluginSidebar>
-				) }
+			{ isLargeViewport && (
+				<PluginSidebar
+					isPinnable={ false }
+					header={ false }
+					identifier={ collabSidebarName }
+					className="editor-collab-sidebar"
+					headerClassName="editor-collab-sidebar__header"
+					backgroundColor={ backgroundColor }
+				>
+					<CollabSidebarContent
+						comments={ unresolvedSortedThreads }
+						showCommentBoard={ showCommentBoard }
+						setShowCommentBoard={ setShowCommentBoard }
+						commentSidebarRef={ commentSidebarRef }
+						reflowComments={ reflowComments }
+						commentLastUpdated={ commentLastUpdated }
+						styles={ {
+							backgroundColor,
+						} }
+						isFloating
+					/>
+				</PluginSidebar>
+			) }
 			<PluginMoreMenuItem
 				icon={ commentIcon }
 				onClick={ () =>

--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -32,6 +32,30 @@ test.describe( 'Block Comments', () => {
 		await expect( topBarButton ).toBeVisible();
 	} );
 
+	test( 'should move focus to add a new note form', async ( {
+		editor,
+		page,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: 'Testing block comments' },
+		} );
+		const form = page.getByRole( 'textbox', {
+			name: 'New Note',
+			exact: true,
+		} );
+
+		await editor.clickBlockOptionsMenuItem( 'Add note' );
+		await expect( form ).toBeFocused();
+		// Close the pinned notes sidebar.
+		await page
+			.getByRole( 'region', { name: 'Editor top bar' } )
+			.getByRole( 'button', { name: 'Notes', exact: true } )
+			.click();
+		await editor.clickBlockOptionsMenuItem( 'Add note' );
+		await expect( form ).toBeFocused();
+	} );
+
 	test( 'can add a comment to a block', async ( { editor, page } ) => {
 		await editor.insertBlock( {
 			name: 'core/paragraph',


### PR DESCRIPTION
## What?
See: https://github.com/WordPress/gutenberg/pull/72431#issuecomment-3415425117 and https://github.com/WordPress/gutenberg/issues/72157#issuecomment-3421349597.

PR fixes a focus transfer bug when adding the first note via the floating sidebar. Because of the condition, the sidebar was mounted too late, and the `commentSidebarRef` wasn't available.

I've moved the condition, and now it's all handled by the `useEnableFloatingSidebar` hook.

## Testing Instructions
1. Create a new post.
2. Insert a block.
3. Click on the "Add note" block option menu item.
4. Confirm that focus is transferred to the form.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/b4c4a922-f438-452d-8783-5f7fc5a8f38c


