### PR TITLE
Use default popover placement for image format popover

### DIFF
--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -72,7 +72,6 @@ function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 
 	return (
 		<Popover
-			placement="bottom"
 			focusOnMount={ false }
 			anchor={ popoverAnchor }
 			className="block-editor-format-toolbar__image-popover"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What, Why, How?

A fix for a bug where the image format’s popover goes partially offscreen because it should not do that. This just removes the `placement` prop so the default is used and that works better.

## Testing Instructions
1. Open a post
2. Paste the following (a full width group so the image is sure to be close to the canvas edge):
   ```html
   <!-- wp:group {"align":"full","layout":{"type":"default"}} -->
   <div class="wp-block-group alignfull"><!-- wp:paragraph -->
   <p><img class="wp-image-18" style="width: 150px;" src="https://placehold.co/150x150" alt=""> Let’s start this paragraph with an inline image.</p>
   <!-- /wp:paragraph --></div>
   <!-- /wp:group -->
   ```

4. Select the image so its popover appears
5. Verify the popover is not going offscreen

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="960" height="700" alt="image-format-popover-before" src="https://github.com/user-attachments/assets/e4dbfb09-ff03-47c1-9dfb-cfc1fe8ef060" /> | <img width="960" height="700" alt="image-format-popover-after" src="https://github.com/user-attachments/assets/13f10e77-85a9-40f8-a4cd-5759d7f942cb" /> |

Looking at this, I now wonder if the popover wouldn’t look better with small `offset`. I’ll keep this PR focused though.
