### PR TITLE
Env: Remove non-functional `WP_ENV_MULTISITE` config

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bug Fixes
 
 -   Add MySQL healthcheck to prevent race condition where WordPress containers start before MySQL is fully initialized. Uses MariaDB's official `healthcheck.sh` script with `MARIADB_AUTO_UPGRADE` to support both new and existing installations.
--   Fix `WP_ENV_MULTISITE` environment variable override not working correctly ([#72567](https://github.com/WordPress/gutenberg/pull/72567)).
+-   Remove non-functional `WP_ENV_MULTISITE` config.
 
 ### Breaking Changes
 

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   Add MySQL healthcheck to prevent race condition where WordPress containers start before MySQL is fully initialized. Uses MariaDB's official `healthcheck.sh` script with `MARIADB_AUTO_UPGRADE` to support both new and existing installations.
+-   Fix `WP_ENV_MULTISITE` environment variable override not working correctly ([#72567](https://github.com/WordPress/gutenberg/pull/72567)).
 
 ### Breaking Changes
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -785,7 +785,7 @@ You can tell `wp-env` to use a specific PHP version for compatibility and testin
 
 ### Multisite support
 
-You can tell `wp-env`  if the site should be multisite enabled. This can also be set via the environment variable `WP_ENV_MULTISITE`.
+You can tell `wp-env` if the site should be multisite enabled.
 
 ```json
 {

--- a/packages/env/lib/config/get-config-from-environment-vars.js
+++ b/packages/env/lib/config/get-config-from-environment-vars.js
@@ -23,7 +23,6 @@ const { checkPort, checkVersion, checkString } = require( './validate-config' );
  * @property {?number}                  phpmyadminPort   An override for the development environment's phpMyAdmin port.
  * @property {?WPSource}                coreSource       An override for all environment's coreSource.
  * @property {?string}                  phpVersion       An override for all environment's PHP version.
- * @property {?boolean}                 multisite        An override for if environmen should be multisite.
  * @property {?Object.<string, string>} lifecycleScripts An override for various lifecycle scripts.
  */
 
@@ -67,13 +66,6 @@ module.exports = function getConfigFromEnvironmentVars( cacheDirectoryPath ) {
 			process.env.WP_ENV_PHP_VERSION
 		);
 		environmentConfig.phpVersion = process.env.WP_ENV_PHP_VERSION;
-	}
-
-	if ( process.env.WP_ENV_MULTISITE ) {
-		const rawValue = process.env.WP_ENV_MULTISITE.trim().toLowerCase();
-		if ( rawValue === '1' || rawValue === 'true' ) {
-			environmentConfig.multisite = true;
-		}
 	}
 
 	return environmentConfig;

--- a/packages/env/lib/config/get-config-from-environment-vars.js
+++ b/packages/env/lib/config/get-config-from-environment-vars.js
@@ -70,7 +70,10 @@ module.exports = function getConfigFromEnvironmentVars( cacheDirectoryPath ) {
 	}
 
 	if ( process.env.WP_ENV_MULTISITE ) {
-		environmentConfig.multisite = !! process.env.WP_ENV_MULTISITE;
+		const rawValue = process.env.WP_ENV_MULTISITE.trim().toLowerCase();
+		if ( rawValue === '1' || rawValue === 'true' ) {
+			environmentConfig.multisite = true;
+		}
 	}
 
 	return environmentConfig;

--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -314,6 +314,12 @@ function getEnvironmentVarOverrides( cacheDirectoryPath ) {
 		overrideConfig.env.tests.phpVersion = overrides.phpVersion;
 	}
 
+	if ( overrides.multisite ) {
+		overrideConfig.multisite = overrides.multisite;
+		overrideConfig.env.development.multisite = overrides.multisite;
+		overrideConfig.env.tests.multisite = overrides.multisite;
+	}
+
 	return overrideConfig;
 }
 


### PR DESCRIPTION
Follow-up https://github.com/WordPress/gutenberg/pull/68792

## What?

I noticed that the `WP_ENV_MULTISITE` environment variable override not working correctly.

## Why?

The necessary code was missing from the `getEnvironmentVarOverrides` function.

## How?

~Multisite is enabled when set to `1` or `true`, as follows:~

- ~`WP_ENV_MULTISITE=1 npm run wp-env start`~
- ~`WP_ENV_MULTISITE="1" npm run wp-env start`~
- ~`WP_ENV_MULTISITE=true npm run wp-env start`~
- ~`WP_ENV_MULTISITE="true" npm run wp-env start`~

After a discussion, we decided to remove the non-functional `WP_ENV_MULTISITE` config. The `multisite` field in `wp-env.json` works as before.

## Testing Instructions

~Run either of the above commands, and confirm that the multisite environment is launched.~

Confirm that the `multisite` field in `wp-env.json` works as before:

```json
{
	"multisite": true
}
```