### PR TITLE
Try disabling template enhancement output buffer to debug performance degradation

### DIFF
--- a/packages/e2e-tests/mu-plugins/server-timing.php
+++ b/packages/e2e-tests/mu-plugins/server-timing.php
@@ -12,6 +12,19 @@
  * is loaded.
  */
 
+// Temporarily disable the template enhancement output buffer to help isolate whether it is the cause for a performance degradation noted in <https://github.com/WordPress/gutenberg/pull/72340#issuecomment-3428729158>.
+add_action(
+	'after_setup_theme',
+	static function () {
+		if ( wp_is_block_theme() ) {
+			return;
+		}
+		add_filter( 'should_load_block_assets_on_demand', '__return_false' );
+		add_filter( 'should_load_separate_core_block_assets', '__return_false' );
+		add_filter( 'wp_should_output_buffer_template_for_enhancement', '__return_false' );
+	}
+);
+
 add_filter(
 	'template_include',
 	static function ( $template ) {


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/pull/72340#issuecomment-3428729158 from @youknowriad:

> I think that there's a non zero chance that this PR had a negative 6% impact on `wpTotal` and `wpBeforeTemplate`. I just wanted to flag this to you all.

The template enhancement output buffer improves LCP by allowing styles to be loaded on demand on classic themes, but this means there can be a degradation in TTFB. Note that TTFB contributes to LCP, and even with the a degradation in TTFB the improvement to LCP far outweighs the hit to increased server response time. See Core-43258, Core-64099. 

See performance impacts in these PR comments:

* [Improved CSS coverage](https://github.com/WordPress/wordpress-develop/pull/8412#issuecomment-3393617482)
* [Web vitals benchmarks for Twenty Twenty on broadband, Fast 4G, and Slow 3G connections](https://github.com/WordPress/wordpress-develop/pull/8412#issuecomment-3393744044)
* [Web vitals benchmarks for all classic themes on a broadband connection](https://github.com/WordPress/wordpress-develop/pull/8412#issuecomment-3393769410) (average LCP improvement: -14.94%)
* [Impact on Lighthouse performance core for all classic themes](https://github.com/WordPress/wordpress-develop/pull/8412#issuecomment-3393956117) (average improvement to score: +7.74%)