### PR TITLE
Update: Hide primary action buttons on mobile

### DIFF
--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -260,7 +260,7 @@ function PrimaryActions< Item >( {
 	registry,
 }: PrimaryActionsProps< Item > ) {
 	const [ activeModalAction, setActiveModalAction ] = useState( null as any );
-	const isMobileViewport = useViewportMatch( 'small', '<' );
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
 
 	if ( isMobileViewport ) {
 		return null;

--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -16,6 +16,7 @@ import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from '@wordpress/element';
 import { moreVertical } from '@wordpress/icons';
 import { useRegistry } from '@wordpress/data';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -259,6 +260,12 @@ function PrimaryActions< Item >( {
 	registry,
 }: PrimaryActionsProps< Item > ) {
 	const [ activeModalAction, setActiveModalAction ] = useState( null as any );
+	const isMobileViewport = useViewportMatch( 'small', '<' );
+
+	if ( isMobileViewport ) {
+		return null;
+	}
+
 	if ( ! Array.isArray( actions ) || actions.length === 0 ) {
 		return null;
 	}


### PR DESCRIPTION
This is a simple PR to not render the primary action buttons on smaller than medium viewports (actions are still rendered on the ellipsis menu).


## Screenshots or screencast <!-- if applicable -->
<img width="614" height="953" alt="Screenshot 2025-10-22 at 16 41 52" src="https://github.com/user-attachments/assets/52afdd02-07fb-421e-a68d-dee3b5913763" />
