### PR TITLE
Command Palette: Disable site editor navigation commands on Network Admin

### DIFF
--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -101,6 +101,10 @@ const getNavigationCommandLoaderPerPostType = ( postType ) =>
 		);
 
 		const commands = useMemo( () => {
+			if ( window.location.pathname.startsWith( '/wp-admin/network/' ) ) {
+				return [];
+			}
+
 			return ( records ?? [] ).map( ( record ) => {
 				const command = {
 					name: postType + '-' + record.id,
@@ -200,6 +204,10 @@ const getNavigationCommandLoaderPerTemplate = ( templateType ) =>
 		}, [ records, search ] );
 
 		const commands = useMemo( () => {
+			if ( window.location.pathname.startsWith( '/wp-admin/network/' ) ) {
+				return [];
+			}
+
 			if (
 				! canCreateTemplate ||
 				( ! isBlockBasedTheme && ! templateType === 'wp_template_part' )
@@ -297,6 +305,10 @@ const getSiteEditorBasicNavigationCommands = () =>
 				};
 			}, [] );
 		const commands = useMemo( () => {
+			if ( window.location.pathname.startsWith( '/wp-admin/network/' ) ) {
+				return [];
+			}
+
 			const result = [];
 
 			if ( canCreateTemplate && isBlockBasedTheme ) {
@@ -422,6 +434,10 @@ const getGlobalStylesOpenCssCommands = () =>
 		}, [] );
 
 		const commands = useMemo( () => {
+			if ( window.location.pathname.includes( '/wp-admin/network/' ) ) {
+				return [];
+			}
+
 			if ( ! canEditCSS ) {
 				return [];
 			}


### PR DESCRIPTION
- Originally reported on Trac: https://core.trac.wordpress.org/ticket/64125
- Closes: #72527

## What? Why?

The Site Editor is not available in the Multisite Network Admin screen and must be disabled.

## How?

Check if `window.location.pathname` includes `/wp-admin/network`.

Another approach might be to check for `is+network_admin()` on the server side and pass the result to the `initializeCommandPalette` function.

## Testing Instructions

Make the following changes to `.wp-env.json` and run `npm run start`.

```diff
diff --git a/.wp-env.json b/.wp-env.json
index d368f3ea1c..f6b348456e 100644
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -5,7 +5,8 @@
        "themes": [ "./test/emptytheme" ],
        "env": {
                "development": {
-                       "phpmyadminPort": 9000
+                       "phpmyadminPort": 9000,
+                       "multisite": true
                },
                "tests": {
                        "mappings": {
```

- Access http://localhost:8888/wp-admin/network/.
- Launch the command palette.
- Make sure that no commands like `Go to: Styles` are displayed.