### PR TITLE
Template activation: remove the ability to deactivate registered templates

### DIFF
--- a/backport-changelog/6.9/8063.md
+++ b/backport-changelog/6.9/8063.md
@@ -12,3 +12,4 @@ https://github.com/WordPress/wordpress-develop/pull/8063
 * https://github.com/WordPress/gutenberg/pull/72223
 * https://github.com/WordPress/gutenberg/pull/72285
 * https://github.com/WordPress/gutenberg/pull/72674
+* https://github.com/WordPress/gutenberg/pull/72636

--- a/lib/compat/wordpress-6.9/template-activate.php
+++ b/lib/compat/wordpress-6.9/template-activate.php
@@ -260,16 +260,6 @@ function gutenberg_resolve_block_template( $template_type, $template_hierarchy, 
 	$specific_template = $object ? get_page_template_slug( $object ) : null;
 	$active_templates  = (array) get_option( 'active_templates', array() );
 
-	// Remove templates slugs that are deactivated, except if it's the specific
-	// template or index.
-	$slugs = array_filter(
-		$slugs,
-		function ( $slug ) use ( $specific_template, $active_templates ) {
-			$should_ignore = $slug === $specific_template || 'index' === $slug;
-			return $should_ignore || ( ! isset( $active_templates[ $slug ] ) || false !== $active_templates[ $slug ] );
-		}
-	);
-
 	// We expect one template for each slug. Use the active template if it is
 	// set and exists. Otherwise use the static template.
 	$templates       = array();
@@ -598,8 +588,6 @@ function gutenberg_get_block_template( $output, $id, $template_type ) {
 					return $template;
 				}
 			}
-		} elseif ( false === $active_templates[ $slug ] ) {
-			return null;
 		}
 	}
 	////////////////////////////

--- a/packages/edit-site/src/components/dataviews-actions/index.js
+++ b/packages/edit-site/src/components/dataviews-actions/index.js
@@ -38,10 +38,9 @@ export const useSetActiveTemplateAction = () => {
 					return false;
 				}
 
-				// If it's not a created template but a registered template
-				// (which means the source property is set), only allow
-				// activating (so when it's inactive).
-				if ( item.source ) {
+				// If it's not a created template but a registered template,
+				// only allow activating (so when it's inactive).
+				if ( typeof item.id !== 'number' ) {
 					return item._isActive === false;
 				}
 

--- a/packages/edit-site/src/components/dataviews-actions/index.js
+++ b/packages/edit-site/src/components/dataviews-actions/index.js
@@ -34,11 +34,18 @@ export const useSetActiveTemplateAction = () => {
 			isPrimary: true,
 			icon: pencil,
 			isEligible( item ) {
-				return (
-					! item._isCustom &&
-					! ( item.slug === 'index' && item.source === 'theme' ) &&
-					item.theme === activeTheme.stylesheet
-				);
+				if ( item.theme !== activeTheme.stylesheet ) {
+					return false;
+				}
+
+				// If it's not a created template but a registered template
+				// (which means the source property is set), only allow
+				// activating (so when it's inactive).
+				if ( item.source ) {
+					return item._isActive === false;
+				}
+
+				return ! item._isCustom;
 			},
 			async callback( items ) {
 				const deactivate = items.some( ( item ) => item._isActive );
@@ -49,11 +56,7 @@ export const useSetActiveTemplateAction = () => {
 				};
 				for ( const item of items ) {
 					if ( deactivate ) {
-						if ( item.source === 'theme' ) {
-							activeTemplates[ item.slug ] = false;
-						} else {
-							delete activeTemplates[ item.slug ];
-						}
+						delete activeTemplates[ item.slug ];
 					} else {
 						activeTemplates[ item.slug ] = item.id;
 					}

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -102,30 +102,20 @@ export default function PageTemplates() {
 		if ( activeTemplatesOption ) {
 			for ( const activeSlug in activeTemplatesOption ) {
 				const activeId = activeTemplatesOption[ activeSlug ];
-				if ( activeId === false ) {
-					// Remove the template from the array.
+				// Replace the template in the array.
+				const template = userRecords.find(
+					( userRecord ) =>
+						userRecord.id === activeId &&
+						userRecord.theme === activeTheme.stylesheet
+				);
+				if ( template ) {
 					const index = _active.findIndex(
-						( template ) => template.slug === activeSlug
+						( { slug } ) => slug === template.slug
 					);
 					if ( index !== -1 ) {
-						_active.splice( index, 1 );
-					}
-				} else {
-					// Replace the template in the array.
-					const template = userRecords.find(
-						( userRecord ) =>
-							userRecord.id === activeId &&
-							userRecord.theme === activeTheme.stylesheet
-					);
-					if ( template ) {
-						const index = _active.findIndex(
-							( { slug } ) => slug === template.slug
-						);
-						if ( index !== -1 ) {
-							_active[ index ] = template;
-						} else {
-							_active.push( template );
-						}
+						_active[ index ] = template;
+					} else {
+						_active.push( template );
 					}
 				}
 			}
@@ -153,7 +143,11 @@ export default function PageTemplates() {
 				( template ) => template.id === record.id
 			),
 			_isCustom:
+				// For registered templates, the is_custom field is defined.
 				record.is_custom ??
+				// For user templates it's custom if the is_wp_suggestion meta
+				// field is not set and the slug is not found in the default
+				// template types.
 				( ! record.meta?.is_wp_suggestion &&
 					! defaultTemplateTypes.find(
 						( type ) => type.slug === record.slug


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

It's not clear what deactivation means exactly for every registered template. Perhaps for some, it's not possible to deactivate. We could potentially keep this for theme templates, but to me it feels like this needs time to properly figure out and there are a lot of other kinks to resolve, so a reduction in complexity would be good.

See #72475.

Let's try this in the next release.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

It should not be possible to deactivate theme templates. Only when a created template is active for the same slug should it be possible to activate.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
