### PR TITLE
Explore performance improvements

### DIFF
--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -26,7 +26,7 @@ import BlockToolbarPopover from './block-toolbar-popover';
 import { store as blockEditorStore } from '../../store';
 import usePopoverScroll from '../block-popover/use-popover-scroll';
 import ZoomOutModeInserters from './zoom-out-mode-inserters';
-import { useShowBlockTools } from './use-show-block-tools';
+import { shouldShowBlockTools } from './should-show-block-tools';
 import { unlock } from '../../lock-unlock';
 import { cleanEmptyObject } from '../../hooks/utils';
 import usePasteStyles from '../use-paste-styles';
@@ -44,19 +44,36 @@ function selector( select ) {
 		getBlockRootClientId,
 		isGroupable,
 		getBlockName,
+		getBlock,
+		getBlockMode,
+		isBlockInterfaceHidden,
 	} = unlock( select( blockEditorStore ) );
 
 	const { getGroupingBlockName } = select( blocksStore );
 
 	const clientId =
 		getSelectedBlockClientId() || getFirstMultiSelectedBlockClientId();
+	const _isTyping = isTyping();
+	const _hasFixedToolbar = getSettings().hasFixedToolbar;
+
+	const { showEmptyBlockSideInserter, showBlockToolbarPopover } =
+		shouldShowBlockTools( {
+			block: getBlock( clientId ),
+			blockMode: clientId ? getBlockMode( clientId ) : null,
+			isBlockInterfaceHidden: isBlockInterfaceHidden(),
+			clientId,
+			isTyping: _isTyping,
+			hasFixedToolbar: _hasFixedToolbar,
+		} );
 
 	return {
 		clientId,
-		hasFixedToolbar: getSettings().hasFixedToolbar,
-		isTyping: isTyping(),
+		hasFixedToolbar: _hasFixedToolbar,
+		isTyping: _isTyping,
 		isZoomOutMode: isZoomOut(),
 		isDragging: isDragging(),
+		showEmptyBlockSideInserter,
+		showBlockToolbarPopover,
 		getBlocksByClientId,
 		getSelectedBlockClientIds,
 		getBlockRootClientId,
@@ -92,11 +109,11 @@ export default function BlockTools( {
 		isGroupable,
 		getBlockName,
 		getGroupingBlockName,
+		showEmptyBlockSideInserter,
+		showBlockToolbarPopover,
 	} = useSelect( selector, [] );
 
 	const isMatch = useShortcutEventMatch();
-	const { showEmptyBlockSideInserter, showBlockToolbarPopover } =
-		useShowBlockTools();
 	const pasteStyles = usePasteStyles();
 
 	const {

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -39,7 +39,14 @@ function selector( select ) {
 		isTyping,
 		isDragging,
 		isZoomOut,
+		getBlocksByClientId,
+		getSelectedBlockClientIds,
+		getBlockRootClientId,
+		isGroupable,
+		getBlockName,
 	} = unlock( select( blockEditorStore ) );
+
+	const { getGroupingBlockName } = select( blocksStore );
 
 	const clientId =
 		getSelectedBlockClientId() || getFirstMultiSelectedBlockClientId();
@@ -50,6 +57,12 @@ function selector( select ) {
 		isTyping: isTyping(),
 		isZoomOutMode: isZoomOut(),
 		isDragging: isDragging(),
+		getBlocksByClientId,
+		getSelectedBlockClientIds,
+		getBlockRootClientId,
+		isGroupable,
+		getBlockName,
+		getGroupingBlockName,
 	};
 }
 
@@ -67,18 +80,21 @@ export default function BlockTools( {
 	__unstableContentRef,
 	...props
 } ) {
-	const { clientId, hasFixedToolbar, isTyping, isZoomOutMode, isDragging } =
-		useSelect( selector, [] );
-
-	const isMatch = useShortcutEventMatch();
 	const {
+		clientId,
+		hasFixedToolbar,
+		isTyping,
+		isZoomOutMode,
+		isDragging,
 		getBlocksByClientId,
 		getSelectedBlockClientIds,
 		getBlockRootClientId,
 		isGroupable,
 		getBlockName,
-	} = useSelect( blockEditorStore );
-	const { getGroupingBlockName } = useSelect( blocksStore );
+		getGroupingBlockName,
+	} = useSelect( selector, [] );
+
+	const isMatch = useShortcutEventMatch();
 	const { showEmptyBlockSideInserter, showBlockToolbarPopover } =
 		useShowBlockTools();
 	const pasteStyles = usePasteStyles();

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -45,6 +45,7 @@ function InbetweenInsertionPointPopover( {
 		isInserterShown,
 		isDistractionFree,
 		isZoomOutMode,
+		getBlockEditingMode,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockOrder,
@@ -55,6 +56,7 @@ function InbetweenInsertionPointPopover( {
 			getNextBlockClientId,
 			getSettings,
 			isZoomOut,
+			getBlockEditingMode: _getBlockEditingMode,
 		} = unlock( select( blockEditorStore ) );
 		const insertionPoint = getBlockInsertionPoint();
 		const order = getBlockOrder( insertionPoint.rootClientId );
@@ -86,9 +88,9 @@ function InbetweenInsertionPointPopover( {
 			isDistractionFree: settings.isDistractionFree,
 			isInserterShown: insertionPoint?.__unstableWithInserter,
 			isZoomOutMode: isZoomOut(),
+			getBlockEditingMode: _getBlockEditingMode,
 		};
 	}, [] );
-	const { getBlockEditingMode } = useSelect( blockEditorStore );
 
 	const disableMotion = useReducedMotion();
 

--- a/packages/block-editor/src/components/block-tools/should-show-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/should-show-block-tools.js
@@ -4,7 +4,7 @@
 import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 
 /**
- * Calculates which block tools should be showing based on the current editor state.
+ * Determines which block tools should be showing based on the current editor state.
  * This is a pure function that can be called from within a selector.
  *
  * @param {Object}  options                        Calculation options.
@@ -17,7 +17,7 @@ import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
  *
  * @return {Object} Object of which block tools will be shown.
  */
-export function calculateShowBlockTools( {
+export function shouldShowBlockTools( {
 	block,
 	blockMode,
 	isBlockInterfaceHidden,

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -142,12 +142,18 @@ function BordersInspectorControl( { label, children, resetAllFilter } ) {
 
 export function BorderPanel( { clientId, name, setAttributes, settings } ) {
 	const isEnabled = useHasBorderPanel( settings );
-	function selector( select ) {
-		const { style, borderColor } =
-			select( blockEditorStore ).getBlockAttributes( clientId ) || {};
-		return { style, borderColor };
-	}
-	const { style, borderColor } = useSelect( selector, [ clientId ] );
+	const { style, borderColor } = useSelect(
+		( select ) => {
+			// Early return to avoid subscription when disabled
+			if ( ! isEnabled ) {
+				return {};
+			}
+			const { style: _style, borderColor: _borderColor } =
+				select( blockEditorStore ).getBlockAttributes( clientId ) || {};
+			return { style: _style, borderColor: _borderColor };
+		},
+		[ clientId, isEnabled ]
+	);
 	const value = useMemo( () => {
 		return attributesToStyle( { style, borderColor } );
 	}, [ style, borderColor ] );

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -262,14 +262,27 @@ function ColorInspectorControl( { children, resetAllFilter } ) {
 
 export function ColorEdit( { clientId, name, setAttributes, settings } ) {
 	const isEnabled = useHasColorPanel( settings );
-	function selector( select ) {
-		const { style, textColor, backgroundColor, gradient } =
-			select( blockEditorStore ).getBlockAttributes( clientId ) || {};
-		return { style, textColor, backgroundColor, gradient };
-	}
+
 	const { style, textColor, backgroundColor, gradient } = useSelect(
-		selector,
-		[ clientId ]
+		( select ) => {
+			// Early return to avoid subscription when disabled
+			if ( ! isEnabled ) {
+				return {};
+			}
+			const {
+				style: _style,
+				textColor: _textColor,
+				backgroundColor: _backgroundColor,
+				gradient: _gradient,
+			} = select( blockEditorStore ).getBlockAttributes( clientId ) || {};
+			return {
+				style: _style,
+				textColor: _textColor,
+				backgroundColor: _backgroundColor,
+				gradient: _gradient,
+			};
+		},
+		[ clientId, isEnabled ]
 	);
 	const value = useMemo( () => {
 		return attributesToStyle( {

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -71,9 +71,15 @@ function DimensionsInspectorControl( { children, resetAllFilter } ) {
 export function DimensionsPanel( { clientId, name, setAttributes, settings } ) {
 	const isEnabled = useHasDimensionsPanel( settings );
 	const value = useSelect(
-		( select ) =>
-			select( blockEditorStore ).getBlockAttributes( clientId )?.style,
-		[ clientId ]
+		( select ) => {
+			// Early return to avoid subscription when disabled
+			if ( ! isEnabled ) {
+				return undefined;
+			}
+			return select( blockEditorStore ).getBlockAttributes( clientId )
+				?.style;
+		},
+		[ clientId, isEnabled ]
 	);
 	const [ visualizedProperty, setVisualizedProperty ] = useVisualizer();
 	const onChange = ( newStyle ) => {

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -74,13 +74,17 @@ export function useLayoutClasses( blockAttributes = {}, blockName = '' ) {
 
 	const hasGlobalPadding = useSelect(
 		( select ) => {
-			return (
-				( usedLayout?.inherit ||
-					usedLayout?.contentSize ||
-					usedLayout?.type === 'constrained' ) &&
-				select( blockEditorStore ).getSettings().__experimentalFeatures
-					?.useRootPaddingAwareAlignments
-			);
+			// Early return to avoid subscription when layout doesn't use global padding
+			if (
+				! usedLayout?.inherit &&
+				! usedLayout?.contentSize &&
+				usedLayout?.type !== 'constrained'
+			) {
+				return false;
+			}
+
+			return select( blockEditorStore ).getSettings()
+				.__experimentalFeatures?.useRootPaddingAwareAlignments;
 		},
 		[ usedLayout?.contentSize, usedLayout?.inherit, usedLayout?.type ]
 	);

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -115,15 +115,29 @@ function TypographyInspectorControl( { children, resetAllFilter } ) {
 }
 
 export function TypographyPanel( { clientId, name, setAttributes, settings } ) {
-	function selector( select ) {
-		const { style, fontFamily, fontSize, fitText } =
-			select( blockEditorStore ).getBlockAttributes( clientId ) || {};
-		return { style, fontFamily, fontSize, fitText };
-	}
-	const { style, fontFamily, fontSize, fitText } = useSelect( selector, [
-		clientId,
-	] );
 	const isEnabled = useHasTypographyPanel( settings );
+
+	const { style, fontFamily, fontSize, fitText } = useSelect(
+		( select ) => {
+			// Early return INSIDE selector to avoid subscription when disabled
+			if ( ! isEnabled ) {
+				return {};
+			}
+			const {
+				style: _style,
+				fontFamily: _fontFamily,
+				fontSize: _fontSize,
+				fitText: _fitText,
+			} = select( blockEditorStore ).getBlockAttributes( clientId ) || {};
+			return {
+				style: _style,
+				fontFamily: _fontFamily,
+				fontSize: _fontSize,
+				fitText: _fitText,
+			};
+		},
+		[ clientId, isEnabled ]
+	);
 	const value = useMemo(
 		() => attributesToStyle( { style, fontFamily, fontSize } ),
 		[ style, fontSize, fontFamily ]

--- a/packages/edit-post/src/components/init-pattern-modal/index.js
+++ b/packages/edit-post/src/components/init-pattern-modal/index.js
@@ -19,19 +19,14 @@ export default function InitPatternModal() {
 	const [ syncType, setSyncType ] = useState( undefined );
 	const [ title, setTitle ] = useState( '' );
 
-	const { postType, isNewPost } = useSelect( ( select ) => {
-		const { getEditedPostAttribute, isCleanNewPost } =
-			select( editorStore );
-		return {
-			postType: getEditedPostAttribute( 'type' ),
-			isNewPost: isCleanNewPost(),
-		};
-	}, [] );
-	const [ isModalOpen, setIsModalOpen ] = useState(
-		() => isNewPost && postType === 'wp_block'
+	const isNewPost = useSelect(
+		( select ) => select( editorStore ).isCleanNewPost(),
+		[]
 	);
 
-	if ( postType !== 'wp_block' || ! isNewPost ) {
+	const [ isModalOpen, setIsModalOpen ] = useState( () => isNewPost );
+
+	if ( ! isNewPost ) {
 		return null;
 	}
 

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -673,7 +673,9 @@ function Layout( {
 						<EditPostKeyboardShortcuts />
 						<EditorKeyboardShortcutsRegister />
 						<BlockKeyboardShortcuts />
-						<InitPatternModal />
+						{ currentPostType === 'wp_block' && (
+							<InitPatternModal />
+						) }
 						<PluginArea onError={ onPluginAreaError } />
 						<PostEditorMoreMenu />
 						{ backButton }

--- a/packages/editor/src/components/pattern-duplicate-modal/index.js
+++ b/packages/editor/src/components/pattern-duplicate-modal/index.js
@@ -17,24 +17,32 @@ const { DuplicatePatternModal } = unlock( patternsPrivateApis );
 export const modalName = 'editor/pattern-duplicate';
 
 export default function PatternDuplicateModal() {
-	const { record, postType } = useSelect( ( select ) => {
-		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
-		const { getEditedEntityRecord } = select( coreStore );
-		const _postType = getCurrentPostType();
-		return {
-			record: getEditedEntityRecord(
-				'postType',
-				_postType,
-				getCurrentPostId()
-			),
-			postType: _postType,
-		};
-	}, [] );
-	const { closeModal } = useDispatch( interfaceStore );
-
 	const isActive = useSelect( ( select ) =>
 		select( interfaceStore ).isModalActive( modalName )
 	);
+
+	const { record, postType } = useSelect(
+		( select ) => {
+			if ( ! isActive ) {
+				return {};
+			}
+
+			const { getCurrentPostType, getCurrentPostId } =
+				select( editorStore );
+			const { getEditedEntityRecord } = select( coreStore );
+			const _postType = getCurrentPostType();
+			return {
+				record: getEditedEntityRecord(
+					'postType',
+					_postType,
+					getCurrentPostId()
+				),
+				postType: _postType,
+			};
+		},
+		[ isActive ]
+	);
+	const { closeModal } = useDispatch( interfaceStore );
 
 	if ( ! isActive || postType !== PATTERN_POST_TYPE ) {
 		return null;

--- a/packages/editor/src/components/pattern-rename-modal/index.js
+++ b/packages/editor/src/components/pattern-rename-modal/index.js
@@ -17,24 +17,33 @@ const { RenamePatternModal } = unlock( patternsPrivateApis );
 export const modalName = 'editor/pattern-rename';
 
 export default function PatternRenameModal() {
-	const { record, postType } = useSelect( ( select ) => {
-		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
-		const { getEditedEntityRecord } = select( coreStore );
-		const _postType = getCurrentPostType();
-		return {
-			record: getEditedEntityRecord(
-				'postType',
-				_postType,
-				getCurrentPostId()
-			),
-			postType: _postType,
-		};
-	}, [] );
-	const { closeModal } = useDispatch( interfaceStore );
-
 	const isActive = useSelect( ( select ) =>
 		select( interfaceStore ).isModalActive( modalName )
 	);
+
+	const { record, postType } = useSelect(
+		( select ) => {
+			if ( ! isActive ) {
+				return {};
+			}
+
+			const { getCurrentPostType, getCurrentPostId } =
+				select( editorStore );
+			const { getEditedEntityRecord } = select( coreStore );
+			const _postType = getCurrentPostType();
+			return {
+				record: getEditedEntityRecord(
+					'postType',
+					_postType,
+					getCurrentPostId()
+				),
+				postType: _postType,
+			};
+		},
+		[ isActive ]
+	);
+
+	const { closeModal } = useDispatch( interfaceStore );
 
 	if ( ! isActive || postType !== PATTERN_POST_TYPE ) {
 		return null;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->


## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
A lot of the [performance metrics](https://www.codevitals.run/project/gutenberg/) are creeping upwards. 

<img width="1325" height="382" alt="Typing metric from codevitals.com/project/gutenberg showing an upward trend over time" src="https://github.com/user-attachments/assets/c8b397b9-1540-4e14-a7a6-bd9da7b51e69" />

This PR is an exploration for improving block editor performance. Related to https://github.com/WordPress/gutenberg/pull/72496/

Bundling these changes to see if we can make a meaningful impact on the metrics, and, if so, we can spin them off into individual PRs in case there are regressions that we need to revert.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Perf improvements = 🚀 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add early return to avoid subscriptions for: 
- [x]Merged: [RichText component for blocks without bindings](https://github.com/WordPress/gutenberg/pull/72634)
- [x] InspectorControls component for blocks without inspector controls:
  - [x] BorderPanel
  - [x] ColorEdit
  - [x] DimensionsPanel
  - [x] TypographyPanel
- [x] Combine 4 BlockTools selectors into 1
- [x] Don't mount InitPatternModal unless on relevant post type
- [x] Don't subscribe PatternRenameModal to core store unless it's mounted
- [x] Don't subscribe PatternDuplicateModal to core store unless it's open

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
There should be no changes in functionality

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
