### PR TITLE
Notes: Fix the 'glitch' when selecting a note with a missing block

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -327,7 +327,7 @@ function Thread( {
 	const handleCommentSelect = () => {
 		setShowCommentBoard( false );
 		setSelectedThread( thread.id );
-		if ( relatedBlockElement ) {
+		if ( !! thread.blockClientId ) {
 			// Pass `null` as the second parameter to prevent focusing the block.
 			selectBlock( thread.blockClientId, null );
 			toggleBlockSpotlight( thread.blockClientId, true );
@@ -350,7 +350,7 @@ function Thread( {
 		stripHTML( thread.content.rendered ),
 		10
 	);
-	const ariaLabel = relatedBlockElement
+	const ariaLabel = !! thread.blockClientId
 		? sprintf(
 				// translators: %s: note excerpt
 				__( 'Note: %s' ),
@@ -416,7 +416,7 @@ function Thread( {
 			>
 				{ __( 'Add new note' ) }
 			</Button>
-			{ ! relatedBlockElement && (
+			{ ! thread.blockClientId && (
 				<Text as="p" weight={ 500 } variant="muted">
 					{ __( 'Original block deleted.' ) }
 				</Text>

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -535,17 +535,19 @@ function Thread( {
 					</VStack>
 				</VStack>
 			) }
-			<Button
-				className="editor-collab-sidebar-panel__skip-to-block"
-				variant="secondary"
-				size="compact"
-				onClick={ ( event ) => {
-					event.stopPropagation();
-					relatedBlockElement?.focus();
-				} }
-			>
-				{ __( 'Back to block' ) }
-			</Button>
+			{ !! thread.blockClientId && (
+				<Button
+					className="editor-collab-sidebar-panel__skip-to-block"
+					variant="secondary"
+					size="compact"
+					onClick={ ( event ) => {
+						event.stopPropagation();
+						relatedBlockElement?.focus();
+					} }
+				>
+					{ __( 'Back to block' ) }
+				</Button>
+			) }
 		</VStack>
 	);
 }

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -327,9 +327,11 @@ function Thread( {
 	const handleCommentSelect = () => {
 		setShowCommentBoard( false );
 		setSelectedThread( thread.id );
-		// pass `null` as the second parameter to prevent focusing the block.
-		selectBlock( thread.blockClientId, null );
-		toggleBlockSpotlight( thread.blockClientId, true );
+		if ( relatedBlockElement ) {
+			// Pass `null` as the second parameter to prevent focusing the block.
+			selectBlock( thread.blockClientId, null );
+			toggleBlockSpotlight( thread.blockClientId, true );
+		}
 	};
 
 	const unselectThread = () => {


### PR DESCRIPTION
## What?
Part of #66377.

PR fixes a minor "glitch" when selecting a note with a missing block. This also prevented note selection and prevented users from performing associated actions.

## Why?
Selecting a note also selects the associated block, which no longer exists, and the selection is clear. The selection change then resets the selected thread state.

## Testing Instructions
1. Create a post.
2. Add a block and note to it.
3. Delete the block.
4. Add a new block.
5. Click on the note with a missing block.
6. Confirm that it's selected correctly.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/a11e276a-3e8d-4366-b114-ea870d946cbc


