### PR TITLE
Block Bindings: Add source label to the modal title UI.

### DIFF
--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -509,7 +509,10 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 				</Text>
 			</ToolsPanel>
 			{ RenderModalContent && (
-				<Modal onRequestClose={ handleCloseModal }>
+				<Modal
+					onRequestClose={ handleCloseModal }
+					title={ sources[ modalState.sourceKey ]?.label }
+				>
 					<RenderModalContent
 						attribute={ modalState.attribute }
 						closeModal={ handleCloseModal }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
The new Modal version of the Block Bindings UI misses a header, which seems to make the UI somewhat empty. As it contains a header with just the closing button.

This PR adds the source label as the Modal header, so the user knows what source is the modal UI referring to.

<!-- In a few words, what is the PR actually doing? -->

Before:
<img width="398" height="197" alt="Screenshot 2025-10-23 at 14 47 24" src="https://github.com/user-attachments/assets/95c0f8e6-938d-45c4-8ea6-337dc503980a" />

After:
<img width="460" height="253" alt="Screenshot 2025-10-23 at 14 47 10" src="https://github.com/user-attachments/assets/99e60e8e-d3e5-4c84-b11b-783418dd45af" />

