### PR TITLE
Block Bindings: Set blocks as read-only UI.

### DIFF
--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -92,16 +92,9 @@ function BlockBindingsPanelMenuContent( {
 		<Menu placement={ isMobile ? 'bottom-start' : 'left-start' }>
 			{ Object.entries( sources ).map( ( [ sourceKey, source ] ) => {
 				// Only show sources that have compatible data for this specific attribute.
-				const sourceDataItems = source.data?.filter( ( item ) => {
-					if ( item.attributes === undefined ) {
-						return item?.type === attributeType;
-					}
-
-					return (
-						item?.type === attributeType &&
-						item?.attributes.includes( attribute )
-					);
-				} );
+				const sourceDataItems = source.data?.filter(
+					( item ) => item?.type === attributeType
+				);
 
 				const noItemsAvailable =
 					! sourceDataItems || sourceDataItems.length === 0;
@@ -221,6 +214,7 @@ function BlockBindingsAttribute( { attribute, binding, sources, blockName } ) {
 	let displayText;
 	let isValid = true;
 	const isNotBound = binding === undefined;
+
 	if ( isNotBound ) {
 		// Check if there are any compatible sources for this attribute type.
 		const attributeType = getAttributeType( blockName, attribute );
@@ -477,7 +471,11 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 
 						const hasCompatibleDataForAttribute = Object.values(
 							sources
-						).some( ( item ) => item?.type === attributeType );
+						).some( ( source ) =>
+							source.data?.some(
+								( item ) => item?.type === attributeType
+							)
+						);
 
 						const isAttributeReadOnly =
 							readOnly || ! hasCompatibleDataForAttribute;

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -35,7 +35,7 @@ import { store as blockEditorStore } from '../store';
 const { Menu } = unlock( componentsPrivateApis );
 
 const EMPTY_OBJECT = {};
-const READ_ONLY_BLOCKS = [ 'core/post-date' ];
+const READONLY_BLOCKS = [ 'core/post-date' ];
 
 /**
  * Get the normalized attribute type for block bindings.
@@ -46,7 +46,7 @@ const READ_ONLY_BLOCKS = [ 'core/post-date' ];
  * @return {string} The normalized attribute type.
  */
 const getAttributeType = ( blockName, attribute ) => {
-	if ( READ_ONLY_BLOCKS.includes( blockName ) ) {
+	if ( READONLY_BLOCKS.includes( blockName ) ) {
 		return '';
 	}
 	const _attributeType =

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -35,6 +35,7 @@ import { store as blockEditorStore } from '../store';
 const { Menu } = unlock( componentsPrivateApis );
 
 const EMPTY_OBJECT = {};
+const READ_ONLY_BLOCKS = [ 'core/post-date' ];
 
 /**
  * Get the normalized attribute type for block bindings.
@@ -45,9 +46,8 @@ const EMPTY_OBJECT = {};
  * @return {string} The normalized attribute type.
  */
 const getAttributeType = ( blockName, attribute ) => {
-	// Temporary workaround for datetime attribute.
-	if ( attribute === 'datetime' ) {
-		return 'datetime';
+	if ( READ_ONLY_BLOCKS.includes( blockName ) ) {
+		return '';
 	}
 	const _attributeType =
 		getBlockType( blockName ).attributes?.[ attribute ]?.type;

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -46,9 +46,6 @@ const READONLY_BLOCKS = [ 'core/post-date' ];
  * @return {string} The normalized attribute type.
  */
 const getAttributeType = ( blockName, attribute ) => {
-	if ( READONLY_BLOCKS.includes( blockName ) ) {
-		return '';
-	}
 	const _attributeType =
 		getBlockType( blockName ).attributes?.[ attribute ]?.type;
 	return _attributeType === 'rich-text' ? 'string' : _attributeType;
@@ -440,7 +437,10 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 	);
 
 	// Lock the UI when the user can't update bindings or there are no fields to connect to.
-	const readOnly = ! canUpdateBlockBindings || ! hasCompatibleData;
+	const readOnly =
+		! canUpdateBlockBindings ||
+		! hasCompatibleData ||
+		READONLY_BLOCKS.includes( blockName );
 
 	const RenderModalContent =
 		sources[ modalState?.sourceKey ]?.renderModalContent;

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -88,9 +88,16 @@ function BlockBindingsPanelMenuContent( {
 		<Menu placement={ isMobile ? 'bottom-start' : 'left-start' }>
 			{ Object.entries( sources ).map( ( [ sourceKey, source ] ) => {
 				// Only show sources that have compatible data for this specific attribute.
-				const sourceDataItems = source.data?.filter(
-					( item ) => item?.type === attributeType
-				);
+				const sourceDataItems = source.data?.filter( ( item ) => {
+					if ( item.attributes === undefined ) {
+						return item?.type === attributeType;
+					}
+
+					return (
+						item?.type === attributeType &&
+						item?.attributes.includes( attribute )
+					);
+				} );
 
 				const noItemsAvailable =
 					! sourceDataItems || sourceDataItems.length === 0;
@@ -210,7 +217,6 @@ function BlockBindingsAttribute( { attribute, binding, sources, blockName } ) {
 	let displayText;
 	let isValid = true;
 	const isNotBound = binding === undefined;
-
 	if ( isNotBound ) {
 		// Check if there are any compatible sources for this attribute type.
 		const attributeType = getAttributeType( blockName, attribute );
@@ -467,11 +473,11 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 
 						const hasCompatibleDataForAttribute = Object.values(
 							sources
-						).some( ( source ) =>
-							source.data?.some(
+						).some( ( source ) => {
+							return source.data?.some(
 								( item ) => item?.type === attributeType
-							)
-						);
+							);
+						} );
 
 						const isAttributeReadOnly =
 							readOnly || ! hasCompatibleDataForAttribute;

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -45,6 +45,10 @@ const EMPTY_OBJECT = {};
  * @return {string} The normalized attribute type.
  */
 const getAttributeType = ( blockName, attribute ) => {
+	// Temporary workaround for datetime attribute.
+	if ( attribute === 'datetime' ) {
+		return 'datetime';
+	}
 	const _attributeType =
 		getBlockType( blockName ).attributes?.[ attribute ]?.type;
 	return _attributeType === 'rich-text' ? 'string' : _attributeType;

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -473,11 +473,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 
 						const hasCompatibleDataForAttribute = Object.values(
 							sources
-						).some( ( source ) => {
-							return source.data?.some(
-								( item ) => item?.type === attributeType
-							);
-						} );
+						).some( ( item ) => item?.type === attributeType );
 
 						const isAttributeReadOnly =
 							readOnly || ! hasCompatibleDataForAttribute;

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -74,20 +74,17 @@ function getPostDataFields( select, context, clientId ) {
 			date: {
 				label: __( 'Post Date' ),
 				value: entityDataValues?.date,
-				type: 'string',
-				attributes: [ 'datetime' ],
+				type: 'datetime',
 			},
 			modified: {
 				label: __( 'Post Modified Date' ),
 				value: entityDataValues?.modified,
-				type: 'string',
-				attributes: [ 'datetime' ],
+				type: 'datetime',
 			},
 			link: {
 				label: __( 'Post Link' ),
 				value: entityDataValues?.link,
 				type: 'string',
-				attributes: [ 'url', 'content' ],
 			},
 		};
 	}
@@ -203,7 +200,6 @@ export default {
 				field: key,
 			},
 			type: field.type,
-			attributes: field.attributes,
 		} ) );
 		/*
 		 * We need to define the data as [{ label: string, value: any, type: https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#type-validation }]

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -74,12 +74,12 @@ function getPostDataFields( select, context, clientId ) {
 			date: {
 				label: __( 'Post Date' ),
 				value: entityDataValues?.date,
-				type: 'datetime',
+				type: 'string',
 			},
 			modified: {
 				label: __( 'Post Modified Date' ),
 				value: entityDataValues?.modified,
-				type: 'datetime',
+				type: 'string',
 			},
 			link: {
 				label: __( 'Post Link' ),

--- a/packages/editor/src/bindings/post-data.js
+++ b/packages/editor/src/bindings/post-data.js
@@ -75,16 +75,19 @@ function getPostDataFields( select, context, clientId ) {
 				label: __( 'Post Date' ),
 				value: entityDataValues?.date,
 				type: 'string',
+				attributes: [ 'datetime' ],
 			},
 			modified: {
 				label: __( 'Post Modified Date' ),
 				value: entityDataValues?.modified,
 				type: 'string',
+				attributes: [ 'datetime' ],
 			},
 			link: {
 				label: __( 'Post Link' ),
 				value: entityDataValues?.link,
 				type: 'string',
+				attributes: [ 'url', 'content' ],
 			},
 		};
 	}
@@ -200,6 +203,7 @@ export default {
 				field: key,
 			},
 			type: field.type,
+			attributes: field.attributes,
 		} ) );
 		/*
 		 * We need to define the data as [{ label: string, value: any, type: https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#type-validation }]

--- a/test/e2e/specs/editor/various/block-bindings/post-data.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-data.spec.js
@@ -77,15 +77,14 @@ test.describe( 'Post Data source', () => {
 					},
 				},
 			} );
-			await page
+			const postDataItem = await page
 				.getByRole( 'button', {
 					name: 'datetime',
 				} )
 				.click();
-			const postDataMenuItem = page.getByRole( 'menuitem', {
-				name: 'Post Data',
-			} );
-			await expect( postDataMenuItem ).toBeVisible();
+			await expect( postDataItem ).toBeVisible();
+			await expect( postDataItem ).toHaveText( 'Post Date' );
+			await expect( postDataItem ).toBeDisabled();
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Fixes https://github.com/WordPress/gutenberg/issues/72446

Right now, block bindings UI filters the editorUI data by type, comparing with the attribute type.

For `post-date` block, the bound attribute `datetime` is a string, but it should only accept `datetime` data, not any string like is doing right now.

That makes that we can connect the post-date block `datetime` to any string type, like an `url`. Causing an `invalid date` error. As shown in the screenshot:

<img width="987" height="222" alt="Screenshot 2025-10-21 at 18 51 07" src="https://github.com/user-attachments/assets/e1c0afb9-5683-48ac-a718-6e8ca1c67d56" />

https://github.com/user-attachments/assets/f3f42d92-4a9f-4ad8-9196-a416b07f2533

## How

Some blocks may use block bindings internally, and don't want to connect to other sources. Also they may want to not allow the user to interact with the Editor UI.

## Problems

We should provide a good UI for this option, set up at the block or even at the attribute level, instead of hard-coding it into a variable.
