### PR TITLE
Navigation: Add underline to navigation links by default

### DIFF
--- a/lib/theme.json
+++ b/lib/theme.json
@@ -357,6 +357,17 @@
 					}
 				}
 			},
+			"core/navigation": {
+				"elements": {
+					"link": {
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
+					}
+				}
+			},
 			"core/site-logo": {
 				"variations": {
 					"rounded": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

In #38277, @ethanclevenger91 said:

> The navigation block comes out of the box disabling default hover states (text underline) and no focus styling, meaning it comes out of the box inaccessible.

This PR adds a hover state to navigation links by default. The focus styling for the block is just the default, which I think is accessible, but I'm curious what I might be missing here.

The problem with this solution is that navigation blocks on existing sites will start to be underlined if they were not previously. I think this might mean that we can't go ahead with this change as we don't want to be changing millions of sites. I'm curious what @iamtakashi thinks about this change.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To make the block more accessible.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add the rule to the shared/global theme.json file.

## Testing Instructions
1. Find a theme that doesn't define rules for the navigation block, or remove the navigation block theme.json rules from your theme
2. Check that the navigation block links have an underline when they are hovered.

## Screenshots or screencast <!-- if applicable -->
<img width="352" height="139" alt="Screenshot 2025-10-23 at 16 44 18" src="https://github.com/user-attachments/assets/eaf4862f-1254-4841-99b4-bc1a8ad2ba40" />
