### PR TITLE
Add snackbar notices for page creation in Navigation block

### DIFF
--- a/packages/block-library/src/navigation-link/link-ui/page-creator.js
+++ b/packages/block-library/src/navigation-link/link-ui/page-creator.js
@@ -12,6 +12,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as noticesStore } from '@wordpress/notices';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useState } from '@wordpress/element';
 
@@ -57,6 +58,8 @@ export function LinkUIPageCreator( {
 	);
 
 	const { saveEntityRecord } = useDispatch( coreStore );
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
 
 	async function createPage( event ) {
 		event.preventDefault();
@@ -85,10 +88,23 @@ export function LinkUIPageCreator( {
 					kind: 'post-type',
 				};
 
+				// Show success notice
+				createSuccessNotice( __( 'Page created successfully.' ), {
+					type: 'snackbar',
+					id: 'page-created-success',
+				} );
+
 				onPageCreated( pageLink );
 			}
 		} catch ( error ) {
-			// Error handling is done via the data store selectors
+			// Show error notice
+			createErrorNotice(
+				__( 'Failed to create page. Please try again.' ),
+				{
+					type: 'snackbar',
+					id: 'page-created-error',
+				}
+			);
 		}
 	}
 

--- a/packages/block-library/src/navigation-link/link-ui/page-creator.js
+++ b/packages/block-library/src/navigation-link/link-ui/page-creator.js
@@ -89,10 +89,17 @@ export function LinkUIPageCreator( {
 				};
 
 				// Show success notice
-				createSuccessNotice( __( 'Page created successfully.' ), {
-					type: 'snackbar',
-					id: 'page-created-success',
-				} );
+				createSuccessNotice(
+					sprintf(
+						__( '%s page created successfully.' ),
+						decodeEntities( savedRecord.title.rendered )
+					),
+					{
+						type: 'snackbar',
+						id: 'page-created-success',
+					}
+				);
+
 
 				onPageCreated( pageLink );
 			}

--- a/packages/block-library/src/navigation-link/link-ui/page-creator.js
+++ b/packages/block-library/src/navigation-link/link-ui/page-creator.js
@@ -101,7 +101,6 @@ export function LinkUIPageCreator( {
 					}
 				);
 
-
 				onPageCreated( pageLink );
 			}
 		} catch ( error ) {

--- a/packages/block-library/src/navigation-link/link-ui/page-creator.js
+++ b/packages/block-library/src/navigation-link/link-ui/page-creator.js
@@ -91,6 +91,7 @@ export function LinkUIPageCreator( {
 				// Show success notice
 				createSuccessNotice(
 					sprintf(
+					// translators: %s: the name of the new page being created.
 						__( '%s page created successfully.' ),
 						decodeEntities( savedRecord.title.rendered )
 					),

--- a/packages/block-library/src/navigation-link/link-ui/page-creator.js
+++ b/packages/block-library/src/navigation-link/link-ui/page-creator.js
@@ -91,7 +91,7 @@ export function LinkUIPageCreator( {
 				// Show success notice
 				createSuccessNotice(
 					sprintf(
-					// translators: %s: the name of the new page being created.
+						// translators: %s: the name of the new page being created.
 						__( '%s page created successfully.' ),
 						decodeEntities( savedRecord.title.rendered )
 					),

--- a/packages/block-library/src/navigation-link/link-ui/page-creator.js
+++ b/packages/block-library/src/navigation-link/link-ui/page-creator.js
@@ -9,7 +9,7 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #72620

Adds snackbar notices to provide immediate feedback when users create a new page from the Navigation block.

## Why?

User testing with 20 participants revealed that users are uncertain whether page creation was successful when using the Navigation block's page creator. Without visual confirmation, users don't know if:
- The action completed successfully
- They need to wait longer
- They should try again

This lack of feedback creates confusion and a poor user experience, especially for less technical users who may not realize the page was created.

## How?

This PR adds snackbar notices to the `LinkUIPageCreator` component in `page-creator.js`:

- **Success notice**: Displays "Page created successfully." when the page is created
- **Error notice**: Displays "Failed to create page. Please try again." when creation fails
- Uses the existing `@wordpress/notices` store for consistency with other Gutenberg notifications
- Snackbar-style notices are non-intrusive and auto-dismiss after a few seconds

The implementation adds:
1. Import of `noticesStore` from `@wordpress/notices`
2. `useDispatch` hook to access `createSuccessNotice` and `createErrorNotice`
3. Success notice triggered after successful page creation
4. Error notice triggered in the catch block when creation fails

## Testing Instructions

1. Open a post or page in the editor
2. Insert a **Navigation** block
3. Click on the Navigation block to open the block settings
4. Click the **"+" button** to add a new page link
5. In the dropdown, click **"Create page"**
6. Enter a page title (e.g., "Test Page")
7. Click **"Create page"** button
8. **Expected**: A green snackbar notice appears at the bottom saying "Page created successfully."
9. The notice should auto-dismiss after a few seconds
10. Try creating another page to verify the notice appears consistently

### Test error scenario:
1. use browser dev tools to simulate network failure
2. Follow steps 1-7 above


### Testing Instructions for Keyboard

--------------------------------------------------------

## Screenshots or screencast
<img width="301" height="288" alt="Screenshot 2025-10-23 at 3 44 34 PM" src="https://github.com/user-attachments/assets/9c8b86f7-b5e2-447a-963c-daf3340a863f" />

|Before|After|
|-|-|
|No visual feedback after clicking "Create page" - users uncertain if action completed| snackbar appears at bottom: "Page created successfully." providing immediate confirmation|
|![Before: No feedback shown](link-to-before-screenshot)|![After: Success snackbar visible](link-to-after-screenshot)|

---

**Note**: This change addresses UX feedback from unmoderated user testing where participants expressed confusion about whether the page creation action had completed successfully.