### PR TITLE
Don't subscribe to store unless fitText option is enabled

### DIFF
--- a/packages/block-editor/src/hooks/fit-text.js
+++ b/packages/block-editor/src/hooks/fit-text.js
@@ -66,12 +66,12 @@ function useFitText( { fitText, name, clientId } ) {
 	// Any attribute may change the available space.
 	const blockAttributes = useSelect(
 		( select ) => {
-			if ( ! clientId ) {
+			if ( ! clientId || ! hasFitTextSupport || ! fitText ) {
 				return;
 			}
 			return select( blockEditorStore ).getBlockAttributes( clientId );
 		},
-		[ clientId ]
+		[ clientId, hasFitTextSupport, fitText ]
 	);
 
 	const applyFitText = useCallback( () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
https://github.com/WordPress/gutenberg/pull/71904 added useFitText, which subscribes every block to monitor every attribute change, even if the option is disabled. 
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Perf cleanup.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
If the option is not enabled (true) or the block doesn't have fit text support, don't subscribe to the store.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
There should be no changes

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
