### PR TITLE
Perf: Avoid rich-text binding subscription if block does not have bindings

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -41,6 +41,7 @@ import { getAllowedFormats } from './utils';
 import { Content, valueToHTMLString } from './content';
 import { withDeprecations } from './with-deprecations';
 import BlockContext from '../block-context';
+import { PrivateBlockContext } from '../block-list/private-block-context';
 
 export const keyboardShortcutContext = createContext();
 keyboardShortcutContext.displayName = 'keyboardShortcutContext';
@@ -124,9 +125,10 @@ export function RichTextWrapper(
 	const instanceId = useInstanceId( RichTextWrapper );
 	const anchorRef = useRef();
 	const context = useBlockEditContext();
-	const { clientId, isSelected: isBlockSelected, name: blockName } = context;
+	const { clientId, isSelected: isBlockSelected } = context;
 	const blockBindings = context[ blockBindingsKey ];
 	const blockContext = useContext( BlockContext );
+	const { bindableAttributes } = useContext( PrivateBlockContext );
 	const registry = useRegistry();
 	const selector = ( select ) => {
 		// Avoid subscribing to the block editor store if the block is not
@@ -171,15 +173,7 @@ export function RichTextWrapper(
 
 	const { disableBoundBlock, bindingsPlaceholder, bindingsLabel } = useSelect(
 		( select ) => {
-			const { __experimentalBlockBindingsSupportedAttributes } =
-				select( blockEditorStore ).getSettings();
-
-			if (
-				! blockBindings?.[ identifier ] ||
-				! (
-					blockName in __experimentalBlockBindingsSupportedAttributes
-				)
-			) {
+			if ( ! blockBindings?.[ identifier ] || ! bindableAttributes ) {
 				return {};
 			}
 
@@ -252,7 +246,7 @@ export function RichTextWrapper(
 		[
 			blockBindings,
 			identifier,
-			blockName,
+			bindableAttributes,
 			adjustedValue,
 			clientId,
 			blockContext,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->
In #71820 a subscription was [added to all RichText components ](https://github.com/WordPress/gutenberg/commit/d55d5fa03c70e6cf3ed58db49c81aea62173393d#diff-bec072c72a2f961596701aef67f67575b0a3b918135a6587229a0cd79bb3db44R179-R181) even if there is no block bindings. This caused the [inserterHover](https://www.codevitals.run/project/gutenberg/inserterHover) and [type](https://www.codevitals.run/project/gutenberg/type) metrics to go up:

<img width="1061" height="693" alt="Inserter Hover metric commit graph with a rise in time at commit d55d5fa" src="https://github.com/user-attachments/assets/4897c0fa-a7e0-42ac-9998-aa36883d04b0" />

https://github.com/WordPress/gutenberg/pull/72351 helped address it, but it doesn't seem like the performance improved as significantly as hoped as it did not remove the RichText subscription.


<!-- In a few words, what is the PR actually doing? -->
 
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Any improvements we can make here impact the whole experience.
Excessive subscriptions degrade performance, so we should reduce subscriptions if possible.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Check for the presence of bindable attributes from the PrivateContext instead of settings, so we don't need to add a new subscription. This returns the inserterHover performance metric back to the baseline before #71820.

The current potential win is an early return to avoid adding unnecessary subscriptions for rich-text bindings:
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
There should be no functional changes from trunk.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
<img width="1012" height="807" alt="Performance metrics of this branch showing -29% improvement in inserterHover and -12.92% improvement in type metrics" src="https://github.com/user-attachments/assets/fd687482-61e5-49d6-a71b-e2e6b99cddf0" />

