### PR TITLE
Templates: Adds 'type' property to `activeField` as boolean in page templates

### DIFF
--- a/packages/edit-site/src/components/page-templates/fields.js
+++ b/packages/edit-site/src/components/page-templates/fields.js
@@ -150,6 +150,7 @@ export const authorField = {
 export const activeField = {
 	label: __( 'Status' ),
 	id: 'active',
+	type: 'boolean',
 	getValue: ( { item } ) => item._isActive,
 	render: function Render( { item } ) {
 		if ( item._isCustom ) {


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/72278 (I think! 🤞🏻 )

## What?

Adds 'type' property to `activeField` as boolean in page templates 



## Why?

The `type` passed to [getFieldTypeDefinition](https://github.com/WordPress/gutenberg/blob/update/refactor-styles-canvas/packages/dataviews/src/field-types/index.tsx#L32) was undefined.


## Testing Instructions
Head to **Appearance > Templates > Active templates > View Options > Sort by > Status**

The templates should be sorted by status

<img width="1172" height="473" alt="Screenshot 2025-10-24 at 4 41 24 pm" src="https://github.com/user-attachments/assets/3f75c466-9ac9-40d6-9891-274394a80a6c" />

