### PR TITLE
Fix error with display of Heading block style variations in style book.

### DIFF
--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -224,19 +224,29 @@ function applyBlockVariationsToExamples( examples, variation ) {
 	if ( ! variation ) {
 		return examples;
 	}
-
-	return examples.map( ( example ) => ( {
-		...example,
-		variation,
-		blocks: {
-			...example.blocks,
-			attributes: {
-				...example.blocks.attributes,
-				style: undefined,
-				className: getVariationClassName( variation ),
-			},
-		},
-	} ) );
+	return examples.map( ( example ) => {
+		return {
+			...example,
+			variation,
+			blocks: Array.isArray( example.blocks )
+				? example.blocks.map( ( block ) => ( {
+						...block,
+						attributes: {
+							...block.attributes,
+							style: undefined,
+							className: getVariationClassName( variation ),
+						},
+				  } ) )
+				: {
+						...example.blocks,
+						attributes: {
+							...example.blocks.attributes,
+							style: undefined,
+							className: getVariationClassName( variation ),
+						},
+				  },
+		};
+	} );
 }
 
 function StyleBook( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Fixes bug noticed when [testing another PR](https://github.com/WordPress/gutenberg/pull/72464#pullrequestreview-3358783387) (unrelated to that PR)

The bug specifically affects the Heading block variations because Heading displays multiple instances of itself in the style book. It would not affect variations of blocks that display a single instance.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open the style book from the left hand sidebar with TT5 enabled
2. Navigate to blocks > Heading > annotation (or any of the other style variations)
3. Check that style book blocks render correctly (it errors on trunk)
4. As a bonus, check that style variations for other blocks, e.g. Image, also render correctly.

<img width="1217" height="579" alt="Screenshot 2025-10-22 at 11 55 22 am" src="https://github.com/user-attachments/assets/c0d88ed7-1638-4ee3-a958-ebfa1623488e" />

