### PR TITLE
Notes: Don't collapse note on Escape if the event has been prevented

### DIFF
--- a/packages/editor/src/components/collab-sidebar/comments.js
+++ b/packages/editor/src/components/collab-sidebar/comments.js
@@ -378,6 +378,9 @@ function Thread( {
 			onFocus={ onMouseEnter }
 			onBlur={ onMouseLeave }
 			onKeyDown={ ( event ) => {
+				if ( event.defaultPrevented ) {
+					return;
+				}
 				// Expand or Collapse thread.
 				if (
 					event.key === 'Enter' &&


### PR DESCRIPTION
Noticed while working on #72650

## What? Why?

When a note is expanded, pressing the `Escape` key closes the note and focuses on that note. However, this is not the case when the action dropdown is open. In that situation, only the action dropdown should close, without closing the note.

## How?
Check if the event has been prevented.

## Testing Instructions

### Testing Instructions for Keyboard

- Expand a note.
- Focus the Actions button and expand the dropdown menu.
- Press the `Escape` key.
- Confirm that the focus gets back to the Actions button and the note isn't collapsed.

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/019e8ca5-1191-4f26-bb5d-1639c6763cd9

### After

https://github.com/user-attachments/assets/05f34118-1ac9-40e2-8ec6-68c2f1b5201c