### PR TITLE
Notes: Fix 'View notes' on mobile screens

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -117,7 +117,8 @@ export default function CollabSidebar() {
 		commentLastUpdated,
 	} = useBlockComments( postId );
 	useEnableFloatingSidebar(
-		unresolvedSortedThreads.length > 0 || showCommentBoard
+		isLargeViewport &&
+			( unresolvedSortedThreads.length > 0 || showCommentBoard )
 	);
 
 	const hasMoreComments = totalPages && totalPages > 1;
@@ -142,7 +143,10 @@ export default function CollabSidebar() {
 
 		// If the notes sidebar is not already active, enable the floating sidebar.
 		if ( ! activeNotesArea ) {
-			enableComplementaryArea( 'core', collabSidebarName );
+			enableComplementaryArea(
+				'core',
+				isLargeViewport ? collabSidebarName : collabHistorySidebarName
+			);
 		}
 
 		const currentArea = await getActiveComplementaryArea( 'core' );


### PR DESCRIPTION
## What?
This is a follow-up to #71834.
Closes #72531.

PR fixes "View notes" and "Add note" block toolbar/option items when editor is rendered in smaller viewports.

## Why?
Floating notes are disabled on smaller screens since they're not dismissible and prevent content editing. 

## Testing Instructions
1. Open a post.
2. Add a block and note.
3. Resize the screen to the mobile viewport.
4. Click the "View note" block toolbar item.
5. Confirm that the Notes pinned sidebar is opened and the note selected.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/5b990f7d-c17e-451f-a244-82b4627321b3


