### PR TITLE
iAPI: Don't use deprecated `data-wp-on-async` in docs

### DIFF
--- a/docs/reference-guides/interactivity-api/api-reference.md
+++ b/docs/reference-guides/interactivity-api/api-reference.md
@@ -351,7 +351,7 @@ The returned value is used to change the inner content of the element: `<div>val
 ### `wp-on`
 
 <div class="callout callout-info">
-  Consider using the more performant <a href="#wp-on-async"><code>wp-on-async</code></a> instead if your directive code does not need synchronous access to the event object. If synchronous access is required, consider implementing an <a href="#async-actions"><code>async action</code></a> which yields to the main thread after calling the synchronous API.
+  This directive runs asynchronously by default to improve performance. If you need synchronous access to the <code>event</code> object, consider implementing an <a href="#async-actions"><code>async action</code></a> which yields to the main thread after calling the synchronous API.
 </div>
 
 This directive runs code on dispatched DOM events like `click` or `keyup`. The syntax is `data-wp-on--[event]` (like `data-wp-on--click` or `data-wp-on--keyup`).
@@ -381,14 +381,10 @@ The `wp-on` directive is executed each time the associated event is triggered.
 
 The callback passed as the reference receives [the event](https://developer.mozilla.org/en-US/docs/Web/API/Event) (`event`), and the returned value by this callback is ignored.
 
-### `wp-on-async`
-
-This directive is a more performant approach for `wp-on`. It immediately yields to main to avoid contributing to a long task, allowing other interactions that otherwise would be waiting on the main thread to run sooner. Use this async version whenever there is no need for synchronous access to the `event` object, in particular the methods `event.preventDefault()`, `event.stopPropagation()`, and `event.stopImmediatePropagation()`.
-
 ### `wp-on-window`
 
 <div class="callout callout-info">
-  Consider using the more performant <a href="#wp-on-async-window"><code>wp-on-async-window</code></a> instead if your directive code does not need synchronous access to the event object. If synchronous access is required, consider implementing an <a href="#async-actions"><code>async action</code></a> which yields to the main thread after calling the synchronous API.
+  This directive runs asynchronously by default to improve performance. If you need synchronous access to the <code>event</code> object, consider implementing an <a href="#async-actions"><code>async action</code></a> which yields to the main thread after calling the synchronous API.
 </div>
 
 This directive allows you to attach global window events like `resize`, `copy`, and `focus` and then execute a defined callback when those happen.
@@ -418,14 +414,10 @@ store( 'myPlugin', {
 
 The callback passed as the reference receives [the event](https://developer.mozilla.org/en-US/docs/Web/API/Event) (`event`), and the returned value by this callback is ignored. When the element is removed from the DOM, the event listener is also removed.
 
-### `wp-on-async-window`
-
-Similar to `wp-on-async`, this is an optimized version of `wp-on-window` that immediately yields to main to avoid contributing to a long task. Use this async version whenever there is no need for synchronous access to the `event` object, in particular the methods `event.preventDefault()`, `event.stopPropagation()`, and `event.stopImmediatePropagation()`. This event listener is also added as [`passive`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#passive).
-
 ### `wp-on-document`
 
 <div class="callout callout-info">
-  Consider using the more performant <a href="#wp-on-async-document"><code>wp-on-async-document</code></a> instead if your directive code does not need synchronous access to the event object. If synchronous access is required, consider implementing an <a href="#async-actions"><code>async action</code></a> which yields to the main thread after calling the synchronous API.
+  This directive runs asynchronously by default to improve performance. If you need synchronous access to the <code>event</code> object, consider implementing an <a href="#async-actions"><code>async action</code></a> which yields to the main thread after calling the synchronous API.
 </div>
 
 This directive allows you to attach global document events like `scroll`, `mousemove`, and `keydown` and then execute a defined callback when those happen.
@@ -454,10 +446,6 @@ store( 'myPlugin', {
 </details>
 
 The callback passed as the reference receives [the event](https://developer.mozilla.org/en-US/docs/Web/API/Event) (`event`), and the returned value by this callback is ignored. When the element is removed from the DOM, the event listener is also removed.
-
-### `wp-on-async-document`
-
-Similar to `wp-on-async`, this is an optimized version of `wp-on-document` that immediately yields to main to avoid contributing to a long task. Use this async version whenever there is no need for synchronous access to the `event` object, in particular the methods `event.preventDefault()`, `event.stopPropagation()`, and `event.stopImmediatePropagation()`. This event listener is also added as [`passive`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#passive).
 
 ### `wp-watch`
 

--- a/docs/reference-guides/interactivity-api/api-reference.md
+++ b/docs/reference-guides/interactivity-api/api-reference.md
@@ -351,7 +351,7 @@ The returned value is used to change the inner content of the element: `<div>val
 ### `wp-on`
 
 <div class="callout callout-info">
-  This directive runs asynchronously by default to improve performance. If you need synchronous access to the <code>event</code> object, consider implementing an <a href="#async-actions"><code>async action</code></a> which yields to the main thread after calling the synchronous API.
+  This directive runs asynchronously by default to improve performance. If you need synchronous access to the <code>event</code> object, use <a href="#withsyncevent"><code>withSyncEvent()</code></a> to wrap your action. For async actions that also need synchronous event access, you can combine <code>withSyncEvent()</code> with a <a href="#async-actions">generator function</a> that yields to the main thread after calling the synchronous API.
 </div>
 
 This directive runs code on dispatched DOM events like `click` or `keyup`. The syntax is `data-wp-on--[event]` (like `data-wp-on--click` or `data-wp-on--keyup`).
@@ -384,7 +384,7 @@ The callback passed as the reference receives [the event](https://developer.mozi
 ### `wp-on-window`
 
 <div class="callout callout-info">
-  This directive runs asynchronously by default to improve performance. If you need synchronous access to the <code>event</code> object, consider implementing an <a href="#async-actions"><code>async action</code></a> which yields to the main thread after calling the synchronous API.
+  This directive runs asynchronously by default to improve performance. If you need synchronous access to the <code>event</code> object, use <a href="#withsyncevent"><code>withSyncEvent()</code></a> to wrap your action. For async actions that also need synchronous event access, you can combine <code>withSyncEvent()</code> with a <a href="#async-actions">generator function</a> that yields to the main thread after calling the synchronous API.
 </div>
 
 This directive allows you to attach global window events like `resize`, `copy`, and `focus` and then execute a defined callback when those happen.
@@ -417,7 +417,7 @@ The callback passed as the reference receives [the event](https://developer.mozi
 ### `wp-on-document`
 
 <div class="callout callout-info">
-  This directive runs asynchronously by default to improve performance. If you need synchronous access to the <code>event</code> object, consider implementing an <a href="#async-actions"><code>async action</code></a> which yields to the main thread after calling the synchronous API.
+  This directive runs asynchronously by default to improve performance. If you need synchronous access to the <code>event</code> object, use <a href="#withsyncevent"><code>withSyncEvent()</code></a> to wrap your action. For async actions that also need synchronous event access, you can combine <code>withSyncEvent()</code> with a <a href="#async-actions">generator function</a> that yields to the main thread after calling the synchronous API.
 </div>
 
 This directive allows you to attach global document events like `scroll`, `mousemove`, and `keydown` and then execute a defined callback when those happen.
@@ -1274,6 +1274,23 @@ store( 'myPlugin', {
 		logSomething: () => {
 			console.log( 'something' );
 		},
+	},
+} );
+```
+
+You can also use `withSyncEvent()` with generator functions (async actions). This is useful when you need both synchronous event access and asynchronous operations:
+
+```js
+import { store, withSyncEvent } from '@wordpress/interactivity';
+
+store( 'myPlugin', {
+	actions: {
+		// Combining withSyncEvent with a generator function for async operations.
+		navigate: withSyncEvent( function* ( event ) {
+			event.preventDefault();
+			const { actions } = yield import( '@wordpress/interactivity-router' );
+			yield actions.navigate( event.target.href );
+		} ),
 	},
 } );
 ```

--- a/docs/reference-guides/interactivity-api/core-concepts/server-side-rendering.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/server-side-rendering.md
@@ -118,10 +118,10 @@ One of the key strengths of the Interactivity API is how it bridges the gap betw
 Let's extend this example to include a button that the user can click to add a new fruit to the list:
 
 ```html
-<button data-wp-on-async--click="actions.addMango">Add Mango</button>
+<button data-wp-on--click="actions.addMango">Add Mango</button>
 ```
 
-This new button has a `data-wp-on-async--click` directive that references `actions.addMango`, which is defined in our JavaScript store:
+This new button has a `data-wp-on--click` directive that references `actions.addMango`, which is defined in our JavaScript store:
 
 ```javascript
 const { state } = store( 'myFruitPlugin', {
@@ -182,7 +182,7 @@ _Please, visit the [Understanding global state, local context and derived state]
 Let's imagine adding a button that can delete all fruits:
 
 ```html
-<button data-wp-on-async--click="actions.deleteFruits">
+<button data-wp-on--click="actions.deleteFruits">
 	Delete all fruits
 </button>
 ```
@@ -325,10 +325,10 @@ wp_interactivity_state( 'myFruitPlugin', array(
 ?>
 
 <div data-wp-interactive="myFruitPlugin">
-  <button data-wp-on-async--click="actions.deleteFruits">
+  <button data-wp-on--click="actions.deleteFruits">
     <?php echo __( 'Delete all fruits' ); ?>
   </button>
-  <button data-wp-on-async--click="actions.addMango">
+  <button data-wp-on--click="actions.addMango">
     <?php echo __( 'Add Mango' ); ?>
   </button>
   <ul data-wp-bind--hidden="!state.hasFruits">

--- a/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md
@@ -759,17 +759,17 @@ Let's consider a quiz that has multiple questions. Each question is a separate p
 ```javascript
 import { store, getServerState, withSyncEvent } from '@wordpress/interactivity';
 
-store( 'myPlugin', {
+const { state } = store( 'myPlugin', {
 	actions: {
 		// This action would be triggered by a directive, like:
-		// <button data-wp-on-click="actions.nextQuestion">Next Question</button>
-		*nextQuestion() {
-			withSyncEvent( () => event.preventDefault( event ) );
+		// <button data-wp-on--click="actions.nextQuestion">Next Question</button>
+		nextQuestion: withSyncEvent( function* ( event ) {
+			event.preventDefault();
 			const { actions } = yield import(
 				'@wordpress/interactivity-router'
 			);
 			actions.navigate( '/question-2' );
-		},
+		} ),
 	},
 	callbacks: {
 		// This callback would be triggered by a directive, like:
@@ -785,7 +785,7 @@ store( 'myPlugin', {
 } );
 ```
 
-_Please note that, when working with synchronous events in the Interactivity API, `withSyncEvent` is used to handle the event properly and prevent potential issues with event propagation and timing._
+_Note: Actions that need to call synchronous event methods like `event.preventDefault()` must wrap the handler with `withSyncEvent()`. See the [withSyncEvent() documentation](/docs/reference-guides/interactivity-api/api-reference.md#withsyncevent) for details._
 
 ### `getServerContext()`
 
@@ -802,19 +802,19 @@ Consider a quiz that has multiple questions. Each question is a separate page. W
 ```
 
 ```javascript
-import { store, getServerContext, withSyncEvent } from '@wordpress/interactivity';
+import { store, getContext, getServerContext, withSyncEvent } from '@wordpress/interactivity';
 
 store( 'myPlugin', {
 	actions: {
 		// This action would be triggered by a directive, like:
-		// <button data-wp-on-click="actions.nextQuestion">Next Question</button>
-		*nextQuestion() {
-			withSyncEvent( () => event.preventDefault( event ) );
+		// <button data-wp-on--click="actions.nextQuestion">Next Question</button>
+		nextQuestion: withSyncEvent( function* ( event ) {
+			event.preventDefault();
 			const { actions } = yield import(
 				'@wordpress/interactivity-router'
 			);
 			actions.navigate( '/question-2' );
-		},
+		} ),
 	},
 	callbacks: {
 		// This callback would be triggered by a directive, like:

--- a/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md
@@ -49,7 +49,7 @@ You should use global state when:
         	<div data-wp-bind--hidden="!state.show">
         		Hello <span data-wp-text="state.helloText"></span>
         	</div>
-        	<button data-wp-on-async--click="actions.toggle">Toggle</button>
+        	<button data-wp-on--click="actions.toggle">Toggle</button>
         </div>
         ```
 
@@ -64,7 +64,7 @@ You should use global state when:
         	<div hidden data-wp-bind--hidden="!state.show">
         		Hello <span data-wp-text="state.helloText">world</span>
         	</div>
-        	<button data-wp-on-async--click="actions.toggle">Toggle</button>
+        	<button data-wp-on--click="actions.toggle">Toggle</button>
         </div>
         ```
 
@@ -219,7 +219,7 @@ In this example, there are two independent interactive blocks. One displays a co
       data-wp-interactive="myCounterPlugin"
       <?php echo get_block_wrapper_attributes(); ?>
     >
-      <button data-wp-on-async--click="actions.increment">
+      <button data-wp-on--click="actions.increment">
         Increment
       </button>
     </div>
@@ -239,7 +239,7 @@ In this example:
 
 1. The global state is initialized on the server using `wp_interactivity_state`, setting an initial `counter` of 0.
 2. The Counter Block displays the current counter using `data-wp-text="state.counter"`, which reads from the global state.
-3. The Increment Block contains a button that triggers the `increment` action when clicked, using `data-wp-on-async--click="actions.increment"`.
+3. The Increment Block contains a button that triggers the `increment` action when clicked, using `data-wp-on--click="actions.increment"`.
 4. In JavaScript, the `increment` action directly modifies the global state by incrementing `state.counter`.
 
 Both blocks are independent and can be placed anywhere on the page. They don't need to be nested or directly related in the DOM structure. Multiple instances of these interactive blocks can be added to the page, and they will all share and update the same global counter value.
@@ -363,7 +363,7 @@ In this example, there is a single interactive block that shows a counter and ca
   data-wp-context='{ "counter": 0 }'
 >
   <p>Counter: <span data-wp-text="context.counter"></span></p>
-  <button data-wp-on-async--click="actions.increment">Increment</button>
+  <button data-wp-on--click="actions.increment">Increment</button>
 </div>
 ```
 
@@ -382,7 +382,7 @@ In this example:
 
 1. A local context with an initial `counter` value of `0` is defined using the `data-wp-context` directive.
 2. The counter is displayed using `data-wp-text="context.counter"`, which reads from the local context.
-3. The increment button uses `data-wp-on-async--click="actions.increment"` to trigger the increment action.
+3. The increment button uses `data-wp-on--click="actions.increment"` to trigger the increment action.
 4. In JavaScript, the `getContext` function is used to access and modify the local context for each block instance.
 
 A user will be able to add multiple instances of this block to a page, and each will maintain its own independent counter. Clicking the "Increment" button on one block will only affect that specific block's counter and not the others.
@@ -675,7 +675,7 @@ store( 'myCounterPlugin', {
 		Double: <span data-wp-text="state.double"></span>
 
 		<!-- This button will increment the local counter. -->
-		<button data-wp-on-async--click="actions.increment">Increment</button>
+		<button data-wp-on--click="actions.increment">Increment</button>
 	</div>
 
 	<!-- This will render "Double: 4" -->
@@ -683,7 +683,7 @@ store( 'myCounterPlugin', {
 		Double: <span data-wp-text="state.double"></span>
 
 		<!-- This button will increment the local counter. -->
-		<button data-wp-on-async--click="actions.increment">Increment</button>
+		<button data-wp-on--click="actions.increment">Increment</button>
 	</div>
 </div>
 ```
@@ -757,14 +757,14 @@ Let's consider a quiz that has multiple questions. Each question is a separate p
 ```
 
 ```javascript
-import { store, getServerState } from '@wordpress/interactivity';
+import { store, getServerState, withSyncEvent } from '@wordpress/interactivity';
 
 store( 'myPlugin', {
 	actions: {
 		// This action would be triggered by a directive, like:
 		// <button data-wp-on-click="actions.nextQuestion">Next Question</button>
 		*nextQuestion() {
-			event.preventDefault( event );
+			withSyncEvent( () => event.preventDefault( event ) );
 			const { actions } = yield import(
 				'@wordpress/interactivity-router'
 			);
@@ -785,6 +785,8 @@ store( 'myPlugin', {
 } );
 ```
 
+_Please note that, when working with synchronous events in the Interactivity API, `withSyncEvent` is used to handle the event properly and prevent potential issues with event propagation and timing._
+
 ### `getServerContext()`
 
 `getServerContext()` allows you to subscribe to changes in the **local context** that occur during client-side navigation. This function is analogous to `getServerState()`, but it works with the local context instead of the global state.
@@ -800,14 +802,14 @@ Consider a quiz that has multiple questions. Each question is a separate page. W
 ```
 
 ```javascript
-import { store, getServerContext } from '@wordpress/interactivity';
+import { store, getServerContext, withSyncEvent } from '@wordpress/interactivity';
 
 store( 'myPlugin', {
 	actions: {
 		// This action would be triggered by a directive, like:
 		// <button data-wp-on-click="actions.nextQuestion">Next Question</button>
 		*nextQuestion() {
-			event.preventDefault( event );
+			withSyncEvent( () => event.preventDefault( event ) );
 			const { actions } = yield import(
 				'@wordpress/interactivity-router'
 			);


### PR DESCRIPTION
Closes #72413

## What?

Since the `data-wp-on-async` and related directives are now deprecated, I updated the relevant document to use the recommended approach. 

## How?

Removed `async` directives from all code examples and added notes about where we should use `withSyncEvent`.

## Testing Instructions

No tests needed.