### PR TITLE
Try adding attributes to private block context

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -813,6 +813,7 @@ function BlockListBlockProvider( props ) {
 		canMove,
 		isBlockHidden,
 		bindableAttributes,
+		attributes,
 	};
 
 	if (

--- a/packages/block-editor/src/components/block-title/use-block-display-title.js
+++ b/packages/block-editor/src/components/block-title/use-block-display-title.js
@@ -6,11 +6,13 @@ import {
 	__experimentalGetBlockLabel as getBlockLabel,
 	store as blocksStore,
 } from '@wordpress/blocks';
+import { useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { PrivateBlockContext } from '../block-list/private-block-context';
 
 /**
  * Returns the block's configured title as a string, or empty if the title
@@ -33,24 +35,38 @@ export default function useBlockDisplayTitle( {
 	maximumLength,
 	context,
 } ) {
+	// Try to get from context to avoid subscription when available
+	const privateContext = useContext( PrivateBlockContext );
+	const contextClientId = privateContext?.clientId;
+	const contextName = privateContext?.name;
+	const contextAttributes = privateContext?.attributes;
+
 	const blockTitle = useSelect(
 		( select ) => {
 			if ( ! clientId ) {
 				return null;
 			}
 
-			const { getBlockName, getBlockAttributes } =
-				select( blockEditorStore );
+			// Use context if available, otherwise get both from store in one call
+			let blockName, attributes;
+			if ( contextClientId === clientId ) {
+				blockName = contextName;
+				attributes = contextAttributes;
+			} else {
+				const { getBlockName, getBlockAttributes } =
+					select( blockEditorStore );
+				blockName = getBlockName( clientId );
+				attributes = getBlockAttributes( clientId );
+			}
+
 			const { getBlockType, getActiveBlockVariation } =
 				select( blocksStore );
 
-			const blockName = getBlockName( clientId );
 			const blockType = getBlockType( blockName );
 			if ( ! blockType ) {
 				return null;
 			}
 
-			const attributes = getBlockAttributes( clientId );
 			const label = getBlockLabel( blockType, attributes, context );
 			// If the label is defined we prioritize it over a possible block variation title match.
 			if ( label !== blockType.title ) {
@@ -61,7 +77,7 @@ export default function useBlockDisplayTitle( {
 			// Label will fallback to the title if no label is defined for the current label context.
 			return match?.title || blockType.title;
 		},
-		[ clientId, context ]
+		[ clientId, context, contextClientId, contextName, contextAttributes ]
 	);
 
 	if ( ! blockTitle ) {

--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -9,11 +9,13 @@ import {
 	__experimentalGetBlockLabel as getBlockLabel,
 } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
+import { useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { PrivateBlockContext } from '../block-list/private-block-context';
 
 /** @typedef {import('@wordpress/blocks').WPIcon} WPIcon */
 
@@ -66,21 +68,36 @@ function getPositionTypeLabel( attributes ) {
  */
 
 export default function useBlockDisplayInformation( clientId ) {
+	// Try to get from context to avoid subscription when available
+	const privateContext = useContext( PrivateBlockContext );
+	const contextClientId = privateContext?.clientId;
+	const contextName = privateContext?.name;
+	const contextAttributes = privateContext?.attributes;
+
 	return useSelect(
 		( select ) => {
 			if ( ! clientId ) {
 				return null;
 			}
-			const { getBlockName, getBlockAttributes } =
-				select( blockEditorStore );
+
+			// Use context if available, otherwise get both from store in one call
+			let blockName, attributes;
+			if ( contextClientId === clientId ) {
+				blockName = contextName;
+				attributes = contextAttributes;
+			} else {
+				const { getBlockName, getBlockAttributes } =
+					select( blockEditorStore );
+				blockName = getBlockName( clientId );
+				attributes = getBlockAttributes( clientId );
+			}
+
 			const { getBlockType, getActiveBlockVariation } =
 				select( blocksStore );
-			const blockName = getBlockName( clientId );
 			const blockType = getBlockType( blockName );
 			if ( ! blockType ) {
 				return null;
 			}
-			const attributes = getBlockAttributes( clientId );
 			const match = getActiveBlockVariation( blockName, attributes );
 			const isSynced =
 				isReusableBlock( blockType ) || isTemplatePart( blockType );
@@ -114,6 +131,6 @@ export default function useBlockDisplayInformation( clientId ) {
 				name: attributes?.metadata?.name,
 			};
 		},
-		[ clientId ]
+		[ clientId, contextClientId, contextName, contextAttributes ]
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Trying something :) I want to see if putting block attributes in the private context improves performance without breaking anything.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
