### PR TITLE
Persist credentials when cherry-picking commits to a release branch

### DIFF
--- a/.github/workflows/cherry-pick-wp-release.yml
+++ b/.github/workflows/cherry-pick-wp-release.yml
@@ -82,7 +82,7 @@ jobs:
               with:
                   token: ${{ secrets.GUTENBERG_TOKEN }}
                   fetch-depth: 0
-                  persist-credentials: false
+                  persist-credentials: true
 
             - name: Set up Git
               if: env.cherry_pick == 'true'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
See the slack convo - https://wordpress.slack.com/archives/C02QB2JS7/p1761097846014379.

Changes the `persist-credentials` option back to `true` for the cherry-pick action.

## Why?
It looks like this was changed to `false` incorrectly in #69126. The credentials are needed in a later step to perform the cherry-picking.

There were also some similar issues that arose from the same PR - (#70007, #70058). It looks like the cherry-pick action possibly wasn't tested after that PR was merged (I expect it's quite difficult to test these actions).