### PR TITLE
Categories Block: Add taxonomy css class

### DIFF
--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -189,12 +189,16 @@ export default function CategoriesEdit( {
 			? 'ul'
 			: 'div';
 
-	const classes = clsx( className, {
-		'wp-block-categories-list':
-			!! categories?.length && ! displayAsDropdown && ! isResolving,
-		'wp-block-categories-dropdown':
-			!! categories?.length && displayAsDropdown && ! isResolving,
-	} );
+	const classes = clsx(
+		className,
+		`wp-block-categories-taxonomy-${ taxonomySlug }`,
+		{
+			'wp-block-categories-list':
+				!! categories?.length && ! displayAsDropdown && ! isResolving,
+			'wp-block-categories-dropdown':
+				!! categories?.length && displayAsDropdown && ! isResolving,
+		}
+	);
 
 	const blockProps = useBlockProps( {
 		className: classes,

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -79,7 +79,7 @@ function render_block_core_categories( $attributes, $content, $block ) {
 		}
 	}
 
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => "wp-block-categories-{$type}" ) );
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => "wp-block-categories-{$type} wp-block-categories-taxonomy-{$attributes['taxonomy']}" ) );
 
 	return sprintf(
 		$wrapper_markup,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/72465

Tiny PR that adds an extra `wp-block-categories-taxonomy-${ taxonomySlug }` to the block. This can help styling specific taxonomies easier.


## Testing Instructions
1. Add the `core/categories` (terms list) block and observe the new class in both the editor and front end.

