### PR TITLE
Prevent registering private APIs twice

### DIFF
--- a/packages/fields/src/actions/duplicate-post.tsx
+++ b/packages/fields/src/actions/duplicate-post.tsx
@@ -6,25 +6,32 @@ import { store as coreStore } from '@wordpress/core-data';
 import { __, sprintf, _x } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from '@wordpress/element';
-import { DataForm } from '@wordpress/dataviews';
 import {
 	Button,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
-import type { Action } from '@wordpress/dataviews';
 
 /**
  * Internal dependencies
  */
-import { titleField } from '../fields';
 import type { BasePost, CoreDataError } from '../types';
 import { getItemTitle } from './utils';
 
-const fields = [ titleField ];
-const formDuplicateAction = {
-	fields: [ 'title' ],
-};
+interface RenderModalProps< Item > {
+	items: Item[];
+	closeModal?: () => void;
+	onActionPerformed?: ( items: Item[] ) => void;
+}
+
+interface Action< Item > {
+	id: string;
+	label: string;
+	isEligible?: ( item: Item ) => boolean;
+	modalFocusOnMount?: string;
+	RenderModal: ( props: RenderModalProps< Item > ) => JSX.Element;
+}
 
 const duplicatePost: Action< BasePost > = {
 	id: 'duplicate-post',
@@ -149,14 +156,15 @@ const duplicatePost: Action< BasePost > = {
 							) }
 						</div>
 					) }
-					<DataForm
-						data={ item }
-						fields={ fields }
-						form={ formDuplicateAction }
-						onChange={ ( changes ) =>
+					<InputControl
+						__next40pxDefaultSize
+						label={ __( 'Title' ) }
+						placeholder={ __( 'No title' ) }
+						value={ getItemTitle( item ) }
+						onChange={ ( value ) =>
 							setItem( ( prev ) => ( {
 								...prev,
-								...changes,
+								title: value || '',
 							} ) )
 						}
 					/>

--- a/packages/fields/src/actions/duplicate-post.tsx
+++ b/packages/fields/src/actions/duplicate-post.tsx
@@ -164,7 +164,7 @@ const duplicatePost: Action< BasePost > = {
 						onChange={ ( value ) =>
 							setItem( ( prev ) => ( {
 								...prev,
-								title: value || '',
+								title: value || __( 'No title' ),
 							} ) )
 						}
 					/>

--- a/packages/fields/src/actions/reorder-page.tsx
+++ b/packages/fields/src/actions/reorder-page.tsx
@@ -32,6 +32,14 @@ interface Action< Item > {
 	RenderModal: ( props: RenderModalProps< Item > ) => JSX.Element;
 }
 
+function isItemValid( item: BasePost ): boolean {
+	return (
+		typeof item.menu_order === 'number' &&
+		Number.isInteger( item.menu_order ) &&
+		item.menu_order > 0
+	);
+}
+
 function ReorderModal( {
 	items,
 	closeModal,
@@ -43,8 +51,14 @@ function ReorderModal( {
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
 
+	const isValid = isItemValid( item );
+
 	async function onOrder( event: React.FormEvent ) {
 		event.preventDefault();
+
+		if ( ! isValid ) {
+			return;
+		}
 
 		try {
 			await editEntityRecord( 'postType', item.type, item.id, {
@@ -83,11 +97,18 @@ function ReorderModal( {
 					__next40pxDefaultSize
 					label={ __( 'Order' ) }
 					type="number"
-					value={ String( item.menu_order ?? 0 ) }
+					value={
+						typeof item.menu_order === 'number' &&
+						Number.isInteger( item.menu_order )
+							? String( item.menu_order )
+							: ''
+					}
 					onChange={ ( value ) => {
 						setItem( {
 							...item,
-							menu_order: value ? parseInt( value, 10 ) : 0,
+							menu_order: [ undefined, '' ].includes( value )
+								? undefined
+								: parseInt( value as string, 10 ),
 						} );
 					} }
 				/>
@@ -105,6 +126,8 @@ function ReorderModal( {
 						__next40pxDefaultSize
 						variant="primary"
 						type="submit"
+						accessibleWhenDisabled
+						disabled={ ! isValid }
 					>
 						{ __( 'Save' ) }
 					</Button>

--- a/packages/fields/src/actions/reorder-page.tsx
+++ b/packages/fields/src/actions/reorder-page.tsx
@@ -104,11 +104,10 @@ function ReorderModal( {
 							: ''
 					}
 					onChange={ ( value ) => {
+						const parsed = parseInt( value as string, 10 ); // absorbs '' and undefined
 						setItem( {
 							...item,
-							menu_order: [ undefined, '' ].includes( value )
-								? undefined
-								: parseInt( value as string, 10 ),
+							menu_order: isNaN( parsed ) ? undefined : parsed,
 						} );
 					} }
 				/>

--- a/packages/fields/src/actions/reorder-page.tsx
+++ b/packages/fields/src/actions/reorder-page.tsx
@@ -6,24 +6,31 @@ import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from '@wordpress/element';
-import { DataForm, useFormValidity } from '@wordpress/dataviews';
 import {
 	Button,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
-import type { Action, RenderModalProps } from '@wordpress/dataviews';
 
 /**
  * Internal dependencies
  */
 import type { CoreDataError, BasePost } from '../types';
-import { orderField } from '../fields';
 
-const fields = [ orderField ];
-const formOrderAction = {
-	fields: [ 'menu_order' ],
-};
+interface RenderModalProps< Item > {
+	items: Item[];
+	closeModal?: () => void;
+	onActionPerformed?: ( items: Item[] ) => void;
+}
+
+interface Action< Item > {
+	id: string;
+	label: string;
+	isEligible?: ( item: Item ) => boolean;
+	modalFocusOnMount?: string;
+	RenderModal: ( props: RenderModalProps< Item > ) => JSX.Element;
+}
 
 function ReorderModal( {
 	items,
@@ -31,28 +38,17 @@ function ReorderModal( {
 	onActionPerformed,
 }: RenderModalProps< BasePost > ) {
 	const [ item, setItem ] = useState( items[ 0 ] );
-	const orderInput = item.menu_order;
 	const { editEntityRecord, saveEditedEntityRecord } =
 		useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
 
-	const { validity, isValid } = useFormValidity(
-		item,
-		fields,
-		formOrderAction
-	);
-
 	async function onOrder( event: React.FormEvent ) {
 		event.preventDefault();
 
-		if ( ! isValid ) {
-			return;
-		}
-
 		try {
 			await editEntityRecord( 'postType', item.type, item.id, {
-				menu_order: orderInput,
+				menu_order: item.menu_order,
 			} );
 			closeModal?.();
 			// Persist edited entity.
@@ -83,15 +79,15 @@ function ReorderModal( {
 						'Determines the order of pages. Pages with the same order value are sorted alphabetically. Negative order values are supported.'
 					) }
 				</div>
-				<DataForm
-					data={ item }
-					fields={ fields }
-					form={ formOrderAction }
-					validity={ validity }
-					onChange={ ( changes ) => {
-						return setItem( {
+				<InputControl
+					__next40pxDefaultSize
+					label={ __( 'Order' ) }
+					type="number"
+					value={ String( item.menu_order ?? 0 ) }
+					onChange={ ( value ) => {
+						setItem( {
 							...item,
-							...changes,
+							menu_order: value ? parseInt( value, 10 ) : 0,
 						} );
 					} }
 				/>
@@ -109,8 +105,6 @@ function ReorderModal( {
 						__next40pxDefaultSize
 						variant="primary"
 						type="submit"
-						accessibleWhenDisabled
-						disabled={ ! isValid }
 					>
 						{ __( 'Save' ) }
 					</Button>

--- a/packages/private-apis/src/implementation.ts
+++ b/packages/private-apis/src/implementation.ts
@@ -60,7 +60,7 @@ const requiredConsent =
 	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.';
 
 // The safety measure is meant for WordPress core where IS_WORDPRESS_CORE is set to true.
-const allowReRegistration = false;
+const allowReRegistration = globalThis.IS_WORDPRESS_CORE ? false : true;
 
 /**
  * Called by a @wordpress package wishing to opt-in to accessing or exposing

--- a/packages/private-apis/src/implementation.ts
+++ b/packages/private-apis/src/implementation.ts
@@ -60,7 +60,7 @@ const requiredConsent =
 	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.';
 
 // The safety measure is meant for WordPress core where IS_WORDPRESS_CORE is set to true.
-const allowReRegistration = globalThis.IS_WORDPRESS_CORE ? false : true;
+const allowReRegistration = false;
 
 /**
  * Called by a @wordpress package wishing to opt-in to accessing or exposing


### PR DESCRIPTION
## What?

This PR prevents registering private APIs twice.

## Why?

So that it builds.

## How?

Do not use DataForm for reorder and duplicate actions.

## Testing Instructions

- Change `const allowReRegistration = globalThis.IS_WORDPRESS_CORE ? false : true;` to `const allowReRegistration = false;` in [private apis](https://github.com/WordPress/gutenberg/blob/26a4fbd87b66d243188cc28b0f07ef4bc81b3677/packages/private-apis/src/implementation.ts#L63).
- Verify the site editor loads as expected.

