### PR TITLE
Notes: Fix 'children' embedding via REST API

### DIFF
--- a/backport-changelog/6.9/10420.md
+++ b/backport-changelog/6.9/10420.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/10420
+
+* https://github.com/WordPress/gutenberg/pull/72561

--- a/lib/compat/wordpress-6.9/class-gutenberg-rest-comment-controller-6-9.php
+++ b/lib/compat/wordpress-6.9/class-gutenberg-rest-comment-controller-6-9.php
@@ -512,6 +512,37 @@ class Gutenberg_REST_Comment_Controller_6_9 extends WP_REST_Comments_Controller 
 	}
 
 	/**
+	 * Prepares links for the request.
+	 *
+	 * @since 4.7.0
+	 *
+	 * @param WP_Comment $comment Comment object.
+	 * @return array Links for the given comment.
+	 */
+	protected function prepare_links( $comment ) {
+		$links = parent::prepare_links( $comment );
+
+		// Embedding children for notes requires `type` and `status` inheritance.
+		// Note: This is only relevant change for the backport.
+		if ( isset( $links['children'] ) && 'note' === $comment->comment_type ) {
+			$args = array(
+				'parent' => $comment->comment_ID,
+				'type'   => $comment->comment_type,
+				'status' => 'all',
+			);
+
+			$rest_url = add_query_arg( $args, rest_url( $this->namespace . '/' . $this->rest_base ) );
+
+			$links['children'] = array(
+				'href'       => $rest_url,
+				'embeddable' => true,
+			);
+		}
+
+		return $links;
+	}
+
+	/**
 	 * Override the schema to change `type` property.
 	 *
 	 * @return array


### PR DESCRIPTION
## What?
Requires #71728.
Related https://github.com/WordPress/gutenberg/issues/71668#issuecomment-3349902890.

PR overrides the `children` embeddable link for notes to allow embedding their replies (children). The current link returns no results because it uses the default `type` and `status` collection params, instead of inheriting from the current query.

An alternative option is to add a new `replies` link just for the `note` comment type and not modify the existing one, but considering we're already patching responses for the Notes, I don't think this is a breaking change.

## Why?
See https://github.com/WordPress/gutenberg/issues/71668#issuecomment-3349902890.

## Testing Instructions
1. Comment out following filter - `add_action( 'comments_clauses', 'exclude_block_comments_from_admin', 10, 2 );`.
2. Create a post.
3. Add blocks.
4. Add notes and their replies to these blocks.
5. Run JS test snippet.

<details><summary>Test JS snippet</summary>
<p>

```js
function testNotesEmbedQuery( ) {
    const postId = wp.data.select( 'core/editor' ).getCurrentPostId();

    const queryArgs = {
		post: postId,
		type: 'note',
		status: 'all',
		parent: 0,
		per_page: 100,
		context: 'edit',
		_embed: 'children',
	};

	return wp.data.select( 'core' ).getEntityRecords( 'root', 'comment', queryArgs );
}

console.log( testNotesEmbedQuery() );
```

</p>
</details> 

### Testing Instructions for Keyboard
Same.

## Screeenshot
<img width="1576" height="417" alt="CleanShot 2025-10-22 at 11 03 13" src="https://github.com/user-attachments/assets/a6859ab9-a8c1-412f-ac6c-877488f91cf2" />
