### PR TITLE
Improve output buffer for sending server-timing header

### DIFF
--- a/lib/compat/wordpress-6.9/command-palette.php
+++ b/lib/compat/wordpress-6.9/command-palette.php
@@ -93,6 +93,6 @@ function gutenberg_enqueue_command_palette_assets() {
 }
 
 if ( has_filter( 'admin_enqueue_scripts', 'wp_enqueue_command_palette_assets' ) ) {
-	remove_filter( 'admin_enqueue_scripts', 'wp_enqueue_command_palette_assets', 9 );
+	remove_filter( 'admin_enqueue_scripts', 'wp_enqueue_command_palette_assets' );
 }
 add_filter( 'admin_enqueue_scripts', 'gutenberg_enqueue_command_palette_assets', 9 );


### PR DESCRIPTION
See [Slack thread](https://wordpress.slack.com/archives/C02QB2JS7/p1761048847619699).

Fixes E2E issues like [this](https://github.com/WordPress/gutenberg/actions/runs/18674912620/job/53242808921#step:7:26):

<img width="2342" height="998" alt="image" src="https://github.com/user-attachments/assets/6febb70e-52a7-4cab-a163-3a273a8fbd5b" />

To reproduce the original issue, active the Twenty Twenty-One theme,

Create and activate a `gutenberg-e2e-server-timing.php` file in your `plugins` directory which contains:

```php
<?php
/**
 * Plugin Name: Gutenberg E2E Server Timing
 */

require_once __DIR__ . '/gutenberg/packages/e2e-tests/mu-plugins/server-timing.php';
```

Then publish a post which contains the following `post_content`:

```html
<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}}}} -->
<p class="has-link-color">Check out this link: <a href="/">HOME</a></p>
<!-- /wp:paragraph -->
```

When working correctly, the link in the paragraph should be white. When failing, the link has no overridden color.

Diff showing prettiered HTML with expected and actual output when failure happens: https://gist.github.com/westonruter/7da9c101d9f4429c2c40bf2907e8cd9f