### PR TITLE
Notes: Disable floating notes for 'template-locked' mode

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -83,12 +83,14 @@ function NotesSidebarContent( {
 	);
 }
 
-function NotesSidebar( { postId } ) {
+function NotesSidebar( { postId, mode } ) {
 	const [ showCommentBoard, setShowCommentBoard ] = useState( false );
 	const { getActiveComplementaryArea } = useSelect( interfaceStore );
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const commentSidebarRef = useRef( null );
+
+	const showFloatingSidebar = isLargeViewport && mode === 'post-only';
 
 	const blockCommentId = useSelect( ( select ) => {
 		const { getBlockAttributes, getSelectedBlockClientId } =
@@ -107,7 +109,7 @@ function NotesSidebar( { postId } ) {
 		commentLastUpdated,
 	} = useBlockComments( postId );
 	useEnableFloatingSidebar(
-		isLargeViewport &&
+		showFloatingSidebar &&
 			( unresolvedSortedThreads.length > 0 || showCommentBoard )
 	);
 
@@ -130,7 +132,9 @@ function NotesSidebar( { postId } ) {
 		if ( ! activeNotesArea ) {
 			enableComplementaryArea(
 				'core',
-				isLargeViewport ? collabSidebarName : collabHistorySidebarName
+				showFloatingSidebar
+					? collabSidebarName
+					: collabHistorySidebarName
 			);
 		}
 
@@ -175,7 +179,7 @@ function NotesSidebar( { postId } ) {
 					commentLastUpdated={ commentLastUpdated }
 				/>
 			</PluginSidebar>
-			{ isLargeViewport && (
+			{ showFloatingSidebar && (
 				<PluginSidebar
 					isPinnable={ false }
 					header={ false }
@@ -203,9 +207,12 @@ function NotesSidebar( { postId } ) {
 }
 
 export default function NotesSidebarContainer() {
-	const postId = useSelect( ( select ) => {
-		const { getCurrentPostId } = select( editorStore );
-		return getCurrentPostId();
+	const { postId, mode } = useSelect( ( select ) => {
+		const { getCurrentPostId, getRenderingMode } = select( editorStore );
+		return {
+			postId: getCurrentPostId(),
+			mode: getRenderingMode(),
+		};
 	}, [] );
 
 	if ( ! postId || typeof postId !== 'number' ) {
@@ -214,7 +221,7 @@ export default function NotesSidebarContainer() {
 
 	return (
 		<PostTypeSupportCheck supportKeys="editor.notes">
-			<NotesSidebar postId={ postId } />
+			<NotesSidebar postId={ postId } mode={ mode } />
 		</PostTypeSupportCheck>
 	);
 }


### PR DESCRIPTION
## What?
Closes #72616

PR disables floating notes when the "Show Template" editor setting is enabled and only allows interaction with notes via the pinned sidebar.

This is a temporary restriction. The notes feature will be enabled for all editor rendering modes in future WP releases.

## Testing Instructions
1. Open a post or page.
2. Add test notes.
3. Toggle "Show Template" option.
4. Confirm that floating notes aren't visible when this option is enabled.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/26d43f3a-9d11-4bd1-bbb9-b70a8a4fc8c9

