### PR TITLE
Notes: Improve pinned sidebar e2e test

### DIFF
--- a/test/e2e/specs/editor/various/block-comments.spec.js
+++ b/test/e2e/specs/editor/various/block-comments.spec.js
@@ -20,6 +20,7 @@ test.describe( 'Block Comments', () => {
 	} );
 
 	test( 'can pin and unpin comments sidebar', async ( {
+		editor,
 		page,
 		blockCommentUtils,
 	} ) => {
@@ -28,7 +29,17 @@ test.describe( 'Block Comments', () => {
 			.getByRole( 'button', { name: 'Unpin from toolbar' } )
 			.click();
 		await expect( topBarButton ).toBeHidden();
+
+		await editor.openDocumentSettingsSidebar();
+		await page
+			.getByRole( 'region', {
+				name: 'Editor top bar',
+			} )
+			.getByRole( 'button', { name: 'Options' } )
+			.click();
+		await page.getByRole( 'menuitemcheckbox', { name: 'Notes' } ).click();
 		await page.getByRole( 'button', { name: 'Pin to toolbar' } ).click();
+
 		await expect( topBarButton ).toBeVisible();
 	} );
 


### PR DESCRIPTION
## What?

PR improves pinned sidebar e2e test for pin and unpin actions. Now it also asserts opening the unpinned sidebar from the More Options menu. Covers #72377.

A backport isn't really required for e2e test changes; adding a label to prevent future merge conflicts.

## Testing Instructions
CI checks are green.