### PR TITLE
Optimize build using shared package cache

### DIFF
--- a/bin/packages/build.mjs
+++ b/bin/packages/build.mjs
@@ -70,6 +70,35 @@ const getDefine = ( scriptDebug ) => ( {
 	'globalThis.SCRIPT_DEBUG': JSON.stringify( scriptDebug ),
 } );
 
+const packageJsonCache = new Map();
+
+/**
+ * Get package.json info for a WordPress package.
+ *
+ * @param {string} packageName The package name (without @wordpress/ prefix).
+ * @return {Promise<Object|null>} Package.json object or null if not found.
+ */
+async function getPackageInfo( packageName ) {
+	let packageJson = packageJsonCache.get( packageName );
+	if ( packageJson === undefined ) {
+		const packageJsonPath = path.join(
+			PACKAGES_DIR,
+			packageName,
+			'package.json'
+		);
+
+		try {
+			packageJson = (
+				await import( packageJsonPath, { with: { type: 'json' } } )
+			).default;
+		} catch {}
+
+		packageJsonCache.set( packageName, packageJson );
+	}
+
+	return packageJson;
+}
+
 /**
  * Create emotion babel plugin for esbuild.
  * This plugin enables emotion's babel transformations for proper CSS-in-JS handling.
@@ -222,36 +251,6 @@ function wordpressExternalsPlugin(
 		setup( build ) {
 			const dependencies = new Set();
 			const moduleDependencies = new Map();
-			const packageJsonCache = new Map();
-
-			/**
-			 * Get package.json info for a WordPress package.
-			 *
-			 * @param {string} packageName The package name (without @wordpress/ prefix).
-			 * @return {Promise<Object|null>} Package.json object or null if not found.
-			 */
-			async function getPackageInfo( packageName ) {
-				if ( packageJsonCache.has( packageName ) ) {
-					return packageJsonCache.get( packageName );
-				}
-
-				const packageJsonPath = path.join(
-					PACKAGES_DIR,
-					packageName,
-					'package.json'
-				);
-
-				try {
-					const packageJson = JSON.parse(
-						await readFile( packageJsonPath, 'utf8' )
-					);
-					packageJsonCache.set( packageName, packageJson );
-					return packageJson;
-				} catch ( error ) {
-					packageJsonCache.set( packageName, null );
-					return null;
-				}
-			}
 
 			/**
 			 * Check if a package import is a script module.

--- a/bin/packages/build.mjs
+++ b/bin/packages/build.mjs
@@ -91,7 +91,9 @@ async function getPackageInfo( packageName ) {
 			packageJson = (
 				await import( packageJsonPath, { with: { type: 'json' } } )
 			).default;
-		} catch {}
+		} catch {
+			packageJson = null;
+		}
 
 		packageJsonCache.set( packageName, packageJson );
 	}


### PR DESCRIPTION
## What?

Applies a few optimizations to the build script:

1. Reuses a global shared cache for package lookup, rather than each package having their own cache
2. Uses `import` instead of `fs.readFile` for loading JSON file contents (micro-benchmarking shows 2.5x faster†)
3. Eliminates a map operation on the cache (`Map#has` + `Map#get` ➡️ `Map#get`)

Overall impact is relatively modest, about 6% reduction in bundling phase time.

<details><summary>Benchmarking details</summary>

Bundling time measured by average of 5 runs after isolating build script to bundling phase:

```diff
diff --git a/bin/packages/build.mjs b/bin/packages/build.mjs
index 2b1727a4b1..15a6cbe177 100644
--- a/bin/packages/build.mjs
+++ b/bin/packages/build.mjs
@@ -1293,15 +1293,2 @@ async function buildAll() {
 
-	console.log( '📝 Phase 1: Transpiling packages...\n' );
-
-	for ( const level of levels ) {
-		await Promise.all(
-			level.map( async ( packageName ) => {
-				const buildTime = await transpilePackage( packageName );
-				console.log(
-					`   ✔ Transpiled ${ packageName } (${ buildTime }ms)`
-				);
-			} )
-		);
-	}
-
 	console.log( '\n📦 Phase 2: Bundling packages...\n' );
@@ -1329,14 +1316,2 @@ async function buildAll() {
 
-	console.log( '\n📄 Generating PHP registration files...\n' );
-	await Promise.all( [
-		generateMainIndexPhp(),
-		generateModuleRegistrationPhp( modules ),
-		generateScriptRegistrationPhp( scripts ),
-	] );
-	console.log( '   ✔ Generated build/modules.php' );
-	console.log( '   ✔ Generated build/modules/index.php' );
-	console.log( '   ✔ Generated build/scripts.php' );
-	console.log( '   ✔ Generated build/scripts/index.php' );
-	console.log( '   ✔ Generated build/index.php' );
-
 	const totalTime = Date.now() - startTime;
```

Measured by `node bin/packages/build.mjs`:

Before: 1174, 1175, 1187, 1170, 1273 (average 1195.8)
After: 1338, 1202, 1261, 1179, 365 (average 1269)

Benchmarking script for `fs.readFile` vs. `import`:

```js
import fs from "fs/promises";
import Benchmark from "benchmark";

const suite = new Benchmark.Suite();

suite.add("fs", async () => {
  const data = await fs.readFile("./package.json", "utf8");
  JSON.parse(data);
});

suite.add("import", async () => {
  await import("./package.json", { with: { type: "json" } });
});

suite.on("cycle", (event) => {
  console.log(String(event.target));
});

suite.run({ async: true });
```

Result:

```
fs x 405,593 ops/sec ±8.53% (77 runs sampled)
import x 1,004,566 ops/sec ±3.54% (83 runs sampled)
```

</details>

## Why?

Improve developer experience by optimizing build, ensuring scalability for large number of packages being built.

## Testing Instructions

Verify build completes successfully:

```
npm run build
```