### PR TITLE
Post Date block: In deprecation, add check if source is `core/post-data`

### DIFF
--- a/packages/block-library/src/post-date/deprecated.js
+++ b/packages/block-library/src/post-date/deprecated.js
@@ -102,7 +102,11 @@ const v3 = {
 		};
 	},
 	isEligible( attributes ) {
-		return !! attributes?.metadata?.bindings?.datetime?.args?.key;
+		return (
+			attributes?.metadata?.bindings?.datetime?.source ===
+				'core/post-data' &&
+			!! attributes?.metadata?.bindings?.datetime?.args?.key
+		);
 	},
 };
 


### PR DESCRIPTION
## What?
In the block deprecation for the Post Date block that changes `args: { key: ... }` to `args: { field: ... }`, add a check that the block bindings source is `core/post-data`.

Follow-up to https://github.com/WordPress/gutenberg/pull/72483.

## Why?
Because it's possible that the block was bound to a different source that actually requires `key` (rather than `field`).

## How?
By adding a simple check.

## Testing Instructions
No new test coverage is added as this is a fairly straight-forward change. To verify that it works, you could apply the following patch

```diff
diff --git a/test/integration/fixtures/blocks/core__post-date__deprecated-v3.html b/test/integration/fixtures/blocks/core__post-date__deprecated-v3.html
index 8c2f8584aa..55982e58c2 100644
--- a/test/integration/fixtures/blocks/core__post-date__deprecated-v3.html
+++ b/test/integration/fixtures/blocks/core__post-date__deprecated-v3.html
@@ -1 +1 @@
-<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"key":"date"}}}}} /-->
+<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"other/source","args":{"key":"date"}}}}} /-->
```

and run `npm run fixtures:regenerate`.

Then, verify that `core__post-date__deprecated-v3*` fixtures have changed and contain `key` rather than `field`.