### PR TITLE
GitHub Actions: Allow writing PRs when auto-cherry-picking

### DIFF
--- a/.github/workflows/cherry-pick-wp-release.yml
+++ b/.github/workflows/cherry-pick-wp-release.yml
@@ -26,7 +26,7 @@ jobs:
         permissions:
             contents: write
             issues: write
-            pull-requests: read
+            pull-requests: write
         # When in the context of a PR, ensure the PR is merged.
         if: github.event.pull_request == null || github.event.pull_request.merged == true
         steps:


### PR DESCRIPTION
- Follow-up https://github.com/WordPress/gutenberg/pull/72556
- See the discussion on Slack: https://wordpress.slack.com/archives/C02QB2JS7/p1761133096282149?thread_ts=1761097846.014379&cid=C02QB2JS7

## What?

When a PR is tagged with the `Backport to WP X.X Beta/RC` label, GitHub Action triggers it to automatically cherry-pick the PR into the `wp/x.x` branch. Some issues were resolved in #72556, and the cherry-pick itself now works correctly, but the following two workflows don't work:

- Remove the `Backport to WP X.X Beta/RC` label.
- Comment about the cherry-pick results on the PR.

My guess is that the reason is that the permission was limited to read by #69126.

https://github.com/WordPress/gutenberg/pull/69126/files#diff-712273121c4cf0e79eab65a0cbc9ee462c9dfef1ffc2a72f164bae6b46e3d625R29

## Testing Instructions
This PR is difficult to test, but let's see if the workflow works correctly after this PR is merged.