### PR TITLE
Core Data: Avoid extraneous when creating a new record

### DIFF
--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -525,8 +525,9 @@ export const saveEntityRecord =
 		if ( ! entityConfig ) {
 			return;
 		}
-		const entityIdKey = entityConfig.key || DEFAULT_ENTITY_KEY;
+		const entityIdKey = entityConfig.key ?? DEFAULT_ENTITY_KEY;
 		const recordId = record[ entityIdKey ];
+		const isNewRecord = !! entityIdKey && ! recordId;
 
 		const lock = await dispatch.__unstableAcquireStoreLock(
 			STORE_NAME,
@@ -580,11 +581,10 @@ export const saveEntityRecord =
 			}
 			try {
 				const path = `${ baseURL }${ recordId ? '/' + recordId : '' }`;
-				const persistedRecord = select.getRawEntityRecord(
-					kind,
-					name,
-					recordId
-				);
+				// Skip the raw values check when creating a new record; they don't exist yet.
+				const persistedRecord = ! isNewRecord
+					? select.getRawEntityRecord( kind, name, recordId )
+					: {};
 
 				if ( isAutosave ) {
 					// Most of this autosave logic is very specific to posts.

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -36,6 +36,7 @@ export const rootEntitiesConfig = [
 	{
 		label: __( 'Base' ),
 		kind: 'root',
+		key: false,
 		name: '__unstableBase',
 		baseURL: '/',
 		baseURLParams: {
@@ -381,6 +382,7 @@ async function loadSiteEntity() {
 		label: __( 'Site' ),
 		name: 'site',
 		kind: 'root',
+		key: false,
 		baseURL: '/wp/v2/settings',
 		meta: {},
 	};


### PR DESCRIPTION
## What?
Closes #71927.

🚧 Work in Progress 🚧 

PR prevents extraneous HTTP requests for entity collections when creating a new entity record.

## Why?
When creating a new record, `select.getRawEntityRecord` is called without `id`, which results in an unwanted collections query.

## How?
* Explicitly set `entityConfig.key` to `false` for entities that represent a single object. For example, the Site settings.
* Check if `saveEntityRecord` is updating an existing record or creating a new one, and call `getRawEntityRecord` conditionally.

## Testing Instructions
1. Open a post.
2. Add a block.
3. Add a note for this block.
4. Confirm that there's no `GET` request 

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<img width="1140" height="362" alt="Image" src="https://github.com/user-attachments/assets/7554237d-06f1-495e-b201-6dc477c38c18" />