### PR TITLE
Real-time collaboration: Ensure Yjs imports are inside experimental flag check

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -19,7 +19,7 @@ import { receiveItems, removeItems, receiveQueriedItems } from './queried-data';
 import { DEFAULT_ENTITY_KEY } from './entities';
 import { createBatch } from './batch';
 import { STORE_NAME } from './name';
-import { LOCAL_EDITOR_ORIGIN, syncManager } from './sync';
+import { LOCAL_EDITOR_ORIGIN, getSyncManager } from './sync';
 import logEntityDeprecation from './utils/log-entity-deprecation';
 
 /**
@@ -415,7 +415,7 @@ export const editEntityRecord =
 				const objectType = `${ kind }/${ name }`;
 				const objectId = recordId;
 
-				syncManager.update(
+				getSyncManager()?.update(
 					objectType,
 					objectId,
 					edit.edits,

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -15,7 +15,7 @@ import apiFetch from '@wordpress/api-fetch';
  */
 import { STORE_NAME } from './name';
 import { additionalEntityConfigLoaders, DEFAULT_ENTITY_KEY } from './entities';
-import { syncManager } from './sync';
+import { getSyncManager } from './sync';
 import {
 	forwardResolver,
 	getNormalizedCommaSeparable,
@@ -185,7 +185,7 @@ export const getEntityRecord =
 						} );
 
 					// Load the entity record for syncing.
-					await syncManager.load(
+					await getSyncManager()?.load(
 						entityConfig.syncConfig,
 						objectType,
 						objectId,

--- a/packages/core-data/src/sync.ts
+++ b/packages/core-data/src/sync.ts
@@ -5,8 +5,20 @@ import {
 	CRDT_RECORD_MAP_KEY,
 	LOCAL_EDITOR_ORIGIN,
 	LOCAL_SYNC_MANAGER_ORIGIN,
+	type SyncManager,
 	createSyncManager,
 } from '@wordpress/sync';
 
 export { CRDT_RECORD_MAP_KEY, LOCAL_EDITOR_ORIGIN, LOCAL_SYNC_MANAGER_ORIGIN };
-export const syncManager = createSyncManager();
+
+let syncManager: SyncManager;
+
+export function getSyncManager(): SyncManager | undefined {
+	if ( syncManager ) {
+		return syncManager;
+	}
+
+	syncManager = createSyncManager();
+
+	return syncManager;
+}

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -6,13 +6,11 @@ import triggerFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import { syncManager } from '../sync';
+import { getSyncManager } from '../sync';
 
 jest.mock( '@wordpress/api-fetch' );
 jest.mock( '../sync', () => ( {
-	syncManager: {
-		load: jest.fn(),
-	},
+	getSyncManager: jest.fn(),
 } ) );
 
 /**
@@ -42,6 +40,8 @@ describe( 'getEntityRecord', () => {
 	const resolveSelect = { getEntitiesConfig: jest.fn( () => ENTITIES ) };
 
 	let dispatch;
+	let syncManager;
+
 	beforeEach( async () => {
 		dispatch = Object.assign( jest.fn(), {
 			receiveEntityRecords: jest.fn(),
@@ -51,7 +51,11 @@ describe( 'getEntityRecord', () => {
 			finishResolutions: jest.fn(),
 		} );
 		triggerFetch.mockReset();
-		syncManager.load.mockClear();
+
+		syncManager = {
+			load: jest.fn(),
+		};
+		getSyncManager.mockImplementation( () => syncManager );
 	} );
 
 	afterEach( () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Ensure Yjs imports are inside an experimental flag check.

## Why?

Code inside experimental flag checks is removed, which allows any code it imports or calls to be tree-shaken from WordPress release builds.

## How?

- Conditionally define `syncConfig` inside experimental flag check.
- Conditionally call `createSyncManager` inside experimental flag check.


## Testing Instructions

Since we are testing the effect of this change on WordPress builds, this gets a little tricky.

1. Checkout this branch.
2. Run `npm run build`.
3. In a separate directory, clone `wordpress-develop`.
4. Run `npm run sync-gutenberg-packages`
   - Confirm that it fails with `Warning: The build/wp-includes/js/dist/core-data.js file must not contain a sourceMappingURL.`
5. Copy the built `core-data` files from step 2 into the WordPress project, e.g.:
   - `cd node_modules/@wordpress/core-data`
   - `rm -rf build*`
   - `cp -r ../../../../gutenberg/packages/core-data/build* .`
6. Comment out [this line](https://github.com/WordPress/wordpress-develop/blob/9b9049cae20a658e0a3c01107bf908828df7e90b/Gruntfile.js#L1381) to prevent the `core-data` package from being overwritten.
7. Re-run `npm run sync-gutenberg-packages`
   - Confirm that it succeeds.

### Testing Instructions for Keyboard

n/a
