### PR TITLE
Real-time collaboration: [pr-72566] Check for the current attribute existing before proceeding

### DIFF
--- a/packages/core-data/src/utils/crdt-blocks.ts
+++ b/packages/core-data/src/utils/crdt-blocks.ts
@@ -298,7 +298,8 @@ export function mergeCrdtBlocks(
 
 							if (
 								isRichText &&
-								'string' === typeof attributeValue
+								'string' === typeof attributeValue &&
+								currentAttributes.has( attributeName )
 							) {
 								// Rich text values are stored as persistent Y.Text instances.
 								// Update the value with a delta in place.

--- a/packages/core-data/src/utils/test/crdt-blocks.ts
+++ b/packages/core-data/src/utils/test/crdt-blocks.ts
@@ -371,5 +371,44 @@ describe( 'crdt-blocks', () => {
 			 ).get( 'content' ) as Y.Text;
 			expect( content.toString() ).toBe( 'Updated Middle' );
 		} );
+
+		it( 'adds new rich-text attribute to existing block without that attribute', () => {
+			// Start with a block that has NO content attribute
+			const initialBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: { level: 1 },
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, initialBlocks, null );
+
+			// Now add the content attribute (rich-text)
+			const updatedBlocks: Block[] = [
+				{
+					name: 'core/paragraph',
+					attributes: {
+						level: 1,
+						content: 'New content added',
+					},
+					innerBlocks: [],
+				},
+			];
+
+			mergeCrdtBlocks( yblocks, updatedBlocks, null );
+
+			expect( yblocks.length ).toBe( 1 );
+			const block = yblocks.get( 0 );
+			const attributes = block.get( 'attributes' ) as YBlockAttributes;
+
+			// The content attribute should now exist
+			expect( attributes.has( 'content' ) ).toBe( true );
+			const content = attributes.get( 'content' ) as Y.Text;
+			expect( content.toString() ).toBe( 'New content added' );
+
+			// The level attribute should still exist
+			expect( attributes.get( 'level' ) ).toBe( 1 );
+		} );
 	} );
 } );


### PR DESCRIPTION
## What?

Currently, any block besides a paragraph block will cause block recovery errors. This'll rectify that and allow all blocks to work.

## Why?

This is due to the fact that the earlier quill delta code only accounted for rich text blocks making it to the inner if condition. Without the quill delta code, all blocks are making it inside. 

## How?

So, by checking if the currentAttribute has an attribute this'll stop that from happening.

## Testing Instructions

- Insert any non text-block, it'll break without this branch.
