### PR TITLE
Run `wp/6.9` e2e tests on top of WP trunk

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -9,7 +9,6 @@
 		},
 		"tests": {
 			"mappings": {
-				"wp-content/plugins/gutenberg": ".",
 				"wp-content/mu-plugins": "./packages/e2e-tests/mu-plugins",
 				"wp-content/plugins/gutenberg-test-plugins": "./packages/e2e-tests/plugins",
 				"wp-content/themes/gutenberg-test-themes": "./test/gutenberg-test-themes",

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "./schemas/json/wp-env.json",
-	"core": "WordPress/WordPress#6.8.3",
-	"plugins": [ "." ],
+	"core": "WordPress/WordPress",
+	"plugins": [],
 	"themes": [ "./test/emptytheme" ],
 	"env": {
 		"development": {


### PR DESCRIPTION
Not for merge. Disables Gutenberg to check e2e test results on WP trunk only.