### PR TITLE
Badge: Add max-width for text truncation

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 -   `Button`: Ensure that icons don't shrink ([#72474](https://github.com/WordPress/gutenberg/pull/72474)).
 -   `Popover`: Fix `onDialogClose` logic to only close the popover if the blur event targets the specific popover instance ([#72376](https://github.com/WordPress/gutenberg/pull/72376)).
+-   `Badge`: Add max-width for text truncation ([#72653](https://github.com/WordPress/gutenberg/pull/72653)).
 
 ## 30.6.0 (2025-10-17)
 

--- a/packages/components/src/badge/styles.scss
+++ b/packages/components/src/badge/styles.scss
@@ -18,6 +18,7 @@ $badge-colors: (
 	min-height: $grid-unit-30;
 	border-radius: $radius-small;
 	line-height: 0;
+	max-width: 100%;
 
 	// Prevents anchor text-decoration styles from being applied through a parent.
 	display: inline-block;


### PR DESCRIPTION
Fixes: #72651
Related: #72097

## What?

I noticed that the text truncation of the Badge component doesn't work properly after #72097 is merged.

## Why? How?

For text truncation to work correctly, we need to set the width not only on the inner wrapper element but also on the component itself. Otherwise, the text will not be able to reference the width that serves as the overflow threshold.

## Testing Instructions

### List View

- Open a new post.
- Insert a Heading block and add the anchor attribute.
- Open the List View and confirm that the block title and anchor text aren't overlapped.
- Confirm that the text is truncated correctly.

### Storybook

- Open the Badge story.
- Add a long text to the `children` prop and apply the "WP Sidebar" width.

## Screenshots or screencast <!-- if applicable -->

### List View

| Before | After |
|--------|--------|
| <img width="351" height="174" alt="list-view-before" src="https://github.com/user-attachments/assets/420849ce-1df9-4b46-bd8c-572167289175" /> | <img width="351" height="174" alt="list-view-after" src="https://github.com/user-attachments/assets/7a6a5866-1efa-40be-b943-bff8c2698be4" /> |

### Storybook

| Before | After |
|--------|--------|
| <img width="600" height="160" alt="storybook-before" src="https://github.com/user-attachments/assets/ddac77ef-6f8f-4d53-8295-6a65c67bced3" /> | <img width="600" height="160" alt="storybook-after" src="https://github.com/user-attachments/assets/4cca9eb9-6f3e-4c1c-9b8f-e4de30391ee1" /> |

