### PR TITLE
`core/table` Improve accessibility with semantic HTML and scope attributes

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -961,7 +961,7 @@ Create structured content in rows and columns to display information. ([Source](
 -	**Name:** core/table
 -	**Category:** text
 -	**Supports:** align, anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
--	**Attributes:** body, caption, foot, hasFixedLayout, head
+-	**Attributes:** body, caption, captionSide, foot, hasFixedLayout, head
 
 ## Table of Contents
 

--- a/packages/block-library/src/table/block.json
+++ b/packages/block-library/src/table/block.json
@@ -14,8 +14,13 @@
 		"caption": {
 			"type": "rich-text",
 			"source": "rich-text",
-			"selector": "figcaption",
+			"selector": "caption",
 			"role": "content"
+		},
+		"captionSide": {
+			"type": "string",
+			"default": "bottom",
+			"enum": [ "bottom", "top" ]
 		},
 		"head": {
 			"type": "array",

--- a/packages/block-library/src/table/deprecated.js
+++ b/packages/block-library/src/table/deprecated.js
@@ -25,6 +25,244 @@ const oldColors = {
 	'subtle-pale-pink': '#fcf0ef',
 };
 
+// Migration from figcaption to caption inside table.
+const v5Query = {
+	content: {
+		type: 'rich-text',
+		source: 'rich-text',
+	},
+	tag: {
+		type: 'string',
+		default: 'td',
+		source: 'tag',
+	},
+	scope: {
+		type: 'string',
+		source: 'attribute',
+		attribute: 'scope',
+	},
+	align: {
+		type: 'string',
+		source: 'attribute',
+		attribute: 'data-align',
+	},
+	colspan: {
+		type: 'string',
+		source: 'attribute',
+		attribute: 'colspan',
+	},
+	rowspan: {
+		type: 'string',
+		source: 'attribute',
+		attribute: 'rowspan',
+	},
+};
+
+const v5 = {
+	attributes: {
+		hasFixedLayout: {
+			type: 'boolean',
+			default: true,
+		},
+		caption: {
+			type: 'rich-text',
+			source: 'rich-text',
+			selector: 'figcaption',
+		},
+		head: {
+			type: 'array',
+			default: [],
+			source: 'query',
+			selector: 'thead tr',
+			query: {
+				cells: {
+					type: 'array',
+					default: [],
+					source: 'query',
+					selector: 'td,th',
+					query: v5Query,
+				},
+			},
+		},
+		body: {
+			type: 'array',
+			default: [],
+			source: 'query',
+			selector: 'tbody tr',
+			query: {
+				cells: {
+					type: 'array',
+					default: [],
+					source: 'query',
+					selector: 'td,th',
+					query: v5Query,
+				},
+			},
+		},
+		foot: {
+			type: 'array',
+			default: [],
+			source: 'query',
+			selector: 'tfoot tr',
+			query: {
+				cells: {
+					type: 'array',
+					default: [],
+					source: 'query',
+					selector: 'td,th',
+					query: v5Query,
+				},
+			},
+		},
+	},
+	supports: {
+		anchor: true,
+		align: true,
+		color: {
+			__experimentalSkipSerialization: true,
+			gradients: true,
+			__experimentalDefaultControls: {
+				background: true,
+				text: true,
+			},
+		},
+		spacing: {
+			margin: true,
+			padding: true,
+			__experimentalDefaultControls: {
+				margin: false,
+				padding: false,
+			},
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalFontStyle: true,
+			__experimentalFontWeight: true,
+			__experimentalLetterSpacing: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalDefaultControls: {
+				fontSize: true,
+			},
+		},
+		__experimentalBorder: {
+			__experimentalSkipSerialization: true,
+			color: true,
+			style: true,
+			width: true,
+			__experimentalDefaultControls: {
+				color: true,
+				style: true,
+				width: true,
+			},
+		},
+		__experimentalSelector: '.wp-block-table > table',
+		interactivity: {
+			clientNavigation: true,
+		},
+	},
+	save( { attributes } ) {
+		const { hasFixedLayout, head, body, foot, caption } = attributes;
+		const isEmpty = ! head.length && ! body.length && ! foot.length;
+
+		if ( isEmpty ) {
+			return null;
+		}
+
+		const colorProps = getColorClassesAndStyles( attributes );
+		const borderProps = getBorderClassesAndStyles( attributes );
+
+		const classes = clsx( colorProps.className, borderProps.className, {
+			'has-fixed-layout': hasFixedLayout,
+		} );
+
+		const hasCaption = ! RichText.isEmpty( caption );
+
+		const Section = ( { type, rows } ) => {
+			if ( ! rows.length ) {
+				return null;
+			}
+
+			const Tag = `t${ type }`;
+
+			return (
+				<Tag>
+					{ rows.map( ( { cells }, rowIndex ) => (
+						<tr key={ rowIndex }>
+							{ cells.map(
+								(
+									{
+										content,
+										tag,
+										scope,
+										align,
+										colspan,
+										rowspan,
+									},
+									cellIndex
+								) => {
+									const cellClasses = clsx( {
+										[ `has-text-align-${ align }` ]: align,
+									} );
+
+									return (
+										<RichText.Content
+											className={
+												cellClasses
+													? cellClasses
+													: undefined
+											}
+											data-align={ align }
+											tagName={ tag }
+											value={ content }
+											key={ cellIndex }
+											scope={
+												tag === 'th' ? scope : undefined
+											}
+											colSpan={ colspan }
+											rowSpan={ rowspan }
+										/>
+									);
+								}
+							) }
+						</tr>
+					) ) }
+				</Tag>
+			);
+		};
+
+		return (
+			<figure { ...useBlockProps.save() }>
+				<table
+					className={ classes === '' ? undefined : classes }
+					style={ { ...colorProps.style, ...borderProps.style } }
+				>
+					<Section type="head" rows={ head } />
+					<Section type="body" rows={ body } />
+					<Section type="foot" rows={ foot } />
+				</table>
+				{ hasCaption && (
+					<RichText.Content
+						tagName="figcaption"
+						value={ caption }
+						className={ __experimentalGetElementClassName(
+							'caption'
+						) }
+					/>
+				) }
+			</figure>
+		);
+	},
+	migrate( attributes ) {
+		return {
+			...attributes,
+			captionSide: 'bottom',
+		};
+	},
+};
+
 // Fixed width table cells on by default.
 const v4Query = {
 	content: {
@@ -790,4 +1028,4 @@ const v1 = {
  *
  * See block-deprecation.md
  */
-export default [ v4, v3, v2, v1 ];
+export default [ v5, v4, v3, v2, v1 ];

--- a/packages/block-library/src/table/deprecated.js
+++ b/packages/block-library/src/table/deprecated.js
@@ -256,9 +256,25 @@ const v5 = {
 		);
 	},
 	migrate( attributes ) {
+		// Add scope="col" to header cells that don't have it
+		const migratedHead = attributes.head?.map( ( row ) => ( {
+			...row,
+			cells: row.cells.map( ( cell ) => {
+				// Add scope="col" to th elements in header section if not present
+				if ( cell.tag === 'th' && ! cell.scope ) {
+					return {
+						...cell,
+						scope: 'col',
+					};
+				}
+				return cell;
+			} ),
+		} ) );
+
 		return {
 			...attributes,
 			captionSide: 'bottom',
+			head: migratedHead || attributes.head,
 		};
 	},
 };

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -28,6 +28,8 @@ import {
 	__experimentalHasSplitBorders as hasSplitBorders,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import {
 	alignLeft,
@@ -100,7 +102,7 @@ function TableEdit( {
 	insertBlocksAfter,
 	isSelected: isSingleSelected,
 } ) {
-	const { hasFixedLayout, head, foot } = attributes;
+	const { hasFixedLayout, head, foot, caption, captionSide } = attributes;
 	const [ initialRowCount, setInitialRowCount ] = useState( 2 );
 	const [ initialColumnCount, setInitialColumnCount ] = useState( 2 );
 	const [ selectedCell, setSelectedCell ] = useState();
@@ -113,6 +115,8 @@ function TableEdit( {
 	const [ hasTableCreated, setHasTableCreated ] = useState( false );
 
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+
+	const hasCaption = ! RichText.isEmpty( caption );
 
 	/**
 	 * Updates the initial column count used for table creation.
@@ -330,6 +334,15 @@ function TableEdit( {
 	}
 
 	/**
+	 * Changes the caption side position.
+	 *
+	 * @param {string} value The new caption side value.
+	 */
+	function onChangeCaptionSide( value ) {
+		setAttributes( { captionSide: value } );
+	}
+
+	/**
 	 * Deletes the currently selected column.
 	 */
 	function onDeleteColumn() {
@@ -455,8 +468,18 @@ function TableEdit( {
 
 	const isEmpty = ! sections.length;
 
+	// Add caption position class to figure
+	const blockPropsClassName = clsx( {
+		'has-caption-top': hasCaption && captionSide === 'top',
+	} );
+
 	return (
-		<figure { ...useBlockProps( { ref: tableRef } ) }>
+		<figure
+			{ ...useBlockProps( {
+				ref: tableRef,
+				className: blockPropsClassName,
+			} ) }
+		>
 			{ ! isEmpty && blockEditingMode === 'default' && (
 				<>
 					<BlockControls group="block">
@@ -537,6 +560,37 @@ function TableEdit( {
 									onChange={ onToggleFooterSection }
 								/>
 							</ToolsPanelItem>
+
+							{ hasCaption && (
+								<ToolsPanelItem
+									hasValue={ () => captionSide !== 'bottom' }
+									label={ __( 'Caption position' ) }
+									onDeselect={ () =>
+										setAttributes( {
+											captionSide: 'bottom',
+										} )
+									}
+									isShownByDefault
+								>
+									<ToggleGroupControl
+										__next40pxDefaultSize
+										__nextHasNoMarginBottom
+										label={ __( 'Caption position' ) }
+										value={ captionSide || 'bottom' }
+										onChange={ onChangeCaptionSide }
+										isBlock
+									>
+										<ToggleGroupControlOption
+											value="top"
+											label={ __( 'Top' ) }
+										/>
+										<ToggleGroupControlOption
+											value="bottom"
+											label={ __( 'Bottom' ) }
+										/>
+									</ToggleGroupControl>
+								</ToolsPanelItem>
+							) }
 						</>
 					) }
 				</ToolsPanel>
@@ -558,10 +612,24 @@ function TableEdit( {
 					) }
 					style={ { ...colorProps.style, ...borderProps.style } }
 				>
+					{ ! isEmpty && (
+						<Caption
+							attributes={ attributes }
+							setAttributes={ setAttributes }
+							isSelected={ isSingleSelected }
+							insertBlocksAfter={ insertBlocksAfter }
+							label={ __( 'Table caption text' ) }
+							tagName="caption"
+							showToolbarButton={
+								isSingleSelected &&
+								blockEditingMode === 'default'
+							}
+						/>
+					) }
 					{ renderedSections }
 				</table>
 			) }
-			{ isEmpty ? (
+			{ isEmpty && (
 				<Placeholder
 					label={ __( 'Table' ) }
 					icon={ <BlockIcon icon={ icon } showColors /> }
@@ -600,17 +668,6 @@ function TableEdit( {
 						</Button>
 					</form>
 				</Placeholder>
-			) : (
-				<Caption
-					attributes={ attributes }
-					setAttributes={ setAttributes }
-					isSelected={ isSingleSelected }
-					insertBlocksAfter={ insertBlocksAfter }
-					label={ __( 'Table caption text' ) }
-					showToolbarButton={
-						isSingleSelected && blockEditingMode === 'default'
-					}
-				/>
 			) }
 		</figure>
 	);

--- a/packages/block-library/src/table/save.js
+++ b/packages/block-library/src/table/save.js
@@ -15,7 +15,8 @@ import {
 } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { hasFixedLayout, head, body, foot, caption } = attributes;
+	const { hasFixedLayout, head, body, foot, caption, captionSide } =
+		attributes;
 	const isEmpty = ! head.length && ! body.length && ! foot.length;
 
 	if ( isEmpty ) {
@@ -30,6 +31,11 @@ export default function save( { attributes } ) {
 	} );
 
 	const hasCaption = ! RichText.isEmpty( caption );
+
+	// Add caption position class to figure
+	const figureClasses = clsx( {
+		'has-caption-top': hasCaption && captionSide === 'top',
+	} );
 
 	const Section = ( { type, rows } ) => {
 		if ( ! rows.length ) {
@@ -85,22 +91,28 @@ export default function save( { attributes } ) {
 	};
 
 	return (
-		<figure { ...useBlockProps.save() }>
+		<figure
+			{ ...useBlockProps.save( {
+				className: figureClasses,
+			} ) }
+		>
 			<table
 				className={ classes === '' ? undefined : classes }
 				style={ { ...colorProps.style, ...borderProps.style } }
 			>
+				{ hasCaption && (
+					<RichText.Content
+						tagName="caption"
+						value={ caption }
+						className={ __experimentalGetElementClassName(
+							'caption'
+						) }
+					/>
+				) }
 				<Section type="head" rows={ head } />
 				<Section type="body" rows={ body } />
 				<Section type="foot" rows={ foot } />
 			</table>
-			{ hasCaption && (
-				<RichText.Content
-					tagName="figcaption"
-					value={ caption }
-					className={ __experimentalGetElementClassName( 'caption' ) }
-				/>
-			) }
 		</figure>
 	);
 }

--- a/packages/block-library/src/table/state.js
+++ b/packages/block-library/src/table/state.js
@@ -184,10 +184,13 @@ export function insertRow( state, { sectionName, rowIndex, columnCount } ) {
 							)
 						);
 
+						const isHeaderSection = sectionName === 'head';
+
 						return {
 							...inheritedAttributes,
 							content: '',
-							tag: sectionName === 'head' ? 'th' : 'td',
+							tag: isHeaderSection ? 'th' : 'td',
+							...( isHeaderSection && { scope: 'col' } ),
 						};
 					}
 				),
@@ -247,12 +250,15 @@ export function insertColumn( state, { columnIndex } ) {
 						return row;
 					}
 
+					const isHeaderSection = sectionName === 'head';
+
 					return {
 						cells: [
 							...row.cells.slice( 0, columnIndex ),
 							{
 								content: '',
-								tag: sectionName === 'head' ? 'th' : 'td',
+								tag: isHeaderSection ? 'th' : 'td',
+								...( isHeaderSection && { scope: 'col' } ),
 							},
 							...row.cells.slice( columnIndex ),
 						],

--- a/packages/block-library/src/table/style.scss
+++ b/packages/block-library/src/table/style.scss
@@ -40,6 +40,16 @@
 		}
 	}
 
+	// Caption position
+	// Default is bottom to match figure conventions in WordPress
+	table caption {
+		caption-side: bottom;
+	}
+
+	&.has-caption-top table caption {
+		caption-side: top;
+	}
+
 	&.alignleft,
 	&.aligncenter,
 	&.alignright {

--- a/packages/block-library/src/table/test/state.js
+++ b/packages/block-library/src/table/test/state.js
@@ -365,6 +365,7 @@ describe( 'insertRow', () => {
 						{
 							content: '',
 							tag: 'th',
+							scope: 'col',
 						},
 					],
 				},
@@ -408,6 +409,7 @@ describe( 'insertColumn', () => {
 						{
 							content: '',
 							tag: 'th',
+							scope: 'col',
 						},
 						{
 							content: 'test',
@@ -482,6 +484,7 @@ describe( 'insertColumn', () => {
 						{
 							content: '',
 							tag: 'th',
+							scope: 'col',
 						},
 					],
 				},
@@ -519,6 +522,7 @@ describe( 'insertColumn', () => {
 						{
 							content: '',
 							tag: 'th',
+							scope: 'col',
 						},
 						{
 							content: '',
@@ -584,6 +588,7 @@ describe( 'insertColumn', () => {
 						{
 							content: '',
 							tag: 'th',
+							scope: 'col',
 						},
 					],
 				},
@@ -968,6 +973,7 @@ describe( 'toggleSection', () => {
 						{
 							content: '',
 							tag: 'th',
+							scope: 'col',
 						},
 					],
 				},
@@ -1009,14 +1015,17 @@ describe( 'toggleSection', () => {
 						{
 							content: '',
 							tag: 'th',
+							scope: 'col',
 						},
 						{
 							content: '',
 							tag: 'th',
+							scope: 'col',
 						},
 						{
 							content: '',
 							tag: 'th',
+							scope: 'col',
 						},
 					],
 				},

--- a/packages/block-library/src/table/transforms.js
+++ b/packages/block-library/src/table/transforms.js
@@ -78,6 +78,7 @@ const transforms = {
 								const colspan = normalizeRowColSpan(
 									col.getAttribute( 'colspan' )
 								);
+								const scope = col.getAttribute( 'scope' );
 
 								const { textAlign } = col.style || {};
 
@@ -95,6 +96,7 @@ const transforms = {
 									content: col.innerHTML,
 									rowspan,
 									colspan,
+									scope,
 									align,
 								} );
 

--- a/test/e2e/specs/editor/blocks/__snapshots__/Table-allows-a-caption-to-be-added-1-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/Table-allows-a-caption-to-be-added-1-chromium.txt
@@ -1,3 +1,3 @@
 <!-- wp:table -->
-<figure class="wp-block-table"><table class="has-fixed-layout"><tbody><tr><td></td><td></td></tr><tr><td></td><td></td></tr></tbody></table><figcaption class="wp-element-caption">Caption!</figcaption></figure>
+<figure class="wp-block-table"><table class="has-fixed-layout"><caption class="wp-element-caption">Caption!</caption><tbody><tr><td></td><td></td></tr><tr><td></td><td></td></tr></tbody></table></figure>
 <!-- /wp:table -->

--- a/test/e2e/specs/editor/blocks/__snapshots__/Table-allows-adding-and-deleting-columns-across-the-table-header-body-and-footer-1-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/Table-allows-adding-and-deleting-columns-across-the-table-header-body-and-footer-1-chromium.txt
@@ -1,3 +1,3 @@
 <!-- wp:table -->
-<figure class="wp-block-table"><table class="has-fixed-layout"><thead><tr><th></th><th></th><th></th></tr></thead><tbody><tr><td></td><td></td><td></td></tr><tr><td></td><td></td><td></td></tr></tbody><tfoot><tr><td></td><td></td><td></td></tr></tfoot></table></figure>
+<figure class="wp-block-table"><table class="has-fixed-layout"><thead><tr><th scope="col"></th><th scope="col"></th><th scope="col"></th></tr></thead><tbody><tr><td></td><td></td><td></td></tr><tr><td></td><td></td><td></td></tr></tbody><tfoot><tr><td></td><td></td><td></td></tr></tfoot></table></figure>
 <!-- /wp:table -->

--- a/test/e2e/specs/editor/blocks/__snapshots__/Table-allows-adding-and-deleting-columns-across-the-table-header-body-and-footer-2-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/Table-allows-adding-and-deleting-columns-across-the-table-header-body-and-footer-2-chromium.txt
@@ -1,3 +1,3 @@
 <!-- wp:table -->
-<figure class="wp-block-table"><table class="has-fixed-layout"><thead><tr><th></th><th></th></tr></thead><tbody><tr><td></td><td></td></tr><tr><td></td><td></td></tr></tbody><tfoot><tr><td></td><td></td></tr></tfoot></table></figure>
+<figure class="wp-block-table"><table class="has-fixed-layout"><thead><tr><th scope="col"></th><th scope="col"></th></tr></thead><tbody><tr><td></td><td></td></tr><tr><td></td><td></td></tr></tbody><tfoot><tr><td></td><td></td></tr></tfoot></table></figure>
 <!-- /wp:table -->

--- a/test/e2e/specs/editor/blocks/__snapshots__/Table-allows-header-and-footer-rows-to-be-switched-on-and-off-1-chromium.txt
+++ b/test/e2e/specs/editor/blocks/__snapshots__/Table-allows-header-and-footer-rows-to-be-switched-on-and-off-1-chromium.txt
@@ -1,3 +1,3 @@
 <!-- wp:table -->
-<figure class="wp-block-table"><table class="has-fixed-layout"><thead><tr><th>header</th><th></th></tr></thead><tbody><tr><td>body</td><td></td></tr><tr><td></td><td></td></tr></tbody><tfoot><tr><td>footer</td><td></td></tr></tfoot></table></figure>
+<figure class="wp-block-table"><table class="has-fixed-layout"><thead><tr><th scope="col">header</th><th scope="col"></th></tr></thead><tbody><tr><td>body</td><td></td></tr><tr><td></td><td></td></tr></tbody><tfoot><tr><td>footer</td><td></td></tr></tfoot></table></figure>
 <!-- /wp:table -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Improves accessibility of the Table block by adding proper semantic HTML structure and ARIA attributes.

Closes https://github.com/WordPress/gutenberg/issues/72490

This PR implements three key accessibility improvements:
1. Changes table caption from `<figcaption>` to `<caption>` element inside the `<table>`
2. Adds automatic `scope="col"` attribute to header cells in `<thead>`
3. Preserves the `scope` attribute when pasting HTML tables

## Why?

The Table block had several accessibility issues that prevented screen reader users from properly understanding table structure and relationships:

**Issue 1: Incorrect caption element**
- **Before:** Caption was rendered as `<figcaption>` outside the `<table>` element
- **Problem:** Screen readers cannot associate the caption with the table structure
- **After:** Caption is now rendered as `<caption>` inside the `<table>` element
- **Impact:** WCAG 2.1 Success Criterion 1.3.1 (Info and Relationships) - **Critical**

**Issue 2: Missing `scope` attribute on header cells**
- **Before:** `<th>` elements had no `scope` attribute
- **Problem:** Screen readers cannot determine if headers apply to rows or columns
- **After:** `<th>` elements in `<thead>` now have `scope="col"`
- **Impact:** WCAG 2.1 Success Criterion 1.3.1 (Info and Relationships) - **Important**

**Screen reader experience comparison:**
- **Before:** "Header 1" → "Body 1/1" (no relationship context)
- **After:** "Table with 2 columns and 2 rows, Caption" → "Column header, Header 1" → "Header 1, Body 1/1" (full context)

## How?

**1. Modified `save.js` and `edit.js`:**
- Changed caption rendering from `<figcaption>` (outside table) to `<caption>` (inside table)
- Caption is now properly associated with the table element

**2. Modified `transforms.js`:**
- Added extraction of the `scope` attribute when pasting HTML tables
- The `scope` attribute is now preserved alongside other attributes like `colspan`, `rowspan`, and `align`

**3. Modified `state.js`:**
- Updated `insertRow()` function to automatically add `scope="col"` to `<th>` cells in `<thead>` sections
- Updated `insertColumn()` function to automatically add `scope="col"` to `<th>` cells in `<thead>` sections
- Preserved existing behavior: `<tfoot>` continues to use `<td>` cells by default (appropriate for notes and contextual information)

**4. Added caption position control:**
- Implemented a new setting in the Table block Inspector Controls to control the caption position
- Users can now choose between "Top" or "Bottom" caption placement (default: bottom)
- Added `captionSide` attribute to store the caption position preference
- Updated styles in `style.scss` to use the CSS `caption-side` property
- When set to "Top", the `.has-caption-top` class is applied to the figure wrapper, positioning the caption above the table
- This improves flexibility for different content presentation needs while maintaining semantic HTML structure
- The CSS `caption-side` property ensures the caption is properly associated with the table regardless of visual position

## Testing Instructions

### Test 1: Caption element position

1. Open a post or page in the editor
2. Insert a Table block
3. Add a caption to the table
4. Switch to Code Editor view
5. Verify the markup structure:
   ```html
   <figure class="wp-block-table">
     <table>
       <caption class="wp-element-caption">Table Caption</caption>
       <!-- table content -->
     </table>
   </figure>
   ```
6. The `<caption>` should be **inside** the `<table>` element (not as a sibling `<figcaption>`)

### Test 2: Creating a new table with header section

1. Open a post or page in the editor
2. Insert a Table block
3. Create a table with 2 columns and 2 rows
4. Enable the "Header section" toggle in the block settings
5. Add a caption
6. Switch to Code Editor view
7. Verify the complete markup:
   ```html
   <figure class="wp-block-table">
     <table class="has-fixed-layout">
       <caption class="wp-element-caption">Caption</caption>
       <thead>
         <tr>
           <th scope="col">Header 1</th>
           <th scope="col">Header 2</th>
         </tr>
       </thead>
       <tbody>
         <tr>
           <td>Body 1/1</td>
           <td>Body 2/1</td>
         </tr>
       </tbody>
     </table>
   </figure>
   ```

### Test 3: Adding columns/rows to existing header section

1. Create a table with header section enabled
2. Click on a header cell
3. Use the table toolbar to insert a column before/after
4. Switch to Code Editor view
5. Verify that the new `<th>` in the header section also has `scope="col"`

### Test 4: Pasting HTML tables

1. Copy the following HTML to your clipboard:
   ```html
   <table>
     <caption>Product List</caption>
     <thead>
       <tr>
         <th scope="col">Name</th>
         <th scope="col">Price</th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <td>Product A</td>
         <td>$10</td>
       </tr>
     </tbody>
   </table>
   ```
2. Paste into the editor
3. Switch to Code Editor view
4. Verify that both `<caption>` and `scope="col"` attributes have been preserved

### Test 5: Caption position control

1. Create a table and add a caption
2. In the block Inspector panel (right sidebar), locate the "Caption position" control
3. Toggle between "Top" and "Bottom" options
4. Verify in the editor that the caption visually moves above or below the table
5. Switch to Code Editor view
6. When "Top" is selected, verify the figure has the class `has-caption-top`:
   ```html
   <figure class="wp-block-table has-caption-top">
     <table>
       <caption>Caption Text</caption>
       <!-- table content -->
     </table>
   </figure>
   ```
7. When "Bottom" is selected (default), verify no `has-caption-top` class is present

### Testing Instructions for Keyboard

1. Use Tab to navigate to the table block
2. Use arrow keys to navigate between cells
3. Use the table toolbar (accessible via keyboard) to insert rows/columns
4. Verify using a screen reader (NVDA, JAWS, or VoiceOver) that:
   - The caption is announced before table content
   - Header cells are announced as "Column header"
   - Data cells include their associated header (e.g., "Header 1, Body 1/1")

### Screen Reader Testing (Recommended)

- **Windows + NVDA/JAWS:** Navigate to table and press T to jump to tables, use Ctrl+Alt+Arrow keys to navigate cells
- **macOS + VoiceOver:** Navigate to table and use VO+Right/Left Arrow to explore structure
- **Expected announcements:** 
  - "Table with X columns and Y rows, [Caption text]"
  - "Column header, [Header text]"
  - "[Header text], [Cell content]"

## Markup

### Before

```html
<figure class="wp-block-table has-caption-top">
	<table class="has-fixed-layout">
		<thead>
			<tr>
				<th>Header 1</th>
				<th>Header 2</th>
				<th>Header 3</th>
				<th>Header 4</th>
			</tr>
		</thead>
		<tbody>
			<tr>
				<td>Body 1/1</td>
				<td>Body 2/1</td>
				<td>Body 3/1</td>
				<td>Body 4/1</td>
			</tr>
			<tr>
				<td>Body 1/2</td>
				<td>Body 2/2</td>
				<td>Body 3/2</td>
				<td>Body 4/2</td>
			</tr>
			<tr>
				<td>Body 1/3</td>
				<td>Body 2/3</td>
				<td>Body 3/3</td>
				<td>Body 4/3</td>
			</tr>
			<tr>
				<td>Body 1/4</td>
				<td>Body 2/4</td>
				<td>Body 3/4</td>
				<td>Body 4/4</td>
			</tr>
		</tbody>
	</table>
	<figcaption class="wp-element-caption">
		Caption
	</figcaption>
</figure>

```

### After

```html
<figure class="wp-block-table has-caption-top">
	<table class="has-fixed-layout">
		<caption class="wp-element-caption">
			Caption
		</caption>
		<thead>
			<tr>
				<th scope="col">Header 1</th>
				<th scope="col">Header 2</th>
				<th scope="col">Header 3</th>
				<th scope="col">Header 4</th>
			</tr>
		</thead>
		<tbody>
			<tr>
				<td>Body 1/1</td>
				<td>Body 2/1</td>
				<td>Body 3/1</td>
				<td>Body 4/1</td>
			</tr>
			<tr>
				<td>Body 1/2</td>
				<td>Body 2/2</td>
				<td>Body 3/2</td>
				<td>Body 4/2</td>
			</tr>
			<tr>
				<td>Body 1/3</td>
				<td>Body 2/3</td>
				<td>Body 3/3</td>
				<td>Body 4/3</td>
			</tr>
			<tr>
				<td>Body 1/4</td>
				<td>Body 2/4</td>
				<td>Body 3/4</td>
				<td>Body 4/4</td>
			</tr>
		</tbody>
	</table>
</figure>
``` 

## Screenshots

<img width="273" height="213" alt="image" src="https://github.com/user-attachments/assets/878a7e2a-3513-47a0-ae92-62158f47529b" />
