### PR TITLE
Dataviews: Make bulk actions text based.

### DIFF
--- a/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
@@ -169,13 +169,12 @@ function ActionTrigger< Item >( {
 		<Button
 			disabled={ isBusy }
 			accessibleWhenDisabled
-			label={ label }
-			icon={ action.icon }
 			size="compact"
 			onClick={ onClick }
 			isBusy={ isBusy }
-			tooltipPosition="top"
-		/>
+		>
+			{ label }
+		</Button>
 	);
 }
 
@@ -335,7 +334,6 @@ function FooterContent< Item >( {
 			actions.filter( ( action ) => {
 				return (
 					action.supportsBulk &&
-					action.icon &&
 					selectedItems.some(
 						( item ) =>
 							! action.isEligible || action.isEligible( item )


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/72417.
Makes bulk actions actions text buttons instead of icons like we did for the single primary actions.

## Screenshots

<img width="951" height="579" alt="Screenshot 2025-10-20 at 17 48 10" src="https://github.com/user-attachments/assets/435a2d92-d8a5-493a-8086-30d933a83a99" />
<img width="953" height="578" alt="Screenshot 2025-10-20 at 17 47 57" src="https://github.com/user-attachments/assets/05d80cb1-18c3-40f4-b670-973d45ffec26" />
<img width="945" height="579" alt="Screenshot 2025-10-20 at 17 47 26" src="https://github.com/user-attachments/assets/0ebeeb23-8b9f-4c01-a703-3d4c494ad778" />

## Testing Instructions
Verify bulk actions for pages, templates, and patterns still work as before.
