### PR TITLE
Fix password suffix alignment

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - DataForm: update spacing for regular and card layouts. [#72249](https://github.com/WordPress/gutenberg/pull/72249).
+- DataForm: Fix password field suffix alignment. [#72524](https://github.com/WordPress/gutenberg/pull/72524).
 
 ## 10.1.0 (2025-10-21)
 

--- a/packages/dataviews/src/dataform-controls/password.tsx
+++ b/packages/dataviews/src/dataform-controls/password.tsx
@@ -1,7 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
+import {
+	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
+	Button,
+} from '@wordpress/components';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { seen, unseen } from '@wordpress/icons';
@@ -34,17 +37,19 @@ export default function Password< Item >( {
 				validity,
 				type: isVisible ? 'text' : 'password',
 				suffix: (
-					<Button
-						icon={ isVisible ? unseen : seen }
-						onClick={ toggleVisibility }
-						size="small"
-						variant="tertiary"
-						aria-label={
-							isVisible
-								? __( 'Hide password' )
-								: __( 'Show password' )
-						}
-					/>
+					<InputControlSuffixWrapper variant="control">
+						<Button
+							icon={ isVisible ? unseen : seen }
+							onClick={ toggleVisibility }
+							size="small"
+							variant="tertiary"
+							aria-label={
+								isVisible
+									? __( 'Hide password' )
+									: __( 'Show password' )
+							}
+						/>
+					</InputControlSuffixWrapper>
 				),
 			} }
 		/>

--- a/packages/dataviews/src/dataform-controls/password.tsx
+++ b/packages/dataviews/src/dataform-controls/password.tsx
@@ -42,8 +42,7 @@ export default function Password< Item >( {
 							icon={ isVisible ? unseen : seen }
 							onClick={ toggleVisibility }
 							size="small"
-							variant="tertiary"
-							aria-label={
+							label={
 								isVisible
 									? __( 'Hide password' )
 									: __( 'Show password' )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
https://github.com/WordPress/gutenberg/pull/71545#issuecomment-3398290321

The password field suffix was not properly configured and aligned.
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- The suffix was not wrapped with InputControlSuffixWrapper 
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
- Checkout this PR.
- Run `npm run storybook:dev`.
- Visit the dataform validation story `?path=/story/dataviews-dataform--validation`.
- The suffix of the password field should be correctly aligned.
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

| Before  | After |
| ------------- | ------------- |
|  <img width="535" height="189" alt="Screenshot 2025-10-21 at 14 35 59" src="https://github.com/user-attachments/assets/b248e69d-17b7-4667-ae04-59838dd6789c" /> | <img width="531" height="164" alt="Screenshot 2025-10-21 at 14 33 31" src="https://github.com/user-attachments/assets/bf1cf28e-7f54-4f84-81b1-783248346f0f" /> | 


