### PR TITLE
Block Notes: Fix issue where box shadow is cut off when active note is the last one.

### DIFF
--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -16,7 +16,7 @@
 }
 
 .editor-collab-sidebar-panel {
-	padding: $grid-unit-20;
+	padding: $grid-unit-20 $grid-unit-20 $grid-unit-30;
 	height: 100%;
 	overflow: hidden;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #72530 

<!-- In a few words, what is the PR actually doing? -->
This PR adjusts the bottom padding on the Notes sidebar panel so that there's enough room for the box shadow to be fully displayed when the active note is the last note in the list of notes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Please refer to #72530 

> If you select and/or focus a comment in the canvas, it has a white background and a drop shadow. This shadow is slighty cropped at the bottom

## Testing Instructions
1. Open a post or page
2. Add a note to a block
3. In the Comments sidebar, select the last note to make it active.
4. Confirm that the drop shadow beneath the note isn't cut off visually.
