### PR TITLE
Template activation: revert to old endpoint for post template picker

### DIFF
--- a/packages/editor/src/components/post-template/hooks.js
+++ b/packages/editor/src/components/post-template/hooks.js
@@ -52,57 +52,16 @@ export function useAllowSwitchingTemplates() {
 }
 
 function useTemplates( postType ) {
-	// To do: create a new selector to checks if templates exist at all instead
-	// of and unbound request. In the modal, the user templates should be
-	// paginated and we should not make an unbound request.
-	const { defaultTemplateTypes, registeredTemplates, userTemplates } =
-		useSelect(
-			( select ) => {
-				return {
-					defaultTemplateTypes:
-						select( coreStore ).getCurrentTheme()
-							?.default_template_types,
-					registeredTemplates: select( coreStore ).getEntityRecords(
-						'postType',
-						'wp_registered_template',
-						{
-							per_page: -1,
-							post_type: postType,
-						}
-					),
-					userTemplates: select( coreStore ).getEntityRecords(
-						'postType',
-						'wp_template',
-						{ per_page: -1, combinedTemplates: false }
-					),
-				};
-			},
-			[ postType ]
-		);
-
-	return useMemo( () => {
-		if (
-			! defaultTemplateTypes ||
-			! registeredTemplates ||
-			! userTemplates
-		) {
-			return [];
-		}
-		return [
-			...registeredTemplates,
-			...userTemplates.filter(
-				( template ) =>
-					// Only give "custom" templates as an option, which
-					// means the is_wp_suggestion meta field is not set and
-					// the slug is not found in the default template types.
-					// https://github.com/WordPress/wordpress-develop/blob/97382397b2bd7c85aef6d4cd1c10bafd397957fc/src/wp-includes/block-template-utils.php#L858-L867
-					! template.meta.is_wp_suggestion &&
-					! defaultTemplateTypes.find(
-						( type ) => type.slug === template.slug
-					)
-			),
-		];
-	}, [ registeredTemplates, userTemplates, defaultTemplateTypes ] );
+	return useSelect(
+		( select ) =>
+			select( coreStore ).getEntityRecords( 'postType', 'wp_template', {
+				per_page: -1,
+				post_type: postType,
+				// We look at the combined templates for now (old endpoint)
+				// because posts only accept slugs for templates, not IDs.
+			} ),
+		[ postType ]
+	);
 }
 
 export function useAvailableTemplates( postType ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #72586.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The template property on post objects only receives template slugs, not IDs. This means you cannot just pick any template from the database: you can only pick the active template for a slug, or custom templates, which is basically what the "old" endpoint queries. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

For now let's keep the querying the "old" endpoint in place until we refactor this to use IDs. This also allows us to do some backwards compatibility testing and have less surface area of the new feature exposed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Pick templates through the post or page editor (through the modal). There's some e2e tests for this.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
