### PR TITLE
Template activation: improve UX for custom templates

### DIFF
--- a/packages/edit-site/src/components/dataviews-actions/index.js
+++ b/packages/edit-site/src/components/dataviews-actions/index.js
@@ -35,7 +35,7 @@ export const useSetActiveTemplateAction = () => {
 			icon: pencil,
 			isEligible( item ) {
 				return (
-					! item.is_custom &&
+					! item._isCustom &&
 					! ( item.slug === 'index' && item.source === 'theme' ) &&
 					item.theme === activeTheme.stylesheet
 				);

--- a/packages/edit-site/src/components/dataviews-actions/index.js
+++ b/packages/edit-site/src/components/dataviews-actions/index.js
@@ -35,6 +35,7 @@ export const useSetActiveTemplateAction = () => {
 			icon: pencil,
 			isEligible( item ) {
 				return (
+					! item.is_custom &&
 					! ( item.slug === 'index' && item.source === 'theme' ) &&
 					item.theme === activeTheme.stylesheet
 				);

--- a/packages/edit-site/src/components/page-templates/fields.js
+++ b/packages/edit-site/src/components/page-templates/fields.js
@@ -11,7 +11,7 @@ import {
 	__experimentalHStack as HStack,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { useState, useMemo } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { parse } from '@wordpress/blocks';
@@ -156,8 +156,16 @@ export const activeField = {
 	getValue: ( { item } ) => item._isActive,
 	render: function Render( { item } ) {
 		if ( item.is_custom ) {
-			// translators: Refers to a type of template: custom template
-			return <Badge intent="info">{ __( 'Custom' ) }</Badge>;
+			return (
+				<Badge
+					intent="info"
+					title={ __(
+						'Custom templates cannot be active nor inactive.'
+					) }
+				>
+					{ __( 'N/A' ) }
+				</Badge>
+			);
 		}
 
 		const isActive = item._isActive;
@@ -195,10 +203,6 @@ export const slugField = {
 		const defaultTemplateType = defaultTemplateTypes.find(
 			( type ) => type.slug === item.slug
 		);
-		return (
-			defaultTemplateType?.title ||
-			// translators: Refers to a type of template: custom template
-			__( 'Custom' )
-		);
+		return defaultTemplateType?.title || _x( 'Custom', 'template type' );
 	},
 };

--- a/packages/edit-site/src/components/page-templates/fields.js
+++ b/packages/edit-site/src/components/page-templates/fields.js
@@ -155,7 +155,7 @@ export const activeField = {
 	id: 'active',
 	getValue: ( { item } ) => item._isActive,
 	render: function Render( { item } ) {
-		if ( item.is_custom ) {
+		if ( item._isCustom ) {
 			return (
 				<Badge
 					intent="info"

--- a/packages/edit-site/src/components/page-templates/fields.js
+++ b/packages/edit-site/src/components/page-templates/fields.js
@@ -155,6 +155,11 @@ export const activeField = {
 	id: 'active',
 	getValue: ( { item } ) => item._isActive,
 	render: function Render( { item } ) {
+		if ( item.is_custom ) {
+			// translators: Refers to a type of template: custom template
+			return <Badge intent="info">{ __( 'Custom' ) }</Badge>;
+		}
+
 		const isActive = item._isActive;
 		return (
 			<Badge intent={ isActive ? 'success' : 'default' }>
@@ -192,7 +197,7 @@ export const slugField = {
 		);
 		return (
 			defaultTemplateType?.title ||
-			// translators: %s is the slug of a custom template.
+			// translators: Refers to a type of template: custom template
 			__( 'Custom' )
 		);
 	},

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -72,14 +72,18 @@ export default function PageTemplates() {
 		},
 	} );
 
-	const { activeTemplatesOption, activeTheme } = useSelect( ( select ) => {
-		const { getEntityRecord, getCurrentTheme } = select( coreStore );
-		return {
-			activeTemplatesOption: getEntityRecord( 'root', 'site' )
-				?.active_templates,
-			activeTheme: getCurrentTheme(),
-		};
-	} );
+	const { activeTemplatesOption, activeTheme, defaultTemplateTypes } =
+		useSelect( ( select ) => {
+			const { getEntityRecord, getCurrentTheme } = select( coreStore );
+			return {
+				activeTemplatesOption: getEntityRecord( 'root', 'site' )
+					?.active_templates,
+				activeTheme: getCurrentTheme(),
+				defaultTemplateTypes:
+					select( coreStore ).getCurrentTheme()
+						?.default_template_types,
+			};
+		} );
 	// Todo: this will have to be better so that we're not fetching all the
 	// records all the time. Active templates query will need to move server
 	// side.
@@ -150,8 +154,14 @@ export default function PageTemplates() {
 			_isActive: activeTemplates.find(
 				( template ) => template.id === record.id
 			),
+			_isCustom:
+				record.is_custom ||
+				( ! record.meta?.is_wp_suggestion &&
+					! defaultTemplateTypes.find(
+						( type ) => type.slug === record.slug
+					) ),
 		} ) );
-	}, [ _records, activeTemplates ] );
+	}, [ _records, activeTemplates, defaultTemplateTypes ] );
 
 	const users = useSelect(
 		( select ) => {


### PR DESCRIPTION
## What?

Follow-up of #67125

In the template editor:

* Disable the "Activate / Deactivate" action for custom templates
* Don't try to label custom templates' status as "Active" or "Inactive"; use "Custom" instead

## Why?

Custom templates aren't part of the template hierarchy and thus aren't subject to activation. The actions available and UI should reflect this.

## Questions

- [ ] In the Status field, I chose to use a Badge component with `intent="info"` to set custom templates apart from deactivated templates. What do you think of this? Happy to remove it and let the default take over.

## Screenshots or screencast 

|Before|After|
|-|-|
|<img width="1777" height="652" alt="Screenshot 2025-10-20 at 16 56 05" src="https://github.com/user-attachments/assets/7ff16996-5ec9-4571-b0f3-d8e330458083" />|<img width="1777" height="652" alt="Screenshot 2025-10-20 at 16 55 45" src="https://github.com/user-attachments/assets/9922b4b4-b3bb-4268-9e55-56c9b05df938" />|
|<img width="294" height="449" alt="Screenshot 2025-10-20 at 16 56 33" src="https://github.com/user-attachments/assets/5820421b-daeb-439d-a93a-71c9d4dc6e22" />|<img width="294" height="449" alt="Screenshot 2025-10-20 at 16 56 48" src="https://github.com/user-attachments/assets/be318bf7-f8f1-4dba-9e04-d2b47db0c11e" />|
