### PR TITLE
Real-time collaboration: Hide lock modal based on user access to feature

### DIFF
--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -32,9 +32,9 @@ function PostLockedModal() {
 		postId,
 		postLockUtils,
 		activePostLock,
+		postSupportsSync,
 		postType,
 		previewLink,
-		supportsSync,
 	} = useSelect( ( select ) => {
 		const {
 			isPostLocked,
@@ -48,7 +48,6 @@ function PostLockedModal() {
 			getEditorSettings,
 		} = select( editorStore );
 		const { getPostType, getEntityConfig } = select( coreStore );
-		const currentPostType = getCurrentPostType();
 		return {
 			isLocked: isPostLocked(),
 			isTakeover: isPostLockTakeover(),
@@ -56,13 +55,19 @@ function PostLockedModal() {
 			postId: getCurrentPostId(),
 			postLockUtils: getEditorSettings().postLockUtils,
 			activePostLock: getActivePostLock(),
+			postSupportsSync: Boolean(
+				getEntityConfig( 'postType', getCurrentPostType() )?.syncConfig
+			),
 			postType: getPostType( getEditedPostAttribute( 'type' ) ),
 			previewLink: getEditedPostPreviewLink(),
-			supportsSync: Boolean(
-				getEntityConfig( 'postType', currentPostType )?.syncConfig
-			),
 		};
 	}, [] );
+
+	let syncEnabled = false;
+	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+		syncEnabled =
+			postSupportsSync && Boolean( window.__experimentalEnableSync );
+	}
 
 	useEffect( () => {
 		/**
@@ -96,6 +101,12 @@ function PostLockedModal() {
 
 			const received = data[ 'wp-refresh-post-lock' ];
 			if ( received.lock_error ) {
+				// If both the current user and the lock owner can collaboratively
+				// edit, do not enforce the takeover.
+				if ( syncEnabled && received.lock_error.syncEnabled ) {
+					return;
+				}
+
 				// Auto save and display the takeover modal.
 				autosave();
 				updatePostLock( {
@@ -154,11 +165,10 @@ function PostLockedModal() {
 		return null;
 	}
 
-	// Avoid sending the modal if sync is supported, but retain functionality around locks etc.
-	if ( window.__experimentalEnableSync && supportsSync ) {
-		if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-			return null;
-		}
+	// If both the current user and the lock owner can collaboratively edit, do not
+	// show the modal.
+	if ( syncEnabled && user.syncEnabled ) {
+		return null;
 	}
 
 	const userDisplayName = user.name;


### PR DESCRIPTION
## What?

Hide the post lock modal based on user access to the collaborative editing feature.

<!-- In a few words, what is the PR actually doing? -->

## Why?

If we want to allow users with access to the feature to exist alongside users without access, we need a way to selectively enforce the post lock.

## How?

If both the current user and the lock owner have access to the collaborative editing feature, then we can safely ignore the post lock (but continue updating it in the background). Otherwise, defer to the current behavior of the post lock.

## Testing Instructions

See https://github.com/Automattic/vip-real-time-collaboration/pull/76

### Testing Instructions for Keyboard

No UI changes in this PR.
