### PR TITLE
Block Bindings: Add `bindableAttributes` in preview context

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -633,6 +633,7 @@ function BlockListBlockProvider( props ) {
 					: undefined,
 				blockTitle: blockType?.title,
 				isBlockHidden: attributes?.metadata?.blockVisibility === false,
+				bindableAttributes,
 			};
 
 			// When in preview mode, we can avoid a lot of selection and
@@ -718,7 +719,6 @@ function BlockListBlockProvider( props ) {
 					? blocksWithSameName[ 0 ]
 					: false,
 				isBlockHidden: _isBlockHidden( clientId ),
-				bindableAttributes,
 			};
 		},
 		[ clientId, rootClientId ]


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/72351

This PR adds the `bindableAttributes` in `previewContext` as well. This results in bindings being processed properly in preview context such as block examples and block previews.

You can see the issue without this change in Query Loop block with `Post date` block, where we are showing the items in block previews:


https://github.com/user-attachments/assets/9529e9f8-da17-4a5f-a916-effdca6ead4f

### Notes

If I'm not missing something, the performance shouldn't be affected by this change, since the main fix in the original PR was about the select call. 



## Testing Instructions
1. An example is the above video
2. Insert Query Loop block and `Start blank`.
3. Select a variation with the `date`
4. Change the `date` to `Post Date` variation (this is fixed [here](https://github.com/WordPress/gutenberg/pull/72617))
5. Observe that the previews are correctly with the post's published date

