### PR TITLE
Optimize CI: Limit the number of job variations (PHP and JS matrix) in PRs

### DIFF
--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -26,8 +26,19 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node: ${{ github.event_name == 'pull_request' && fromJSON('["20"]') || fromJSON('["20", "22", "24"]') }}
-                os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-24.04"]') || fromJSON('["macos-15", "ubuntu-24.04", "windows-2025"]') }}
+                event: ['${{ github.event_name }}']
+                node: ['20', '22', '24']
+                os: ['macos-15', 'ubuntu-24.04', 'windows-2025']
+                exclude:
+                    # On PRs: Only test Node 20 on Ubuntu
+                    - event: 'pull_request'
+                      node: '22'
+                    - event: 'pull_request'
+                      node: '24'
+                    - event: 'pull_request'
+                      os: 'macos-15'
+                    - event: 'pull_request'
+                      os: 'windows-2025'
 
         steps:
             - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -26,8 +26,8 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node: ['20', '22', '24']
-                os: ['macos-15', 'ubuntu-24.04', 'windows-2025']
+                node: ${{ github.event_name == 'pull_request' && fromJSON('["20"]') || fromJSON('["20", "22", "24"]') }}
+                os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-24.04"]') || fromJSON('["macos-15", "ubuntu-24.04", "windows-2025"]') }}
 
         steps:
             - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -33,7 +33,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node: ['20', '22', '24']
+                node: ${{ github.event_name == 'pull_request' && fromJSON('["20"]') || fromJSON('["20", "22", "24"]') }}
                 shard: ['1/4', '2/4', '3/4', '4/4']
 
         steps:
@@ -78,7 +78,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node: ['20', '22', '24']
+                node: ${{ github.event_name == 'pull_request' && fromJSON('["20"]') || fromJSON('["20", "22", "24"]') }}
 
         steps:
             - name: Checkout repository
@@ -170,15 +170,8 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php:
-                    - '7.2'
-                    - '7.3'
-                    - '7.4'
-                    - '8.0'
-                    - '8.1'
-                    - '8.2'
-                    - '8.3'
-                multisite: [false, true]
+                php: ${{ github.event_name == 'pull_request' && fromJSON('["8.3"]') || fromJSON('["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]') }}
+                multisite: ${{ github.event_name == 'pull_request' && fromJSON('[false]') || fromJSON('[false, true]') }}
                 wordpress: [''] # Latest WordPress version.
                 include:
                     # Test with the previous WP version.

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -172,14 +172,16 @@ jobs:
             matrix:
                 php: ${{ github.event_name == 'pull_request' && fromJSON('["8.3"]') || fromJSON('["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]') }}
                 multisite: ${{ github.event_name == 'pull_request' && fromJSON('[false]') || fromJSON('[false, true]') }}
-                wordpress: [''] # Latest WordPress version.
-                include:
-                    # Test with the previous WP version.
-                    - php: '7.2'
+                wordpress: ${{ github.event_name == 'pull_request' && fromJSON('[""]') || fromJSON('["", "previous major version"]') }}
+                exclude:
+                    # On trunk/releases: Only test previous WP version with specific PHP versions.
+                    - php: '7.3'
                       wordpress: 'previous major version'
-                    - php: '7.4'
+                    - php: '8.0'
                       wordpress: 'previous major version'
-                    - php: '8.3'
+                    - php: '8.1'
+                      wordpress: 'previous major version'
+                    - php: '8.2'
                       wordpress: 'previous major version'
 
         env:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -33,8 +33,15 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node: ${{ github.event_name == 'pull_request' && fromJSON('["20"]') || fromJSON('["20", "22", "24"]') }}
+                event: ['${{ github.event_name }}']
+                node: ['20', '22', '24']
                 shard: ['1/4', '2/4', '3/4', '4/4']
+                exclude:
+                    # On PRs: Only test Node 20
+                    - event: 'pull_request'
+                      node: '22'
+                    - event: 'pull_request'
+                      node: '24'
 
         steps:
             - name: Checkout repository
@@ -78,7 +85,14 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node: ${{ github.event_name == 'pull_request' && fromJSON('["20"]') || fromJSON('["20", "22", "24"]') }}
+                event: ['${{ github.event_name }}']
+                node: ['20', '22', '24']
+                exclude:
+                    # On PRs: Only test Node 20
+                    - event: 'pull_request'
+                      node: '22'
+                    - event: 'pull_request'
+                      node: '24'
 
         steps:
             - name: Checkout repository
@@ -170,11 +184,29 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php: ${{ github.event_name == 'pull_request' && fromJSON('["8.3"]') || fromJSON('["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]') }}
-                multisite: ${{ github.event_name == 'pull_request' && fromJSON('[false]') || fromJSON('[false, true]') }}
-                wordpress: ${{ github.event_name == 'pull_request' && fromJSON('[""]') || fromJSON('["", "previous major version"]') }}
+                event: ['${{ github.event_name }}']
+                php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+                multisite: [false, true]
+                wordpress: ['', 'previous major version']
                 exclude:
-                    # On trunk/releases: Only test previous WP version with specific PHP versions.
+                    # On PRs: Only test PHP 8.3, single-site, latest WP
+                    - event: 'pull_request'
+                      php: '7.2'
+                    - event: 'pull_request'
+                      php: '7.3'
+                    - event: 'pull_request'
+                      php: '7.4'
+                    - event: 'pull_request'
+                      php: '8.0'
+                    - event: 'pull_request'
+                      php: '8.1'
+                    - event: 'pull_request'
+                      php: '8.2'
+                    - event: 'pull_request'
+                      multisite: true
+                    - event: 'pull_request'
+                      wordpress: 'previous major version'
+                    # On trunk/releases: Only test previous WP version with specific PHP versions
                     - php: '7.3'
                       wordpress: 'previous major version'
                     - php: '8.0'


### PR DESCRIPTION
## What

  Reduces the unit test matrix for pull requests to run only a single Node.js version (20) and single PHP version (8.3), while maintaining full multi-version testing on trunk and release branches.

##  Why

  - Faster PR feedback: Reduces PR test jobs from ~32 to ~6-10, significantly improving CI turnaround time
  - Cost savings: Reduces compute resource usage on PRs where full version coverage is less critical
  - Maintains quality: Full version coverage still runs on trunk/releases where it matters most for production deployments

##  How

  Uses conditional fromJSON() expressions in GitHub Actions matrix configuration based on github.event_name:
  - PRs: Node 20 only (5 jobs) + PHP 8.3 single-site only (1 job)
  - Trunk/releases: All versions - Node 20/22/24 (15 jobs) + PHP 7.2-8.3 with multisite variants (17 jobs)