### PR TITLE
List View: Fix sub-pixel gap in background of selected rows

### DIFF
--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -71,9 +71,17 @@
 	// The background has to be applied to the td, not tr, or border-radius won't work.
 	&.is-selected td {
 		background: var(--wp-admin-theme-color);
+
+		&:first-child:not(:only-child) {
+			box-shadow: 1px 0 0 0 var(--wp-admin-theme-color);
+		}
 	}
 	&.is-selected.is-synced td {
 		background: var(--wp-block-synced-color);
+
+		&:first-child:not(:only-child) {
+			box-shadow: 1px 0 0 0 var(--wp-block-synced-color);
+		}
 	}
 	&.is-synced:not(.is-selected) .block-editor-list-view-block-contents {
 		&:hover,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

In the List View, add a 1px solid box shadow to the right of the first cell in the list row, when the list item is selected. This is to compensate for a sub-pixel rendering gap between the background of each cell in a selected row.

This is a low-priority PR, but the visual issue was frustrating me a little bit on HiDPI displays as it makes the selected item in the list view not feel quite as solid as it could.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It turns out that we're applying a `will-change: transform` rule to the list view (added back in https://github.com/WordPress/gutenberg/pull/49793 and used in a mixin [here](https://github.com/WordPress/gutenberg/blob/0f050c9c23617b1fc25871e5767c118618db39ce/packages/base-styles/_mixins.scss#L657) and applied to the list view panel content [here](https://github.com/WordPress/gutenberg/blob/248d8dbbb228edff0da91a51a402f2e171366f86/packages/editor/src/components/list-view-sidebar/style.scss#L18)). This causes the panel content to be rendered in a compositing layer by the GPU.

As it's being rendered by the GPU, in Chrome at least, the adjacent selected `td` cells of the list view (with background color set individually) wind up rendering with a sub-pixel gap between the cells.

As the `will-change` rule was added to fix an issue with Safari, I think it's best to leave that rule in, and so the idea in this PR is to mitigate the issue by adding a `1px` box-shadow using the same colour as the first cell.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* For the first cell of selected list view rows, add a `1px` box-shadow using the same color as the background for the selected row
* Only apply this if the `td` is not the only child — for example, in the Widget editor, the row is rendered as one cell, so this fix is not needed there

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Open up the post editor
* In the Post panel in the right hand sidebar, select Template > Show template (if you haven't already)
* Open up the list view, and select the Header template part
* In `trunk`, I see a sub-pixel vertical line between the two cells of the list view item
* With this PR applied, there should be no sub-pixel gap
* You can also test selecting a regular block in the list view so that you can see it with the blue background instead of purple

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before

<img width="736" height="488" alt="image" src="https://github.com/user-attachments/assets/be864809-10fd-4ae1-94f8-c997259fb9c4" />

### After

<img width="736" height="492" alt="image" src="https://github.com/user-attachments/assets/b8e15011-ecb4-4782-ba24-7f1734561e4d" />


