### PR TITLE
Fit text: Remove sizing limitation when the block is selected.

### DIFF
--- a/packages/block-editor/src/utils/fit-text-utils.js
+++ b/packages/block-editor/src/utils/fit-text-utils.js
@@ -20,18 +20,17 @@ function generateCSSRule( elementSelector, fontSize ) {
  * @param {HTMLElement} textElement     The text element
  * @param {string}      elementSelector CSS selector for the text element
  * @param {Function}    applyStylesFn   Function to apply test styles
- * @param {number}      maxSize         Maximum font size in pixels (default: 600)
  * @return {number} Optimal font size
  */
 function findOptimalFontSize(
 	textElement,
 	elementSelector,
-	applyStylesFn,
-	maxSize = 600
+	applyStylesFn
 ) {
 	const alreadyHasScrollableHeight =
 		textElement.scrollHeight > textElement.clientHeight;
 	let minSize = 5;
+	let maxSize = 600;
 	let bestSize = minSize;
 
 	while ( minSize <= maxSize ) {
@@ -61,13 +60,11 @@ function findOptimalFontSize(
  * @param {HTMLElement} textElement     The text element (paragraph, heading, etc.)
  * @param {string}      elementSelector CSS selector for the text element
  * @param {Function}    applyStylesFn   Function to apply CSS styles (pass empty string to clear)
- * @param {number}      maxSize         Maximum font size in pixels.
  */
 export function optimizeFitText(
 	textElement,
 	elementSelector,
-	applyStylesFn,
-	maxSize
+	applyStylesFn
 ) {
 	if ( ! textElement ) {
 		return;
@@ -78,8 +75,7 @@ export function optimizeFitText(
 	const optimalSize = findOptimalFontSize(
 		textElement,
 		elementSelector,
-		applyStylesFn,
-		maxSize
+		applyStylesFn
 	);
 
 	const cssRule = generateCSSRule( elementSelector, optimalSize );

--- a/packages/block-editor/src/utils/fit-text-utils.js
+++ b/packages/block-editor/src/utils/fit-text-utils.js
@@ -22,11 +22,7 @@ function generateCSSRule( elementSelector, fontSize ) {
  * @param {Function}    applyStylesFn   Function to apply test styles
  * @return {number} Optimal font size
  */
-function findOptimalFontSize(
-	textElement,
-	elementSelector,
-	applyStylesFn
-) {
+function findOptimalFontSize( textElement, elementSelector, applyStylesFn ) {
 	const alreadyHasScrollableHeight =
 		textElement.scrollHeight > textElement.clientHeight;
 	let minSize = 5;
@@ -61,11 +57,7 @@ function findOptimalFontSize(
  * @param {string}      elementSelector CSS selector for the text element
  * @param {Function}    applyStylesFn   Function to apply CSS styles (pass empty string to clear)
  */
-export function optimizeFitText(
-	textElement,
-	elementSelector,
-	applyStylesFn
-) {
+export function optimizeFitText( textElement, elementSelector, applyStylesFn ) {
 	if ( ! textElement ) {
 		return;
 	}


### PR DESCRIPTION
Some users thought that having a different font size for fit text when the block is selected vs unselected was a bug. So we are reverting this change as a way to simplify, and receive feedback on the simple version without any restriction.


## Testing Instructions
Add a paragraph, type some character like "A".
Enable fit text
Unselect the block and select it again verify the font size does not changes.
