### PR TITLE
`useFormValidity`: fix nesting levels

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug fixes
 
+- useFormValidity: make it work with any level of nesting in the form. [#72588](https://github.com/WordPress/gutenberg/pull/72588)
 - Fix: DataViews modal actions in list layout. [#72793](https://github.com/WordPress/gutenberg/pull/72793)
 
 ## 10.2.0 (2025-10-29)

--- a/packages/dataviews/src/hooks/use-form-validity.ts
+++ b/packages/dataviews/src/hooks/use-form-validity.ts
@@ -606,17 +606,13 @@ function getFormFieldValue< Item >(
 	item: Item
 ): any {
 	const fieldValue = formField?.field?.getValue( { item } );
-	if ( ! formField.children ) {
+	if ( formField.children.length === 0 ) {
 		return fieldValue;
 	}
 
-	const childrenValues =
-		formField.children.length > 0
-			? formField.children.map( ( child ) =>
-					getFormFieldValue( child, item )
-			  )
-			: undefined;
-
+	const childrenValues = formField.children.map( ( child ) =>
+		getFormFieldValue( child, item )
+	);
 	if ( ! childrenValues ) {
 		return fieldValue;
 	}

--- a/packages/dataviews/src/hooks/use-form-validity.ts
+++ b/packages/dataviews/src/hooks/use-form-validity.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import deepMerge from 'deepmerge';
+import fastDeepEqual from 'fast-deep-equal/es6';
 
 /**
  * WordPress dependencies
@@ -20,6 +21,7 @@ import type {
 	Form,
 	FormValidity,
 	NormalizedField,
+	NormalizedFormField,
 } from '../types';
 const isEmptyNullOrUndefined = ( value: any ) =>
 	[ undefined, '', null ].includes( value );
@@ -74,68 +76,527 @@ function isFormValid( formValidity: FormValidity | undefined ): boolean {
 	} );
 }
 
-function updateFieldValidity(
-	setFormValidity: React.Dispatch< React.SetStateAction< FormValidity > >,
-	parentFieldId: string | undefined,
-	fieldId: string,
-	newValidity: FieldValidity
-) {
-	if ( parentFieldId ) {
-		setFormValidity( ( prev ) => ( {
-			...prev,
-			[ parentFieldId ]: {
-				...prev?.[ parentFieldId ],
-				children: {
-					...prev?.[ parentFieldId ]?.children,
-					[ fieldId ]: {
-						...newValidity,
-					},
-				},
-			},
-		} ) );
-	} else {
-		setFormValidity( ( prev ) => ( {
-			...prev,
-			[ fieldId ]: {
-				...newValidity,
-			},
-		} ) );
-	}
-}
+type FormFieldToValidate< Item > = {
+	id: string;
+	children: FormFieldToValidate< Item >[];
+	field?: NormalizedField< Item >;
+};
 
-function getFieldsToValidate< Item >(
-	fields: Field< Item >[],
-	form: Form
-): {
-	fields: NormalizedField< Item >[];
-	fieldToParent: Map< string, string >;
-} {
+function getFormFieldsToValidate< Item >(
+	form: Form,
+	fields: Field< Item >[]
+): FormFieldToValidate< Item >[] {
 	const normalizedForm = normalizeForm( form );
 	if ( normalizedForm.fields.length === 0 ) {
-		return { fields: [], fieldToParent: new Map() };
+		return [];
 	}
 
-	const fieldToParent = new Map< string, string >();
-	const fieldIdsToValidate: string[] = [];
-	normalizedForm.fields.forEach( ( formField ) => {
-		if ( !! formField.children ) {
-			formField.children.forEach( ( child ) => {
-				const childId = typeof child === 'string' ? child : child.id;
-				fieldIdsToValidate.push( childId );
-				fieldToParent.set( childId, formField.id );
-			} );
-		} else {
-			fieldIdsToValidate.push( formField.id );
-		}
+	// Create a map of field IDs to Field definitions for fast lookup
+	const fieldsMap = new Map< string, Field< Item > >();
+	fields.forEach( ( field ) => {
+		fieldsMap.set( field.id, field );
 	} );
 
+	// Recursive function to process form fields and their children
+	function processFormField(
+		formField: NormalizedFormField
+	): FormFieldToValidate< Item > | null {
+		// Handle combined fields (fields with children)
+		if ( 'children' in formField && Array.isArray( formField.children ) ) {
+			const processedChildren = formField.children
+				.map( processFormField )
+				.filter( ( child ) => child !== null );
+
+			if ( processedChildren.length === 0 ) {
+				return null;
+			}
+
+			const fieldDef = fieldsMap.get( formField.id );
+			if ( fieldDef ) {
+				const [ normalizedField ] = normalizeFields< Item >( [
+					fieldDef,
+				] );
+
+				return {
+					id: formField.id,
+					children: processedChildren,
+					field: normalizedField,
+				} satisfies FormFieldToValidate< Item >;
+			}
+
+			return {
+				id: formField.id,
+				children: processedChildren,
+			} satisfies FormFieldToValidate< Item >;
+		}
+
+		// Handle leaf fields (fields without children)
+		const fieldDef = fieldsMap.get( formField.id );
+		if ( ! fieldDef ) {
+			return null;
+		}
+
+		const [ normalizedField ] = normalizeFields< Item >( [ fieldDef ] );
+		return {
+			id: formField.id,
+			children: [],
+			field: normalizedField,
+		} as FormFieldToValidate< Item >;
+	}
+
+	const toValidate = normalizedForm.fields
+		.map( processFormField )
+		.filter( ( field ) => field !== null );
+
+	return toValidate;
+}
+
+function setValidityAtPath(
+	formValidity: FormValidity | undefined,
+	fieldValidity: FieldValidity,
+	path: string[]
+): FormValidity {
+	// Handle empty validity or empty path
+	if ( ! formValidity ) {
+		formValidity = {};
+	}
+
+	if ( path.length === 0 ) {
+		return formValidity;
+	}
+
+	// Clone the root to avoid mutations
+	const result = { ...formValidity };
+
+	// Navigate through the path, creating/cloning objects as needed
+	let current: any = result;
+	for ( let i = 0; i < path.length - 1; i++ ) {
+		const segment = path[ i ];
+
+		// Ensure the current segment exists
+		if ( ! current[ segment ] ) {
+			current[ segment ] = {};
+		} else {
+			// Clone to maintain immutability
+			current[ segment ] = { ...current[ segment ] };
+		}
+
+		// Move to the next level
+		current = current[ segment ];
+	}
+
+	// At the final destination, merge the new validity with existing
+	const finalKey = path[ path.length - 1 ];
+	current[ finalKey ] = {
+		...( current[ finalKey ] || {} ),
+		...fieldValidity,
+	};
+
+	return result;
+}
+
+function handleElementsValidationAsync< Item >(
+	promise: Promise< any >,
+	formField: FormFieldToValidate< Item >,
+	promiseHandler: PromiseHandler< Item >
+) {
+	const { elementsCounterRef, setFormValidity, path, item } = promiseHandler;
+	const currentToken =
+		( elementsCounterRef.current[ formField.id ] || 0 ) + 1;
+	elementsCounterRef.current[ formField.id ] = currentToken;
+
+	promise
+		.then( ( result ) => {
+			if ( currentToken !== elementsCounterRef.current[ formField.id ] ) {
+				return;
+			}
+
+			if ( ! Array.isArray( result ) ) {
+				setFormValidity( ( prev ) => {
+					const newFormValidity = setValidityAtPath(
+						prev,
+						{
+							elements: {
+								type: 'invalid',
+								message: 'Could not validate elements.',
+							},
+						},
+						[ ...path, formField.id ]
+					);
+					return newFormValidity;
+				} );
+				return;
+			}
+
+			const validValues = result.map( ( el ) => el.value );
+			if (
+				!! formField.field &&
+				formField.field.type !== 'array' &&
+				! validValues.includes( formField.field.getValue( { item } ) )
+			) {
+				setFormValidity( ( prev ) => {
+					const newFormValidity = setValidityAtPath(
+						prev,
+						{
+							elements: {
+								type: 'invalid',
+								message: 'Value must be one of the elements.',
+							},
+						},
+						[ ...path, formField.id ]
+					);
+					return newFormValidity;
+				} );
+				return;
+			}
+
+			if (
+				!! formField.field &&
+				formField.field.type === 'array' &&
+				! Array.isArray( formField.field.getValue( { item } ) )
+			) {
+				setFormValidity( ( prev ) => {
+					const newFormValidity = setValidityAtPath(
+						prev,
+						{
+							elements: {
+								type: 'invalid',
+								message: 'Value must be an array.',
+							},
+						},
+						[ ...path, formField.id ]
+					);
+					return newFormValidity;
+				} );
+				return;
+			}
+
+			if (
+				!! formField.field &&
+				formField.field.type === 'array' &&
+				formField.field
+					.getValue( { item } )
+					.some( ( v: any ) => ! validValues.includes( v ) )
+			) {
+				setFormValidity( ( prev ) => {
+					const newFormValidity = setValidityAtPath(
+						prev,
+						{
+							elements: {
+								type: 'invalid',
+								message: 'Value must be one of the elements.',
+							},
+						},
+						[ ...path, formField.id ]
+					);
+					return newFormValidity;
+				} );
+			}
+		} )
+		.catch( ( error ) => {
+			if ( currentToken !== elementsCounterRef.current[ formField.id ] ) {
+				return;
+			}
+
+			setFormValidity( ( prev ) => {
+				const newFormValidity = setValidityAtPath(
+					prev,
+					{
+						elements: {
+							type: 'invalid',
+							message: error.message,
+						},
+					},
+					[ ...path, formField.id ]
+				);
+				return newFormValidity;
+			} );
+		} );
+}
+
+function handleCustomValidationAsync< Item >(
+	promise: Promise< any >,
+	formField: FormFieldToValidate< Item >,
+	promiseHandler: PromiseHandler< Item >
+) {
+	const { customCounterRef, setFormValidity, path } = promiseHandler;
+	const currentToken = ( customCounterRef.current[ formField.id ] || 0 ) + 1;
+	customCounterRef.current[ formField.id ] = currentToken;
+
+	promise
+		.then( ( result ) => {
+			if ( currentToken !== customCounterRef.current[ formField.id ] ) {
+				return;
+			}
+
+			if ( result === null ) {
+				setFormValidity( ( prev ) => {
+					const newFormValidity = setValidityAtPath(
+						prev,
+						{
+							custom: {
+								type: 'valid',
+								message: __( 'Valid' ),
+							},
+						},
+						[ ...path, formField.id ]
+					);
+					return newFormValidity;
+				} );
+				return;
+			}
+
+			if ( typeof result === 'string' ) {
+				setFormValidity( ( prev ) => {
+					const newFormValidity = setValidityAtPath(
+						prev,
+						{
+							custom: {
+								type: 'invalid',
+								message: result,
+							},
+						},
+						[ ...path, formField.id ]
+					);
+					return newFormValidity;
+				} );
+				return;
+			}
+
+			setFormValidity( ( prev ) => {
+				const newFormValidity = setValidityAtPath(
+					prev,
+					{
+						custom: {
+							type: 'invalid',
+							message: __( 'Validation could not be processed.' ),
+						},
+					},
+					[ ...path, formField.id ]
+				);
+				return newFormValidity;
+			} );
+		} )
+		.catch( ( error ) => {
+			if ( currentToken !== customCounterRef.current[ formField.id ] ) {
+				return;
+			}
+
+			setFormValidity( ( prev ) => {
+				const newFormValidity = setValidityAtPath(
+					prev,
+					{
+						custom: {
+							type: 'invalid',
+							message: error.message,
+						},
+					},
+					[ ...path, formField.id ]
+				);
+				return newFormValidity;
+			} );
+		} );
+}
+
+type PromiseHandler< Item > = {
+	customCounterRef: React.MutableRefObject< Record< string, number > >;
+	elementsCounterRef: React.MutableRefObject< Record< string, number > >;
+	setFormValidity: React.Dispatch< React.SetStateAction< FormValidity > >;
+	path: string[];
+	item: Item;
+};
+
+function validateFormField< Item >(
+	item: Item,
+	formField: FormFieldToValidate< Item >,
+	promiseHandler: PromiseHandler< Item >
+): FieldValidity | undefined {
+	// Validate the field: isValid.required
+	if (
+		!! formField.field &&
+		formField.field.isValid.required &&
+		isInvalidForRequired(
+			formField.field.type,
+			formField.field.getValue( { item } )
+		)
+	) {
+		return {
+			required: { type: 'invalid' },
+		};
+	}
+
+	// Validate the field: isValid.elements (static)
+	if (
+		!! formField.field &&
+		formField.field.isValid.elements &&
+		formField.field.hasElements &&
+		! formField.field.getElements &&
+		Array.isArray( formField.field.elements )
+	) {
+		const value = formField.field.getValue( { item } );
+		const validValues = formField.field.elements.map( ( el ) => el.value );
+
+		if (
+			formField.field.type !== 'array' &&
+			! validValues.includes( value )
+		) {
+			return {
+				elements: {
+					type: 'invalid',
+					message: __( 'Value must be one of the elements.' ),
+				},
+			};
+		}
+
+		if ( formField.field.type === 'array' && ! Array.isArray( value ) ) {
+			return {
+				elements: {
+					type: 'invalid',
+					message: __( 'Value must be an array.' ),
+				},
+			};
+		}
+		if (
+			formField.field.type === 'array' &&
+			value.some( ( v: any ) => ! validValues.includes( v ) )
+		) {
+			return {
+				elements: {
+					type: 'invalid',
+					message: __( 'Value must be one of the elements.' ),
+				},
+			};
+		}
+	}
+
+	// Validate the field: isValid.elements (async)
+	if (
+		!! formField.field &&
+		formField.field.isValid.elements &&
+		formField.field.hasElements &&
+		typeof formField.field.getElements === 'function'
+	) {
+		handleElementsValidationAsync(
+			formField.field.getElements(),
+			formField,
+			promiseHandler
+		);
+
+		return {
+			elements: {
+				type: 'validating',
+				message: 'Validating…',
+			},
+		};
+	}
+
+	// Validate the field: isValid.custom (sync)
+	let customError;
+	if ( !! formField.field ) {
+		try {
+			const value = formField.field.getValue( { item } );
+			customError = formField.field.isValid?.custom?.(
+				deepMerge(
+					item,
+					formField.field.setValue( {
+						item,
+						value,
+					} ) as Partial< Item >
+				),
+				formField.field
+			);
+		} catch ( error: any ) {
+			let errorMessage;
+			if ( error instanceof Error ) {
+				errorMessage = error.message;
+			} else {
+				errorMessage =
+					String( error ) ||
+					__( 'Unknown error when running custom validation.' );
+			}
+			return {
+				custom: {
+					type: 'invalid',
+					message: errorMessage,
+				},
+			};
+		}
+	}
+
+	if ( typeof customError === 'string' ) {
+		return {
+			custom: {
+				type: 'invalid',
+				message: customError,
+			},
+		};
+	}
+
+	// Validate the field: isValid.custom (async)
+	if ( customError instanceof Promise ) {
+		handleCustomValidationAsync( customError, formField, promiseHandler );
+
+		return {
+			custom: {
+				type: 'validating',
+				message: __( 'Validating…' ),
+			},
+		};
+	}
+
+	// Validate its children.
+	if ( formField.children ) {
+		const result: Record< string, FieldValidity | undefined > = {};
+		formField.children.forEach( ( child ) => {
+			result[ child.id ] = validateFormField( item, child, {
+				...promiseHandler,
+				path: [ ...promiseHandler.path, formField.id, 'children' ],
+			} );
+		} );
+
+		const filteredResult: Record< string, FieldValidity > = {};
+		Object.entries( result ).forEach( ( [ key, value ] ) => {
+			if ( value !== undefined ) {
+				filteredResult[ key ] = value;
+			}
+		} );
+
+		if ( Object.keys( filteredResult ).length === 0 ) {
+			return undefined;
+		}
+
+		return {
+			children: filteredResult,
+		};
+	}
+
+	// No errors for this field or its children.
+	return undefined;
+}
+
+function getFormFieldValue< Item >(
+	formField: FormFieldToValidate< Item >,
+	item: Item
+): any {
+	const fieldValue = formField?.field?.getValue( { item } );
+	if ( ! formField.children ) {
+		return fieldValue;
+	}
+
+	const childrenValues =
+		formField.children.length > 0
+			? formField.children.map( ( child ) =>
+					getFormFieldValue( child, item )
+			  )
+			: undefined;
+
+	if ( ! childrenValues ) {
+		return fieldValue;
+	}
+
 	return {
-		fields: normalizeFields(
-			fields.filter( ( field ) =>
-				fieldIdsToValidate.includes( field.id )
-			)
-		),
-		fieldToParent,
+		value: fieldValue,
+		children: childrenValues,
 	};
 }
 
@@ -154,406 +615,78 @@ export function useFormValidity< Item >(
 	form: Form
 ): { validity: FormValidity; isValid: boolean } {
 	const [ formValidity, setFormValidity ] = useState< FormValidity >();
-	const previousValidatedValuesRef = useRef< Record< string, any > >( {} );
-
-	// The following counters are used to track the validation promises triggered
-	// by executing isValid.custom and the elements validation. When the promise resolves,
-	// it will update the form validity state ONLY if its counter matches the current one.
-	const customValidationCounterRef = useRef< Record< string, number > >( {} );
-	const elementsValidationCounterRef = useRef< Record< string, number > >(
-		{}
-	);
+	const customCounterRef = useRef< Record< string, number > >( {} );
+	const elementsCounterRef = useRef< Record< string, number > >( {} );
+	const previousValuesRef = useRef< Record< string, any > >( {} );
 
 	const validate = useCallback( () => {
-		const { fields: fieldsToValidate, fieldToParent } = getFieldsToValidate(
-			fields,
-			form
-		);
-		if ( fieldsToValidate.length === 0 ) {
+		const promiseHandler = {
+			customCounterRef,
+			elementsCounterRef,
+			setFormValidity,
+			path: [],
+			item,
+		};
+
+		const formFieldsToValidate = getFormFieldsToValidate( form, fields );
+		if ( formFieldsToValidate.length === 0 ) {
 			setFormValidity( undefined );
 			return;
 		}
 
-		fieldsToValidate.forEach( ( field ) => {
-			const value = field.getValue( { item } );
+		const newFormValidity: FormValidity = {};
+		const untouchedFields: string[] = [];
+		formFieldsToValidate.forEach( ( formField ) => {
+			// Skip fields that did not change.
+			const value = getFormFieldValue< Item >( formField, item );
 			if (
-				previousValidatedValuesRef.current.hasOwnProperty( field.id ) &&
-				value === previousValidatedValuesRef.current[ field.id ]
+				previousValuesRef.current.hasOwnProperty( formField.id ) &&
+				fastDeepEqual(
+					previousValuesRef.current[ formField.id ],
+					value
+				)
 			) {
+				untouchedFields.push( formField.id );
 				return;
 			}
-			previousValidatedValuesRef.current[ field.id ] = value;
+			previousValuesRef.current[ formField.id ] = value;
 
-			const parentFieldId = fieldToParent.get( field.id );
-
-			// isValid.required
-			if (
-				field.isValid.required &&
-				isInvalidForRequired( field.type, value )
-			) {
-				updateFieldValidity( setFormValidity, parentFieldId, field.id, {
-					required: { type: 'invalid' },
-				} );
-				return;
+			// Calculate validity for those fields that changed.
+			const fieldValidity = validateFormField(
+				item,
+				formField,
+				promiseHandler
+			);
+			if ( fieldValidity !== undefined ) {
+				newFormValidity[ formField.id ] = fieldValidity;
 			}
+		} );
 
-			// isValid.elements (static elements)
-			if (
-				field.isValid.elements &&
-				field.hasElements &&
-				! field.getElements &&
-				Array.isArray( field.elements )
-			) {
-				const validValues = field.elements.map( ( el ) => el.value );
+		setFormValidity( ( existingFormValidity ) => {
+			let validity: FormValidity = {
+				...existingFormValidity,
+				...newFormValidity,
+			};
 
-				if (
-					field.type !== 'array' &&
-					! validValues.includes( value )
-				) {
-					updateFieldValidity(
-						setFormValidity,
-						parentFieldId,
-						field.id,
-						{
-							elements: {
-								type: 'invalid',
-								message: 'Value must be one of the elements.',
-							},
-						}
-					);
-					return;
+			const fieldsToKeep = [
+				...untouchedFields,
+				...Object.keys( newFormValidity ),
+			];
+			Object.keys( validity ).forEach( ( key ) => {
+				if ( validity && ! fieldsToKeep.includes( key ) ) {
+					delete validity[ key ];
 				}
-
-				if ( field.type === 'array' && ! Array.isArray( value ) ) {
-					updateFieldValidity(
-						setFormValidity,
-						parentFieldId,
-						field.id,
-						{
-							elements: {
-								type: 'invalid',
-								message: 'Value must be an array.',
-							},
-						}
-					);
-					return;
-				}
-				if (
-					field.type === 'array' &&
-					value.some( ( v: any ) => ! validValues.includes( v ) )
-				) {
-					updateFieldValidity(
-						setFormValidity,
-						parentFieldId,
-						field.id,
-						{
-							elements: {
-								type: 'invalid',
-								message: 'Value must be one of the elements.',
-							},
-						}
-					);
-					return;
-				}
-			}
-
-			// isValid.elements (get them via getElements first)
-			if (
-				field.isValid.elements &&
-				field.hasElements &&
-				typeof field.getElements === 'function'
-			) {
-				const currentToken =
-					( elementsValidationCounterRef.current[ field.id ] || 0 ) +
-					1;
-				elementsValidationCounterRef.current[ field.id ] = currentToken;
-				updateFieldValidity( setFormValidity, parentFieldId, field.id, {
-					elements: {
-						type: 'validating',
-						message: 'Validating...',
-					},
-				} );
-
-				field
-					.getElements()
-					.then( ( result ) => {
-						if (
-							elementsValidationCounterRef.current[ field.id ] !==
-							currentToken
-						) {
-							return;
-						}
-
-						if ( ! Array.isArray( result ) ) {
-							updateFieldValidity(
-								setFormValidity,
-								parentFieldId,
-								field.id,
-								{
-									elements: {
-										type: 'invalid',
-										message: 'Could not validate elements.',
-									},
-								}
-							);
-							return;
-						}
-
-						const validValues = result.map( ( el ) => el.value );
-						if (
-							field.type !== 'array' &&
-							! validValues.includes( value )
-						) {
-							updateFieldValidity(
-								setFormValidity,
-								parentFieldId,
-								field.id,
-								{
-									elements: {
-										type: 'invalid',
-										message:
-											'Value must be one of the elements.',
-									},
-								}
-							);
-							return;
-						}
-
-						if (
-							field.type === 'array' &&
-							! Array.isArray( value )
-						) {
-							updateFieldValidity(
-								setFormValidity,
-								parentFieldId,
-								field.id,
-								{
-									elements: {
-										type: 'invalid',
-										message: 'Value must be an array.',
-									},
-								}
-							);
-							return;
-						}
-
-						if (
-							field.type === 'array' &&
-							value.some(
-								( v: any ) => ! validValues.includes( v )
-							)
-						) {
-							updateFieldValidity(
-								setFormValidity,
-								parentFieldId,
-								field.id,
-								{
-									elements: {
-										type: 'invalid',
-										message:
-											'Value must be one of the elements.',
-									},
-								}
-							);
-						}
-					} )
-					.catch( ( error ) => {
-						if (
-							elementsValidationCounterRef.current[ field.id ] !==
-							currentToken
-						) {
-							return;
-						}
-
-						updateFieldValidity(
-							setFormValidity,
-							parentFieldId,
-							field.id,
-							{
-								elements: {
-									type: 'invalid',
-									message: error.message,
-								},
-							}
-						);
-					} );
-			}
-
-			// Check isValid.custom
-			let customError;
-			try {
-				customError = field.isValid?.custom?.(
-					deepMerge(
-						item,
-						field.setValue( {
-							item,
-							value,
-						} ) as Partial< Item >
-					),
-					field
-				);
-			} catch ( error: any ) {
-				let errorMessage;
-				if ( error instanceof Error ) {
-					errorMessage = error.message;
-				} else {
-					errorMessage =
-						String( error ) ||
-						__( 'Unknown error when running custom validation.' );
-				}
-
-				updateFieldValidity( setFormValidity, parentFieldId, field.id, {
-					custom: {
-						type: 'invalid',
-						message: errorMessage,
-					},
-				} );
-			}
-
-			// — isValid.custom (sync version)
-			if ( typeof customError === 'string' ) {
-				updateFieldValidity( setFormValidity, parentFieldId, field.id, {
-					custom: {
-						type: 'invalid',
-						message: customError,
-					},
-				} );
-				return;
-			}
-
-			// — isValid.custom (async version)
-			if ( customError instanceof Promise ) {
-				// Increment token for this field to track the latest validation
-				const currentToken =
-					( customValidationCounterRef.current[ field.id ] || 0 ) + 1;
-				customValidationCounterRef.current[ field.id ] = currentToken;
-
-				updateFieldValidity( setFormValidity, parentFieldId, field.id, {
-					custom: {
-						type: 'validating',
-						message: 'Validating...',
-					},
-				} );
-
-				customError
-					.then( ( result ) => {
-						if (
-							customValidationCounterRef.current[ field.id ] !==
-							currentToken
-						) {
-							return;
-						}
-
-						if ( result === null ) {
-							updateFieldValidity(
-								setFormValidity,
-								parentFieldId,
-								field.id,
-								{
-									custom: {
-										type: 'valid',
-										message: 'Valid',
-									},
-								}
-							);
-							return;
-						}
-
-						if ( typeof result === 'string' ) {
-							updateFieldValidity(
-								setFormValidity,
-								parentFieldId,
-								field.id,
-								{
-									custom: {
-										type: 'invalid',
-										message: result,
-									},
-								}
-							);
-						}
-					} )
-					.catch( ( error ) => {
-						if (
-							customValidationCounterRef.current[ field.id ] !==
-							currentToken
-						) {
-							return;
-						}
-
-						updateFieldValidity(
-							setFormValidity,
-							parentFieldId,
-							field.id,
-							{
-								custom: {
-									type: 'invalid',
-									message: error.message,
-								},
-							}
-						);
-					} );
-
-				return;
-			}
-
-			// No errors for this field, remove from errors object
-			setFormValidity( ( prev ) => {
-				if ( ! prev ) {
-					return prev;
-				}
-
-				if ( parentFieldId ) {
-					// This field is a child - remove it from parent's children
-					const parentField = prev[ parentFieldId ];
-					if ( ! parentField?.children ) {
-						return prev;
-					}
-
-					const { [ field.id ]: removed, ...restChildren } =
-						parentField.children as any;
-
-					// If no more children, remove the children property
-					if ( Object.keys( restChildren ).length === 0 ) {
-						const { children, ...restParent } = parentField;
-						if ( Object.keys( restParent ).length === 0 ) {
-							// Remove parent field entirely if no other validations
-							const {
-								[ parentFieldId ]: removedParent,
-								...restFields
-							} = prev;
-							return Object.keys( restFields ).length === 0
-								? undefined
-								: restFields;
-						}
-						return {
-							...prev,
-							[ parentFieldId ]: restParent,
-						};
-					}
-
-					return {
-						...prev,
-						[ parentFieldId ]: {
-							...parentField,
-							children: restChildren,
-						},
-					};
-				}
-
-				// Regular field - remove from top level
-				if ( ! prev[ field.id ] ) {
-					return prev;
-				}
-
-				const { [ field.id ]: removed, ...rest } = prev;
-
-				if ( Object.keys( rest ).length === 0 ) {
-					return undefined;
-				}
-
-				return rest;
 			} );
+			if ( Object.keys( validity ).length === 0 ) {
+				validity = undefined;
+			}
+
+			const areEqual = fastDeepEqual( existingFormValidity, validity );
+			if ( areEqual ) {
+				return existingFormValidity;
+			}
+
+			return validity;
 		} );
 	}, [ item, fields, form ] );
 

--- a/packages/dataviews/src/hooks/use-form-validity.ts
+++ b/packages/dataviews/src/hooks/use-form-validity.ts
@@ -168,24 +168,19 @@ function setValidityAtPath(
 	// Clone the root to avoid mutations
 	const result = { ...formValidity };
 
-	// Navigate through the path, creating/cloning objects as needed
+	// Navigate through the result tree,
+	// setting up empty paths if they don't exist.
 	let current: any = result;
 	for ( let i = 0; i < path.length - 1; i++ ) {
 		const segment = path[ i ];
-
-		// Ensure the current segment exists
 		if ( ! current[ segment ] ) {
 			current[ segment ] = {};
-		} else {
-			// Clone to maintain immutability
-			current[ segment ] = { ...current[ segment ] };
 		}
 
-		// Move to the next level
 		current = current[ segment ];
 	}
 
-	// At the final destination, merge the new validity with existing
+	// At the final destination, merge the new validity with the existing.
 	const finalKey = path[ path.length - 1 ];
 	current[ finalKey ] = {
 		...( current[ finalKey ] || {} ),

--- a/packages/dataviews/src/hooks/use-form-validity.ts
+++ b/packages/dataviews/src/hooks/use-form-validity.ts
@@ -302,13 +302,24 @@ function handleElementsValidationAsync< Item >(
 				return;
 			}
 
+			let errorMessage;
+			if ( error instanceof Error ) {
+				errorMessage = error.message;
+			} else {
+				errorMessage =
+					String( error ) ||
+					__(
+						'Unknown error when running elements validation asynchronously.'
+					);
+			}
+
 			setFormValidity( ( prev ) => {
 				const newFormValidity = setValidityAtPath(
 					prev,
 					{
 						elements: {
 							type: 'invalid',
-							message: error.message,
+							message: errorMessage,
 						},
 					},
 					[ ...path, formField.id ]
@@ -386,13 +397,24 @@ function handleCustomValidationAsync< Item >(
 				return;
 			}
 
+			let errorMessage;
+			if ( error instanceof Error ) {
+				errorMessage = error.message;
+			} else {
+				errorMessage =
+					String( error ) ||
+					__(
+						'Unknown error when running custom validation asynchronously.'
+					);
+			}
+
 			setFormValidity( ( prev ) => {
 				const newFormValidity = setValidityAtPath(
 					prev,
 					{
 						custom: {
 							type: 'invalid',
-							message: error.message,
+							message: errorMessage,
 						},
 					},
 					[ ...path, formField.id ]
@@ -509,7 +531,7 @@ function validateFormField< Item >(
 				),
 				formField.field
 			);
-		} catch ( error: any ) {
+		} catch ( error ) {
 			let errorMessage;
 			if ( error instanceof Error ) {
 				errorMessage = error.message;
@@ -518,6 +540,7 @@ function validateFormField< Item >(
 					String( error ) ||
 					__( 'Unknown error when running custom validation.' );
 			}
+
 			return {
 				custom: {
 					type: 'invalid',

--- a/packages/dataviews/src/hooks/use-form-validity.ts
+++ b/packages/dataviews/src/hooks/use-form-validity.ts
@@ -218,7 +218,7 @@ function handleElementsValidationAsync< Item >(
 						{
 							elements: {
 								type: 'invalid',
-								message: 'Could not validate elements.',
+								message: __( 'Could not validate elements.' ),
 							},
 						},
 						[ ...path, formField.id ]
@@ -240,7 +240,9 @@ function handleElementsValidationAsync< Item >(
 						{
 							elements: {
 								type: 'invalid',
-								message: 'Value must be one of the elements.',
+								message: __(
+									'Value must be one of the elements.'
+								),
 							},
 						},
 						[ ...path, formField.id ]
@@ -261,7 +263,7 @@ function handleElementsValidationAsync< Item >(
 						{
 							elements: {
 								type: 'invalid',
-								message: 'Value must be an array.',
+								message: __( 'Value must be an array.' ),
 							},
 						},
 						[ ...path, formField.id ]
@@ -284,7 +286,9 @@ function handleElementsValidationAsync< Item >(
 						{
 							elements: {
 								type: 'invalid',
-								message: 'Value must be one of the elements.',
+								message: __(
+									'Value must be one of the elements.'
+								),
 							},
 						},
 						[ ...path, formField.id ]
@@ -485,7 +489,7 @@ function validateFormField< Item >(
 		return {
 			elements: {
 				type: 'validating',
-				message: 'Validating…',
+				message: __( 'Validating…' ),
 			},
 		};
 	}

--- a/packages/dataviews/src/hooks/use-form-validity.ts
+++ b/packages/dataviews/src/hooks/use-form-validity.ts
@@ -549,7 +549,7 @@ function validateFormField< Item >(
 	}
 
 	// Validate its children.
-	if ( formField.children ) {
+	if ( formField.children.length > 0 ) {
 		const result: Record< string, FieldValidity | undefined > = {};
 		formField.children.forEach( ( child ) => {
 			result[ child.id ] = validateFormField( item, child, {

--- a/packages/dataviews/src/stories/dataform.story.tsx
+++ b/packages/dataviews/src/stories/dataform.story.tsx
@@ -539,13 +539,11 @@ function CustomEditControl< Item >( {
 const ValidationComponent = ( {
 	required,
 	elements,
-	type,
 	custom,
 }: {
 	required: boolean;
 	elements: 'sync' | 'async' | 'none';
 	custom: 'sync' | 'async' | 'none';
-	type: 'regular' | 'panel';
 } ) => {
 	type ValidatedItem = {
 		text: string;
@@ -570,10 +568,6 @@ const ValidationComponent = ( {
 		datetime?: string;
 	};
 
-	const DateRangeEdit = ( props: DataFormControlProps< ValidatedItem > ) => {
-		return <DateControl { ...props } operator="between" />;
-	};
-
 	const [ post, setPost ] = useState< ValidatedItem >( {
 		text: 'Can have letters and spaces',
 		select: undefined,
@@ -596,184 +590,6 @@ const ValidationComponent = ( {
 		dateRange: undefined,
 		datetime: undefined,
 	} );
-
-	const makeAsync = ( rule: ( item: ValidatedItem ) => null | string ) => {
-		return async ( value: ValidatedItem ) => {
-			return await new Promise< string | null >( ( resolve ) => {
-				setTimeout( () => {
-					const validationResult = rule( value );
-					resolve( validationResult );
-				}, 2000 );
-			} );
-		};
-	};
-
-	const customTextRule = ( value: ValidatedItem ) => {
-		if ( ! /^[a-zA-Z ]+$/.test( value.text ) ) {
-			return 'Value must only contain letters and spaces.';
-		}
-
-		return null;
-	};
-
-	const customSelectRule = ( value: ValidatedItem ) => {
-		if ( value.select !== 'option1' ) {
-			return 'Value must be Option 1.';
-		}
-		return null;
-	};
-
-	const customTextRadioRule = ( value: ValidatedItem ) => {
-		if ( value.textWithRadio !== 'item1' ) {
-			return 'Value must be Item 1.';
-		}
-
-		return null;
-	};
-
-	const customTextareaRule = ( value: ValidatedItem ) => {
-		if ( ! /^[a-zA-Z ]+$/.test( value.textarea ) ) {
-			return 'Value must only contain letters and spaces.';
-		}
-
-		return null;
-	};
-	const customEmailRule = ( value: ValidatedItem ) => {
-		if ( ! /^[a-zA-Z0-9._%+-]+@example\.com$/.test( value.email ) ) {
-			return 'Email address must be from @example.com domain.';
-		}
-
-		return null;
-	};
-	const customTelephoneRule = ( value: ValidatedItem ) => {
-		if ( ! /^\+30\d{10}$/.test( value.telephone ) ) {
-			return 'Telephone number must start with +30 and have 10 digits after.';
-		}
-
-		return null;
-	};
-	const customUrlRule = ( value: ValidatedItem ) => {
-		if ( ! /^https:\/\/example\.com$/.test( value.url ) ) {
-			return 'URL must be from https://example.com domain.';
-		}
-
-		return null;
-	};
-	const customColorRule = ( value: ValidatedItem ) => {
-		if ( ! /^#[0-9A-Fa-f]{6}$/.test( value.color ) ) {
-			return 'Color must be a valid hex format (e.g., #ff6600).';
-		}
-
-		return null;
-	};
-	const customIntegerRule = ( value: ValidatedItem ) => {
-		if ( value.integer % 2 !== 0 ) {
-			return 'Integer must be an even number.';
-		}
-
-		return null;
-	};
-	const customNumberRule = ( value: ValidatedItem ) => {
-		if ( ! /^\d+\.\d{2}$/.test( value?.number?.toString() ) ) {
-			return 'Number must have exactly two decimal places.';
-		}
-
-		return null;
-	};
-	const customBooleanRule = ( value: ValidatedItem ) => {
-		if ( value.boolean !== true ) {
-			return 'Boolean must be active.';
-		}
-
-		return null;
-	};
-	const customToggleRule = ( value: ValidatedItem ) => {
-		if ( value.toggle !== true ) {
-			return 'Toggle must be checked.';
-		}
-
-		return null;
-	};
-	const customToggleGroupRule = ( value: ValidatedItem ) => {
-		if ( value.toggleGroup !== 'option1' ) {
-			return 'Value must be Option 1.';
-		}
-
-		return null;
-	};
-
-	const customPasswordRule = ( value: ValidatedItem ) => {
-		if ( value.password.length < 8 ) {
-			return 'Password must be at least 8 characters long.';
-		}
-		if ( ! /[A-Z]/.test( value.password ) ) {
-			return 'Password must contain at least one uppercase letter.';
-		}
-		if ( ! /[0-9]/.test( value.password ) ) {
-			return 'Password must contain at least one number.';
-		}
-
-		return null;
-	};
-
-	const customDateRule = ( value: ValidatedItem ) => {
-		if ( ! value.date ) {
-			return null;
-		}
-		const selectedDate = new Date( value.date );
-		const today = new Date();
-		today.setHours( 0, 0, 0, 0 );
-		if ( selectedDate < today ) {
-			return 'Date must not be in the past.';
-		}
-
-		return null;
-	};
-	const customDateTimeRule = ( value: ValidatedItem ) => {
-		if ( ! value.datetime ) {
-			return null;
-		}
-		const selectedDateTime = new Date( value.datetime );
-		const now = new Date();
-		if ( selectedDateTime < now ) {
-			return 'Date and time must not be in the past.';
-		}
-
-		return null;
-	};
-
-	const customDateRangeRule = ( value: ValidatedItem ) => {
-		if ( ! value.dateRange ) {
-			return null;
-		}
-		const [ fromDate, toDate ] = value.dateRange;
-		if ( ! fromDate || ! toDate ) {
-			return null;
-		}
-		const from = new Date( fromDate );
-		const to = new Date( toDate );
-		const daysDiff = Math.ceil(
-			( to.getTime() - from.getTime() ) / ( 1000 * 60 * 60 * 24 )
-		);
-		if ( daysDiff > 30 ) {
-			return 'Date range must not exceed 30 days.';
-		}
-		return null;
-	};
-
-	const maybeCustomRule = (
-		rule: ( item: ValidatedItem ) => null | string
-	) => {
-		if ( custom === 'sync' ) {
-			return rule;
-		}
-
-		if ( custom === 'async' ) {
-			return makeAsync( rule );
-		}
-
-		return undefined;
-	};
 
 	// Cache for getElements functions - ensures promises are only created once
 	const getElements = useMemo( () => {
@@ -810,8 +626,14 @@ const ValidationComponent = ( {
 							setTimeout(
 								() =>
 									resolve( [
-										{ value: 'item1', label: 'Item 1' },
-										{ value: 'item2', label: 'Item 2' },
+										{
+											value: 'item1',
+											label: 'Item 1',
+										},
+										{
+											value: 'item2',
+											label: 'Item 2',
+										},
 									] ),
 								3500
 							)
@@ -827,15 +649,27 @@ const ValidationComponent = ( {
 											value: 'us',
 											label: 'United States',
 										},
-										{ value: 'ca', label: 'Canada' },
+										{
+											value: 'ca',
+											label: 'Canada',
+										},
 										{
 											value: 'uk',
 											label: 'United Kingdom',
 										},
-										{ value: 'fr', label: 'France' },
-										{ value: 'de', label: 'Germany' },
+										{
+											value: 'fr',
+											label: 'France',
+										},
+										{
+											value: 'de',
+											label: 'Germany',
+										},
 										{ value: 'jp', label: 'Japan' },
-										{ value: 'au', label: 'Australia' },
+										{
+											value: 'au',
+											label: 'Australia',
+										},
 									] ),
 								3500
 							)
@@ -872,279 +706,503 @@ const ValidationComponent = ( {
 				return promiseCache[ fieldId ];
 			};
 		};
-	}, [ elements ] );
+	}, [] );
 
-	const _fields: Field< ValidatedItem >[] = [
-		{
-			id: 'text',
-			type: 'text',
-			label: 'Text',
-			isValid: {
-				required,
-				elements: elements !== 'none' ? true : false,
-				custom: maybeCustomRule( customTextRule ),
-			},
-		},
-		{
-			id: 'select',
-			type: 'text',
-			label: 'Select',
-			elements:
-				elements === 'async'
-					? undefined
-					: [
-							{ value: 'option1', label: 'Option 1' },
-							{ value: 'option2', label: 'Option 2' },
-					  ],
-			getElements:
-				elements === 'async' ? getElements( 'select' ) : undefined,
-			isValid: {
-				required,
-				elements: elements !== 'none' ? true : false,
-				custom: maybeCustomRule( customSelectRule ),
-			},
-		},
-		{
-			id: 'textWithRadio',
-			type: 'text',
-			Edit: 'radio',
-			label: 'Text with radio',
-			elements:
-				elements === 'async'
-					? undefined
-					: [
-							{ value: 'item1', label: 'Item 1' },
-							{ value: 'item2', label: 'Item 2' },
-					  ],
-			getElements:
-				elements === 'async'
-					? getElements( 'textWithRadio' )
-					: undefined,
-			isValid: {
-				required,
-				elements: elements !== 'none' ? true : false,
-				custom: maybeCustomRule( customTextRadioRule ),
-			},
-		},
-		{
-			id: 'textarea',
-			type: 'text',
-			Edit: 'textarea',
-			label: 'Textarea',
-			isValid: {
-				required,
-				elements: elements !== 'none' ? true : false,
-				custom: maybeCustomRule( customTextareaRule ),
-			},
-		},
-		{
-			id: 'email',
-			type: 'email',
-			label: 'e-mail',
-			isValid: {
-				required,
-				elements: elements !== 'none' ? true : false,
-				custom: maybeCustomRule( customEmailRule ),
-			},
-		},
-		{
-			id: 'telephone',
-			type: 'telephone',
-			label: 'telephone',
-			isValid: {
-				required,
-				elements: elements !== 'none' ? true : false,
-				custom: maybeCustomRule( customTelephoneRule ),
-			},
-		},
-		{
-			id: 'url',
-			type: 'url',
-			label: 'URL',
-			isValid: {
-				required,
-				elements: elements !== 'none' ? true : false,
-				custom: maybeCustomRule( customUrlRule ),
-			},
-		},
-		{
-			id: 'color',
-			type: 'color',
-			label: 'Color',
-			isValid: {
-				required,
-				elements: elements !== 'none' ? true : false,
-				custom: maybeCustomRule( customColorRule ),
-			},
-		},
-		{
-			id: 'integer',
-			type: 'integer',
-			label: 'Integer',
-			isValid: {
-				required,
-				elements: elements !== 'none' ? true : false,
-				custom: maybeCustomRule( customIntegerRule ),
-			},
-		},
-		{
-			id: 'number',
-			type: 'number',
-			label: 'Number',
-			isValid: {
-				required,
-				elements: elements !== 'none' ? true : false,
-				custom: maybeCustomRule( customNumberRule ),
-			},
-		},
-		{
-			id: 'boolean',
-			type: 'boolean',
-			label: 'Boolean',
-			isValid: {
-				required,
-				elements: elements !== 'none' ? true : false,
-				custom: maybeCustomRule( customBooleanRule ),
-			},
-		},
-		{
-			id: 'countries',
-			label: 'Countries Visited',
-			type: 'array' as const,
-			placeholder: 'Select countries',
-			description: 'Countries you have visited',
-			isValid: {
-				required,
-				elements: elements !== 'none' ? true : false,
-			},
-			elements:
-				elements === 'async'
-					? undefined
-					: [
-							{ value: 'us', label: 'United States' },
-							{ value: 'ca', label: 'Canada' },
-							{ value: 'uk', label: 'United Kingdom' },
-							{ value: 'fr', label: 'France' },
-							{ value: 'de', label: 'Germany' },
-							{ value: 'jp', label: 'Japan' },
-							{ value: 'au', label: 'Australia' },
-					  ],
-			getElements:
-				elements === 'async' ? getElements( 'countries' ) : undefined,
-		},
-		{
-			id: 'customEdit',
-			label: 'Custom Control',
-			Edit: CustomEditControl,
-			isValid: {
-				required,
-				elements: elements !== 'none' ? true : false,
-			},
-		},
-		{
-			id: 'password',
-			type: 'password',
-			label: 'Password',
-			isValid: {
-				required,
-				elements: elements !== 'none' ? true : false,
-				custom: maybeCustomRule( customPasswordRule ),
-			},
-		},
-		{
-			id: 'toggle',
-			type: 'boolean',
-			label: 'Toggle',
-			Edit: 'toggle',
-			isValid: {
-				required,
-				elements: elements !== 'none' ? true : false,
-				custom: maybeCustomRule( customToggleRule ),
-			},
-		},
-		{
-			id: 'toggleGroup',
-			type: 'text',
-			label: 'Toggle Group',
-			Edit: 'toggleGroup',
-			elements:
-				elements === 'async'
-					? undefined
-					: [
-							{ value: 'option1', label: 'Option 1' },
-							{ value: 'option2', label: 'Option 2' },
-							{ value: 'option3', label: 'Option 3' },
-					  ],
-			getElements:
-				elements === 'async' ? getElements( 'toggleGroup' ) : undefined,
-			isValid: {
-				required,
-				elements: elements !== 'none' ? true : false,
-				custom: maybeCustomRule( customToggleGroupRule ),
-			},
-		},
-		{
-			id: 'date',
-			type: 'date',
-			label: 'Date',
-			isValid: {
-				required,
-				elements: elements !== 'none' ? true : false,
-				custom: maybeCustomRule( customDateRule ),
-			},
-		},
-		{
-			id: 'dateRange',
-			type: 'date',
-			label: 'Date Range',
-			Edit: DateRangeEdit,
-			isValid: {
-				required,
-				elements: elements !== 'none' ? true : false,
-				custom: maybeCustomRule( customDateRangeRule ),
-			},
-		},
-		{
-			id: 'datetime',
-			type: 'datetime',
-			label: 'Date Time',
-			isValid: {
-				required,
-				elements: elements !== 'none' ? true : false,
-				custom: maybeCustomRule( customDateTimeRule ),
-			},
-		},
-	];
+	const _fields: Field< ValidatedItem >[] = useMemo( () => {
+		const DateRangeEdit = (
+			props: DataFormControlProps< ValidatedItem >
+		) => {
+			return <DateControl { ...props } operator="between" />;
+		};
+		const makeAsync = (
+			rule: ( item: ValidatedItem ) => null | string
+		) => {
+			return async ( value: ValidatedItem ) => {
+				return await new Promise< string | null >( ( resolve ) => {
+					setTimeout( () => {
+						const validationResult = rule( value );
+						resolve( validationResult );
+					}, 2000 );
+				} );
+			};
+		};
 
-	const form = {
-		layout: { type },
-		fields: [
-			// Use field object for testing purposes.
-			{ id: 'text' },
-			'select',
-			'textWithRadio',
-			'textarea',
-			'email',
-			'telephone',
-			'url',
-			'color',
-			'integer',
-			'number',
-			'boolean',
-			'categories',
-			'countries',
-			'toggle',
-			'toggleGroup',
-			'password',
-			'customEdit',
-			// Use field object with children for testing purposes.
+		const customTextRule = ( value: ValidatedItem ) => {
+			if ( ! /^[a-zA-Z ]+$/.test( value.text ) ) {
+				return 'Value must only contain letters and spaces.';
+			}
+
+			return null;
+		};
+
+		const customSelectRule = ( value: ValidatedItem ) => {
+			if ( value.select !== 'option1' ) {
+				return 'Value must be Option 1.';
+			}
+			return null;
+		};
+
+		const customTextRadioRule = ( value: ValidatedItem ) => {
+			if ( value.textWithRadio !== 'item1' ) {
+				return 'Value must be Item 1.';
+			}
+
+			return null;
+		};
+
+		const customTextareaRule = ( value: ValidatedItem ) => {
+			if ( ! /^[a-zA-Z ]+$/.test( value.textarea ) ) {
+				return 'Value must only contain letters and spaces.';
+			}
+
+			return null;
+		};
+		const customEmailRule = ( value: ValidatedItem ) => {
+			if ( ! /^[a-zA-Z0-9._%+-]+@example\.com$/.test( value.email ) ) {
+				return 'Email address must be from @example.com domain.';
+			}
+
+			return null;
+		};
+		const customTelephoneRule = ( value: ValidatedItem ) => {
+			if ( ! /^\+30\d{10}$/.test( value.telephone ) ) {
+				return 'Telephone number must start with +30 and have 10 digits after.';
+			}
+
+			return null;
+		};
+		const customUrlRule = ( value: ValidatedItem ) => {
+			if ( ! /^https:\/\/example\.com$/.test( value.url ) ) {
+				return 'URL must be from https://example.com domain.';
+			}
+
+			return null;
+		};
+		const customColorRule = ( value: ValidatedItem ) => {
+			if ( ! /^#[0-9A-Fa-f]{6}$/.test( value.color ) ) {
+				return 'Color must be a valid hex format (e.g., #ff6600).';
+			}
+
+			return null;
+		};
+		const customIntegerRule = ( value: ValidatedItem ) => {
+			if ( value.integer % 2 !== 0 ) {
+				return 'Integer must be an even number.';
+			}
+
+			return null;
+		};
+		const customNumberRule = ( value: ValidatedItem ) => {
+			if ( ! /^\d+\.\d{2}$/.test( value?.number?.toString() ) ) {
+				return 'Number must have exactly two decimal places.';
+			}
+
+			return null;
+		};
+		const customBooleanRule = ( value: ValidatedItem ) => {
+			if ( value.boolean !== true ) {
+				return 'Boolean must be active.';
+			}
+
+			return null;
+		};
+		const customToggleRule = ( value: ValidatedItem ) => {
+			if ( value.toggle !== true ) {
+				return 'Toggle must be checked.';
+			}
+
+			return null;
+		};
+		const customToggleGroupRule = ( value: ValidatedItem ) => {
+			if ( value.toggleGroup !== 'option1' ) {
+				return 'Value must be Option 1.';
+			}
+
+			return null;
+		};
+
+		const customPasswordRule = ( value: ValidatedItem ) => {
+			if ( value.password.length < 8 ) {
+				return 'Password must be at least 8 characters long.';
+			}
+			if ( ! /[A-Z]/.test( value.password ) ) {
+				return 'Password must contain at least one uppercase letter.';
+			}
+			if ( ! /[0-9]/.test( value.password ) ) {
+				return 'Password must contain at least one number.';
+			}
+
+			return null;
+		};
+
+		const customDateRule = ( value: ValidatedItem ) => {
+			if ( ! value.date ) {
+				return null;
+			}
+			const selectedDate = new Date( value.date );
+			const today = new Date();
+			today.setHours( 0, 0, 0, 0 );
+			if ( selectedDate < today ) {
+				return 'Date must not be in the past.';
+			}
+
+			return null;
+		};
+		const customDateTimeRule = ( value: ValidatedItem ) => {
+			if ( ! value.datetime ) {
+				return null;
+			}
+			const selectedDateTime = new Date( value.datetime );
+			const now = new Date();
+			if ( selectedDateTime < now ) {
+				return 'Date and time must not be in the past.';
+			}
+
+			return null;
+		};
+
+		const customDateRangeRule = ( value: ValidatedItem ) => {
+			if ( ! value.dateRange ) {
+				return null;
+			}
+			const [ fromDate, toDate ] = value.dateRange;
+			if ( ! fromDate || ! toDate ) {
+				return null;
+			}
+			const from = new Date( fromDate );
+			const to = new Date( toDate );
+			const daysDiff = Math.ceil(
+				( to.getTime() - from.getTime() ) / ( 1000 * 60 * 60 * 24 )
+			);
+			if ( daysDiff > 30 ) {
+				return 'Date range must not exceed 30 days.';
+			}
+			return null;
+		};
+
+		const maybeCustomRule = (
+			rule: ( item: ValidatedItem ) => null | string
+		) => {
+			if ( custom === 'sync' ) {
+				return rule;
+			}
+
+			if ( custom === 'async' ) {
+				return makeAsync( rule );
+			}
+
+			return undefined;
+		};
+
+		return [
 			{
-				id: 'dates',
-				label: 'Dates',
-				children: [ 'date', 'dateRange', 'datetime' ],
+				id: 'text',
+				type: 'text',
+				label: 'Text',
+				isValid: {
+					required,
+					elements: elements !== 'none' ? true : false,
+					custom: maybeCustomRule( customTextRule ),
+				},
 			},
-		],
-	};
+			{
+				id: 'select',
+				type: 'text',
+				label: 'Select',
+				elements:
+					elements === 'async'
+						? undefined
+						: [
+								{ value: 'option1', label: 'Option 1' },
+								{ value: 'option2', label: 'Option 2' },
+						  ],
+				getElements:
+					elements === 'async' ? getElements( 'select' ) : undefined,
+				isValid: {
+					required,
+					elements: elements !== 'none' ? true : false,
+					custom: maybeCustomRule( customSelectRule ),
+				},
+			},
+			{
+				id: 'textWithRadio',
+				type: 'text',
+				Edit: 'radio',
+				label: 'Text with radio',
+				elements:
+					elements === 'async'
+						? undefined
+						: [
+								{ value: 'item1', label: 'Item 1' },
+								{ value: 'item2', label: 'Item 2' },
+						  ],
+				getElements:
+					elements === 'async'
+						? getElements( 'textWithRadio' )
+						: undefined,
+				isValid: {
+					required,
+					elements: elements !== 'none' ? true : false,
+					custom: maybeCustomRule( customTextRadioRule ),
+				},
+			},
+			{
+				id: 'textarea',
+				type: 'text',
+				Edit: 'textarea',
+				label: 'Textarea',
+				isValid: {
+					required,
+					elements: elements !== 'none' ? true : false,
+					custom: maybeCustomRule( customTextareaRule ),
+				},
+			},
+			{
+				id: 'email',
+				type: 'email',
+				label: 'e-mail',
+				isValid: {
+					required,
+					elements: elements !== 'none' ? true : false,
+					custom: maybeCustomRule( customEmailRule ),
+				},
+			},
+			{
+				id: 'telephone',
+				type: 'telephone',
+				label: 'telephone',
+				isValid: {
+					required,
+					elements: elements !== 'none' ? true : false,
+					custom: maybeCustomRule( customTelephoneRule ),
+				},
+			},
+			{
+				id: 'url',
+				type: 'url',
+				label: 'URL',
+				isValid: {
+					required,
+					elements: elements !== 'none' ? true : false,
+					custom: maybeCustomRule( customUrlRule ),
+				},
+			},
+			{
+				id: 'color',
+				type: 'color',
+				label: 'Color',
+				isValid: {
+					required,
+					elements: elements !== 'none' ? true : false,
+					custom: maybeCustomRule( customColorRule ),
+				},
+			},
+			{
+				id: 'integer',
+				type: 'integer',
+				label: 'Integer',
+				isValid: {
+					required,
+					elements: elements !== 'none' ? true : false,
+					custom: maybeCustomRule( customIntegerRule ),
+				},
+			},
+			{
+				id: 'number',
+				type: 'number',
+				label: 'Number',
+				isValid: {
+					required,
+					elements: elements !== 'none' ? true : false,
+					custom: maybeCustomRule( customNumberRule ),
+				},
+			},
+			{
+				id: 'boolean',
+				type: 'boolean',
+				label: 'Boolean',
+				isValid: {
+					required,
+					elements: elements !== 'none' ? true : false,
+					custom: maybeCustomRule( customBooleanRule ),
+				},
+			},
+			{
+				id: 'array',
+				label: 'Array',
+				type: 'array',
+				placeholder: 'Select countries',
+				description: 'Countries you have visited',
+				isValid: {
+					required,
+					elements: elements !== 'none' ? true : false,
+				},
+				elements:
+					elements === 'async'
+						? undefined
+						: [
+								{ value: 'us', label: 'United States' },
+								{ value: 'ca', label: 'Canada' },
+								{ value: 'uk', label: 'United Kingdom' },
+								{ value: 'fr', label: 'France' },
+								{ value: 'de', label: 'Germany' },
+								{ value: 'jp', label: 'Japan' },
+								{ value: 'au', label: 'Australia' },
+						  ],
+				getElements:
+					elements === 'async'
+						? getElements( 'countries' )
+						: undefined,
+			},
+			{
+				id: 'customEdit',
+				label: 'Custom Control',
+				Edit: CustomEditControl,
+				isValid: {
+					required,
+					elements: elements !== 'none' ? true : false,
+				},
+			},
+			{
+				id: 'password',
+				type: 'password',
+				label: 'Password',
+				isValid: {
+					required,
+					elements: elements !== 'none' ? true : false,
+					custom: maybeCustomRule( customPasswordRule ),
+				},
+			},
+			{
+				id: 'toggle',
+				type: 'boolean',
+				label: 'Toggle',
+				Edit: 'toggle',
+				isValid: {
+					required,
+					elements: elements !== 'none' ? true : false,
+					custom: maybeCustomRule( customToggleRule ),
+				},
+			},
+			{
+				id: 'toggleGroup',
+				type: 'text',
+				label: 'Toggle Group',
+				Edit: 'toggleGroup',
+				elements:
+					elements === 'async'
+						? undefined
+						: [
+								{ value: 'option1', label: 'Option 1' },
+								{ value: 'option2', label: 'Option 2' },
+								{ value: 'option3', label: 'Option 3' },
+						  ],
+				getElements:
+					elements === 'async'
+						? getElements( 'toggleGroup' )
+						: undefined,
+				isValid: {
+					required,
+					elements: elements !== 'none' ? true : false,
+					custom: maybeCustomRule( customToggleGroupRule ),
+				},
+			},
+			{
+				id: 'date',
+				type: 'date',
+				label: 'Date',
+				isValid: {
+					required,
+					elements: elements !== 'none' ? true : false,
+					custom: maybeCustomRule( customDateRule ),
+				},
+			},
+			{
+				id: 'dateRange',
+				type: 'date',
+				label: 'Date Range',
+				Edit: DateRangeEdit,
+				isValid: {
+					required,
+					elements: elements !== 'none' ? true : false,
+					custom: maybeCustomRule( customDateRangeRule ),
+				},
+			},
+			{
+				id: 'datetime',
+				type: 'datetime',
+				label: 'Date Time',
+				isValid: {
+					required,
+					elements: elements !== 'none' ? true : false,
+					custom: maybeCustomRule( customDateTimeRule ),
+				},
+			},
+		];
+	}, [ elements, custom, required, getElements ] );
+
+	const form = useMemo(
+		() => ( {
+			fields: [
+				'text',
+				{ id: 'customEdit' },
+				{
+					id: 'level1Integer',
+					children: [ 'integer' ],
+				},
+				{
+					id: 'level1Number',
+					children: [
+						{ id: 'level2Number', children: [ 'number' ] },
+					],
+				},
+				{
+					id: 'level1Email',
+					children: [
+						{
+							id: 'level2Email',
+							children: [
+								{ id: 'level3Email', children: [ 'email' ] },
+							],
+						},
+					],
+				},
+				{
+					id: 'level1Telephone',
+					children: [
+						{
+							id: 'level2Telephone',
+							children: [
+								{
+									id: 'level3Telephone',
+									children: [
+										{
+											id: 'level4Telephone',
+											children: [ 'telephone' ],
+										},
+									],
+								},
+							],
+						},
+					],
+				},
+				'url',
+				'color',
+				'password',
+				'textarea',
+				'select',
+				'textWithRadio',
+				'boolean',
+				'toggle',
+				'toggleGroup',
+				'array',
+				'date',
+				'dateRange',
+				'datetime',
+			],
+		} ),
+		[]
+	);
 
 	const { validity, isValid } = useFormValidity( post, _fields, form );
 
@@ -1946,17 +2004,11 @@ export const Validation = {
 			description: 'Whether or not the custom validation rule is active.',
 			options: [ 'sync', 'async', 'none' ],
 		},
-		type: {
-			control: { type: 'select' },
-			description: 'Chooses the layout type.',
-			options: [ 'regular', 'panel', 'card', 'row' ],
-		},
 	},
 	args: {
 		required: true,
 		elements: 'sync',
 		custom: 'sync',
-		type: 'regular',
 	},
 };
 


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/71412, https://github.com/WordPress/gutenberg/pull/72848

## What?

This PR makes the `useFormValidity` hook work for any nested level.

## Why?

It was only working for fields up to one nesting level.

All fields here were validated:

```
fields: [
  'topLevelField',
  {
    id: 'level1',
    children: [ 'fieldAtLevel1' ],
  }
]
```

In this case, all fields but `fieldAtLevel2` were validated:

```
fields: [
  'topLevelField',
  {
    id: 'level1',
    children: [ 'fieldAtLevel1' ],
  },
  {
    id: 'level1',
    children: [
      { id: 'level2', children: [ 'fieldAtLevel2' ] }
    ],
  }
]
```

## How

No API changes.

- `useFormValidity` has been updated to work recursively and work at any nesting level.
- The story has been updated to consider fields up to the 4th nesting level.

## Testing Instructions

- Automated tests should pass.
- Open the storybook locally (`npm run storybook:dev`), and navigate to "DataViews > DataForm > Validation". Verify the validation messages are triggered as expected.

The story has been updated so that some fields have up to 4 nesting levels. If you want to reproduce the issue in `trunk` paste the existing form config there and observe how fields with nested levels > 2 were not validated.