### PR TITLE
Template activation: duplicate action should be available outside GB

### DIFF
--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -141,12 +141,9 @@ export const registerPostTypeSchema =
 			duplicatePost;
 
 		// @ts-ignore
-		if ( ! globalThis.IS_GUTENBERG_PLUGIN ) {
-			if (
-				! [ 'wp_template', 'wp_block', 'wp_template_part' ].includes(
-					postType
-				)
-			) {
+		if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+			// Outside Gutenberg, disable duplication except for wp_template.
+			if ( 'wp_template' !== postTypeConfig.slug ) {
 				canDuplicate = undefined;
 			}
 		}

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -141,7 +141,7 @@ export const registerPostTypeSchema =
 			duplicatePost;
 
 		// @ts-ignore
-		if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+		if ( ! globalThis.IS_GUTENBERG_PLUGIN ) {
 			// Outside Gutenberg, disable duplication except for wp_template.
 			if ( 'wp_template' !== postTypeConfig.slug ) {
 				canDuplicate = undefined;

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -141,7 +141,7 @@ export const registerPostTypeSchema =
 			duplicatePost;
 
 		// @ts-ignore
-		if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+		if ( ! globalThis.IS_GUTENBERG_PLUGIN ) {
 			if ( postType === 'page' ) {
 				canDuplicate = undefined;
 			}

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -133,19 +133,27 @@ export const registerPostTypeSchema =
 			.resolveSelect( coreStore )
 			.getCurrentTheme();
 
+		let canDuplicate =
+			! [ 'wp_block', 'wp_template_part' ].includes(
+				postTypeConfig.slug
+			) &&
+			canCreate &&
+			duplicatePost;
+
+		// @ts-ignore
+		if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+			if ( postType === 'page' ) {
+				canDuplicate = undefined;
+			}
+		}
+
 		const actions = [
 			postTypeConfig.viewable ? viewPost : undefined,
 			!! postTypeConfig.supports?.revisions
 				? viewPostRevisions
 				: undefined,
 			// @ts-ignore
-			globalThis.IS_GUTENBERG_PLUGIN
-				? ! [ 'wp_block', 'wp_template_part' ].includes(
-						postTypeConfig.slug
-				  ) &&
-				  canCreate &&
-				  duplicatePost
-				: undefined,
+			canDuplicate,
 			postTypeConfig.slug === 'wp_template_part' &&
 			canCreate &&
 			currentTheme?.is_block_theme

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -142,7 +142,11 @@ export const registerPostTypeSchema =
 
 		// @ts-ignore
 		if ( ! globalThis.IS_GUTENBERG_PLUGIN ) {
-			if ( postType === 'page' ) {
+			if (
+				! [ 'wp_template', 'wp_block', 'wp_template_part' ].includes(
+					postType
+				)
+			) {
 				canDuplicate = undefined;
 			}
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

The duplicate activation is not available outside of GB. Apparently it should be removed for pages, so I'm explicitly removing it for that post type and leaving things otherwise the same.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's an essential part of the template activation feature.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Edit the code and remove the `globalThis.IS_GUTENBERG_PLUGIN` negation. Verify that you can't duplicate pages. Verify that you can duplicate templates.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
