### PR TITLE
Build: Inline CSS modules stylesheet content

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -32,8 +32,7 @@
 		},
 		"./design-tokens.css": "./src/prebuilt/css/design-tokens.css",
 		"./design-tokens.js": "./src/prebuilt/js/design-tokens.js",
-		"./package.json": "./package.json",
-		"./build-style/": "./build-style/"
+		"./package.json": "./package.json"
 	},
 	"react-native": "src/index",
 	"wpScript": true,

--- a/storybook/package-styles/config.js
+++ b/storybook/package-styles/config.js
@@ -15,7 +15,6 @@ import dataviewsLtr from '../package-styles/dataviews-ltr.lazy.scss';
 import dataviewsRtl from '../package-styles/dataviews-rtl.lazy.scss';
 import fieldsLtr from '../package-styles/fields-ltr.lazy.scss';
 import fieldsRtl from '../package-styles/fields-rtl.lazy.scss';
-import theme from '../package-styles/theme.lazy.scss';
 
 /**
  * Stylesheets to lazy load when the story's context.componentId matches the
@@ -65,16 +64,6 @@ const CONFIG = [
 		componentIdMatcher: /^fields-/,
 		ltr: [ componentsLtr, dataviewsLtr, fieldsLtr ],
 		rtl: [ componentsRtl, dataviewsRtl, fieldsRtl ],
-	},
-
-	// These components exclusively use logical properties, so the same
-	// stylesheet is used regardless of text direction.
-	//
-	// See: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values
-	{
-		componentIdMatcher: /^theme-/,
-		ltr: [ theme ],
-		rtl: [ theme ],
 	},
 ];
 

--- a/storybook/package-styles/theme.lazy.scss
+++ b/storybook/package-styles/theme.lazy.scss
@@ -1,1 +1,0 @@
-@import "../../packages/theme/build-style/style.css";


### PR DESCRIPTION
## What?

Updates build script to inline contents of CSS modules into built JavaScript rather than emitting separate stylesheets.

Follow-up to #72305

## Why?

It may end up simplifying dependency tracking and developer experience for consuming from packages which provide styles through CSS modules. For example, #72305 mentions "Probably move the styles in the stylesheet to an inline style attribute" as a follow-up action item because the inclusion of a separate stylesheet adds additional developer friction.

On the other hand, it may be worth keeping an eye on this and revisiting down the line, since there may be some ramifications:

- If the package is loaded multiple times, the current experience is that a unique style tag is added each time it's loaded
   - This might be possible to mitigate if we override default behavior of how `esbuild-sass-plugin` generates code for adding the style tag (i.e. make it idempotent)
- Injecting stylesheets may create challenges for sites employing a [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP)
- There may be performance ramifications of inlining styles through JavaScript compared to more traditional stylesheets

## Testing Instructions

1. Run `npm run build`
2. Verify that the outputs of the bundled theme package include inlined styles: `grep -C 5 _root_ build/scripts/theme/index.js`

```
      themeProviderStyles
    };
  }

  // packages/theme/build-module/style.module.css
  var css = `._root_th78q_1 {
	display: contents;
}
`;
  document.head.appendChild(document.createElement("style")).appendChild(document.createTextNode(css));
  var style_default = {
    "root": "_root_th78q_1"
  };

  // packages/theme/build-module/theme-provider.js
  function cssObjectToText(values) {
    return Object.entries(values).map(([key, value]) => `${key}: ${value};`).join("");
```