### PR TITLE
Update: Label of "Move to trash" action to "Trash".

### DIFF
--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -818,7 +818,7 @@ The user facing description of the action.
 
 ```js
 {
-	label: Move to Trash
+	label: Trash
 }
 ```
 

--- a/packages/fields/src/actions/trash-post.tsx
+++ b/packages/fields/src/actions/trash-post.tsx
@@ -23,7 +23,7 @@ import type { CoreDataError, PostWithPermissions } from '../types';
 
 const trashPost: Action< PostWithPermissions > = {
 	id: 'move-to-trash',
-	label: __( 'Move to trash' ),
+	label: __( 'Trash' ),
 	isPrimary: true,
 	icon: trash,
 	isEligible( item ) {

--- a/test/e2e/specs/editor/various/change-detection.spec.js
+++ b/test/e2e/specs/editor/various/change-detection.spec.js
@@ -414,7 +414,7 @@ test.describe( 'Change detection', () => {
 			.click();
 		await page
 			.getByRole( 'menu' )
-			.getByRole( 'menuitem', { name: 'Move to trash' } )
+			.getByRole( 'menuitem', { name: 'Trash' } )
 			.click();
 		await page
 			.getByRole( 'dialog' )

--- a/test/e2e/specs/site-editor/template-registration.spec.js
+++ b/test/e2e/specs/site-editor/template-registration.spec.js
@@ -94,7 +94,7 @@ test.describe( 'Block template registration', () => {
 		);
 		const searchResults = page.getByLabel( 'Actions' );
 		await searchResults.first().click();
-		await page.getByRole( 'menuitem', { name: 'Move to trash' } ).click();
+		await page.getByRole( 'menuitem', { name: 'Trash' } ).click();
 		await page.getByRole( 'button', { name: 'Trash' } ).click();
 
 		await expect( resetNotice ).toBeVisible();
@@ -228,7 +228,7 @@ test.describe( 'Block template registration', () => {
 		);
 		const searchResults = page.getByLabel( 'Actions' );
 		await searchResults.first().click();
-		await page.getByRole( 'menuitem', { name: 'Move to trash' } ).click();
+		await page.getByRole( 'menuitem', { name: 'Trash' } ).click();
 		await page.getByRole( 'button', { name: 'Trash' } ).click();
 
 		await expect( deletedNotice ).toBeVisible();
@@ -350,7 +350,7 @@ test.describe( 'Block template registration', () => {
 			.click();
 		const actions = page.getByLabel( 'Actions' );
 		await actions.first().click();
-		await page.getByRole( 'menuitem', { name: 'Move to trash' } ).click();
+		await page.getByRole( 'menuitem', { name: 'Trash' } ).click();
 		await page.getByRole( 'button', { name: 'Trash' } ).click();
 
 		await expect( resetNotice ).toBeVisible();


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/72539
Updates the label of "Move to trash" action to "Trash".



## Testing Instructions
Go to /wp-admin/site-editor.php?p=%2Fpage
Hover a page and very the action to tash is labeled as "Trash".
Select multiple pages and verify the action is still labeled "Trash".