### PR TITLE
Limit max-height of Note threads and make scrollable

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -260,6 +260,7 @@ export function Comments( {
 		? {
 				container: 'thread stack / size',
 				height: '100%',
+				flexShrink: 0,
 		  }
 		: undefined;
 

--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -256,8 +256,15 @@ export function Comments( {
 		);
 	}
 
+	const style = isFloating
+		? {
+				container: 'thread stack / size',
+				height: '100%',
+		  }
+		: undefined;
+
 	return (
-		<VStack spacing="3">
+		<VStack style={ style } spacing="3">
 			{ threads.map( ( thread ) => (
 				<Thread
 					key={ thread.id }
@@ -398,7 +405,7 @@ function Thread( {
 			aria-label={ ariaLabel }
 			aria-expanded={ isSelected }
 			ref={ isFloating ? refs.setFloating : undefined }
-			style={ isFloating ? { top: y } : undefined }
+			style={ isFloating ? { '--floating-top': `${ y }px` } : undefined }
 		>
 			<Button
 				className="editor-collab-sidebar-panel__skip-to-comment"

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -29,6 +29,7 @@
 	background-color: $gray-100;
 	overflow: hidden;
 	width: auto;
+	flex-shrink: 0;
 
 	&.is-selected {
 		background-color: $white;

--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -42,10 +42,21 @@
 	}
 
 	&.is-floating {
+		translate: 0 var(--floating-top);
+		top: 0;
 		left: $grid-unit-20;
 		right: $grid-unit-20;
 		position: absolute;
 		margin-top: $grid-unit-20;
+		max-height: calc(100cqb - var(--floating-top));
+		overflow: auto;
+		justify-content: initial;
+
+		> * {
+			// Prevents shrinking children flex items. E.g. VStack components which have
+			// min-height: 0px causing them to overlap sibliings.
+			flex-shrink: 0;
+		}
 	}
 }
 
@@ -132,26 +143,24 @@
 .editor-collab-sidebar-panel__skip-to-comment,
 .editor-collab-sidebar-panel__skip-to-block {
 	position: absolute;
-	top: -9999px;
-	right: -9999px;
 	overflow: hidden;
 	clip-path: inset(50%);
 	background: $white !important;
 	z-index: -1;
 
 	&:focus {
+		position: sticky;
 		overflow: visible;
 		clip-path: none;
 		z-index: 1;
-		right: $grid-unit-10;
+		align-self: end;
 	}
 }
 .editor-collab-sidebar-panel__skip-to-comment:focus {
-	top: $grid-unit-10;
+	top: 0;
 }
 .editor-collab-sidebar-panel__skip-to-block:focus {
-	top: auto;
-	bottom: $grid-unit-10;
+	bottom: 0;
 }
 
 // Comment avatar indicators.


### PR DESCRIPTION
## What?
An experiment aimed at #72507 and alternative to #72454

Makes Note threads scrollable with their maximum height dynamic according to their vertical position.

> [!NOTE]
> This isn’t a complete solution for two known cases where thread’s height may be too short for decent usability:
> - The site editor in post-only mode doesn’t have the ”padding appender” that adds space to the bottom of the post content like the post editor does. See the second screen recording. UPDATE: this can be resolved by #72598.
>  - A post template might not have footer or may have a very short one and this would cause the same problem

## Why?

Without this, long notes/threads can be cut off if there’s not enough overflow in the canvas to scroll far enough.

Additionally, this offers some improvement to viewing any long threads because without it going to end of a long thread entails scrolling the block (at least partially) out of view. That said, there remains a different concern for very tall blocks, where the thread scrolls out of view when scrolling to the end of the block. We need stickiness I guess.

## How?

- Assigns the `y` position as a CSS variable so both positioning and max-height CSS values can utilize it
- Adds CSS `overflow` to threads
- Revises the skip link/button styling a bit as entailed by the overflow change

## Testing Instructions
…

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Fix demonstrated:
https://github.com/user-attachments/assets/3943a20a-8686-4507-aaff-3fc3961245e9

### Trouble in site editor post-only views
This can also be an issue in the template view if the template has a short footer or lacks one.

https://github.com/user-attachments/assets/cbf1d79c-dfc2-4368-b629-43343dfeaa92

### Side benefit
View whole threads without scrolling block out of view.

https://github.com/user-attachments/assets/f8baf767-d76d-413b-b20a-f19a78024b99





