### PR TITLE
Add isCollapsible to the card layout in DataForm

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - Dataviews: Use text based buttons for actions instead of text. [#72417](https://github.com/WordPress/gutenberg/pull/72417)
+- DataForm: Add support for non collapsible cards. [#72540](https://github.com/WordPress/gutenberg/pull/72540)
 
 ## 10.0.0 (2025-10-17)
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -1610,6 +1610,7 @@ For example:
     -   A string (single field ID)
     -   An array of strings (multiple field IDs)
     -   An array of objects for per-field visibility control `[{ id: string, visibility: 'always' | 'when-collapsed' }]`
+-   `isCollapsible`: boolean. Optional. `true` by default. Specifies whether the card can be collapsed.
 
 Cards can be collapsed while visible, so you can control when summary fields appear:
 

--- a/packages/dataviews/src/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/card/index.tsx
@@ -1,7 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { Button, Card, CardBody, CardHeader } from '@wordpress/components';
+import {
+	Button,
+	Card,
+	CardBody,
+	CardHeader as OriginalCardHeader,
+} from '@wordpress/components';
 import { useCallback, useContext, useMemo, useState } from '@wordpress/element';
 import { chevronDown, chevronUp } from '@wordpress/icons';
 
@@ -23,8 +28,30 @@ import { isCombinedField } from '../is-combined-field';
 import { DEFAULT_LAYOUT, normalizeLayout } from '../normalize-form-fields';
 import { getSummaryFields } from '../get-summary-fields';
 
-export function useCollapsibleCard( initialIsOpen: boolean = true ) {
-	const [ isOpen, setIsOpen ] = useState( initialIsOpen );
+const NonCollapsibleCardHeader = ( {
+	children,
+	...props
+}: {
+	children: React.ReactNode;
+} ) => (
+	<OriginalCardHeader { ...props }>
+		<div
+			style={ {
+				height: '40px', // This is to match the chevron's __next40pxDefaultSize
+				width: '100%',
+				display: 'flex',
+				justifyContent: 'space-between',
+				alignItems: 'center',
+			} }
+		>
+			{ children }
+		</div>
+	</OriginalCardHeader>
+);
+
+export function useCardHeader( layout: NormalizedCardLayout ) {
+	const { isOpened, isCollapsible } = layout;
+	const [ isOpen, setIsOpen ] = useState( isOpened );
 
 	const toggle = useCallback( () => {
 		setIsOpen( ( prev ) => ! prev );
@@ -38,7 +65,7 @@ export function useCollapsibleCard( initialIsOpen: boolean = true ) {
 			children: React.ReactNode;
 			[ key: string ]: any;
 		} ) => (
-			<CardHeader
+			<OriginalCardHeader
 				{ ...props }
 				onClick={ toggle }
 				style={ {
@@ -63,12 +90,17 @@ export function useCollapsibleCard( initialIsOpen: boolean = true ) {
 					aria-expanded={ isOpen }
 					aria-label={ isOpen ? 'Collapse' : 'Expand' }
 				/>
-			</CardHeader>
+			</OriginalCardHeader>
 		),
 		[ toggle, isOpen ]
 	);
 
-	return { isOpen, CollapsibleCardHeader };
+	const effectiveIsOpen = isCollapsible ? isOpen : true;
+	const CardHeaderComponent = isCollapsible
+		? CollapsibleCardHeader
+		: NonCollapsibleCardHeader;
+
+	return { isOpen: effectiveIsOpen, CardHeader: CardHeaderComponent };
 }
 
 function isSummaryFieldVisible< Item >(
@@ -122,27 +154,6 @@ function isSummaryFieldVisible< Item >(
 	return true;
 }
 
-const NonCollapsibleCardHeader = ( {
-	children,
-	...props
-}: {
-	children: React.ReactNode;
-} ) => (
-	<CardHeader { ...props }>
-		<div
-			style={ {
-				height: '40px', // This is to match the chevron's __next40pxDefaultSize
-				width: '100%',
-				display: 'flex',
-				justifyContent: 'space-between',
-				alignItems: 'center',
-			} }
-		>
-			{ children }
-		</div>
-	</CardHeader>
-);
-
 export default function FormCardField< Item >( {
 	data,
 	field,
@@ -165,9 +176,7 @@ export default function FormCardField< Item >( {
 		[ field ]
 	);
 
-	const { isOpen, CollapsibleCardHeader } = useCollapsibleCard(
-		layout.isOpened
-	);
+	const { isOpen, CardHeader } = useCardHeader( layout );
 
 	const summaryFields = getSummaryFields< Item >( layout.summary, fields );
 
@@ -175,19 +184,13 @@ export default function FormCardField< Item >( {
 		isSummaryFieldVisible( summaryField, layout.summary, isOpen )
 	);
 
-	const shouldUseCollapsible = layout.isCollapsible;
-	const effectiveIsOpen = shouldUseCollapsible ? isOpen : true;
-
 	if ( isCombinedField( field ) ) {
 		const withHeader = !! field.label && layout.withHeader;
-		const CardHeaderComponent = shouldUseCollapsible
-			? CollapsibleCardHeader
-			: NonCollapsibleCardHeader;
 
 		return (
 			<Card className="dataforms-layouts-card__field">
 				{ withHeader && (
-					<CardHeaderComponent className="dataforms-layouts-card__field-header">
+					<CardHeader className="dataforms-layouts-card__field-header">
 						<span className="dataforms-layouts-card__field-header-label">
 							{ field.label }
 						</span>
@@ -205,9 +208,9 @@ export default function FormCardField< Item >( {
 									) }
 								</div>
 							) }
-					</CardHeaderComponent>
+					</CardHeader>
 				) }
-				{ ( effectiveIsOpen || ! withHeader ) && (
+				{ ( isOpen || ! withHeader ) && (
 					// If it doesn't have a header, keep it open.
 					// Otherwise, the card will not be visible.
 					<CardBody className="dataforms-layouts-card__field-control">
@@ -241,14 +244,11 @@ export default function FormCardField< Item >( {
 		return null;
 	}
 	const withHeader = !! fieldDefinition.label && layout.withHeader;
-	const CardHeaderComponent = shouldUseCollapsible
-		? CollapsibleCardHeader
-		: NonCollapsibleCardHeader;
 
 	return (
 		<Card className="dataforms-layouts-card__field">
 			{ withHeader && (
-				<CardHeaderComponent className="dataforms-layouts-card__field-header">
+				<CardHeader className="dataforms-layouts-card__field-header">
 					<span className="dataforms-layouts-card__field-header-label">
 						{ fieldDefinition.label }
 					</span>
@@ -263,9 +263,9 @@ export default function FormCardField< Item >( {
 							) ) }
 						</div>
 					) }
-				</CardHeaderComponent>
+				</CardHeader>
 			) }
-			{ ( effectiveIsOpen || ! withHeader ) && (
+			{ ( isOpen || ! withHeader ) && (
 				// If it doesn't have a header, keep it open.
 				// Otherwise, the card will not be visible.
 				<CardBody className="dataforms-layouts-card__field-control">

--- a/packages/dataviews/src/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/card/index.tsx
@@ -50,7 +50,7 @@ const NonCollapsibleCardHeader = ( {
 );
 
 export function useCardHeader( layout: NormalizedCardLayout ) {
-	const { isOpened, isCollapsible } = layout;
+	const { isOpened = true, isCollapsible } = layout;
 	const [ isOpen, setIsOpen ] = useState( isOpened );
 
 	const toggle = useCallback( () => {

--- a/packages/dataviews/src/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/card/index.tsx
@@ -50,7 +50,7 @@ const NonCollapsibleCardHeader = ( {
 );
 
 export function useCardHeader( layout: NormalizedCardLayout ) {
-	const { isOpened = true, isCollapsible } = layout;
+	const { isOpened, isCollapsible } = layout;
 	const [ isOpen, setIsOpen ] = useState( isOpened );
 
 	const toggle = useCallback( () => {

--- a/packages/dataviews/src/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/card/index.tsx
@@ -122,6 +122,26 @@ function isSummaryFieldVisible< Item >(
 	return true;
 }
 
+const NonCollapsibleCardHeader = ( {
+	children,
+	...props
+}: {
+	children: React.ReactNode;
+} ) => (
+	<CardHeader { ...props }>
+		<div
+			style={ {
+				height: '40px', // This is to match the chevron's __next40pxDefaultSize
+				width: '100%',
+				display: 'flex',
+				alignItems: 'center',
+			} }
+		>
+			{ children }
+		</div>
+	</CardHeader>
+);
+
 export default function FormCardField< Item >( {
 	data,
 	field,
@@ -154,12 +174,19 @@ export default function FormCardField< Item >( {
 		isSummaryFieldVisible( summaryField, layout.summary, isOpen )
 	);
 
+	const shouldUseCollapsible = layout.isCollapsible;
+	const effectiveIsOpen = shouldUseCollapsible ? isOpen : true;
+
 	if ( isCombinedField( field ) ) {
 		const withHeader = !! field.label && layout.withHeader;
+		const CardHeaderComponent = shouldUseCollapsible
+			? CollapsibleCardHeader
+			: NonCollapsibleCardHeader;
+
 		return (
 			<Card className="dataforms-layouts-card__field">
 				{ withHeader && (
-					<CollapsibleCardHeader className="dataforms-layouts-card__field-header">
+					<CardHeaderComponent className="dataforms-layouts-card__field-header">
 						<span className="dataforms-layouts-card__field-header-label">
 							{ field.label }
 						</span>
@@ -177,9 +204,9 @@ export default function FormCardField< Item >( {
 									) }
 								</div>
 							) }
-					</CollapsibleCardHeader>
+					</CardHeaderComponent>
 				) }
-				{ ( isOpen || ! withHeader ) && (
+				{ ( effectiveIsOpen || ! withHeader ) && (
 					// If it doesn't have a header, keep it open.
 					// Otherwise, the card will not be visible.
 					<CardBody className="dataforms-layouts-card__field-control">
@@ -213,10 +240,14 @@ export default function FormCardField< Item >( {
 		return null;
 	}
 	const withHeader = !! fieldDefinition.label && layout.withHeader;
+	const CardHeaderComponent = shouldUseCollapsible
+		? CollapsibleCardHeader
+		: NonCollapsibleCardHeader;
+
 	return (
 		<Card className="dataforms-layouts-card__field">
 			{ withHeader && (
-				<CollapsibleCardHeader className="dataforms-layouts-card__field-header">
+				<CardHeaderComponent className="dataforms-layouts-card__field-header">
 					<span className="dataforms-layouts-card__field-header-label">
 						{ fieldDefinition.label }
 					</span>
@@ -231,9 +262,9 @@ export default function FormCardField< Item >( {
 							) ) }
 						</div>
 					) }
-				</CollapsibleCardHeader>
+				</CardHeaderComponent>
 			) }
-			{ ( isOpen || ! withHeader ) && (
+			{ ( effectiveIsOpen || ! withHeader ) && (
 				// If it doesn't have a header, keep it open.
 				// Otherwise, the card will not be visible.
 				<CardBody className="dataforms-layouts-card__field-control">

--- a/packages/dataviews/src/dataform-layouts/card/index.tsx
+++ b/packages/dataviews/src/dataform-layouts/card/index.tsx
@@ -134,6 +134,7 @@ const NonCollapsibleCardHeader = ( {
 				height: '40px', // This is to match the chevron's __next40pxDefaultSize
 				width: '100%',
 				display: 'flex',
+				justifyContent: 'space-between',
 				alignItems: 'center',
 			} }
 		>

--- a/packages/dataviews/src/dataform-layouts/normalize-form-fields.ts
+++ b/packages/dataviews/src/dataform-layouts/normalize-form-fields.ts
@@ -85,7 +85,10 @@ export function normalizeLayout( layout?: Layout ): NormalizedLayout {
 						? layout.isOpened
 						: true,
 				summary: normalizeCardSummaryField( summary ),
-				isCollapsible: layout.isCollapsible ?? false,
+				isCollapsible:
+					layout.isCollapsible === undefined
+						? true
+						: layout.isCollapsible,
 			} satisfies NormalizedCardLayout;
 		}
 	} else if ( layout?.type === 'row' ) {

--- a/packages/dataviews/src/dataform-layouts/normalize-form-fields.ts
+++ b/packages/dataviews/src/dataform-layouts/normalize-form-fields.ts
@@ -72,6 +72,7 @@ export function normalizeLayout( layout?: Layout ): NormalizedLayout {
 				withHeader: false,
 				isOpened: true,
 				summary: [],
+				isCollapsible: false,
 			} satisfies NormalizedCardLayout;
 		} else {
 			const summary = layout.summary ?? [];
@@ -84,6 +85,7 @@ export function normalizeLayout( layout?: Layout ): NormalizedLayout {
 						? layout.isOpened
 						: true,
 				summary: normalizeCardSummaryField( summary ),
+				isCollapsible: layout.isCollapsible ?? false,
 			} satisfies NormalizedCardLayout;
 		}
 	} else if ( layout?.type === 'row' ) {

--- a/packages/dataviews/src/stories/dataform.story.tsx
+++ b/packages/dataviews/src/stories/dataform.story.tsx
@@ -9,7 +9,6 @@ import deepMerge from 'deepmerge';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import {
 	Button,
-	Notice,
 	__experimentalVStack as VStack,
 	privateApis,
 } from '@wordpress/components';
@@ -1253,7 +1252,13 @@ const VisibilityComponent = () => {
 	);
 };
 
-const LayoutCardComponent = ( { withHeader }: { withHeader: boolean } ) => {
+const LayoutCardComponent = ( {
+	withHeader,
+	isCollapsible,
+}: {
+	withHeader: boolean;
+	isCollapsible: boolean;
+} ) => {
 	type Customer = {
 		name: string;
 		email: string;
@@ -1356,21 +1361,6 @@ const LayoutCardComponent = ( { withHeader }: { withHeader: boolean } ) => {
 				return <Badge>{ item.plan }</Badge>;
 			},
 		},
-		{
-			id: 'important-note',
-			label: 'Important notice regarding your account',
-			type: 'text',
-			readOnly: true,
-			render: () => {
-				return (
-					<Notice status="warning" isDismissible={ false }>
-						This card can not be collapsed and is used to display
-						important messages or when it is the only card in the
-						page.
-					</Notice>
-				);
-			},
-		},
 	];
 
 	const [ customer, setCustomer ] = useState< Customer >( {
@@ -1399,7 +1389,11 @@ const LayoutCardComponent = ( { withHeader }: { withHeader: boolean } ) => {
 			fields: [
 				{
 					id: 'customerCard',
-					layout: { type: 'card', summary: 'plan-summary' },
+					layout: {
+						type: 'card',
+						summary: 'plan-summary',
+						isCollapsible,
+					},
 					label: 'Customer',
 					description:
 						'Enter your contact details, plan type, and addresses to complete your customer information.',
@@ -1458,27 +1452,19 @@ const LayoutCardComponent = ( { withHeader }: { withHeader: boolean } ) => {
 					},
 				},
 				{
-					id: 'important-information',
-					label: 'Important information',
-					layout: {
-						type: 'card',
-						isCollapsible: false,
-					},
-					children: [ 'important-note' ],
-				},
-				{
 					id: 'taxConfiguration',
 					label: 'Taxes',
 					layout: {
 						type: 'card',
 						isOpened: false,
 						summary: [ { id: 'dueDate', visibility: 'always' } ],
+						isCollapsible,
 					},
 					children: [ 'vat', 'commission' ],
 				},
 			],
 		} ),
-		[ withHeader ]
+		[ withHeader, isCollapsible ]
 	);
 
 	return (
@@ -1884,9 +1870,14 @@ export const LayoutCard = {
 			control: { type: 'boolean' },
 			description: 'Whether the card has a header.',
 		},
+		isCollapsible: {
+			control: { type: 'boolean' },
+			description: 'Whether the card can be collapsed/expanded.',
+		},
 	},
 	args: {
 		withHeader: true,
+		isCollapsible: true,
 	},
 };
 

--- a/packages/dataviews/src/stories/dataform.story.tsx
+++ b/packages/dataviews/src/stories/dataform.story.tsx
@@ -9,6 +9,7 @@ import deepMerge from 'deepmerge';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import {
 	Button,
+	Notice,
 	__experimentalVStack as VStack,
 	privateApis,
 } from '@wordpress/components';
@@ -1355,6 +1356,21 @@ const LayoutCardComponent = ( { withHeader }: { withHeader: boolean } ) => {
 				return <Badge>{ item.plan }</Badge>;
 			},
 		},
+		{
+			id: 'important-note',
+			label: 'Important notice regarding your account',
+			type: 'text',
+			readOnly: true,
+			render: () => {
+				return (
+					<Notice status="warning" isDismissible={ false }>
+						This card can not be collapsed and is used to display
+						important messages or when it is the only card in the
+						page.
+					</Notice>
+				);
+			},
+		},
 	];
 
 	const [ customer, setCustomer ] = useState< Customer >( {
@@ -1440,6 +1456,15 @@ const LayoutCardComponent = ( { withHeader }: { withHeader: boolean } ) => {
 						type: 'card',
 						withHeader: false,
 					},
+				},
+				{
+					id: 'important-information',
+					label: 'Important information',
+					layout: {
+						type: 'card',
+						isCollapsible: false,
+					},
+					children: [ 'important-note' ],
 				},
 				{
 					id: 'taxConfiguration',

--- a/packages/dataviews/src/test/normalize-form-fields.ts
+++ b/packages/dataviews/src/test/normalize-form-fields.ts
@@ -143,6 +143,7 @@ describe( 'normalizeFormFields', () => {
 						withHeader: true,
 						isOpened: true,
 						summary: [],
+						isCollapsible: true,
 					},
 				},
 			] );
@@ -169,6 +170,7 @@ describe( 'normalizeFormFields', () => {
 						withHeader: false,
 						isOpened: true,
 						summary: [],
+						isCollapsible: false,
 					},
 				},
 			] );
@@ -193,6 +195,7 @@ describe( 'normalizeFormFields', () => {
 						withHeader: true,
 						isOpened: false,
 						summary: [ { id: 'field1', visibility: 'always' } ],
+						isCollapsible: true,
 					},
 				},
 			] );
@@ -208,6 +211,7 @@ describe( 'normalizeFormFields', () => {
 						'field2',
 						{ id: 'field1', visibility: 'always' },
 					],
+					isCollapsible: true,
 				},
 				fields: [ 'field1' ],
 			};
@@ -223,6 +227,7 @@ describe( 'normalizeFormFields', () => {
 							{ id: 'field2', visibility: 'when-collapsed' },
 							{ id: 'field1', visibility: 'always' },
 						],
+						isCollapsible: true,
 					},
 				},
 			] );
@@ -279,6 +284,7 @@ describe( 'normalizeFormFields', () => {
 						withHeader: false,
 						isOpened: true,
 						summary: [],
+						isCollapsible: false,
 					},
 				},
 				{
@@ -288,6 +294,7 @@ describe( 'normalizeFormFields', () => {
 						withHeader: true,
 						isOpened: false,
 						summary: [],
+						isCollapsible: true,
 					},
 				},
 			] );

--- a/packages/dataviews/src/types/dataform.ts
+++ b/packages/dataviews/src/types/dataform.ts
@@ -56,7 +56,7 @@ export type CardLayout =
 			// isOpened cannot be false if withHeader is false as well.
 			// Otherwise, the card would not be visible.
 			isOpened?: true;
-			// isCollapsible cannot be false if withHeader is false as well.
+			// isCollapsible cannot be true if withHeader is false as well.
 			isCollapsible?: false;
 	  }
 	| {

--- a/packages/dataviews/src/types/dataform.ts
+++ b/packages/dataviews/src/types/dataform.ts
@@ -56,12 +56,15 @@ export type CardLayout =
 			// isOpened cannot be false if withHeader is false as well.
 			// Otherwise, the card would not be visible.
 			isOpened?: true;
+			// isCollapsible cannot be false if withHeader is false as well.
+			isCollapsible?: false;
 	  }
 	| {
 			type: 'card';
 			withHeader?: true | undefined;
 			isOpened?: boolean;
 			summary?: CardSummaryField;
+			isCollapsible?: boolean | undefined;
 	  };
 export type NormalizedCardLayout =
 	| {
@@ -72,12 +75,15 @@ export type NormalizedCardLayout =
 			isOpened: true;
 			// Summary is an empty array
 			summary: [];
+			// If no header, the card should not be collapsible.
+			isCollapsible: false;
 	  }
 	| {
 			type: 'card';
 			withHeader: true;
 			isOpened: boolean;
 			summary: NormalizedCardSummaryField;
+			isCollapsible: boolean;
 	  };
 
 export type RowLayout = {


### PR DESCRIPTION
## What?

This adds support for the `isCollapsible` field in the `card` layout. To keep backward compatibility, if the field isn't defined, it defaults to `true`.

## Why?

Non-collapsible cards can be used to display important details or when only one card is present on a page.

## Testing Instructions

1. An example is added to the storybook

## Screenshots or screencast 

<img width="1952" height="408" alt="CleanShot 2025-10-21 at 16 54 29@2x" src="https://github.com/user-attachments/assets/12594270-4bd8-4aa1-a62f-07da58662099" />
