### PR TITLE
Latest Comments: Add option to display full comments

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -448,7 +448,7 @@ Display a list of your most recent comments. ([Source](https://github.com/WordPr
 -	**Name:** core/latest-comments
 -	**Category:** widgets
 -	**Supports:** align, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** commentsToShow, displayAvatar, displayDate, displayExcerpt
+-	**Attributes:** commentsToShow, displayAvatar, displayContent, displayDate
 
 ## Latest Posts
 

--- a/packages/block-library/src/latest-comments/block.json
+++ b/packages/block-library/src/latest-comments/block.json
@@ -1,65 +1,66 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 3,
-	"name": "core/latest-comments",
-	"title": "Latest Comments",
-	"category": "widgets",
-	"description": "Display a list of your most recent comments.",
-	"keywords": [ "recent comments" ],
-	"textdomain": "default",
-	"attributes": {
-		"commentsToShow": {
-			"type": "number",
-			"default": 5,
-			"minimum": 1,
-			"maximum": 100
-		},
-		"displayAvatar": {
-			"type": "boolean",
-			"default": true
-		},
-		"displayDate": {
-			"type": "boolean",
-			"default": true
-		},
-		"displayExcerpt": {
-			"type": "boolean",
-			"default": true
-		}
-	},
-	"supports": {
-		"align": true,
-		"color": {
-			"gradients": true,
-			"link": true,
-			"__experimentalDefaultControls": {
-				"background": true,
-				"text": true,
-				"link": true
-			}
-		},
-		"html": false,
-		"spacing": {
-			"margin": true,
-			"padding": true
-		},
-		"typography": {
-			"fontSize": true,
-			"lineHeight": true,
-			"__experimentalFontFamily": true,
-			"__experimentalFontWeight": true,
-			"__experimentalFontStyle": true,
-			"__experimentalTextTransform": true,
-			"__experimentalTextDecoration": true,
-			"__experimentalLetterSpacing": true,
-			"__experimentalDefaultControls": {
-				"fontSize": true
-			}
-		},
-		"interactivity": {
-			"clientNavigation": true
-		}
-	},
-	"editorStyle": "wp-block-latest-comments-editor",
-	"style": "wp-block-latest-comments"
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "core/latest-comments",
+    "title": "Latest Comments",
+    "category": "widgets",
+    "description": "Display a list of your most recent comments.",
+    "keywords": [ "recent comments" ],
+    "textdomain": "default",
+    "attributes": {
+        "commentsToShow": {
+            "type": "number",
+            "default": 5,
+            "minimum": 1,
+            "maximum": 100
+        },
+        "displayAvatar": {
+            "type": "boolean",
+            "default": true
+        },
+        "displayDate": {
+            "type": "boolean",
+            "default": true
+        },
+        "displayContent": {
+            "type": "string",
+            "default": "excerpt",
+            "enum": [ "none", "excerpt", "full" ]
+        }
+    },
+    "supports": {
+        "align": true,
+        "color": {
+            "gradients": true,
+            "link": true,
+            "__experimentalDefaultControls": {
+                "background": true,
+                "text": true,
+                "link": true
+            }
+        },
+        "html": false,
+        "spacing": {
+            "margin": true,
+            "padding": true
+        },
+        "typography": {
+            "fontSize": true,
+            "lineHeight": true,
+            "__experimentalFontFamily": true,
+            "__experimentalFontWeight": true,
+            "__experimentalFontStyle": true,
+            "__experimentalTextTransform": true,
+            "__experimentalTextDecoration": true,
+            "__experimentalLetterSpacing": true,
+            "__experimentalDefaultControls": {
+                "fontSize": true
+            }
+        },
+        "interactivity": {
+            "clientNavigation": true
+        }
+    },
+    "editorStyle": "wp-block-latest-comments-editor",
+    "style": "wp-block-latest-comments"
 }

--- a/packages/block-library/src/latest-comments/block.json
+++ b/packages/block-library/src/latest-comments/block.json
@@ -25,7 +25,7 @@
 		"displayContent": {
 			"type": "string",
 			"default": "excerpt",
-            "enum": [ "none", "excerpt", "full"]
+			"enum": [ "none", "excerpt", "full" ]
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/latest-comments/block.json
+++ b/packages/block-library/src/latest-comments/block.json
@@ -1,66 +1,66 @@
 {
-    "$schema": "https://schemas.wp.org/trunk/block.json",
-    "apiVersion": 3,
-    "name": "core/latest-comments",
-    "title": "Latest Comments",
-    "category": "widgets",
-    "description": "Display a list of your most recent comments.",
-    "keywords": [ "recent comments" ],
-    "textdomain": "default",
-    "attributes": {
-        "commentsToShow": {
-            "type": "number",
-            "default": 5,
-            "minimum": 1,
-            "maximum": 100
-        },
-        "displayAvatar": {
-            "type": "boolean",
-            "default": true
-        },
-        "displayDate": {
-            "type": "boolean",
-            "default": true
-        },
-        "displayContent": {
-            "type": "string",
-            "default": "excerpt",
-            "enum": [ "none", "excerpt", "full" ]
-        }
-    },
-    "supports": {
-        "align": true,
-        "color": {
-            "gradients": true,
-            "link": true,
-            "__experimentalDefaultControls": {
-                "background": true,
-                "text": true,
-                "link": true
-            }
-        },
-        "html": false,
-        "spacing": {
-            "margin": true,
-            "padding": true
-        },
-        "typography": {
-            "fontSize": true,
-            "lineHeight": true,
-            "__experimentalFontFamily": true,
-            "__experimentalFontWeight": true,
-            "__experimentalFontStyle": true,
-            "__experimentalTextTransform": true,
-            "__experimentalTextDecoration": true,
-            "__experimentalLetterSpacing": true,
-            "__experimentalDefaultControls": {
-                "fontSize": true
-            }
-        },
-        "interactivity": {
-            "clientNavigation": true
-        }
-    },
-    "editorStyle": "wp-block-latest-comments-editor",
-    "style": "wp-block-latest-comments"
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "core/latest-comments",
+	"title": "Latest Comments",
+	"category": "widgets",
+	"description": "Display a list of your most recent comments.",
+	"keywords": [ "recent comments" ],
+	"textdomain": "default",
+	"attributes": {
+		"commentsToShow": {
+			"type": "number",
+			"default": 5,
+			"minimum": 1,
+			"maximum": 100
+		},
+		"displayAvatar": {
+			"type": "boolean",
+			"default": true
+		},
+		"displayDate": {
+			"type": "boolean",
+			"default": true
+		},
+		"displayContent": {
+			"type": "string",
+			"default": "excerpt",
+            "enum": [ "none", "excerpt", "full"]
+		}
+	},
+	"supports": {
+		"align": true,
+		"color": {
+			"gradients": true,
+			"link": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true,
+				"link": true
+			}
+		},
+		"html": false,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		},
+		"interactivity": {
+			"clientNavigation": true
+		}
+	},
+	"editorStyle": "wp-block-latest-comments-editor",
+	"style": "wp-block-latest-comments"
 }

--- a/packages/block-library/src/latest-comments/deprecated.js
+++ b/packages/block-library/src/latest-comments/deprecated.js
@@ -3,53 +3,52 @@
  */
 
 const v1 = [
-  {
-    // Only run this deprecation when the legacy attribute exists.
-    isEligible( attributes ) {
-      return attributes?.displayExcerpt !== undefined;
-    },
+	{
+		// Only run this deprecation when the legacy attribute exists.
+		isEligible( attributes ) {
+			return attributes?.displayExcerpt !== undefined;
+		},
 
-    attributes: {
-      commentsToShow: {
-        type: 'number',
-        default: 5,
-      },
-      displayAvatar: {
-        type: 'boolean',
-        default: true,
-      },
-      displayDate: {
-        type: 'boolean',
-        default: true,
-      },
-      // Legacy attribute (deprecated)
-      displayExcerpt: {
-        type: 'boolean',
-        default: true,
-      },
-    },
+		attributes: {
+			commentsToShow: {
+				type: 'number',
+				default: 5,
+			},
+			displayAvatar: {
+				type: 'boolean',
+				default: true,
+			},
+			displayDate: {
+				type: 'boolean',
+				default: true,
+			},
+			// Legacy attribute (deprecated)
+			displayExcerpt: {
+				type: 'boolean',
+				default: true,
+			},
+		},
 
-  /**
- * Migrate legacy attributes to the new format.
- *
- * @param {Object} attributes Legacy block attributes.
- * @return {Object} Migrated block attributes with displayContent replacing displayExcerpt.
- */
-migrate( attributes ) {
+		/**
+		 * Migrate legacy attributes to the new format.
+		 *
+		 * @param {Object} attributes Legacy block attributes.
+		 * @return {Object} Migrated block attributes with displayContent replacing displayExcerpt.
+		 */
+		migrate( attributes ) {
+			return {
+				// keep other attributes the same (including commentsToShow/displayAvatar/displayDate)
+				...attributes,
+				// normalize the legacy boolean to the new string-based displayContent
+				displayContent: attributes.displayExcerpt ? 'excerpt' : 'none',
+			};
+		},
 
-      return {
-        // keep other attributes the same (including commentsToShow/displayAvatar/displayDate)
-        ...attributes,
-        // normalize the legacy boolean to the new string-based displayContent
-        displayContent: attributes.displayExcerpt ? 'excerpt' : 'none',
-      };
-    },
-
-    // Dynamic block → no client-side save.
-    save() {
-      return null;
-    },
-  },
+		// Dynamic block → no client-side save.
+		save() {
+			return null;
+		},
+	},
 ];
 
 export default [ v1 ];

--- a/packages/block-library/src/latest-comments/deprecated.js
+++ b/packages/block-library/src/latest-comments/deprecated.js
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+
+const v1 = [
+  {
+    // Only run this deprecation when the legacy attribute exists.
+    isEligible( attributes ) {
+      return attributes?.displayExcerpt !== undefined;
+    },
+
+    attributes: {
+      commentsToShow: {
+        type: 'number',
+        default: 5,
+      },
+      displayAvatar: {
+        type: 'boolean',
+        default: true,
+      },
+      displayDate: {
+        type: 'boolean',
+        default: true,
+      },
+      // Legacy attribute (deprecated)
+      displayExcerpt: {
+        type: 'boolean',
+        default: true,
+      },
+    },
+
+  /**
+ * Migrate legacy attributes to the new format.
+ *
+ * @param {Object} attributes Legacy block attributes.
+ * @return {Object} Migrated block attributes with displayContent replacing displayExcerpt.
+ */
+migrate( attributes ) {
+
+      return {
+        // keep other attributes the same (including commentsToShow/displayAvatar/displayDate)
+        ...attributes,
+        // normalize the legacy boolean to the new string-based displayContent
+        displayContent: attributes.displayExcerpt ? 'excerpt' : 'none',
+      };
+    },
+
+    // Dynamic block → no client-side save.
+    save() {
+      return null;
+    },
+  },
+];
+
+export default [ v1 ];

--- a/packages/block-library/src/latest-comments/deprecated.js
+++ b/packages/block-library/src/latest-comments/deprecated.js
@@ -2,36 +2,36 @@
  * WordPress dependencies
  */
 
-const v1 = [
-	{
-		attributes: {
-			commentsToShow: {
-				type: 'number',
-				default: 5,
-			},
-			displayAvatar: {
-				type: 'boolean',
-				default: true,
-			},
-			displayDate: {
-				type: 'boolean',
-				default: true,
-			},
-			displayExcerpt: {
-				type: 'boolean',
-				default: true,
-			},
+const v1 = {
+	attributes: {
+		commentsToShow: {
+			type: 'number',
+			default: 5,
+			minimum: 1,
+			maximum: 100,
 		},
-		isEligible( attributes ) {
-			return attributes?.displayExcerpt === false;
+		displayAvatar: {
+			type: 'boolean',
+			default: true,
 		},
-		migrate( attributes ) {
-			return {
-				...attributes,
-				displayContent: attributes.displayExcerpt ? 'excerpt' : 'none',
-			};
+		displayDate: {
+			type: 'boolean',
+			default: true,
+		},
+		displayExcerpt: {
+			type: 'boolean',
+			default: true,
 		},
 	},
-];
+	isEligible( attributes ) {
+		return attributes?.displayExcerpt === false;
+	},
+	migrate( attributes ) {
+		return {
+			...attributes,
+			displayContent: attributes.displayExcerpt ? 'excerpt' : 'none',
+		};
+	},
+};
 
 export default [ v1 ];

--- a/packages/block-library/src/latest-comments/deprecated.js
+++ b/packages/block-library/src/latest-comments/deprecated.js
@@ -4,11 +4,6 @@
 
 const v1 = [
 	{
-		// Only run this deprecation when the legacy attribute exists.
-		isEligible( attributes ) {
-			return attributes?.displayExcerpt !== undefined;
-		},
-
 		attributes: {
 			commentsToShow: {
 				type: 'number',
@@ -22,31 +17,19 @@ const v1 = [
 				type: 'boolean',
 				default: true,
 			},
-			// Legacy attribute (deprecated)
 			displayExcerpt: {
 				type: 'boolean',
 				default: true,
 			},
 		},
-
-		/**
-		 * Migrate legacy attributes to the new format.
-		 *
-		 * @param {Object} attributes Legacy block attributes.
-		 * @return {Object} Migrated block attributes with displayContent replacing displayExcerpt.
-		 */
+		isEligible( attributes ) {
+			return attributes?.displayExcerpt === false;
+		},
 		migrate( attributes ) {
 			return {
-				// keep other attributes the same (including commentsToShow/displayAvatar/displayDate)
 				...attributes,
-				// normalize the legacy boolean to the new string-based displayContent
 				displayContent: attributes.displayExcerpt ? 'excerpt' : 'none',
 			};
-		},
-
-		// Dynamic block → no client-side save.
-		save() {
-			return null;
 		},
 	},
 ];

--- a/packages/block-library/src/latest-comments/edit.js
+++ b/packages/block-library/src/latest-comments/edit.js
@@ -109,7 +109,7 @@ export default function LatestComments( { attributes, setAttributes } ) {
 						<SelectControl
 							__nextHasNoMarginBottom
 							__next40pxDefaultSize
-							label={ __( 'Display Content' ) }
+							label={ __( 'Display content' ) }
 							value={ displayContent }
 							options={ [
 								{ label: __( 'No content' ), value: 'none' },

--- a/packages/block-library/src/latest-comments/edit.js
+++ b/packages/block-library/src/latest-comments/edit.js
@@ -112,14 +112,15 @@ export default function LatestComments( { attributes, setAttributes } ) {
 							label={ __( 'Display Content' ) }
 							value={ displayContent }
 							options={ [
-                                { label: __( 'No content' ), value: 'none' },
-                                { label: __( 'Excerpt' ), value: 'excerpt' },
-                                { label: __( 'Full content' ), value: 'full' },
-                            ] }
-							onChange={ ( value ) => 
-								setAttributes({
-									displayContent:value
-								})}
+								{ label: __( 'No content' ), value: 'none' },
+								{ label: __( 'Excerpt' ), value: 'excerpt' },
+								{ label: __( 'Full content' ), value: 'full' },
+							] }
+							onChange={ ( value ) =>
+								setAttributes( {
+									displayContent: value,
+								} )
+							}
 						/>
 					</ToolsPanelItem>
 

--- a/packages/block-library/src/latest-comments/edit.js
+++ b/packages/block-library/src/latest-comments/edit.js
@@ -3,11 +3,12 @@
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
-	Disabled,
-	RangeControl,
-	ToggleControl,
-	__experimentalToolsPanel as ToolsPanel,
-	__experimentalToolsPanelItem as ToolsPanelItem,
+    Disabled,
+    RangeControl,
+    SelectControl,
+    ToggleControl,
+    __experimentalToolsPanel as ToolsPanel,
+    __experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import ServerSideRender from '@wordpress/server-side-render';
 import { __ } from '@wordpress/i18n';
@@ -31,125 +32,130 @@ const MIN_COMMENTS = 1;
 const MAX_COMMENTS = 100;
 
 export default function LatestComments( { attributes, setAttributes } ) {
-	const { commentsToShow, displayAvatar, displayDate, displayExcerpt } =
-		attributes;
+    
+    const { commentsToShow, displayAvatar, displayDate, displayContent } = attributes;
 
-	const serverSideAttributes = {
-		...attributes,
-		style: {
-			...attributes?.style,
-			spacing: undefined,
-		},
-	};
+    const serverSideAttributes = {
+        ...attributes,
+        style: {
+            ...attributes?.style,
+            spacing: undefined,
+        },
+    };
 
-	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+    const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
-	return (
-		<div { ...useBlockProps() }>
-			<InspectorControls>
-				<ToolsPanel
-					label={ __( 'Settings' ) }
-					resetAll={ () => {
-						setAttributes( {
-							commentsToShow: 5,
-							displayAvatar: true,
-							displayDate: true,
-							displayExcerpt: true,
-						} );
-					} }
-					dropdownMenuProps={ dropdownMenuProps }
-				>
-					<ToolsPanelItem
-						hasValue={ () => ! displayAvatar }
-						label={ __( 'Display avatar' ) }
-						onDeselect={ () =>
-							setAttributes( { displayAvatar: true } )
-						}
-						isShownByDefault
-					>
-						<ToggleControl
-							__nextHasNoMarginBottom
-							label={ __( 'Display avatar' ) }
-							checked={ displayAvatar }
-							onChange={ () =>
-								setAttributes( {
-									displayAvatar: ! displayAvatar,
-								} )
-							}
-						/>
-					</ToolsPanelItem>
+    return (
+        <div { ...useBlockProps() }>
+            <InspectorControls>
+                <ToolsPanel
+                    label={ __( 'Settings' ) }
+                    resetAll={ () => {
+                        setAttributes( {
+                            commentsToShow: 5,
+                            displayAvatar: true,
+                            displayDate: true,
+                            displayContent: 'excerpt',
+                        } );
+                    } }
+                    dropdownMenuProps={ dropdownMenuProps }
+                >
+                    <ToolsPanelItem
+                        hasValue={ () => ! displayAvatar }
+                        label={ __( 'Display avatar' ) }
+                        onDeselect={ () =>
+                            setAttributes( { displayAvatar: true } )
+                        }
+                        isShownByDefault
+                    >
+                        <ToggleControl
+                            __nextHasNoMarginBottom
+                            label={ __( 'Display avatar' ) }
+                            checked={ displayAvatar }
+                            onChange={ () =>
+                                setAttributes( {
+                                    displayAvatar: ! displayAvatar,
+                                } )
+                            }
+                        />
+                    </ToolsPanelItem>
 
-					<ToolsPanelItem
-						hasValue={ () => ! displayDate }
-						label={ __( 'Display date' ) }
-						onDeselect={ () =>
-							setAttributes( { displayDate: true } )
-						}
-						isShownByDefault
-					>
-						<ToggleControl
-							__nextHasNoMarginBottom
-							label={ __( 'Display date' ) }
-							checked={ displayDate }
-							onChange={ () =>
-								setAttributes( { displayDate: ! displayDate } )
-							}
-						/>
-					</ToolsPanelItem>
+                    <ToolsPanelItem
+                        hasValue={ () => ! displayDate }
+                        label={ __( 'Display date' ) }
+                        onDeselect={ () =>
+                            setAttributes( { displayDate: true } )
+                        }
+                        isShownByDefault
+                    >
+                        <ToggleControl
+                            __nextHasNoMarginBottom
+                            label={ __( 'Display date' ) }
+                            checked={ displayDate }
+                            onChange={ () =>
+                                setAttributes( { displayDate: ! displayDate } )
+                            }
+                        />
+                    </ToolsPanelItem>
 
-					<ToolsPanelItem
-						hasValue={ () => ! displayExcerpt }
-						label={ __( 'Display excerpt' ) }
-						onDeselect={ () =>
-							setAttributes( { displayExcerpt: true } )
-						}
-						isShownByDefault
-					>
-						<ToggleControl
-							__nextHasNoMarginBottom
-							label={ __( 'Display excerpt' ) }
-							checked={ displayExcerpt }
-							onChange={ () =>
-								setAttributes( {
-									displayExcerpt: ! displayExcerpt,
-								} )
-							}
-						/>
-					</ToolsPanelItem>
+                    <ToolsPanelItem
+                        hasValue={ () => displayContent !== 'excerpt' }
+                        label={ __( 'Display content' ) }
+                        onDeselect={ () =>
+                            setAttributes( { displayContent: 'excerpt' } )
+                        }
+                        isShownByDefault
+                    >
+                        <SelectControl
+                            __nextHasNoMarginBottom
+                            __next40pxDefaultSize
+                            label={ __( 'Display content' ) }
+                            value={ displayContent }
+                            options={ [
+                                { label: __( 'No content' ), value: 'none' },
+                                { label: __( 'Excerpt' ), value: 'excerpt' },
+                                { label: __( 'Full content' ), value: 'full' },
+                            ] }
+                            onChange={ ( value ) =>
+                                setAttributes( { displayContent: value } )
+                            }
+                        />
+                    </ToolsPanelItem>
 
-					<ToolsPanelItem
-						hasValue={ () => commentsToShow !== 5 }
-						label={ __( 'Number of comments' ) }
-						onDeselect={ () =>
-							setAttributes( { commentsToShow: 5 } )
-						}
-						isShownByDefault
-					>
-						<RangeControl
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-							label={ __( 'Number of comments' ) }
-							value={ commentsToShow }
-							onChange={ ( value ) =>
-								setAttributes( { commentsToShow: value } )
-							}
-							min={ MIN_COMMENTS }
-							max={ MAX_COMMENTS }
-							required
-						/>
-					</ToolsPanelItem>
-				</ToolsPanel>
-			</InspectorControls>
-			<Disabled>
-				<ServerSideRender
-					block="core/latest-comments"
-					attributes={ serverSideAttributes }
-					// The preview uses the site's locale to make it more true to how
-					// the block appears on the frontend. Setting the locale
-					// explicitly prevents any middleware from setting it to 'user'.
-					urlQueryArgs={ { _locale: 'site' } }
-				/>
-			</Disabled>
-		</div>
-	);
+                    <ToolsPanelItem
+                        hasValue={ () => commentsToShow !== 5 }
+                        label={ __( 'Number of comments' ) }
+                        onDeselect={ () =>
+                            setAttributes( { commentsToShow: 5 } )
+                        }
+                        isShownByDefault
+                    >
+                        <RangeControl
+                            __nextHasNoMarginBottom
+                            __next40pxDefaultSize
+                            label={ __( 'Number of comments' ) }
+                            value={ commentsToShow }
+                            onChange={ ( value ) =>
+                                setAttributes( { commentsToShow: value } )
+                            }
+                            min={ MIN_COMMENTS }
+                            max={ MAX_COMMENTS }
+                            required
+                        />
+                    </ToolsPanelItem>
+                </ToolsPanel>
+            </InspectorControls>
+            <Disabled>
+                <ServerSideRender
+                    block="core/latest-comments"
+                    attributes={ serverSideAttributes }
+                    // The preview uses the site's locale to make it more true to how
+                    // the block appears on the frontend. Setting the locale
+                    // explicitly prevents any middleware from setting it to 'user'.
+                    urlQueryArgs={ { _locale: 'site' } }
+                />
+            </Disabled>
+        </div>
+    );
 }
+

--- a/packages/block-library/src/latest-comments/edit.js
+++ b/packages/block-library/src/latest-comments/edit.js
@@ -3,12 +3,12 @@
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
-    Disabled,
-    RangeControl,
-    SelectControl,
-    ToggleControl,
-    __experimentalToolsPanel as ToolsPanel,
-    __experimentalToolsPanelItem as ToolsPanelItem,
+	Disabled,
+	RangeControl,
+	SelectControl,
+	ToggleControl,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import ServerSideRender from '@wordpress/server-side-render';
 import { __ } from '@wordpress/i18n';
@@ -32,130 +32,130 @@ const MIN_COMMENTS = 1;
 const MAX_COMMENTS = 100;
 
 export default function LatestComments( { attributes, setAttributes } ) {
-    
-    const { commentsToShow, displayAvatar, displayDate, displayContent } = attributes;
+	const { commentsToShow, displayAvatar, displayDate, displayContent } =
+		attributes;
 
-    const serverSideAttributes = {
-        ...attributes,
-        style: {
-            ...attributes?.style,
-            spacing: undefined,
-        },
-    };
+	const serverSideAttributes = {
+		...attributes,
+		style: {
+			...attributes?.style,
+			spacing: undefined,
+		},
+	};
 
-    const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
-    return (
-        <div { ...useBlockProps() }>
-            <InspectorControls>
-                <ToolsPanel
-                    label={ __( 'Settings' ) }
-                    resetAll={ () => {
-                        setAttributes( {
-                            commentsToShow: 5,
-                            displayAvatar: true,
-                            displayDate: true,
-                            displayContent: 'excerpt',
-                        } );
-                    } }
-                    dropdownMenuProps={ dropdownMenuProps }
-                >
-                    <ToolsPanelItem
-                        hasValue={ () => ! displayAvatar }
-                        label={ __( 'Display avatar' ) }
-                        onDeselect={ () =>
-                            setAttributes( { displayAvatar: true } )
-                        }
-                        isShownByDefault
-                    >
-                        <ToggleControl
-                            __nextHasNoMarginBottom
-                            label={ __( 'Display avatar' ) }
-                            checked={ displayAvatar }
-                            onChange={ () =>
-                                setAttributes( {
-                                    displayAvatar: ! displayAvatar,
-                                } )
-                            }
-                        />
-                    </ToolsPanelItem>
+	return (
+		<div { ...useBlockProps() }>
+			<InspectorControls>
+				<ToolsPanel
+					label={ __( 'Settings' ) }
+					resetAll={ () => {
+						setAttributes( {
+							commentsToShow: 5,
+							displayAvatar: true,
+							displayDate: true,
+							displayContent: 'excerpt',
+						} );
+					} }
+					dropdownMenuProps={ dropdownMenuProps }
+				>
+					<ToolsPanelItem
+						hasValue={ () => ! displayAvatar }
+						label={ __( 'Display avatar' ) }
+						onDeselect={ () =>
+							setAttributes( { displayAvatar: true } )
+						}
+						isShownByDefault
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Display avatar' ) }
+							checked={ displayAvatar }
+							onChange={ () =>
+								setAttributes( {
+									displayAvatar: ! displayAvatar,
+								} )
+							}
+						/>
+					</ToolsPanelItem>
 
-                    <ToolsPanelItem
-                        hasValue={ () => ! displayDate }
-                        label={ __( 'Display date' ) }
-                        onDeselect={ () =>
-                            setAttributes( { displayDate: true } )
-                        }
-                        isShownByDefault
-                    >
-                        <ToggleControl
-                            __nextHasNoMarginBottom
-                            label={ __( 'Display date' ) }
-                            checked={ displayDate }
-                            onChange={ () =>
-                                setAttributes( { displayDate: ! displayDate } )
-                            }
-                        />
-                    </ToolsPanelItem>
+					<ToolsPanelItem
+						hasValue={ () => ! displayDate }
+						label={ __( 'Display date' ) }
+						onDeselect={ () =>
+							setAttributes( { displayDate: true } )
+						}
+						isShownByDefault
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Display date' ) }
+							checked={ displayDate }
+							onChange={ () =>
+								setAttributes( { displayDate: ! displayDate } )
+							}
+						/>
+					</ToolsPanelItem>
 
-                    <ToolsPanelItem
-                        hasValue={ () => displayContent !== 'excerpt' }
-                        label={ __( 'Display content' ) }
-                        onDeselect={ () =>
-                            setAttributes( { displayContent: 'excerpt' } )
-                        }
-                        isShownByDefault
-                    >
-                        <SelectControl
-                            __nextHasNoMarginBottom
-                            __next40pxDefaultSize
-                            label={ __( 'Display content' ) }
-                            value={ displayContent }
-                            options={ [
+					<ToolsPanelItem
+						hasValue={ () => displayContent !== 'excerpt' }
+						label={ __( 'Display Content' ) }
+						onDeselect={ () =>
+							setAttributes( { displayContent: 'excerpt' } )
+						}
+						isShownByDefault
+					>
+						<SelectControl
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+							label={ __( 'Display Content' ) }
+							value={ displayContent }
+							options={ [
                                 { label: __( 'No content' ), value: 'none' },
                                 { label: __( 'Excerpt' ), value: 'excerpt' },
                                 { label: __( 'Full content' ), value: 'full' },
                             ] }
-                            onChange={ ( value ) =>
-                                setAttributes( { displayContent: value } )
-                            }
-                        />
-                    </ToolsPanelItem>
+							onChange={ ( value ) => 
+								setAttributes({
+									displayContent:value
+								})}
+						/>
+					</ToolsPanelItem>
 
-                    <ToolsPanelItem
-                        hasValue={ () => commentsToShow !== 5 }
-                        label={ __( 'Number of comments' ) }
-                        onDeselect={ () =>
-                            setAttributes( { commentsToShow: 5 } )
-                        }
-                        isShownByDefault
-                    >
-                        <RangeControl
-                            __nextHasNoMarginBottom
-                            __next40pxDefaultSize
-                            label={ __( 'Number of comments' ) }
-                            value={ commentsToShow }
-                            onChange={ ( value ) =>
-                                setAttributes( { commentsToShow: value } )
-                            }
-                            min={ MIN_COMMENTS }
-                            max={ MAX_COMMENTS }
-                            required
-                        />
-                    </ToolsPanelItem>
-                </ToolsPanel>
-            </InspectorControls>
-            <Disabled>
-                <ServerSideRender
-                    block="core/latest-comments"
-                    attributes={ serverSideAttributes }
-                    // The preview uses the site's locale to make it more true to how
-                    // the block appears on the frontend. Setting the locale
-                    // explicitly prevents any middleware from setting it to 'user'.
-                    urlQueryArgs={ { _locale: 'site' } }
-                />
-            </Disabled>
-        </div>
-    );
+					<ToolsPanelItem
+						hasValue={ () => commentsToShow !== 5 }
+						label={ __( 'Number of comments' ) }
+						onDeselect={ () =>
+							setAttributes( { commentsToShow: 5 } )
+						}
+						isShownByDefault
+					>
+						<RangeControl
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+							label={ __( 'Number of comments' ) }
+							value={ commentsToShow }
+							onChange={ ( value ) =>
+								setAttributes( { commentsToShow: value } )
+							}
+							min={ MIN_COMMENTS }
+							max={ MAX_COMMENTS }
+							required
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
+			</InspectorControls>
+			<Disabled>
+				<ServerSideRender
+					block="core/latest-comments"
+					attributes={ serverSideAttributes }
+					// The preview uses the site's locale to make it more true to how
+					// the block appears on the frontend. Setting the locale
+					// explicitly prevents any middleware from setting it to 'user'.
+					urlQueryArgs={ { _locale: 'site' } }
+				/>
+			</Disabled>
+		</div>
+	);
 }
-

--- a/packages/block-library/src/latest-comments/edit.js
+++ b/packages/block-library/src/latest-comments/edit.js
@@ -100,7 +100,7 @@ export default function LatestComments( { attributes, setAttributes } ) {
 
 					<ToolsPanelItem
 						hasValue={ () => displayContent !== 'excerpt' }
-						label={ __( 'Display Content' ) }
+						label={ __( 'Display content' ) }
 						onDeselect={ () =>
 							setAttributes( { displayContent: 'excerpt' } )
 						}

--- a/packages/block-library/src/latest-comments/index.js
+++ b/packages/block-library/src/latest-comments/index.js
@@ -9,6 +9,7 @@ import { comment as icon } from '@wordpress/icons';
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
+import deprecated from './deprecated';
 
 const { name } = metadata;
 
@@ -18,6 +19,7 @@ export const settings = {
 	icon,
 	example: {},
 	edit,
+	deprecated,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -122,8 +122,8 @@ function render_block_core_latest_comments( $attributes ) {
 			if ( 'full' === $display_content ) {
 				$list_items_markup .= '<div class="wp-block-latest-comments__comment-excerpt">' . wpautop( get_comment_text( $comment ) ) . '</div>';
 			} elseif ( 'excerpt' === $display_content ) {
-$list_items_markup .= '<div class="wp-block-latest-comments__comment-excerpt">' . wpautop( get_comment_excerpt( $comment ) ) . '</div>';
-}
+				$list_items_markup .= '<div class="wp-block-latest-comments__comment-excerpt">' . wpautop( get_comment_excerpt( $comment ) ) . '</div>';
+			}
 			$list_items_markup .= '</article></li>';
 		}
 	}

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -26,11 +26,11 @@
  * @return string The post title if set; "(no title)" if no title is set.
  */
 function wp_latest_comments_draft_or_post_title( $post = 0 ) {
-	$title = get_the_title( $post );
-	if ( empty( $title ) ) {
-		$title = __( '(no title)' );
-	}
-	return $title;
+    $title = get_the_title( $post );
+    if ( empty( $title ) ) {
+        $title = __( '(no title)' );
+    }
+    return $title;
 }
 
 /**
@@ -43,106 +43,119 @@ function wp_latest_comments_draft_or_post_title( $post = 0 ) {
  * @return string Returns the post content with latest comments added.
  */
 function render_block_core_latest_comments( $attributes ) {
-	$comments = get_comments(
-		/** This filter is documented in wp-includes/widgets/class-wp-widget-recent-comments.php */
-		apply_filters(
-			'widget_comments_args',
-			array(
-				'number'      => $attributes['commentsToShow'],
-				'status'      => 'approve',
-				'post_status' => 'publish',
-			),
-			array()
-		)
-	);
+    // Handle backward compatibility: check for old displayExcerpt attribute
+    if ( isset( $attributes['displayExcerpt'] ) ) {
+        $display_content = $attributes['displayExcerpt'] ? 'excerpt' : 'none';
+    } else {
+        $display_content = isset( $attributes['displayContent'] ) ? $attributes['displayContent'] : 'excerpt';
+    }
 
-	$list_items_markup = '';
-	if ( ! empty( $comments ) ) {
-		// Prime the cache for associated posts. This is copied from \WP_Widget_Recent_Comments::widget().
-		$post_ids = array_unique( wp_list_pluck( $comments, 'comment_post_ID' ) );
-		_prime_post_caches( $post_ids, strpos( get_option( 'permalink_structure' ), '%category%' ), false );
+    $comments = get_comments(
+        /** This filter is documented in wp-includes/widgets/class-wp-widget-recent-comments.php */
+        apply_filters(
+            'widget_comments_args',
+            array(
+                'number'      => $attributes['commentsToShow'],
+                'status'      => 'approve',
+                'post_status' => 'publish',
+            ),
+            array()
+        )
+    );
 
-		foreach ( $comments as $comment ) {
-			$list_items_markup .= '<li class="wp-block-latest-comments__comment">';
-			if ( $attributes['displayAvatar'] ) {
-				$avatar = get_avatar(
-					$comment,
-					48,
-					'',
-					'',
-					array(
-						'class' => 'wp-block-latest-comments__comment-avatar',
-					)
-				);
-				if ( $avatar ) {
-					$list_items_markup .= $avatar;
-				}
-			}
+    $list_items_markup = '';
+    if ( ! empty( $comments ) ) {
+        // Prime the cache for associated posts. This is copied from \WP_Widget_Recent_Comments::widget().
+        $post_ids = array_unique( wp_list_pluck( $comments, 'comment_post_ID' ) );
+        _prime_post_caches( $post_ids, strpos( get_option( 'permalink_structure' ), '%category%' ), false );
 
-			$list_items_markup .= '<article>';
-			$list_items_markup .= '<footer class="wp-block-latest-comments__comment-meta">';
-			$author_url         = get_comment_author_url( $comment );
-			if ( empty( $author_url ) && ! empty( $comment->user_id ) ) {
-				$author_url = get_author_posts_url( $comment->user_id );
-			}
+        foreach ( $comments as $comment ) {
+            $list_items_markup .= '<li class="wp-block-latest-comments__comment">';
+            if ( $attributes['displayAvatar'] ) {
+                $avatar = get_avatar(
+                    $comment,
+                    48,
+                    '',
+                    '',
+                    array(
+                        'class' => 'wp-block-latest-comments__comment-avatar',
+                    )
+                );
+                if ( $avatar ) {
+                    $list_items_markup .= $avatar;
+                }
+            }
 
-			$author_markup = '';
-			if ( $author_url ) {
-				$author_markup .= '<a class="wp-block-latest-comments__comment-author" href="' . esc_url( $author_url ) . '">' . get_comment_author( $comment ) . '</a>';
-			} else {
-				$author_markup .= '<span class="wp-block-latest-comments__comment-author">' . get_comment_author( $comment ) . '</span>';
-			}
+            $list_items_markup .= '<article>';
+            $list_items_markup .= '<footer class="wp-block-latest-comments__comment-meta">';
+            $author_url         = get_comment_author_url( $comment );
+            if ( empty( $author_url ) && ! empty( $comment->user_id ) ) {
+                $author_url = get_author_posts_url( $comment->user_id );
+            }
 
-			// `_draft_or_post_title` calls `esc_html()` so we don't need to wrap that call in
-			// `esc_html`.
-			$post_title = '<a class="wp-block-latest-comments__comment-link" href="' . esc_url( get_comment_link( $comment ) ) . '">' . wp_latest_comments_draft_or_post_title( $comment->comment_post_ID ) . '</a>';
+            $author_markup = '';
+            if ( $author_url ) {
+                $author_markup .= '<a class="wp-block-latest-comments__comment-author" href="' . esc_url( $author_url ) . '">' . get_comment_author( $comment ) . '</a>';
+            } else {
+                $author_markup .= '<span class="wp-block-latest-comments__comment-author">' . get_comment_author( $comment ) . '</span>';
+            }
 
-			$list_items_markup .= sprintf(
-				/* translators: 1: author name (inside <a> or <span> tag, based on if they have a URL), 2: post title related to this comment */
-				__( '%1$s on %2$s' ),
-				$author_markup,
-				$post_title
-			);
+            // `_draft_or_post_title` calls `esc_html()` so we don't need to wrap that call in
+            // `esc_html`.
+            $post_title = '<a class="wp-block-latest-comments__comment-link" href="' . esc_url( get_comment_link( $comment ) ) . '">' . wp_latest_comments_draft_or_post_title( $comment->comment_post_ID ) . '</a>';
 
-			if ( $attributes['displayDate'] ) {
-				$list_items_markup .= sprintf(
-					'<time datetime="%1$s" class="wp-block-latest-comments__comment-date">%2$s</time>',
-					esc_attr( get_comment_date( 'c', $comment ) ),
-					date_i18n( get_option( 'date_format' ), get_comment_date( 'U', $comment ) )
-				);
-			}
-			$list_items_markup .= '</footer>';
-			if ( $attributes['displayExcerpt'] ) {
-				$list_items_markup .= '<div class="wp-block-latest-comments__comment-excerpt">' . wpautop( get_comment_excerpt( $comment ) ) . '</div>';
-			}
-			$list_items_markup .= '</article></li>';
-		}
-	}
+            $list_items_markup .= sprintf(
+                /* translators: 1: author name (inside <a> or <span> tag, based on if they have a URL), 2: post title related to this comment */
+                __( '%1$s on %2$s' ),
+                $author_markup,
+                $post_title
+            );
 
-	$classnames = array();
-	if ( $attributes['displayAvatar'] ) {
-		$classnames[] = 'has-avatars';
-	}
-	if ( $attributes['displayDate'] ) {
-		$classnames[] = 'has-dates';
-	}
-	if ( $attributes['displayExcerpt'] ) {
-		$classnames[] = 'has-excerpts';
-	}
-	if ( empty( $comments ) ) {
-		$classnames[] = 'no-comments';
-	}
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classnames ) ) );
+            if ( $attributes['displayDate'] ) {
+                $list_items_markup .= sprintf(
+                    '<time datetime="%1$s" class="wp-block-latest-comments__comment-date">%2$s</time>',
+                    esc_attr( get_comment_date( 'c', $comment ) ),
+                    date_i18n( get_option( 'date_format' ), get_comment_date( 'U', $comment ) )
+                );
+            }
+            $list_items_markup .= '</footer>';
+            
+            // Handle different display content options
+            if ( 'full' === $display_content ) {
+                $list_items_markup .= '<div class="wp-block-latest-comments__comment-excerpt">' . wpautop( get_comment_text( $comment ) ) . '</div>';
+            } elseif ( 'excerpt' === $display_content ) {
+                $list_items_markup .= '<div class="wp-block-latest-comments__comment-excerpt">' . wpautop( get_comment_excerpt( $comment ) ) . '</div>';
+            }
+            // If 'none', don't add any content
+            
+            $list_items_markup .= '</article></li>';
+        }
+    }
 
-	return ! empty( $comments ) ? sprintf(
-		'<ol %1$s>%2$s</ol>',
-		$wrapper_attributes,
-		$list_items_markup
-	) : sprintf(
-		'<div %1$s>%2$s</div>',
-		$wrapper_attributes,
-		__( 'No comments to show.' )
-	);
+    $classnames = array();
+    if ( $attributes['displayAvatar'] ) {
+        $classnames[] = 'has-avatars';
+    }
+    if ( $attributes['displayDate'] ) {
+        $classnames[] = 'has-dates';
+    }
+    if ( 'none' !== $display_content ) {
+        $classnames[] = 'has-excerpts';
+    }
+    if ( empty( $comments ) ) {
+        $classnames[] = 'no-comments';
+    }
+    $wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classnames ) ) );
+
+    return ! empty( $comments ) ? sprintf(
+        '<ol %1$s>%2$s</ol>',
+        $wrapper_attributes,
+        $list_items_markup
+    ) : sprintf(
+        '<div %1$s>%2$s</div>',
+        $wrapper_attributes,
+        __( 'No comments to show.' )
+    );
 }
 
 /**
@@ -151,12 +164,12 @@ function render_block_core_latest_comments( $attributes ) {
  * @since 5.3.0
  */
 function register_block_core_latest_comments() {
-	register_block_type_from_metadata(
-		__DIR__ . '/latest-comments',
-		array(
-			'render_callback' => 'render_block_core_latest_comments',
-		)
-	);
+    register_block_type_from_metadata(
+        __DIR__ . '/latest-comments',
+        array(
+            'render_callback' => 'render_block_core_latest_comments',
+        )
+    );
 }
 
 add_action( 'init', 'register_block_core_latest_comments' );

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -119,15 +119,11 @@ function render_block_core_latest_comments( $attributes ) {
 				);
 			}
 			$list_items_markup .= '</footer>';
-			
-			// Handle different display content options
 			if ( 'full' === $display_content ) {
 				$list_items_markup .= '<div class="wp-block-latest-comments__comment-excerpt">' . wpautop( get_comment_text( $comment ) ) . '</div>';
 			} elseif ( 'excerpt' === $display_content ) {
-				$list_items_markup .= '<div class="wp-block-latest-comments__comment-excerpt">' . wpautop( get_comment_excerpt( $comment ) ) . '</div>';
-			}
-			// If 'none', don't add any content
-			
+$list_items_markup .= '<div class="wp-block-latest-comments__comment-excerpt">' . wpautop( get_comment_excerpt( $comment ) ) . '</div>';
+}
 			$list_items_markup .= '</article></li>';
 		}
 	}

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -26,11 +26,11 @@
  * @return string The post title if set; "(no title)" if no title is set.
  */
 function wp_latest_comments_draft_or_post_title( $post = 0 ) {
-    $title = get_the_title( $post );
-    if ( empty( $title ) ) {
-        $title = __( '(no title)' );
-    }
-    return $title;
+	$title = get_the_title( $post );
+	if ( empty( $title ) ) {
+		$title = __( '(no title)' );
+	}
+	return $title;
 }
 
 /**
@@ -43,119 +43,119 @@ function wp_latest_comments_draft_or_post_title( $post = 0 ) {
  * @return string Returns the post content with latest comments added.
  */
 function render_block_core_latest_comments( $attributes ) {
-    // Handle backward compatibility: check for old displayExcerpt attribute
-    if ( isset( $attributes['displayExcerpt'] ) ) {
-        $display_content = $attributes['displayExcerpt'] ? 'excerpt' : 'none';
-    } else {
-        $display_content = isset( $attributes['displayContent'] ) ? $attributes['displayContent'] : 'excerpt';
-    }
+	// Handle backward compatibility: check for old displayExcerpt attribute
+	if ( isset( $attributes['displayExcerpt'] ) ) {
+		$display_content = $attributes['displayExcerpt'] ? 'excerpt' : 'none';
+	} else {
+		$display_content = isset( $attributes['displayContent'] ) ? $attributes['displayContent'] : 'excerpt';
+	}
 
-    $comments = get_comments(
-        /** This filter is documented in wp-includes/widgets/class-wp-widget-recent-comments.php */
-        apply_filters(
-            'widget_comments_args',
-            array(
-                'number'      => $attributes['commentsToShow'],
-                'status'      => 'approve',
-                'post_status' => 'publish',
-            ),
-            array()
-        )
-    );
+	$comments = get_comments(
+		/** This filter is documented in wp-includes/widgets/class-wp-widget-recent-comments.php */
+		apply_filters(
+			'widget_comments_args',
+			array(
+				'number'      => $attributes['commentsToShow'],
+				'status'      => 'approve',
+				'post_status' => 'publish',
+			),
+			array()
+		)
+	);
 
-    $list_items_markup = '';
-    if ( ! empty( $comments ) ) {
-        // Prime the cache for associated posts. This is copied from \WP_Widget_Recent_Comments::widget().
-        $post_ids = array_unique( wp_list_pluck( $comments, 'comment_post_ID' ) );
-        _prime_post_caches( $post_ids, strpos( get_option( 'permalink_structure' ), '%category%' ), false );
+	$list_items_markup = '';
+	if ( ! empty( $comments ) ) {
+		// Prime the cache for associated posts. This is copied from \WP_Widget_Recent_Comments::widget().
+		$post_ids = array_unique( wp_list_pluck( $comments, 'comment_post_ID' ) );
+		_prime_post_caches( $post_ids, strpos( get_option( 'permalink_structure' ), '%category%' ), false );
 
-        foreach ( $comments as $comment ) {
-            $list_items_markup .= '<li class="wp-block-latest-comments__comment">';
-            if ( $attributes['displayAvatar'] ) {
-                $avatar = get_avatar(
-                    $comment,
-                    48,
-                    '',
-                    '',
-                    array(
-                        'class' => 'wp-block-latest-comments__comment-avatar',
-                    )
-                );
-                if ( $avatar ) {
-                    $list_items_markup .= $avatar;
-                }
-            }
+		foreach ( $comments as $comment ) {
+			$list_items_markup .= '<li class="wp-block-latest-comments__comment">';
+			if ( $attributes['displayAvatar'] ) {
+				$avatar = get_avatar(
+					$comment,
+					48,
+					'',
+					'',
+					array(
+						'class' => 'wp-block-latest-comments__comment-avatar',
+					)
+				);
+				if ( $avatar ) {
+					$list_items_markup .= $avatar;
+				}
+			}
 
-            $list_items_markup .= '<article>';
-            $list_items_markup .= '<footer class="wp-block-latest-comments__comment-meta">';
-            $author_url         = get_comment_author_url( $comment );
-            if ( empty( $author_url ) && ! empty( $comment->user_id ) ) {
-                $author_url = get_author_posts_url( $comment->user_id );
-            }
+			$list_items_markup .= '<article>';
+			$list_items_markup .= '<footer class="wp-block-latest-comments__comment-meta">';
+			$author_url         = get_comment_author_url( $comment );
+			if ( empty( $author_url ) && ! empty( $comment->user_id ) ) {
+				$author_url = get_author_posts_url( $comment->user_id );
+			}
 
-            $author_markup = '';
-            if ( $author_url ) {
-                $author_markup .= '<a class="wp-block-latest-comments__comment-author" href="' . esc_url( $author_url ) . '">' . get_comment_author( $comment ) . '</a>';
-            } else {
-                $author_markup .= '<span class="wp-block-latest-comments__comment-author">' . get_comment_author( $comment ) . '</span>';
-            }
+			$author_markup = '';
+			if ( $author_url ) {
+				$author_markup .= '<a class="wp-block-latest-comments__comment-author" href="' . esc_url( $author_url ) . '">' . get_comment_author( $comment ) . '</a>';
+			} else {
+				$author_markup .= '<span class="wp-block-latest-comments__comment-author">' . get_comment_author( $comment ) . '</span>';
+			}
 
-            // `_draft_or_post_title` calls `esc_html()` so we don't need to wrap that call in
-            // `esc_html`.
-            $post_title = '<a class="wp-block-latest-comments__comment-link" href="' . esc_url( get_comment_link( $comment ) ) . '">' . wp_latest_comments_draft_or_post_title( $comment->comment_post_ID ) . '</a>';
+			// `_draft_or_post_title` calls `esc_html()` so we don't need to wrap that call in
+			// `esc_html`.
+			$post_title = '<a class="wp-block-latest-comments__comment-link" href="' . esc_url( get_comment_link( $comment ) ) . '">' . wp_latest_comments_draft_or_post_title( $comment->comment_post_ID ) . '</a>';
 
-            $list_items_markup .= sprintf(
-                /* translators: 1: author name (inside <a> or <span> tag, based on if they have a URL), 2: post title related to this comment */
-                __( '%1$s on %2$s' ),
-                $author_markup,
-                $post_title
-            );
+			$list_items_markup .= sprintf(
+				/* translators: 1: author name (inside <a> or <span> tag, based on if they have a URL), 2: post title related to this comment */
+				__( '%1$s on %2$s' ),
+				$author_markup,
+				$post_title
+			);
 
-            if ( $attributes['displayDate'] ) {
-                $list_items_markup .= sprintf(
-                    '<time datetime="%1$s" class="wp-block-latest-comments__comment-date">%2$s</time>',
-                    esc_attr( get_comment_date( 'c', $comment ) ),
-                    date_i18n( get_option( 'date_format' ), get_comment_date( 'U', $comment ) )
-                );
-            }
-            $list_items_markup .= '</footer>';
-            
-            // Handle different display content options
-            if ( 'full' === $display_content ) {
-                $list_items_markup .= '<div class="wp-block-latest-comments__comment-excerpt">' . wpautop( get_comment_text( $comment ) ) . '</div>';
-            } elseif ( 'excerpt' === $display_content ) {
-                $list_items_markup .= '<div class="wp-block-latest-comments__comment-excerpt">' . wpautop( get_comment_excerpt( $comment ) ) . '</div>';
-            }
-            // If 'none', don't add any content
-            
-            $list_items_markup .= '</article></li>';
-        }
-    }
+			if ( $attributes['displayDate'] ) {
+				$list_items_markup .= sprintf(
+					'<time datetime="%1$s" class="wp-block-latest-comments__comment-date">%2$s</time>',
+					esc_attr( get_comment_date( 'c', $comment ) ),
+					date_i18n( get_option( 'date_format' ), get_comment_date( 'U', $comment ) )
+				);
+			}
+			$list_items_markup .= '</footer>';
+			
+			// Handle different display content options
+			if ( 'full' === $display_content ) {
+				$list_items_markup .= '<div class="wp-block-latest-comments__comment-excerpt">' . wpautop( get_comment_text( $comment ) ) . '</div>';
+			} elseif ( 'excerpt' === $display_content ) {
+				$list_items_markup .= '<div class="wp-block-latest-comments__comment-excerpt">' . wpautop( get_comment_excerpt( $comment ) ) . '</div>';
+			}
+			// If 'none', don't add any content
+			
+			$list_items_markup .= '</article></li>';
+		}
+	}
 
-    $classnames = array();
-    if ( $attributes['displayAvatar'] ) {
-        $classnames[] = 'has-avatars';
-    }
-    if ( $attributes['displayDate'] ) {
-        $classnames[] = 'has-dates';
-    }
-    if ( 'none' !== $display_content ) {
-        $classnames[] = 'has-excerpts';
-    }
-    if ( empty( $comments ) ) {
-        $classnames[] = 'no-comments';
-    }
-    $wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classnames ) ) );
+	$classnames = array();
+	if ( $attributes['displayAvatar'] ) {
+		$classnames[] = 'has-avatars';
+	}
+	if ( $attributes['displayDate'] ) {
+		$classnames[] = 'has-dates';
+	}
+	if ( 'none' !== $display_content ) {
+		$classnames[] = 'has-excerpts';
+	}
+	if ( empty( $comments ) ) {
+		$classnames[] = 'no-comments';
+	}
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classnames ) ) );
 
-    return ! empty( $comments ) ? sprintf(
-        '<ol %1$s>%2$s</ol>',
-        $wrapper_attributes,
-        $list_items_markup
-    ) : sprintf(
-        '<div %1$s>%2$s</div>',
-        $wrapper_attributes,
-        __( 'No comments to show.' )
-    );
+	return ! empty( $comments ) ? sprintf(
+		'<ol %1$s>%2$s</ol>',
+		$wrapper_attributes,
+		$list_items_markup
+	) : sprintf(
+		'<div %1$s>%2$s</div>',
+		$wrapper_attributes,
+		__( 'No comments to show.' )
+	);
 }
 
 /**
@@ -164,12 +164,12 @@ function render_block_core_latest_comments( $attributes ) {
  * @since 5.3.0
  */
 function register_block_core_latest_comments() {
-    register_block_type_from_metadata(
-        __DIR__ . '/latest-comments',
-        array(
-            'render_callback' => 'render_block_core_latest_comments',
-        )
-    );
+	register_block_type_from_metadata(
+		__DIR__ . '/latest-comments',
+		array(
+			'render_callback' => 'render_block_core_latest_comments',
+		)
+	);
 }
 
 add_action( 'init', 'register_block_core_latest_comments' );

--- a/test/integration/fixtures/blocks/core__latest-comments.json
+++ b/test/integration/fixtures/blocks/core__latest-comments.json
@@ -6,7 +6,7 @@
 			"commentsToShow": 5,
 			"displayAvatar": true,
 			"displayDate": true,
-			"displayExcerpt": true
+			"displayContent": "excerpt"
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__latest-comments__deprecated-v1.html
+++ b/test/integration/fixtures/blocks/core__latest-comments__deprecated-v1.html
@@ -1,0 +1,1 @@
+<!-- wp:latest-comments {"displayExcerpt":false} /-->

--- a/test/integration/fixtures/blocks/core__latest-comments__deprecated-v1.json
+++ b/test/integration/fixtures/blocks/core__latest-comments__deprecated-v1.json
@@ -1,0 +1,11 @@
+[
+	{
+		"blockName": "core/latest-comments",
+		"attrs": {
+			"displayExcerpt": false
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__latest-comments__deprecated-v1.json
+++ b/test/integration/fixtures/blocks/core__latest-comments__deprecated-v1.json
@@ -6,7 +6,8 @@
 			"commentsToShow": 5,
 			"displayAvatar": true,
 			"displayDate": true,
-			"displayContent": "excerpt"
+			"displayExcerpt": false,
+			"displayContent": "none"
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__latest-comments__deprecated-v1.json
+++ b/test/integration/fixtures/blocks/core__latest-comments__deprecated-v1.json
@@ -1,11 +1,13 @@
 [
 	{
-		"blockName": "core/latest-comments",
-		"attrs": {
-			"displayExcerpt": false
+		"name": "core/latest-comments",
+		"isValid": true,
+		"attributes": {
+			"commentsToShow": 5,
+			"displayAvatar": true,
+			"displayDate": true,
+			"displayContent": "excerpt"
 		},
-		"innerBlocks": [],
-		"innerHTML": "",
-		"innerContent": []
+		"innerBlocks": []
 	}
 ]

--- a/test/integration/fixtures/blocks/core__latest-comments__deprecated-v1.parsed.json
+++ b/test/integration/fixtures/blocks/core__latest-comments__deprecated-v1.parsed.json
@@ -1,0 +1,11 @@
+[
+	{
+		"blockName": "core/latest-comments",
+		"attrs": {
+			"displayExcerpt": false
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__latest-comments__deprecated-v1.serialized.html
+++ b/test/integration/fixtures/blocks/core__latest-comments__deprecated-v1.serialized.html
@@ -1,0 +1,1 @@
+<!-- wp:latest-comments {"displayContent":"none"} /-->

--- a/test/integration/fixtures/blocks/core__latest-comments__deprecated-v1.serialized.html
+++ b/test/integration/fixtures/blocks/core__latest-comments__deprecated-v1.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:latest-comments {"displayContent":"none"} /-->
+<!-- wp:latest-comments /-->

--- a/test/integration/fixtures/blocks/core__latest-comments__deprecated-v1.serialized.html
+++ b/test/integration/fixtures/blocks/core__latest-comments__deprecated-v1.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:latest-comments /-->
+<!-- wp:latest-comments {"displayContent":"none"} /-->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Closes #72348

Replaces the "Display excerpt" toggle with a "Display content" dropdown in the Latest Comments block, providing three options: No content, Excerpt, and Full content.

## Why?

The Latest Comments block currently only offers a binary choice (show excerpt or hide it). This limits flexibility for users who want to display the full comment text or hide comment content entirely while still showing author information and metadata. This enhancement provides more granular control over comment display.

## How?

- Updated `block.json` to replace the `displayExcerpt` boolean attribute with a new `displayContent` string attribute (enum: "none", "excerpt", "full")
- Modified `edit.js` to replace the `ToggleControl` with a `SelectControl` dropdown offering three options
- Added `deprecated.js` with migration logic to automatically convert blocks using the old `displayExcerpt` boolean to the new `displayContent` string format
- Updated `index.php` rendering logic to:
  - Handle backward compatibility by checking for the legacy `displayExcerpt` attribute first
  - Call `get_comment_text()` when "Full content" is selected
  - Call `get_comment_excerpt()` when "Excerpt" is selected  
  - Display no content when "None" is selected
- Updated CSS class logic to apply `has-excerpts` class when content is displayed
- Added test fixtures (`core__latest-comments__deprecated-v1.*`) to verify migration works correctly

## Testing Instructions

1. Open a post or page in the block editor
2. Insert a **Latest Comments** block
3. Open the block settings panel on the right sidebar
4. Locate the "Display content" dropdown (previously "Display excerpt" toggle)
5. Test each option:
   - Select **"No content"** - verify only comment author, post title, and date (if enabled) are shown
   - Select **"Excerpt"** - verify comment excerpts are displayed (default behavior)
   - Select **"Full content"** - verify full comment text is displayed
6. Save and view on the frontend to ensure all three options render correctly
7. Test with comments of varying lengths to ensure full content doesn't break the layout

### Backward Compatibility Testing

8. **Test deprecated attribute migration:**
   - Switch to Code Editor view
   - Manually insert an old-format block: `<!-- wp:latest-comments {"displayExcerpt":false} /-->`
   - Switch back to Visual Editor
   - Verify the dropdown shows "No content" selected
   - View on frontend - should display no content (only author/date/post title)
   - Make any edit to the block (e.g., toggle display avatar)
   - Switch back to Code Editor
   - Verify the block now uses `"displayContent":"none"` instead of `"displayExcerpt":false`
9. Repeat step 8 with `{"displayExcerpt":true}` and verify it migrates to `"displayContent":"excerpt"`

### Testing Instructions for Keyboard

1. Open a post or page in the block editor
2. Insert a **Latest Comments** block using the inserter (press `/` then type "latest comments")
3. Press `Tab` to navigate to the block toolbar, then continue tabbing to reach the settings sidebar
4. Use `Tab` to navigate to the "Display content" dropdown
5. Press `Space` or `Enter` to open the dropdown
6. Use `Arrow Up/Down` keys to navigate through the three options
7. Press `Enter` to select an option
8. Verify the block preview updates accordingly
9. Use `Tab` to navigate to other settings and ensure keyboard navigation works smoothly throughout

## Screenshots or screencast

https://github.com/user-attachments/assets/beed7fc3-b750-4466-994b-8c2dbc4ca8cf

### Additional Notes

- The default value is "Excerpt" to maintain existing behavior
- The CSS class `has-excerpts` is applied when content is displayed (excerpt or full)
- Full comment content uses `get_comment_text()` as suggested in the original issue
- All comment content is wrapped in `wpautop()` for proper paragraph formatting
- **Backward compatibility**: Blocks with the old `displayExcerpt` attribute are automatically migrated via deprecation logic when edited, and render correctly on the frontend via PHP fallback logic
- Migration is triggered by `isEligible()` check that only runs when the legacy `displayExcerpt` attribute exists
- Test fixtures ensure the migration from `displayExcerpt: false` → `displayContent: "none"` and `displayExcerpt: true` → `displayContent: "excerpt"` works correctly