### PR TITLE
Notes: Remove custom 'PluginMoreMenuItem' handler

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -31,7 +31,6 @@ import {
 	useEnableFloatingSidebar,
 } from './hooks';
 import { focusCommentThread } from './utils';
-import PluginMoreMenuItem from '../plugin-more-menu-item';
 import PostTypeSupportCheck from '../post-type-support-check';
 
 function NotesSidebarContent( {
@@ -162,6 +161,7 @@ function NotesSidebar( { postId } ) {
 			<AddCommentMenuItem onClick={ openTheSidebar } />
 			<PluginSidebar
 				identifier={ collabHistorySidebarName }
+				name={ collabHistorySidebarName }
 				title={ __( 'Notes' ) }
 				icon={ commentIcon }
 				closeLabel={ __( 'Close Notes' ) }
@@ -198,14 +198,6 @@ function NotesSidebar( { postId } ) {
 					/>
 				</PluginSidebar>
 			) }
-			<PluginMoreMenuItem
-				icon={ commentIcon }
-				onClick={ () =>
-					enableComplementaryArea( 'core', collabHistorySidebarName )
-				}
-			>
-				{ __( 'Notes' ) }
-			</PluginMoreMenuItem>
 		</>
 	);
 }


### PR DESCRIPTION
## What?
A minor code quality improvement for the pinned notes sidebar. Removes the custom `PluginMoreMenuItem` handler in favor of the auto-registered one by `PluginSidebar`.

## Why?
Requires less code.

## Testing Instructions
1. Open a post or page.
2. Unpin the Notes sidebar.
3. Open document settings to hide the pinned sidebar.
4. Confirm that you can re-enable the pinned notes sidebar from the main Options menu.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/2360afdd-8e61-405b-a9f7-2f8668ee0299

