### PR TITLE
[WP6.9] Badge: Add max-width for text truncation

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `Badge`: Add max-width for text truncation ([#72653](https://github.com/WordPress/gutenberg/pull/72653)).
+
 ## 30.6.0 (2025-10-17)
 
 ### Enhancements

--- a/packages/components/src/badge/styles.scss
+++ b/packages/components/src/badge/styles.scss
@@ -18,6 +18,7 @@ $badge-colors: (
 	min-height: $grid-unit-30;
 	border-radius: $radius-small;
 	line-height: 0;
+	max-width: 100%;
 
 	// Prevents anchor text-decoration styles from being applied through a parent.
 	display: inline-block;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

The automatic cherry-picking process failed, so I will backport #72653 to the .`wp/6.9` branch manually.

## Testing Instructions

See #72653