### PR TITLE
Disable font size picker when fit text is on.

### DIFF
--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -424,7 +424,7 @@ export default function TypographyPanel( {
 					/>
 				</ToolsPanelItem>
 			) }
-			{ hasFontSizeEnabled && ! fitText && (
+			{ hasFontSizeEnabled && (
 				<ToolsPanelItem
 					label={ __( 'Size' ) }
 					hasValue={ hasFontSize }
@@ -440,6 +440,7 @@ export default function TypographyPanel( {
 						withReset={ false }
 						withSlider
 						size="__unstable-large"
+						disabled={ fitText }
 					/>
 				</ToolsPanelItem>
 			) }

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -178,6 +178,7 @@ export default function TypographyPanel( {
 	settings,
 	panelId,
 	defaultControls = DEFAULT_CONTROLS,
+	fitText = false,
 } ) {
 	const decodeValue = ( rawValue ) =>
 		getValueFromVariable( { settings }, '', rawValue );
@@ -423,7 +424,7 @@ export default function TypographyPanel( {
 					/>
 				</ToolsPanelItem>
 			) }
-			{ hasFontSizeEnabled && (
+			{ hasFontSizeEnabled && ! fitText && (
 				<ToolsPanelItem
 					label={ __( 'Size' ) }
 					hasValue={ hasFontSize }

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -116,11 +116,13 @@ function TypographyInspectorControl( { children, resetAllFilter } ) {
 
 export function TypographyPanel( { clientId, name, setAttributes, settings } ) {
 	function selector( select ) {
-		const { style, fontFamily, fontSize } =
+		const { style, fontFamily, fontSize, fitText } =
 			select( blockEditorStore ).getBlockAttributes( clientId ) || {};
-		return { style, fontFamily, fontSize };
+		return { style, fontFamily, fontSize, fitText };
 	}
-	const { style, fontFamily, fontSize } = useSelect( selector, [ clientId ] );
+	const { style, fontFamily, fontSize, fitText } = useSelect( selector, [
+		clientId,
+	] );
 	const isEnabled = useHasTypographyPanel( settings );
 	const value = useMemo(
 		() => attributesToStyle( { style, fontFamily, fontSize } ),
@@ -148,6 +150,7 @@ export function TypographyPanel( { clientId, name, setAttributes, settings } ) {
 			value={ value }
 			onChange={ onChange }
 			defaultControls={ defaultControls }
+			fitText={ fitText }
 		/>
 	);
 }

--- a/packages/components/src/custom-select-control-v2/custom-select.tsx
+++ b/packages/components/src/custom-select-control-v2/custom-select.tsx
@@ -93,6 +93,7 @@ function _CustomSelect(
 ) {
 	const {
 		children,
+		disabled = false,
 		hideLabelFromVision = false,
 		label,
 		size,
@@ -135,11 +136,13 @@ function _CustomSelect(
 				__next40pxDefaultSize
 				size={ size }
 				suffix={ <SelectControlChevronDown /> }
+				disabled={ disabled }
 			>
 				<CustomSelectButton
 					{ ...restProps }
 					size={ size }
 					store={ store }
+					disabled={ disabled }
 					// Match legacy behavior (move selection rather than open the popover)
 					showOnKeyDown={ ! isLegacy }
 				/>

--- a/packages/components/src/custom-select-control-v2/types.ts
+++ b/packages/components/src/custom-select-control-v2/types.ts
@@ -68,6 +68,12 @@ export type _CustomSelectProps = CustomSelectButtonProps & {
 	 */
 	children: React.ReactNode;
 	/**
+	 * If true, the control will be disabled and the user will not be able to interact with it.
+	 *
+	 * @default false
+	 */
+	disabled?: boolean;
+	/**
 	 * Used to visually hide the label. It will always be visible to screen readers.
 	 *
 	 * @default false

--- a/packages/components/src/custom-select-control/index.tsx
+++ b/packages/components/src/custom-select-control/index.tsx
@@ -59,6 +59,7 @@ function CustomSelectControl< T extends CustomSelectOption >(
 		__next40pxDefaultSize = false,
 		__shouldNotWarnDeprecated36pxSize,
 		describedBy,
+		disabled = false,
 		options,
 		onChange,
 		size = 'default',
@@ -188,6 +189,7 @@ function CustomSelectControl< T extends CustomSelectOption >(
 		<>
 			<_CustomSelect
 				aria-describedby={ descriptionId }
+				disabled={ disabled }
 				renderSelectedValue={
 					showSelectedHint ? renderSelectedValueHint : undefined
 				}

--- a/packages/components/src/custom-select-control/types.ts
+++ b/packages/components/src/custom-select-control/types.ts
@@ -38,6 +38,12 @@ export type CustomSelectProps< T extends CustomSelectOption > = {
 	 */
 	className?: string;
 	/**
+	 * If true, the control will be disabled and the user will not be able to interact with it.
+	 *
+	 * @default false
+	 */
+	disabled?: boolean;
+	/**
 	 * Hide the label visually, while keeping available to assistive technology.
 	 */
 	hideLabelFromVision?: boolean;

--- a/packages/components/src/font-size-picker/font-size-picker-select.tsx
+++ b/packages/components/src/font-size-picker/font-size-picker-select.tsx
@@ -20,7 +20,14 @@ const DEFAULT_OPTION: FontSizePickerSelectOption = {
 };
 
 const FontSizePickerSelect = ( props: FontSizePickerSelectProps ) => {
-	const { __next40pxDefaultSize, fontSizes, value, size, onChange } = props;
+	const {
+		__next40pxDefaultSize,
+		fontSizes,
+		value,
+		size,
+		disabled,
+		onChange,
+	} = props;
 
 	const options: FontSizePickerSelectOption[] = [
 		DEFAULT_OPTION,
@@ -56,6 +63,7 @@ const FontSizePickerSelect = ( props: FontSizePickerSelectProps ) => {
 			options={ options }
 			value={ selectedOption }
 			showSelectedHint
+			disabled={ disabled }
 			onChange={ ( {
 				selectedItem,
 			}: {

--- a/packages/components/src/font-size-picker/font-size-picker-toggle-group.tsx
+++ b/packages/components/src/font-size-picker/font-size-picker-toggle-group.tsx
@@ -14,7 +14,14 @@ import { T_SHIRT_ABBREVIATIONS, T_SHIRT_NAMES } from './constants';
 import type { FontSizePickerToggleGroupProps } from './types';
 
 const FontSizePickerToggleGroup = ( props: FontSizePickerToggleGroupProps ) => {
-	const { fontSizes, value, __next40pxDefaultSize, size, onChange } = props;
+	const {
+		fontSizes,
+		value,
+		__next40pxDefaultSize,
+		size,
+		disabled,
+		onChange,
+	} = props;
 	return (
 		<ToggleGroupControl
 			__nextHasNoMarginBottom
@@ -26,6 +33,7 @@ const FontSizePickerToggleGroup = ( props: FontSizePickerToggleGroupProps ) => {
 			onChange={ onChange }
 			isBlock
 			size={ size }
+			disabled={ disabled }
 		>
 			{ fontSizes.map( ( fontSize, index ) => (
 				<ToggleGroupControlOption
@@ -34,6 +42,7 @@ const FontSizePickerToggleGroup = ( props: FontSizePickerToggleGroupProps ) => {
 					label={ T_SHIRT_ABBREVIATIONS[ index ] }
 					aria-label={ fontSize.name || T_SHIRT_NAMES[ index ] }
 					showTooltip
+					disabled={ disabled }
 				/>
 			) ) }
 		</ToggleGroupControl>

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -97,7 +97,7 @@ const UnforwardedFontSizePicker = (
 	);
 	const isValueUnitRelative =
 		!! valueUnit && [ 'em', 'rem', 'vw', 'vh' ].includes( valueUnit );
-	const isDisabled = value === undefined;
+	const isDisabled = disabled || value === undefined;
 
 	maybeWarnDeprecated36pxSize( {
 		componentName: 'FontSizePicker',
@@ -131,6 +131,7 @@ const UnforwardedFontSizePicker = (
 							}
 							isPressed={ currentPickerType === 'custom' }
 							size="small"
+							disabled={ disabled }
 						/>
 					) }
 				</Header>
@@ -143,6 +144,7 @@ const UnforwardedFontSizePicker = (
 						value={ value }
 						disableCustomFontSizes={ disableCustomFontSizes }
 						size={ size }
+						disabled={ disabled }
 						onChange={ ( newValue ) => {
 							if ( newValue === undefined ) {
 								onChange?.( undefined );
@@ -165,6 +167,7 @@ const UnforwardedFontSizePicker = (
 						value={ value }
 						__next40pxDefaultSize={ __next40pxDefaultSize }
 						size={ size }
+						disabled={ disabled }
 						onChange={ ( newValue ) => {
 							if ( newValue === undefined ) {
 								onChange?.( undefined );
@@ -190,6 +193,7 @@ const UnforwardedFontSizePicker = (
 								labelPosition="top"
 								hideLabelFromVision
 								value={ value }
+								disabled={ disabled }
 								onChange={ ( newValue ) => {
 									setUserRequestedCustom( true );
 
@@ -223,6 +227,7 @@ const UnforwardedFontSizePicker = (
 										value={ valueQuantity }
 										initialPosition={ fallbackFontSize }
 										withInputField={ false }
+										disabled={ disabled }
 										onChange={ ( newValue ) => {
 											setUserRequestedCustom( true );
 

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -42,6 +42,7 @@ const UnforwardedFontSizePicker = (
 		fallbackFontSize,
 		fontSizes = [],
 		disableCustomFontSizes = false,
+		disabled = false,
 		onChange,
 		size = 'default',
 		units: unitsProp = DEFAULT_UNITS,
@@ -110,6 +111,7 @@ const UnforwardedFontSizePicker = (
 			className="components-font-size-picker"
 			// This Container component renders a fieldset element that needs to be labeled.
 			aria-labelledby={ labelId }
+			disabled={ disabled }
 		>
 			<Spacer>
 				<Header className="components-font-size-picker__header">

--- a/packages/components/src/font-size-picker/types.ts
+++ b/packages/components/src/font-size-picker/types.ts
@@ -7,6 +7,13 @@ export type FontSizePickerProps = {
 	 */
 	disableCustomFontSizes?: boolean;
 	/**
+	 * If `true`, the font size picker will be disabled and the user will not
+	 * be able to change the font size.
+	 *
+	 * @default false
+	 */
+	disabled?: boolean;
+	/**
 	 * If no value exists, this prop defines the starting position for the font
 	 * size picker slider. Only relevant if `withSlider` is `true`.
 	 */
@@ -100,7 +107,7 @@ export type FontSize = {
 
 export type FontSizePickerSelectProps = Pick<
 	FontSizePickerProps,
-	'value' | 'size'
+	'value' | 'size' | 'disabled'
 > & {
 	fontSizes: NonNullable< FontSizePickerProps[ 'fontSizes' ] >;
 	disableCustomFontSizes: NonNullable<
@@ -120,7 +127,7 @@ export type FontSizePickerSelectOption = {
 
 export type FontSizePickerToggleGroupProps = Pick<
 	FontSizePickerProps,
-	'value' | 'size' | '__next40pxDefaultSize'
+	'value' | 'size' | '__next40pxDefaultSize' | 'disabled'
 > & {
 	fontSizes: NonNullable< FontSizePickerProps[ 'fontSizes' ] >;
 	onChange: NonNullable< FontSizePickerProps[ 'onChange' ] >;


### PR DESCRIPTION
Part of the solution to https://github.com/WordPress/gutenberg/issues/72219.
When fit text is on the font size is dynamically computed based on the available space, and changing font size values has no impact at all.
The font size attribute is still kept so if the user disables fit text things go back to how they were before.

This PR hides the font size picker when fit text is on.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/a34b930f-9d9d-4dec-8e0e-9e7cf8c0c3df


## Testing
- Add a paragraph
- Choose some font size.
- Enabled fit text, verify font size picker disappears.
- Disable fit text, verify font size appears with the value previously set.
- Repeat the test for heading.


