### PR TITLE
add: Missing JSON Schema for blocks.

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1151,10 +1151,10 @@
 				"core/template-part": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
-				"core/term-description": {
+				"core/term-count": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
-				"core/term-count": {
+				"core/term-description": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/term-name": {
@@ -2171,10 +2171,10 @@
 				"core/template-part": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
-				"core/term-description": {
+				"core/term-count": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
-				"core/term-count": {
+				"core/term-description": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
 				"core/term-name": {
@@ -2615,10 +2615,10 @@
 				"core/template-part": {
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
 				},
-				"core/term-description": {
+				"core/term-count": {
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
 				},
-				"core/term-count": {
+				"core/term-description": {
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
 				},
 				"core/term-name": {

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -860,9 +860,6 @@
 			"description": "Settings defined on a per-block basis.",
 			"type": "object",
 			"properties": {
-				"core/archives": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
-				},
 				"core/accordion": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
@@ -873,6 +870,9 @@
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/accordion-panel": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/archives": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/audio": {
@@ -980,9 +980,6 @@
 				"core/image": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
-				"core/math": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
-				},
 				"core/latest-comments": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
@@ -996,6 +993,9 @@
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/loginout": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/math": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/media-text": {
@@ -1058,9 +1058,6 @@
 				"core/post-excerpt": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
-				"core/post-time-to-read": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
-				},
 				"core/post-featured-image": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
@@ -1071,6 +1068,9 @@
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/post-terms": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-time-to-read": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/post-title": {
@@ -1880,9 +1880,6 @@
 			"description": "Styles defined on a per-block basis using the block's selector.",
 			"type": "object",
 			"properties": {
-				"core/archives": {
-					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
-				},
 				"core/accordion": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
@@ -1893,6 +1890,9 @@
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
 				"core/accordion-panel": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/archives": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
 				"core/audio": {
@@ -2000,9 +2000,6 @@
 				"core/image": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
-				"core/math": {
-					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
-				},
 				"core/latest-comments": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
@@ -2016,6 +2013,9 @@
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
 				"core/loginout": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/math": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
 				"core/media-text": {
@@ -2078,9 +2078,6 @@
 				"core/post-excerpt": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
-				"core/post-time-to-read": {
-					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
-				},
 				"core/post-featured-image": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
@@ -2091,6 +2088,9 @@
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
 				"core/post-terms": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-time-to-read": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
 				"core/post-title": {
@@ -2324,6 +2324,18 @@
 		"stylesVariationBlocksPropertiesComplete": {
 			"type": "object",
 			"properties": {
+				"core/accordion": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/accordion-heading": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/accordion-item": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/accordion-panel": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
 				"core/archives": {
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
 				},
@@ -2447,6 +2459,9 @@
 				"core/loginout": {
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
 				},
+				"core/math": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
 				"core/media-text": {
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
 				},
@@ -2517,6 +2532,9 @@
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
 				},
 				"core/post-terms": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/post-time-to-read": {
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
 				},
 				"core/post-title": {
@@ -2598,6 +2616,18 @@
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
 				},
 				"core/term-description": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/term-count": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/term-name": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/term-template": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/terms-query": {
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
 				},
 				"core/text-columns": {

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -863,6 +863,18 @@
 				"core/archives": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
+				"core/accordion": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/accordion-heading": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/accordion-item": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/accordion-panel": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
 				"core/audio": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
@@ -968,6 +980,9 @@
 				"core/image": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
+				"core/math": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
 				"core/latest-comments": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
@@ -1041,6 +1056,9 @@
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/post-excerpt": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-time-to-read": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/post-featured-image": {
@@ -1134,6 +1152,18 @@
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/term-description": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/term-count": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/term-name": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/term-template": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/terms-query": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/text-columns": {
@@ -1853,6 +1883,18 @@
 				"core/archives": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
+				"core/accordion": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/accordion-heading": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/accordion-item": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/accordion-panel": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
 				"core/audio": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
@@ -1958,6 +2000,9 @@
 				"core/image": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
+				"core/math": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
 				"core/latest-comments": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
@@ -2031,6 +2076,9 @@
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
 				"core/post-excerpt": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-time-to-read": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
 				"core/post-featured-image": {
@@ -2124,6 +2172,18 @@
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
 				"core/term-description": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/term-count": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/term-name": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/term-template": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/terms-query": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
 				"core/text-columns": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #72562

This PR adds missing block entries to the JSON theme schema so these core blocks are exposed to theme-level settings and styles:


- core/accordion
- core/accordion-heading
- core/accordion-item
- core/accordion-panel
- core/math
- core/post-time-to-read
- core/term-count
- core/term-name
- core/term-template
- core/terms-query

<!-- In a few words, what is the PR actually doing? -->

## Why?

- Missing schema entries reported in #72562
- Better theme support and validation for recently added core blocks (accordion, math, time-to-read, terms-related blocks, etc.)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
