### PR TITLE
Post Date: Fix variations for Query Loop

### DIFF
--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -23,7 +23,19 @@ import { list, grid } from '@wordpress/icons';
 
 const TEMPLATE = [
 	[ 'core/post-title' ],
-	[ 'core/post-date' ],
+	[
+		'core/post-date',
+		{
+			metadata: {
+				bindings: {
+					datetime: {
+						source: 'core/post-data',
+						args: { field: 'date' },
+					},
+				},
+			},
+		},
+	],
 	[ 'core/post-excerpt' ],
 ];
 

--- a/packages/block-library/src/query/index.js
+++ b/packages/block-library/src/query/index.js
@@ -51,6 +51,16 @@ export const settings = {
 					},
 					{
 						name: 'core/post-date',
+						attributes: {
+							metadata: {
+								bindings: {
+									datetime: {
+										source: 'core/post-data',
+										args: { field: 'date' },
+									},
+								},
+							},
+						},
 					},
 					{
 						name: 'core/post-excerpt',

--- a/packages/block-library/src/query/variations.js
+++ b/packages/block-library/src/query/variations.js
@@ -13,6 +13,20 @@ import {
 	imageDateTitle,
 } from './icons';
 
+const postDate = [
+	'core/post-date',
+	{
+		metadata: {
+			bindings: {
+				datetime: {
+					source: 'core/post-data',
+					args: { field: 'date' },
+				},
+			},
+		},
+	},
+];
+
 const variations = [
 	{
 		name: 'title-date',
@@ -20,11 +34,7 @@ const variations = [
 		icon: titleDate,
 		attributes: {},
 		innerBlocks: [
-			[
-				'core/post-template',
-				{},
-				[ [ 'core/post-title' ], [ 'core/post-date' ] ],
-			],
+			[ 'core/post-template', {}, [ [ 'core/post-title' ], postDate ] ],
 			[ 'core/query-pagination' ],
 			[ 'core/query-no-results' ],
 		],
@@ -55,11 +65,7 @@ const variations = [
 			[
 				'core/post-template',
 				{},
-				[
-					[ 'core/post-title' ],
-					[ 'core/post-date' ],
-					[ 'core/post-excerpt' ],
-				],
+				[ [ 'core/post-title' ], postDate, [ 'core/post-excerpt' ] ],
 			],
 			[ 'core/query-pagination' ],
 			[ 'core/query-no-results' ],
@@ -77,7 +83,7 @@ const variations = [
 				{},
 				[
 					[ 'core/post-featured-image' ],
-					[ 'core/post-date' ],
+					postDate,
 					[ 'core/post-title' ],
 				],
 			],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/70585

The above PR essentially updated the default value of `Post Date` block from published date to a custom date. This PR updates the post date instances that should be the post's published date.

## Testing Instructions
1. Insert Query Loop block and select `Start blank`
2. Select any variation with `date`
3. Observe that the used date is the published date
4. Check front end too

