### PR TITLE
Post Date: Update logic when to show the `edit` control

### DIFF
--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -85,23 +85,23 @@ export default function PostDateEdit( {
 		postType,
 		siteFormat = dateSettings.formats.date,
 		siteTimeFormat = dateSettings.formats.time,
-		activeBlockVariationName,
 	} = useSelect(
 		( select ) => {
 			const { getPostType, getEntityRecord } = select( coreStore );
 			const siteSettings = getEntityRecord( 'root', 'site' );
-			const { getActiveBlockVariation } = select( blocksStore );
 			return {
 				siteFormat: siteSettings?.date_format,
 				siteTimeFormat: siteSettings?.time_format,
 				postType: postTypeSlug ? getPostType( postTypeSlug ) : null,
-				activeBlockVariationName: getActiveBlockVariation(
-					name,
-					attributes
-				)?.name,
 			};
 		},
-		[ postTypeSlug, name, attributes ]
+		[ postTypeSlug ]
+	);
+	const activeBlockVariationName = useSelect(
+		( select ) =>
+			select( blocksStore ).getActiveBlockVariation( name, attributes )
+				?.name,
+		[ name, attributes ]
 	);
 
 	const blockEditingMode = useBlockEditingMode();

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -35,6 +35,7 @@ import { __, _x, sprintf } from '@wordpress/i18n';
 import { pencil } from '@wordpress/icons';
 import { DOWN } from '@wordpress/keycodes';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { store as blocksStore } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -42,14 +43,12 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 export default function PostDateEdit( {
-	attributes: { datetime, textAlign, format, isLink, metadata },
+	attributes,
 	context: { postType: postTypeSlug, queryId },
 	setAttributes,
+	name,
 } ) {
-	const displayType =
-		metadata?.bindings?.datetime?.source === 'core/post-data' &&
-		metadata?.bindings?.datetime?.args?.field;
-
+	const { datetime, textAlign, format, isLink } = attributes;
 	const blockProps = useBlockProps( {
 		className: clsx( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
@@ -86,18 +85,23 @@ export default function PostDateEdit( {
 		postType,
 		siteFormat = dateSettings.formats.date,
 		siteTimeFormat = dateSettings.formats.time,
+		activeBlockVariationName,
 	} = useSelect(
 		( select ) => {
 			const { getPostType, getEntityRecord } = select( coreStore );
 			const siteSettings = getEntityRecord( 'root', 'site' );
-
+			const { getActiveBlockVariation } = select( blocksStore );
 			return {
 				siteFormat: siteSettings?.date_format,
 				siteTimeFormat: siteSettings?.time_format,
 				postType: postTypeSlug ? getPostType( postTypeSlug ) : null,
+				activeBlockVariationName: getActiveBlockVariation(
+					name,
+					attributes
+				)?.name,
 			};
 		},
-		[ postTypeSlug ]
+		[ postTypeSlug, name, attributes ]
 	);
 
 	const blockEditingMode = useBlockEditingMode();
@@ -120,7 +124,6 @@ export default function PostDateEdit( {
 			</a>
 		);
 	}
-
 	return (
 		<>
 			{ ( blockEditingMode === 'default' ||
@@ -133,15 +136,17 @@ export default function PostDateEdit( {
 						} }
 					/>
 
-					{ displayType !== 'modified' &&
-						! isDescendentOfQueryLoop && (
+					{ activeBlockVariationName !== 'post-date-modified' &&
+						( ! isDescendentOfQueryLoop ||
+							! activeBlockVariationName ) && (
 							<ToolbarGroup>
 								<Dropdown
 									popoverProps={ popoverProps }
 									renderContent={ ( { onClose } ) => (
 										<PublishDateTimePicker
 											title={
-												displayType === 'date'
+												activeBlockVariationName ===
+												'post-date'
 													? __( 'Publish Date' )
 													: __( 'Date' )
 											}

--- a/packages/block-library/src/post-date/variations.js
+++ b/packages/block-library/src/post-date/variations.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { postDate } from '@wordpress/icons';
 
 const variations = [
 	{
@@ -19,13 +18,12 @@ const variations = [
 				},
 			},
 		},
-		scope: [ 'block', 'inserter', 'transform' ],
+		scope: [ 'inserter', 'transform' ],
 		isActive: ( blockAttributes ) =>
 			blockAttributes?.metadata?.bindings?.datetime?.source ===
 				'core/post-data' &&
 			blockAttributes?.metadata?.bindings?.datetime?.args?.field ===
 				'date',
-		icon: postDate,
 	},
 	{
 		name: 'post-date-modified',
@@ -42,13 +40,12 @@ const variations = [
 			},
 			className: 'wp-block-post-date__modified-date',
 		},
-		scope: [ 'block', 'inserter', 'transform' ],
+		scope: [ 'inserter', 'transform' ],
 		isActive: ( blockAttributes ) =>
 			blockAttributes?.metadata?.bindings?.datetime?.source ===
 				'core/post-data' &&
 			blockAttributes?.metadata?.bindings?.datetime?.args?.field ===
 				'modified',
-		icon: postDate,
 	},
 ];
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Tiny code quality PR that updates the logic to show the `edit` control when inside Query Loop, but only for custom dates.



## Testing Instructions
1. Post Date should work as before
2. The `edit` control when inside Query Loop, should be visible for custom dates.

