### PR TITLE
 Math Block: Use monospaced font for LaTeX input

### DIFF
--- a/packages/block-library/src/math/edit.js
+++ b/packages/block-library/src/math/edit.js
@@ -82,6 +82,7 @@ export default function MathEdit( { attributes, setAttributes, isSelected } ) {
 								label={ __( 'LaTeX math syntax' ) }
 								hideLabelFromVision
 								value={ latex }
+								style={ { fontFamily: 'monospace' } }
 								onChange={ ( newLatex ) => {
 									if ( ! latexToMathML ) {
 										setAttributes( { latex: newLatex } );


### PR DESCRIPTION
## What?
Adds a monospaced font to the LaTeX input field in the Math block.

Closes #72542

## Why?
LaTeX syntax uses special characters, brackets, and precise spacing that are easier to read and edit in a monospaced font (similar to code editors). This improves the user experience when writing mathematical expressions.

## How?
Added `style={ { fontFamily: 'monospace' } }` prop to the `TextareaControl` component in the Math block's edit component.

## Testing Instructions
1. Create or edit a Math block
2. Click on the block to open the LaTeX input popover
3. Verify that the input field now displays text in a monospaced font
4. Type some LaTeX syntax (e.g., `\frac{a}{b}`, `x^2 + y^2 = r^2`) and confirm it's more readable

## Checklist
- [x] My code is tested
- [x] My code follows the WordPress code style
- [x] My code has proper inline documentation
- [x] I've included developer documentation if appropriate
