### PR TITLE
Add PHP function prefixing documentation

### DIFF
--- a/docs/contributors/code/build-system-function-prefixing.md
+++ b/docs/contributors/code/build-system-function-prefixing.md
@@ -1,0 +1,66 @@
+# Build System: Function Prefixing and Block Loading
+
+Gutenberg uses a build system that automatically transforms PHP function names to avoid conflicts with WordPress Core. This system allows Gutenberg to use standard WordPress function names in source code while ensuring the plugin can coexist with WordPress Core without naming collisions.
+
+## Key Concept
+
+**Source files use standard WordPress function names** (e.g., `block_core_navigation_link_build_css_colors`), but **the build system transforms them to prefixed versions** (e.g., `gutenberg_block_core_navigation_link_build_css_colors`) in the built files that are actually loaded at runtime.
+
+## How the System Works
+
+### Source Code Structure
+
+Gutenberg's source code is organized in the `packages/` directory:
+
+```
+packages/block-library/src/
+├── navigation-link/
+│   ├── index.php          # Source file with standard function names
+│   ├── block.json
+│   └── edit.js
+├── post-time-to-read/
+│   ├── index.php          # Source file with standard function names
+│   └── block.json
+└── ...
+```
+
+### Build Process
+
+The build system is configured in `packages/block-library/package.json` and transforms:
+
+-   **Function names**: `block_core_navigation_link_build_css_colors()` → `gutenberg_block_core_navigation_link_build_css_colors()`
+-   **Function calls**: `wp_get_typography_font_size_value()` → `gutenberg_get_typography_font_size_value()`
+-   **Class names**: `WP_Style_Engine` → `WP_Style_Engine_Gutenberg`
+
+### Built File Locations
+
+The build system creates transformed files in the `build/` directory:
+
+```
+build/
+├── block-library/                    # Main block library
+│   ├── navigation-link.php          # Prefixed functions
+│   ├── post-time-to-read.php        # Prefixed functions
+│   └── ...
+├── scripts/block-library/            # Script-specific builds
+│   ├── navigation-link.php          # Same prefixed functions
+│   └── ...
+└── scripts/style-engine/             # Style engine with prefixed classes
+    ├── class-wp-style-engine-gutenberg.php
+    └── ...
+```
+
+The `lib/blocks.php` file loads built blocks in priority order.
+
+## Why This System is Necessary
+
+-   **Avoids function name conflicts** between WordPress Core and Gutenberg plugin
+-   **Enables backport compatibility** - Gutenberg can continue using prefixed versions when functions are backported to Core
+-   **Provides plugin independence** - Gutenberg can evolve independently of WordPress Core release cycles
+-   **Allows testing isolation** - Tests can target specific function versions (Gutenberg vs Core)
+
+## Testing Built PHP Functions
+
+For information on how to test the built (prefixed) PHP functions, see the [Testing Prefixed Functions](/docs/contributors/code/testing-overview.md#testing-prefixed-functions) section in the testing overview documentation.
+
+This system ensures Gutenberg can evolve independently while maintaining compatibility with WordPress Core, providing a robust foundation for the block editor's continued development.

--- a/docs/contributors/code/build-system-function-prefixing.md
+++ b/docs/contributors/code/build-system-function-prefixing.md
@@ -1,14 +1,14 @@
-# Build System: Function Prefixing and Block Loading
+# Build system: Function prefixing and block loading
 
 Gutenberg uses a build system that automatically transforms PHP function names to avoid conflicts with WordPress Core. This system allows Gutenberg to use standard WordPress function names in source code while ensuring the plugin can coexist with WordPress Core without naming collisions.
 
-## Key Concept
+## Key concept
 
 **Source files use standard WordPress function names** (e.g., `block_core_navigation_link_build_css_colors`), but **the build system transforms them to prefixed versions** (e.g., `gutenberg_block_core_navigation_link_build_css_colors`) in the built files that are actually loaded at runtime.
 
-## How the System Works
+## How the system works
 
-### Source Code Structure
+### Source code structure
 
 Gutenberg's source code is organized in the `packages/` directory:
 
@@ -24,7 +24,7 @@ packages/block-library/src/
 └── ...
 ```
 
-### Build Process
+### Build process
 
 The build system is configured in `packages/block-library/package.json` and transforms:
 
@@ -32,7 +32,7 @@ The build system is configured in `packages/block-library/package.json` and tran
 -   **Function calls**: `wp_get_typography_font_size_value()` → `gutenberg_get_typography_font_size_value()`
 -   **Class names**: `WP_Style_Engine` → `WP_Style_Engine_Gutenberg`
 
-### Built File Locations
+### Built file locations
 
 The build system creates transformed files in the `build/` directory:
 
@@ -52,14 +52,14 @@ build/
 
 The `lib/blocks.php` file loads built blocks in priority order.
 
-## Why This System is Necessary
+## Why this system is necessary
 
 -   **Avoids function name conflicts** between WordPress Core and Gutenberg plugin
 -   **Enables backport compatibility** - Gutenberg can continue using prefixed versions when functions are backported to Core
 -   **Provides plugin independence** - Gutenberg can evolve independently of WordPress Core release cycles
 -   **Allows testing isolation** - Tests can target specific function versions (Gutenberg vs Core)
 
-## Testing Built PHP Functions
+## Testing built PHP functions
 
 For information on how to test the built (prefixed) PHP functions, see the [Testing Prefixed Functions](/docs/contributors/code/testing-overview.md#testing-prefixed-functions) section in the testing overview documentation.
 

--- a/docs/contributors/code/testing-overview.md
+++ b/docs/contributors/code/testing-overview.md
@@ -614,6 +614,38 @@ Code style in PHP is enforced using [PHP_CodeSniffer](https://github.com/squizla
 
 To run unit tests only, without the linter, use `npm run test:unit:php` instead.
 
+### Testing Prefixed Functions
+
+Gutenberg's build system automatically prefixes PHP functions with `gutenberg_` to avoid conflicts with WordPress Core. When writing tests for block functions, you must test the **built (prefixed) versions** of functions, not the source versions.
+
+#### Understanding Function Prefixing
+
+For a detailed explanation of how function prefixing works, see the [Build System: Function Prefixing and Block Loading](/docs/contributors/code/build-system-function-prefixing.md) documentation.
+
+#### Writing Tests for Prefixed Functions & Classes
+
+Always test the built (prefixed) function names and class names in your PHPUnit tests:
+
+```php
+// phpunit/blocks/my-block-test.php
+class My_Block_Test extends WP_UnitTestCase {
+    public function test_my_function() {
+        // Test the built function (with gutenberg_ prefix)
+        $result = gutenberg_block_core_my_block_render_function( $args );
+        $this->assertEquals( $expected, $result );
+    }
+
+    public function test_my_class() {
+        // Test the built class (with _Gutenberg suffix)
+        $handler = new WP_Example_Block_Handler_Gutenberg();
+        $result = $handler->process( $input );
+        $this->assertEquals( $expected, $result );
+    }
+}
+```
+
+For more detailed information about the build system and function prefixing, see the [Build System: Function Prefixing and Block Loading](/docs/contributors/code/build-system-function-prefixing.md) documentation.
+
 [snapshot testing]: https://jestjs.io/docs/en/snapshot-testing.html
 [update snapshots]: https://jestjs.io/docs/en/snapshot-testing.html#updating-snapshots
 

--- a/docs/contributors/code/testing-overview.md
+++ b/docs/contributors/code/testing-overview.md
@@ -618,6 +618,8 @@ To run unit tests only, without the linter, use `npm run test:unit:php` instead.
 
 Gutenberg's build system automatically prefixes PHP functions with `gutenberg_` to avoid conflicts with WordPress Core. When writing tests for block functions, you must test the **built (prefixed) versions** of functions, not the source versions.
 
+If the tests are backported to WordPress Core, then they must be updated to test the non-prefixed functions.
+
 #### Writing Tests for Prefixed Functions & Classes
 
 Always test the built (prefixed) function names and class names in your PHPUnit tests:

--- a/docs/contributors/code/testing-overview.md
+++ b/docs/contributors/code/testing-overview.md
@@ -618,10 +618,6 @@ To run unit tests only, without the linter, use `npm run test:unit:php` instead.
 
 Gutenberg's build system automatically prefixes PHP functions with `gutenberg_` to avoid conflicts with WordPress Core. When writing tests for block functions, you must test the **built (prefixed) versions** of functions, not the source versions.
 
-#### Understanding Function Prefixing
-
-For a detailed explanation of how function prefixing works, see the [Build System: Function Prefixing and Block Loading](/docs/contributors/code/build-system-function-prefixing.md) documentation.
-
 #### Writing Tests for Prefixed Functions & Classes
 
 Always test the built (prefixed) function names and class names in your PHPUnit tests:


### PR DESCRIPTION
### What
This PR adds documentation specifically about how Gutenberg's build system prefixes PHP functions to avoid conflicts with WordPress Core. The documentation explains the build process that transforms function names from source to built files, and provides testing guidance for developers working with prefixed functions and classes.

### Why

This PR came about after I hit roadblocks trying to write tests in https://github.com/WordPress/gutenberg/pull/72517. It took a while to remember how this build process works and how to write the tests. This should be clearly documented so developers don't need assumed knowledge to contribute tests.

Gutenberg's build system automatically prefixes PHP functions with `gutenberg_` to avoid naming conflicts with WordPress Core. This system allows Gutenberg to use standard WordPress function names in source code while ensuring the plugin can coexist with WordPress Core. However, this specific aspect of the build system wasn't well documented, making it difficult for contributors to understand:

- How PHP function prefixing works
- Why functions are prefixed to avoid Core conflicts
- How to test the built (prefixed) functions
- The relationship between source and built PHP files

This documentation fills that gap and provides clear guidance for developers working with PHP functions in Gutenberg.

### How
- **New documentation file**: `docs/contributors/code/build-system-function-prefixing.md` - Focused guide covering:
  - Key concepts of PHP function prefixing
  - Build process that transforms function names from source to built files
  - Why the system is necessary (avoiding conflicts with WordPress Core)
  - Testing guidance with cross-reference to testing documentation

- **Updated testing documentation**: `docs/contributors/code/testing-overview.md` - Added section on testing prefixed functions:
  - Understanding function prefixing (with link to main documentation)
  - Writing tests for both prefixed functions and classes
  - Removed redundant content to avoid duplication

The documentation is concise and focused specifically on PHP function prefixing, not the broader build system.

### Testing Instructions
- Review the documentation for accuracy and completeness
- Verify that the PHP function prefixing concepts are correctly explained
- Check that testing examples are practical and helpful
- Ensure cross-references between documents work correctly

**Related Issues:** None (documentation improvement)

This documentation specifically covers the PHP function prefixing aspect of Gutenberg's build system, not the entire build system comprehensively.