### PR TITLE
Date block: Update block description

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -678,7 +678,7 @@ Displays the contents of a post or page. ([Source](https://github.com/WordPress/
 
 ## Date
 
-Display the publish date for an entry such as a post or page. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-date))
+Display a custom date. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-date))
 
 -	**Name:** core/post-date
 -	**Category:** theme

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -4,7 +4,7 @@
 	"name": "core/post-date",
 	"title": "Date",
 	"category": "theme",
-	"description": "Display the publish date for an entry such as a post or page.",
+	"description": "Display a custom date.",
 	"textdomain": "default",
 	"attributes": {
 		"datetime": {


### PR DESCRIPTION
## What?
Update the Date block's description.

## Why?
Per https://github.com/WordPress/gutenberg/pull/70585, the Date block defaults to allowing the user to setting a custom date. (The previous default behavior — showing the publish date of the containing post — was turned into a block variation). 

However, the block description was not updated accordingly, as [pointed out](https://github.com/WordPress/gutenberg/pull/70585#issuecomment-3421895254) by @ntsekouras. This PR remediates that.