### PR TITLE
PluginSidebar: Fix auto more menu item props

### DIFF
--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -291,6 +291,7 @@ function ComplementaryArea( {
 					target={ name }
 					scope={ scope }
 					icon={ icon }
+					identifier={ identifier }
 				>
 					{ title }
 				</ComplementaryAreaMoreMenuItem>


### PR DESCRIPTION
## What?
This is a follow-up to #29081.

PR fixes a bug where the plugin sidebar's more menu items couldn't toggle the sidebar when both `name` and `identifier` props are provided.

## Why?
The `ComplementaryAreaMoreMenuItem` was trying to derive the identifier from `name` instead of using the provided prop.

## Testing Instructions
1. Open a post or page.
2. Register a test plugin with the plugin sidebar.
3. Unpin and close the sidebar.
4. Confirm that you can re-enable the sidebar from the Options menu.

### Test Snippet
```js
const el = React.createElement;
const registerPlugin = wp.plugins.registerPlugin;
const PluginSidebar = wp.editor.PluginSidebar;

registerPlugin( 'my-plugin-sidebar', {
	render: function () {
		return el(
			PluginSidebar,
			{
				name: 'my-plugin-sidebar',
				identifier: 'test/my-plugin-sidebar',
				icon: 'smiley',
				title: 'My plugin sidebar',
			},
			'Meta field'
		);
	},
} );
```

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/ab914a45-0087-44a4-8398-01181efdca1c

