### PR TITLE
Fix build command for tokens package on Windows

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -52,6 +52,6 @@
 		"access": "public"
 	},
 	"scripts": {
-		"build": "rimraf src/prebuilt docs && node bin/build-tokens.js && prettier --write tokens/color.json src/prebuilt/* docs/*"
+		"build": "rimraf src/prebuilt docs && node bin/build-tokens.js && prettier --write tokens/color.json 'src/prebuilt/**' 'docs/*'"
 	}
 }

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -52,6 +52,6 @@
 		"access": "public"
 	},
 	"scripts": {
-		"build": "rimraf src/prebuilt docs && node bin/build-tokens.js && prettier --write tokens/color.json 'src/prebuilt/**' 'docs/*'"
+		"build": "rimraf src/prebuilt docs && node bin/build-tokens.js && prettier --write tokens/color.json src/prebuilt docs"
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes an issue where the `@wordpress/theme` package `build` script fails on Windows.

Follow-up to #72305 

## Why?

So that builds will pass.

Related Slack thread: https://wordpress.slack.com/archives/C02RQBWTW/p1761156071684359

## How?

Avoids `*` which expands in non-Windows environment. The result should be the same by passing just the directory names.

## Testing Instructions

`npm run --workspace @wordpress/theme build` should not fail.

Also check that making formatting changes to the affected files in `packages/theme/src/prebuilt` and then rerunning the command will apply Prettier formatting as expected.