### PR TITLE
Fix Query Loop block rendering for users without permissions to edit the post type

### DIFF
--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -220,6 +220,7 @@ export default function PostTemplateEdit( {
 				posts: getEntityRecords( 'postType', usedPostType, {
 					...query,
 					...restQueryArgs,
+					context: 'view',
 				} ),
 				blocks: getBlocks( clientId ),
 			};

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -62,13 +62,21 @@ export default function PostTitleEdit( {
 		},
 		[ isDescendentOfQueryLoop, postType, postId ]
 	);
+	const context = userCanEdit ? 'edit' : 'view';
 	const [ rawTitle = '', setTitle, fullTitle ] = useEntityProp(
 		'postType',
 		postType,
 		'title',
-		postId
+		postId,
+		context
 	);
-	const [ link ] = useEntityProp( 'postType', postType, 'link', postId );
+	const [ link ] = useEntityProp(
+		'postType',
+		postType,
+		'link',
+		postId,
+		context
+	);
 	const onSplitAtEnd = () => {
 		insertBlocksAfter( createBlock( getDefaultBlockName() ) );
 	};

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -1030,6 +1030,7 @@ _Parameters_
 -   _name_ `string`: The entity name.
 -   _prop_ `string`: The property name.
 -   _\_id_ `[number|string]`: An entity ID to use instead of the context-provided one.
+-   _context_ `[string]`: The context to use when accessing the entity.
 
 _Returns_
 

--- a/packages/core-data/src/hooks/use-entity-prop.js
+++ b/packages/core-data/src/hooks/use-entity-prop.js
@@ -15,19 +15,20 @@ import useEntityId from './use-entity-id';
  * specified property of the nearest provided
  * entity of the specified type.
  *
- * @param {string}        kind  The entity kind.
- * @param {string}        name  The entity name.
- * @param {string}        prop  The property name.
- * @param {number|string} [_id] An entity ID to use instead of the context-provided one.
+ * @param {string}        kind      The entity kind.
+ * @param {string}        name      The entity name.
+ * @param {string}        prop      The property name.
+ * @param {number|string} [_id]     An entity ID to use instead of the context-provided one.
+ * @param {string}        [context] The context to use when accessing the entity.
  *
  * @return {[*, Function, *]} An array where the first item is the
  *                            property value, the second is the
  *                            setter and the third is the full value
- * 							  object from REST API containing more
- * 							  information like `raw`, `rendered` and
- * 							  `protected` props.
+ *                            object from REST API containing more
+ *                            information like `raw`, `rendered` and
+ *                            `protected` props.
  */
-export default function useEntityProp( kind, name, prop, _id ) {
+export default function useEntityProp( kind, name, prop, _id, context ) {
 	const providerId = useEntityId( kind, name );
 	const id = _id ?? providerId;
 
@@ -35,16 +36,29 @@ export default function useEntityProp( kind, name, prop, _id ) {
 		( select ) => {
 			const { getEntityRecord, getEditedEntityRecord } =
 				select( STORE_NAME );
-			const record = getEntityRecord( kind, name, id ); // Trigger resolver.
+			const query = context ? { context } : null;
+			const record = getEntityRecord( kind, name, id, query ); // Trigger resolver.
+
+			if ( ! record ) {
+				return {};
+			}
+
+			if ( context === 'view' ) {
+				return {
+					value: record[ prop ],
+					fullValue: record[ prop ],
+				};
+			}
+
 			const editedRecord = getEditedEntityRecord( kind, name, id );
-			return record && editedRecord
+			return editedRecord
 				? {
 						value: editedRecord[ prop ],
 						fullValue: record[ prop ],
 				  }
 				: {};
 		},
-		[ kind, name, id, prop ]
+		[ kind, name, id, prop, context ]
 	);
 	const { editEntityRecord } = useDispatch( STORE_NAME );
 	const setValue = useCallback(


### PR DESCRIPTION
## What?

There is currently a bug that users without permissions to edit a specific product type aren't allowed to see the _Query Loop_ block in the editor if it queries that product type. For example, if an author user edits a post containing the _Query Loop_ block with _Pages_ as the post type, the block only renders an infinite spinner.

## Why?

While right now users are not allowed to select post types they don't have permissions to edit in the _Query Loop_ block, other users might modify their posts and add the block. Right now, Gutenberg only renders an infinite scroll which seems broken.

In addition to that, some plugins out there like WooCommerce might use blocks like _Post Title_ for products and make them available to users without permission to edit titles.

## How?

This PR:

* Fixes the _Query Loop_ block so it fetches the post items with `context: view`, so users don't need to have permission to edit that post type to be able to see the _Query Loop_ block preview.
* Fixes the _Post Title_ block in a similar way, so it fetches data with `context: view`, so the correct title is displayed.

## Testing Instructions

**Only Gutenberg:**

1. With an author user, create a post.
2. Now, with an admin, edit that post and insert the _Query Loop_ block. Select a _Custom_ query with _Pages_ as the post type.
3. Edit the post again with the author.
4. Verify the _Query Loop_ block renders correctly, instead of being stuck showing a spinner.

Before | After
--- | ---
<img width="936" height="857" alt="image" src="https://github.com/user-attachments/assets/8e175f4a-f658-4237-862e-7a263af8dc3a" /> | <img width="936" height="857" alt="image" src="https://github.com/user-attachments/assets/0aaa02be-b477-4c66-befb-ed0cf67f8c1e" />

**On WooCommerce:**

1. With an author user, insert the _Product_ block.
2. Verify the product title is displayed.

Before | After
--- | ---
<img width="1113" height="816" alt="image" src="https://github.com/user-attachments/assets/d8deada5-7e29-4b22-9d1d-5cff42e2bdce" /> | <img width="1113" height="816" alt="image" src="https://github.com/user-attachments/assets/708cf8a9-906f-4986-8e7f-6d81aaea9b17" />