### PR TITLE
[WP 6.9] Disable font size when fit text is enabled and the opposite and add e2e tests

### DIFF
--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -180,12 +180,16 @@ function useFitText( { fitText, name, clientId } ) {
  * @param {Function} props.setAttributes Function to set block attributes.
  * @param {string}   props.name          Block name.
  * @param {boolean}  props.fitText       Whether fit text is enabled.
+ * @param {string}   props.fontSize      Font size slug.
+ * @param {Object}   props.style         Block style object.
  */
 export function FitTextControl( {
 	clientId,
 	fitText = false,
 	setAttributes,
 	name,
+	fontSize,
+	style,
 } ) {
 	if ( ! hasBlockSupport( name, FIT_TEXT_SUPPORT_KEY ) ) {
 		return null;
@@ -203,9 +207,28 @@ export function FitTextControl( {
 					__nextHasNoMarginBottom
 					label={ __( 'Fit text' ) }
 					checked={ fitText }
-					onChange={ () =>
-						setAttributes( { fitText: ! fitText || undefined } )
-					}
+					onChange={ () => {
+						const newFitText = ! fitText || undefined;
+						const updates = { fitText: newFitText };
+
+						// When enabling fit text, clear font size if it has a value
+						if ( newFitText ) {
+							if ( fontSize ) {
+								updates.fontSize = undefined;
+							}
+							if ( style?.typography?.fontSize ) {
+								updates.style = {
+									...style,
+									typography: {
+										...style?.typography,
+										fontSize: undefined,
+									},
+								};
+							}
+						}
+
+						setAttributes( updates );
+					} }
 					help={
 						fitText
 							? __( 'Text will resize to fit its container.' )
@@ -278,7 +301,7 @@ const hasFitTextSupport = ( blockNameOrType ) => {
 export default {
 	useBlockProps,
 	addSaveProps,
-	attributeKeys: [ 'fitText' ],
+	attributeKeys: [ 'fitText', 'fontSize', 'style' ],
 	hasSupport: hasFitTextSupport,
 	edit: FitTextControl,
 };

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -116,11 +116,13 @@ function TypographyInspectorControl( { children, resetAllFilter } ) {
 
 export function TypographyPanel( { clientId, name, setAttributes, settings } ) {
 	function selector( select ) {
-		const { style, fontFamily, fontSize } =
+		const { style, fontFamily, fontSize, fitText } =
 			select( blockEditorStore ).getBlockAttributes( clientId ) || {};
-		return { style, fontFamily, fontSize };
+		return { style, fontFamily, fontSize, fitText };
 	}
-	const { style, fontFamily, fontSize } = useSelect( selector, [ clientId ] );
+	const { style, fontFamily, fontSize, fitText } = useSelect( selector, [
+		clientId,
+	] );
 	const isEnabled = useHasTypographyPanel( settings );
 	const value = useMemo(
 		() => attributesToStyle( { style, fontFamily, fontSize } ),
@@ -128,7 +130,16 @@ export function TypographyPanel( { clientId, name, setAttributes, settings } ) {
 	);
 
 	const onChange = ( newStyle ) => {
-		setAttributes( styleToAttributes( newStyle ) );
+		const newAttributes = styleToAttributes( newStyle );
+
+		// If setting a font size and fitText is currently enabled, disable it
+		const hasFontSize =
+			newAttributes.fontSize || newAttributes.style?.typography?.fontSize;
+		if ( hasFontSize && fitText ) {
+			newAttributes.fitText = undefined;
+		}
+
+		setAttributes( newAttributes );
 	};
 
 	if ( ! isEnabled ) {

--- a/test/e2e/specs/editor/blocks/fit-text.spec.js
+++ b/test/e2e/specs/editor/blocks/fit-text.spec.js
@@ -1,0 +1,414 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Fit Text', () => {
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test.describe( 'Editor functionality', () => {
+		test( 'should enable fit text on a heading block', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/heading',
+				attributes: {
+					content: 'Test Heading',
+					level: 2,
+				},
+			} );
+
+			await editor.openDocumentSettingsSidebar();
+
+			// Enable Fit text control via Typography options menu
+			await page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Typography options' } )
+				.click();
+			await page
+				.getByRole( 'menu', { name: 'Typography options' } )
+				.getByRole( 'menuitemcheckbox', { name: 'Show Fit text' } )
+				.click();
+
+			const fitTextToggle = page.getByRole( 'checkbox', {
+				name: 'Fit text',
+			} );
+
+			await fitTextToggle.click();
+
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/heading',
+					attributes: {
+						content: 'Test Heading',
+						level: 2,
+						fitText: true,
+					},
+				},
+			] );
+
+			const headingBlock = editor.canvas.locator(
+				'[data-type="core/heading"]'
+			);
+
+			await expect( headingBlock ).toHaveClass( /has-fit-text/ );
+		} );
+
+		test( 'should disable fit text when toggled off', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/heading',
+				attributes: {
+					content: 'Test Heading',
+					level: 2,
+					fitText: true,
+				},
+			} );
+
+			await editor.openDocumentSettingsSidebar();
+
+			const fitTextToggle = page.getByRole( 'checkbox', {
+				name: 'Fit text',
+			} );
+
+			await fitTextToggle.click();
+
+			const blocks = await editor.getBlocks();
+			expect( blocks[ 0 ].attributes.fitText ).toBeUndefined();
+		} );
+
+		test( 'should enable fit text on a paragraph block', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: {
+					content: 'Test paragraph with fit text enabled',
+				},
+			} );
+
+			await editor.openDocumentSettingsSidebar();
+
+			// Enable Fit text control via Typography options menu
+			await page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Typography options' } )
+				.click();
+			await page
+				.getByRole( 'menu', { name: 'Typography options' } )
+				.getByRole( 'menuitemcheckbox', { name: 'Show Fit text' } )
+				.click();
+
+			const fitTextToggle = page.getByRole( 'checkbox', {
+				name: 'Fit text',
+			} );
+
+			await fitTextToggle.click();
+
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/paragraph',
+					attributes: {
+						content: 'Test paragraph with fit text enabled',
+						fitText: true,
+					},
+				},
+			] );
+
+			const paragraphBlock = editor.canvas.locator(
+				'[data-type="core/paragraph"]'
+			);
+
+			await expect( paragraphBlock ).toHaveClass( /has-fit-text/ );
+		} );
+
+		test( 'should apply font size dynamically based on container width in editor', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/heading',
+				attributes: {
+					content: 'Resizable Text',
+					level: 2,
+					fitText: true,
+				},
+			} );
+
+			const headingBlock = editor.canvas.locator(
+				'[data-type="core/heading"]'
+			);
+
+			// Wait for fit text to apply
+			await headingBlock.waitFor( { state: 'attached' } );
+			await expect( headingBlock ).toHaveClass( /has-fit-text/ );
+
+			const initialFontSize = await headingBlock.evaluate( ( el ) => {
+				return window.getComputedStyle( el ).fontSize;
+			} );
+
+			// Add more text to force smaller font size
+			await headingBlock.click();
+			await page.keyboard.press( 'End' );
+			await page.keyboard.type(
+				' that is much longer and should have smaller font'
+			);
+
+			// Wait for DOM to update and fit text to recalculate
+			await headingBlock.waitFor( { state: 'attached' } );
+
+			const newFontSize = await headingBlock.evaluate( ( el ) => {
+				return window.getComputedStyle( el ).fontSize;
+			} );
+
+			const initialSize = parseFloat( initialFontSize );
+			const newSize = parseFloat( newFontSize );
+
+			// Font size should decrease with more content
+			expect( newSize ).toBeLessThan( initialSize );
+		} );
+
+		test( 'should apply much larger font size with fit text compared to without fit text for a short text', async ( {
+			editor,
+		} ) => {
+			// Insert two paragraphs with same content for comparison
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: {
+					content: 'Hello',
+				},
+			} );
+
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: {
+					content: 'Hello',
+					fitText: true,
+				},
+			} );
+
+			const paragraphBlocks = editor.canvas.locator(
+				'[data-type="core/paragraph"]'
+			);
+
+			// Wait for fit text to apply
+			await paragraphBlocks.nth( 1 ).waitFor( { state: 'attached' } );
+			await expect( paragraphBlocks.nth( 1 ) ).toHaveClass(
+				/has-fit-text/
+			);
+
+			const normalFontSize = await paragraphBlocks
+				.nth( 0 )
+				.evaluate( ( el ) => {
+					return window.getComputedStyle( el ).fontSize;
+				} );
+
+			const fitTextFontSize = await paragraphBlocks
+				.nth( 1 )
+				.evaluate( ( el ) => {
+					return window.getComputedStyle( el ).fontSize;
+				} );
+
+			const normalSize = parseFloat( normalFontSize );
+			const fitTextSize = parseFloat( fitTextFontSize );
+
+			// Fit text should scale up significantly for short content
+			expect( fitTextSize ).toBeGreaterThan( normalSize * 2 );
+		} );
+	} );
+
+	test.describe( 'Frontend functionality', () => {
+		test( 'should render fit text correctly on the frontend', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/heading',
+				attributes: {
+					content: 'Frontend Test',
+					level: 2,
+					fitText: true,
+				},
+			} );
+
+			await editor.publishPost();
+
+			const postUrl = await page.evaluate( () =>
+				window.wp.data.select( 'core/editor' ).getPermalink()
+			);
+
+			await page.goto( postUrl );
+
+			const heading = page.locator( 'h2.has-fit-text' );
+
+			await expect( heading ).toBeVisible();
+			await expect( heading ).toHaveClass( /has-fit-text/ );
+
+			// Verify data attribute is set (added by frontend script)
+			const fitTextId = await heading.getAttribute( 'data-fit-text-id' );
+			expect( fitTextId ).toBeTruthy();
+
+			// Verify style element exists for this fit text instance.
+			const styleElement = page.locator(
+				`style#fit-text-${ fitTextId }`
+			);
+			await expect( styleElement ).toBeAttached();
+
+			const computedFontSize = await heading.evaluate( ( el ) => {
+				return window.getComputedStyle( el ).fontSize;
+			} );
+
+			const styleContent = await styleElement.textContent();
+			const fontSizeMatch = styleContent.match(
+				/font-size:\s*(\d+(?:\.\d+)?)px/
+			);
+			expect( fontSizeMatch ).toBeTruthy();
+			const expectedFontSize = parseFloat( fontSizeMatch[ 1 ] );
+
+			expect( parseFloat( computedFontSize ) ).toBe( expectedFontSize );
+		} );
+
+		test( 'should resize text on window resize on the frontend', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/heading',
+				attributes: {
+					content: 'Resize Me',
+					level: 2,
+					fitText: true,
+				},
+			} );
+
+			await editor.publishPost();
+
+			const postUrl = await page.evaluate( () =>
+				window.wp.data.select( 'core/editor' ).getPermalink()
+			);
+
+			await page.goto( postUrl );
+
+			const heading = page.locator( 'h2.has-fit-text' );
+
+			// Wait for fit text to initialize (verify frontend script ran)
+			await heading.waitFor( { state: 'attached' } );
+			const fitTextId = await heading.getAttribute( 'data-fit-text-id' );
+			expect( fitTextId ).toBeTruthy();
+
+			// Verify style element exists for this fit text instance
+			const styleElement = page.locator(
+				`style#fit-text-${ fitTextId }`
+			);
+			await styleElement.waitFor( { state: 'attached' } );
+
+			const initialFontSize = await heading.evaluate( ( el ) => {
+				return window.getComputedStyle( el ).fontSize;
+			} );
+
+			// Capture style content before resize
+			const styleBeforeResize = await styleElement.textContent();
+
+			await page.setViewportSize( { width: 440, height: 720 } );
+
+			// Wait for fit text to recalculate (style content changes)
+			await page.waitForFunction(
+				( { styleId, previousContent } ) => {
+					const style = document.getElementById( styleId );
+					return (
+						style &&
+						style.textContent !== previousContent &&
+						style.textContent.trim().length > 0
+					);
+				},
+				{
+					styleId: `fit-text-${ fitTextId }`,
+					previousContent: styleBeforeResize,
+				},
+				{ timeout: 5000 }
+			);
+
+			// Verify the same element instance is maintained (ID unchanged)
+			const fitTextIdAfterResize =
+				await heading.getAttribute( 'data-fit-text-id' );
+			expect( fitTextIdAfterResize ).toBe( fitTextId );
+
+			const newFontSize = await heading.evaluate( ( el ) => {
+				return window.getComputedStyle( el ).fontSize;
+			} );
+
+			const initialSize = parseFloat( initialFontSize );
+			const newSize = parseFloat( newFontSize );
+
+			// Font size should adapt to narrower viewport
+			expect( newSize ).toBeLessThan( initialSize );
+		} );
+
+		test( 'should apply much larger font size with fit text compared to without fit text on frontend for a short text', async ( {
+			editor,
+			page,
+		} ) => {
+			// Insert two paragraphs with same content for comparison
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: {
+					content: 'Hello',
+				},
+			} );
+
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+				attributes: {
+					content: 'Hello',
+					fitText: true,
+				},
+			} );
+
+			await editor.publishPost();
+
+			const postUrl = await page.evaluate( () =>
+				window.wp.data.select( 'core/editor' ).getPermalink()
+			);
+
+			await page.goto( postUrl );
+
+			const fitTextParagraph = page.locator( 'p.has-fit-text' );
+
+			// Wait for fit text to initialize (verify frontend script ran)
+			await fitTextParagraph.waitFor( { state: 'visible' } );
+			const fitTextId =
+				await fitTextParagraph.getAttribute( 'data-fit-text-id' );
+			expect( fitTextId ).toBeTruthy();
+
+			// Verify style element exists for this fit text instance
+			const styleElement = page.locator(
+				`style#fit-text-${ fitTextId }`
+			);
+			await expect( styleElement ).toBeAttached();
+
+			const paragraphs = page.locator( 'p' );
+
+			const normalFontSize = await paragraphs
+				.first()
+				.evaluate( ( el ) => {
+					return window.getComputedStyle( el ).fontSize;
+				} );
+
+			const fitTextFontSize = await fitTextParagraph.evaluate( ( el ) => {
+				return window.getComputedStyle( el ).fontSize;
+			} );
+
+			const normalSize = parseFloat( normalFontSize );
+			const fitTextSize = parseFloat( fitTextFontSize );
+
+			// Fit text should scale up significantly for short content
+			expect( fitTextSize ).toBeGreaterThan( normalSize * 2 );
+		} );
+	} );
+} );

--- a/test/e2e/specs/editor/blocks/fit-text.spec.js
+++ b/test/e2e/specs/editor/blocks/fit-text.spec.js
@@ -221,6 +221,89 @@ test.describe( 'Fit Text', () => {
 			// Fit text should scale up significantly for short content
 			expect( fitTextSize ).toBeGreaterThan( normalSize * 2 );
 		} );
+
+		test( 'should disable fit text when a font size is selected', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/heading',
+				attributes: {
+					content: 'Test Heading',
+					level: 2,
+					fitText: true,
+				},
+			} );
+
+			await editor.openDocumentSettingsSidebar();
+
+			// Set a custom font size
+			await page.click(
+				'role=region[name="Editor settings"i] >> role=button[name="Set custom size"i]'
+			);
+			await page.click( 'role=spinbutton[name="Font size"i]' );
+			await page.keyboard.type( '24' );
+
+			// fitText should be cleared
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/heading',
+					attributes: expect.objectContaining( {
+						content: 'Test Heading',
+						level: 2,
+						style: {
+							typography: {
+								fontSize: '24px',
+							},
+						},
+					} ),
+				},
+			] );
+		} );
+
+		test( 'should clear font size when fit text is enabled', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/heading',
+				attributes: {
+					content: 'Test Heading',
+					level: 2,
+					fontSize: 'large',
+				},
+			} );
+
+			await editor.openDocumentSettingsSidebar();
+
+			// Enable Fit text control via Typography options menu
+			await page
+				.getByRole( 'region', { name: 'Editor settings' } )
+				.getByRole( 'button', { name: 'Typography options' } )
+				.click();
+			await page
+				.getByRole( 'menu', { name: 'Typography options' } )
+				.getByRole( 'menuitemcheckbox', { name: 'Show Fit text' } )
+				.click();
+
+			const fitTextToggle = page.getByRole( 'checkbox', {
+				name: 'Fit text',
+			} );
+
+			await fitTextToggle.click();
+
+			// fontSize should be cleared
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/heading',
+					attributes: expect.objectContaining( {
+						content: 'Test Heading',
+						level: 2,
+						fitText: true,
+					} ),
+				},
+			] );
+		} );
 	} );
 
 	test.describe( 'Frontend functionality', () => {


### PR DESCRIPTION
## What?

Cherry-pick the following PRs for the `wp/6.9` branch,

- https://github.com/WordPress/gutenberg/pull/72406/
- https://github.com/WordPress/gutenberg/pull/72533/


## Why? How?

We tried to cherry-pick only #72533, but because the `fit-text.spec.js` file itself didn't exist in the `wp/6.9` branch in the first place, a conflict occurred, and the automatic cherry-pick failed.

To resolve this issue, this PR also backports the E2E tests to the `wp/6.9` branch.

## Testing Instructions
It would be enough to make sure that CI is ✅.